### PR TITLE
fix(agents): enforce config runTimeoutSeconds as minimum floor for subagent timeouts

### DIFF
--- a/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts
@@ -85,4 +85,5 @@ describe("sessions_spawn default runTimeoutSeconds", () => {
     const calls = await getGatewayCalls();
     const agentCall = findLastCall(calls, (call) => call.method === "agent");
     expect(agentCall?.params?.timeout).toBe(900);
+  });
 });

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts
@@ -67,13 +67,22 @@ describe("sessions_spawn default runTimeoutSeconds", () => {
     expect(agentCall?.params?.timeout).toBe(900);
   });
 
-  it("explicit runTimeoutSeconds wins over config default", async () => {
+  it("explicit runTimeoutSeconds above floor wins over config default", async () => {
     const tool = createSessionsSpawnTool({ agentSessionKey: "agent:test:main" });
-    const result = await tool.execute("call-2", { task: "hello", runTimeoutSeconds: 300 });
+    const result = await tool.execute("call-2", { task: "hello", runTimeoutSeconds: 1200 });
     expect(result.details).toMatchObject({ status: "accepted" });
 
     const calls = await getGatewayCalls();
     const agentCall = findLastCall(calls, (call) => call.method === "agent");
-    expect(agentCall?.params?.timeout).toBe(300);
+    expect(agentCall?.params?.timeout).toBe(1200);
   });
+
+  it("explicit runTimeoutSeconds below floor is raised to config default", async () => {
+    const tool = createSessionsSpawnTool({ agentSessionKey: "agent:test:main" });
+    const result = await tool.execute("call-3", { task: "hello", runTimeoutSeconds: 300 });
+    expect(result.details).toMatchObject({ status: "accepted" });
+
+    const calls = await getGatewayCalls();
+    const agentCall = findLastCall(calls, (call) => call.method === "agent");
+    expect(agentCall?.params?.timeout).toBe(900);
 });


### PR DESCRIPTION
## Summary
- `agents.defaults.subagents.runTimeoutSeconds` previously acted only as a default when the LLM omitted the parameter. LLMs frequently ignore prompt instructions and pass low values (e.g. 60s), overriding the config entirely.
- Changed semantics so the config value acts as a **minimum floor**: `Math.max(llmValue, configValue)`. The LLM can still request *longer* timeouts, but cannot go below the configured floor.
- Preserves existing behavior when config is unset (0 = no timeout).

Fixes #25810

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Changed `agents.defaults.subagents.runTimeoutSeconds` from a default value (used when LLM omits the parameter) to a minimum floor (enforced via `Math.max(paramTimeout, cfgSubagentTimeout)`), preventing LLMs from setting timeouts below the configured value.

**Issues found:**
- Test `openclaw-tools.subagents.sessions-spawn-default-timeout.test.ts:70-78` will fail: expects explicit `runTimeoutSeconds: 300` to use 300 when config is 900, but now uses max(300, 900) = 900
- Documentation in `docs/gateway/configuration-reference.md:1701` and `docs/tools/subagents.md` describes this as a "default" not a floor
- zh-CN docs also need updates

<h3>Confidence Score: 2/5</h3>

- This PR has a critical test failure and incomplete documentation updates
- The code logic change itself is straightforward and addresses the stated problem (LLMs ignoring timeout instructions). However, the PR breaks an existing test that explicitly validates the old behavior where explicit parameters override config defaults. Additionally, user-facing documentation wasn't updated to reflect the semantic change from "default" to "minimum floor". These issues make this unsafe to merge without fixes.
- Tests need updating to reflect new floor behavior, and documentation needs to be updated in `docs/gateway/configuration-reference.md` and `docs/tools/subagents.md`

<sub>Last reviewed commit: dd3798e</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->