### PR TITLE
feat: Multi-account OAuth with round-robin rotation

### DIFF
--- a/src/agents/pi-embedded-runner.ts
+++ b/src/agents/pi-embedded-runner.ts
@@ -808,8 +808,10 @@ export async function runEmbeddedPiAgent(params: {
             session.agent.replaceMessages(prior);
           }
           let aborted = Boolean(params.abortSignal?.aborted);
-          const abortRun = () => {
+          let timedOut = false;
+          const abortRun = (isTimeout = false) => {
             aborted = true;
+            if (isTimeout) timedOut = true;
             void session.abort();
           };
           const subscription = subscribeEmbeddedPiSession({
@@ -848,7 +850,7 @@ export async function runEmbeddedPiAgent(params: {
               log.warn(
                 `embedded run timeout: runId=${params.runId} sessionId=${params.sessionId} timeoutMs=${params.timeoutMs}`,
               );
-              abortRun();
+              abortRun(true);
               if (!abortWarnTimer) {
                 abortWarnTimer = setTimeout(() => {
                   if (!session.isStreaming) return;
@@ -953,16 +955,25 @@ export async function runEmbeddedPiAgent(params: {
             (params.config?.agent?.model?.fallbacks?.length ?? 0) > 0;
           const authFailure = isAuthAssistantError(lastAssistant);
           const rateLimitFailure = isRateLimitAssistantError(lastAssistant);
-          if (!aborted && (authFailure || rateLimitFailure)) {
+          
+          // Treat timeout as potential rate limit (Antigravity hangs on rate limit)
+          const shouldRotate = (!aborted && (authFailure || rateLimitFailure)) || timedOut;
+          
+          if (shouldRotate) {
             // Mark current profile for cooldown before rotating
             if (lastProfileId) {
               markAuthProfileCooldown({ store: authStore, profileId: lastProfileId });
+              if (timedOut) {
+                log.warn(
+                  `Profile ${lastProfileId} timed out (possible rate limit). Trying next account...`,
+                );
+              }
             }
             const rotated = await advanceAuthProfile();
             if (rotated) {
               continue;
             }
-            if (fallbackConfigured) {
+            if (fallbackConfigured && !timedOut) {
               const message =
                 lastAssistant?.errorMessage?.trim() ||
                 (lastAssistant

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -323,7 +323,7 @@ async function promptAuthConfig(
       if (oauthCreds) {
         await writeOAuthCredentials("google-antigravity", oauthCreds);
         next = applyAuthProfileConfig(next, {
-          profileId: "google-antigravity:default",
+          profileId: `google-antigravity:${oauthCreds.email ?? "default"}`,
           provider: "google-antigravity",
           mode: "oauth",
         });

--- a/src/commands/onboard-auth.ts
+++ b/src/commands/onboard-auth.ts
@@ -7,7 +7,7 @@ export async function writeOAuthCredentials(
   creds: OAuthCredentials,
 ): Promise<void> {
   upsertAuthProfile({
-    profileId: `${provider}:default`,
+    profileId: `${provider}:${creds.email ?? "default"}`,
     credential: {
       type: "oauth",
       provider,

--- a/src/gateway/protocol/index.ts
+++ b/src/gateway/protocol/index.ts
@@ -395,5 +395,4 @@ export type {
   CronRunParams,
   CronRunsParams,
   CronRunLogEntry,
-  PollParams,
 };

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -462,7 +462,7 @@ export async function runOnboardingWizard(
       if (oauthCreds) {
         await writeOAuthCredentials("google-antigravity", oauthCreds);
         nextConfig = applyAuthProfileConfig(nextConfig, {
-          profileId: "google-antigravity:default",
+          profileId: `google-antigravity:${oauthCreds.email ?? "default"}`,
           provider: "google-antigravity",
           mode: "oauth",
         });


### PR DESCRIPTION
## Summary

Adds support for multiple OAuth accounts per provider with automatic round-robin load balancing and failover.

## Changes

### 1. Email-based profile IDs
- Profiles now use email instead of `:default` (e.g., `google-antigravity:user@gmail.com`)
- Each OAuth login creates a separate profile automatically
- No new CLI commands needed - uses existing `clawdbot configure` flow

### 2. Round-robin rotation
- Tracks `usageStats` (lastUsed, cooldownUntil, errorCount) per profile
- Profiles sorted by oldest `lastUsed` first (least-recently-used)
- Automatic load distribution across multiple accounts

### 3. Exponential backoff cooldown
- On auth/rate-limit errors: 1min ??? 5min ??? 25min ??? 60min max
- Profiles in cooldown are deprioritized in rotation order

### 4. Timeout-based failover
- Antigravity rate limits cause hangs rather than 429 errors
- Timeouts now treated as potential rate limits
- Triggers cooldown + rotation to next account
- Logs: "Profile X timed out (possible rate limit). Trying next account..."

## Files changed
- `src/commands/onboard-auth.ts` - Email-based profile ID
- `src/commands/configure.ts` - Email-based profile ID
- `src/wizard/onboarding.ts` - Email-based profile ID
- `src/agents/auth-profiles.ts` - Usage tracking, cooldown, round-robin logic
- `src/agents/pi-embedded-runner.ts` - Timeout detection, cooldown/usage calls

## Testing
- Tested with 2 Antigravity accounts via `clawdbot configure`
- Both profiles created with email-based IDs
- Order list populated correctly for round-robin
