### PR TITLE
fix(config): preserve missing keys from original in restoreRedactedValues

### DIFF
--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -987,6 +987,37 @@ describe("restoreRedactedValues", () => {
     expect(result.channels.slack.accounts[0].botToken).toBe("original-token-first-account");
     expect(result.channels.slack.accounts[1].botToken).toBe("user-provided-new-token-value");
   });
+
+  it("preserves top-level keys missing from incoming when using uiHints lookup", () => {
+    const hints: ConfigUiHints = {
+      "gateway.auth.token": { sensitive: true },
+    };
+    const incoming = {
+      ui: { seamColor: "#ff0000" },
+    };
+    const original = {
+      ui: { seamColor: "#0088cc" },
+      gateway: { auth: { token: "real-secret-token-value" } },
+    };
+
+    const result = restoreRedactedValues(incoming, original, hints) as typeof original;
+    expect(result.ui.seamColor).toBe("#ff0000");
+    expect(result.gateway.auth.token).toBe("real-secret-token-value");
+  });
+
+  it("preserves top-level keys missing from incoming when guessing sensitive paths", () => {
+    const incoming = {
+      ui: { seamColor: "#ff0000" },
+    };
+    const original = {
+      ui: { seamColor: "#0088cc" },
+      gateway: { auth: { token: "real-secret-token-value" } },
+    };
+
+    const result = restoreRedactedValues(incoming, original) as typeof original;
+    expect(result.ui.seamColor).toBe("#ff0000");
+    expect(result.gateway.auth.token).toBe("real-secret-token-value");
+  });
 });
 
 describe("realredactConfigSnapshot_real", () => {

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -543,6 +543,14 @@ function restoreRedactedValuesWithLookup(
       }
     }
   }
+
+  // Preserve keys from original that are missing in incoming.
+  for (const key of Object.keys(orig)) {
+    if (!(key in (incoming as Record<string, unknown>))) {
+      result[key] = orig[key];
+    }
+  }
+
   return result;
 }
 
@@ -586,5 +594,13 @@ function restoreRedactedValuesGuessing(
       result[key] = value;
     }
   }
+
+  // Preserve keys from original that are missing in incoming.
+  for (const key of Object.keys(orig)) {
+    if (!(key in (incoming as Record<string, unknown>))) {
+      result[key] = orig[key];
+    }
+  }
+
   return result;
 }


### PR DESCRIPTION
## Problem
When Mac App calls `config.set`, keys present in original config but missing from incoming (e.g., `gateway.auth`) were being silently dropped.

## Root Cause
`restoreRedactedValuesWithLookup()` and `restoreRedactedValuesGuessing()` only iterate over `incoming` keys, not preserving keys from `original` that don't exist in `incoming`.

## Fix
After iterating incoming keys, also copy keys from original that don't exist in incoming. This preserves:
- Top-level keys (like `gateway.auth`)
- Nested keys (recursive functions apply the fix at each level)

## Testing
Added 2 regression tests covering both lookup and guessing code paths.

Fixes #21009

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed silent data loss when Mac App calls `config.set` with partial config updates. The `restoreRedactedValuesWithLookup()` and `restoreRedactedValuesGuessing()` functions only iterated over keys present in the incoming config, causing keys from the original config (like `gateway.auth`) to be dropped if they weren't in the incoming update.

The fix adds a final loop in both functions to copy any keys from the original that don't exist in the incoming config, preserving the complete configuration across partial updates. This works at each recursion level, ensuring both top-level and nested keys are preserved.

- Added comprehensive regression tests covering both code paths (with and without `uiHints`)
- Tests verify that missing keys are preserved while incoming changes are still applied
- Fix is minimal and maintains backward compatibility

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-targeted, addressing a clear bug with a simple solution. The implementation correctly preserves missing keys from the original config at each recursion level. Tests comprehensively cover both code paths (with and without ConfigUiHints). The change is minimal and doesn't alter existing behavior for keys that are present in incoming configs.
- No files require special attention

<sub>Last reviewed commit: b133a56</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->