### PR TITLE
tools(exec): add configurable approval timeout

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -48,6 +48,7 @@ export type ProcessGatewayAllowlistParams = {
   warnings: string[];
   notifySessionKey?: string;
   approvalRunningNoticeMs: number;
+  approvalTimeoutMs?: number;
   maxOutput: number;
   pendingMaxOutput: number;
   trustedSafeBinDirs?: ReadonlySet<string>;
@@ -144,7 +145,8 @@ export async function processGatewayAllowlist(
     const effectiveTimeout =
       typeof params.timeoutSec === "number" ? params.timeoutSec : params.defaultTimeoutSec;
     const warningText = params.warnings.length ? `${params.warnings.join("\n")}\n\n` : "";
-    let expiresAtMs = Date.now() + DEFAULT_APPROVAL_TIMEOUT_MS;
+    const approvalTimeoutMs = params.approvalTimeoutMs ?? DEFAULT_APPROVAL_TIMEOUT_MS;
+    let expiresAtMs = Date.now() + approvalTimeoutMs;
     let preResolvedDecision: string | null | undefined;
 
     try {
@@ -159,6 +161,7 @@ export async function processGatewayAllowlist(
         agentId: params.agentId,
         resolvedPath,
         sessionKey: params.sessionKey,
+        timeoutMs: approvalTimeoutMs,
       });
       expiresAtMs = registration.expiresAtMs;
       preResolvedDecision = registration.finalDecision;

--- a/src/agents/bash-tools.exec-host-node.ts
+++ b/src/agents/bash-tools.exec-host-node.ts
@@ -41,6 +41,7 @@ export type ExecuteNodeHostCommandParams = {
   timeoutSec?: number;
   defaultTimeoutSec: number;
   approvalRunningNoticeMs: number;
+  approvalTimeoutMs?: number;
   warnings: string[];
   notifySessionKey?: string;
   trustedSafeBinDirs?: ReadonlySet<string>;
@@ -186,7 +187,8 @@ export async function executeNodeHostCommand(
     const contextKey = `exec:${approvalId}`;
     const noticeSeconds = Math.max(1, Math.round(params.approvalRunningNoticeMs / 1000));
     const warningText = params.warnings.length ? `${params.warnings.join("\n")}\n\n` : "";
-    let expiresAtMs = Date.now() + DEFAULT_APPROVAL_TIMEOUT_MS;
+    const approvalTimeoutMs = params.approvalTimeoutMs ?? DEFAULT_APPROVAL_TIMEOUT_MS;
+    let expiresAtMs = Date.now() + approvalTimeoutMs;
     let preResolvedDecision: string | null | undefined;
 
     try {
@@ -201,6 +203,7 @@ export async function executeNodeHostCommand(
         ask: hostAsk,
         agentId: params.agentId,
         sessionKey: params.sessionKey,
+        timeoutMs: approvalTimeoutMs,
       });
       expiresAtMs = registration.expiresAtMs;
       preResolvedDecision = registration.finalDecision;

--- a/src/agents/bash-tools.exec-runtime.ts
+++ b/src/agents/bash-tools.exec-runtime.ts
@@ -238,6 +238,16 @@ export function resolveApprovalRunningNoticeMs(value?: number) {
   return Math.floor(value);
 }
 
+export function resolveApprovalTimeoutMs(value?: number) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_APPROVAL_TIMEOUT_MS;
+  }
+  if (value <= 0) {
+    return DEFAULT_APPROVAL_TIMEOUT_MS;
+  }
+  return Math.floor(value);
+}
+
 export function emitExecSystemEvent(
   text: string,
   opts: { sessionKey?: string; contextKey?: string },

--- a/src/agents/bash-tools.exec-types.ts
+++ b/src/agents/bash-tools.exec-types.ts
@@ -15,6 +15,7 @@ export type ExecToolDefaults = {
   backgroundMs?: number;
   timeoutSec?: number;
   approvalRunningNoticeMs?: number;
+  approvalTimeoutMs?: number;
   sandbox?: BashSandboxConfig;
   elevated?: ExecElevatedDefaults;
   allowBackground?: boolean;

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -24,6 +24,7 @@ import {
   normalizePathPrepend,
   renderExecHostLabel,
   resolveApprovalRunningNoticeMs,
+  resolveApprovalTimeoutMs,
   runExecProcess,
   execSchema,
   validateHostEnv,
@@ -190,6 +191,7 @@ export function createExecTool(
   const notifyOnExitEmptySuccess = defaults?.notifyOnExitEmptySuccess === true;
   const notifySessionKey = defaults?.sessionKey?.trim() || undefined;
   const approvalRunningNoticeMs = resolveApprovalRunningNoticeMs(defaults?.approvalRunningNoticeMs);
+  const approvalTimeoutMs = resolveApprovalTimeoutMs(defaults?.approvalTimeoutMs);
   // Derive agentId only when sessionKey is an agent session key.
   const parsedAgentSession = parseAgentSessionKey(defaults?.sessionKey);
   const agentId =
@@ -408,6 +410,7 @@ export function createExecTool(
           timeoutSec: params.timeout,
           defaultTimeoutSec,
           approvalRunningNoticeMs,
+          approvalTimeoutMs,
           warnings,
           notifySessionKey,
           trustedSafeBinDirs,
@@ -432,6 +435,7 @@ export function createExecTool(
           warnings,
           notifySessionKey,
           approvalRunningNoticeMs,
+          approvalTimeoutMs,
           maxOutput,
           pendingMaxOutput,
           trustedSafeBinDirs,

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -116,6 +116,7 @@ function resolveExecConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
     timeoutSec: agentExec?.timeoutSec ?? globalExec?.timeoutSec,
     approvalRunningNoticeMs:
       agentExec?.approvalRunningNoticeMs ?? globalExec?.approvalRunningNoticeMs,
+    approvalTimeoutMs: agentExec?.approvalTimeoutMs ?? globalExec?.approvalTimeoutMs,
     cleanupMs: agentExec?.cleanupMs ?? globalExec?.cleanupMs,
     notifyOnExit: agentExec?.notifyOnExit ?? globalExec?.notifyOnExit,
     notifyOnExitEmptySuccess:
@@ -390,6 +391,7 @@ export function createOpenClawCodingTools(options?: {
     timeoutSec: options?.exec?.timeoutSec ?? execConfig.timeoutSec,
     approvalRunningNoticeMs:
       options?.exec?.approvalRunningNoticeMs ?? execConfig.approvalRunningNoticeMs,
+    approvalTimeoutMs: options?.exec?.approvalTimeoutMs ?? execConfig.approvalTimeoutMs,
     notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
     notifyOnExitEmptySuccess:
       options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -40,6 +40,7 @@ type ExecDefaults = {
   node?: string;
   pathPrepend?: string[];
   safeBins?: string[];
+  approvalTimeoutMs?: number;
 };
 
 function normalizeExecSecurity(value?: string | null): ExecSecurity | null {
@@ -71,6 +72,7 @@ function resolveExecDefaults(
           node: globalExec.node,
           pathPrepend: globalExec.pathPrepend,
           safeBins: globalExec.safeBins,
+          approvalTimeoutMs: globalExec.approvalTimeoutMs,
         }
       : undefined;
   }
@@ -81,6 +83,7 @@ function resolveExecDefaults(
     node: agentExec?.node ?? globalExec?.node,
     pathPrepend: agentExec?.pathPrepend ?? globalExec?.pathPrepend,
     safeBins: agentExec?.safeBins ?? globalExec?.safeBins,
+    approvalTimeoutMs: agentExec?.approvalTimeoutMs ?? globalExec?.approvalTimeoutMs,
   };
 }
 
@@ -236,7 +239,8 @@ export function registerNodesInvokeCommands(nodes: Command) {
           let approvalId: string | null = null;
           if (requiresAsk) {
             approvalId = crypto.randomUUID();
-            const approvalTimeoutMs = DEFAULT_EXEC_APPROVAL_TIMEOUT_MS;
+            const approvalTimeoutMs =
+              execDefaults?.approvalTimeoutMs ?? DEFAULT_EXEC_APPROVAL_TIMEOUT_MS;
             // The CLI transport timeout (opts.timeout) must be longer than the
             // gateway-side approval wait so the connection stays alive while the
             // user decides.  Without this override the default 35 s transport

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -444,6 +444,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Per-agent provider-specific tool policy overrides for channel-scoped capability control. Use this when a single agent needs tighter restrictions on one provider than others.",
   "tools.exec.approvalRunningNoticeMs":
     "Delay in milliseconds before showing an in-progress notice after an exec approval is granted. Increase to reduce flicker for fast commands, or lower for quicker operator feedback.",
+  "tools.exec.approvalTimeoutMs":
+    "Timeout in milliseconds for exec approval requests. How long to wait for user approval before timing out (default: 120000ms = 2 minutes).",
   "tools.links.enabled":
     "Enable automatic link understanding pre-processing so URLs can be summarized before agent reasoning. Keep enabled for richer context, and disable when strict minimal processing is required.",
   "tools.links.maxLinks":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -169,6 +169,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.exec.notifyOnExit": "Exec Notify On Exit",
   "tools.exec.notifyOnExitEmptySuccess": "Exec Notify On Empty Success",
   "tools.exec.approvalRunningNoticeMs": "Exec Approval Running Notice (ms)",
+  "tools.exec.approvalTimeoutMs": "Exec Approval Timeout (ms)",
   "tools.exec.host": "Exec Host",
   "tools.exec.security": "Exec Security",
   "tools.exec.ask": "Exec Ask",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -237,6 +237,8 @@ export type ExecToolConfig = {
   timeoutSec?: number;
   /** Emit a running notice (ms) when approval-backed exec runs long (default: 10000, 0 = off). */
   approvalRunningNoticeMs?: number;
+  /** Approval timeout in milliseconds (default: 120000). How long to wait for user approval before timing out. */
+  approvalTimeoutMs?: number;
   /** How long to keep finished sessions in memory (ms). */
   cleanupMs?: number;
   /** Emit a system event and heartbeat when a backgrounded exec exits. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -392,6 +392,7 @@ const AgentToolExecSchema = z
   .object({
     ...ToolExecBaseShape,
     approvalRunningNoticeMs: z.number().int().nonnegative().optional(),
+    approvalTimeoutMs: z.number().int().positive().optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

Add `tools.exec.approvalTimeoutMs` config option to allow customizing how long to wait for user approval before timing out (default: 120000ms = 2 minutes).

## Changes

- **TypeScript types**: Added `approvalTimeoutMs` option to `AgentToolExec` interface
- **Validation**: Added Zod schema validation (positive integer)
- **UI labels**: Added display label for the config option
- **Help documentation**: Added user-facing documentation

## Files modified

- `src/config/types.tools.ts`
- `src/config/zod-schema.agent-runtime.ts`
- `src/config/schema.labels.ts`
- `src/config/schema.help.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Added TypeScript types, Zod validation, UI labels, and help documentation for `tools.exec.approvalTimeoutMs` config option, but the configuration value is never wired through to the actual execution path.

The config option properly validates positive integers and provides clear documentation stating it controls "how long to wait for user approval before timing out (default: 120000ms = 2 minutes)." However, the implementation is incomplete:

- `ExecToolDefaults` type in `bash-tools.exec-types.ts` missing `approvalTimeoutMs` field
- Config resolution in `pi-tools.ts` doesn't read or pass through the value
- Approval request in `bash-tools.exec-approval-request.ts:73` uses hardcoded `DEFAULT_APPROVAL_TIMEOUT_MS` 
- CLI invoke logic in `register.invoke.ts:239` also uses hardcoded constant

This means users can set the config option, but it will have no effect on actual approval timeouts.

<h3>Confidence Score: 2/5</h3>

- This PR adds config plumbing but the feature doesn't work - the timeout value is never read or used
- The implementation is incomplete. While the PR correctly adds TypeScript types, Zod validation, labels, and help text for the new config option, it fails to wire the configuration value through to where it's actually needed. The approval timeout remains hardcoded to `DEFAULT_APPROVAL_TIMEOUT_MS` (120000ms) throughout the codebase regardless of the config setting.
- Focus on `src/agents/bash-tools.exec-types.ts`, `src/agents/pi-tools.ts`, and `src/agents/bash-tools.exec-approval-request.ts` - these need updates to actually use the config value

<sub>Last reviewed commit: d504e68</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->