### PR TITLE
fix(agents): skip forced store=true when model declares supportsStore=false

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -208,7 +208,13 @@ function shouldForceResponsesStore(model: {
   api?: unknown;
   provider?: unknown;
   baseUrl?: unknown;
+  compat?: { supportsStore?: boolean };
 }): boolean {
+  // Never force store=true when the model explicitly declares supportsStore=false
+  // (e.g. Azure OpenAI Responses API without server-side persistence).
+  if (model.compat?.supportsStore === false) {
+    return false;
+  }
   if (typeof model.api !== "string" || typeof model.provider !== "string") {
     return false;
   }


### PR DESCRIPTION
## Summary

Fixes #25058

When using the `azure-responses` provider with `compat.supportsStore=false`, the adapter still forces `store=true` in the request payload. Azure OpenAI Responses API then returns HTTP 400 because it references a prior `rs_*` response ID that was never persisted.

## Root Cause

`createOpenAIResponsesStoreWrapper` forces `store=true` for all OpenAI Responses API providers via `shouldForceResponsesStore()`. This function checks the API type and provider but never checks the `compat.supportsStore` flag, so models configured with `supportsStore: false` still get `store=true` injected.

## Fix

Added an early return in `shouldForceResponsesStore()` that checks `model.compat?.supportsStore === false`. When this flag is explicitly set to `false`, the function returns `false` and the store wrapper skips the `store=true` injection.

## Before

```json
{
  "providers": {
    "azure-responses": {
      "models": [{ "id": "gpt-5.2", "compat": { "supportsStore": false } }]
    }
  }
}
```
→ HTTP 400: `Item with id 'rs_...' not found. Items are not persisted when store is set to false.`

## After

With `supportsStore: false`, the adapter no longer injects `store=true`, preventing the 400 error.

## Verification

- LSP diagnostics clean
- The check is minimal and early-exit — no behavioral change for providers that don't set `supportsStore: false`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds an early-exit check in `shouldForceResponsesStore()` to respect `model.compat.supportsStore === false`, preventing forced `store=true` injection for models that explicitly declare they don't support server-side persistence.

- The fix is a minimal, well-placed guard that short-circuits before the existing API/provider checks
- Uses strict `=== false` comparison, so only explicit opt-outs are affected — no behavioral change for models that omit the flag
- The `compat` type annotation aligns with the existing `ModelCompatConfig` type and Zod schema (`ModelCompatSchema`)
- Note: the PR description's Azure scenario may not perfectly match the current guard logic (Azure providers typically wouldn't pass the `OPENAI_RESPONSES_PROVIDERS` check), but the fix is still correct as a general-purpose guard for any provider/API combination where `supportsStore: false` is set
- No tests are included; the `shouldForceResponsesStore` function had no tests prior to this PR either

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — a minimal, defensive early-return guard with no side effects on existing behavior.
- The change is small (6 lines), logically correct (strict `=== false` check), properly typed, and doesn't alter behavior for any model that doesn't explicitly set `supportsStore: false`. No tests are included but the risk surface is very low.
- No files require special attention.

<sub>Last reviewed commit: f4db921</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->