### PR TITLE
feat(slack): Add App Home tab support

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -524,6 +524,63 @@ Slack tool actions can be gated with `channels.slack.actions.*`:
 | pins         | enabled | Pin/unpin/list         |
 | memberInfo   | enabled | Member info            |
 | emojiList    | enabled | Custom emoji list      |
+| homeTab      | enabled | Home Tab updates       |
+
+## Home Tab
+
+When a user opens the bot's **Home** tab in Slack, OpenClaw automatically publishes a Block Kit view showing:
+
+- Agent name and status
+- Version, model, and uptime
+- Getting started instructions (DM, mentions, slash commands)
+- Configured channels
+- Links to docs, GitHub, and community
+
+The view is cached per user and only re-published when the version changes (e.g., after an update or restart). No additional configuration is required — the Home Tab works out of the box.
+
+### Configuration
+
+```yaml
+channels:
+  slack:
+    homeTab:
+      enabled: true # default: true
+      showCommands: true # default: true — show slash command reference
+      customBlocks: [] # optional static Block Kit blocks to append
+```
+
+### Custom Home Tab via `updateHomeTab`
+
+Agents can dynamically customize a user's Home Tab using the `updateHomeTab` action:
+
+| Parameter | Type       | Required | Description                            |
+| --------- | ---------- | -------- | -------------------------------------- |
+| `userId`  | `string`   | yes      | Slack user ID whose Home tab to update |
+| `blocks`  | `object[]` | yes      | Block Kit blocks array for the view    |
+
+Example:
+
+```json
+{
+  "action": "updateHomeTab",
+  "userId": "U12345",
+  "blocks": [{ "type": "section", "text": { "type": "mrkdwn", "text": "Hello from your agent!" } }]
+}
+```
+
+Once an agent publishes a custom view, the default Home Tab view will **not** overwrite it on subsequent tab opens. Use `resetHomeTab` (with `userId`) to clear the custom view and restore the default.
+
+This action is gated by the `homeTab` key in the actions config (enabled by default).
+
+### Setup for existing apps
+
+If your Slack app was created before this feature, you need to add the `app_home_opened` event subscription:
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) → select your app
+2. **Event Subscriptions** → **Subscribe to bot events** → add `app_home_opened`
+3. Save and reinstall if prompted
+
+New apps created via the onboarding wizard include this automatically.
 
 ## Security notes
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -568,9 +568,17 @@ Example:
 }
 ```
 
-Once an agent publishes a custom view, the default Home Tab view will **not** overwrite it on subsequent tab opens. Use `resetHomeTab` (with `userId`) to clear the custom view and restore the default.
+Once an agent publishes a custom view, the default Home Tab view will **not** overwrite it on subsequent tab opens.
 
-This action is gated by the `homeTab` key in the actions config (enabled by default).
+To restore the default view, use the `resetHomeTab` action:
+
+| Parameter | Type     | Required | Description                                      |
+| --------- | -------- | -------- | ------------------------------------------------ |
+| `userId`  | `string` | yes      | Slack user ID whose Home tab to reset to default |
+
+The default view also resumes automatically after a process restart.
+
+Both actions are gated by the `homeTab` key in the actions config (enabled by default).
 
 ### Setup for existing apps
 

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -333,7 +333,7 @@ export async function handleSlackAction(
       throw new Error("Slack Home Tab updates are disabled.");
     }
     const userId = readStringParam(params, "userId", { required: true });
-    resetSlackHomeTab(userId);
+    resetSlackHomeTab(userId, writeOpts ?? {});
     return jsonResult({
       ok: true,
       message: "Custom Home Tab cleared; default will restore on next visit.",

--- a/src/agents/tools/slack-actions.ts
+++ b/src/agents/tools/slack-actions.ts
@@ -9,10 +9,12 @@ import {
   listSlackPins,
   listSlackReactions,
   pinSlackMessage,
+  publishSlackHomeTab,
   reactSlackMessage,
   readSlackMessages,
   removeOwnSlackReactions,
   removeSlackReaction,
+  resetSlackHomeTab,
   sendSlackMessage,
   unpinSlackMessage,
 } from "../../slack/actions.js";
@@ -307,6 +309,35 @@ export async function handleSlackAction(
     }
     const emojis = readOpts ? await listSlackEmojis(readOpts) : await listSlackEmojis();
     return jsonResult({ ok: true, emojis });
+  }
+
+  if (action === "updateHomeTab") {
+    if (!isActionEnabled("homeTab")) {
+      throw new Error("Slack Home Tab updates are disabled.");
+    }
+    const userId = readStringParam(params, "userId", { required: true });
+    const blocks = params.blocks;
+    if (!Array.isArray(blocks)) {
+      throw new Error("blocks (array) is required for updateHomeTab.");
+    }
+    if (writeOpts) {
+      await publishSlackHomeTab(userId, blocks as Record<string, unknown>[], writeOpts);
+    } else {
+      await publishSlackHomeTab(userId, blocks as Record<string, unknown>[]);
+    }
+    return jsonResult({ ok: true });
+  }
+
+  if (action === "resetHomeTab") {
+    if (!isActionEnabled("homeTab")) {
+      throw new Error("Slack Home Tab updates are disabled.");
+    }
+    const userId = readStringParam(params, "userId", { required: true });
+    resetSlackHomeTab(userId);
+    return jsonResult({
+      ok: true,
+      message: "Custom Home Tab cleared; default will restore on next visit.",
+    });
   }
 
   throw new Error(`Unknown action: ${action}`);

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -49,6 +49,7 @@ function buildSlackManifest(botName: string) {
         always_online: false,
       },
       app_home: {
+        home_tab_enabled: true,
         messages_tab_enabled: true,
         messages_tab_read_only_enabled: false,
       },

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -98,6 +98,7 @@ function buildSlackManifest(botName: string) {
           "channel_rename",
           "pin_added",
           "pin_removed",
+          "app_home_opened",
         ],
       },
     },

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -55,6 +55,16 @@ export type SlackActionConfig = {
   memberInfo?: boolean;
   channelInfo?: boolean;
   emojiList?: boolean;
+  homeTab?: boolean;
+};
+
+export type SlackHomeTabConfig = {
+  /** If false, disable the Home tab. Default: true. */
+  enabled?: boolean;
+  /** Show available commands/interaction methods. Default: true. */
+  showCommands?: boolean;
+  /** Optional static Block Kit blocks to append to the default view. */
+  customBlocks?: unknown[];
 };
 
 export type SlackSlashCommandConfig = {
@@ -144,6 +154,8 @@ export type SlackAccountConfig = {
   heartbeat?: ChannelHeartbeatVisibilityConfig;
   /** Outbound response prefix override for this channel/account. */
   responsePrefix?: string;
+  /** Home tab configuration. */
+  homeTab?: SlackHomeTabConfig;
 };
 
 export type SlackConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -496,6 +496,15 @@ export const SlackAccountSchema = z
         memberInfo: z.boolean().optional(),
         channelInfo: z.boolean().optional(),
         emojiList: z.boolean().optional(),
+        homeTab: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
+    homeTab: z
+      .object({
+        enabled: z.boolean().optional(),
+        showCommands: z.boolean().optional(),
+        customBlocks: z.array(z.unknown()).optional(),
       })
       .strict()
       .optional(),

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -3,6 +3,7 @@ import { loadConfig } from "../config/config.js";
 import { logVerbose } from "../globals.js";
 import { resolveSlackAccount } from "./accounts.js";
 import { createSlackWebClient } from "./client.js";
+import { clearHomeTabCustom, markHomeTabCustom } from "./home-tab-state.js";
 import { sendMessageSlack } from "./send.js";
 import { resolveSlackBotToken } from "./token.js";
 
@@ -260,4 +261,32 @@ export async function listSlackPins(
   const client = await getClient(opts);
   const result = await client.pins.list({ channel: channelId });
   return (result.items ?? []) as SlackPin[];
+}
+
+/**
+ * Publish a custom Block Kit view to a user's Slack App Home tab.
+ *
+ * After a successful publish the user is marked as having a custom view so the
+ * default `app_home_opened` handler will not overwrite it.
+ */
+export async function publishSlackHomeTab(
+  userId: string,
+  blocks: Record<string, unknown>[],
+  opts: SlackActionClientOpts = {},
+): Promise<void> {
+  const client = await getClient(opts);
+  await client.views.publish({
+    user_id: userId,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Block Kit JSON built dynamically
+    view: { type: "home", blocks: blocks as any },
+  });
+  markHomeTabCustom(userId);
+}
+
+/**
+ * Clear a user's custom Home Tab view, allowing the default view to be
+ * published again on the next `app_home_opened` event.
+ */
+export function resetSlackHomeTab(userId: string): void {
+  clearHomeTabCustom(userId);
 }

--- a/src/slack/actions.ts
+++ b/src/slack/actions.ts
@@ -274,19 +274,21 @@ export async function publishSlackHomeTab(
   blocks: Record<string, unknown>[],
   opts: SlackActionClientOpts = {},
 ): Promise<void> {
+  const accountId = opts.accountId ?? "default";
   const client = await getClient(opts);
   await client.views.publish({
     user_id: userId,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Block Kit JSON built dynamically
     view: { type: "home", blocks: blocks as any },
   });
-  markHomeTabCustom(userId);
+  markHomeTabCustom(accountId, userId);
 }
 
 /**
  * Clear a user's custom Home Tab view, allowing the default view to be
  * published again on the next `app_home_opened` event.
  */
-export function resetSlackHomeTab(userId: string): void {
-  clearHomeTabCustom(userId);
+export function resetSlackHomeTab(userId: string, opts: SlackActionClientOpts = {}): void {
+  const accountId = opts.accountId ?? "default";
+  clearHomeTabCustom(accountId, userId);
 }

--- a/src/slack/home-tab-state.test.ts
+++ b/src/slack/home-tab-state.test.ts
@@ -1,38 +1,72 @@
-import { describe, expect, it } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
-  clearHomeTabCustom,
-  hasCurrentHomeTab,
-  hasCustomHomeTab,
   markHomeTabCustom,
+  clearHomeTabCustom,
+  hasCustomHomeTab,
   markHomeTabPublished,
+  hasCurrentHomeTab,
+  isPublishInFlight,
+  markPublishInFlight,
+  clearPublishInFlight,
 } from "./home-tab-state.js";
 
+const ACCOUNT = "default";
+
 describe("home-tab-state", () => {
-  it("markHomeTabCustom → hasCustomHomeTab returns true", () => {
-    markHomeTabCustom("U_CUSTOM_1");
-    expect(hasCustomHomeTab("U_CUSTOM_1")).toBe(true);
+  it("tracks custom view per account+user", () => {
+    markHomeTabCustom(ACCOUNT, "U1");
+    expect(hasCustomHomeTab(ACCOUNT, "U1")).toBe(true);
+    expect(hasCustomHomeTab(ACCOUNT, "U2")).toBe(false);
+    clearHomeTabCustom(ACCOUNT, "U1");
+    expect(hasCustomHomeTab(ACCOUNT, "U1")).toBe(false);
   });
 
-  it("clearHomeTabCustom removes custom flag", () => {
-    markHomeTabCustom("U_CUSTOM_2");
-    clearHomeTabCustom("U_CUSTOM_2");
-    expect(hasCustomHomeTab("U_CUSTOM_2")).toBe(false);
+  it("tracks published version per account+user", () => {
+    markHomeTabPublished(ACCOUNT, "U1", "1.0.0");
+    expect(hasCurrentHomeTab(ACCOUNT, "U1", "1.0.0")).toBe(true);
+    expect(hasCurrentHomeTab(ACCOUNT, "U1", "2.0.0")).toBe(false);
+    expect(hasCurrentHomeTab(ACCOUNT, "U2", "1.0.0")).toBe(false);
   });
 
-  it("markHomeTabCustom clears published version cache", () => {
-    markHomeTabPublished("U_CUSTOM_3", "1.0.0");
-    expect(hasCurrentHomeTab("U_CUSTOM_3", "1.0.0")).toBe(true);
-    markHomeTabCustom("U_CUSTOM_3");
-    expect(hasCurrentHomeTab("U_CUSTOM_3", "1.0.0")).toBe(false);
+  it("markHomeTabCustom clears published version", () => {
+    markHomeTabPublished(ACCOUNT, "U3", "1.0.0");
+    expect(hasCurrentHomeTab(ACCOUNT, "U3", "1.0.0")).toBe(true);
+    markHomeTabCustom(ACCOUNT, "U3");
+    expect(hasCurrentHomeTab(ACCOUNT, "U3", "1.0.0")).toBe(false);
   });
 
-  it("markHomeTabPublished / hasCurrentHomeTab roundtrip", () => {
-    markHomeTabPublished("U_PUB_1", "2.0.0");
-    expect(hasCurrentHomeTab("U_PUB_1", "2.0.0")).toBe(true);
-    expect(hasCurrentHomeTab("U_PUB_1", "3.0.0")).toBe(false);
+  it("clearHomeTabCustom does not restore published version", () => {
+    markHomeTabPublished(ACCOUNT, "U4", "1.0.0");
+    markHomeTabCustom(ACCOUNT, "U4");
+    clearHomeTabCustom(ACCOUNT, "U4");
+    expect(hasCurrentHomeTab(ACCOUNT, "U4", "1.0.0")).toBe(false);
   });
 
-  it("hasCustomHomeTab returns false for unknown users", () => {
-    expect(hasCustomHomeTab("U_UNKNOWN")).toBe(false);
+  it("clears custom independently per user", () => {
+    markHomeTabCustom(ACCOUNT, "U5");
+    markHomeTabCustom(ACCOUNT, "U6");
+    clearHomeTabCustom(ACCOUNT, "U5");
+    expect(hasCustomHomeTab(ACCOUNT, "U5")).toBe(false);
+    expect(hasCustomHomeTab(ACCOUNT, "U6")).toBe(true);
+    clearHomeTabCustom(ACCOUNT, "U6");
+  });
+
+  it("isolates state across different accounts", () => {
+    markHomeTabCustom("account-a", "U1");
+    markHomeTabPublished("account-b", "U1", "1.0.0");
+    expect(hasCustomHomeTab("account-a", "U1")).toBe(true);
+    expect(hasCustomHomeTab("account-b", "U1")).toBe(false);
+    expect(hasCurrentHomeTab("account-a", "U1", "1.0.0")).toBe(false);
+    expect(hasCurrentHomeTab("account-b", "U1", "1.0.0")).toBe(true);
+    clearHomeTabCustom("account-a", "U1");
+  });
+
+  it("tracks in-flight publish state", () => {
+    expect(isPublishInFlight(ACCOUNT, "U1")).toBe(false);
+    markPublishInFlight(ACCOUNT, "U1");
+    expect(isPublishInFlight(ACCOUNT, "U1")).toBe(true);
+    expect(isPublishInFlight(ACCOUNT, "U2")).toBe(false);
+    clearPublishInFlight(ACCOUNT, "U1");
+    expect(isPublishInFlight(ACCOUNT, "U1")).toBe(false);
   });
 });

--- a/src/slack/home-tab-state.test.ts
+++ b/src/slack/home-tab-state.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearHomeTabCustom,
+  hasCurrentHomeTab,
+  hasCustomHomeTab,
+  markHomeTabCustom,
+  markHomeTabPublished,
+} from "./home-tab-state.js";
+
+describe("home-tab-state", () => {
+  it("markHomeTabCustom → hasCustomHomeTab returns true", () => {
+    markHomeTabCustom("U_CUSTOM_1");
+    expect(hasCustomHomeTab("U_CUSTOM_1")).toBe(true);
+  });
+
+  it("clearHomeTabCustom removes custom flag", () => {
+    markHomeTabCustom("U_CUSTOM_2");
+    clearHomeTabCustom("U_CUSTOM_2");
+    expect(hasCustomHomeTab("U_CUSTOM_2")).toBe(false);
+  });
+
+  it("markHomeTabCustom clears published version cache", () => {
+    markHomeTabPublished("U_CUSTOM_3", "1.0.0");
+    expect(hasCurrentHomeTab("U_CUSTOM_3", "1.0.0")).toBe(true);
+    markHomeTabCustom("U_CUSTOM_3");
+    expect(hasCurrentHomeTab("U_CUSTOM_3", "1.0.0")).toBe(false);
+  });
+
+  it("markHomeTabPublished / hasCurrentHomeTab roundtrip", () => {
+    markHomeTabPublished("U_PUB_1", "2.0.0");
+    expect(hasCurrentHomeTab("U_PUB_1", "2.0.0")).toBe(true);
+    expect(hasCurrentHomeTab("U_PUB_1", "3.0.0")).toBe(false);
+  });
+
+  it("hasCustomHomeTab returns false for unknown users", () => {
+    expect(hasCustomHomeTab("U_UNKNOWN")).toBe(false);
+  });
+});

--- a/src/slack/home-tab-state.ts
+++ b/src/slack/home-tab-state.ts
@@ -3,51 +3,80 @@
  * handler and the `publishSlackHomeTab` action.
  *
  * Both modules import from here so they share the same in-memory caches.
- * State is cleared on process restart (a fresh publish after restart is desirable).
+ *
+ * State is keyed by `accountId:userId` to prevent cross-contamination in
+ * multi-account setups (Slack user IDs are workspace-local and can collide).
  */
+
+function stateKey(accountId: string, userId: string): string {
+  return `${accountId}:${userId}`;
+}
 
 /**
  * Per-user cache of the VERSION string at the time the default Home Tab view
- * was last published. Avoids redundant `views.publish` calls when the view
- * hasn't changed.
+ * was last published. Cleared on process restart (a fresh publish after
+ * restart is desirable).
  */
 const publishedVersionByUser = new Map<string, string>();
 
 /**
- * Set of user IDs whose Home Tab is currently showing a custom (agent-pushed)
- * view. While a user is in this set the default `app_home_opened` handler
- * will skip publishing the default view.
+ * Set of (accountId:userId) keys whose Home Tab is currently showing a custom
+ * (agent-pushed) view. While a key is in this set the default `app_home_opened`
+ * handler will skip publishing the default view.
  */
 const customViewUsers = new Set<string>();
 
+/**
+ * Set of (accountId:userId) keys that currently have an in-flight publish.
+ * Used to deduplicate concurrent `app_home_opened` events for the same user.
+ */
+const publishingInFlight = new Set<string>();
+
 /** Mark a user as having a custom (agent-pushed) Home Tab view. */
-export function markHomeTabCustom(userId: string): void {
-  customViewUsers.add(userId);
-  publishedVersionByUser.delete(userId);
+export function markHomeTabCustom(accountId: string, userId: string): void {
+  const key = stateKey(accountId, userId);
+  customViewUsers.add(key);
+  publishedVersionByUser.delete(key);
 }
 
 /** Clear the custom-view flag so the default view can be published again. */
-export function clearHomeTabCustom(userId: string): void {
-  customViewUsers.delete(userId);
+export function clearHomeTabCustom(accountId: string, userId: string): void {
+  customViewUsers.delete(stateKey(accountId, userId));
 }
 
 /** Returns `true` if the user currently has a custom Home Tab view. */
-export function hasCustomHomeTab(userId: string): boolean {
-  return customViewUsers.has(userId);
+export function hasCustomHomeTab(accountId: string, userId: string): boolean {
+  return customViewUsers.has(stateKey(accountId, userId));
 }
 
 /** Record that the default Home Tab was published for `userId` at `version`. */
-export function markHomeTabPublished(userId: string, version: string): void {
-  publishedVersionByUser.set(userId, version);
+export function markHomeTabPublished(accountId: string, userId: string, version: string): void {
+  publishedVersionByUser.set(stateKey(accountId, userId), version);
 }
 
 /** Returns `true` if the user already has the default view at `version`. */
-export function hasCurrentHomeTab(userId: string, version: string): boolean {
-  return publishedVersionByUser.get(userId) === version;
+export function hasCurrentHomeTab(accountId: string, userId: string, version: string): boolean {
+  return publishedVersionByUser.get(stateKey(accountId, userId)) === version;
+}
+
+/** Returns `true` if a publish is currently in-flight for this user. */
+export function isPublishInFlight(accountId: string, userId: string): boolean {
+  return publishingInFlight.has(stateKey(accountId, userId));
+}
+
+/** Mark a publish as in-flight. */
+export function markPublishInFlight(accountId: string, userId: string): void {
+  publishingInFlight.add(stateKey(accountId, userId));
+}
+
+/** Clear the in-flight flag. */
+export function clearPublishInFlight(accountId: string, userId: string): void {
+  publishingInFlight.delete(stateKey(accountId, userId));
 }
 
 /** Reset all state. @internal For testing only. */
 export function resetHomeTabState(): void {
   publishedVersionByUser.clear();
   customViewUsers.clear();
+  publishingInFlight.clear();
 }

--- a/src/slack/home-tab-state.ts
+++ b/src/slack/home-tab-state.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared Home Tab state for coordinating between the `app_home_opened` event
+ * handler and the `publishSlackHomeTab` action.
+ *
+ * Both modules import from here so they share the same in-memory caches.
+ * State is cleared on process restart (a fresh publish after restart is desirable).
+ */
+
+/**
+ * Per-user cache of the VERSION string at the time the default Home Tab view
+ * was last published. Avoids redundant `views.publish` calls when the view
+ * hasn't changed.
+ */
+const publishedVersionByUser = new Map<string, string>();
+
+/**
+ * Set of user IDs whose Home Tab is currently showing a custom (agent-pushed)
+ * view. While a user is in this set the default `app_home_opened` handler
+ * will skip publishing the default view.
+ */
+const customViewUsers = new Set<string>();
+
+/** Mark a user as having a custom (agent-pushed) Home Tab view. */
+export function markHomeTabCustom(userId: string): void {
+  customViewUsers.add(userId);
+  publishedVersionByUser.delete(userId);
+}
+
+/** Clear the custom-view flag so the default view can be published again. */
+export function clearHomeTabCustom(userId: string): void {
+  customViewUsers.delete(userId);
+}
+
+/** Returns `true` if the user currently has a custom Home Tab view. */
+export function hasCustomHomeTab(userId: string): boolean {
+  return customViewUsers.has(userId);
+}
+
+/** Record that the default Home Tab was published for `userId` at `version`. */
+export function markHomeTabPublished(userId: string, version: string): void {
+  publishedVersionByUser.set(userId, version);
+}
+
+/** Returns `true` if the user already has the default view at `version`. */
+export function hasCurrentHomeTab(userId: string, version: string): boolean {
+  return publishedVersionByUser.get(userId) === version;
+}
+
+/** Reset all state. @internal For testing only. */
+export function resetHomeTabState(): void {
+  publishedVersionByUser.clear();
+  customViewUsers.clear();
+}

--- a/src/slack/home-tab.test.ts
+++ b/src/slack/home-tab.test.ts
@@ -9,25 +9,28 @@ describe("buildDefaultHomeView", () => {
 
   it("includes blocks array", () => {
     const view = buildDefaultHomeView();
-    expect(Array.isArray(view.blocks)).toBe(true);
-    expect(view.blocks!.length).toBeGreaterThan(0);
+    const blocks = view.blocks as unknown[];
+    expect(Array.isArray(blocks)).toBe(true);
+    expect(blocks.length).toBeGreaterThan(0);
   });
 
   it("uses provided bot name in header", () => {
     const view = buildDefaultHomeView({ botName: "Slurpy" });
-    const header = view.blocks![0] as { text: { text: string } };
+    const blocks = view.blocks as Array<{ text: { text: string } }>;
+    const header = blocks[0];
     expect(header.text.text).toContain("Slurpy");
   });
 
   it("defaults bot name to OpenClaw", () => {
     const view = buildDefaultHomeView();
-    const header = view.blocks![0] as { text: { text: string } };
+    const blocks = view.blocks as Array<{ text: { text: string } }>;
+    const header = blocks[0];
     expect(header.text.text).toContain("OpenClaw");
   });
 
   it("includes commands section when showCommands is true", () => {
     const view = buildDefaultHomeView({ showCommands: true });
-    const blocks = view.blocks! as Array<{ type: string; text?: { text: string } }>;
+    const blocks = view.blocks as Array<{ type: string; text?: { text: string } }>;
     const commandBlock = blocks.find(
       (b) => b.type === "section" && b.text?.text?.includes("How to interact"),
     );
@@ -36,7 +39,7 @@ describe("buildDefaultHomeView", () => {
 
   it("omits commands section when showCommands is false", () => {
     const view = buildDefaultHomeView({ showCommands: false });
-    const blocks = view.blocks! as Array<{ type: string; text?: { text: string } }>;
+    const blocks = view.blocks as Array<{ type: string; text?: { text: string } }>;
     const commandBlock = blocks.find(
       (b) => b.type === "section" && b.text?.text?.includes("How to interact"),
     );
@@ -49,7 +52,7 @@ describe("buildDefaultHomeView", () => {
       slashCommandEnabled: true,
       slashCommandName: "mybot",
     });
-    const blocks = view.blocks! as Array<{ type: string; text?: { text: string } }>;
+    const blocks = view.blocks as Array<{ type: string; text?: { text: string } }>;
     const commandBlock = blocks.find(
       (b) => b.type === "section" && b.text?.text?.includes("/mybot"),
     );
@@ -62,7 +65,7 @@ describe("buildDefaultHomeView", () => {
       slashCommandEnabled: false,
       slashCommandName: "mybot",
     });
-    const blocks = view.blocks! as Array<{ type: string; text?: { text: string } }>;
+    const blocks = view.blocks as Array<{ type: string; text?: { text: string } }>;
     const commandBlock = blocks.find(
       (b) => b.type === "section" && b.text?.text?.includes("/mybot"),
     );
@@ -72,14 +75,14 @@ describe("buildDefaultHomeView", () => {
   it("appends custom blocks", () => {
     const custom = [{ type: "section", text: { type: "mrkdwn", text: "Custom!" } }];
     const view = buildDefaultHomeView({ customBlocks: custom });
-    const blocks = view.blocks! as Array<{ type: string; text?: { text: string } }>;
+    const blocks = view.blocks as Array<{ type: string; text?: { text: string } }>;
     const customBlock = blocks.find((b) => b.type === "section" && b.text?.text === "Custom!");
     expect(customBlock).toBeDefined();
   });
 
   it("includes OpenClaw context footer", () => {
     const view = buildDefaultHomeView();
-    const blocks = view.blocks! as Array<{ type: string; elements?: Array<{ text: string }> }>;
+    const blocks = view.blocks as Array<{ type: string; elements?: Array<{ text: string }> }>;
     const context = blocks.find(
       (b) => b.type === "context" && b.elements?.some((e) => e.text?.includes("OpenClaw")),
     );
@@ -90,12 +93,11 @@ describe("buildDefaultHomeView", () => {
     const view = buildDefaultHomeView({ customBlocks: [] });
     expect(view.type).toBe("home");
     // No extra divider should be added for empty custom blocks
-    const blocks = view.blocks! as Array<{ type: string }>;
+    const blocks = view.blocks as Array<{ type: string }>;
     const dividers = blocks.filter((b) => b.type === "divider");
     const viewWithoutCustom = buildDefaultHomeView();
-    const dividersWithout = (viewWithoutCustom.blocks! as Array<{ type: string }>).filter(
-      (b) => b.type === "divider",
-    );
+    const blocksWithout = viewWithoutCustom.blocks as Array<{ type: string }>;
+    const dividersWithout = blocksWithout.filter((b) => b.type === "divider");
     expect(dividers.length).toBe(dividersWithout.length);
   });
 });

--- a/src/slack/home-tab.test.ts
+++ b/src/slack/home-tab.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { buildDefaultHomeView } from "./home-tab.js";
+
+describe("buildDefaultHomeView", () => {
+  it("returns a view with type home", () => {
+    const view = buildDefaultHomeView();
+    expect(view.type).toBe("home");
+  });
+
+  it("includes blocks array", () => {
+    const view = buildDefaultHomeView();
+    expect(Array.isArray(view.blocks)).toBe(true);
+    expect(view.blocks!.length).toBeGreaterThan(0);
+  });
+
+  it("uses provided bot name in header", () => {
+    const view = buildDefaultHomeView({ botName: "Slurpy" });
+    const header = view.blocks![0] as { text: { text: string } };
+    expect(header.text.text).toContain("Slurpy");
+  });
+
+  it("defaults bot name to OpenClaw", () => {
+    const view = buildDefaultHomeView();
+    const header = view.blocks![0] as { text: { text: string } };
+    expect(header.text.text).toContain("OpenClaw");
+  });
+
+  it("includes commands section when showCommands is true", () => {
+    const view = buildDefaultHomeView({ showCommands: true });
+    const blocks = view.blocks! as Array<{ type: string; text?: { text: string } }>;
+    const commandBlock = blocks.find(
+      (b) => b.type === "section" && b.text?.text?.includes("How to interact"),
+    );
+    expect(commandBlock).toBeDefined();
+  });
+
+  it("omits commands section when showCommands is false", () => {
+    const view = buildDefaultHomeView({ showCommands: false });
+    const blocks = view.blocks! as Array<{ type: string; text?: { text: string } }>;
+    const commandBlock = blocks.find(
+      (b) => b.type === "section" && b.text?.text?.includes("How to interact"),
+    );
+    expect(commandBlock).toBeUndefined();
+  });
+
+  it("includes slash command when enabled", () => {
+    const view = buildDefaultHomeView({
+      showCommands: true,
+      slashCommandEnabled: true,
+      slashCommandName: "mybot",
+    });
+    const blocks = view.blocks! as Array<{ type: string; text?: { text: string } }>;
+    const commandBlock = blocks.find(
+      (b) => b.type === "section" && b.text?.text?.includes("/mybot"),
+    );
+    expect(commandBlock).toBeDefined();
+  });
+
+  it("omits slash command when disabled", () => {
+    const view = buildDefaultHomeView({
+      showCommands: true,
+      slashCommandEnabled: false,
+      slashCommandName: "mybot",
+    });
+    const blocks = view.blocks! as Array<{ type: string; text?: { text: string } }>;
+    const commandBlock = blocks.find(
+      (b) => b.type === "section" && b.text?.text?.includes("/mybot"),
+    );
+    expect(commandBlock).toBeUndefined();
+  });
+
+  it("appends custom blocks", () => {
+    const custom = [{ type: "section", text: { type: "mrkdwn", text: "Custom!" } }];
+    const view = buildDefaultHomeView({ customBlocks: custom });
+    const blocks = view.blocks! as Array<{ type: string; text?: { text: string } }>;
+    const customBlock = blocks.find((b) => b.type === "section" && b.text?.text === "Custom!");
+    expect(customBlock).toBeDefined();
+  });
+
+  it("includes OpenClaw context footer", () => {
+    const view = buildDefaultHomeView();
+    const blocks = view.blocks! as Array<{ type: string; elements?: Array<{ text: string }> }>;
+    const context = blocks.find(
+      (b) => b.type === "context" && b.elements?.some((e) => e.text?.includes("OpenClaw")),
+    );
+    expect(context).toBeDefined();
+  });
+
+  it("handles empty customBlocks gracefully", () => {
+    const view = buildDefaultHomeView({ customBlocks: [] });
+    expect(view.type).toBe("home");
+    // No extra divider should be added for empty custom blocks
+    const blocks = view.blocks! as Array<{ type: string }>;
+    const dividers = blocks.filter((b) => b.type === "divider");
+    const viewWithoutCustom = buildDefaultHomeView();
+    const dividersWithout = (viewWithoutCustom.blocks! as Array<{ type: string }>).filter(
+      (b) => b.type === "divider",
+    );
+    expect(dividers.length).toBe(dividersWithout.length);
+  });
+});

--- a/src/slack/home-tab.ts
+++ b/src/slack/home-tab.ts
@@ -21,6 +21,8 @@ export type HomeTabParams = {
   channelIds?: string[];
   /** Bot user ID for mention formatting. */
   botUserId?: string;
+  /** Owner's IANA timezone (e.g. "America/Los_Angeles"). Defaults to UTC. */
+  ownerTimezone?: string;
 };
 
 /**
@@ -74,7 +76,27 @@ export function buildDefaultHomeView(params: HomeTabParams = {}): View {
     statusFields.push({ type: "mrkdwn", text: `*Model:*\n${params.model}` });
   }
   if (params.uptimeMs != null) {
-    statusFields.push({ type: "mrkdwn", text: `*Uptime:*\n${formatUptime(params.uptimeMs)}` });
+    const startedAt = new Date(Date.now() - params.uptimeMs);
+    const tz = params.ownerTimezone || "UTC";
+    let startedStr: string;
+    try {
+      startedStr = startedAt.toLocaleString("en-US", {
+        timeZone: tz,
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: true,
+      });
+    } catch {
+      startedStr = startedAt.toISOString().replace("T", " ").slice(0, 19) + " UTC";
+    }
+    const tzShort = tz === "UTC" ? "UTC" : tz.split("/").pop()?.replace(/_/g, " ") || tz;
+    statusFields.push({
+      type: "mrkdwn",
+      text: `*Uptime:*\n${formatUptime(params.uptimeMs)}\n_since ${startedStr} ${tzShort}_`,
+    });
   }
   blocks.push({ type: "section", fields: statusFields });
 

--- a/src/slack/home-tab.ts
+++ b/src/slack/home-tab.ts
@@ -1,0 +1,84 @@
+import type { View } from "@slack/web-api";
+
+export type HomeTabParams = {
+  /** Agent/bot display name. */
+  botName?: string;
+  /** Whether to show available commands section. */
+  showCommands?: boolean;
+  /** Slash command name (e.g. "openclaw"). */
+  slashCommandName?: string;
+  /** Whether slash command is enabled. */
+  slashCommandEnabled?: boolean;
+  /** Optional static Block Kit blocks to append. */
+  customBlocks?: unknown[];
+};
+
+/**
+ * Build the default Home tab view for the OpenClaw Slack app.
+ * Returns a Slack Block Kit view with `type: "home"`.
+ */
+export function buildDefaultHomeView(params: HomeTabParams = {}): View {
+  const botName = params.botName?.trim() || "OpenClaw";
+  const showCommands = params.showCommands ?? true;
+  const slashCommandName = params.slashCommandName?.trim() || "openclaw";
+  const slashCommandEnabled = params.slashCommandEnabled ?? false;
+
+  const blocks: unknown[] = [
+    {
+      type: "header",
+      text: {
+        type: "plain_text",
+        text: `🦞 ${botName}`,
+        emoji: true,
+      },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `Hey! I'm *${botName}*, your AI assistant. Send me a DM to get started.`,
+      },
+    },
+    { type: "divider" },
+  ];
+
+  if (showCommands) {
+    const commandLines: string[] = ["*How to interact:*", "• Send me a direct message to chat"];
+
+    if (slashCommandEnabled) {
+      commandLines.push(`• Use \`/${slashCommandName}\` in any channel`);
+    }
+
+    commandLines.push("• Mention me in a channel to get my attention");
+
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: commandLines.join("\n"),
+      },
+    });
+
+    blocks.push({ type: "divider" });
+  }
+
+  blocks.push({
+    type: "context",
+    elements: [
+      {
+        type: "mrkdwn",
+        text: `Powered by <https://openclaw.ai|OpenClaw>`,
+      },
+    ],
+  });
+
+  if (Array.isArray(params.customBlocks) && params.customBlocks.length > 0) {
+    blocks.push({ type: "divider" });
+    blocks.push(...params.customBlocks);
+  }
+
+  return {
+    type: "home",
+    blocks,
+  } as View;
+}

--- a/src/slack/monitor.test-helpers.ts
+++ b/src/slack/monitor.test-helpers.ts
@@ -127,6 +127,9 @@ vi.mock("@slack/bolt", () => {
         user: { profile: { display_name: "Ada" } },
       }),
     },
+    views: {
+      publish: vi.fn().mockResolvedValue({ ok: true }),
+    },
     assistant: {
       threads: {
         setStatus: vi.fn().mockResolvedValue({ ok: true }),

--- a/src/slack/monitor/events.ts
+++ b/src/slack/monitor/events.ts
@@ -1,6 +1,7 @@
 import type { ResolvedSlackAccount } from "../accounts.js";
 import type { SlackMonitorContext } from "./context.js";
 import type { SlackMessageHandler } from "./message-handler.js";
+import { registerSlackAppHomeEvents } from "./events/app-home.js";
 import { registerSlackChannelEvents } from "./events/channels.js";
 import { registerSlackMemberEvents } from "./events/members.js";
 import { registerSlackMessageEvents } from "./events/messages.js";
@@ -20,4 +21,5 @@ export function registerSlackMonitorEvents(params: {
   registerSlackMemberEvents({ ctx: params.ctx });
   registerSlackChannelEvents({ ctx: params.ctx });
   registerSlackPinEvents({ ctx: params.ctx });
+  registerSlackAppHomeEvents({ ctx: params.ctx });
 }

--- a/src/slack/monitor/events/app-home.test.ts
+++ b/src/slack/monitor/events/app-home.test.ts
@@ -215,10 +215,9 @@ describe("app_home_opened event", () => {
         },
       },
     });
-    await fireAppHomeOpened();
 
-    const client = getSlackClient() as { views: { publish: ReturnType<typeof vi.fn> } };
-    expect(client.views.publish).not.toHaveBeenCalled();
+    // When disabled, the event handler is not registered at all
+    expect(getSlackHandlers()?.has("app_home_opened")).toBe(false);
   });
 
   it("handles views.publish errors gracefully without throwing", async () => {

--- a/src/slack/monitor/events/app-home.test.ts
+++ b/src/slack/monitor/events/app-home.test.ts
@@ -102,7 +102,9 @@ const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 async function waitForEvent(name: string) {
   for (let i = 0; i < 10; i++) {
-    if (getSlackHandlers()?.has(name)) return;
+    if (getSlackHandlers()?.has(name)) {
+      return;
+    }
     await flush();
   }
 }
@@ -135,7 +137,9 @@ describe("app_home_opened event", () => {
   });
 
   async function setupProvider(overrideConfig?: Record<string, unknown>) {
-    if (overrideConfig) config = overrideConfig;
+    if (overrideConfig) {
+      config = overrideConfig;
+    }
     // Don't await — it runs forever until aborted
     void monitorSlackProvider({
       botToken: "xoxb-test",
@@ -150,7 +154,9 @@ describe("app_home_opened event", () => {
     bodyOverrides: Record<string, unknown> = {},
   ) {
     const handler = getSlackHandlers()?.get("app_home_opened");
-    if (!handler) throw new Error("app_home_opened handler not registered");
+    if (!handler) {
+      throw new Error("app_home_opened handler not registered");
+    }
     await handler({
       event: {
         type: "app_home_opened",

--- a/src/slack/monitor/events/app-home.test.ts
+++ b/src/slack/monitor/events/app-home.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getSlackHandlers = () =>
+  (
+    globalThis as {
+      __slackHandlers?: Map<string, (args: unknown) => Promise<void>>;
+    }
+  ).__slackHandlers;
+const getSlackClient = () =>
+  (globalThis as { __slackClient?: Record<string, unknown> }).__slackClient;
+
+let config: Record<string, unknown> = {};
+
+vi.mock("../../../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => config,
+  };
+});
+
+vi.mock("../../../auto-reply/reply.js", () => ({
+  getReplyFromConfig: vi.fn(),
+}));
+
+vi.mock("../../resolve-channels.js", () => ({
+  resolveSlackChannelAllowlist: async ({ entries }: { entries: string[] }) =>
+    entries.map((input: string) => ({ input, resolved: false })),
+}));
+
+vi.mock("../../resolve-users.js", () => ({
+  resolveSlackUserAllowlist: async ({ entries }: { entries: string[] }) =>
+    entries.map((input: string) => ({ input, resolved: false })),
+}));
+
+vi.mock("../../send.js", () => ({
+  sendMessageSlack: vi.fn(),
+}));
+
+vi.mock("../../../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore: vi.fn().mockResolvedValue([]),
+  upsertChannelPairingRequest: vi.fn().mockResolvedValue({ code: "PAIRCODE", created: true }),
+}));
+
+vi.mock("../../../config/sessions.js", () => ({
+  resolveStorePath: vi.fn(() => "/tmp/openclaw-sessions.json"),
+  updateLastRoute: vi.fn(),
+  resolveSessionKey: vi.fn(),
+  readSessionUpdatedAt: vi.fn(() => undefined),
+  recordSessionMetaFromInbound: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@slack/bolt", () => {
+  const handlers = new Map<string, (args: unknown) => Promise<void>>();
+  (globalThis as { __slackHandlers?: typeof handlers }).__slackHandlers = handlers;
+  const client = {
+    auth: { test: vi.fn().mockResolvedValue({ user_id: "bot-user" }) },
+    conversations: {
+      info: vi.fn().mockResolvedValue({
+        channel: { name: "dm", is_im: true },
+      }),
+      replies: vi.fn().mockResolvedValue({ messages: [] }),
+    },
+    users: {
+      info: vi.fn().mockResolvedValue({
+        user: { profile: { display_name: "Ada" } },
+      }),
+    },
+    views: {
+      publish: vi.fn().mockResolvedValue({ ok: true }),
+    },
+    assistant: {
+      threads: {
+        setStatus: vi.fn().mockResolvedValue({ ok: true }),
+      },
+    },
+    reactions: {
+      add: vi.fn(),
+    },
+  };
+  (globalThis as { __slackClient?: typeof client }).__slackClient = client;
+  class App {
+    client = client;
+    event(name: string, handler: (args: unknown) => Promise<void>) {
+      handlers.set(name, handler);
+    }
+    command() {
+      /* no-op */
+    }
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+  }
+  class HTTPReceiver {
+    requestListener = vi.fn();
+  }
+  return { App, HTTPReceiver, default: { App, HTTPReceiver } };
+});
+
+const { monitorSlackProvider } = await import("../provider.js");
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+async function waitForEvent(name: string) {
+  for (let i = 0; i < 10; i++) {
+    if (getSlackHandlers()?.has(name)) return;
+    await flush();
+  }
+}
+
+describe("app_home_opened event", () => {
+  let controller: AbortController;
+
+  beforeEach(() => {
+    getSlackHandlers()?.clear();
+    controller = new AbortController();
+    config = {
+      messages: {
+        responsePrefix: "PFX",
+        ackReaction: "👀",
+        ackReactionScope: "group-mentions",
+      },
+      channels: {
+        slack: {
+          dm: { enabled: true, policy: "open", allowFrom: ["*"] },
+          groupPolicy: "open",
+        },
+      },
+    };
+    const client = getSlackClient() as Record<string, Record<string, { mockClear?: () => void }>>;
+    client?.views?.publish?.mockClear?.();
+  });
+
+  afterEach(() => {
+    controller.abort();
+  });
+
+  async function setupProvider(overrideConfig?: Record<string, unknown>) {
+    if (overrideConfig) config = overrideConfig;
+    // Don't await — it runs forever until aborted
+    void monitorSlackProvider({
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      abortSignal: controller.signal,
+    });
+    await waitForEvent("app_home_opened");
+  }
+
+  async function fireAppHomeOpened(
+    eventOverrides: Record<string, unknown> = {},
+    bodyOverrides: Record<string, unknown> = {},
+  ) {
+    const handler = getSlackHandlers()?.get("app_home_opened");
+    if (!handler) throw new Error("app_home_opened handler not registered");
+    await handler({
+      event: {
+        type: "app_home_opened",
+        user: "U_TEST_USER",
+        tab: "home",
+        ...eventOverrides,
+      },
+      body: {
+        type: "event_callback",
+        api_app_id: "",
+        team_id: "",
+        ...bodyOverrides,
+      },
+    });
+  }
+
+  it("registers the app_home_opened handler", async () => {
+    await setupProvider();
+    expect(getSlackHandlers()?.has("app_home_opened")).toBe(true);
+  });
+
+  it("publishes default home view on app_home_opened", async () => {
+    await setupProvider();
+    await fireAppHomeOpened();
+
+    const client = getSlackClient() as { views: { publish: ReturnType<typeof vi.fn> } };
+    expect(client.views.publish).toHaveBeenCalledOnce();
+
+    const call = client.views.publish.mock.calls[0][0] as {
+      user_id: string;
+      view: { type: string; blocks: unknown[] };
+    };
+    expect(call.user_id).toBe("U_TEST_USER");
+    expect(call.view.type).toBe("home");
+    expect(call.view.blocks.length).toBeGreaterThan(0);
+  });
+
+  it("skips non-home tabs", async () => {
+    await setupProvider();
+    await fireAppHomeOpened({ tab: "messages" });
+
+    const client = getSlackClient() as { views: { publish: ReturnType<typeof vi.fn> } };
+    expect(client.views.publish).not.toHaveBeenCalled();
+  });
+
+  it("skips when homeTab is disabled", async () => {
+    await setupProvider({
+      messages: { responsePrefix: "PFX", ackReactionScope: "group-mentions" },
+      channels: {
+        slack: {
+          dm: { enabled: true, policy: "open", allowFrom: ["*"] },
+          groupPolicy: "open",
+          homeTab: { enabled: false },
+        },
+      },
+    });
+    await fireAppHomeOpened();
+
+    const client = getSlackClient() as { views: { publish: ReturnType<typeof vi.fn> } };
+    expect(client.views.publish).not.toHaveBeenCalled();
+  });
+
+  it("handles views.publish errors gracefully without throwing", async () => {
+    await setupProvider();
+
+    const client = getSlackClient() as { views: { publish: ReturnType<typeof vi.fn> } };
+    client.views.publish.mockRejectedValueOnce(new Error("slack_api_error"));
+
+    await expect(fireAppHomeOpened()).resolves.toBeUndefined();
+  });
+
+  it("includes header block in published view", async () => {
+    await setupProvider();
+    await fireAppHomeOpened();
+
+    const client = getSlackClient() as { views: { publish: ReturnType<typeof vi.fn> } };
+    const call = client.views.publish.mock.calls[0][0] as {
+      view: { blocks: Array<{ type: string }> };
+    };
+    expect(call.view.blocks[0]).toHaveProperty("type", "header");
+  });
+
+  it("passes bot token to views.publish", async () => {
+    await setupProvider();
+    await fireAppHomeOpened();
+
+    const client = getSlackClient() as { views: { publish: ReturnType<typeof vi.fn> } };
+    const call = client.views.publish.mock.calls[0][0] as { token: string };
+    expect(call.token).toBe("xoxb-test");
+  });
+});

--- a/src/slack/monitor/events/app-home.ts
+++ b/src/slack/monitor/events/app-home.ts
@@ -1,6 +1,7 @@
 import type { AgentConfig } from "../../../config/types.agents.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import type { SlackMonitorContext } from "../context.js";
+import { resolveUserTimezone } from "../../../agents/date-time.js";
 import { danger, logVerbose } from "../../../globals.js";
 import { VERSION } from "../../../version.js";
 import {
@@ -170,6 +171,7 @@ export function registerSlackAppHomeEvents(params: { ctx: SlackMonitorContext })
             model,
             channelIds: resolveChannelIds(ctx),
             botUserId: ctx.botUserId,
+            ownerTimezone: resolveUserTimezone(ctx.cfg.agents?.defaults?.userTimezone),
           };
 
           const view = buildDefaultHomeView(viewParams);

--- a/src/slack/monitor/events/app-home.ts
+++ b/src/slack/monitor/events/app-home.ts
@@ -1,6 +1,11 @@
 import type { SlackMonitorContext } from "../context.js";
 import { danger } from "../../../globals.js";
+import { VERSION } from "../../../version.js";
+import { hasCurrentHomeTab, hasCustomHomeTab, markHomeTabPublished } from "../../home-tab-state.js";
 import { buildDefaultHomeView, type HomeTabParams } from "../../home-tab.js";
+
+/** Gateway process start time — used for uptime display. */
+const GATEWAY_START_MS = Date.now();
 
 export type AppHomeConfig = {
   enabled?: boolean;
@@ -42,6 +47,31 @@ function resolveBotName(ctx: SlackMonitorContext): string {
   );
 }
 
+function resolveModel(ctx: SlackMonitorContext): string | undefined {
+  const cfg = ctx.cfg;
+  const agents = cfg.agents?.list ?? [];
+  const defaultAgent = agents.find((a) => a.default) ?? agents[0];
+  const model = defaultAgent?.model;
+  if (model) {
+    return typeof model === "string" ? model : (model.primary ?? undefined);
+  }
+  const defaultsModel = cfg.agents?.defaults?.model;
+  if (defaultsModel?.primary) {
+    return defaultsModel.primary;
+  }
+  return undefined;
+}
+
+function resolveChannelIds(ctx: SlackMonitorContext): string[] {
+  const cfg = ctx.cfg;
+  const slackCfg = cfg.channels?.slack as Record<string, unknown> | undefined;
+  const channels = slackCfg?.channels as Record<string, unknown> | undefined;
+  if (!channels) {
+    return [];
+  }
+  return Object.keys(channels).filter((k) => k !== "*");
+}
+
 export function registerSlackAppHomeEvents(params: { ctx: SlackMonitorContext }) {
   const { ctx } = params;
 
@@ -60,8 +90,20 @@ export function registerSlackAppHomeEvents(params: { ctx: SlackMonitorContext })
           return;
         }
 
+        const userId = event.user as string;
+
         const homeTabConfig = resolveHomeTabConfig(ctx);
         if (!homeTabConfig.enabled) {
+          return;
+        }
+
+        // Skip if user has a custom (agent-pushed) view
+        if (hasCustomHomeTab(userId)) {
+          return;
+        }
+
+        // Skip if we already published the current version for this user
+        if (hasCurrentHomeTab(userId, VERSION)) {
           return;
         }
 
@@ -74,15 +116,22 @@ export function registerSlackAppHomeEvents(params: { ctx: SlackMonitorContext })
           slashCommandName: slashCmd.name,
           slashCommandEnabled: slashCmd.enabled,
           customBlocks: homeTabConfig.customBlocks,
+          version: VERSION,
+          uptimeMs: Date.now() - GATEWAY_START_MS,
+          model: resolveModel(ctx),
+          channelIds: resolveChannelIds(ctx),
+          botUserId: ctx.botUserId,
         };
 
         const view = buildDefaultHomeView(viewParams);
 
         await ctx.app.client.views.publish({
           token: ctx.botToken,
-          user_id: event.user as string,
+          user_id: userId,
           view,
         });
+
+        markHomeTabPublished(userId, VERSION);
       } catch (err) {
         ctx.runtime.error?.(danger(`slack app_home_opened handler failed: ${String(err)}`));
       }

--- a/src/slack/monitor/events/app-home.ts
+++ b/src/slack/monitor/events/app-home.ts
@@ -1,0 +1,91 @@
+import type { SlackMonitorContext } from "../context.js";
+import { danger } from "../../../globals.js";
+import { buildDefaultHomeView, type HomeTabParams } from "../../home-tab.js";
+
+export type AppHomeConfig = {
+  enabled?: boolean;
+  showCommands?: boolean;
+  customBlocks?: unknown[];
+};
+
+function resolveHomeTabConfig(ctx: SlackMonitorContext): AppHomeConfig {
+  const cfg = ctx.cfg;
+  const slackCfg = cfg.channels?.slack as Record<string, unknown> | undefined;
+  const homeTab = slackCfg?.homeTab as AppHomeConfig | undefined;
+  return {
+    enabled: homeTab?.enabled ?? true,
+    showCommands: homeTab?.showCommands ?? true,
+    customBlocks: homeTab?.customBlocks,
+  };
+}
+
+function resolveSlashCommandInfo(ctx: SlackMonitorContext): {
+  enabled: boolean;
+  name: string;
+} {
+  const cfg = ctx.cfg;
+  const slackCfg = cfg.channels?.slack as Record<string, unknown> | undefined;
+  const slashCommand = slackCfg?.slashCommand as { enabled?: boolean; name?: string } | undefined;
+  return {
+    enabled: slashCommand?.enabled ?? false,
+    name: slashCommand?.name?.trim() || "openclaw",
+  };
+}
+
+function resolveBotName(ctx: SlackMonitorContext): string {
+  const cfg = ctx.cfg;
+  const slackCfg = cfg.channels?.slack as Record<string, unknown> | undefined;
+  return (
+    (typeof slackCfg?.name === "string" ? slackCfg.name.trim() : "") ||
+    (typeof cfg.ui?.assistant?.name === "string" ? cfg.ui.assistant.name.trim() : "") ||
+    "OpenClaw"
+  );
+}
+
+export function registerSlackAppHomeEvents(params: { ctx: SlackMonitorContext }) {
+  const { ctx } = params;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (ctx.app as any).event(
+    "app_home_opened",
+    async (args: { event: Record<string, unknown>; body: unknown }) => {
+      const { event, body } = args;
+      try {
+        if (ctx.shouldDropMismatchedSlackEvent(body)) {
+          return;
+        }
+
+        // Only handle the "home" tab, not "messages"
+        if (event.tab !== "home") {
+          return;
+        }
+
+        const homeTabConfig = resolveHomeTabConfig(ctx);
+        if (!homeTabConfig.enabled) {
+          return;
+        }
+
+        const slashCmd = resolveSlashCommandInfo(ctx);
+        const botName = resolveBotName(ctx);
+
+        const viewParams: HomeTabParams = {
+          botName,
+          showCommands: homeTabConfig.showCommands,
+          slashCommandName: slashCmd.name,
+          slashCommandEnabled: slashCmd.enabled,
+          customBlocks: homeTabConfig.customBlocks,
+        };
+
+        const view = buildDefaultHomeView(viewParams);
+
+        await ctx.app.client.views.publish({
+          token: ctx.botToken,
+          user_id: event.user as string,
+          view,
+        });
+      } catch (err) {
+        ctx.runtime.error?.(danger(`slack app_home_opened handler failed: ${String(err)}`));
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Adds support for the Slack App Home tab by listening for `app_home_opened` events and publishing a default view via `views.publish`.

When a user clicks on the OpenClaw bot in Slack and navigates to the **Home** tab, they now see a useful default view instead of an empty page.

### What it does

- **Default Home tab view** — Shows agent name, interaction instructions (DM, mentions, slash commands), and an OpenClaw footer
- **Event handler** — Registers `app_home_opened` listener, filters non-home tabs and mismatched events, publishes view per-user
- **Configurable** — `channels.slack.homeTab.enabled` (default: `true`), `showCommands`, and `customBlocks` for static Block Kit additions
- **No new OAuth scopes needed** — `views.publish` works with existing bot token

### Files changed

| File | Change |
|------|--------|
| `src/slack/home-tab.ts` | New — default Home tab view builder |
| `src/slack/home-tab.test.ts` | New — 11 tests for view builder |
| `src/slack/monitor/events/app-home.ts` | New — `app_home_opened` event handler |
| `src/slack/monitor/events/app-home.test.ts` | New — 7 tests for event handler |
| `src/slack/monitor/events.ts` | Wire `registerSlackAppHomeEvents` |
| `src/config/types.slack.ts` | Add `SlackHomeTabConfig` type + `homeTab` field |
| `src/config/zod-schema.providers-core.ts` | Add `homeTab` to Zod schema (strict-compatible) |
| `src/channels/plugins/onboarding/slack.ts` | Add `app_home_opened` to manifest bot_events |
| `src/slack/monitor.test-helpers.ts` | Add `views.publish` to mock client |

### Setup for existing apps

Existing Slack apps need to subscribe to the `app_home_opened` bot event in their app settings (Event Subscriptions → Subscribe to bot events). New apps created via the onboarding wizard will have it automatically.

### Testing

- 18 tests total (11 view builder + 7 event handler)
- All 149 existing Slack tests pass
- All 305 config tests pass
- Build passes clean

### Screenshot

The Home tab displays:
- 🦞 Agent name header
- Interaction instructions (DM, mentions, slash command if enabled)
- OpenClaw footer link

### Future work (Phase 2)

Agent-driven Home tab updates via a tool action (`updateHomeTab`/`resetHomeTab`) — tracked separately.

Closes #11655