### PR TITLE
docs: add Mistral provider setup guide

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -142,6 +142,14 @@
       "destination": "/providers/glm"
     },
     {
+      "source": "/mistral",
+      "destination": "/providers/mistral"
+    },
+    {
+      "source": "/mistral/",
+      "destination": "/providers/mistral"
+    },
+    {
       "source": "/zai",
       "destination": "/providers/zai"
     },
@@ -1030,7 +1038,8 @@
           "providers/synthetic",
           "providers/opencode",
           "providers/glm",
-          "providers/zai"
+          "providers/zai",
+          "providers/mistral"
         ]
       },
       {

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -48,6 +48,7 @@ See [Venice AI](/providers/venice).
 - [GLM models](/providers/glm)
 - [MiniMax](/providers/minimax)
 - [Venice (Venice AI, privacy-focused)](/providers/venice)
+- [Mistral AI](/providers/mistral)
 - [Ollama (local models)](/providers/ollama)
 
 ## Transcription providers

--- a/docs/providers/mistral.md
+++ b/docs/providers/mistral.md
@@ -1,0 +1,45 @@
+---
+summary: "Use Mistral AI models with OpenClaw"
+read_when:
+  - You want Mistral models in OpenClaw
+  - You need MISTRAL_API_KEY setup
+title: "Mistral"
+---
+
+# Mistral
+
+Mistral AI provides powerful open-weight and proprietary models via their API platform.
+Create your API key at [console.mistral.ai](https://console.mistral.ai).
+
+## CLI setup
+
+```bash
+openclaw models auth paste-token --provider mistral
+```
+
+You will be prompted to paste your Mistral API key.
+
+## Config snippet
+
+```json5
+{
+  env: { MISTRAL_API_KEY: "..." },
+  agents: { defaults: { model: { primary: "mistral/mistral-large-latest" } } },
+}
+```
+
+## Available models
+
+Common Mistral model IDs:
+
+- `mistral/mistral-large-latest` - Flagship model
+- `mistral/mistral-medium-latest` - Balanced performance
+- `mistral/mistral-small-latest` - Fast and efficient
+- `mistral/codestral-latest` - Code-optimized
+- `mistral/open-mistral-nemo` - Open-weight model
+
+## Notes
+
+- Model refs use `mistral/<model-id>` format.
+- Mistral uses Bearer auth with your API key.
+- For model selection and failover config, see [/concepts/models](/concepts/models).


### PR DESCRIPTION
Mistral provider setup wasn't documented. Added provider page with CLI auth command and config examples.

Changes:
- New provider page at `docs/providers/mistral.md`
- Added Mistral to provider index
- Added navigation and redirects in docs.json

Fixes #6170

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds first-party documentation for the Mistral provider, wires it into the providers index, and updates `docs/docs.json` navigation/redirects so `/mistral` routes to `/providers/mistral`.

Overall the changes fit the existing Mintlify docs structure (provider pages under `docs/providers/*` and discoverable via `docs/providers/index.md`). The main things to double-check are that the CLI auth command shown on the new page reflects an actually-supported flow, and that the config example format matches what OpenClaw expects users to paste.

<h3>Confidence Score: 4/5</h3>

- This PR is low-risk and primarily documentation/navigation changes.
- Changes are limited to docs content and Mintlify navigation/redirect configuration; the only meaningful risk is user confusion if the documented CLI auth command or config format doesn’t match actual supported behavior.
- docs/providers/mistral.md (verify command/config accuracy)

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->