### PR TITLE
feat(hooks): wire outbound message lifecycle hooks

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -264,8 +264,6 @@ Planned event types:
 - **`session:start`**: When a new session begins
 - **`session:end`**: When a session ends
 - **`agent:error`**: When an agent encounters an error
-- **`message:sent`**: When a message is sent
-- **`message:received`**: When a message is received
 
 ## Creating Custom Hooks
 

--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -246,6 +246,11 @@ Triggered when the gateway starts:
 
 - **`gateway:startup`**: After channels start and hooks are loaded
 
+### Plugin Hook Events
+
+- **`message_received`**, **`message_sending`**, **`message_sent`**
+- `message_sent` also fires for canceled sends with `success: false` and `error: "canceled by message_sending hook"`.
+
 ### Tool Result Hooks (Plugin API)
 
 These hooks are not event-stream listeners; they let plugins synchronously adjust tool results before OpenClaw persists them.

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -12,6 +12,7 @@ import {
   logSessionStateChange,
 } from "../../logging/diagnostic.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { normalizeSessionKey } from "../../sessions/session-key-utils.js";
 import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
 import { getReplyFromConfig } from "../reply.js";
 import { formatAbortReplyText, tryFastAbortFromMessage } from "./abort.js";
@@ -67,7 +68,9 @@ const resolveSessionTtsAuto = (
   const storePath = resolveStorePath(cfg.session?.store, { agentId });
   try {
     const store = loadSessionStore(storePath);
-    const entry = store[sessionKey.toLowerCase()] ?? store[sessionKey];
+    const normalizedSessionKey = normalizeSessionKey(sessionKey);
+    const entry =
+      (normalizedSessionKey ? store[normalizedSessionKey] : undefined) ?? store[sessionKey];
     return normalizeTtsAutoMode(entry?.ttsAuto);
   } catch {
     return undefined;
@@ -190,6 +193,7 @@ export async function dispatchReplyFromConfig(params: {
           channelId,
           accountId: ctx.AccountId,
           conversationId,
+          sessionKey: ctx.SessionKey,
         },
       )
       .catch((err) => {
@@ -290,7 +294,6 @@ export async function dispatchReplyFromConfig(params: {
     // TTS audio separately from the accumulated block content.
     let accumulatedBlockText = "";
     let blockCount = 0;
-
     const shouldSendToolSummaries = ctx.ChatType !== "group" && ctx.CommandSource !== "native";
 
     const replyResult = await (params.replyResolver ?? getReplyFromConfig)(

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -12,7 +12,6 @@ import {
   logSessionStateChange,
 } from "../../logging/diagnostic.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { normalizeSessionKey } from "../../sessions/session-key-utils.js";
 import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
 import { getReplyFromConfig } from "../reply.js";
 import { formatAbortReplyText, tryFastAbortFromMessage } from "./abort.js";
@@ -68,9 +67,7 @@ const resolveSessionTtsAuto = (
   const storePath = resolveStorePath(cfg.session?.store, { agentId });
   try {
     const store = loadSessionStore(storePath);
-    const normalizedSessionKey = normalizeSessionKey(sessionKey);
-    const entry =
-      (normalizedSessionKey ? store[normalizedSessionKey] : undefined) ?? store[sessionKey];
+    const entry = store[sessionKey.toLowerCase()] ?? store[sessionKey];
     return normalizeTtsAutoMode(entry?.ttsAuto);
   } catch {
     return undefined;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -12,6 +12,7 @@ import {
   logSessionStateChange,
 } from "../../logging/diagnostic.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { normalizeSessionKey } from "../../sessions/session-key-utils.js";
 import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
 import { getReplyFromConfig } from "../reply.js";
 import { formatAbortReplyText, tryFastAbortFromMessage } from "./abort.js";
@@ -63,11 +64,15 @@ const resolveSessionTtsAuto = (
   if (!sessionKey) {
     return undefined;
   }
+  const normalizedSessionKey = normalizeSessionKey(sessionKey);
+  if (!normalizedSessionKey) {
+    return undefined;
+  }
   const agentId = resolveSessionAgentId({ sessionKey, config: cfg });
   const storePath = resolveStorePath(cfg.session?.store, { agentId });
   try {
     const store = loadSessionStore(storePath);
-    const entry = store[sessionKey.toLowerCase()] ?? store[sessionKey];
+    const entry = store[normalizedSessionKey];
     return normalizeTtsAutoMode(entry?.ttsAuto);
   } catch {
     return undefined;

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -120,6 +120,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       channel: channelId,
       to,
       accountId: accountId ?? undefined,
+      sessionKey: params.sessionKey,
       payloads: [normalized],
       replyToId: resolvedReplyToId ?? null,
       threadId: resolvedThreadId,

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -574,6 +574,8 @@ export async function runCronIsolatedAgentTurn(params: {
             channel: resolvedDelivery.channel,
             to: resolvedDelivery.to,
             accountId: resolvedDelivery.accountId,
+            sessionKey: runSessionKey,
+            sessionId: runSessionId,
             threadId: resolvedDelivery.threadId,
             payloads: payloadsForDelivery,
             identity,

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -181,11 +181,13 @@ export const sendHandlers: GatewayRequestHandlers = {
             route: derivedRoute,
           });
         }
+        const hookSessionKey = providedSessionKey ?? derivedRoute?.sessionKey;
         const results = await deliverOutboundPayloads({
           cfg,
           channel: outboundChannel,
           to: resolved.to,
           accountId,
+          sessionKey: hookSessionKey,
           payloads: [{ text: message, mediaUrl, mediaUrls }],
           gifPlayback: request.gifPlayback,
           deps: outboundDeps,

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -93,9 +93,7 @@ export type HeartbeatSummary = {
 
 const DEFAULT_HEARTBEAT_TARGET = "last";
 
-// Prompt used when an async exec has completed and the result should be relayed to the user.
-// This overrides the standard heartbeat prompt to ensure the model responds with the exec result
-// instead of just "HEARTBEAT_OK".
+// Prompt used when async exec completes; overrides standard heartbeat prompt so model relays exec result instead of only "HEARTBEAT_OK".
 const EXEC_EVENT_PROMPT =
   "An async command you ran earlier has completed. The result is shown in the system messages above. " +
   "Please relay the command output to the user in a helpful way. If the command succeeded, share the relevant output. " +

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -539,6 +539,7 @@ export async function runHeartbeatOnce(opts: {
       channel: delivery.channel,
       to: delivery.to,
       accountId: delivery.accountId,
+      sessionKey,
       payloads: [{ text: heartbeatOkText }],
       deps: opts.deps,
     });
@@ -718,6 +719,7 @@ export async function runHeartbeatOnce(opts: {
       channel: delivery.channel,
       to: delivery.to,
       accountId: deliveryAccountId,
+      sessionKey,
       payloads: [
         ...reasoningPayloads,
         ...(shouldSkipMain

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -215,6 +215,43 @@ describe("deliverOutboundPayloads", () => {
     getGlobalHookRunnerSpy.mockRestore();
   });
 
+  it("reports failed Signal chunk sends with the exact chunk content", async () => {
+    const sendSignal = vi.fn().mockRejectedValue(new Error("signal down"));
+    const runMessageSending = vi.fn().mockResolvedValue({ content: "AB" });
+    const runMessageSent = vi.fn().mockResolvedValue(undefined);
+    const getGlobalHookRunnerSpy = vi
+      .spyOn(hookRunnerGlobal, "getGlobalHookRunner")
+      .mockReturnValue({
+        hasHooks: (name: string) => name === "message_sending" || name === "message_sent",
+        runMessageSending,
+        runMessageSent,
+      } as unknown as PluginHookRunner);
+
+    await deliverOutboundPayloads({
+      cfg: { channels: { signal: { textChunkLimit: 2 } } },
+      channel: "signal",
+      to: "+1555",
+      payloads: [{ text: "abcd" }],
+      deps: { sendSignal },
+      bestEffort: true,
+    });
+
+    expect(runMessageSending).toHaveBeenCalledTimes(1);
+    expect(sendSignal).toHaveBeenCalledTimes(1);
+    expect(runMessageSent).toHaveBeenCalledTimes(1);
+    expect(runMessageSent).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        content: "AB",
+        success: false,
+        error: "signal down",
+      }),
+      expect.any(Object),
+    );
+
+    getGlobalHookRunnerSpy.mockRestore();
+  });
+
   it("chunks WhatsApp text and returns all results", async () => {
     const sendWhatsApp = vi
       .fn()

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -252,6 +252,43 @@ describe("deliverOutboundPayloads", () => {
     getGlobalHookRunnerSpy.mockRestore();
   });
 
+  it("reports failed text chunk sends with exact rewritten chunk content", async () => {
+    const sendWhatsApp = vi.fn().mockRejectedValue(new Error("wa down"));
+    const runMessageSending = vi.fn().mockResolvedValue({ content: "AB" });
+    const runMessageSent = vi.fn().mockResolvedValue(undefined);
+    const getGlobalHookRunnerSpy = vi
+      .spyOn(hookRunnerGlobal, "getGlobalHookRunner")
+      .mockReturnValue({
+        hasHooks: (name: string) => name === "message_sending" || name === "message_sent",
+        runMessageSending,
+        runMessageSent,
+      } as unknown as PluginHookRunner);
+
+    await deliverOutboundPayloads({
+      cfg: { channels: { whatsapp: { textChunkLimit: 2 } } },
+      channel: "whatsapp",
+      to: "+1555",
+      payloads: [{ text: "abcd" }],
+      deps: { sendWhatsApp },
+      bestEffort: true,
+    });
+
+    expect(runMessageSending).toHaveBeenCalledTimes(1);
+    expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+    expect(runMessageSent).toHaveBeenCalledTimes(1);
+    expect(runMessageSent).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        content: "AB",
+        success: false,
+        error: "wa down",
+      }),
+      expect.any(Object),
+    );
+
+    getGlobalHookRunnerSpy.mockRestore();
+  });
+
   it("chunks WhatsApp text and returns all results", async () => {
     const sendWhatsApp = vi
       .fn()

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { PluginHookRunner } from "../../plugins/hook-types.js";
 import { signalOutbound } from "../../channels/plugins/outbound/signal.js";
 import { telegramOutbound } from "../../channels/plugins/outbound/telegram.js";
 import { whatsappOutbound } from "../../channels/plugins/outbound/whatsapp.js";
@@ -487,7 +488,7 @@ describe("deliverOutboundPayloads", () => {
       .mockReturnValue({
         hasHooks: (name: string) => name === "message_sent",
         runMessageSent,
-      } as any);
+      } as unknown as PluginHookRunner);
 
     await deliverOutboundPayloads({
       cfg: {},

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -285,6 +285,8 @@ async function deliverOutboundPayloadsCore(params: {
   channel: Exclude<OutboundChannel, "none">;
   to: string;
   accountId?: string;
+  sessionKey?: string;
+  sessionId?: string;
   payloads: ReplyPayload[];
   replyToId?: string | null;
   threadId?: string | number | null;
@@ -568,7 +570,6 @@ async function deliverOutboundPayloadsCore(params: {
     const normalized = normalizeWhatsAppPayload(payload);
     return normalized ? [normalized] : [];
   });
-  const hookRunner = getGlobalHookRunner();
   for (const payload of normalizedPayloads) {
     const payloadSummary: NormalizedOutboundPayload = {
       text: payload.text ?? "",

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -407,15 +407,31 @@ async function deliverOutboundPayloadsCore(params: {
   };
 
   const sendTextChunks = async (text: string) => {
-    throwIfAborted(abortSignal);
-    if (!handler.chunker || textLimit === undefined) {
-      const hookResult = await runMessageSendingHook(text);
+    const sendTextChunk = async (chunk: string) => {
+      throwIfAborted(abortSignal);
+      const hookResult = await runMessageSendingHook(chunk);
       if (hookResult.canceled) {
-        await runMessageSentHook(text, false, "canceled by message_sending hook");
+        await runMessageSentHook(chunk, false, "canceled by message_sending hook");
         return;
       }
-      results.push(await handler.sendText(hookResult.content));
-      await runMessageSentHook(hookResult.content, true);
+      try {
+        results.push(await handler.sendText(hookResult.content));
+        await runMessageSentHook(hookResult.content, true);
+      } catch (err) {
+        const normalizedErr = normalizeUnknownError(err);
+        await runMessageSentHook(hookResult.content, false, normalizedErr.message);
+        (
+          normalizedErr as Error & {
+            [MESSAGE_SENT_HOOK_HANDLED]?: boolean;
+          }
+        )[MESSAGE_SENT_HOOK_HANDLED] = true;
+        throw normalizedErr;
+      }
+    };
+
+    throwIfAborted(abortSignal);
+    if (!handler.chunker || textLimit === undefined) {
+      await sendTextChunk(text);
       return;
     }
     if (chunkMode === "newline") {
@@ -434,28 +450,14 @@ async function deliverOutboundPayloadsCore(params: {
           chunks.push(blockChunk);
         }
         for (const chunk of chunks) {
-          throwIfAborted(abortSignal);
-          const hookResult = await runMessageSendingHook(chunk);
-          if (hookResult.canceled) {
-            await runMessageSentHook(chunk, false, "canceled by message_sending hook");
-            continue;
-          }
-          results.push(await handler.sendText(hookResult.content));
-          await runMessageSentHook(hookResult.content, true);
+          await sendTextChunk(chunk);
         }
       }
       return;
     }
     const chunks = handler.chunker(text, textLimit);
     for (const chunk of chunks) {
-      throwIfAborted(abortSignal);
-      const hookResult = await runMessageSendingHook(chunk);
-      if (hookResult.canceled) {
-        await runMessageSentHook(chunk, false, "canceled by message_sending hook");
-        continue;
-      }
-      results.push(await handler.sendText(hookResult.content));
-      await runMessageSentHook(hookResult.content, true);
+      await sendTextChunk(chunk);
     }
   };
 

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -189,6 +189,11 @@ function createPluginHandler(params: {
 
 const isAbortError = (err: unknown): boolean => err instanceof Error && err.name === "AbortError";
 const log = createSubsystemLogger("infra/outbound");
+const MESSAGE_SENT_HOOK_HANDLED = Symbol("messageSentHookHandled");
+
+function normalizeUnknownError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}
 
 export async function deliverOutboundPayloads(params: {
   cfg: OpenClawConfig;
@@ -500,8 +505,19 @@ async function deliverOutboundPayloadsCore(params: {
       }
       for (const rewrittenChunk of rewrittenChunks) {
         onAttempt?.(rewrittenChunk.text);
-        results.push(await sendSignalText(rewrittenChunk.text, rewrittenChunk.styles));
-        await runMessageSentHook(rewrittenChunk.text, true);
+        try {
+          results.push(await sendSignalText(rewrittenChunk.text, rewrittenChunk.styles));
+          await runMessageSentHook(rewrittenChunk.text, true);
+        } catch (err) {
+          const normalizedErr = normalizeUnknownError(err);
+          await runMessageSentHook(rewrittenChunk.text, false, normalizedErr.message);
+          (
+            normalizedErr as Error & {
+              [MESSAGE_SENT_HOOK_HANDLED]?: boolean;
+            }
+          )[MESSAGE_SENT_HOOK_HANDLED] = true;
+          throw normalizedErr;
+        }
       }
     }
   };
@@ -610,15 +626,20 @@ async function deliverOutboundPayloadsCore(params: {
         }
       }
     } catch (err) {
-      await runMessageSentHook(
-        attemptedSendContent,
-        false,
-        err instanceof Error ? err.message : String(err),
-      );
-      if (!params.bestEffort) {
-        throw err;
+      const normalizedErr = normalizeUnknownError(err);
+      const handledInNestedSend =
+        (
+          normalizedErr as Error & {
+            [MESSAGE_SENT_HOOK_HANDLED]?: boolean;
+          }
+        )[MESSAGE_SENT_HOOK_HANDLED] === true;
+      if (!handledInNestedSend) {
+        await runMessageSentHook(attemptedSendContent, false, normalizedErr.message);
       }
-      params.onError?.(err, payloadSummary);
+      if (!params.bestEffort) {
+        throw normalizedErr;
+      }
+      params.onError?.(normalizedErr, payloadSummary);
     }
   }
   if (params.mirror && results.length > 0) {

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -552,7 +552,7 @@ async function deliverOutboundPayloadsCore(params: {
       for (const url of payloadSummary.mediaUrls) {
         throwIfAborted(abortSignal);
         const caption = first ? payloadSummary.text : "";
-        const messageSentContent = caption;
+        const messageSentContent = caption || payloadSummary.text || url;
         attemptedSendContent = messageSentContent;
         first = false;
         if (isSignalChannel) {

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -167,6 +167,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       channel: outboundChannel,
       to: resolvedTarget.to,
       accountId: params.accountId,
+      sessionKey: params.mirror?.sessionKey,
       payloads: normalizedPayloads,
       replyToId: params.replyToId,
       threadId: params.threadId,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -376,6 +376,8 @@ export type PluginHookMessageContext = {
   channelId: string;
   accountId?: string;
   conversationId?: string;
+  sessionKey?: string;
+  sessionId?: string;
 };
 
 // message_received hook

--- a/src/sessions/session-key-utils.ts
+++ b/src/sessions/session-key-utils.ts
@@ -81,3 +81,8 @@ export function resolveThreadParentSessionKey(
   const parent = raw.slice(0, idx).trim();
   return parent ? parent : null;
 }
+
+export function normalizeSessionKey(sessionKey: string | undefined | null): string | undefined {
+  const raw = (sessionKey ?? "").trim();
+  return raw ? raw.toLowerCase() : undefined;
+}


### PR DESCRIPTION
## Why
Message lifecycle hooks were not fully wired across outbound delivery paths, limiting observability and intervention points for message guardrails. This PR completes outbound lifecycle wiring and propagates session context so hook consumers can attribute events reliably.

## Detailed Changes
- Wired outbound plugin hooks in delivery pipeline:
  - `message_sending`
  - `message_sent` (success/failure/cancel-aware)
- Added message hook context fields in outbound flow:
  - `sessionKey`
  - `sessionId`
- Added `sessionKey` into `message_received` hook context from dispatch flow
- Applied session-key normalization touch-up in dispatch store lookup path

## Related Links and Issues
- Existing source PR: #9761
- Related issues:
  - Closes #8807 
  - Closes #7067 
  - Closes #9871
  - #9387 
  - #9524 

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR completes wiring for outbound message lifecycle plugin hooks by invoking `message_sending` (with cancel/modify support) and `message_sent` (success/failure/cancel-aware) across outbound delivery paths, including text chunking, Signal chunk formatting, and media sends. It also extends hook context with `sessionKey`/`sessionId` and propagates these fields through several call sites (gateway send, cron isolated-agent, heartbeat, auto-reply routing) so hook consumers can better attribute events.

Core changes live in `src/infra/outbound/deliver.ts`, which now runs the hooks around per-chunk/per-attachment sends and ensures failures are attributed to the attempted content. Tests were expanded substantially in `src/infra/outbound/deliver.test.ts` to cover chunk rewrite limits, cancel behavior, and accurate failure reporting.

<h3>Confidence Score: 4/5</h3>

- This PR is close to safe to merge, but there is a concrete session-context propagation bug that undermines the stated observability goal in at least one outbound send path.
- Most hook wiring changes in `deliver.ts` are internally consistent and are backed by new regression tests for chunk rewrite/cancel/failure attribution. However, `sendMessage()` appears to pass `sessionKey` from the mirror config rather than from the actual session context, so hook consumers will still miss session attribution in common direct-send flows unless this is corrected.
- src/infra/outbound/message.ts

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->