### PR TITLE
fix(agents): strip [Historical context: ...] and tool call text from streaming path

### DIFF
--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -15,7 +15,7 @@ import {
   normalizeTextForComparison,
 } from "./pi-embedded-helpers.js";
 import { createEmbeddedPiSessionEventHandler } from "./pi-embedded-subscribe.handlers.js";
-import { formatReasoningMessage } from "./pi-embedded-utils.js";
+import { formatReasoningMessage, stripDowngradedToolCallText } from "./pi-embedded-utils.js";
 import { hasNonzeroUsage, normalizeUsage, type UsageLike } from "./usage.js";
 
 const THINKING_TAG_SCAN_RE = /<\s*(\/?)\s*(?:think(?:ing)?|thought|antthinking)\s*>/gi;
@@ -449,7 +449,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       return;
     }
     // Strip <think> and <final> blocks across chunk boundaries to avoid leaking reasoning.
-    const chunk = stripBlockTags(text, state.blockState).trimEnd();
+    // Also strip downgraded tool call text ([Tool Call: ...], [Historical context: ...], etc.).
+    const chunk = stripDowngradedToolCallText(stripBlockTags(text, state.blockState)).trimEnd();
     if (!chunk) {
       return;
     }

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -1,6 +1,10 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
-import { extractAssistantText, formatReasoningMessage } from "./pi-embedded-utils.js";
+import {
+  extractAssistantText,
+  formatReasoningMessage,
+  stripDowngradedToolCallText,
+} from "./pi-embedded-utils.js";
 
 describe("extractAssistantText", () => {
   it("strips Minimax tool invocation XML from text", () => {
@@ -557,5 +561,41 @@ describe("formatReasoningMessage", () => {
     expect(formatReasoningMessage("  \n  Reasoning here  \n  ")).toBe(
       "Reasoning:\n_Reasoning here_",
     );
+  });
+});
+
+describe("stripDowngradedToolCallText", () => {
+  it("strips [Historical context: ...] blocks", () => {
+    const text = `[Historical context: a different model called tool "exec" with arguments {"command":"git status"}]`;
+    expect(stripDowngradedToolCallText(text)).toBe("");
+  });
+
+  it("preserves text before [Historical context: ...] blocks", () => {
+    const text = `Here is the answer.\n[Historical context: a different model called tool "read"]`;
+    expect(stripDowngradedToolCallText(text)).toBe("Here is the answer.");
+  });
+
+  it("preserves text around [Historical context: ...] blocks", () => {
+    const text = `Before.\n[Historical context: tool call info]\nAfter.`;
+    expect(stripDowngradedToolCallText(text)).toBe("Before.\nAfter.");
+  });
+
+  it("strips multiple [Historical context: ...] blocks", () => {
+    const text = `[Historical context: first tool call]\n[Historical context: second tool call]`;
+    expect(stripDowngradedToolCallText(text)).toBe("");
+  });
+
+  it("strips mixed [Tool Call: ...] and [Historical context: ...] blocks", () => {
+    const text = `Intro.\n[Tool Call: exec (ID: toolu_1)]\nArguments: { "command": "ls" }\n[Historical context: a different model called tool "read"]`;
+    expect(stripDowngradedToolCallText(text)).toBe("Intro.");
+  });
+
+  it("returns text unchanged when no markers are present", () => {
+    const text = "Just a normal response with no markers.";
+    expect(stripDowngradedToolCallText(text)).toBe("Just a normal response with no markers.");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(stripDowngradedToolCallText("")).toBe("");
   });
 });

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -37,7 +37,7 @@ export function stripDowngradedToolCallText(text: string): string {
   if (!text) {
     return text;
   }
-  if (!/\[Tool (?:Call|Result)/i.test(text)) {
+  if (!/\[Tool (?:Call|Result)/i.test(text) && !/\[Historical context/i.test(text)) {
     return text;
   }
 
@@ -185,6 +185,9 @@ export function stripDowngradedToolCallText(text: string): string {
 
   // Remove [Tool Result for ID ...] blocks and their content.
   cleaned = cleaned.replace(/\[Tool Result for ID[^\]]*\]\n?[\s\S]*?(?=\n*\[Tool |\n*$)/gi, "");
+
+  // Remove [Historical context: ...] markers (self-contained within brackets).
+  cleaned = cleaned.replace(/\[Historical context:[^\]]*\]\n?/gi, "");
 
   return cleaned.trim();
 }


### PR DESCRIPTION
## Summary

- Add `[Historical context: ...]` pattern to `stripDowngradedToolCallText()` — Google Gemini models generate these markers when replaying downgraded tool history, and they were leaking into user-facing messages
- Apply `stripDowngradedToolCallText()` in `emitBlockChunk()` streaming path — previously only `stripBlockTags()` ran during streaming, so `[Tool Call: ...]` and `[Historical context: ...]` markers passed through to Telegram/other channels
- Add 7 test cases for the new pattern stripping

## Relation to #11053

PR #11053 fixes `<think>` tag stripping in the **messaging tool send path** (`message-tool.ts`). This PR is **complementary, not overlapping** — it targets two separate gaps:

1. A **missing pattern** (`[Historical context: ...]`) not covered by any existing sanitization
2. The **streaming block reply path** (`emitBlockChunk`) which skipped `stripDowngradedToolCallText()` entirely

Both PRs can merge independently without conflict.

## Test plan

- [x] `pnpm build` — passes
- [x] `pnpm check` (format + type check + lint) — passes
- [x] `pnpm test` — all 258 tests pass (43 test files)
- [x] New `stripDowngradedToolCallText` describe block with 7 cases covering: standalone markers, text preservation around markers, multiple markers, mixed marker types, no-op for clean text, empty input

Closes #13326

cc @quotentiroler @gumadeiras — would appreciate a review when you get a chance!

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends `stripDowngradedToolCallText()` to also remove Gemini-generated `[Historical context: ...]` markers, and wires that sanitization into the streaming block reply path (`emitBlockChunk`) so downgraded tool-call text/markers don’t leak to user-facing streaming surfaces (Telegram/etc). It also adds unit tests covering the new stripping behavior.

The change fits into the existing embedded agent text sanitization pipeline alongside the existing Minimax XML stripping and thinking-tag stripping (`src/agents/pi-embedded-utils.ts`), and complements the separate non-streaming/message-tool sanitization paths.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are localized to text sanitization and a single streaming call site, with comprehensive new unit tests. I did not find any correctness, integration, or security regressions introduced by the diff.
- No files require special attention

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->