### PR TITLE
fix(skills): complete clawhub SKILL.md with missing commands

### DIFF
--- a/skills/clawhub/SKILL.md
+++ b/skills/clawhub/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: clawhub
-description: Use the ClawHub CLI to search, install, update, and publish agent skills from clawhub.com. Use when you need to fetch new skills on the fly, sync installed skills to latest or a specific version, or publish new/updated skill folders with the npm-installed clawhub CLI.
+description: Use the ClawHub CLI to search, install, update, sync, and publish agent skills from clawhub.ai. Use when you need to fetch new skills on the fly, sync installed skills to latest or a specific version, or publish new/updated skill folders with the npm-installed clawhub CLI.
 metadata:
   {
     "openclaw":
@@ -28,50 +28,81 @@ Install
 npm i -g clawhub
 ```
 
-Auth (publish)
+## Auth
 
 ```bash
 clawhub login
 clawhub whoami
+clawhub logout
 ```
 
-Search
+## Search
 
 ```bash
 clawhub search "postgres backups"
+clawhub search "calendar" --limit 5
 ```
 
-Install
+## Install
 
 ```bash
 clawhub install my-skill
 clawhub install my-skill --version 1.2.3
+clawhub install my-skill --force          # overwrite existing folder
 ```
 
-Update (hash-based match + upgrade)
+## Update
+
+Hash-based match: compares local files to registry versions, upgrades to latest unless `--version` is set.
 
 ```bash
 clawhub update my-skill
 clawhub update my-skill --version 1.2.3
 clawhub update --all
-clawhub update my-skill --force
 clawhub update --all --no-input --force
 ```
 
-List
+## List
+
+Shows installed skills from `.clawhub/lock.json`:
 
 ```bash
 clawhub list
 ```
 
-Publish
+## Sync
+
+Scan local skill folders, publish new or updated skills in bulk:
+
+```bash
+clawhub sync --dry-run                    # preview what would be uploaded
+clawhub sync                              # interactive prompts per skill
+clawhub sync --all                        # publish everything, no prompts
+clawhub sync --bump minor --changelog "New features"
+```
+
+Options: `--root <dir>` (extra scan roots), `--bump patch|minor|major`, `--concurrency <n>`, `--tags <tags>`.
+
+## Publish
+
+Single skill publish:
 
 ```bash
 clawhub publish ./my-skill --slug my-skill --name "My Skill" --version 1.2.0 --changelog "Fixes + docs"
 ```
 
-Notes
+## Delete / Undelete
 
-- Default registry: https://clawhub.com (override with CLAWHUB_REGISTRY or --registry)
-- Default workdir: cwd (falls back to OpenClaw workspace); install dir: ./skills (override with --workdir / --dir / CLAWHUB_WORKDIR)
-- Update command hashes local files, resolves matching version, and upgrades to latest unless --version is set
+Owner or admin only:
+
+```bash
+clawhub delete my-skill --yes
+clawhub undelete my-skill --yes
+```
+
+## Notes
+
+- Default registry: https://clawhub.ai (override with `CLAWHUB_REGISTRY` or `--registry`)
+- Default workdir: cwd (falls back to OpenClaw workspace); install dir: `./skills` (override with `--workdir` / `--dir` / `CLAWHUB_WORKDIR`)
+- Installed skills tracked in `.clawhub/lock.json`; check with `clawhub list` before installing
+- Use `--no-input` on any command to disable prompts for scripting and automation


### PR DESCRIPTION
## Summary

- Add missing CLI commands: `sync`, `delete`/`undelete`, `logout`
- Add `--force` flag to `install` and `--limit` to `search`
- Fix registry URL from `clawhub.com` to `clawhub.ai` (matches CONTRIBUTING.md and docs/tools/clawhub.md)
- Add lockfile mention (`.clawhub/lock.json`) and `--no-input` note
- Use `##` headings for consistent structure

The bundled SKILL.md was missing several commands documented in `docs/tools/clawhub.md`, most notably `clawhub sync`. The registry URL also pointed to the old `clawhub.com` instead of `clawhub.ai`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updated `skills/clawhub/SKILL.md` to align with the authoritative documentation in `docs/tools/clawhub.md`. Added missing commands (`sync`, `logout`, `delete`/`undelete`), added missing flags (`--force` for install, `--limit` for search), corrected the registry URL from `clawhub.com` to `clawhub.ai`, and improved documentation structure with consistent `##` headings and additional details about `.clawhub/lock.json` and `--no-input`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Documentation-only change that adds missing commands and corrects URLs to match authoritative sources. All additions are verified against `docs/tools/clawhub.md` and `CONTRIBUTING.md`
- No files require special attention

<sub>Last reviewed commit: 98b0d39</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->