### PR TITLE
fix: prevent raw tool/API errors from leaking to messaging surfaces (#7867)

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -66,9 +66,9 @@ describe("formatAssistantErrorText", () => {
 
   it("does not leak filesystem paths in tool error messages", () => {
     const msg = makeAssistantError(
-      "Edit tool failed: Could not find exact text in /Users/wade.digital/.openclaw/workspace/MEMORY.md",
+      "Edit tool failed: Could not find exact text in /Users/alice/.openclaw/workspace/MEMORY.md",
     );
     const result = formatAssistantErrorText(msg);
-    expect(result).not.toContain("/Users/wade.digital");
+    expect(result).not.toContain("/Users/alice");
   });
 });

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -37,4 +37,30 @@ describe("sanitizeUserFacingText", () => {
     const text = "Hello there!\n\nDifferent line.";
     expect(sanitizeUserFacingText(text)).toBe(text);
   });
+
+  it("sanitizes Brave Search API rate limit errors", () => {
+    const raw =
+      'Brave Search API error (429): {"type":"ErrorResponse","error":{"id":"32433a2a-3426-4831-8123-4553d4be9455","status":429,"detail":"Request rate limit exceeded for plan","meta":{"plan":"Free","rate_limit":1,"rate_current":1,"quota_limit":2000,"quota_current":210},"code":"RATE_LIMITED"},"time":1771039449}';
+    const result = sanitizeUserFacingText(raw);
+    expect(result).not.toContain("32433a2a");
+    expect(result).not.toContain("quota_current");
+    expect(result).not.toContain("ErrorResponse");
+    expect(result.toLowerCase()).toMatch(/rate.?limit|too many requests|try again/);
+  });
+
+  it("sanitizes tool execution errors with filesystem paths", () => {
+    const raw =
+      "Could not find exact text to replace in /Users/wade.digital/.openclaw/workspace/memory/2026-02-14.md";
+    const result = sanitizeUserFacingText(raw);
+    expect(result).not.toContain("/Users/wade.digital");
+    expect(result).not.toContain(".openclaw/workspace");
+  });
+
+  it("sanitizes generic external API error JSON payloads", () => {
+    const raw =
+      '{"type":"ErrorResponse","error":{"status":429,"detail":"Request rate limit exceeded for plan","meta":{"plan":"Free","rate_limit":1},"code":"RATE_LIMITED"}}';
+    const result = sanitizeUserFacingText(raw);
+    expect(result).not.toContain("RATE_LIMITED");
+    expect(result).not.toContain('"meta"');
+  });
 });

--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -50,10 +50,18 @@ describe("sanitizeUserFacingText", () => {
 
   it("sanitizes tool execution errors with filesystem paths", () => {
     const raw =
-      "Could not find exact text to replace in /Users/wade.digital/.openclaw/workspace/memory/2026-02-14.md";
+      "Could not find exact text to replace in /Users/alice/.openclaw/workspace/memory/2026-02-14.md";
     const result = sanitizeUserFacingText(raw);
-    expect(result).not.toContain("/Users/wade.digital");
+    expect(result).not.toContain("/Users/alice");
     expect(result).not.toContain(".openclaw/workspace");
+  });
+
+  it("sanitizes Windows filesystem paths", () => {
+    const raw =
+      "Could not find exact text to replace in C:\\Users\\bob\\AppData\\Local\\.openclaw\\workspace\\MEMORY.md";
+    const result = sanitizeUserFacingText(raw);
+    expect(result).not.toContain("C:\\Users\\bob");
+    expect(result).not.toContain("AppData");
   });
 
   it("sanitizes generic external API error JSON payloads", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -397,7 +397,8 @@ export function formatAssistantErrorText(
   return safeRaw.length > 600 ? `${safeRaw.slice(0, 600)}…` : safeRaw;
 }
 
-const FILESYSTEM_PATH_RE = /\/(?:Users|home|tmp|var|etc)\/[^\s,)}\]]+/g;
+const FILESYSTEM_PATH_RE =
+  /(?:\/(?:Users|home|tmp|var|etc)\/[^\s,)}\]]+|[A-Z]:\\(?:Users|Documents|AppData|Program Files)[^\s,)}\]]*)/g;
 
 function stripFilesystemPaths(text: string): string {
   return text.replace(FILESYSTEM_PATH_RE, "<path>");

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -11,6 +11,7 @@ import {
   getApiErrorPayloadFingerprint,
   isRawApiErrorPayload,
   normalizeTextForComparison,
+  sanitizeUserFacingText,
 } from "../../pi-embedded-helpers.js";
 import {
   extractAssistantText,
@@ -223,7 +224,9 @@ export function buildEmbeddedRunPayloads(params: {
         params.lastToolError.meta ? [params.lastToolError.meta] : undefined,
         { markdown: useMarkdown },
       );
-      const errorSuffix = params.lastToolError.error ? `: ${params.lastToolError.error}` : "";
+      const rawError = params.lastToolError.error ?? "";
+      const sanitizedError = rawError ? sanitizeUserFacingText(rawError) : "";
+      const errorSuffix = sanitizedError ? `: ${sanitizedError}` : "";
       replyItems.push({
         text: `⚠️ ${toolSummary} failed${errorSuffix}`,
         isError: true,


### PR DESCRIPTION
## Summary

Fixes #7867 — raw error text from tool execution and external API failures was leaking verbatim to messaging surfaces (Discord, Telegram, etc.).

### Three variants fixed:

1. **Brave Search 429** — full JSON `ErrorResponse` payload (including request IDs, plan metadata, quota info) was dumped to channels
2. **Edit tool failures** — filesystem paths like `/Users/user/.openclaw/workspace/...` leaked to users
3. **Malformed tool call JSON** from streaming parse errors

### Root cause

In `payloads.ts`, the `errorSuffix` from `lastToolError.error` was appended verbatim without sanitization. Additionally, `sanitizeUserFacingText()` and related functions had gaps:

- `isErrorPayloadObject()` only checked `type === "error"` but Brave uses `type === "ErrorResponse"`
- `parseApiErrorPayload()` only tried whole-string JSON parsing, missing embedded JSON like `Brave Search API error (429): {...}`
- `parseApiErrorInfo()` didn't extract the `detail` field (Brave uses `detail` instead of `message`)
- No filesystem path stripping anywhere in the error pipeline

### Changes

- **`errors.ts`**: Added `ErrorResponse` type detection, embedded JSON extraction, `detail` field support, filesystem path stripping via `stripFilesystemPaths()`, and early rate-limit detection
- **`payloads.ts`**: Pass `errorSuffix` through `sanitizeUserFacingText()` before surfacing
- **Tests**: 5 new test cases across both test files covering all three variants

All 123 existing + new unit tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes a security-relevant gap where raw error text from tool execution and external API failures (Brave Search, filesystem paths, malformed JSON) was leaking verbatim to messaging surfaces (Discord, Telegram, etc.).

- **`errors.ts`**: Extended `isErrorPayloadObject()` to recognize Brave's `"ErrorResponse"` type, added embedded JSON extraction in `parseApiErrorPayload()` for strings like `"prefix: {json}"`, added `detail` field fallback in `parseApiErrorInfo()`, introduced `stripFilesystemPaths()` for sanitizing Unix and Windows filesystem paths, and added early rate-limit detection in `sanitizeUserFacingText()`
- **`payloads.ts`**: Tool error strings now pass through `sanitizeUserFacingText()` before being surfaced to users, preventing raw error payloads from reaching messaging channels
- **Tests**: 5 new test cases covering Brave Search 429 errors, filesystem path stripping (Unix and Windows), and generic `ErrorResponse` payloads across both `formatAssistantErrorText` and `sanitizeUserFacingText`

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds defense-in-depth sanitization to error paths with no impact on happy-path behavior.
- The changes are focused on error sanitization with clear test coverage for all three variant categories. The logic is straightforward (regex-based path stripping, JSON extraction with try/catch, type detection broadening) and the existing test suite plus 5 new tests validate the behavior. The only reason this isn't a 5 is that the filesystem path regex, while covering common cases, is inherently heuristic-based.
- No files require special attention.

<sub>Last reviewed commit: 75c09f4</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->