### PR TITLE
fix(googlechat): detect bot @mentions via user.type when botUser not configured

### DIFF
--- a/extensions/googlechat/src/monitor-access.ts
+++ b/extensions/googlechat/src/monitor-access.ts
@@ -93,6 +93,15 @@ export function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?
   const hasAnyMention = mentionAnnotations.length > 0;
   const trimmedBotUser = botUser?.trim() || null;
   const botTargets = new Set(["users/app", trimmedBotUser].filter(Boolean) as string[]);
+  // Pre-compute distinct BOT users for multi-bot safety check (avoid recalculating in loop)
+  const distinctBotUsers = !trimmedBotUser
+    ? new Set(
+        mentionAnnotations
+          .filter((m) => m.userMention?.user?.type?.toUpperCase() === "BOT")
+          .map((m) => m.userMention?.user?.name)
+          .filter(Boolean),
+      )
+    : null;
   const wasMentioned = mentionAnnotations.some((entry) => {
     const userName = entry.userMention?.user?.name;
     if (!userName) {
@@ -110,13 +119,7 @@ export function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?
     // only reliable signal. For multi-bot safety, only use this fallback when
     // exactly one distinct BOT-type user exists — with multiple bots we can't
     // tell which one is ours without an explicit botUser configuration.
-    if (!trimmedBotUser && entry.userMention?.user?.type?.toUpperCase() === "BOT") {
-      const distinctBotUsers = new Set(
-        mentionAnnotations
-          .filter((m) => m.userMention?.user?.type?.toUpperCase() === "BOT")
-          .map((m) => m.userMention?.user?.name)
-          .filter(Boolean),
-      );
+    if (distinctBotUsers && entry.userMention?.user?.type?.toUpperCase() === "BOT") {
       return distinctBotUsers.size === 1;
     }
     return false;

--- a/extensions/googlechat/src/monitor-access.ts
+++ b/extensions/googlechat/src/monitor-access.ts
@@ -88,10 +88,11 @@ function resolveGroupConfig(params: {
   return { entry: entry ?? fallback, allowlistConfigured: true, fallback };
 }
 
-function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?: string | null) {
+export function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?: string | null) {
   const mentionAnnotations = annotations.filter((entry) => entry.type === "USER_MENTION");
   const hasAnyMention = mentionAnnotations.length > 0;
-  const botTargets = new Set(["users/app", botUser?.trim()].filter(Boolean) as string[]);
+  const trimmedBotUser = botUser?.trim() || null;
+  const botTargets = new Set(["users/app", trimmedBotUser].filter(Boolean) as string[]);
   const wasMentioned = mentionAnnotations.some((entry) => {
     const userName = entry.userMention?.user?.name;
     if (!userName) {
@@ -100,7 +101,22 @@ function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?: strin
     if (botTargets.has(userName)) {
       return true;
     }
-    return normalizeUserId(userName) === "app";
+    if (normalizeUserId(userName) === "app") {
+      return true;
+    }
+    // When botUser is not explicitly configured, fall back to checking the
+    // user.type field. Google Chat sends numeric user IDs (e.g. "users/123...")
+    // instead of "users/app" for webhook-based bots, so the type field is the
+    // only reliable signal. For multi-bot safety, only use this fallback when
+    // exactly one BOT-type mention exists — with multiple bots we can't tell
+    // which one is ours without an explicit botUser configuration.
+    if (!trimmedBotUser && entry.userMention?.user?.type?.toUpperCase() === "BOT") {
+      const botTypeMentionCount = mentionAnnotations.filter(
+        (m) => m.userMention?.user?.type?.toUpperCase() === "BOT",
+      ).length;
+      return botTypeMentionCount === 1;
+    }
+    return false;
   });
   return { hasAnyMention, wasMentioned };
 }

--- a/extensions/googlechat/src/monitor-access.ts
+++ b/extensions/googlechat/src/monitor-access.ts
@@ -108,13 +108,16 @@ export function extractMentionInfo(annotations: GoogleChatAnnotation[], botUser?
     // user.type field. Google Chat sends numeric user IDs (e.g. "users/123...")
     // instead of "users/app" for webhook-based bots, so the type field is the
     // only reliable signal. For multi-bot safety, only use this fallback when
-    // exactly one BOT-type mention exists — with multiple bots we can't tell
-    // which one is ours without an explicit botUser configuration.
+    // exactly one distinct BOT-type user exists — with multiple bots we can't
+    // tell which one is ours without an explicit botUser configuration.
     if (!trimmedBotUser && entry.userMention?.user?.type?.toUpperCase() === "BOT") {
-      const botTypeMentionCount = mentionAnnotations.filter(
-        (m) => m.userMention?.user?.type?.toUpperCase() === "BOT",
-      ).length;
-      return botTypeMentionCount === 1;
+      const distinctBotUsers = new Set(
+        mentionAnnotations
+          .filter((m) => m.userMention?.user?.type?.toUpperCase() === "BOT")
+          .map((m) => m.userMention?.user?.name)
+          .filter(Boolean),
+      );
+      return distinctBotUsers.size === 1;
     }
     return false;
   });

--- a/extensions/googlechat/src/monitor.test.ts
+++ b/extensions/googlechat/src/monitor.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
+import type { GoogleChatAnnotation } from "./types.js";
 import { isSenderAllowed } from "./monitor.js";
+import { extractMentionInfo } from "./monitor-access.js";
 
 describe("isSenderAllowed", () => {
   it("matches raw email entries only when dangerous name matching is enabled", () => {
@@ -21,5 +23,85 @@ describe("isSenderAllowed", () => {
     expect(isSenderAllowed("users/123", "jane@example.com", ["other@example.com"], true)).toBe(
       false,
     );
+  });
+});
+
+describe("extractMentionInfo", () => {
+  function mentionAnnotation(userName: string, userType?: string): GoogleChatAnnotation {
+    return {
+      type: "USER_MENTION",
+      userMention: {
+        user: { name: userName, type: userType },
+      },
+    };
+  }
+
+  it("detects mention via users/app alias", () => {
+    const annotations = [mentionAnnotation("users/app")];
+    const result = extractMentionInfo(annotations);
+    expect(result).toEqual({ hasAnyMention: true, wasMentioned: true });
+  });
+
+  it("detects mention via explicit botUser config", () => {
+    const annotations = [mentionAnnotation("users/112986094383820258709")];
+    const result = extractMentionInfo(annotations, "users/112986094383820258709");
+    expect(result).toEqual({ hasAnyMention: true, wasMentioned: true });
+  });
+
+  it("detects mention via BOT user type when botUser is not configured", () => {
+    // This is the core bug (#12323): Google Chat webhook sends numeric user IDs
+    // like "users/112986094383820258709" instead of "users/app". Without botUser
+    // configured, the only way to detect the bot mention is via user.type === "BOT".
+    const annotations = [mentionAnnotation("users/112986094383820258709", "BOT")];
+    const result = extractMentionInfo(annotations);
+    expect(result).toEqual({ hasAnyMention: true, wasMentioned: true });
+  });
+
+  it("skips BOT-type fallback when multiple BOT mentions exist (multi-bot safety)", () => {
+    // In multi-bot Spaces, we can't distinguish which bot is ours without botUser config.
+    // When multiple BOT-type mentions exist, require explicit botUser configuration.
+    const annotations = [
+      mentionAnnotation("users/112986094383820258709", "BOT"),
+      mentionAnnotation("users/998877665544332211", "BOT"),
+    ];
+    const result = extractMentionInfo(annotations);
+    expect(result).toEqual({ hasAnyMention: true, wasMentioned: false });
+  });
+
+  it("uses explicit botUser even when multiple BOT mentions exist", () => {
+    const annotations = [
+      mentionAnnotation("users/112986094383820258709", "BOT"),
+      mentionAnnotation("users/998877665544332211", "BOT"),
+    ];
+    const result = extractMentionInfo(annotations, "users/112986094383820258709");
+    expect(result).toEqual({ hasAnyMention: true, wasMentioned: true });
+  });
+
+  it("returns wasMentioned false for non-bot numeric user ID without config", () => {
+    // Human mentions should not trigger the bot
+    const annotations = [mentionAnnotation("users/112986094383820258709", "HUMAN")];
+    const result = extractMentionInfo(annotations);
+    expect(result).toEqual({ hasAnyMention: true, wasMentioned: false });
+  });
+
+  it("returns hasAnyMention false for empty annotations", () => {
+    const result = extractMentionInfo([]);
+    expect(result).toEqual({ hasAnyMention: false, wasMentioned: false });
+  });
+
+  it("ignores non-USER_MENTION annotations", () => {
+    const annotations: GoogleChatAnnotation[] = [{ type: "SLASH_COMMAND" }, { type: "RICH_LINK" }];
+    const result = extractMentionInfo(annotations);
+    expect(result).toEqual({ hasAnyMention: false, wasMentioned: false });
+  });
+
+  it("detects BOT-type mention alongside human mentions", () => {
+    // One BOT mention + one human mention: BOT fallback should still work
+    const annotations = [
+      mentionAnnotation("users/112986094383820258709", "BOT"),
+      mentionAnnotation("users/555666777888999", "HUMAN"),
+    ];
+    const result = extractMentionInfo(annotations);
+    expect(result).toEqual({ hasAnyMention: true, wasMentioned: true });
   });
 });

--- a/extensions/googlechat/src/monitor.test.ts
+++ b/extensions/googlechat/src/monitor.test.ts
@@ -104,4 +104,15 @@ describe("extractMentionInfo", () => {
     const result = extractMentionInfo(annotations);
     expect(result).toEqual({ hasAnyMention: true, wasMentioned: true });
   });
+
+  it("detects same bot mentioned twice (duplicate annotations, one distinct bot)", () => {
+    // Same bot mentioned twice in one message — should still trigger since
+    // there is only one distinct BOT user, not two different bots.
+    const annotations = [
+      mentionAnnotation("users/112986094383820258709", "BOT"),
+      mentionAnnotation("users/112986094383820258709", "BOT"),
+    ];
+    const result = extractMentionInfo(annotations);
+    expect(result).toEqual({ hasAnyMention: true, wasMentioned: true });
+  });
 });


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Google Chat webhooks send numeric user IDs (e.g., `users/112986094383820258709`) instead of `users/app` alias for bot @mentions. Without `botUser` explicitly configured, `extractMentionInfo()` fails to recognize mentions, causing bot to silently ignore Space messages where it was @mentioned.
- Why it matters: Breaks Space functionality completely with zero error output. DMs work fine, creating false confidence that setup is correct. Costs hours of debugging to discover the `botUser` config requirement is effectively mandatory for Spaces.
- What changed: Added BOT user type fallback in `extractMentionInfo()` that checks `annotation.userMention.user.type === "BOT"` when `botUser` not configured. Multi-bot safety guard ensures fallback only triggers when exactly 1 distinct BOT user is mentioned.
- What did NOT change (scope boundary): DM handling unchanged. Existing `users/app` alias detection unchanged. Explicit `botUser` config behavior unchanged. Multi-bot Spaces with `botUser` configured work same as before.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25639
- Related #12323
- Related #13829

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Google Chat bot now detects @mentions in Spaces without requiring `botUser` configuration
- Multi-bot Spaces: BOT type fallback only triggers when exactly 1 distinct BOT-type user is mentioned (safety guard against false positives)
- Explicit `botUser` config still works and takes precedence, bypassing multi-bot guard

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux, macOS
- Runtime/container: Node 22+
- Model/provider: Any
- Integration/channel (if any): Google Chat (HTTP webhook, service account auth)
- Relevant config (redacted):
```json
{
  "googlechat": {
    "groupPolicy": "open"
    // Note: botUser NOT configured (this triggers the bug)
  }
}
```

### Steps

1. Configure Google Chat bot without `botUser` field in config
2. Set `groupPolicy: "open"` or any policy allowing group messages  
3. Send a DM to the bot → observe it works fine
4. @mention the bot in a Google Chat Space → observe behavior

### Expected

- Bot detects @mention in Space and responds

### Actual

- Before fix: Message silently dropped, no response, no error logs
- After fix: Bot detects mention via BOT user type fallback and responds

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

**Test evidence:**
New test suite in `extensions/googlechat/src/monitor.test.ts` with 10 test cases:
- `users/app` alias detection (existing, regression guard)
- Explicit `botUser` config detection (existing, regression guard)  
- **BOT type fallback detects mentions when `botUser` not configured** (NEW - core fix)
- **Multi-bot safety: rejects when multiple distinct BOT users mentioned** (NEW - safety guard)
- Explicit `botUser` overrides multi-bot guard (NEW - config precedence)
- HUMAN-type mentions don't trigger bot (NEW - type validation)
- Empty annotations handled (NEW - edge case)
- Non-USER_MENTION annotations ignored (NEW - edge case)
- BOT mention alongside human mentions detected (NEW - mixed scenario)
- Same bot mentioned twice correctly detected as single bot (NEW - deduplication)

All 10 tests fail before fix, pass after fix.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `users/app` alias detection still works (read code + tests)
  - Explicit `botUser` config detection still works (read code + tests)
  - BOT type fallback activates only when `botUser` not configured (unit test verification)
  - Multi-bot safety guard correctly counts distinct BOT users (unit test verification)
  - Explicit `botUser` bypasses multi-bot guard (unit test verification)
- Edge cases checked:
  - HUMAN-type user mentions don't trigger bot (type check in fallback)
  - Empty annotations return correct default `{ hasAnyMention: false, wasMentioned: false }`
  - Non-USER_MENTION annotation types are filtered out before processing
  - Duplicate mentions of same bot (multiple annotations, one user) correctly detected
- What you did **not** verify:
  - Production Google Chat Space with real multi-bot scenario (no test Google Chat Space available; relied on unit test coverage)
  - Webhook event shape variations across different Google Chat deployment types

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: 
  - Revert this commit, or
  - Explicitly configure `botUser` in googlechat channel config to bypass new fallback logic entirely
- Files/config to restore: `extensions/googlechat/src/monitor.ts` only (plus test file if desired)
- Known bad symptoms reviewers should watch for:
  - Bot responding to other bots' mentions in multi-bot Spaces (indicates multi-bot guard failure)
  - Mention detection failing in Spaces where `botUser` is explicitly configured (indicates regression in existing logic)
  - Bot responding in Spaces when not @mentioned (indicates wasMentioned logic error)

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: In multi-bot Spaces without `botUser` config, if user @mentions multiple bots, new guard rejects all mentions (conservative failure → bot doesn't respond even if ours was mentioned)
  - Mitigation: Multi-bot safety guard (`distinctBotUsers.size === 1`) prevents worse failure mode (responding to other bots' mentions). Users can configure explicit `botUser` for reliable multi-bot Space support. Documentation should recommend `botUser` for multi-bot scenarios.
- Risk: BOT user type field might not be present in all Google Chat webhook event variations
  - Mitigation: Fallback only triggers when field exists and equals "BOT" (uppercase normalized). Falls through to `false` if missing, preserving current behavior. Explicit `botUser` config always takes precedence.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds BOT user type fallback for detecting bot `@mentions` in Google Chat Spaces when `botUser` is not explicitly configured. Previously, the bot silently dropped messages in Spaces because Google Chat webhooks send numeric user IDs (`users/123...`) instead of the `users/app` alias. The fix checks `user.type === "BOT"` with a multi-bot safety guard that only activates when exactly one distinct BOT user is mentioned.

- Well-scoped fix that preserves existing behavior for DMs, explicit `botUser` config, and `users/app` alias detection
- Comprehensive test coverage (10 test cases) covering the core fix, multi-bot safety, edge cases, and regression guards
- Clear code comments explaining the fallback logic and multi-bot safety rationale
- Minor performance consideration: `distinctBotUsers` Set is recalculated on each BOT-type iteration within `.some()`, but impact is negligible since multi-bot scenarios are rare

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested bug fix with comprehensive test coverage and conservative multi-bot safety guard
- Straightforward bug fix with excellent test coverage (10 test cases including edge cases and regressions). Logic is correct and preserves all existing behavior. Only minor performance consideration that doesn't affect correctness. PR description is thorough with clear scope boundaries and risk analysis.
- No files require special attention

<sub>Last reviewed commit: 553d713</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->