### PR TITLE
fix(onboard): validate workspace directory before setup steps

### DIFF
--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -500,26 +500,8 @@ describe("runOnboardingWizard", () => {
     );
     ensureWorkspaceAndSessions.mockRejectedValueOnce(eaccesError);
 
-    const prompter: WizardPrompter = {
-      intro: vi.fn(async () => {}),
-      outro: vi.fn(async () => {}),
-      note: vi.fn(async () => {}),
-      select: vi.fn(
-        async (_params: WizardSelectParams<unknown>) => "quickstart",
-      ) as unknown as WizardPrompter["select"],
-      multiselect: vi.fn(async () => []),
-      text: vi.fn(async () => ""),
-      confirm: vi.fn(async () => false),
-      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
-    };
-
-    const runtime: RuntimeEnv = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn((code: number) => {
-        throw new Error(`exit:${code}`);
-      }),
-    };
+    const prompter = buildWizardPrompter();
+    const runtime = createRuntime({ throwsOnExit: true });
 
     await expect(
       runOnboardingWizard(
@@ -550,26 +532,8 @@ describe("runOnboardingWizard", () => {
     );
     ensureWorkspaceAndSessions.mockRejectedValueOnce(eaccesError);
 
-    const prompter: WizardPrompter = {
-      intro: vi.fn(async () => {}),
-      outro: vi.fn(async () => {}),
-      note: vi.fn(async () => {}),
-      select: vi.fn(
-        async (_params: WizardSelectParams<unknown>) => "quickstart",
-      ) as unknown as WizardPrompter["select"],
-      multiselect: vi.fn(async () => []),
-      text: vi.fn(async () => ""),
-      confirm: vi.fn(async () => false),
-      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
-    };
-
-    const runtime: RuntimeEnv = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn((code: number) => {
-        throw new Error(`exit:${code}`);
-      }),
-    };
+    const prompter = buildWizardPrompter();
+    const runtime = createRuntime({ throwsOnExit: true });
 
     await expect(
       runOnboardingWizard(
@@ -600,33 +564,15 @@ describe("runOnboardingWizard", () => {
     });
     ensureWorkspaceAndSessions.mockRejectedValueOnce(enoentError);
 
-    const prompter: WizardPrompter = {
-      intro: vi.fn(async () => {}),
-      outro: vi.fn(async () => {}),
-      note: vi.fn(async () => {}),
-      select: vi.fn(
-        async (_params: WizardSelectParams<unknown>) => "quickstart",
-      ) as unknown as WizardPrompter["select"],
-      multiselect: vi.fn(async () => []),
-      text: vi.fn(async () => ""),
-      confirm: vi.fn(async () => false),
-      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
-    };
-
-    const runtime: RuntimeEnv = {
-      log: vi.fn(),
-      error: vi.fn(),
-      exit: vi.fn((code: number) => {
-        throw new Error(`exit:${code}`);
-      }),
-    };
+    const prompter = buildWizardPrompter();
+    const runtime = createRuntime({ throwsOnExit: true });
 
     await expect(
       runOnboardingWizard(
         {
           acceptRisk: true,
           flow: "quickstart",
-          workspace: "/root/workspace",
+          workspace: "/tmp/nonexistent/deep/path",
           authChoice: "skip",
           installDaemon: false,
           skipProviders: true,
@@ -638,5 +584,7 @@ describe("runOnboardingWizard", () => {
         prompter,
       ),
     ).rejects.toThrow("ENOENT");
+
+    expect(prompter.outro).not.toHaveBeenCalled();
   });
 });

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createWizardPrompter as buildWizardPrompter } from "../../test/helpers/wizard-prompter.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../agents/workspace.js";
 import type { RuntimeEnv } from "../runtime.js";
@@ -227,6 +227,8 @@ describe("runOnboardingWizard", () => {
     suiteRoot = "";
     suiteCase = 0;
   });
+
+  beforeEach(() => vi.clearAllMocks());
 
   async function makeCaseDir(prefix: string): Promise<string> {
     const dir = path.join(suiteRoot, `${prefix}${++suiteCase}`);
@@ -489,5 +491,152 @@ describe("runOnboardingWizard", () => {
         secretInputMode: "ref",
       }),
     );
+  });
+
+  it("validates workspace before writing config or setting up channels", async () => {
+    const eaccesError = Object.assign(
+      new Error("EACCES: permission denied, mkdir '/root/workspace'"),
+      { code: "EACCES" },
+    );
+    ensureWorkspaceAndSessions.mockRejectedValueOnce(eaccesError);
+
+    const prompter: WizardPrompter = {
+      intro: vi.fn(async () => {}),
+      outro: vi.fn(async () => {}),
+      note: vi.fn(async () => {}),
+      select: vi.fn(
+        async (_params: WizardSelectParams<unknown>) => "quickstart",
+      ) as unknown as WizardPrompter["select"],
+      multiselect: vi.fn(async () => []),
+      text: vi.fn(async () => ""),
+      confirm: vi.fn(async () => false),
+      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+    };
+
+    const runtime: RuntimeEnv = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn((code: number) => {
+        throw new Error(`exit:${code}`);
+      }),
+    };
+
+    await expect(
+      runOnboardingWizard(
+        {
+          acceptRisk: true,
+          flow: "quickstart",
+          workspace: "/root/workspace",
+          authChoice: "skip",
+          installDaemon: false,
+          skipProviders: true,
+          skipSkills: true,
+          skipHealth: true,
+          skipUi: true,
+        },
+        runtime,
+        prompter,
+      ),
+    ).rejects.toThrow("exit:1");
+
+    expect(writeConfigFile).not.toHaveBeenCalled();
+    expect(setupChannels).not.toHaveBeenCalled();
+  });
+
+  it("shows workspace error message when directory is not writable", async () => {
+    const eaccesError = Object.assign(
+      new Error("EACCES: permission denied, mkdir '/root/workspace'"),
+      { code: "EACCES" },
+    );
+    ensureWorkspaceAndSessions.mockRejectedValueOnce(eaccesError);
+
+    const prompter: WizardPrompter = {
+      intro: vi.fn(async () => {}),
+      outro: vi.fn(async () => {}),
+      note: vi.fn(async () => {}),
+      select: vi.fn(
+        async (_params: WizardSelectParams<unknown>) => "quickstart",
+      ) as unknown as WizardPrompter["select"],
+      multiselect: vi.fn(async () => []),
+      text: vi.fn(async () => ""),
+      confirm: vi.fn(async () => false),
+      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+    };
+
+    const runtime: RuntimeEnv = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn((code: number) => {
+        throw new Error(`exit:${code}`);
+      }),
+    };
+
+    await expect(
+      runOnboardingWizard(
+        {
+          acceptRisk: true,
+          flow: "quickstart",
+          workspace: "/root/workspace",
+          authChoice: "skip",
+          installDaemon: false,
+          skipProviders: true,
+          skipSkills: true,
+          skipHealth: true,
+          skipUi: true,
+        },
+        runtime,
+        prompter,
+      ),
+    ).rejects.toThrow("exit:1");
+
+    const outroCalls = (prompter.outro as ReturnType<typeof vi.fn>).mock.calls;
+    expect(outroCalls.length).toBe(1);
+    expect(outroCalls[0][0]).toMatch(/workspace/i);
+  });
+
+  it("re-throws non-permission workspace errors", async () => {
+    const enoentError = Object.assign(new Error("ENOENT: no such file or directory"), {
+      code: "ENOENT",
+    });
+    ensureWorkspaceAndSessions.mockRejectedValueOnce(enoentError);
+
+    const prompter: WizardPrompter = {
+      intro: vi.fn(async () => {}),
+      outro: vi.fn(async () => {}),
+      note: vi.fn(async () => {}),
+      select: vi.fn(
+        async (_params: WizardSelectParams<unknown>) => "quickstart",
+      ) as unknown as WizardPrompter["select"],
+      multiselect: vi.fn(async () => []),
+      text: vi.fn(async () => ""),
+      confirm: vi.fn(async () => false),
+      progress: vi.fn(() => ({ update: vi.fn(), stop: vi.fn() })),
+    };
+
+    const runtime: RuntimeEnv = {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: vi.fn((code: number) => {
+        throw new Error(`exit:${code}`);
+      }),
+    };
+
+    await expect(
+      runOnboardingWizard(
+        {
+          acceptRisk: true,
+          flow: "quickstart",
+          workspace: "/root/workspace",
+          authChoice: "skip",
+          installDaemon: false,
+          skipProviders: true,
+          skipSkills: true,
+          skipHealth: true,
+          skipUi: true,
+        },
+        runtime,
+        prompter,
+      ),
+    ).rejects.toThrow("ENOENT");
   });
 });

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -367,6 +367,23 @@ export async function runOnboardingWizard(
 
   const workspaceDir = resolveUserPath(workspaceInput.trim() || onboardHelpers.DEFAULT_WORKSPACE);
 
+  try {
+    await onboardHelpers.ensureWorkspaceAndSessions(workspaceDir, runtime, {
+      skipBootstrap: Boolean(baseConfig.agents?.defaults?.skipBootstrap),
+    });
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "EACCES" || code === "EPERM") {
+      const msg = err instanceof Error ? err.message : "Permission denied";
+      await prompter.outro(
+        `Workspace not writable: ${workspaceDir}\n${msg}\nFix directory permissions, then re-run onboarding.`,
+      );
+      runtime.exit(1);
+      return;
+    }
+    throw err;
+  }
+
   const { applyOnboardingLocalWorkspaceConfig } = await import("../commands/onboard-config.js");
   let nextConfig: OpenClawConfig = applyOnboardingLocalWorkspaceConfig(baseConfig, workspaceDir);
 
@@ -469,9 +486,6 @@ export async function runOnboardingWizard(
   await writeConfigFile(nextConfig);
   const { logConfigUpdated } = await import("../config/logging.js");
   logConfigUpdated(runtime);
-  await onboardHelpers.ensureWorkspaceAndSessions(workspaceDir, runtime, {
-    skipBootstrap: Boolean(nextConfig.agents?.defaults?.skipBootstrap),
-  });
 
   if (opts.skipSkills) {
     await prompter.note("Skipping skills setup.", "Skills");


### PR DESCRIPTION
## Summary

- Problem: Onboarding wizard validates workspace directory permissions after user completes auth setup, model selection, gateway configuration, and channel setup, wasting all that time if permissions fail
- Why it matters: Poor UX - users who enter an unwritable workspace path must restart entire onboarding after fixing permissions
- What changed: Moved `ensureWorkspaceAndSessions()` to immediately after workspace path resolution with try-catch that shows clear error for EACCES/EPERM and exits before any setup prompts
- What did NOT change: Non-permission errors (e.g., ENOENT) are re-thrown and handled normally; workspace validation still creates the directory if possible; all setup steps proceed normally when workspace is writable

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25622
- Related #13330 (original issue, auto-closed as stale)
- Related #13577 (original PR, auto-closed as stale)

## User-visible / Behavior Changes

Users running onboarding with custom workspace paths will now see immediate validation errors if the directory is not writable, before any interactive setup steps. Clear error message shows the unwritable path and instructs user to fix permissions then re-run onboarding.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux / macOS / all platforms
- Runtime/container: Node 22+
- Model/provider: N/A (onboarding step)
- Integration/channel: N/A (onboarding step)
- Relevant config: Custom workspace path with no write permissions

### Steps

1. Run `openclaw onboard`
2. When prompted for workspace, enter a directory without write permissions (e.g., `/root/workspace`)
3. Observe immediate error before any setup prompts

### Expected

Clear error message about unwritable workspace, exit before any setup steps

### Actual

Before fix: User completes auth/model/gateway/channel setup, then gets EACCES at the end
After fix: Immediate error message, exit before any setup prompts

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Three new tests:
1. Validates workspace before writing config or setting up channels
2. Shows workspace error message when directory is not writable
3. Re-throws non-permission workspace errors

All tests pass (8 total in onboarding test suite).

## Human Verification (required)

Verified scenarios:
- New test suite passes (3 tests covering permission errors, error message, non-permission error re-throw)
- Existing onboarding tests pass (5 existing + 3 new = 8 total)
- `pnpm build && pnpm check` passes clean

Edge cases checked:
- EACCES/EPERM errors show clear message and exit early
- ENOENT and other errors are re-thrown (not treated as permission errors)
- Workspace validation still creates directory when possible
- Late workspace call removed (was at line ~454 after all setup)

What I did not verify:
- End-to-end testing with actual unwritable directory in Docker environment (requires container setup with specific permission configuration)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit or cherry-pick the inverse
- Files/config to restore: None (no config changes)
- Known bad symptoms reviewers should watch for: Workspace validation failing incorrectly for edge-case directory names or permission setups

## Risks and Mitigations

- Risk: Early validation might fail for some directory structures that the late validation would have created
  - Mitigation: `ensureWorkspaceAndSessions()` is the same function being called early vs late, just moved to before setup prompts; it still creates directories when possible

- Risk: Error handling might swallow legitimate errors by treating them as permission errors
  - Mitigation: Only EACCES and EPERM codes trigger the early exit; all other errors are re-thrown and handled normally (covered by test)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two changes:

1. **Onboarding workspace validation (main fix):** Moves the `ensureWorkspaceAndSessions()` call from after all interactive setup prompts (auth, model, gateway, channels) to immediately after workspace path resolution. Permission errors (EACCES/EPERM) now show a clear message and exit early, while other errors are re-thrown. This prevents users from completing the entire setup flow only to fail at the end due to unwritable directories.

2. **Type fix in `buildExternalLinkRel`:** Widens `new Set(REQUIRED_EXTERNAL_REL_TOKENS)` to `new Set<string>(...)` so `.has(token)` works correctly with `string` arguments under strict TypeScript settings.

- The `skipBootstrap` parameter changed from using `nextConfig` to `baseConfig`, which is safe since no onboarding step modifies this value
- Three new tests cover permission error handling, error messaging, and non-permission error re-throwing
- Added `beforeEach(() => vi.clearAllMocks())` to prevent mock state leaking between tests

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it moves an existing validation earlier in the flow with proper error handling and good test coverage.
- The main change is a straightforward reordering of an existing function call with added error handling. The `skipBootstrap` parameter source change (baseConfig vs nextConfig) was verified to be semantically equivalent. The Set type widening is a correct TypeScript fix. All changes have test coverage, and no behavior changes occur on the happy path.
- No files require special attention.

<sub>Last reviewed commit: d658730</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->