### PR TITLE
feat(whatsapp,telegram): add groupPolicy config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 - Typing indicators: stop typing once the reply dispatcher drains to prevent stuck typing across Discord/Telegram/WhatsApp.
+- WhatsApp/Telegram: add groupPolicy handling for group messages and normalize allowFrom matching (tg/telegram prefixes). Thanks @mneves75.
 - Auto-reply: add configurable ack reactions for inbound messages (default 👀 or `identity.emoji`) with scope controls. Thanks @obviyus for PR #178.
 - Onboarding: resolve CLI entrypoint when running via `npx` so gateway daemon install works without a build step.
 - Onboarding: when OpenAI Codex OAuth is used, default to `openai-codex/gpt-5.2` and warn if the selected model lacks auth.

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -16,13 +16,17 @@ Clawdbot treats group chats consistently across surfaces: WhatsApp, Telegram, Di
 - UI labels use `displayName` when available, formatted as `surface:<token>`.
 - `#room` is reserved for rooms/channels; group chats use `g-<slug>` (lowercase, spaces -> `-`, keep `#@+._-`).
 
-## Group policy (WhatsApp)
-WhatsApp supports a `groupPolicy` config to control how group messages are handled:
+## Group policy (WhatsApp & Telegram)
+Both WhatsApp and Telegram support a `groupPolicy` config to control how group messages are handled:
 
 ```json5
 {
   whatsapp: {
     allowFrom: ["+15551234567"],
+    groupPolicy: "disabled"  // "open" | "disabled" | "allowlist"
+  },
+  telegram: {
+    allowFrom: ["77112533", "@username"],
     groupPolicy: "disabled"  // "open" | "disabled" | "allowlist"
   }
 }
@@ -34,7 +38,9 @@ WhatsApp supports a `groupPolicy` config to control how group messages are handl
 | `"disabled"` | Block all group messages entirely. |
 | `"allowlist"` | Only allow group messages from senders listed in `allowFrom`. |
 
-Note: `groupPolicy` is separate from `allowFrom` (which only filters DMs) and from mention-gating (which requires @mentions).
+Notes:
+- `groupPolicy` is separate from `allowFrom` (which only filters DMs) and from mention-gating (which requires @mentions).
+- For Telegram `allowlist`, the sender can be matched by user ID (e.g., `"77112533"`) or username (e.g., `"@mneves"` or `"mneves"`).
 
 ## Mention gating (default)
 Group messages require a mention unless overridden per group. Defaults live per subsystem under `*.groups."*"`.

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -16,6 +16,26 @@ Clawdbot treats group chats consistently across surfaces: WhatsApp, Telegram, Di
 - UI labels use `displayName` when available, formatted as `surface:<token>`.
 - `#room` is reserved for rooms/channels; group chats use `g-<slug>` (lowercase, spaces -> `-`, keep `#@+._-`).
 
+## Group policy (WhatsApp)
+WhatsApp supports a `groupPolicy` config to control how group messages are handled:
+
+```json5
+{
+  whatsapp: {
+    allowFrom: ["+15551234567"],
+    groupPolicy: "disabled"  // "open" | "disabled" | "allowlist"
+  }
+}
+```
+
+| Policy | Behavior |
+|--------|----------|
+| `"open"` | Default. Groups bypass `allowFrom`, only mention-gating applies. |
+| `"disabled"` | Block all group messages entirely. |
+| `"allowlist"` | Only allow group messages from senders listed in `allowFrom`. |
+
+Note: `groupPolicy` is separate from `allowFrom` (which only filters DMs) and from mention-gating (which requires @mentions).
+
 ## Mention gating (default)
 Group messages require a mention unless overridden per group. Defaults live per subsystem under `*.groups."*"`.
 

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -41,7 +41,7 @@ Both WhatsApp and Telegram support a `groupPolicy` config to control how group m
 Notes:
 - `allowFrom` filters DMs by default. With `groupPolicy: "allowlist"`, it also filters group message senders.
 - `groupPolicy` is separate from mention-gating (which requires @mentions).
-- For Telegram `allowlist`, the sender can be matched by user ID (e.g., `"123456789"` or `"telegram:123456789"`) or username (e.g., `"@alice"` or `"alice"`).
+- For Telegram `allowlist`, the sender can be matched by user ID (e.g., `"123456789"`, `"telegram:123456789"`, or `"tg:123456789"`; prefixes are case-insensitive) or username (e.g., `"@alice"` or `"alice"`).
 
 ## Mention gating (default)
 Group messages require a mention unless overridden per group. Defaults live per subsystem under `*.groups."*"`.

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -26,7 +26,7 @@ Both WhatsApp and Telegram support a `groupPolicy` config to control how group m
     groupPolicy: "disabled"  // "open" | "disabled" | "allowlist"
   },
   telegram: {
-    allowFrom: ["77112533", "@username"],
+    allowFrom: ["123456789", "@username"],
     groupPolicy: "disabled"  // "open" | "disabled" | "allowlist"
   }
 }
@@ -40,7 +40,7 @@ Both WhatsApp and Telegram support a `groupPolicy` config to control how group m
 
 Notes:
 - `groupPolicy` is separate from `allowFrom` (which only filters DMs) and from mention-gating (which requires @mentions).
-- For Telegram `allowlist`, the sender can be matched by user ID (e.g., `"77112533"`) or username (e.g., `"@mneves"` or `"mneves"`).
+- For Telegram `allowlist`, the sender can be matched by user ID (e.g., `"123456789"`) or username (e.g., `"@alice"` or `"alice"`).
 
 ## Mention gating (default)
 Group messages require a mention unless overridden per group. Defaults live per subsystem under `*.groups."*"`.

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -39,8 +39,9 @@ Both WhatsApp and Telegram support a `groupPolicy` config to control how group m
 | `"allowlist"` | Only allow group messages from senders listed in `allowFrom`. |
 
 Notes:
-- `groupPolicy` is separate from `allowFrom` (which only filters DMs) and from mention-gating (which requires @mentions).
-- For Telegram `allowlist`, the sender can be matched by user ID (e.g., `"123456789"`) or username (e.g., `"@alice"` or `"alice"`).
+- `allowFrom` filters DMs by default. With `groupPolicy: "allowlist"`, it also filters group message senders.
+- `groupPolicy` is separate from mention-gating (which requires @mentions).
+- For Telegram `allowlist`, the sender can be matched by user ID (e.g., `"123456789"` or `"telegram:123456789"`) or username (e.g., `"@alice"` or `"alice"`).
 
 ## Mention gating (default)
 Group messages require a mention unless overridden per group. Defaults live per subsystem under `*.groups."*"`.

--- a/docs/plans/group-policy-hardening.md
+++ b/docs/plans/group-policy-hardening.md
@@ -1,0 +1,240 @@
+# Engineering Execution Spec: groupPolicy Hardening
+
+**Date**: 2026-01-05
+**Status**: In Progress
+**PR**: #216 (feat/whatsapp-group-policy)
+
+---
+
+## Executive Summary
+
+Self-critique of the `groupPolicy` feature implementation revealed 3 issues and 2 test gaps that need addressing before the PR can be considered production-ready.
+
+---
+
+## Findings Analysis
+
+### [MED] F1: Telegram Group Allowlist Ignores Prefixed IDs
+
+**Location**: `src/telegram/bot.ts:105-128`
+
+**Problem**: The DM allowlist (lines 140-153) accepts both raw IDs (`123456789`) and prefixed IDs (`telegram:123456789`), but the group allowlist only checks raw IDs/usernames.
+
+```typescript
+// DM check (correct - supports prefix):
+const candidateWithPrefix = `telegram:${candidate}`;
+normalizedAllowFrom.some((v) => v === candidateWithPrefix);
+
+// Group check (missing prefix support):
+const senderIdAllowed = normalizedAllowFrom.includes(String(senderId));
+// ^ Only checks raw ID, not telegram:123456789
+```
+
+**Impact**: Users who configure `allowFrom: ["telegram:123456789"]` will find:
+- DMs work correctly
+- Group messages get blocked (even though sender is in allowlist)
+
+**Fix**: Strip `telegram:` prefix when matching sender IDs in group allowlist.
+
+---
+
+### [LOW] F2: Documentation Contradiction
+
+**Location**: `docs/groups.md:41-43`
+
+**Problem**: The docs state:
+> `groupPolicy` is separate from `allowFrom` (which only filters DMs)
+
+But `groupPolicy: "allowlist"` explicitly uses `allowFrom` for group filtering. This is misleading.
+
+**Fix**: Reword to clarify that `allowFrom` is used for:
+1. DMs (always, when set)
+2. Groups (only when `groupPolicy: "allowlist"`)
+
+---
+
+### [LOW] F3: Zod Schema `.default().optional()` Pattern
+
+**Location**: `src/config/zod-schema.ts:549,580`
+
+**Problem**: Using `GroupPolicySchema.default("open").optional()` may seem redundant.
+
+**Analysis**: This is actually correct behavior:
+- `.optional()` - Field can be omitted from input
+- `.default("open")` - If omitted, parsing returns "open"
+
+The combination ensures:
+- TypeScript type is `"open" | "disabled" | "allowlist" | undefined` for input
+- Runtime always resolves to `"open"` if not provided
+
+**Decision**: Keep current implementation - it's correct. Add a code comment explaining the pattern.
+
+---
+
+## Test Gaps
+
+### T1: WhatsApp Wildcard Allowlist Test
+
+**Missing**: Test for `groupPolicy: "allowlist"` with `allowFrom: ["*"]`
+
+The Telegram tests include wildcard coverage, but WhatsApp does not.
+
+---
+
+### T2: Telegram Prefixed ID Test
+
+**Missing**: Test for `groupPolicy: "allowlist"` with `allowFrom: ["telegram:123456789"]`
+
+After fixing F1, need a test to verify prefixed IDs work.
+
+---
+
+## Implementation Phases
+
+### Phase 1: Fix [MED] Telegram Prefixed ID Support
+
+**File**: `src/telegram/bot.ts`
+**Lines**: 105-128
+
+**Changes**:
+1. Strip `telegram:` prefix when building the normalized allowlist (at pre-computation, not per-message)
+2. Update `normalizedAllowFrom` to handle both raw and prefixed formats
+
+**Code**:
+```typescript
+// Pre-compute: strip telegram: prefix for group matching
+const normalizedAllowFrom = (allowFrom ?? []).map((v) => {
+  const s = String(v);
+  return s.startsWith("telegram:") ? s.slice(9) : s;
+});
+```
+
+---
+
+### Phase 2: Fix [LOW] Documentation
+
+**File**: `docs/groups.md`
+**Lines**: 41-43
+
+**Changes**:
+Replace:
+> `groupPolicy` is separate from `allowFrom` (which only filters DMs)
+
+With:
+> `allowFrom` filters DMs by default. With `groupPolicy: "allowlist"`, it also filters group message senders.
+
+---
+
+### Phase 3: Add Code Comment for Zod Pattern
+
+**File**: `src/config/zod-schema.ts`
+**Lines**: 549, 580
+
+**Changes**:
+Add comment above `groupPolicy` field:
+```typescript
+// .default("open") ensures runtime always has a value
+// .optional() allows omission in input config
+groupPolicy: GroupPolicySchema.default("open").optional(),
+```
+
+---
+
+### Phase 4: Add Missing Tests
+
+**File**: `src/web/monitor-inbox.test.ts`
+
+**Add Test**: WhatsApp wildcard allowlist
+```typescript
+it("allows all group senders with wildcard in groupPolicy allowlist", async () => {
+  mockLoadConfig.mockReturnValue({
+    whatsapp: {
+      allowFrom: ["*"],
+      groupPolicy: "allowlist",
+    },
+    messages: { ... },
+  });
+  // ... emit group message, verify onMessage called
+});
+```
+
+**File**: `src/telegram/bot.test.ts`
+
+**Add Test**: Telegram prefixed ID
+```typescript
+it("matches telegram:-prefixed allowFrom entries in group allowlist", async () => {
+  loadConfig.mockReturnValue({
+    telegram: {
+      groupPolicy: "allowlist",
+      allowFrom: ["telegram:123456789"],
+      groups: { "*": { requireMention: false } },
+    },
+  });
+  // ... emit group message from user 123456789, verify reply called
+});
+```
+
+---
+
+### Phase 5: Verification
+
+1. Run `pnpm build` - TypeScript compilation
+2. Run `pnpm lint` - Biome linting
+3. Run `pnpm test` - All tests (886+)
+4. Manual verification of changes
+
+---
+
+### Phase 6: Commit and PR Update
+
+1. Stage changes with `scripts/committer`
+2. Push to fork
+3. Update PR description with hardening changes
+
+---
+
+## Files Modified
+
+| File | Change Type | Description |
+|------|-------------|-------------|
+| `src/telegram/bot.ts` | Fix | Strip telegram: prefix in group allowlist |
+| `src/config/zod-schema.ts` | Comment | Explain default+optional pattern |
+| `docs/groups.md` | Fix | Clarify allowFrom usage with groupPolicy |
+| `src/web/monitor-inbox.test.ts` | Test | Add wildcard allowlist test |
+| `src/telegram/bot.test.ts` | Test | Add prefixed ID test |
+
+---
+
+## Success Criteria
+
+- [ ] F1: Prefixed IDs work in Telegram group allowlist
+- [ ] F2: Docs accurately describe allowFrom behavior
+- [ ] F3: Zod pattern has explanatory comment
+- [ ] T1: WhatsApp wildcard test exists and passes
+- [ ] T2: Telegram prefixed ID test exists and passes
+- [ ] All 888+ tests pass
+- [ ] Build succeeds
+- [ ] Lint passes
+- [ ] PR updated with hardening notes
+
+---
+
+## Risk Assessment
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Breaking existing configs | Low | Prefix stripping is additive, not breaking |
+| Test interference | Low | New tests are isolated |
+| Doc changes | None | Documentation only |
+
+---
+
+## Estimated Complexity
+
+- **Phase 1**: Low (3 lines of code change)
+- **Phase 2**: Low (2 sentences)
+- **Phase 3**: Low (2 line comment)
+- **Phase 4**: Medium (2 new tests)
+- **Phase 5-6**: Low (standard workflow)
+
+**Total**: ~30 minutes estimated execution time

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -25,7 +25,7 @@ Status: ready for bot-mode use with grammY (long-polling by default; webhook sup
      - If you need a different public port/host, set `telegram.webhookUrl` to the externally reachable URL and use a reverse proxy to forward to `:8787`.
 4) Direct chats: user sends the first message; all subsequent turns land in the shared `main` session (default, no extra config).
 5) Groups: add the bot, disable privacy mode (or make it admin) so it can read messages; group threads stay on `telegram:group:<chatId>`. When `telegram.groups` is set, it becomes a group allowlist (use `"*"` to allow all). Mention/command gating defaults come from `telegram.groups`.
-6) Optional allowlist: use `telegram.allowFrom` for direct chats by chat id (`123456789` or `telegram:123456789`).
+6) Optional allowlist: use `telegram.allowFrom` for direct chats by chat id (`123456789`, `telegram:123456789`, or `tg:123456789`; prefixes are case-insensitive).
 
 ## Capabilities & limits (Bot API)
 - Sees only messages sent after it’s added to a chat; no pre-history access.

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -78,6 +78,13 @@ export type AgentElevatedAllowFromConfig = {
 export type WhatsAppConfig = {
   /** Optional allowlist for WhatsApp direct chats (E.164). */
   allowFrom?: string[];
+  /**
+   * Controls how group messages are handled:
+   * - "open" (default): groups bypass allowFrom, only mention-gating applies
+   * - "disabled": block all group messages entirely
+   * - "allowlist": only allow group messages from senders in allowFrom
+   */
+  groupPolicy?: "open" | "disabled" | "allowlist";
   /** Outbound text chunk size (chars). Default: 4000. */
   textChunkLimit?: number;
   groups?: Record<
@@ -207,6 +214,13 @@ export type TelegramConfig = {
     }
   >;
   allowFrom?: Array<string | number>;
+  /**
+   * Controls how group messages are handled:
+   * - "open" (default): groups bypass allowFrom, only mention-gating applies
+   * - "disabled": block all group messages entirely
+   * - "allowlist": only allow group messages from senders in allowFrom
+   */
+  groupPolicy?: "open" | "disabled" | "allowlist";
   /** Outbound text chunk size (chars). Default: 4000. */
   textChunkLimit?: number;
   mediaMaxMb?: number;

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -626,6 +626,10 @@ export const ClawdbotSchema = z.object({
         )
         .optional(),
       allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+      groupPolicy: z
+        .enum(["open", "disabled", "allowlist"])
+        .default("open")
+        .optional(),
       textChunkLimit: z.number().int().positive().optional(),
       mediaMaxMb: z.number().positive().optional(),
       proxy: z.string().optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -593,6 +593,10 @@ export const ClawdbotSchema = z.object({
     .object({
       allowFrom: z.array(z.string()).optional(),
       textChunkLimit: z.number().int().positive().optional(),
+      groupPolicy: z
+        .enum(["open", "disabled", "allowlist"])
+        .default("open")
+        .optional(),
       groups: z
         .record(
           z.string(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -81,6 +81,8 @@ const ReplyToModeSchema = z.union([
   z.literal("all"),
 ]);
 
+const GroupPolicySchema = z.enum(["open", "disabled", "allowlist"]);
+
 const QueueModeBySurfaceSchema = z
   .object({
     whatsapp: QueueModeSchema.optional(),
@@ -592,11 +594,8 @@ export const ClawdbotSchema = z.object({
   whatsapp: z
     .object({
       allowFrom: z.array(z.string()).optional(),
+      groupPolicy: GroupPolicySchema.default("open").optional(),
       textChunkLimit: z.number().int().positive().optional(),
-      groupPolicy: z
-        .enum(["open", "disabled", "allowlist"])
-        .default("open")
-        .optional(),
       groups: z
         .record(
           z.string(),
@@ -626,10 +625,7 @@ export const ClawdbotSchema = z.object({
         )
         .optional(),
       allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
-      groupPolicy: z
-        .enum(["open", "disabled", "allowlist"])
-        .default("open")
-        .optional(),
+      groupPolicy: GroupPolicySchema.default("open").optional(),
       textChunkLimit: z.number().int().positive().optional(),
       mediaMaxMb: z.number().positive().optional(),
       proxy: z.string().optional(),

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -81,6 +81,10 @@ const ReplyToModeSchema = z.union([
   z.literal("all"),
 ]);
 
+// GroupPolicySchema: controls how group messages are handled
+// Used with .default("open").optional() pattern:
+//   - .optional() allows field omission in input config
+//   - .default("open") ensures runtime always resolves to "open" if not provided
 const GroupPolicySchema = z.enum(["open", "disabled", "allowlist"]);
 
 const QueueModeBySurfaceSchema = z

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -643,4 +643,331 @@ describe("createTelegramBot", () => {
     });
     expect(sendPhotoSpy).not.toHaveBeenCalled();
   });
+
+  // groupPolicy tests
+  it("blocks all group messages when groupPolicy is 'disabled'", async () => {
+    onSpy.mockReset();
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    replySpy.mockReset();
+    loadConfig.mockReturnValue({
+      telegram: {
+        groupPolicy: "disabled",
+        allowFrom: ["77112533"],
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = onSpy.mock.calls[0][1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        from: { id: 77112533, username: "mneves" },
+        text: "@clawdbot_bot hello",
+        date: 1736380800,
+      },
+      me: { username: "clawdbot_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    // Should NOT call getReplyFromConfig because groupPolicy is disabled
+    expect(replySpy).not.toHaveBeenCalled();
+  });
+
+  it("blocks group messages from senders not in allowFrom when groupPolicy is 'allowlist'", async () => {
+    onSpy.mockReset();
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    replySpy.mockReset();
+    loadConfig.mockReturnValue({
+      telegram: {
+        groupPolicy: "allowlist",
+        allowFrom: ["77112533"], // Does not include sender 999999
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = onSpy.mock.calls[0][1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        from: { id: 999999, username: "notallowed" }, // Not in allowFrom
+        text: "@clawdbot_bot hello",
+        date: 1736380800,
+      },
+      me: { username: "clawdbot_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).not.toHaveBeenCalled();
+  });
+
+  it("allows group messages from senders in allowFrom (by ID) when groupPolicy is 'allowlist'", async () => {
+    onSpy.mockReset();
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    replySpy.mockReset();
+    loadConfig.mockReturnValue({
+      telegram: {
+        groupPolicy: "allowlist",
+        allowFrom: ["77112533"],
+        groups: { "*": { requireMention: false } }, // Skip mention check
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = onSpy.mock.calls[0][1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        from: { id: 77112533, username: "mneves" }, // In allowFrom
+        text: "hello",
+        date: 1736380800,
+      },
+      me: { username: "clawdbot_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows group messages from senders in allowFrom (by username) when groupPolicy is 'allowlist'", async () => {
+    onSpy.mockReset();
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    replySpy.mockReset();
+    loadConfig.mockReturnValue({
+      telegram: {
+        groupPolicy: "allowlist",
+        allowFrom: ["@mneves"], // By username
+        groups: { "*": { requireMention: false } },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = onSpy.mock.calls[0][1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        from: { id: 12345, username: "mneves" }, // Username matches @mneves
+        text: "hello",
+        date: 1736380800,
+      },
+      me: { username: "clawdbot_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows group messages from telegram:-prefixed allowFrom entries when groupPolicy is 'allowlist'", async () => {
+    onSpy.mockReset();
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    replySpy.mockReset();
+    loadConfig.mockReturnValue({
+      telegram: {
+        groupPolicy: "allowlist",
+        allowFrom: ["telegram:77112533"],
+        groups: { "*": { requireMention: false } },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = onSpy.mock.calls[0][1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        from: { id: 77112533, username: "mneves" },
+        text: "hello",
+        date: 1736380800,
+      },
+      me: { username: "clawdbot_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows group messages from tg:-prefixed allowFrom entries case-insensitively when groupPolicy is 'allowlist'", async () => {
+    onSpy.mockReset();
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    replySpy.mockReset();
+    loadConfig.mockReturnValue({
+      telegram: {
+        groupPolicy: "allowlist",
+        allowFrom: ["TG:77112533"],
+        groups: { "*": { requireMention: false } },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = onSpy.mock.calls[0][1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        from: { id: 77112533, username: "mneves" },
+        text: "hello",
+        date: 1736380800,
+      },
+      me: { username: "clawdbot_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows all group messages when groupPolicy is 'open' (default)", async () => {
+    onSpy.mockReset();
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    replySpy.mockReset();
+    loadConfig.mockReturnValue({
+      telegram: {
+        // groupPolicy not set, should default to "open"
+        groups: { "*": { requireMention: false } },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = onSpy.mock.calls[0][1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        from: { id: 999999, username: "random" }, // Random sender
+        text: "hello",
+        date: 1736380800,
+      },
+      me: { username: "clawdbot_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows direct messages regardless of groupPolicy", async () => {
+    onSpy.mockReset();
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    replySpy.mockReset();
+    loadConfig.mockReturnValue({
+      telegram: {
+        groupPolicy: "disabled", // Even with disabled, DMs should work
+        allowFrom: ["77112533"],
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = onSpy.mock.calls[0][1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 77112533, type: "private" }, // Direct message
+        from: { id: 77112533, username: "mneves" },
+        text: "hello",
+        date: 1736380800,
+      },
+      me: { username: "clawdbot_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows group messages with wildcard in allowFrom when groupPolicy is 'allowlist'", async () => {
+    onSpy.mockReset();
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    replySpy.mockReset();
+    loadConfig.mockReturnValue({
+      telegram: {
+        groupPolicy: "allowlist",
+        allowFrom: ["*"], // Wildcard allows everyone
+        groups: { "*": { requireMention: false } },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = onSpy.mock.calls[0][1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        from: { id: 999999, username: "random" }, // Random sender, but wildcard allows
+        text: "hello",
+        date: 1736380800,
+      },
+      me: { username: "clawdbot_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("blocks group messages with no sender ID when groupPolicy is 'allowlist'", async () => {
+    onSpy.mockReset();
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    replySpy.mockReset();
+    loadConfig.mockReturnValue({
+      telegram: {
+        groupPolicy: "allowlist",
+        allowFrom: ["77112533"],
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = onSpy.mock.calls[0][1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        // No `from` field (e.g., channel post or anonymous admin)
+        text: "hello",
+        date: 1736380800,
+      },
+      me: { username: "clawdbot_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).not.toHaveBeenCalled();
+  });
 });

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -654,7 +654,7 @@ describe("createTelegramBot", () => {
     loadConfig.mockReturnValue({
       telegram: {
         groupPolicy: "disabled",
-        allowFrom: ["77112533"],
+        allowFrom: ["123456789"],
       },
     });
 
@@ -666,7 +666,7 @@ describe("createTelegramBot", () => {
     await handler({
       message: {
         chat: { id: -100123456789, type: "group", title: "Test Group" },
-        from: { id: 77112533, username: "mneves" },
+        from: { id: 123456789, username: "testuser" },
         text: "@clawdbot_bot hello",
         date: 1736380800,
       },
@@ -687,7 +687,7 @@ describe("createTelegramBot", () => {
     loadConfig.mockReturnValue({
       telegram: {
         groupPolicy: "allowlist",
-        allowFrom: ["77112533"], // Does not include sender 999999
+        allowFrom: ["123456789"], // Does not include sender 999999
       },
     });
 
@@ -719,7 +719,7 @@ describe("createTelegramBot", () => {
     loadConfig.mockReturnValue({
       telegram: {
         groupPolicy: "allowlist",
-        allowFrom: ["77112533"],
+        allowFrom: ["123456789"],
         groups: { "*": { requireMention: false } }, // Skip mention check
       },
     });
@@ -732,7 +732,7 @@ describe("createTelegramBot", () => {
     await handler({
       message: {
         chat: { id: -100123456789, type: "group", title: "Test Group" },
-        from: { id: 77112533, username: "mneves" }, // In allowFrom
+        from: { id: 123456789, username: "testuser" }, // In allowFrom
         text: "hello",
         date: 1736380800,
       },
@@ -752,7 +752,7 @@ describe("createTelegramBot", () => {
     loadConfig.mockReturnValue({
       telegram: {
         groupPolicy: "allowlist",
-        allowFrom: ["@mneves"], // By username
+        allowFrom: ["@testuser"], // By username
         groups: { "*": { requireMention: false } },
       },
     });
@@ -765,7 +765,7 @@ describe("createTelegramBot", () => {
     await handler({
       message: {
         chat: { id: -100123456789, type: "group", title: "Test Group" },
-        from: { id: 12345, username: "mneves" }, // Username matches @mneves
+        from: { id: 12345, username: "testuser" }, // Username matches @testuser
         text: "hello",
         date: 1736380800,
       },
@@ -883,7 +883,7 @@ describe("createTelegramBot", () => {
     loadConfig.mockReturnValue({
       telegram: {
         groupPolicy: "allowlist",
-        allowFrom: ["@MNeves"], // Uppercase in config
+        allowFrom: ["@TestUser"], // Uppercase in config
         groups: { "*": { requireMention: false } },
       },
     });
@@ -896,7 +896,7 @@ describe("createTelegramBot", () => {
     await handler({
       message: {
         chat: { id: -100123456789, type: "group", title: "Test Group" },
-        from: { id: 12345, username: "mneves" }, // Lowercase in message
+        from: { id: 12345, username: "testuser" }, // Lowercase in message
         text: "hello",
         date: 1736380800,
       },
@@ -916,7 +916,7 @@ describe("createTelegramBot", () => {
     loadConfig.mockReturnValue({
       telegram: {
         groupPolicy: "disabled", // Even with disabled, DMs should work
-        allowFrom: ["77112533"],
+        allowFrom: ["123456789"],
       },
     });
 
@@ -927,8 +927,8 @@ describe("createTelegramBot", () => {
 
     await handler({
       message: {
-        chat: { id: 77112533, type: "private" }, // Direct message
-        from: { id: 77112533, username: "mneves" },
+        chat: { id: 123456789, type: "private" }, // Direct message
+        from: { id: 123456789, username: "testuser" },
         text: "hello",
         date: 1736380800,
       },
@@ -981,7 +981,7 @@ describe("createTelegramBot", () => {
     loadConfig.mockReturnValue({
       telegram: {
         groupPolicy: "allowlist",
-        allowFrom: ["77112533"],
+        allowFrom: ["123456789"],
       },
     });
 

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -874,6 +874,39 @@ describe("createTelegramBot", () => {
     expect(replySpy).toHaveBeenCalledTimes(1);
   });
 
+  it("matches usernames case-insensitively when groupPolicy is 'allowlist'", async () => {
+    onSpy.mockReset();
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    replySpy.mockReset();
+    loadConfig.mockReturnValue({
+      telegram: {
+        groupPolicy: "allowlist",
+        allowFrom: ["@MNeves"], // Uppercase in config
+        groups: { "*": { requireMention: false } },
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = onSpy.mock.calls[0][1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: -100123456789, type: "group", title: "Test Group" },
+        from: { id: 12345, username: "mneves" }, // Lowercase in message
+        text: "hello",
+        date: 1736380800,
+      },
+      me: { username: "clawdbot_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
   it("allows direct messages regardless of groupPolicy", async () => {
     onSpy.mockReset();
     const replySpy = replyModule.__replySpy as unknown as ReturnType<

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -970,6 +970,37 @@ describe("createTelegramBot", () => {
     expect(replySpy).toHaveBeenCalledTimes(1);
   });
 
+  it("allows direct messages with telegram:-prefixed allowFrom entries", async () => {
+    onSpy.mockReset();
+    const replySpy = replyModule.__replySpy as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    replySpy.mockReset();
+    loadConfig.mockReturnValue({
+      telegram: {
+        allowFrom: ["telegram:123456789"],
+      },
+    });
+
+    createTelegramBot({ token: "tok" });
+    const handler = onSpy.mock.calls[0][1] as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 123456789, type: "private" },
+        from: { id: 123456789, username: "testuser" },
+        text: "hello",
+        date: 1736380800,
+      },
+      me: { username: "clawdbot_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
   it("allows group messages with wildcard in allowFrom when groupPolicy is 'allowlist'", async () => {
     onSpy.mockReset();
     const replySpy = replyModule.__replySpy as unknown as ReturnType<

--- a/src/web/inbound.ts
+++ b/src/web/inbound.ts
@@ -176,35 +176,46 @@ export async function monitorWebInbox(options: {
       const isSamePhone = from === selfE164;
       const isSelfChat = isSelfChatMode(selfE164, configuredAllowFrom);
 
+      // Pre-compute normalized allowlist for filtering (used by both group and DM checks)
+      const hasWildcard = allowFrom?.includes("*") ?? false;
+      const normalizedAllowFrom =
+        allowFrom && allowFrom.length > 0
+          ? allowFrom.map(normalizeE164)
+          : [];
+
       // Group policy filtering: controls how group messages are handled
+      // - "open" (default): groups bypass allowFrom, only mention-gating applies
+      // - "disabled": block all group messages entirely
+      // - "allowlist": only allow group messages from senders in allowFrom
       const groupPolicy = cfg.whatsapp?.groupPolicy ?? "open";
       if (group && groupPolicy === "disabled") {
         logVerbose(`Blocked group message (groupPolicy: disabled)`);
         continue;
       }
       if (group && groupPolicy === "allowlist") {
-        const allowedList = allowFrom?.map(normalizeE164) ?? [];
+        // For allowlist mode, the sender (participant) must be in allowFrom
+        // If we can't resolve the sender E164, block the message for safety
         const senderAllowed =
-          allowFrom?.includes("*") ||
-          (senderE164 && allowedList.includes(senderE164));
+          hasWildcard ||
+          (senderE164 != null && normalizedAllowFrom.includes(senderE164));
         if (!senderAllowed) {
           logVerbose(
-            `Blocked group message from ${senderE164 ?? "unknown"} (groupPolicy: allowlist, sender not in allowFrom)`,
+            `Blocked group message from ${senderE164 ?? "unknown sender"} (groupPolicy: allowlist)`,
           );
           continue;
         }
       }
 
+      // DM allowlist filtering (unchanged behavior)
       const allowlistEnabled =
         !group && Array.isArray(allowFrom) && allowFrom.length > 0;
       if (!isSamePhone && allowlistEnabled) {
         const candidate = from;
-        const allowedList = allowFrom.map(normalizeE164);
-        if (!allowFrom.includes("*") && !allowedList.includes(candidate)) {
+        if (!hasWildcard && !normalizedAllowFrom.includes(candidate)) {
           logVerbose(
             `Blocked unauthorized sender ${candidate} (not in allowFrom list)`,
           );
-          continue; // Skip processing entirely
+          continue;
         }
       }
 

--- a/src/web/inbound.ts
+++ b/src/web/inbound.ts
@@ -179,9 +179,7 @@ export async function monitorWebInbox(options: {
       // Pre-compute normalized allowlist for filtering (used by both group and DM checks)
       const hasWildcard = allowFrom?.includes("*") ?? false;
       const normalizedAllowFrom =
-        allowFrom && allowFrom.length > 0
-          ? allowFrom.map(normalizeE164)
-          : [];
+        allowFrom && allowFrom.length > 0 ? allowFrom.map(normalizeE164) : [];
 
       // Group policy filtering: controls how group messages are handled
       // - "open" (default): groups bypass allowFrom, only mention-gating applies

--- a/src/web/inbound.ts
+++ b/src/web/inbound.ts
@@ -176,6 +176,25 @@ export async function monitorWebInbox(options: {
       const isSamePhone = from === selfE164;
       const isSelfChat = isSelfChatMode(selfE164, configuredAllowFrom);
 
+      // Group policy filtering: controls how group messages are handled
+      const groupPolicy = cfg.whatsapp?.groupPolicy ?? "open";
+      if (group && groupPolicy === "disabled") {
+        logVerbose(`Blocked group message (groupPolicy: disabled)`);
+        continue;
+      }
+      if (group && groupPolicy === "allowlist") {
+        const allowedList = allowFrom?.map(normalizeE164) ?? [];
+        const senderAllowed =
+          allowFrom?.includes("*") ||
+          (senderE164 && allowedList.includes(senderE164));
+        if (!senderAllowed) {
+          logVerbose(
+            `Blocked group message from ${senderE164 ?? "unknown"} (groupPolicy: allowlist, sender not in allowFrom)`,
+          );
+          continue;
+        }
+      }
+
       const allowlistEnabled =
         !group && Array.isArray(allowFrom) && allowFrom.length > 0;
       if (!isSamePhone && allowlistEnabled) {

--- a/src/web/monitor-inbox.test.ts
+++ b/src/web/monitor-inbox.test.ts
@@ -670,6 +670,132 @@ describe("web monitor inbox", () => {
     await listener.close();
   });
 
+  it("blocks all group messages when groupPolicy is 'disabled'", async () => {
+    mockLoadConfig.mockReturnValue({
+      whatsapp: {
+        allowFrom: ["+1234"],
+        groupPolicy: "disabled",
+      },
+      messages: {
+        messagePrefix: undefined,
+        responsePrefix: undefined,
+        timestampPrefix: false,
+      },
+    });
+
+    const onMessage = vi.fn();
+    const listener = await monitorWebInbox({ verbose: false, onMessage });
+    const sock = await createWaSocket();
+
+    const upsert = {
+      type: "notify",
+      messages: [
+        {
+          key: {
+            id: "grp-disabled",
+            fromMe: false,
+            remoteJid: "11111@g.us",
+            participant: "999@s.whatsapp.net",
+          },
+          message: { conversation: "group message should be blocked" },
+        },
+      ],
+    };
+
+    sock.ev.emit("messages.upsert", upsert);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // Should NOT call onMessage because groupPolicy is disabled
+    expect(onMessage).not.toHaveBeenCalled();
+
+    await listener.close();
+  });
+
+  it("blocks group messages from senders not in allowFrom when groupPolicy is 'allowlist'", async () => {
+    mockLoadConfig.mockReturnValue({
+      whatsapp: {
+        allowFrom: ["+1234"], // Does not include +999
+        groupPolicy: "allowlist",
+      },
+      messages: {
+        messagePrefix: undefined,
+        responsePrefix: undefined,
+        timestampPrefix: false,
+      },
+    });
+
+    const onMessage = vi.fn();
+    const listener = await monitorWebInbox({ verbose: false, onMessage });
+    const sock = await createWaSocket();
+
+    const upsert = {
+      type: "notify",
+      messages: [
+        {
+          key: {
+            id: "grp-allowlist-blocked",
+            fromMe: false,
+            remoteJid: "11111@g.us",
+            participant: "999@s.whatsapp.net",
+          },
+          message: { conversation: "unauthorized group sender" },
+        },
+      ],
+    };
+
+    sock.ev.emit("messages.upsert", upsert);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // Should NOT call onMessage because sender +999 not in allowFrom
+    expect(onMessage).not.toHaveBeenCalled();
+
+    await listener.close();
+  });
+
+  it("allows group messages from senders in allowFrom when groupPolicy is 'allowlist'", async () => {
+    mockLoadConfig.mockReturnValue({
+      whatsapp: {
+        allowFrom: ["+15551234567"], // Includes the sender
+        groupPolicy: "allowlist",
+      },
+      messages: {
+        messagePrefix: undefined,
+        responsePrefix: undefined,
+        timestampPrefix: false,
+      },
+    });
+
+    const onMessage = vi.fn();
+    const listener = await monitorWebInbox({ verbose: false, onMessage });
+    const sock = await createWaSocket();
+
+    const upsert = {
+      type: "notify",
+      messages: [
+        {
+          key: {
+            id: "grp-allowlist-allowed",
+            fromMe: false,
+            remoteJid: "11111@g.us",
+            participant: "15551234567@s.whatsapp.net",
+          },
+          message: { conversation: "authorized group sender" },
+        },
+      ],
+    };
+
+    sock.ev.emit("messages.upsert", upsert);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // Should call onMessage because sender is in allowFrom
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    const payload = onMessage.mock.calls[0][0];
+    expect(payload.chatType).toBe("group");
+    expect(payload.senderE164).toBe("+15551234567");
+
+    await listener.close();
+  });
+
   it("allows messages from senders in allowFrom list", async () => {
     mockLoadConfig.mockReturnValue({
       whatsapp: {


### PR DESCRIPTION
## Summary

Adds `groupPolicy` config option to **WhatsApp** and **Telegram** for controlling group message handling.

## The Problem

Users expect `allowFrom` to restrict all communication, but groups bypass this check entirely (by design - they use mention-gating instead). This leaves no way to block group messages completely.

## Solution

New `groupPolicy` option with 3 modes:

| Policy | Behavior |
|--------|----------|
| `open` | **Default.** Groups bypass `allowFrom`, only mention-gating applies. |
| `disabled` | Block all group messages entirely. |
| `allowlist` | Only respond if sender is in `allowFrom`. |

```json5
{
  whatsapp: {
    allowFrom: ["+15551234567"],
    groupPolicy: "disabled"
  },
  telegram: {
    allowFrom: ["123456789", "@username", "telegram:123456789"],
    groupPolicy: "disabled"
  }
}
```

## Implementation Details

- **Shared schema**: Extracted `GroupPolicySchema` constant for DRY validation
- **Consistent field ordering**: `groupPolicy` follows `allowFrom` in both schemas
- **WhatsApp**: Matches sender's E.164 against normalized `allowFrom`
- **Telegram**: Matches sender by user ID or username (case-insensitive, with/without `@` prefix)
- **Telegram prefix support**: `telegram:123456789` format works in group allowlist
- Pre-computed allowlist values for efficiency (no redundant `.map()` calls per message)

## Changes

| File | Change |
|------|--------|
| `src/config/zod-schema.ts` | Shared `GroupPolicySchema` constant with explanatory comment |
| `src/config/types.ts` | Add `groupPolicy` to `WhatsAppConfig` and `TelegramConfig` |
| `src/web/inbound.ts` | WhatsApp group policy filtering |
| `src/telegram/bot.ts` | Telegram group policy filtering with prefix stripping |
| `src/web/monitor-inbox.test.ts` | 4 tests for WhatsApp (incl. wildcard) |
| `src/telegram/bot.test.ts` | 10 tests for Telegram (incl. prefixed ID) |
| `docs/groups.md` | Accurate documentation for both surfaces |
| `docs/plans/group-policy-hardening.md` | Engineering execution spec |

## Self-Critique Fixes (Hardening)

| Finding | Severity | Fix |
|---------|----------|-----|
| Telegram group allowlist ignores `telegram:` prefix | MED | Strip prefix during normalization |
| Docs say allowFrom only filters DMs | LOW | Clarified that allowlist mode uses it for groups |
| Zod `.default().optional()` pattern undocumented | LOW | Added explanatory comment |
| Missing WhatsApp wildcard test | TEST | Added test for `allowFrom: ["*"]` |
| Missing Telegram prefixed ID test | TEST | Added test for `telegram:123456789` format |

## Backwards Compatibility

Default is `open` - existing users see no behavior change.

## Test Plan

- [x] All 888 tests pass (2 new tests added)
- [x] `groupPolicy: "disabled"` blocks all group messages
- [x] `groupPolicy: "allowlist"` filters by sender (ID or username)
- [x] `groupPolicy: "open"` (default) preserves existing behavior
- [x] Case-insensitive username matching for Telegram
- [x] Wildcard `["*"]` allows all senders in allowlist mode
- [x] `telegram:123456789` prefix works in group allowlist