### PR TITLE
fix(web-search): clarify Brave Search search_lang and ui_lang format requirements

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -53,12 +53,14 @@ const WebSearchSchema = Type.Object({
   ),
   search_lang: Type.Optional(
     Type.String({
-      description: "2-letter ISO 639-1 language code for search results (e.g., 'de', 'en', 'fr', 'tr'). Must be a short code, NOT a locale.",
+      description:
+        "2-letter ISO 639-1 language code for search results (e.g., 'de', 'en', 'fr', 'tr'). Must be a short code, NOT a locale.",
     }),
   ),
   ui_lang: Type.Optional(
     Type.String({
-      description: "Locale code for UI elements in 'xx-XX' format (e.g., 'de-DE', 'en-US', 'fr-FR', 'tr-TR'). Must include region subtag.",
+      description:
+        "Locale code for UI elements in 'xx-XX' format (e.g., 'de-DE', 'en-US', 'fr-FR', 'tr-TR'). Must include region subtag.",
     }),
   ),
   freshness: Type.Optional(

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -53,12 +53,12 @@ const WebSearchSchema = Type.Object({
   ),
   search_lang: Type.Optional(
     Type.String({
-      description: "ISO language code for search results (e.g., 'de', 'en', 'fr').",
+      description: "2-letter ISO 639-1 language code for search results (e.g., 'de', 'en', 'fr', 'tr'). Must be a short code, NOT a locale.",
     }),
   ),
   ui_lang: Type.Optional(
     Type.String({
-      description: "ISO language code for UI elements.",
+      description: "Locale code for UI elements in 'xx-XX' format (e.g., 'de-DE', 'en-US', 'fr-FR', 'tr-TR'). Must include region subtag.",
     }),
   ),
   freshness: Type.Optional(


### PR DESCRIPTION
## Summary

Fixes #23826

The Brave Search API returns HTTP 422 errors because `search_lang` and `ui_lang` parameter format descriptions in the tool schema were ambiguous/swapped:

- `search_lang` expects **2-letter ISO 639-1** codes (e.g., `tr`, `en`, `fr`)
- `ui_lang` expects **locale format** with region (e.g., `tr-TR`, `en-US`, `fr-FR`)

## Changes

- Updated `search_lang` schema description to explicitly specify 2-letter ISO 639-1 format with examples
- Updated `ui_lang` schema description to explicitly specify locale format (xx-XX) with examples

## Testing

- Verified schema descriptions match [Brave Search API documentation](https://api.search.brave.com/app/documentation/web-search/query)
- No logic changes — schema description clarification only

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Clarified parameter format requirements for Brave Search API `search_lang` and `ui_lang` fields to prevent HTTP 422 errors. The updated descriptions now explicitly specify that `search_lang` expects 2-letter ISO 639-1 codes (e.g., `tr`, `en`) while `ui_lang` expects locale format with region (e.g., `tr-TR`, `en-US`).

- Updated `search_lang` description in `WebSearchSchema` to explicitly specify "2-letter ISO 639-1 language code" with additional examples and a warning that it must NOT be a locale
- Updated `ui_lang` description to explicitly specify "Locale code for UI elements in 'xx-XX' format" with examples and a requirement to include region subtag
- No logic changes, only schema description improvements for better API clarity

<h3>Confidence Score: 5/5</h3>

- Safe to merge - documentation-only change that clarifies API parameter formats
- This PR only updates schema description strings to clarify the expected format for Brave Search API parameters. No logic changes, no new dependencies, no runtime behavior modifications. The changes accurately reflect the Brave Search API requirements and will help prevent HTTP 422 errors from incorrect parameter formats.
- No files require special attention

<sub>Last reviewed commit: 7305364</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->