### PR TITLE
Docker: harden UID/GID remap and docker-setup flow, convenience update to PATH for tool shims

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:22-bookworm@sha256:cd7bcd2e7a1e6f72052feb023c7f6b722205d3fcab7bbcbd2d1bfdab10b1e935
 
+# Map container user/group IDs to the host (for bind-mounted volumes).
+# Defaults match the upstream node image user (uid/gid 1000).
+ARG OPENCLAW_UID=1000
+ARG OPENCLAW_GID=1000
+
 # Install Bun (required for build scripts)
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:${PATH}"
@@ -58,6 +63,14 @@ RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw \
 
 ENV NODE_ENV=production
 
+# Prepend the mounted OpenClaw state bin dir so persistent tool shims are available.
+ENV PATH="/home/node/.openclaw/bin:${PATH}"
+
+# Map the built-in `node` user/group to the host UID/GID, then ensure /app is writable.
+USER root
+RUN groupmod -g "${OPENCLAW_GID}" node && \
+    usermod -u "${OPENCLAW_UID}" -g "${OPENCLAW_GID}" node && \
+    chown -R node:node /app
 # Security hardening: Run as non-root user
 # The node:22-bookworm image includes a 'node' user (uid 1000)
 # This reduces the attack surface by preventing container escape via root privileges

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,8 +68,15 @@ ENV PATH="/home/node/.openclaw/bin:${PATH}"
 
 # Map the built-in `node` user/group to the host UID/GID, then ensure /app is writable.
 USER root
-RUN groupmod -g "${OPENCLAW_GID}" node && \
-    usermod -u "${OPENCLAW_UID}" -g "${OPENCLAW_GID}" node && \
+RUN set -eu; \
+    case "${OPENCLAW_GID}" in (""|*[!0-9]*|0) ;; (*) \
+      grp="$(getent group "${OPENCLAW_GID}" 2>/dev/null | cut -d: -f1 || true)"; \
+      if [ -n "$grp" ] && [ "$grp" != node ]; then usermod -g "$grp" node; else groupmod -g "${OPENCLAW_GID}" node; fi ;; \
+    esac; \
+    case "${OPENCLAW_UID}" in (""|*[!0-9]*|0) ;; (*) \
+      usr="$(getent passwd "${OPENCLAW_UID}" 2>/dev/null | cut -d: -f1 || true)"; \
+      if [ -z "$usr" ] || [ "$usr" = node ]; then usermod -u "${OPENCLAW_UID}" node; fi ;; \
+    esac; \
     chown -R node:node /app
 # Security hardening: Run as non-root user
 # The node:22-bookworm image includes a 'node' user (uid 1000)

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,9 @@ RUN set -eu; \
     esac; \
     case "${OPENCLAW_UID}" in (""|*[!0-9]*|0) ;; (*) \
       usr="$(getent passwd "${OPENCLAW_UID}" 2>/dev/null | cut -d: -f1 || true)"; \
+      if [ -n "$usr" ] && [ "$usr" != node ]; then \
+        echo "OPENCLAW_UID ${OPENCLAW_UID} already used by ${usr}; choose a different UID" >&2; exit 1; \
+      fi; \
       if [ -z "$usr" ] || [ "$usr" = node ]; then usermod -u "${OPENCLAW_UID}" node; fi ;; \
     esac; \
     chown -R node:node /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN ln -sf /app/openclaw.mjs /usr/local/bin/openclaw \
 
 ENV NODE_ENV=production
 
-# Prepend the mounted OpenClaw state bin dir so persistent tool shims are available.
+# Prepend the mounted OpenClaw state bin so persisted tool shims (agent-installed) are discoverable.
 ENV PATH="/home/node/.openclaw/bin:${PATH}"
 
 # Map the built-in `node` user/group to the host UID/GID, then ensure /app is writable.

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,14 @@ USER root
 RUN set -eu; \
     case "${OPENCLAW_GID}" in (""|*[!0-9]*|0) ;; (*) \
       grp="$(getent group "${OPENCLAW_GID}" 2>/dev/null | cut -d: -f1 || true)"; \
-      if [ -n "$grp" ] && [ "$grp" != node ]; then usermod -g "$grp" node; else groupmod -g "${OPENCLAW_GID}" node; fi ;; \
+      if [ -n "$grp" ] && [ "$grp" != node ]; then \
+        echo "OPENCLAW_GID ${OPENCLAW_GID} already used by ${grp}; choose a different GID" >&2; exit 1; \
+      fi; \
+      if [ -z "$grp" ]; then \
+        usermod -g root node; \
+        groupmod -g "${OPENCLAW_GID}" node; \
+        usermod -g node node; \
+      fi ;; \
     esac; \
     case "${OPENCLAW_UID}" in (""|*[!0-9]*|0) ;; (*) \
       usr="$(getent passwd "${OPENCLAW_UID}" 2>/dev/null | cut -d: -f1 || true)"; \

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -11,17 +11,22 @@ EOF
 }
 
 build_only=false
-for arg in "$@"; do
-  case "$arg" in
+while [[ $# -gt 0 ]]; do
+  case "$1" in
     --help|-h)
       usage
       exit 0
       ;;
     --build-only)
       build_only=true
+      shift
+      ;;
+    --)
+      shift
+      break
       ;;
     *)
-      echo "Unknown argument: $arg" >&2
+      echo "Unknown argument: $1" >&2
       usage >&2
       exit 2
       ;;

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -168,6 +168,9 @@ export OPENCLAW_DOCKER_APT_PACKAGES="${OPENCLAW_DOCKER_APT_PACKAGES:-}"
 export OPENCLAW_EXTRA_MOUNTS="$EXTRA_MOUNTS"
 export OPENCLAW_HOME_VOLUME="$HOME_VOLUME_NAME"
 
+export OPENCLAW_UID="${OPENCLAW_UID:-$(id -u)}"
+export OPENCLAW_GID="${OPENCLAW_GID:-$(id -g)}"
+
 if [[ -z "${OPENCLAW_GATEWAY_TOKEN:-}" ]]; then
   EXISTING_CONFIG_TOKEN="$(read_config_gateway_token || true)"
   if [[ -n "$EXISTING_CONFIG_TOKEN" ]]; then
@@ -321,12 +324,16 @@ upsert_env "$ENV_FILE" \
   OPENCLAW_IMAGE \
   OPENCLAW_EXTRA_MOUNTS \
   OPENCLAW_HOME_VOLUME \
+  OPENCLAW_UID \
+  OPENCLAW_GID \
   OPENCLAW_DOCKER_APT_PACKAGES
 
 if [[ "$IMAGE_NAME" == "openclaw:local" ]]; then
   echo "==> Building Docker image: $IMAGE_NAME"
   docker build \
     --build-arg "OPENCLAW_DOCKER_APT_PACKAGES=${OPENCLAW_DOCKER_APT_PACKAGES}" \
+    --build-arg "OPENCLAW_UID=${OPENCLAW_UID}" \
+    --build-arg "OPENCLAW_GID=${OPENCLAW_GID}" \
     -t "$IMAGE_NAME" \
     -f "$ROOT_DIR/Dockerfile" \
     "$ROOT_DIR"

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -1,6 +1,33 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+  cat <<'EOF'
+Usage: docker-setup.sh [--build-only]
+
+Options:
+  --build-only   Build the Docker image and exit (skip onboarding + starting gateway).
+EOF
+}
+
+build_only=false
+for arg in "$@"; do
+  case "$arg" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --build-only)
+      build_only=true
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMPOSE_FILE="$ROOT_DIR/docker-compose.yml"
 EXTRA_COMPOSE_FILE="$ROOT_DIR/docker-compose.extra.yml"
@@ -343,6 +370,12 @@ else
     echo "ERROR: Failed to pull image $IMAGE_NAME. Please check the image name and your access permissions." >&2
     exit 1
   fi
+fi
+
+if [[ "$build_only" == true ]]; then
+  echo ""
+  echo "==> Build-only mode: skipping onboarding and gateway start."
+  exit 0
 fi
 
 echo ""


### PR DESCRIPTION
#### Summary
  Harden Docker UID/GID remapping and docker-setup so bind-mounted volumes don’t silently keep `node` at UID 1000 (which breaks permissions). 
  
  Also clarify the utility of having `/home/node/.openclaw/bin` on PATH for tool shims. (e.g. rg if its not on the docker container, but available via a local install and mounted in the container)

lobster-biscuit FTW

  #### Repro Steps
  1. Build with `OPENCLAW_UID` set to a UID already used by a different user in the base image.
  2. Run with bind-mounted state/workspace.
  3. Previously, build succeeded but `node` remained UID 1000, leaving permissions broken.

  #### Root Cause
  - UID remap skipped `usermod` when the target UID belonged to a different user, silently leaving `node` at UID 1000.
  - docker-setup accepted non-numeric IDs without validation.

  #### Behavior Changes
  - **Dockerfile**
    - Accepts `OPENCLAW_UID`/`OPENCLAW_GID` build args.
    - Prepends `/home/node/.openclaw/bin` so tool shims in the mounted state volume are discoverable.
    - Hard-fails if `OPENCLAW_UID` collides with a different user.
  - **docker-setup.sh**
    - Adds `--build-only` mode.
    - Validates numeric UID/GID (falls back to defaults if `id -u/-g` fails).
    - Persists `OPENCLAW_UID/GID` in `.env` and passes them into docker build args.
  - **Docs**
    - `docs/install/docker.md` now explains that `/home/node/.openclaw/bin` contains shim scripts that exec tools under `/home/node/.openclaw/tools/...`, with a concrete example.

  #### Tests
  Not run (Dockerfile + shell script + docs changes only).

  #### Manual Testing (omit if N/A)
  N/A

  ### Prerequisites
  - Docker + Docker Compose installed.

  ### Steps
  1. Build with a colliding `OPENCLAW_UID` (expect failure with explicit error).
  2. Build with a free UID/GID (expect success and remapped `node` user).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hardens Docker UID/GID remapping to prevent silent permission failures when `OPENCLAW_UID` collides with existing users. The Dockerfile now fails fast on UID collisions (preventing `node` from staying at default UID 1000), and `docker-setup.sh` adds `--build-only` mode plus persists UID/GID to `.env`. Also prepends `/home/node/.openclaw/bin` to PATH for tool shims.

- Dockerfile: added build args `OPENCLAW_UID`/`OPENCLAW_GID`, remapping logic with collision checks for UID (hard-fails on collision), and PATH update for tool shims
- docker-setup.sh: added argument parsing for `--build-only`, UID/GID persistence in `.env`, and passes build args to docker build
- Previous review threads identified two GID issues (collision detection asymmetry vs UID, and groupmod ordering) that remain unaddressed

<h3>Confidence Score: 3/5</h3>

- Safe to merge with known GID edge cases documented in previous threads
- The UID remapping correctly prevents the original silent failure mode, and the docker-setup flow is sound. Score reflects that two GID-related issues were already identified in previous review threads (GID collision handling differs from UID, and groupmod sequencing) but haven't been addressed yet. These are edge cases that only affect builds with pre-existing GID collisions
- No files require special attention beyond the documented GID edge cases

<sub>Last reviewed commit: 8536c82</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->