### PR TITLE
fix(telegram): fix streaming with extended thinking models overwriting previous messages/ also happens to Execution error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Docs: https://docs.openclaw.ai
 - Telegram: keep draft-stream preview replies attached to the user message for `replyToMode: "all"` in groups and DMs, preserving threaded reply context from preview through finalization. (#17880) Thanks @yinghaosang.
 - Telegram: disable block streaming when `channels.telegram.streamMode` is `off`, preventing newline/content-block replies from splitting into multiple messages. (#17679) Thanks @saivarunk.
 - Telegram: route non-abort slash commands on the normal chat/topic sequential lane while keeping true abort requests (`/stop`, `stop`) on the control lane, preventing command/reply race conditions from control-lane bypass. (#17899) Thanks @obviyus.
+- Telegram: prevent streaming final replies from being overwritten by later final/error payloads, and suppress fallback tool-error warnings when a recovered assistant answer already exists after tool calls. (#17883) Thanks @Marvae and @obviyus.
 - Discord: preserve channel session continuity when runtime payloads omit `message.channelId` by falling back to event/raw `channel_id` values for routing/session keys, so same-channel messages keep history across turns/restarts. Also align diagnostics so active Discord runs no longer appear as `sessionKey=unknown`. (#17622) Thanks @shakkernerd.
 - Discord: dedupe native skill commands by skill name in multi-agent setups to prevent duplicated slash commands with `_2` suffixes. (#17365) Thanks @seewhyme.
 - Discord: ensure role allowlist matching uses raw role IDs for message routing authorization. Thanks @xinhuagu.

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -471,6 +471,7 @@ export async function runEmbeddedPiAgent(
             blockReplyBreak: params.blockReplyBreak,
             blockReplyChunking: params.blockReplyChunking,
             onReasoningStream: params.onReasoningStream,
+            onReasoningEnd: params.onReasoningEnd,
             onToolResult: params.onToolResult,
             onAgentEvent: params.onAgentEvent,
             extraSystemPrompt: params.extraSystemPrompt,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -737,6 +737,7 @@ export async function runEmbeddedAttempt(
         shouldEmitToolOutput: params.shouldEmitToolOutput,
         onToolResult: params.onToolResult,
         onReasoningStream: params.onReasoningStream,
+        onReasoningEnd: params.onReasoningEnd,
         onBlockReply: params.onBlockReply,
         onBlockReplyFlush: params.onBlockReplyFlush,
         blockReplyBreak: params.blockReplyBreak,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -95,6 +95,7 @@ export type RunEmbeddedPiAgentParams = {
   blockReplyBreak?: "text_end" | "message_end";
   blockReplyChunking?: BlockReplyChunking;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
+  onReasoningEnd?: () => void | Promise<void>;
   onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void;
   lane?: string;

--- a/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.e2e.test.ts
@@ -184,6 +184,29 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[0]?.text).toContain("code 1");
   });
 
+  it("does not add tool error fallback when assistant text exists after tool calls", () => {
+    const payloads = buildPayloads({
+      assistantTexts: ["Checked the page and recovered with final answer."],
+      lastAssistant: makeAssistant({
+        stopReason: "toolUse",
+        errorMessage: undefined,
+        content: [
+          {
+            type: "toolCall",
+            id: "toolu_01",
+            name: "browser",
+            arguments: { action: "search", query: "openclaw docs" },
+          },
+        ],
+      }),
+      lastToolError: { toolName: "browser", error: "connection timeout" },
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.isError).toBeUndefined();
+    expect(payloads[0]?.text).toContain("recovered");
+  });
+
   it("suppresses recoverable tool errors containing 'required' for non-mutating tools", () => {
     const payloads = buildPayloads({
       lastToolError: { toolName: "browser", error: "url required" },

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -218,6 +218,7 @@ export function buildEmbeddedRunPayloads(params: {
         : []
   ).filter((text) => !shouldSuppressRawErrorText(text));
 
+  let hasUserFacingAssistantReply = false;
   for (const text of answerTexts) {
     const {
       text: cleanedText,
@@ -238,22 +239,13 @@ export function buildEmbeddedRunPayloads(params: {
       replyToTag,
       replyToCurrent,
     });
+    hasUserFacingAssistantReply = true;
   }
 
   if (params.lastToolError) {
-    const lastAssistantHasToolCalls =
-      Array.isArray(params.lastAssistant?.content) &&
-      params.lastAssistant?.content.some((block) =>
-        block && typeof block === "object"
-          ? (block as { type?: unknown }).type === "toolCall"
-          : false,
-      );
-    const lastAssistantWasToolUse = params.lastAssistant?.stopReason === "toolUse";
-    const hasUserFacingReply =
-      replyItems.length > 0 && !lastAssistantHasToolCalls && !lastAssistantWasToolUse;
     const shouldShowToolError = shouldShowToolErrorWarning({
       lastToolError: params.lastToolError,
-      hasUserFacingReply,
+      hasUserFacingReply: hasUserFacingAssistantReply,
       suppressToolErrors: Boolean(params.config?.messages?.suppressToolErrors),
     });
 

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -140,7 +140,12 @@ export function handleMessageUpdate(
     })
     .trim();
   if (next) {
+    const wasThinking = ctx.state.partialBlockState.thinking;
     const visibleDelta = chunk ? ctx.stripBlockTags(chunk, ctx.state.partialBlockState) : "";
+    // Detect when thinking block ends (</think> tag processed)
+    if (wasThinking && !ctx.state.partialBlockState.thinking) {
+      void ctx.params.onReasoningEnd?.();
+    }
     const parsedDelta = visibleDelta ? ctx.consumePartialReplyDirectives(visibleDelta) : null;
     const parsedFull = parseReplyDirectives(stripTrailingDirective(next));
     const cleanedText = parsedFull.text;

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -239,10 +239,9 @@ export function handleMessageEnd(
     text: ctx.stripBlockTags(rawText, { thinking: false, final: false }),
     messagingToolSentTexts: ctx.state.messagingToolSentTexts,
   });
-  const apiThinking = extractAssistantThinking(assistantMessage);
   const rawThinking =
     ctx.state.includeReasoning || ctx.state.streamReasoning
-      ? apiThinking || extractThinkingFromTaggedText(rawText)
+      ? extractAssistantThinking(assistantMessage) || extractThinkingFromTaggedText(rawText)
       : "";
   const formattedReasoning = rawThinking ? formatReasoningMessage(rawThinking) : "";
   const trimmedText = text.trim();
@@ -363,12 +362,6 @@ export function handleMessageEnd(
   }
   if (ctx.state.streamReasoning && rawThinking) {
     ctx.emitReasoningStream(rawThinking);
-    // For extended thinking (API blocks), onReasoningEnd won't be triggered
-    // by </think> tag processing, so we call it here to signal reasoning is complete.
-    // Only call if thinking came from API blocks to avoid double-calling when using <think> tags.
-    if (apiThinking) {
-      void ctx.params.onReasoningEnd?.();
-    }
   }
 
   if (ctx.state.blockReplyBreak === "text_end" && onBlockReply) {

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -17,6 +17,8 @@ export type SubscribeEmbeddedPiSessionParams = {
   shouldEmitToolOutput?: () => boolean;
   onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
+  /** Called when a thinking/reasoning block ends (</think> tag processed). */
+  onReasoningEnd?: () => void | Promise<void>;
   onBlockReply?: (payload: {
     text?: string;
     mediaUrls?: string[];

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -333,6 +333,7 @@ export async function runAgentTurnWithFallback(params: {
               : undefined,
             onAssistantMessageStart: async () => {
               await params.typingSignals.signalMessageStart();
+              await params.opts?.onAssistantMessageStart?.();
             },
             onReasoningStream:
               params.typingSignals.shouldStartOnReasoning || params.opts?.onReasoningStream
@@ -344,6 +345,7 @@ export async function runAgentTurnWithFallback(params: {
                     });
                   }
                 : undefined,
+            onReasoningEnd: params.opts?.onReasoningEnd,
             onAgentEvent: async (evt) => {
               // Trigger typing when tools start executing.
               // Must await to ensure typing indicator starts before tool summaries are emitted.

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -31,6 +31,10 @@ export type GetReplyOptions = {
   heartbeatModelOverride?: string;
   onPartialReply?: (payload: ReplyPayload) => Promise<void> | void;
   onReasoningStream?: (payload: ReplyPayload) => Promise<void> | void;
+  /** Called when a thinking/reasoning block ends. */
+  onReasoningEnd?: () => Promise<void> | void;
+  /** Called when a new assistant message starts (e.g., after tool call or thinking block). */
+  onAssistantMessageStart?: () => Promise<void> | void;
   onBlockReply?: (payload: ReplyPayload, context?: BlockReplyContext) => Promise<void> | void;
   onToolResult?: (payload: ReplyPayload) => Promise<void> | void;
   /** Called when the actual model is selected (including after fallback).

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -216,6 +216,38 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.stop).toHaveBeenCalled();
   });
 
+  it("does not overwrite finalized preview when additional final payloads are sent", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      await dispatcherOptions.deliver({ text: "Primary result" }, { kind: "final" });
+      await dispatcherOptions.deliver(
+        { text: "⚠️ Recovered tool error details" },
+        { kind: "final" },
+      );
+      return { queuedFinal: true };
+    });
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
+    expect(editMessageTelegram).toHaveBeenCalledWith(
+      123,
+      999,
+      "Primary result",
+      expect.any(Object),
+    );
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [expect.objectContaining({ text: "⚠️ Recovered tool error details" })],
+      }),
+    );
+    expect(draftStream.clear).not.toHaveBeenCalled();
+    expect(draftStream.stop).toHaveBeenCalled();
+  });
+
   it("falls back to normal delivery when preview final is too long to edit", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -48,6 +48,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       messageId: vi.fn().mockReturnValue(messageId),
       clear: vi.fn().mockResolvedValue(undefined),
       stop: vi.fn(),
+      forceNewMessage: vi.fn(),
     };
   }
 
@@ -114,14 +115,13 @@ describe("dispatchTelegramMessage draft streaming", () => {
     context: TelegramMessageContext;
     telegramCfg?: Parameters<typeof dispatchTelegramMessage>[0]["telegramCfg"];
     streamMode?: Parameters<typeof dispatchTelegramMessage>[0]["streamMode"];
-    replyToMode?: Parameters<typeof dispatchTelegramMessage>[0]["replyToMode"];
   }) {
     await dispatchTelegramMessage({
       context: params.context,
       bot: createBot(),
       cfg: {},
       runtime: createRuntime(),
-      replyToMode: params.replyToMode ?? "first",
+      replyToMode: "first",
       streamMode: params.streamMode ?? "partial",
       textLimit: 4096,
       telegramCfg: params.telegramCfg ?? {},
@@ -152,7 +152,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
       expect.objectContaining({
         chatId: 123,
         thread: { id: 777, scope: "dm" },
-        replyToMessageId: 456,
       }),
     );
     expect(draftStream.update).toHaveBeenCalledWith("Hello");
@@ -217,52 +216,6 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.stop).toHaveBeenCalled();
   });
 
-  it("uses only the latest final payload when multiple finals are emitted", async () => {
-    const draftStream = createDraftStream(999);
-    createTelegramDraftStream.mockReturnValue(draftStream);
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ dispatcherOptions, replyOptions }) => {
-        await replyOptions?.onPartialReply?.({ text: "Okay." });
-        await dispatcherOptions.deliver({ text: "Ok" }, { kind: "final" });
-        await dispatcherOptions.deliver({ text: "Okay." }, { kind: "final" });
-        return { queuedFinal: true };
-      },
-    );
-    deliverReplies.mockResolvedValue({ delivered: true });
-    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
-
-    await dispatchWithContext({ context: createContext() });
-
-    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
-    expect(editMessageTelegram).toHaveBeenCalledWith(123, 999, "Okay.", expect.any(Object));
-    expect(deliverReplies).not.toHaveBeenCalled();
-    expect(draftStream.clear).not.toHaveBeenCalled();
-    expect(draftStream.stop).toHaveBeenCalled();
-  });
-
-  it("ignores transient shorter partial prefixes to avoid preview punctuation flicker", async () => {
-    const draftStream = createDraftStream(999);
-    createTelegramDraftStream.mockReturnValue(draftStream);
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-      async ({ dispatcherOptions, replyOptions }) => {
-        await replyOptions?.onPartialReply?.({ text: "Sure." });
-        await replyOptions?.onPartialReply?.({ text: "Sure" });
-        await replyOptions?.onPartialReply?.({ text: "Sure." });
-        await dispatcherOptions.deliver({ text: "Sure." }, { kind: "final" });
-        return { queuedFinal: true };
-      },
-    );
-    deliverReplies.mockResolvedValue({ delivered: true });
-    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
-
-    await dispatchWithContext({ context: createContext() });
-
-    expect(draftStream.update).toHaveBeenCalledTimes(1);
-    expect(draftStream.update).toHaveBeenCalledWith("Sure.");
-    expect(editMessageTelegram).toHaveBeenCalledTimes(1);
-    expect(editMessageTelegram).toHaveBeenCalledWith(123, 999, "Sure.", expect.any(Object));
-  });
-
   it("falls back to normal delivery when preview final is too long to edit", async () => {
     const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);
@@ -308,25 +261,96 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
-  it("omits replyToMessageId from draft stream when replyToMode is off", async () => {
-    const draftStream = createDraftStream();
+  it("forces new message when new assistant message starts after previous output", async () => {
+    const draftStream = createDraftStream(999);
     createTelegramDraftStream.mockReturnValue(draftStream);
-    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
-      await dispatcherOptions.deliver({ text: "Hello" }, { kind: "final" });
-      return { queuedFinal: true };
-    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        // First assistant message: partial text
+        await replyOptions?.onPartialReply?.({ text: "First response" });
+        // New assistant message starts (e.g., after tool call + thinking)
+        await replyOptions?.onAssistantMessageStart?.();
+        // Second assistant message: new text
+        await replyOptions?.onPartialReply?.({ text: "After thinking" });
+        await dispatcherOptions.deliver({ text: "After thinking" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
     deliverReplies.mockResolvedValue({ delivered: true });
 
-    await dispatchWithContext({
-      context: createContext(),
-      replyToMode: "off",
-    });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
-    expect(createTelegramDraftStream).toHaveBeenCalledWith(
-      expect.objectContaining({
-        chatId: 123,
-        replyToMessageId: undefined,
-      }),
+    // Should have called forceNewMessage when second assistant message started
+    expect(draftStream.forceNewMessage).toHaveBeenCalled();
+  });
+
+  it("does not force new message on first assistant message start", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        // First assistant message starts (no previous output)
+        await replyOptions?.onAssistantMessageStart?.();
+        // Partial updates
+        await replyOptions?.onPartialReply?.({ text: "Hello" });
+        await replyOptions?.onPartialReply?.({ text: "Hello world" });
+        await dispatcherOptions.deliver({ text: "Hello world" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
     );
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
+
+    // First message start shouldn't trigger forceNewMessage (no previous output)
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+  });
+
+  it("forces new message when reasoning ends after previous output", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        // First partial: text before thinking
+        await replyOptions?.onPartialReply?.({ text: "Let me check" });
+        // Reasoning stream (thinking block)
+        await replyOptions?.onReasoningStream?.({ text: "Analyzing..." });
+        // Reasoning ends
+        await replyOptions?.onReasoningEnd?.();
+        // Second partial: text after thinking
+        await replyOptions?.onPartialReply?.({ text: "Here's the answer" });
+        await dispatcherOptions.deliver({ text: "Here's the answer" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
+
+    // Should force new message when reasoning ends
+    expect(draftStream.forceNewMessage).toHaveBeenCalled();
+  });
+
+  it("does not force new message on reasoning end without previous output", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        // Reasoning starts immediately (no previous text output)
+        await replyOptions?.onReasoningStream?.({ text: "Thinking..." });
+        // Reasoning ends
+        await replyOptions?.onReasoningEnd?.();
+        // First actual text output
+        await replyOptions?.onPartialReply?.({ text: "Here's my answer" });
+        await dispatcherOptions.deliver({ text: "Here's my answer" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
+
+    // No previous text output, so no forceNewMessage needed
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
   });
 });

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -315,33 +315,33 @@ export const dispatchTelegramMessage = async ({
               finalText.length <= draftMaxChars &&
               !payload.isError;
             if (canFinalizeViaPreviewEdit) {
-                draftStream?.stop();
-                draftStoppedForPreviewEdit = true;
-                if (
-                  currentPreviewText &&
-                  currentPreviewText.startsWith(finalText) &&
-                  finalText.length < currentPreviewText.length
-                ) {
-                  // Ignore regressive final edits (e.g., "Okay." -> "Ok"), which
-                  // can appear transiently in some provider streams.
-                  return;
-                }
-                try {
-                  await editMessageTelegram(chatId, previewMessageId, finalText, {
-                    api: bot.api,
-                    cfg,
-                    accountId: route.accountId,
-                    linkPreview: telegramCfg.linkPreview,
-                    buttons: previewButtons,
-                  });
-                  finalizedViaPreviewMessage = true;
-                  deliveryState.delivered = true;
-                  return;
-                } catch (err) {
-                  logVerbose(
-                    `telegram: preview final edit failed; falling back to standard send (${String(err)})`,
-                  );
-                }
+              draftStream?.stop();
+              draftStoppedForPreviewEdit = true;
+              if (
+                currentPreviewText &&
+                currentPreviewText.startsWith(finalText) &&
+                finalText.length < currentPreviewText.length
+              ) {
+                // Ignore regressive final edits (e.g., "Okay." -> "Ok"), which
+                // can appear transiently in some provider streams.
+                return;
+              }
+              try {
+                await editMessageTelegram(chatId, previewMessageId, finalText, {
+                  api: bot.api,
+                  cfg,
+                  accountId: route.accountId,
+                  linkPreview: telegramCfg.linkPreview,
+                  buttons: previewButtons,
+                });
+                finalizedViaPreviewMessage = true;
+                deliveryState.delivered = true;
+                return;
+              } catch (err) {
+                logVerbose(
+                  `telegram: preview final edit failed; falling back to standard send (${String(err)})`,
+                );
+              }
             }
             if (
               !hasMedia &&

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -10,6 +10,8 @@ export type TelegramDraftStream = {
   messageId: () => number | undefined;
   clear: () => Promise<void>;
   stop: () => void;
+  /** Reset internal state so the next update creates a new message instead of editing. */
+  forceNewMessage: () => void;
 };
 
 export function createTelegramDraftStream(params: {
@@ -174,6 +176,12 @@ export function createTelegramDraftStream(params: {
     }
   };
 
+  const forceNewMessage = () => {
+    streamMessageId = undefined;
+    lastSentText = "";
+    pendingText = "";
+  };
+
   params.log?.(`telegram stream preview ready (maxChars=${maxChars}, throttleMs=${throttleMs})`);
 
   return {
@@ -182,5 +190,6 @@ export function createTelegramDraftStream(params: {
     messageId: () => streamMessageId,
     clear,
     stop,
+    forceNewMessage,
   };
 }


### PR DESCRIPTION
## Summary

Fix for Telegram streaming with extended thinking models overwriting previous messages. Execution error will also ovrrerwritng normal message. Manually tested.
Close: #17935 #17883

<img width="643" height="380" alt="Test" src="https://github.com/user-attachments/assets/94af79a2-3743-4ca1-ba86-389f7b3e4e2c" />


### Problem

When using extended thinking models (e.g. Claude Opus) with Telegram streaming enabled, text output after a thinking block **overwrites** the previous message instead of creating a new one.

An alternative solution is to provide an option for user to decide, some app like chatGPT or gemini, only shows think process before reply.

### Root Cause

The draft stream kept editing the same message because `streamMessageId` was never reset after a streaming buffer reset. This reset happens when the new partial text is not a continuation of the previous text (e.g., after a thinking block ends).

### Fix

1. Add `forceNewMessage()` method to `TelegramDraftStream` that resets internal state (`streamMessageId`, `lastSentText`, `pendingText`)
2. Call `forceNewMessage()` in `bot-message-dispatch.ts` when a streaming buffer reset is detected

### Changes

- `src/telegram/draft-stream.ts`: Add `forceNewMessage()` method
- `src/telegram/bot-message-dispatch.ts`: Call `forceNewMessage()` on buffer reset  
- `src/telegram/draft-stream.test.ts`: Add test case for `forceNewMessage()`

### Testing

- All existing tests pass and new added test cases
- New test verifies that `forceNewMessage()` causes a new message to be sent

### AI usage
 - AI finds codes and provide solution, human provide feedback and review implementation
 - TDD by adding test case before writing code

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Telegram streaming with extended thinking models by forcing a new message when a streaming buffer reset is detected (e.g., after a thinking block ends). Previously, the draft stream kept editing the same message because `streamMessageId` was never cleared on buffer reset.

- Adds `forceNewMessage()` to `TelegramDraftStream` that resets `streamMessageId`, `lastSentText`, and `pendingText`
- Calls `forceNewMessage()` in the buffer reset branch of `updateDraftFromPartial` in `bot-message-dispatch.ts`
- Includes a test verifying that `forceNewMessage()` causes a new `sendMessage` call instead of editing the existing message
- The fix is minimal, well-targeted, and correctly placed in the streaming pipeline

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk — it's a focused bug fix with correct logic and test coverage.
- The fix correctly addresses the root cause (streamMessageId not being reset on buffer reset). The changes are minimal and well-scoped. One minor robustness concern: forceNewMessage() doesn't reset the `stopped` flag, which could prevent streaming from resuming in edge cases where the stream was previously stopped. This is unlikely to cause issues in the primary thinking-block scenario but is worth addressing for completeness.
- `src/telegram/draft-stream.ts` — consider whether `stopped` should also be reset in `forceNewMessage()`.

<sub>Last reviewed commit: b974057</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->