### PR TITLE
revert(browser): remove extraArgs config

### DIFF
--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -70,7 +70,6 @@ function buildSandboxBrowserResolvedConfig(params: {
     noSandbox: false,
     attachOnly: true,
     defaultProfile: DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
-    extraArgs: [],
     profiles: {
       [DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME]: {
         cdpPort: params.cdpPort,

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -217,11 +217,6 @@ export async function launchOpenClawChrome(
     // Stealth: hide navigator.webdriver from automation detection (#80)
     args.push("--disable-blink-features=AutomationControlled");
 
-    // Append user-configured extra arguments (e.g., stealth flags, window size)
-    if (resolved.extraArgs.length > 0) {
-      args.push(...resolved.extraArgs);
-    }
-
     // Always open a blank tab to ensure a target exists.
     args.push("about:blank");
 

--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -149,37 +149,4 @@ describe("browser config", () => {
     expect(resolveProfile(resolved, "chrome")).toBe(null);
     expect(resolved.defaultProfile).toBe("openclaw");
   });
-
-  it("defaults extraArgs to empty array when not provided", () => {
-    const resolved = resolveBrowserConfig(undefined);
-    expect(resolved.extraArgs).toEqual([]);
-  });
-
-  it("passes through valid extraArgs strings", () => {
-    const resolved = resolveBrowserConfig({
-      extraArgs: ["--no-sandbox", "--disable-gpu"],
-    });
-    expect(resolved.extraArgs).toEqual(["--no-sandbox", "--disable-gpu"]);
-  });
-
-  it("filters out empty strings and whitespace-only entries from extraArgs", () => {
-    const resolved = resolveBrowserConfig({
-      extraArgs: ["--flag", "", "  ", "--other"],
-    });
-    expect(resolved.extraArgs).toEqual(["--flag", "--other"]);
-  });
-
-  it("filters out non-string entries from extraArgs", () => {
-    const resolved = resolveBrowserConfig({
-      extraArgs: ["--flag", 42, null, undefined, true, "--other"] as unknown as string[],
-    });
-    expect(resolved.extraArgs).toEqual(["--flag", "--other"]);
-  });
-
-  it("defaults extraArgs to empty array when set to non-array", () => {
-    const resolved = resolveBrowserConfig({
-      extraArgs: "not-an-array" as unknown as string[],
-    });
-    expect(resolved.extraArgs).toEqual([]);
-  });
 });

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -31,7 +31,6 @@ export type ResolvedBrowserConfig = {
   attachOnly: boolean;
   defaultProfile: string;
   profiles: Record<string, BrowserProfileConfig>;
-  extraArgs: string[];
 };
 
 export type ResolvedBrowserProfile = {
@@ -197,10 +196,6 @@ export function resolveBrowserConfig(
       ? DEFAULT_BROWSER_DEFAULT_PROFILE_NAME
       : DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME);
 
-  const extraArgs = Array.isArray(cfg?.extraArgs)
-    ? cfg.extraArgs.filter((a): a is string => typeof a === "string" && a.trim().length > 0)
-    : [];
-
   return {
     enabled,
     evaluateEnabled,
@@ -217,7 +212,6 @@ export function resolveBrowserConfig(
     attachOnly,
     defaultProfile,
     profiles,
-    extraArgs,
   };
 }
 

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -38,10 +38,4 @@ export type BrowserConfig = {
   profiles?: Record<string, BrowserProfileConfig>;
   /** Default snapshot options (applied by the browser tool/CLI when unset). */
   snapshotDefaults?: BrowserSnapshotDefaults;
-  /**
-   * Additional Chrome launch arguments.
-   * Useful for stealth flags, window size overrides, or custom user-agent strings.
-   * Example: ["--window-size=1920,1080", "--disable-infobars"]
-   */
-  extraArgs?: string[];
 };


### PR DESCRIPTION
## Summary
- Revert browser.extraArgs support and related tests/config additions.
- Removes extra Chrome arg injection to undo accidental merge.

## Testing
- Not run (revert only).

Reverts: https://github.com/openclaw/openclaw/pull/18443

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR cleanly reverts the `browser.extraArgs` configuration feature that was added in three commits (039fc1e0, 2977f732, 47f8c920). The revert removes:
- The `extraArgs` property from `BrowserConfig` type definition
- The `extraArgs` field from `ResolvedBrowserConfig` 
- The filtering/validation logic for `extraArgs` in `resolveBrowserConfig()`
- The Chrome argument injection code in `launchOpenClawChrome()`
- The `extraArgs: []` initialization in `buildSandboxBrowserResolvedConfig()`
- All 5 test cases covering `extraArgs` behavior

The revert is complete and doesn't leave any dangling references. All changes are pure deletions that undo the original feature without introducing new logic.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The revert is complete and correct. All additions from the three commits being reverted (039fc1e0, 2977f732, 47f8c920) have been cleanly removed. No dangling references to `extraArgs` remain in the TypeScript/JavaScript codebase. The changes are pure deletions with no new logic introduced, making this a straightforward and safe revert operation.
- No files require special attention

<sub>Last reviewed commit: d03339a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->