### PR TITLE
fix(telegram): prevent crash loop on oversized file attachments

### DIFF
--- a/extensions/telegram/src/bot-handlers.media.ts
+++ b/extensions/telegram/src/bot-handlers.media.ts
@@ -5,8 +5,11 @@ export const APPROVE_CALLBACK_DATA_RE =
   /^\/approve(?:@[^\s]+)?\s+[A-Za-z0-9][A-Za-z0-9._:-]*\s+(allow-once|allow-always|deny)\b/i;
 
 export function isMediaSizeLimitError(err: unknown): boolean {
+  if (err instanceof MediaFetchError && err.code === "max_bytes") {
+    return true;
+  }
   const errMsg = String(err);
-  return errMsg.includes("exceeds") && errMsg.includes("MB limit");
+  return errMsg.includes("exceeds") && (errMsg.includes("MB limit") || errMsg.includes("maxBytes"));
 }
 
 export function isRecoverableMediaGroupError(err: unknown): boolean {


### PR DESCRIPTION
## Problem

When a Telegram user sends a file exceeding `mediaMaxMb` (default 5MB), the gateway crashes instead of gracefully rejecting it. With systemd/launchd auto-restart, Telegram replays the same update, causing an **infinite crash loop** that requires manual intervention to resolve.

Closes #26246

## Root Cause

Two bugs in the Telegram media handling path:

### 1. String matcher mismatch in `isMediaSizeLimitError()`

The error detection function checks for `'exceeds'` + `'MB limit'` in the error message:

```typescript
// bot-handlers.ts (before)
function isMediaSizeLimitError(err: unknown): boolean {
  const errMsg = String(err);
  return errMsg.includes("exceeds") && errMsg.includes("MB limit");
}
```

But `MediaFetchError` throws messages containing `'exceeds maxBytes'`:

```
Failed to fetch media from ...: payload exceeds maxBytes 5242880
```

The strings never match → error falls through to the general handler → gateway crashes.

### 2. No pre-download size check

`resolveMedia()` downloads the entire file before checking against `mediaMaxMb`. For large files (e.g., 16MB zip with 5MB limit), this wastes bandwidth and can cause memory pressure before the size check even runs.

## Fix

### 1. Type-safe error detection

`isMediaSizeLimitError()` now checks `MediaFetchError.code === 'max_bytes'` first (type-safe, no string matching needed), with the string fallback updated to also match `'maxBytes'`:

```typescript
function isMediaSizeLimitError(err: unknown): boolean {
  if (err instanceof MediaFetchError && err.code === "max_bytes") {
    return true;
  }
  const errMsg = String(err);
  return errMsg.includes("exceeds") && (errMsg.includes("MB limit") || errMsg.includes("maxBytes"));
}
```

### 2. Pre-download size check

Added an early `file_size` check in `resolveMedia()` using Telegram's message metadata (available before download). Files exceeding the limit are rejected immediately without downloading:

```typescript
if (maxBytes && "file_size" in m && typeof m.file_size === "number" && m.file_size > maxBytes) {
  throw new MediaFetchError("max_bytes", `File size ... exceeds maxBytes limit of ...`);
}
```

## Impact

- **Before:** Oversized file → crash → restart → Telegram replays update → crash loop (requires manual `getUpdates?offset=` flush)
- **After:** Oversized file → caught gracefully → user sees '⚠️ File too large' message → update acknowledged → no crash

## Testing

Verified manually against a 16MB zip file with the default 5MB `mediaMaxMb` limit. The gateway now sends the oversize warning and continues processing normally.