### PR TITLE
fix(telegram): await runner.stop() before retry to prevent 409 conflicts

### DIFF
--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -209,6 +209,12 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         }
       } finally {
         opts.abortSignal?.removeEventListener("abort", stopOnAbort);
+        // Fully stop the runner before retry or return to prevent duplicate getUpdates.
+        try {
+          await runner.stop();
+        } catch {
+          // already stopped
+        }
       }
     }
   } finally {


### PR DESCRIPTION
## Summary

- Problem: grammY polling loop did not `await runner.stop()` before starting the next runner on retry, leaving two concurrent `getUpdates` sessions
- Why it matters: Duplicate polling sessions cause escalating 409 conflicts where each restart spawns another conflicting session
- What changed: Added `await runner.stop()` in the `finally` block so each runner is fully torn down before the next one starts; added test asserting stop ordering
- What did NOT change (scope boundary): Runner options, backoff policy, webhook path — only teardown sequencing in the retry loop

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #18671

## User-visible / Behavior Changes

- Telegram polling no longer triggers cascading 409 `getUpdates` conflicts on transient errors or reconnects

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Integration/channel (if any): Telegram long-polling

### Steps

1. Start Telegram monitor with long-polling
2. Trigger a recoverable error (network blip or 409 conflict)
3. Observe retry behavior

### Expected

- Previous runner fully stops before next runner starts; no duplicate `getUpdates`

### Actual

- Before fix: `runner.stop()` not awaited, two concurrent polling sessions cause 409 loop
- After fix: sequential teardown, clean restart

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm build`, `pnpm check`, `pnpm test` all pass
  - New test "stops runner before retry on 409 conflict" confirms runner-1 stopped before runner-2 starts
- Edge cases checked:
  - Runner already stopped (caught and ignored in try/catch)
  - Abort signal during polling (stop still awaited in finally)
- What you did **not** verify:
  - Live Telegram bot under real 409 conditions

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR
- Files/config to restore: `src/telegram/monitor.ts`
- Known bad symptoms reviewers should watch for: Polling loop hanging on `stop()` if grammY runner never resolves

## Risks and Mitigations

- Risk: `runner.stop()` could hang if grammY has an internal bug
  - Mitigation: Existing `maxRetryTime` and abort signal provide escape hatches; `stop()` is already used elsewhere in the codebase

cc @gumadeiras @quotentiroler — review would be great when you have a moment

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a bug where the grammY polling runner was not fully stopped before retrying on transient errors (e.g., 409 `getUpdates` conflicts), causing duplicate concurrent polling sessions that escalated into cascading 409 conflicts.

- Adds `await runner.stop()` in the `finally` block of the retry loop so each runner is fully torn down before the next one starts
- The `try/catch` around `runner.stop()` handles the case where the runner is already stopped (e.g., via abort signal or normal completion)
- New test validates that runner-1 is fully stopped before runner-2 starts on a 409 conflict

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a single awaited teardown call in the correct place with proper error handling.
- The change is minimal (6 lines of production code), well-scoped to the retry loop's finally block, and correctly handles all edge cases: already-stopped runners (try/catch), abort signal races (idempotent stop), and normal completion paths. The fix directly addresses the root cause of cascading 409 conflicts. The new test validates the critical ordering invariant.
- No files require special attention.

<sub>Last reviewed commit: baa5b5d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->