### PR TITLE
fix(sessions-spawn): resolve target agent's bound accountId for subagent gateway calls

### DIFF
--- a/src/agents/sessions-spawn-bound-accountid.test.ts
+++ b/src/agents/sessions-spawn-bound-accountid.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayMock = vi.fn();
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+let configOverride: ReturnType<(typeof import("../config/config.js"))["loadConfig"]> = {
+  session: {
+    mainKey: "main",
+    scope: "per-sender",
+  },
+};
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => configOverride,
+    resolveGatewayPort: () => 18789,
+  };
+});
+
+import "./test-helpers/fast-core-tools.js";
+import { createOpenClawTools } from "./openclaw-tools.js";
+import { resetSubagentRegistryForTests } from "./subagent-registry.js";
+
+describe("sessions_spawn bound accountId resolution", () => {
+  beforeEach(() => {
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+    configOverride = {
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+    };
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const req = opts as { method?: string };
+      if (req.method === "agent") {
+        return { runId: "run-1", status: "accepted", acceptedAt: 1 };
+      }
+      if (req.method === "agent.wait") {
+        return { runId: "run-1", status: "running" };
+      }
+      return {};
+    });
+  });
+
+  it("uses target agent's bound accountId over requester's accountId", async () => {
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        list: [
+          {
+            id: "main",
+            subagents: { allowAgents: ["rex"] },
+          },
+          { id: "rex" },
+        ],
+      },
+      bindings: [
+        {
+          agentId: "rex",
+          match: { channel: "telegram", accountId: "rex-bot-token" },
+        },
+      ],
+    };
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "main",
+      agentChannel: "telegram",
+      agentAccountId: "aria-bot-token",
+      agentTo: "telegram:123",
+      agentThreadId: 42,
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    await tool.execute("call", {
+      task: "research this topic",
+      agentId: "rex",
+      runTimeoutSeconds: 1,
+    });
+
+    const agentCall = callGatewayMock.mock.calls.find(
+      ([opts]: [{ method?: string }]) => opts.method === "agent",
+    );
+    expect(agentCall).toBeDefined();
+    const params = agentCall![0].params;
+    // Target agent's bound accountId should win over requester's.
+    expect(params.accountId).toBe("rex-bot-token");
+    // Thread context from requester should still be passed through.
+    expect(params.to).toBe("telegram:123");
+    expect(params.threadId).toBe("42");
+  });
+
+  it("falls back to requester's accountId when target has no binding", async () => {
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        list: [
+          {
+            id: "main",
+            subagents: { allowAgents: ["scout"] },
+          },
+          { id: "scout" },
+        ],
+      },
+      // No bindings for scout.
+      bindings: [],
+    };
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "main",
+      agentChannel: "telegram",
+      agentAccountId: "aria-bot-token",
+      agentTo: "telegram:456",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    await tool.execute("call", {
+      task: "scout this",
+      agentId: "scout",
+      runTimeoutSeconds: 1,
+    });
+
+    const agentCall = callGatewayMock.mock.calls.find(
+      ([opts]: [{ method?: string }]) => opts.method === "agent",
+    );
+    expect(agentCall).toBeDefined();
+    const params = agentCall![0].params;
+    // No binding for scout → falls back to requester's accountId.
+    expect(params.accountId).toBe("aria-bot-token");
+    expect(params.to).toBe("telegram:456");
+  });
+
+  it("skips accountId resolution when requester has no channel (cron/hook spawns)", async () => {
+    configOverride = {
+      session: { mainKey: "main", scope: "per-sender" },
+      bindings: [
+        {
+          agentId: "main",
+          match: { channel: "telegram", accountId: "main-bot-token" },
+        },
+      ],
+    };
+
+    // No channel/accountId — simulates a cron or hook spawn.
+    const tool = createOpenClawTools({
+      agentSessionKey: "main",
+    }).find((candidate) => candidate.name === "sessions_spawn");
+    if (!tool) {
+      throw new Error("missing sessions_spawn tool");
+    }
+
+    await tool.execute("call", {
+      task: "scheduled job",
+      runTimeoutSeconds: 1,
+    });
+
+    const agentCall = callGatewayMock.mock.calls.find(
+      ([opts]: [{ method?: string }]) => opts.method === "agent",
+    );
+    expect(agentCall).toBeDefined();
+    const params = agentCall![0].params;
+    // No channel means no binding resolution and no requester accountId.
+    expect(params.accountId).toBeUndefined();
+  });
+});

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -5,6 +5,7 @@ import type { AnyAgentTool } from "./common.js";
 import { formatThinkingLevels, normalizeThinkLevel } from "../../auto-reply/thinking.js";
 import { loadConfig } from "../../config/config.js";
 import { callGateway } from "../../gateway/call.js";
+import { resolveAgentBoundAccountId } from "../../routing/bindings.js";
 import {
   isSubagentSessionKey,
   normalizeAgentId,
@@ -222,6 +223,13 @@ export function createSessionsSpawnTool(opts?: {
         task,
       });
 
+      // Resolve the target agent's bound accountId for the channel.
+      // This ensures sub-agents use their own messaging identity (e.g., their own Telegram bot)
+      // rather than the requester's or system default.
+      const targetAccountId = requesterOrigin?.channel
+        ? resolveAgentBoundAccountId(cfg, targetAgentId, requesterOrigin.channel)
+        : null;
+
       const childIdem = crypto.randomUUID();
       let childRunId: string = childIdem;
       try {
@@ -232,7 +240,9 @@ export function createSessionsSpawnTool(opts?: {
             sessionKey: childSessionKey,
             channel: requesterOrigin?.channel,
             to: requesterOrigin?.to ?? undefined,
-            accountId: requesterOrigin?.accountId ?? undefined,
+            // Prefer target agent's bound accountId (for multi-agent setups with separate bots),
+            // fall back to requester's accountId (for parent context inheritance).
+            accountId: targetAccountId ?? requesterOrigin?.accountId ?? undefined,
             threadId:
               requesterOrigin?.threadId != null ? String(requesterOrigin.threadId) : undefined,
             idempotencyKey: childIdem,

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -223,9 +223,13 @@ export function createSessionsSpawnTool(opts?: {
         task,
       });
 
-      // Resolve the target agent's bound accountId for the channel.
-      // This ensures sub-agents use their own messaging identity (e.g., their own Telegram bot)
-      // rather than the requester's or system default.
+      // Resolve the target agent's bound accountId for the requester's channel.
+      // This ensures sub-agents spawned from chat use their own messaging identity
+      // (e.g., their own Telegram bot) rather than the requester's or system default.
+      //
+      // When requesterOrigin.channel is absent (cron/hook/internal spawns), we intentionally
+      // skip resolution here. In those cases, the sub-agent controls its own outbound routing
+      // via explicit accountId in its message tool calls, or falls back to its configured default.
       const targetAccountId = requesterOrigin?.channel
         ? resolveAgentBoundAccountId(cfg, targetAgentId, requesterOrigin.channel)
         : null;

--- a/src/routing/bindings.ts
+++ b/src/routing/bindings.ts
@@ -77,6 +77,44 @@ export function resolveDefaultAgentBoundAccountId(
   return null;
 }
 
+/**
+ * Resolve the bound accountId for a specific agent on a given channel.
+ * Returns the first matching accountId from the agent's bindings, or null if none found.
+ */
+export function resolveAgentBoundAccountId(
+  cfg: OpenClawConfig,
+  agentId: string,
+  channelId: string,
+): string | null {
+  const normalizedChannel = normalizeBindingChannelId(channelId);
+  if (!normalizedChannel) {
+    return null;
+  }
+  const normalizedAgentId = normalizeAgentId(agentId);
+  for (const binding of listBindings(cfg)) {
+    if (!binding || typeof binding !== "object") {
+      continue;
+    }
+    if (normalizeAgentId(binding.agentId) !== normalizedAgentId) {
+      continue;
+    }
+    const match = binding.match;
+    if (!match || typeof match !== "object") {
+      continue;
+    }
+    const channel = normalizeBindingChannelId(match.channel);
+    if (!channel || channel !== normalizedChannel) {
+      continue;
+    }
+    const accountId = typeof match.accountId === "string" ? match.accountId.trim() : "";
+    if (!accountId || accountId === "*") {
+      continue;
+    }
+    return normalizeAccountId(accountId);
+  }
+  return null;
+}
+
 export function buildChannelAccountBindings(cfg: OpenClawConfig) {
   const map = new Map<string, Map<string, string[]>>();
   for (const binding of listBindings(cfg)) {


### PR DESCRIPTION
## Summary

Builds on top of a13efbe2b (`fix: pass threadId/to/accountId from parent to subagent gateway call`) which correctly forwards requester context (threadId, to, accountId) so sub-agents reply to the correct thread/topic.

This PR adds **binding-aware accountId resolution** so that when a sub-agent has its own bot identity configured via `bindings`, it uses that identity instead of inheriting the parent's.

**Example scenario:**
- Aria (main agent, bound to `aria-bot`) spawns Rex (content agent, bound to `rex-bot`) via `sessions_spawn`
- Rex needs to send a Telegram message back to the user
- **Before (a13efbe2b only):** Rex replies through Aria's bot (correct thread, wrong identity)
- **After (this PR):** Rex replies through Rex's own bot (correct thread, correct identity)

The two fixes are complementary:
| Fix | Solves |
|-----|--------|
| a13efbe2b (upstream) | Sub-agent replies land in the correct forum topic/thread |
| This PR | Sub-agent replies come from the correct bot identity |

## Changes

1. **Added `resolveAgentBoundAccountId()`** in `src/routing/bindings.ts`
   - Looks up an agent's bound accountId for a given channel from config bindings
   - Follows the same pattern as existing `resolveDefaultAgentBoundAccountId()`

2. **Updated `sessions-spawn-tool.ts`**
   - Resolves the target agent's bound accountId before the gateway call
   - Uses `targetAccountId ?? requesterOrigin?.accountId` — binding wins when configured, parent context is the fallback
   - Preserves upstream's `to` and `threadId` passthrough

3. **Added tests** in `sessions-spawn-bound-accountid.test.ts`
   - Target agent's bound accountId takes priority over requester's
   - Falls back to requester's accountId when no binding exists
   - Skips resolution for cron/hook spawns (no channel context)

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes
- [x] 3 new unit tests pass (binding priority, fallback, cron/hook)
- [ ] Manual testing with multi-agent setup (spawning agent with separate Telegram binding)