### PR TITLE
feat(hooks): add agentId to hook mappings

### DIFF
--- a/src/config/types.hooks.ts
+++ b/src/config/types.hooks.ts
@@ -33,6 +33,8 @@ export type HookMappingConfig = {
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  /** Route this hook to a specific agent (by agent ID). */
+  agentId?: string;
   transform?: HookMappingTransform;
 };
 

--- a/src/config/zod-schema.hooks.ts
+++ b/src/config/zod-schema.hooks.ts
@@ -32,6 +32,7 @@ export const HookMappingSchema = z
     model: z.string().optional(),
     thinking: z.string().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
+    agentId: z.string().optional(),
     transform: z
       .object({
         module: z.string(),

--- a/src/gateway/hooks-mapping.ts
+++ b/src/gateway/hooks-mapping.ts
@@ -24,6 +24,7 @@ export type HookMappingResolved = {
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  agentId?: string;
   transform?: HookMappingTransformResolved;
 };
 
@@ -57,6 +58,7 @@ export type HookAction =
       model?: string;
       thinking?: string;
       timeoutSeconds?: number;
+      agentId?: string;
     };
 
 export type HookMappingResult =
@@ -95,6 +97,7 @@ type HookTransformResult = Partial<{
   model: string;
   thinking: string;
   timeoutSeconds: number;
+  agentId: string;
 }> | null;
 
 type HookTransformFn = (
@@ -180,6 +183,7 @@ function normalizeHookMapping(
     model: mapping.model,
     thinking: mapping.thinking,
     timeoutSeconds: mapping.timeoutSeconds,
+    agentId: mapping.agentId,
     transform,
   };
 }
@@ -225,6 +229,7 @@ function buildActionFromMapping(
       model: renderOptional(mapping.model, ctx),
       thinking: renderOptional(mapping.thinking, ctx),
       timeoutSeconds: mapping.timeoutSeconds,
+      agentId: renderOptional(mapping.agentId, ctx),
     },
   };
 }
@@ -261,6 +266,7 @@ function mergeAction(
     model: override.model ?? baseAgent?.model,
     thinking: override.thinking ?? baseAgent?.thinking,
     timeoutSeconds: override.timeoutSeconds ?? baseAgent?.timeoutSeconds,
+    agentId: override.agentId ?? baseAgent?.agentId,
   });
 }
 

--- a/src/gateway/hooks.ts
+++ b/src/gateway/hooks.ts
@@ -134,6 +134,7 @@ export type HookAgentPayload = {
   model?: string;
   thinking?: string;
   timeoutSeconds?: number;
+  agentId?: string;
 };
 
 const listHookChannelValues = () => ["last", ...listChannelPlugins().map((plugin) => plugin.id)];
@@ -193,6 +194,9 @@ export function normalizeAgentPayload(
     typeof timeoutRaw === "number" && Number.isFinite(timeoutRaw) && timeoutRaw > 0
       ? Math.floor(timeoutRaw)
       : undefined;
+  const agentIdRaw = payload.agentId;
+  const agentId =
+    typeof agentIdRaw === "string" && agentIdRaw.trim() ? agentIdRaw.trim() : undefined;
   return {
     ok: true,
     value: {
@@ -206,6 +210,7 @@ export function normalizeAgentPayload(
       model,
       thinking,
       timeoutSeconds,
+      agentId,
     },
   };
 }

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -46,6 +46,7 @@ type HookDispatchers = {
     model?: string;
     thinking?: string;
     timeoutSeconds?: number;
+    agentId?: string;
   }) => string;
 };
 
@@ -173,6 +174,7 @@ export function createHooksRequestHandler(
             model: mapped.action.model,
             thinking: mapped.action.thinking,
             timeoutSeconds: mapped.action.timeoutSeconds,
+            agentId: mapped.action.agentId,
           });
           sendJson(res, 202, { ok: true, runId });
           return true;

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -41,6 +41,7 @@ export function createGatewayHooksRequestHandler(params: {
     model?: string;
     thinking?: string;
     timeoutSeconds?: number;
+    agentId?: string;
   }) => {
     const sessionKey = value.sessionKey.trim() ? value.sessionKey.trim() : `hook:${randomUUID()}`;
     const mainSessionKey = resolveMainSessionKeyFromConfig();
@@ -78,6 +79,7 @@ export function createGatewayHooksRequestHandler(params: {
           job,
           message: value.message,
           sessionKey,
+          agentId: value.agentId,
           lane: "cron",
         });
         const summary = result.summary?.trim() || result.error?.trim() || result.status;


### PR DESCRIPTION
## Summary

- Add optional `agentId` field to hook mappings, allowing webhooks to route to a specific agent instead of always using the default agent
- `runCronIsolatedAgentTurn` already accepts `agentId` — this wires it through the full hook dispatch chain
- Supports Mustache templates (e.g. `{{payload.agent}}`) for dynamic routing

## Motivation

When running multiple agents with distinct roles (e.g. research, coding, ops), incoming webhooks always route to the default agent because `agentId` is never passed from hooks to `runCronIsolatedAgentTurn`. This forces workarounds like encoding agent IDs in session keys or patching the dispatch manually.

## Changes (6 files, 18 lines added)

1. `src/config/types.hooks.ts` — Add `agentId?: string` to `HookMappingConfig`
2. `src/config/zod-schema.hooks.ts` — Add `agentId: z.string().optional()` to Zod schema
3. `src/gateway/hooks-mapping.ts` — Thread `agentId` through `HookMappingResolved`, `HookAction`, `HookTransformResult`, `normalizeHookMapping`, `buildActionFromMapping`, `mergeAction`
4. `src/gateway/hooks.ts` — Add `agentId` to `HookAgentPayload` and `normalizeAgentPayload`
5. `src/gateway/server-http.ts` — Add `agentId` to `HookDispatchers` type and mapped dispatch call
6. `src/gateway/server/hooks.ts` — Pass `value.agentId` to `runCronIsolatedAgentTurn`

## Usage

```json
{
  "hooks": {
    "mappings": [
      {
        "match": { "path": "notify" },
        "action": "agent",
        "agentId": "{{payload.agent}}",
        "messageTemplate": "{{payload.message}}"
      }
    ]
  }
}
```

## Test plan

- [ ] Verify hook mapping with static `agentId` routes to the correct agent
- [ ] Verify hook mapping with template `agentId` (e.g. `{{payload.agent}}`) resolves dynamically
- [ ] Verify omitting `agentId` falls back to default agent (backward compatible)
- [ ] Verify transform overrides work with `agentId`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

- Extends hook mapping config/schema to accept an optional `agentId` string.
- Threads `agentId` through hook mapping resolution/templating, agent payload normalization, and HTTP hook dispatch.
- Updates gateway hook server to pass `agentId` into `runCronIsolatedAgentTurn`, enabling per-hook agent routing (static or template-rendered).

<h3>Confidence Score: 4/5</h3>

- Mostly safe to merge, but there is a real config validation inconsistency to fix first.
- The `agentId` threading is straightforward and stays optional end-to-end, but the hook mapping Zod schema’s `channel` union is now more likely to reject a valid `googlechat` value that the TS config types allow, causing runtime config load failures for users with that mapping.
- src/config/zod-schema.hooks.ts

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->