### PR TITLE
LINE: send processed flex messages before template in mixed rich replies (#17308)

### DIFF
--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -403,14 +403,15 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
           });
         }
 
-        if (lineData.templateMessage) {
-          const template = buildTemplate(lineData.templateMessage);
-          if (template) {
-            lastResult = await sendTemplate(to, template, {
-              verbose: false,
-              accountId: accountId ?? undefined,
-            });
-          }
+        // Send processed flex messages (tables/code blocks) before template so
+        // detail content appears above pagination/buttons (#17308).
+        for (const flexMsg of processed.flexMessages) {
+          // LINE SDK expects FlexContainer but we receive contents as unknown
+          const flexContents = flexMsg.contents as Parameters<typeof sendFlex>[2];
+          lastResult = await sendFlex(to, flexMsg.altText, flexContents, {
+            verbose: false,
+            accountId: accountId ?? undefined,
+          });
         }
 
         if (lineData.location) {
@@ -420,13 +421,14 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
           });
         }
 
-        for (const flexMsg of processed.flexMessages) {
-          // LINE SDK expects FlexContainer but we receive contents as unknown
-          const flexContents = flexMsg.contents as Parameters<typeof sendFlex>[2];
-          lastResult = await sendFlex(to, flexMsg.altText, flexContents, {
-            verbose: false,
-            accountId: accountId ?? undefined,
-          });
+        if (lineData.templateMessage) {
+          const template = buildTemplate(lineData.templateMessage);
+          if (template) {
+            lastResult = await sendTemplate(to, template, {
+              verbose: false,
+              accountId: accountId ?? undefined,
+            });
+          }
         }
       }
 
@@ -465,11 +467,14 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
             contents: lineData.flexMessage.contents,
           });
         }
-        if (lineData.templateMessage) {
-          const template = buildTemplate(lineData.templateMessage);
-          if (template) {
-            quickReplyMessages.push(template);
-          }
+        // Processed flex messages (tables/code blocks) before template so
+        // detail content appears above pagination/buttons (#17308).
+        for (const flexMsg of processed.flexMessages) {
+          quickReplyMessages.push({
+            type: "flex",
+            altText: flexMsg.altText.slice(0, 400),
+            contents: flexMsg.contents,
+          });
         }
         if (lineData.location) {
           quickReplyMessages.push({
@@ -480,12 +485,11 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = {
             longitude: lineData.location.longitude,
           });
         }
-        for (const flexMsg of processed.flexMessages) {
-          quickReplyMessages.push({
-            type: "flex",
-            altText: flexMsg.altText.slice(0, 400),
-            contents: flexMsg.contents,
-          });
+        if (lineData.templateMessage) {
+          const template = buildTemplate(lineData.templateMessage);
+          if (template) {
+            quickReplyMessages.push(template);
+          }
         }
         for (const url of mediaUrls) {
           const trimmed = url?.trim();


### PR DESCRIPTION
## Summary

- Problem: LINE mixed rich replies send the pagination/buttons card (template) before the detail table card (processed flex messages), confusing users
- Why it matters: Users see summary/pagination before details, causing misread context in reporting/ledger bots
- What changed: Reordered `processed.flexMessages` to be sent before `templateMessage` in both the main send path and the quick-reply batch path in `sendPayload`
- What did NOT change (scope boundary): Custom `lineData.flexMessage`, location, media, quick reply attachment, and text chunking logic are untouched

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #17308
- Related #17318 (closed without merge), #17327 (closed without merge)

## User-visible / Behavior Changes

In LINE channel: when a reply contains both markdown tables and `[[buttons:...]]`, the detail table card now appears first and the pagination/buttons card appears second.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux / any
- Runtime/container: Node 22+
- Model/provider: any
- Integration/channel (if any): LINE
- Relevant config (redacted): LINE channel with mixed rich reply (table + buttons)

### Steps

1. Use OpenClaw LINE channel
2. Trigger a reply that includes a markdown table and `[[buttons:...]]`
3. Observe message order in LINE

### Expected

- Detail table card appears first, pagination/buttons card appears second

### Actual

- (Before fix) Pagination/buttons card appears first, detail table appears after it

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

2 new tests added:
1. `sends processed flex messages (tables) before template message` — verifies `invocationCallOrder` in main send path
2. `orders processed flex before template in quick-reply batch` — verifies array index ordering in batch path

Both tests fail before the fix (flex order 25 > template order 24; flex index 1 > template index 0), pass after.

## Human Verification (required)

- Verified scenarios: All 9 tests pass (7 existing + 2 new); `pnpm build` clean; `pnpm check` clean
- Edge cases checked: Quick-reply batch path (same ordering bug existed there per Greptile review of prior PR #17327); template-only and flex-only payloads still work via existing tests
- What you did **not** verify: Live LINE channel testing (no LINE account available)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; the reorder is contained in `extensions/line/src/channel.ts`
- Files/config to restore: `extensions/line/src/channel.ts`
- Known bad symptoms reviewers should watch for: Template/buttons appearing after media or in unexpected position relative to location messages

## Risks and Mitigations

- Risk: Location message position changed (now appears between processed flex and template instead of between template and processed flex)
  - Mitigation: Location is contextual data that makes sense between detail and action cards; no user-facing regression expected

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reorders LINE message components to send detail cards (processed flex messages from markdown tables) before pagination/button cards (template messages).

- Swaps order of `processed.flexMessages` loop and `templateMessage` conditional in two paths: main send path (lines 405-431) and quick-reply batch path (lines 469-491)
- Location messages now appear between flex and template (previously between template and flex)
- Two new tests verify ordering via `invocationCallOrder` (main path) and array index positions (batch path)
- Custom `lineData.flexMessage`, media, and text chunking logic remain unchanged

<h3>Confidence Score: 5/5</h3>

- Safe to merge with minimal risk
- The change is a simple reordering of two code blocks with no logic modifications. Two comprehensive tests verify the fix in both execution paths. All existing tests remain valid, confirming no regressions. The scope is well-contained to the LINE channel extension.
- No files require special attention

<sub>Last reviewed commit: 38579fe</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->