### PR TITLE
fix(imessage): use phone number for DM replies instead of chat_id

### DIFF
--- a/src/imessage/monitor.ts
+++ b/src/imessage/monitor.ts
@@ -351,7 +351,10 @@ export async function monitorIMessageProvider(
           : normalizeIMessageHandle(sender),
       },
     });
-    const imessageTo = chatTarget || `imessage:${sender}`;
+    // For DMs, use phone number directly (chat_id doesn't work with AppleScript for 1:1 chats)
+    const imessageTo = isGroup
+      ? chatTarget || `imessage:${sender}`
+      : `imessage:${sender}`;
     const ctxPayload = {
       Body: body,
       From: isGroup ? `group:${chatId}` : `imessage:${sender}`,


### PR DESCRIPTION
## Summary
Fix iMessage DM replies failing with "Internal error" when using `chat_id` parameter.

## Problem
When replying to iMessage DMs, clawdbot uses `chat_id` (e.g., `chat_id:18`) as the reply target. The `imsg` CLI then fails with:

```
{"error":{"code":-32603,"data":"AppleScript failed: execution error: Messages got an error: Can't get chat id \"+1XXXXXXXXXX\". (-1728)","message":"Internal error"}}
```

The `imsg` CLI appears to be looking up the chat by numeric ID, then incorrectly passing the chat's identifier (phone number) to AppleScript as `chat id "+1XXXXXXXXXX"` instead of using the numeric ID or a different AppleScript syntax.

## Solution
For DMs, use the sender's phone number directly (e.g., `to: "+1XXXXXXXXXX"`) which works reliably with AppleScript. Groups continue to use `chat_id` as it's necessary for targeting group chats.

## Test results
- `imsg send --to "+1XXXXXXXXXX" --text "test"` → ✅ works
- `imsg rpc` with `{"to":"+1XXXXXXXXXX",...}` → ✅ works  
- `imsg rpc` with `{"chat_id":18,...}` → ❌ fails with AppleScript error above

## Note
This may be a bug in the `imsg` CLI itself (incorrect AppleScript generation for `chat_id` on 1:1 chats), but this workaround resolves the issue for clawdbot users.