### PR TITLE
fix(bluebubbles): skip typing indicator for tapback/reaction messages

### DIFF
--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1305,6 +1305,11 @@ export async function processMessage(
           if (!baseUrl || !password) {
             return;
           }
+          // Skip typing indicator for tapback/reaction messages to avoid lingering
+          // indicator when agent returns NO_REPLY (fixes #11189)
+          if (isTapbackMessage) {
+            return;
+          }
           streamingActive = true;
           clearTypingRestartTimer();
           try {

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -1305,8 +1305,8 @@ export async function processMessage(
           if (!baseUrl || !password) {
             return;
           }
-          // Skip typing indicator for tapback/reaction messages to avoid lingering
-          // indicator when agent returns NO_REPLY (fixes #11189)
+          // Skip typing for tapback/reaction messages because they usually end in
+          // NO_REPLY, which would otherwise leave a redundant cleanup call.
           if (isTapbackMessage) {
             return;
           }
@@ -1345,7 +1345,8 @@ export async function processMessage(
     });
   } finally {
     const shouldStopTyping =
-      Boolean(chatGuidForActions && baseUrl && password) && (streamingActive || !sentMessage);
+      Boolean(chatGuidForActions && baseUrl && password) &&
+      (streamingActive || (!sentMessage && !isTapbackMessage));
     streamingActive = false;
     clearTypingRestartTimer();
     if (sentMessage && chatGuidForActions && ackMessageId) {

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -1880,6 +1880,57 @@ describe("BlueBubbles webhook monitor", () => {
         expect.any(Object),
       );
     });
+
+    it("does not start typing indicator for tapback/reaction messages", async () => {
+      const { sendBlueBubblesTyping } = await import("./chat.js");
+      vi.mocked(sendBlueBubblesTyping).mockClear();
+
+      const account = createMockAccount();
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      // Tapback message with standard iMessage reaction text pattern
+      const payload = {
+        type: "new-message",
+        data: {
+          text: 'Loved "hello world"',
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-tapback-1",
+          chatGuid: "iMessage;-;+15551234567",
+          date: Date.now(),
+        },
+      };
+
+      mockDispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params) => {
+        // Simulate what happens when onReplyStart is called for tapback messages
+        await params.dispatcherOptions.onReplyStart?.();
+        // Agent returns NO_REPLY for tapback messages, so no deliver() call
+      });
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      // Typing indicator should NOT be started for tapback messages
+      // because they typically result in NO_REPLY and the indicator would linger
+      const typingStartCalls = vi
+        .mocked(sendBlueBubblesTyping)
+        .mock.calls.filter(([, isTyping]) => isTyping === true);
+      expect(typingStartCalls).toHaveLength(0);
+    });
   });
 
   describe("outbound message ids", () => {

--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -1881,7 +1881,7 @@ describe("BlueBubbles webhook monitor", () => {
       );
     });
 
-    it("does not start typing indicator for tapback/reaction messages", async () => {
+    it("does not send typing indicator calls for tapback text messages", async () => {
       const { sendBlueBubblesTyping } = await import("./chat.js");
       vi.mocked(sendBlueBubblesTyping).mockClear();
 
@@ -1916,6 +1916,7 @@ describe("BlueBubbles webhook monitor", () => {
         // Simulate what happens when onReplyStart is called for tapback messages
         await params.dispatcherOptions.onReplyStart?.();
         // Agent returns NO_REPLY for tapback messages, so no deliver() call
+        return EMPTY_DISPATCH_RESULT;
       });
 
       const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
@@ -1924,12 +1925,56 @@ describe("BlueBubbles webhook monitor", () => {
       await handleBlueBubblesWebhookRequest(req, res);
       await flushAsync();
 
-      // Typing indicator should NOT be started for tapback messages
-      // because they typically result in NO_REPLY and the indicator would linger
-      const typingStartCalls = vi
-        .mocked(sendBlueBubblesTyping)
-        .mock.calls.filter(([, isTyping]) => isTyping === true);
-      expect(typingStartCalls).toHaveLength(0);
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+      expect(sendBlueBubblesTyping).not.toHaveBeenCalled();
+    });
+
+    it("does not send typing indicator calls for metadata tapback messages", async () => {
+      const { sendBlueBubblesTyping } = await import("./chat.js");
+      vi.mocked(sendBlueBubblesTyping).mockClear();
+
+      const account = createMockAccount();
+      const config: OpenClawConfig = {};
+      const core = createMockRuntime();
+      setBlueBubblesRuntime(core);
+
+      unregister = registerBlueBubblesWebhookTarget({
+        account,
+        config,
+        runtime: { log: vi.fn(), error: vi.fn() },
+        core,
+        path: "/bluebubbles-webhook",
+      });
+
+      const payload = {
+        type: "new-message",
+        data: {
+          text: 'Loved "hello world"',
+          handle: { address: "+15551234567" },
+          isGroup: false,
+          isFromMe: false,
+          guid: "msg-tapback-2",
+          chatGuid: "iMessage;-;+15551234567",
+          // Keep the payload on the message path while still exercising
+          // associatedMessageType-based tapback detection.
+          associatedMessageType: 2000,
+          date: Date.now(),
+        },
+      };
+
+      mockDispatchReplyWithBufferedBlockDispatcher.mockImplementationOnce(async (params) => {
+        await params.dispatcherOptions.onReplyStart?.();
+        return EMPTY_DISPATCH_RESULT;
+      });
+
+      const req = createMockRequest("POST", "/bluebubbles-webhook", payload);
+      const res = createMockResponse();
+
+      await handleBlueBubblesWebhookRequest(req, res);
+      await flushAsync();
+
+      expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+      expect(sendBlueBubblesTyping).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

- Problem: BlueBubbles starts a typing indicator for tapback/reaction messages even when the resulting run is silent
- Why it matters: Typing implies a visible reply is coming, which is misleading for tapback flows
- What changed: Added an early return in BlueBubbles `onReplyStart` when `isTapbackMessage` is true
- What did NOT change: Normal message typing indicators, tapback delivery behavior, and other BlueBubbles flows remain unchanged

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25515
- Related #6523

## User-visible / Behavior Changes

BlueBubbles users no longer see a typing indicator for tapback/reaction messages. Typing still appears for normal reply flows.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / iOS (BlueBubbles environment)
- Runtime/container: Node 22+
- Model/provider: N/A (integration bug)
- Integration/channel: BlueBubbles (iMessage)
- Relevant config: BlueBubbles integration enabled

### Steps

1. Configure OpenClaw with BlueBubbles integration
2. Send a tapback/reaction (for example, thumbs up or heart) on an iMessage without typing any text
3. Observe typing indicator behavior

### Expected

- No typing indicator should appear for tapback-only messages
- Typing indicator should only appear when a visible reply is being sent

### Actual

Before fix: Typing starts for tapback messages even though the run is silent  
After fix: Typing does not start for tapback messages

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Updated test coverage in `extensions/bluebubbles/src/monitor.test.ts` verifies that typing start is skipped for tapback messages.

## Human Verification (required)

What was personally verified, and how:

- Verified scenarios:
  - Applied the patch cleanly to current `upstream/main`
  - Ran `pnpm exec vitest run --config vitest.extensions.config.ts extensions/bluebubbles/src/monitor.test.ts`
  - Confirmed the added test verifies typing start is not called for tapback messages

- Edge cases checked:
  - Tapback messages with `isTapbackMessage: true` skip typing start
  - Normal messages continue to use the existing typing path

- What was **not** verified:
  - End-to-end testing with a live BlueBubbles server and iMessage client
  - Broader build/lint checks beyond the targeted BlueBubbles test file

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit 391ca3c3489a7a15f2321646c237b0094a858573
- Files/config to restore: `extensions/bluebubbles/src/monitor-processing.ts`
- Known bad symptoms reviewers should watch for: typing indicators failing to appear for regular text messages

## Risks and Mitigations

- Risk: If `isTapbackMessage` is detected too broadly, a normal message could skip typing
  - Mitigation: The change reuses the existing tapback detection path already used elsewhere in the BlueBubbles monitor, and the test coverage exercises the new guard
