### PR TITLE
fix(cli): improve update version check messaging

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -679,7 +679,9 @@ describe("update-cli", () => {
 
     await updateCommand({});
 
-    expect(defaultRuntime.log).toHaveBeenCalledWith(expect.stringContaining("Already up to date (1.2.3)"));
+    expect(defaultRuntime.log).toHaveBeenCalledWith(
+      expect.stringContaining("Already up to date (1.2.3)"),
+    );
   });
 
   it("keeps channel persistence when target version resolution fails", async () => {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -614,6 +614,108 @@ describe("update-cli", () => {
     expect(runGatewayUpdate).toHaveBeenCalled();
   });
 
+  it("reports unresolved channel version without downgrade messaging", async () => {
+    const tempDir = await createCaseDir("openclaw-update");
+
+    setTty(false);
+    readPackageVersion.mockResolvedValue("2.0.0");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(tempDir);
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root: tempDir,
+      installKind: "package",
+      packageManager: "npm",
+      deps: {
+        manager: "npm",
+        status: "ok",
+        lockfilePath: null,
+        markerPath: null,
+      },
+    });
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
+      tag: "latest",
+      version: null,
+    });
+    vi.mocked(runGatewayUpdate).mockResolvedValue({
+      status: "ok",
+      mode: "npm",
+      steps: [],
+      durationMs: 100,
+    });
+
+    await updateCommand({});
+
+    expect(defaultRuntime.error).toHaveBeenCalledWith("Could not resolve version for latest");
+    expect(defaultRuntime.error).not.toHaveBeenCalledWith(
+      expect.stringContaining("Downgrade confirmation required."),
+    );
+  });
+
+  it("logs already up to date when current and target versions match", async () => {
+    const tempDir = await createCaseDir("openclaw-update");
+
+    readPackageVersion.mockResolvedValue("1.2.3");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(tempDir);
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root: tempDir,
+      installKind: "package",
+      packageManager: "npm",
+      deps: {
+        manager: "npm",
+        status: "ok",
+        lockfilePath: null,
+        markerPath: null,
+      },
+    });
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
+      tag: "latest",
+      version: "1.2.3",
+    });
+    vi.mocked(runGatewayUpdate).mockResolvedValue({
+      status: "ok",
+      mode: "npm",
+      steps: [],
+      durationMs: 100,
+    });
+
+    await updateCommand({});
+
+    expect(defaultRuntime.log).toHaveBeenCalledWith(expect.stringContaining("Already up to date (1.2.3)"));
+  });
+
+  it("keeps channel persistence when target version resolution fails", async () => {
+    const tempDir = await createCaseDir("openclaw-update");
+
+    readPackageVersion.mockResolvedValue("1.0.0");
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(tempDir);
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root: tempDir,
+      installKind: "package",
+      packageManager: "npm",
+      deps: {
+        manager: "npm",
+        status: "ok",
+        lockfilePath: null,
+        markerPath: null,
+      },
+    });
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
+      tag: "latest",
+      version: null,
+    });
+    vi.mocked(runGatewayUpdate).mockResolvedValue({
+      status: "ok",
+      mode: "npm",
+      steps: [],
+      durationMs: 100,
+    });
+
+    await updateCommand({ channel: "beta" });
+
+    expect(defaultRuntime.error).toHaveBeenCalledWith("Could not resolve version for latest");
+    expect(writeConfigFile).toHaveBeenCalled();
+    expect(runGatewayUpdate).toHaveBeenCalled();
+  });
+
   it("updateWizardCommand requires a TTY", async () => {
     setTty(false);
     vi.mocked(defaultRuntime.error).mockClear();

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -516,10 +516,17 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
         });
     const cmp =
       currentVersion && targetVersion ? compareSemverStrings(currentVersion, targetVersion) : null;
+    if (targetVersion == null) {
+      defaultRuntime.error(`Could not resolve version for ${tag}`);
+    } else if (!opts.json && currentVersion != null && cmp === 0) {
+      defaultRuntime.log(theme.muted(`Already up to date (${currentVersion})`));
+    }
     const needsConfirm =
       !fallbackToLatest &&
       currentVersion != null &&
-      (targetVersion == null || (cmp != null && cmp > 0));
+      targetVersion != null &&
+      cmp != null &&
+      cmp > 0;
 
     if (needsConfirm && !opts.yes) {
       if (!process.stdin.isTTY || opts.json) {


### PR DESCRIPTION
## Summary
When npm registry is unreachable and `targetVersion` is null, the update command incorrectly treats it as a 'downgrade' and shows 'Downgrading from X to (unknown)' which is confusing.

## Changes
- Show 'Could not resolve version for \<tag\>' when npm registry is unreachable (instead of downgrade message)
- Show 'Already up to date (version)' when current matches target version
- Only trigger downgrade confirmation for actual downgrades (`cmp > 0`), not unknown versions
- Preserve channel persistence and plugin updates even when version resolution fails

## Testing
Added 3 test cases:
- `reports unresolved channel version without downgrade messaging`
- `logs already up to date when current and target versions match`
- `keeps channel persistence when target version resolution fails`

All 24 tests passing.

Closes #8450
Closes #10690