### PR TITLE
feat(hooks): bridge after_tool_call to internal hook handler system

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -1,6 +1,6 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
-import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
+import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
 import { normalizeTextForComparison } from "./pi-embedded-helpers.js";
@@ -400,9 +400,10 @@ export async function handleToolExecutionEnd(
   if (hookRunnerAfter?.hasHooks("after_tool_call")) {
     const hookEvent: PluginHookAfterToolCallEvent = {
       toolName,
-      params: (afterCallArgs && typeof afterCallArgs === "object"
-        ? afterCallArgs
-        : {}) as Record<string, unknown>,
+      params: (afterCallArgs && typeof afterCallArgs === "object" ? afterCallArgs : {}) as Record<
+        string,
+        unknown
+      >,
       result: sanitizedResult,
       error: isToolError ? extractToolErrorMessage(sanitizedResult) : undefined,
       durationMs: afterCallDurationMs,
@@ -424,9 +425,10 @@ export async function handleToolExecutionEnd(
   void triggerInternalHook(
     createInternalHookEvent("tool", "after_call", ctx.params.runId ?? "", {
       toolName,
-      params: (afterCallArgs && typeof afterCallArgs === "object"
-        ? afterCallArgs
-        : {}) as Record<string, unknown>,
+      params: (afterCallArgs && typeof afterCallArgs === "object" ? afterCallArgs : {}) as Record<
+        string,
+        unknown
+      >,
       result: sanitizedResult,
       error: isToolError ? extractToolErrorMessage(sanitizedResult) : undefined,
       durationMs: afterCallDurationMs,

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -5,6 +5,7 @@ import type {
 } from "@mariozechner/pi-agent-core";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
 import { logDebug, logError } from "../logger.js";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { isPlainObject } from "../utils.js";
 import type { ClientToolDefinition } from "./pi-embedded-runner/run/params.js";
@@ -135,6 +136,15 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
             }
           }
 
+          // Bridge to internal hook handler system (fire-and-forget)
+          void triggerInternalHook(
+            createInternalHookEvent("tool", "after_call", "", {
+              toolName: name,
+              params: isPlainObject(afterParams) ? afterParams : {},
+              result,
+            }),
+          );
+
           return result;
         } catch (err) {
           if (signal?.aborted) {
@@ -180,6 +190,15 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
               );
             }
           }
+
+          // Bridge to internal hook handler system (fire-and-forget)
+          void triggerInternalHook(
+            createInternalHookEvent("tool", "after_call", "", {
+              toolName: normalizedName,
+              params: isPlainObject(params) ? params : {},
+              error: described.message,
+            }),
+          );
 
           return errorResult;
         }

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -4,8 +4,8 @@ import type {
   AgentToolUpdateCallback,
 } from "@mariozechner/pi-agent-core";
 import type { ToolDefinition } from "@mariozechner/pi-coding-agent";
-import { logDebug, logError } from "../logger.js";
 import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
+import { logDebug, logError } from "../logger.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import { isPlainObject } from "../utils.js";
 import type { ClientToolDefinition } from "./pi-embedded-runner/run/params.js";

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -9,7 +9,13 @@ import type { WorkspaceBootstrapFile } from "../agents/workspace.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
+export type InternalHookEventType =
+  | "command"
+  | "session"
+  | "agent"
+  | "gateway"
+  | "message"
+  | "tool";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;
@@ -90,6 +96,29 @@ export type MessageSentHookEvent = InternalHookEvent & {
   type: "message";
   action: "sent";
   context: MessageSentHookContext;
+};
+
+// ============================================================================
+// Tool Hook Events
+// ============================================================================
+
+export type ToolAfterCallHookContext = {
+  /** Name of the tool that was executed */
+  toolName: string;
+  /** Input parameters passed to the tool */
+  params: Record<string, unknown>;
+  /** Result returned by the tool (undefined on error) */
+  result?: unknown;
+  /** Error message if the tool call failed */
+  error?: string;
+  /** Execution duration in milliseconds */
+  durationMs?: number;
+};
+
+export type ToolAfterCallHookEvent = InternalHookEvent & {
+  type: "tool";
+  action: "after_call";
+  context: ToolAfterCallHookContext;
 };
 
 export interface InternalHookEvent {
@@ -281,4 +310,17 @@ export function isMessageSentEvent(event: InternalHookEvent): event is MessageSe
     typeof context.channelId === "string" &&
     typeof context.success === "boolean"
   );
+}
+
+export function isToolAfterCallEvent(
+  event: InternalHookEvent,
+): event is ToolAfterCallHookEvent {
+  if (event.type !== "tool" || event.action !== "after_call") {
+    return false;
+  }
+  const context = event.context as Partial<ToolAfterCallHookContext> | null;
+  if (!context || typeof context !== "object") {
+    return false;
+  }
+  return typeof context.toolName === "string";
 }

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -312,9 +312,7 @@ export function isMessageSentEvent(event: InternalHookEvent): event is MessageSe
   );
 }
 
-export function isToolAfterCallEvent(
-  event: InternalHookEvent,
-): event is ToolAfterCallHookEvent {
+export function isToolAfterCallEvent(event: InternalHookEvent): event is ToolAfterCallHookEvent {
   if (event.type !== "tool" || event.action !== "after_call") {
     return false;
   }


### PR DESCRIPTION
## Summary

Bridges the plugin hook system's `after_tool_call` event to the internal hook handler system, so plugins in `~/.openclaw/hooks/<plugin>/handler.ts` can observe tool executions.

Discussed in #20575. Related to #20570.

---

## Problem

OpenClaw has two hook systems that don't talk to each other:

**Plugin Hook System** (internal): fires `after_tool_call` inside the agent pipeline with full tool context.

**Internal Hook Handler System** (external, `~/.openclaw/hooks/`): never receives tool events — blind to everything happening inside a session.

The result: memory, observability, and audit plugins can't record what tools ran, what the inputs were, or what came back.

## Changes

### `src/hooks/internal-hooks.ts`
- Add `"tool"` to `InternalHookEventType`
- Add `ToolAfterCallHookContext` + `ToolAfterCallHookEvent` types
- Add `isToolAfterCallEvent()` type guard

### `src/agents/pi-embedded-subscribe.handlers.tools.ts`
- After existing plugin hook fires → bridge to `triggerInternalHook("tool", "after_call", ...)` (fire-and-forget, never blocks execution)

### `src/agents/pi-tool-definition-adapter.ts`
- Same bridge in both success path and error path

### `src/hooks/internal-hooks.test.ts`
- 6 new tests: `isToolAfterCallEvent` guard (true/false cases) + handler triggering

## Behaviour

The bridge fires **unconditionally** — it does not require any plugin hooks to be registered. It is always fire-and-forget and can never block or throw into the agent pipeline.

Payload delivered to external handlers:
```ts
event.type    // "tool"
event.action  // "after_call"
event.context // { toolName, params, result?, error?, durationMs? }
```

## Usage Example

```ts
// ~/.openclaw/hooks/my-memory/handler.ts
import type { HookHandler } from '../../src/hooks/hooks.js';
import { isToolAfterCallEvent } from '../../src/hooks/internal-hooks.js';

const handler: HookHandler = async (event) => {
  if (isToolAfterCallEvent(event)) {
    const { toolName, params, result, error, durationMs } = event.context;
    await recordObservation({ toolName, params, result, error, durationMs });
  }
};

export default handler;
```

HOOK.md metadata to subscribe:
```yaml
metadata: { "openclaw": { "events": ["tool:after_call"] } }
```

## Test Results

```
Test Files  1 passed (1)
      Tests  36 passed (36)   ← 6 new, 30 existing
```
Build: `pnpm build` — clean, zero errors.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bridges the plugin hook system's `after_tool_call` event to the internal hook handler system. This enables external plugins in `~/.openclaw/hooks/<plugin>/handler.ts` to observe tool executions that were previously only visible to internal plugin hooks.

- Adds `"tool"` event type to `InternalHookEventType` union with `ToolAfterCallHookContext` and `ToolAfterCallHookEvent` types
- Adds `isToolAfterCallEvent()` type guard for type-safe event filtering
- Bridges tool execution events in both `pi-embedded-subscribe.handlers.tools.ts` (embedded agent path) and `pi-tool-definition-adapter.ts` (tool definition adapter paths) 
- Fire-and-forget pattern ensures hooks never block tool execution
- Comprehensive test coverage with 6 new tests validating type guards and handler triggering

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows established patterns in the codebase, uses fire-and-forget to prevent blocking, includes comprehensive test coverage (6 new tests, all passing), and maintains type safety throughout. The changes are isolated to the hook system with no breaking changes to existing APIs.
- No files require special attention

<sub>Last reviewed commit: 81572ae</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->