### PR TITLE
feat(cli): add --session-key targeting for openclaw agent

### DIFF
--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -100,6 +100,25 @@ describe("registerAgentCommands", () => {
     );
   });
 
+  it("forwards --session-key", async () => {
+    await runCli([
+      "agent",
+      "--message",
+      "hi",
+      "--session-key",
+      "agent:demo:slack:channel:c0123456789",
+    ]);
+
+    expect(agentCliCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "hi",
+        sessionKey: "agent:demo:slack:channel:c0123456789",
+      }),
+      runtime,
+      { deps: true },
+    );
+  });
+
   it("runs agents add and computes hasFlags based on explicit options", async () => {
     await runCli(["agents", "add", "alpha"]);
     expect(agentsAddCommandMock).toHaveBeenNthCalledWith(

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -25,6 +25,7 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
     .description("Run an agent turn via the Gateway (use --local for embedded)")
     .requiredOption("-m, --message <text>", "Message body for the agent")
     .option("-t, --to <number>", "Recipient number in E.164 used to derive the session key")
+    .option("--session-key <key>", "Use an explicit session key")
     .option("--session-id <id>", "Use an explicit session id")
     .option("--agent <id>", "Agent id (overrides routing bindings)")
     .option("--thinking <level>", "Thinking level: off | minimal | low | medium | high")
@@ -56,8 +57,12 @@ ${formatHelpExamples([
   ['openclaw agent --to +15555550123 --message "status update"', "Start a new session."],
   ['openclaw agent --agent ops --message "Summarize logs"', "Use a specific agent."],
   [
+    'openclaw agent --session-key "agent:demo:slack:channel:c0123456789" --message "Summarize inbox" --thinking medium',
+    "Target a session key with explicit thinking level.",
+  ],
+  [
     'openclaw agent --session-id 1234 --message "Summarize inbox" --thinking medium',
-    "Target a session with explicit thinking level.",
+    "Target a session by id.",
   ],
   [
     'openclaw agent --to +15555550123 --message "Trace logs" --verbose on --json',

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -107,6 +107,27 @@ describe("agentCliCommand", () => {
     });
   });
 
+  it("accepts --session-key and forwards it to gateway", async () => {
+    await withTempStore(async () => {
+      mockGatewaySuccessReply();
+      const explicitSessionKey = "agent:demo:slack:channel:c0123456789";
+
+      await agentCliCommand(
+        {
+          message: "hi",
+          sessionKey: explicitSessionKey,
+        },
+        runtime,
+      );
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      const request = vi.mocked(callGateway).mock.calls[0]?.[0] as {
+        params?: { sessionKey?: string };
+      };
+      expect(request.params?.sessionKey).toBe(explicitSessionKey);
+    });
+  });
+
   it("falls back to embedded agent when gateway fails", async () => {
     await withTempStore(async () => {
       vi.mocked(callGateway).mockRejectedValue(new Error("gateway not connected"));

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -36,6 +36,7 @@ export type AgentCliOpts = {
   message: string;
   agent?: string;
   to?: string;
+  sessionKey?: string;
   sessionId?: string;
   thinking?: string;
   verbose?: string;
@@ -89,8 +90,10 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
   if (!body) {
     throw new Error("Message (--message) is required");
   }
-  if (!opts.to && !opts.sessionId && !opts.agent) {
-    throw new Error("Pass --to <E.164>, --session-id, or --agent to choose a session");
+  if (!opts.to && !opts.sessionKey && !opts.sessionId && !opts.agent) {
+    throw new Error(
+      "Pass --session-key, --session-id, --to <E.164>, or --agent to choose a session",
+    );
   }
 
   const cfg = loadConfig();
@@ -115,6 +118,7 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
     agentId,
     to: opts.to,
     sessionId: opts.sessionId,
+    sessionKey: opts.sessionKey,
   }).sessionKey;
 
   const channel = normalizeMessageChannel(opts.channel);


### PR DESCRIPTION
## Summary
Adds first-class `--session-key` support to `openclaw agent` so callers can target stable session keys directly (for example: `agent:demo:slack:channel:c0123456789`) instead of relying on rotating `sessionId` UUIDs.

This addresses callback routing reliability for external automation flows where a stable session key is known ahead of time but a session UUID is not.

## Problem
Today, `openclaw agent` supports `--session-id`, `--to`, and `--agent`, but not `--session-key`.

In multi-channel/multi-agent setups, this can cause CLI-triggered deliveries to resolve to the agent main session key (`agent:<id>:main`) instead of the intended channel session key, because:
- `sessionId` is UUID-based and not stable/discoverable externally,
- `--to` is sender-derived and not always available in callback environments,
- `--agent` alone falls back to the explicit agent main key.

## What changed
### 1) New CLI flag
- Added `--session-key <key>` to `openclaw agent` in:
  - `src/cli/program/register.agent.ts`

### 2) Pass-through to session resolution
- Added `sessionKey?: string` to `AgentCliOpts` and forwarded it into:
  - `resolveSessionKeyForRequest({ sessionKey })`
- File:
  - `src/commands/agent-via-gateway.ts`

### 3) Selection/precedence behavior
Session targeting now resolves in the intended order:
1. `--session-key`
2. `--session-id`
3. `--to`
4. `--agent` explicit main key fallback

This order is implemented by existing resolution behavior once `sessionKey` is supplied, with no changes required to core resolver semantics.

### 4) UX/help updates
- Updated command validation error text to include `--session-key`.
- Added `--session-key` example in CLI help output.

## Tests
Added coverage for both CLI option parsing and gateway parameter forwarding:

- `src/cli/program/register.agent.test.ts`
  - verifies `--session-key` is parsed and forwarded to `agentCliCommand`.

- `src/commands/agent-via-gateway.test.ts`
  - verifies explicit `sessionKey` is forwarded into gateway call params.

Local test run:
- `pnpm vitest src/commands/agent-via-gateway.test.ts src/cli/program/register.agent.test.ts --run`
- Result: all tests passing.

## Backwards compatibility
- No behavior changes for existing callers that use `--session-id`, `--to`, or `--agent`.
- `--session-key` is additive and opt-in.

## Related context
This change is motivated by recurring session-targeting UX friction in `openclaw agent` flows. Related issues:

- https://github.com/openclaw/openclaw/issues/22085
- https://github.com/openclaw/openclaw/issues/13635
- https://github.com/openclaw/openclaw/issues/12881 (historical)

This PR does **not** claim to fully resolve those reports; it adds an explicit, stable targeting path (`--session-key`) that reduces routing ambiguity for CLI automation and callback workflows.

## Acceptance check
Expected to route to channel session instead of agent main:

```bash
openclaw agent \
  --session-key "agent:demo:slack:channel:c0123456789" \
  --message "callback route test" \
  --deliver
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds first-class `--session-key` flag to `openclaw agent` command, enabling stable session targeting for CLI automation and callback workflows. The implementation cleanly extends existing session resolution without breaking backward compatibility.

- Added `--session-key <key>` CLI option in register.agent.ts with updated help examples
- Extended `AgentCliOpts` type and forwarded `sessionKey` parameter through the gateway call chain
- Updated validation error message to include the new `--session-key` option
- Added comprehensive test coverage for CLI parsing and gateway forwarding
- Session resolution precedence remains unchanged: explicit `sessionKey` takes priority when provided

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- The changes are well-implemented, focused, and thoroughly tested. The new `--session-key` parameter integrates cleanly with existing session resolution logic. Test coverage validates both CLI option parsing and parameter forwarding. Error messages and help text are appropriately updated. The implementation follows the codebase's existing patterns and maintains full backward compatibility.
- No files require special attention.

<sub>Last reviewed commit: ef51f27</sub>

<!-- greptile_other_comments_section -->

<sub>(4/5) You can add custom instructions or style guidelines for the agent [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->