### PR TITLE
fix(ui): preserve chat input when aborting a session (#35419)

### DIFF
--- a/ui/src/ui/app-chat.node.test.ts
+++ b/ui/src/ui/app-chat.node.test.ts
@@ -31,7 +31,7 @@ vi.mock("./uuid.ts", () => ({
 }));
 
 import type { ChatHost } from "./app-chat.ts";
-import { handleAbortChat, isChatStopCommand } from "./app-chat.ts";
+import { handleAbortChat, handleSendChat, isChatStopCommand } from "./app-chat.ts";
 
 function createHost(overrides?: Partial<ChatHost>): ChatHost {
   return {
@@ -83,6 +83,34 @@ describe("handleAbortChat", () => {
     await handleAbortChat(host);
 
     expect(host.chatMessage).toBe("some text");
+  });
+});
+
+describe("handleSendChat stop-command path", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("clears the stop command from chatMessage when typed in the input", async () => {
+    const host = createHost({
+      chatMessage: "stop",
+      chatRunId: "run-1",
+    });
+
+    await handleSendChat(host);
+
+    expect(host.chatMessage).toBe("");
+  });
+
+  it("preserves chatMessage when stop command is sent via messageOverride", async () => {
+    const host = createHost({
+      chatMessage: "my draft",
+      chatRunId: "run-1",
+    });
+
+    await handleSendChat(host, "stop");
+
+    expect(host.chatMessage).toBe("my draft");
   });
 });
 

--- a/ui/src/ui/app-chat.node.test.ts
+++ b/ui/src/ui/app-chat.node.test.ts
@@ -120,6 +120,8 @@ describe("isChatStopCommand", () => {
     expect(isChatStopCommand("/stop")).toBe(true);
     expect(isChatStopCommand("abort")).toBe(true);
     expect(isChatStopCommand("esc")).toBe(true);
+    expect(isChatStopCommand("wait")).toBe(true);
+    expect(isChatStopCommand("exit")).toBe(true);
   });
 
   it("rejects non-stop text", () => {

--- a/ui/src/ui/app-chat.node.test.ts
+++ b/ui/src/ui/app-chat.node.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./controllers/chat.ts", () => ({
+  abortChatRun: vi.fn().mockResolvedValue(undefined),
+  loadChatHistory: vi.fn().mockResolvedValue(undefined),
+  sendChatMessage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./controllers/sessions.ts", () => ({
+  loadSessions: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./app-scroll.ts", () => ({
+  scheduleChatScroll: vi.fn(),
+}));
+
+vi.mock("./app-settings.ts", () => ({
+  setLastActiveSessionKey: vi.fn(),
+}));
+
+vi.mock("./app-tool-stream.ts", () => ({
+  resetToolStream: vi.fn(),
+}));
+
+vi.mock("./navigation.ts", () => ({
+  normalizeBasePath: vi.fn((p: string) => p),
+}));
+
+vi.mock("./uuid.ts", () => ({
+  generateUUID: vi.fn(() => "test-uuid"),
+}));
+
+import type { ChatHost } from "./app-chat.ts";
+import { handleAbortChat, isChatStopCommand } from "./app-chat.ts";
+
+function createHost(overrides?: Partial<ChatHost>): ChatHost {
+  return {
+    connected: true,
+    chatMessage: "",
+    chatAttachments: [],
+    chatQueue: [],
+    chatRunId: null,
+    chatSending: false,
+    sessionKey: "main",
+    basePath: "",
+    hello: null,
+    chatAvatarUrl: null,
+    refreshSessionsAfterChat: new Set<string>(),
+    ...overrides,
+  };
+}
+
+describe("handleAbortChat", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves chatMessage when aborting a running session", async () => {
+    const host = createHost({
+      chatMessage: "my draft message",
+      chatRunId: "run-1",
+    });
+
+    await handleAbortChat(host);
+
+    expect(host.chatMessage).toBe("my draft message");
+  });
+
+  it("does not clear an empty chatMessage", async () => {
+    const host = createHost({ chatMessage: "" });
+
+    await handleAbortChat(host);
+
+    expect(host.chatMessage).toBe("");
+  });
+
+  it("does nothing when not connected", async () => {
+    const host = createHost({
+      connected: false,
+      chatMessage: "some text",
+    });
+
+    await handleAbortChat(host);
+
+    expect(host.chatMessage).toBe("some text");
+  });
+});
+
+describe("isChatStopCommand", () => {
+  it("recognizes stop commands", () => {
+    expect(isChatStopCommand("stop")).toBe(true);
+    expect(isChatStopCommand("/stop")).toBe(true);
+    expect(isChatStopCommand("abort")).toBe(true);
+    expect(isChatStopCommand("esc")).toBe(true);
+  });
+
+  it("rejects non-stop text", () => {
+    expect(isChatStopCommand("hello")).toBe(false);
+    expect(isChatStopCommand("")).toBe(false);
+  });
+});

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -64,7 +64,6 @@ export async function handleAbortChat(host: ChatHost) {
   if (!host.connected) {
     return;
   }
-  host.chatMessage = "";
   await abortChatRun(host as unknown as OpenClawApp);
 }
 

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -175,6 +175,9 @@ export async function handleSendChat(
   }
 
   if (isChatStopCommand(message)) {
+    if (messageOverride == null) {
+      host.chatMessage = "";
+    }
     await handleAbortChat(host);
     return;
   }


### PR DESCRIPTION
## Summary

- Problem: Clicking the Stop button (or any abort path) called `handleAbortChat()`, which unconditionally set `host.chatMessage = ""`, destroying whatever text the user had typed but not yet sent.
- Why it matters: Users composing a long message lose their draft every time they stop a running session — a common interaction pattern when the model produces an unwanted response mid-stream.
- What changed: Removed `host.chatMessage = ""` from `handleAbortChat()` so the Stop button no longer wipes the input. Added `host.chatMessage = ""` inside `handleSendChat()` exclusively on the typed stop-command path (`messageOverride == null`) so that typing "stop" / "/stop" / "abort" / "esc" and pressing Enter still clears those command words from the field.
- What did NOT change (scope boundary): All other send flows, session abort mechanics, `abortChatRun()` internals, and the UI rendering of the Stop button are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35419
- Supersedes #22063

## User-visible / Behavior Changes

- Clicking the Stop button while text is in the chat input no longer clears that text.
- Typing a stop command (e.g. `stop`, `/stop`, `abort`, `esc`) and pressing Enter still clears the input field as expected.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (also reproducible on macOS/web)
- Runtime/container: Node 22+, Bun
- Model/provider: Any
- Integration/channel (if any): Web UI (webchat)
- Relevant config (redacted): N/A

### Steps

1. Open the web UI and start a session with a model that produces a long response.
2. While the response is streaming, type some text into the chat input (do not send it).
3. Click the Stop button to abort the session.

### Expected

- The text typed in the chat input is preserved after the session stops.

### Actual

- The chat input is cleared immediately when Stop is clicked, losing the draft.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test file `ui/src/ui/app-chat.node.test.ts` with 7 tests:
- `handleAbortChat` preserves `chatMessage` when aborting a running session
- `handleAbortChat` does not clear an empty `chatMessage`
- `handleAbortChat` does nothing when not connected
- `handleSendChat` stop-command path clears `chatMessage` when stop command is typed
- `handleSendChat` stop-command path preserves `chatMessage` when stop command is via `messageOverride`
- `isChatStopCommand` recognizes stop commands
- `isChatStopCommand` rejects non-stop text

## Human Verification (required)

- Verified scenarios: Stop button preserves draft; typed stop commands still clear input; disconnected host no-ops correctly.
- Edge cases checked: Empty `chatMessage` on abort (stays empty); `messageOverride`-driven stop (draft preserved); all four recognized stop words (`stop`, `/stop`, `abort`, `esc`).
- What you did **not** verify: End-to-end browser test in a live session (unit tests cover the logic path; UI rendering is unchanged).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `445595875` to restore `host.chatMessage = ""` in `handleAbortChat()`.
- Files/config to restore: `ui/src/ui/app-chat.ts` only.
- Known bad symptoms reviewers should watch for: Stop button leaves stop-command text (e.g. `stop`) visible in the input after a typed abort — would indicate the `messageOverride == null` guard is not working correctly.

## Risks and Mitigations

- Risk: A caller that relied on `handleAbortChat()` clearing the input as a side effect may now leave stale text.
  - Mitigation: Audited all call sites — `handleAbortChat()` is only called from `handleSendChat()` (stop-command path, now guarded) and from UI event handlers wiring the Stop button. The Stop button path was the bug — preserving the draft is the correct behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removed unconditional `host.chatMessage = ""` from `handleAbortChat()` and moved it to the stop-command path in `handleSendChat()` with a guard that only clears when the stop command is typed directly (`messageOverride == null`). This preserves user drafts when clicking the Stop button while still clearing stop-command keywords when typed.

- The fix correctly identifies the root cause: `handleAbortChat()` was clearing the input regardless of how it was triggered
- The solution is minimal and surgically targets the bug without changing abort mechanics or other flows
- Tests verify both the new behavior (preserve draft on button abort) and existing behavior (clear typed stop commands)
- All other `chatMessage = ""` assignments are for session-switching, which correctly should clear the input
- The `messageOverride == null` guard correctly distinguishes between user-typed commands (clear) and programmatic calls (preserve)

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no breaking changes or functional risks
- The change is minimal (3 lines added, 1 removed), well-tested with comprehensive unit tests, and the logic is correct. All call sites have been verified and the fix preserves existing behavior while fixing the reported bug. The guard condition (`messageOverride == null`) correctly distinguishes the two abort paths.
- No files require special attention

<sub>Last reviewed commit: 620088a</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->
