### PR TITLE
fix(whatsapp): use RawBody for command detection in group chats

### DIFF
--- a/src/auto-reply/reply.raw-body.test.ts
+++ b/src/auto-reply/reply.raw-body.test.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withTempHome as withTempHomeBase } from "../../test/helpers/temp-home.js";
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
+import { getReplyFromConfig } from "./reply.js";
+
+vi.mock("../agents/pi-embedded.js", () => ({
+  abortEmbeddedPiRun: vi.fn().mockReturnValue(false),
+  runEmbeddedPiAgent: vi.fn(),
+  queueEmbeddedPiMessage: vi.fn().mockReturnValue(false),
+  resolveEmbeddedSessionLane: (key: string) => `session:${key.trim() || "main"}`,
+  isEmbeddedPiRunActive: vi.fn().mockReturnValue(false),
+  isEmbeddedPiRunStreaming: vi.fn().mockReturnValue(false),
+}));
+vi.mock("../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(),
+}));
+
+async function withTempHome<T>(fn: (home: string) => Promise<T>): Promise<T> {
+  return withTempHomeBase(
+    async (home) => {
+      return await fn(home);
+    },
+    {
+      env: {
+        CLAWDBOT_AGENT_DIR: (home) => path.join(home, ".clawdbot", "agent"),
+        PI_CODING_AGENT_DIR: (home) => path.join(home, ".clawdbot", "agent"),
+      },
+      prefix: "clawdbot-rawbody-",
+    },
+  );
+}
+
+describe("RawBody directive parsing", () => {
+  beforeEach(() => {
+    vi.mocked(runEmbeddedPiAgent).mockReset();
+    vi.mocked(loadModelCatalog).mockResolvedValue([
+      { id: "claude-opus-4-5", name: "Opus 4.5", provider: "anthropic" },
+    ]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("/model, /think, /verbose directives detected from RawBody even when Body has structural wrapper", async () => {
+    await withTempHome(async (home) => {
+      vi.mocked(runEmbeddedPiAgent).mockReset();
+
+      const groupMessageCtx = {
+        Body: `[Chat messages since your last reply - for context]\\n[WhatsApp ...] Someone: hello\\n\\n[Current message - respond to this]\\n[WhatsApp ...] Jake: /think:high\\n[from: Jake McInteer (+6421807830)]`,
+        RawBody: "/think:high",
+        From: "+1222",
+        To: "+1222",
+        ChatType: "group",
+      };
+
+      const res = await getReplyFromConfig(
+        groupMessageCtx,
+        {},
+        {
+          agents: {
+            defaults: {
+              model: "anthropic/claude-opus-4-5",
+              workspace: path.join(home, "clawd"),
+            },
+          },
+          whatsapp: { allowFrom: ["*"] },
+          session: { store: path.join(home, "sessions.json") },
+        },
+      );
+
+      const text = Array.isArray(res) ? res[0]?.text : res?.text;
+      expect(text).toContain("Thinking level set to high.");
+      expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
+    });
+  });
+
+  it("/model status detected from RawBody", async () => {
+    await withTempHome(async (home) => {
+      vi.mocked(runEmbeddedPiAgent).mockReset();
+
+      const groupMessageCtx = {
+        Body: `[Context]\nJake: /model status\n[from: Jake]`,
+        RawBody: "/model status",
+        From: "+1222",
+        To: "+1222",
+        ChatType: "group",
+      };
+
+      const res = await getReplyFromConfig(
+        groupMessageCtx,
+        {},
+        {
+          agents: {
+            defaults: {
+              model: "anthropic/claude-opus-4-5",
+              workspace: path.join(home, "clawd"),
+              models: {
+                "anthropic/claude-opus-4-5": {},
+              },
+            },
+          },
+          whatsapp: { allowFrom: ["*"] },
+          session: { store: path.join(home, "sessions.json") },
+        },
+      );
+
+      const text = Array.isArray(res) ? res[0]?.text : res?.text;
+      expect(text).toContain("anthropic/claude-opus-4-5");
+      expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
+    });
+  });
+
+  it("Integration: WhatsApp group message with structural wrapper and RawBody command", async () => {
+    await withTempHome(async (home) => {
+      vi.mocked(runEmbeddedPiAgent).mockReset();
+
+      const groupMessageCtx = {
+        Body: `[Chat messages since your last reply - for context]\\n[WhatsApp ...] Someone: hello\\n\\n[Current message - respond to this]\\n[WhatsApp ...] Jake: /status\\n[from: Jake McInteer (+6421807830)]`,
+        RawBody: "/status",
+        ChatType: "group",
+        From: "+1222",
+        To: "+1222",
+        SessionKey: "agent:main:whatsapp:group:G1",
+        Provider: "whatsapp",
+        Surface: "whatsapp",
+        SenderE164: "+1222",
+      };
+
+      const res = await getReplyFromConfig(
+        groupMessageCtx,
+        {},
+        {
+          agents: {
+            defaults: {
+              model: "anthropic/claude-opus-4-5",
+              workspace: path.join(home, "clawd"),
+            },
+          },
+          whatsapp: { allowFrom: ["+1222"] },
+          session: { store: path.join(home, "sessions.json") },
+        },
+      );
+
+      const text = Array.isArray(res) ? res[0]?.text : res?.text;
+      expect(text).toContain("Session: agent:main:whatsapp:group:G1");
+      expect(text).toContain("anthropic/claude-opus-4-5");
+      expect(runEmbeddedPiAgent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/auto-reply/reply.ts
+++ b/src/auto-reply/reply.ts
@@ -336,7 +336,8 @@ export async function getReplyFromConfig(
     triggerBodyNormalized,
   } = sessionState;
 
-  const rawBody = sessionCtx.BodyStripped ?? sessionCtx.Body ?? "";
+  // Prefer RawBody (clean message without structural context) for directive parsing.
+  const rawBody = sessionCtx.RawBody ?? sessionCtx.BodyStripped ?? sessionCtx.Body ?? "";
   const clearInlineDirectives = (cleaned: string): InlineDirectives => ({
     cleaned,
     hasThinkDirective: false,
@@ -750,7 +751,8 @@ export async function getReplyFromConfig(
     .filter(Boolean)
     .join("\n\n");
   const baseBody = sessionCtx.BodyStripped ?? sessionCtx.Body ?? "";
-  const rawBodyTrimmed = (ctx.Body ?? "").trim();
+  // Use RawBody for bare reset detection (clean message without structural context).
+  const rawBodyTrimmed = (ctx.RawBody ?? ctx.Body ?? "").trim();
   const baseBodyTrimmedRaw = baseBody.trim();
   if (
     allowTextCommands &&

--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isAbortTrigger } from "./abort.js";
+import { initSessionState } from "./session.js";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { ClawdbotConfig } from "../../config/config.js";
+
+describe("abort detection", () => {
+  it("triggerBodyNormalized extracts /stop from RawBody for abort detection", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-abort-"));
+    const storePath = path.join(root, "sessions.json");
+    const cfg = { session: { store: storePath } } as ClawdbotConfig;
+
+    const groupMessageCtx = {
+      Body: `[Context]\nJake: /stop\n[from: Jake]`,
+      RawBody: "/stop",
+      ChatType: "group",
+      SessionKey: "agent:main:whatsapp:group:G1",
+    };
+
+    const result = await initSessionState({
+      ctx: groupMessageCtx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // /stop is detected via exact match in handleAbort, not isAbortTrigger
+    expect(result.triggerBodyNormalized).toBe("/stop");
+  });
+
+  it("isAbortTrigger matches bare word triggers (without slash)", () => {
+    expect(isAbortTrigger("stop")).toBe(true);
+    expect(isAbortTrigger("esc")).toBe(true);
+    expect(isAbortTrigger("abort")).toBe(true);
+    expect(isAbortTrigger("wait")).toBe(true);
+    expect(isAbortTrigger("exit")).toBe(true);
+    expect(isAbortTrigger("hello")).toBe(false);
+    // /stop is NOT matched by isAbortTrigger - it's handled separately
+    expect(isAbortTrigger("/stop")).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -81,7 +81,8 @@ export async function tryFastAbortFromMessage(params: {
     sessionKey: targetKey ?? ctx.SessionKey ?? "",
     config: cfg,
   });
-  const raw = stripStructuralPrefixes(ctx.Body ?? "");
+  // Use RawBody for abort detection (clean message without structural context).
+  const raw = stripStructuralPrefixes(ctx.RawBody ?? ctx.Body ?? "");
   const isGroup = ctx.ChatType?.trim().toLowerCase() === "group";
   const stripped = isGroup ? stripMentions(raw, ctx, cfg, agentId) : raw;
   const normalized = normalizeCommandBody(stripped);

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -89,11 +89,13 @@ export function stripStructuralPrefixes(text: string): string {
   // detection still works in group batches that include history/context.
   const marker = "[Current message - respond to this]";
   const afterMarker = text.includes(marker)
-    ? text.slice(text.indexOf(marker) + marker.length)
+    ? text.slice(text.indexOf(marker) + marker.length).trimStart()
     : text;
+  
   return afterMarker
     .replace(/\[[^\]]+\]\s*/g, "")
     .replace(/^[ \t]*[A-Za-z0-9+()\-_. ]+:\s*/gm, "")
+    .replace(/\\n/g, " ")
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -105,9 +107,9 @@ export function stripMentions(
   agentId?: string,
 ): string {
   let result = text;
-  const patterns = normalizeMentionPatterns(
-    resolveMentionPatterns(cfg, agentId),
-  );
+  const rawPatterns = resolveMentionPatterns(cfg, agentId);
+  const patterns = normalizeMentionPatterns(rawPatterns);
+
   for (const p of patterns) {
     try {
       const re = new RegExp(p, "gi");

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -110,3 +110,67 @@ describe("initSessionState thread forking", () => {
     );
   });
 });
+
+describe("initSessionState RawBody", () => {
+  it("triggerBodyNormalized correctly extracts commands when Body contains context but RawBody is clean", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-rawbody-"));
+    const storePath = path.join(root, "sessions.json");
+    const cfg = { session: { store: storePath } } as ClawdbotConfig;
+
+    const groupMessageCtx = {
+      Body: `[Chat messages since your last reply - for context]\n[WhatsApp ...] Someone: hello\n\n[Current message - respond to this]\n[WhatsApp ...] Jake: /status\n[from: Jake McInteer (+6421807830)]`,
+      RawBody: "/status",
+      ChatType: "group",
+      SessionKey: "agent:main:whatsapp:group:G1",
+    };
+
+    const result = await initSessionState({
+      ctx: groupMessageCtx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.triggerBodyNormalized).toBe("/status");
+  });
+
+  it("Reset triggers (/new, /reset) work with RawBody", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-rawbody-reset-"));
+    const storePath = path.join(root, "sessions.json");
+    const cfg = { session: { store: storePath } } as ClawdbotConfig;
+
+    const groupMessageCtx = {
+      Body: `[Context]\nJake: /new\n[from: Jake]`,
+      RawBody: "/new",
+      ChatType: "group",
+      SessionKey: "agent:main:whatsapp:group:G1",
+    };
+
+    const result = await initSessionState({
+      ctx: groupMessageCtx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.isNewSession).toBe(true);
+    expect(result.bodyStripped).toBe("");
+  });
+
+  it("falls back to Body when RawBody is undefined", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "clawdbot-rawbody-fallback-"));
+    const storePath = path.join(root, "sessions.json");
+    const cfg = { session: { store: storePath } } as ClawdbotConfig;
+
+    const ctx = {
+      Body: "/status",
+      SessionKey: "agent:main:whatsapp:dm:S1",
+    };
+
+    const result = await initSessionState({
+      ctx,
+      cfg,
+      commandAuthorized: true,
+    });
+
+    expect(result.triggerBodyNormalized).toBe("/status");
+  });
+});

--- a/src/auto-reply/templating.ts
+++ b/src/auto-reply/templating.ts
@@ -11,6 +11,11 @@ export type OriginatingChannelType =
 
 export type MsgContext = {
   Body?: string;
+  /**
+   * Raw message body without structural context (history, sender labels).
+   * Used for command detection. Falls back to Body if not set.
+   */
+  RawBody?: string;
   From?: string;
   To?: string;
   SessionKey?: string;

--- a/src/web/auto-reply.ts
+++ b/src/web/auto-reply.ts
@@ -1221,6 +1221,7 @@ export async function monitorWebProvider(
       const { queuedFinal } = await dispatchReplyWithBufferedBlockDispatcher({
         ctx: {
           Body: combinedBody,
+          RawBody: msg.body,
           From: msg.from,
           To: msg.to,
           SessionKey: route.sessionKey,


### PR DESCRIPTION
## Summary

WhatsApp group messages include structural context (history, sender labels) in the `Body` field for LLM context. This caused command detection to fail when the formatted body did not match exact command strings like `/status`.

## Problem

In WhatsApp group chats, the gateway constructs a `combinedBody` with:
- History context: `[Chat messages since your last reply - for context]\n...`
- Current message with envelope: `[WhatsApp ...] Sender: message`  
- Sender metadata: `\n[from: Name (phone)]`

Commands like `/status\n[from: Jake McInteer]` failed exact matching against `/status`.

## Solution

Add `RawBody` field to `MsgContext` carrying the clean message text (original Baileys message). Command detection, directive parsing, abort detection, and reset triggers now prefer `RawBody` over `Body`.

This separates concerns:
- `Body`: Formatted LLM context (history, sender labels)
- `RawBody`: Clean text for command matching

## Changes

- `src/auto-reply/templating.ts`: Add `RawBody` field to `MsgContext`
- `src/web/auto-reply.ts`: Set `RawBody: msg.body` in WhatsApp gateway
- `src/auto-reply/reply/session.ts`: Use `RawBody` for `triggerBodyNormalized` and reset triggers
- `src/auto-reply/reply.ts`: Use `RawBody` for directive parsing
- `src/auto-reply/reply/abort.ts`: Use `RawBody` for abort detection
- `src/auto-reply/reply/mentions.ts`: Cleanup debug logging

## Tests

- `session.test.ts`: RawBody extraction, reset triggers, fallback to Body
- `abort.test.ts`: `/stop` detection, bare word triggers  
- `reply.raw-body.test.ts`: `/think`, `/model`, `/status` directive parsing with structural wrappers

## Related

- #638 (RFC: Structured MsgContext and Decomposition of CombinedBody)

## Note

Discord has a similar `combinedBody` pattern that may need the same fix. See #638 for broader architectural discussion.