### PR TITLE
iOS Settings: fix build errors from gateway connect UX commit

### DIFF
--- a/apps/ios/Sources/Settings/SettingsTab.swift
+++ b/apps/ios/Sources/Settings/SettingsTab.swift
@@ -33,7 +33,6 @@ struct SettingsTab: View {
     @AppStorage("gateway.discovery.debugLogs") private var discoveryDebugLogsEnabled: Bool = false
     @AppStorage("canvas.debugStatusEnabled") private var canvasDebugStatusEnabled: Bool = false
     @AppStorage("onboarding.requestID") private var onboardingRequestID: Int = 0
-    @State private var connectStatus = ConnectStatusStore()
     @State private var connectingGatewayID: String?
     @State private var localIPAddress: String?
     @State private var lastLocationModeRaw: String = OpenClawLocationMode.off.rawValue
@@ -241,7 +240,6 @@ struct SettingsTab: View {
                                     .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 10, style: .continuous))
                             }
                         }
-                    }
                     } label: {
                         HStack(spacing: 10) {
                             Circle()
@@ -610,7 +608,7 @@ struct SettingsTab: View {
 
         let err = await self.gatewayController.connectWithDiagnostics(gateway)
         if let err {
-            self.connectStatus.text = err
+            self.setupStatusText = err
         }
     }
 
@@ -1113,7 +1111,7 @@ struct SettingsTab: View {
             GatewaySettingsStore.saveGatewayPassword(trimmedPassword, instanceId: freshInstanceId)
         }
 
-        self.connectStatus.text = "Onboarding reset"
+        self.setupStatusText = "Onboarding reset"
         self.gatewayController.restartDiscovery()
 
         let defaults = UserDefaults.standard
@@ -1146,7 +1144,7 @@ struct SettingsTab: View {
             return
         }
 
-        self.connectStatus.text = "Reconnecting to \(host)…"
+        self.setupStatusText = "Reconnecting to \(host)…"
         self.connectingGatewayID = "reset"
         Task {
             await self.gatewayController.connectManual(host: host, port: port, useTLS: tls)


### PR DESCRIPTION
Fixes build errors introduced in 1a39dc29 ("iOS: fix gateway connect roles; improve discovery/connect UX; stabilize chat sending"):

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes two build errors in `SettingsTab.swift` introduced by commit 1a39dc29:

- **Removed extraneous closing brace** at line 243 that was left behind when `DisclosureGroup("Advanced")` was relocated, causing a scope issue
- **Removed orphaned `@State private var connectStatus = ConnectStatusStore()`** property (line 36) that referenced the deleted `ConnectStatusStore` class
- **Routed status messages to `setupStatusText`** instead of the removed `connectStatus.text` in three locations (connect error handling, onboarding reset, and reconnecting message)

The changes correctly restore compilation by eliminating references to removed code and fixing the brace mismatch. All three status messages now properly flow to `setupStatusText`, which is already wired to the UI via the `setupStatusLine` computed property.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The changes are straightforward build fixes that remove leftover code from a previous refactoring. The PR correctly removes an orphaned class reference and fixes a scope issue caused by an extra closing brace. All three status message assignments are properly redirected to the existing `setupStatusText` property, which is already integrated into the UI. No logic changes, no new features, just cleanup.
- No files require special attention

<sub>Last reviewed commit: c607c82</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->