### PR TITLE
fix(discord): resolve numeric guildId/channelId pairs in channel allowlist

### DIFF
--- a/src/discord/resolve-channels.test.ts
+++ b/src/discord/resolve-channels.test.ts
@@ -53,7 +53,8 @@ describe("resolveDiscordChannelAllowlist", () => {
   });
 
   it("resolves guildId/channelId when both are numeric", async () => {
-    const fetcher = async (url: string) => {
+    const fetcher = async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
       if (url.endsWith("/users/@me/guilds")) {
         return jsonResponse([{ id: "111222333", name: "Test Server" }]);
       }
@@ -80,7 +81,8 @@ describe("resolveDiscordChannelAllowlist", () => {
   });
 
   it("rejects guildId/channelId when channel belongs to a different guild", async () => {
-    const fetcher = async (url: string) => {
+    const fetcher = async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
       if (url.endsWith("/users/@me/guilds")) {
         return jsonResponse([
           { id: "111222333", name: "Guild A" },
@@ -109,7 +111,8 @@ describe("resolveDiscordChannelAllowlist", () => {
   });
 
   it("marks invalid numeric channelId as unresolved without aborting batch", async () => {
-    const fetcher = async (url: string) => {
+    const fetcher = async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
       if (url.endsWith("/users/@me/guilds")) {
         return jsonResponse([{ id: "111222333", name: "Test Server" }]);
       }
@@ -145,7 +148,8 @@ describe("resolveDiscordChannelAllowlist", () => {
   });
 
   it("treats 403 channel lookup as unresolved without aborting batch", async () => {
-    const fetcher = async (url: string) => {
+    const fetcher = async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
       if (url.endsWith("/users/@me/guilds")) {
         return jsonResponse([{ id: "111222333", name: "Test Server" }]);
       }
@@ -181,7 +185,8 @@ describe("resolveDiscordChannelAllowlist", () => {
   });
 
   it("falls back to name matching when numeric channel name is not a valid ID", async () => {
-    const fetcher = async (url: string) => {
+    const fetcher = async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
       if (url.endsWith("/users/@me/guilds")) {
         return jsonResponse([{ id: "111222333", name: "Test Server" }]);
       }
@@ -210,7 +215,8 @@ describe("resolveDiscordChannelAllowlist", () => {
   });
 
   it("does not fall back to name matching when channel lookup returns 403", async () => {
-    const fetcher = async (url: string) => {
+    const fetcher = async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
       if (url.endsWith("/users/@me/guilds")) {
         return jsonResponse([{ id: "111222333", name: "Test Server" }]);
       }
@@ -238,7 +244,8 @@ describe("resolveDiscordChannelAllowlist", () => {
   });
 
   it("does not fall back to name matching when channel payload is malformed", async () => {
-    const fetcher = async (url: string) => {
+    const fetcher = async (input: RequestInfo | URL) => {
+      const url = urlToString(input);
       if (url.endsWith("/users/@me/guilds")) {
         return jsonResponse([{ id: "111222333", name: "Test Server" }]);
       }

--- a/src/discord/resolve-channels.test.ts
+++ b/src/discord/resolve-channels.test.ts
@@ -364,14 +364,15 @@ describe("resolveDiscordChannelAllowlist", () => {
       return new Response("not found", { status: 404 });
     });
 
-    // Without the guild: prefix, a bare numeric string hits /channels/999 → 404 → throws
-    await expect(
-      resolveDiscordChannelAllowlist({
-        token: "test",
-        entries: ["999"],
-        fetcher,
-      }),
-    ).rejects.toThrow(/404/);
+    // Without the guild: prefix, a bare numeric string hits /channels/999 → 404 → resolved: false
+    const res = await resolveDiscordChannelAllowlist({
+      token: "test",
+      entries: ["999"],
+      fetcher,
+    });
+    expect(res[0]?.resolved).toBe(false);
+    expect(res[0]?.channelId).toBe("999");
+    expect(res[0]?.guildId).toBeUndefined();
 
     // With the guild: prefix, it correctly resolves as a guild (never hits /channels/)
     const res2 = await resolveDiscordChannelAllowlist({

--- a/src/discord/resolve-channels.test.ts
+++ b/src/discord/resolve-channels.test.ts
@@ -209,6 +209,60 @@ describe("resolveDiscordChannelAllowlist", () => {
     expect(res[0]?.channelName).toBe("2024");
   });
 
+  it("does not fall back to name matching when channel lookup returns 403", async () => {
+    const fetcher = async (url: string) => {
+      if (url.endsWith("/users/@me/guilds")) {
+        return jsonResponse([{ id: "111222333", name: "Test Server" }]);
+      }
+      if (url.endsWith("/channels/2024")) {
+        return new Response("Missing Access", { status: 403 });
+      }
+      if (url.endsWith("/guilds/111222333/channels")) {
+        return jsonResponse([
+          { id: "c1", name: "2024", guild_id: "111222333", type: 0 },
+          { id: "c2", name: "general", guild_id: "111222333", type: 0 },
+        ]);
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const res = await resolveDiscordChannelAllowlist({
+      token: "test",
+      entries: ["111222333/2024"],
+      fetcher,
+    });
+
+    expect(res[0]?.resolved).toBe(false);
+    expect(res[0]?.channelId).toBe("2024");
+    expect(res[0]?.guildId).toBe("111222333");
+  });
+
+  it("does not fall back to name matching when channel payload is malformed", async () => {
+    const fetcher = async (url: string) => {
+      if (url.endsWith("/users/@me/guilds")) {
+        return jsonResponse([{ id: "111222333", name: "Test Server" }]);
+      }
+      if (url.endsWith("/channels/2024")) {
+        // 200 but missing guild_id — malformed payload
+        return jsonResponse({ id: "2024", name: "unknown", type: 0 });
+      }
+      if (url.endsWith("/guilds/111222333/channels")) {
+        return jsonResponse([{ id: "c1", name: "2024", guild_id: "111222333", type: 0 }]);
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const res = await resolveDiscordChannelAllowlist({
+      token: "test",
+      entries: ["111222333/2024"],
+      fetcher,
+    });
+
+    expect(res[0]?.resolved).toBe(false);
+    expect(res[0]?.channelId).toBe("2024");
+    expect(res[0]?.guildId).toBe("111222333");
+  });
+
   it("resolves channel id to guild", async () => {
     const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
       const url = urlToString(input);

--- a/src/discord/resolve-channels.test.ts
+++ b/src/discord/resolve-channels.test.ts
@@ -52,6 +52,128 @@ describe("resolveDiscordChannelAllowlist", () => {
     expect(res[0]?.channelId).toBe("c1");
   });
 
+  it("resolves guildId/channelId when both are numeric", async () => {
+    const fetcher = async (url: string) => {
+      if (url.endsWith("/users/@me/guilds")) {
+        return jsonResponse([{ id: "111222333", name: "Test Server" }]);
+      }
+      if (url.endsWith("/channels/444555666")) {
+        return jsonResponse({
+          id: "444555666",
+          name: "general",
+          guild_id: "111222333",
+          type: 0,
+        });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const res = await resolveDiscordChannelAllowlist({
+      token: "test",
+      entries: ["111222333/444555666"],
+      fetcher,
+    });
+
+    expect(res[0]?.resolved).toBe(true);
+    expect(res[0]?.guildId).toBe("111222333");
+    expect(res[0]?.channelId).toBe("444555666");
+  });
+
+  it("rejects guildId/channelId when channel belongs to a different guild", async () => {
+    const fetcher = async (url: string) => {
+      if (url.endsWith("/users/@me/guilds")) {
+        return jsonResponse([
+          { id: "111222333", name: "Guild A" },
+          { id: "999888777", name: "Guild B" },
+        ]);
+      }
+      if (url.endsWith("/channels/444555666")) {
+        return jsonResponse({
+          id: "444555666",
+          name: "general",
+          guild_id: "999888777",
+          type: 0,
+        });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const res = await resolveDiscordChannelAllowlist({
+      token: "test",
+      entries: ["111222333/444555666"],
+      fetcher,
+    });
+
+    expect(res[0]?.resolved).toBe(false);
+    expect(res[0]?.note).toMatch(/guild/i);
+  });
+
+  it("marks invalid numeric channelId as unresolved without aborting batch", async () => {
+    const fetcher = async (url: string) => {
+      if (url.endsWith("/users/@me/guilds")) {
+        return jsonResponse([{ id: "111222333", name: "Test Server" }]);
+      }
+      if (url.endsWith("/channels/444555666")) {
+        return jsonResponse({
+          id: "444555666",
+          name: "general",
+          guild_id: "111222333",
+          type: 0,
+        });
+      }
+      if (url.endsWith("/channels/999000111")) {
+        return new Response("not found", { status: 404 });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const res = await resolveDiscordChannelAllowlist({
+      token: "test",
+      entries: ["111222333/999000111", "111222333/444555666"],
+      fetcher,
+    });
+
+    expect(res).toHaveLength(2);
+    expect(res[0]?.resolved).toBe(false);
+    expect(res[0]?.channelId).toBe("999000111");
+    expect(res[0]?.guildId).toBe("111222333");
+    expect(res[1]?.resolved).toBe(true);
+    expect(res[1]?.channelId).toBe("444555666");
+  });
+
+  it("treats 403 channel lookup as unresolved without aborting batch", async () => {
+    const fetcher = async (url: string) => {
+      if (url.endsWith("/users/@me/guilds")) {
+        return jsonResponse([{ id: "111222333", name: "Test Server" }]);
+      }
+      if (url.endsWith("/channels/777888999")) {
+        return new Response("Missing Access", { status: 403 });
+      }
+      if (url.endsWith("/channels/444555666")) {
+        return jsonResponse({
+          id: "444555666",
+          name: "general",
+          guild_id: "111222333",
+          type: 0,
+        });
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const res = await resolveDiscordChannelAllowlist({
+      token: "test",
+      entries: ["111222333/777888999", "111222333/444555666"],
+      fetcher,
+    });
+
+    expect(res).toHaveLength(2);
+    expect(res[0]?.resolved).toBe(false);
+    expect(res[0]?.channelId).toBe("777888999");
+    expect(res[0]?.guildId).toBe("111222333");
+    expect(res[1]?.resolved).toBe(true);
+    expect(res[1]?.channelId).toBe("444555666");
+  });
+
   it("resolves channel id to guild", async () => {
     const fetcher = withFetchPreconnect(async (input: RequestInfo | URL) => {
       const url = urlToString(input);

--- a/src/discord/resolve-channels.test.ts
+++ b/src/discord/resolve-channels.test.ts
@@ -113,6 +113,9 @@ describe("resolveDiscordChannelAllowlist", () => {
       if (url.endsWith("/users/@me/guilds")) {
         return jsonResponse([{ id: "111222333", name: "Test Server" }]);
       }
+      if (url.endsWith("/guilds/111222333/channels")) {
+        return jsonResponse([{ id: "444555666", name: "general", guild_id: "111222333", type: 0 }]);
+      }
       if (url.endsWith("/channels/444555666")) {
         return jsonResponse({
           id: "444555666",
@@ -146,6 +149,9 @@ describe("resolveDiscordChannelAllowlist", () => {
       if (url.endsWith("/users/@me/guilds")) {
         return jsonResponse([{ id: "111222333", name: "Test Server" }]);
       }
+      if (url.endsWith("/guilds/111222333/channels")) {
+        return jsonResponse([{ id: "444555666", name: "general", guild_id: "111222333", type: 0 }]);
+      }
       if (url.endsWith("/channels/777888999")) {
         return new Response("Missing Access", { status: 403 });
       }
@@ -172,6 +178,35 @@ describe("resolveDiscordChannelAllowlist", () => {
     expect(res[0]?.guildId).toBe("111222333");
     expect(res[1]?.resolved).toBe(true);
     expect(res[1]?.channelId).toBe("444555666");
+  });
+
+  it("falls back to name matching when numeric channel name is not a valid ID", async () => {
+    const fetcher = async (url: string) => {
+      if (url.endsWith("/users/@me/guilds")) {
+        return jsonResponse([{ id: "111222333", name: "Test Server" }]);
+      }
+      if (url.endsWith("/channels/2024")) {
+        return new Response("not found", { status: 404 });
+      }
+      if (url.endsWith("/guilds/111222333/channels")) {
+        return jsonResponse([
+          { id: "c1", name: "2024", guild_id: "111222333", type: 0 },
+          { id: "c2", name: "general", guild_id: "111222333", type: 0 },
+        ]);
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const res = await resolveDiscordChannelAllowlist({
+      token: "test",
+      entries: ["111222333/2024"],
+      fetcher,
+    });
+
+    expect(res[0]?.resolved).toBe(true);
+    expect(res[0]?.guildId).toBe("111222333");
+    expect(res[0]?.channelId).toBe("c1");
+    expect(res[0]?.channelName).toBe("2024");
   });
 
   it("resolves channel id to guild", async () => {

--- a/src/discord/resolve-channels.ts
+++ b/src/discord/resolve-channels.ts
@@ -95,28 +95,40 @@ async function listGuildChannels(
     .filter((channel) => Boolean(channel.id) && Boolean(channel.name));
 }
 
+type FetchChannelResult =
+  | { status: "found"; channel: DiscordChannelSummary }
+  | { status: "not-found" }
+  | { status: "forbidden" }
+  | { status: "invalid" };
+
 async function fetchChannel(
   token: string,
   fetcher: typeof fetch,
   channelId: string,
-): Promise<DiscordChannelSummary | null> {
+): Promise<FetchChannelResult> {
   let raw: DiscordChannelPayload;
   try {
     raw = await fetchDiscord<DiscordChannelPayload>(`/channels/${channelId}`, token, fetcher);
   } catch (err) {
-    if (err instanceof DiscordApiError && (err.status === 404 || err.status === 403)) {
-      return null;
+    if (err instanceof DiscordApiError && err.status === 403) {
+      return { status: "forbidden" };
+    }
+    if (err instanceof DiscordApiError && err.status === 404) {
+      return { status: "not-found" };
     }
     throw err;
   }
   if (!raw || typeof raw.guild_id !== "string" || typeof raw.id !== "string") {
-    return null;
+    return { status: "invalid" };
   }
   return {
-    id: raw.id,
-    name: typeof raw.name === "string" ? raw.name : "",
-    guildId: raw.guild_id,
-    type: raw.type,
+    status: "found",
+    channel: {
+      id: raw.id,
+      name: typeof raw.name === "string" ? raw.name : "",
+      guildId: raw.guild_id,
+      type: raw.type,
+    },
   };
 }
 
@@ -199,8 +211,9 @@ export async function resolveDiscordChannelAllowlist(params: {
     }
 
     if (parsed.channelId) {
-      const channel = await fetchChannel(token, fetcher, parsed.channelId);
-      if (channel?.guildId) {
+      const result = await fetchChannel(token, fetcher, parsed.channelId);
+      if (result.status === "found") {
+        const channel = result.channel;
         if (parsed.guildId && channel.guildId !== parsed.guildId) {
           const expectedGuild = guilds.find((entry) => entry.id === parsed.guildId);
           const actualGuild = guilds.find((entry) => entry.id === channel.guildId);
@@ -229,7 +242,7 @@ export async function resolveDiscordChannelAllowlist(params: {
         });
         continue;
       }
-      if (parsed.guildId) {
+      if (result.status === "not-found" && parsed.guildId) {
         const guild = guilds.find((entry) => entry.id === parsed.guildId);
         if (guild) {
           const channels = await getChannels(guild.id);

--- a/src/discord/resolve-channels.ts
+++ b/src/discord/resolve-channels.ts
@@ -1,4 +1,4 @@
-import { fetchDiscord } from "./api.js";
+import { DiscordApiError, fetchDiscord } from "./api.js";
 import { listGuilds, type DiscordGuildSummary } from "./guilds.js";
 import { normalizeDiscordSlug } from "./monitor/allow-list.js";
 import { normalizeDiscordToken } from "./token.js";
@@ -100,7 +100,15 @@ async function fetchChannel(
   fetcher: typeof fetch,
   channelId: string,
 ): Promise<DiscordChannelSummary | null> {
-  const raw = await fetchDiscord<DiscordChannelPayload>(`/channels/${channelId}`, token, fetcher);
+  let raw: DiscordChannelPayload;
+  try {
+    raw = await fetchDiscord<DiscordChannelPayload>(`/channels/${channelId}`, token, fetcher);
+  } catch (err) {
+    if (err instanceof DiscordApiError && (err.status === 404 || err.status === 403)) {
+      return null;
+    }
+    throw err;
+  }
   if (!raw || typeof raw.guild_id !== "string" || typeof raw.id !== "string") {
     return null;
   }
@@ -194,7 +202,7 @@ export async function resolveDiscordChannelAllowlist(params: {
     if (parsed.channelId) {
       const channel = await fetchChannel(token, fetcher, parsed.channelId);
       if (channel?.guildId) {
-        if (parsed.guildId && parsed.guildId !== channel.guildId) {
+        if (parsed.guildId && channel.guildId !== parsed.guildId) {
           const expectedGuild = guilds.find((entry) => entry.id === parsed.guildId);
           const actualGuild = guilds.find((entry) => entry.id === channel.guildId);
           results.push({
@@ -208,22 +216,23 @@ export async function resolveDiscordChannelAllowlist(params: {
               ? `channel belongs to guild ${actualGuild.name}`
               : "channel belongs to a different guild",
           });
-          continue;
+        } else {
+          const guild = guilds.find((entry) => entry.id === channel.guildId);
+          results.push({
+            input,
+            resolved: true,
+            guildId: channel.guildId,
+            guildName: guild?.name,
+            channelId: channel.id,
+            channelName: channel.name,
+            archived: channel.archived,
+          });
         }
-        const guild = guilds.find((entry) => entry.id === channel.guildId);
-        results.push({
-          input,
-          resolved: true,
-          guildId: channel.guildId,
-          guildName: guild?.name,
-          channelId: channel.id,
-          channelName: channel.name,
-          archived: channel.archived,
-        });
       } else {
         results.push({
           input,
           resolved: false,
+          guildId: parsed.guildId,
           channelId: parsed.channelId,
         });
       }

--- a/src/discord/resolve-channels.ts
+++ b/src/discord/resolve-channels.ts
@@ -175,12 +175,11 @@ export async function resolveDiscordChannelAllowlist(params: {
   for (const input of params.entries) {
     const parsed = parseDiscordChannelInput(input);
     if (parsed.guildOnly) {
+      const guildById = parsed.guildId
+        ? guilds.find((entry) => entry.id === parsed.guildId)
+        : undefined;
       const guild =
-        parsed.guildId && guilds.find((entry) => entry.id === parsed.guildId)
-          ? guilds.find((entry) => entry.id === parsed.guildId)
-          : parsed.guild
-            ? resolveGuildByName(guilds, parsed.guild)
-            : undefined;
+        guildById ?? (parsed.guild ? resolveGuildByName(guilds, parsed.guild) : undefined);
       if (guild) {
         results.push({
           input,
@@ -216,36 +215,57 @@ export async function resolveDiscordChannelAllowlist(params: {
               ? `channel belongs to guild ${actualGuild.name}`
               : "channel belongs to a different guild",
           });
-        } else {
-          const guild = guilds.find((entry) => entry.id === channel.guildId);
-          results.push({
-            input,
-            resolved: true,
-            guildId: channel.guildId,
-            guildName: guild?.name,
-            channelId: channel.id,
-            channelName: channel.name,
-            archived: channel.archived,
-          });
+          continue;
         }
-      } else {
+        const guild = guilds.find((entry) => entry.id === channel.guildId);
         results.push({
           input,
-          resolved: false,
-          guildId: parsed.guildId,
-          channelId: parsed.channelId,
+          resolved: true,
+          guildId: channel.guildId,
+          guildName: guild?.name,
+          channelId: channel.id,
+          channelName: channel.name,
+          archived: channel.archived,
         });
+        continue;
       }
+      if (parsed.guildId) {
+        const guild = guilds.find((entry) => entry.id === parsed.guildId);
+        if (guild) {
+          const channels = await getChannels(guild.id);
+          const matches = channels.filter(
+            (ch) => normalizeDiscordSlug(ch.name) === normalizeDiscordSlug(parsed.channelId!),
+          );
+          const match = preferActiveMatch(matches);
+          if (match) {
+            results.push({
+              input,
+              resolved: true,
+              guildId: guild.id,
+              guildName: guild.name,
+              channelId: match.id,
+              channelName: match.name,
+              archived: match.archived,
+            });
+            continue;
+          }
+        }
+      }
+      results.push({
+        input,
+        resolved: false,
+        guildId: parsed.guildId,
+        channelId: parsed.channelId,
+      });
       continue;
     }
 
     if (parsed.guildId || parsed.guild) {
+      const guildById = parsed.guildId
+        ? guilds.find((entry) => entry.id === parsed.guildId)
+        : undefined;
       const guild =
-        parsed.guildId && guilds.find((entry) => entry.id === parsed.guildId)
-          ? guilds.find((entry) => entry.id === parsed.guildId)
-          : parsed.guild
-            ? resolveGuildByName(guilds, parsed.guild)
-            : undefined;
+        guildById ?? (parsed.guild ? resolveGuildByName(guilds, parsed.guild) : undefined);
       const channelQuery = parsed.channel?.trim();
       if (!guild || !channelQuery) {
         results.push({


### PR DESCRIPTION
Fixes #12185

## Summary

When users configure Discord channel allowlists with numeric `guildId/channelId` pairs (e.g. `111222333/444555666`), `parseDiscordChannelInput` treated the channel part as a channel *name* rather than an ID. This caused the resolution to attempt a name-based lookup against guild channels, which always failed for numeric IDs, silently dropping inbound messages from those channels.

### Changes

- **Numeric channel ID detection**: when both halves of `guild/channel` are all-digits, parse the channel part as `channelId` for direct API lookup
- **Guild membership validation**: reject entries where the fetched channel belongs to a different guild than specified
- **Graceful error handling**: catch 404/403 from channel lookups so one bad entry doesn't abort the entire batch
- **Guild context preservation**: include `guildId` on unresolved results so downstream onboarding doesn't default to wildcard guild
- **Name fallback**: when a numeric channel ID lookup fails and a guild was specified, fall back to name matching within that guild (supports channels with numeric names like "2024")

### Test plan

- [x] `"111222333/444555666"` resolves via direct channel ID lookup (TDD — test written first)
- [x] `"111222333/444555666"` where channel belongs to different guild → `resolved: false` with note
- [x] `"111222333/999000111"` where channel ID is 404 → marks unresolved, doesn't abort batch, preserves `guildId`
- [x] `"111222333/777888999"` where channel ID is 403 → marks unresolved, doesn't abort batch
- [x] `"111222333/2024"` where "2024" is a channel name → falls back to name matching within guild
- [x] All 7 new tests fail before fix, pass after
- [x] All 12 existing discord test files pass (40+ tests)
- [x] `pnpm build && pnpm check` clean

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates Discord allowlist parsing/resolution to correctly handle numeric `guildId/channelId` inputs by treating the channel segment as an ID (with optional guild-scoped name fallback on 404), adds a guild-membership consistency check for resolved channels, and improves channel fetch error classification (403 vs 404 vs invalid payload) so a single bad entry doesn’t abort batch resolution.

The main logic lives in `src/discord/resolve-channels.ts`, where `parseDiscordChannelInput` now returns `{guildId, channelId}` when both segments are all-digits, and `fetchChannel` now returns a discriminated `FetchChannelResult` to avoid conflating forbidden/not-found/invalid responses. `src/discord/resolve-channels.test.ts` adds coverage for the numeric-pair path, guild mismatch rejection, 404/403 behavior, and malformed payload handling.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The changes are localized to Discord allowlist parsing/resolution, add targeted tests for the new numeric `guildId/channelId` path, and the new error classification avoids previously reported incorrect fallbacks. I did not find any additional deterministic logic issues in the diff beyond previously addressed threads.
- No files require special attention

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->