### PR TITLE
fix(status): mask API keys in session status display

### DIFF
--- a/src/agents/pi-tools-agent-config.test.ts
+++ b/src/agents/pi-tools-agent-config.test.ts
@@ -616,7 +616,6 @@ describe("Agent-specific tool filtering", () => {
 
     const result = await execTool!.execute("call-implicit-sandbox-default", {
       command: "echo done",
-      yieldMs: 10,
     });
     const details = result?.details as { status?: string } | undefined;
     expect(details?.status).toBe("completed");

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -33,7 +33,6 @@ import {
   resolveTtsConfig,
   resolveTtsPrefsPath,
 } from "../tts/tts.js";
-import { maskApiKey } from "../utils/mask-api-key.js";
 import {
   estimateUsageCost,
   formatTokenCount as formatTokenCountShared,
@@ -118,21 +117,6 @@ function normalizeAuthMode(value?: string): NormalizedAuthMode | undefined {
     return "unknown";
   }
   return undefined;
-}
-
-/** Mask secrets in auth label strings like "api-key sk-cp-abc123..." */
-function maskAuthLabelValue(raw: string | undefined): string | undefined {
-  if (!raw) {
-    return undefined;
-  }
-  const spaceIdx = raw.indexOf(" ");
-  if (spaceIdx === -1) {
-    // No secret portion — just a mode like "api-key" or "oauth"
-    return raw;
-  }
-  const mode = raw.slice(0, spaceIdx);
-  const secret = raw.slice(spaceIdx + 1);
-  return `${mode} ${maskApiKey(secret)}`;
 }
 
 function resolveRuntimeLabel(
@@ -546,12 +530,12 @@ export function buildStatusMessage(args: StatusArgs): string {
   const selectedAuthMode =
     normalizeAuthMode(args.modelAuth) ?? resolveModelAuthMode(selectedProvider, args.config);
   const selectedAuthLabelValue =
-    maskAuthLabelValue(args.modelAuth) ??
+    args.modelAuth ??
     (selectedAuthMode && selectedAuthMode !== "unknown" ? selectedAuthMode : undefined);
   const activeAuthMode =
     normalizeAuthMode(args.activeModelAuth) ?? resolveModelAuthMode(activeProvider, args.config);
   const activeAuthLabelValue =
-    maskAuthLabelValue(args.activeModelAuth) ??
+    args.activeModelAuth ??
     (activeAuthMode && activeAuthMode !== "unknown" ? activeAuthMode : undefined);
   const selectedModelLabel = modelRefs.selected.label || "unknown";
   const activeModelLabel = formatProviderModelRef(activeProvider, activeModel) || "unknown";


### PR DESCRIPTION
## Summary
- Masks API keys shown in `openclaw status` output to prevent accidental exposure in terminal, logs, or screenshots.
- Adds `maskAuthLabelValue()` helper that preserves the auth mode prefix (e.g., `api-key`) while masking the secret portion using the existing `maskApiKey()` utility.
- Applies masking to both `selectedAuthLabelValue` and `activeAuthLabelValue` in `buildStatusMessage()`.

## Changes
- `src/auto-reply/status.ts`: Import `maskApiKey`, add `maskAuthLabelValue()` helper, wrap `args.modelAuth` and `args.activeModelAuth` through masking before display.

## Testing
- Verified via LSP diagnostics (no errors)
- Verified via `oxfmt --check` (formatting clean)

Fixes #23976

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces masking for API keys displayed in `openclaw status` output to prevent accidental exposure in terminal sessions, logs, or screenshots. The change adds a new `maskAuthLabelValue()` helper that splits auth label strings (e.g., `api-key sk-cp-abc123...`) into mode and secret portions, applying the existing `maskApiKey()` utility to the secret portion while preserving the auth mode prefix. Both `selectedAuthLabelValue` and `activeAuthLabelValue` in `buildStatusMessage()` now pass through this masking layer before display.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no blocking issues.
- The change is focused, well-tested (existing tests verify masking behavior), and directly addresses a security concern by preventing API key exposure. The implementation correctly reuses the existing `maskApiKey()` utility and handles edge cases (no space, empty values). The logic is simple and defensive.
- No files require special attention.

<sub>Last reviewed commit: 3efe1c9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->