### PR TITLE
fix(skills): refresh stale skill snapshots on gateway restart and in agent command path

### DIFF
--- a/src/auto-reply/reply/session-updates.ts
+++ b/src/auto-reply/reply/session-updates.ts
@@ -154,8 +154,9 @@ export async function ensureSkillSnapshot(params: {
   const remoteEligibility = getRemoteSkillEligibility();
   const snapshotVersion = getSkillsSnapshotVersion(workspaceDir);
   ensureSkillsWatcher({ workspaceDir, config: cfg });
+  const sessionSkillVersion = nextEntry?.skillsSnapshot?.version ?? 0;
   const shouldRefreshSnapshot =
-    snapshotVersion > 0 && (nextEntry?.skillsSnapshot?.version ?? 0) < snapshotVersion;
+    snapshotVersion > 0 ? sessionSkillVersion < snapshotVersion : sessionSkillVersion > 0;
 
   if (isFirstTurnInSession && sessionStore && sessionKey) {
     const current = nextEntry ??

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -7,6 +7,7 @@ import {
 } from "../agents/model-selection.js";
 import { resolveAgentSessionDirs } from "../agents/session-dirs.js";
 import { cleanStaleLockFiles } from "../agents/session-write-lock.js";
+import { bumpSkillsSnapshotVersion } from "../agents/skills/refresh.js";
 import type { CliDeps } from "../cli/deps.js";
 import type { loadConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
@@ -44,6 +45,10 @@ export async function startGatewaySidecars(params: {
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
   logBrowser: { error: (msg: string) => void };
 }) {
+  // Seed the skill snapshot version so sessions from previous runs refresh
+  // their cached skill prompts on the first message after restart.
+  bumpSkillsSnapshotVersion({ reason: "manual" });
+
   try {
     const stateDir = resolveStateDir(process.env);
     const sessionDirs = await resolveAgentSessionDirs(stateDir);


### PR DESCRIPTION
## Summary

- Bump the in-memory `snapshotVersion` counter on gateway startup (`startGatewaySidecars`), so sessions from a previous run detect their cached skill prompts as stale on the first message after restart.
- Add `shouldRefreshSnapshot` check to the `agent.ts` (hooks/cron) code path, which previously only rebuilt skill snapshots for new sessions or missing snapshots — never for stale ones.
- Harden the `shouldRefreshSnapshot` logic in `session-updates.ts` to also detect staleness when `snapshotVersion` resets to 0 (e.g., CLI agent invocations outside the gateway process).

### Problem

After a gateway restart (or plugin update + restart), skill files on disk could be updated but existing sessions would keep serving their cached `skillsSnapshot` indefinitely because:

1. The `agent.ts` path (used by hooks/cron agents) had no version check at all — it only rebuilt if `isNewSession || !sessionEntry?.skillsSnapshot`.
2. The `session-updates.ts` path checked `snapshotVersion > 0 && sessionVersion < snapshotVersion`, but after a restart the in-memory counter resets to `0`, making the entire condition `false`.

### Fix

1. **Gateway startup seed**: call `bumpSkillsSnapshotVersion()` in `startGatewaySidecars` so the counter is non-zero from the start. Any session whose snapshot version is lower (i.e., from a previous run) will refresh on its next message.
2. **`agent.ts` version check**: mirror the `shouldRefreshSnapshot` logic from `session-updates.ts`, plus call `ensureSkillsWatcher` to set up the file watcher for live edits.
3. **Robust zero-version fallback**: when `snapshotVersion === 0` (fresh process, no bumps yet), treat any session with a non-zero version as stale. This covers CLI `openclaw agent` invocations that run outside the gateway.

## Test plan

- [x] Added two new tests in `agent.test.ts`:
  - "refreshes skill snapshot when version is stale" — verifies rebuild when `snapshotVersion > sessionVersion`
  - "refreshes skill snapshot after restart when version resets to zero" — verifies rebuild when `snapshotVersion === 0` but session has non-zero version
- [x] All existing 22 agent tests pass
- [x] Cron skill-filter tests pass
- [x] TypeScript type check (`pnpm tsgo`) passes
- [x] Lint clean


Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes stale skill snapshot caching by ensuring sessions detect and refresh outdated skill prompts after gateway restarts or when invoked via `openclaw agent`. The changes add version checking to the agent command path and harden the staleness detection logic to handle version resets.

- Bumps the global `snapshotVersion` counter on gateway startup so existing sessions detect their cached snapshots as stale
- Adds `shouldRefreshSnapshot` logic to `agent.ts` (hooks/cron path), which previously only rebuilt snapshots for new sessions or missing snapshots
- Hardens the version comparison in `session-updates.ts` to handle the zero-version edge case when the in-memory counter resets (CLI invocations outside gateway process)
- Includes comprehensive tests covering both stale version detection and post-restart scenarios

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified issues
- The implementation correctly addresses the stated problem with clean, focused changes. The logic handles all edge cases (gateway restart, CLI invocations, version resets). Tests thoroughly cover both normal staleness detection and the zero-version restart scenario. The changes follow existing patterns in the codebase and are isolated to the skill snapshot refresh logic.
- No files require special attention

<sub>Last reviewed commit: dfef7d1</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->