### PR TITLE
fix(logging): use local time for gateway console timestamps

### DIFF
--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -209,7 +209,10 @@ function formatConsoleLine(opts: {
   const displayMessage = stripRedundantSubsystemPrefixForConsole(opts.message, displaySubsystem);
   const time = (() => {
     if (opts.style === "pretty") {
-      return color.gray(new Date().toISOString().slice(11, 19));
+      const d = new Date();
+      return color.gray(
+        `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}:${String(d.getSeconds()).padStart(2, "0")}`,
+      );
     }
     if (loggingState.consoleTimestampPrefix) {
       return color.gray(new Date().toISOString());


### PR DESCRIPTION
## Summary
- Replace `toISOString().slice(11, 19)` (always UTC) with local-time-aware `getHours()`/`getMinutes()`/`getSeconds()` in `formatConsoleLine` so the gateway console shows the correct local time instead of UTC.

Closes #23955

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed gateway console timestamps from UTC to local time by replacing `toISOString().slice(11, 19)` with manual `getHours()/getMinutes()/getSeconds()` formatting in the "pretty" style console output. This only affects the visual console display - file logging and JSON output still use ISO timestamps as appropriate.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The change is minimal, well-scoped, and correctly implements local time formatting for console output only. The implementation uses standard JavaScript Date methods, maintains the same HH:MM:SS format with proper zero-padding, and doesn't affect file logging or JSON output which appropriately continue using ISO timestamps.
- No files require special attention

<sub>Last reviewed commit: 728edf1</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->