### PR TITLE
fix(security): fail-closed SSRF protection for node camera downloads

### DIFF
--- a/src/agents/openclaw-tools.camera.test.ts
+++ b/src/agents/openclaw-tools.camera.test.ts
@@ -34,7 +34,7 @@ async function executeNodes(input: Record<string, unknown>) {
 
 function mockNodeList(commands?: string[]) {
   return {
-    nodes: [{ nodeId: NODE_ID, ...(commands ? { commands } : {}) }],
+    nodes: [{ nodeId: NODE_ID, remoteIp: "10.0.0.5", ...(commands ? { commands } : {}) }],
   };
 }
 
@@ -146,6 +146,35 @@ describe("nodes camera_snap", () => {
         deviceId: "cam-123",
       }),
     ).rejects.toThrow(/facing=both is not allowed when deviceId is set/i);
+  });
+
+  it("fails closed when remoteIp is missing", async () => {
+    callGateway.mockImplementation(async ({ method }) => {
+      if (method === "node.list") {
+        return {
+          nodes: [{ nodeId: NODE_ID }],
+        };
+      }
+      if (method === "node.invoke") {
+        return {
+          payload: {
+            format: "jpg",
+            base64: "aGVsbG8=",
+            width: 1,
+            height: 1,
+          },
+        };
+      }
+      return unexpectedGatewayMethod(method);
+    });
+
+    await expect(
+      executeNodes({
+        action: "camera_snap",
+        node: NODE_ID,
+        facing: "front",
+      }),
+    ).rejects.toThrow(/camera_snap requires node\.remoteIp/i);
   });
 });
 

--- a/src/agents/tools/nodes-tool.ts
+++ b/src/agents/tools/nodes-tool.ts
@@ -1,7 +1,6 @@
+import crypto from "node:crypto";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import { Type } from "@sinclair/typebox";
-import crypto from "node:crypto";
-import type { OpenClawConfig } from "../../config/config.js";
 import {
   type CameraFacing,
   cameraTempPath,

--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -12,16 +12,25 @@ import {
 } from "./nodes-camera.js";
 import { parseScreenRecordPayload, screenRecordTempPath } from "./nodes-screen.js";
 
+const { fetchWithSsrFGuardMock } = vi.hoisted(() => ({
+  fetchWithSsrFGuardMock: vi.fn(),
+}));
+
+vi.mock("../infra/net/fetch-guard.js", () => ({
+  fetchWithSsrFGuard: (...args: unknown[]) => fetchWithSsrFGuardMock(...args),
+}));
+
 async function withCameraTempDir<T>(run: (dir: string) => Promise<T>): Promise<T> {
   return await withTempDir("openclaw-test-", run);
 }
 
 describe("nodes camera helpers", () => {
-  function stubFetchResponse(response: Response) {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => response),
-    );
+  function stubGuardedFetchResponse(response: Response) {
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response,
+      finalUrl: "https://example.com/final",
+      release: vi.fn(async () => {}),
+    });
   }
 
   it("parses camera.snap payload", () => {
@@ -93,7 +102,7 @@ describe("nodes camera helpers", () => {
   });
 
   it("writes camera clip payload from url", async () => {
-    stubFetchResponse(new Response("url-clip", { status: 200 }));
+    stubGuardedFetchResponse(new Response("url-clip", { status: 200 }));
     await withCameraTempDir(async (dir) => {
       const out = await writeCameraClipPayloadToFile({
         payload: {
@@ -103,6 +112,7 @@ describe("nodes camera helpers", () => {
           hasAudio: false,
         },
         facing: "back",
+        expectedHost: "example.com",
         tmpDir: dir,
         id: "clip2",
       });
@@ -120,14 +130,14 @@ describe("nodes camera helpers", () => {
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
+    fetchWithSsrFGuardMock.mockReset();
   });
 
   it("writes url payload to file", async () => {
-    stubFetchResponse(new Response("url-content", { status: 200 }));
+    stubGuardedFetchResponse(new Response("url-content", { status: 200 }));
     await withCameraTempDir(async (dir) => {
       const out = path.join(dir, "x.bin");
-      await writeUrlToFile(out, "https://example.com/clip.mp4");
+      await writeUrlToFile(out, "https://example.com/clip.mp4", "example.com");
       await expect(fs.readFile(out, "utf8")).resolves.toBe("url-content");
     });
   });
@@ -169,12 +179,25 @@ describe("nodes camera helpers", () => {
 
     for (const testCase of cases) {
       if (testCase.response) {
-        stubFetchResponse(testCase.response);
+        stubGuardedFetchResponse(testCase.response);
       }
-      await expect(writeUrlToFile("/tmp/ignored", testCase.url), testCase.name).rejects.toThrow(
-        testCase.expectedMessage,
-      );
+      await expect(
+        writeUrlToFile("/tmp/ignored", testCase.url, "example.com"),
+        testCase.name,
+      ).rejects.toThrow(testCase.expectedMessage);
     }
+  });
+
+  it("rejects when expectedHost is missing", async () => {
+    await expect(writeUrlToFile("/tmp/ignored", "https://example.com/x.bin", "")).rejects.toThrow(
+      /expectedHost is required/i,
+    );
+  });
+
+  it("rejects url host mismatch", async () => {
+    await expect(
+      writeUrlToFile("/tmp/ignored", "https://example.com/x.bin", "10.0.0.4"),
+    ).rejects.toThrow(/does not match expected host/i);
   });
 
   it("removes partially written file when url stream fails", async () => {
@@ -184,13 +207,13 @@ describe("nodes camera helpers", () => {
         controller.error(new Error("stream exploded"));
       },
     });
-    stubFetchResponse(new Response(stream, { status: 200 }));
+    stubGuardedFetchResponse(new Response(stream, { status: 200 }));
 
     await withCameraTempDir(async (dir) => {
       const out = path.join(dir, "broken.bin");
-      await expect(writeUrlToFile(out, "https://example.com/broken.bin")).rejects.toThrow(
-        /stream exploded/i,
-      );
+      await expect(
+        writeUrlToFile(out, "https://example.com/broken.bin", "example.com"),
+      ).rejects.toThrow(/stream exploded/i);
       await expect(fs.stat(out)).rejects.toThrow();
     });
   });

--- a/src/cli/nodes-camera.test.ts
+++ b/src/cli/nodes-camera.test.ts
@@ -93,6 +93,7 @@ describe("nodes camera helpers", () => {
           hasAudio: false,
         },
         facing: "front",
+        expectedHost: "10.0.0.5",
         tmpDir: dir,
         id: "clip1",
       });

--- a/src/cli/nodes-camera.ts
+++ b/src/cli/nodes-camera.ts
@@ -1,5 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import { normalizeHostname } from "../infra/net/hostname.js";
 import { resolveCliName } from "./cli-name.js";
 import {
   asBoolean,
@@ -72,67 +74,89 @@ export function cameraTempPath(opts: {
   return path.join(tmpDir, `${cliName}-camera-${opts.kind}${facingPart}-${id}${ext}`);
 }
 
-export async function writeUrlToFile(filePath: string, url: string) {
+export async function writeUrlToFile(filePath: string, url: string, expectedHost: string) {
+  const normalizedExpectedHost = normalizeHostname(expectedHost);
+  if (!normalizedExpectedHost) {
+    throw new Error("writeUrlToFile: expectedHost is required");
+  }
+
   const parsed = new URL(url);
   if (parsed.protocol !== "https:") {
     throw new Error(`writeUrlToFile: only https URLs are allowed, got ${parsed.protocol}`);
   }
-
-  const res = await fetch(url);
-  if (!res.ok) {
-    throw new Error(`failed to download ${url}: ${res.status} ${res.statusText}`);
-  }
-
-  const contentLengthRaw = res.headers.get("content-length");
-  const contentLength = contentLengthRaw ? Number.parseInt(contentLengthRaw, 10) : undefined;
-  if (
-    typeof contentLength === "number" &&
-    Number.isFinite(contentLength) &&
-    contentLength > MAX_CAMERA_URL_DOWNLOAD_BYTES
-  ) {
+  if (normalizeHostname(parsed.hostname) !== normalizedExpectedHost) {
     throw new Error(
-      `writeUrlToFile: content-length ${contentLength} exceeds max ${MAX_CAMERA_URL_DOWNLOAD_BYTES}`,
+      `writeUrlToFile: URL hostname ${parsed.hostname} does not match expected host ${normalizedExpectedHost}`,
     );
   }
 
-  const body = res.body;
-  if (!body) {
-    throw new Error(`failed to download ${url}: empty response body`);
-  }
+  const { response: res, release } = await fetchWithSsrFGuard({
+    url,
+    policy: {
+      allowedHostnames: [normalizedExpectedHost],
+      hostnameAllowlist: [normalizedExpectedHost],
+    },
+    auditContext: "nodes-camera",
+  });
 
-  const fileHandle = await fs.open(filePath, "w");
-  let bytes = 0;
-  let thrown: unknown;
   try {
-    const reader = body.getReader();
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        break;
-      }
-      if (!value || value.byteLength === 0) {
-        continue;
-      }
-      bytes += value.byteLength;
-      if (bytes > MAX_CAMERA_URL_DOWNLOAD_BYTES) {
-        throw new Error(
-          `writeUrlToFile: downloaded ${bytes} bytes, exceeds max ${MAX_CAMERA_URL_DOWNLOAD_BYTES}`,
-        );
-      }
-      await fileHandle.write(value);
+    if (!res.ok) {
+      throw new Error(`failed to download ${url}: ${res.status} ${res.statusText}`);
     }
-  } catch (err) {
-    thrown = err;
+
+    const contentLengthRaw = res.headers.get("content-length");
+    const contentLength = contentLengthRaw ? Number.parseInt(contentLengthRaw, 10) : undefined;
+    if (
+      typeof contentLength === "number" &&
+      Number.isFinite(contentLength) &&
+      contentLength > MAX_CAMERA_URL_DOWNLOAD_BYTES
+    ) {
+      throw new Error(
+        `writeUrlToFile: content-length ${contentLength} exceeds max ${MAX_CAMERA_URL_DOWNLOAD_BYTES}`,
+      );
+    }
+
+    const body = res.body;
+    if (!body) {
+      throw new Error(`failed to download ${url}: empty response body`);
+    }
+
+    const fileHandle = await fs.open(filePath, "w");
+    let bytes = 0;
+    let thrown: unknown;
+    try {
+      const reader = body.getReader();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        if (!value || value.byteLength === 0) {
+          continue;
+        }
+        bytes += value.byteLength;
+        if (bytes > MAX_CAMERA_URL_DOWNLOAD_BYTES) {
+          throw new Error(
+            `writeUrlToFile: downloaded ${bytes} bytes, exceeds max ${MAX_CAMERA_URL_DOWNLOAD_BYTES}`,
+          );
+        }
+        await fileHandle.write(value);
+      }
+    } catch (err) {
+      thrown = err;
+    } finally {
+      await fileHandle.close();
+    }
+
+    if (thrown) {
+      await fs.unlink(filePath).catch(() => {});
+      throw thrown;
+    }
+
+    return { path: filePath, bytes };
   } finally {
-    await fileHandle.close();
+    await release();
   }
-
-  if (thrown) {
-    await fs.unlink(filePath).catch(() => {});
-    throw thrown;
-  }
-
-  return { path: filePath, bytes };
 }
 
 export async function writeBase64ToFile(filePath: string, base64: string) {
@@ -144,6 +168,7 @@ export async function writeBase64ToFile(filePath: string, base64: string) {
 export async function writeCameraClipPayloadToFile(params: {
   payload: CameraClipPayload;
   facing: CameraFacing;
+  expectedHost: string;
   tmpDir?: string;
   id?: string;
 }): Promise<string> {
@@ -155,7 +180,7 @@ export async function writeCameraClipPayloadToFile(params: {
     id: params.id,
   });
   if (params.payload.url) {
-    await writeUrlToFile(filePath, params.payload.url);
+    await writeUrlToFile(filePath, params.payload.url, params.expectedHost);
   } else if (params.payload.base64) {
     await writeBase64ToFile(filePath, params.payload.base64);
   } else {

--- a/src/cli/nodes-cli/register.camera.ts
+++ b/src/cli/nodes-cli/register.camera.ts
@@ -1,5 +1,4 @@
 import type { Command } from "commander";
-import type { NodeListNode, NodesRpcOpts } from "./types.js";
 import { defaultRuntime } from "../../runtime.js";
 import { renderTable } from "../../terminal/table.js";
 import { shortenHomePath } from "../../utils.js";
@@ -21,6 +20,7 @@ import {
   resolveNode,
   resolveNodeId,
 } from "./rpc.js";
+import type { NodeListNode, NodesRpcOpts } from "./types.js";
 
 function requireNodeRemoteIp(node: NodeListNode, action: string): string {
   const remoteIp = typeof node.remoteIp === "string" ? node.remoteIp.trim() : "";

--- a/src/cli/nodes-cli/register.camera.ts
+++ b/src/cli/nodes-cli/register.camera.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import type { NodeListNode, NodesRpcOpts } from "./types.js";
 import { defaultRuntime } from "../../runtime.js";
 import { renderTable } from "../../terminal/table.js";
 import { shortenHomePath } from "../../utils.js";
@@ -13,8 +14,21 @@ import {
 } from "../nodes-camera.js";
 import { parseDurationMs } from "../parse-duration.js";
 import { getNodesTheme, runNodesCommand } from "./cli-utils.js";
-import { buildNodeInvokeParams, callGatewayCli, nodesCallOpts, resolveNodeId } from "./rpc.js";
-import type { NodesRpcOpts } from "./types.js";
+import {
+  buildNodeInvokeParams,
+  callGatewayCli,
+  nodesCallOpts,
+  resolveNode,
+  resolveNodeId,
+} from "./rpc.js";
+
+function requireNodeRemoteIp(node: NodeListNode, action: string): string {
+  const remoteIp = typeof node.remoteIp === "string" ? node.remoteIp.trim() : "";
+  if (!remoteIp) {
+    throw new Error(`${action} requires node.remoteIp`);
+  }
+  return remoteIp;
+}
 
 const parseFacing = (value: string): CameraFacing => {
   const v = String(value ?? "")
@@ -102,7 +116,9 @@ export function registerNodesCameraCommands(nodes: Command) {
       .option("--invoke-timeout <ms>", "Node invoke timeout in ms (default 20000)", "20000")
       .action(async (opts: NodesRpcOpts) => {
         await runNodesCommand("camera snap", async () => {
-          const nodeId = await resolveNodeId(opts, String(opts.node ?? ""));
+          const node = await resolveNode(opts, String(opts.node ?? ""));
+          const nodeId = node.nodeId;
+          const expectedHost = requireNodeRemoteIp(node, "camera snap");
           const facingOpt = String(opts.facing ?? "both")
             .trim()
             .toLowerCase();
@@ -160,7 +176,7 @@ export function registerNodesCameraCommands(nodes: Command) {
               ext: payload.format === "jpeg" ? "jpg" : payload.format,
             });
             if (payload.url) {
-              await writeUrlToFile(filePath, payload.url);
+              await writeUrlToFile(filePath, payload.url, expectedHost);
             } else if (payload.base64) {
               await writeBase64ToFile(filePath, payload.base64);
             }
@@ -198,7 +214,9 @@ export function registerNodesCameraCommands(nodes: Command) {
       .option("--invoke-timeout <ms>", "Node invoke timeout in ms (default 90000)", "90000")
       .action(async (opts: NodesRpcOpts & { audio?: boolean }) => {
         await runNodesCommand("camera clip", async () => {
-          const nodeId = await resolveNodeId(opts, String(opts.node ?? ""));
+          const node = await resolveNode(opts, String(opts.node ?? ""));
+          const nodeId = node.nodeId;
+          const expectedHost = requireNodeRemoteIp(node, "camera clip");
           const facing = parseFacing(String(opts.facing ?? "front"));
           const durationMs = parseDurationMs(String(opts.duration ?? "3000"));
           const includeAudio = opts.audio !== false;
@@ -226,6 +244,7 @@ export function registerNodesCameraCommands(nodes: Command) {
           const filePath = await writeCameraClipPayloadToFile({
             payload,
             facing,
+            expectedHost,
           });
 
           if (opts.json) {

--- a/src/cli/nodes-cli/rpc.ts
+++ b/src/cli/nodes-cli/rpc.ts
@@ -1,10 +1,10 @@
 import type { Command } from "commander";
-import type { NodeListNode, NodesRpcOpts } from "./types.js";
 import { callGateway, randomIdempotencyKey } from "../../gateway/call.js";
 import { resolveNodeIdFromCandidates } from "../../shared/node-match.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
 import { withProgress } from "../progress.js";
 import { parseNodeList, parsePairingList } from "./format.js";
+import type { NodeListNode, NodesRpcOpts } from "./types.js";
 
 export const nodesCallOpts = (cmd: Command, defaults?: { timeoutMs?: number }) =>
   cmd

--- a/src/cli/nodes-cli/rpc.ts
+++ b/src/cli/nodes-cli/rpc.ts
@@ -1,10 +1,10 @@
 import type { Command } from "commander";
+import type { NodeListNode, NodesRpcOpts } from "./types.js";
 import { callGateway, randomIdempotencyKey } from "../../gateway/call.js";
 import { resolveNodeIdFromCandidates } from "../../shared/node-match.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../../utils/message-channel.js";
 import { withProgress } from "../progress.js";
 import { parseNodeList, parsePairingList } from "./format.js";
-import type { NodeListNode, NodesRpcOpts } from "./types.js";
 
 export const nodesCallOpts = (cmd: Command, defaults?: { timeoutMs?: number }) =>
   cmd
@@ -72,20 +72,14 @@ export function unauthorizedHintForMessage(message: string): string | null {
   return null;
 }
 
-export async function resolveNodeId(opts: NodesRpcOpts, query: string) {
-  const q = String(query ?? "").trim();
-  if (!q) {
-    throw new Error("node required");
-  }
-
-  let nodes: NodeListNode[] = [];
+async function listNodesCli(opts: NodesRpcOpts): Promise<NodeListNode[]> {
   try {
     const res = await callGatewayCli("node.list", opts, {});
-    nodes = parseNodeList(res);
+    return parseNodeList(res);
   } catch {
     const res = await callGatewayCli("node.pair.list", opts, {});
     const { paired } = parsePairingList(res);
-    nodes = paired.map((n) => ({
+    return paired.map((n) => ({
       nodeId: n.nodeId,
       displayName: n.displayName,
       platform: n.platform,
@@ -93,5 +87,27 @@ export async function resolveNodeId(opts: NodesRpcOpts, query: string) {
       remoteIp: n.remoteIp,
     }));
   }
+}
+
+export async function resolveNodeId(opts: NodesRpcOpts, query: string) {
+  const q = String(query ?? "").trim();
+  if (!q) {
+    throw new Error("node required");
+  }
+  const nodes = await listNodesCli(opts);
   return resolveNodeIdFromCandidates(nodes, q);
+}
+
+export async function resolveNode(opts: NodesRpcOpts, query: string): Promise<NodeListNode> {
+  const q = String(query ?? "").trim();
+  if (!q) {
+    throw new Error("node required");
+  }
+  const nodes = await listNodesCli(opts);
+  const nodeId = resolveNodeIdFromCandidates(nodes, q);
+  const node = nodes.find((n) => n.nodeId === nodeId);
+  if (!node) {
+    throw new Error(`node not found: ${nodeId}`);
+  }
+  return node;
 }

--- a/src/cli/program.nodes-media.test.ts
+++ b/src/cli/program.nodes-media.test.ts
@@ -340,7 +340,7 @@ describe("cli program (nodes media)", () => {
         command: "camera.snap" as const,
         payload: {
           format: "jpg",
-          url: "https://example.com/photo.jpg",
+          url: "http://192.168.0.88/photo.jpg",
           width: 640,
           height: 480,
         },
@@ -352,7 +352,7 @@ describe("cli program (nodes media)", () => {
         command: "camera.clip" as const,
         payload: {
           format: "mp4",
-          url: "https://example.com/clip.mp4",
+          url: "https://192.168.0.88/clip.mp4",
           durationMs: 5000,
           hasAudio: true,
         },


### PR DESCRIPTION
## Summary

Addresses the concerns raised when closing #21145 about fail-open paths in security-sensitive code.

## What changed

The previous implementation had `expectedHost` as optional, which meant enforcement could silently drop to weaker behavior when node metadata was incomplete.

### This PR makes it fail-closed:

1. **`expectedHost` is now required** — `writeUrlToFile(filePath, url, expectedHost)` signature enforces this at compile time

2. **`requireNodeRemoteIp()`** — explicitly throws if `node.remoteIp` is missing or empty:
   ```typescript
   function requireNodeRemoteIp(node: NodeListNode, action: string): string {
     const remoteIp = typeof node.remoteIp === "string" ? node.remoteIp.trim() : "";
     if (!remoteIp) {
       throw new Error(`${action} requires node.remoteIp`);
     }
     return remoteIp;
   }
   ```

3. **Pre-validation** — hostname is validated before fetch to fail fast on mismatch

4. **Host-bound fetch** — uses `fetchWithSsrFGuard` with `allowedHostnames` policy to restrict downloads to the resolved node host

## Why this approach

Per the closure comment on #21145:
> host binding depends on optional node metadata (`remoteIp`), so enforcement can silently drop to weaker behavior

This PR ensures:
- No optional fallback — missing `remoteIp` = explicit error
- No silent degradation — the operation fails rather than proceeding unguarded
- Narrower attack surface — only the specific node host is allowed

## Tests

All 24 tests pass:
- `src/cli/nodes-camera.test.ts` (17 tests)
- `src/agents/openclaw-tools.camera.test.ts` (7 tests)

Fixes #21151

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR strengthens SSRF protection for node camera downloads by enforcing fail-closed security instead of fail-open behavior. The key change is making `node.remoteIp` mandatory — downloads now explicitly fail if this metadata is missing rather than silently proceeding with weaker protections.

**Major changes:**
- Made `expectedHost` a required parameter in `writeUrlToFile()` (enforced at compile time)
- Added `requireNodeRemoteIp()` helper that throws explicitly when `node.remoteIp` is missing/empty
- Added pre-validation of hostname before fetch to fail fast on mismatches
- Integrated `fetchWithSsrFGuard` with hostname allowlist policy to restrict downloads to the specific node host only
- Updated both `camera_snap` and `camera_clip` actions to resolve the full node object and extract `remoteIp` before processing

**Test coverage:**
- Added test for fail-closed behavior when `remoteIp` is missing (throws error)
- Added test for `expectedHost` validation (empty string rejected)
- Added test for hostname mismatch detection
- All 24 existing tests pass, confirming backward compatibility for valid cases

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it strengthens security without breaking existing functionality
- The implementation follows security best practices by enforcing fail-closed behavior, has comprehensive test coverage including edge cases (missing remoteIp, hostname mismatch), all 24 tests pass, and the changes are minimal and focused. The PR addresses a real security concern (silent degradation of SSRF protection) with a clear, type-safe solution.
- No files require special attention

<sub>Last reviewed commit: 37885f2</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->