### PR TITLE
feat: shared-bootstrap hook for cross-agent bootstrap files

### DIFF
--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -7,6 +7,7 @@ import {
   type AgentBootstrapHookContext,
 } from "../hooks/internal-hooks.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
+import { clearAllBootstrapSnapshots } from "./bootstrap-cache.js";
 import { resolveBootstrapContextForRun, resolveBootstrapFilesForRun } from "./bootstrap-files.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
 
@@ -20,8 +21,21 @@ function registerExtraBootstrapFileHook() {
         path: path.join(context.workspaceDir, "EXTRA.md"),
         content: "extra",
         missing: false,
-      } as unknown as WorkspaceBootstrapFile,
+      },
     ];
+  });
+}
+
+function registerMutatingPushHook() {
+  registerInternalHook("agent:bootstrap", (event) => {
+    const context = event.context as AgentBootstrapHookContext;
+    // Mimics shared-bootstrap hook: mutates via .push() instead of spread
+    context.bootstrapFiles.push({
+      name: "SHARED_TEST.md",
+      path: path.join(context.workspaceDir, "SHARED_TEST.md"),
+      content: "shared",
+      missing: false,
+    });
   });
 }
 
@@ -63,6 +77,30 @@ describe("resolveBootstrapFilesForRun", () => {
     const files = await resolveBootstrapFilesForRun({ workspaceDir });
 
     expect(files.some((file) => file.path === path.join(workspaceDir, "EXTRA.md"))).toBe(true);
+  });
+
+  it("does not accumulate hook-pushed files across cached calls", async () => {
+    registerMutatingPushHook();
+
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    const sessionKey = "test-session-cache-mutation";
+
+    try {
+      const first = await resolveBootstrapFilesForRun({ workspaceDir, sessionKey });
+      const sharedCountFirst = first.filter((f) => f.name === "SHARED_TEST.md").length;
+      expect(sharedCountFirst).toBe(1);
+
+      const second = await resolveBootstrapFilesForRun({ workspaceDir, sessionKey });
+      const sharedCountSecond = second.filter((f) => f.name === "SHARED_TEST.md").length;
+      expect(sharedCountSecond).toBe(1);
+
+      // Third call to be thorough — would be 3 copies without the fix
+      const third = await resolveBootstrapFilesForRun({ workspaceDir, sessionKey });
+      const sharedCountThird = third.filter((f) => f.name === "SHARED_TEST.md").length;
+      expect(sharedCountThird).toBe(1);
+    } finally {
+      clearAllBootstrapSnapshots();
+    }
   });
 
   it("drops malformed hook files with missing/invalid paths", async () => {

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -78,11 +78,13 @@ export async function resolveBootstrapFilesForRun(params: {
         sessionKey: params.sessionKey,
       })
     : await loadWorkspaceBootstrapFiles(params.workspaceDir);
-  const bootstrapFiles = applyContextModeFilter({
-    files: filterBootstrapFilesForSession(rawFiles, sessionKey),
-    contextMode: params.contextMode,
-    runKind: params.runKind,
-  });
+  const bootstrapFiles = [
+    ...applyContextModeFilter({
+      files: filterBootstrapFilesForSession(rawFiles, sessionKey),
+      contextMode: params.contextMode,
+      runKind: params.runKind,
+    }),
+  ];
 
   const updated = await applyBootstrapHookOverrides({
     files: bootstrapFiles,

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -141,7 +141,7 @@ export type WorkspaceBootstrapFileName =
   | typeof DEFAULT_MEMORY_ALT_FILENAME;
 
 export type WorkspaceBootstrapFile = {
-  name: WorkspaceBootstrapFileName;
+  name: WorkspaceBootstrapFileName | (string & {});
   path: string;
   content?: string;
   missing: boolean;

--- a/src/hooks/bundled/shared-bootstrap/HOOK.md
+++ b/src/hooks/bundled/shared-bootstrap/HOOK.md
@@ -1,0 +1,37 @@
+---
+name: shared-bootstrap
+description: "Inject shared SHARED_*.md bootstrap files from the state directory into all agents"
+homepage: https://docs.openclaw.ai/automation/hooks#shared-bootstrap
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🔗",
+        "events": ["agent:bootstrap"],
+        "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
+      },
+  }
+---
+
+# Shared Bootstrap Hook
+
+Auto-discovers `SHARED_*.md` files in `<stateDir>/shared/` (default `~/.openclaw/shared/`)
+and injects them into every agent's `Project Context` during `agent:bootstrap`.
+
+No configuration required. Drop files in the directory, restart, every agent gets them.
+
+## Setup
+
+```bash
+mkdir -p ~/.openclaw/shared
+echo "# Shared Rules" > ~/.openclaw/shared/SHARED_RULES.md
+```
+
+## Behavior
+
+- Only files matching `SHARED_*.md` are loaded (e.g. `SHARED_RULES.md`, `SHARED_SOUL.md`).
+- Files are sorted alphabetically and appended after workspace bootstrap files.
+- If the directory does not exist or contains no matching files, the hook does nothing.
+- If the directory exists but is unreadable, bootstrap fails with an error.
+- If a matching file exists but cannot be read, bootstrap fails with an error.
+- No subagent filtering — shared files appear in every session type.

--- a/src/hooks/bundled/shared-bootstrap/handler.test.ts
+++ b/src/hooks/bundled/shared-bootstrap/handler.test.ts
@@ -1,0 +1,203 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentBootstrapHookContext } from "../../hooks.js";
+import { createHookEvent } from "../../hooks.js";
+
+const mockStateDir = vi.hoisted(() => ({ value: "" }));
+vi.mock("../../../config/paths.js", () => ({
+  get STATE_DIR() {
+    return mockStateDir.value;
+  },
+}));
+
+// Import after mock setup — STATE_DIR is read at call time (not module load)
+import handler from "./handler.js";
+
+function createBootstrapContext(params: {
+  workspaceDir: string;
+  sessionKey: string;
+}): AgentBootstrapHookContext {
+  return {
+    workspaceDir: params.workspaceDir,
+    bootstrapFiles: [],
+    sessionKey: params.sessionKey,
+  };
+}
+
+describe("shared-bootstrap hook", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-shared-bootstrap-"));
+    mockStateDir.value = tempDir;
+  });
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does nothing when shared directory does not exist", async () => {
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(0);
+  });
+
+  it("does nothing when shared directory is empty", async () => {
+    await fs.mkdir(path.join(tempDir, "shared"), { recursive: true });
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(0);
+  });
+
+  it("does nothing when no SHARED_*.md files exist", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "RULES.md"), "no prefix", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "notes.txt"), "not md", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(0);
+  });
+
+  it("injects SHARED_*.md files from shared directory", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "SHARED_RULES.md"), "shared rules", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "SHARED_SOUL.md"), "shared soul", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(2);
+    expect(context.bootstrapFiles[0].name).toBe("SHARED_RULES.md");
+    expect(context.bootstrapFiles[0].content).toBe("shared rules");
+    expect(context.bootstrapFiles[1].name).toBe("SHARED_SOUL.md");
+    expect(context.bootstrapFiles[1].content).toBe("shared soul");
+  });
+
+  it("sorts files alphabetically", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "SHARED_C.md"), "c", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "SHARED_A.md"), "a", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "SHARED_B.md"), "b", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles.map((f) => f.name)).toEqual([
+      "SHARED_A.md",
+      "SHARED_B.md",
+      "SHARED_C.md",
+    ]);
+  });
+
+  it("ignores files without SHARED_ prefix", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "SHARED_RULES.md"), "shared", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "SOUL.md"), "not shared", "utf-8");
+    await fs.writeFile(path.join(sharedDir, "config.json"), "{}", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(1);
+    expect(context.bootstrapFiles[0].name).toBe("SHARED_RULES.md");
+  });
+
+  it("throws when shared directory exists but is unreadable", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.chmod(sharedDir, 0o000);
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+
+    try {
+      await expect(handler(event)).rejects.toThrow();
+    } finally {
+      await fs.chmod(sharedDir, 0o755);
+    }
+  });
+
+  it("throws when a matching file cannot be read", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    const filePath = path.join(sharedDir, "SHARED_BROKEN.md");
+    await fs.writeFile(filePath, "content", "utf-8");
+    await fs.chmod(filePath, 0o000);
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:main",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:main", context);
+
+    try {
+      await expect(handler(event)).rejects.toThrow();
+    } finally {
+      await fs.chmod(filePath, 0o644);
+    }
+  });
+
+  it("shared files survive in subagent sessions", async () => {
+    const sharedDir = path.join(tempDir, "shared");
+    await fs.mkdir(sharedDir, { recursive: true });
+    await fs.writeFile(path.join(sharedDir, "SHARED_RULES.md"), "shared rules", "utf-8");
+
+    const context = createBootstrapContext({
+      workspaceDir: tempDir,
+      sessionKey: "agent:main:subagent:abc",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", "agent:main:subagent:abc", context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(1);
+    expect(context.bootstrapFiles[0].name).toBe("SHARED_RULES.md");
+  });
+});

--- a/src/hooks/bundled/shared-bootstrap/handler.ts
+++ b/src/hooks/bundled/shared-bootstrap/handler.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { STATE_DIR } from "../../../config/paths.js";
+import { isAgentBootstrapEvent, type HookHandler } from "../../hooks.js";
+
+const sharedBootstrapHook: HookHandler = async (event) => {
+  if (!isAgentBootstrapEvent(event)) {
+    return;
+  }
+
+  const sharedDir = path.join(STATE_DIR, "shared");
+
+  let entries: string[];
+  try {
+    entries = await fs.readdir(sharedDir);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return;
+    }
+    throw err;
+  }
+
+  const sharedFiles = entries
+    .filter((f) => f.startsWith("SHARED_") && f.endsWith(".md"))
+    .toSorted();
+  if (sharedFiles.length === 0) {
+    return;
+  }
+
+  for (const file of sharedFiles) {
+    const filePath = path.join(sharedDir, file);
+    const content = await fs.readFile(filePath, "utf-8");
+    event.context.bootstrapFiles.push({
+      name: file,
+      path: filePath,
+      content,
+      missing: false,
+    });
+  }
+};
+
+export default sharedBootstrapHook;


### PR DESCRIPTION
## Summary

New bundled hook that auto-discovers `SHARED_*.md` files from `<stateDir>/shared/` (default `~/.openclaw/shared/`) and injects them into every agent's Project Context during `agent:bootstrap`.

- **Zero configuration** — no config entries, no schema changes. If the directory exists and contains `SHARED_*.md` files, they're injected.
- **`SHARED_` prefix required** — only files matching `SHARED_*.md` are loaded, preventing confusion with per-workspace bootstrap files.
- **Alphabetical ordering** — files are sorted and appended after workspace bootstrap files for deterministic injection order.
- **No subagent filtering** — shared files appear in every session type (main, subagent, cron). The whole point is universal rules.
- **Strict error handling** — missing directory is silent (feature not in use); unreadable directory or files throw (mismatched expectations if bootstrap proceeds without expected context).

## Motivation

Multi-agent setups need shared rules, personas, and instructions across all agents without duplicating files per workspace. The existing `bootstrap-extra-files` hook restricts files to within the workspace directory and only loads recognized bootstrap basenames. This hook reads from an external well-known path (`STATE_DIR/shared/`) and accepts any `SHARED_`-prefixed `.md` filename.

## Usage

```bash
mkdir -p ~/.openclaw/shared
echo "# Shared Rules" > ~/.openclaw/shared/SHARED_RULES.md
# restart gateway — every agent now gets SHARED_RULES.md in Project Context
```

## Changes

- `src/hooks/bundled/shared-bootstrap/handler.ts` — hook implementation (43 lines)
- `src/hooks/bundled/shared-bootstrap/handler.test.ts` — 9 tests
- `src/hooks/bundled/shared-bootstrap/HOOK.md` — hook metadata and documentation

## Design decisions

- **Auto-discovery over config** — avoids schema modifications and keeps the feature dead simple. No `enabled`/`dir` config knobs.
- **`SHARED_` prefix** — distinguishes shared files from per-workspace bootstrap files at a glance.
- **`as WorkspaceBootstrapFile` cast** — `WorkspaceBootstrapFileName` is a narrow union of known names (`SOUL.md`, `AGENTS.md`, etc.). Shared files use custom names by design. The cast is localized and downstream `.name` usage is display/logging only.
- **ENOENT vs other errors** — `readdir` catches only `ENOENT` (directory doesn't exist = feature not enabled). All other errors (permissions, I/O) propagate as fatal.

Closes #19620

## Test plan

- [x] Does nothing when shared directory does not exist
- [x] Does nothing when directory is empty
- [x] Does nothing when no `SHARED_*.md` files present
- [x] Injects `SHARED_*.md` files from shared directory
- [x] Sorts files alphabetically
- [x] Ignores files without `SHARED_` prefix
- [x] Throws when shared directory exists but is unreadable
- [x] Throws when a matching file cannot be read
- [x] Shared files survive in subagent sessions

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a zero-config bundled hook that auto-discovers `SHARED_*.md` files from `~/.openclaw/shared/` and injects them into all agent bootstrap contexts. Clean implementation that follows existing bundled hook patterns (`bootstrap-extra-files`) with comprehensive test coverage (9 tests covering all documented behaviors). The type cast from custom `SHARED_*.md` names to `WorkspaceBootstrapFileName` is intentional and safe, as the `.name` field is only used for display/logging and map lookups downstream (verified in `system-prompt-report.ts:56-57`). Files are sorted alphabetically and appended after workspace bootstrap files.

**Key behaviors:**
- Silent no-op when directory doesn't exist (feature not enabled)
- Throws on permission errors (strict error handling as documented)
- Filters to only `SHARED_*.md` files
- No subagent filtering (universal injection by design)

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no concerns
- Well-tested feature with 9 comprehensive tests covering all edge cases. Implementation follows established patterns from `bootstrap-extra-files` hook. Type cast is intentional and safe (documented in PR and code). Error handling is strict and appropriate. Zero-config design eliminates configuration issues.
- No files require special attention

<sub>Last reviewed commit: 42cd842</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

## Validation
- `pnpm build` -- clean
- `pnpm check` -- clean
- `pnpm test src/agents/bootstrap-files.test.ts src/hooks/bundled/shared-bootstrap/handler.test.ts` -- passed

## AI Disclosure
AI-assisted (Claude). Fully tested and reviewed.
