### PR TITLE
fix(routing): use fresh config in resolveAgentRoute to prevent stale bindings

### DIFF
--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -13,7 +13,6 @@ import { formatAllowlistMatchMeta } from "../../channels/allowlist-match.js";
 import { resolveControlCommandGate } from "../../channels/command-gating.js";
 import { logInboundDrop } from "../../channels/logging.js";
 import { resolveMentionGatingWithBypass } from "../../channels/mention-gating.js";
-import { loadConfig } from "../../config/config.js";
 import { isDangerousNameMatchingEnabled } from "../../config/dangerous-name-matching.js";
 import { logVerbose, shouldLogVerbose } from "../../globals.js";
 import { recordChannelActivity } from "../../infra/channel-activity.js";
@@ -278,12 +277,11 @@ export async function preflightDiscordMessage(
     earlyThreadParentType = parentInfo.type;
   }
 
-  // Fresh config for bindings lookup; other routing inputs are payload-derived.
   const memberRoleIds = Array.isArray(params.data.rawMember?.roles)
     ? params.data.rawMember.roles.map((roleId: string) => String(roleId))
     : [];
   const route = resolveAgentRoute({
-    cfg: loadConfig(),
+    cfg: params.cfg,
     channel: "discord",
     accountId: params.accountId,
     guildId: params.data.guild_id ?? undefined,

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -1,7 +1,20 @@
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 import type { ChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { resolveAgentRoute } from "./resolve-route.js";
+
+const loadConfigMock = vi.hoisted(() => vi.fn<() => OpenClawConfig>(() => ({})));
+vi.mock("../config/config.js", () => ({ loadConfig: loadConfigMock }));
+
+import type { ResolveAgentRouteInput } from "./resolve-route.js";
+import { resolveAgentRoute as resolveAgentRouteImpl } from "./resolve-route.js";
+
+/** Wrapper that feeds the test cfg into the loadConfig mock. */
+function resolveAgentRoute(input: ResolveAgentRouteInput) {
+  if (input.cfg) {
+    loadConfigMock.mockReturnValue(input.cfg);
+  }
+  return resolveAgentRouteImpl(input);
+}
 
 describe("resolveAgentRoute", () => {
   const resolveDiscordGuildRoute = (cfg: OpenClawConfig) =>
@@ -766,5 +779,43 @@ describe("role-based agent routing", () => {
       expectedAgentId: "guild-roles",
       expectedMatchedBy: "binding.guild+roles",
     });
+  });
+});
+
+describe("loadConfig fallback", () => {
+  test("falls back to input.cfg when loadConfig returns empty object", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [{ agentId: "fallback-agent", match: { channel: "telegram" } }],
+    };
+    // Simulate loadConfig() degrading to {} on parse/read failure.
+    loadConfigMock.mockReturnValue({});
+    const route = resolveAgentRouteImpl({ cfg, channel: "telegram" });
+    expect(route.agentId).toBe("fallback-agent");
+    expect(route.matchedBy).toBe("binding.account");
+  });
+
+  test("prefers fresh loadConfig over input.cfg when available", () => {
+    const staleCfg: OpenClawConfig = {
+      bindings: [{ agentId: "stale-agent", match: { channel: "telegram" } }],
+    };
+    const freshCfg: OpenClawConfig = {
+      bindings: [{ agentId: "fresh-agent", match: { channel: "telegram" } }],
+    };
+    loadConfigMock.mockReturnValue(freshCfg);
+    const route = resolveAgentRouteImpl({ cfg: staleCfg, channel: "telegram" });
+    expect(route.agentId).toBe("fresh-agent");
+    expect(route.matchedBy).toBe("binding.account");
+  });
+
+  test("falls back to input.cfg when loadConfig throws", () => {
+    const cfg: OpenClawConfig = {
+      bindings: [{ agentId: "safe-agent", match: { channel: "slack" } }],
+    };
+    loadConfigMock.mockImplementation(() => {
+      throw new Error("DuplicateAgentDirError");
+    });
+    const route = resolveAgentRouteImpl({ cfg, channel: "slack" });
+    expect(route.agentId).toBe("safe-agent");
+    expect(route.matchedBy).toBe("binding.account");
   });
 });

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -2,6 +2,7 @@ import { resolveDefaultAgentId } from "../agents/agent-scope.js";
 import type { ChatType } from "../channels/chat-type.js";
 import { normalizeChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { loadConfig } from "../config/config.js";
 import { shouldLogVerbose } from "../globals.js";
 import { logDebug } from "../logger.js";
 import { listBindings } from "./bindings.js";
@@ -24,7 +25,8 @@ export type RoutePeer = {
 };
 
 export type ResolveAgentRouteInput = {
-  cfg: OpenClawConfig;
+  /** @deprecated Config is now loaded internally via loadConfig(). Kept as optional fallback. */
+  cfg?: OpenClawConfig;
   channel: string;
   accountId?: string | null;
   peer?: RoutePeer | null;
@@ -528,6 +530,19 @@ function matchesBindingScope(match: NormalizedBindingMatch, scope: BindingScope)
 }
 
 export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentRoute {
+  // Prefer fresh config so hot-reloaded binding changes take effect
+  // immediately. loadConfig() is sync with a TTL cache so there is no
+  // performance penalty. Fall back to the caller-provided cfg when
+  // loadConfig() degrades to {} (transient parse/read failures) or throws
+  // (e.g. DuplicateAgentDirError during live config edits).
+  let freshCfg: OpenClawConfig | undefined;
+  try {
+    freshCfg = loadConfig();
+  } catch {
+    // Swallow — fall through to input.cfg below.
+  }
+  const cfg =
+    freshCfg && Object.keys(freshCfg).length > 0 ? freshCfg : (input.cfg ?? freshCfg ?? {});
   const channel = normalizeToken(input.channel);
   const accountId = normalizeAccountId(input.accountId);
   const peer = input.peer
@@ -540,8 +555,8 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const teamId = normalizeId(input.teamId);
   const memberRoleIds = input.memberRoleIds ?? [];
   const memberRoleIdSet = new Set(memberRoleIds);
-  const dmScope = input.cfg.session?.dmScope ?? "main";
-  const identityLinks = input.cfg.session?.identityLinks;
+  const dmScope = cfg.session?.dmScope ?? "main";
+  const identityLinks = cfg.session?.identityLinks;
   const shouldLogDebug = shouldLogVerbose();
   const parentPeer = input.parentPeer
     ? {
@@ -551,7 +566,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     : null;
 
   const routeCache =
-    !shouldLogDebug && !identityLinks ? resolveRouteCacheForConfig(input.cfg) : null;
+    !shouldLogDebug && !identityLinks ? resolveRouteCacheForConfig(cfg) : null;
   const routeCacheKey = routeCache
     ? buildResolvedRouteCacheKey({
         channel,
@@ -571,11 +586,11 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     }
   }
 
-  const bindings = getEvaluatedBindingsForChannelAccount(input.cfg, channel, accountId);
-  const bindingsIndex = getEvaluatedBindingIndexForChannelAccount(input.cfg, channel, accountId);
+  const bindings = getEvaluatedBindingsForChannelAccount(cfg, channel, accountId);
+  const bindingsIndex = getEvaluatedBindingIndexForChannelAccount(cfg, channel, accountId);
 
   const choose = (agentId: string, matchedBy: ResolvedAgentRoute["matchedBy"]) => {
-    const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
+    const resolvedAgentId = pickFirstExistingAgentId(cfg, agentId);
     const sessionKey = buildAgentSessionKey({
       agentId: resolvedAgentId,
       channel,
@@ -715,5 +730,5 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     }
   }
 
-  return choose(resolveDefaultAgentId(input.cfg), "default");
+  return choose(resolveDefaultAgentId(cfg), "default");
 }

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -817,9 +817,8 @@ export const registerTelegramHandlers = ({
         : undefined;
       const peerId = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : String(chatId);
       const parentPeer = buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId });
-      // Fresh config for bindings lookup; other routing inputs are payload-derived.
       const route = resolveAgentRoute({
-        cfg: loadConfig(),
+        cfg,
         channel: "telegram",
         accountId,
         peer: { kind: isGroup ? "group" : "direct", id: peerId },

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -28,7 +28,6 @@ import {
   type StatusReactionController,
 } from "../channels/status-reactions.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { loadConfig } from "../config/config.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../config/sessions.js";
 import type {
   DmPolicy,
@@ -198,9 +197,8 @@ export const buildTelegramMessageContext = async ({
     ? buildTelegramGroupPeerId(chatId, resolvedThreadId)
     : resolveTelegramDirectPeerId({ chatId, senderId });
   const parentPeer = buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId });
-  // Fresh config for bindings lookup; other routing inputs are payload-derived.
   const route = resolveAgentRoute({
-    cfg: loadConfig(),
+    cfg,
     channel: "telegram",
     accountId: account.accountId,
     peer: {

--- a/src/web/auto-reply/monitor/on-message.ts
+++ b/src/web/auto-reply/monitor/on-message.ts
@@ -1,6 +1,6 @@
 import type { getReplyFromConfig } from "../../../auto-reply/reply.js";
 import type { MsgContext } from "../../../auto-reply/templating.js";
-import { loadConfig } from "../../../config/config.js";
+import type { OpenClawConfig } from "../../../config/config.js";
 import { logVerbose } from "../../../globals.js";
 import { resolveAgentRoute } from "../../../routing/resolve-route.js";
 import { buildGroupHistoryKey } from "../../../routing/session-key.js";
@@ -16,7 +16,7 @@ import { resolvePeerId } from "./peer.js";
 import { processMessage } from "./process-message.js";
 
 export function createWebOnMessageHandler(params: {
-  cfg: ReturnType<typeof loadConfig>;
+  cfg: OpenClawConfig;
   verbose: boolean;
   connectionId: string;
   maxMediaBytes: number;
@@ -63,9 +63,8 @@ export function createWebOnMessageHandler(params: {
   return async (msg: WebInboundMsg) => {
     const conversationId = msg.conversationId ?? msg.from;
     const peerId = resolvePeerId(msg);
-    // Fresh config for bindings lookup; other routing inputs are payload-derived.
     const route = resolveAgentRoute({
-      cfg: loadConfig(),
+      cfg: params.cfg,
       channel: "whatsapp",
       accountId: msg.accountId,
       peer: {


### PR DESCRIPTION
## Summary

- `resolveAgentRoute()` now calls `loadConfig()` internally instead of relying on `input.cfg`, which was often a stale closure snapshot captured at channel handler startup
- Falls back to `input.cfg` when `loadConfig()` degrades to `{}` (transient parse/read failures) or throws (e.g. `DuplicateAgentDirError`)
- Makes `cfg` optional on `ResolveAgentRouteInput` (deprecated — config is now loaded internally)
- Adds tests verifying both fallback paths

Fixes #18773

## Root Cause

Channel handlers across Telegram, LINE, Slack, Signal, Discord, Mattermost, iMessage, LINQ, and WhatsApp auto-reply all capture `cfg` once at startup and pass it through closures to `resolveAgentRoute()`. When config is hot-reloaded (e.g., bindings updated via the configure wizard or gateway API), the closure config is stale and routing decisions use outdated binding data.

Four call sites had already been individually patched to use `loadConfig()`:
- `src/telegram/bot-message-context.ts:172`
- `src/telegram/bot-handlers.ts:533`
- `src/discord/monitor/message-handler.preflight.ts:244`
- `src/web/auto-reply/monitor/on-message.ts:68`

Including one with an explicit comment: *"Fresh config for bindings lookup"* (commit `8d96955e1`). But 15+ call sites still passed stale config.

This fix moves the `loadConfig()` call into `resolveAgentRoute()` itself, fixing all callers at once. Since `loadConfig()` is sync with a TTL cache, there is no performance penalty.

Related issues: #5283, #13869
Supersedes: #14915

## Test plan

- [x] All 38 routing tests pass (35 existing + 3 new fallback tests)
- [x] Verified fallback: when `loadConfig()` returns `{}`, routing uses caller-provided `input.cfg`
- [x] Verified fallback: when `loadConfig()` throws, routing uses caller-provided `input.cfg`
- [x] Verified preference: when `loadConfig()` returns valid config, it takes precedence over stale `input.cfg`
- [x] Build passes (`pnpm build`)
- [x] Format and lint clean (`oxfmt --check`, `oxlint`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Moves `loadConfig()` call inside `resolveAgentRoute()` to ensure hot-reloaded binding changes take effect immediately across all channel handlers (Telegram, Discord, Slack, Signal, WhatsApp, and others). Previously, channel handlers captured config at startup in closures, causing stale routing decisions when config was updated via the configure wizard or gateway API.

**Key changes:**
- `resolveAgentRoute()` now calls `loadConfig()` internally on line 305 and prefers fresh config over caller-provided `input.cfg`
- Falls back to `input.cfg` when `loadConfig()` returns empty object (transient parse/read failures) or throws (e.g., `DuplicateAgentDirError`)
- Makes `cfg` optional on `ResolveAgentRouteInput` (line 28) with deprecation notice since config is now loaded internally
- Removes `loadConfig()` imports from 4 call sites that had already been individually patched (Discord, Telegram 2x, WhatsApp)
- All other call sites continue passing `cfg` as before, which now acts as fallback

**Test coverage:**
- 3 new tests verify fallback behavior: empty config fallback, fresh config preference, and exception fallback
- All 38 routing tests pass (35 existing + 3 new)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-designed with proper fallback handling, comprehensive test coverage (38 tests), and backwards compatibility. The logic correctly handles edge cases (empty config, exceptions), and the approach fixes the root cause for all channels at once rather than patching individual call sites.
- No files require special attention

<sub>Last reviewed commit: 5c433b0</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->