### PR TITLE
fix(telegram): auto-detect captionable messages for editMessageCaption

### DIFF
--- a/src/telegram/send.test-harness.ts
+++ b/src/telegram/send.test-harness.ts
@@ -5,6 +5,8 @@ const { botApi, botCtorSpy } = vi.hoisted(() => ({
   botApi: {
     deleteMessage: vi.fn(),
     editMessageText: vi.fn(),
+    editMessageCaption: vi.fn(),
+    editMessageReplyMarkup: vi.fn(),
     sendMessage: vi.fn(),
     sendPoll: vi.fn(),
     sendPhoto: vi.fn(),

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -1,5 +1,5 @@
 import type { Bot } from "grammy";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   getTelegramSendTestMocks,
   importTelegramSendModule,
@@ -1394,6 +1394,13 @@ describe("shared send behaviors", () => {
 });
 
 describe("editMessageTelegram", () => {
+  beforeEach(() => {
+    botApi.editMessageText.mockReset();
+    botApi.editMessageCaption.mockReset();
+    botApi.editMessageReplyMarkup.mockReset();
+    botCtorSpy.mockReset();
+  });
+
   it.each([
     {
       name: "buttons undefined keeps existing keyboard",
@@ -1494,6 +1501,110 @@ describe("editMessageTelegram", () => {
         link_preview_options: { is_disabled: true },
       }),
     );
+  });
+
+  it("auto-detects captionable message: retries with editMessageCaption when editMessageText returns 'no text'", async () => {
+    botApi.editMessageText.mockRejectedValueOnce(
+      new Error("400: Bad Request: there is no text in the message to edit"),
+    );
+    botApi.editMessageCaption.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+
+    await editMessageTelegram("123", 1, "new caption", {
+      token: "tok",
+      cfg: {},
+    });
+
+    expect(botApi.editMessageText).toHaveBeenCalledTimes(1);
+    expect(botApi.editMessageCaption).toHaveBeenCalledTimes(1);
+    const extra = (botApi.editMessageCaption.mock.calls[0] ?? [])[2] as Record<string, unknown>;
+    expect(extra).toEqual(
+      expect.objectContaining({ caption: expect.any(String), parse_mode: "HTML" }),
+    );
+  });
+
+  it("auto-detect passes reply_markup to editMessageCaption when buttons are provided", async () => {
+    botApi.editMessageText.mockRejectedValueOnce(
+      new Error("400: Bad Request: there is no text in the message to edit"),
+    );
+    botApi.editMessageCaption.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+
+    await editMessageTelegram("123", 1, "new caption", {
+      token: "tok",
+      cfg: {},
+      buttons: [[{ text: "Click", callback_data: "cb" }]],
+    });
+
+    expect(botApi.editMessageCaption).toHaveBeenCalledTimes(1);
+    const extra = (botApi.editMessageCaption.mock.calls[0] ?? [])[2] as Record<string, unknown>;
+    expect(extra).toHaveProperty("reply_markup");
+  });
+
+  it("treats MESSAGE_NOT_MODIFIED as success after auto-detect caption retry", async () => {
+    botApi.editMessageText.mockRejectedValueOnce(
+      new Error("400: Bad Request: there is no text in the message to edit"),
+    );
+    botApi.editMessageCaption.mockRejectedValueOnce(
+      new Error(
+        "400: Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message",
+      ),
+    );
+
+    await expect(
+      editMessageTelegram("123", 1, "unchanged caption", {
+        token: "tok",
+        cfg: {},
+      }),
+    ).resolves.toEqual({ ok: true, messageId: "1", chatId: "123" });
+    expect(botApi.editMessageText).toHaveBeenCalledTimes(1);
+    expect(botApi.editMessageCaption).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not swallow unrelated errors from editMessageText", async () => {
+    botApi.editMessageText.mockRejectedValueOnce(
+      new Error("400: Bad Request: message to edit not found"),
+    );
+
+    await expect(
+      editMessageTelegram("123", 1, "hi", {
+        token: "tok",
+        cfg: {},
+      }),
+    ).rejects.toThrow("message to edit not found");
+    expect(botApi.editMessageCaption).not.toHaveBeenCalled();
+  });
+
+  it("uses editMessageReplyMarkup when text is empty and buttons are provided", async () => {
+    botApi.editMessageReplyMarkup.mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+
+    await editMessageTelegram("123", 1, "", {
+      token: "tok",
+      cfg: {},
+      buttons: [[{ text: "OK", callback_data: "ok" }]],
+    });
+
+    expect(botApi.editMessageReplyMarkup).toHaveBeenCalledTimes(1);
+    expect(botApi.editMessageText).not.toHaveBeenCalled();
+    expect(botApi.editMessageCaption).not.toHaveBeenCalled();
+    const extra = (botApi.editMessageReplyMarkup.mock.calls[0] ?? [])[2] as Record<string, unknown>;
+    expect(extra).toHaveProperty("reply_markup");
+  });
+
+  it("treats MESSAGE_NOT_MODIFIED as success when editing only buttons", async () => {
+    botApi.editMessageReplyMarkup.mockRejectedValueOnce(
+      new Error(
+        "400: Bad Request: message is not modified: specified new message content and reply markup are exactly the same as a current content and reply markup of the message",
+      ),
+    );
+
+    await expect(
+      editMessageTelegram("123", 1, "", {
+        token: "tok",
+        cfg: {},
+        buttons: [[{ text: "OK", callback_data: "ok" }]],
+      }),
+    ).resolves.toEqual({ ok: true, messageId: "1", chatId: "123" });
+    expect(botApi.editMessageReplyMarkup).toHaveBeenCalledTimes(1);
+    expect(botApi.editMessageText).not.toHaveBeenCalled();
   });
 });
 

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -101,6 +101,7 @@ const THREAD_NOT_FOUND_RE = /400:\s*Bad Request:\s*message thread not found/i;
 const MESSAGE_NOT_MODIFIED_RE =
   /400:\s*Bad Request:\s*message is not modified|MESSAGE_NOT_MODIFIED/i;
 const CHAT_NOT_FOUND_RE = /400: Bad Request: chat not found/i;
+const NO_TEXT_IN_MESSAGE_RE = /400:\s*Bad Request:\s*there is no text in the message to edit/i;
 const sendLogger = createSubsystemLogger("telegram/send");
 const diagLogger = createSubsystemLogger("telegram/diagnostic");
 
@@ -226,6 +227,10 @@ function isTelegramThreadNotFoundError(err: unknown): boolean {
 
 function isTelegramMessageNotModifiedError(err: unknown): boolean {
   return MESSAGE_NOT_MODIFIED_RE.test(formatErrorMessage(err));
+}
+
+function isTelegramNoTextInMessageError(err: unknown): boolean {
+  return NO_TEXT_IN_MESSAGE_RE.test(formatErrorMessage(err));
 }
 
 function hasMessageThreadIdParam(params?: Record<string, unknown>): boolean {
@@ -908,26 +913,78 @@ export async function editMessageTelegram(
     plainParams.reply_markup = replyMarkup;
   }
 
+  const textIsEmpty = !text || text.trim() === "";
+
   try {
-    await withTelegramHtmlParseFallback({
-      label: "editMessage",
-      verbose: opts.verbose,
-      requestHtml: (retryLabel) =>
-        requestWithEditShouldLog(
-          () => api.editMessageText(chatId, messageId, htmlText, editParams),
-          retryLabel,
-          (err) => !isTelegramMessageNotModifiedError(err),
-        ),
-      requestPlain: (retryLabel) =>
-        requestWithEditShouldLog(
-          () =>
-            Object.keys(plainParams).length > 0
-              ? api.editMessageText(chatId, messageId, text, plainParams)
-              : api.editMessageText(chatId, messageId, text),
-          retryLabel,
-          (plainErr) => !isTelegramMessageNotModifiedError(plainErr),
-        ),
-    });
+    // Case 1: Buttons-only update — use editMessageReplyMarkup directly.
+    // Works for both text and captionable (media) messages without needing to know the type.
+    if (textIsEmpty && shouldTouchButtons && replyMarkup !== undefined) {
+      await requestWithEditShouldLog(
+        () => api.editMessageReplyMarkup(chatId, messageId, { reply_markup: replyMarkup }),
+        "editMessageReplyMarkup",
+        (err) => !isTelegramMessageNotModifiedError(err),
+      );
+    } else {
+      // Case 2: Try editMessageText first.
+      // If Telegram rejects with "there is no text in the message", the message has a caption
+      // (photo, video, audio, document, etc.) — auto-detect and retry with editMessageCaption.
+      try {
+        await withTelegramHtmlParseFallback({
+          label: "editMessage",
+          verbose: opts.verbose,
+          requestHtml: (retryLabel) =>
+            requestWithEditShouldLog(
+              () => api.editMessageText(chatId, messageId, htmlText, editParams),
+              retryLabel,
+              (err) => !isTelegramMessageNotModifiedError(err),
+            ),
+          requestPlain: (retryLabel) =>
+            requestWithEditShouldLog(
+              () =>
+                Object.keys(plainParams).length > 0
+                  ? api.editMessageText(chatId, messageId, text, plainParams)
+                  : api.editMessageText(chatId, messageId, text),
+              retryLabel,
+              (plainErr) => !isTelegramMessageNotModifiedError(plainErr),
+            ),
+        });
+      } catch (innerErr) {
+        if (!isTelegramNoTextInMessageError(innerErr)) {
+          throw innerErr;
+        }
+        if (opts.verbose) {
+          console.warn(
+            `[telegram] editMessageText failed: message has a caption, retrying with editMessageCaption`,
+          );
+        }
+        // Case 3: Captionable message (photo, video, audio, document, etc.)
+        await withTelegramHtmlParseFallback({
+          label: "editCaption",
+          verbose: opts.verbose,
+          requestHtml: (retryLabel) =>
+            requestWithEditShouldLog(
+              () =>
+                api.editMessageCaption(chatId, messageId, {
+                  caption: htmlText,
+                  parse_mode: "HTML",
+                  ...(replyMarkup !== undefined && { reply_markup: replyMarkup }),
+                }),
+              retryLabel,
+              (err) => !isTelegramMessageNotModifiedError(err),
+            ),
+          requestPlain: (retryLabel) =>
+            requestWithEditShouldLog(
+              () =>
+                api.editMessageCaption(chatId, messageId, {
+                  caption: text,
+                  ...(replyMarkup !== undefined && { reply_markup: replyMarkup }),
+                }),
+              retryLabel,
+              (plainErr) => !isTelegramMessageNotModifiedError(plainErr),
+            ),
+        });
+      }
+    }
   } catch (err) {
     if (isTelegramMessageNotModifiedError(err)) {
       // no-op: Telegram reports message content unchanged, treat as success


### PR DESCRIPTION
## Summary

- **Problem:** When editing a Telegram message containing media (photo, video, audio, document, animation), OpenClaw calls `api.editMessageText()` — Telegram rejects this with `400: there is no text in the message to edit`
- **Why it matters:** Any `message(action=edit)` call on a captionable message silently fails with a 400 error, leaving the UI in an inconsistent state
- **What changed:** `editMessageTelegram` in `send.ts` now auto-detects captionable messages by catching the specific 400 and retrying with `editMessageCaption`; buttons-only updates use `editMessageReplyMarkup` directly
- **What did NOT change:** The generic `message` tool interface is unchanged — no new parameters, no Telegram-specific details exposed to callers; all other channel adapters untouched

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

`message(action=edit)` on messages containing photo, video, audio, document, or animation now succeeds instead of throwing a 400 error. No config or interface changes.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- **Explanation:** Two new Telegram Bot API methods are now called (`editMessageCaption`, `editMessageReplyMarkup`). Both are standard endpoints scoped to the bot's existing token — no new capabilities or data access beyond what `editMessageText` already had.

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0 (arm64)
- Runtime/container: Node.js v22.22.0
- Model/provider: anthropic/claude-sonnet-4-6
- Integration/channel: Telegram
- Relevant config: Standard Telegram bot token

### Steps

1. Send a photo or video message via the `message` tool to a Telegram chat
2. Call `message(action=edit, messageId=..., message="updated caption")` on that message
3. Observe result

### Expected

Caption updates successfully on the media message

### Actual (before fix)

400: Bad Request: there is no text in the message to edit

## Evidence

- [x] Failing test/log before + passing after — 510/510 unit tests passing; 6 new tests added covering:
- Auto-detect retry path (`editMessageText` → catch → `editMessageCaption`)
- Buttons-only path (direct `editMessageReplyMarkup`)
- Error propagation (non-matching errors still throw)
- `MESSAGE_NOT_MODIFIED` swallowed as success on all paths

## Human Verification

- **Verified scenarios:** All three code paths via unit tests; `MESSAGE_NOT_MODIFIED` handling; HTML parse mode fallback preserved on both text and caption paths
- **Edge cases checked:** Non-matching 400 errors propagate normally; regex scoped tightly to the specific Telegram error string
- **What I did not verify:** Live end-to-end manual test with a real Telegram bot (unit tests mock the API layer)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery

- **How to disable/revert:** Revert `src/telegram/send.ts` to previous `editMessageTelegram` implementation
- **Files/config to restore:** `src/telegram/send.ts` only
- **Known bad symptoms:** Unexpected retry loops on 400 errors — check `NO_TEXT_IN_MESSAGE_RE` regex against actual Telegram error wording

## Risks and Mitigations

- **Risk:** `NO_TEXT_IN_MESSAGE_RE` regex may not match if Telegram changes their error message wording
- **Mitigation:** Failure mode is graceful — unmatched errors propagate as before (old behavior), no new failure modes introduced

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes message editing failures for Telegram media messages (photo, video, audio, document, animation) by auto-detecting captionable messages and retrying with the correct API method.

**Key Changes:**
- Added `NO_TEXT_IN_MESSAGE_RE` regex to detect Telegram's "no text in message" error
- `editMessageTelegram` now catches the 400 error and retries with `editMessageCaption` for media messages
- Added direct `editMessageReplyMarkup` path for buttons-only updates (works for both text and media)
- Preserved HTML parse fallback behavior on both text and caption paths
- All three code paths properly handle `MESSAGE_NOT_MODIFIED` as success

**Test Coverage:**
Six new tests cover all code paths: auto-detect retry, buttons-only, error propagation, and `MESSAGE_NOT_MODIFIED` handling. Implementation is backward compatible with no API surface changes.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The implementation follows a defensive error-handling pattern with graceful fallbacks. The regex is scoped tightly to the specific Telegram error message. Six comprehensive tests cover all code paths including edge cases (MESSAGE_NOT_MODIFIED handling, error propagation, buttons-only updates). The change is backward compatible with no API surface modifications and only affects the Telegram channel adapter. Failure mode is graceful—unmatched errors propagate as before.
- No files require special attention

<sub>Last reviewed commit: 2e0852c</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->