### PR TITLE
fix(agents): classify overloaded errors as timeout, not rate_limit (#22294)

### DIFF
--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -490,7 +490,7 @@ describe("classifyFailoverReason", () => {
       classifyFailoverReason(
         '{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}',
       ),
-    ).toBe("rate_limit");
+    ).toBe("timeout");
     expect(classifyFailoverReason("invalid request format")).toBe("format");
     expect(classifyFailoverReason("credit balance too low")).toBe("billing");
     expect(classifyFailoverReason("deadline exceeded")).toBe("timeout");
@@ -521,18 +521,18 @@ describe("classifyFailoverReason", () => {
       "rate_limit",
     );
   });
-  it("classifies provider high-demand / service-unavailable messages as rate_limit", () => {
+  it("classifies provider high-demand / service-unavailable messages as timeout", () => {
     expect(
       classifyFailoverReason(
         "This model is currently experiencing high demand. Please try again later.",
       ),
-    ).toBe("rate_limit");
-    expect(classifyFailoverReason("LLM error: service unavailable")).toBe("rate_limit");
+    ).toBe("timeout");
+    expect(classifyFailoverReason("LLM error: service unavailable")).toBe("timeout");
     expect(
       classifyFailoverReason(
         '{"error":{"code":503,"message":"The model is overloaded. Please try later","status":"UNAVAILABLE"}}',
       ),
-    ).toBe("rate_limit");
+    ).toBe("timeout");
   });
   it("classifies permanent auth errors as auth_permanent", () => {
     expect(classifyFailoverReason("invalid_api_key")).toBe("auth_permanent");

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -801,7 +801,8 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
     return "rate_limit";
   }
   if (isOverloadedErrorMessage(raw)) {
-    return "rate_limit";
+    // Overloaded/service-unavailable errors are transient capacity issues, not quota exhaustion.
+    return "timeout";
   }
   if (isCloudCodeAssistFormatError(raw)) {
     return "format";


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `classifyFailoverReason()` returns `"rate_limit"` for overloaded/service-unavailable errors (HTTP 503, `overloaded_error`, `"service unavailable"`, `"high demand"`). These are transient capacity issues, not quota exhaustion.
- Why it matters: `"rate_limit"` increments the auth profile failure counter and triggers exponential cooldown (1 min → 5 min → 25 min → 60 min). Brief provider capacity spikes take agents offline for up to 60 minutes.
- What changed: `isOverloadedErrorMessage()` branch now returns `"timeout"` instead of `"rate_limit"`, with a clarifying comment. 4 test assertions updated to match.
- What did NOT change (scope boundary): Rate-limit detection logic is untouched. `isOverloadedErrorMessage()` predicate strings are unchanged. All other `classifyFailoverReason()` branches are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #22294
- Related #

## User-visible / Behavior Changes

Agents will no longer accumulate cooldown on auth profiles when a provider returns 503/overloaded responses. Brief capacity spikes will retry as transient errors rather than triggering multi-minute cooldowns.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 24.04)
- Runtime/container: Node 22 / Bun
- Model/provider: Any provider returning 503 or overloaded_error
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Configure an agent with a provider profile
2. Provider returns `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`
3. Observe auth profile failure counter behavior

### Expected

- `classifyFailoverReason()` returns `"timeout"` for overloaded errors
- Auth profile failure marking is skipped; no cooldown begins

### Actual

- Returned `"rate_limit"`, incremented failure counter, triggered exponential cooldown

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Read `classifyFailoverReason()` and traced full branch order. Confirmed `isOverloadedErrorMessage()` fires after `isRateLimitErrorMessage()` and before `isBillingErrorMessage()`. Confirmed `"timeout"` reason skips auth-profile failure marking at the callsite.
- Edge cases checked: Verified `isRateLimitErrorMessage()` still precedes `isOverloadedErrorMessage()` in the branch chain, so genuine 429/quota errors still classify as `"rate_limit"`.
- What you did **not** verify: Live provider integration test with a real 503 response; cooldown reset behavior in a running gateway session.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert one-line change in `src/agents/pi-embedded-helpers/errors.ts` (restore `return "rate_limit"` in the `isOverloadedErrorMessage` branch)
- Files/config to restore: `src/agents/pi-embedded-helpers/errors.ts`
- Known bad symptoms reviewers should watch for: Overloaded errors bypassing retry entirely (they still get the `"timeout"` retry path)

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: A provider that rate-limits via 503/overloaded (instead of 429) would no longer accumulate cooldown.
  - Mitigation: 503 is a capacity signal, not a quota signal. Providers use 429 for quota exhaustion. This is the correct classification per HTTP semantics.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reclassifies overloaded/503 errors from `rate_limit` to `timeout` in `classifyFailoverReason()`. Previously, HTTP 503 and overloaded_error responses triggered auth profile failure counters and exponential cooldown (up to 60 minutes), treating transient capacity issues as quota exhaustion. The fix correctly treats these as retryable timeout errors.

- Changed return value in `isOverloadedErrorMessage()` branch from `"rate_limit"` to `"timeout"` with clarifying comment
- Updated 4 test assertions to expect `"timeout"` for overloaded/high-demand/service-unavailable messages
- Auth profile failure marking is skipped for `"timeout"` reason (see `maybeMarkAuthProfileFailure` in `run.ts:526`)
- Rate limit detection logic and branch order remain unchanged - actual rate limits (429, quota errors) still classify correctly

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk - minimal change with clear correctness improvement
- Single-line logic change with comprehensive test coverage, correct HTTP semantics (503 is capacity, not quota), and proper branch ordering ensures no regression in rate limit detection
- No files require special attention

<sub>Last reviewed commit: 2587f47</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->