### PR TITLE
fix(exec): add EAGAIN to default retry codes

### DIFF
--- a/src/process/spawn-utils.ts
+++ b/src/process/spawn-utils.ts
@@ -21,7 +21,7 @@ type SpawnWithFallbackParams = {
   onFallback?: (err: unknown, fallback: SpawnFallback) => void;
 };
 
-const DEFAULT_RETRY_CODES = ["EBADF"];
+const DEFAULT_RETRY_CODES = ["EBADF", "EAGAIN"];
 
 export function resolveCommandStdio(params: {
   hasInput: boolean;


### PR DESCRIPTION
## Summary
- Add `EAGAIN` (resource temporarily unavailable) to `DEFAULT_RETRY_CODES` in `spawn-utils.ts` so the exec tool automatically retries on transient resource exhaustion errors instead of failing immediately.

Closes #24024

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added `EAGAIN` to retry codes for process spawning to handle transient resource exhaustion errors. This follows the existing pattern of retrying on `EBADF` and makes the spawn utility more resilient when system resources are temporarily unavailable.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - straightforward addition to error retry list with existing safeguards
- Simple, well-contained change that adds a standard POSIX error code to an existing retry mechanism. The retry logic already has safeguards (requires fallback options, checks error codes explicitly), and EAGAIN is semantically appropriate for retry behavior as it indicates temporary resource unavailability.
- No files require special attention

<sub>Last reviewed commit: 2eaea78</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->