### PR TITLE
fix: route logs to stderr during completion script generation

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -2,6 +2,7 @@ import { Command, Option } from "commander";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { routeLogsToStderr } from "../logging/console.js";
 import { getSubCliEntries, registerSubCliByName } from "./program/register.subclis.js";
 
 export function registerCompletionCli(program: Command) {
@@ -16,6 +17,10 @@ export function registerCompletionCli(program: Command) {
     .option("-i, --install", "Install completion script to shell profile")
     .option("-y, --yes", "Skip confirmation (non-interactive)", false)
     .action(async (options) => {
+      // Route all logs to stderr so stdout contains only the completion script.
+      // This prevents plugin loading messages from breaking `source <(openclaw completion ...)`.
+      routeLogsToStderr();
+
       const shell = options.shell;
       // Eagerly register all subcommands to build the full tree
       const entries = getSubCliEntries();


### PR DESCRIPTION
Turns out plugin logs were going to stdout during completion generation, which completely breaks the standard `source <(openclaw completion --shell bash)` pattern in .bashrc/.zshrc.

Shell tries to execute stuff like `[plugins] feishu_doc...` as commands, causing errors on every terminal launch.

Fix: call `routeLogsToStderr()` before loading subcommands. stdout stays clean for the actual completion script.

Tested locally, all passed.

Fixes #6236

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR routes CLI logs to **stderr** during `openclaw completion` generation by calling `routeLogsToStderr()` at the start of the `completion` command action in `src/cli/completion-cli.ts`. The intent is to keep **stdout** reserved for the actual completion script so patterns like `source <(openclaw completion --shell bash)` don’t break when plugins emit log lines during subcommand registration.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The change is a small, well-scoped behavior fix (rerouting logs before subcommand/plugin loading) and it aligns with the stated goal of keeping completion output clean; no other control flow or data paths are affected.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=0d0c8278-ef8e-4d6c-ab21-f5527e322f13))

<!-- /greptile_comment -->