### PR TITLE
fix: use exact match for win32 platform detection

### DIFF
--- a/src/infra/node-shell.ts
+++ b/src/infra/node-shell.ts
@@ -2,7 +2,7 @@ export function buildNodeShellCommand(command: string, platform?: string | null)
   const normalized = String(platform ?? "")
     .trim()
     .toLowerCase();
-  if (normalized.includes("win")) {
+  if (normalized === "win32") {
     return ["cmd.exe", "/d", "/s", "/c", command];
   }
   return ["/bin/sh", "-lc", command];


### PR DESCRIPTION
The previous check used includes(win) which incorrectly matched darwin (macOS) because it contains win. This caused cmd.exe to be used on macOS instead of /bin/sh, resulting in spawn cmd.exe ENOENT errors.

Changes:
- Changed normalized.includes(win) to normalized === win32

Testing:
- Verified on macOS (darwin) that /bin/sh is now correctly used