### PR TITLE
fix: pass target as channelId for plugin-custom message actions

### DIFF
--- a/src/infra/outbound/channel-target.ts
+++ b/src/infra/outbound/channel-target.ts
@@ -39,5 +39,12 @@ export function applyTargetToParams(params: {
     params.args.to = target;
     return;
   }
+  // For plugin-custom actions not in the known action map, pass target
+  // through as channelId so external plugin actions can receive it.
+  const isKnownAction = params.action in MESSAGE_ACTION_TARGET_MODE;
+  if (!isKnownAction) {
+    params.args.channelId = target;
+    return;
+  }
   throw new Error(`Action ${params.action} does not accept a target.`);
 }


### PR DESCRIPTION
## Problem

External plugins can declare custom message actions via `handleAction`/`listActions`, but `applyTargetToParams` rejects `target` for any action not in the hardcoded `MESSAGE_ACTION_TARGET_MODE` map:

```
throw new Error(`Action ${params.action} does not accept a target.`);
```

This means plugin-custom actions have no way to accept `target` — the framework throws before `handleAction` is ever called. The plugin extension API provides no mechanism to register custom action target modes.

## Fix

For actions **not in the known map** (i.e. plugin-custom actions), pass `target` through as `channelId` so the plugin's `handleAction` receives it. Known framework actions with `mode="none"` (e.g. `broadcast`, `search`) still correctly reject `target` since they ARE in the map.

## Changes

- `src/infra/outbound/channel-target.ts`: Check `params.action in MESSAGE_ACTION_TARGET_MODE` before throwing; pass through as `channelId` for unknown (plugin-custom) actions.

## Testing

- TypeScript typecheck passes
- Existing behavior preserved for all known framework actions (map lookup unchanged)
- Plugin-custom actions now receive `target` as `channelId` instead of throwing

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a limitation in the plugin extension API where custom message actions declared via `handleAction`/`listActions` couldn't accept a `target` parameter. Previously, `applyTargetToParams` rejected any action not in the hardcoded `MESSAGE_ACTION_TARGET_MODE` map.

The fix checks whether an action is in the known map before throwing. For plugin-custom actions (not in the map), it passes `target` through as `channelId` so the plugin's `handleAction` receives it. Framework actions with `mode="none"` (like `broadcast`, `search`) correctly continue to reject `target` since they ARE in the map.

This change enables external plugins to receive targeting information without modifying the framework's core action registry.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The logic is straightforward and correct: it adds a fallback case for unknown actions (plugin-custom) before the existing error throw. Known framework actions preserve their exact behavior since the check happens after mode-based routing. The change is minimal (7 lines), well-commented, and TypeScript type-checks pass.
- No files require special attention

<sub>Last reviewed commit: 6efd24e</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->