### PR TITLE
fix(config): strip shell-escaped spaces from workspace paths in resolveUserPath

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -290,15 +290,19 @@ export function resolveUserPath(input: string): string {
   if (!trimmed) {
     return trimmed;
   }
-  if (trimmed.startsWith("~")) {
-    const expanded = expandHomePrefix(trimmed, {
+  // Strip shell-style backslash escapes (e.g., "Mobile\ Documents" → "Mobile Documents")
+  // This is common when users copy paths from terminal autocomplete on macOS.
+  // Only unescape backslash followed by space - preserve other backslash usage.
+  const unescaped = trimmed.replace(/\\ /g, " ");
+  if (unescaped.startsWith("~")) {
+    const expanded = expandHomePrefix(unescaped, {
       home: resolveRequiredHomeDir(process.env, os.homedir),
       env: process.env,
       homedir: os.homedir,
     });
     return path.resolve(expanded);
   }
-  return path.resolve(trimmed);
+  return path.resolve(unescaped);
 }
 
 export function resolveConfigDir(


### PR DESCRIPTION
## Summary

- Problem: Terminal autocomplete on macOS produces shell-escaped paths (e.g., `~/Library/Mobile\ Documents/...`) that get stored literally in `openclaw.json`, causing workspace paths to fail silently at startup
- Why it matters: Users with space-containing paths (common with iCloud Drive, Application Support) cannot load workspaces, and the failure is silent/unclear
- What changed: `resolveUserPath()` now strips `\ ` → ` ` (space) before resolving paths, normalizing shell-escaped input from terminal autocomplete
- What did NOT change: Windows backslash path separators are preserved; only backslash-space sequences are normalized

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25521
- Related #10939

## User-visible / Behavior Changes

Users can now paste shell-escaped paths (with `\ ` sequences) from terminal autocomplete into `openclaw configure` and the paths will work correctly. Previously these paths would fail silently at startup.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (any version with space-containing paths like iCloud Drive)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: Any workspace path containing spaces

### Steps

1. Run `openclaw configure`
2. At workspace path prompt, type path with spaces and use tab-completion (macOS automatically inserts `\ ` for spaces)
3. Example: `~/Library/Mobile\ Documents/com~apple~CloudDocs/workspace`
4. Save configuration
5. Restart OpenClaw gateway

### Expected

Before fix: Workspace fails to load (path stored with literal backslashes)
After fix: Workspace loads correctly (backslash-space normalized to space)

### Actual

With fix: Shell-escaped paths are normalized and work correctly.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added 3 new tests in `src/utils.test.ts`:
- Test shell-escaped spaces in `~` paths
- Test shell-escaped spaces in absolute paths
- Test that Windows backslashes are preserved (not stripped)

All 31 tests in `src/utils.test.ts` pass.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - All utils tests pass (31 tests)
  - Build completes successfully
  - Lint and format checks pass
  - New tests specifically validate shell-escape normalization

- Edge cases checked:
  - Paths with multiple escaped spaces work correctly
  - Windows-style backslashes are NOT stripped
  - Empty/null inputs handled gracefully
  - `~` expansion works with escaped spaces

- What you did **not** verify:
  - End-to-end testing with real macOS iCloud Drive paths
  - Interactive `openclaw configure` wizard with tab-completion

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

Existing configs with incorrectly stored `\ ` sequences will now be resolved correctly on next restart.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit 50265cbc9 or cherry-pick the inverse
- Files/config to restore: `src/utils.ts` (revert the `.replace(/\\ /g, " ")` normalization)
- Known bad symptoms reviewers should watch for: Windows paths with backslashes being corrupted (would indicate over-aggressive normalization)

## Risks and Mitigations

- Risk: Windows paths with intentional backslash-space sequences might be normalized incorrectly
  - Mitigation: Windows uses backslash as path separator (not escape character); shell-escaping is primarily a Unix/macOS terminal feature. Test coverage verifies Windows backslash preservation.
- Risk: Legitimate use cases requiring literal `\ ` in paths might break
  - Mitigation: Unix filesystems rarely allow literal backslashes in filenames; shell-escaped spaces are the dominant pattern from terminal autocomplete. This fix targets the common case.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where shell-escaped paths from terminal autocomplete (containing `\ ` sequences) were stored literally in `openclaw.json`, causing workspace paths to fail silently at startup. The fix normalizes `\ ` → ` ` (space) in `resolveUserPath()` before path resolution.

Key changes:
- Added `.replace(/\\ /g, " ")` in `resolveUserPath()` to strip shell-style backslash-space escapes
- Preserves Windows backslash path separators (only strips backslash-space sequences)
- Added 3 comprehensive tests covering tilde paths, absolute paths, and Windows path preservation

The fix is targeted and backward-compatible - existing configs with incorrectly stored `\ ` sequences will now resolve correctly on next restart.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is minimal (single line change), well-tested, and solves a real user-facing issue. The regex pattern is precise (`/\\ /g`) and only targets the problematic backslash-space sequences while preserving other backslash usage. Test coverage validates the core scenarios including Windows path preservation.
- No files require special attention

<sub>Last reviewed commit: 50265cb</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->