### PR TITLE
docs(pr): add AI-assisted disclosure section to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,6 +32,26 @@ Describe the problem and fix in 2–5 bullets:
 - Closes #
 - Related #
 
+## AI Assistance (if used)
+
+<!--
+AI/Vibe-Coded PRs Welcome! 🤖
+Built with Codex, Claude, or other AI tools? Awesome — just mark it.
+AI PRs are first-class citizens here. We just want transparency so reviewers know what to look for.
+-->
+
+- [ ] AI-assisted PR
+- [ ] I confirm I understand what the code does
+
+<details>
+<summary>AI prompts / session logs (optional, but super helpful)</summary>
+
+```text
+
+```
+
+</details>
+
 ## User-visible / Behavior Changes
 
 List user-visible changes (including defaults/config).  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Docs: https://docs.openclaw.ai
 - Control UI/usage: drop the empty session-detail placeholder card so the usage view stays single-column until a real session detail panel is selected. (#52013) Thanks @BunsDev.
 - Hooks/workspace: keep repo-local `<workspace>/hooks` disabled until explicitly enabled, block workspace hook name collisions from shadowing bundled/managed/plugin hooks, and treat `hooks.internal.load.extraDirs` as trusted managed hook sources.
 - CLI/hooks: route hook-pack install and update through `openclaw plugins`, keep `openclaw hooks` focused on hook visibility and per-hook controls, and show plugin-managed hook details in CLI output.
+- Docs/PR template: add an AI Assistance disclosure section to the default pull request template so contributors can mark AI-assisted work, confirm they understand the code, and optionally attach prompts or session logs. (#24868) thanks @martinfrancois.
 
 ### Fixes
 


### PR DESCRIPTION
I noticed a couple things in OpenClaw's `contributing.md` that are clearly part of the project's expectations for PRs, especially around AI-assisted work, but the default PR template did not really make space for them. So I tried to add just enough structure to encourage the right behavior without making the template feel heavier.

### Design decisions and alternatives I considered

#### Whether to add a checkbox for `pnpm build && pnpm check && pnpm test`
I also noticed `contributing.md` mentions running `pnpm build && pnpm check && pnpm test` locally. I considered adding a checkbox for it, but since CI is fast and trustworthy, I figured maintainers will look at CI anyway, so it did not feel essential to include in the template.

That said, if you'd still prefer to have it in the template as a "signal of intent" to contributors, I'd be happy to add it.

#### Where to put the AI Assistance section
I originally thought about placing the AI section further down, mostly because I wondered if it might not be as important as the change description and verification details, and I did not want AI-related metadata to dominate the top of the PR. But OpenClaw explicitly values transparency and is welcoming to AI-assisted contributions, so I ended up leaning toward placing the section higher up. I wanted the template to reflect that culture right away, instead of making AI disclosure feel like an afterthought tucked away at the bottom where it is easier to overlook or forget.

#### How to handle prompts and session logs without making the template huge
I added a collapsible `<details>` block for prompts/session logs because it keeps the PR description readable while still making it easy to include useful context. If there are no logs, the PR stays compact. If there are logs, they can be pasted without turning the description into a wall of text.

Alternatives I considered:
- Always-visible section: simple, but quickly becomes noisy and hard to scan.
- Telling people to attach files or link elsewhere: more friction, less consistent, and easy to forget.

#### Whether to add a checkbox like "I included prompts/session logs"
I did think about adding a third checkbox like "I added AI prompts/session logs" so maintainers could avoid expanding the details when nothing is there. But I decided against it because it is really easy for that sort of checkbox to get out of sync. People might forget to tick it even if they paste logs, or tick it and then forget to actually add anything. At that point it stops saving effort and just creates a new thing to police.

Alternatives I considered:
- A "Prompts/logs included: Yes/No" line: same sync problem, just not a checkbox.
- Two mutually exclusive checkboxes ("included" vs "not included"): better forcing function, but still drift-prone and adds ceremony.

#### Where to put "I confirm I understand what the code does"
This one I went back and forth on. You could argue it applies to every PR, AI or not. I also considered whether putting it inside "AI Assistance (if used)" could confuse non-AI contributors into wondering if they should check it anyway. In the end, I kept it there because it is mostly relevant when AI is involved, and the section itself is explicitly conditional. Also, since it is only a single checkbox, it felt awkward to give it its own standalone section or introduce a broader contributor checklist just to avoid that edge case.

Alternatives I considered:
- Make it global for all PRs: arguably more universally correct, but can feel redundant unless paired with a larger, meaningful checklist.
- Add a general Contributor Checklist: that started to feel either empty or redundant unless we added more items, and I did not want to inflate the template.

#### Keeping the scope of the template change small
Finally, I tried hard to only change what was necessary and leave everything else exactly as-is. The goal was not to redesign the template, just to make the expectations from `contributing.md` easier to follow by default.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added an "AI Assistance" section to the PR template to encourage transparency for AI-assisted contributions. The new section includes checkboxes to mark AI-assisted PRs and confirm code understanding, plus a collapsible details block for optional prompts/session logs.

- Matches the expectations from `CONTRIBUTING.md` about AI transparency
- Positioned prominently in the template after the "Linked Issue/PR" section
- Uses collapsible `<details>` block to keep prompts/logs from cluttering the PR description
- One notable omission: `CONTRIBUTING.md` mentions "Note the degree of testing (untested / lightly tested / fully tested)" but the template doesn't include this checkbox

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it only modifies documentation/template content
- Template-only change with no code modifications. The addition aligns well with project values around AI transparency. The one small omission (testing degree checkbox) is minor and could be addressed in a follow-up if desired, but doesn't block this PR.
- No files require special attention

<sub>Last reviewed commit: 13a7c5f</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->