### PR TITLE
fix: prevent subagent announce from leaking internal prompts and stats

### DIFF
--- a/src/agents/subagent-announce-queue.ts
+++ b/src/agents/subagent-announce-queue.ts
@@ -15,6 +15,7 @@ import {
 
 export type AnnounceQueueItem = {
   prompt: string;
+  extraSystemPrompt?: string;
   summaryLine?: string;
   enqueuedAt: number;
   sessionKey: string;

--- a/src/agents/subagent-announce-queue.ts
+++ b/src/agents/subagent-announce-queue.ts
@@ -151,7 +151,11 @@ function scheduleAnnounceDrain(key: string) {
             break;
           }
           // Keep the original extraSystemPrompt when overriding the prompt with a summary
-          await queue.send({ ...next, prompt: summaryPrompt, extraSystemPrompt: next.extraSystemPrompt });
+          await queue.send({
+            ...next,
+            prompt: summaryPrompt,
+            extraSystemPrompt: next.extraSystemPrompt,
+          });
           continue;
         }
 

--- a/src/agents/subagent-announce-queue.ts
+++ b/src/agents/subagent-announce-queue.ts
@@ -131,7 +131,16 @@ function scheduleAnnounceDrain(key: string) {
           if (!last) {
             break;
           }
-          await queue.send({ ...last, prompt });
+          // Merge extraSystemPrompt from all collected items so findings are not lost
+          const mergedSystemPrompt = items
+            .map((item) => item.extraSystemPrompt)
+            .filter(Boolean)
+            .join("\n\n---\n\n");
+          await queue.send({
+            ...last,
+            prompt,
+            extraSystemPrompt: mergedSystemPrompt || undefined,
+          });
           continue;
         }
 
@@ -141,7 +150,8 @@ function scheduleAnnounceDrain(key: string) {
           if (!next) {
             break;
           }
-          await queue.send({ ...next, prompt: summaryPrompt });
+          // Keep the original extraSystemPrompt when overriding the prompt with a summary
+          await queue.send({ ...next, prompt: summaryPrompt, extraSystemPrompt: next.extraSystemPrompt });
           continue;
         }
 

--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -100,7 +100,8 @@ describe("subagent announce formatting", () => {
     const msg = call?.params?.message as string;
     const systemPrompt = call?.params?.extraSystemPrompt as string;
     expect(call?.params?.sessionKey).toBe("agent:main:main");
-    // User-visible message is clean – no internal details
+    // User-visible message keeps the original format but no internal details
+    expect(msg).toContain("subagent task");
     expect(msg).toContain("do thing");
     expect(msg).toContain("failed");
     expect(msg).not.toContain("Findings:");

--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -575,4 +575,96 @@ describe("subagent announce formatting", () => {
     expect(accountIds).toContain("acct-b");
     expect(agentSpy).toHaveBeenCalledTimes(2);
   });
+
+  it("merges extraSystemPrompt from all collected items in collect mode", async () => {
+    const { runSubagentAnnounceFlow } = await import("./subagent-announce.js");
+    embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(true);
+    embeddedRunMock.isEmbeddedPiRunStreaming.mockReturnValue(false);
+    readLatestAssistantReplyMock
+      .mockResolvedValueOnce("reply from task A")
+      .mockResolvedValueOnce("reply from task B");
+    sessionStore = {
+      "agent:main:main": {
+        sessionId: "session-merge",
+        lastChannel: "whatsapp",
+        lastTo: "+1555",
+        queueMode: "collect",
+        queueDebounceMs: 0,
+      },
+    };
+
+    await Promise.all([
+      runSubagentAnnounceFlow({
+        childSessionKey: "agent:main:subagent:merge-a",
+        childRunId: "run-merge-a",
+        requesterSessionKey: "main",
+        requesterDisplayKey: "main",
+        task: "task A",
+        timeoutMs: 1000,
+        cleanup: "keep",
+        waitForCompletion: false,
+        startedAt: 10,
+        endedAt: 20,
+        outcome: { status: "ok" },
+      }),
+      runSubagentAnnounceFlow({
+        childSessionKey: "agent:main:subagent:merge-b",
+        childRunId: "run-merge-b",
+        requesterSessionKey: "main",
+        requesterDisplayKey: "main",
+        task: "task B",
+        timeoutMs: 1000,
+        cleanup: "keep",
+        waitForCompletion: false,
+        startedAt: 10,
+        endedAt: 20,
+        outcome: { status: "ok" },
+      }),
+    ]);
+
+    await expect.poll(() => agentSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+    const call = agentSpy.mock.calls[0]?.[0] as {
+      params?: { extraSystemPrompt?: string };
+    };
+    const systemPrompt = call?.params?.extraSystemPrompt ?? "";
+    // Both tasks' findings should be present in the merged extraSystemPrompt
+    expect(systemPrompt).toContain("reply from task A");
+    expect(systemPrompt).toContain("reply from task B");
+  });
+
+  it("includes findings in steer path message since it only supports plain text", async () => {
+    const { runSubagentAnnounceFlow } = await import("./subagent-announce.js");
+    embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(true);
+    embeddedRunMock.isEmbeddedPiRunStreaming.mockReturnValue(true);
+    embeddedRunMock.queueEmbeddedPiMessage.mockReturnValue(true);
+    readLatestAssistantReplyMock.mockResolvedValue("steer findings here");
+    sessionStore = {
+      "agent:main:main": {
+        sessionId: "session-steer-findings",
+        lastChannel: "whatsapp",
+        lastTo: "+1555",
+        queueMode: "steer",
+      },
+    };
+
+    await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:steer-test",
+      childRunId: "run-steer-findings",
+      requesterSessionKey: "main",
+      requesterDisplayKey: "main",
+      task: "lookup weather",
+      timeoutMs: 1000,
+      cleanup: "keep",
+      waitForCompletion: false,
+      startedAt: 10,
+      endedAt: 20,
+      outcome: { status: "ok" },
+    });
+
+    expect(embeddedRunMock.queueEmbeddedPiMessage).toHaveBeenCalled();
+    const steeredText = embeddedRunMock.queueEmbeddedPiMessage.mock.calls[0]?.[1] as string;
+    expect(steeredText).toContain("lookup weather");
+    expect(steeredText).toContain("steer findings here");
+    expect(steeredText).not.toContain("Stats:");
+  });
 });

--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -102,14 +102,15 @@ describe("subagent announce formatting", () => {
     expect(call?.params?.sessionKey).toBe("agent:main:main");
     // User-visible message keeps the original format but no internal details
     expect(msg).toContain("subagent task");
-    expect(msg).toContain("do thing");
     expect(msg).toContain("failed");
+    // task prompt should NOT leak into user-visible message (only label or generic "task")
     expect(msg).not.toContain("Findings:");
     expect(msg).not.toContain("Stats:");
     expect(msg).not.toContain("Summarize");
-    // Findings and instructions are in extraSystemPrompt (not visible to user)
+    // Findings, task prompt, and instructions are in extraSystemPrompt (not visible to user)
     expect(systemPrompt).toContain("Findings:");
     expect(systemPrompt).toContain("raw subagent reply");
+    expect(systemPrompt).toContain("do thing");
     expect(systemPrompt).toContain("craft a natural response");
   });
 

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -122,6 +122,7 @@ async function sendAnnounce(item: AnnounceQueueItem) {
     params: {
       sessionKey: item.sessionKey,
       message: item.prompt,
+      extraSystemPrompt: item.extraSystemPrompt,
       channel: origin?.channel,
       accountId: origin?.accountId,
       to: origin?.to,
@@ -169,6 +170,7 @@ function loadRequesterSessionEntry(requesterSessionKey: string) {
 async function maybeQueueSubagentAnnounce(params: {
   requesterSessionKey: string;
   triggerMessage: string;
+  extraSystemPrompt?: string;
   summaryLine?: string;
   requesterOrigin?: DeliveryContext;
 }): Promise<"steered" | "queued" | "none"> {
@@ -188,6 +190,7 @@ async function maybeQueueSubagentAnnounce(params: {
 
   const shouldSteer = queueSettings.mode === "steer" || queueSettings.mode === "steer-backlog";
   if (shouldSteer) {
+    // steer path only supports plain text; send the clean trigger message
     const steered = queueEmbeddedPiMessage(sessionId, params.triggerMessage);
     if (steered) {
       return "steered";
@@ -205,6 +208,7 @@ async function maybeQueueSubagentAnnounce(params: {
       key: canonicalKey,
       item: {
         prompt: params.triggerMessage,
+        extraSystemPrompt: params.extraSystemPrompt,
         summaryLine: params.summaryLine,
         enqueuedAt: Date.now(),
         sessionKey: canonicalKey,
@@ -475,12 +479,13 @@ export async function runSubagentAnnounceFlow(params: {
       outcome = { status: "unknown" };
     }
 
-    // Build stats
+    // Build stats (internal logging only – never sent to user)
     const statsLine = await buildSubagentStatsLine({
       sessionKey: params.childSessionKey,
       startedAt: params.startedAt,
       endedAt: params.endedAt,
     });
+    defaultRuntime.info?.(`subagent announce stats [${params.childSessionKey}]: ${statsLine}`);
 
     // Build status label
     const statusLabel =
@@ -492,25 +497,26 @@ export async function runSubagentAnnounceFlow(params: {
             ? `failed: ${outcome.error || "unknown error"}`
             : "finished with unknown status";
 
-    // Build instructional message for main agent
+    // Build a clean, user-visible message (no internal details)
     const announceType = params.announceType ?? "subagent task";
     const taskLabel = params.label || params.task || "task";
-    const triggerMessage = [
-      `A ${announceType} "${taskLabel}" just ${statusLabel}.`,
+    const triggerMessage = `The background task "${taskLabel}" has ${statusLabel}.`;
+
+    // Internal context for the agent (not visible to the user)
+    const announceSystemPrompt = [
+      "The user will see the message above. Use the findings below to craft a natural response.",
+      "Keep it brief (1-2 sentences). Flow it into the conversation naturally.",
+      `Do not mention technical details like tokens, stats, or that this was a ${announceType}.`,
+      "You can respond with NO_REPLY if no announcement is needed (e.g., internal task with no user-facing result).",
       "",
       "Findings:",
       reply || "(no output)",
-      "",
-      statsLine,
-      "",
-      "Summarize this naturally for the user. Keep it brief (1-2 sentences). Flow it into the conversation naturally.",
-      `Do not mention technical details like tokens, stats, or that this was a ${announceType}.`,
-      "You can respond with NO_REPLY if no announcement is needed (e.g., internal task with no user-facing result).",
     ].join("\n");
 
     const queued = await maybeQueueSubagentAnnounce({
       requesterSessionKey: params.requesterSessionKey,
       triggerMessage,
+      extraSystemPrompt: announceSystemPrompt,
       summaryLine: taskLabel,
       requesterOrigin,
     });
@@ -534,6 +540,7 @@ export async function runSubagentAnnounceFlow(params: {
       params: {
         sessionKey: params.requesterSessionKey,
         message: triggerMessage,
+        extraSystemPrompt: announceSystemPrompt,
         deliver: true,
         channel: directOrigin?.channel,
         accountId: directOrigin?.accountId,

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -503,7 +503,7 @@ export async function runSubagentAnnounceFlow(params: {
     // Build a clean, user-visible message (no internal details)
     const announceType = params.announceType ?? "subagent task";
     const taskLabel = params.label || params.task || "task";
-    const triggerMessage = `The background task "${taskLabel}" has ${statusLabel}.`;
+    const triggerMessage = `A ${announceType} "${taskLabel}" just ${statusLabel}.`;
 
     // Internal context for the agent (not visible to the user)
     const announceSystemPrompt = [

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -502,7 +502,7 @@ export async function runSubagentAnnounceFlow(params: {
 
     // Build a clean, user-visible message (no internal details)
     const announceType = params.announceType ?? "subagent task";
-    const taskLabel = params.label || params.task || "task";
+    const taskLabel = params.label || "task";
     const triggerMessage = `A ${announceType} "${taskLabel}" just ${statusLabel}.`;
 
     // Internal context for the agent (not visible to the user)
@@ -511,6 +511,8 @@ export async function runSubagentAnnounceFlow(params: {
       "Keep it brief (1-2 sentences). Flow it into the conversation naturally.",
       `Do not mention technical details like tokens, stats, or that this was a ${announceType}.`,
       "You can respond with NO_REPLY if no announcement is needed (e.g., internal task with no user-facing result).",
+      "",
+      `Task: ${params.task || taskLabel}`,
       "",
       "Findings:",
       reply || "(no output)",


### PR DESCRIPTION
## Summary

- Move subagent findings and LLM instructions from user-visible `message` to `extraSystemPrompt` (hidden from users)
- Remove `statsLine` (token counts, session IDs, file paths, costs) from the announce payload; log it internally via `defaultRuntime.info()` instead
- Add `extraSystemPrompt` field to `AnnounceQueueItem` so all delivery paths (direct, queue, steer) handle it correctly

## Test plan

- [x] All 14 existing `subagent-announce.format.test.ts` tests pass
- [x] Verified `message` no longer contains `Findings:`, `Stats:`, or `Summarize` instructions
- [x] Verified `extraSystemPrompt` contains findings and agent instructions
- [x] No regressions in other subagent-related tests

Fixes #6669

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This change moves subagent findings/instructions out of the user-visible `message` and into a new `extraSystemPrompt` field (and stops sending stats in the announce payload, logging them internally instead). It also plumbs `extraSystemPrompt` through `AnnounceQueueItem` and the direct announce send path so the gateway receives hidden context.

One issue remains in the announce queue draining logic: when messages are *collected* into a single combined prompt, or when overflow is *summarized*, the corresponding `extraSystemPrompt` context is not merged/preserved correctly. In those queue scenarios, the hidden findings/instructions added by this PR can be silently dropped or mismatched, leading to inconsistent announce behavior compared to direct delivery.

<h3>Confidence Score: 3/5</h3>

- This PR is moderately safe to merge but has a real regression in queued announce aggregation paths.
- Core goal (stop leaking internal prompts/stats via user-visible message) is implemented and covered by existing tests, but collect/overflow queue drain paths don’t preserve or correctly associate the new extraSystemPrompt, so hidden findings/instructions can be dropped under backlog/overflow scenarios.
- src/agents/subagent-announce-queue.ts

<sub>Last reviewed commit: 5b67d3c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->