### PR TITLE
fix(usage): extract UUID from timestamped session filenames for channel attribution

### DIFF
--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -248,6 +248,19 @@ const parseDateRange = (params: {
 
 type DiscoveredSessionWithAgent = DiscoveredSession & { agentId: string };
 
+/**
+ * Pi-SDK session transcript filenames use "<timestamp>_<UUID>.jsonl" where
+ * the timestamp is an ISO date with colons/dots replaced by dashes.
+ * This helper extracts the UUID when the filename matches that shape,
+ * returning `undefined` for all other formats.
+ */
+const PI_SDK_TS_RE =
+  /^\d{4}-\d{2}-\d{2}T[\d-]+Z?_([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i;
+
+function extractUuidFromTimestampedId(sessionId: string): string | undefined {
+  return PI_SDK_TS_RE.exec(sessionId)?.[1];
+}
+
 function buildStoreBySessionId(
   store: Record<string, SessionEntry>,
 ): Map<string, { key: string; entry: SessionEntry }> {
@@ -468,11 +481,24 @@ export const usageHandlers: GatewayRequestHandlers = {
       const storeBySessionId = buildStoreBySessionId(store);
 
       for (const discovered of discoveredSessions) {
-        const storeMatch = storeBySessionId.get(discovered.sessionId);
+        // Pi-SDK timestamped files use "<timestamp>_<UUID>.jsonl" but the
+        // session store indexes by plain UUID — try both for matching.
+        const directMatch = storeBySessionId.get(discovered.sessionId);
+        const uuidFallback = !directMatch
+          ? extractUuidFromTimestampedId(discovered.sessionId)
+          : undefined;
+        const storeMatch =
+          directMatch ?? (uuidFallback ? storeBySessionId.get(uuidFallback) : undefined);
         if (storeMatch) {
-          // Named session from store
+          // Use the store key when the store entry has a sessionFile that
+          // detail handlers can resolve. For UUID-fallback matches where the
+          // entry might lack sessionFile, keep the discovered key so the
+          // raw filename stem is available for path resolution.
+          const useStoreKey = directMatch || storeMatch.entry.sessionFile?.trim();
           mergedEntries.push({
-            key: storeMatch.key,
+            key: useStoreKey
+              ? storeMatch.key
+              : `agent:${discovered.agentId}:${discovered.sessionId}`,
             sessionId: discovered.sessionId,
             sessionFile: discovered.sessionFile,
             label: storeMatch.entry.label,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Pi-SDK creates session transcript files as `<timestamp>_<UUID>.jsonl` but the session store indexes by plain UUID. `discoverAllSessions()` returns the raw filename stem (including timestamp prefix), so `storeBySessionId.get(discovered.sessionId)` never matches — all sessions lose channel attribution.
- Why it matters: Usage dashboard "Top Channels" shows all sessions as unnamed with no channel info.
- What changed: Added UUID extraction fallback in the store lookup (`usage.ts`). When a direct sessionId match fails, the code detects the pi-SDK timestamp pattern and retries with the extracted UUID. Added safeguards for detail handler file resolution when store entries lack `sessionFile`.
- What did NOT change (scope boundary): `discoverAllSessions()` still returns the raw filename stem — file path resolution is preserved. Session store format unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #17775

## User-visible / Behavior Changes

Usage dashboard "Top Channels" and per-session channel attribution now correctly resolve for sessions created by pi-SDK (timestamped filenames).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22+ / Bun
- Model/provider: N/A
- Integration/channel (if any): Any channel (iMessage, WhatsApp, Telegram, etc.)
- Relevant config (redacted): N/A

### Steps

1. Process messages via any non-webchat channel
2. Open usage dashboard ("Top Channels")
3. Observe sessions attributed to the channel

### Expected

- Sessions show channel name (e.g., "iMessage", "WhatsApp") in usage dashboard

### Actual

- All sessions show as unnamed with no channel attribution

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

3 new tests added:
1. `preserves raw filename stem as sessionId for all filename formats` — verifies `discoverAllSessions` returns raw filename stems
2. `matches timestamped pi-SDK filenames to store entries by extracted UUID` — verifies UUID fallback lookup works when store entry has `sessionFile`
3. `keeps discovered key for UUID fallback when store entry lacks sessionFile` — verifies detail handlers can resolve files when store metadata is incomplete

All 18 tests pass (10 in session-cost-usage, 8 in usage.sessions-usage).

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Traced session file creation at `session.ts:134` (`${fileTimestamp}_${sessionId}.jsonl`) confirming the pi-SDK timestamp format. Verified `storeBySessionId` indexes by plain UUID. Confirmed the UUID extraction regex only matches the exact pi-SDK ISO timestamp shape (anchored to start, requires `T`, digits, dashes, optional `Z`, underscore separator).
- Edge cases checked: Plain `<UUID>.jsonl` (no fallback needed), `customer-<uuid>.jsonl` (dash-separated — regex won't match, preserves full name), `customer_<uuid>.jsonl` (underscore-separated but lacks ISO timestamp prefix — regex won't match), store entries with and without `sessionFile` field.
- What you did **not** verify: Live usage dashboard rendering with real session data across multiple channels.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; the UUID extraction is isolated to `usage.ts`
- Files/config to restore: `src/gateway/server-methods/usage.ts`
- Known bad symptoms reviewers should watch for: Sessions appearing with wrong channel attribution or duplicate entries in usage dashboard

## Risks and Mitigations

- Risk: UUID extraction regex matches a non-pi-SDK filename that happens to start with a date-like prefix followed by underscore and UUID.
  - Mitigation: The regex is anchored to the full string (`^...$`) and requires exact ISO timestamp shape (`YYYY-MM-DDTHH-MM-SS-mmmZ`). Only the pi-SDK code path generates this pattern.
- Risk: Store entry matched via UUID fallback has no `sessionFile`, breaking detail handler resolution.
  - Mitigation: `useStoreKey` check falls back to the discovered key (containing the raw filename stem) when the store entry lacks `sessionFile`, preserving file resolution.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds UUID extraction fallback to match pi-SDK timestamped session filenames (`<timestamp>_<UUID>.jsonl`) to session store entries indexed by plain UUID. When a direct sessionId lookup fails, the code extracts the UUID from the timestamped format and retries the lookup, preserving channel attribution for the usage dashboard's "Top Channels" feature. The fix preserves file path resolution by using the discovered key when store entries lack a `sessionFile` field.

Changes:
- Added `extractUuidFromTimestampedId()` helper with regex pattern to extract UUIDs from pi-SDK timestamped filenames
- Modified session lookup logic in `usage.ts` to attempt UUID fallback when direct match fails
- Conditional key selection: uses store key when `sessionFile` is present, discovered key otherwise
- Added 3 tests covering UUID extraction, store matching with/without `sessionFile`, and filename stem preservation

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The fix is well-scoped and addresses a clear bug with channel attribution. The regex pattern is appropriately specific for the pi-SDK timestamp format, and the conditional key selection logic correctly handles both presence and absence of the `sessionFile` field. Test coverage validates all three critical scenarios: UUID extraction from timestamped filenames, store matching with `sessionFile` present, and fallback to discovered key when `sessionFile` is missing.
- No files require special attention

<sub>Last reviewed commit: a5a474a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->