### PR TITLE
feat(discord): support permission_overwrites for channel-create/channel-edit

### DIFF
--- a/src/agents/tools/discord-actions.test.ts
+++ b/src/agents/tools/discord-actions.test.ts
@@ -697,4 +697,49 @@ describe("handleDiscordAction per-account gating", () => {
       { accountId: "ops" },
     );
   });
+
+  it("passes permission_overwrites through channel create/edit actions", async () => {
+    const cfg = {
+      channels: {
+        discord: {
+          actions: { channels: true },
+        },
+      },
+    } as OpenClawConfig;
+
+    const overwrites = [
+      { id: "G1", type: 0 as const, deny: "1024" },
+      { id: "U1", type: 1 as const, allow: "1024" },
+    ];
+
+    await handleDiscordAction(
+      {
+        action: "channelCreate",
+        guildId: "G1",
+        name: "private-room",
+        permissionOverwrites: overwrites,
+      },
+      cfg,
+    );
+
+    expect(createChannelDiscord).toHaveBeenCalledWith(
+      expect.objectContaining({ permissionOverwrites: overwrites }),
+    );
+
+    await handleDiscordAction(
+      {
+        action: "channelEdit",
+        channelId: "C1",
+        permission_overwrites: overwrites,
+      },
+      cfg,
+    );
+
+    expect(editChannelDiscord).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: "C1",
+        permissionOverwrites: overwrites,
+      }),
+    );
+  });
 });

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -374,6 +374,15 @@ function buildPresenceSchema() {
 }
 
 function buildChannelManagementSchema() {
+  const permissionOverwriteSchema = Type.Object({
+    id: Type.String({ description: "Role/user id for permission overwrite." }),
+    type: Type.Union([
+      Type.Number({ description: "0=role, 1=member" }),
+      Type.String({ description: "role|member|0|1" }),
+    ]),
+    allow: Type.Optional(Type.String({ description: "Discord allow bitfield string." })),
+    deny: Type.Optional(Type.String({ description: "Discord deny bitfield string." })),
+  });
   return {
     name: Type.Optional(Type.String()),
     type: Type.Optional(Type.Number()),
@@ -383,6 +392,17 @@ function buildChannelManagementSchema() {
     nsfw: Type.Optional(Type.Boolean()),
     rateLimitPerUser: Type.Optional(Type.Number()),
     categoryId: Type.Optional(Type.String()),
+    permission_overwrites: Type.Optional(
+      Type.Array(permissionOverwriteSchema, {
+        description:
+          "Discord channel permission overwrites for channel-create/channel-edit.",
+      }),
+    ),
+    permissionOverwrites: Type.Optional(
+      Type.Array(permissionOverwriteSchema, {
+        description: "Alias of permission_overwrites.",
+      }),
+    ),
     clearParent: Type.Optional(
       Type.Boolean({
         description: "Clear the parent/category when supported by the provider.",

--- a/src/discord/send.channels.ts
+++ b/src/discord/send.channels.ts
@@ -32,6 +32,9 @@ export async function createChannelDiscord(
   if (payload.nsfw !== undefined) {
     body.nsfw = payload.nsfw;
   }
+  if (payload.permissionOverwrites !== undefined) {
+    body.permission_overwrites = payload.permissionOverwrites;
+  }
   return (await rest.post(Routes.guildChannels(payload.guildId), {
     body,
   })) as APIChannel;
@@ -78,6 +81,9 @@ export async function editChannelDiscord(
       ...(t.emoji_id !== undefined && { emoji_id: t.emoji_id }),
       ...(t.emoji_name !== undefined && { emoji_name: t.emoji_name }),
     }));
+  }
+  if (payload.permissionOverwrites !== undefined) {
+    body.permission_overwrites = payload.permissionOverwrites;
   }
   return (await rest.patch(Routes.channel(payload.channelId), {
     body,

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -124,6 +124,13 @@ export type DiscordStickerUpload = {
   mediaUrl: string;
 };
 
+export type DiscordPermissionOverwrite = {
+  id: string;
+  type: 0 | 1;
+  allow?: string;
+  deny?: string;
+};
+
 export type DiscordChannelCreate = {
   guildId: string;
   name: string;
@@ -132,6 +139,7 @@ export type DiscordChannelCreate = {
   topic?: string;
   position?: number;
   nsfw?: boolean;
+  permissionOverwrites?: DiscordPermissionOverwrite[];
 };
 
 export type DiscordForumTag = {
@@ -154,6 +162,7 @@ export type DiscordChannelEdit = {
   locked?: boolean;
   autoArchiveDuration?: number;
   availableTags?: DiscordForumTag[];
+  permissionOverwrites?: DiscordPermissionOverwrite[];
 };
 
 export type DiscordChannelMove = {


### PR DESCRIPTION
## Summary
Adds first-class `permission_overwrites` support for Discord channel create/edit flows end-to-end.

## What changed
- Message tool schema now exposes:
  - `permission_overwrites`
  - alias `permissionOverwrites`
- Discord action handlers parse and validate overwrite entries (id/type/allow/deny).
- Guild action plumbing forwards overwrites to Discord send layer.
- Discord REST channel create/edit payload builders now set `body.permission_overwrites`.
- Added/updated test coverage for overwrite passthrough in guild actions.

## Why
Without overwrite passthrough, private-by-default channel creation cannot be automated safely, because `@everyone` view deny cannot be applied at create/edit time.

## Related
- Closes/addresses openclaw/openclaw#26197

## Notes
I couldn't run the full test suite in this environment because `pnpm` is unavailable on host, but changes are scoped and compile-level consistent with existing patterns.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds first-class support for Discord `permission_overwrites` in channel create/edit operations, enabling private-by-default channel creation by allowing permission overrides at creation time.

**Key changes:**
- Exposed `permission_overwrites` and alias `permissionOverwrites` in message tool schema
- Added parsing/validation for overwrite entries (id/type/allow/deny) in action handlers
- Forwarded overwrites through Discord REST API payload builders
- Added test coverage for overwrite passthrough

**Issues found:**
- Tool schema uses `Type.Union` which violates repository's google-antigravity guardrails (CLAUDE.md:200)
- Duplicated `readPermissionOverwritesParam` function in two files

<h3>Confidence Score: 3/5</h3>

- Safe to merge after addressing the Type.Union schema issue
- The PR correctly implements permission overwrites end-to-end with proper validation and tests. However, it violates the repository's tool schema guardrails by using Type.Union, which could cause compatibility issues with certain validators. The code duplication is a style issue but doesn't affect functionality.
- src/agents/tools/message-tool.ts requires fixing the Type.Union usage before merge

<sub>Last reviewed commit: d4523ac</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=fd949e91-5c3a-4ab5-90a1-cbe184fd6ce8))

<!-- /greptile_comment -->