### PR TITLE
fix(gateway): pass bind mode to launchd/systemd service

### DIFF
--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -43,8 +43,10 @@ export async function buildGatewayInstallPlan(params: {
       env: params.env,
       runtime: params.runtime,
     }));
+  const bind = params.config?.gateway?.bind;
   const { programArguments, workingDirectory } = await resolveGatewayProgramArguments({
     port: params.port,
+    bind,
     dev: devMode,
     runtime: params.runtime,
     nodePath,

--- a/src/daemon/program-args.ts
+++ b/src/daemon/program-args.ts
@@ -241,11 +241,15 @@ async function resolveCliProgramArguments(params: {
 
 export async function resolveGatewayProgramArguments(params: {
   port: number;
+  bind?: "loopback" | "lan" | "auto" | "custom" | "tailnet";
   dev?: boolean;
   runtime?: GatewayRuntimePreference;
   nodePath?: string;
 }): Promise<GatewayProgramArgs> {
   const gatewayArgs = ["gateway", "--port", String(params.port)];
+  if (params.bind && params.bind !== "loopback") {
+    gatewayArgs.push("--bind", params.bind);
+  }
   return resolveCliProgramArguments({
     args: gatewayArgs,
     dev: params.dev,


### PR DESCRIPTION
## Summary

When installing the gateway as a service (launchd on macOS, systemd on Linux), the bind mode from config was not being passed to the service command arguments. This caused services to always use the default `loopback` binding regardless of the `gateway.bind` config setting.

## Changes

- Add `bind` parameter to `resolveGatewayProgramArguments`
- Read `gateway.bind` from config in `buildGatewayInstallPlan` and pass it through
- Only add `--bind` arg when bind mode is not `loopback` (the default)

## Test plan

1. Set `gateway.bind: "lan"` in config
2. Run `openclaw gateway install --force`
3. Check launchd plist — should now include `--bind lan` in program arguments
4. Verify gateway listens on LAN IP after restart

Fixes #4947

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Passes the `gateway.bind` config setting to launchd/systemd service program arguments, ensuring services respect the configured bind mode instead of defaulting to loopback.

- Extracts bind mode from config in `buildGatewayInstallPlan`
- Passes bind parameter through to `resolveGatewayProgramArguments`
- Only adds `--bind` argument when mode differs from default (`loopback`)
- Implementation follows existing patterns and correctly handles all bind modes: `loopback`, `lan`, `auto`, `custom`, `tailnet`

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is a straightforward bug fix that correctly propagates an existing config value through to service installation. The implementation follows established patterns, properly types the parameter, and maintains backward compatibility by only adding the flag when needed. No security concerns or edge cases identified.
- No files require special attention

<sub>Last reviewed commit: d6e8dfc</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->