### PR TITLE
fix(googlechat): typing indicator shows 'OpenClaw' instead of agent identity.name

### DIFF
--- a/extensions/googlechat/src/monitor.test.ts
+++ b/extensions/googlechat/src/monitor.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isSenderAllowed } from "./monitor.js";
+import { isSenderAllowed, resolveBotDisplayName } from "./monitor.js";
 
 describe("isSenderAllowed", () => {
   it("matches raw email entries only when dangerous name matching is enabled", () => {
@@ -21,5 +21,38 @@ describe("isSenderAllowed", () => {
     expect(isSenderAllowed("users/123", "jane@example.com", ["other@example.com"], true)).toBe(
       false,
     );
+  });
+});
+
+
+describe("resolveBotDisplayName", () => {
+  it("prefers identity.name and strips control characters", () => {
+    expect(
+      resolveBotDisplayName({
+        accountName: undefined,
+        agentId: "agent-1",
+        config: {
+          agents: {
+            list: [
+              {
+                id: "agent-1",
+                identity: { name: "Moon\nBot\t" },
+                name: "Fallback Name",
+              },
+            ],
+          },
+        } as never,
+      }),
+    ).toBe("Moon Bot");
+  });
+
+  it("sanitizes accountName before returning it", () => {
+    expect(
+      resolveBotDisplayName({
+        accountName: "Open\u0000Claw\n",
+        agentId: "agent-1",
+        config: {} as never,
+      }),
+    ).toBe("Open Claw");
   });
 });

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -368,8 +368,9 @@ function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?: strin
 /**
  * Resolve bot display name with fallback chain:
  * 1. Account config name
- * 2. Agent name from config
- * 3. "OpenClaw" as generic fallback
+ * 2. Agent identity name (`agents.list[].identity.name`)
+ * 3. Agent name (`agents.list[].name`)
+ * 4. "OpenClaw" as generic fallback
  */
 function resolveBotDisplayName(params: {
   accountName?: string;
@@ -381,6 +382,10 @@ function resolveBotDisplayName(params: {
     return accountName.trim();
   }
   const agent = config.agents?.list?.find((a) => a.id === agentId);
+  const identityName = agent?.identity?.name?.trim();
+  if (identityName) {
+    return identityName;
+  }
   if (agent?.name?.trim()) {
     return agent.name.trim();
   }

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -372,6 +372,10 @@ function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?: strin
  * 3. Agent name (`agents.list[].name`)
  * 4. "OpenClaw" as generic fallback
  */
+function sanitizeTypingDisplayName(name: string): string {
+  return name.replace(/[\u0000-\u001f\u007f]+/g, " ").trim();
+}
+
 function resolveBotDisplayName(params: {
   accountName?: string;
   agentId: string;
@@ -379,15 +383,15 @@ function resolveBotDisplayName(params: {
 }): string {
   const { accountName, agentId, config } = params;
   if (accountName?.trim()) {
-    return accountName.trim();
+    return sanitizeTypingDisplayName(accountName);
   }
   const agent = config.agents?.list?.find((a) => a.id === agentId);
   const identityName = agent?.identity?.name?.trim();
   if (identityName) {
-    return identityName;
+    return sanitizeTypingDisplayName(identityName);
   }
   if (agent?.name?.trim()) {
-    return agent.name.trim();
+    return sanitizeTypingDisplayName(agent.name);
   }
   return "OpenClaw";
 }


### PR DESCRIPTION
## Problem

The Google Chat typing indicator always shows "OpenClaw is typing..." even when the agent has `identity.name` configured. This is because `resolveBotDisplayName()` checks `agent.name` but skips `agent.identity.name`, which is the standard place many users configure the agent display name.

## Root Cause

`resolveBotDisplayName()` fallback chain was:
1. Account config name
2. `agent.name`
3. `"OpenClaw"`

Missing: `agent.identity.name` (from `agents.list[].identity.name`)

## Fix

Insert `identity.name` as step 2 in the fallback chain, before `agent.name`:

1. Account config name
2. **`agent.identity.name`** ← added
3. `agent.name`
4. `"OpenClaw"`

## Changes

| File | Change |
|------|--------|
| `extensions/googlechat/src/monitor.ts` | Check `identity.name` before `name` in `resolveBotDisplayName()` |

Related to #18580
