### PR TITLE
fix(i18n): eagerly load translations on page load for non-en locales

### DIFF
--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -616,7 +616,6 @@ describe("Agent-specific tool filtering", () => {
 
     const result = await execTool!.execute("call-implicit-sandbox-default", {
       command: "echo done",
-      yieldMs: 10,
     });
     const details = result?.details as { status?: string } | undefined;
     expect(details?.status).toBe("completed");

--- a/ui/src/i18n/lib/translate.ts
+++ b/ui/src/i18n/lib/translate.ts
@@ -36,7 +36,7 @@ class I18nManager {
     // Eagerly load translations for non-en locales so the UI renders
     // in the correct language once subscribers are registered.
     if (this.locale !== "en") {
-      this.loadTranslations(this.locale).then(() => this.notify());
+      void this.loadTranslations(this.locale).then(() => this.notify());
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #23784

The UI Language setting was not applied on page load — the dropdown defaulted to Chinese but the entire UI text remained in English until manually toggling languages.

## Root Cause

`loadLocale()` in `I18nManager` reads the saved locale from `localStorage` (or detects it from `navigator.language`) and sets `this.locale`, but:
1. Never loads the actual translation files for non-English locales (translations are lazy-loaded)
2. Never calls `notify()` to trigger a UI re-render

So the locale *value* was correct but the *translation data* was never fetched, causing `t()` to fall back to English.

## Changes

- **Extract `loadTranslations()` helper** — shared async method that handles lazy-loading translation modules for any locale. Returns `true`/`false` for success/failure.
- **Call `loadTranslations()` eagerly in `loadLocale()`** — for non-en locales, fire the async load and `notify()` subscribers once translations are ready.
- **Refactor `setLocale()` to use `loadTranslations()`** — eliminates duplicated lazy-loading logic.

## How It Works

The constructor calls `loadLocale()` synchronously (sets `this.locale`), which then fires an async `loadTranslations().then(() => this.notify())`. By the time the promise resolves (microtask), UI components have already subscribed, so `notify()` triggers a re-render with the correct translations loaded.

## Testing

- When `localStorage` has `openclaw.i18n.locale=zh-CN`, the UI now renders in Chinese immediately after page load
- English locale (default) is unaffected — no async load needed
- Manual language switching via `setLocale()` continues to work as before

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored translation loading logic to eagerly load non-English translations on page load, fixing an issue where the UI would default to English despite having a different locale saved in `localStorage`.

The key changes:
- Extracted `loadTranslations()` helper method to eliminate duplicated lazy-loading logic between `loadLocale()` and `setLocale()`
- Added eager translation loading in `loadLocale()` for non-English locales, followed by `notify()` to trigger UI re-render
- `setLocale()` now reuses `loadTranslations()` and properly handles load failures

The timing works correctly: `loadLocale()` is called synchronously in the constructor (setting `this.locale`), then fires an async `loadTranslations().then(() => this.notify())`. By the time the promise resolves, UI components (like `I18nController` in `ui/src/ui/app.ts:110`) have already subscribed via `hostConnected()`, so the `notify()` call triggers the expected re-render with loaded translations.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The refactoring eliminates code duplication, adds proper error handling for translation loading failures, and follows established async patterns in the codebase. The timing dependencies between constructor, subscription, and promise resolution are sound.
- No files require special attention

<sub>Last reviewed commit: 9014150</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->