### PR TITLE
docs: remove note about personal single-user access from trusted proxy auth guidance

### DIFF
--- a/docs/gateway/trusted-proxy-auth.md
+++ b/docs/gateway/trusted-proxy-auth.md
@@ -27,7 +27,6 @@ Use `trusted-proxy` auth mode when:
 - If your proxy doesn't authenticate users (just a TLS terminator or load balancer).
 - If there's any path to the Gateway that bypasses the proxy (firewall holes, internal network access).
 - If you're unsure whether your proxy correctly strips/overwrites forwarded headers.
-- If you only need personal single-user access (consider Tailscale Serve + loopback for simpler setup).
 
 ## How it works
 


### PR DESCRIPTION
## Summary

A small follow up PR related to #1710.

Describe the problem and fix in 2–5 bullets:

Updates the trusted proxy auth docs "when not to use" section and removes the bullet point about them not being suitable for personal use. I use an identity aware proxy for my homelab to harden access to OpenClaw as well as provide hardened access via SSH. That was the whole reason I implemented #15940. 😅 Same if you have some other trusted proxy.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #1710

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

N/A

### Expected

-

### Actual

-

## Evidence

N/A

## Human Verification (required)

What you personally verified (not just CI), and how:

N/A

## Compatibility / Migration

N/A

## Failure Recovery (if this breaks)

N/A

## Risks and Mitigations

N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes outdated guidance from the trusted-proxy auth documentation. The removed bullet point incorrectly suggested that trusted-proxy auth wasn't suitable for personal single-user access, but as the PR author demonstrates, identity-aware proxies work well for hardening homelab deployments. The documentation still appropriately references Tailscale as a simpler alternative for tailnet-only access in the "Related" section.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only change that removes a single bullet point from the "When NOT to Use" section. The removed guidance was outdated and contradicted the author's successful real-world use case. No code changes, no behavioral changes, and the remaining documentation is coherent and complete.
- No files require special attention

<sub>Last reviewed commit: c50b814</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->