### PR TITLE
fix(telegram): suppress toolUse intermediate message_end block replies

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -41,6 +41,25 @@ function emitReasoningEnd(ctx: EmbeddedPiSubscribeContext) {
   void ctx.params.onReasoningEnd?.();
 }
 
+function hasToolCallBlock(message: AgentMessage): boolean {
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) {
+    return false;
+  }
+  return content.some((block) => {
+    if (!block || typeof block !== "object") {
+      return false;
+    }
+    const type = (block as { type?: unknown }).type;
+    return type === "toolCall" || type === "toolUse" || type === "functionCall";
+  });
+}
+
+function shouldSuppressMessageEndBlockReply(message: AgentMessage): boolean {
+  const stopReason = (message as { stopReason?: unknown }).stopReason;
+  return stopReason === "toolUse" && hasToolCallBlock(message);
+}
+
 export function resolveSilentReplyFallbackText(params: {
   text: string;
   messagingToolSentTexts: string[];
@@ -326,10 +345,14 @@ export function handleMessageEnd(
   ctx.finalizeAssistantTexts({ text, addedDuringMessage, chunkerHasBuffered });
 
   const onBlockReply = ctx.params.onBlockReply;
+  const suppressMessageEndReply =
+    ctx.state.blockReplyBreak === "message_end" &&
+    shouldSuppressMessageEndBlockReply(assistantMessage);
   const shouldEmitReasoning = Boolean(
     ctx.state.includeReasoning &&
     formattedReasoning &&
     onBlockReply &&
+    !suppressMessageEndReply &&
     formattedReasoning !== ctx.state.lastReasoningSent,
   );
   const shouldEmitReasoningBeforeAnswer =
@@ -350,7 +373,8 @@ export function handleMessageEnd(
     (ctx.state.blockReplyBreak === "message_end" ||
       (ctx.blockChunker ? ctx.blockChunker.hasBuffered() : ctx.state.blockBuffer.length > 0)) &&
     text &&
-    onBlockReply
+    onBlockReply &&
+    !suppressMessageEndReply
   ) {
     if (ctx.blockChunker?.hasBuffered()) {
       ctx.blockChunker.drain({ force: true, emit: ctx.emitBlockChunk });


### PR DESCRIPTION
## Summary

- Problem: Telegram `stream + reasoning` flows could emit intermediate `toolUse` assistant turns (e.g. "让我检查状态…") as visible `message_end` block replies.
- Why it matters: internal progress chatter leaks into user-visible chat, causing final answer flow to look overwritten/interleaved.
- What changed: added a narrow guard in `handleMessageEnd` to suppress `message_end` block reply emission for assistant turns that are `stopReason === "toolUse"` **and** contain tool-call blocks.
- What did NOT change (scope boundary): no protocol/API changes; no changes to normal `stop` turns, no changes to `text_end` block reply flow.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24376
- Related #17935 #17973 #20774 #22613 #23202 #19180 #19193 #20568

## User-visible / Behavior Changes

- Telegram: intermediate assistant `toolUse` status text is no longer emitted as a `message_end` visible reply when that turn contains tool-call blocks.
- Final normal `stop` answer turns continue to be emitted.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: bailian / kimi-k2.5 (repro evidence from local sessions)
- Integration/channel (if any): Telegram
- Relevant config (redacted): Telegram streaming enabled, reasoning visible

### Steps

1. Enable Telegram streaming + reasoning visibility.
2. Trigger a run that performs tool polling (`stopReason=toolUse`) before final answer.
3. Observe intermediate status text being emitted as visible message_end replies.

### Expected

- Intermediate `toolUse` status turns should not be emitted as visible message_end replies.
- Final `stop` turn should still be emitted.

### Actual

- Before fix: `onBlockReply` was called for `toolUse` turn text (failing test showed payload text `"让我检查状态："`).
- After fix: `toolUse + toolCall` turn is suppressed; normal `stop` turn still emits.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Details:

- Before fix, this test failed:
  - `src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-message-end-block-replies-message-tool.test.ts`
  - Assertion: expected `onBlockReply` not called, but got 1 call with `text: "让我检查状态："`.
- After fix, same test passes along with related suites:
  - `pnpm exec vitest run src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-message-end-block-replies-message-tool.test.ts src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.subscribeembeddedpisession.test.ts src/telegram/bot-message-dispatch.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `toolUse + toolCall block` message_end no longer calls `onBlockReply`.
  - Normal `stop` turn still calls `onBlockReply`.
  - `toolUse` turn without tool-call block is not suppressed.
- Edge cases checked:
  - Existing message-tool dedupe tests still pass in the touched suite.
  - Telegram dispatch tests still pass.
- What you did **not** verify:
  - Live Telegram end-user UI replay in this PR run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `9f0f64686`.
- Files/config to restore:
  - `src/agents/pi-embedded-subscribe.handlers.messages.ts`
  - `src/agents/pi-embedded-subscribe.subscribe-embedded-pi-session.suppresses-message-end-block-replies-message-tool.test.ts`
- Known bad symptoms reviewers should watch for:
  - Missing final message for normal `stop` turns (should not happen).
  - Unexpected suppression of non-tool intermediate text.

## Risks and Mitigations

- Risk:
  - Over-suppressing legitimate message_end text.
  - Mitigation:
    - Guard is narrow: only when `blockReplyBreak === "message_end" && stopReason === "toolUse" && content contains tool-call blocks`.
- Risk:
  - Regression in related streaming/reasoning paths.
  - Mitigation:
    - Added targeted tests plus related suite runs (`pi-embedded-subscribe`, `telegram dispatch`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds narrow guard to suppress intermediate `toolUse` assistant turn `message_end` block replies when tool-call blocks are present, preventing internal progress chatter from leaking into user-visible Telegram chats during streaming + reasoning flows.

The change introduces two helper functions (`hasToolCallBlock` and `shouldSuppressMessageEndBlockReply`) that check whether an assistant message should be suppressed. The suppression logic is applied in two places within `handleMessageEnd`:
- Before emitting reasoning (line 355)
- Before calling `onBlockReply` for the main text (line 377)

The implementation correctly handles the three key scenarios verified by tests:
- Suppresses `message_end` for `stopReason === "toolUse"` turns that contain tool-call blocks
- Preserves normal `stop` turn replies 
- Does not suppress `toolUse` turns without tool-call blocks

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk
- The implementation is narrow and well-tested with three test cases covering the main scenarios. The guard only triggers when both conditions are met (`stopReason === "toolUse"` AND message contains tool-call blocks), minimizing risk of over-suppression. However, scoring 4 instead of 5 due to lack of live end-to-end verification in actual Telegram UI as noted in the PR description.
- No files require special attention

<sub>Last reviewed commit: 9f0f646</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->