### PR TITLE
docs: clarify personal vs private in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 **Clawdis** is a *personal AI assistant* you run on your own devices.
 It answers you on the surfaces you already use (WhatsApp, Telegram, Discord, WebChat), can speak and listen on macOS/iOS, and can render a live Canvas you control. The Gateway is just the control plane — the product is the assistant.
 
-If you want a private, single-user assistant that feels local, fast, and always-on, this is it.
+If you want a personal, single-user assistant that feels local, fast, and always-on, this is it.
 
 Using Claude Pro/Max subscription? See `docs/onboarding.md` for the Anthropic OAuth setup.
 


### PR DESCRIPTION
Fixes #125

## Summary
Changed "private" to "personal" in README.md main description to better reflect that Clawdis uses cloud AI providers (like Claude) by default, which may retain data per their terms.

## Changes
- Line 20 in README.md: "private, single-user" → "personal, single-user"

## Rationale
While Clawdis *can* be configured for 100% local/private operation, the default setup uses Anthropic's Claude API. Using "personal" is more accurate and avoids misleading users about data privacy guarantees.

---
*Generated via parallel Codex worktree workflow* 🥷