### PR TITLE
fix: strip HEARTBEAT_OK tokens anywhere in heartbeat mode

### DIFF
--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -152,6 +152,17 @@ export function stripHeartbeatToken(
   const strippedNormalized = stripTokenAtEdges(trimmedNormalized);
   const picked =
     strippedOriginal.didStrip && strippedOriginal.text ? strippedOriginal : strippedNormalized;
+  if (mode === "heartbeat") {
+    const baseText = picked.didStrip ? picked.text : trimmedNormalized;
+    const collapsed = baseText.replaceAll(HEARTBEAT_TOKEN, " ").replace(/\s+/g, " ").trim();
+    if (!collapsed) {
+      return { shouldSkip: true, text: "", didStrip: true };
+    }
+    if (collapsed.length <= maxAckChars) {
+      return { shouldSkip: true, text: "", didStrip: true };
+    }
+    return { shouldSkip: false, text: collapsed, didStrip: true };
+  }
   if (!picked.didStrip) {
     return { shouldSkip: false, text: trimmed, didStrip: false };
   }
@@ -161,11 +172,5 @@ export function stripHeartbeatToken(
   }
 
   const rest = picked.text.trim();
-  if (mode === "heartbeat") {
-    if (rest.length <= maxAckChars) {
-      return { shouldSkip: true, text: "", didStrip: true };
-    }
-  }
-
   return { shouldSkip: false, text: rest, didStrip: true };
 }


### PR DESCRIPTION
## Fix: HEARTBEAT_OK leaks to Telegram DM despite showOk: false

Fixes #17646

### Problem

`HEARTBEAT_OK` messages were intermittently delivered to Telegram DMs even when `channels.telegram.heartbeat.showOk` was set to `false`.

### Root Cause

`stripHeartbeatToken()` only stripped tokens at the **edges** of the message. When the model output something like `"all good HEARTBEAT_OK thanks"` (token in the middle), the entire message—including the token—was delivered.

Additionally, when tokens appeared at **both** edge and middle (e.g., `"HEARTBEAT_OK hello HEARTBEAT_OK world"`), only the edge token was stripped, leaving the middle token to leak.

### Solution

In `heartbeat` mode, use `replaceAll()` to remove **all** `HEARTBEAT_OK` tokens regardless of position, then apply the existing short-message skip logic.

Key changes:
- Move heartbeat-mode handling **before** the `picked.didStrip` check to ensure all tokens are processed
- Use `replaceAll(HEARTBEAT_TOKEN, " ")` to strip tokens anywhere in the message
- Collapse whitespace and apply `maxAckChars` threshold for skip decision
- `message` mode behavior is unchanged (tokens in the middle are preserved)

### Test Coverage

Added tests for:
- Token in the middle → skip as ack
- Long content with middle token → preserve content, strip token
- Edge + middle tokens combined (`"HEARTBEAT_OK hello HEARTBEAT_OK world"`)
- Multiple consecutive tokens
- HTML-wrapped token in the middle

### Validation

- [x] `pnpm build` ✅
- [x] `pnpm check` ✅  
- [x] `pnpm test` ✅ (all tests pass including new ones)

### AI Assistance Disclosure

This PR was developed with AI assistance (Claude/GPT-based agents):
- **Root cause analysis**: AI traced code path through `stripHeartbeatToken()` → `stripTokenAtEdges()`
- **Initial fix**: AI-generated, then reviewed by separate AI reviewer which caught edge+middle case bug
- **Final fix**: AI-generated v2 addressing the edge case
- **Tests**: AI-generated covering identified scenarios
- **Human oversight**: All changes reviewed and validated by human contributor

**Testing level**: Fully tested — unit tests written and executed locally via `pnpm test`.

**Session log summary**: 
1. Traced issue to `stripTokenAtEdges()` only handling edge positions
2. v1 fix proposed → AI reviewer approved but another reviewer caught edge+middle edge case
3. v2 fix: moved heartbeat block before `didStrip` check, used `replaceAll()` for comprehensive token removal
4. Added 6 test cases covering all identified scenarios

**Code understanding confirmed**: I understand this change modifies `stripHeartbeatToken()` to use `replaceAll()` in heartbeat mode, ensuring all `HEARTBEAT_OK` tokens are removed regardless of position. The existing `maxAckChars` threshold still applies to determine if the cleaned message should be skipped or delivered. Message mode remains unchanged to preserve backward compatibility.
