### PR TITLE
fix(slack): enable session-store lookup for announce target accountId

### DIFF
--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -82,6 +82,26 @@ const installRegistry = async () => {
           },
         },
       },
+      {
+        pluginId: "slack",
+        source: "test",
+        plugin: {
+          id: "slack",
+          meta: {
+            id: "slack",
+            label: "Slack",
+            selectionLabel: "Slack",
+            docsPath: "/channels/slack",
+            blurb: "Slack test stub.",
+            preferSessionLookupForAnnounceTarget: true,
+          },
+          capabilities: { chatTypes: ["direct", "channel", "thread"] },
+          config: {
+            listAccountIds: () => ["default"],
+            resolveAccount: () => ({}),
+          },
+        },
+      },
     ]),
   );
 };
@@ -243,6 +263,36 @@ describe("resolveAnnounceTarget", () => {
     const first = callGatewayMock.mock.calls[0]?.[0] as { method?: string } | undefined;
     expect(first).toBeDefined();
     expect(first?.method).toBe("sessions.list");
+  });
+
+  it("hydrates Slack accountId from sessions.list when available", async () => {
+    const { resolveAnnounceTarget } = await loadResolveAnnounceTarget();
+    callGatewayMock.mockResolvedValueOnce({
+      sessions: [
+        {
+          key: "agent:main:slack:channel:C0123ABC",
+          deliveryContext: {
+            channel: "slack",
+            to: "C0123ABC",
+            accountId: "work",
+          },
+        },
+      ],
+    });
+
+    const target = await resolveAnnounceTarget({
+      sessionKey: "agent:main:slack:channel:C0123ABC",
+      displayKey: "agent:main:slack:channel:C0123ABC",
+    });
+    expect(target).toEqual({
+      channel: "slack",
+      to: "C0123ABC",
+      accountId: "work",
+    });
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    const slackFirst = callGatewayMock.mock.calls[0]?.[0] as { method?: string } | undefined;
+    expect(slackFirst).toBeDefined();
+    expect(slackFirst?.method).toBe("sessions.list");
   });
 });
 


### PR DESCRIPTION
## Summary

- Problem: In multi-account Slack setups, `sessions_send` announce replies use the default bot token instead of the target agent's token because `resolveAnnounceTarget()` returns the key-parsed fallback (no `accountId`) for Slack
- Why it matters: Messages appear under the wrong bot identity, breaking multi-agent setups
- What changed: Added `preferSessionLookupForAnnounceTarget: true` to Slack channel plugin meta, matching the existing WhatsApp pattern
- What did NOT change (scope boundary): No changes to `resolveAnnounceTarget()` logic or any other channel plugin

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30956
- Related #14854 (original report, auto-closed by stale bot)

## User-visible / Behavior Changes

In multi-account Slack setups, `sessions_send` announce replies now post using the correct bot token for the target agent's Slack account instead of always using the default account's token.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: All
- Runtime/container: Any
- Model/provider: N/A
- Integration/channel (if any): Slack (multi-account)
- Relevant config (redacted): Two Slack accounts with separate bot tokens

### Steps

1. Configure two Slack accounts (default + secondary) with separate bot tokens
2. Agent A (default account) sends a message to Agent B (secondary account) via `sessions_send`
3. Agent B's announce reply posts to the channel

### Expected

- Reply is posted using Agent B's bot token

### Actual

- Reply is posted using Agent A's (default) bot token

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test in `src/agents/tools/sessions.test.ts` verifies `resolveAnnounceTarget()` hydrates `accountId` from `sessions.list` for Slack sessions. Test fails without the flag.

## Human Verification (required)

- Verified scenarios: New test confirms session-store lookup path is triggered for Slack
- Edge cases checked: Single-account setups unaffected (accountId absence is harmless when only one account exists)
- What you did **not** verify: Live multi-account Slack environment

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove `preferSessionLookupForAnnounceTarget: true` from `extensions/slack/src/channel.ts`
- Files/config to restore: `extensions/slack/src/channel.ts`
- Known bad symptoms reviewers should watch for: Announce messages failing or timing out due to session-store lookup errors

## Risks and Mitigations

- Risk: Session-store lookup adds a `sessions.list` call to the announce path for Slack
  - Mitigation: WhatsApp has used this exact path since the feature was introduced with no reported issues
