### PR TITLE
feat(iOS): QR code scanning for gateway onboarding

### DIFF
--- a/apps/ios/Sources/Model/NodeAppModel.swift
+++ b/apps/ios/Sources/Model/NodeAppModel.swift
@@ -457,6 +457,8 @@ final class NodeAppModel {
         switch route {
         case let .agent(link):
             await self.handleAgentDeepLink(link, originalURL: url)
+        case .gateway:
+            break
         }
     }
 

--- a/apps/ios/Sources/Onboarding/OnboardingStateStore.swift
+++ b/apps/ios/Sources/Onboarding/OnboardingStateStore.swift
@@ -28,9 +28,11 @@ enum OnboardingStateStore {
         return appModel.gatewayServerName == nil
     }
 
-    static func markCompleted(mode: OnboardingConnectionMode, defaults: UserDefaults = .standard) {
+    static func markCompleted(mode: OnboardingConnectionMode? = nil, defaults: UserDefaults = .standard) {
         defaults.set(true, forKey: Self.completedDefaultsKey)
-        defaults.set(mode.rawValue, forKey: Self.lastModeDefaultsKey)
+        if let mode {
+            defaults.set(mode.rawValue, forKey: Self.lastModeDefaultsKey)
+        }
         defaults.set(Int(Date().timeIntervalSince1970), forKey: Self.lastSuccessTimeDefaultsKey)
     }
 

--- a/apps/ios/Sources/Onboarding/QRScannerView.swift
+++ b/apps/ios/Sources/Onboarding/QRScannerView.swift
@@ -1,0 +1,65 @@
+import OpenClawKit
+import SwiftUI
+import VisionKit
+
+struct QRScannerView: UIViewControllerRepresentable {
+    let onGatewayLink: (GatewayConnectDeepLink) -> Void
+    let onError: (String) -> Void
+    let onDismiss: () -> Void
+
+    func makeUIViewController(context: Context) -> DataScannerViewController {
+        let scanner = DataScannerViewController(
+            recognizedDataTypes: [.barcode(symbologies: [.qr])],
+            isHighlightingEnabled: true)
+        scanner.delegate = context.coordinator
+        try? scanner.startScanning()
+        return scanner
+    }
+
+    func updateUIViewController(_: DataScannerViewController, context _: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    final class Coordinator: NSObject, DataScannerViewControllerDelegate {
+        let parent: QRScannerView
+        private var handled = false
+
+        init(parent: QRScannerView) {
+            self.parent = parent
+        }
+
+        func dataScanner(_: DataScannerViewController, didAdd items: [RecognizedItem], allItems _: [RecognizedItem]) {
+            guard !self.handled else { return }
+            for item in items {
+                guard case let .barcode(barcode) = item,
+                      let payload = barcode.payloadStringValue
+                else { continue }
+
+                // Try setup code format first (base64url JSON from /pair qr).
+                if let link = GatewayConnectDeepLink.fromSetupCode(payload) {
+                    self.handled = true
+                    self.parent.onGatewayLink(link)
+                    return
+                }
+
+                // Fall back to deep link URL format (openclaw://gateway?...).
+                if let url = URL(string: payload),
+                   let route = DeepLinkParser.parse(url),
+                   case let .gateway(link) = route
+                {
+                    self.handled = true
+                    self.parent.onGatewayLink(link)
+                    return
+                }
+            }
+        }
+
+        func dataScanner(_: DataScannerViewController, didRemove _: [RecognizedItem], allItems _: [RecognizedItem]) {}
+
+        func dataScanner(_: DataScannerViewController, becameUnavailableWithError error: DataScannerViewController.ScanningUnavailable) {
+            self.parent.onError("Camera is not available on this device.")
+        }
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/DeepLinks.swift
@@ -2,6 +2,56 @@ import Foundation
 
 public enum DeepLinkRoute: Sendable, Equatable {
     case agent(AgentDeepLink)
+    case gateway(GatewayConnectDeepLink)
+}
+
+public struct GatewayConnectDeepLink: Codable, Sendable, Equatable {
+    public let host: String
+    public let port: Int
+    public let tls: Bool
+    public let token: String?
+    public let password: String?
+
+    public init(host: String, port: Int, tls: Bool, token: String?, password: String?) {
+        self.host = host
+        self.port = port
+        self.tls = tls
+        self.token = token
+        self.password = password
+    }
+
+    public var websocketURL: URL? {
+        let scheme = self.tls ? "wss" : "ws"
+        return URL(string: "\(scheme)://\(self.host):\(self.port)")
+    }
+
+    /// Parse a device-pair setup code (base64url-encoded JSON: `{url, token?, password?}`).
+    public static func fromSetupCode(_ code: String) -> GatewayConnectDeepLink? {
+        guard let data = Self.decodeBase64Url(code) else { return nil }
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        guard let urlString = json["url"] as? String,
+              let parsed = URLComponents(string: urlString),
+              let hostname = parsed.host, !hostname.isEmpty
+        else { return nil }
+
+        let scheme = parsed.scheme ?? "ws"
+        let tls = scheme == "wss"
+        let port = parsed.port ?? 18789
+        let token = json["token"] as? String
+        let password = json["password"] as? String
+        return GatewayConnectDeepLink(host: hostname, port: port, tls: tls, token: token, password: password)
+    }
+
+    private static func decodeBase64Url(_ input: String) -> Data? {
+        var base64 = input
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = base64.count % 4
+        if remainder > 0 {
+            base64.append(contentsOf: String(repeating: "=", count: 4 - remainder))
+        }
+        return Data(base64Encoded: base64)
+    }
 }
 
 public struct AgentDeepLink: Codable, Sendable, Equatable {
@@ -69,6 +119,23 @@ public enum DeepLinkParser {
                     channel: query["channel"],
                     timeoutSeconds: timeoutSeconds,
                     key: query["key"]))
+
+        case "gateway":
+            guard let hostParam = query["host"],
+                  !hostParam.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else {
+                return nil
+            }
+            let port = query["port"].flatMap { Int($0) } ?? 18789
+            let tls = (query["tls"] as NSString?)?.boolValue ?? false
+            return .gateway(
+                .init(
+                    host: hostParam,
+                    port: port,
+                    tls: tls,
+                    token: query["token"],
+                    password: query["password"]))
+
         default:
             return nil
         }

--- a/extensions/device-pair/index.ts
+++ b/extensions/device-pair/index.ts
@@ -1,6 +1,15 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import os from "node:os";
-import { approveDevicePairing, listDevicePairing } from "openclaw/plugin-sdk";
+import { approveDevicePairing, listDevicePairing, renderQrPngBase64 } from "openclaw/plugin-sdk";
+import qrcode from "qrcode-terminal";
+
+function renderQrAscii(data: string): Promise<string> {
+  return new Promise((resolve) => {
+    qrcode.generate(data, { small: true }, (output: string) => {
+      resolve(output);
+    });
+  });
+}
 
 const DEFAULT_GATEWAY_PORT = 18789;
 
@@ -448,6 +457,84 @@ export default function register(api: OpenClawPluginApi) {
         token: auth.token,
         password: auth.password,
       };
+
+      if (action === "qr") {
+        const setupCode = encodeSetupCode(payload);
+        const [qrBase64, qrAscii] = await Promise.all([
+          renderQrPngBase64(setupCode),
+          renderQrAscii(setupCode),
+        ]);
+        const authLabel = auth.label ?? "auth";
+        const dataUrl = `data:image/png;base64,${qrBase64}`;
+
+        const channel = ctx.channel;
+        const target = ctx.senderId?.trim() || ctx.from?.trim() || ctx.to?.trim() || "";
+
+        if (channel === "telegram" && target) {
+          try {
+            const send = api.runtime?.channel?.telegram?.sendMessageTelegram;
+            if (send) {
+              await send(target, "Scan this QR code with the OpenClaw iOS app:", {
+                ...(ctx.messageThreadId != null ? { messageThreadId: ctx.messageThreadId } : {}),
+                ...(ctx.accountId ? { accountId: ctx.accountId } : {}),
+                mediaUrl: dataUrl,
+              });
+              return {
+                text: [
+                  `Gateway: ${payload.url}`,
+                  `Auth: ${authLabel}`,
+                  "",
+                  "After scanning, come back here and run `/pair approve` to complete pairing.",
+                ].join("\n"),
+              };
+            }
+          } catch (err) {
+            api.logger.warn?.(
+              `device-pair: telegram QR send failed, falling back (${String(
+                (err as Error)?.message ?? err,
+              )})`,
+            );
+          }
+        }
+
+        // Render based on channel capability
+        api.logger.info?.(`device-pair: QR fallback channel=${channel} target=${target}`);
+        const infoLines = [
+          `Gateway: ${payload.url}`,
+          `Auth: ${authLabel}`,
+          "",
+          "After scanning, run `/pair approve` to complete pairing.",
+        ];
+
+        // TUI (gateway-client) needs ASCII, WebUI can render markdown images
+        const isTui = target === "gateway-client" || channel !== "webchat";
+
+        if (!isTui) {
+          // WebUI: markdown image only
+          return {
+            text: [
+              "Scan this QR code with the OpenClaw iOS app:",
+              "",
+              `![Pairing QR](${dataUrl})`,
+              "",
+              ...infoLines,
+            ].join("\n"),
+          };
+        }
+
+        // CLI/TUI: ASCII QR only
+        return {
+          text: [
+            "Scan this QR code with the OpenClaw iOS app:",
+            "",
+            "```",
+            qrAscii,
+            "```",
+            "",
+            ...infoLines,
+          ].join("\n"),
+        };
+      }
 
       const channel = ctx.channel;
       const target = ctx.senderId?.trim() || ctx.from?.trim() || ctx.to?.trim() || "";

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -377,3 +377,6 @@ export type { ProcessedLineMessage } from "../line/markdown-to-line.js";
 
 // Media utilities
 export { loadWebMedia, type WebMediaResult } from "../web/media.js";
+
+// QR code utilities
+export { renderQrPngBase64 } from "../web/qr-image.js";

--- a/src/web/media.ts
+++ b/src/web/media.ts
@@ -201,6 +201,19 @@ async function loadWebMediaInternal(
     };
   };
 
+  // Handle data: URLs (base64-encoded inline data)
+  if (mediaUrl.startsWith("data:")) {
+    const match = mediaUrl.match(/^data:([^;,]+)?(?:;base64)?,(.*)$/);
+    if (!match) {
+      throw new Error("Invalid data: URL format");
+    }
+    const contentType = match[1] || "application/octet-stream";
+    const base64Data = match[2];
+    const buffer = Buffer.from(base64Data, "base64");
+    const kind = mediaKindFromMime(contentType);
+    return await clampAndFinalize({ buffer, contentType, kind });
+  }
+
   if (/^https?:\/\//i.test(mediaUrl)) {
     // Enforce a download cap during fetch to avoid unbounded memory usage.
     // For optimized images, allow fetching larger payloads before compression.


### PR DESCRIPTION
  ## Summary

  - Add device pairing plugin with `/pair qr` command that generates a QR code for one-tap gateway
  onboarding — works across Telegram, Web UI, and TUI
  - Add guided onboarding wizard on iOS with QR scanning (camera + photo picker), mDNS gateway
  discovery, and manual connection fallback
  - Default-deny dangerous node commands on the gateway; commands like reboot/shutdown are now
  opt-in via config

  ## Details

  **Gateway & Plugins**
  - New `device-pair` plugin: `/pair qr` generates a setup QR code, `/pair approve` completes
  pairing
  - Plugin SDK exports device pairing helpers and adds `configSchema` support
  - Canonicalize `sessionKey` for correct chat routing
  - Dangerous node commands (reboot, shutdown, etc.) require explicit opt-in
  
| Telegram | Web UI | TUI |
|---|---|---|
| <img width="566" height="905" alt="telegram" src="https://github.com/user-attachments/assets/fc5370aa-bb64-4584-97d3-f44d380c1ec7" />| <img width="634" height="489" alt="webui" src="https://github.com/user-attachments/assets/8e55d9fb-a386-47e2-a519-93445872b2f7" />| <img width="682" height="735" alt="TUI" src="https://github.com/user-attachments/assets/255a2e01-6feb-4798-b29e-0eb45c0eef70" /> |



  **iOS**
  - New `OnboardingWizardView` with step-by-step flow: welcome → mode → connect → auth → success
  - QR scanner via camera with fallback to photo library (CIDetector-based QR detection)
  - mDNS discovery for LAN gateways, manual host/port entry, developer local mode
  - `GatewayConnectionIssue` detection for auth token and pairing errors
  - `OnboardingStateStore` for persisting onboarding completion state
  - OpenClawKit: support pairing reset and request ID error parsing

  ## Test I have done

  - [x] `/pair qr` generates valid QR code on Telegram, Web UI, and TUI
  - [x] iOS app scans QR code via camera and auto-connects
  - [x] iOS app scans QR code from photo library

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR adds QR code scanning functionality to streamline iOS gateway onboarding. The iOS app now presents a welcome screen with options to scan a QR code or set up manually. When users run `/pair qr` on their gateway, the backend generates a base64url-encoded setup code containing connection details (URL, token, password) and renders it as an ASCII QR for TUI, markdown image for WebUI, or media attachment for Telegram.

**Key changes:**
- iOS: `QRScannerView` using `DataScannerViewController` for live QR scanning, plus photo library support via `CIDetector` for saved QR images
- Deep link parser: added `gateway` route supporting both `openclaw://gateway?...` URLs and base64url setup codes
- Backend: `/pair qr` action generates QR codes with channel-appropriate rendering (ASCII/markdown/media)
- Media pipeline: added data URI support to `loadWebMedia` for inline base64 media handling
- Onboarding UX: full-screen welcome/success steps, back navigation, step indicators for manual flow

**Issues found:**
- `DataScannerViewController` requires iOS 16+ and camera support - missing availability checks before presenting scanner (see comments on `QRScannerView.swift:10` and `OnboardingWizardView.swift:492`)
- The implementation looks solid otherwise with proper fallbacks between QR formats and good error handling for photo library QR detection

<h3>Confidence Score: 3/5</h3>

- Safe to merge with availability checks added for `DataScannerViewController`
- The implementation is well-structured with proper error handling and fallbacks, but has a critical bug where `DataScannerViewController` is used without checking device support, which will crash on older devices or simulators. Once the availability checks are added (2 line fix), this is a solid feature addition.
- `apps/ios/Sources/Onboarding/QRScannerView.swift` and `apps/ios/Sources/Onboarding/OnboardingWizardView.swift` need availability checks before presenting the scanner

<sub>Last reviewed commit: d79ed65</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->