### PR TITLE
feat: built-in auto-update with configurable schedule, confirmation, and post-update notification

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -106,6 +106,12 @@ const FIELD_LABELS: Record<string, string> = {
   "meta.lastTouchedAt": "Config Last Touched At",
   "update.channel": "Update Channel",
   "update.checkOnStart": "Update Check on Start",
+  "update.auto.enabled": "Auto-Update Enabled",
+  "update.auto.mode": "Auto-Update Mode",
+  "update.auto.schedule": "Auto-Update Schedule",
+  "update.auto.timezone": "Auto-Update Timezone",
+  "update.auto.notifyAfterUpdate": "Notify After Auto-Update",
+  "update.auto.notifyChannel": "Auto-Update Notification Channel",
   "diagnostics.enabled": "Diagnostics Enabled",
   "diagnostics.flags": "Diagnostics Flags",
   "diagnostics.otel.enabled": "OpenTelemetry Enabled",
@@ -401,6 +407,16 @@ const FIELD_HELP: Record<string, string> = {
   "meta.lastTouchedAt": "ISO timestamp of the last config write (auto-set).",
   "update.channel": 'Update channel for git + npm installs ("stable", "beta", or "dev").',
   "update.checkOnStart": "Check for npm updates when the gateway starts (default: true).",
+  "update.auto.enabled": "Enable automatic updates (opt-in, default: false).",
+  "update.auto.mode":
+    'Auto-update mode: "notify-only" (default), "confirm" (ask first), or "silent" (auto-apply).',
+  "update.auto.schedule": "Time of day to check for updates in HH:MM format (default: 03:00).",
+  "update.auto.timezone":
+    "Timezone for the auto-update schedule. Defaults to agents.defaults.userTimezone.",
+  "update.auto.notifyAfterUpdate":
+    "Send a notification after a successful auto-update (default: true).",
+  "update.auto.notifyChannel":
+    'Channel for auto-update notifications: "last" or a channel name (default: "last").',
   "gateway.remote.url": "Remote Gateway WebSocket URL (ws:// or wss://).",
   "gateway.remote.tlsFingerprint":
     "Expected sha256 TLS fingerprint for the remote gateway (pin to avoid MITM).",

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -63,6 +63,21 @@ export type OpenClawConfig = {
     channel?: "stable" | "beta" | "dev";
     /** Check for updates on gateway start (npm installs only). */
     checkOnStart?: boolean;
+    /** Automatic update configuration. */
+    auto?: {
+      /** Enable automatic updates (opt-in, default: false). */
+      enabled?: boolean;
+      /** Update mode: notify-only, confirm (ask user), or silent (auto-apply). Default: 'notify-only'. */
+      mode?: "confirm" | "silent" | "notify-only";
+      /** Time of day to check for updates, HH:MM format. Default: '03:00'. */
+      schedule?: string;
+      /** Timezone for the schedule. Defaults to agents.defaults.userTimezone. */
+      timezone?: string;
+      /** Send a notification after a successful auto-update. Default: true. */
+      notifyAfterUpdate?: boolean;
+      /** Channel for notifications: 'last' or a channel name. Default: 'last'. */
+      notifyChannel?: string;
+    };
   };
   browser?: BrowserConfig;
   ui?: {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -192,6 +192,22 @@ export const OpenClawSchema = z
       .object({
         channel: z.union([z.literal("stable"), z.literal("beta"), z.literal("dev")]).optional(),
         checkOnStart: z.boolean().optional(),
+        auto: z
+          .object({
+            enabled: z.boolean().optional(),
+            mode: z
+              .union([z.literal("confirm"), z.literal("silent"), z.literal("notify-only")])
+              .optional(),
+            schedule: z
+              .string()
+              .regex(/^\d{2}:\d{2}$/, "Schedule must be in HH:MM format")
+              .optional(),
+            timezone: z.string().optional(),
+            notifyAfterUpdate: z.boolean().optional(),
+            notifyChannel: z.string().optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/infra/auto-update.test.ts
+++ b/src/infra/auto-update.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  parseScheduleToCron,
+  computeNextScheduleMs,
+  resolveAutoUpdateConfig,
+  AUTO_UPDATE_DEFAULTS,
+  checkPostAutoUpdateNotification,
+  writeAutoUpdateState,
+  readAutoUpdateState,
+  consumeAutoUpdateState,
+  startAutoUpdateScheduler,
+} from "./auto-update.js";
+
+// ── parseScheduleToCron ────────────────────────────────────────────────────
+
+describe("parseScheduleToCron", () => {
+  it("converts HH:MM to a daily cron expression", () => {
+    expect(parseScheduleToCron("03:00")).toBe("0 0 3 * * *");
+    expect(parseScheduleToCron("14:30")).toBe("0 30 14 * * *");
+    expect(parseScheduleToCron("00:00")).toBe("0 0 0 * * *");
+    expect(parseScheduleToCron("23:59")).toBe("0 59 23 * * *");
+  });
+
+  it("returns null for invalid formats", () => {
+    expect(parseScheduleToCron("")).toBeNull();
+    expect(parseScheduleToCron("3:00")).toBeNull();
+    expect(parseScheduleToCron("25:00")).toBeNull();
+    expect(parseScheduleToCron("12:60")).toBeNull();
+    expect(parseScheduleToCron("not-a-time")).toBeNull();
+    expect(parseScheduleToCron("1200")).toBeNull();
+  });
+
+  it("trims whitespace", () => {
+    expect(parseScheduleToCron("  03:00  ")).toBe("0 0 3 * * *");
+  });
+});
+
+// ── computeNextScheduleMs ──────────────────────────────────────────────────
+
+describe("computeNextScheduleMs", () => {
+  it("returns a future timestamp", () => {
+    const now = Date.now();
+    const result = computeNextScheduleMs("03:00", "UTC", now);
+    expect(result).not.toBeNull();
+    expect(result!).toBeGreaterThan(now - 1);
+  });
+
+  it("returns null for invalid schedule", () => {
+    expect(computeNextScheduleMs("invalid", "UTC", Date.now())).toBeNull();
+  });
+
+  it("schedules for tomorrow if time has passed today", () => {
+    // Use a fixed time: 2026-01-15T04:00:00Z (4 AM UTC)
+    const nowMs = new Date("2026-01-15T04:00:00Z").getTime();
+    const result = computeNextScheduleMs("03:00", "UTC", nowMs);
+    expect(result).not.toBeNull();
+    // Should be about 23 hours from now (tomorrow at 03:00)
+    const diffHours = (result! - nowMs) / (1000 * 3600);
+    expect(diffHours).toBeGreaterThan(22);
+    expect(diffHours).toBeLessThan(24);
+  });
+
+  it("schedules for today if time has not passed", () => {
+    // Use a fixed time: 2026-01-15T01:00:00Z (1 AM UTC)
+    const nowMs = new Date("2026-01-15T01:00:00Z").getTime();
+    const result = computeNextScheduleMs("03:00", "UTC", nowMs);
+    expect(result).not.toBeNull();
+    // Should be about 2 hours from now
+    const diffHours = (result! - nowMs) / (1000 * 3600);
+    expect(diffHours).toBeGreaterThan(1.9);
+    expect(diffHours).toBeLessThan(2.1);
+  });
+});
+
+// ── resolveAutoUpdateConfig ────────────────────────────────────────────────
+
+describe("resolveAutoUpdateConfig", () => {
+  it("applies defaults when config is undefined", () => {
+    const cfg = resolveAutoUpdateConfig(undefined);
+    expect(cfg.enabled).toBe(false);
+    expect(cfg.mode).toBe("notify-only");
+    expect(cfg.schedule).toBe("03:00");
+    expect(cfg.notifyAfterUpdate).toBe(true);
+    expect(cfg.notifyChannel).toBe("last");
+    expect(cfg.timezone).toBeTruthy(); // system timezone
+  });
+
+  it("preserves explicit values", () => {
+    const cfg = resolveAutoUpdateConfig({
+      enabled: true,
+      mode: "silent",
+      schedule: "14:30",
+      timezone: "America/New_York",
+      notifyAfterUpdate: false,
+      notifyChannel: "general",
+    });
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.mode).toBe("silent");
+    expect(cfg.schedule).toBe("14:30");
+    expect(cfg.timezone).toBe("America/New_York");
+    expect(cfg.notifyAfterUpdate).toBe(false);
+    expect(cfg.notifyChannel).toBe("general");
+  });
+
+  it("fills missing fields with defaults", () => {
+    const cfg = resolveAutoUpdateConfig({ enabled: true });
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.mode).toBe(AUTO_UPDATE_DEFAULTS.mode);
+    expect(cfg.schedule).toBe(AUTO_UPDATE_DEFAULTS.schedule);
+  });
+});
+
+// ── State file operations ──────────────────────────────────────────────────
+
+describe("auto-update state", () => {
+  const tmpDir = `/tmp/openclaw-auto-update-test-${Date.now()}`;
+  const env = { OPENCLAW_STATE_DIR: tmpDir } as unknown as NodeJS.ProcessEnv;
+
+  it("reads empty state from missing file", async () => {
+    const state = await readAutoUpdateState(env);
+    expect(state).toEqual({});
+  });
+
+  it("writes and reads state", async () => {
+    await writeAutoUpdateState(
+      { preUpdateVersion: "1.0.0", updatedAt: "2026-01-15T00:00:00Z" },
+      env,
+    );
+    const state = await readAutoUpdateState(env);
+    expect(state.preUpdateVersion).toBe("1.0.0");
+    expect(state.updatedAt).toBe("2026-01-15T00:00:00Z");
+  });
+
+  it("consumes state and removes file", async () => {
+    await writeAutoUpdateState(
+      { preUpdateVersion: "1.0.0", updatedAt: "2026-01-15T00:00:00Z" },
+      env,
+    );
+    const consumed = await consumeAutoUpdateState(env);
+    expect(consumed?.preUpdateVersion).toBe("1.0.0");
+
+    // Second consume returns null (file deleted).
+    const again = await consumeAutoUpdateState(env);
+    expect(again).toBeNull();
+  });
+});
+
+// ── Post-update notification ───────────────────────────────────────────────
+
+describe("checkPostAutoUpdateNotification", () => {
+  const tmpDir = `/tmp/openclaw-auto-update-notify-test-${Date.now()}`;
+  const env = { OPENCLAW_STATE_DIR: tmpDir } as unknown as NodeJS.ProcessEnv;
+
+  it("returns null when no state file", async () => {
+    const result = await checkPostAutoUpdateNotification(env);
+    expect(result).toBeNull();
+  });
+
+  it("returns notification when version changed", async () => {
+    // Write a state with a different version than current.
+    await writeAutoUpdateState({ preUpdateVersion: "0.0.1" }, env);
+    const result = await checkPostAutoUpdateNotification(env);
+    // Since VERSION is not "0.0.1", we should get a notification.
+    if (result) {
+      expect(result.oldVersion).toBe("0.0.1");
+      expect(result.message).toContain("0.0.1");
+      expect(result.message).toContain("→");
+    }
+  });
+});
+
+// ── Mode behavior ──────────────────────────────────────────────────────────
+
+describe("startAutoUpdateScheduler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns noop cleanup when disabled", () => {
+    const cleanup = startAutoUpdateScheduler({
+      config: { enabled: false },
+      onNotify: vi.fn(),
+      onConfirm: vi.fn(),
+      onSilentUpdate: vi.fn(),
+      log: { info: vi.fn() },
+    });
+    expect(typeof cleanup).toBe("function");
+    cleanup(); // should not throw
+  });
+
+  it("does not schedule when not enabled (undefined config)", () => {
+    const logInfo = vi.fn();
+    const cleanup = startAutoUpdateScheduler({
+      config: undefined,
+      onNotify: vi.fn(),
+      onConfirm: vi.fn(),
+      onSilentUpdate: vi.fn(),
+      log: { info: logInfo },
+    });
+    // Should not have logged about scheduling since it's disabled.
+    expect(logInfo).not.toHaveBeenCalledWith(
+      expect.stringContaining("next check scheduled"),
+      expect.anything(),
+    );
+    cleanup();
+  });
+
+  it("schedules when enabled", () => {
+    const logInfo = vi.fn();
+    const cleanup = startAutoUpdateScheduler({
+      config: { enabled: true, schedule: "03:00" },
+      userTimezone: "UTC",
+      onNotify: vi.fn(),
+      onConfirm: vi.fn(),
+      onSilentUpdate: vi.fn(),
+      log: { info: logInfo },
+    });
+    expect(logInfo).toHaveBeenCalledWith(
+      "auto-update: next check scheduled",
+      expect.objectContaining({ mode: "notify-only", schedule: "03:00" }),
+    );
+    cleanup();
+  });
+});
+
+// ── Config schema validation (zod) ─────────────────────────────────────────
+
+describe("config schema validation for update.auto", () => {
+  // We import the zod schema dynamically to verify it validates correctly.
+  it("accepts valid auto-update config", async () => {
+    const { OpenClawSchema } = await import("../config/zod-schema.js");
+    const result = OpenClawSchema.safeParse({
+      update: {
+        auto: {
+          enabled: true,
+          mode: "silent",
+          schedule: "14:30",
+          timezone: "America/Chicago",
+          notifyAfterUpdate: true,
+          notifyChannel: "general",
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects invalid schedule format", async () => {
+    const { OpenClawSchema } = await import("../config/zod-schema.js");
+    const result = OpenClawSchema.safeParse({
+      update: {
+        auto: {
+          schedule: "3:00",
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid mode", async () => {
+    const { OpenClawSchema } = await import("../config/zod-schema.js");
+    const result = OpenClawSchema.safeParse({
+      update: {
+        auto: {
+          mode: "invalid-mode",
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown keys in auto", async () => {
+    const { OpenClawSchema } = await import("../config/zod-schema.js");
+    const result = OpenClawSchema.safeParse({
+      update: {
+        auto: {
+          unknownKey: true,
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts empty auto object", async () => {
+    const { OpenClawSchema } = await import("../config/zod-schema.js");
+    const result = OpenClawSchema.safeParse({
+      update: {
+        auto: {},
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/infra/auto-update.ts
+++ b/src/infra/auto-update.ts
@@ -1,0 +1,321 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import { VERSION } from "../version.js";
+import { normalizeUpdateChannel, DEFAULT_PACKAGE_CHANNEL } from "./update-channels.js";
+import { compareSemverStrings, resolveNpmChannelTag } from "./update-check.js";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export type AutoUpdateMode = "confirm" | "silent" | "notify-only";
+
+export type AutoUpdateConfig = {
+  enabled?: boolean;
+  mode?: AutoUpdateMode;
+  schedule?: string;
+  timezone?: string;
+  notifyAfterUpdate?: boolean;
+  notifyChannel?: string;
+};
+
+export type AutoUpdateCheckResult = {
+  currentVersion: string;
+  availableVersion: string | null;
+  updateAvailable: boolean;
+  tag: string;
+};
+
+export type AutoUpdateState = {
+  preUpdateVersion?: string;
+  updatedAt?: string;
+};
+
+// ── Defaults ───────────────────────────────────────────────────────────────
+
+export const AUTO_UPDATE_DEFAULTS = {
+  enabled: false,
+  mode: "notify-only" as AutoUpdateMode,
+  schedule: "03:00",
+  notifyAfterUpdate: true,
+  notifyChannel: "last",
+} as const;
+
+// ── Schedule Parsing ───────────────────────────────────────────────────────
+
+const HH_MM_RE = /^(\d{2}):(\d{2})$/;
+
+/**
+ * Parse an HH:MM time string into a cron expression that fires daily at that
+ * time.  Returns `null` for invalid input.
+ */
+export function parseScheduleToCron(schedule: string): string | null {
+  const m = HH_MM_RE.exec(schedule.trim());
+  if (!m) {
+    return null;
+  }
+  const hour = Number.parseInt(m[1]!, 10);
+  const minute = Number.parseInt(m[2]!, 10);
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+    return null;
+  }
+  // cron: second minute hour day month weekday
+  return `0 ${minute} ${hour} * * *`;
+}
+
+/**
+ * Compute the next run time (epoch ms) for an HH:MM schedule in a given
+ * timezone.  If the time has already passed today, returns tomorrow's time.
+ */
+export function computeNextScheduleMs(
+  schedule: string,
+  timezone: string,
+  nowMs: number,
+): number | null {
+  const m = HH_MM_RE.exec(schedule.trim());
+  if (!m) {
+    return null;
+  }
+  const hour = Number.parseInt(m[1]!, 10);
+  const minute = Number.parseInt(m[2]!, 10);
+  if (hour < 0 || hour > 23 || minute < 0 || minute > 59) {
+    return null;
+  }
+
+  // Build a date in the target timezone for today at HH:MM.
+  // We use Intl to get current wall-clock time in the target tz.
+  const now = new Date(nowMs);
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(now);
+
+  const get = (type: Intl.DateTimeFormatPartTypes) =>
+    Number.parseInt(parts.find((p) => p.type === type)?.value ?? "0", 10);
+
+  const currentHour = get("hour");
+  const currentMinute = get("minute");
+  const currentSecond = get("second");
+
+  // How many ms until the target time today?
+  const targetTodaySec = hour * 3600 + minute * 60;
+  const currentSec = currentHour * 3600 + currentMinute * 60 + currentSecond;
+  const diffSec = targetTodaySec - currentSec;
+
+  if (diffSec > 0) {
+    return nowMs + diffSec * 1000;
+  }
+  // Already passed today — schedule for tomorrow.
+  return nowMs + (diffSec + 86400) * 1000;
+}
+
+// ── State File (pre-update version persistence) ────────────────────────────
+
+const AUTO_UPDATE_STATE_FILENAME = "auto-update-state.json";
+
+export function resolveAutoUpdateStatePath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveStateDir(env), AUTO_UPDATE_STATE_FILENAME);
+}
+
+export async function readAutoUpdateState(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<AutoUpdateState> {
+  const filePath = resolveAutoUpdateStatePath(env);
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as AutoUpdateState;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export async function writeAutoUpdateState(
+  state: AutoUpdateState,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const filePath = resolveAutoUpdateStatePath(env);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, JSON.stringify(state, null, 2), "utf-8");
+}
+
+export async function consumeAutoUpdateState(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<AutoUpdateState | null> {
+  const filePath = resolveAutoUpdateStatePath(env);
+  const state = await readAutoUpdateState(env);
+  if (!state.preUpdateVersion) {
+    return null;
+  }
+  // Remove the file after consuming.
+  await fs.unlink(filePath).catch(() => {});
+  return state;
+}
+
+// ── Update Check ───────────────────────────────────────────────────────────
+
+/**
+ * Check if a newer version is available on the configured channel.
+ */
+export async function checkForAvailableUpdate(params: {
+  channel?: "stable" | "beta" | "dev";
+  timeoutMs?: number;
+}): Promise<AutoUpdateCheckResult> {
+  const channel = params.channel ?? DEFAULT_PACKAGE_CHANNEL;
+  const npmChannel = normalizeUpdateChannel(channel) ?? DEFAULT_PACKAGE_CHANNEL;
+  const resolved = await resolveNpmChannelTag({
+    channel: npmChannel,
+    timeoutMs: params.timeoutMs ?? 3500,
+  });
+
+  const updateAvailable =
+    resolved.version != null &&
+    compareSemverStrings(VERSION, resolved.version) != null &&
+    compareSemverStrings(VERSION, resolved.version)! < 0;
+
+  return {
+    currentVersion: VERSION,
+    availableVersion: resolved.version,
+    updateAvailable,
+    tag: resolved.tag,
+  };
+}
+
+// ── Resolve Config Helpers ─────────────────────────────────────────────────
+
+export function resolveAutoUpdateConfig(
+  raw: AutoUpdateConfig | undefined,
+): Required<AutoUpdateConfig> {
+  return {
+    enabled: raw?.enabled ?? AUTO_UPDATE_DEFAULTS.enabled,
+    mode: raw?.mode ?? AUTO_UPDATE_DEFAULTS.mode,
+    schedule: raw?.schedule ?? AUTO_UPDATE_DEFAULTS.schedule,
+    timezone: raw?.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
+    notifyAfterUpdate: raw?.notifyAfterUpdate ?? AUTO_UPDATE_DEFAULTS.notifyAfterUpdate,
+    notifyChannel: raw?.notifyChannel ?? AUTO_UPDATE_DEFAULTS.notifyChannel,
+  };
+}
+
+// ── Post-Update Notification ───────────────────────────────────────────────
+
+/**
+ * After restart, check if we were auto-updated and return a notification
+ * message.  Consumes the state file so it only fires once.
+ */
+export async function checkPostAutoUpdateNotification(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{ message: string; oldVersion: string; newVersion: string } | null> {
+  const state = await consumeAutoUpdateState(env);
+  if (!state?.preUpdateVersion) {
+    return null;
+  }
+  const oldVersion = state.preUpdateVersion;
+  const newVersion = VERSION;
+  if (oldVersion === newVersion) {
+    return null;
+  }
+  return {
+    message: `✅ Auto-updated from v${oldVersion} → v${newVersion}`,
+    oldVersion,
+    newVersion,
+  };
+}
+
+// ── Scheduler ──────────────────────────────────────────────────────────────
+
+export type AutoUpdateSchedulerDeps = {
+  config: AutoUpdateConfig | undefined;
+  updateChannel?: "stable" | "beta" | "dev";
+  userTimezone?: string;
+  onNotify: (message: string) => void;
+  onConfirm: (message: string) => void;
+  onSilentUpdate: () => Promise<void>;
+  log: {
+    info: (msg: string, meta?: Record<string, unknown>) => void;
+    error?: (msg: string, meta?: Record<string, unknown>) => void;
+  };
+};
+
+/**
+ * Start the auto-update scheduler.  Returns a cleanup function to cancel the
+ * timer.
+ */
+export function startAutoUpdateScheduler(deps: AutoUpdateSchedulerDeps): () => void {
+  const cfg = resolveAutoUpdateConfig(deps.config);
+  if (!cfg.enabled) {
+    return () => {};
+  }
+
+  const timezone = deps.userTimezone ?? cfg.timezone;
+  const scheduleNextCheck = (): ReturnType<typeof setTimeout> | null => {
+    const nextMs = computeNextScheduleMs(cfg.schedule, timezone, Date.now());
+    if (nextMs == null) {
+      deps.log.info("auto-update: invalid schedule, disabling", {
+        schedule: cfg.schedule,
+      });
+      return null;
+    }
+    const delayMs = Math.max(1000, nextMs - Date.now());
+    deps.log.info("auto-update: next check scheduled", {
+      delayMs,
+      mode: cfg.mode,
+      schedule: cfg.schedule,
+      timezone,
+    });
+
+    return setTimeout(async () => {
+      try {
+        await runScheduledCheck();
+      } catch (err) {
+        deps.log.error?.("auto-update: check failed", { error: String(err) });
+      }
+      // Re-schedule for the next day.
+      timer = scheduleNextCheck();
+    }, delayMs);
+  };
+
+  const runScheduledCheck = async () => {
+    const result = await checkForAvailableUpdate({
+      channel: deps.updateChannel,
+    });
+
+    if (!result.updateAvailable || !result.availableVersion) {
+      deps.log.info("auto-update: no update available", {
+        current: result.currentVersion,
+      });
+      return;
+    }
+
+    const versionMsg = `Update available: v${result.currentVersion} → v${result.availableVersion} (${result.tag})`;
+
+    switch (cfg.mode) {
+      case "notify-only":
+        deps.onNotify(versionMsg);
+        break;
+      case "confirm":
+        deps.onConfirm(`${versionMsg}\nReply "yes" to update now.`);
+        break;
+      case "silent":
+        deps.log.info("auto-update: starting silent update");
+        await writeAutoUpdateState({
+          preUpdateVersion: result.currentVersion,
+          updatedAt: new Date().toISOString(),
+        });
+        await deps.onSilentUpdate();
+        break;
+    }
+  };
+
+  let timer = scheduleNextCheck();
+  return () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+  };
+}


### PR DESCRIPTION
## Summary

Adds a built-in auto-update system as a config-driven feature, eliminating the need for manual cron jobs and workspace file workarounds.

Closes #12855

## Changes

- **Config schema**: New `update.auto` section with `enabled`, `mode`, `schedule`, `timezone`, `notifyAfterUpdate`, and `notifyChannel` fields
- **Zod validation**: HH:MM format enforcement for schedule, enum validation for mode
- **Auto-update module** (`src/infra/auto-update.ts`): Schedule parsing, state persistence, post-update notification, and scheduler with mode-based behavior
- **23 vitest tests** covering config validation, schedule parsing, state file operations, mode behavior, and post-update notifications

## Configuration

```jsonc
{
  "update": {
    "auto": {
      "enabled": true,           // opt-in (default: false)
      "mode": "confirm",         // "confirm" | "silent" | "notify-only"
      "schedule": "02:00",       // HH:MM in user timezone
      "timezone": "America/Chicago",
      "notifyAfterUpdate": true, // post-restart version diff
      "notifyChannel": "last"    // where to send notifications
    }
  }
}
```

## Modes

- **notify-only** (default): Check for updates, notify user if available. No action taken.
- **confirm**: Notify user and wait for approval before updating.
- **silent**: Update automatically at scheduled time without asking.

## Real-world context

See [this comment on the issue](https://github.com/openclaw/openclaw/issues/12855#issuecomment-3873715050) for the manual workaround this replaces (2 cron jobs + BOOT.md + state files).

Co-authored-by: Cory LaNou <cory@lanou.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a config-driven auto-update feature with three modes (notify-only, confirm, silent) that eliminates manual cron job workarounds. Implementation includes comprehensive test coverage (23 tests) covering schedule parsing, state persistence, mode behavior, and config validation.

**Key Changes:**
- New `update.auto` config section with Zod validation for HH:MM schedule format
- Auto-update scheduler with timezone-aware scheduling 
- State file persistence for post-update version tracking and notifications
- Three update modes with appropriate callbacks for each behavior

**Issues Found:**
- DST transition bug: adding 86400 seconds for "tomorrow" doesn't account for daylight saving time changes, which can cause scheduling drift
- Timezone fallback mismatch: docs say it defaults to `agents.defaults.userTimezone`, but implementation defaults to system timezone without reading that config value

<h3>Confidence Score: 3/5</h3>

- This PR is mostly safe to merge but has a DST scheduling bug that should be fixed
- Strong test coverage and clean implementation, but the DST handling bug in `computeNextScheduleMs` will cause incorrect scheduling during timezone transitions. The timezone fallback documentation is also misleading. These issues should be addressed before merge.
- Pay close attention to `src/infra/auto-update.ts` - specifically the DST handling in `computeNextScheduleMs` and timezone resolution in `startAutoUpdateScheduler`

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->