### PR TITLE
fix: preserve thinking.signature for Anthropic/Bedrock Extended Thinking

### DIFF
--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -107,12 +107,17 @@ export function resolveTranscriptPolicy(params: {
     : undefined;
   const normalizeAntigravityThinkingBlocks = isAntigravityClaudeModel;
 
+  // Anthropic (including Bedrock) requires thinking.signature to be preserved
+  // when Extended Thinking is enabled. Without it, API returns:
+  // "messages.X.content.Y.thinking.signature: Field required"
+  const preserveSignatures = isAntigravityClaudeModel || isAnthropic;
+
   return {
     sanitizeMode: isOpenAi ? "images-only" : needsNonImageSanitize ? "full" : "images-only",
     sanitizeToolCallIds: !isOpenAi && sanitizeToolCallIds,
     toolCallIdMode,
     repairToolUseResultPairing: !isOpenAi && repairToolUseResultPairing,
-    preserveSignatures: isAntigravityClaudeModel,
+    preserveSignatures,
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     normalizeAntigravityThinkingBlocks,
     applyGoogleTurnOrdering: !isOpenAi && isGoogle,


### PR DESCRIPTION
When using Extended Thinking with Claude on Bedrock, after many conversation turns you get:

```
messages.219.content.0.thinking.signature: Field required
```

The `preserveSignatures` flag in `transcript-policy.ts` was only enabled for Antigravity Claude models, so the `thinking.signature` field got stripped for regular Anthropic/Bedrock calls. But the API requires it when Extended Thinking is on.

Extended the flag to cover all Anthropic API calls:

```typescript
const preserveSignatures = isAntigravityClaudeModel || isAnthropic;
```

Fixes #10775