### PR TITLE
fix(discord): harden replyToMode first/off in delivery layer

### DIFF
--- a/src/discord/monitor/reply-delivery.test.ts
+++ b/src/discord/monitor/reply-delivery.test.ts
@@ -259,6 +259,104 @@ describe("deliverDiscordReply", () => {
     );
   });
 
+  it("uses replyToId on all chunks when replyToMode is all (default)", async () => {
+    await deliverDiscordReply({
+      replies: [{ text: "1234567890" }],
+      target: "channel:789",
+      token: "token",
+      runtime,
+      textLimit: 5,
+      replyToId: "reply-1",
+      replyToMode: "all",
+    });
+
+    expect(sendMessageDiscordMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageDiscordMock.mock.calls[0]?.[2]?.replyTo).toBe("reply-1");
+    expect(sendMessageDiscordMock.mock.calls[1]?.[2]?.replyTo).toBe("reply-1");
+  });
+
+  it("suppresses replyToId entirely when replyToMode is off", async () => {
+    await deliverDiscordReply({
+      replies: [{ text: "1234567890" }],
+      target: "channel:789",
+      token: "token",
+      runtime,
+      textLimit: 5,
+      replyToId: "reply-1",
+      replyToMode: "off",
+    });
+
+    expect(sendMessageDiscordMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageDiscordMock.mock.calls[0]?.[2]?.replyTo).toBeUndefined();
+    expect(sendMessageDiscordMock.mock.calls[1]?.[2]?.replyTo).toBeUndefined();
+  });
+
+  it("uses replyToId on only the first payload across multiple replies when replyToMode is first", async () => {
+    await deliverDiscordReply({
+      replies: [{ text: "first block" }, { text: "second block" }, { text: "third block" }],
+      target: "channel:789",
+      token: "token",
+      runtime,
+      textLimit: 2000,
+      replyToId: "reply-1",
+      replyToMode: "first",
+    });
+
+    expect(sendMessageDiscordMock).toHaveBeenCalledTimes(3);
+    expect(sendMessageDiscordMock.mock.calls[0]?.[2]?.replyTo).toBe("reply-1");
+    expect(sendMessageDiscordMock.mock.calls[1]?.[2]?.replyTo).toBeUndefined();
+    expect(sendMessageDiscordMock.mock.calls[2]?.[2]?.replyTo).toBeUndefined();
+  });
+
+  it("uses replyToId on only the first voice send when replyToMode is first", async () => {
+    await deliverDiscordReply({
+      replies: [
+        {
+          text: "Voice with text",
+          mediaUrls: ["https://example.com/voice.ogg", "https://example.com/extra.mp3"],
+          audioAsVoice: true,
+        },
+      ],
+      target: "channel:789",
+      token: "token",
+      runtime,
+      textLimit: 2000,
+      replyToId: "reply-1",
+      replyToMode: "first",
+    });
+
+    expect(sendVoiceMessageDiscordMock).toHaveBeenCalledTimes(1);
+    expect(sendVoiceMessageDiscordMock.mock.calls[0]?.[2]?.replyTo).toBe("reply-1");
+
+    // Text follow-up and extra media should NOT get reply
+    expect(sendMessageDiscordMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageDiscordMock.mock.calls[0]?.[2]?.replyTo).toBeUndefined();
+    expect(sendMessageDiscordMock.mock.calls[1]?.[2]?.replyTo).toBeUndefined();
+  });
+
+  it("uses replyToId on only the first media send when replyToMode is first", async () => {
+    await deliverDiscordReply({
+      replies: [
+        {
+          text: "Caption",
+          mediaUrls: ["https://example.com/img1.png", "https://example.com/img2.png"],
+        },
+      ],
+      target: "channel:789",
+      token: "token",
+      runtime,
+      textLimit: 2000,
+      replyToId: "reply-1",
+      replyToMode: "first",
+    });
+
+    expect(sendMessageDiscordMock).toHaveBeenCalledTimes(2);
+    // First send: caption + first media with reply
+    expect(sendMessageDiscordMock.mock.calls[0]?.[2]?.replyTo).toBe("reply-1");
+    // Second send: extra media without reply
+    expect(sendMessageDiscordMock.mock.calls[1]?.[2]?.replyTo).toBeUndefined();
+  });
+
   it("does not use thread webhook when outbound target is not a bound thread", async () => {
     const threadBindings = await createBoundThreadBindings();
 

--- a/src/discord/monitor/reply-delivery.ts
+++ b/src/discord/monitor/reply-delivery.ts
@@ -152,20 +152,18 @@ export async function deliverDiscordReply(params: {
   const chunkLimit = Math.min(params.textLimit, 2000);
   const replyTo = params.replyToId?.trim() || undefined;
   const replyToMode = params.replyToMode ?? "all";
-  // replyToMode=first should only apply to the first physical send.
-  const replyOnce = replyToMode === "first";
   let replyUsed = false;
   const resolveReplyTo = () => {
-    if (!replyTo) {
+    if (!replyTo || replyToMode === "off") {
       return undefined;
     }
-    if (!replyOnce) {
+    if (replyToMode === "first") {
+      if (replyUsed) {
+        return undefined;
+      }
+      replyUsed = true;
       return replyTo;
     }
-    if (replyUsed) {
-      return undefined;
-    }
-    replyUsed = true;
     return replyTo;
   };
   const binding = resolveBoundThreadBinding({


### PR DESCRIPTION
## Summary

- Problem: `replyToMode: "first"` on Discord causes every physical bubble in a turn to carry a native reply link, triggering notification spam (10 bubbles = 10 pings). The `"off"` mode also lacked defense-in-depth at the delivery layer.
- Why it matters: Users relying on `replyToMode: "first"` with `blockStreaming: true` receive excessive notification pings, making native replies unusable for long agent responses.
- What changed: Restructured `resolveReplyTo()` inside `deliverDiscordReply` to explicitly handle all three modes (`"first"`, `"off"`, `"all"`) instead of only gating on `"first"` vs everything else. Added 5 new tests covering multi-payload, voice, media, `"off"`, and `"all"` scenarios.
- What did NOT change (scope boundary): The `replyReferencePlanner` (per-block gating) and `createReplyToModeFilter` (payload-level pipeline filter) are unchanged. Only the per-chunk delivery layer is tightened.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #20726
- Related #19508 (introduced regression), 64c29c375 (partial fix)

## User-visible / Behavior Changes

- `replyToMode: "first"`: only the first physical Discord send in a delivery call carries the native reply reference; subsequent chunks, media follow-ups, and voice follow-ups no longer ping.
- `replyToMode: "off"`: reply references are now suppressed at the delivery layer even if a `replyToId` is accidentally passed by upstream callers.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any (Discord channel)
- Runtime/container: Node 22+
- Model/provider: Any
- Integration/channel: Discord with `blockStreaming: true`
- Relevant config: `channels.discord.replyToMode: "first"`, `channels.discord.blockStreaming: true`

### Steps

1. Configure Discord with `replyToMode: "first"` and `blockStreaming: true`
2. Send a message that triggers a long agent response (multiple chunks/bubbles)
3. Observe notification pings

### Expected

- Only the first physical bubble carries a native Discord reply link (single ping)

### Actual

- Every bubble carries a reply link (N bubbles = N pings)

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

All 12 tests in `reply-delivery.test.ts` pass. 5 new tests cover: `"all"` mode on all chunks, `"off"` suppression, multi-payload `"first"`, voice `"first"`, media `"first"`.

## Human Verification (required)

- Verified scenarios: All 12 unit tests pass covering text chunking, multi-payload, voice+text+media, media-only, webhook fallback, and whitespace-only payloads across all three replyToMode values.
- Edge cases checked: whitespace-only payloads don't consume the reply slot; `"off"` mode suppresses even when replyToId is provided; voice path consumes the reply on the voice send not the text follow-up.
- What you did **not** verify: Live Discord delivery (unit test only; mocked send functions).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; `resolveReplyTo()` is self-contained in `reply-delivery.ts`.
- Files/config to restore: `src/discord/monitor/reply-delivery.ts`
- Known bad symptoms reviewers should watch for: Reply references missing entirely (all modes broken) or still appearing on every chunk (`"first"` mode not gating).

## Risks and Mitigations

- Risk: `"off"` mode guard could suppress intentional reply references if upstream incorrectly passes `replyToMode: "off"` with a valid `replyToId`.
  - Mitigation: All upstream callers (message-handler, agent-components) derive `replyToId` from `replyReference.use()` which already returns `undefined` for `"off"` mode, so the guard is purely defense-in-depth.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactored the `resolveReplyTo()` helper in `deliverDiscordReply` to explicitly handle all three `replyToMode` values (`"first"`, `"off"`, `"all"`) instead of only gating on `"first"` vs everything else. Previously, `replyToMode: "off"` would still attach reply references because it fell through to the default behavior. The new implementation adds defense-in-depth by explicitly suppressing replies when mode is `"off"`, and inverts the `"first"` logic for better clarity.

- Fixed notification spam bug where `replyToMode: "first"` caused every chunk to ping (now only first chunk pings)
- Added explicit `"off"` mode handling at delivery layer as defense-in-depth
- Restructured logic from negative check (`!replyOnce`) to positive checks for each mode
- Added 5 comprehensive tests covering multi-payload, voice, media, `"off"`, and `"all"` scenarios
- No changes to upstream planning layers (`replyReferencePlanner`, `createReplyToModeFilter`)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The logic transformation is correct and well-tested. The refactoring makes the code more explicit by handling all three `replyToMode` values explicitly, fixing a bug where `"off"` mode wasn't properly suppressing replies. The change is isolated to a single helper function with comprehensive test coverage (12 tests total, 5 new tests for the fixed behavior). The PR correctly maintains backward compatibility for `"all"` and `"first"` modes while fixing the `"off"` mode bug.
- No files require special attention

<sub>Last reviewed commit: cda3e49</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->