### PR TITLE
fix(security): use SSRF guard for node camera URL downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -415,7 +415,7 @@ Docs: https://docs.openclaw.ai
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.
 - UI/Usage: reload usage data immediately when timezone changes so Local/UTC toggles apply the selected date range without requiring a manual refresh. (#17774)
-- Security/CLI: bind node camera payload URL downloads to the resolved node host/IP (with guarded redirect handling) so `nodes-camera` fetches cannot pivot to unrelated targets. (#21145)
+- Security/CLI: bind node camera payload URL downloads to the resolved node host/IP (with guarded redirect handling) so `nodes-camera` and node camera tool fetches cannot pivot to unrelated targets. (#21145) Thanks @Marvae and @vincentkoc.
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
 - iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.
 - iOS/Onboarding: stabilize pairing and reconnect behavior by resetting stale pairing request state on manual retry, disconnecting both operator and node gateways on operator failure, and avoiding duplicate pairing loops from operator transport identity attachment. (#20056) Thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -415,7 +415,7 @@ Docs: https://docs.openclaw.ai
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.
 - UI/Usage: reload usage data immediately when timezone changes so Local/UTC toggles apply the selected date range without requiring a manual refresh. (#17774)
-- Security/CLI: route node camera payload URL downloads through `fetchWithSsrFGuard` to block private-network/metadata SSRF targets and unsafe redirects in `nodes-camera` flows. (#21145)
+- Security/CLI: bind node camera payload URL downloads to the resolved node host/IP (with guarded redirect handling) so `nodes-camera` fetches cannot pivot to unrelated targets. (#21145)
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
 - iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.
 - iOS/Onboarding: stabilize pairing and reconnect behavior by resetting stale pairing request state on manual retry, disconnecting both operator and node gateways on operator failure, and avoiding duplicate pairing loops from operator transport identity attachment. (#20056) Thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 
 - Agents/Compaction: count auto-compactions only after a non-retry `auto_compaction_end`, keeping session `compactionCount` aligned to completed compactions.
 - Security/CLI: redact sensitive values in `openclaw config get` output before printing config paths, preventing credential leakage to terminal output/history. (#13683) Thanks @SleuthCo.
+- Security/CLI: bind node camera payload URL downloads to the resolved node host/IP (with guarded redirect handling) so `nodes-camera` and node camera tool fetches cannot pivot to unrelated targets. (#21145) Thanks @Marvae and @vincentkoc.
 - Install/Discord Voice: make `@discordjs/opus` an optional dependency so `openclaw` install/update no longer hard-fails when native Opus builds fail, while keeping `opusscript` as the runtime fallback decoder for Discord voice flows. (#23737, #23733, #23703) Thanks @jeadland, @Sheetaa, and @Breakyman.
 - Docker/Setup: precreate `$OPENCLAW_CONFIG_DIR/identity` during `docker-setup.sh` so CLI commands that need device identity (for example `devices list`) avoid `EACCES ... /home/node/.openclaw/identity` failures on restrictive bind mounts. (#23948) Thanks @ackson-beep.
 - Exec/Background: stop applying the default exec timeout to background sessions (`background: true` or explicit `yieldMs`) when no explicit timeout is set, so long-running background jobs are no longer terminated at the default timeout boundary. (#23303)
@@ -415,7 +416,6 @@ Docs: https://docs.openclaw.ai
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.
 - UI/Usage: reload usage data immediately when timezone changes so Local/UTC toggles apply the selected date range without requiring a manual refresh. (#17774)
-- Security/CLI: bind node camera payload URL downloads to the resolved node host/IP (with guarded redirect handling) so `nodes-camera` and node camera tool fetches cannot pivot to unrelated targets. (#21145) Thanks @Marvae and @vincentkoc.
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
 - iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.
 - iOS/Onboarding: stabilize pairing and reconnect behavior by resetting stale pairing request state on manual retry, disconnecting both operator and node gateways on operator failure, and avoiding duplicate pairing loops from operator transport identity attachment. (#20056) Thanks @mbelinky.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -415,6 +415,7 @@ Docs: https://docs.openclaw.ai
 - iOS/Chat: use a dedicated iOS chat session key for ChatSheet routing to avoid cross-client session collisions with main-session traffic. (#21139) thanks @mbelinky.
 - iOS/Chat: auto-resync chat history after reconnect sequence gaps, clear stale pending runs, and avoid dead-end manual refresh errors after transient disconnects. (#21135) thanks @mbelinky.
 - UI/Usage: reload usage data immediately when timezone changes so Local/UTC toggles apply the selected date range without requiring a manual refresh. (#17774)
+- Security/CLI: route node camera payload URL downloads through `fetchWithSsrFGuard` to block private-network/metadata SSRF targets and unsafe redirects in `nodes-camera` flows. (#21145)
 - iOS/Screen: move `WKWebView` lifecycle ownership into `ScreenWebView` coordinator and explicit attach/detach flow to reduce gesture/lifecycle crash risk (`__NSArrayM insertObject:atIndex:` paths) during screen tab updates. (#20366) Thanks @ngutman.
 - iOS/Onboarding: prevent pairing-status flicker during auto-resume by keeping resumed state transitions stable. (#20310) Thanks @mbelinky.
 - iOS/Onboarding: stabilize pairing and reconnect behavior by resetting stale pairing request state on manual retry, disconnecting both operator and node gateways on operator failure, and avoiding duplicate pairing loops from operator transport identity attachment. (#20056) Thanks @mbelinky.

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2306,15 +2306,39 @@ public struct CronJob: Codable, Sendable {
 
 public struct CronListParams: Codable, Sendable {
     public let includedisabled: Bool?
+    public let limit: Int?
+    public let offset: Int?
+    public let query: String?
+    public let enabled: AnyCodable?
+    public let sortby: AnyCodable?
+    public let sortdir: AnyCodable?
 
     public init(
-        includedisabled: Bool?)
+        includedisabled: Bool?,
+        limit: Int?,
+        offset: Int?,
+        query: String?,
+        enabled: AnyCodable?,
+        sortby: AnyCodable?,
+        sortdir: AnyCodable?)
     {
         self.includedisabled = includedisabled
+        self.limit = limit
+        self.offset = offset
+        self.query = query
+        self.enabled = enabled
+        self.sortby = sortby
+        self.sortdir = sortdir
     }
 
     private enum CodingKeys: String, CodingKey {
         case includedisabled = "includeDisabled"
+        case limit
+        case offset
+        case query
+        case enabled
+        case sortby = "sortBy"
+        case sortdir = "sortDir"
     }
 }
 
@@ -2374,6 +2398,60 @@ public struct CronAddParams: Codable, Sendable {
     }
 }
 
+public struct CronRunsParams: Codable, Sendable {
+    public let scope: AnyCodable?
+    public let id: String?
+    public let jobid: String?
+    public let limit: Int?
+    public let offset: Int?
+    public let statuses: [AnyCodable]?
+    public let status: AnyCodable?
+    public let deliverystatuses: [AnyCodable]?
+    public let deliverystatus: AnyCodable?
+    public let query: String?
+    public let sortdir: AnyCodable?
+
+    public init(
+        scope: AnyCodable?,
+        id: String?,
+        jobid: String?,
+        limit: Int?,
+        offset: Int?,
+        statuses: [AnyCodable]?,
+        status: AnyCodable?,
+        deliverystatuses: [AnyCodable]?,
+        deliverystatus: AnyCodable?,
+        query: String?,
+        sortdir: AnyCodable?)
+    {
+        self.scope = scope
+        self.id = id
+        self.jobid = jobid
+        self.limit = limit
+        self.offset = offset
+        self.statuses = statuses
+        self.status = status
+        self.deliverystatuses = deliverystatuses
+        self.deliverystatus = deliverystatus
+        self.query = query
+        self.sortdir = sortdir
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case scope
+        case id
+        case jobid = "jobId"
+        case limit
+        case offset
+        case statuses
+        case status
+        case deliverystatuses = "deliveryStatuses"
+        case deliverystatus = "deliveryStatus"
+        case query
+        case sortdir = "sortDir"
+    }
+}
+
 public struct CronRunLogEntry: Codable, Sendable {
     public let ts: Int
     public let jobid: String
@@ -2389,6 +2467,10 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let runatms: Int?
     public let durationms: Int?
     public let nextrunatms: Int?
+    public let model: String?
+    public let provider: String?
+    public let usage: [String: AnyCodable]?
+    public let jobname: String?
 
     public init(
         ts: Int,
@@ -2404,7 +2486,11 @@ public struct CronRunLogEntry: Codable, Sendable {
         sessionkey: String?,
         runatms: Int?,
         durationms: Int?,
-        nextrunatms: Int?)
+        nextrunatms: Int?,
+        model: String?,
+        provider: String?,
+        usage: [String: AnyCodable]?,
+        jobname: String?)
     {
         self.ts = ts
         self.jobid = jobid
@@ -2420,6 +2506,10 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.runatms = runatms
         self.durationms = durationms
         self.nextrunatms = nextrunatms
+        self.model = model
+        self.provider = provider
+        self.usage = usage
+        self.jobname = jobname
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -2437,6 +2527,10 @@ public struct CronRunLogEntry: Codable, Sendable {
         case runatms = "runAtMs"
         case durationms = "durationMs"
         case nextrunatms = "nextRunAtMs"
+        case model
+        case provider
+        case usage
+        case jobname = "jobName"
     }
 }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2306,15 +2306,39 @@ public struct CronJob: Codable, Sendable {
 
 public struct CronListParams: Codable, Sendable {
     public let includedisabled: Bool?
+    public let limit: Int?
+    public let offset: Int?
+    public let query: String?
+    public let enabled: AnyCodable?
+    public let sortby: AnyCodable?
+    public let sortdir: AnyCodable?
 
     public init(
-        includedisabled: Bool?)
+        includedisabled: Bool?,
+        limit: Int?,
+        offset: Int?,
+        query: String?,
+        enabled: AnyCodable?,
+        sortby: AnyCodable?,
+        sortdir: AnyCodable?)
     {
         self.includedisabled = includedisabled
+        self.limit = limit
+        self.offset = offset
+        self.query = query
+        self.enabled = enabled
+        self.sortby = sortby
+        self.sortdir = sortdir
     }
 
     private enum CodingKeys: String, CodingKey {
         case includedisabled = "includeDisabled"
+        case limit
+        case offset
+        case query
+        case enabled
+        case sortby = "sortBy"
+        case sortdir = "sortDir"
     }
 }
 
@@ -2374,6 +2398,60 @@ public struct CronAddParams: Codable, Sendable {
     }
 }
 
+public struct CronRunsParams: Codable, Sendable {
+    public let scope: AnyCodable?
+    public let id: String?
+    public let jobid: String?
+    public let limit: Int?
+    public let offset: Int?
+    public let statuses: [AnyCodable]?
+    public let status: AnyCodable?
+    public let deliverystatuses: [AnyCodable]?
+    public let deliverystatus: AnyCodable?
+    public let query: String?
+    public let sortdir: AnyCodable?
+
+    public init(
+        scope: AnyCodable?,
+        id: String?,
+        jobid: String?,
+        limit: Int?,
+        offset: Int?,
+        statuses: [AnyCodable]?,
+        status: AnyCodable?,
+        deliverystatuses: [AnyCodable]?,
+        deliverystatus: AnyCodable?,
+        query: String?,
+        sortdir: AnyCodable?)
+    {
+        self.scope = scope
+        self.id = id
+        self.jobid = jobid
+        self.limit = limit
+        self.offset = offset
+        self.statuses = statuses
+        self.status = status
+        self.deliverystatuses = deliverystatuses
+        self.deliverystatus = deliverystatus
+        self.query = query
+        self.sortdir = sortdir
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case scope
+        case id
+        case jobid = "jobId"
+        case limit
+        case offset
+        case statuses
+        case status
+        case deliverystatuses = "deliveryStatuses"
+        case deliverystatus = "deliveryStatus"
+        case query
+        case sortdir = "sortDir"
+    }
+}
+
 public struct CronRunLogEntry: Codable, Sendable {
     public let ts: Int
     public let jobid: String
@@ -2389,6 +2467,10 @@ public struct CronRunLogEntry: Codable, Sendable {
     public let runatms: Int?
     public let durationms: Int?
     public let nextrunatms: Int?
+    public let model: String?
+    public let provider: String?
+    public let usage: [String: AnyCodable]?
+    public let jobname: String?
 
     public init(
         ts: Int,
@@ -2404,7 +2486,11 @@ public struct CronRunLogEntry: Codable, Sendable {
         sessionkey: String?,
         runatms: Int?,
         durationms: Int?,
-        nextrunatms: Int?)
+        nextrunatms: Int?,
+        model: String?,
+        provider: String?,
+        usage: [String: AnyCodable]?,
+        jobname: String?)
     {
         self.ts = ts
         self.jobid = jobid
@@ -2420,6 +2506,10 @@ public struct CronRunLogEntry: Codable, Sendable {
         self.runatms = runatms
         self.durationms = durationms
         self.nextrunatms = nextrunatms
+        self.model = model
+        self.provider = provider
+        self.usage = usage
+        self.jobname = jobname
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -2437,6 +2527,10 @@ public struct CronRunLogEntry: Codable, Sendable {
         case runatms = "runAtMs"
         case durationms = "durationMs"
         case nextrunatms = "nextRunAtMs"
+        case model
+        case provider
+        case usage
+        case jobname = "jobName"
     }
 }
 

--- a/src/agents/tools/nodes-utils.ts
+++ b/src/agents/tools/nodes-utils.ts
@@ -75,6 +75,15 @@ export async function resolveNodeId(
   query?: string,
   allowDefault = false,
 ) {
+  return (await resolveNode(opts, query, allowDefault)).nodeId;
+}
+
+export async function resolveNode(
+  opts: GatewayCallOptions,
+  query?: string,
+  allowDefault = false,
+): Promise<NodeListNode> {
   const nodes = await loadNodes(opts);
-  return resolveNodeIdFromList(nodes, query, allowDefault);
+  const nodeId = resolveNodeIdFromList(nodes, query, allowDefault);
+  return nodes.find((node) => node.nodeId === nodeId) ?? { nodeId };
 }

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -106,14 +106,17 @@ export async function writeUrlToFile(
         }
       : undefined;
 
-  const { response: res, release } = await fetchWithSsrFGuard({
-    url,
-    auditContext: "writeUrlToFile",
-    policy,
-  });
-
+  let release: () => Promise<void> = async () => {};
   let bytes = 0;
   try {
+    const guarded = await fetchWithSsrFGuard({
+      url,
+      auditContext: "writeUrlToFile",
+      policy,
+    });
+    const res = guarded.response;
+    release = guarded.release;
+
     if (!res.ok) {
       throw new Error(`failed to download ${url}: ${res.status} ${res.statusText}`);
     }

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import { normalizeHostname } from "../infra/net/hostname.js";
 import { resolveCliName } from "./cli-name.js";
 import {
   asBoolean,
@@ -29,14 +30,6 @@ export type CameraClipPayload = {
   durationMs: number;
   hasAudio: boolean;
 };
-
-function normalizeHostname(value: string): string {
-  const trimmed = value.trim().toLowerCase();
-  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
-    return trimmed.slice(1, -1);
-  }
-  return trimmed;
-}
 
 export function parseCameraSnapPayload(value: unknown): CameraSnapPayload {
   const obj = asRecord(value);

--- a/src/cli/nodes-cli/register.camera.ts
+++ b/src/cli/nodes-cli/register.camera.ts
@@ -103,7 +103,8 @@ export function registerNodesCameraCommands(nodes: Command) {
       .option("--invoke-timeout <ms>", "Node invoke timeout in ms (default 20000)", "20000")
       .action(async (opts: NodesRpcOpts) => {
         await runNodesCommand("camera snap", async () => {
-          const nodeId = await resolveNodeId(opts, String(opts.node ?? ""));
+          const node = await resolveNode(opts, String(opts.node ?? ""));
+          const nodeId = node.nodeId;
           const facingOpt = String(opts.facing ?? "both")
             .trim()
             .toLowerCase();

--- a/src/cli/nodes-cli/rpc.ts
+++ b/src/cli/nodes-cli/rpc.ts
@@ -73,6 +73,10 @@ export function unauthorizedHintForMessage(message: string): string | null {
 }
 
 export async function resolveNodeId(opts: NodesRpcOpts, query: string) {
+  return (await resolveNode(opts, query)).nodeId;
+}
+
+export async function resolveNode(opts: NodesRpcOpts, query: string): Promise<NodeListNode> {
   const q = String(query ?? "").trim();
   if (!q) {
     throw new Error("node required");
@@ -93,5 +97,6 @@ export async function resolveNodeId(opts: NodesRpcOpts, query: string) {
       remoteIp: n.remoteIp,
     }));
   }
-  return resolveNodeIdFromCandidates(nodes, q);
+  const nodeId = resolveNodeIdFromCandidates(nodes, q);
+  return nodes.find((node) => node.nodeId === nodeId) ?? { nodeId };
 }

--- a/src/cli/program.nodes-media.test.ts
+++ b/src/cli/program.nodes-media.test.ts
@@ -308,7 +308,7 @@ describe("cli program (nodes media)", () => {
         command: "camera.snap" as const,
         payload: {
           format: "jpg",
-          url: "https://example.com/photo.jpg",
+          url: "https://192.168.0.88/photo.jpg",
           width: 640,
           height: 480,
         },
@@ -320,7 +320,7 @@ describe("cli program (nodes media)", () => {
         command: "camera.clip" as const,
         payload: {
           format: "mp4",
-          url: "https://example.com/clip.mp4",
+          url: "https://192.168.0.88/clip.mp4",
           durationMs: 5000,
           hasAudio: true,
         },


### PR DESCRIPTION
## Problem

`writeUrlToFile()` in `src/cli/nodes-camera.ts` fetched arbitrary URLs from node payloads using bare `fetch()` without SSRF protection.

A malicious or compromised node could return a `payload.url` pointing to internal/private network endpoints, causing the gateway to make requests to those targets.

## Fix

Replace `fetch()` with `fetchWithSsrFGuard()` to enforce:
- Private IP/hostname blocking
- DNS rebinding protection  
- Redirect validation

## Note

This will block requests to private/internal IPs by default. If there are use cases where nodes legitimately return internal URLs (e.g., self-hosted storage), a `policy.allowPrivateNetwork` passthrough may be needed.

## Testing

Build passes. Existing SSRF guard tests cover the underlying protection.

## Related

Issue: #21151

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced bare `fetch()` with `fetchWithSsrFGuard()` in node camera URL downloads to prevent SSRF attacks. The fix binds camera payload URLs to the resolved node host/IP and enforces redirect validation, DNS rebinding protection, and private IP blocking (with allowlist override when `expectedHost` is provided).

Key changes:
- `writeUrlToFile()` now accepts `expectedHost` parameter and validates URL hostname matches before fetch
- Uses `fetchWithSsrFGuard()` with `allowPrivateNetwork: true` and hostname allowlist when `expectedHost` is specified
- Updated `resolveNode()` helpers in `rpc.ts` and `nodes-utils.ts` to return full node objects (including `remoteIp`) instead of just `nodeId`
- Applied consistently across CLI (`register.camera.ts`) and agent tools (`nodes-tool.ts`)
- Test coverage added for hostname validation

Swift protocol model changes (`GatewayModels.swift`) are unrelated - they sync cron API parameters and are auto-generated.

<h3>Confidence Score: 4/5</h3>

- This security PR is safe to merge with one minor style improvement available
- The SSRF guard implementation is solid and consistently applied across all code paths. The fix properly validates hostnames, uses the existing well-tested `fetchWithSsrFGuard()` infrastructure, and includes test coverage. Deducted one point for the duplicated `normalizeHostname()` function which should be imported rather than redefined.
- No files require special attention - the implementation is thorough and consistent

<sub>Last reviewed commit: cf3acc9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->