### PR TITLE
fix: pass session thinkingLevel to session_status tool (#26909)

### DIFF
--- a/src/agents/tools/session-status-tool.test.ts
+++ b/src/agents/tools/session-status-tool.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SessionEntry } from "../../config/sessions.js";
+
+const mockLoadConfig = vi.fn();
+const mockLoadSessionStore = vi.fn();
+const mockResolveStorePath = vi.fn();
+const mockUpdateSessionStore = vi.fn();
+const mockLoadCombinedSessionStoreForGateway = vi.fn();
+const mockBuildStatusMessage = vi.fn(() => "status text");
+const mockResolveQueueSettings = vi.fn(() => ({
+  mode: "collect",
+  debounceMs: 0,
+  cap: 0,
+  dropPolicy: undefined,
+}));
+const mockGetFollowupQueueDepth = vi.fn(() => 0);
+const mockNormalizeGroupActivation = vi.fn();
+const mockResolveAgentDir = vi.fn(() => "/tmp/agent");
+const mockResolveModelAuthLabel = vi.fn(() => "api-key");
+const mockFormatUserTime = vi.fn(() => "12:00");
+const mockResolveUserTimeFormat = vi.fn(() => "24h");
+const mockResolveUserTimezone = vi.fn(() => "UTC");
+const mockLoadProviderUsageSummary = vi.fn();
+const mockFormatUsageWindowSummary = vi.fn();
+const mockResolveUsageProviderId = vi.fn();
+
+vi.mock("../../auto-reply/status.js", () => ({
+  buildStatusMessage: mockBuildStatusMessage,
+}));
+
+vi.mock("../../config/config.js", () => ({
+  loadConfig: mockLoadConfig,
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  loadSessionStore: mockLoadSessionStore,
+  resolveStorePath: mockResolveStorePath,
+  updateSessionStore: mockUpdateSessionStore,
+}));
+
+vi.mock("../../gateway/session-utils.js", () => ({
+  loadCombinedSessionStoreForGateway: mockLoadCombinedSessionStoreForGateway,
+}));
+
+vi.mock("../../auto-reply/reply/queue.js", () => ({
+  resolveQueueSettings: mockResolveQueueSettings,
+  getFollowupQueueDepth: mockGetFollowupQueueDepth,
+}));
+
+vi.mock("../../auto-reply/group-activation.js", () => ({
+  normalizeGroupActivation: mockNormalizeGroupActivation,
+}));
+
+vi.mock("../agent-scope.js", () => ({
+  resolveAgentDir: mockResolveAgentDir,
+}));
+
+vi.mock("../model-auth-label.js", () => ({
+  resolveModelAuthLabel: mockResolveModelAuthLabel,
+}));
+
+vi.mock("../date-time.js", () => ({
+  formatUserTime: mockFormatUserTime,
+  resolveUserTimeFormat: mockResolveUserTimeFormat,
+  resolveUserTimezone: mockResolveUserTimezone,
+}));
+
+vi.mock("../../infra/provider-usage.js", () => ({
+  loadProviderUsageSummary: mockLoadProviderUsageSummary,
+  formatUsageWindowSummary: mockFormatUsageWindowSummary,
+  resolveUsageProviderId: mockResolveUsageProviderId,
+}));
+
+vi.mock("../model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(async () => ({ models: [] })),
+}));
+
+vi.mock("../../sessions/model-overrides.js", () => ({
+  applyModelOverrideToSessionEntry: vi.fn(() => ({ updated: false })),
+}));
+
+vi.mock("../model-selection.js", () => ({
+  buildAllowedModelSet: vi.fn(() => ({ allowedKeys: new Set() })),
+  buildModelAliasIndex: vi.fn(() => new Map()),
+  modelKey: vi.fn((provider: string, model: string) => `${provider}/${model}`),
+  resolveDefaultModelForAgent: vi.fn(() => ({
+    provider: "anthropic",
+    model: "claude-opus-4-6",
+  })),
+  resolveModelRefFromString: vi.fn(),
+}));
+
+vi.mock("./sessions-helpers.js", () => ({
+  shouldResolveSessionIdInput: vi.fn(() => false),
+  resolveInternalSessionKey: vi.fn(({ key }: { key: string }) => key),
+  resolveMainSessionAlias: vi.fn(() => ({
+    mainKey: "main",
+    alias: "main",
+  })),
+  createAgentToAgentPolicy: vi.fn(() => ({
+    enabled: false,
+    isAllowed: () => false,
+  })),
+}));
+
+vi.mock("../../routing/session-key.js", () => ({
+  buildAgentMainSessionKey: vi.fn(() => "agent:main:main"),
+  DEFAULT_AGENT_ID: "main",
+  resolveAgentIdFromSessionKey: vi.fn(() => "main"),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("createSessionStatusTool", () => {
+  it("passes session-level thinkingLevel to buildStatusMessage as resolvedThink", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "sess-1",
+      updatedAt: Date.now(),
+      thinkingLevel: "high",
+      verboseLevel: "on",
+      reasoningLevel: "stream",
+      elevatedLevel: "full",
+    };
+
+    const store: Record<string, SessionEntry> = {
+      "agent:main:main": sessionEntry,
+    };
+
+    const cfg = {
+      agents: { defaults: {} },
+      session: {},
+    } as unknown as import("../../config/config.js").OpenClawConfig;
+
+    mockResolveStorePath.mockReturnValue("/tmp/store.json");
+    mockLoadSessionStore.mockReturnValue(store);
+    mockResolveUsageProviderId.mockReturnValue(undefined);
+
+    const { createSessionStatusTool } = await import("./session-status-tool.js");
+    const tool = createSessionStatusTool({
+      agentSessionKey: "agent:main:main",
+      config: cfg,
+    });
+
+    await tool.execute("call-1", { sessionKey: "agent:main:main" });
+
+    expect(mockBuildStatusMessage).toHaveBeenCalledOnce();
+    const statusArgs = (mockBuildStatusMessage.mock.calls as never[][])[0][0] as Record<
+      string,
+      unknown
+    >;
+
+    // The bug: resolvedThink was not passed, causing "Think: off".
+    // After fix: session entry's thinkingLevel should be forwarded.
+    expect(statusArgs.resolvedThink).toBe("high");
+    expect(statusArgs.resolvedVerbose).toBe("on");
+    expect(statusArgs.resolvedReasoning).toBe("stream");
+    expect(statusArgs.resolvedElevated).toBe("full");
+  });
+
+  it("falls back gracefully when session has no thinking overrides", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "sess-2",
+      updatedAt: Date.now(),
+    };
+
+    const store: Record<string, SessionEntry> = {
+      "agent:main:main": sessionEntry,
+    };
+
+    const cfg = {
+      agents: { defaults: {} },
+      session: {},
+    } as unknown as import("../../config/config.js").OpenClawConfig;
+
+    mockResolveStorePath.mockReturnValue("/tmp/store.json");
+    mockLoadSessionStore.mockReturnValue(store);
+    mockResolveUsageProviderId.mockReturnValue(undefined);
+
+    const { createSessionStatusTool } = await import("./session-status-tool.js");
+    const tool = createSessionStatusTool({
+      agentSessionKey: "agent:main:main",
+      config: cfg,
+    });
+
+    await tool.execute("call-2", { sessionKey: "agent:main:main" });
+
+    expect(mockBuildStatusMessage).toHaveBeenCalledOnce();
+    const statusArgs = (mockBuildStatusMessage.mock.calls as never[][])[0][0] as Record<
+      string,
+      unknown
+    >;
+
+    // When session has no overrides, resolved values should be undefined
+    // (letting buildStatusMessage use its own fallback chain).
+    expect(statusArgs.resolvedThink).toBeUndefined();
+    expect(statusArgs.resolvedVerbose).toBeUndefined();
+    expect(statusArgs.resolvedReasoning).toBeUndefined();
+    expect(statusArgs.resolvedElevated).toBeUndefined();
+  });
+});

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -2,6 +2,12 @@ import { Type } from "@sinclair/typebox";
 import { normalizeGroupActivation } from "../../auto-reply/group-activation.js";
 import { getFollowupQueueDepth, resolveQueueSettings } from "../../auto-reply/reply/queue.js";
 import { buildStatusMessage } from "../../auto-reply/status.js";
+import type {
+  ElevatedLevel,
+  ReasoningLevel,
+  ThinkLevel,
+  VerboseLevel,
+} from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import {
@@ -365,6 +371,10 @@ export function createSessionStatusTool(opts?: {
         sessionKey: resolved.key,
         sessionStorePath: storePath,
         groupActivation,
+        resolvedThink: resolved.entry.thinkingLevel as ThinkLevel | undefined,
+        resolvedVerbose: resolved.entry.verboseLevel as VerboseLevel | undefined,
+        resolvedReasoning: resolved.entry.reasoningLevel as ReasoningLevel | undefined,
+        resolvedElevated: resolved.entry.elevatedLevel as ElevatedLevel | undefined,
         modelAuth: resolveModelAuthLabel({
           provider: providerForCard,
           cfg,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `session_status` tool always showed `Think: off` even when a session had `thinkingLevel`, `verboseLevel`, `reasoningLevel`, or `elevatedLevel` set, because the resolved session entry's overrides were never passed to `buildStatusMessage`.
- Why it matters: Users relying on per-session thinking overrides had no way to confirm from inside the agent whether their thinking level was actually active.
- What changed: `createSessionStatusTool` now reads the four level fields from `resolved.entry` and forwards them as `resolvedThink`, `resolvedVerbose`, `resolvedReasoning`, and `resolvedElevated` to `buildStatusMessage`. A new test file covers both the override and default (no override) cases.
- What did NOT change (scope boundary): No changes to how thinking levels are stored, resolved, or applied during inference. No changes to config schema or session storage. Only the display path in `session_status` is touched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #26909
- Related #

## User-visible / Behavior Changes

`session_status` tool output now correctly reflects the active per-session thinking override (thinkingLevel, verboseLevel, reasoningLevel, elevatedLevel). Previously always showed `Think: off` regardless of session config.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 24.04)
- Runtime/container: Node 22 / Bun
- Model/provider: N/A (unit test)
- Integration/channel (if any): N/A
- Relevant config (redacted): `sessions.thinkingLevel: "high"`

### Steps

1. Configure a session with `thinkingLevel` set (e.g., `"high"`)
2. From the agent, call the `session_status` tool
3. Observe the `Think:` field in the returned status card

### Expected

- Status card shows the active thinking level (e.g., `Think: high`)

### Actual

- Status card always showed `Think: off` regardless of session-level override

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test file `src/agents/tools/session-status-tool.test.ts` covers:
- Session entry with all four level overrides set — verifies each is forwarded to `buildStatusMessage`
- Session entry with no thinking overrides — verifies fields are `undefined` (no regression on default path)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Ran `pnpm build && pnpm check` clean. Ran vitest on the new test file — all pass. Reviewed `buildStatusMessage` call site to confirm the four resolved fields are consumed correctly. Compared with the `/status` command pattern in `commands-status.ts`.
- Edge cases checked: `undefined` entries (no session-level override) do not break the status card. Type casts match the imported union types from `auto-reply/thinking.ts`.
- What you did **not** verify: Live end-to-end test with a real session and a real model. macOS-specific paths. Any channel integration.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the four `resolved*` lines added to `createSessionStatusTool` in `src/agents/tools/session-status-tool.ts`.
- Files/config to restore: `src/agents/tools/session-status-tool.ts` (remove 4 added lines); delete `src/agents/tools/session-status-tool.test.ts`.
- Known bad symptoms reviewers should watch for: `session_status` output reverting to `Think: off` even when a session override is set.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Type cast (`as ThinkLevel | undefined`) could silently pass an unexpected string if session storage ever writes an unrecognized value.
  - Mitigation: The cast matches the existing codebase pattern for session-level overrides. `buildStatusMessage` handles unknown values gracefully (falls back to display default). No runtime crash path introduced.