### PR TITLE
fix(nostr): handle string return from nip19.decode in normalizePubkey

### DIFF
--- a/extensions/nostr/src/nostr-bus.test.ts
+++ b/extensions/nostr/src/nostr-bus.test.ts
@@ -1,199 +1,60 @@
-import { describe, expect, it } from "vitest";
-import {
-  validatePrivateKey,
-  getPublicKeyFromPrivate,
-  isValidPubkey,
-  normalizePubkey,
-  pubkeyToNpub,
-} from "./nostr-bus.js";
-
-// Test private key (DO NOT use in production - this is a known test key)
-const TEST_HEX_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-const TEST_NSEC = "nsec1qypqxpq9qtpqscx7peytzfwtdjmcv0mrz5rjpej8vjppfkqfqy8skqfv3l";
-
-describe("validatePrivateKey", () => {
-  describe("hex format", () => {
-    it("accepts valid 64-char hex key", () => {
-      const result = validatePrivateKey(TEST_HEX_KEY);
-      expect(result).toBeInstanceOf(Uint8Array);
-      expect(result.length).toBe(32);
-    });
-
-    it("accepts lowercase hex", () => {
-      const result = validatePrivateKey(TEST_HEX_KEY.toLowerCase());
-      expect(result).toBeInstanceOf(Uint8Array);
-    });
-
-    it("accepts uppercase hex", () => {
-      const result = validatePrivateKey(TEST_HEX_KEY.toUpperCase());
-      expect(result).toBeInstanceOf(Uint8Array);
-    });
-
-    it("accepts mixed case hex", () => {
-      const mixed = "0123456789ABCdef0123456789abcDEF0123456789abcdef0123456789ABCDEF";
-      const result = validatePrivateKey(mixed);
-      expect(result).toBeInstanceOf(Uint8Array);
-    });
-
-    it("trims whitespace", () => {
-      const result = validatePrivateKey(`  ${TEST_HEX_KEY}  `);
-      expect(result).toBeInstanceOf(Uint8Array);
-    });
-
-    it("trims newlines", () => {
-      const result = validatePrivateKey(`${TEST_HEX_KEY}\n`);
-      expect(result).toBeInstanceOf(Uint8Array);
-    });
-
-    it("rejects 63-char hex (too short)", () => {
-      expect(() => validatePrivateKey(TEST_HEX_KEY.slice(0, 63))).toThrow(
-        "Private key must be 64 hex characters",
-      );
-    });
-
-    it("rejects 65-char hex (too long)", () => {
-      expect(() => validatePrivateKey(TEST_HEX_KEY + "0")).toThrow(
-        "Private key must be 64 hex characters",
-      );
-    });
-
-    it("rejects non-hex characters", () => {
-      const invalid = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg"; // 'g' at end
-      expect(() => validatePrivateKey(invalid)).toThrow("Private key must be 64 hex characters");
-    });
-
-    it("rejects empty string", () => {
-      expect(() => validatePrivateKey("")).toThrow("Private key must be 64 hex characters");
-    });
-
-    it("rejects whitespace-only string", () => {
-      expect(() => validatePrivateKey("   ")).toThrow("Private key must be 64 hex characters");
-    });
-
-    it("rejects key with 0x prefix", () => {
-      expect(() => validatePrivateKey("0x" + TEST_HEX_KEY)).toThrow(
-        "Private key must be 64 hex characters",
-      );
-    });
-  });
-
-  describe("nsec format", () => {
-    it("rejects invalid nsec (wrong checksum)", () => {
-      const badNsec = "nsec1invalidinvalidinvalidinvalidinvalidinvalidinvalidinvalid";
-      expect(() => validatePrivateKey(badNsec)).toThrow();
-    });
-
-    it("rejects npub (wrong type)", () => {
-      const npub = "npub1qypqxpq9qtpqscx7peytzfwtdjmcv0mrz5rjpej8vjppfkqfqy8s5epk55";
-      expect(() => validatePrivateKey(npub)).toThrow();
-    });
-  });
-});
-
-describe("isValidPubkey", () => {
-  describe("hex format", () => {
-    it("accepts valid 64-char hex pubkey", () => {
-      const validHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-      expect(isValidPubkey(validHex)).toBe(true);
-    });
-
-    it("accepts uppercase hex", () => {
-      const validHex = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
-      expect(isValidPubkey(validHex)).toBe(true);
-    });
-
-    it("rejects 63-char hex", () => {
-      const shortHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde";
-      expect(isValidPubkey(shortHex)).toBe(false);
-    });
-
-    it("rejects 65-char hex", () => {
-      const longHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0";
-      expect(isValidPubkey(longHex)).toBe(false);
-    });
-
-    it("rejects non-hex characters", () => {
-      const invalid = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg";
-      expect(isValidPubkey(invalid)).toBe(false);
-    });
-  });
-
-  describe("npub format", () => {
-    it("rejects invalid npub", () => {
-      expect(isValidPubkey("npub1invalid")).toBe(false);
-    });
-
-    it("rejects nsec (wrong type)", () => {
-      expect(isValidPubkey(TEST_NSEC)).toBe(false);
-    });
-  });
-
-  describe("edge cases", () => {
-    it("rejects empty string", () => {
-      expect(isValidPubkey("")).toBe(false);
-    });
-
-    it("handles whitespace-padded input", () => {
-      const validHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-      expect(isValidPubkey(`  ${validHex}  `)).toBe(true);
-    });
-  });
-});
+import * as nip19 from "nostr-tools/nip19";
+import { describe, expect, test } from "vitest";
+import { normalizePubkey } from "./nostr-bus.js";
 
 describe("normalizePubkey", () => {
-  describe("hex format", () => {
-    it("lowercases hex pubkey", () => {
-      const upper = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
-      const result = normalizePubkey(upper);
-      expect(result).toBe(upper.toLowerCase());
-    });
-
-    it("trims whitespace", () => {
-      const hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-      expect(normalizePubkey(`  ${hex}  `)).toBe(hex);
-    });
-
-    it("rejects invalid hex", () => {
-      expect(() => normalizePubkey("invalid")).toThrow("Pubkey must be 64 hex characters");
-    });
-  });
-});
-
-describe("getPublicKeyFromPrivate", () => {
-  it("derives public key from hex private key", () => {
-    const pubkey = getPublicKeyFromPrivate(TEST_HEX_KEY);
-    expect(pubkey).toMatch(/^[0-9a-f]{64}$/);
-    expect(pubkey.length).toBe(64);
+  test("converts hex pubkey to lowercase", () => {
+    const hex = "ABCD".repeat(16); // 64 hex chars
+    expect(normalizePubkey(hex)).toBe(hex.toLowerCase());
   });
 
-  it("derives consistent public key", () => {
-    const pubkey1 = getPublicKeyFromPrivate(TEST_HEX_KEY);
-    const pubkey2 = getPublicKeyFromPrivate(TEST_HEX_KEY);
-    expect(pubkey1).toBe(pubkey2);
+  test("preserves lowercase hex pubkey", () => {
+    const hex = "abcd".repeat(16); // 64 hex chars
+    expect(normalizePubkey(hex)).toBe(hex);
   });
 
-  it("throws for invalid private key", () => {
-    expect(() => getPublicKeyFromPrivate("invalid")).toThrow();
-  });
-});
-
-describe("pubkeyToNpub", () => {
-  it("converts hex pubkey to npub format", () => {
-    const hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    const npub = pubkeyToNpub(hex);
-    expect(npub).toMatch(/^npub1[a-z0-9]+$/);
+  test("trims whitespace from hex input", () => {
+    const hex = "abcd".repeat(16);
+    expect(normalizePubkey(`  ${hex}  `)).toBe(hex);
   });
 
-  it("produces consistent output", () => {
-    const hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    const npub1 = pubkeyToNpub(hex);
-    const npub2 = pubkeyToNpub(hex);
-    expect(npub1).toBe(npub2);
+  test("throws on invalid hex length", () => {
+    expect(() => normalizePubkey("abcd")).toThrow("Pubkey must be 64 hex characters");
   });
 
-  it("normalizes uppercase hex first", () => {
-    const lower = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    const upper = lower.toUpperCase();
-    expect(pubkeyToNpub(lower)).toBe(pubkeyToNpub(upper));
+  test("throws on invalid hex characters", () => {
+    expect(() => normalizePubkey("z".repeat(64))).toThrow("Pubkey must be 64 hex characters");
+  });
+
+  test("decodes npub key with current nostr-tools (returns string in 2.23+)", () => {
+    // Generate a real npub using current nostr-tools
+    const testHex = "1234567890abcdef".repeat(4);
+    const npub = nip19.npubEncode(testHex);
+
+    const result = normalizePubkey(npub);
+    expect(result).toBe(testHex);
+    expect(result).toHaveLength(64);
+    expect(/^[0-9a-f]{64}$/.test(result)).toBe(true);
+  });
+
+  test("handles multiple npub keys correctly", () => {
+    const testCases = [
+      "0000000000000000000000000000000000000000000000000000000000000001",
+      "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    ];
+
+    for (const hex of testCases) {
+      const npub = nip19.npubEncode(hex);
+      const result = normalizePubkey(npub);
+      expect(result).toBe(hex);
+    }
+  });
+
+  test("round-trip conversion: hex -> npub -> hex", () => {
+    const originalHex = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    const npub = nip19.npubEncode(originalHex);
+    const normalizedHex = normalizePubkey(npub);
+    expect(normalizedHex).toBe(originalHex);
   });
 });

--- a/extensions/nostr/src/nostr-bus.test.ts
+++ b/extensions/nostr/src/nostr-bus.test.ts
@@ -1,60 +1,234 @@
 import * as nip19 from "nostr-tools/nip19";
-import { describe, expect, test } from "vitest";
-import { normalizePubkey } from "./nostr-bus.js";
+import { describe, expect, it } from "vitest";
+import {
+  validatePrivateKey,
+  getPublicKeyFromPrivate,
+  isValidPubkey,
+  normalizePubkey,
+  pubkeyToNpub,
+} from "./nostr-bus.js";
+
+// Test private key (DO NOT use in production - this is a known test key)
+const TEST_HEX_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+describe("validatePrivateKey", () => {
+  describe("hex format", () => {
+    it("accepts valid 64-char hex key", () => {
+      const result = validatePrivateKey(TEST_HEX_KEY);
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(result.length).toBe(32);
+    });
+
+    it("accepts lowercase hex", () => {
+      const result = validatePrivateKey(TEST_HEX_KEY.toLowerCase());
+      expect(result).toBeInstanceOf(Uint8Array);
+    });
+
+    it("accepts uppercase hex", () => {
+      const result = validatePrivateKey(TEST_HEX_KEY.toUpperCase());
+      expect(result).toBeInstanceOf(Uint8Array);
+    });
+
+    it("accepts mixed case hex", () => {
+      const mixed = "0123456789ABCdef0123456789abcDEF0123456789abcdef0123456789ABCDEF";
+      const result = validatePrivateKey(mixed);
+      expect(result).toBeInstanceOf(Uint8Array);
+    });
+
+    it("trims whitespace", () => {
+      const result = validatePrivateKey(`  ${TEST_HEX_KEY}  `);
+      expect(result).toBeInstanceOf(Uint8Array);
+    });
+
+    it("trims newlines", () => {
+      const result = validatePrivateKey(`${TEST_HEX_KEY}\n`);
+      expect(result).toBeInstanceOf(Uint8Array);
+    });
+
+    it("rejects 63-char hex (too short)", () => {
+      expect(() => validatePrivateKey(TEST_HEX_KEY.slice(0, 63))).toThrow(
+        "Private key must be 64 hex characters",
+      );
+    });
+
+    it("rejects 65-char hex (too long)", () => {
+      expect(() => validatePrivateKey(TEST_HEX_KEY + "0")).toThrow(
+        "Private key must be 64 hex characters",
+      );
+    });
+
+    it("rejects non-hex characters", () => {
+      const invalid = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg"; // 'g' at end
+      expect(() => validatePrivateKey(invalid)).toThrow("Private key must be 64 hex characters");
+    });
+
+    it("rejects empty string", () => {
+      expect(() => validatePrivateKey("")).toThrow("Private key must be 64 hex characters");
+    });
+
+    it("rejects whitespace-only string", () => {
+      expect(() => validatePrivateKey("   ")).toThrow("Private key must be 64 hex characters");
+    });
+
+    it("rejects key with 0x prefix", () => {
+      expect(() => validatePrivateKey("0x" + TEST_HEX_KEY)).toThrow(
+        "Private key must be 64 hex characters",
+      );
+    });
+  });
+
+  describe("nsec format", () => {
+    it("rejects invalid nsec (wrong checksum)", () => {
+      const badNsec = "nsec1invalidinvalidinvalidinvalidinvalidinvalidinvalidinvalid";
+      expect(() => validatePrivateKey(badNsec)).toThrow();
+    });
+
+    it("rejects npub (wrong type)", () => {
+      const npub = nip19.npubEncode(TEST_HEX_KEY);
+      expect(() => validatePrivateKey(npub)).toThrow();
+    });
+  });
+});
+
+describe("isValidPubkey", () => {
+  describe("hex format", () => {
+    it("accepts valid 64-char hex pubkey", () => {
+      const validHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+      expect(isValidPubkey(validHex)).toBe(true);
+    });
+
+    it("accepts uppercase hex", () => {
+      const validHex = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
+      expect(isValidPubkey(validHex)).toBe(true);
+    });
+
+    it("rejects 63-char hex", () => {
+      const shortHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcde";
+      expect(isValidPubkey(shortHex)).toBe(false);
+    });
+
+    it("rejects 65-char hex", () => {
+      const longHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0";
+      expect(isValidPubkey(longHex)).toBe(false);
+    });
+
+    it("rejects non-hex characters", () => {
+      const invalid = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdeg";
+      expect(isValidPubkey(invalid)).toBe(false);
+    });
+  });
+
+  describe("npub format", () => {
+    it("rejects invalid npub", () => {
+      expect(isValidPubkey("npub1invalid")).toBe(false);
+    });
+
+    it("rejects nsec (wrong type)", () => {
+      // Use pre-encoded nsec (nsecEncode expects Uint8Array in nostr-tools 2.23+)
+      const nsec = nip19.nsecEncode(validatePrivateKey(TEST_HEX_KEY));
+      expect(isValidPubkey(nsec)).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("rejects empty string", () => {
+      expect(isValidPubkey("")).toBe(false);
+    });
+
+    it("handles whitespace-padded input", () => {
+      const validHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+      expect(isValidPubkey(`  ${validHex}  `)).toBe(true);
+    });
+  });
+});
 
 describe("normalizePubkey", () => {
-  test("converts hex pubkey to lowercase", () => {
-    const hex = "ABCD".repeat(16); // 64 hex chars
-    expect(normalizePubkey(hex)).toBe(hex.toLowerCase());
+  describe("hex format", () => {
+    it("lowercases hex pubkey", () => {
+      const upper = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
+      const result = normalizePubkey(upper);
+      expect(result).toBe(upper.toLowerCase());
+    });
+
+    it("trims whitespace", () => {
+      const hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+      expect(normalizePubkey(`  ${hex}  `)).toBe(hex);
+    });
+
+    it("rejects invalid hex", () => {
+      expect(() => normalizePubkey("invalid")).toThrow("Pubkey must be 64 hex characters");
+    });
   });
 
-  test("preserves lowercase hex pubkey", () => {
-    const hex = "abcd".repeat(16); // 64 hex chars
-    expect(normalizePubkey(hex)).toBe(hex);
-  });
+  describe("npub format", () => {
+    it("decodes npub to hex (handles string return in nostr-tools 2.23+)", () => {
+      const testHex = "1234567890abcdef".repeat(4);
+      const npub = nip19.npubEncode(testHex);
 
-  test("trims whitespace from hex input", () => {
-    const hex = "abcd".repeat(16);
-    expect(normalizePubkey(`  ${hex}  `)).toBe(hex);
-  });
-
-  test("throws on invalid hex length", () => {
-    expect(() => normalizePubkey("abcd")).toThrow("Pubkey must be 64 hex characters");
-  });
-
-  test("throws on invalid hex characters", () => {
-    expect(() => normalizePubkey("z".repeat(64))).toThrow("Pubkey must be 64 hex characters");
-  });
-
-  test("decodes npub key with current nostr-tools (returns string in 2.23+)", () => {
-    // Generate a real npub using current nostr-tools
-    const testHex = "1234567890abcdef".repeat(4);
-    const npub = nip19.npubEncode(testHex);
-
-    const result = normalizePubkey(npub);
-    expect(result).toBe(testHex);
-    expect(result).toHaveLength(64);
-    expect(/^[0-9a-f]{64}$/.test(result)).toBe(true);
-  });
-
-  test("handles multiple npub keys correctly", () => {
-    const testCases = [
-      "0000000000000000000000000000000000000000000000000000000000000001",
-      "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
-    ];
-
-    for (const hex of testCases) {
-      const npub = nip19.npubEncode(hex);
       const result = normalizePubkey(npub);
-      expect(result).toBe(hex);
-    }
+      expect(result).toBe(testHex);
+      expect(result).toHaveLength(64);
+      expect(/^[0-9a-f]{64}$/.test(result)).toBe(true);
+    });
+
+    it("round-trip conversion: hex -> npub -> hex", () => {
+      const originalHex = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+      const npub = nip19.npubEncode(originalHex);
+      const normalizedHex = normalizePubkey(npub);
+      expect(normalizedHex).toBe(originalHex);
+    });
+
+    it("handles multiple npub keys correctly", () => {
+      const testCases = [
+        "0000000000000000000000000000000000000000000000000000000000000001",
+        "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+        "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+      ];
+
+      for (const hex of testCases) {
+        const npub = nip19.npubEncode(hex);
+        const result = normalizePubkey(npub);
+        expect(result).toBe(hex);
+      }
+    });
+  });
+});
+
+describe("getPublicKeyFromPrivate", () => {
+  it("derives public key from hex private key", () => {
+    const pubkey = getPublicKeyFromPrivate(TEST_HEX_KEY);
+    expect(pubkey).toMatch(/^[0-9a-f]{64}$/);
+    expect(pubkey.length).toBe(64);
   });
 
-  test("round-trip conversion: hex -> npub -> hex", () => {
-    const originalHex = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
-    const npub = nip19.npubEncode(originalHex);
-    const normalizedHex = normalizePubkey(npub);
-    expect(normalizedHex).toBe(originalHex);
+  it("derives consistent public key", () => {
+    const pubkey1 = getPublicKeyFromPrivate(TEST_HEX_KEY);
+    const pubkey2 = getPublicKeyFromPrivate(TEST_HEX_KEY);
+    expect(pubkey1).toBe(pubkey2);
+  });
+
+  it("throws for invalid private key", () => {
+    expect(() => getPublicKeyFromPrivate("invalid")).toThrow();
+  });
+});
+
+describe("pubkeyToNpub", () => {
+  it("converts hex pubkey to npub format", () => {
+    const hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const npub = pubkeyToNpub(hex);
+    expect(npub).toMatch(/^npub1[a-z0-9]+$/);
+  });
+
+  it("produces consistent output", () => {
+    const hex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const npub1 = pubkeyToNpub(hex);
+    const npub2 = pubkeyToNpub(hex);
+    expect(npub1).toBe(npub2);
+  });
+
+  it("normalizes uppercase hex first", () => {
+    const lower = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    const upper = lower.toUpperCase();
+    expect(pubkeyToNpub(lower)).toBe(pubkeyToNpub(upper));
   });
 });

--- a/extensions/nostr/src/nostr-bus.ts
+++ b/extensions/nostr/src/nostr-bus.ts
@@ -696,8 +696,12 @@ export function normalizePubkey(input: string): string {
     if (decoded.type !== "npub") {
       throw new Error("Invalid npub key");
     }
-    // Convert Uint8Array to hex string
-    return Array.from(decoded.data as unknown as Uint8Array)
+    // nostr-tools ≥2.23 returns string, older versions return Uint8Array
+    if (typeof decoded.data === "string") {
+      return decoded.data;
+    }
+    // Convert Uint8Array to hex string (older versions)
+    return Array.from(decoded.data as Uint8Array)
       .map((b) => b.toString(16).padStart(2, "0"))
       .join("");
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: The `normalizePubkey()` function assumes `nip19.decode().data` returns a `Uint8Array`, but nostr-tools ≥2.23 changed this to return a hex string. The function uses `Array.from(decoded.data as unknown as Uint8Array)` which splits strings into individual characters instead of converting bytes, producing garbage hex output.
- Why it matters: All npub key normalization operations fail with the current nostr-tools version (^2.23.1), breaking core Nostr plugin functionality for public key handling.
- What changed: Added typeof check in `normalizePubkey()` to handle both string (≥2.23) and Uint8Array (older versions). If `decoded.data` is a string, return it directly. If Uint8Array, convert to hex using the existing byte-to-hex mapping logic.
- What did NOT change (scope boundary): No changes to other nostr-bus functions. No changes to npub encoding logic. No changes to hex validation or other normalizePubkey paths.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25653
- Related #8570 (original closed issue)
- Related #14904 (original auto-closed PR)

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Nostr extension now correctly normalizes npub keys with nostr-tools 2.23+
- Public key operations that were silently failing will now work correctly

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: All platforms (library-level bug)
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): Nostr extension
- Relevant config (redacted): Uses nostr-tools ^2.23.1

### Steps

1. Install OpenClaw with Nostr extension
2. Call `normalizePubkey()` with an npub key (e.g., `npub1abc123...`)
3. Observe output

### Expected

- Function returns valid 64-character hex string representing the public key

### Actual

- Before fix: `Array.from()` splits the hex string into characters, producing incorrect output
- After fix: Function correctly returns the hex string directly (when string) or converts bytes to hex (when Uint8Array)

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

**Test evidence:**
New test suite in `extensions/nostr/src/nostr-bus.test.ts` with 8 test cases:
- Hex pubkey normalization (uppercase, lowercase, whitespace trimming)
- Invalid input validation (length, characters)
- npub key decoding with current nostr-tools (string return)
- Multiple npub keys with different values
- Round-trip conversion (hex → npub → hex)

All tests pass with the fix.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - npub decoding with nostr-tools 2.23.1 (current version) produces correct hex output
  - Multiple npub keys with different hex values all decode correctly
  - Round-trip conversion (hex → npub → hex) preserves original value
  - Hex input validation still works (length, character checking)
  - Uppercase/lowercase hex normalization unchanged
- Edge cases checked:
  - Empty strings rejected by validation
  - Invalid hex characters rejected
  - Invalid length rejected
  - Whitespace trimming works
- What you did **not** verify:
  - Behavior with older nostr-tools versions (no easy way to downgrade; typeof check handles both paths)
  - Production Nostr relay integration (no test relay available)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this commit
  - Downgrade nostr-tools to <2.23 (not recommended)
- Files/config to restore: `extensions/nostr/src/nostr-bus.ts` only (plus test file if desired)
- Known bad symptoms reviewers should watch for:
  - npub decoding failures (wrong hex output)
  - TypeError when calling normalizePubkey with npub input
  - Nostr plugin connection failures

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: The typeof check assumes that if `decoded.data` is not a string, it must be a Uint8Array. If nostr-tools introduces a third type in the future, this will fail.
  - Mitigation: Type cast is now cleaner (`as Uint8Array` instead of `as unknown as Uint8Array`), and TypeScript will catch type mismatches. Tests verify both code paths work correctly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed `normalizePubkey()` to handle nostr-tools ≥2.23 API change where `nip19.decode().data` returns a hex string instead of `Uint8Array` for npub keys. The function now checks the type and handles both string (current) and `Uint8Array` (legacy) return types.

- Added `typeof` check to detect string vs `Uint8Array` return from `nip19.decode()`
- Preserved backward compatibility with older nostr-tools versions
- Removed 140+ lines of unrelated tests, keeping only `normalizePubkey` tests
- All 6 test cases pass with current nostr-tools 2.23.1
- Tests verify hex normalization, npub decoding, and round-trip conversion

<h3>Confidence Score: 5/5</h3>

- Safe to merge - targeted bug fix with backward compatibility and comprehensive test coverage
- The fix correctly handles the breaking API change in nostr-tools ≥2.23 with a proper typeof check, maintains backward compatibility with older versions, and includes comprehensive test coverage. The change is minimal, well-scoped, and addresses the root cause of npub decoding failures.
- No files require special attention

<sub>Last reviewed commit: 2a891fd</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->