### PR TITLE
Config Builder: align with existing OpenClaw web UI stack

### DIFF
--- a/apps/config-builder/README.md
+++ b/apps/config-builder/README.md
@@ -12,11 +12,12 @@ Use the same front-end stack as the existing OpenClaw web UI (`ui/`):
 
 ## Current status
 
-Phase 0 spike is in place:
+Phase 0 and Phase 1 are in place:
 
 - app boots with Vite + Lit
 - `OpenClawSchema.toJSONSchema()` runs in browser bundle
 - `buildConfigSchema()` UI hints load in browser bundle
+- Explorer read-only scaffold renders grouped sections + field metadata
 
 To run locally:
 

--- a/apps/config-builder/README.md
+++ b/apps/config-builder/README.md
@@ -10,6 +10,27 @@ Use the same front-end stack as the existing OpenClaw web UI (`ui/`):
 - Lit
 - Plain CSS (no Next.js/Tailwind)
 
-## Planning
+## Current status
+
+Phase 0 spike is in place:
+
+- app boots with Vite + Lit
+- `OpenClawSchema.toJSONSchema()` runs in browser bundle
+- `buildConfigSchema()` UI hints load in browser bundle
+
+To run locally:
+
+```bash
+pnpm --filter @openclaw/config-builder dev
+```
+
+## Notes
 
 Implementation details are tracked in `.local/config-builder-spec.md`.
+
+For the spike, Vite aliases lightweight browser shims for:
+
+- `src/version.ts`
+- `src/channels/registry.ts`
+
+This keeps schema imports browser-safe while preserving the existing Node runtime modules.

--- a/apps/config-builder/README.md
+++ b/apps/config-builder/README.md
@@ -12,14 +12,18 @@ Use the same front-end stack as the existing OpenClaw web UI (`ui/`):
 
 ## Current status
 
-Phase 0, Phase 1, and Phase 2 are in place:
+Phase 0, Phase 1, Phase 2, and Phase 3 are in place:
 
 - app boots with Vite + Lit
 - `OpenClawSchema.toJSONSchema()` runs in browser bundle
 - `buildConfigSchema()` UI hints load in browser bundle
 - Explorer scaffold renders grouped sections + field metadata
-- Primitive field editing writes sparse config state by dot-path
-- Draft state persists to localStorage
+- Sparse draft state persists to localStorage and renders to JSON5 preview
+- Typed field renderer covers:
+  - strings, numbers, integers, booleans, enums
+  - primitive arrays with add/remove
+  - record-like objects (key/value editor)
+  - JSON fallback editor for complex array/object shapes
 - Live JSON5 preview supports copy/download/reset
 
 To run locally:

--- a/apps/config-builder/README.md
+++ b/apps/config-builder/README.md
@@ -12,19 +12,33 @@ Use the same front-end stack as the existing OpenClaw web UI (`ui/`):
 
 ## Current status
 
-Phase 0, Phase 1, Phase 2, and Phase 3 are in place:
+Phase 0 through Phase 6 are implemented:
 
 - app boots with Vite + Lit
 - `OpenClawSchema.toJSONSchema()` runs in browser bundle
 - `buildConfigSchema()` UI hints load in browser bundle
-- Explorer scaffold renders grouped sections + field metadata
-- Sparse draft state persists to localStorage and renders to JSON5 preview
+- Explorer mode supports grouped schema editing + search/filter
 - Typed field renderer covers:
   - strings, numbers, integers, booleans, enums
   - primitive arrays with add/remove
   - record-like objects (key/value editor)
   - JSON fallback editor for complex array/object shapes
-- Live JSON5 preview supports copy/download/reset
+- Validation + error UX:
+  - real-time `OpenClawSchema` validation
+  - inline field-level errors
+  - section-level error counts + global summary
+- Wizard mode:
+  - 7 curated steps with progress indicators
+  - back/continue flow with shared renderer/state
+- JSON5 preview panel:
+  - sparse output
+  - copy/download/reset
+  - sensitive-value warning banner
+- Routing + polish:
+  - landing page + mode routing via hash (`#/`, `#/explorer`, `#/wizard`)
+  - responsive layout including mobile preview drawer behavior
+  - docs link in topbar
+  - Vercel static config (`apps/config-builder/vercel.json`)
 
 To run locally:
 

--- a/apps/config-builder/README.md
+++ b/apps/config-builder/README.md
@@ -1,0 +1,15 @@
+# Config Builder (WIP)
+
+This workspace package will host the standalone OpenClaw config builder app.
+
+## Stack
+
+Use the same front-end stack as the existing OpenClaw web UI (`ui/`):
+
+- Vite
+- Lit
+- Plain CSS (no Next.js/Tailwind)
+
+## Planning
+
+Implementation details are tracked in `.local/config-builder-spec.md`.

--- a/apps/config-builder/README.md
+++ b/apps/config-builder/README.md
@@ -12,12 +12,15 @@ Use the same front-end stack as the existing OpenClaw web UI (`ui/`):
 
 ## Current status
 
-Phase 0 and Phase 1 are in place:
+Phase 0, Phase 1, and Phase 2 are in place:
 
 - app boots with Vite + Lit
 - `OpenClawSchema.toJSONSchema()` runs in browser bundle
 - `buildConfigSchema()` UI hints load in browser bundle
-- Explorer read-only scaffold renders grouped sections + field metadata
+- Explorer scaffold renders grouped sections + field metadata
+- Primitive field editing writes sparse config state by dot-path
+- Draft state persists to localStorage
+- Live JSON5 preview supports copy/download/reset
 
 To run locally:
 

--- a/apps/config-builder/index.html
+++ b/apps/config-builder/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OpenClaw Config Builder</title>
+  </head>
+  <body>
+    <config-builder-app></config-builder-app>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/apps/config-builder/package.json
+++ b/apps/config-builder/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@openclaw/config-builder",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite",
+    "preview": "vite preview",
+    "test": "vitest run --config vitest.config.ts"
+  },
+  "dependencies": {
+    "json5": "^2.2.3",
+    "lit": "^3.3.2",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "vite": "7.3.1",
+    "vitest": "4.0.18"
+  }
+}

--- a/apps/config-builder/src/lib/config-store.test.ts
+++ b/apps/config-builder/src/lib/config-store.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { clearFieldValue, getFieldValue, setFieldValue } from "./config-store.ts";
+
+describe("config-store helpers", () => {
+  it("sets and reads nested fields", () => {
+    const next = setFieldValue({}, "gateway.auth.token", "abc123");
+    expect(getFieldValue(next, "gateway.auth.token")).toBe("abc123");
+    expect(next.gateway).toBeTruthy();
+  });
+
+  it("clears nested fields and prunes empty parents", () => {
+    const seeded = setFieldValue({}, "gateway.auth.token", "abc123");
+    const cleared = clearFieldValue(seeded, "gateway.auth.token");
+
+    expect(getFieldValue(cleared, "gateway.auth.token")).toBeUndefined();
+    expect(cleared.gateway).toBeUndefined();
+  });
+});

--- a/apps/config-builder/src/lib/config-store.ts
+++ b/apps/config-builder/src/lib/config-store.ts
@@ -60,7 +60,10 @@ export function setFieldValue(config: ConfigDraft, path: string, value: unknown)
   let cursor: Record<string, unknown> = next;
 
   for (let index = 0; index < segments.length - 1; index += 1) {
-    const segment = segments[index]!;
+    const segment = segments[index];
+    if (!segment) {
+      continue;
+    }
     const existing = cursor[segment];
     if (isRecord(existing)) {
       cursor = existing;
@@ -94,8 +97,12 @@ export function clearFieldValue(config: ConfigDraft, path: string): ConfigDraft 
     if (!isRecord(cursor)) {
       return next;
     }
+    const segment = segments[index];
+    if (!segment) {
+      return next;
+    }
     parents.push(cursor);
-    cursor = cursor[segments[index]!];
+    cursor = cursor[segment];
   }
 
   if (!isRecord(cursor)) {
@@ -111,7 +118,10 @@ export function clearFieldValue(config: ConfigDraft, path: string): ConfigDraft 
 
   for (let index = segments.length - 2; index >= 0; index -= 1) {
     const parent = parents[index];
-    const key = segments[index]!;
+    const key = segments[index];
+    if (!parent || !key) {
+      continue;
+    }
     const child = parent[key];
     if (!isRecord(child)) {
       continue;

--- a/apps/config-builder/src/lib/config-store.ts
+++ b/apps/config-builder/src/lib/config-store.ts
@@ -1,0 +1,160 @@
+export type ConfigDraft = Record<string, unknown>;
+
+const STORAGE_KEY = "openclaw.config-builder.v1";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function cloneDraft(input: ConfigDraft): ConfigDraft {
+  if (typeof structuredClone === "function") {
+    return structuredClone(input);
+  }
+  return JSON.parse(JSON.stringify(input)) as ConfigDraft;
+}
+
+function normalizePath(path: string): string[] {
+  return path
+    .split(".")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function pruneEmptyObjects(value: unknown): unknown {
+  if (!isRecord(value)) {
+    return value;
+  }
+  const next: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    const cleaned = pruneEmptyObjects(nested);
+    if (cleaned === undefined) {
+      continue;
+    }
+    if (isRecord(cleaned) && Object.keys(cleaned).length === 0) {
+      continue;
+    }
+    next[key] = cleaned;
+  }
+  return Object.keys(next).length === 0 ? undefined : next;
+}
+
+export function getFieldValue(config: ConfigDraft, path: string): unknown {
+  const segments = normalizePath(path);
+  let current: unknown = config;
+  for (const segment of segments) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    current = current[segment];
+  }
+  return current;
+}
+
+export function setFieldValue(config: ConfigDraft, path: string, value: unknown): ConfigDraft {
+  const segments = normalizePath(path);
+  if (segments.length === 0) {
+    return config;
+  }
+
+  const next = cloneDraft(config);
+  let cursor: Record<string, unknown> = next;
+
+  for (let index = 0; index < segments.length - 1; index += 1) {
+    const segment = segments[index]!;
+    const existing = cursor[segment];
+    if (isRecord(existing)) {
+      cursor = existing;
+      continue;
+    }
+    const child: Record<string, unknown> = {};
+    cursor[segment] = child;
+    cursor = child;
+  }
+
+  const leaf = segments.at(-1);
+  if (!leaf) {
+    return next;
+  }
+
+  cursor[leaf] = value;
+  return next;
+}
+
+export function clearFieldValue(config: ConfigDraft, path: string): ConfigDraft {
+  const segments = normalizePath(path);
+  if (segments.length === 0) {
+    return config;
+  }
+
+  const next = cloneDraft(config);
+  const parents: Array<Record<string, unknown>> = [];
+  let cursor: unknown = next;
+
+  for (let index = 0; index < segments.length - 1; index += 1) {
+    if (!isRecord(cursor)) {
+      return next;
+    }
+    parents.push(cursor);
+    cursor = cursor[segments[index]!];
+  }
+
+  if (!isRecord(cursor)) {
+    return next;
+  }
+
+  const leaf = segments.at(-1);
+  if (!leaf) {
+    return next;
+  }
+
+  delete cursor[leaf];
+
+  for (let index = segments.length - 2; index >= 0; index -= 1) {
+    const parent = parents[index];
+    const key = segments[index]!;
+    const child = parent[key];
+    if (!isRecord(child)) {
+      continue;
+    }
+    if (Object.keys(child).length === 0) {
+      delete parent[key];
+    }
+  }
+
+  const cleaned = pruneEmptyObjects(next);
+  return isRecord(cleaned) ? cleaned : {};
+}
+
+export function resetDraft(): ConfigDraft {
+  return {};
+}
+
+export function loadPersistedDraft(storage: Storage | null = globalThis.localStorage ?? null): ConfigDraft {
+  if (!storage) {
+    return {};
+  }
+  try {
+    const raw = storage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed = JSON.parse(raw) as unknown;
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function persistDraft(
+  config: ConfigDraft,
+  storage: Storage | null = globalThis.localStorage ?? null,
+): void {
+  if (!storage) {
+    return;
+  }
+  try {
+    storage.setItem(STORAGE_KEY, JSON.stringify(config));
+  } catch {
+    // best-effort persistence only
+  }
+}

--- a/apps/config-builder/src/lib/json5-format.test.ts
+++ b/apps/config-builder/src/lib/json5-format.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { formatConfigJson5 } from "./json5-format.ts";
+
+describe("formatConfigJson5", () => {
+  it("formats sparse config and computes size metadata", () => {
+    const preview = formatConfigJson5({ gateway: { port: 18789 } });
+    expect(preview.text).toContain("gateway");
+    expect(preview.text).toContain("18789");
+    expect(preview.lineCount).toBeGreaterThan(0);
+    expect(preview.byteCount).toBeGreaterThan(0);
+  });
+});

--- a/apps/config-builder/src/lib/json5-format.ts
+++ b/apps/config-builder/src/lib/json5-format.ts
@@ -1,0 +1,34 @@
+import JSON5 from "json5";
+import type { ConfigDraft } from "./config-store.ts";
+
+export type Json5Preview = {
+  text: string;
+  lineCount: number;
+  byteCount: number;
+};
+
+export function formatConfigJson5(config: ConfigDraft): Json5Preview {
+  const text = `${JSON5.stringify(config, null, 2)}\n`;
+  const lineCount = text.split(/\r?\n/).length - 1;
+  const byteCount = new TextEncoder().encode(text).byteLength;
+  return {
+    text,
+    lineCount,
+    byteCount,
+  };
+}
+
+export function downloadJson5File(text: string, filename = "openclaw.json"): void {
+  if (typeof document === "undefined") {
+    return;
+  }
+  const blob = new Blob([text], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}

--- a/apps/config-builder/src/lib/schema-spike.test.ts
+++ b/apps/config-builder/src/lib/schema-spike.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { buildExplorerSnapshot } from "./schema-spike.ts";
+
+describe("buildExplorerSnapshot", () => {
+  it("builds ordered sections and field metadata", () => {
+    const snapshot = buildExplorerSnapshot();
+
+    expect(snapshot.sectionCount).toBeGreaterThan(0);
+    expect(snapshot.fieldCount).toBeGreaterThan(0);
+    expect(snapshot.sections[0]?.order).toBeLessThanOrEqual(snapshot.sections.at(-1)?.order ?? 0);
+
+    const gatewaySection = snapshot.sections.find((section) => section.id === "gateway");
+    expect(gatewaySection).toBeTruthy();
+    expect(gatewaySection?.fields.some((field) => field.path === "gateway.auth.token")).toBe(true);
+
+    const tokenField = gatewaySection?.fields.find((field) => field.path === "gateway.auth.token");
+    expect(tokenField?.sensitive).toBe(true);
+  });
+});

--- a/apps/config-builder/src/lib/schema-spike.test.ts
+++ b/apps/config-builder/src/lib/schema-spike.test.ts
@@ -39,8 +39,6 @@ describe("buildExplorerSnapshot", () => {
       .find((field) => field.path === "tools.alsoAllow");
     expect(arrayField?.kind).toBe("array");
     expect(arrayField?.itemKind).toBe("string");
-    expect(arrayField?.itemEnumValues).toContain("exec");
-    expect(arrayField?.itemEnumValues).toContain("group:fs");
 
     const recordField = snapshot.sections
       .flatMap((section) => section.fields)

--- a/apps/config-builder/src/lib/schema-spike.test.ts
+++ b/apps/config-builder/src/lib/schema-spike.test.ts
@@ -15,5 +15,12 @@ describe("buildExplorerSnapshot", () => {
 
     const tokenField = gatewaySection?.fields.find((field) => field.path === "gateway.auth.token");
     expect(tokenField?.sensitive).toBe(true);
+    expect(tokenField?.kind).toBe("string");
+    expect(tokenField?.editable).toBe(true);
+
+    const wildcardField = snapshot.sections
+      .flatMap((section) => section.fields)
+      .find((field) => field.path.includes("*"));
+    expect(wildcardField?.editable).toBe(false);
   });
 });

--- a/apps/config-builder/src/lib/schema-spike.test.ts
+++ b/apps/config-builder/src/lib/schema-spike.test.ts
@@ -22,5 +22,17 @@ describe("buildExplorerSnapshot", () => {
       .flatMap((section) => section.fields)
       .find((field) => field.path.includes("*"));
     expect(wildcardField?.editable).toBe(false);
+
+    const arrayField = snapshot.sections
+      .flatMap((section) => section.fields)
+      .find((field) => field.path === "tools.alsoAllow");
+    expect(arrayField?.kind).toBe("array");
+    expect(arrayField?.itemKind).toBe("string");
+
+    const recordField = snapshot.sections
+      .flatMap((section) => section.fields)
+      .find((field) => field.path === "diagnostics.otel.headers");
+    expect(recordField?.kind).toBe("object");
+    expect(recordField?.recordValueKind).toBe("string");
   });
 });

--- a/apps/config-builder/src/lib/schema-spike.test.ts
+++ b/apps/config-builder/src/lib/schema-spike.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildExplorerSnapshot } from "./schema-spike.ts";
+import { buildExplorerSnapshot, resolveExplorerField } from "./schema-spike.ts";
 
 describe("buildExplorerSnapshot", () => {
   it("builds ordered sections and field metadata", () => {
@@ -34,5 +34,18 @@ describe("buildExplorerSnapshot", () => {
       .find((field) => field.path === "diagnostics.otel.headers");
     expect(recordField?.kind).toBe("object");
     expect(recordField?.recordValueKind).toBe("string");
+  });
+});
+
+describe("resolveExplorerField", () => {
+  it("resolves metadata for paths that do not have explicit UI hints", () => {
+    const port = resolveExplorerField("gateway.port");
+    expect(port).toBeTruthy();
+    expect(port?.kind).toBe("integer");
+    expect(port?.editable).toBe(true);
+  });
+
+  it("returns null for unknown paths", () => {
+    expect(resolveExplorerField("this.path.does.not.exist")).toBeNull();
   });
 });

--- a/apps/config-builder/src/lib/schema-spike.test.ts
+++ b/apps/config-builder/src/lib/schema-spike.test.ts
@@ -23,17 +23,36 @@ describe("buildExplorerSnapshot", () => {
       .find((field) => field.path.includes("*"));
     expect(wildcardField?.editable).toBe(false);
 
+    const telegramToken = snapshot.sections
+      .flatMap((section) => section.fields)
+      .find((field) => field.path === "channels.telegram.botToken");
+    expect(telegramToken?.kind).toBe("string");
+
+    const updateChannel = snapshot.sections
+      .flatMap((section) => section.fields)
+      .find((field) => field.path === "update.channel");
+    expect(updateChannel?.kind).toBe("enum");
+    expect(updateChannel?.enumValues).toContain("stable");
+
     const arrayField = snapshot.sections
       .flatMap((section) => section.fields)
       .find((field) => field.path === "tools.alsoAllow");
     expect(arrayField?.kind).toBe("array");
     expect(arrayField?.itemKind).toBe("string");
+    expect(arrayField?.itemEnumValues).toContain("exec");
+    expect(arrayField?.itemEnumValues).toContain("group:fs");
 
     const recordField = snapshot.sections
       .flatMap((section) => section.fields)
       .find((field) => field.path === "diagnostics.otel.headers");
     expect(recordField?.kind).toBe("object");
     expect(recordField?.recordValueKind).toBe("string");
+
+    const browserFields = snapshot.sections
+      .find((section) => section.id === "browser")
+      ?.fields.map((field) => field.path) ?? [];
+    expect(browserFields.includes("browser.snapshotDefaults.mode")).toBe(true);
+    expect(browserFields.includes("browser.snapshotDefaults")).toBe(false);
   });
 });
 
@@ -47,5 +66,9 @@ describe("resolveExplorerField", () => {
 
   it("returns null for unknown paths", () => {
     expect(resolveExplorerField("this.path.does.not.exist")).toBeNull();
+  });
+
+  it("drops hint-only paths that are not in the schema", () => {
+    expect(resolveExplorerField("tools.web.fetch.firecrawl.enabled")).toBeNull();
   });
 });

--- a/apps/config-builder/src/lib/schema-spike.ts
+++ b/apps/config-builder/src/lib/schema-spike.ts
@@ -1,0 +1,32 @@
+import { buildConfigSchema } from "@openclaw/config/schema.ts";
+import { OpenClawSchema } from "@openclaw/config/zod-schema.ts";
+
+type JsonSchemaRoot = {
+  properties?: Record<string, unknown>;
+};
+
+export type SchemaSpikeSummary = {
+  schemaRootProperties: number;
+  schemaTopSections: string[];
+  uiHintCount: number;
+  generatedAt: string;
+  version: string;
+};
+
+export function runSchemaSpike(): SchemaSpikeSummary {
+  const schema = OpenClawSchema.toJSONSchema({
+    target: "draft-07",
+    unrepresentable: "any",
+  }) as JsonSchemaRoot;
+  const topLevelProps = Object.keys(schema.properties ?? {});
+
+  const configSchema = buildConfigSchema();
+
+  return {
+    schemaRootProperties: topLevelProps.length,
+    schemaTopSections: topLevelProps.slice(0, 10),
+    uiHintCount: Object.keys(configSchema.uiHints).length,
+    generatedAt: configSchema.generatedAt,
+    version: configSchema.version,
+  };
+}

--- a/apps/config-builder/src/lib/schema-spike.ts
+++ b/apps/config-builder/src/lib/schema-spike.ts
@@ -1,32 +1,157 @@
-import { buildConfigSchema } from "@openclaw/config/schema.ts";
-import { OpenClawSchema } from "@openclaw/config/zod-schema.ts";
+import { buildConfigSchema, type ConfigUiHint } from "@openclaw/config/schema.ts";
 
-type JsonSchemaRoot = {
-  properties?: Record<string, unknown>;
+type JsonSchemaNode = {
+  description?: string;
+  properties?: Record<string, JsonSchemaNode>;
 };
 
-export type SchemaSpikeSummary = {
-  schemaRootProperties: number;
-  schemaTopSections: string[];
-  uiHintCount: number;
-  generatedAt: string;
+export type ExplorerField = {
+  path: string;
+  label: string;
+  help: string;
+  sensitive: boolean;
+  advanced: boolean;
+};
+
+export type ExplorerSection = {
+  id: string;
+  label: string;
+  order: number;
+  description: string;
+  fields: ExplorerField[];
+};
+
+export type ExplorerSnapshot = {
   version: string;
+  generatedAt: string;
+  sectionCount: number;
+  fieldCount: number;
+  sections: ExplorerSection[];
 };
 
-export function runSchemaSpike(): SchemaSpikeSummary {
-  const schema = OpenClawSchema.toJSONSchema({
-    target: "draft-07",
-    unrepresentable: "any",
-  }) as JsonSchemaRoot;
-  const topLevelProps = Object.keys(schema.properties ?? {});
+const SECTION_FALLBACK_ORDER = 500;
 
+function humanizeKey(value: string): string {
+  if (!value.trim()) {
+    return value;
+  }
+  return value
+    .replace(/[_-]+/g, " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^./, (char) => char.toUpperCase());
+}
+
+function firstPathSegment(path: string): string {
+  const [segment] = path.split(".");
+  return segment?.trim() ?? "";
+}
+
+function lastPathSegment(path: string): string {
+  const segments = path.split(".");
+  return segments.at(-1) ?? path;
+}
+
+function isSectionHint(path: string, hint: ConfigUiHint): boolean {
+  return !path.includes(".") && typeof hint.order === "number" && typeof hint.group === "string";
+}
+
+function fieldSort(a: ExplorerField, b: ExplorerField): number {
+  return a.path.localeCompare(b.path);
+}
+
+function sectionSort(a: ExplorerSection, b: ExplorerSection): number {
+  if (a.order !== b.order) {
+    return a.order - b.order;
+  }
+  return a.label.localeCompare(b.label);
+}
+
+export function buildExplorerSnapshot(): ExplorerSnapshot {
   const configSchema = buildConfigSchema();
+  const uiHints = configSchema.uiHints;
+  const schemaRoot = (configSchema.schema as JsonSchemaNode).properties ?? {};
+
+  const sections = new Map<string, ExplorerSection>();
+
+  for (const [path, hint] of Object.entries(uiHints)) {
+    if (!isSectionHint(path, hint)) {
+      continue;
+    }
+    sections.set(path, {
+      id: path,
+      label: hint.label?.trim() || hint.group?.trim() || humanizeKey(path),
+      order: hint.order,
+      description: "",
+      fields: [],
+    });
+  }
+
+  for (const [rootKey, node] of Object.entries(schemaRoot)) {
+    if (sections.has(rootKey)) {
+      const existing = sections.get(rootKey);
+      if (existing) {
+        existing.description = node.description?.trim() ?? existing.description;
+      }
+      continue;
+    }
+    const rootHint = uiHints[rootKey];
+    sections.set(rootKey, {
+      id: rootKey,
+      label: rootHint?.label?.trim() || humanizeKey(rootKey),
+      order: rootHint?.order ?? SECTION_FALLBACK_ORDER,
+      description: node.description?.trim() ?? rootHint?.help?.trim() ?? "",
+      fields: [],
+    });
+  }
+
+  for (const [path, hint] of Object.entries(uiHints)) {
+    const rootKey = firstPathSegment(path);
+    if (!rootKey) {
+      continue;
+    }
+
+    const section = sections.get(rootKey);
+    if (!section) {
+      sections.set(rootKey, {
+        id: rootKey,
+        label: humanizeKey(rootKey),
+        order: SECTION_FALLBACK_ORDER,
+        description: "",
+        fields: [],
+      });
+    }
+
+    const target = sections.get(rootKey);
+    if (!target) {
+      continue;
+    }
+
+    if (isSectionHint(path, hint)) {
+      continue;
+    }
+
+    target.fields.push({
+      path,
+      label: hint.label?.trim() || humanizeKey(lastPathSegment(path)),
+      help: hint.help?.trim() ?? "",
+      sensitive: Boolean(hint.sensitive),
+      advanced: Boolean(hint.advanced),
+    });
+  }
+
+  const orderedSections = Array.from(sections.values())
+    .map((section) => ({ ...section, fields: section.fields.toSorted(fieldSort) }))
+    .toSorted(sectionSort);
+
+  const fieldCount = orderedSections.reduce((sum, section) => sum + section.fields.length, 0);
 
   return {
-    schemaRootProperties: topLevelProps.length,
-    schemaTopSections: topLevelProps.slice(0, 10),
-    uiHintCount: Object.keys(configSchema.uiHints).length,
-    generatedAt: configSchema.generatedAt,
     version: configSchema.version,
+    generatedAt: configSchema.generatedAt,
+    sectionCount: orderedSections.length,
+    fieldCount,
+    sections: orderedSections,
   };
 }

--- a/apps/config-builder/src/lib/validation.test.ts
+++ b/apps/config-builder/src/lib/validation.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigDraft } from "./validation.ts";
+
+describe("validateConfigDraft", () => {
+  it("accepts empty drafts", () => {
+    const result = validateConfigDraft({});
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it("collects issues by path and section", () => {
+    const result = validateConfigDraft({
+      gateway: {
+        auth: {
+          token: 123,
+        },
+      },
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.issues.length).toBeGreaterThan(0);
+    expect(result.issuesByPath["gateway.auth.token"]?.length).toBeGreaterThan(0);
+    expect(result.sectionErrorCounts.gateway).toBeGreaterThan(0);
+  });
+
+  it("tracks root-level schema issues", () => {
+    const result = validateConfigDraft({
+      __unexpected__: true,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.sectionErrorCounts.root).toBeGreaterThan(0);
+  });
+});

--- a/apps/config-builder/src/lib/validation.ts
+++ b/apps/config-builder/src/lib/validation.ts
@@ -1,0 +1,73 @@
+import { OpenClawSchema } from "@openclaw/config/zod-schema.ts";
+import type { ConfigDraft } from "./config-store.ts";
+
+export type ValidationIssue = {
+  path: string;
+  section: string;
+  message: string;
+};
+
+export type ValidationResult = {
+  valid: boolean;
+  issues: ValidationIssue[];
+  issuesByPath: Record<string, string[]>;
+  sectionErrorCounts: Record<string, number>;
+};
+
+function issuePath(path: Array<string | number>): string {
+  if (path.length === 0) {
+    return "";
+  }
+  return path
+    .map((segment) => (typeof segment === "number" ? String(segment) : segment))
+    .join(".");
+}
+
+function issueSection(path: string): string {
+  if (!path) {
+    return "root";
+  }
+  const [section] = path.split(".");
+  return section?.trim() || "root";
+}
+
+export function validateConfigDraft(config: ConfigDraft): ValidationResult {
+  const parsed = OpenClawSchema.safeParse(config);
+  if (parsed.success) {
+    return {
+      valid: true,
+      issues: [],
+      issuesByPath: {},
+      sectionErrorCounts: {},
+    };
+  }
+
+  const issues: ValidationIssue[] = parsed.error.issues.map((issue) => {
+    const path = issuePath(issue.path);
+    return {
+      path,
+      section: issueSection(path),
+      message: issue.message,
+    };
+  });
+
+  const issuesByPath: Record<string, string[]> = {};
+  const sectionErrorCounts: Record<string, number> = {};
+
+  for (const issue of issues) {
+    const key = issue.path;
+    if (!issuesByPath[key]) {
+      issuesByPath[key] = [];
+    }
+    issuesByPath[key].push(issue.message);
+
+    sectionErrorCounts[issue.section] = (sectionErrorCounts[issue.section] ?? 0) + 1;
+  }
+
+  return {
+    valid: false,
+    issues,
+    issuesByPath,
+    sectionErrorCounts,
+  };
+}

--- a/apps/config-builder/src/main.ts
+++ b/apps/config-builder/src/main.ts
@@ -1,0 +1,2 @@
+import "./styles.css";
+import "./ui/app.ts";

--- a/apps/config-builder/src/shims/channel-registry.ts
+++ b/apps/config-builder/src/shims/channel-registry.ts
@@ -1,0 +1,10 @@
+// Browser-safe channel ID shim for config-builder schema imports.
+export const CHANNEL_IDS = [
+  "telegram",
+  "whatsapp",
+  "discord",
+  "googlechat",
+  "slack",
+  "signal",
+  "imessage",
+] as const;

--- a/apps/config-builder/src/shims/version.ts
+++ b/apps/config-builder/src/shims/version.ts
@@ -1,0 +1,3 @@
+// Browser-safe version shim for config-builder schema imports.
+// Real gateway/runtime paths can still use src/version.ts.
+export const VERSION = "dev";

--- a/apps/config-builder/src/styles.css
+++ b/apps/config-builder/src/styles.css
@@ -11,21 +11,123 @@ config-builder-app {
 
 .builder-screen {
   min-height: 100vh;
-  padding: 0;
   background: var(--bg);
 }
 
+/* -------------------------------------------
+   Topbar + mode routing controls
+   ------------------------------------------- */
+
+.builder-topbar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--chrome);
+  backdrop-filter: blur(8px);
+}
+
+.builder-brand {
+  min-width: 0;
+}
+
+.builder-brand__title {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.builder-brand__subtitle {
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.builder-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+}
+
+.builder-mode-toggle__btn {
+  border: 0;
+  border-radius: var(--radius-sm);
+  padding: 7px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted);
+  background: transparent;
+  cursor: pointer;
+}
+
+.builder-mode-toggle__btn:hover {
+  color: var(--text);
+}
+
+.builder-mode-toggle__btn.active {
+  color: var(--accent-foreground);
+  background: var(--accent);
+}
+
+/* -------------------------------------------
+   Landing mode
+   ------------------------------------------- */
+
+.builder-landing {
+  min-height: calc(100vh - 58px);
+  display: grid;
+  place-items: center;
+  padding: 24px;
+}
+
+.builder-landing__card {
+  max-width: 760px;
+  width: 100%;
+}
+
+.builder-landing__actions {
+  margin-top: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.builder-landing__notes {
+  margin-top: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+/* -------------------------------------------
+   Workspace layout
+   ------------------------------------------- */
+
 .builder-layout.config-layout {
   margin: 0;
-  height: 100vh;
   border: 0;
   border-radius: 0;
+  height: calc(100vh - 58px);
+  grid-template-columns: 260px minmax(0, 1fr) 400px;
 }
 
 @supports (height: 100dvh) {
   .builder-layout.config-layout {
-    height: 100dvh;
+    height: calc(100dvh - 58px);
   }
+}
+
+.builder-layout--wizard.config-layout {
+  grid-template-columns: minmax(0, 1fr) 400px;
 }
 
 .builder-subtitle {
@@ -48,6 +150,21 @@ config-builder-app {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.builder-error-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: var(--radius-full);
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  background: var(--danger-subtle);
+  color: var(--danger);
   font-size: 10px;
   font-weight: 700;
 }
@@ -77,11 +194,50 @@ config-builder-app {
   color: var(--accent);
 }
 
+.builder-error-text {
+  color: var(--danger);
+}
+
+/* -------------------------------------------
+   Validation summary
+   ------------------------------------------- */
+
+.builder-validation-summary {
+  margin-bottom: 14px;
+}
+
+.builder-validation-summary__title {
+  font-weight: 700;
+}
+
+.builder-validation-summary__sections {
+  margin-top: 8px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.builder-validation-summary__list {
+  margin: 10px 0 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
+  font-size: 12px;
+}
+
+/* -------------------------------------------
+   Field rendering
+   ------------------------------------------- */
+
 .builder-field {
   padding: 12px;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-accent);
+}
+
+.builder-field--set {
+  border-color: var(--border-strong);
 }
 
 .builder-field__head {
@@ -104,21 +260,97 @@ config-builder-app {
   word-break: break-word;
 }
 
-@media (max-width: 980px) {
-  .builder-layout.config-layout {
-    height: auto;
-    min-height: 100vh;
-  }
+.builder-field__controls {
+  display: grid;
+  gap: 8px;
 }
 
-/* Phase 2 layout: add dedicated JSON5 preview panel. */
-.builder-layout.config-layout {
-  grid-template-columns: 260px minmax(0, 1fr) 400px;
+.builder-field__actions {
+  margin-top: 2px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }
+
+.builder-toggle-row {
+  margin: 0;
+}
+
+/* -------------------------------------------
+   Wizard mode
+   ------------------------------------------- */
+
+.builder-wizard {
+  display: grid;
+  gap: 14px;
+}
+
+.builder-wizard__progress {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.builder-wizard__step {
+  display: grid;
+  justify-items: center;
+  gap: 4px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--muted);
+  padding: 8px 6px;
+  cursor: pointer;
+}
+
+.builder-wizard__step:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.builder-wizard__step--active {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+.builder-wizard__step--done {
+  border-color: rgba(34, 197, 94, 0.4);
+  color: var(--ok);
+}
+
+.builder-wizard__step-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-full);
+  border: 1px solid currentColor;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.builder-wizard__step-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-align: center;
+}
+
+.builder-wizard__actions {
+  margin-top: 16px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+/* -------------------------------------------
+   Preview panel
+   ------------------------------------------- */
 
 .builder-preview {
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
   min-height: 0;
   background: var(--bg-accent);
   border-left: 1px solid var(--border);
@@ -150,6 +382,10 @@ config-builder-app {
   color: var(--muted);
 }
 
+.builder-preview__mobile-toggle {
+  display: none;
+}
+
 .builder-preview__code {
   margin: 0;
   border: 0;
@@ -161,30 +397,36 @@ config-builder-app {
   padding: 12px;
 }
 
-.builder-field--set {
-  border-color: var(--border-strong);
+.builder-sensitive-warning {
+  margin: 10px 12px 0;
 }
 
-.builder-field__controls {
-  display: grid;
-  gap: 8px;
+.builder-sensitive-warning__paths {
+  margin-top: 6px;
+  font-size: 11px;
+  color: var(--warn);
+  word-break: break-word;
 }
 
-.builder-field__actions {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 2px;
-}
-
-.builder-toggle-row {
-  margin: 0;
-}
+/* -------------------------------------------
+   Responsive
+   ------------------------------------------- */
 
 @media (max-width: 1500px) {
   .builder-layout.config-layout {
     grid-template-columns: 260px minmax(0, 1fr);
     height: auto;
-    min-height: 100vh;
+    min-height: calc(100vh - 58px);
+  }
+
+  @supports (height: 100dvh) {
+    .builder-layout.config-layout {
+      min-height: calc(100dvh - 58px);
+    }
+  }
+
+  .builder-layout--wizard.config-layout {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .builder-preview {
@@ -192,5 +434,59 @@ config-builder-app {
     border-left: 0;
     border-top: 1px solid var(--border);
     min-height: 320px;
+  }
+}
+
+@media (max-width: 980px) {
+  .builder-topbar {
+    flex-wrap: wrap;
+  }
+
+  .builder-mode-toggle {
+    order: 3;
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .builder-mode-toggle__btn {
+    flex: 1;
+  }
+
+  .builder-layout.config-layout {
+    grid-template-columns: 1fr;
+    min-height: calc(100vh - 88px);
+  }
+
+  .config-sidebar {
+    border-right: 0;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .builder-wizard__progress {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .builder-preview {
+    position: sticky;
+    bottom: 0;
+    z-index: 20;
+    min-height: 0;
+    max-height: 72vh;
+    transition: transform var(--duration-normal) var(--ease-out);
+    border-top: 1px solid var(--border);
+    box-shadow: var(--shadow-lg);
+    background: var(--panel-strong);
+  }
+
+  .builder-preview__mobile-toggle {
+    display: inline-flex;
+  }
+
+  .builder-preview.mobile-collapsed {
+    transform: translateY(calc(100% - 46px));
+  }
+
+  .builder-preview.mobile-open {
+    transform: translateY(0);
   }
 }

--- a/apps/config-builder/src/styles.css
+++ b/apps/config-builder/src/styles.css
@@ -2,159 +2,523 @@
 @import "../../../ui/src/styles/components.css";
 @import "../../../ui/src/styles/config.css";
 
-/* Config-builder specific wrappers (reuse OpenClaw UI tokens/classes above). */
+/* ===========================================
+   Config Builder — App Shell
+   =========================================== */
 
 config-builder-app {
   display: block;
   min-height: 100vh;
 }
 
-.builder-screen {
+.cb-screen {
   min-height: 100vh;
   background: var(--bg);
 }
 
-/* -------------------------------------------
-   Topbar + mode routing controls
-   ------------------------------------------- */
+/* --- Icons --- */
 
-.builder-topbar {
+.cb-icon {
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
+  vertical-align: middle;
+}
+
+/* ===========================================
+   Topbar
+   =========================================== */
+
+.cb-topbar {
   position: sticky;
   top: 0;
   z-index: 30;
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 12px;
-  padding: 10px 14px;
+  padding: 0 16px;
+  height: 56px;
   border-bottom: 1px solid var(--border);
   background: var(--chrome);
-  backdrop-filter: blur(8px);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
 }
 
-.builder-brand {
+.cb-topbar__brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   min-width: 0;
+  margin-right: auto;
 }
 
-.builder-brand__title {
+.cb-topbar__logo {
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-md);
+  background: var(--accent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--primary-foreground);
   font-size: 14px;
+  font-weight: 800;
+  flex-shrink: 0;
+  box-shadow: 0 0 12px var(--accent-glow);
+}
+
+.cb-topbar__title {
+  font-family: var(--font-display);
+  font-size: 15px;
   font-weight: 700;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.02em;
+  color: var(--text-strong);
+  white-space: nowrap;
 }
 
-.builder-brand__subtitle {
-  margin-top: 2px;
-  font-size: 11px;
-  color: var(--muted);
-}
-
-.builder-mode-toggle {
+.cb-topbar__nav {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  padding: 4px;
+  gap: 2px;
+  padding: 3px;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
 }
 
-.builder-mode-toggle__btn {
+.cb-topbar__nav-btn {
   border: 0;
   border-radius: var(--radius-sm);
-  padding: 7px 12px;
+  padding: 7px 14px;
   font-size: 12px;
   font-weight: 600;
   color: var(--muted);
   background: transparent;
   cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
 }
 
-.builder-mode-toggle__btn:hover {
+.cb-topbar__nav-btn:hover {
   color: var(--text);
 }
 
-.builder-mode-toggle__btn.active {
+.cb-topbar__nav-btn.active {
   color: var(--accent-foreground);
   background: var(--accent);
+  box-shadow: var(--shadow-sm);
 }
 
-/* -------------------------------------------
-   Landing mode
-   ------------------------------------------- */
-
-.builder-landing {
-  min-height: calc(100vh - 58px);
-  display: grid;
-  place-items: center;
-  padding: 24px;
-}
-
-.builder-landing__card {
-  max-width: 760px;
-  width: 100%;
-}
-
-.builder-landing__actions {
-  margin-top: 16px;
+.cb-topbar__actions {
   display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-}
-
-.builder-landing__notes {
-  margin-top: 16px;
-  display: flex;
-  flex-wrap: wrap;
+  align-items: center;
   gap: 8px;
 }
 
-/* -------------------------------------------
-   Workspace layout
-   ------------------------------------------- */
+.cb-search-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  background: var(--bg-elevated);
+  color: var(--muted);
+  font-size: 12px;
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease-out);
+}
 
-.builder-layout.config-layout {
+.cb-search-trigger:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.cb-search-trigger .cb-icon {
+  font-size: 14px;
+}
+
+.cb-search-trigger kbd {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 500;
+  padding: 2px 5px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.1);
+  opacity: 0.7;
+}
+
+:root[data-theme="light"] .cb-search-trigger kbd {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.cb-theme-toggle {
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  transition: all var(--duration-fast) var(--ease-out);
+}
+
+.cb-theme-toggle:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+/* ===========================================
+   Landing Page
+   =========================================== */
+
+.cb-landing {
+  min-height: calc(100vh - 56px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 24px;
+  animation: fade-in 0.4s var(--ease-out);
+}
+
+.cb-landing__hero {
+  text-align: center;
+  max-width: 640px;
+  margin-bottom: 40px;
+}
+
+.cb-landing__heading {
+  font-family: var(--font-display);
+  font-size: 42px;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  line-height: 1.1;
+  background: linear-gradient(135deg, var(--text-strong) 0%, var(--accent) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
   margin: 0;
-  border: 0;
-  border-radius: 0;
-  height: calc(100vh - 58px);
-  grid-template-columns: 260px minmax(0, 1fr) 400px;
+}
+
+.cb-landing__sub {
+  margin-top: 12px;
+  font-size: 16px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.cb-landing__cards {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  max-width: 640px;
+  width: 100%;
+}
+
+.cb-landing__card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--card);
+  padding: 24px;
+  cursor: pointer;
+  transition: all var(--duration-normal) var(--ease-out);
+  box-shadow: var(--shadow-sm), inset 0 1px 0 var(--card-highlight);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.cb-landing__card:hover {
+  border-color: var(--border-strong);
+  box-shadow: var(--shadow-md), inset 0 1px 0 var(--card-highlight);
+  transform: translateY(-2px);
+}
+
+.cb-landing__card--primary:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow-md), 0 0 20px var(--accent-glow);
+}
+
+.cb-landing__card-icon {
+  font-size: 28px;
+  color: var(--accent);
+}
+
+.cb-landing__card-title {
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-strong);
+}
+
+.cb-landing__card-meta {
+  font-size: 12px;
+  color: var(--muted);
+  font-family: var(--mono);
+}
+
+.cb-landing__card-desc {
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.cb-landing__card-cta {
+  margin-top: auto;
+  padding-top: 4px;
+}
+
+.cb-landing__import {
+  margin-top: 20px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.cb-landing__import a {
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.cb-landing__import a:hover {
+  text-decoration: underline;
+}
+
+.cb-landing__features {
+  margin-top: 32px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+}
+
+.cb-landing__feature {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  background: var(--secondary);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted);
+}
+
+.cb-landing__feature .cb-icon {
+  font-size: 14px;
+  color: var(--ok);
+}
+
+.cb-landing__footer {
+  margin-top: 32px;
+  font-size: 12px;
+  color: var(--muted-strong);
+  text-align: center;
+}
+
+/* ===========================================
+   Workspace Layout
+   =========================================== */
+
+.cb-workspace {
+  display: grid;
+  height: calc(100vh - 56px);
+  animation: fade-in 0.3s var(--ease-out);
 }
 
 @supports (height: 100dvh) {
-  .builder-layout.config-layout {
-    height: calc(100dvh - 58px);
+  .cb-workspace {
+    height: calc(100dvh - 56px);
   }
 }
 
-.builder-layout--wizard.config-layout {
-  grid-template-columns: minmax(0, 1fr) 400px;
+.cb-workspace--explorer {
+  grid-template-columns: 260px minmax(0, 1fr) var(--cb-preview-width, 380px);
 }
 
-.builder-subtitle {
-  margin-top: 4px;
-  font-size: 12px;
+.cb-workspace--wizard {
+  grid-template-columns: minmax(0, 1fr) var(--cb-preview-width, 380px);
+}
+
+.cb-workspace--preview-collapsed {
+  --cb-preview-width: 48px;
+}
+
+/* ===========================================
+   Sidebar (Explorer)
+   =========================================== */
+
+.cb-sidebar {
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-accent);
+  border-right: 1px solid var(--border);
+  min-height: 0;
+  overflow: hidden;
+}
+
+:root[data-theme="light"] .cb-sidebar {
+  background: var(--bg-hover);
+}
+
+.cb-sidebar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.cb-sidebar__title {
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: -0.01em;
+  color: var(--text-strong);
+}
+
+/* Sidebar search */
+.cb-sidebar__search {
+  position: relative;
+  padding: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.cb-sidebar__search-icon {
+  position: absolute;
+  left: 24px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 15px;
   color: var(--muted);
+  pointer-events: none;
 }
 
-.builder-count {
-  margin-left: auto;
-  font-size: 11px;
-  color: var(--muted);
-}
-
-.builder-icon {
-  width: 18px;
-  height: 18px;
-  border-radius: var(--radius-full);
+.cb-sidebar__search-input {
+  width: 100%;
+  padding: 9px 32px 9px 36px;
   border: 1px solid var(--border);
-  display: inline-flex;
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  font-size: 12px;
+  outline: none;
+  transition: all var(--duration-fast) ease;
+}
+
+.cb-sidebar__search-input::placeholder {
+  color: var(--muted);
+}
+
+.cb-sidebar__search-input:focus {
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+:root[data-theme="light"] .cb-sidebar__search-input {
+  background: white;
+}
+
+.cb-sidebar__search-clear {
+  position: absolute;
+  right: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: var(--radius-full);
+  background: var(--bg-hover);
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 10px;
-  font-weight: 700;
 }
 
-.builder-error-count {
+.cb-sidebar__search-clear:hover {
+  background: var(--border-strong);
+  color: var(--text);
+}
+
+/* Sidebar nav */
+.cb-sidebar__nav {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.cb-sidebar__nav-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 12px;
+  border: none;
+  border-radius: var(--radius-md);
+  border-left: 3px solid transparent;
+  background: transparent;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition: all var(--duration-fast) ease;
+}
+
+.cb-sidebar__nav-item:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+:root[data-theme="light"] .cb-sidebar__nav-item:hover {
+  background: rgba(0, 0, 0, 0.04);
+}
+
+.cb-sidebar__nav-item.active {
+  border-left-color: var(--accent);
+  background: var(--accent-subtle);
+  color: var(--accent);
+}
+
+.cb-sidebar__nav-icon {
+  font-size: 17px;
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+.cb-sidebar__nav-item:hover .cb-sidebar__nav-icon,
+.cb-sidebar__nav-item.active .cb-sidebar__nav-icon {
+  opacity: 1;
+}
+
+.cb-sidebar__nav-label {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cb-sidebar__nav-count {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--muted);
+  padding: 2px 6px;
+  border-radius: var(--radius-full);
+  background: var(--bg-elevated);
+}
+
+.cb-sidebar__nav-item.active .cb-sidebar__nav-count {
+  background: rgba(255, 92, 92, 0.15);
+  color: var(--accent);
+}
+
+.cb-sidebar__nav-errors {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -162,331 +526,1307 @@ config-builder-app {
   height: 18px;
   padding: 0 5px;
   border-radius: var(--radius-full);
-  border: 1px solid rgba(239, 68, 68, 0.4);
   background: var(--danger-subtle);
   color: var(--danger);
   font-size: 10px;
   font-weight: 700;
 }
 
-.builder-footer-note {
+.cb-sidebar__footer {
+  margin-top: auto;
+  padding: 12px;
+  border-top: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--muted-strong);
+  line-height: 1.45;
+}
+
+/* ===========================================
+   Main Content Area
+   =========================================== */
+
+.cb-main {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  background: var(--panel);
+  overflow: hidden;
+}
+
+/* Action bar */
+.cb-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 20px;
+  background: var(--bg-accent);
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+:root[data-theme="light"] .cb-actions {
+  background: var(--bg-hover);
+}
+
+.cb-actions__left,
+.cb-actions__right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cb-actions__status {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+/* Content scroll area */
+.cb-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: 20px;
+}
+
+/* ===========================================
+   Section Cards (Explorer)
+   =========================================== */
+
+.cb-sections {
+  display: grid;
+  gap: 12px;
+}
+
+.cb-section {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  overflow: hidden;
+  transition: border-color var(--duration-fast) ease;
+  animation: rise 0.35s var(--ease-out) backwards;
+}
+
+.cb-section:hover {
+  border-color: var(--border-strong);
+}
+
+:root[data-theme="light"] .cb-section {
+  background: white;
+}
+
+.cb-section__header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 18px;
+  cursor: pointer;
+  user-select: none;
+  transition: background var(--duration-fast) ease;
+}
+
+.cb-section__header:hover {
+  background: var(--bg-hover);
+}
+
+:root[data-theme="light"] .cb-section__header:hover {
+  background: var(--bg-muted);
+}
+
+.cb-section__icon {
+  font-size: 22px;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.cb-section__info {
+  flex: 1;
+  min-width: 0;
+}
+
+.cb-section__title {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--text-strong);
+}
+
+.cb-section__desc {
+  margin-top: 2px;
+  font-size: 12px;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cb-section__meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.cb-section__count {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.cb-section__count--has-values {
+  color: var(--ok);
+}
+
+.cb-section__error-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 20px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: var(--radius-full);
+  background: var(--danger-subtle);
+  color: var(--danger);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.cb-section__chevron {
+  font-size: 16px;
+  color: var(--muted);
+  transition: transform var(--duration-normal) var(--ease-out);
+}
+
+.cb-section--open .cb-section__chevron {
+  transform: rotate(180deg);
+}
+
+.cb-section__body {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows var(--duration-normal) var(--ease-out);
+}
+
+.cb-section--open .cb-section__body {
+  grid-template-rows: 1fr;
+}
+
+.cb-section__body-inner {
+  overflow: hidden;
+}
+
+.cb-section__fields {
+  padding: 4px 18px 18px;
+  display: grid;
+  gap: 12px;
+}
+
+/* ===========================================
+   Field Cards
+   =========================================== */
+
+.cb-field {
+  display: grid;
+  gap: 6px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-accent);
+  border-left: 3px solid transparent;
+  transition: all var(--duration-fast) ease;
+  animation: fade-in 0.2s var(--ease-out) backwards;
+}
+
+:root[data-theme="light"] .cb-field {
+  background: var(--bg);
+}
+
+.cb-field--set {
+  border-left-color: var(--ok);
+}
+
+.cb-field--error {
+  border-left-color: var(--danger);
+}
+
+.cb-field__header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.cb-field__label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.cb-field__badges {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.cb-field__badge {
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--bg-elevated);
+  color: var(--muted);
+  border: 1px solid var(--border);
+}
+
+.cb-field__badge--sensitive {
+  color: var(--warn);
+  border-color: var(--warn-subtle);
+  background: var(--warn-subtle);
+}
+
+.cb-field__path {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted-strong);
+  word-break: break-word;
+}
+
+.cb-field__help {
   font-size: 12px;
   color: var(--muted);
   line-height: 1.45;
 }
 
-.builder-search-state {
-  margin-bottom: 14px;
-  font-size: 13px;
-  color: var(--muted);
-}
-
-.builder-section-glyph {
-  width: 34px;
-  height: 34px;
-  border-radius: var(--radius-full);
-  border: 1px solid var(--border);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 13px;
-  font-weight: 700;
-  color: var(--accent);
-}
-
-.builder-error-text {
-  color: var(--danger);
-}
-
-/* -------------------------------------------
-   Validation summary
-   ------------------------------------------- */
-
-.builder-validation-summary {
-  margin-bottom: 14px;
-}
-
-.builder-validation-summary__title {
-  font-weight: 700;
-}
-
-.builder-validation-summary__sections {
-  margin-top: 8px;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.builder-validation-summary__list {
-  margin: 10px 0 0;
-  padding-left: 18px;
+.cb-field__control {
   display: grid;
   gap: 6px;
-  font-size: 12px;
 }
 
-/* -------------------------------------------
-   Field rendering
-   ------------------------------------------- */
-
-.builder-field {
-  padding: 12px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: var(--bg-accent);
+.cb-typeahead {
+  position: relative;
 }
 
-.builder-field--set {
-  border-color: var(--border-strong);
-}
-
-.builder-field__head {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  justify-content: space-between;
-}
-
-.builder-field__badges {
-  display: inline-flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.builder-field__path {
-  margin-top: 6px;
-  font-size: 12px;
-  color: var(--muted);
-  word-break: break-word;
-}
-
-.builder-field__controls {
-  display: grid;
-  gap: 8px;
-}
-
-.builder-field__actions {
-  margin-top: 2px;
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
-.builder-toggle-row {
-  margin: 0;
-}
-
-/* -------------------------------------------
-   Wizard mode
-   ------------------------------------------- */
-
-.builder-wizard {
-  display: grid;
-  gap: 14px;
-}
-
-.builder-wizard__progress {
-  display: grid;
-  grid-template-columns: repeat(7, minmax(0, 1fr));
-  gap: 8px;
-}
-
-.builder-wizard__step {
-  display: grid;
-  justify-items: center;
-  gap: 4px;
+.cb-typeahead__menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 12;
+  display: none;
+  max-height: 220px;
+  overflow: auto;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--bg-elevated);
-  color: var(--muted);
-  padding: 8px 6px;
+  box-shadow: var(--shadow-md);
+  padding: 4px;
+}
+
+.cb-typeahead:focus-within .cb-typeahead__menu {
+  display: grid;
+  gap: 2px;
+}
+
+.cb-typeahead__option {
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 12px;
+  text-align: left;
+  border-radius: var(--radius-sm);
+  padding: 7px 8px;
   cursor: pointer;
 }
 
-.builder-wizard__step:hover {
-  border-color: var(--border-strong);
-  color: var(--text);
+.cb-typeahead__option:hover {
+  background: var(--bg-hover);
 }
 
-.builder-wizard__step--active {
-  border-color: var(--accent);
+.cb-typeahead--compact .cb-typeahead__menu {
+  font-size: 11px;
+}
+
+.cb-field__error {
+  font-size: 12px;
+  color: var(--danger);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.cb-field__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+/* Hide clear button when field has no value */
+.cb-field:not(.cb-field--set) .cb-field__actions .cb-field__clear-btn {
+  display: none;
+}
+
+/* ===========================================
+   Wizard
+   =========================================== */
+
+.cb-wizard {
+  display: grid;
+  gap: 24px;
+  max-width: 800px;
+  margin: 0 auto;
+  width: 100%;
+  animation: fade-in 0.3s var(--ease-out);
+}
+
+/* Stepper */
+.cb-stepper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  padding: 8px 0;
+}
+
+.cb-stepper__step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  padding: 4px 0;
+  min-width: 0;
+}
+
+.cb-stepper__circle {
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 700;
+  transition: all var(--duration-normal) var(--ease-out);
+  flex-shrink: 0;
+}
+
+.cb-stepper__step--future .cb-stepper__circle {
+  border: 2px solid var(--border-strong);
+  color: var(--muted);
+  background: transparent;
+}
+
+.cb-stepper__step--active .cb-stepper__circle {
+  border: 2px solid var(--accent);
+  color: var(--accent-foreground);
+  background: var(--accent);
+  box-shadow: 0 0 16px var(--accent-glow);
+  animation: glow-pulse 2s ease-in-out infinite;
+}
+
+.cb-stepper__step--done .cb-stepper__circle {
+  border: 2px solid var(--ok);
+  color: var(--ok);
+  background: var(--ok-subtle);
+}
+
+.cb-stepper__step--done .cb-stepper__circle .cb-icon {
+  font-size: 14px;
+}
+
+.cb-stepper__label {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--muted);
+  text-align: center;
+  max-width: 64px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cb-stepper__step--active .cb-stepper__label {
   color: var(--accent);
-  background: var(--accent-subtle);
 }
 
-.builder-wizard__step--done {
-  border-color: rgba(34, 197, 94, 0.4);
+.cb-stepper__step--done .cb-stepper__label {
   color: var(--ok);
 }
 
-.builder-wizard__step-index {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 24px;
-  height: 24px;
-  border-radius: var(--radius-full);
-  border: 1px solid currentColor;
-  font-size: 11px;
-  font-weight: 700;
+.cb-stepper__line {
+  flex: 1;
+  height: 2px;
+  background: var(--border-strong);
+  margin: 0 4px;
+  margin-bottom: 20px;
+  max-width: 48px;
+  min-width: 16px;
+  transition: background var(--duration-normal) ease;
 }
 
-.builder-wizard__step-label {
-  font-size: 11px;
-  font-weight: 600;
-  text-align: center;
+.cb-stepper__line--done {
+  background: var(--ok);
 }
 
-.builder-wizard__actions {
-  margin-top: 16px;
+/* Wizard step content */
+.cb-wizard__card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elevated);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+}
+
+:root[data-theme="light"] .cb-wizard__card {
+  background: white;
+}
+
+.cb-wizard__card-header {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  gap: 16px;
+  padding: 24px;
+  background: var(--bg-accent);
+  border-bottom: 1px solid var(--border);
+}
+
+:root[data-theme="light"] .cb-wizard__card-header {
+  background: var(--bg-hover);
+}
+
+.cb-wizard__card-icon {
+  font-size: 32px;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.cb-wizard__card-title {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-strong);
+}
+
+.cb-wizard__card-desc {
+  margin-top: 4px;
+  font-size: 13px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.cb-wizard__card-body {
+  padding: 24px;
+}
+
+.cb-wizard__card-fields {
+  display: grid;
+  gap: 16px;
+}
+
+/* Wizard action bar */
+.cb-wizard__actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 24px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-accent);
+}
+
+:root[data-theme="light"] .cb-wizard__actions {
+  background: var(--bg-hover);
+}
+
+.cb-wizard__actions-left {
+  display: flex;
+  align-items: center;
   gap: 8px;
 }
 
-/* -------------------------------------------
-   Preview panel
-   ------------------------------------------- */
+.cb-wizard__actions-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
 
-.builder-preview {
+.cb-wizard__skip {
+  font-size: 12px;
+  color: var(--muted);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px 8px;
+}
+
+.cb-wizard__skip:hover {
+  color: var(--text);
+  text-decoration: underline;
+}
+
+/* Wizard completion */
+.cb-wizard__complete {
+  text-align: center;
+  padding: 48px 24px;
+  animation: scale-in 0.35s var(--ease-out);
+}
+
+.cb-wizard__complete-icon {
+  font-size: 56px;
+  color: var(--ok);
+  margin-bottom: 16px;
+}
+
+.cb-wizard__complete-title {
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: var(--text-strong);
+}
+
+.cb-wizard__complete-sub {
+  margin-top: 8px;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.cb-wizard__complete-actions {
+  margin-top: 24px;
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+}
+
+/* ===========================================
+   Preview Panel
+   =========================================== */
+
+.cb-preview {
   display: grid;
   grid-template-rows: auto auto minmax(0, 1fr) auto;
   min-height: 0;
   background: var(--bg-accent);
   border-left: 1px solid var(--border);
+  transition: width var(--duration-normal) var(--ease-out);
 }
 
-.builder-preview__header,
-.builder-preview__footer {
+:root[data-theme="light"] .cb-preview {
+  background: var(--bg-hover);
+}
+
+.cb-preview__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  padding: 12px;
+  padding: 12px 14px;
   border-bottom: 1px solid var(--border);
 }
 
-.builder-preview__footer {
-  border-top: 1px solid var(--border);
-  border-bottom: none;
-  justify-content: flex-start;
+.cb-preview__title-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
 }
 
-.builder-preview__title {
+.cb-preview__file-icon {
+  font-size: 16px;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.cb-preview__title {
+  font-family: var(--mono);
   font-size: 13px;
   color: var(--text);
+  white-space: nowrap;
 }
 
-.builder-preview__meta {
+.cb-preview__meta {
+  font-family: var(--mono);
   font-size: 11px;
   color: var(--muted);
 }
 
-.builder-preview__mobile-toggle {
+.cb-preview__toggle {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  transition: all var(--duration-fast) ease;
+  flex-shrink: 0;
+}
+
+.cb-preview__toggle:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+/* Collapsed rail */
+.cb-preview--collapsed {
+  grid-template-rows: auto;
+}
+
+.cb-preview--collapsed .cb-preview__header {
+  flex-direction: column;
+  padding: 12px 8px;
+  border-bottom: none;
+  height: 100%;
+  justify-content: flex-start;
+  gap: 12px;
+}
+
+.cb-preview--collapsed .cb-preview__title-group,
+.cb-preview--collapsed .cb-preview__warning,
+.cb-preview--collapsed .cb-preview__code,
+.cb-preview--collapsed .cb-preview__footer {
   display: none;
 }
 
-.builder-preview__code {
+.cb-preview--collapsed .cb-preview__toggle {
+  writing-mode: horizontal-tb;
+}
+
+/* Sensitive warning */
+.cb-preview__warning {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  font-size: 12px;
+  color: var(--warn);
+  border-bottom: 1px solid var(--border);
+}
+
+.cb-preview__warning .cb-icon {
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+/* Code area */
+.cb-preview__code {
   margin: 0;
+  padding: 14px;
   border: 0;
   border-radius: 0;
   background: transparent;
+  font-family: var(--mono);
   font-size: 12px;
-  line-height: 1.55;
+  line-height: 1.6;
   overflow: auto;
-  padding: 12px;
+  color: var(--text);
 }
 
-.builder-sensitive-warning {
-  margin: 10px 12px 0;
+.cb-code-lines {
+  min-width: max-content;
 }
 
-.builder-sensitive-warning__paths {
-  margin-top: 6px;
+.cb-code-line {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  align-items: start;
+  gap: 10px;
+  line-height: 1.6;
+}
+
+.cb-code-line__num {
+  color: var(--muted);
+  text-align: right;
+  user-select: none;
+  opacity: 0.7;
+}
+
+.cb-code-line__content {
+  display: block;
+  white-space: pre;
+}
+
+.cb-code-token--key {
+  color: var(--text-strong);
+}
+
+.cb-code-token--string {
+  color: #ff8a6b;
+}
+
+.cb-code-token--number {
+  color: #7dd3fc;
+}
+
+.cb-code-token--boolean,
+.cb-code-token--null {
+  color: #c084fc;
+}
+
+.cb-code-token--comment {
+  color: var(--muted);
+  font-style: italic;
+}
+
+.cb-code-token--punct {
+  color: var(--muted);
+}
+
+/* Preview footer */
+.cb-preview__footer {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 14px;
+  border-top: 1px solid var(--border);
+}
+
+.cb-preview__footer .btn {
   font-size: 11px;
-  color: var(--warn);
-  word-break: break-word;
 }
 
-/* -------------------------------------------
+.cb-preview__spacer {
+  flex: 1;
+}
+
+/* ===========================================
+   Command Palette (⌘K)
+   =========================================== */
+
+.cb-palette-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 20vh;
+  animation: fade-in 0.15s var(--ease-out);
+}
+
+.cb-palette {
+  width: min(540px, calc(100vw - 48px));
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  overflow: hidden;
+  animation: scale-in 0.2s var(--ease-out);
+}
+
+.cb-palette__input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--border);
+}
+
+.cb-palette__input-icon {
+  font-size: 18px;
+  color: var(--muted);
+  flex-shrink: 0;
+}
+
+.cb-palette__input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-size: 15px;
+  outline: none;
+  color: var(--text);
+}
+
+.cb-palette__input::placeholder {
+  color: var(--muted);
+}
+
+.cb-palette__results {
+  max-height: 320px;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.cb-palette__group-label {
+  padding: 8px 10px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.cb-palette__result {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--duration-fast) ease;
+}
+
+.cb-palette__result:hover,
+.cb-palette__result--active {
+  background: var(--bg-hover);
+}
+
+.cb-palette__result-label {
+  flex: 1;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+}
+
+.cb-palette__result-path {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.cb-palette__result-value {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--accent);
+}
+
+.cb-palette__empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+/* ===========================================
+   Import Dialog
+   =========================================== */
+
+.cb-import-dialog {
+  width: min(520px, calc(100vw - 48px));
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xl);
+  overflow: hidden;
+  animation: scale-in 0.2s var(--ease-out);
+}
+
+.cb-import-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+}
+
+.cb-import-dialog__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.cb-import-dialog__title .cb-icon {
+  font-size: 18px;
+  color: var(--accent);
+}
+
+.cb-import-dialog__close {
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+}
+
+.cb-import-dialog__close:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.cb-import-dialog__tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.cb-import-dialog__tab {
+  flex: 1;
+  padding: 10px 16px;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--duration-fast) ease;
+  border-bottom: 2px solid transparent;
+}
+
+.cb-import-dialog__tab:hover {
+  color: var(--text);
+}
+
+.cb-import-dialog__tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.cb-import-dialog__body {
+  padding: 20px;
+}
+
+.cb-import-dialog__textarea {
+  width: 100%;
+  padding: 12px 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  background: var(--bg-accent);
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.6;
+  resize: vertical;
+  outline: none;
+  min-height: 180px;
+  transition: border-color var(--duration-fast) ease, box-shadow var(--duration-fast) ease;
+}
+
+.cb-import-dialog__textarea:focus {
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+
+:root[data-theme="light"] .cb-import-dialog__textarea {
+  background: white;
+}
+
+.cb-import-dialog__drop-zone {
+  border: 2px dashed var(--border-strong);
+  border-radius: var(--radius-lg);
+  padding: 40px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  text-align: center;
+  transition: all var(--duration-fast) ease;
+}
+
+.cb-import-dialog__drop-zone--active {
+  border-color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+.cb-import-dialog__drop-icon {
+  font-size: 36px;
+  color: var(--muted-strong);
+}
+
+.cb-import-dialog__drop-text {
+  font-size: 14px;
+  color: var(--text);
+  font-weight: 500;
+}
+
+.cb-import-dialog__drop-sub {
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.cb-import-dialog__file-label {
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.cb-import-dialog__error {
+  margin-top: 12px;
+  padding: 10px 14px;
+  border-radius: var(--radius-md);
+  background: var(--danger-subtle);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  color: var(--danger);
+  font-size: 12px;
+}
+
+.cb-import-dialog__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 14px 20px;
+  border-top: 1px solid var(--border);
+}
+
+/* ===========================================
+   Empty States
+   =========================================== */
+
+.cb-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 48px 24px;
+  text-align: center;
+  animation: fade-in 0.3s var(--ease-out);
+}
+
+.cb-empty__icon {
+  font-size: 40px;
+  color: var(--muted-strong);
+  opacity: 0.5;
+}
+
+.cb-empty__text {
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.cb-empty__sub {
+  font-size: 12px;
+  color: var(--muted-strong);
+}
+
+/* ===========================================
+   Validation Summary (compact)
+   =========================================== */
+
+.cb-validation {
+  padding: 12px 16px;
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, rgba(239, 68, 68, 0.06) 0%, rgba(239, 68, 68, 0.02) 100%);
+  margin-bottom: 16px;
+  animation: fade-in 0.2s var(--ease-out);
+}
+
+.cb-validation__title {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--danger);
+}
+
+.cb-validation__list {
+  margin: 8px 0 0;
+  padding-left: 16px;
+  display: grid;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--danger);
+}
+
+/* ===========================================
+   Microinteraction Animations
+   =========================================== */
+
+@keyframes cb-flash-set {
+  0% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.4); }
+  50% { box-shadow: 0 0 12px 2px rgba(34, 197, 94, 0.2); }
+  100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0); }
+}
+
+@keyframes cb-shake {
+  0%, 100% { transform: translateX(0); }
+  20% { transform: translateX(-4px); }
+  40% { transform: translateX(4px); }
+  60% { transform: translateX(-3px); }
+  80% { transform: translateX(2px); }
+}
+
+@keyframes cb-check-draw {
+  0% { stroke-dashoffset: 24; }
+  100% { stroke-dashoffset: 0; }
+}
+
+.cb-field--flash {
+  animation: cb-flash-set 0.6s var(--ease-out);
+}
+
+.cb-field--error-shake {
+  animation: cb-shake 0.4s var(--ease-out);
+}
+
+/* Smooth section expand content */
+.cb-section__body-inner {
+  transition: opacity var(--duration-normal) var(--ease-out);
+}
+
+.cb-section:not(.cb-section--open) .cb-section__body-inner {
+  opacity: 0;
+}
+
+.cb-section--open .cb-section__body-inner {
+  opacity: 1;
+}
+
+/* Topbar scroll shadow */
+.cb-topbar--scrolled {
+  box-shadow: var(--shadow-md);
+  border-bottom-color: transparent;
+}
+
+/* Preview toggle rotation */
+.cb-preview--collapsed .cb-preview__toggle .cb-icon {
+  transform: rotate(180deg);
+}
+
+/* ===========================================
+   Stagger animation helpers
+   =========================================== */
+
+.cb-stagger-1 { animation-delay: 0ms; }
+.cb-stagger-2 { animation-delay: 40ms; }
+.cb-stagger-3 { animation-delay: 80ms; }
+.cb-stagger-4 { animation-delay: 120ms; }
+.cb-stagger-5 { animation-delay: 160ms; }
+.cb-stagger-6 { animation-delay: 200ms; }
+.cb-stagger-7 { animation-delay: 240ms; }
+.cb-stagger-8 { animation-delay: 280ms; }
+.cb-stagger-9 { animation-delay: 320ms; }
+.cb-stagger-10 { animation-delay: 360ms; }
+
+/* ===========================================
    Responsive
-   ------------------------------------------- */
+   =========================================== */
 
-@media (max-width: 1500px) {
-  .builder-layout.config-layout {
-    grid-template-columns: 260px minmax(0, 1fr);
-    height: auto;
-    min-height: calc(100vh - 58px);
+@media (max-width: 1400px) {
+  .cb-workspace--explorer {
+    grid-template-columns: 240px minmax(0, 1fr);
   }
 
-  @supports (height: 100dvh) {
-    .builder-layout.config-layout {
-      min-height: calc(100dvh - 58px);
-    }
-  }
-
-  .builder-layout--wizard.config-layout {
+  .cb-workspace--wizard {
     grid-template-columns: minmax(0, 1fr);
   }
 
-  .builder-preview {
+  .cb-preview {
     grid-column: 1 / -1;
     border-left: 0;
     border-top: 1px solid var(--border);
-    min-height: 320px;
+    max-height: 400px;
+  }
+
+  .cb-preview--collapsed {
+    max-height: 48px;
+  }
+
+  .cb-preview--collapsed .cb-preview__header {
+    flex-direction: row;
+    padding: 10px 14px;
+    height: auto;
   }
 }
 
-@media (max-width: 980px) {
-  .builder-topbar {
+@media (max-width: 900px) {
+  .cb-topbar {
     flex-wrap: wrap;
+    height: auto;
+    padding: 10px 14px;
+    gap: 8px;
   }
 
-  .builder-mode-toggle {
+  .cb-topbar__nav {
     order: 3;
     width: 100%;
-    justify-content: stretch;
   }
 
-  .builder-mode-toggle__btn {
+  .cb-topbar__nav-btn {
     flex: 1;
+    text-align: center;
   }
 
-  .builder-layout.config-layout {
+  .cb-search-trigger span {
+    display: none;
+  }
+
+  .cb-workspace--explorer {
     grid-template-columns: 1fr;
-    min-height: calc(100vh - 88px);
+    height: auto;
+    min-height: calc(100vh - 100px);
   }
 
-  .config-sidebar {
+  .cb-sidebar {
     border-right: 0;
     border-bottom: 1px solid var(--border);
+    max-height: 260px;
   }
 
-  .builder-wizard__progress {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .cb-landing__cards {
+    grid-template-columns: 1fr;
   }
 
-  .builder-preview {
+  .cb-landing__heading {
+    font-size: 32px;
+  }
+
+  .cb-stepper__label {
+    display: none;
+  }
+
+  .cb-stepper__line {
+    max-width: 24px;
+  }
+
+  .cb-preview {
     position: sticky;
     bottom: 0;
     z-index: 20;
-    min-height: 0;
-    max-height: 72vh;
-    transition: transform var(--duration-normal) var(--ease-out);
-    border-top: 1px solid var(--border);
+    max-height: 60vh;
     box-shadow: var(--shadow-lg);
-    background: var(--panel-strong);
+    border-top: 1px solid var(--border);
   }
 
-  .builder-preview__mobile-toggle {
-    display: inline-flex;
+  .cb-preview--collapsed {
+    max-height: 48px;
   }
 
-  .builder-preview.mobile-collapsed {
-    transform: translateY(calc(100% - 46px));
+  .cb-wizard {
+    padding: 0 4px;
   }
 
-  .builder-preview.mobile-open {
-    transform: translateY(0);
+  .cb-landing__heading {
+    font-size: 28px;
+  }
+
+  .cb-landing__sub {
+    font-size: 14px;
+  }
+
+  .cb-palette {
+    width: calc(100vw - 24px);
+  }
+}
+
+@media (max-width: 480px) {
+  .cb-topbar__title {
+    display: none;
+  }
+
+  .cb-sidebar__nav-label {
+    display: none;
+  }
+
+  .cb-sidebar {
+    max-height: 200px;
+  }
+
+  .cb-field__badges {
+    display: none;
   }
 }

--- a/apps/config-builder/src/styles.css
+++ b/apps/config-builder/src/styles.css
@@ -110,3 +110,87 @@ config-builder-app {
     min-height: 100vh;
   }
 }
+
+/* Phase 2 layout: add dedicated JSON5 preview panel. */
+.builder-layout.config-layout {
+  grid-template-columns: 260px minmax(0, 1fr) 400px;
+}
+
+.builder-preview {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  min-height: 0;
+  background: var(--bg-accent);
+  border-left: 1px solid var(--border);
+}
+
+.builder-preview__header,
+.builder-preview__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.builder-preview__footer {
+  border-top: 1px solid var(--border);
+  border-bottom: none;
+  justify-content: flex-start;
+}
+
+.builder-preview__title {
+  font-size: 13px;
+  color: var(--text);
+}
+
+.builder-preview__meta {
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.builder-preview__code {
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  font-size: 12px;
+  line-height: 1.55;
+  overflow: auto;
+  padding: 12px;
+}
+
+.builder-field--set {
+  border-color: var(--border-strong);
+}
+
+.builder-field__controls {
+  display: grid;
+  gap: 8px;
+}
+
+.builder-field__actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 2px;
+}
+
+.builder-toggle-row {
+  margin: 0;
+}
+
+@media (max-width: 1500px) {
+  .builder-layout.config-layout {
+    grid-template-columns: 260px minmax(0, 1fr);
+    height: auto;
+    min-height: 100vh;
+  }
+
+  .builder-preview {
+    grid-column: 1 / -1;
+    border-left: 0;
+    border-top: 1px solid var(--border);
+    min-height: 320px;
+  }
+}

--- a/apps/config-builder/src/styles.css
+++ b/apps/config-builder/src/styles.css
@@ -1,21 +1,112 @@
-:root {
-  color-scheme: dark;
-  font-family: Inter, "Segoe UI", Roboto, sans-serif;
-  background: #09090b;
-  color: #fafafa;
-}
+@import "../../../ui/src/styles/base.css";
+@import "../../../ui/src/styles/components.css";
+@import "../../../ui/src/styles/config.css";
 
-* {
-  box-sizing: border-box;
-}
+/* Config-builder specific wrappers (reuse OpenClaw UI tokens/classes above). */
 
-html,
-body {
-  margin: 0;
-  min-height: 100%;
-  background: #09090b;
-}
-
-body {
+config-builder-app {
+  display: block;
   min-height: 100vh;
+}
+
+.builder-screen {
+  min-height: 100vh;
+  padding: 0;
+  background: var(--bg);
+}
+
+.builder-layout.config-layout {
+  margin: 0;
+  height: 100vh;
+  border: 0;
+  border-radius: 0;
+}
+
+@supports (height: 100dvh) {
+  .builder-layout.config-layout {
+    height: 100dvh;
+  }
+}
+
+.builder-subtitle {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.builder-count {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+.builder-icon {
+  width: 18px;
+  height: 18px;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--border);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.builder-footer-note {
+  font-size: 12px;
+  color: var(--muted);
+  line-height: 1.45;
+}
+
+.builder-search-state {
+  margin-bottom: 14px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.builder-section-glyph {
+  width: 34px;
+  height: 34px;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--border);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.builder-field {
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-accent);
+}
+
+.builder-field__head {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  justify-content: space-between;
+}
+
+.builder-field__badges {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.builder-field__path {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--muted);
+  word-break: break-word;
+}
+
+@media (max-width: 980px) {
+  .builder-layout.config-layout {
+    height: auto;
+    min-height: 100vh;
+  }
 }

--- a/apps/config-builder/src/styles.css
+++ b/apps/config-builder/src/styles.css
@@ -1,0 +1,21 @@
+:root {
+  color-scheme: dark;
+  font-family: Inter, "Segoe UI", Roboto, sans-serif;
+  background: #09090b;
+  color: #fafafa;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  background: #09090b;
+}
+
+body {
+  min-height: 100vh;
+}

--- a/apps/config-builder/src/ui/app.ts
+++ b/apps/config-builder/src/ui/app.ts
@@ -18,6 +18,31 @@ import {
 import { validateConfigDraft, type ValidationResult } from "../lib/validation.ts";
 import { modeToHash, parseModeFromHash, type ConfigBuilderMode } from "./navigation.ts";
 import { renderFieldEditor } from "./components/field-renderer.ts";
+import {
+  iconCheck,
+  iconChevronDown,
+  iconChevronLeft,
+  iconCode,
+  iconCopy,
+  iconDownload,
+  iconExternalLink,
+  iconFile,
+  iconGrid,
+  iconMoon,
+  iconPanelRight,
+  iconSearch,
+  iconShield,
+  iconSparkles,
+  iconSun,
+  iconTrash,
+  iconX,
+  sectionIcon,
+} from "./components/icons.ts";
+import {
+  createImportDialogState,
+  renderImportDialog,
+  type ImportDialogState,
+} from "./components/import-dialog.ts";
 import { WIZARD_STEPS, wizardStepByIndex, wizardStepFields } from "./wizard.ts";
 
 type AppState =
@@ -27,14 +52,26 @@ type AppState =
 
 type CopyState = "idle" | "copied" | "failed";
 
+const COMMON_MODEL_IDS = [
+  "anthropic/claude-opus-4-6",
+  "anthropic/claude-sonnet-4-5",
+  "openai/gpt-5.2",
+  "openai/gpt-5-mini",
+  "google/gemini-3-flash-preview",
+  "openrouter/openai/gpt-5-mini",
+  "xai/grok-4",
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
 function includesQuery(value: string, query: string): boolean {
   return value.toLowerCase().includes(query);
 }
 
 function matchesField(field: ExplorerField, query: string): boolean {
-  if (!query) {
-    return true;
-  }
+  if (!query) {return true;}
   return (
     includesQuery(field.path, query) ||
     includesQuery(field.label, query) ||
@@ -43,9 +80,7 @@ function matchesField(field: ExplorerField, query: string): boolean {
 }
 
 function matchesSection(section: ExplorerSection, query: string): boolean {
-  if (!query) {
-    return true;
-  }
+  if (!query) {return true;}
   return (
     includesQuery(section.id, query) ||
     includesQuery(section.label, query) ||
@@ -53,8 +88,169 @@ function matchesSection(section: ExplorerSection, query: string): boolean {
   );
 }
 
-function sectionGlyph(label: string): string {
-  return label.trim().charAt(0).toUpperCase() || "•";
+type PreviewTokenKind =
+  | "text"
+  | "key"
+  | "string"
+  | "number"
+  | "boolean"
+  | "null"
+  | "comment"
+  | "punct";
+
+type PreviewToken = {
+  kind: PreviewTokenKind;
+  value: string;
+};
+
+function isIdentifierStart(char: string): boolean {
+  return /[A-Za-z_$]/.test(char);
+}
+
+function isIdentifierPart(char: string): boolean {
+  return /[A-Za-z0-9_$-]/.test(char);
+}
+
+function tokenizeJson5Line(line: string): PreviewToken[] {
+  if (!line) {
+    return [{ kind: "text", value: "" }];
+  }
+
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith("//")) {
+    return [{ kind: "comment", value: line }];
+  }
+
+  const tokens: PreviewToken[] = [];
+  let index = 0;
+
+  const push = (kind: PreviewTokenKind, value: string) => {
+    if (!value) {return;}
+    const previous = tokens.at(-1);
+    if (previous && previous.kind === kind) {
+      previous.value += value;
+      return;
+    }
+    tokens.push({ kind, value });
+  };
+
+  while (index < line.length) {
+    const char = line[index] ?? "";
+
+    if (/\s/.test(char)) {
+      let end = index + 1;
+      while (end < line.length && /\s/.test(line[end] ?? "")) {
+        end += 1;
+      }
+      push("text", line.slice(index, end));
+      index = end;
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      const quote = char;
+      let end = index + 1;
+      while (end < line.length) {
+        const current = line[end] ?? "";
+        if (current === "\\") {
+          end += 2;
+          continue;
+        }
+        if (current === quote) {
+          end += 1;
+          break;
+        }
+        end += 1;
+      }
+      push("string", line.slice(index, end));
+      index = end;
+      continue;
+    }
+
+    const punct = "{}[]:,";
+    if (punct.includes(char)) {
+      push("punct", char);
+      index += 1;
+      continue;
+    }
+
+    const remaining = line.slice(index);
+    const numberMatch = remaining.match(/^-?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?/);
+    if (numberMatch) {
+      const value = numberMatch[0] ?? "";
+      push("number", value);
+      index += value.length;
+      continue;
+    }
+
+    if (isIdentifierStart(char)) {
+      let end = index + 1;
+      while (end < line.length && isIdentifierPart(line[end] ?? "")) {
+        end += 1;
+      }
+      const ident = line.slice(index, end);
+
+      let lookahead = end;
+      while (lookahead < line.length && /\s/.test(line[lookahead] ?? "")) {
+        lookahead += 1;
+      }
+
+      if (line[lookahead] === ":") {
+        push("key", ident);
+      } else if (ident === "true" || ident === "false") {
+        push("boolean", ident);
+      } else if (ident === "null") {
+        push("null", ident);
+      } else {
+        push("text", ident);
+      }
+
+      index = end;
+      continue;
+    }
+
+    push("text", char);
+    index += 1;
+  }
+
+  return tokens;
+}
+
+const PREVIEW_COLLAPSED_KEY = "openclaw.config-builder.preview-collapsed";
+const THEME_KEY = "openclaw.config-builder.theme";
+
+function loadPreviewCollapsed(): boolean {
+  try {
+    return localStorage.getItem(PREVIEW_COLLAPSED_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function persistPreviewCollapsed(collapsed: boolean): void {
+  try {
+    localStorage.setItem(PREVIEW_COLLAPSED_KEY, String(collapsed));
+  } catch {
+    // best-effort
+  }
+}
+
+function loadTheme(): "dark" | "light" {
+  try {
+    const stored = localStorage.getItem(THEME_KEY);
+    if (stored === "light") {return "light";}
+  } catch {
+    // ignore
+  }
+  return "dark";
+}
+
+function persistTheme(theme: "dark" | "light"): void {
+  try {
+    localStorage.setItem(THEME_KEY, theme);
+  } catch {
+    // best-effort
+  }
 }
 
 class ConfigBuilderApp extends LitElement {
@@ -66,14 +262,28 @@ class ConfigBuilderApp extends LitElement {
   private searchQuery = "";
   private fieldErrors: Record<string, string> = {};
   private wizardStepIndex = 0;
-  private previewOpenMobile = false;
+  private wizardComplete = false;
   private copyState: CopyState = "idle";
   private copyResetTimer: number | null = null;
+  private previewCollapsed = false;
+  private theme: "dark" | "light" = "dark";
+  private expandedSections = new Set<string>();
+  private commandPaletteOpen = false;
+  private commandPaletteQuery = "";
+  private commandPaletteIndex = 0;
+  private importState: ImportDialogState = createImportDialogState();
+
+  private suggestionCacheConfig: ConfigDraft | null = null;
+  private modelSuggestionsCache: string[] = [];
+  private authProfileSuggestionsCache: string[] = [];
+
+  private topbarScrolled = false;
 
   private readonly hashChangeHandler = () => this.handleHashChange();
+  private readonly keydownHandler = (e: KeyboardEvent) => this.handleGlobalKeydown(e);
+  private readonly scrollHandler = () => this.handleScroll();
 
   override createRenderRoot() {
-    // Match the existing OpenClaw web UI approach (global CSS classes/tokens).
     return this;
   }
 
@@ -81,10 +291,14 @@ class ConfigBuilderApp extends LitElement {
     super.connectedCallback();
     this.bootstrap();
     window.addEventListener("hashchange", this.hashChangeHandler);
+    window.addEventListener("keydown", this.keydownHandler);
+    window.addEventListener("scroll", this.scrollHandler, { passive: true });
   }
 
   override disconnectedCallback(): void {
     window.removeEventListener("hashchange", this.hashChangeHandler);
+    window.removeEventListener("keydown", this.keydownHandler);
+    window.removeEventListener("scroll", this.scrollHandler);
     if (this.copyResetTimer != null) {
       window.clearTimeout(this.copyResetTimer);
       this.copyResetTimer = null;
@@ -97,6 +311,9 @@ class ConfigBuilderApp extends LitElement {
       this.mode = parseModeFromHash(window.location.hash);
       this.config = loadPersistedDraft();
       this.validation = validateConfigDraft(this.config);
+      this.previewCollapsed = loadPreviewCollapsed();
+      this.theme = loadTheme();
+      this.applyTheme();
       const snapshot = buildExplorerSnapshot();
       this.state = { status: "ready", snapshot };
     } catch (error) {
@@ -106,14 +323,28 @@ class ConfigBuilderApp extends LitElement {
     this.requestUpdate();
   }
 
+  private applyTheme(): void {
+    if (this.theme === "light") {
+      document.documentElement.setAttribute("data-theme", "light");
+    } else {
+      document.documentElement.removeAttribute("data-theme");
+    }
+  }
+
+  private toggleTheme(): void {
+    this.theme = this.theme === "dark" ? "light" : "dark";
+    persistTheme(this.theme);
+    this.applyTheme();
+    this.requestUpdate();
+  }
+
   private handleHashChange(): void {
     const next = parseModeFromHash(window.location.hash);
-    if (next === this.mode) {
-      return;
-    }
+    if (next === this.mode) {return;}
     this.mode = next;
     if (next !== "wizard") {
       this.wizardStepIndex = 0;
+      this.wizardComplete = false;
     }
     this.requestUpdate();
   }
@@ -128,12 +359,74 @@ class ConfigBuilderApp extends LitElement {
       window.location.hash = hash;
     }
     if (mode === "wizard") {
+      this.wizardComplete = false;
       this.focusWizardStep();
     }
   }
 
+  private handleScroll(): void {
+    const scrolled = window.scrollY > 4;
+    if (scrolled !== this.topbarScrolled) {
+      this.topbarScrolled = scrolled;
+      this.requestUpdate();
+    }
+  }
+
+  private handleGlobalKeydown(e: KeyboardEvent): void {
+    const isMod = e.metaKey || e.ctrlKey;
+    // ⌘K — command palette
+    if (isMod && e.key === "k") {
+      e.preventDefault();
+      this.commandPaletteOpen = !this.commandPaletteOpen;
+      this.commandPaletteQuery = "";
+      this.commandPaletteIndex = 0;
+      this.requestUpdate();
+      if (this.commandPaletteOpen) {
+        window.setTimeout(() => {
+          const input = document.querySelector<HTMLInputElement>(".cb-palette__input");
+          input?.focus();
+        }, 50);
+      }
+      return;
+    }
+    // ⌘\ — toggle preview
+    if (isMod && e.key === "\\") {
+      e.preventDefault();
+      this.togglePreview();
+      return;
+    }
+    // ⌘S — download
+    if (isMod && e.key === "s") {
+      e.preventDefault();
+      const preview = formatConfigJson5(this.config);
+      downloadJson5File(preview.text);
+      return;
+    }
+    // Escape — close palette
+    if (e.key === "Escape" && this.commandPaletteOpen) {
+      this.commandPaletteOpen = false;
+      this.requestUpdate();
+      return;
+    }
+  }
+
+  // --- State mutations ---
+
   private setSection(sectionId: string | null): void {
     this.selectedSectionId = sectionId;
+    // Auto-expand the selected section
+    if (sectionId) {
+      this.expandedSections.add(sectionId);
+    }
+    this.requestUpdate();
+  }
+
+  private toggleSection(sectionId: string): void {
+    if (this.expandedSections.has(sectionId)) {
+      this.expandedSections.delete(sectionId);
+    } else {
+      this.expandedSections.add(sectionId);
+    }
     this.requestUpdate();
   }
 
@@ -145,22 +438,118 @@ class ConfigBuilderApp extends LitElement {
   private saveConfig(next: ConfigDraft): void {
     this.config = next;
     this.validation = validateConfigDraft(next);
+    this.suggestionCacheConfig = null;
     persistDraft(next);
     this.requestUpdate();
   }
 
-  private setFieldError(path: string, message: string): void {
-    this.fieldErrors = {
-      ...this.fieldErrors,
-      [path]: message,
+  private collectModelSuggestionsFromConfig(): string[] {
+    const suggestions = new Set<string>(COMMON_MODEL_IDS);
+
+    const catalog = getFieldValue(this.config, "agents.defaults.models");
+    if (isRecord(catalog)) {
+      for (const key of Object.keys(catalog)) {
+        if (key.trim()) {
+          suggestions.add(key.trim());
+        }
+      }
+    }
+
+    const visit = (value: unknown): void => {
+      if (typeof value === "string") {
+        const trimmed = value.trim();
+        if (trimmed.includes("/") && !trimmed.includes("://")) {
+          suggestions.add(trimmed);
+        }
+        return;
+      }
+
+      if (Array.isArray(value)) {
+        for (const entry of value) {
+          visit(entry);
+        }
+        return;
+      }
+
+      if (isRecord(value)) {
+        for (const entry of Object.values(value)) {
+          visit(entry);
+        }
+      }
     };
+
+    visit(this.config);
+
+    return Array.from(suggestions).toSorted((a, b) => a.localeCompare(b));
+  }
+
+  private collectAuthProfileSuggestionsFromConfig(): string[] {
+    const profiles = getFieldValue(this.config, "auth.profiles");
+    if (!isRecord(profiles)) {
+      return [];
+    }
+    return Object.keys(profiles)
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .toSorted((a, b) => a.localeCompare(b));
+  }
+
+  private refreshSuggestionCaches(): void {
+    if (this.suggestionCacheConfig === this.config) {
+      return;
+    }
+    this.suggestionCacheConfig = this.config;
+    this.modelSuggestionsCache = this.collectModelSuggestionsFromConfig();
+    this.authProfileSuggestionsCache = this.collectAuthProfileSuggestionsFromConfig();
+  }
+
+  private fieldSuggestions(field: ExplorerField): string[] {
+    this.refreshSuggestionCaches();
+
+    const suggestions = new Set<string>();
+    const addMany = (values: string[]) => {
+      for (const value of values) {
+        const trimmed = value.trim();
+        if (trimmed) {
+          suggestions.add(trimmed);
+        }
+      }
+    };
+
+    // Schema-derived suggestions (including open unions like enum + string).
+    if (field.kind === "string" && field.enumValues.length > 0) {
+      addMany(field.enumValues);
+    }
+    if (field.kind === "array" && field.itemKind === "string" && field.itemEnumValues.length > 0) {
+      addMany(field.itemEnumValues);
+    }
+    if (
+      field.kind === "object" &&
+      field.recordValueKind === "string" &&
+      field.recordEnumValues.length > 0
+    ) {
+      addMany(field.recordEnumValues);
+    }
+
+    // Runtime-derived suggestions.
+    if (/model/i.test(field.path)) {
+      addMany(this.modelSuggestionsCache);
+    }
+
+    if (field.path === "auth.order") {
+      addMany(this.authProfileSuggestionsCache);
+    }
+
+    return Array.from(suggestions).toSorted((a, b) => a.localeCompare(b));
+  }
+
+  private setFieldError(path: string, message: string): void {
+    this.fieldErrors = { ...this.fieldErrors, [path]: message };
     this.requestUpdate();
   }
 
   private clearFieldError(path: string): void {
-    if (!(path in this.fieldErrors)) {
-      return;
-    }
+    if (!(path in this.fieldErrors)) {return;}
     const next = { ...this.fieldErrors };
     delete next[path];
     this.fieldErrors = next;
@@ -181,12 +570,55 @@ class ConfigBuilderApp extends LitElement {
     this.saveConfig(resetDraft());
   }
 
+  private openImportDialog(): void {
+    this.importState = createImportDialogState();
+    this.importState.open = true;
+    this.requestUpdate();
+  }
+
+  private deepMergeConfig(incoming: ConfigDraft): void {
+    const merged = this.deepMerge(this.config, incoming);
+    this.saveConfig(merged);
+  }
+
+  private deepMerge(
+    base: Record<string, unknown>,
+    incoming: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const result = { ...base };
+    for (const [key, value] of Object.entries(incoming)) {
+      const existing = result[key];
+      if (
+        typeof value === "object" && value !== null && !Array.isArray(value) &&
+        typeof existing === "object" && existing !== null && !Array.isArray(existing)
+      ) {
+        result[key] = this.deepMerge(
+          existing as Record<string, unknown>,
+          value as Record<string, unknown>,
+        );
+      } else {
+        result[key] = value;
+      }
+    }
+    return result;
+  }
+
   private sectionErrorCount(sectionId: string): number {
     return this.validation.sectionErrorCounts[sectionId] ?? 0;
   }
 
+  private sectionSetCount(section: ExplorerSection): number {
+    return section.fields.filter((f) => getFieldValue(this.config, f.path) !== undefined).length;
+  }
+
   private totalErrorCount(): number {
     return this.validation.issues.length;
+  }
+
+  private togglePreview(): void {
+    this.previewCollapsed = !this.previewCollapsed;
+    persistPreviewCollapsed(this.previewCollapsed);
+    this.requestUpdate();
   }
 
   private async copyPreview(text: string): Promise<void> {
@@ -196,33 +628,27 @@ class ConfigBuilderApp extends LitElement {
     } catch {
       this.copyState = "failed";
     }
-
-    if (this.copyResetTimer != null) {
-      window.clearTimeout(this.copyResetTimer);
-    }
-
+    if (this.copyResetTimer != null) {window.clearTimeout(this.copyResetTimer);}
     this.copyResetTimer = window.setTimeout(() => {
       this.copyState = "idle";
       this.copyResetTimer = null;
       this.requestUpdate();
     }, 1500);
-
     this.requestUpdate();
   }
 
   private setWizardStep(index: number): void {
     const clamped = Math.max(0, Math.min(WIZARD_STEPS.length - 1, index));
-    if (clamped === this.wizardStepIndex) {
-      return;
-    }
+    if (clamped === this.wizardStepIndex) {return;}
     this.wizardStepIndex = clamped;
+    this.wizardComplete = false;
     this.requestUpdate();
     this.focusWizardStep();
   }
 
   private focusWizardStep(): void {
     window.setTimeout(() => {
-      const root = document.querySelector(".builder-wizard");
+      const root = document.querySelector(".cb-wizard");
       const target = root?.querySelector<HTMLElement>("input, select, textarea, button");
       target?.focus();
     }, 0);
@@ -230,13 +656,11 @@ class ConfigBuilderApp extends LitElement {
 
   private getVisibleSections(snapshot: ExplorerSnapshot): ExplorerSection[] {
     const bySection = this.selectedSectionId
-      ? snapshot.sections.filter((section) => section.id === this.selectedSectionId)
+      ? snapshot.sections.filter((s) => s.id === this.selectedSectionId)
       : snapshot.sections;
 
     const query = this.searchQuery;
-    if (!query) {
-      return bySection;
-    }
+    if (!query) {return bySection;}
 
     const visible: ExplorerSection[] = [];
     for (const section of bySection) {
@@ -244,13 +668,10 @@ class ConfigBuilderApp extends LitElement {
         visible.push(section);
         continue;
       }
-      const fields = section.fields.filter((field) => matchesField(field, query));
-      if (fields.length === 0) {
-        continue;
-      }
+      const fields = section.fields.filter((f) => matchesField(f, query));
+      if (fields.length === 0) {continue;}
       visible.push({ ...section, fields });
     }
-
     return visible;
   }
 
@@ -258,136 +679,195 @@ class ConfigBuilderApp extends LitElement {
     const paths: string[] = [];
     for (const section of snapshot.sections) {
       for (const field of section.fields) {
-        if (!field.sensitive) {
-          continue;
-        }
-        if (getFieldValue(this.config, field.path) === undefined) {
-          continue;
-        }
+        if (!field.sensitive) {continue;}
+        if (getFieldValue(this.config, field.path) === undefined) {continue;}
         paths.push(field.path);
       }
     }
     return paths;
   }
 
+  private getCommandPaletteResults(snapshot: ExplorerSnapshot): ExplorerField[] {
+    const q = this.commandPaletteQuery.trim().toLowerCase();
+    const results: ExplorerField[] = [];
+    for (const section of snapshot.sections) {
+      for (const field of section.fields) {
+        if (!q || matchesField(field, q)) {
+          results.push(field);
+        }
+        if (results.length >= 20) {return results;}
+      }
+    }
+    return results;
+  }
+
+  // --- Renderers ---
+
   private renderTopbar() {
     const modeButton = (mode: ConfigBuilderMode, label: string) => html`
       <button
-        class="builder-mode-toggle__btn ${this.mode === mode ? "active" : ""}"
+        class="cb-topbar__nav-btn ${this.mode === mode ? "active" : ""}"
         @click=${() => this.navigateMode(mode)}
-      >
-        ${label}
-      </button>
+      >${label}</button>
     `;
 
     return html`
-      <header class="builder-topbar">
-        <div class="builder-brand">
-          <div class="builder-brand__title">OpenClaw Config Builder</div>
-          <div class="builder-brand__subtitle">Wizard + Explorer</div>
+      <header class="cb-topbar ${this.topbarScrolled ? "cb-topbar--scrolled" : ""}"
+        <div class="cb-topbar__brand">
+          <div class="cb-topbar__logo">OC</div>
+          <span class="cb-topbar__title">Config Builder</span>
         </div>
 
-        <div class="builder-mode-toggle" role="tablist" aria-label="Builder mode">
+        <nav class="cb-topbar__nav" role="tablist">
           ${modeButton("landing", "Home")}
           ${modeButton("explorer", "Explorer")}
           ${modeButton("wizard", "Wizard")}
-        </div>
+        </nav>
 
-        <a
-          class="btn btn--sm"
-          href="https://docs.openclaw.ai/configuration"
-          target="_blank"
-          rel="noreferrer"
-        >
-          Docs
-        </a>
+        <div class="cb-topbar__actions">
+          <button
+            class="cb-search-trigger"
+            @click=${() => {
+              this.commandPaletteOpen = true;
+              this.commandPaletteQuery = "";
+              this.commandPaletteIndex = 0;
+              this.requestUpdate();
+              window.setTimeout(() => {
+                const input = document.querySelector<HTMLInputElement>(".cb-palette__input");
+                input?.focus();
+              }, 50);
+            }}
+          >
+            ${iconSearch}
+            <span>Search fields…</span>
+            <kbd>⌘K</kbd>
+          </button>
+
+          <button class="cb-theme-toggle" @click=${() => this.toggleTheme()} title="Toggle theme">
+            ${this.theme === "dark" ? iconSun : iconMoon}
+          </button>
+
+          <a class="btn btn--sm" href="https://docs.openclaw.ai/configuration" target="_blank" rel="noreferrer">
+            ${iconExternalLink} Docs
+          </a>
+        </div>
       </header>
     `;
   }
 
-  private renderSearch() {
+  private renderLanding(snapshot: ExplorerSnapshot) {
     return html`
-      <div class="config-search">
-        <svg
-          class="config-search__icon"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          aria-hidden="true"
-        >
-          <circle cx="11" cy="11" r="8"></circle>
-          <path d="M21 21l-4.35-4.35"></path>
-        </svg>
-        <input
-          class="config-search__input"
-          type="text"
-          placeholder="Search fields, labels, help…"
-          @input=${(event: Event) => this.setSearchQuery((event.target as HTMLInputElement).value)}
-        />
-        ${this.searchQuery
-          ? html`
-              <button
-                class="config-search__clear"
-                title="Clear search"
-                @click=${() => this.setSearchQuery("")}
-              >
-                ×
-              </button>
-            `
-          : nothing}
+      <div class="cb-landing">
+        <div class="cb-landing__hero">
+          <h1 class="cb-landing__heading">Config Builder</h1>
+          <p class="cb-landing__sub">
+            Build your <code style="font-family:var(--mono);font-size:0.9em">openclaw.json</code> visually.
+            Guided wizard or full schema explorer — your config never leaves your browser.
+          </p>
+        </div>
+
+        <div class="cb-landing__cards">
+          <div class="cb-landing__card cb-landing__card--primary" @click=${() => this.navigateMode("wizard")}>
+            <div class="cb-landing__card-icon">${iconSparkles}</div>
+            <div class="cb-landing__card-title">Guided Setup</div>
+            <div class="cb-landing__card-meta">${WIZARD_STEPS.length} steps · ~5 min</div>
+            <div class="cb-landing__card-desc">
+              Walk through the most important settings step by step. Perfect for first-time setup.
+            </div>
+            <div class="cb-landing__card-cta">
+              <button class="btn primary">Start Wizard</button>
+            </div>
+          </div>
+
+          <div class="cb-landing__card" @click=${() => this.navigateMode("explorer")}>
+            <div class="cb-landing__card-icon">${iconGrid}</div>
+            <div class="cb-landing__card-title">Full Explorer</div>
+            <div class="cb-landing__card-meta">${snapshot.sectionCount} sections · ${snapshot.fieldCount} fields</div>
+            <div class="cb-landing__card-desc">
+              Browse every schema-backed field with search, filtering, and real-time validation.
+            </div>
+            <div class="cb-landing__card-cta">
+              <button class="btn">Open Explorer</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="cb-landing__import">
+          or <a @click=${() => this.openImportDialog()}>import an existing config</a>
+        </div>
+
+        <div class="cb-landing__features">
+          <span class="cb-landing__feature">${iconCheck} Real-time validation</span>
+          <span class="cb-landing__feature">${iconCode} JSON5 output</span>
+          <span class="cb-landing__feature">${iconShield} Schema-backed</span>
+          <span class="cb-landing__feature">${iconFile} LocalStorage draft</span>
+        </div>
+
+        <div class="cb-landing__footer">
+          All processing happens client-side. Your config data never leaves your browser.
+        </div>
       </div>
     `;
   }
 
   private renderSidebar(snapshot: ExplorerSnapshot) {
     return html`
-      <aside class="config-sidebar">
-        <div class="config-sidebar__header">
-          <div>
-            <div class="config-sidebar__title">Explorer</div>
-            <div class="builder-subtitle">Schema-backed field editor</div>
-          </div>
+      <aside class="cb-sidebar">
+        <div class="cb-sidebar__header">
+          <span class="cb-sidebar__title">Sections</span>
           <span class="pill pill--sm ${this.validation.valid ? "pill--ok" : "pill--danger"}">
-            ${this.validation.valid ? "valid" : "errors"}
+            ${this.validation.valid ? "valid" : `${this.totalErrorCount()} errors`}
           </span>
         </div>
 
-        ${this.renderSearch()}
+        <div class="cb-sidebar__search">
+          <span class="cb-sidebar__search-icon">${iconSearch}</span>
+          <input
+            class="cb-sidebar__search-input"
+            type="text"
+            placeholder="Filter sections…"
+            .value=${this.searchQuery}
+            @input=${(e: Event) => this.setSearchQuery((e.target as HTMLInputElement).value)}
+          />
+          ${this.searchQuery
+            ? html`<button class="cb-sidebar__search-clear" @click=${() => this.setSearchQuery("")}>×</button>`
+            : nothing}
+        </div>
 
-        <nav class="config-nav">
+        <nav class="cb-sidebar__nav">
           <button
-            class="config-nav__item ${this.selectedSectionId === null ? "active" : ""}"
+            class="cb-sidebar__nav-item ${this.selectedSectionId === null ? "active" : ""}"
             @click=${() => this.setSection(null)}
           >
-            <span class="config-nav__icon builder-icon" aria-hidden="true">A</span>
-            <span class="config-nav__label">All sections</span>
-            <span class="builder-count mono">${snapshot.fieldCount}</span>
+            <span class="cb-sidebar__nav-icon">${iconGrid}</span>
+            <span class="cb-sidebar__nav-label">All</span>
+            <span class="cb-sidebar__nav-count">${snapshot.fieldCount}</span>
           </button>
 
-          ${snapshot.sections.map(
-            (section) => html`
+          ${snapshot.sections.map((section) => {
+            const setCount = this.sectionSetCount(section);
+            const errCount = this.sectionErrorCount(section.id);
+            return html`
               <button
-                class="config-nav__item ${this.selectedSectionId === section.id ? "active" : ""}"
+                class="cb-sidebar__nav-item ${this.selectedSectionId === section.id ? "active" : ""}"
                 @click=${() => this.setSection(section.id)}
               >
-                <span class="config-nav__icon builder-icon" aria-hidden="true"
-                  >${sectionGlyph(section.label)}</span
-                >
-                <span class="config-nav__label">${section.label}</span>
-                <span class="builder-count mono">${section.fields.length}</span>
-                ${this.sectionErrorCount(section.id) > 0
-                  ? html`<span class="builder-error-count">${this.sectionErrorCount(section.id)}</span>`
+                <span class="cb-sidebar__nav-icon">${sectionIcon(section.id)}</span>
+                <span class="cb-sidebar__nav-label">${section.label}</span>
+                <span class="cb-sidebar__nav-count ${setCount > 0 ? "cb-sidebar__nav-count--active" : ""}">
+                  ${setCount}/${section.fields.length}
+                </span>
+                ${errCount > 0
+                  ? html`<span class="cb-sidebar__nav-errors">${errCount}</span>`
                   : nothing}
               </button>
-            `,
-          )}
+            `;
+          })}
         </nav>
 
-        <div class="config-sidebar__footer">
-          <div class="builder-footer-note">
-            Draft values persist to localStorage. Validation updates in real time.
-          </div>
+        <div class="cb-sidebar__footer">
+          Draft auto-saved to localStorage.<br />
+          Validation updates in real time.
         </div>
       </aside>
     `;
@@ -398,323 +878,476 @@ class ConfigBuilderApp extends LitElement {
     const hasValue = value !== undefined;
     const localError = this.fieldErrors[field.path] ?? null;
     const schemaErrors = this.validation.issuesByPath[field.path] ?? [];
+    const hasError = Boolean(localError) || schemaErrors.length > 0;
 
     return html`
-      <div class="cfg-field builder-field ${hasValue ? "builder-field--set" : ""}">
-        <div class="builder-field__head">
-          <div class="cfg-field__label">${field.label}</div>
-          <div class="builder-field__badges">
-            ${hasValue ? html`<span class="pill pill--sm">set</span>` : nothing}
-            ${field.sensitive ? html`<span class="pill pill--sm pill--danger">sensitive</span>` : nothing}
-            ${field.advanced ? html`<span class="pill pill--sm">advanced</span>` : nothing}
-            <span class="pill pill--sm mono">${field.kind}</span>
-            ${field.kind === "array" && field.itemKind
-              ? html`<span class="pill pill--sm mono">item:${field.itemKind}</span>`
-              : nothing}
-            ${field.kind === "object" && field.recordValueKind
-              ? html`<span class="pill pill--sm mono">value:${field.recordValueKind}</span>`
-              : nothing}
+      <div class="cb-field ${hasValue ? "cb-field--set" : ""} ${hasError ? "cb-field--error" : ""}">
+        <div class="cb-field__header">
+          <span class="cb-field__label">${field.label}</span>
+          <div class="cb-field__badges">
+            ${field.sensitive ? html`<span class="cb-field__badge cb-field__badge--sensitive">🔒 sensitive</span>` : nothing}
+            <span class="cb-field__badge">${field.kind}</span>
           </div>
         </div>
 
-        <div class="builder-field__path mono">${field.path}</div>
+        <div class="cb-field__path">${field.path}</div>
 
-        ${field.help ? html`<div class="cfg-field__help">${field.help}</div>` : nothing}
+        ${field.help ? html`<div class="cb-field__help">${field.help}</div>` : nothing}
 
-        <div class="builder-field__controls">
+        <div class="cb-field__control">
           ${renderFieldEditor({
             field,
             value,
-            onSet: (nextValue: unknown) => this.setField(field.path, nextValue),
+            onSet: (v: unknown) => this.setField(field.path, v),
             onClear: () => this.clearField(field.path),
-            onValidationError: (message: string) => this.setFieldError(field.path, message),
+            onValidationError: (msg: string) => this.setFieldError(field.path, msg),
+            suggestions: this.fieldSuggestions(field),
           })}
         </div>
 
-        ${localError ? html`<div class="cfg-field__error">${localError}</div>` : nothing}
-        ${schemaErrors.map((message) => html`<div class="cfg-field__error">${message}</div>`)}
+        ${localError ? html`<div class="cb-field__error">${localError}</div>` : nothing}
+        ${schemaErrors.map((msg) => html`<div class="cb-field__error">${msg}</div>`)}
 
-        <div class="builder-field__actions">
-          <button class="btn btn--sm" @click=${() => this.clearField(field.path)}>Clear</button>
+        <div class="cb-field__actions">
           ${context === "wizard"
             ? html`<button class="btn btn--sm" @click=${() => this.navigateMode("explorer")}>Open in Explorer</button>`
             : nothing}
+          <button class="btn btn--sm cb-field__clear-btn" @click=${() => this.clearField(field.path)}>Clear</button>
         </div>
       </div>
     `;
   }
 
-  private renderValidationSummary() {
-    if (this.validation.valid) {
-      return nothing;
-    }
-
-    const sectionEntries = Object.entries(this.validation.sectionErrorCounts).toSorted((a, b) =>
-      a[0].localeCompare(b[0]),
-    );
+  private renderSectionCard(section: ExplorerSection, index: number) {
+    const isOpen = this.expandedSections.has(section.id) ||
+      this.selectedSectionId === section.id ||
+      Boolean(this.searchQuery);
+    const setCount = this.sectionSetCount(section);
+    const errCount = this.sectionErrorCount(section.id);
+    const stagger = Math.min(index + 1, 10);
 
     return html`
-      <div class="callout danger builder-validation-summary" role="alert">
-        <div class="builder-validation-summary__title">
-          ${this.totalErrorCount()} validation error${this.totalErrorCount() === 1 ? "" : "s"}
+      <div class="cb-section ${isOpen ? "cb-section--open" : ""} cb-stagger-${stagger}">
+        <div class="cb-section__header" @click=${() => this.toggleSection(section.id)}>
+          <span class="cb-section__icon">${sectionIcon(section.id)}</span>
+          <div class="cb-section__info">
+            <div class="cb-section__title">${section.label}</div>
+            ${section.description
+              ? html`<div class="cb-section__desc">${section.description}</div>`
+              : nothing}
+          </div>
+          <div class="cb-section__meta">
+            <span class="cb-section__count ${setCount > 0 ? "cb-section__count--has-values" : ""}">
+              ${setCount}/${section.fields.length}
+            </span>
+            ${errCount > 0
+              ? html`<span class="cb-section__error-count">${errCount}</span>`
+              : nothing}
+          </div>
+          <span class="cb-section__chevron">${iconChevronDown}</span>
         </div>
-        <div class="builder-validation-summary__sections">
-          ${sectionEntries.map(
-            ([section, count]) => html`<span class="pill pill--sm">${section}: ${count}</span>`,
-          )}
+        <div class="cb-section__body">
+          <div class="cb-section__body-inner">
+            <div class="cb-section__fields">
+              ${section.fields.map((field) => this.renderField(field, "explorer"))}
+            </div>
+          </div>
         </div>
-        <ul class="builder-validation-summary__list">
-          ${this.validation.issues.slice(0, 8).map(
-            (issue) => html`<li><span class="mono">${issue.path || "(root)"}</span> — ${issue.message}</li>`,
-          )}
-        </ul>
       </div>
     `;
   }
 
-  private renderExplorerSections(visibleSections: ExplorerSection[]) {
-    if (visibleSections.length === 0) {
-      return html`<div class="config-empty"><div class="config-empty__text">No matching sections/fields for this filter.</div></div>`;
-    }
+  private renderExplorer(snapshot: ExplorerSnapshot) {
+    const visibleSections = this.getVisibleSections(snapshot);
 
     return html`
-      <div class="config-form config-form--modern">
-        ${visibleSections.map(
-          (section) => html`
-            <section class="config-section-card" id=${`section-${section.id}`}>
-              <div class="config-section-card__header">
-                <div class="config-section-card__icon builder-section-glyph" aria-hidden="true">
-                  ${sectionGlyph(section.label)}
-                </div>
-                <div class="config-section-card__titles">
-                  <h2 class="config-section-card__title">${section.label}</h2>
-                  <div class="config-section-card__desc">
-                    <span class="mono">${section.id}</span>
-                    · ${section.fields.length} field hint${section.fields.length === 1 ? "" : "s"}
-                    ${this.sectionErrorCount(section.id) > 0
-                      ? html` · <span class="builder-error-text">${this.sectionErrorCount(section.id)} errors</span>`
-                      : nothing}
-                    ${section.description ? html`<br />${section.description}` : nothing}
-                  </div>
-                </div>
-              </div>
+      ${this.renderSidebar(snapshot)}
 
-              <div class="config-section-card__content">
-                <div class="cfg-fields">
-                  ${section.fields.map((field) => this.renderField(field, "explorer"))}
+      <main class="cb-main">
+        <div class="cb-actions">
+          <div class="cb-actions__left">
+            <span class="cb-actions__status">
+              ${this.selectedSectionId
+                ? `${visibleSections[0]?.label ?? "Section"}`
+                : this.searchQuery
+                  ? `Search: "${this.searchQuery}"`
+                  : "All sections"}
+            </span>
+          </div>
+          <div class="cb-actions__right">
+            <span class="pill pill--sm mono">v${snapshot.version}</span>
+            ${this.totalErrorCount() > 0
+              ? html`<span class="pill pill--sm pill--danger">${this.totalErrorCount()} errors</span>`
+              : html`<span class="pill pill--sm pill--ok">valid</span>`}
+          </div>
+        </div>
+
+        <div class="cb-content">
+          ${visibleSections.length === 0
+            ? html`
+                <div class="cb-empty">
+                  <div class="cb-empty__icon">${iconSearch}</div>
+                  <div class="cb-empty__text">No matching sections or fields</div>
+                  <div class="cb-empty__sub">Try a different search term</div>
                 </div>
-              </div>
-            </section>
-          `,
-        )}
+              `
+            : html`
+                <div class="cb-sections">
+                  ${visibleSections.map((section, i) => this.renderSectionCard(section, i))}
+                </div>
+              `}
+        </div>
+      </main>
+    `;
+  }
+
+  private renderWizardStepper() {
+    return html`
+      <div class="cb-stepper">
+        ${WIZARD_STEPS.map((step, index) => {
+          const state =
+            this.wizardComplete || index < this.wizardStepIndex
+              ? "done"
+              : index === this.wizardStepIndex && !this.wizardComplete
+                ? "active"
+                : "future";
+
+          return html`
+            ${index > 0 ? html`<div class="cb-stepper__line ${index <= this.wizardStepIndex ? "cb-stepper__line--done" : ""}"></div>` : nothing}
+            <button
+              class="cb-stepper__step cb-stepper__step--${state}"
+              @click=${() => { this.wizardComplete = false; this.setWizardStep(index); }}
+            >
+              <span class="cb-stepper__circle">
+                ${state === "done" ? iconCheck : `${index + 1}`}
+              </span>
+              <span class="cb-stepper__label">${step.label}</span>
+            </button>
+          `;
+        })}
       </div>
     `;
   }
 
-  private renderWizardView() {
+  private renderWizardContent() {
+    if (this.wizardComplete) {
+      const setCount = Object.keys(this.config).length > 0
+        ? WIZARD_STEPS.reduce(
+            (sum, step) =>
+              sum +
+              wizardStepFields(step).filter(
+                (f) => getFieldValue(this.config, f.path) !== undefined,
+              ).length,
+            0,
+          )
+        : 0;
+
+      return html`
+        <div class="cb-wizard__complete">
+          <div class="cb-wizard__complete-icon">${iconCheck}</div>
+          <div class="cb-wizard__complete-title">Your config is ready!</div>
+          <div class="cb-wizard__complete-sub">
+            ${setCount} field${setCount === 1 ? "" : "s"} configured across ${WIZARD_STEPS.length} steps
+          </div>
+          <div class="cb-wizard__complete-actions">
+            <button class="btn primary" @click=${() => {
+              const preview = formatConfigJson5(this.config);
+              downloadJson5File(preview.text);
+            }}>
+              ${iconDownload} Download JSON5
+            </button>
+            <button class="btn" @click=${() => this.navigateMode("explorer")}>
+              ${iconGrid} Open in Explorer
+            </button>
+          </div>
+        </div>
+      `;
+    }
+
     const step = wizardStepByIndex(this.wizardStepIndex);
     const fields = wizardStepFields(step);
+    const isLast = this.wizardStepIndex >= WIZARD_STEPS.length - 1;
 
     return html`
-      <div class="builder-wizard">
-        <div class="builder-wizard__progress" role="list">
-          ${WIZARD_STEPS.map((entry, index) => {
-            const state =
-              index < this.wizardStepIndex ? "done" : index === this.wizardStepIndex ? "active" : "todo";
-            return html`
-              <button
-                class="builder-wizard__step builder-wizard__step--${state}"
-                @click=${() => this.setWizardStep(index)}
-                role="listitem"
-                aria-current=${index === this.wizardStepIndex ? "step" : "false"}
-              >
-                <span class="builder-wizard__step-index">${index + 1}</span>
-                <span class="builder-wizard__step-label">${entry.label}</span>
-              </button>
-            `;
-          })}
+      <div class="cb-wizard__card">
+        <div class="cb-wizard__card-header">
+          <span class="cb-wizard__card-icon">${sectionIcon(step.id)}</span>
+          <div>
+            <div class="cb-wizard__card-title">${step.label}</div>
+            <div class="cb-wizard__card-desc">${step.description}</div>
+          </div>
         </div>
 
-        <section class="config-section-card">
-          <div class="config-section-card__header">
-            <div class="config-section-card__icon builder-section-glyph" aria-hidden="true">
-              ${sectionGlyph(step.label)}
-            </div>
-            <div class="config-section-card__titles">
-              <h2 class="config-section-card__title">${step.label}</h2>
-              <div class="config-section-card__desc">${step.description}</div>
-            </div>
+        <div class="cb-wizard__card-body">
+          <div class="cb-wizard__card-fields">
+            ${fields.map((field) => this.renderField(field, "wizard"))}
           </div>
+        </div>
 
-          <div class="config-section-card__content">
-            <div class="cfg-fields">
-              ${fields.map((field) => this.renderField(field, "wizard"))}
-            </div>
-
-            <div class="builder-wizard__actions">
-              <button
-                class="btn btn--sm"
-                ?disabled=${this.wizardStepIndex === 0}
-                @click=${() => this.setWizardStep(this.wizardStepIndex - 1)}
-              >
-                Back
-              </button>
-
-              <button
-                class="btn btn--sm primary"
-                @click=${() => {
-                  if (this.wizardStepIndex >= WIZARD_STEPS.length - 1) {
-                    this.navigateMode("explorer");
-                    return;
-                  }
-                  this.setWizardStep(this.wizardStepIndex + 1);
-                }}
-              >
-                ${this.wizardStepIndex >= WIZARD_STEPS.length - 1 ? "Finish" : "Continue"}
-              </button>
-            </div>
+        <div class="cb-wizard__actions">
+          <div class="cb-wizard__actions-left">
+            <button
+              class="btn btn--sm"
+              ?disabled=${this.wizardStepIndex === 0}
+              @click=${() => this.setWizardStep(this.wizardStepIndex - 1)}
+            >
+              ${iconChevronLeft} Back
+            </button>
           </div>
-        </section>
+          <div class="cb-wizard__actions-right">
+            <button
+              class="cb-wizard__skip"
+              @click=${() => {
+                if (isLast) {
+                  this.wizardComplete = true;
+                  this.requestUpdate();
+                  return;
+                }
+                this.setWizardStep(this.wizardStepIndex + 1);
+              }}
+            >
+              Skip this step
+            </button>
+            <button
+              class="btn btn--sm primary"
+              @click=${() => {
+                if (isLast) {
+                  this.wizardComplete = true;
+                  this.requestUpdate();
+                  return;
+                }
+                this.setWizardStep(this.wizardStepIndex + 1);
+              }}
+            >
+              ${isLast ? html`${iconSparkles} Finish & Review` : "Continue →"}
+            </button>
+          </div>
+        </div>
       </div>
     `;
   }
 
-  private toggleMobilePreview(): void {
-    this.previewOpenMobile = !this.previewOpenMobile;
-    this.requestUpdate();
+  private renderWizard() {
+    return html`
+      <main class="cb-main">
+        <div class="cb-actions">
+          <div class="cb-actions__left">
+            <span class="cb-actions__status">
+              ${this.wizardComplete
+                ? "Setup complete"
+                : `Step ${this.wizardStepIndex + 1} of ${WIZARD_STEPS.length}`}
+            </span>
+          </div>
+          <div class="cb-actions__right">
+            ${this.totalErrorCount() > 0
+              ? html`<span class="pill pill--sm pill--danger">${this.totalErrorCount()} errors</span>`
+              : html`<span class="pill pill--sm pill--ok">valid</span>`}
+          </div>
+        </div>
+
+        <div class="cb-content">
+          <div class="cb-wizard">
+            ${this.renderWizardStepper()}
+            ${this.renderWizardContent()}
+          </div>
+        </div>
+      </main>
+    `;
+  }
+
+  private renderPreviewCode(text: string) {
+    const rawLines = text.split(/\r?\n/);
+    const lines = rawLines.at(-1) === "" ? rawLines.slice(0, -1) : rawLines;
+
+    return html`<div class="cb-code-lines">${lines.map((line, index) => {
+      const tokens = tokenizeJson5Line(line);
+      return html`<div class="cb-code-line"><span class="cb-code-line__num">${index + 1}</span><span class="cb-code-line__content">${tokens.map((token) => html`<span class="cb-code-token cb-code-token--${token.kind}">${token.value}</span>`)}</span></div>`;
+    })}</div>`;
   }
 
   private renderPreview(snapshot: ExplorerSnapshot) {
+    const collapsed = this.previewCollapsed;
     const preview = formatConfigJson5(this.config);
     const sensitivePaths = this.sensitiveFieldsWithValues(snapshot);
 
     return html`
-      <aside class="builder-preview ${this.previewOpenMobile ? "mobile-open" : "mobile-collapsed"}">
-        <div class="builder-preview__header">
-          <div>
-            <div class="builder-preview__title mono">openclaw.json</div>
-            <div class="builder-preview__meta mono">${preview.lineCount} lines · ${preview.byteCount} B</div>
+      <aside class="cb-preview ${collapsed ? "cb-preview--collapsed" : ""}">
+        <div class="cb-preview__header">
+          <div class="cb-preview__title-group">
+            <span class="cb-preview__file-icon">${iconFile}</span>
+            <span class="cb-preview__title">openclaw.json</span>
+            <span class="cb-preview__meta">${preview.lineCount} lines</span>
           </div>
-
           <button
-            class="btn btn--sm builder-preview__mobile-toggle"
-            @click=${() => this.toggleMobilePreview()}
-            aria-expanded=${this.previewOpenMobile ? "true" : "false"}
+            class="cb-preview__toggle"
+            @click=${() => this.togglePreview()}
+            title="${collapsed ? "Show preview" : "Hide preview"}"
           >
-            ${this.previewOpenMobile ? "Hide" : "Show"} preview
+            ${iconPanelRight}
           </button>
         </div>
 
-        ${sensitivePaths.length > 0
+        ${sensitivePaths.length > 0 && !collapsed
           ? html`
-              <div class="callout warn builder-sensitive-warning">
-                Sensitive values included in output (${sensitivePaths.length}).
-                <div class="mono builder-sensitive-warning__paths">${sensitivePaths.join(", ")}</div>
+              <div class="cb-preview__warning">
+                ${iconShield}
+                ${sensitivePaths.length} sensitive value${sensitivePaths.length === 1 ? "" : "s"} in output
               </div>
             `
           : nothing}
 
-        <pre class="builder-preview__code code-block">${preview.text}</pre>
+        <div class="cb-preview__code">${this.renderPreviewCode(preview.text)}</div>
 
-        <div class="builder-preview__footer">
+        <div class="cb-preview__footer">
           <button class="btn btn--sm" @click=${() => this.copyPreview(preview.text)}>
-            ${this.copyState === "copied"
-              ? "Copied"
-              : this.copyState === "failed"
-                ? "Copy failed"
-                : "Copy"}
+            ${this.copyState === "copied" ? iconCheck : iconCopy}
+            ${this.copyState === "copied" ? "Copied!" : this.copyState === "failed" ? "Failed" : "Copy"}
           </button>
-          <button class="btn btn--sm" @click=${() => downloadJson5File(preview.text)}>Download</button>
-          <button class="btn btn--sm danger" @click=${() => this.resetAllFields()}>Reset all</button>
+          <button class="btn btn--sm" @click=${() => downloadJson5File(preview.text)}>
+            ${iconDownload} Download
+          </button>
+          <span class="cb-preview__spacer"></span>
+          <button class="btn btn--sm danger" @click=${() => this.resetAllFields()}>
+            ${iconTrash} Reset
+          </button>
         </div>
       </aside>
     `;
   }
 
-  private renderLanding() {
-    return html`
-      <div class="builder-landing">
-        <section class="card builder-landing__card">
-          <h2 class="card-title">Choose your setup flow</h2>
-          <p class="card-sub">
-            Start with the guided wizard for common setups, or use explorer for full schema control.
-          </p>
+  private renderCommandPalette(snapshot: ExplorerSnapshot) {
+    if (!this.commandPaletteOpen) {return nothing;}
 
-          <div class="builder-landing__actions">
-            <button class="btn primary" @click=${() => this.navigateMode("wizard")}>Start Wizard</button>
-            <button class="btn" @click=${() => this.navigateMode("explorer")}>Open Explorer</button>
-          </div>
-
-          <div class="builder-landing__notes">
-            <div class="pill pill--sm">7 curated wizard steps</div>
-            <div class="pill pill--sm">Live JSON5 preview</div>
-            <div class="pill pill--sm">Real-time schema validation</div>
-          </div>
-        </section>
-      </div>
-    `;
-  }
-
-  private renderWorkspace(snapshot: ExplorerSnapshot) {
-    const explorerSections = this.getVisibleSections(snapshot);
-    const layoutClass = this.mode === "wizard" ? "builder-layout builder-layout--wizard" : "builder-layout";
+    const results = this.getCommandPaletteResults(snapshot);
 
     return html`
-      <div class="config-layout ${layoutClass}">
-        ${this.mode === "explorer" ? this.renderSidebar(snapshot) : nothing}
-
-        <main class="config-main">
-          <div class="config-actions">
-            <div class="config-actions__left">
-              <span class="config-status">
-                ${this.mode === "wizard"
-                  ? `Wizard step ${this.wizardStepIndex + 1} of ${WIZARD_STEPS.length}`
-                  : "Explorer mode"}
-              </span>
-            </div>
-            <div class="config-actions__right">
-              <span class="pill pill--sm">sections: ${snapshot.sectionCount}</span>
-              <span class="pill pill--sm">fields: ${snapshot.fieldCount}</span>
-              <span class="pill pill--sm mono">v${snapshot.version}</span>
-              ${this.totalErrorCount() > 0
-                ? html`<span class="pill pill--sm pill--danger">errors: ${this.totalErrorCount()}</span>`
-                : html`<span class="pill pill--sm pill--ok">valid</span>`}
-            </div>
+      <div class="cb-palette-overlay" @click=${(e: Event) => {
+        if (e.target === e.currentTarget) {
+          this.commandPaletteOpen = false;
+          this.requestUpdate();
+        }
+      }}>
+        <div class="cb-palette">
+          <div class="cb-palette__input-wrap">
+            <span class="cb-palette__input-icon">${iconSearch}</span>
+            <input
+              class="cb-palette__input"
+              type="text"
+              placeholder="Search fields…"
+              .value=${this.commandPaletteQuery}
+              @input=${(e: Event) => {
+                this.commandPaletteQuery = (e.target as HTMLInputElement).value;
+                this.commandPaletteIndex = 0;
+                this.requestUpdate();
+              }}
+              @keydown=${(e: KeyboardEvent) => {
+                if (e.key === "ArrowDown") {
+                  e.preventDefault();
+                  this.commandPaletteIndex = Math.min(this.commandPaletteIndex + 1, results.length - 1);
+                  this.requestUpdate();
+                } else if (e.key === "ArrowUp") {
+                  e.preventDefault();
+                  this.commandPaletteIndex = Math.max(this.commandPaletteIndex - 1, 0);
+                  this.requestUpdate();
+                } else if (e.key === "Enter" && results[this.commandPaletteIndex]) {
+                  e.preventDefault();
+                  const field = results[this.commandPaletteIndex];
+                  if (field) {
+                    const sectionId = field.path.split(".")[0] ?? null;
+                    this.commandPaletteOpen = false;
+                    this.navigateMode("explorer");
+                    this.setSection(sectionId);
+                    if (sectionId) {this.expandedSections.add(sectionId);}
+                    this.requestUpdate();
+                  }
+                }
+              }}
+            />
           </div>
-
-          <div class="config-content">
-            ${this.renderValidationSummary()}
-
-            ${this.mode === "explorer" && this.searchQuery
-              ? html`<div class="builder-search-state">Search: <span class="mono">${this.searchQuery}</span></div>`
-              : nothing}
-
-            ${this.mode === "wizard"
-              ? this.renderWizardView()
-              : this.renderExplorerSections(explorerSections)}
+          <div class="cb-palette__results">
+            ${results.length === 0
+              ? html`<div class="cb-palette__empty">No fields match your search</div>`
+              : results.map((field, i) => {
+                  const val = getFieldValue(this.config, field.path);
+                  return html`
+                    <div
+                      class="cb-palette__result ${i === this.commandPaletteIndex ? "cb-palette__result--active" : ""}"
+                      @click=${() => {
+                        const sectionId = field.path.split(".")[0] ?? null;
+                        this.commandPaletteOpen = false;
+                        this.navigateMode("explorer");
+                        this.setSection(sectionId);
+                        if (sectionId) {this.expandedSections.add(sectionId);}
+                        this.requestUpdate();
+                      }}
+                    >
+                      <span class="cb-palette__result-label">${field.label}</span>
+                      <span class="cb-palette__result-path">${field.path}</span>
+                      ${val !== undefined
+                        ? html`<span class="cb-palette__result-value">${typeof val === "string" ? val : JSON.stringify(val)}</span>`
+                        : nothing}
+                    </div>
+                  `;
+                })}
           </div>
-        </main>
-
-        ${this.renderPreview(snapshot)}
+        </div>
       </div>
     `;
   }
 
   override render() {
     if (this.state.status === "loading") {
-      return html`<div class="builder-screen"><div class="card">Loading config builder…</div></div>`;
+      return html`<div class="cb-screen" style="display:grid;place-items:center;"><div class="card">Loading config builder…</div></div>`;
     }
 
     if (this.state.status === "error") {
-      return html`<div class="builder-screen"><pre class="callout danger">${this.state.message}</pre></div>`;
+      return html`<div class="cb-screen" style="display:grid;place-items:center;"><pre class="callout danger">${this.state.message}</pre></div>`;
     }
 
     const { snapshot } = this.state;
 
+    const importDialog = renderImportDialog(
+      this.importState,
+      Object.keys(this.config).length > 0,
+      {
+        onReplace: (config) => this.saveConfig(config),
+        onMerge: (config) => this.deepMergeConfig(config),
+        onClose: () => {
+          this.importState = { ...this.importState, open: false };
+          this.requestUpdate();
+        },
+        onStateChange: (next) => {
+          this.importState = next;
+          this.requestUpdate();
+        },
+      },
+    );
+
+    if (this.mode === "landing") {
+      return html`
+        <div class="cb-screen">
+          ${this.renderTopbar()}
+          ${this.renderLanding(snapshot)}
+          ${this.renderCommandPalette(snapshot)}
+          ${importDialog}
+        </div>
+      `;
+    }
+
+    const workspaceClass = this.mode === "wizard"
+      ? "cb-workspace cb-workspace--wizard"
+      : "cb-workspace cb-workspace--explorer";
+    const previewClass = this.previewCollapsed ? "cb-workspace--preview-collapsed" : "";
+
     return html`
-      <div class="builder-screen">
+      <div class="cb-screen">
         ${this.renderTopbar()}
-        ${this.mode === "landing" ? this.renderLanding() : this.renderWorkspace(snapshot)}
+        <div class="${workspaceClass} ${previewClass}">
+          ${this.mode === "explorer" ? this.renderExplorer(snapshot) : this.renderWizard()}
+          ${this.renderPreview(snapshot)}
+        </div>
+        ${this.renderCommandPalette(snapshot)}
+        ${importDialog}
       </div>
     `;
   }

--- a/apps/config-builder/src/ui/app.ts
+++ b/apps/config-builder/src/ui/app.ts
@@ -36,7 +36,6 @@ import {
   iconSparkles,
   iconSun,
   iconTrash,
-  iconX,
   sectionIcon,
 } from "./components/icons.ts";
 import {

--- a/apps/config-builder/src/ui/app.ts
+++ b/apps/config-builder/src/ui/app.ts
@@ -1,10 +1,41 @@
-import { LitElement, css, html } from "lit";
-import { runSchemaSpike, type SchemaSpikeSummary } from "../lib/schema-spike.ts";
+import { LitElement, css, html, nothing } from "lit";
+import {
+  buildExplorerSnapshot,
+  type ExplorerField,
+  type ExplorerSection,
+  type ExplorerSnapshot,
+} from "../lib/schema-spike.ts";
 
 type AppState =
   | { status: "loading" }
-  | { status: "ready"; summary: SchemaSpikeSummary }
+  | { status: "ready"; snapshot: ExplorerSnapshot }
   | { status: "error"; message: string };
+
+function includesQuery(value: string, query: string): boolean {
+  return value.toLowerCase().includes(query);
+}
+
+function matchesField(field: ExplorerField, query: string): boolean {
+  if (!query) {
+    return true;
+  }
+  return (
+    includesQuery(field.path, query) ||
+    includesQuery(field.label, query) ||
+    includesQuery(field.help, query)
+  );
+}
+
+function matchesSection(section: ExplorerSection, query: string): boolean {
+  if (!query) {
+    return true;
+  }
+  return (
+    includesQuery(section.id, query) ||
+    includesQuery(section.label, query) ||
+    includesQuery(section.description, query)
+  );
+}
 
 class ConfigBuilderApp extends LitElement {
   static override styles = css`
@@ -13,60 +44,240 @@ class ConfigBuilderApp extends LitElement {
       min-height: 100vh;
       background: #09090b;
       color: #fafafa;
+      font-family: Inter, "Segoe UI", Roboto, sans-serif;
     }
 
     .shell {
-      max-width: 900px;
-      margin: 0 auto;
-      padding: 40px 20px;
+      min-height: 100vh;
+      display: grid;
+      grid-template-columns: 260px minmax(0, 1fr);
     }
 
-    .title {
-      font-size: 1.4rem;
+    .sidebar {
+      border-right: 1px solid #27272a;
+      background: #09090b;
+      padding: 16px;
+      position: sticky;
+      top: 0;
+      max-height: 100vh;
+      overflow-y: auto;
+    }
+
+    .brand {
+      font-size: 0.98rem;
       font-weight: 700;
       margin: 0;
     }
 
-    .subtitle {
-      margin-top: 10px;
+    .sub {
+      margin-top: 6px;
       color: #a1a1aa;
-      font-size: 0.95rem;
+      font-size: 0.82rem;
+      line-height: 1.4;
     }
 
-    .card {
-      margin-top: 20px;
+    .search {
+      margin-top: 16px;
+      width: 100%;
+      background: #18181b;
+      border: 1px solid #27272a;
+      border-radius: 8px;
+      color: #fafafa;
+      font-size: 0.86rem;
+      padding: 10px 12px;
+    }
+
+    .search:focus-visible {
+      outline: 2px solid #ff5a36;
+      outline-offset: 1px;
+      border-color: #ff5a36;
+    }
+
+    .nav {
+      margin-top: 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .nav-btn {
+      width: 100%;
+      border: 1px solid #27272a;
+      background: #18181b;
+      color: #a1a1aa;
+      border-radius: 8px;
+      text-align: left;
+      font-size: 0.82rem;
+      padding: 8px 10px;
+      display: flex;
+      justify-content: space-between;
+      gap: 8px;
+      cursor: pointer;
+    }
+
+    .nav-btn:hover {
+      color: #fafafa;
+      border-color: #3f3f46;
+    }
+
+    .nav-btn.active {
+      color: #ff5a36;
+      border-color: #ff5a36;
+      background: rgba(255, 90, 54, 0.08);
+    }
+
+    .count {
+      color: #71717a;
+      font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+        monospace;
+      font-size: 0.75rem;
+    }
+
+    .main {
+      padding: 20px;
+    }
+
+    .hero {
+      border: 1px solid #27272a;
+      background: #18181b;
+      border-radius: 12px;
+      padding: 16px;
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .hero-item {
+      border: 1px solid #27272a;
+      border-radius: 10px;
+      padding: 10px;
+      background: #0f0f12;
+    }
+
+    .hero-label {
+      color: #71717a;
+      font-size: 0.74rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .hero-value {
+      margin-top: 6px;
+      font-size: 0.9rem;
+      font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+        monospace;
+      word-break: break-word;
+    }
+
+    .sections {
+      margin-top: 18px;
+      display: grid;
+      gap: 14px;
+    }
+
+    .section-card {
       border: 1px solid #27272a;
       border-radius: 12px;
       background: #18181b;
-      padding: 18px;
+      overflow: hidden;
     }
 
-    .row {
-      display: flex;
-      justify-content: space-between;
-      gap: 12px;
-      padding: 8px 0;
+    .section-header {
       border-bottom: 1px solid #27272a;
-      font-size: 0.92rem;
+      padding: 14px;
+      background: #111114;
     }
 
-    .row:last-child {
-      border-bottom: none;
+    .section-title {
+      margin: 0;
+      font-size: 1rem;
+      font-weight: 700;
     }
 
-    .label {
+    .section-meta {
+      margin-top: 6px;
       color: #a1a1aa;
+      font-size: 0.82rem;
+      line-height: 1.4;
     }
 
-    .value {
-      font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-        monospace;
-      text-align: right;
+    .field-list {
+      padding: 6px 10px 10px;
+      display: grid;
+      gap: 8px;
+    }
+
+    .field {
+      border: 1px solid #27272a;
+      border-radius: 10px;
+      padding: 10px;
+      background: #121216;
+    }
+
+    .field-head {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+    }
+
+    .field-label {
+      font-size: 0.86rem;
+      font-weight: 600;
       color: #fafafa;
     }
 
-    .ok {
-      color: #4ade80;
+    .badges {
+      display: inline-flex;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+
+    .badge {
+      border: 1px solid #3f3f46;
+      border-radius: 999px;
+      padding: 2px 7px;
+      font-size: 0.68rem;
+      color: #a1a1aa;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .badge.sensitive {
+      color: #fb7185;
+      border-color: #fb7185;
+    }
+
+    .badge.advanced {
+      color: #fbbf24;
+      border-color: #fbbf24;
+    }
+
+    .field-path {
+      margin-top: 6px;
+      font-size: 0.75rem;
+      color: #71717a;
+      font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+        monospace;
+      word-break: break-word;
+    }
+
+    .field-help {
+      margin-top: 6px;
+      color: #a1a1aa;
+      font-size: 0.78rem;
+      line-height: 1.4;
+    }
+
+    .empty,
+    .error,
+    .loading {
+      border: 1px solid #27272a;
+      border-radius: 12px;
+      padding: 16px;
+      background: #18181b;
+      margin-top: 18px;
+      color: #a1a1aa;
     }
 
     .error {
@@ -74,18 +285,30 @@ class ConfigBuilderApp extends LitElement {
       white-space: pre-wrap;
       font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
         monospace;
-      font-size: 0.85rem;
-      line-height: 1.4;
+      font-size: 0.8rem;
     }
 
-    .hint {
-      margin-top: 16px;
-      color: #71717a;
-      font-size: 0.85rem;
+    @media (max-width: 980px) {
+      .shell {
+        grid-template-columns: 1fr;
+      }
+
+      .sidebar {
+        position: static;
+        max-height: none;
+        border-right: none;
+        border-bottom: 1px solid #27272a;
+      }
+
+      .hero {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
     }
   `;
 
   private state: AppState = { status: "loading" };
+  private selectedSectionId: string | null = null;
+  private searchQuery = "";
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -94,8 +317,8 @@ class ConfigBuilderApp extends LitElement {
 
   private bootstrap(): void {
     try {
-      const summary = runSchemaSpike();
-      this.state = { status: "ready", summary };
+      const snapshot = buildExplorerSnapshot();
+      this.state = { status: "ready", snapshot };
     } catch (error) {
       const message = error instanceof Error ? error.stack ?? error.message : String(error);
       this.state = { status: "error", message };
@@ -103,61 +326,165 @@ class ConfigBuilderApp extends LitElement {
     this.requestUpdate();
   }
 
-  override render() {
-    return html`<main class="shell">
-      <h1 class="title">OpenClaw Config Builder</h1>
-      <div class="subtitle">Phase 0 spike: schema imports + browser runtime checks.</div>
-
-      ${this.renderBody()}
-
-      <div class="hint">
-        Next: replace this spike page with Explorer read-only group rendering.
-      </div>
-    </main>`;
+  private setSection(sectionId: string | null): void {
+    this.selectedSectionId = sectionId;
+    this.requestUpdate();
   }
 
-  private renderBody() {
+  private setSearchQuery(raw: string): void {
+    this.searchQuery = raw.trim().toLowerCase();
+    this.requestUpdate();
+  }
+
+  private getVisibleSections(snapshot: ExplorerSnapshot): ExplorerSection[] {
+    const bySection = this.selectedSectionId
+      ? snapshot.sections.filter((section) => section.id === this.selectedSectionId)
+      : snapshot.sections;
+
+    const query = this.searchQuery;
+    if (!query) {
+      return bySection;
+    }
+
+    const visible: ExplorerSection[] = [];
+    for (const section of bySection) {
+      if (matchesSection(section, query)) {
+        visible.push(section);
+        continue;
+      }
+      const fields = section.fields.filter((field) => matchesField(field, query));
+      if (fields.length === 0) {
+        continue;
+      }
+      visible.push({ ...section, fields });
+    }
+
+    return visible;
+  }
+
+  override render() {
     if (this.state.status === "loading") {
-      return html`<section class="card">Loading schema spike…</section>`;
+      return html`<main class="main"><div class="loading">Loading schema explorer…</div></main>`;
     }
 
     if (this.state.status === "error") {
-      return html`<section class="card">
-        <div class="row">
-          <span class="label">Schema import status</span>
-          <span class="value error">failed</span>
-        </div>
-        <pre class="error">${this.state.message}</pre>
-      </section>`;
+      return html`<main class="main"><pre class="error">${this.state.message}</pre></main>`;
     }
 
-    const { summary } = this.state;
-    return html`<section class="card">
-      <div class="row">
-        <span class="label">Schema import status</span>
-        <span class="value ok">ok</span>
+    const { snapshot } = this.state;
+    const visibleSections = this.getVisibleSections(snapshot);
+
+    return html`
+      <div class="shell">
+        <aside class="sidebar">
+          <h1 class="brand">OpenClaw Config Builder</h1>
+          <div class="sub">Explorer read-only scaffold (Phase 1)</div>
+
+          <input
+            class="search"
+            type="text"
+            placeholder="Search fields, labels, help…"
+            @input=${(event: Event) =>
+              this.setSearchQuery((event.target as HTMLInputElement).value)}
+          />
+
+          <nav class="nav">
+            <button
+              class="nav-btn ${this.selectedSectionId === null ? "active" : ""}"
+              @click=${() => this.setSection(null)}
+            >
+              <span>All sections</span>
+              <span class="count">${snapshot.fieldCount}</span>
+            </button>
+            ${snapshot.sections.map(
+              (section) => html`
+                <button
+                  class="nav-btn ${this.selectedSectionId === section.id ? "active" : ""}"
+                  @click=${() => this.setSection(section.id)}
+                >
+                  <span>${section.label}</span>
+                  <span class="count">${section.fields.length}</span>
+                </button>
+              `,
+            )}
+          </nav>
+        </aside>
+
+        <main class="main">
+          <section class="hero">
+            <div class="hero-item">
+              <div class="hero-label">Schema status</div>
+              <div class="hero-value">ready</div>
+            </div>
+            <div class="hero-item">
+              <div class="hero-label">Sections</div>
+              <div class="hero-value">${snapshot.sectionCount}</div>
+            </div>
+            <div class="hero-item">
+              <div class="hero-label">Field hints</div>
+              <div class="hero-value">${snapshot.fieldCount}</div>
+            </div>
+            <div class="hero-item">
+              <div class="hero-label">Version</div>
+              <div class="hero-value">${snapshot.version}</div>
+            </div>
+          </section>
+
+          ${this.searchQuery
+            ? html`<div class="sub" style="margin-top: 12px;">
+                Search: <code>${this.searchQuery}</code>
+              </div>`
+            : nothing}
+
+          ${visibleSections.length === 0
+            ? html`<div class="empty">No matching sections/fields for this filter.</div>`
+            : html`
+                <div class="sections">
+                  ${visibleSections.map(
+                    (section) => html`
+                      <section class="section-card">
+                        <header class="section-header">
+                          <h2 class="section-title">${section.label}</h2>
+                          <div class="section-meta">
+                            <strong>${section.id}</strong>
+                            · ${section.fields.length} field hint${
+                              section.fields.length === 1 ? "" : "s"
+                            }
+                            ${section.description ? html`<br />${section.description}` : nothing}
+                          </div>
+                        </header>
+
+                        <div class="field-list">
+                          ${section.fields.map(
+                            (field) => html`
+                              <article class="field">
+                                <div class="field-head">
+                                  <div class="field-label">${field.label}</div>
+                                  <div class="badges">
+                                    ${field.sensitive
+                                      ? html`<span class="badge sensitive">sensitive</span>`
+                                      : nothing}
+                                    ${field.advanced
+                                      ? html`<span class="badge advanced">advanced</span>`
+                                      : nothing}
+                                  </div>
+                                </div>
+                                <div class="field-path">${field.path}</div>
+                                ${field.help
+                                  ? html`<div class="field-help">${field.help}</div>`
+                                  : nothing}
+                              </article>
+                            `,
+                          )}
+                        </div>
+                      </section>
+                    `,
+                  )}
+                </div>
+              `}
+        </main>
       </div>
-      <div class="row">
-        <span class="label">Top-level schema sections</span>
-        <span class="value">${summary.schemaRootProperties}</span>
-      </div>
-      <div class="row">
-        <span class="label">UI hint entries</span>
-        <span class="value">${summary.uiHintCount}</span>
-      </div>
-      <div class="row">
-        <span class="label">Schema version</span>
-        <span class="value">${summary.version}</span>
-      </div>
-      <div class="row">
-        <span class="label">Generated at</span>
-        <span class="value">${summary.generatedAt}</span>
-      </div>
-      <div class="row">
-        <span class="label">Sample sections</span>
-        <span class="value">${summary.schemaTopSections.join(", ") || "(none)"}</span>
-      </div>
-    </section>`;
+    `;
   }
 }
 

--- a/apps/config-builder/src/ui/app.ts
+++ b/apps/config-builder/src/ui/app.ts
@@ -1,4 +1,4 @@
-import { LitElement, css, html, nothing } from "lit";
+import { LitElement, html, nothing } from "lit";
 import {
   buildExplorerSnapshot,
   type ExplorerField,
@@ -37,278 +37,19 @@ function matchesSection(section: ExplorerSection, query: string): boolean {
   );
 }
 
+function sectionGlyph(label: string): string {
+  return label.trim().charAt(0).toUpperCase() || "•";
+}
+
 class ConfigBuilderApp extends LitElement {
-  static override styles = css`
-    :host {
-      display: block;
-      min-height: 100vh;
-      background: #09090b;
-      color: #fafafa;
-      font-family: Inter, "Segoe UI", Roboto, sans-serif;
-    }
-
-    .shell {
-      min-height: 100vh;
-      display: grid;
-      grid-template-columns: 260px minmax(0, 1fr);
-    }
-
-    .sidebar {
-      border-right: 1px solid #27272a;
-      background: #09090b;
-      padding: 16px;
-      position: sticky;
-      top: 0;
-      max-height: 100vh;
-      overflow-y: auto;
-    }
-
-    .brand {
-      font-size: 0.98rem;
-      font-weight: 700;
-      margin: 0;
-    }
-
-    .sub {
-      margin-top: 6px;
-      color: #a1a1aa;
-      font-size: 0.82rem;
-      line-height: 1.4;
-    }
-
-    .search {
-      margin-top: 16px;
-      width: 100%;
-      background: #18181b;
-      border: 1px solid #27272a;
-      border-radius: 8px;
-      color: #fafafa;
-      font-size: 0.86rem;
-      padding: 10px 12px;
-    }
-
-    .search:focus-visible {
-      outline: 2px solid #ff5a36;
-      outline-offset: 1px;
-      border-color: #ff5a36;
-    }
-
-    .nav {
-      margin-top: 14px;
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
-
-    .nav-btn {
-      width: 100%;
-      border: 1px solid #27272a;
-      background: #18181b;
-      color: #a1a1aa;
-      border-radius: 8px;
-      text-align: left;
-      font-size: 0.82rem;
-      padding: 8px 10px;
-      display: flex;
-      justify-content: space-between;
-      gap: 8px;
-      cursor: pointer;
-    }
-
-    .nav-btn:hover {
-      color: #fafafa;
-      border-color: #3f3f46;
-    }
-
-    .nav-btn.active {
-      color: #ff5a36;
-      border-color: #ff5a36;
-      background: rgba(255, 90, 54, 0.08);
-    }
-
-    .count {
-      color: #71717a;
-      font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-        monospace;
-      font-size: 0.75rem;
-    }
-
-    .main {
-      padding: 20px;
-    }
-
-    .hero {
-      border: 1px solid #27272a;
-      background: #18181b;
-      border-radius: 12px;
-      padding: 16px;
-      display: grid;
-      grid-template-columns: repeat(4, minmax(0, 1fr));
-      gap: 12px;
-    }
-
-    .hero-item {
-      border: 1px solid #27272a;
-      border-radius: 10px;
-      padding: 10px;
-      background: #0f0f12;
-    }
-
-    .hero-label {
-      color: #71717a;
-      font-size: 0.74rem;
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
-    }
-
-    .hero-value {
-      margin-top: 6px;
-      font-size: 0.9rem;
-      font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-        monospace;
-      word-break: break-word;
-    }
-
-    .sections {
-      margin-top: 18px;
-      display: grid;
-      gap: 14px;
-    }
-
-    .section-card {
-      border: 1px solid #27272a;
-      border-radius: 12px;
-      background: #18181b;
-      overflow: hidden;
-    }
-
-    .section-header {
-      border-bottom: 1px solid #27272a;
-      padding: 14px;
-      background: #111114;
-    }
-
-    .section-title {
-      margin: 0;
-      font-size: 1rem;
-      font-weight: 700;
-    }
-
-    .section-meta {
-      margin-top: 6px;
-      color: #a1a1aa;
-      font-size: 0.82rem;
-      line-height: 1.4;
-    }
-
-    .field-list {
-      padding: 6px 10px 10px;
-      display: grid;
-      gap: 8px;
-    }
-
-    .field {
-      border: 1px solid #27272a;
-      border-radius: 10px;
-      padding: 10px;
-      background: #121216;
-    }
-
-    .field-head {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 8px;
-    }
-
-    .field-label {
-      font-size: 0.86rem;
-      font-weight: 600;
-      color: #fafafa;
-    }
-
-    .badges {
-      display: inline-flex;
-      gap: 6px;
-      flex-wrap: wrap;
-    }
-
-    .badge {
-      border: 1px solid #3f3f46;
-      border-radius: 999px;
-      padding: 2px 7px;
-      font-size: 0.68rem;
-      color: #a1a1aa;
-      text-transform: uppercase;
-      letter-spacing: 0.04em;
-    }
-
-    .badge.sensitive {
-      color: #fb7185;
-      border-color: #fb7185;
-    }
-
-    .badge.advanced {
-      color: #fbbf24;
-      border-color: #fbbf24;
-    }
-
-    .field-path {
-      margin-top: 6px;
-      font-size: 0.75rem;
-      color: #71717a;
-      font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-        monospace;
-      word-break: break-word;
-    }
-
-    .field-help {
-      margin-top: 6px;
-      color: #a1a1aa;
-      font-size: 0.78rem;
-      line-height: 1.4;
-    }
-
-    .empty,
-    .error,
-    .loading {
-      border: 1px solid #27272a;
-      border-radius: 12px;
-      padding: 16px;
-      background: #18181b;
-      margin-top: 18px;
-      color: #a1a1aa;
-    }
-
-    .error {
-      color: #f87171;
-      white-space: pre-wrap;
-      font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-        monospace;
-      font-size: 0.8rem;
-    }
-
-    @media (max-width: 980px) {
-      .shell {
-        grid-template-columns: 1fr;
-      }
-
-      .sidebar {
-        position: static;
-        max-height: none;
-        border-right: none;
-        border-bottom: 1px solid #27272a;
-      }
-
-      .hero {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-      }
-    }
-  `;
-
   private state: AppState = { status: "loading" };
   private selectedSectionId: string | null = null;
   private searchQuery = "";
+
+  override createRenderRoot() {
+    // Match the existing OpenClaw web UI approach (global CSS classes/tokens).
+    return this;
+  }
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -362,127 +103,177 @@ class ConfigBuilderApp extends LitElement {
     return visible;
   }
 
+  private renderSearch() {
+    return html`
+      <div class="config-search">
+        <svg
+          class="config-search__icon"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <circle cx="11" cy="11" r="8"></circle>
+          <path d="M21 21l-4.35-4.35"></path>
+        </svg>
+        <input
+          class="config-search__input"
+          type="text"
+          placeholder="Search fields, labels, help…"
+          @input=${(event: Event) => this.setSearchQuery((event.target as HTMLInputElement).value)}
+        />
+        ${this.searchQuery
+          ? html`
+              <button
+                class="config-search__clear"
+                title="Clear search"
+                @click=${() => this.setSearchQuery("")}
+              >
+                ×
+              </button>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderSidebar(snapshot: ExplorerSnapshot) {
+    return html`
+      <aside class="config-sidebar">
+        <div class="config-sidebar__header">
+          <div>
+            <div class="config-sidebar__title">Config Builder</div>
+            <div class="builder-subtitle">Explorer scaffold</div>
+          </div>
+          <span class="pill pill--sm pill--ok">ready</span>
+        </div>
+
+        ${this.renderSearch()}
+
+        <nav class="config-nav">
+          <button
+            class="config-nav__item ${this.selectedSectionId === null ? "active" : ""}"
+            @click=${() => this.setSection(null)}
+          >
+            <span class="config-nav__icon builder-icon" aria-hidden="true">A</span>
+            <span class="config-nav__label">All sections</span>
+            <span class="builder-count mono">${snapshot.fieldCount}</span>
+          </button>
+
+          ${snapshot.sections.map(
+            (section) => html`
+              <button
+                class="config-nav__item ${this.selectedSectionId === section.id ? "active" : ""}"
+                @click=${() => this.setSection(section.id)}
+              >
+                <span class="config-nav__icon builder-icon" aria-hidden="true"
+                  >${sectionGlyph(section.label)}</span
+                >
+                <span class="config-nav__label">${section.label}</span>
+                <span class="builder-count mono">${section.fields.length}</span>
+              </button>
+            `,
+          )}
+        </nav>
+
+        <div class="config-sidebar__footer">
+          <div class="builder-footer-note">
+            Read-only schema explorer using OpenClaw config hints.
+          </div>
+        </div>
+      </aside>
+    `;
+  }
+
+  private renderField(field: ExplorerField) {
+    return html`
+      <div class="cfg-field builder-field">
+        <div class="builder-field__head">
+          <div class="cfg-field__label">${field.label}</div>
+          <div class="builder-field__badges">
+            ${field.sensitive ? html`<span class="pill pill--sm pill--danger">sensitive</span>` : nothing}
+            ${field.advanced ? html`<span class="pill pill--sm">advanced</span>` : nothing}
+          </div>
+        </div>
+        <div class="builder-field__path mono">${field.path}</div>
+        ${field.help ? html`<div class="cfg-field__help">${field.help}</div>` : nothing}
+      </div>
+    `;
+  }
+
+  private renderSections(visibleSections: ExplorerSection[]) {
+    if (visibleSections.length === 0) {
+      return html`<div class="config-empty"><div class="config-empty__text">No matching sections/fields for this filter.</div></div>`;
+    }
+
+    return html`
+      <div class="config-form config-form--modern">
+        ${visibleSections.map(
+          (section) => html`
+            <section class="config-section-card" id=${`section-${section.id}`}>
+              <div class="config-section-card__header">
+                <div class="config-section-card__icon builder-section-glyph" aria-hidden="true">
+                  ${sectionGlyph(section.label)}
+                </div>
+                <div class="config-section-card__titles">
+                  <h2 class="config-section-card__title">${section.label}</h2>
+                  <div class="config-section-card__desc">
+                    <span class="mono">${section.id}</span>
+                    · ${section.fields.length} field hint${section.fields.length === 1 ? "" : "s"}
+                    ${section.description ? html`<br />${section.description}` : nothing}
+                  </div>
+                </div>
+              </div>
+
+              <div class="config-section-card__content">
+                <div class="cfg-fields">${section.fields.map((field) => this.renderField(field))}</div>
+              </div>
+            </section>
+          `,
+        )}
+      </div>
+    `;
+  }
+
   override render() {
     if (this.state.status === "loading") {
-      return html`<main class="main"><div class="loading">Loading schema explorer…</div></main>`;
+      return html`<div class="builder-screen"><div class="card">Loading schema explorer…</div></div>`;
     }
 
     if (this.state.status === "error") {
-      return html`<main class="main"><pre class="error">${this.state.message}</pre></main>`;
+      return html`<div class="builder-screen"><pre class="callout danger">${this.state.message}</pre></div>`;
     }
 
     const { snapshot } = this.state;
     const visibleSections = this.getVisibleSections(snapshot);
 
     return html`
-      <div class="shell">
-        <aside class="sidebar">
-          <h1 class="brand">OpenClaw Config Builder</h1>
-          <div class="sub">Explorer read-only scaffold (Phase 1)</div>
+      <div class="builder-screen">
+        <div class="config-layout builder-layout">
+          ${this.renderSidebar(snapshot)}
 
-          <input
-            class="search"
-            type="text"
-            placeholder="Search fields, labels, help…"
-            @input=${(event: Event) =>
-              this.setSearchQuery((event.target as HTMLInputElement).value)}
-          />
-
-          <nav class="nav">
-            <button
-              class="nav-btn ${this.selectedSectionId === null ? "active" : ""}"
-              @click=${() => this.setSection(null)}
-            >
-              <span>All sections</span>
-              <span class="count">${snapshot.fieldCount}</span>
-            </button>
-            ${snapshot.sections.map(
-              (section) => html`
-                <button
-                  class="nav-btn ${this.selectedSectionId === section.id ? "active" : ""}"
-                  @click=${() => this.setSection(section.id)}
-                >
-                  <span>${section.label}</span>
-                  <span class="count">${section.fields.length}</span>
-                </button>
-              `,
-            )}
-          </nav>
-        </aside>
-
-        <main class="main">
-          <section class="hero">
-            <div class="hero-item">
-              <div class="hero-label">Schema status</div>
-              <div class="hero-value">ready</div>
+          <main class="config-main">
+            <div class="config-actions">
+              <div class="config-actions__left">
+                <span class="config-status">Schema explorer (read-only)</span>
+              </div>
+              <div class="config-actions__right">
+                <span class="pill pill--sm">sections: ${snapshot.sectionCount}</span>
+                <span class="pill pill--sm">fields: ${snapshot.fieldCount}</span>
+                <span class="pill pill--sm mono">v${snapshot.version}</span>
+              </div>
             </div>
-            <div class="hero-item">
-              <div class="hero-label">Sections</div>
-              <div class="hero-value">${snapshot.sectionCount}</div>
-            </div>
-            <div class="hero-item">
-              <div class="hero-label">Field hints</div>
-              <div class="hero-value">${snapshot.fieldCount}</div>
-            </div>
-            <div class="hero-item">
-              <div class="hero-label">Version</div>
-              <div class="hero-value">${snapshot.version}</div>
-            </div>
-          </section>
 
-          ${this.searchQuery
-            ? html`<div class="sub" style="margin-top: 12px;">
-                Search: <code>${this.searchQuery}</code>
-              </div>`
-            : nothing}
+            <div class="config-content">
+              ${this.searchQuery
+                ? html`<div class="builder-search-state">Search: <span class="mono">${this.searchQuery}</span></div>`
+                : nothing}
 
-          ${visibleSections.length === 0
-            ? html`<div class="empty">No matching sections/fields for this filter.</div>`
-            : html`
-                <div class="sections">
-                  ${visibleSections.map(
-                    (section) => html`
-                      <section class="section-card">
-                        <header class="section-header">
-                          <h2 class="section-title">${section.label}</h2>
-                          <div class="section-meta">
-                            <strong>${section.id}</strong>
-                            · ${section.fields.length} field hint${
-                              section.fields.length === 1 ? "" : "s"
-                            }
-                            ${section.description ? html`<br />${section.description}` : nothing}
-                          </div>
-                        </header>
-
-                        <div class="field-list">
-                          ${section.fields.map(
-                            (field) => html`
-                              <article class="field">
-                                <div class="field-head">
-                                  <div class="field-label">${field.label}</div>
-                                  <div class="badges">
-                                    ${field.sensitive
-                                      ? html`<span class="badge sensitive">sensitive</span>`
-                                      : nothing}
-                                    ${field.advanced
-                                      ? html`<span class="badge advanced">advanced</span>`
-                                      : nothing}
-                                  </div>
-                                </div>
-                                <div class="field-path">${field.path}</div>
-                                ${field.help
-                                  ? html`<div class="field-help">${field.help}</div>`
-                                  : nothing}
-                              </article>
-                            `,
-                          )}
-                        </div>
-                      </section>
-                    `,
-                  )}
-                </div>
-              `}
-        </main>
+              ${this.renderSections(visibleSections)}
+            </div>
+          </main>
+        </div>
       </div>
     `;
   }

--- a/apps/config-builder/src/ui/app.ts
+++ b/apps/config-builder/src/ui/app.ts
@@ -1,0 +1,164 @@
+import { LitElement, css, html } from "lit";
+import { runSchemaSpike, type SchemaSpikeSummary } from "../lib/schema-spike.ts";
+
+type AppState =
+  | { status: "loading" }
+  | { status: "ready"; summary: SchemaSpikeSummary }
+  | { status: "error"; message: string };
+
+class ConfigBuilderApp extends LitElement {
+  static override styles = css`
+    :host {
+      display: block;
+      min-height: 100vh;
+      background: #09090b;
+      color: #fafafa;
+    }
+
+    .shell {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 40px 20px;
+    }
+
+    .title {
+      font-size: 1.4rem;
+      font-weight: 700;
+      margin: 0;
+    }
+
+    .subtitle {
+      margin-top: 10px;
+      color: #a1a1aa;
+      font-size: 0.95rem;
+    }
+
+    .card {
+      margin-top: 20px;
+      border: 1px solid #27272a;
+      border-radius: 12px;
+      background: #18181b;
+      padding: 18px;
+    }
+
+    .row {
+      display: flex;
+      justify-content: space-between;
+      gap: 12px;
+      padding: 8px 0;
+      border-bottom: 1px solid #27272a;
+      font-size: 0.92rem;
+    }
+
+    .row:last-child {
+      border-bottom: none;
+    }
+
+    .label {
+      color: #a1a1aa;
+    }
+
+    .value {
+      font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+        monospace;
+      text-align: right;
+      color: #fafafa;
+    }
+
+    .ok {
+      color: #4ade80;
+    }
+
+    .error {
+      color: #f87171;
+      white-space: pre-wrap;
+      font-family: "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+        monospace;
+      font-size: 0.85rem;
+      line-height: 1.4;
+    }
+
+    .hint {
+      margin-top: 16px;
+      color: #71717a;
+      font-size: 0.85rem;
+    }
+  `;
+
+  private state: AppState = { status: "loading" };
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.bootstrap();
+  }
+
+  private bootstrap(): void {
+    try {
+      const summary = runSchemaSpike();
+      this.state = { status: "ready", summary };
+    } catch (error) {
+      const message = error instanceof Error ? error.stack ?? error.message : String(error);
+      this.state = { status: "error", message };
+    }
+    this.requestUpdate();
+  }
+
+  override render() {
+    return html`<main class="shell">
+      <h1 class="title">OpenClaw Config Builder</h1>
+      <div class="subtitle">Phase 0 spike: schema imports + browser runtime checks.</div>
+
+      ${this.renderBody()}
+
+      <div class="hint">
+        Next: replace this spike page with Explorer read-only group rendering.
+      </div>
+    </main>`;
+  }
+
+  private renderBody() {
+    if (this.state.status === "loading") {
+      return html`<section class="card">Loading schema spike…</section>`;
+    }
+
+    if (this.state.status === "error") {
+      return html`<section class="card">
+        <div class="row">
+          <span class="label">Schema import status</span>
+          <span class="value error">failed</span>
+        </div>
+        <pre class="error">${this.state.message}</pre>
+      </section>`;
+    }
+
+    const { summary } = this.state;
+    return html`<section class="card">
+      <div class="row">
+        <span class="label">Schema import status</span>
+        <span class="value ok">ok</span>
+      </div>
+      <div class="row">
+        <span class="label">Top-level schema sections</span>
+        <span class="value">${summary.schemaRootProperties}</span>
+      </div>
+      <div class="row">
+        <span class="label">UI hint entries</span>
+        <span class="value">${summary.uiHintCount}</span>
+      </div>
+      <div class="row">
+        <span class="label">Schema version</span>
+        <span class="value">${summary.version}</span>
+      </div>
+      <div class="row">
+        <span class="label">Generated at</span>
+        <span class="value">${summary.generatedAt}</span>
+      </div>
+      <div class="row">
+        <span class="label">Sample sections</span>
+        <span class="value">${summary.schemaTopSections.join(", ") || "(none)"}</span>
+      </div>
+    </section>`;
+  }
+}
+
+customElements.define("config-builder-app", ConfigBuilderApp);

--- a/apps/config-builder/src/ui/components/field-renderer.ts
+++ b/apps/config-builder/src/ui/components/field-renderer.ts
@@ -1,0 +1,469 @@
+import { html, nothing, type TemplateResult } from "lit";
+import type { ExplorerField, FieldKind } from "../../lib/schema-spike.ts";
+
+type FieldRendererParams = {
+  field: ExplorerField;
+  value: unknown;
+  onSet: (value: unknown) => void;
+  onClear: () => void;
+  onValidationError?: (message: string) => void;
+};
+
+function defaultValueForKind(kind: FieldKind): unknown {
+  if (kind === "boolean") {
+    return false;
+  }
+  if (kind === "number" || kind === "integer") {
+    return 0;
+  }
+  return "";
+}
+
+function parseScalar(kind: FieldKind, raw: string): unknown {
+  if (kind === "number") {
+    const parsed = Number(raw);
+    if (Number.isNaN(parsed)) {
+      throw new Error("Enter a valid number.");
+    }
+    return parsed;
+  }
+
+  if (kind === "integer") {
+    const parsed = Number(raw);
+    if (Number.isNaN(parsed)) {
+      throw new Error("Enter a valid integer.");
+    }
+    return Math.trunc(parsed);
+  }
+
+  if (kind === "boolean") {
+    if (raw === "true") {
+      return true;
+    }
+    if (raw === "false") {
+      return false;
+    }
+    throw new Error("Use true or false.");
+  }
+
+  return raw;
+}
+
+function asObject(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function jsonValue(value: unknown): string {
+  if (value === undefined) {
+    return "{}";
+  }
+  try {
+    return JSON.stringify(value, null, 2) ?? "{}";
+  } catch {
+    return "{}";
+  }
+}
+
+function renderScalarControl(params: {
+  field: ExplorerField;
+  value: unknown;
+  onSet: (value: unknown) => void;
+  onClear: () => void;
+  onValidationError?: (message: string) => void;
+}): TemplateResult {
+  const { field, value, onSet, onClear, onValidationError } = params;
+
+  if (field.kind === "boolean") {
+    return html`
+      <label class="cfg-toggle-row builder-toggle-row">
+        <span class="cfg-field__help">Toggle value</span>
+        <div class="cfg-toggle">
+          <input
+            type="checkbox"
+            .checked=${value === true}
+            @change=${(event: Event) => onSet((event.target as HTMLInputElement).checked)}
+          />
+          <span class="cfg-toggle__track"></span>
+        </div>
+      </label>
+    `;
+  }
+
+  if (field.kind === "enum") {
+    const selected = typeof value === "string" ? value : "";
+    if (field.enumValues.length > 0 && field.enumValues.length <= 4) {
+      return html`
+        <div class="cfg-segmented">
+          ${field.enumValues.map(
+            (entry) => html`
+              <button
+                type="button"
+                class="cfg-segmented__btn ${entry === selected ? "active" : ""}"
+                @click=${() => onSet(entry)}
+              >
+                ${entry}
+              </button>
+            `,
+          )}
+          <button type="button" class="cfg-segmented__btn ${selected ? "" : "active"}" @click=${onClear}>
+            unset
+          </button>
+        </div>
+      `;
+    }
+
+    return html`
+      <select
+        class="cfg-select"
+        .value=${selected}
+        @change=${(event: Event) => {
+          const next = (event.target as HTMLSelectElement).value;
+          if (!next) {
+            onClear();
+            return;
+          }
+          onSet(next);
+        }}
+      >
+        <option value="">(unset)</option>
+        ${field.enumValues.map((entry) => html`<option value=${entry}>${entry}</option>`)}
+      </select>
+    `;
+  }
+
+  const inputType = field.kind === "number" || field.kind === "integer" ? "number" : "text";
+  const inputValue = value == null ? "" : String(value);
+
+  return html`
+    <input
+      class="cfg-input"
+      type=${field.sensitive ? "password" : inputType}
+      .value=${inputValue}
+      @input=${(event: Event) => {
+        const raw = (event.target as HTMLInputElement).value;
+        if (raw.trim() === "") {
+          onClear();
+          return;
+        }
+        try {
+          onSet(parseScalar(field.kind, raw));
+        } catch (error) {
+          onValidationError?.(error instanceof Error ? error.message : String(error));
+        }
+      }}
+    />
+  `;
+}
+
+function renderPrimitiveArray(params: {
+  field: ExplorerField;
+  value: unknown;
+  onSet: (value: unknown) => void;
+  onValidationError?: (message: string) => void;
+}): TemplateResult {
+  const { field, value, onSet, onValidationError } = params;
+  const list = asArray(value);
+  const itemKind = field.itemKind;
+  const itemEnum = field.itemEnumValues;
+
+  if (!itemKind || itemKind === "unknown" || itemKind === "object" || itemKind === "array") {
+    return renderJsonControl({ field, value, onSet, onValidationError });
+  }
+
+  return html`
+    <div class="cfg-array">
+      <div class="cfg-array__header">
+        <span class="cfg-array__label">Items</span>
+        <span class="cfg-array__count">${list.length} item${list.length === 1 ? "" : "s"}</span>
+        <button
+          type="button"
+          class="cfg-array__add"
+          @click=${() => onSet([...list, defaultValueForKind(itemKind)])}
+        >
+          Add
+        </button>
+      </div>
+
+      ${list.length === 0
+        ? html`<div class="cfg-array__empty">No items yet.</div>`
+        : html`
+            <div class="cfg-array__items">
+              ${list.map((item, index) =>
+                html`
+                  <div class="cfg-array__item">
+                    <div class="cfg-array__item-header">
+                      <span class="cfg-array__item-index">#${index + 1}</span>
+                      <button
+                        type="button"
+                        class="cfg-array__item-remove"
+                        title="Remove item"
+                        @click=${() => {
+                          const next = [...list];
+                          next.splice(index, 1);
+                          onSet(next);
+                        }}
+                      >
+                        ×
+                      </button>
+                    </div>
+                    <div class="cfg-array__item-content">
+                      ${itemKind === "boolean"
+                        ? html`
+                            <label class="cfg-toggle-row builder-toggle-row">
+                              <span class="cfg-field__help">boolean</span>
+                              <div class="cfg-toggle">
+                                <input
+                                  type="checkbox"
+                                  .checked=${item === true}
+                                  @change=${(event: Event) => {
+                                    const next = [...list];
+                                    next[index] = (event.target as HTMLInputElement).checked;
+                                    onSet(next);
+                                  }}
+                                />
+                                <span class="cfg-toggle__track"></span>
+                              </div>
+                            </label>
+                          `
+                        : itemKind === "enum" && itemEnum.length > 0
+                          ? html`
+                              <select
+                                class="cfg-select"
+                                .value=${String(item ?? "")}
+                                @change=${(event: Event) => {
+                                  const next = [...list];
+                                  next[index] = (event.target as HTMLSelectElement).value;
+                                  onSet(next);
+                                }}
+                              >
+                                ${itemEnum.map(
+                                  (entry) => html`<option value=${entry}>${entry}</option>`,
+                                )}
+                              </select>
+                            `
+                          : html`
+                              <input
+                                class="cfg-input"
+                                type=${itemKind === "number" || itemKind === "integer" ? "number" : "text"}
+                                .value=${item == null ? "" : String(item)}
+                                @input=${(event: Event) => {
+                                  const raw = (event.target as HTMLInputElement).value;
+                                  const next = [...list];
+                                  if (raw.trim() === "") {
+                                    next[index] = defaultValueForKind(itemKind);
+                                    onSet(next);
+                                    return;
+                                  }
+                                  try {
+                                    next[index] = parseScalar(itemKind, raw);
+                                    onSet(next);
+                                  } catch (error) {
+                                    onValidationError?.(
+                                      error instanceof Error ? error.message : String(error),
+                                    );
+                                  }
+                                }}
+                              />
+                            `}
+                    </div>
+                  </div>
+                `,
+              )}
+            </div>
+          `}
+    </div>
+  `;
+}
+
+function renderRecordObject(params: {
+  field: ExplorerField;
+  value: unknown;
+  onSet: (value: unknown) => void;
+  onValidationError?: (message: string) => void;
+}): TemplateResult {
+  const { field, value, onSet, onValidationError } = params;
+  const record = asObject(value);
+  const entries = Object.entries(record);
+  const valueKind = field.recordValueKind;
+
+  if (!valueKind || valueKind === "unknown" || valueKind === "object" || valueKind === "array") {
+    return renderJsonControl(params);
+  }
+
+  return html`
+    <div class="cfg-map">
+      <div class="cfg-map__header">
+        <span class="cfg-map__label">Entries</span>
+        <button
+          type="button"
+          class="cfg-map__add"
+          @click=${() => {
+            const next = { ...record };
+            let index = 1;
+            let key = `key-${index}`;
+            while (key in next) {
+              index += 1;
+              key = `key-${index}`;
+            }
+            next[key] = defaultValueForKind(valueKind);
+            onSet(next);
+          }}
+        >
+          Add Entry
+        </button>
+      </div>
+
+      ${entries.length === 0
+        ? html`<div class="cfg-map__empty">No entries yet.</div>`
+        : html`
+            <div class="cfg-map__items">
+              ${entries.map(([key, entryValue]) =>
+                html`
+                  <div class="cfg-map__item">
+                    <div class="cfg-map__item-key">
+                      <input
+                        type="text"
+                        class="cfg-input cfg-input--sm"
+                        .value=${key}
+                        @change=${(event: Event) => {
+                          const nextKey = (event.target as HTMLInputElement).value.trim();
+                          if (!nextKey || nextKey === key || nextKey in record) {
+                            return;
+                          }
+                          const next = { ...record };
+                          next[nextKey] = next[key];
+                          delete next[key];
+                          onSet(next);
+                        }}
+                      />
+                    </div>
+
+                    <div class="cfg-map__item-value">
+                      ${valueKind === "boolean"
+                        ? html`
+                            <label class="cfg-toggle-row builder-toggle-row">
+                              <span class="cfg-field__help">boolean</span>
+                              <div class="cfg-toggle">
+                                <input
+                                  type="checkbox"
+                                  .checked=${entryValue === true}
+                                  @change=${(event: Event) => {
+                                    const next = { ...record };
+                                    next[key] = (event.target as HTMLInputElement).checked;
+                                    onSet(next);
+                                  }}
+                                />
+                                <span class="cfg-toggle__track"></span>
+                              </div>
+                            </label>
+                          `
+                        : html`
+                            <input
+                              class="cfg-input cfg-input--sm"
+                              type=${valueKind === "number" || valueKind === "integer" ? "number" : "text"}
+                              .value=${entryValue == null ? "" : String(entryValue)}
+                              @input=${(event: Event) => {
+                                const raw = (event.target as HTMLInputElement).value;
+                                const next = { ...record };
+                                try {
+                                  next[key] = raw.trim() === "" ? defaultValueForKind(valueKind) : parseScalar(valueKind, raw);
+                                  onSet(next);
+                                } catch (error) {
+                                  onValidationError?.(
+                                    error instanceof Error ? error.message : String(error),
+                                  );
+                                }
+                              }}
+                            />
+                          `}
+                    </div>
+
+                    <button
+                      type="button"
+                      class="cfg-map__item-remove"
+                      title="Remove entry"
+                      @click=${() => {
+                        const next = { ...record };
+                        delete next[key];
+                        onSet(next);
+                      }}
+                    >
+                      ×
+                    </button>
+                  </div>
+                `,
+              )}
+            </div>
+          `}
+    </div>
+  `;
+}
+
+function renderJsonControl(params: {
+  field: ExplorerField;
+  value: unknown;
+  onSet: (value: unknown) => void;
+  onValidationError?: (message: string) => void;
+}): TemplateResult {
+  const { field, value, onSet, onValidationError } = params;
+  return html`
+    <label class="cfg-field">
+      <span class="cfg-field__help">Edit as JSON (${field.kind})</span>
+      <textarea
+        class="cfg-textarea"
+        rows="4"
+        .value=${jsonValue(value ?? (field.kind === "array" ? [] : {}))}
+        @change=${(event: Event) => {
+          const raw = (event.target as HTMLTextAreaElement).value.trim();
+          if (!raw) {
+            onSet(field.kind === "array" ? [] : {});
+            return;
+          }
+          try {
+            onSet(JSON.parse(raw));
+          } catch {
+            onValidationError?.("Invalid JSON value.");
+            (event.target as HTMLTextAreaElement).value = jsonValue(
+              value ?? (field.kind === "array" ? [] : {}),
+            );
+          }
+        }}
+      ></textarea>
+    </label>
+  `;
+}
+
+export function renderFieldEditor(params: FieldRendererParams): TemplateResult | typeof nothing {
+  const { field, value, onSet, onClear, onValidationError } = params;
+
+  if (!field.editable) {
+    return html`<div class="cfg-field__help">Read-only in this phase.</div>`;
+  }
+
+  if (
+    field.kind === "string" ||
+    field.kind === "number" ||
+    field.kind === "integer" ||
+    field.kind === "boolean" ||
+    field.kind === "enum"
+  ) {
+    return renderScalarControl({ field, value, onSet, onClear, onValidationError });
+  }
+
+  if (field.kind === "array") {
+    return renderPrimitiveArray({ field, value, onSet, onValidationError });
+  }
+
+  if (field.kind === "object") {
+    return renderRecordObject({ field, value, onSet, onValidationError });
+  }
+
+  return html`<div class="cfg-field__help">Unsupported schema node.</div>`;
+}

--- a/apps/config-builder/src/ui/components/field-renderer.ts
+++ b/apps/config-builder/src/ui/components/field-renderer.ts
@@ -71,6 +71,19 @@ function jsonValue(value: unknown): string {
   }
 }
 
+function scalarInputValue(value: unknown): string {
+  if (value == null) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  return "";
+}
+
 function renderScalarControl(params: {
   field: ExplorerField;
   value: unknown;
@@ -139,7 +152,7 @@ function renderScalarControl(params: {
   }
 
   const inputType = field.kind === "number" || field.kind === "integer" ? "number" : "text";
-  const inputValue = value == null ? "" : String(value);
+  const inputValue = scalarInputValue(value);
 
   return html`
     <input
@@ -236,7 +249,7 @@ function renderPrimitiveArray(params: {
                           ? html`
                               <select
                                 class="cfg-select"
-                                .value=${String(item ?? "")}
+                                .value=${scalarInputValue(item)}
                                 @change=${(event: Event) => {
                                   const next = [...list];
                                   next[index] = (event.target as HTMLSelectElement).value;
@@ -252,7 +265,7 @@ function renderPrimitiveArray(params: {
                               <input
                                 class="cfg-input"
                                 type=${itemKind === "number" || itemKind === "integer" ? "number" : "text"}
-                                .value=${item == null ? "" : String(item)}
+                                .value=${scalarInputValue(item)}
                                 @input=${(event: Event) => {
                                   const raw = (event.target as HTMLInputElement).value;
                                   const next = [...list];
@@ -368,7 +381,7 @@ function renderRecordObject(params: {
                             <input
                               class="cfg-input cfg-input--sm"
                               type=${valueKind === "number" || valueKind === "integer" ? "number" : "text"}
-                              .value=${entryValue == null ? "" : String(entryValue)}
+                              .value=${scalarInputValue(entryValue)}
                               @input=${(event: Event) => {
                                 const raw = (event.target as HTMLInputElement).value;
                                 const next = { ...record };

--- a/apps/config-builder/src/ui/components/field-renderer.ts
+++ b/apps/config-builder/src/ui/components/field-renderer.ts
@@ -305,6 +305,7 @@ function renderRecordObject(params: {
   const record = asObject(value);
   const entries = Object.entries(record);
   const valueKind = field.recordValueKind;
+  const recordEnums = field.recordEnumValues;
 
   if (!valueKind || valueKind === "unknown" || valueKind === "object" || valueKind === "array") {
     return renderJsonControl(params);
@@ -377,25 +378,42 @@ function renderRecordObject(params: {
                               </div>
                             </label>
                           `
-                        : html`
-                            <input
-                              class="cfg-input cfg-input--sm"
-                              type=${valueKind === "number" || valueKind === "integer" ? "number" : "text"}
-                              .value=${scalarInputValue(entryValue)}
-                              @input=${(event: Event) => {
-                                const raw = (event.target as HTMLInputElement).value;
-                                const next = { ...record };
-                                try {
-                                  next[key] = raw.trim() === "" ? defaultValueForKind(valueKind) : parseScalar(valueKind, raw);
+                        : valueKind === "enum" && recordEnums.length > 0
+                          ? html`
+                              <select
+                                class="cfg-select cfg-select--sm"
+                                .value=${String(entryValue)}
+                                @change=${(event: Event) => {
+                                  const next = { ...record };
+                                  next[key] = (event.target as HTMLSelectElement).value;
                                   onSet(next);
-                                } catch (error) {
-                                  onValidationError?.(
-                                    error instanceof Error ? error.message : String(error),
-                                  );
-                                }
-                              }}
-                            />
-                          `}
+                                }}
+                              >
+                                ${recordEnums.map((entry) => html`<option value=${entry}>${entry}</option>`)}
+                              </select>
+                            `
+                          : html`
+                              <input
+                                class="cfg-input cfg-input--sm"
+                                type=${valueKind === "number" || valueKind === "integer"
+                                  ? "number"
+                                  : "text"}
+                                .value=${scalarInputValue(entryValue)}
+                                @input=${(event: Event) => {
+                                  const raw = (event.target as HTMLInputElement).value;
+                                  const next = { ...record };
+                                  try {
+                                    next[key] =
+                                      raw.trim() === "" ? defaultValueForKind(valueKind) : parseScalar(valueKind, raw);
+                                    onSet(next);
+                                  } catch (error) {
+                                    onValidationError?.(
+                                      error instanceof Error ? error.message : String(error),
+                                    );
+                                  }
+                                }}
+                              />
+                            `}
                     </div>
 
                     <button

--- a/apps/config-builder/src/ui/components/field-renderer.ts
+++ b/apps/config-builder/src/ui/components/field-renderer.ts
@@ -1,5 +1,5 @@
 import { html, nothing, type TemplateResult } from "lit";
-import type { ExplorerField, FieldKind } from "../../lib/schema-spike.ts";
+import type { ExplorerField, ExplorerSchemaNode, FieldKind } from "../../lib/schema-spike.ts";
 
 type FieldRendererParams = {
   field: ExplorerField;
@@ -7,16 +7,72 @@ type FieldRendererParams = {
   onSet: (value: unknown) => void;
   onClear: () => void;
   onValidationError?: (message: string) => void;
+  suggestions?: string[];
 };
 
-function defaultValueForKind(kind: FieldKind): unknown {
+type ScalarKind = "string" | "number" | "integer" | "boolean" | "enum";
+
+type ScalarControlParams = {
+  kind: ScalarKind;
+  enumValues: string[];
+  value: unknown;
+  sensitive?: boolean;
+  compact?: boolean;
+  onSet: (value: unknown) => void;
+  onClear?: () => void;
+  onValidationError?: (message: string) => void;
+  suggestions?: string[];
+};
+
+type NodeRendererParams = {
+  node: ExplorerSchemaNode | null;
+  value: unknown;
+  onSet: (value: unknown) => void;
+  onClear?: () => void;
+  onValidationError?: (message: string) => void;
+  depth?: number;
+  compact?: boolean;
+  suggestions?: string[];
+};
+
+const MAX_EDITOR_DEPTH = 6;
+
+function humanizeKey(value: string): string {
+  if (!value.trim()) {
+    return value;
+  }
+  return value
+    .replace(/[_-]+/g, " ")
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/^./, (char) => char.toUpperCase());
+}
+
+function defaultValueForKind(kind: FieldKind, enumValues: string[] = []): unknown {
   if (kind === "boolean") {
     return false;
   }
   if (kind === "number" || kind === "integer") {
     return 0;
   }
+  if (kind === "array") {
+    return [];
+  }
+  if (kind === "object") {
+    return {};
+  }
+  if (kind === "enum") {
+    return enumValues[0] ?? "";
+  }
   return "";
+}
+
+function defaultValueForNode(node: ExplorerSchemaNode | null): unknown {
+  if (!node) {
+    return "";
+  }
+  return defaultValueForKind(node.kind, node.enumValues);
 }
 
 function parseScalar(kind: FieldKind, raw: string): unknown {
@@ -30,7 +86,7 @@ function parseScalar(kind: FieldKind, raw: string): unknown {
 
   if (kind === "integer") {
     const parsed = Number(raw);
-    if (Number.isNaN(parsed)) {
+    if (Number.isNaN(parsed) || !Number.isFinite(parsed)) {
       throw new Error("Enter a valid integer.");
     }
     return Math.trunc(parsed);
@@ -84,16 +140,129 @@ function scalarInputValue(value: unknown): string {
   return "";
 }
 
-function renderScalarControl(params: {
-  field: ExplorerField;
+function normalizeSuggestion(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function dedupeSuggestions(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const entry of values) {
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      continue;
+    }
+    const normalized = normalizeSuggestion(trimmed);
+    if (seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+function subsequenceScore(query: string, candidate: string): number {
+  let qi = 0;
+  let score = 0;
+  for (let i = 0; i < candidate.length && qi < query.length; i += 1) {
+    if (candidate[i] === query[qi]) {
+      score += i;
+      qi += 1;
+    }
+  }
+  if (qi !== query.length) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return score;
+}
+
+function fuzzyFilterSuggestions(options: string[], query: string, limit = 8): string[] {
+  const unique = dedupeSuggestions(options);
+  const normalizedQuery = normalizeSuggestion(query);
+
+  if (!normalizedQuery) {
+    return unique.slice(0, limit);
+  }
+
+  const ranked = unique
+    .map((entry) => {
+      const normalized = normalizeSuggestion(entry);
+
+      if (normalized === normalizedQuery) {
+        return { entry, score: 0 };
+      }
+
+      if (normalized.startsWith(normalizedQuery)) {
+        return { entry, score: 1 + normalized.length / 1000 };
+      }
+
+      const includesAt = normalized.indexOf(normalizedQuery);
+      if (includesAt >= 0) {
+        return { entry, score: 2 + includesAt / 100 };
+      }
+
+      const subseq = subsequenceScore(normalizedQuery, normalized);
+      if (Number.isFinite(subseq)) {
+        return { entry, score: 3 + subseq / 1000 };
+      }
+
+      return null;
+    })
+    .filter((entry): entry is { entry: string; score: number } => entry !== null)
+    .toSorted((a, b) => {
+      if (a.score !== b.score) {
+        return a.score - b.score;
+      }
+      if (a.entry.length !== b.entry.length) {
+        return a.entry.length - b.entry.length;
+      }
+      return a.entry.localeCompare(b.entry);
+    });
+
+  return ranked.slice(0, limit).map((entry) => entry.entry);
+}
+
+function renderJsonControl(params: {
+  kind: FieldKind;
   value: unknown;
   onSet: (value: unknown) => void;
-  onClear: () => void;
   onValidationError?: (message: string) => void;
 }): TemplateResult {
-  const { field, value, onSet, onClear, onValidationError } = params;
+  const { kind, value, onSet, onValidationError } = params;
+  const fallback = kind === "array" ? [] : {};
 
-  if (field.kind === "boolean") {
+  return html`
+    <label class="cfg-field">
+      <span class="cfg-field__help">Edit as JSON (${kind})</span>
+      <textarea
+        class="cfg-textarea"
+        rows="4"
+        .value=${jsonValue(value ?? fallback)}
+        @change=${(event: Event) => {
+          const target = event.target as HTMLTextAreaElement;
+          const raw = target.value.trim();
+          if (!raw) {
+            onSet(fallback);
+            return;
+          }
+          try {
+            onSet(JSON.parse(raw));
+          } catch {
+            onValidationError?.("Invalid JSON value.");
+            target.value = jsonValue(value ?? fallback);
+          }
+        }}
+      ></textarea>
+    </label>
+  `;
+}
+
+function renderScalarControl(params: ScalarControlParams): TemplateResult {
+  const { kind, enumValues, value, sensitive, compact, onSet, onClear, onValidationError, suggestions } =
+    params;
+
+  if (kind === "boolean") {
     return html`
       <label class="cfg-toggle-row builder-toggle-row">
         <span class="cfg-field__help">Toggle value</span>
@@ -109,12 +278,13 @@ function renderScalarControl(params: {
     `;
   }
 
-  if (field.kind === "enum") {
+  if (kind === "enum") {
     const selected = typeof value === "string" ? value : "";
-    if (field.enumValues.length > 0 && field.enumValues.length <= 4) {
+
+    if (!compact && enumValues.length > 0 && enumValues.length <= 4) {
       return html`
         <div class="cfg-segmented">
-          ${field.enumValues.map(
+          ${enumValues.map(
             (entry) => html`
               <button
                 type="button"
@@ -125,69 +295,117 @@ function renderScalarControl(params: {
               </button>
             `,
           )}
-          <button type="button" class="cfg-segmented__btn ${selected ? "" : "active"}" @click=${onClear}>
-            unset
-          </button>
+          ${onClear
+            ? html`
+                <button
+                  type="button"
+                  class="cfg-segmented__btn ${selected ? "" : "active"}"
+                  @click=${onClear}
+                >
+                  unset
+                </button>
+              `
+            : nothing}
         </div>
       `;
     }
 
     return html`
       <select
-        class="cfg-select"
+        class="cfg-select ${compact ? "cfg-select--sm" : ""}"
         .value=${selected}
         @change=${(event: Event) => {
           const next = (event.target as HTMLSelectElement).value;
           if (!next) {
-            onClear();
+            if (onClear) {
+              onClear();
+            } else if (enumValues[0]) {
+              onSet(enumValues[0]);
+            }
             return;
           }
           onSet(next);
         }}
       >
-        <option value="">(unset)</option>
-        ${field.enumValues.map((entry) => html`<option value=${entry}>${entry}</option>`)}
+        ${onClear ? html`<option value="">(unset)</option>` : nothing}
+        ${enumValues.map((entry) => html`<option value=${entry}>${entry}</option>`) }
       </select>
     `;
   }
 
-  const inputType = field.kind === "number" || field.kind === "integer" ? "number" : "text";
+  const inputType = kind === "number" || kind === "integer" ? "number" : "text";
   const inputValue = scalarInputValue(value);
 
-  return html`
+  const applyRawValue = (raw: string) => {
+    if (raw.trim() === "") {
+      if (onClear) {
+        onClear();
+      } else {
+        onSet(defaultValueForKind(kind));
+      }
+      return;
+    }
+
+    try {
+      onSet(parseScalar(kind, raw));
+    } catch (error) {
+      onValidationError?.(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const input = html`
     <input
-      class="cfg-input"
-      type=${field.sensitive ? "password" : inputType}
+      class="cfg-input ${compact ? "cfg-input--sm" : ""}"
+      type=${sensitive ? "password" : inputType}
       .value=${inputValue}
       @input=${(event: Event) => {
-        const raw = (event.target as HTMLInputElement).value;
-        if (raw.trim() === "") {
-          onClear();
-          return;
-        }
-        try {
-          onSet(parseScalar(field.kind, raw));
-        } catch (error) {
-          onValidationError?.(error instanceof Error ? error.message : String(error));
-        }
+        applyRawValue((event.target as HTMLInputElement).value);
       }}
     />
   `;
+
+  if (kind !== "string") {
+    return input;
+  }
+
+  const filteredSuggestions = fuzzyFilterSuggestions(suggestions ?? [], inputValue);
+  if (filteredSuggestions.length === 0) {
+    return input;
+  }
+
+  return html`
+    <div class="cb-typeahead ${compact ? "cb-typeahead--compact" : ""}">
+      ${input}
+      <div class="cb-typeahead__menu" role="listbox" aria-label="Suggestions">
+        ${filteredSuggestions.map((entry) => html`
+          <button
+            type="button"
+            class="cb-typeahead__option"
+            @mousedown=${(event: Event) => event.preventDefault()}
+            @click=${() => onSet(entry)}
+          >
+            ${entry}
+          </button>
+        `)}
+      </div>
+    </div>
+  `;
 }
 
-function renderPrimitiveArray(params: {
-  field: ExplorerField;
+function renderArrayNodeControl(params: {
+  node: ExplorerSchemaNode;
   value: unknown;
   onSet: (value: unknown) => void;
   onValidationError?: (message: string) => void;
+  depth: number;
+  suggestions?: string[];
 }): TemplateResult {
-  const { field, value, onSet, onValidationError } = params;
+  const { node, value, onSet, onValidationError, depth, suggestions } = params;
   const list = asArray(value);
-  const itemKind = field.itemKind;
-  const itemEnum = field.itemEnumValues;
+  const itemNode = node.item;
 
-  if (!itemKind || itemKind === "unknown" || itemKind === "object" || itemKind === "array") {
-    return renderJsonControl({ field, value, onSet, onValidationError });
+  if (!itemNode || itemNode.kind === "unknown") {
+    return renderJsonControl({ kind: "array", value, onSet, onValidationError });
   }
 
   return html`
@@ -198,7 +416,7 @@ function renderPrimitiveArray(params: {
         <button
           type="button"
           class="cfg-array__add"
-          @click=${() => onSet([...list, defaultValueForKind(itemKind)])}
+          @click=${() => onSet([...list, defaultValueForNode(itemNode)])}
         >
           Add
         </button>
@@ -227,64 +445,19 @@ function renderPrimitiveArray(params: {
                       </button>
                     </div>
                     <div class="cfg-array__item-content">
-                      ${itemKind === "boolean"
-                        ? html`
-                            <label class="cfg-toggle-row builder-toggle-row">
-                              <span class="cfg-field__help">boolean</span>
-                              <div class="cfg-toggle">
-                                <input
-                                  type="checkbox"
-                                  .checked=${item === true}
-                                  @change=${(event: Event) => {
-                                    const next = [...list];
-                                    next[index] = (event.target as HTMLInputElement).checked;
-                                    onSet(next);
-                                  }}
-                                />
-                                <span class="cfg-toggle__track"></span>
-                              </div>
-                            </label>
-                          `
-                        : itemKind === "enum" && itemEnum.length > 0
-                          ? html`
-                              <select
-                                class="cfg-select"
-                                .value=${scalarInputValue(item)}
-                                @change=${(event: Event) => {
-                                  const next = [...list];
-                                  next[index] = (event.target as HTMLSelectElement).value;
-                                  onSet(next);
-                                }}
-                              >
-                                ${itemEnum.map(
-                                  (entry) => html`<option value=${entry}>${entry}</option>`,
-                                )}
-                              </select>
-                            `
-                          : html`
-                              <input
-                                class="cfg-input"
-                                type=${itemKind === "number" || itemKind === "integer" ? "number" : "text"}
-                                .value=${scalarInputValue(item)}
-                                @input=${(event: Event) => {
-                                  const raw = (event.target as HTMLInputElement).value;
-                                  const next = [...list];
-                                  if (raw.trim() === "") {
-                                    next[index] = defaultValueForKind(itemKind);
-                                    onSet(next);
-                                    return;
-                                  }
-                                  try {
-                                    next[index] = parseScalar(itemKind, raw);
-                                    onSet(next);
-                                  } catch (error) {
-                                    onValidationError?.(
-                                      error instanceof Error ? error.message : String(error),
-                                    );
-                                  }
-                                }}
-                              />
-                            `}
+                      ${renderNodeEditor({
+                        node: itemNode,
+                        value: item,
+                        onSet: (nextValue) => {
+                          const next = [...list];
+                          next[index] = nextValue;
+                          onSet(next);
+                        },
+                        onValidationError,
+                        depth: depth + 1,
+                        compact: true,
+                        suggestions,
+                      })}
                     </div>
                   </div>
                 `,
@@ -295,184 +468,228 @@ function renderPrimitiveArray(params: {
   `;
 }
 
-function renderRecordObject(params: {
-  field: ExplorerField;
+function renderObjectNodeControl(params: {
+  node: ExplorerSchemaNode;
   value: unknown;
   onSet: (value: unknown) => void;
   onValidationError?: (message: string) => void;
+  depth: number;
+  suggestions?: string[];
 }): TemplateResult {
-  const { field, value, onSet, onValidationError } = params;
+  const { node, value, onSet, onValidationError, depth, suggestions } = params;
   const record = asObject(value);
-  const entries = Object.entries(record);
-  const valueKind = field.recordValueKind;
-  const recordEnums = field.recordEnumValues;
 
-  if (!valueKind || valueKind === "unknown" || valueKind === "object" || valueKind === "array") {
-    return renderJsonControl(params);
+  const fixedEntries = Object.entries(node.properties);
+  const fixedKeys = new Set(fixedEntries.map(([key]) => key));
+
+  const extraSchema = node.additionalProperties;
+  const extraEntries = Object.entries(record).filter(([key]) => !fixedKeys.has(key));
+
+  const hasFixed = fixedEntries.length > 0;
+  const canEditExtras = Boolean(extraSchema && extraSchema.kind !== "unknown");
+
+  if (!hasFixed && !canEditExtras && node.allowsUnknownProperties) {
+    return renderJsonControl({ kind: "object", value, onSet, onValidationError });
   }
 
+  const setChildValue = (key: string, nextValue: unknown) => {
+    const next = { ...record };
+    next[key] = nextValue;
+    onSet(next);
+  };
+
+  const clearChildValue = (key: string) => {
+    const next = { ...record };
+    delete next[key];
+    onSet(next);
+  };
+
+  const addExtraEntry = () => {
+    if (!extraSchema) {
+      return;
+    }
+    const next = { ...record };
+    let index = 1;
+    let key = `key-${index}`;
+    while (key in next) {
+      index += 1;
+      key = `key-${index}`;
+    }
+    next[key] = defaultValueForNode(extraSchema);
+    onSet(next);
+  };
+
   return html`
-    <div class="cfg-map">
-      <div class="cfg-map__header">
-        <span class="cfg-map__label">Entries</span>
-        <button
-          type="button"
-          class="cfg-map__add"
-          @click=${() => {
-            const next = { ...record };
-            let index = 1;
-            let key = `key-${index}`;
-            while (key in next) {
-              index += 1;
-              key = `key-${index}`;
-            }
-            next[key] = defaultValueForKind(valueKind);
-            onSet(next);
-          }}
-        >
-          Add Entry
-        </button>
-      </div>
+    <div class="cfg-object-stack">
+      ${hasFixed
+        ? html`
+            <div class="cfg-map">
+              <div class="cfg-map__header">
+                <span class="cfg-map__label">Fields</span>
+              </div>
+              <div class="cfg-map__items">
+                ${fixedEntries.map(([key, childNode]) => {
+                  const childValue = record[key];
+                  const hasValue = childValue !== undefined;
 
-      ${entries.length === 0
-        ? html`<div class="cfg-map__empty">No entries yet.</div>`
-        : html`
-            <div class="cfg-map__items">
-              ${entries.map(([key, entryValue]) =>
-                html`
-                  <div class="cfg-map__item">
-                    <div class="cfg-map__item-key">
-                      <input
-                        type="text"
-                        class="cfg-input cfg-input--sm"
-                        .value=${key}
-                        @change=${(event: Event) => {
-                          const nextKey = (event.target as HTMLInputElement).value.trim();
-                          if (!nextKey || nextKey === key || nextKey in record) {
-                            return;
-                          }
-                          const next = { ...record };
-                          next[nextKey] = next[key];
-                          delete next[key];
-                          onSet(next);
-                        }}
-                      />
+                  return html`
+                    <div class="cfg-map__item">
+                      <div class="cfg-map__item-key">
+                        <span class="cfg-field__help">${humanizeKey(key)}</span>
+                      </div>
+                      <div class="cfg-map__item-value">
+                        ${renderNodeEditor({
+                          node: childNode,
+                          value: childValue,
+                          onSet: (nextValue) => setChildValue(key, nextValue),
+                          onClear: () => clearChildValue(key),
+                          onValidationError,
+                          depth: depth + 1,
+                          compact: true,
+                          suggestions,
+                        })}
+                      </div>
+                      <button
+                        type="button"
+                        class="cfg-map__item-remove"
+                        title="Clear field"
+                        ?disabled=${!hasValue}
+                        @click=${() => clearChildValue(key)}
+                      >
+                        ×
+                      </button>
                     </div>
+                  `;
+                })}
+              </div>
+            </div>
+          `
+        : nothing}
 
-                    <div class="cfg-map__item-value">
-                      ${valueKind === "boolean"
-                        ? html`
-                            <label class="cfg-toggle-row builder-toggle-row">
-                              <span class="cfg-field__help">boolean</span>
-                              <div class="cfg-toggle">
-                                <input
-                                  type="checkbox"
-                                  .checked=${entryValue === true}
-                                  @change=${(event: Event) => {
-                                    const next = { ...record };
-                                    next[key] = (event.target as HTMLInputElement).checked;
-                                    onSet(next);
-                                  }}
-                                />
-                                <span class="cfg-toggle__track"></span>
-                              </div>
-                            </label>
-                          `
-                        : valueKind === "enum" && recordEnums.length > 0
-                          ? html`
-                              <select
-                                class="cfg-select cfg-select--sm"
-                                .value=${String(entryValue)}
+      ${canEditExtras && extraSchema
+        ? html`
+            <div class="cfg-map">
+              <div class="cfg-map__header">
+                <span class="cfg-map__label">Entries</span>
+                <button type="button" class="cfg-map__add" @click=${addExtraEntry}>Add Entry</button>
+              </div>
+
+              ${extraEntries.length === 0
+                ? html`<div class="cfg-map__empty">No entries yet.</div>`
+                : html`
+                    <div class="cfg-map__items">
+                      ${extraEntries.map(([key, entryValue]) =>
+                        html`
+                          <div class="cfg-map__item">
+                            <div class="cfg-map__item-key">
+                              <input
+                                type="text"
+                                class="cfg-input cfg-input--sm"
+                                .value=${key}
                                 @change=${(event: Event) => {
+                                  const nextKey = (event.target as HTMLInputElement).value.trim();
+                                  if (!nextKey || nextKey === key || nextKey in record) {
+                                    return;
+                                  }
                                   const next = { ...record };
-                                  next[key] = (event.target as HTMLSelectElement).value;
+                                  next[nextKey] = next[key];
+                                  delete next[key];
                                   onSet(next);
                                 }}
-                              >
-                                ${recordEnums.map((entry) => html`<option value=${entry}>${entry}</option>`)}
-                              </select>
-                            `
-                          : html`
-                              <input
-                                class="cfg-input cfg-input--sm"
-                                type=${valueKind === "number" || valueKind === "integer"
-                                  ? "number"
-                                  : "text"}
-                                .value=${scalarInputValue(entryValue)}
-                                @input=${(event: Event) => {
-                                  const raw = (event.target as HTMLInputElement).value;
-                                  const next = { ...record };
-                                  try {
-                                    next[key] =
-                                      raw.trim() === "" ? defaultValueForKind(valueKind) : parseScalar(valueKind, raw);
-                                    onSet(next);
-                                  } catch (error) {
-                                    onValidationError?.(
-                                      error instanceof Error ? error.message : String(error),
-                                    );
-                                  }
-                                }}
                               />
-                            `}
-                    </div>
+                            </div>
 
-                    <button
-                      type="button"
-                      class="cfg-map__item-remove"
-                      title="Remove entry"
-                      @click=${() => {
-                        const next = { ...record };
-                        delete next[key];
-                        onSet(next);
-                      }}
-                    >
-                      ×
-                    </button>
-                  </div>
-                `,
-              )}
+                            <div class="cfg-map__item-value">
+                              ${renderNodeEditor({
+                                node: extraSchema,
+                                value: entryValue,
+                                onSet: (nextValue) => setChildValue(key, nextValue),
+                                onValidationError,
+                                depth: depth + 1,
+                                compact: true,
+                                suggestions,
+                              })}
+                            </div>
+
+                            <button
+                              type="button"
+                              class="cfg-map__item-remove"
+                              title="Remove entry"
+                              @click=${() => clearChildValue(key)}
+                            >
+                              ×
+                            </button>
+                          </div>
+                        `,
+                      )}
+                    </div>
+                  `}
             </div>
-          `}
+          `
+        : nothing}
+
+      ${!hasFixed && !canEditExtras && !node.allowsUnknownProperties
+        ? html`<div class="cfg-field__help">No editable keys in this object schema.</div>`
+        : nothing}
     </div>
   `;
 }
 
-function renderJsonControl(params: {
-  field: ExplorerField;
-  value: unknown;
-  onSet: (value: unknown) => void;
-  onValidationError?: (message: string) => void;
-}): TemplateResult {
-  const { field, value, onSet, onValidationError } = params;
-  return html`
-    <label class="cfg-field">
-      <span class="cfg-field__help">Edit as JSON (${field.kind})</span>
-      <textarea
-        class="cfg-textarea"
-        rows="4"
-        .value=${jsonValue(value ?? (field.kind === "array" ? [] : {}))}
-        @change=${(event: Event) => {
-          const raw = (event.target as HTMLTextAreaElement).value.trim();
-          if (!raw) {
-            onSet(field.kind === "array" ? [] : {});
-            return;
-          }
-          try {
-            onSet(JSON.parse(raw));
-          } catch {
-            onValidationError?.("Invalid JSON value.");
-            (event.target as HTMLTextAreaElement).value = jsonValue(
-              value ?? (field.kind === "array" ? [] : {}),
-            );
-          }
-        }}
-      ></textarea>
-    </label>
-  `;
+function renderNodeEditor(params: NodeRendererParams): TemplateResult {
+  const { node, value, onSet, onClear, onValidationError, suggestions } = params;
+  const depth = params.depth ?? 0;
+  const compact = params.compact ?? false;
+
+  if (!node || depth > MAX_EDITOR_DEPTH) {
+    return renderJsonControl({ kind: "object", value, onSet, onValidationError });
+  }
+
+  if (
+    node.kind === "string" ||
+    node.kind === "number" ||
+    node.kind === "integer" ||
+    node.kind === "boolean" ||
+    node.kind === "enum"
+  ) {
+    return renderScalarControl({
+      kind: node.kind,
+      enumValues: node.enumValues,
+      value,
+      onSet,
+      onClear,
+      onValidationError,
+      compact,
+      suggestions,
+    });
+  }
+
+  if (node.kind === "array") {
+    return renderArrayNodeControl({
+      node,
+      value,
+      onSet,
+      onValidationError,
+      depth,
+      suggestions,
+    });
+  }
+
+  if (node.kind === "object") {
+    return renderObjectNodeControl({
+      node,
+      value,
+      onSet,
+      onValidationError,
+      depth,
+      suggestions,
+    });
+  }
+
+  return renderJsonControl({ kind: node.kind, value, onSet, onValidationError });
 }
 
 export function renderFieldEditor(params: FieldRendererParams): TemplateResult | typeof nothing {
-  const { field, value, onSet, onClear, onValidationError } = params;
+  const { field, value, onSet, onClear, onValidationError, suggestions } = params;
 
   if (!field.editable) {
     return html`<div class="cfg-field__help">Read-only in this phase.</div>`;
@@ -485,15 +702,27 @@ export function renderFieldEditor(params: FieldRendererParams): TemplateResult |
     field.kind === "boolean" ||
     field.kind === "enum"
   ) {
-    return renderScalarControl({ field, value, onSet, onClear, onValidationError });
+    return renderScalarControl({
+      kind: field.kind,
+      enumValues: field.enumValues,
+      value,
+      sensitive: field.sensitive,
+      onSet,
+      onClear,
+      onValidationError,
+      suggestions,
+    });
   }
 
-  if (field.kind === "array") {
-    return renderPrimitiveArray({ field, value, onSet, onValidationError });
-  }
-
-  if (field.kind === "object") {
-    return renderRecordObject({ field, value, onSet, onValidationError });
+  if (field.kind === "array" || field.kind === "object") {
+    return renderNodeEditor({
+      node: field.schemaNode,
+      value,
+      onSet,
+      onValidationError,
+      depth: 0,
+      suggestions,
+    });
   }
 
   return html`<div class="cfg-field__help">Unsupported schema node.</div>`;

--- a/apps/config-builder/src/ui/components/icons.ts
+++ b/apps/config-builder/src/ui/components/icons.ts
@@ -1,0 +1,329 @@
+import { svg, type TemplateResult } from "lit";
+
+// Lucide-style SVG icons used throughout the config builder.
+// Ported from the OpenClaw web UI icon set + additions.
+
+function icon(content: TemplateResult): TemplateResult {
+  return svg`<svg
+    class="cb-icon"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    ${content}
+  </svg>`;
+}
+
+// --- Section icons (match web UI sidebar) ---
+
+export const iconGateway = icon(svg`
+  <circle cx="12" cy="12" r="10"></circle>
+  <line x1="2" y1="12" x2="22" y2="12"></line>
+  <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+`);
+
+export const iconChannels = icon(svg`
+  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"></path>
+`);
+
+export const iconAgents = icon(svg`
+  <path d="M12 2a2 2 0 0 1 2 2c0 .74-.4 1.39-1 1.73V7h1a7 7 0 0 1 7 7h1a1 1 0 0 1 1 1v3a1 1 0 0 1-1 1h-1v1a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-1H2a1 1 0 0 1-1-1v-3a1 1 0 0 1 1-1h1a7 7 0 0 1 7-7h1V5.73c-.6-.34-1-.99-1-1.73a2 2 0 0 1 2-2z"></path>
+  <circle cx="8" cy="14" r="1"></circle>
+  <circle cx="16" cy="14" r="1"></circle>
+`);
+
+export const iconAuth = icon(svg`
+  <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+  <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+`);
+
+export const iconMessages = icon(svg`
+  <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"></path>
+  <polyline points="22,6 12,13 2,6"></polyline>
+`);
+
+export const iconTools = icon(svg`
+  <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"></path>
+`);
+
+export const iconSession = icon(svg`
+  <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+  <circle cx="9" cy="7" r="4"></circle>
+  <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+  <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+`);
+
+export const iconHooks = icon(svg`
+  <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"></path>
+  <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"></path>
+`);
+
+export const iconSkills = icon(svg`
+  <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>
+`);
+
+export const iconCommands = icon(svg`
+  <polyline points="4 17 10 11 4 5"></polyline>
+  <line x1="12" y1="19" x2="20" y2="19"></line>
+`);
+
+export const iconModels = icon(svg`
+  <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
+  <polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline>
+  <line x1="12" y1="22.08" x2="12" y2="12"></line>
+`);
+
+export const iconEnv = icon(svg`
+  <circle cx="12" cy="12" r="3"></circle>
+  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+`);
+
+export const iconUpdate = icon(svg`
+  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+  <polyline points="7 10 12 15 17 10"></polyline>
+  <line x1="12" y1="15" x2="12" y2="3"></line>
+`);
+
+export const iconLogging = icon(svg`
+  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+  <polyline points="14 2 14 8 20 8"></polyline>
+  <line x1="16" y1="13" x2="8" y2="13"></line>
+  <line x1="16" y1="17" x2="8" y2="17"></line>
+`);
+
+export const iconBroadcast = icon(svg`
+  <path d="M4.9 19.1C1 15.2 1 8.8 4.9 4.9"></path>
+  <path d="M7.8 16.2c-2.3-2.3-2.3-6.1 0-8.5"></path>
+  <circle cx="12" cy="12" r="2"></circle>
+  <path d="M16.2 7.8c2.3 2.3 2.3 6.1 0 8.5"></path>
+  <path d="M19.1 4.9C23 8.8 23 15.1 19.1 19"></path>
+`);
+
+export const iconPlugins = icon(svg`
+  <path d="M12 2v6"></path>
+  <path d="m4.93 10.93 4.24 4.24"></path>
+  <path d="M2 12h6"></path>
+  <path d="m4.93 13.07 4.24-4.24"></path>
+  <path d="M12 22v-6"></path>
+  <path d="m19.07 13.07-4.24-4.24"></path>
+  <path d="M22 12h-6"></path>
+  <path d="m19.07 10.93-4.24 4.24"></path>
+`);
+
+export const iconWeb = icon(svg`
+  <circle cx="12" cy="12" r="10"></circle>
+  <line x1="2" y1="12" x2="22" y2="12"></line>
+  <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"></path>
+`);
+
+export const iconCron = icon(svg`
+  <circle cx="12" cy="12" r="10"></circle>
+  <polyline points="12 6 12 12 16 14"></polyline>
+`);
+
+export const iconAudio = icon(svg`
+  <path d="M9 18V5l12-2v13"></path>
+  <circle cx="6" cy="18" r="3"></circle>
+  <circle cx="18" cy="16" r="3"></circle>
+`);
+
+export const iconUI = icon(svg`
+  <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
+  <line x1="3" y1="9" x2="21" y2="9"></line>
+  <line x1="9" y1="21" x2="9" y2="9"></line>
+`);
+
+export const iconWizard = icon(svg`
+  <path d="M15 4V2"></path>
+  <path d="M15 16v-2"></path>
+  <path d="M8 9h2"></path>
+  <path d="M20 9h2"></path>
+  <path d="M17.8 11.8 19 13"></path>
+  <path d="M15 9h0"></path>
+  <path d="M17.8 6.2 19 5"></path>
+  <path d="m3 21 9-9"></path>
+  <path d="M12.2 6.2 11 5"></path>
+`);
+
+export const iconDefault = icon(svg`
+  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+  <polyline points="14 2 14 8 20 8"></polyline>
+`);
+
+// --- UI action icons ---
+
+export const iconSearch = icon(svg`
+  <circle cx="11" cy="11" r="8"></circle>
+  <path d="M21 21l-4.35-4.35"></path>
+`);
+
+export const iconChevronDown = icon(svg`
+  <polyline points="6 9 12 15 18 9"></polyline>
+`);
+
+export const iconChevronRight = icon(svg`
+  <polyline points="9 18 15 12 9 6"></polyline>
+`);
+
+export const iconChevronLeft = icon(svg`
+  <polyline points="15 18 9 12 15 6"></polyline>
+`);
+
+export const iconCopy = icon(svg`
+  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+`);
+
+export const iconDownload = icon(svg`
+  <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+  <polyline points="7 10 12 15 17 10"></polyline>
+  <line x1="12" y1="15" x2="12" y2="3"></line>
+`);
+
+export const iconTrash = icon(svg`
+  <polyline points="3 6 5 6 21 6"></polyline>
+  <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+`);
+
+export const iconCheck = icon(svg`
+  <polyline points="20 6 9 17 4 12"></polyline>
+`);
+
+export const iconX = icon(svg`
+  <line x1="18" y1="6" x2="6" y2="18"></line>
+  <line x1="6" y1="6" x2="18" y2="18"></line>
+`);
+
+export const iconSparkles = icon(svg`
+  <path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z"></path>
+  <path d="M5 3v4"></path>
+  <path d="M19 17v4"></path>
+  <path d="M3 5h4"></path>
+  <path d="M17 19h4"></path>
+`);
+
+export const iconImport = icon(svg`
+  <path d="M12 3v12"></path>
+  <path d="m8 11 4 4 4-4"></path>
+  <path d="M8 5H4a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V7a2 2 0 0 0-2-2h-4"></path>
+`);
+
+export const iconExternalLink = icon(svg`
+  <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path>
+  <polyline points="15 3 21 3 21 9"></polyline>
+  <line x1="10" y1="14" x2="21" y2="3"></line>
+`);
+
+export const iconEye = icon(svg`
+  <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+  <circle cx="12" cy="12" r="3"></circle>
+`);
+
+export const iconEyeOff = icon(svg`
+  <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"></path>
+  <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"></path>
+  <line x1="1" y1="1" x2="23" y2="23"></line>
+  <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24"></path>
+`);
+
+export const iconGrid = icon(svg`
+  <rect x="3" y="3" width="7" height="7"></rect>
+  <rect x="14" y="3" width="7" height="7"></rect>
+  <rect x="14" y="14" width="7" height="7"></rect>
+  <rect x="3" y="14" width="7" height="7"></rect>
+`);
+
+export const iconLock = icon(svg`
+  <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+  <path d="M7 11V7a5 5 0 0 1 10 0v4"></path>
+`);
+
+export const iconShield = icon(svg`
+  <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"></path>
+`);
+
+export const iconCode = icon(svg`
+  <polyline points="16 18 22 12 16 6"></polyline>
+  <polyline points="8 6 2 12 8 18"></polyline>
+`);
+
+export const iconSun = icon(svg`
+  <circle cx="12" cy="12" r="5"></circle>
+  <line x1="12" y1="1" x2="12" y2="3"></line>
+  <line x1="12" y1="21" x2="12" y2="23"></line>
+  <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+  <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+  <line x1="1" y1="12" x2="3" y2="12"></line>
+  <line x1="21" y1="12" x2="23" y2="12"></line>
+  <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+  <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+`);
+
+export const iconMoon = icon(svg`
+  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+`);
+
+export const iconArrowRight = icon(svg`
+  <line x1="5" y1="12" x2="19" y2="12"></line>
+  <polyline points="12 5 19 12 12 19"></polyline>
+`);
+
+export const iconArrowLeft = icon(svg`
+  <line x1="19" y1="12" x2="5" y2="12"></line>
+  <polyline points="12 19 5 12 12 5"></polyline>
+`);
+
+export const iconMoreVertical = icon(svg`
+  <circle cx="12" cy="12" r="1"></circle>
+  <circle cx="12" cy="5" r="1"></circle>
+  <circle cx="12" cy="19" r="1"></circle>
+`);
+
+export const iconFile = icon(svg`
+  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+  <polyline points="14 2 14 8 20 8"></polyline>
+`);
+
+export const iconPanelRight = icon(svg`
+  <rect x="3" y="3" width="18" height="18" rx="2"></rect>
+  <line x1="15" y1="3" x2="15" y2="21"></line>
+`);
+
+export const iconSidebar = icon(svg`
+  <rect x="3" y="3" width="18" height="18" rx="2"></rect>
+  <line x1="9" y1="3" x2="9" y2="21"></line>
+`);
+
+// --- Section icon lookup ---
+
+const SECTION_ICON_MAP: Record<string, TemplateResult> = {
+  gateway: iconGateway,
+  channels: iconChannels,
+  agents: iconAgents,
+  auth: iconAuth,
+  messages: iconMessages,
+  tools: iconTools,
+  session: iconSession,
+  hooks: iconHooks,
+  skills: iconSkills,
+  commands: iconCommands,
+  models: iconModels,
+  env: iconEnv,
+  update: iconUpdate,
+  logging: iconLogging,
+  broadcast: iconBroadcast,
+  plugins: iconPlugins,
+  web: iconWeb,
+  cron: iconCron,
+  audio: iconAudio,
+  ui: iconUI,
+  wizard: iconWizard,
+};
+
+export function sectionIcon(sectionId: string): TemplateResult {
+  return SECTION_ICON_MAP[sectionId] ?? iconDefault;
+}

--- a/apps/config-builder/src/ui/components/import-dialog.ts
+++ b/apps/config-builder/src/ui/components/import-dialog.ts
@@ -1,0 +1,247 @@
+import { html, nothing, type TemplateResult } from "lit";
+import JSON5 from "json5";
+import type { ConfigDraft } from "../../lib/config-store.ts";
+import { iconImport, iconFile, iconX, iconCheck } from "./icons.ts";
+
+export type ImportDialogState = {
+  open: boolean;
+  tab: "paste" | "upload";
+  pasteValue: string;
+  error: string | null;
+  dragOver: boolean;
+};
+
+export function createImportDialogState(): ImportDialogState {
+  return {
+    open: false,
+    tab: "paste",
+    pasteValue: "",
+    error: null,
+    dragOver: false,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function deepMerge(
+  base: Record<string, unknown>,
+  incoming: Record<string, unknown>,
+): Record<string, unknown> {
+  const result = { ...base };
+  for (const [key, value] of Object.entries(incoming)) {
+    if (isRecord(value) && isRecord(result[key])) {
+      result[key] = deepMerge(result[key], value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function parseInput(raw: string): { config: ConfigDraft; error: string | null } {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return { config: {}, error: "Input is empty." };
+  }
+  try {
+    const parsed = JSON5.parse(trimmed) as unknown;
+    if (!isRecord(parsed)) {
+      return { config: {}, error: "Parsed value is not an object." };
+    }
+    return { config: parsed, error: null };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { config: {}, error: `Parse error: ${message}` };
+  }
+}
+
+export type ImportCallbacks = {
+  onReplace: (config: ConfigDraft) => void;
+  onMerge: (config: ConfigDraft) => void;
+  onClose: () => void;
+  onStateChange: (state: ImportDialogState) => void;
+};
+
+export function renderImportDialog(
+  state: ImportDialogState,
+  hasExistingDraft: boolean,
+  callbacks: ImportCallbacks,
+): TemplateResult | typeof nothing {
+  if (!state.open) {return nothing;}
+
+  const handlePasteImport = (mode: "replace" | "merge") => {
+    const { config, error } = parseInput(state.pasteValue);
+    if (error) {
+      callbacks.onStateChange({ ...state, error });
+      return;
+    }
+    if (mode === "replace") {
+      callbacks.onReplace(config);
+    } else {
+      callbacks.onMerge(config);
+    }
+    callbacks.onClose();
+  };
+
+  const handleFileContent = (content: string, mode: "replace" | "merge") => {
+    const { config, error } = parseInput(content);
+    if (error) {
+      callbacks.onStateChange({ ...state, error });
+      return;
+    }
+    if (mode === "replace") {
+      callbacks.onReplace(config);
+    } else {
+      callbacks.onMerge(config);
+    }
+    callbacks.onClose();
+  };
+
+  const handleFileDrop = (e: DragEvent, mode: "replace" | "merge") => {
+    e.preventDefault();
+    callbacks.onStateChange({ ...state, dragOver: false });
+    const file = e.dataTransfer?.files?.[0];
+    if (!file) {return;}
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        handleFileContent(reader.result, mode);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const handleFilePick = (e: Event, mode: "replace" | "merge") => {
+    const file = (e.target as HTMLInputElement).files?.[0];
+    if (!file) {return;}
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        handleFileContent(reader.result, mode);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  return html`
+    <div class="cb-palette-overlay" @click=${(e: Event) => {
+      if (e.target === e.currentTarget) {callbacks.onClose();}
+    }}>
+      <div class="cb-import-dialog">
+        <div class="cb-import-dialog__header">
+          <div class="cb-import-dialog__title">
+            ${iconImport} Import Config
+          </div>
+          <button class="cb-import-dialog__close" @click=${callbacks.onClose}>
+            ${iconX}
+          </button>
+        </div>
+
+        <div class="cb-import-dialog__tabs">
+          <button
+            class="cb-import-dialog__tab ${state.tab === "paste" ? "active" : ""}"
+            @click=${() => callbacks.onStateChange({ ...state, tab: "paste", error: null })}
+          >
+            Paste JSON5
+          </button>
+          <button
+            class="cb-import-dialog__tab ${state.tab === "upload" ? "active" : ""}"
+            @click=${() => callbacks.onStateChange({ ...state, tab: "upload", error: null })}
+          >
+            Upload File
+          </button>
+        </div>
+
+        <div class="cb-import-dialog__body">
+          ${state.tab === "paste"
+            ? html`
+                <textarea
+                  class="cb-import-dialog__textarea"
+                  rows="10"
+                  placeholder='Paste your openclaw.json or JSON5 content here…\n\n{\n  gateway: { port: 18789 },\n  agents: { ... }\n}'
+                  .value=${state.pasteValue}
+                  @input=${(e: Event) => {
+                    callbacks.onStateChange({
+                      ...state,
+                      pasteValue: (e.target as HTMLTextAreaElement).value,
+                      error: null,
+                    });
+                  }}
+                ></textarea>
+              `
+            : html`
+                <div
+                  class="cb-import-dialog__drop-zone ${state.dragOver ? "cb-import-dialog__drop-zone--active" : ""}"
+                  @dragover=${(e: DragEvent) => {
+                    e.preventDefault();
+                    if (!state.dragOver) {
+                      callbacks.onStateChange({ ...state, dragOver: true });
+                    }
+                  }}
+                  @dragleave=${() => {
+                    callbacks.onStateChange({ ...state, dragOver: false });
+                  }}
+                  @drop=${(e: DragEvent) => handleFileDrop(e, hasExistingDraft ? "merge" : "replace")}
+                >
+                  <div class="cb-import-dialog__drop-icon">${iconFile}</div>
+                  <div class="cb-import-dialog__drop-text">
+                    Drop your config file here
+                  </div>
+                  <div class="cb-import-dialog__drop-sub">
+                    or
+                    <label class="cb-import-dialog__file-label">
+                      browse files
+                      <input
+                        type="file"
+                        accept=".json,.json5,.jsonc"
+                        style="display:none"
+                        @change=${(e: Event) => handleFilePick(e, hasExistingDraft ? "merge" : "replace")}
+                      />
+                    </label>
+                  </div>
+                </div>
+              `}
+
+          ${state.error
+            ? html`<div class="cb-import-dialog__error">${state.error}</div>`
+            : nothing}
+        </div>
+
+        ${state.tab === "paste"
+          ? html`
+              <div class="cb-import-dialog__footer">
+                ${hasExistingDraft
+                  ? html`
+                      <button
+                        class="btn btn--sm"
+                        ?disabled=${!state.pasteValue.trim()}
+                        @click=${() => handlePasteImport("merge")}
+                      >
+                        Merge with draft
+                      </button>
+                      <button
+                        class="btn btn--sm danger"
+                        ?disabled=${!state.pasteValue.trim()}
+                        @click=${() => handlePasteImport("replace")}
+                      >
+                        Replace draft
+                      </button>
+                    `
+                  : html`
+                      <button
+                        class="btn btn--sm primary"
+                        ?disabled=${!state.pasteValue.trim()}
+                        @click=${() => handlePasteImport("replace")}
+                      >
+                        ${iconCheck} Import
+                      </button>
+                    `}
+              </div>
+            `
+          : nothing}
+      </div>
+    </div>
+  `;
+}

--- a/apps/config-builder/src/ui/navigation.test.ts
+++ b/apps/config-builder/src/ui/navigation.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { modeToHash, parseModeFromHash } from "./navigation.ts";
+
+describe("navigation mode hash", () => {
+  it("parses known hashes", () => {
+    expect(parseModeFromHash("#/wizard")).toBe("wizard");
+    expect(parseModeFromHash("#/explorer")).toBe("explorer");
+    expect(parseModeFromHash("#/")).toBe("landing");
+  });
+
+  it("falls back to landing for unknown hash", () => {
+    expect(parseModeFromHash("#/unknown")).toBe("landing");
+  });
+
+  it("builds hashes for modes", () => {
+    expect(modeToHash("landing")).toBe("#/");
+    expect(modeToHash("explorer")).toBe("#/explorer");
+    expect(modeToHash("wizard")).toBe("#/wizard");
+  });
+});

--- a/apps/config-builder/src/ui/navigation.ts
+++ b/apps/config-builder/src/ui/navigation.ts
@@ -1,0 +1,29 @@
+export type ConfigBuilderMode = "landing" | "explorer" | "wizard";
+
+export function parseModeFromHash(hash: string): ConfigBuilderMode {
+  const normalized = hash.trim().toLowerCase();
+  if (!normalized) {
+    return "landing";
+  }
+
+  if (normalized === "#/wizard" || normalized === "#wizard") {
+    return "wizard";
+  }
+  if (normalized === "#/explorer" || normalized === "#explorer") {
+    return "explorer";
+  }
+  if (normalized === "#/" || normalized === "#") {
+    return "landing";
+  }
+  return "landing";
+}
+
+export function modeToHash(mode: ConfigBuilderMode): string {
+  if (mode === "wizard") {
+    return "#/wizard";
+  }
+  if (mode === "explorer") {
+    return "#/explorer";
+  }
+  return "#/";
+}

--- a/apps/config-builder/src/ui/wizard.test.ts
+++ b/apps/config-builder/src/ui/wizard.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { WIZARD_STEPS, wizardStepFields } from "./wizard.ts";
+
+describe("wizard step definitions", () => {
+  it("defines the expected number of curated steps", () => {
+    expect(WIZARD_STEPS).toHaveLength(7);
+  });
+
+  it("resolves all configured fields to schema metadata", () => {
+    for (const step of WIZARD_STEPS) {
+      const fields = wizardStepFields(step);
+      expect(fields).toHaveLength(step.fields.length);
+    }
+  });
+});

--- a/apps/config-builder/src/ui/wizard.ts
+++ b/apps/config-builder/src/ui/wizard.ts
@@ -1,0 +1,105 @@
+import type { ExplorerField } from "../lib/schema-spike.ts";
+import { resolveExplorerField } from "../lib/schema-spike.ts";
+
+export type WizardStep = {
+  id: string;
+  label: string;
+  description: string;
+  fields: string[];
+};
+
+export const WIZARD_STEPS: WizardStep[] = [
+  {
+    id: "gateway",
+    label: "Gateway",
+    description: "Core gateway networking and auth settings.",
+    fields: [
+      "gateway.port",
+      "gateway.mode",
+      "gateway.bind",
+      "gateway.auth.mode",
+      "gateway.auth.token",
+      "gateway.auth.password",
+    ],
+  },
+  {
+    id: "channels",
+    label: "Channels",
+    description: "Common channel credentials and DM policies.",
+    fields: [
+      "channels.whatsapp.dmPolicy",
+      "channels.telegram.botToken",
+      "channels.telegram.dmPolicy",
+      "channels.discord.token",
+      "channels.discord.dm.policy",
+      "channels.slack.botToken",
+      "channels.slack.dm.policy",
+      "channels.signal.account",
+      "channels.signal.dmPolicy",
+    ],
+  },
+  {
+    id: "agents",
+    label: "Agents",
+    description: "Default model + workspace behavior.",
+    fields: [
+      "agents.defaults.model.primary",
+      "agents.defaults.model.fallbacks",
+      "agents.defaults.workspace",
+      "agents.defaults.repoRoot",
+      "agents.defaults.humanDelay.mode",
+    ],
+  },
+  {
+    id: "models",
+    label: "Models",
+    description: "Auth and model catalog data.",
+    fields: ["agents.defaults.models", "auth.profiles", "auth.order"],
+  },
+  {
+    id: "messages",
+    label: "Messages",
+    description: "Reply behavior and acknowledgment defaults.",
+    fields: [
+      "messages.ackReaction",
+      "messages.ackReactionScope",
+      "messages.inbound.debounceMs",
+      "channels.telegram.streamMode",
+    ],
+  },
+  {
+    id: "session",
+    label: "Session",
+    description: "DM scoping and agent-to-agent behavior.",
+    fields: ["session.dmScope", "session.identityLinks", "session.agentToAgent.maxPingPongTurns"],
+  },
+  {
+    id: "tools",
+    label: "Tools",
+    description: "Web and execution tool defaults.",
+    fields: [
+      "tools.profile",
+      "tools.web.search.enabled",
+      "tools.web.search.provider",
+      "tools.web.search.apiKey",
+      "tools.web.fetch.enabled",
+      "tools.exec.applyPatch.enabled",
+    ],
+  },
+];
+
+export function wizardStepFields(step: WizardStep): ExplorerField[] {
+  return step.fields
+    .map((path) => resolveExplorerField(path))
+    .filter((field): field is ExplorerField => field !== null);
+}
+
+export function wizardStepByIndex(index: number): WizardStep {
+  const clamped = Math.max(0, Math.min(index, WIZARD_STEPS.length - 1));
+  return WIZARD_STEPS[clamped] ?? WIZARD_STEPS[0] ?? {
+    id: "empty",
+    label: "Empty",
+    description: "No wizard steps configured.",
+    fields: [],
+  };
+}

--- a/apps/config-builder/tsconfig.json
+++ b/apps/config-builder/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["vite/client"],
+    "paths": {
+      "@openclaw/config/*": ["../../src/config/*"]
+    }
+  },
+  "include": ["src/**/*", "vite.config.ts"]
+}

--- a/apps/config-builder/vercel.json
+++ b/apps/config-builder/vercel.json
@@ -1,0 +1,5 @@
+{
+  "installCommand": "pnpm install",
+  "buildCommand": "vite build --outDir dist",
+  "outputDirectory": "dist"
+}

--- a/apps/config-builder/vite.config.ts
+++ b/apps/config-builder/vite.config.ts
@@ -1,0 +1,60 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+
+function normalizeBase(input: string): string {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return "/";
+  }
+  if (trimmed === "./") {
+    return "./";
+  }
+  if (trimmed.endsWith("/")) {
+    return trimmed;
+  }
+  return `${trimmed}/`;
+}
+
+export default defineConfig(() => {
+  const envBase = process.env.OPENCLAW_CONFIG_BUILDER_BASE_PATH?.trim();
+  const base = envBase ? normalizeBase(envBase) : "./";
+  return {
+    base,
+    publicDir: path.resolve(here, "public"),
+    resolve: {
+      alias: [
+        {
+          find: "@openclaw/config",
+          replacement: path.resolve(repoRoot, "src/config"),
+        },
+        {
+          // src/config/schema.ts imports ../version.js; redirect to a browser-safe shim.
+          find: "../version.js",
+          replacement: path.resolve(here, "src/shims/version.ts"),
+        },
+        {
+          // src/config/schema.ts imports ../channels/registry.js; redirect to a light shim.
+          find: "../channels/registry.js",
+          replacement: path.resolve(here, "src/shims/channel-registry.ts"),
+        },
+      ],
+    },
+    optimizeDeps: {
+      include: ["lit"],
+    },
+    build: {
+      outDir: path.resolve(here, "../../dist/config-builder"),
+      emptyOutDir: true,
+      sourcemap: true,
+    },
+    server: {
+      host: true,
+      port: 5174,
+      strictPort: true,
+    },
+  };
+});

--- a/apps/config-builder/vitest.config.ts
+++ b/apps/config-builder/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/apps/config-builder/vitest.config.ts
+++ b/apps/config-builder/vitest.config.ts
@@ -1,6 +1,16 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "../..");
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@openclaw/config": path.resolve(repoRoot, "src/config"),
+    },
+  },
   test: {
     environment: "node",
     include: ["src/**/*.test.ts"],

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - ui
   - packages/*
   - extensions/*
+  - apps/*
 
 onlyBuiltDependencies:
   - "@lydell/node-pty"

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -473,6 +473,7 @@ const ERROR_PATTERNS = {
     "insufficient credits",
     "credit balance",
     "plans & billing",
+    "billing:",
     "insufficient balance",
   ],
   auth: [
@@ -534,7 +535,7 @@ export function isBillingErrorMessage(raw: string): boolean {
   if (!value) {
     return false;
   }
-  
+
   return matchesErrorPatterns(value, ERROR_PATTERNS.billing);
 }
 

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -101,36 +101,4 @@ describe("config schema", () => {
     expect(defaultsHint?.help).toContain("last");
     expect(listHint?.help).toContain("bluebubbles");
   });
-
-  it("includes tool policy suggestions in schema while still allowing free-form strings", () => {
-    const res = buildConfigSchema();
-    const schema = res.schema as { properties?: Record<string, unknown> };
-
-    const toolsNode = schema.properties?.tools as
-      | { properties?: Record<string, unknown> }
-      | undefined;
-    const allowNode = toolsNode?.properties?.allow as
-      | { items?: Record<string, unknown> }
-      | undefined;
-    const itemNode = allowNode?.items;
-    const variants = [
-      ...(Array.isArray(itemNode?.anyOf) ? itemNode.anyOf : []),
-      ...(Array.isArray(itemNode?.oneOf) ? itemNode.oneOf : []),
-      ...(Array.isArray(itemNode?.allOf) ? itemNode.allOf : []),
-    ] as Array<Record<string, unknown>>;
-
-    const hasSuggestedEntry = variants.some((entry) => {
-      const values = Array.isArray(entry.enum) ? entry.enum : [];
-      return values.includes("exec") || values.includes("group:fs");
-    });
-
-    const hasOpenString = variants.some((entry) => {
-      const type = entry.type;
-      const allowsString = type === "string" || (Array.isArray(type) && type.includes("string"));
-      return allowsString && !Array.isArray(entry.enum) && entry.const === undefined;
-    });
-
-    expect(hasSuggestedEntry).toBe(true);
-    expect(hasOpenString).toBe(true);
-  });
 });

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { TOOL_GROUPS } from "../agents/tool-policy.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
 import {
   GroupChatSchema,
@@ -151,30 +150,11 @@ export const SandboxPruneSchema = z
   .strict()
   .optional();
 
-const TOOL_POLICY_SUGGESTED_ENTRIES = Array.from(
-  new Set([
-    ...Object.keys(TOOL_GROUPS),
-    ...Object.values(TOOL_GROUPS).flat(),
-    // Expanded later against runtime plugin registrations.
-    "group:plugins",
-  ]),
-).toSorted((a, b) => a.localeCompare(b));
-
-const ToolPolicySuggestedEntrySchema =
-  TOOL_POLICY_SUGGESTED_ENTRIES.length > 0
-    ? z.enum(TOOL_POLICY_SUGGESTED_ENTRIES as [string, ...string[]])
-    : z.never();
-
-const ToolPolicyEntrySchema =
-  TOOL_POLICY_SUGGESTED_ENTRIES.length > 0
-    ? z.union([ToolPolicySuggestedEntrySchema, z.string()])
-    : z.string();
-
 const ToolPolicyBaseSchema = z
   .object({
-    allow: z.array(ToolPolicyEntrySchema).optional(),
-    alsoAllow: z.array(ToolPolicyEntrySchema).optional(),
-    deny: z.array(ToolPolicyEntrySchema).optional(),
+    allow: z.array(z.string()).optional(),
+    alsoAllow: z.array(z.string()).optional(),
+    deny: z.array(z.string()).optional(),
   })
   .strict();
 
@@ -243,9 +223,9 @@ export const ToolProfileSchema = z
 
 export const ToolPolicyWithProfileSchema = z
   .object({
-    allow: z.array(ToolPolicyEntrySchema).optional(),
-    alsoAllow: z.array(ToolPolicyEntrySchema).optional(),
-    deny: z.array(ToolPolicyEntrySchema).optional(),
+    allow: z.array(z.string()).optional(),
+    alsoAllow: z.array(z.string()).optional(),
+    deny: z.array(z.string()).optional(),
     profile: ToolProfileSchema,
   })
   .strict()
@@ -282,9 +262,9 @@ export const AgentSandboxSchema = z
 export const AgentToolsSchema = z
   .object({
     profile: ToolProfileSchema,
-    allow: z.array(ToolPolicyEntrySchema).optional(),
-    alsoAllow: z.array(ToolPolicyEntrySchema).optional(),
-    deny: z.array(ToolPolicyEntrySchema).optional(),
+    allow: z.array(z.string()).optional(),
+    alsoAllow: z.array(z.string()).optional(),
+    deny: z.array(z.string()).optional(),
     byProvider: z.record(z.string(), ToolPolicyWithProfileSchema).optional(),
     elevated: z
       .object({
@@ -497,9 +477,9 @@ export const AgentEntrySchema = z
 export const ToolsSchema = z
   .object({
     profile: ToolProfileSchema,
-    allow: z.array(ToolPolicyEntrySchema).optional(),
-    alsoAllow: z.array(ToolPolicyEntrySchema).optional(),
-    deny: z.array(ToolPolicyEntrySchema).optional(),
+    allow: z.array(z.string()).optional(),
+    alsoAllow: z.array(z.string()).optional(),
+    deny: z.array(z.string()).optional(),
     byProvider: z.record(z.string(), ToolPolicyWithProfileSchema).optional(),
     web: ToolsWebSchema,
     media: ToolsMediaSchema,


### PR DESCRIPTION
## Summary
- switch the config-builder plan away from Next.js/Tailwind to the same stack as the OpenClaw web UI (`ui/`)
- bootstrap `apps/config-builder/` as a workspace package placeholder
- add `apps/*` to the pnpm workspace so implementation can start in this branch
- implement Phases 0–6 in vertical slices:
  - schema/browser compatibility spike
  - explorer scaffold + typed field rendering
  - persisted sparse config state + JSON5 preview
  - real-time validation with field/section error UX
  - wizard mode (7 curated steps)
  - landing + hash routing + responsive preview drawer + static-host config

## Run in dev mode (for now)
```bash
pnpm --filter @openclaw/config-builder dev
```

## Notes
- planning details are maintained in `.local/config-builder-spec.md`
- draft PR opened before implementation, per request
- this is still a draft; UX iteration is expected before merge

## What is next
- UX improvement pass (scheduled for tomorrow), including:
  - tighter visual hierarchy and spacing
  - better complex/nested editor affordances
  - improved field grouping/collapse behavior
  - polish around validation messaging and action flows
- continue strengthening focused UI tests around wizard/explorer interactions
