### PR TITLE
ui: suppress no-op tool cards

### DIFF
--- a/ui/src/ui/app-tool-stream.ts
+++ b/ui/src/ui/app-tool-stream.ts
@@ -414,6 +414,7 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
   }
   const name = typeof data.name === "string" ? data.name : "tool";
   const phase = typeof data.phase === "string" ? data.phase : "";
+  const isError = data.isError === true;
   const args = phase === "start" ? data.args : undefined;
   const output =
     phase === "update"
@@ -431,7 +432,8 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
       sessionKey,
       name,
       args,
-      output: output || undefined,
+      output:
+        phase === "result" && isError && !output ? "Error (details hidden)" : output || undefined,
       startedAt: typeof payload.ts === "number" ? payload.ts : now,
       updatedAt: now,
       message: {},
@@ -444,7 +446,8 @@ export function handleAgentEvent(host: ToolStreamHost, payload?: AgentEventPaylo
       entry.args = args;
     }
     if (output !== undefined) {
-      entry.output = output || undefined;
+      entry.output =
+        phase === "result" && isError && !output ? "Error (details hidden)" : output || undefined;
     }
     entry.updatedAt = now;
   }

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { extractToolCards } from "./tool-cards.ts";
+
+describe("extractToolCards", () => {
+  const suppressedTool = "ikentic_locus_check_task";
+
+  it("suppresses call and empty result cards for suppressWhenNoOutput tools when no result text exists", () => {
+    const message = {
+      content: [
+        { type: "tool_call", name: suppressedTool, arguments: { taskId: "task-1" } },
+        { type: "tool_result", name: suppressedTool, content: "" },
+      ],
+    };
+
+    const cards = extractToolCards(message);
+
+    expect(cards).toEqual([]);
+  });
+
+  it("keeps cards for non-suppressed tools when no result text exists", () => {
+    const message = {
+      content: [
+        { type: "tool_call", name: "search", arguments: {} },
+        { type: "tool_result", name: "search", content: "" },
+      ],
+    };
+
+    const cards = extractToolCards(message);
+
+    expect(cards.map((card) => card.kind)).toEqual(["call", "result"]);
+  });
+
+  it("does not suppress when any result has text", () => {
+    const message = {
+      content: [
+        { type: "tool_call", name: suppressedTool, arguments: {} },
+        { type: "tool_result", name: "search", content: "ok" },
+      ],
+    };
+
+    const cards = extractToolCards(message);
+
+    expect(cards.some((card) => card.kind === "call" && card.name === suppressedTool)).toBe(true);
+  });
+});

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -30,16 +30,19 @@ describe("extractToolCards", () => {
     expect(cards.map((card) => card.kind)).toEqual(["call", "result"]);
   });
 
-  it("does not suppress when any result has text", () => {
+  it("does not suppress suppressible tool cards when that tool result has text", () => {
     const message = {
       content: [
         { type: "tool_call", name: suppressedTool, arguments: {} },
-        { type: "tool_result", name: "search", content: "ok" },
+        { type: "tool_result", name: suppressedTool, content: "ok" },
       ],
     };
 
     const cards = extractToolCards(message);
 
-    expect(cards.some((card) => card.kind === "call" && card.name === suppressedTool)).toBe(true);
+    expect(cards.map((card) => `${card.kind}:${card.name}`)).toEqual([
+      `call:${suppressedTool}`,
+      `result:${suppressedTool}`,
+    ]);
   });
 });

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -46,7 +46,7 @@ describe("extractToolCards", () => {
     ]);
   });
 
-  it("suppresses only suppressible tools with empty output when another tool has text", () => {
+  it("suppresses empty suppressible tool even when other tools have output", () => {
     const message = {
       content: [
         { type: "tool_call", name: suppressedTool, arguments: { taskId: "task-1" } },

--- a/ui/src/ui/chat/tool-cards.test.ts
+++ b/ui/src/ui/chat/tool-cards.test.ts
@@ -45,4 +45,22 @@ describe("extractToolCards", () => {
       `result:${suppressedTool}`,
     ]);
   });
+
+  it("suppresses only suppressible tools with empty output when another tool has text", () => {
+    const message = {
+      content: [
+        { type: "tool_call", name: suppressedTool, arguments: { taskId: "task-1" } },
+        { type: "tool_result", name: suppressedTool, content: "" },
+        { type: "tool_call", name: "search", arguments: { q: "test" } },
+        { type: "tool_result", name: "search", content: "ok" },
+      ],
+    };
+
+    const cards = extractToolCards(message);
+
+    expect(cards.map((card) => `${card.kind}:${card.name}`)).toEqual([
+      "call:search",
+      "result:search",
+    ]);
+  });
 });

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -51,9 +51,18 @@ export function extractToolCards(message: unknown): ToolCard[] {
 
   const hasResultText = cards.some((card) => card.kind === "result" && Boolean(card.text?.trim()));
   if (!hasResultText) {
-    return cards.filter(
-      (card) => card.kind !== "call" || !shouldSuppressToolCardWhenNoOutput(card.name),
-    );
+    return cards.filter((card) => {
+      if (!shouldSuppressToolCardWhenNoOutput(card.name)) {
+        return true;
+      }
+      if (card.kind === "call") {
+        return false;
+      }
+      if (card.kind === "result" && !card.text?.trim()) {
+        return false;
+      }
+      return true;
+    });
   }
 
   return cards;

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -1,6 +1,6 @@
 import { html, nothing } from "lit";
-import { icons } from "../icons.ts";
 import type { ToolCard } from "../types/chat-types.ts";
+import { icons } from "../icons.ts";
 import {
   formatToolDetail,
   resolveToolDisplay,
@@ -49,23 +49,26 @@ export function extractToolCards(message: unknown): ToolCard[] {
     cards.push({ kind: "result", name, text });
   }
 
-  const hasResultText = cards.some((card) => card.kind === "result" && Boolean(card.text?.trim()));
-  if (!hasResultText) {
-    return cards.filter((card) => {
-      if (!shouldSuppressToolCardWhenNoOutput(card.name)) {
-        return true;
-      }
-      if (card.kind === "call") {
-        return false;
-      }
-      if (card.kind === "result" && !card.text?.trim()) {
-        return false;
-      }
+  const toolsWithResultText = new Set(
+    cards
+      .filter((card) => card.kind === "result" && Boolean(card.text?.trim()))
+      .map((card) => card.name.toLowerCase()),
+  );
+  return cards.filter((card) => {
+    if (!shouldSuppressToolCardWhenNoOutput(card.name)) {
       return true;
-    });
-  }
-
-  return cards;
+    }
+    if (toolsWithResultText.has(card.name.toLowerCase())) {
+      return true;
+    }
+    if (card.kind === "call") {
+      return false;
+    }
+    if (card.kind === "result" && !card.text?.trim()) {
+      return false;
+    }
+    return true;
+  });
 }
 
 export function renderToolCardSidebar(card: ToolCard, onOpenSidebar?: (content: string) => void) {

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -1,11 +1,11 @@
 import { html, nothing } from "lit";
-import type { ToolCard } from "../types/chat-types.ts";
 import { icons } from "../icons.ts";
 import {
   formatToolDetail,
   resolveToolDisplay,
   shouldSuppressToolCardWhenNoOutput,
 } from "../tool-display.ts";
+import type { ToolCard } from "../types/chat-types.ts";
 import { TOOL_INLINE_THRESHOLD } from "./constants.ts";
 import { extractTextCached } from "./message-extract.ts";
 import { isToolResultMessage } from "./message-normalizer.ts";

--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -1,7 +1,11 @@
 import { html, nothing } from "lit";
 import { icons } from "../icons.ts";
-import { formatToolDetail, resolveToolDisplay } from "../tool-display.ts";
 import type { ToolCard } from "../types/chat-types.ts";
+import {
+  formatToolDetail,
+  resolveToolDisplay,
+  shouldSuppressToolCardWhenNoOutput,
+} from "../tool-display.ts";
 import { TOOL_INLINE_THRESHOLD } from "./constants.ts";
 import { extractTextCached } from "./message-extract.ts";
 import { isToolResultMessage } from "./message-normalizer.ts";
@@ -43,6 +47,13 @@ export function extractToolCards(message: unknown): ToolCard[] {
       "tool";
     const text = extractTextCached(message) ?? undefined;
     cards.push({ kind: "result", name, text });
+  }
+
+  const hasResultText = cards.some((card) => card.kind === "result" && Boolean(card.text?.trim()));
+  if (!hasResultText) {
+    return cards.filter(
+      (card) => card.kind !== "call" || !shouldSuppressToolCardWhenNoOutput(card.name),
+    );
   }
 
   return cards;

--- a/ui/src/ui/tool-display.json
+++ b/ui/src/ui/tool-display.json
@@ -113,6 +113,12 @@
         "a2ui_reset": { "label": "A2UI reset", "detailKeys": ["node", "nodeId"] }
       }
     },
+    "ikentic_locus_check_task": {
+      "icon": "check",
+      "title": "Ike Locus Check Task",
+      "detailKeys": ["taskId"],
+      "suppressWhenNoOutput": true
+    },
     "nodes": {
       "icon": "smartphone",
       "title": "Nodes",

--- a/ui/src/ui/tool-display.ts
+++ b/ui/src/ui/tool-display.ts
@@ -16,6 +16,7 @@ import rawConfig from "./tool-display.json" with { type: "json" };
 
 type ToolDisplaySpec = ToolDisplaySpecBase & {
   icon?: string;
+  suppressWhenNoOutput?: boolean;
 };
 
 type ToolDisplayConfig = {
@@ -126,6 +127,11 @@ export function resolveToolDisplay(params: {
     verb,
     detail,
   };
+}
+
+export function shouldSuppressToolCardWhenNoOutput(name?: string): boolean {
+  const key = normalizeToolName(name).toLowerCase();
+  return TOOL_MAP[key]?.suppressWhenNoOutput === true;
 }
 
 export function formatToolDetail(display: ToolDisplay): string | undefined {


### PR DESCRIPTION
#### Summary

  Tool calls that return no output were still rendering empty or near-empty cards in the chat UI. This is noisy and confusing for users because it implies “something happened” without any usable result, and it can clutter the transcript when tools are run opportunistically (e.g., background checks or silent validations). We now allow tools to opt into suppression when there is no result text, and we filter both the call card and an empty result card in those cases. Separately, when a tool finishes with an error but provides no output, we now render a short fallback message so the user sees a meaningful error state rather than a blank card.

  #### Screenshots or Video

  Not captured.

  #### Accessibility Impact

  None expected; this removes empty cards and adds plain-text error context.

  #### Tests

  - `pnpm test` (failed: `src/agents/bash-tools.exec.path.test.ts` — login shell PATH includes local `.zshenv`/host PATH entries in this environment)

  #### Manual Testing

  ### Prerequisites

  - None.

  ### Steps

  3. Trigger a tool call that errors with no output and verify the fallback error text is displayed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements per-tool suppression for empty tool cards by checking if each suppressible tool has result text, allowing tools with `suppressWhenNoOutput: true` to hide their call and result cards when they produce no output.

- Added `suppressWhenNoOutput` flag to tool display config (`ikentic_locus_check_task`)
- Per-tool filtering logic correctly matches each tool's results to determine suppression
- Error fallback text "Error (details hidden)" now displays for tools that fail with no output
- Test coverage includes single tool, multi-tool, and mixed scenarios

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The implementation correctly handles per-tool suppression with proper test coverage. The logic is sound and addresses the stated requirements. The error fallback prevents blank error cards. No critical issues found, though the previous review comments appear to reference an older implementation that has already been corrected.
- No files require special attention

<sub>Last reviewed commit: 31a10bd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->