### PR TITLE
fix(skills): refresh notion skill for API 2026-03-11

### DIFF
--- a/skills/notion/SKILL.md
+++ b/skills/notion/SKILL.md
@@ -34,11 +34,11 @@ All requests need:
 NOTION_KEY=$(cat ~/.config/notion/api_key)
 curl -X GET "https://api.notion.com/v1/..." \
   -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03" \
+  -H "Notion-Version: 2026-03-11" \
   -H "Content-Type: application/json"
 ```
 
-> **Note:** The `Notion-Version` header is required. This skill uses `2025-09-03` (latest). In this version, databases are called "data sources" in the API.
+> **Note:** The `Notion-Version` header is required. This skill uses `2026-03-11` (latest). It builds on the 2025-09-03 "data sources" model (databases expose one or more data sources for queries and writes) and adds three renames: `archived` → `in_trash`, the `after` parameter on Append Block Children → a `position` object, and the `transcription` block type → `meeting_notes`.
 
 ## Common Operations
 
@@ -47,7 +47,7 @@ curl -X GET "https://api.notion.com/v1/..." \
 ```bash
 curl -X POST "https://api.notion.com/v1/search" \
   -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03" \
+  -H "Notion-Version: 2026-03-11" \
   -H "Content-Type: application/json" \
   -d '{"query": "page title"}'
 ```
@@ -57,7 +57,7 @@ curl -X POST "https://api.notion.com/v1/search" \
 ```bash
 curl "https://api.notion.com/v1/pages/{page_id}" \
   -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03"
+  -H "Notion-Version: 2026-03-11"
 ```
 
 **Get page content (blocks):**
@@ -65,18 +65,41 @@ curl "https://api.notion.com/v1/pages/{page_id}" \
 ```bash
 curl "https://api.notion.com/v1/blocks/{page_id}/children" \
   -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03"
+  -H "Notion-Version: 2026-03-11"
 ```
 
+**Create a database:**
+
+```bash
+curl -X POST "https://api.notion.com/v1/databases" \
+  -H "Authorization: Bearer $NOTION_KEY" \
+  -H "Notion-Version: 2026-03-11" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "parent": {"type": "page_id", "page_id": "PARENT_PAGE_ID"},
+    "title": [{"text": {"content": "My Database"}}],
+    "initial_data_source": {
+      "properties": {
+        "Name": {"title": {}},
+        "Status": {"select": {"options": [{"name": "Todo"}, {"name": "Done"}]}}
+      }
+    }
+  }'
+```
+
+The response is a [database object](https://developers.notion.com/reference/database) that includes a `data_sources` array. Use the returned `data_sources[0].id` value as the `data_source_id` when creating pages or querying the database contents. If the response is partial and `data_sources` is missing, retrieve the full object with `GET /v1/databases/{database_id}` to find the `data_source_id`.
+
 **Create page in a data source:**
+
+To add items to a database, target its `data_source_id`, not its `database_id`.
 
 ```bash
 curl -X POST "https://api.notion.com/v1/pages" \
   -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03" \
+  -H "Notion-Version: 2026-03-11" \
   -H "Content-Type: application/json" \
   -d '{
-    "parent": {"database_id": "xxx"},
+    "parent": {"type": "data_source_id", "data_source_id": "DATA_SOURCE_ID"},
     "properties": {
       "Name": {"title": [{"text": {"content": "New Item"}}]},
       "Status": {"select": {"name": "Todo"}}
@@ -89,29 +112,11 @@ curl -X POST "https://api.notion.com/v1/pages" \
 ```bash
 curl -X POST "https://api.notion.com/v1/data_sources/{data_source_id}/query" \
   -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03" \
+  -H "Notion-Version: 2026-03-11" \
   -H "Content-Type: application/json" \
   -d '{
     "filter": {"property": "Status", "select": {"equals": "Active"}},
     "sorts": [{"property": "Date", "direction": "descending"}]
-  }'
-```
-
-**Create a data source (database):**
-
-```bash
-curl -X POST "https://api.notion.com/v1/data_sources" \
-  -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "parent": {"page_id": "xxx"},
-    "title": [{"text": {"content": "My Database"}}],
-    "properties": {
-      "Name": {"title": {}},
-      "Status": {"select": {"options": [{"name": "Todo"}, {"name": "Done"}]}},
-      "Date": {"date": {}}
-    }
   }'
 ```
 
@@ -120,7 +125,7 @@ curl -X POST "https://api.notion.com/v1/data_sources" \
 ```bash
 curl -X PATCH "https://api.notion.com/v1/pages/{page_id}" \
   -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03" \
+  -H "Notion-Version: 2026-03-11" \
   -H "Content-Type: application/json" \
   -d '{"properties": {"Status": {"select": {"name": "Done"}}}}'
 ```
@@ -130,13 +135,25 @@ curl -X PATCH "https://api.notion.com/v1/pages/{page_id}" \
 ```bash
 curl -X PATCH "https://api.notion.com/v1/blocks/{page_id}/children" \
   -H "Authorization: Bearer $NOTION_KEY" \
-  -H "Notion-Version: 2025-09-03" \
+  -H "Notion-Version: 2026-03-11" \
   -H "Content-Type: application/json" \
   -d '{
     "children": [
       {"object": "block", "type": "paragraph", "paragraph": {"rich_text": [{"text": {"content": "Hello"}}]}}
     ]
   }'
+```
+
+By default, blocks are appended to the end. To insert elsewhere, pass a `position` object (`{"type": "start"}`, `{"type": "end"}`, or `{"type": "after_block", "after_block": {"id": "BLOCK_ID"}}`). The flat `after` parameter from earlier API versions was replaced by `position` in 2026-03-11.
+
+**Move a page to trash:**
+
+```bash
+curl -X PATCH "https://api.notion.com/v1/pages/{page_id}" \
+  -H "Authorization: Bearer $NOTION_KEY" \
+  -H "Notion-Version: 2026-03-11" \
+  -H "Content-Type: application/json" \
+  -d '{"in_trash": true}'
 ```
 
 ## Property Types
@@ -154,21 +171,32 @@ Common property formats for database items:
 - **Email:** `{"email": "a@b.com"}`
 - **Relation:** `{"relation": [{"id": "page_id"}]}`
 
-## Key Differences in 2025-09-03
+## Key Differences in 2026-03-11
 
-- **Databases → Data Sources:** Use `/data_sources/` endpoints for queries and retrieval
-- **Two IDs:** Each database now has both a `database_id` and a `data_source_id`
-  - Use `database_id` when creating pages (`parent: {"database_id": "..."}`)
-  - Use `data_source_id` when querying (`POST /v1/data_sources/{id}/query`)
-- **Search results:** Databases return as `"object": "data_source"` with their `data_source_id`
-- **Parent in responses:** Pages show `parent.data_source_id` alongside `parent.database_id`
-- **Finding the data_source_id:** Search for the database, or call `GET /v1/data_sources/{data_source_id}`
+This version layers three renames on top of the 2025-09-03 data-sources model.
+
+**Renames in 2026-03-11:**
+
+- `archived` → `in_trash` on pages, databases, blocks, and data sources (both request bodies and responses).
+- The `after` parameter on Append Block Children → a `position` object with `type: "start" | "end" | "after_block"` (default `end`).
+- Block type `transcription` → `meeting_notes`.
+
+**Data sources model (carried over from 2025-09-03):**
+
+- **Databases → Data Sources:** Use `/data_sources/` endpoints for queries and retrieval.
+- **Database creation:** Use `POST /v1/databases` with `initial_data_source` to define the first schema.
+- **Two IDs:** Each database has both a `database_id` and a `data_source_id`.
+  - Use `data_source_id` when creating pages (`parent: {"type": "data_source_id", "data_source_id": "..."}`) and when querying (`POST /v1/data_sources/{id}/query`).
+  - `database_id` is still accepted for backward compatibility in page parents, but `data_source_id` is the canonical approach.
+- **Finding the data_source_id:** Call `GET /v1/databases/{database_id}` — the response includes a `data_sources` array with each child's `id` and `name`. Alternatively, search results return databases with their `data_sources` array.
+- **Search results:** Databases return as `"object": "database"` with a `data_sources` array; capture the `data_source_id` you need for later writes and queries.
+- **Parent in responses:** Pages show `parent.data_source_id` alongside `parent.database_id`.
 
 ## Notes
 
-- Page/database IDs are UUIDs (with or without dashes)
-- The API cannot set database view filters — that's UI-only
-- Rate limit: ~3 requests/second average, with `429 rate_limited` responses using `Retry-After`
-- Append block children: up to 100 children per request, up to two levels of nesting in a single append request
-- Payload size limits: up to 1000 block elements and 500KB overall
-- Use `is_inline: true` when creating data sources to embed them in pages
+- Page/database IDs are UUIDs (with or without dashes).
+- The API cannot set database view filters; that remains UI-only.
+- Rate limit: ~3 requests/second average, with `429 rate_limited` responses using `Retry-After`.
+- Append block children: up to 100 children per request, up to two levels of nesting in a single append request.
+- Payload size limits: up to 1000 block elements and 500KB overall.
+- Use `is_inline: true` when creating data sources to embed them in pages.


### PR DESCRIPTION
## Summary

Refreshes the Notion skill to align with API version `2026-03-11` (replaces the previous 2025-09-03 scope after maintainer review feedback).

### Changes

- **Version bump:** `Notion-Version` header updated to `2026-03-11` across all examples.
- **Field renames documented:**
  - `archived` → `in_trash` on pages, databases, blocks, and data sources (request bodies and responses).
  - Block type `transcription` → `meeting_notes`.
- **`after` → `position` on Append Block Children:** documents the new `position` object (`type: "start" | "end" | "after_block"`) with the default end-of-list behavior.
- **New example:** "Move a page to trash" using `in_trash: true`.
- **Two-ID model (carried over from 2025-09-03):** restores the `database_id` vs `data_source_id` guidance — page parents use `data_source_id`, queries use `POST /v1/data_sources/{id}/query`, and database creation uses `POST /v1/databases` with `initial_data_source`. Also documents how to discover the `data_source_id` via `GET /v1/databases/{database_id}` or search results.

Rebased on current `main`.