### PR TITLE
fix(discord): coerce numeric IDs to strings to prevent Snowflake overflow (#17802)

### DIFF
--- a/src/channels/plugins/onboarding/helpers.ts
+++ b/src/channels/plugins/onboarding/helpers.ts
@@ -5,9 +5,7 @@ export const promptAccountId: PromptAccountId = async (params: PromptAccountIdPa
   return await promptAccountIdSdk(params);
 };
 
-export function addWildcardAllowFrom(
-  allowFrom?: Array<string | number> | null,
-): Array<string | number> {
+export function addWildcardAllowFrom(allowFrom?: Array<string | number> | null): Array<string> {
   const next = (allowFrom ?? []).map((v) => String(v).trim()).filter(Boolean);
   if (!next.includes("*")) {
     next.push("*");

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -17,11 +17,11 @@ export type DiscordDmConfig = {
   /** Direct message access policy (default: pairing). */
   policy?: DmPolicy;
   /** Allowlist for DM senders (ids or names). */
-  allowFrom?: Array<string | number>;
+  allowFrom?: Array<string>;
   /** If true, allow group DMs (default: false). */
   groupEnabled?: boolean;
   /** Optional allowlist for group DM channels (ids or slugs). */
-  groupChannels?: Array<string | number>;
+  groupChannels?: Array<string>;
 };
 
 export type DiscordGuildChannelConfig = {
@@ -35,9 +35,9 @@ export type DiscordGuildChannelConfig = {
   /** If false, disable the bot for this channel. */
   enabled?: boolean;
   /** Optional allowlist for channel senders (ids or names). */
-  users?: Array<string | number>;
+  users?: Array<string>;
   /** Optional allowlist for channel senders by role ID. */
-  roles?: Array<string | number>;
+  roles?: Array<string>;
   /** Optional system prompt snippet for this channel. */
   systemPrompt?: string;
   /** If false, omit thread starter context for this channel (default: true). */
@@ -55,9 +55,9 @@ export type DiscordGuildEntry = {
   /** Reaction notification mode (off|own|all|allowlist). Default: own. */
   reactionNotifications?: DiscordReactionNotificationMode;
   /** Optional allowlist for guild senders (ids or names). */
-  users?: Array<string | number>;
+  users?: Array<string>;
   /** Optional allowlist for guild senders by role ID. */
-  roles?: Array<string | number>;
+  roles?: Array<string>;
   channels?: Record<string, DiscordGuildChannelConfig>;
 };
 
@@ -95,7 +95,7 @@ export type DiscordExecApprovalConfig = {
   /** Enable exec approval forwarding to Discord DMs. Default: false. */
   enabled?: boolean;
   /** Discord user IDs to receive approval prompts. Required if enabled. */
-  approvers?: Array<string | number>;
+  approvers?: Array<string>;
   /** Only forward approvals for these agent IDs. Omit = all agents. */
   agentFilter?: string[];
   /** Only forward approvals matching these session key patterns (substring or regex). */
@@ -182,7 +182,7 @@ export type DiscordAccountConfig = {
    * Alias for dm.allowFrom (prefer this so it inherits cleanly via base->account shallow merge).
    * Legacy key: channels.discord.dm.allowFrom.
    */
-  allowFrom?: Array<string | number>;
+  allowFrom?: Array<string>;
   dm?: DiscordDmConfig;
   /** New per-guild config keyed by guild id or slug. */
   guilds?: Record<string, DiscordGuildEntry>;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -306,6 +306,12 @@ export const CliBackendSchema = z
   })
   .strict();
 
+/**
+ * Zod schema that accepts string or number but always coerces to string.
+ * Prevents JS Number precision loss on large integer IDs (e.g. Discord Snowflake > 2^53).
+ */
+export const StringIdSchema = z.union([z.string(), z.number()]).transform(String);
+
 export const normalizeAllowFrom = (values?: Array<string | number>): string[] =>
   (values ?? []).map((v) => String(v).trim()).filter(Boolean);
 

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -19,6 +19,7 @@ import {
   ProviderCommandsSchema,
   ReplyToModeSchema,
   RetryConfigSchema,
+  StringIdSchema,
   requireOpenAllowFrom,
 } from "./zod-schema.core.js";
 import { sensitive } from "./zod-schema.sensitive.js";
@@ -214,9 +215,9 @@ export const DiscordDmSchema = z
   .object({
     enabled: z.boolean().optional(),
     policy: DmPolicySchema.optional(),
-    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    allowFrom: z.array(StringIdSchema).optional(),
     groupEnabled: z.boolean().optional(),
-    groupChannels: z.array(z.union([z.string(), z.number()])).optional(),
+    groupChannels: z.array(StringIdSchema).optional(),
   })
   .strict();
 
@@ -228,8 +229,8 @@ export const DiscordGuildChannelSchema = z
     toolsBySender: ToolPolicyBySenderSchema,
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
-    users: z.array(z.union([z.string(), z.number()])).optional(),
-    roles: z.array(z.union([z.string(), z.number()])).optional(),
+    users: z.array(StringIdSchema).optional(),
+    roles: z.array(StringIdSchema).optional(),
     systemPrompt: z.string().optional(),
     includeThreadStarter: z.boolean().optional(),
     autoThread: z.boolean().optional(),
@@ -243,8 +244,8 @@ export const DiscordGuildSchema = z
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
-    users: z.array(z.union([z.string(), z.number()])).optional(),
-    roles: z.array(z.union([z.string(), z.number()])).optional(),
+    users: z.array(StringIdSchema).optional(),
+    roles: z.array(StringIdSchema).optional(),
     channels: z.record(z.string(), DiscordGuildChannelSchema.optional()).optional(),
   })
   .strict();
@@ -311,14 +312,14 @@ export const DiscordAccountSchema = z
     // Aliases for channels.discord.dm.policy / channels.discord.dm.allowFrom. Prefer these for
     // inheritance in multi-account setups (shallow merge works; nested dm object doesn't).
     dmPolicy: DmPolicySchema.optional(),
-    allowFrom: z.array(z.union([z.string(), z.number()])).optional(),
+    allowFrom: z.array(StringIdSchema).optional(),
     dm: DiscordDmSchema.optional(),
     guilds: z.record(z.string(), DiscordGuildSchema.optional()).optional(),
     heartbeat: ChannelHeartbeatVisibilitySchema,
     execApprovals: z
       .object({
         enabled: z.boolean().optional(),
-        approvers: z.array(z.union([z.string(), z.number()])).optional(),
+        approvers: z.array(StringIdSchema).optional(),
         agentFilter: z.array(z.string()).optional(),
         sessionFilter: z.array(z.string()).optional(),
         cleanupAfterResolve: z.boolean().optional(),

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -334,7 +334,7 @@ export type AgentComponentContext = {
   token?: string;
   guildEntries?: Record<string, DiscordGuildEntryResolved>;
   /** DM allowlist (from allowFrom config; legacy: dm.allowFrom) */
-  allowFrom?: Array<string | number>;
+  allowFrom?: Array<string>;
   /** DM policy (default: "pairing") */
   dmPolicy?: "open" | "pairing" | "allowlist" | "disabled";
 };

--- a/src/discord/monitor/allow-list.ts
+++ b/src/discord/monitor/allow-list.ts
@@ -21,8 +21,8 @@ export type DiscordGuildEntryResolved = {
   slug?: string;
   requireMention?: boolean;
   reactionNotifications?: "off" | "own" | "all" | "allowlist";
-  users?: Array<string | number>;
-  roles?: Array<string | number>;
+  users?: Array<string>;
+  roles?: Array<string>;
   channels?: Record<
     string,
     {
@@ -30,8 +30,8 @@ export type DiscordGuildEntryResolved = {
       requireMention?: boolean;
       skills?: string[];
       enabled?: boolean;
-      users?: Array<string | number>;
-      roles?: Array<string | number>;
+      users?: Array<string>;
+      roles?: Array<string>;
       systemPrompt?: string;
       includeThreadStarter?: boolean;
       autoThread?: boolean;
@@ -44,8 +44,8 @@ export type DiscordChannelConfigResolved = {
   requireMention?: boolean;
   skills?: string[];
   enabled?: boolean;
-  users?: Array<string | number>;
-  roles?: Array<string | number>;
+  users?: Array<string>;
+  roles?: Array<string>;
   systemPrompt?: string;
   includeThreadStarter?: boolean;
   autoThread?: boolean;
@@ -53,10 +53,7 @@ export type DiscordChannelConfigResolved = {
   matchSource?: ChannelMatchSource;
 };
 
-export function normalizeDiscordAllowList(
-  raw: Array<string | number> | undefined,
-  prefixes: string[],
-) {
+export function normalizeDiscordAllowList(raw: Array<string> | undefined, prefixes: string[]) {
   if (!raw || raw.length === 0) {
     return null;
   }
@@ -141,7 +138,7 @@ export function resolveDiscordAllowListMatch(params: {
 }
 
 export function resolveDiscordUserAllowed(params: {
-  allowList?: Array<string | number>;
+  allowList?: Array<string>;
   userId: string;
   userName?: string;
   userTag?: string;
@@ -158,7 +155,7 @@ export function resolveDiscordUserAllowed(params: {
 }
 
 export function resolveDiscordRoleAllowed(params: {
-  allowList?: Array<string | number>;
+  allowList?: Array<string>;
   memberRoleIds: string[];
 }) {
   // Role allowlists accept role IDs only (string or number). Names are ignored.
@@ -173,8 +170,8 @@ export function resolveDiscordRoleAllowed(params: {
 }
 
 export function resolveDiscordMemberAllowed(params: {
-  userAllowList?: Array<string | number>;
-  roleAllowList?: Array<string | number>;
+  userAllowList?: Array<string>;
+  roleAllowList?: Array<string>;
   memberRoleIds: string[];
   userId: string;
   userName?: string;
@@ -253,7 +250,7 @@ export function resolveDiscordOwnerAllowFrom(params: {
 
 export function resolveDiscordCommandAuthorized(params: {
   isDirectMessage: boolean;
-  allowFrom?: Array<string | number>;
+  allowFrom?: Array<string>;
   guildInfo?: DiscordGuildEntryResolved | null;
   author: User;
 }) {
@@ -478,7 +475,7 @@ export function isDiscordGroupAllowedByPolicy(params: {
 }
 
 export function resolveGroupDmAllow(params: {
-  channels?: Array<string | number>;
+  channels?: Array<string>;
   channelId: string;
   channelName?: string;
   channelSlug: string;
@@ -503,7 +500,7 @@ export function shouldEmitDiscordReactionNotification(params: {
   userId: string;
   userName?: string;
   userTag?: string;
-  allowlist?: Array<string | number>;
+  allowlist?: Array<string>;
 }) {
   const mode = params.mode ?? "own";
   if (mode === "off") {

--- a/src/discord/monitor/exec-approvals.ts
+++ b/src/discord/monitor/exec-approvals.ts
@@ -721,7 +721,7 @@ export class DiscordExecApprovalHandler {
   }
 
   /** Return the list of configured approver IDs. */
-  getApprovers(): Array<string | number> {
+  getApprovers(): Array<string> {
     return this.opts.config.approvers ?? [];
   }
 }

--- a/src/discord/monitor/message-handler.preflight.types.ts
+++ b/src/discord/monitor/message-handler.preflight.types.ts
@@ -95,8 +95,8 @@ export type DiscordMessagePreflightParams = {
   replyToMode: ReplyToMode;
   dmEnabled: boolean;
   groupDmEnabled: boolean;
-  groupDmChannels?: Array<string | number>;
-  allowFrom?: Array<string | number>;
+  groupDmChannels?: Array<string>;
+  allowFrom?: Array<string>;
   guildEntries?: Record<string, DiscordGuildEntryResolved>;
   ackReactionScope: DiscordMessagePreflightContext["ackReactionScope"];
   groupPolicy: DiscordMessagePreflightContext["groupPolicy"];

--- a/src/discord/monitor/provider.ts
+++ b/src/discord/monitor/provider.ts
@@ -77,7 +77,7 @@ export type MonitorDiscordOpts = {
   replyToMode?: ReplyToMode;
 };
 
-function summarizeAllowList(list?: Array<string | number>) {
+function summarizeAllowList(list?: Array<string>) {
   if (!list || list.length === 0) {
     return "any";
   }
@@ -352,7 +352,7 @@ export async function monitorDiscordProvider(opts: MonitorDiscordOpts = {}) {
               continue;
             }
             const nextGuild = { ...guildConfig } as Record<string, unknown>;
-            const users = (guildConfig as { users?: Array<string | number> }).users;
+            const users = (guildConfig as { users?: Array<string> }).users;
             if (Array.isArray(users) && users.length > 0) {
               const additions = resolveAllowlistIdAdditions({ existing: users, resolvedMap });
               nextGuild.users = mergeAllowlist({ existing: users, additions });


### PR DESCRIPTION
## Summary

- Discord Snowflake IDs are 64-bit integers that can exceed JavaScript's `Number.MAX_SAFE_INTEGER` (2^53 - 1), causing silent precision loss when stored as numbers
- The Zod config schemas accepted `string | number` for Discord ID fields — if a user wrote an unquoted numeric ID in JSON config, it would be parsed as a JS number and potentially corrupted
- Added `StringIdSchema` that accepts both string and number inputs but always coerces to string, maintaining backward compatibility while ensuring all downstream code operates on strings
- Updated all Discord TypeScript types from `Array<string | number>` to `Array<string>`

## Changes

- `src/config/zod-schema.core.ts` — new `StringIdSchema` (reusable for other channels)
- `src/config/zod-schema.providers-core.ts` — Discord schemas use `StringIdSchema`
- `src/config/types.discord.ts` — all Discord ID fields narrowed to `string[]`
- `src/discord/monitor/allow-list.ts` — function signatures updated
- `src/discord/monitor/provider.ts`, `exec-approvals.ts`, `agent-components.ts`, `message-handler.preflight.types.ts` — type alignment
- `src/channels/plugins/onboarding/helpers.ts` — `addWildcardAllowFrom` return type corrected
- `src/config/config.discord.test.ts` — added test for numeric ID coercion

> **Note:** `StringIdSchema` is intentionally reusable — other channels (Telegram, Slack, etc.) share the same pattern and can adopt it separately.

## Test plan

- [x] New test: numeric IDs in Discord config are coerced to strings (allowFrom, users, roles, approvers, groupChannels)
- [x] Existing Discord config test still passes
- [x] `pnpm build` passes
- [x] `pnpm check` (format + lint) passes

Fixes #17802

---

Dug into the issue and confirmed no duplicate PRs are open. Would appreciate a review from @steipete or @thewilloftheshadow given the Discord subsystem scope.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `StringIdSchema` in `zod-schema.core.ts` — a Zod schema that accepts both string and number inputs but always coerces to string — and applies it to all Discord ID fields (allowFrom, groupChannels, users, roles, approvers). The corresponding TypeScript types in `types.discord.ts` are narrowed from `Array<string | number>` to `Array<string>`, and all downstream function signatures across the Discord monitor module are aligned accordingly.

- **Core change**: `StringIdSchema = z.union([z.string(), z.number()]).transform(String)` ensures numeric IDs in JSON config are coerced to strings at parse time, preventing downstream code from operating on `number` values that could silently lose precision for 64-bit Discord Snowflake IDs
- **Type narrowing**: All Discord ID fields narrowed from `string | number` to `string` across types, function signatures, and resolved config objects — a clean, consistent change
- **Backward compatible**: The Zod schema still accepts numeric input (for users with unquoted IDs in config), and the `addWildcardAllowFrom` helper parameter retains `Array<string | number>` for non-Discord callers
- **Test coverage**: New test verifies numeric coercion across all Discord config locations (DM allowFrom, groupChannels, guild users/roles, channel users/roles, exec approvers)
- **Scope intentionally limited to Discord**: Other channels (Telegram, Slack, Signal, etc.) still use `z.union([z.string(), z.number()])` and can adopt `StringIdSchema` separately

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a well-scoped type-narrowing change with no behavioral risk.
- All changes are type-level narrowings backed by a Zod transform that coerces at parse time. The existing runtime code already called `String()` on these values defensively, so the behavioral change is minimal. The test is well-structured and covers all affected config paths. No logic changes, no new code paths, no risk of regression.
- No files require special attention.

<sub>Last reviewed commit: d49c0fd</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->