### PR TITLE
fix: reject placeholder secrets in config.apply/config.patch writes

### DIFF
--- a/src/config/detect-placeholder-secrets.test.ts
+++ b/src/config/detect-placeholder-secrets.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { REDACTED_SENTINEL, detectPlaceholderSecrets } from "./redact-snapshot.js";
+import type { ConfigUiHints } from "./schema.js";
+
+describe("detectPlaceholderSecrets", () => {
+  it("detects common placeholder patterns on sensitive paths", () => {
+    const placeholders = [
+      "REDACTED",
+      "redacted",
+      "xoxb-REDACTED",
+      "xapp-REDACTED",
+      "sk-redacted",
+      "sk-proj-REDACTED",
+      "xoxb-REPLACE_ME",
+      "xapp-REPLACE_ME",
+      "sk-proj-placeholder",
+      "your-token-here",
+      "your_api_key_here",
+      "changeme",
+      "replace-me",
+      "PLACEHOLDER",
+      "xxx",
+      "XXXXX",
+      "TODO",
+      "N/A",
+      "n/a",
+    ];
+    for (const placeholder of placeholders) {
+      const config = { channels: { slack: { token: placeholder } } };
+      const result = detectPlaceholderSecrets(config);
+      expect(result.ok, `expected "${placeholder}" to be detected`).toBe(false);
+      expect(result.paths.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("accepts real credential values on sensitive paths", () => {
+    const realValues = [
+      "xoxb-real-credential-value-abc123",
+      "sk-proj-abcdef1234567890ghij",
+      "MTIzNDU2Nzg5MDEyMzQ1Njc4.GaBcDe.FgH",
+      "gsk_abc123def456ghi789jkl012mno",
+      "my-actual-secret-key-2024",
+      "my-redacted-token-v2", // legit value containing "redacted" as substring
+    ];
+    for (const value of realValues) {
+      const config = { channels: { slack: { token: value } } };
+      const result = detectPlaceholderSecrets(config);
+      expect(result.ok, `expected "${value}" to pass`).toBe(true);
+    }
+  });
+
+  it("ignores placeholder values on non-sensitive paths", () => {
+    const config = { ui: { seamColor: "REDACTED" }, gateway: { port: 18789 } };
+    const result = detectPlaceholderSecrets(config);
+    expect(result.ok).toBe(true);
+  });
+
+  it("reports the offending path", () => {
+    const config = { gateway: { auth: { token: "REDACTED" } } };
+    const result = detectPlaceholderSecrets(config);
+    expect(result.ok).toBe(false);
+    expect(result.paths).toContain("gateway.auth.token");
+  });
+
+  it("respects uiHints sensitive:false override", () => {
+    const hints: ConfigUiHints = { "gateway.auth.token": { sensitive: false } };
+    const config = { gateway: { auth: { token: "REDACTED" } } };
+    const result = detectPlaceholderSecrets(config, hints);
+    expect(result.ok).toBe(true);
+  });
+
+  it("does not flag the official REDACTED_SENTINEL", () => {
+    const config = { channels: { slack: { token: REDACTED_SENTINEL } } };
+    const result = detectPlaceholderSecrets(config);
+    expect(result.ok).toBe(true);
+  });
+
+  it("handles null/undefined/non-object input gracefully", () => {
+    expect(detectPlaceholderSecrets(null).ok).toBe(true);
+    expect(detectPlaceholderSecrets(undefined).ok).toBe(true);
+    expect(detectPlaceholderSecrets("string").ok).toBe(true);
+  });
+
+  it("detects placeholders with uiHints lookup path", () => {
+    const hints: ConfigUiHints = { "custom.mySecret": { sensitive: true } };
+    const config = { custom: { mySecret: "your-secret-here" } };
+    const result = detectPlaceholderSecrets(config, hints);
+    expect(result.ok).toBe(false);
+    expect(result.paths).toContain("custom.mySecret");
+  });
+
+  it("accepts valid values with uiHints lookup path", () => {
+    const hints: ConfigUiHints = { "custom.mySecret": { sensitive: true } };
+    const config = { custom: { mySecret: "real-api-key-abc123def456" } };
+    const result = detectPlaceholderSecrets(config, hints);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/config/redact-snapshot.ts
+++ b/src/config/redact-snapshot.ts
@@ -408,6 +408,166 @@ export type RedactionResult = {
   humanReadableMessage?: string;
 };
 
+export type PlaceholderDetectionResult = {
+  ok: boolean;
+  /** Paths where placeholder values were found. Empty when ok=true. */
+  paths: string[];
+};
+
+/**
+ * Common placeholder patterns that should never be written as real credentials.
+ * Catches values like "REDACTED", "xoxb-REDACTED", "your-token-here", etc.
+ */
+const PLACEHOLDER_PATTERNS = [
+  /^redacted$/i,
+  /^placeholder$/i,
+  /^your[_-]?\w*[_-]?here$/i,
+  /^(change|replace|insert|enter|add|put|set)[_-]?me$/i,
+  /^xxx+$/i,
+  /^todo$/i,
+  /^n\/?a$/i,
+  // Catches "xoxb-REDACTED", "sk-proj-REDACTED", "xapp-redacted" etc.
+  // Allows any number of prefix segments before the terminal "redacted".
+  // Does NOT match "my-redacted-token-v2" (legitimate value with "redacted" mid-string)
+  /^[\w]+(-[\w]+)*-redacted$/i,
+  // Catches prefixed placeholder forms like "xoxb-REPLACE_ME", "sk-proj-PLACEHOLDER"
+  /^[\w]+(-[\w]+)*-(placeholder|changeme|replace[_-]?me|todo|your[_-]?\w*[_-]?here|xxx+)$/i,
+];
+
+function isPlaceholderSecret(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === REDACTED_SENTINEL) {
+    return false;
+  }
+  return PLACEHOLDER_PATTERNS.some((p) => p.test(trimmed));
+}
+
+/**
+ * Walk a config object and detect placeholder values at sensitive paths.
+ * Called after restoreRedactedValues() to catch non-sentinel placeholders
+ * (e.g. "xoxb-REDACTED") that would silently corrupt credentials.
+ */
+export function detectPlaceholderSecrets(
+  config: unknown,
+  hints?: ConfigUiHints,
+): PlaceholderDetectionResult {
+  const paths: string[] = [];
+  if (config === null || config === undefined || typeof config !== "object") {
+    return { ok: true, paths };
+  }
+  if (hints) {
+    const lookup = buildRedactionLookup(hints);
+    if (lookup.has("")) {
+      detectPlaceholdersWithLookup(config, lookup, "", paths, hints);
+    } else {
+      detectPlaceholdersGuessing(config, "", paths, hints);
+    }
+  } else {
+    detectPlaceholdersGuessing(config, "", paths);
+  }
+  return { ok: paths.length === 0, paths };
+}
+
+function detectPlaceholdersWithLookup(
+  obj: unknown,
+  lookup: Set<string>,
+  prefix: string,
+  found: string[],
+  hints: ConfigUiHints,
+): void {
+  if (obj === null || obj === undefined) {
+    return;
+  }
+  if (Array.isArray(obj)) {
+    const path = `${prefix}[]`;
+    if (!lookup.has(path)) {
+      detectPlaceholdersGuessing(obj, prefix, found, hints);
+      return;
+    }
+    for (const item of obj) {
+      if (typeof item === "string" && isPlaceholderSecret(item)) {
+        found.push(path);
+      } else {
+        detectPlaceholdersWithLookup(item, lookup, path, found, hints);
+      }
+    }
+    return;
+  }
+  if (typeof obj === "object") {
+    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+      const path = prefix ? `${prefix}.${key}` : key;
+      const wildcardPath = prefix ? `${prefix}.*` : "*";
+      let matched = false;
+      for (const candidate of [path, wildcardPath]) {
+        if (lookup.has(candidate)) {
+          matched = true;
+          if (typeof value === "string" && isPlaceholderSecret(value)) {
+            // Always report the concrete path, not the wildcard hint
+            found.push(path);
+          } else if (typeof value === "object" && value !== null) {
+            detectPlaceholdersWithLookup(value, lookup, candidate, found, hints);
+          }
+          break;
+        }
+      }
+      if (!matched) {
+        const markedNonSensitive = isExplicitlyNonSensitivePath(hints, [path, wildcardPath]);
+        if (typeof value === "string" && !markedNonSensitive && isSensitivePath(path)) {
+          if (isPlaceholderSecret(value)) {
+            found.push(path);
+          }
+        } else if (typeof value === "object" && value !== null) {
+          detectPlaceholdersGuessing(value, path, found, hints);
+        }
+      }
+    }
+  }
+}
+
+function detectPlaceholdersGuessing(
+  obj: unknown,
+  prefix: string,
+  found: string[],
+  hints?: ConfigUiHints,
+): void {
+  if (obj === null || obj === undefined) {
+    return;
+  }
+  if (Array.isArray(obj)) {
+    const path = `${prefix}[]`;
+    for (const item of obj) {
+      if (
+        !isExplicitlyNonSensitivePath(hints, [path]) &&
+        isSensitivePath(path) &&
+        typeof item === "string" &&
+        isPlaceholderSecret(item)
+      ) {
+        found.push(path);
+      } else {
+        detectPlaceholdersGuessing(item, path, found, hints);
+      }
+    }
+    return;
+  }
+  if (typeof obj === "object") {
+    for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+      const dotPath = prefix ? `${prefix}.${key}` : key;
+      const wildcardPath = prefix ? `${prefix}.*` : "*";
+      if (
+        !isExplicitlyNonSensitivePath(hints, [dotPath, wildcardPath]) &&
+        isSensitivePath(dotPath) &&
+        typeof value === "string"
+      ) {
+        if (isPlaceholderSecret(value)) {
+          found.push(dotPath);
+        }
+      } else if (typeof value === "object" && value !== null) {
+        detectPlaceholdersGuessing(value, dotPath, found, hints);
+      }
+    }
+  }
+}
+
 /**
  * Deep-walk `incoming` and replace any {@link REDACTED_SENTINEL} values
  * (on sensitive paths) with the corresponding value from `original`.


### PR DESCRIPTION
## Summary

- Problem: `config.apply` and `config.patch` allow obvious placeholder secrets (e.g. `REDACTED`, `xoxb-REDACTED`, `your-token-here`, `changeme`) to overwrite live credentials on sensitive paths, silently corrupting production configuration.
- Why it matters: After a round-trip through the Web UI with placeholder values, gateway restart causes channels (e.g. Slack) to fail with `invalid_auth`. The existing `restoreRedactedValues()` only handles the official `__OPENCLAW_REDACTED__` sentinel but not other placeholder forms.
- What changed: Added `detectPlaceholderSecrets()` function that walks config trees and rejects common placeholder patterns on sensitive paths. Integrated as a guard in both `config.set`/`config.apply` (via `parseValidateConfigFromRawOrRespond`) and `config.patch` (after legacy migrations).
- What did NOT change (scope boundary): The existing redact/restore sentinel mechanism is untouched. Schema validation, `restoreRedactedValues()`, and `isSensitiveConfigPath()` all remain as-is.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #21573
- Related #13058

## User-visible / Behavior Changes

`config.apply` and `config.patch` now reject writes when sensitive paths contain obvious placeholder values (e.g. `REDACTED`, `xoxb-REDACTED`, `your-token-here`, `changeme`, `TODO`, `N/A`). Returns `INVALID_REQUEST` with a clear error listing the offending paths. The official `__OPENCLAW_REDACTED__` sentinel, env var placeholders (`${VAR}`), and real credential values are unaffected.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `Yes` — adds rejection of placeholder values on sensitive config paths
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: Defense-in-depth guard only. Uses the same `isSensitiveConfigPath()` and `buildRedactionLookup()` infrastructure as existing redaction. No new attack surface. False positives are unlikely due to conservative pattern matching (only exact matches like `REDACTED`, `changeme`, etc.).

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 / Bun
- Model/provider: N/A
- Integration/channel (if any): Any channel with sensitive config (e.g. Slack token)
- Relevant config (redacted): Any config with `token`, `password`, `secret`, or `apiKey` paths

### Steps

1. `config.get` → receive config with redacted values
2. `config.apply` with raw containing `"token": "xoxb-REDACTED"` on a Slack path
3. Before fix: writes silently, gateway restarts, Slack fails with `invalid_auth`
4. After fix: returns `INVALID_REQUEST` error listing the offending path

### Expected

- Placeholder values on sensitive paths are rejected with a clear error message

### Actual

- Before: Placeholder values silently overwrite real credentials

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

9 new tests covering: 19 placeholder patterns detected, 6 legitimate values accepted, non-sensitive paths ignored, concrete path reporting, `sensitive:false` override, official sentinel passthrough, null/undefined handling, uiHints lookup path detection.

## Human Verification (required)

- Verified scenarios: All 9 test cases pass; `pnpm build && pnpm check` clean after rebase onto upstream/main
- Edge cases checked: Prefixed placeholders (`sk-proj-REDACTED`, `xoxb-REPLACE_ME`), legitimate values containing "redacted" as substring (`my-redacted-token-v2`), official sentinel passthrough, env var placeholders (`${VAR}`)
- What you did **not** verify: Live gateway round-trip with Web UI

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this single commit
- Files/config to restore: None — no data/config changes
- Known bad symptoms reviewers should watch for: `INVALID_REQUEST` error on `config.apply`/`config.patch` for legitimate credential values that happen to match placeholder patterns

## Risks and Mitigations

- Risk: False positive rejecting a legitimate credential that happens to match a placeholder pattern (e.g. a token that is literally `changeme`)
  - Mitigation: Patterns are conservative (exact match only); real credentials with these as substrings pass (e.g. `my-redacted-token-v2`). The official `__OPENCLAW_REDACTED__` sentinel is explicitly excluded.