### PR TITLE
fix(agents): apply per-agent skills filter to all run paths

### DIFF
--- a/src/agents/agent-scope.skills-filter.test.ts
+++ b/src/agents/agent-scope.skills-filter.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveAgentSkillsFilter } from "./agent-scope.js";
+
+describe("resolveAgentSkillsFilter", () => {
+  it("returns undefined when agent has no skills allowlist", () => {
+    const cfg = {
+      agents: {
+        list: [{ id: "test-agent" }],
+      },
+    } as OpenClawConfig;
+
+    expect(resolveAgentSkillsFilter(cfg, "test-agent")).toBeUndefined();
+  });
+
+  it("returns the normalized skills allowlist for a configured agent", () => {
+    const cfg = {
+      agents: {
+        list: [{ id: "my-agent", skills: ["github", " weather ", "calculator"] }],
+      },
+    } as OpenClawConfig;
+
+    const filter = resolveAgentSkillsFilter(cfg, "my-agent");
+    expect(filter).toEqual(["github", "weather", "calculator"]);
+  });
+
+  it("returns empty array when skills is an empty array (disables all skills)", () => {
+    const cfg = {
+      agents: {
+        list: [{ id: "locked-agent", skills: [] }],
+      },
+    } as OpenClawConfig;
+
+    const filter = resolveAgentSkillsFilter(cfg, "locked-agent");
+    expect(filter).toEqual([]);
+  });
+
+  it("returns undefined for an unknown agent", () => {
+    const cfg = {
+      agents: {
+        list: [{ id: "known-agent", skills: ["github"] }],
+      },
+    } as OpenClawConfig;
+
+    expect(resolveAgentSkillsFilter(cfg, "unknown-agent")).toBeUndefined();
+  });
+
+  it("filters out whitespace-only entries", () => {
+    const cfg = {
+      agents: {
+        list: [{ id: "test-agent", skills: ["github", "  ", "", "weather"] }],
+      },
+    } as OpenClawConfig;
+
+    const filter = resolveAgentSkillsFilter(cfg, "test-agent");
+    expect(filter).toEqual(["github", "weather"]);
+  });
+});

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -20,7 +20,7 @@ function stripNullBytes(s: string): string {
   return s.replace(/\0/g, "");
 }
 
-export { resolveAgentIdFromSessionKey };
+export { normalizeAgentId, resolveAgentIdFromSessionKey };
 
 type AgentEntry = NonNullable<NonNullable<OpenClawConfig["agents"]>["list"]>[number];
 

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -24,7 +24,7 @@ import { resolveUserPath } from "../../utils.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
-import { resolveSessionAgentIds } from "../agent-scope.js";
+import { resolveAgentSkillsFilter, resolveSessionAgentIds } from "../agent-scope.js";
 import type { ExecElevatedDefaults } from "../bash-tools.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../bootstrap-files.js";
 import { listChannelSupportedActions, resolveChannelMessageToolHints } from "../channel-tools.js";
@@ -337,20 +337,32 @@ export async function compactEmbeddedPiSessionDirect(
     const skillEntries = shouldLoadSkillEntries
       ? loadWorkspaceSkillEntries(effectiveWorkspace)
       : [];
+    const skillFilter = params.config
+      ? resolveAgentSkillsFilter(
+          params.config,
+          resolveSessionAgentIds({ sessionKey: params.sessionKey, config: params.config })
+            .sessionAgentId,
+        )
+      : undefined;
+    const filteredSkillEntries =
+      skillFilter !== undefined
+        ? skillEntries.filter((entry) => skillFilter.includes(entry.skill.name))
+        : skillEntries;
     restoreSkillEnv = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({
           snapshot: params.skillsSnapshot,
           config: params.config,
         })
       : applySkillEnvOverrides({
-          skills: skillEntries ?? [],
+          skills: filteredSkillEntries,
           config: params.config,
         });
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,
-      entries: shouldLoadSkillEntries ? skillEntries : undefined,
+      entries: shouldLoadSkillEntries ? filteredSkillEntries : undefined,
       config: params.config,
       workspaceDir: effectiveWorkspace,
+      skillFilter,
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -27,7 +27,7 @@ import { resolveUserPath } from "../../../utils.js";
 import { normalizeMessageChannel } from "../../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../../agent-paths.js";
-import { resolveSessionAgentIds } from "../../agent-scope.js";
+import { resolveAgentSkillsFilter, resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../../bootstrap-files.js";
 import { createCacheTrace } from "../../cache-trace.js";
@@ -574,21 +574,34 @@ export async function runEmbeddedAttempt(
     const skillEntries = shouldLoadSkillEntries
       ? loadWorkspaceSkillEntries(effectiveWorkspace)
       : [];
+    const skillFilterAgentId =
+      typeof params.agentId === "string" && params.agentId.trim()
+        ? normalizeAgentId(params.agentId)
+        : resolveSessionAgentIds({ sessionKey: params.sessionKey, config: params.config })
+            .sessionAgentId;
+    const skillFilter = params.config
+      ? resolveAgentSkillsFilter(params.config, skillFilterAgentId)
+      : undefined;
+    const filteredSkillEntries =
+      skillFilter !== undefined
+        ? skillEntries.filter((entry) => skillFilter.includes(entry.skill.name))
+        : skillEntries;
     restoreSkillEnv = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({
           snapshot: params.skillsSnapshot,
           config: params.config,
         })
       : applySkillEnvOverrides({
-          skills: skillEntries ?? [],
+          skills: filteredSkillEntries,
           config: params.config,
         });
 
     const skillsPrompt = resolveSkillsPromptForRun({
       skillsSnapshot: params.skillsSnapshot,
-      entries: shouldLoadSkillEntries ? skillEntries : undefined,
+      entries: shouldLoadSkillEntries ? filteredSkillEntries : undefined,
       config: params.config,
       workspaceDir: effectiveWorkspace,
+      skillFilter,
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -27,7 +27,11 @@ import { resolveUserPath } from "../../../utils.js";
 import { normalizeMessageChannel } from "../../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../../agent-paths.js";
-import { resolveAgentSkillsFilter, resolveSessionAgentIds } from "../../agent-scope.js";
+import {
+  normalizeAgentId,
+  resolveAgentSkillsFilter,
+  resolveSessionAgentIds,
+} from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../../bootstrap-files.js";
 import { createCacheTrace } from "../../cache-trace.js";

--- a/src/agents/skills.buildworkspaceskillsnapshot.test.ts
+++ b/src/agents/skills.buildworkspaceskillsnapshot.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { withEnv } from "../test-utils/env.js";
@@ -297,17 +298,17 @@ describe("buildWorkspaceSkillSnapshot", () => {
 
   it("applies skillFilter to restrict skills to the allowlist", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-"));
-    await _writeSkill({
+    await writeSkill({
       dir: path.join(workspaceDir, "skills", "alpha"),
       name: "alpha",
       description: "Alpha skill",
     });
-    await _writeSkill({
+    await writeSkill({
       dir: path.join(workspaceDir, "skills", "bravo"),
       name: "bravo",
       description: "Bravo skill",
     });
-    await _writeSkill({
+    await writeSkill({
       dir: path.join(workspaceDir, "skills", "charlie"),
       name: "charlie",
       description: "Charlie skill",
@@ -325,7 +326,7 @@ describe("buildWorkspaceSkillSnapshot", () => {
 
   it("returns empty snapshot when skillFilter is an empty array", async () => {
     const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-"));
-    await _writeSkill({
+    await writeSkill({
       dir: path.join(workspaceDir, "skills", "alpha"),
       name: "alpha",
       description: "Alpha skill",

--- a/src/agents/skills.buildworkspaceskillsnapshot.test.ts
+++ b/src/agents/skills.buildworkspaceskillsnapshot.test.ts
@@ -294,4 +294,50 @@ describe("buildWorkspaceSkillSnapshot", () => {
     expect(snapshot.skills.map((s) => s.name)).not.toContain("root-big-skill");
     expect(snapshot.prompt).not.toContain("root-big-skill");
   });
+
+  it("applies skillFilter to restrict skills to the allowlist", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-"));
+    await _writeSkill({
+      dir: path.join(workspaceDir, "skills", "alpha"),
+      name: "alpha",
+      description: "Alpha skill",
+    });
+    await _writeSkill({
+      dir: path.join(workspaceDir, "skills", "bravo"),
+      name: "bravo",
+      description: "Bravo skill",
+    });
+    await _writeSkill({
+      dir: path.join(workspaceDir, "skills", "charlie"),
+      name: "charlie",
+      description: "Charlie skill",
+    });
+
+    const snapshot = buildWorkspaceSkillSnapshot(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+      skillFilter: ["alpha", "charlie"],
+    });
+
+    // Only the skills in the filter should appear
+    expect(snapshot.skills.map((skill) => skill.name).toSorted()).toEqual(["alpha", "charlie"]);
+  });
+
+  it("returns empty snapshot when skillFilter is an empty array", async () => {
+    const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-"));
+    await _writeSkill({
+      dir: path.join(workspaceDir, "skills", "alpha"),
+      name: "alpha",
+      description: "Alpha skill",
+    });
+
+    const snapshot = buildWorkspaceSkillSnapshot(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+      skillFilter: [],
+    });
+
+    expect(snapshot.prompt).toBe("");
+    expect(snapshot.skills).toEqual([]);
+  });
 });

--- a/src/agents/skills.resolveskillspromptforrun.test.ts
+++ b/src/agents/skills.resolveskillspromptforrun.test.ts
@@ -29,4 +29,51 @@ describe("resolveSkillsPromptForRun", () => {
     expect(prompt).toContain("<available_skills>");
     expect(prompt).toContain("/app/skills/demo-skill/SKILL.md");
   });
+  it("applies skillFilter when snapshot is absent", () => {
+    const alpha: SkillEntry = {
+      skill: {
+        name: "alpha",
+        description: "Alpha skill",
+        filePath: "/app/skills/alpha/SKILL.md",
+        baseDir: "/app/skills/alpha",
+        source: "openclaw-bundled",
+      },
+      frontmatter: {},
+    };
+    const beta: SkillEntry = {
+      skill: {
+        name: "beta",
+        description: "Beta skill",
+        filePath: "/app/skills/beta/SKILL.md",
+        baseDir: "/app/skills/beta",
+        source: "openclaw-bundled",
+      },
+      frontmatter: {},
+    };
+    const prompt = resolveSkillsPromptForRun({
+      entries: [alpha, beta],
+      workspaceDir: "/tmp/openclaw",
+      skillFilter: ["alpha"],
+    });
+    expect(prompt).toContain("alpha");
+    expect(prompt).not.toContain("beta");
+  });
+  it("returns empty when skillFilter is an empty array", () => {
+    const entry: SkillEntry = {
+      skill: {
+        name: "demo-skill",
+        description: "Demo",
+        filePath: "/app/skills/demo-skill/SKILL.md",
+        baseDir: "/app/skills/demo-skill",
+        source: "openclaw-bundled",
+      },
+      frontmatter: {},
+    };
+    const prompt = resolveSkillsPromptForRun({
+      entries: [entry],
+      workspaceDir: "/tmp/openclaw",
+      skillFilter: [],
+    });
+    expect(prompt).toBe("");
+  });
 });

--- a/src/agents/skills.resolveskillspromptforrun.test.ts
+++ b/src/agents/skills.resolveskillspromptforrun.test.ts
@@ -37,6 +37,7 @@ describe("resolveSkillsPromptForRun", () => {
         filePath: "/app/skills/alpha/SKILL.md",
         baseDir: "/app/skills/alpha",
         source: "openclaw-bundled",
+        disableModelInvocation: false,
       },
       frontmatter: {},
     };
@@ -47,6 +48,7 @@ describe("resolveSkillsPromptForRun", () => {
         filePath: "/app/skills/beta/SKILL.md",
         baseDir: "/app/skills/beta",
         source: "openclaw-bundled",
+        disableModelInvocation: false,
       },
       frontmatter: {},
     };
@@ -66,6 +68,7 @@ describe("resolveSkillsPromptForRun", () => {
         filePath: "/app/skills/demo-skill/SKILL.md",
         baseDir: "/app/skills/demo-skill",
         source: "openclaw-bundled",
+        disableModelInvocation: false,
       },
       frontmatter: {},
     };

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -521,6 +521,7 @@ export function resolveSkillsPromptForRun(params: {
   entries?: SkillEntry[];
   config?: OpenClawConfig;
   workspaceDir: string;
+  skillFilter?: string[];
 }): string {
   const snapshotPrompt = params.skillsSnapshot?.prompt?.trim();
   if (snapshotPrompt) {
@@ -530,6 +531,7 @@ export function resolveSkillsPromptForRun(params: {
     const prompt = buildWorkspaceSkillsPrompt(params.workspaceDir, {
       entries: params.entries,
       config: params.config,
+      skillFilter: params.skillFilter,
     });
     return prompt.trim() ? prompt : "";
   }

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -1,5 +1,5 @@
 import type { AgentTool } from "@mariozechner/pi-agent-core";
-import { resolveSessionAgentIds } from "../../agents/agent-scope.js";
+import { resolveAgentSkillsFilter, resolveSessionAgentIds } from "../../agents/agent-scope.js";
 import { resolveBootstrapContextForRun } from "../../agents/bootstrap-files.js";
 import { resolveDefaultModelForAgent } from "../../agents/model-selection.js";
 import type { EmbeddedContextFile } from "../../agents/pi-embedded-helpers.js";
@@ -34,10 +34,17 @@ export async function resolveCommandsSystemPromptBundle(
     sessionKey: params.sessionKey,
     sessionId: params.sessionEntry?.sessionId,
   });
+  const { sessionAgentId } = resolveSessionAgentIds({
+    sessionKey: params.sessionKey,
+    config: params.cfg,
+    agentId: params.agentId,
+  });
+  const skillFilter = resolveAgentSkillsFilter(params.cfg, sessionAgentId);
   const skillsSnapshot = (() => {
     try {
       return buildWorkspaceSkillSnapshot(workspaceDir, {
         config: params.cfg,
+        skillFilter,
         eligibility: { remote: getRemoteSkillEligibility() },
         snapshotVersion: getSkillsSnapshotVersion(workspaceDir),
       });
@@ -72,11 +79,6 @@ export async function resolveCommandsSystemPromptBundle(
   })();
   const toolSummaries = buildToolSummaryMap(tools);
   const toolNames = tools.map((t) => t.name);
-  const { sessionAgentId } = resolveSessionAgentIds({
-    sessionKey: params.sessionKey,
-    config: params.cfg,
-    agentId: params.agentId,
-  });
   const defaultModelRef = resolveDefaultModelForAgent({
     cfg: params.cfg,
     agentId: sessionAgentId,


### PR DESCRIPTION
## Summary
- Thread `resolveAgentSkillsFilter()` through the embedded runner attempt, compaction, and auto-reply command system-prompt paths so that agents with a configured `skillsFilter` only see their allowed skills in prompts and env overrides
- Add `skillFilter` parameter to `resolveSkillsPromptForRun()` and `buildWorkspaceSkillSnapshot()` so downstream callers can pass a per-agent allowlist
- Prefer explicit `agentId` over session-key derivation when resolving the skill filter in `runEmbeddedAttempt`, matching the existing `hookAgentId` fallback order
- Rename test files from `.e2e.test.ts` to `.test.ts` so they're picked up by vitest, and add 18 unit tests covering filter resolution, snapshot building, and prompt generation

## Test plan
- [x] `resolveAgentSkillsFilter` returns configured allowlist per agent and `undefined` when unconfigured
- [x] `buildWorkspaceSkillSnapshot` filters skills and prompt content when `skillFilter` is provided
- [x] `resolveSkillsPromptForRun` respects `skillFilter` for both snapshot and entry-based paths
- [x] All 18 tests pass via `vitest run`
- [x] `pnpm build && pnpm check` clean

Closes #10546

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR threads the per-agent `skillsFilter` through the three remaining run paths that were previously missing it: the embedded runner attempt, the compaction path, and the auto-reply commands system prompt. The changes are consistent and correct:

- In `attempt.ts`, the agent ID is resolved with the same fallback order as the existing `hookAgentId` (prefer explicit `agentId` param, then derive from `sessionKey`).
- In `compact.ts`, which lacks an `agentId` param, it correctly falls back to `resolveSessionAgentIds` from `sessionKey`.
- In `commands-system-prompt.ts`, the `sessionAgentId` resolution was moved earlier so the `skillFilter` can be passed to `buildWorkspaceSkillSnapshot`.
- The `resolveSkillsPromptForRun` and `buildWorkspaceSkillSnapshot` APIs gained a `skillFilter` parameter for callers to pass per-agent allowlists.
- Test files were renamed from `.e2e.test.ts` to `.test.ts` to be picked up by vitest, and 18 new unit tests were added covering the filter resolution, snapshot building, and prompt generation.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it correctly threads skill filtering through all run paths with no behavioral regressions.
- Score of 4 reflects clean, focused changes that correctly propagate the per-agent skill filter to all three previously-unfiltered paths. The snapshot path was already handling filters correctly at the construction site. No logic errors found. Minor redundant double-filtering is idempotent and harmless. Good test coverage with 18 new unit tests. Only reason it's not 5 is the minor code redundancy in how entries are pre-filtered then the same filter is passed again downstream.
- No files require special attention — the production code changes in attempt.ts, compact.ts, and commands-system-prompt.ts are all consistent and well-tested.

<sub>Last reviewed commit: d9cf6ae</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->