### PR TITLE
fix(tools): log warning when ownerOnly tools are stripped

### DIFF
--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -583,6 +583,15 @@ export function createOpenClawCodingTools(options?: {
   // Security: treat unknown/undefined as unauthorized (opt-in, not opt-out)
   const senderIsOwner = options?.senderIsOwner === true;
   const toolsByAuthorization = applyOwnerOnlyToolPolicy(toolsForModelProvider, senderIsOwner);
+  if (!senderIsOwner) {
+    const stripped = toolsForModelProvider.filter((t) => !toolsByAuthorization.includes(t));
+    if (stripped.length > 0) {
+      logWarn(
+        `Stripped ${stripped.length} owner-only tool(s) (${stripped.map((t) => t.name).join(", ")}) ` +
+          `because senderIsOwner=false. To fix, set commands.ownerAllowFrom in your config.`,
+      );
+    }
+  }
   const subagentFiltered = applyToolPolicyPipeline({
     tools: toolsByAuthorization,
     toolMeta: (tool) => getPluginToolMeta(tool),


### PR DESCRIPTION
## Problem

When `senderIsOwner` resolves to `false`, owner-only tools (`cron`, `gateway`, `whatsapp_login`) are **silently removed** from the agent's tool list. There is no log entry, no error, and no indication to the user or the agent that tools were filtered out.

Users see the agent fail to create cron jobs or use the gateway, with no clue that a missing `commands.ownerAllowFrom` config is the cause. This is especially common in self-hosted setups (fresh installs, channel-level `allowFrom` not configured, sender ID format mismatches).

## Fix

Add a warning log after `applyOwnerOnlyToolPolicy` when tools are actually stripped:

```
[tools] Stripped 2 owner-only tool(s) (cron, gateway) because senderIsOwner=false.
        To fix, set commands.ownerAllowFrom in your config.
```

The log is placed in `pi-tools.ts` (the caller) rather than `tool-policy.ts`, following the pattern documented in `tool-policy.ts`: *"logging happens in the caller (pi-tools/tools-invoke)"*.

One file changed, 9 lines added. No behavioral changes to tool filtering.

## Test plan

- [ ] `pnpm build` passes
- [ ] Format check passes
- [ ] Unit tests pass in `tool-policy.test.ts` and `pi-tools.policy.test.ts`
- [ ] Warning logged when ownerOnly tools stripped (`senderIsOwner=false`)
- [ ] No warning when `senderIsOwner=true`

## Compatibility

Rebased onto current `main` (v2026.3.28). The patch correctly uses `toolsForModelProvider` (the input to `applyOwnerOnlyToolPolicy` after the upstream `applyModelProviderToolPolicy` step was added).