### PR TITLE
fix: attempt fallback providers when primary provider is exhausted

### DIFF
--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -1,4 +1,5 @@
 import type { OpenClawConfig } from "../config/config.js";
+import type { FailoverReason } from "./pi-embedded-helpers.js";
 import {
   ensureAuthProfileStore,
   getSoonestCooldownExpiry,
@@ -21,7 +22,6 @@ import {
   resolveConfiguredModelRef,
   resolveModelRefFromString,
 } from "./model-selection.js";
-import type { FailoverReason } from "./pi-embedded-helpers.js";
 import { isLikelyContextOverflowError } from "./pi-embedded-helpers.js";
 
 type ModelCandidate = {
@@ -329,39 +329,50 @@ export async function runWithModelFallback<T>(params: {
 
       if (profileIds.length > 0 && !isAnyProfileAvailable) {
         // All profiles for this provider are in cooldown.
-        // For the primary model (i === 0), probe it if the soonest cooldown
-        // expiry is close or already past. This avoids staying on a fallback
-        // model long after the real rate-limit window clears.
-        const now = Date.now();
-        const probeThrottleKey = resolveProbeThrottleKey(candidate.provider, params.agentDir);
-        const shouldProbe = shouldProbePrimaryDuringCooldown({
-          isPrimary: i === 0,
-          hasFallbackCandidates,
-          now,
-          throttleKey: probeThrottleKey,
-          authStore,
-          profileIds,
-        });
-        if (!shouldProbe) {
-          const inferredReason =
-            resolveProfilesUnavailableReason({
-              store: authStore,
-              profileIds,
-              now,
-            }) ?? "rate_limit";
-          // Skip without attempting
-          attempts.push({
-            provider: candidate.provider,
-            model: candidate.model,
-            error: `Provider ${candidate.provider} is in cooldown (all profiles unavailable)`,
-            reason: inferredReason,
+        //
+        // Primary model (i === 0): apply probe logic — skip unless a probe is
+        // warranted (cooldown nearly expired or already past). This avoids
+        // staying on a fallback long after the primary rate-limit window clears.
+        //
+        // Fallback models (i > 0): always attempt regardless of cooldown.
+        // We are already in fallback mode; silently skipping a fallback because
+        // its profiles happen to be cooled-down would prevent cross-provider
+        // traversal entirely (issue #23829). The inner runner handles per-profile
+        // cooldown errors and throws a FailoverError if all profiles fail, which
+        // the outer loop catches to try the next candidate.
+        if (i === 0) {
+          const now = Date.now();
+          const probeThrottleKey = resolveProbeThrottleKey(candidate.provider, params.agentDir);
+          const shouldProbe = shouldProbePrimaryDuringCooldown({
+            isPrimary: true,
+            hasFallbackCandidates,
+            now,
+            throttleKey: probeThrottleKey,
+            authStore,
+            profileIds,
           });
-          continue;
+          if (!shouldProbe) {
+            const inferredReason =
+              resolveProfilesUnavailableReason({
+                store: authStore,
+                profileIds,
+                now,
+              }) ?? "rate_limit";
+            // Skip primary without attempting
+            attempts.push({
+              provider: candidate.provider,
+              model: candidate.model,
+              error: `Provider ${candidate.provider} is in cooldown (all profiles unavailable)`,
+              reason: inferredReason,
+            });
+            continue;
+          }
+          // Primary model probe: attempt it despite cooldown to detect recovery.
+          // If it fails, the error is caught below and we fall through to the
+          // next candidate as usual.
+          lastProbeAttempt.set(probeThrottleKey, now);
         }
-        // Primary model probe: attempt it despite cooldown to detect recovery.
-        // If it fails, the error is caught below and we fall through to the
-        // next candidate as usual.
-        lastProbeAttempt.set(probeThrottleKey, now);
+        // Fallback candidates (i > 0): fall through and attempt despite cooldown.
       }
     }
     try {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -97,10 +97,6 @@ type ModelFallbackRunResult<T> = {
   attempts: FallbackAttempt[];
 };
 
-function sameModelCandidate(a: ModelCandidate, b: ModelCandidate): boolean {
-  return a.provider === b.provider && a.model === b.model;
-}
-
 function throwFallbackFailureSummary(params: {
   attempts: FallbackAttempt[];
   candidates: ModelCandidate[];
@@ -198,7 +194,6 @@ function resolveFallbackCandidates(params: {
   const providerRaw = String(params.provider ?? "").trim() || defaultProvider;
   const modelRaw = String(params.model ?? "").trim() || defaultModel;
   const normalizedPrimary = normalizeModelRef(providerRaw, modelRaw);
-  const configuredPrimary = normalizeModelRef(defaultProvider, defaultModel);
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg ?? {},
     defaultProvider,
@@ -215,11 +210,10 @@ function resolveFallbackCandidates(params: {
     if (params.fallbacksOverride !== undefined) {
       return params.fallbacksOverride;
     }
-    // Skip configured fallback chain when the user runs a non-default override.
-    // In that case, retry should return directly to configured primary.
-    if (!sameModelCandidate(normalizedPrimary, configuredPrimary)) {
-      return []; // Override model failed → go straight to configured default
-    }
+    // Keep the configured fallback chain even when the current runtime model is
+    // not the configured primary (for example, when a prior turn already
+    // failed over). This preserves cross-provider recovery instead of forcing a
+    // dead-end retry against primary-only.
     const model = params.cfg?.agents?.defaults?.model as
       | { fallbacks?: string[] }
       | string

--- a/src/line/monitor.abort-lifecycle.test.ts
+++ b/src/line/monitor.abort-lifecycle.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+
+vi.mock("../plugins/http-path.js", () => ({
+  normalizePluginHttpPath: vi.fn(() => "/line/webhook"),
+}));
+
+const unregisterHttp = vi.fn();
+vi.mock("../plugins/http-registry.js", () => ({
+  registerPluginHttpRoute: vi.fn(() => unregisterHttp),
+}));
+
+vi.mock("./webhook-node.js", () => ({
+  createLineNodeWebhookHandler: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("./bot.js", () => ({
+  createLineBot: vi.fn(() => ({
+    account: { id: "line-account" },
+    handleWebhook: vi.fn(async () => {}),
+  })),
+}));
+
+import { monitorLineProvider } from "./monitor.js";
+
+describe("monitorLineProvider lifecycle", () => {
+  it("stays pending until abortSignal is aborted", async () => {
+    const ac = new AbortController();
+
+    const monitorPromise = monitorLineProvider({
+      channelAccessToken: "token",
+      channelSecret: "secret",
+      accountId: "default",
+      config: {} as OpenClawConfig,
+      runtime: {} as RuntimeEnv,
+      abortSignal: ac.signal,
+    });
+
+    const settledEarly = await Promise.race([
+      monitorPromise.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 25)),
+    ]);
+
+    expect(settledEarly).toBe(false);
+
+    ac.abort();
+
+    const monitor = await monitorPromise;
+    expect(monitor.account).toEqual({ id: "line-account" });
+    expect(unregisterHttp).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/line/monitor.ts
+++ b/src/line/monitor.ts
@@ -1,12 +1,13 @@
 import type { WebhookRequestBody } from "@line/bot-sdk";
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { LineChannelData, ResolvedLineAccount } from "./types.js";
 import { chunkMarkdownText } from "../auto-reply/chunk.js";
 import { dispatchReplyWithBufferedBlockDispatcher } from "../auto-reply/reply/provider-dispatcher.js";
 import { createReplyPrefixOptions } from "../channels/reply-prefix.js";
-import type { OpenClawConfig } from "../config/config.js";
 import { danger, logVerbose } from "../globals.js";
 import { normalizePluginHttpPath } from "../plugins/http-path.js";
 import { registerPluginHttpRoute } from "../plugins/http-registry.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { deliverLineAutoReply } from "./auto-reply-delivery.js";
 import { createLineBot } from "./bot.js";
 import { processLineMessage } from "./markdown-to-line.js";
@@ -25,7 +26,6 @@ import {
   createLocationMessage,
 } from "./send.js";
 import { buildTemplateMessageFromPayload } from "./template-messages.js";
-import type { LineChannelData, ResolvedLineAccount } from "./types.js";
 import { createLineNodeWebhookHandler } from "./webhook-node.js";
 
 export interface MonitorLineProviderOptions {
@@ -310,6 +310,18 @@ export async function monitorLineProvider(
   };
 
   abortSignal?.addEventListener("abort", stopHandler);
+
+  // Keep webhook-mode monitor alive until the channel is aborted.
+  // The gateway channel manager treats early resolution as a crash and will restart.
+  if (abortSignal && !abortSignal.aborted) {
+    await new Promise<void>((resolve) => {
+      const onAbort = () => {
+        abortSignal.removeEventListener("abort", onAbort);
+        resolve();
+      };
+      abortSignal.addEventListener("abort", onAbort, { once: true });
+    });
+  }
 
   return {
     account: bot.account,


### PR DESCRIPTION
## Problem

When all auth profiles for the primary provider enter cooldown (e.g., all Google Code Assist accounts hit 429), Gateway fails with `All models failed (1)` instead of attempting models from different providers in the configured fallbacks list.

**Root cause:** In `runWithModelFallback`, the per-candidate cooldown check calls `shouldProbePrimaryDuringCooldown()` with `isPrimary: i === 0`. For fallback candidates (`i > 0`), this function immediately returns `false` — meaning `shouldProbe = false` — which triggers the `if (!shouldProbe) { continue }` skip. **Every fallback provider whose profiles happened to be cooled-down was silently skipped, including providers with completely independent rate-limit windows.**

## Fix

Restrict the probe/skip block to the primary candidate only (`i === 0`). For fallback candidates (`i > 0`), always attempt regardless of their cooldown status:

- We are already in fallback mode — skipping due to cooldown blocks cross-provider traversal entirely
- The inner runner handles per-profile cooldown and throws a `FailoverError`, which the outer loop catches to try the next provider
- This allows the full configured fallback chain (e.g., `google-antigravity → google-vertex → anthropic → deepseek`) to be traversed

## Tests

- Renamed the old `"does NOT probe non-primary candidates during cooldown"` test — that described the buggy behavior
- Added: primary probed + first fallback succeeds → returns fallback result
- Added: all providers cooled-down, all fail → all candidates are attempted (not silently skipped)

Fixes #23829

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed critical bug preventing fallback provider traversal when primary provider hits rate limits. Previously, when all auth profiles for the primary provider entered cooldown (e.g., Google Code Assist accounts hitting 429), Gateway would fail with "All models failed (1)" instead of attempting fallback providers with independent rate-limit windows.

**Key changes:**
- Restricted probe/skip logic to primary candidate only (`i === 0`)
- Fallback candidates (`i > 0`) now always attempt regardless of cooldown status
- Inner runner handles per-profile cooldown and throws `FailoverError` for proper traversal
- Updated tests to verify fallback chain traversal (primary → anthropic → deepseek)

The fix correctly allows the configured fallback chain to be fully traversed when in fallback mode, while preserving the primary probe logic that detects when the primary provider recovers from cooldown.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-targeted and addresses the root cause correctly. The logic change is minimal and well-documented with inline comments. Comprehensive test coverage includes both success and failure cases for fallback traversal. The change preserves existing primary probe behavior while fixing the fallback skip bug.
- No files require special attention

<sub>Last reviewed commit: a7d4207</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->