### PR TITLE
fix: pass bashElevated to runEmbeddedPiAgent in cron and agent command paths

### DIFF
--- a/src/auto-reply/reply/reply-elevated.ts
+++ b/src/auto-reply/reply/reply-elevated.ts
@@ -245,6 +245,11 @@ export function resolveElevatedPermissions(params: {
  * `!== false` (default-enabled) because `allowFrom` acts as a second gate,
  * system-initiated contexts have no sender so we require explicit
  * `enabled: true` to avoid silently granting host-exec privileges.
+ *
+ * Security: `sessions_send` is owner-only + dangerous-tools gated, and the
+ * parent session already validates the sender via `resolveElevatedPermissions`.
+ * Cron and CLI agent commands are trusted local contexts. The `allowFrom`
+ * sender gate is therefore not applicable here.
  */
 export function resolveSystemElevatedDefaults(params: {
   cfg: OpenClawConfig;

--- a/src/auto-reply/reply/reply-elevated.ts
+++ b/src/auto-reply/reply/reply-elevated.ts
@@ -240,13 +240,18 @@ export function resolveElevatedPermissions(params: {
  * Resolve elevated exec defaults for system-initiated contexts (cron, agent
  * command, sessions_send) where there is no sender to verify against
  * `allowFrom`. Only the global and per-agent `enabled` gates apply.
+ *
+ * Unlike the inbound path (`resolveElevatedPermissions`) which uses
+ * `!== false` (default-enabled) because `allowFrom` acts as a second gate,
+ * system-initiated contexts have no sender so we require explicit
+ * `enabled: true` to avoid silently granting host-exec privileges.
  */
 export function resolveSystemElevatedDefaults(params: {
   cfg: OpenClawConfig;
   agentId: string;
   elevatedDefault?: ElevatedLevel;
 }): ExecElevatedDefaults {
-  const globalEnabled = params.cfg.tools?.elevated?.enabled !== false;
+  const globalEnabled = params.cfg.tools?.elevated?.enabled === true;
   const agentEnabled =
     resolveAgentConfig(params.cfg, params.agentId)?.tools?.elevated?.enabled !== false;
   const enabled = globalEnabled && agentEnabled;

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -38,12 +38,14 @@ import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
 import { getSkillsSnapshotVersion } from "../agents/skills/refresh.js";
 import { resolveAgentTimeoutMs } from "../agents/timeout.js";
 import { ensureAgentWorkspace } from "../agents/workspace.js";
+import { resolveSystemElevatedDefaults } from "../auto-reply/reply/reply-elevated.js";
 import {
   formatThinkingLevels,
   formatXHighModelHint,
   normalizeThinkLevel,
   normalizeVerboseLevel,
   supportsXHighThinking,
+  type ElevatedLevel,
   type ThinkLevel,
   type VerboseLevel,
 } from "../auto-reply/thinking.js";
@@ -169,6 +171,7 @@ function runAgentAttempt(params: {
   messageChannel: ReturnType<typeof resolveMessageChannel>;
   skillsSnapshot: ReturnType<typeof buildWorkspaceSkillSnapshot> | undefined;
   resolvedVerboseLevel: VerboseLevel | undefined;
+  bashElevated?: { enabled: boolean; allowed: boolean; defaultLevel: ElevatedLevel };
   agentDir: string;
   onAgentEvent: (evt: { stream: string; data?: Record<string, unknown> }) => void;
   primaryProvider: string;
@@ -316,6 +319,7 @@ function runAgentAttempt(params: {
     authProfileIdSource: authProfileId ? params.sessionEntry?.authProfileOverrideSource : undefined,
     thinkLevel: params.resolvedThinkLevel,
     verboseLevel: params.resolvedVerboseLevel,
+    bashElevated: params.bashElevated,
     timeoutMs: params.timeoutMs,
     runId: params.runId,
     lane: params.opts.lane,
@@ -821,6 +825,16 @@ async function agentCommandInternal(
         opts.replyChannel ?? opts.channel,
       );
       const spawnedBy = opts.spawnedBy ?? sessionEntry?.spawnedBy;
+
+      // Resolve elevated exec permissions so agent command runs (including
+      // sessions_send nested runs) can use elevated tools when configured.
+      // Agent commands are system-initiated (no sender), so only enablement applies.
+      const bashElevated = resolveSystemElevatedDefaults({
+        cfg,
+        agentId: sessionAgentId,
+        elevatedDefault: agentCfg?.elevatedDefault as ElevatedLevel | undefined,
+      });
+
       // Keep fallback candidate resolution centralized so session model overrides,
       // per-agent overrides, and default fallbacks stay consistent across callers.
       const effectiveFallbacksOverride = resolveEffectiveModelFallbacks({
@@ -862,6 +876,7 @@ async function agentCommandInternal(
             messageChannel,
             skillsSnapshot,
             resolvedVerboseLevel,
+            bashElevated,
             agentDir,
             primaryProvider: provider,
             sessionStore,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -433,6 +433,7 @@ async function agentCommandInternal(
     isNewSession,
     persistedThinking,
     persistedVerbose,
+    persistedElevated,
   } = sessionResolution;
   const sessionAgentId =
     agentIdOverride ??
@@ -829,10 +830,13 @@ async function agentCommandInternal(
       // Resolve elevated exec permissions so agent command runs (including
       // sessions_send nested runs) can use elevated tools when configured.
       // Agent commands are system-initiated (no sender), so only enablement applies.
+      // Persisted session elevated level takes priority over config default
+      // (honours /elevated off set during the session).
       const bashElevated = resolveSystemElevatedDefaults({
         cfg,
         agentId: sessionAgentId,
-        elevatedDefault: agentCfg?.elevatedDefault as ElevatedLevel | undefined,
+        elevatedDefault:
+          persistedElevated ?? (agentCfg?.elevatedDefault as ElevatedLevel | undefined),
       });
 
       // Keep fallback candidate resolution centralized so session model overrides,

--- a/src/commands/agent/session.ts
+++ b/src/commands/agent/session.ts
@@ -2,6 +2,8 @@ import crypto from "node:crypto";
 import { listAgentIds } from "../../agents/agent-scope.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import {
+  type ElevatedLevel,
+  normalizeElevatedLevel,
   normalizeThinkLevel,
   normalizeVerboseLevel,
   type ThinkLevel,
@@ -31,6 +33,7 @@ export type SessionResolution = {
   isNewSession: boolean;
   persistedThinking?: ThinkLevel;
   persistedVerbose?: VerboseLevel;
+  persistedElevated?: ElevatedLevel;
 };
 
 type SessionKeyResolution = {
@@ -152,6 +155,10 @@ export function resolveSession(opts: {
     fresh && sessionEntry?.verboseLevel
       ? normalizeVerboseLevel(sessionEntry.verboseLevel)
       : undefined;
+  const persistedElevated =
+    fresh && sessionEntry?.elevatedLevel
+      ? normalizeElevatedLevel(sessionEntry.elevatedLevel)
+      : undefined;
 
   return {
     sessionId,
@@ -162,5 +169,6 @@ export function resolveSession(opts: {
     isNewSession,
     persistedThinking,
     persistedVerbose,
+    persistedElevated,
   };
 }

--- a/src/cron/isolated-agent/run.elevated.test.ts
+++ b/src/cron/isolated-agent/run.elevated.test.ts
@@ -1,0 +1,370 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { runWithModelFallback } from "../../agents/model-fallback.js";
+
+// ---------- mocks ----------
+
+const resolveAgentConfigMock = vi.fn();
+const getModelRefStatusMock = vi.fn().mockReturnValue({ allowed: false });
+const isCliProviderMock = vi.fn().mockReturnValue(false);
+const resolveAllowedModelRefMock = vi.fn();
+const resolveConfiguredModelRefMock = vi.fn();
+const resolveHooksGmailModelMock = vi.fn();
+const resolveThinkingDefaultMock = vi.fn();
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveAgentConfig: resolveAgentConfigMock,
+  resolveAgentDir: vi.fn().mockReturnValue("/tmp/agent-dir"),
+  resolveAgentModelFallbacksOverride: vi.fn().mockReturnValue(undefined),
+  resolveAgentWorkspaceDir: vi.fn().mockReturnValue("/tmp/workspace"),
+  resolveDefaultAgentId: vi.fn().mockReturnValue("default"),
+  resolveAgentSkillsFilter: vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock("../../agents/skills.js", () => ({
+  buildWorkspaceSkillSnapshot: vi.fn().mockReturnValue({
+    prompt: "<available_skills></available_skills>",
+    resolvedSkills: [],
+    version: 42,
+  }),
+}));
+
+vi.mock("../../agents/skills/refresh.js", () => ({
+  getSkillsSnapshotVersion: vi.fn().mockReturnValue(42),
+}));
+
+vi.mock("../../agents/workspace.js", () => ({
+  ensureAgentWorkspace: vi.fn().mockResolvedValue({ dir: "/tmp/workspace" }),
+}));
+
+vi.mock("../../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn().mockResolvedValue({ models: [] }),
+}));
+
+vi.mock("../../agents/model-selection.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/model-selection.js")>();
+  return {
+    ...actual,
+    getModelRefStatus: getModelRefStatusMock,
+    isCliProvider: isCliProviderMock,
+    resolveAllowedModelRef: resolveAllowedModelRefMock,
+    resolveConfiguredModelRef: resolveConfiguredModelRefMock,
+    resolveHooksGmailModel: resolveHooksGmailModelMock,
+    resolveThinkingDefault: resolveThinkingDefaultMock,
+  };
+});
+
+vi.mock("../../agents/model-fallback.js", () => ({
+  runWithModelFallback: vi.fn().mockResolvedValue({
+    result: {
+      payloads: [{ text: "test output" }],
+      meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+    },
+    provider: "openai",
+    model: "gpt-4",
+  }),
+}));
+
+const runWithModelFallbackMock = vi.mocked(runWithModelFallback);
+
+vi.mock("../../agents/pi-embedded.js", () => ({
+  runEmbeddedPiAgent: vi.fn().mockResolvedValue({
+    payloads: [{ text: "test output" }],
+    meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+  }),
+}));
+
+vi.mock("../../agents/context.js", () => ({
+  lookupContextTokens: vi.fn().mockReturnValue(128000),
+}));
+
+vi.mock("../../agents/date-time.js", () => ({
+  formatUserTime: vi.fn().mockReturnValue("2026-02-10 12:00"),
+  resolveUserTimeFormat: vi.fn().mockReturnValue("24h"),
+  resolveUserTimezone: vi.fn().mockReturnValue("UTC"),
+}));
+
+vi.mock("../../agents/timeout.js", () => ({
+  resolveAgentTimeoutMs: vi.fn().mockReturnValue(60_000),
+}));
+
+vi.mock("../../agents/usage.js", () => ({
+  deriveSessionTotalTokens: vi.fn().mockReturnValue(30),
+  hasNonzeroUsage: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../../agents/subagent-announce.js", () => ({
+  runSubagentAnnounceFlow: vi.fn().mockResolvedValue(true),
+}));
+
+vi.mock("../../agents/cli-runner.js", () => ({
+  runCliAgent: vi.fn(),
+}));
+
+vi.mock("../../agents/cli-session.js", () => ({
+  getCliSessionId: vi.fn().mockReturnValue(undefined),
+  setCliSessionId: vi.fn(),
+}));
+
+vi.mock("../../auto-reply/thinking.js", () => ({
+  normalizeThinkLevel: vi.fn().mockReturnValue(undefined),
+  normalizeVerboseLevel: vi.fn().mockReturnValue("off"),
+  supportsXHighThinking: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../../cli/outbound-send-deps.js", () => ({
+  createOutboundSendDeps: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../../config/sessions.js", () => ({
+  resolveAgentMainSessionKey: vi.fn().mockReturnValue("main:default"),
+  resolveSessionTranscriptPath: vi.fn().mockReturnValue("/tmp/transcript.jsonl"),
+  setSessionRuntimeModel: vi.fn(),
+  updateSessionStore: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../routing/session-key.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../routing/session-key.js")>();
+  return {
+    ...actual,
+    buildAgentMainSessionKey: vi.fn().mockReturnValue("agent:default:cron:test"),
+    normalizeAgentId: vi.fn((id: string) => id),
+  };
+});
+
+vi.mock("../../infra/agent-events.js", () => ({
+  registerAgentRunContext: vi.fn(),
+}));
+
+vi.mock("../../infra/outbound/deliver.js", () => ({
+  deliverOutboundPayloads: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../infra/skills-remote.js", () => ({
+  getRemoteSkillEligibility: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../../logger.js", () => ({
+  logWarn: vi.fn(),
+}));
+
+vi.mock("../../security/external-content.js", () => ({
+  buildSafeExternalPrompt: vi.fn().mockReturnValue("safe prompt"),
+  detectSuspiciousPatterns: vi.fn().mockReturnValue([]),
+  getHookType: vi.fn().mockReturnValue("unknown"),
+  isExternalHookSession: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock("../delivery.js", () => ({
+  resolveCronDeliveryPlan: vi.fn().mockReturnValue({ requested: false }),
+}));
+
+vi.mock("./delivery-target.js", () => ({
+  resolveDeliveryTarget: vi.fn().mockResolvedValue({
+    channel: "telegram",
+    to: undefined,
+    accountId: undefined,
+    error: undefined,
+  }),
+}));
+
+vi.mock("./helpers.js", () => ({
+  isHeartbeatOnlyResponse: vi.fn().mockReturnValue(false),
+  pickLastDeliverablePayload: vi.fn().mockReturnValue(undefined),
+  pickLastNonEmptyTextFromPayloads: vi.fn().mockReturnValue("test output"),
+  pickSummaryFromOutput: vi.fn().mockReturnValue("summary"),
+  pickSummaryFromPayloads: vi.fn().mockReturnValue("summary"),
+  resolveHeartbeatAckMaxChars: vi.fn().mockReturnValue(100),
+}));
+
+const resolveCronSessionMock = vi.fn();
+vi.mock("./session.js", () => ({
+  resolveCronSession: resolveCronSessionMock,
+}));
+
+vi.mock("../../agents/defaults.js", () => ({
+  DEFAULT_CONTEXT_TOKENS: 128000,
+  DEFAULT_MODEL: "gpt-4",
+  DEFAULT_PROVIDER: "openai",
+}));
+
+const { runCronIsolatedAgentTurn } = await import("./run.js");
+
+// ---------- helpers ----------
+
+function makeJob(overrides?: Record<string, unknown>) {
+  return {
+    id: "test-job",
+    name: "Test Job",
+    schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+    sessionTarget: "isolated",
+    payload: { kind: "agentTurn", message: "test" },
+    ...overrides,
+  } as never;
+}
+
+function makeParams(overrides?: Record<string, unknown>) {
+  return {
+    cfg: {},
+    deps: {} as never,
+    job: makeJob(),
+    message: "test",
+    sessionKey: "cron:test",
+    ...overrides,
+  };
+}
+
+// ---------- tests ----------
+
+describe("runCronIsolatedAgentTurn — elevated exec (#18748)", () => {
+  let previousFastTestEnv: string | undefined;
+  beforeEach(() => {
+    vi.clearAllMocks();
+    previousFastTestEnv = process.env.OPENCLAW_TEST_FAST;
+    delete process.env.OPENCLAW_TEST_FAST;
+    resolveAgentConfigMock.mockReturnValue(undefined);
+    resolveConfiguredModelRefMock.mockReturnValue({ provider: "openai", model: "gpt-4" });
+    resolveAllowedModelRefMock.mockReturnValue({ ref: { provider: "openai", model: "gpt-4" } });
+    resolveHooksGmailModelMock.mockReturnValue(null);
+    resolveThinkingDefaultMock.mockReturnValue(undefined);
+    getModelRefStatusMock.mockReturnValue({ allowed: false });
+    isCliProviderMock.mockReturnValue(false);
+    resolveCronSessionMock.mockReturnValue({
+      storePath: "/tmp/store.json",
+      store: {},
+      sessionEntry: {
+        sessionId: "test-session-id",
+        updatedAt: 0,
+        systemSent: false,
+        skillsSnapshot: undefined,
+      },
+      systemSent: false,
+      isNewSession: true,
+    });
+  });
+
+  afterEach(() => {
+    if (previousFastTestEnv == null) {
+      delete process.env.OPENCLAW_TEST_FAST;
+      return;
+    }
+    process.env.OPENCLAW_TEST_FAST = previousFastTestEnv;
+  });
+
+  it("passes bashElevated with enabled+allowed when config enables elevated globally", async () => {
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        cfg: {
+          tools: {
+            elevated: {
+              enabled: true,
+            },
+          },
+          agents: {
+            defaults: {
+              elevatedDefault: "full",
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runWithModelFallbackMock).toHaveBeenCalledOnce();
+
+    // Extract the run callback and invoke it to get the runEmbeddedPiAgent call
+    const runFn = runWithModelFallbackMock.mock.calls[0][0].run;
+    await runFn("openai", "gpt-4");
+
+    const { runEmbeddedPiAgent } = await import("../../agents/pi-embedded.js");
+    const callArgs = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0];
+    expect(callArgs).toHaveProperty("bashElevated");
+    expect(callArgs.bashElevated).toEqual({
+      enabled: true,
+      allowed: true,
+      defaultLevel: "full",
+    });
+  });
+
+  it("passes bashElevated with enabled=false when elevated is disabled", async () => {
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        cfg: {
+          tools: {
+            elevated: {
+              enabled: false,
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runWithModelFallbackMock).toHaveBeenCalledOnce();
+
+    const runFn = runWithModelFallbackMock.mock.calls[0][0].run;
+    await runFn("openai", "gpt-4");
+
+    const { runEmbeddedPiAgent } = await import("../../agents/pi-embedded.js");
+    const callArgs = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0];
+    expect(callArgs).toHaveProperty("bashElevated");
+    expect(callArgs.bashElevated?.enabled).toBe(false);
+  });
+
+  it("defaults elevated level to 'on' when no elevatedDefault is configured", async () => {
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        cfg: {
+          tools: {
+            elevated: {
+              enabled: true,
+            },
+          },
+        },
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runWithModelFallbackMock).toHaveBeenCalledOnce();
+
+    const runFn = runWithModelFallbackMock.mock.calls[0][0].run;
+    await runFn("openai", "gpt-4");
+
+    const { runEmbeddedPiAgent } = await import("../../agents/pi-embedded.js");
+    const callArgs = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0];
+    expect(callArgs.bashElevated).toEqual({
+      enabled: true,
+      allowed: true,
+      defaultLevel: "on",
+    });
+  });
+
+  it("respects per-agent elevated config override", async () => {
+    resolveAgentConfigMock.mockReturnValue({
+      tools: { elevated: { enabled: false } },
+    });
+
+    const result = await runCronIsolatedAgentTurn(
+      makeParams({
+        cfg: {
+          tools: {
+            elevated: {
+              enabled: true,
+              allowFrom: { "*": ["*"] },
+            },
+          },
+        },
+        agentId: "scout",
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runWithModelFallbackMock).toHaveBeenCalledOnce();
+
+    const runFn = runWithModelFallbackMock.mock.calls[0][0].run;
+    await runFn("openai", "gpt-4");
+
+    const { runEmbeddedPiAgent } = await import("../../agents/pi-embedded.js");
+    const callArgs = vi.mocked(runEmbeddedPiAgent).mock.calls[0]?.[0];
+    expect(callArgs.bashElevated?.enabled).toBe(false);
+  });
+});

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -120,6 +120,7 @@ vi.mock("../../agents/cli-session.js", () => ({
 }));
 
 vi.mock("../../auto-reply/thinking.js", () => ({
+  normalizeElevatedLevel: vi.fn().mockReturnValue(undefined),
   normalizeThinkLevel: vi.fn().mockReturnValue(undefined),
   normalizeVerboseLevel: vi.fn().mockReturnValue("off"),
   supportsXHighThinking: vi.fn().mockReturnValue(false),

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -29,6 +29,7 @@ import { deriveSessionTotalTokens, hasNonzeroUsage } from "../../agents/usage.js
 import { ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveSystemElevatedDefaults } from "../../auto-reply/reply/reply-elevated.js";
 import {
+  normalizeElevatedLevel,
   normalizeThinkLevel,
   normalizeVerboseLevel,
   supportsXHighThinking,
@@ -345,10 +346,13 @@ export async function runCronIsolatedAgentTurn(params: {
   // Resolve elevated exec permissions so cron runs can use elevated tools
   // when the config enables them. Cron is system-initiated (no sender), so
   // only the enablement check applies — the allowFrom sender gate is skipped.
+  // Persisted session elevated level takes priority over config default
+  // (honours /elevated off set during the session).
+  const persistedElevated = normalizeElevatedLevel(cronSession.sessionEntry.elevatedLevel);
   const bashElevated = resolveSystemElevatedDefaults({
     cfg: cfgWithAgentDefaults,
     agentId,
-    elevatedDefault: agentCfg?.elevatedDefault,
+    elevatedDefault: persistedElevated ?? agentCfg?.elevatedDefault,
   });
 
   const { formattedTime, timeLine } = resolveCronStyleNow(params.cfg, now);

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -27,6 +27,7 @@ import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { deriveSessionTotalTokens, hasNonzeroUsage } from "../../agents/usage.js";
 import { ensureAgentWorkspace } from "../../agents/workspace.js";
+import { resolveSystemElevatedDefaults } from "../../auto-reply/reply/reply-elevated.js";
 import {
   normalizeThinkLevel,
   normalizeVerboseLevel,
@@ -341,6 +342,15 @@ export async function runCronIsolatedAgentTurn(params: {
     sessionKey: params.job.sessionKey,
   });
 
+  // Resolve elevated exec permissions so cron runs can use elevated tools
+  // when the config enables them. Cron is system-initiated (no sender), so
+  // only the enablement check applies — the allowFrom sender gate is skipped.
+  const bashElevated = resolveSystemElevatedDefaults({
+    cfg: cfgWithAgentDefaults,
+    agentId,
+    elevatedDefault: agentCfg?.elevatedDefault,
+  });
+
   const { formattedTime, timeLine } = resolveCronStyleNow(params.cfg, now);
   const base = `[cron:${params.job.id} ${params.job.name}] ${params.message}`.trim();
 
@@ -518,6 +528,7 @@ export async function runCronIsolatedAgentTurn(params: {
           authProfileIdSource,
           thinkLevel,
           verboseLevel: resolvedVerboseLevel,
+          bashElevated,
           timeoutMs,
           bootstrapContextMode: agentPayload?.lightContext ? "lightweight" : undefined,
           bootstrapContextRunKind: "cron",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `runEmbeddedPiAgent()` in the cron isolated-agent path and the `agentCommand` path (used by `sessions_send` and CLI `openclaw agent`) never passed `bashElevated`, so `elevatedDefaults` was always `undefined` in `bash-tools.exec.ts`, causing elevated exec to silently fail despite correct config.
- Why it matters: Users who configured `tools.elevated.enabled: true` expected cron and `sessions_send` runs to honour elevated exec, but it was always disabled in these code paths.
- What changed: Added `resolveSystemElevatedDefaults()` helper that checks only config enablement gates (no sender `allowFrom` — inapplicable in system-initiated contexts). Both `run.ts` (cron) and `agent.ts` now resolve and pass `bashElevated` to `runEmbeddedPiAgent()`. Session-persisted elevated level (`/elevated off`) is honoured over config default.
- What did NOT change (scope boundary): The inbound message path (already working) is untouched. No config schema changes. No new dependencies.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #18748
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Cron runs and `sessions_send` nested runs now correctly support elevated exec when `tools.elevated.enabled: true` is set in config.
- System-initiated contexts (cron, agent command) require explicit `enabled: true` — elevated is NOT implicitly enabled when `tools.elevated` is absent from config (stronger than the inbound path which has `allowFrom` as a second gate).
- Session-persisted elevated level (set via `/elevated off`) is now honoured by cron and agent command continuations.

## Security Impact (required)

- New permissions/capabilities? (`Yes`) — cron/agent-command paths can now use elevated exec (previously always blocked). Requires explicit `tools.elevated.enabled: true`.
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`) — elevated exec now reachable from cron and `sessions_send` paths when config explicitly enables it.
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: System-initiated contexts bypass `allowFrom` sender check because there is no sender. Mitigated by: (1) requiring explicit `enabled: true` (not default-enabled like inbound), (2) `sessions_send` is owner-only + dangerous-tools gated, (3) cron and CLI are trusted local contexts.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 24
- Model/provider: Any
- Integration/channel (if any): Any with elevated enabled
- Relevant config (redacted):
  ```yaml
  tools:
    elevated:
      enabled: true
  agents:
    defaults:
      elevatedDefault: full
  ```

### Steps

1. Configure `tools.elevated.enabled: true` and `agents.defaults.elevatedDefault: full`
2. Set up a cron job with `sessionTarget: isolated`
3. Observe that the cron run's agent can use elevated exec

### Expected

- `bashElevated` passed to `runEmbeddedPiAgent` with `{ enabled: true, allowed: true, defaultLevel: "full" }`

### Actual

- Before fix: `bashElevated` was `undefined`, elevated exec silently failed with "elevated is not available right now (runtime=sandboxed)"

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

6 tests in `run.elevated.test.ts`:
1. Enabled+allowed when config enables elevated globally
2. Disabled when `enabled: false`
3. Default level `"on"` when no `elevatedDefault` configured
4. Disabled when `tools.elevated` not configured at all (explicit opt-in)
5. Session persisted elevated level overrides config default
6. Per-agent elevated config override respected

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: All 6 test cases pass; `pnpm build && pnpm check` clean; codex review clean
- Edge cases checked: No config = disabled (explicit opt-in); session `/elevated off` overrides config default; per-agent override
- What you did **not** verify: Live cron run with real elevated config (test-only verification)

## Compatibility / Migration

- Backward compatible? (`Yes`) — previously elevated never worked in these paths, so no existing behaviour changes for configs without `tools.elevated.enabled: true`
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Set `tools.elevated.enabled: false` in config, or revert the 3 commits on this branch
- Files/config to restore: `src/auto-reply/reply/reply-elevated.ts`, `src/cron/isolated-agent/run.ts`, `src/commands/agent.ts`, `src/commands/agent/session.ts`
- Known bad symptoms reviewers should watch for: Unexpected elevated exec in cron or sessions_send runs

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: `sessions_send` nested runs inherit elevated from config without sender-level `allowFrom` check
  - Mitigation: `sessions_send` is owner-only + dangerous-tools gated; parent session already validates sender; explicit `enabled: true` required
