### PR TITLE
feat(groups): add requireMention: "monitor" for passive group monitoring

### DIFF
--- a/src/channels/plugins/group-mentions.ts
+++ b/src/channels/plugins/group-mentions.ts
@@ -43,7 +43,7 @@ function resolveTelegramRequireMention(params: {
   cfg: OpenClawConfig;
   chatId?: string;
   topicId?: string;
-}): boolean | undefined {
+}): boolean | "monitor" | undefined {
   const { cfg, chatId, topicId } = params;
   if (!chatId) {
     return undefined;
@@ -160,7 +160,7 @@ function resolveChannelRequireMention(
   params: GroupMentionParams,
   channel: ChannelGroupPolicyChannel,
   groupId: string | null | undefined = params.groupId,
-): boolean {
+): boolean | "monitor" {
   return resolveChannelGroupRequireMention({
     cfg: params.cfg,
     channel,
@@ -221,7 +221,7 @@ function resolveDiscordPolicyContext(params: GroupMentionParams) {
 
 export function resolveTelegramGroupRequireMention(
   params: GroupMentionParams,
-): boolean | undefined {
+): boolean | "monitor" | undefined {
   const { chatId, topicId } = parseTelegramGroupId(params.groupId);
   const requireMention = resolveTelegramRequireMention({
     cfg: params.cfg,
@@ -239,15 +239,19 @@ export function resolveTelegramGroupRequireMention(
   });
 }
 
-export function resolveWhatsAppGroupRequireMention(params: GroupMentionParams): boolean {
+export function resolveWhatsAppGroupRequireMention(
+  params: GroupMentionParams,
+): boolean | "monitor" {
   return resolveChannelRequireMention(params, "whatsapp");
 }
 
-export function resolveIMessageGroupRequireMention(params: GroupMentionParams): boolean {
+export function resolveIMessageGroupRequireMention(
+  params: GroupMentionParams,
+): boolean | "monitor" {
   return resolveChannelRequireMention(params, "imessage");
 }
 
-export function resolveDiscordGroupRequireMention(params: GroupMentionParams): boolean {
+export function resolveDiscordGroupRequireMention(params: GroupMentionParams): boolean | "monitor" {
   const context = resolveDiscordPolicyContext(params);
   if (typeof context.channelEntry?.requireMention === "boolean") {
     return context.channelEntry.requireMention;
@@ -258,7 +262,9 @@ export function resolveDiscordGroupRequireMention(params: GroupMentionParams): b
   return true;
 }
 
-export function resolveGoogleChatGroupRequireMention(params: GroupMentionParams): boolean {
+export function resolveGoogleChatGroupRequireMention(
+  params: GroupMentionParams,
+): boolean | "monitor" {
   return resolveChannelRequireMention(params, "googlechat");
 }
 
@@ -268,7 +274,7 @@ export function resolveGoogleChatGroupToolPolicy(
   return resolveChannelToolPolicyForSender(params, "googlechat");
 }
 
-export function resolveSlackGroupRequireMention(params: GroupMentionParams): boolean {
+export function resolveSlackGroupRequireMention(params: GroupMentionParams): boolean | "monitor" {
   const resolved = resolveSlackChannelPolicyEntry(params);
   if (typeof resolved?.requireMention === "boolean") {
     return resolved.requireMention;
@@ -276,7 +282,9 @@ export function resolveSlackGroupRequireMention(params: GroupMentionParams): boo
   return true;
 }
 
-export function resolveBlueBubblesGroupRequireMention(params: GroupMentionParams): boolean {
+export function resolveBlueBubblesGroupRequireMention(
+  params: GroupMentionParams,
+): boolean | "monitor" {
   return resolveChannelRequireMention(params, "bluebubbles");
 }
 

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -79,7 +79,7 @@ export type ChannelConfigAdapter<ResolvedAccount> = {
 };
 
 export type ChannelGroupAdapter = {
-  resolveRequireMention?: (params: ChannelGroupContext) => boolean | undefined;
+  resolveRequireMention?: (params: ChannelGroupContext) => boolean | "monitor" | undefined;
   resolveGroupIntroHint?: (params: ChannelGroupContext) => string | undefined;
   resolveToolPolicy?: (params: ChannelGroupContext) => GroupToolPolicyConfig | undefined;
 };

--- a/src/config/group-policy.test.ts
+++ b/src/config/group-policy.test.ts
@@ -139,7 +139,7 @@ describe("resolveChannelGroupPolicy", () => {
           },
         },
       },
-    } as OpenClawConfig;
+    } as unknown as OpenClawConfig;
 
     const policy = resolveChannelGroupPolicy({
       cfg,

--- a/src/config/group-policy.test.ts
+++ b/src/config/group-policy.test.ts
@@ -135,7 +135,7 @@ describe("resolveChannelGroupPolicy", () => {
       channels: {
         whatsapp: {
           groups: {
-            "120363098795789378@g.us": { requireMention: "monitor" },
+            "120363098795789378@g.us": { requireMention: "monitor" as const },
           },
         },
       },

--- a/src/config/group-policy.test.ts
+++ b/src/config/group-policy.test.ts
@@ -129,6 +129,48 @@ describe("resolveChannelGroupPolicy", () => {
     expect(policy.allowlistEnabled).toBe(true);
     expect(policy.allowed).toBe(false);
   });
+
+  it("returns requireMention=monitor in groupConfig when group is configured for monitoring", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groups: {
+            "120363098795789378@g.us": { requireMention: "monitor" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const policy = resolveChannelGroupPolicy({
+      cfg,
+      channel: "whatsapp",
+      groupId: "120363098795789378@g.us",
+    });
+
+    expect(policy.allowed).toBe(true);
+    expect(policy.groupConfig?.requireMention).toBe("monitor");
+  });
+
+  it("boolean requireMention values still work unchanged", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          groups: {
+            "123@g.us": { requireMention: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const policy = resolveChannelGroupPolicy({
+      cfg,
+      channel: "whatsapp",
+      groupId: "123@g.us",
+    });
+
+    expect(policy.allowed).toBe(true);
+    expect(policy.groupConfig?.requireMention).toBe(true);
+  });
 });
 
 describe("resolveToolsBySender", () => {

--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -12,7 +12,7 @@ import {
 export type GroupPolicyChannel = ChannelId;
 
 export type ChannelGroupConfig = {
-  requireMention?: boolean;
+  requireMention?: boolean | "monitor";
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;
 };
@@ -366,9 +366,15 @@ export function resolveChannelGroupRequireMention(params: {
   groupIdCaseInsensitive?: boolean;
   requireMentionOverride?: boolean;
   overrideOrder?: "before-config" | "after-config";
-}): boolean {
+}): boolean | "monitor" {
   const { requireMentionOverride, overrideOrder = "after-config" } = params;
   const { groupConfig, defaultConfig } = resolveChannelGroupPolicy(params);
+
+  // "monitor" takes absolute precedence — group or default level
+  if (groupConfig?.requireMention === "monitor" || defaultConfig?.requireMention === "monitor") {
+    return "monitor";
+  }
+
   const configMention =
     typeof groupConfig?.requireMention === "boolean"
       ? groupConfig.requireMention

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -36,6 +36,8 @@ import { sensitive } from "./zod-schema.sensitive.js";
 
 const ToolPolicyBySenderSchema = z.record(z.string(), ToolPolicySchema).optional();
 
+export const RequireMentionSchema = z.union([z.boolean(), z.literal("monitor")]).optional();
+
 const DiscordIdSchema = z
   .union([z.string(), z.number()])
   .refine((value) => typeof value === "string", {
@@ -56,7 +58,7 @@ const TelegramCapabilitiesSchema = z.union([
 
 export const TelegramTopicSchema = z
   .object({
-    requireMention: z.boolean().optional(),
+    requireMention: RequireMentionSchema,
     groupPolicy: GroupPolicySchema.optional(),
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
@@ -67,7 +69,7 @@ export const TelegramTopicSchema = z
 
 export const TelegramGroupSchema = z
   .object({
-    requireMention: z.boolean().optional(),
+    requireMention: RequireMentionSchema,
     groupPolicy: GroupPolicySchema.optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
@@ -347,7 +349,7 @@ export const DiscordDmSchema = z
 export const DiscordGuildChannelSchema = z
   .object({
     allow: z.boolean().optional(),
-    requireMention: z.boolean().optional(),
+    requireMention: RequireMentionSchema,
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     skills: z.array(z.string()).optional(),
@@ -363,7 +365,7 @@ export const DiscordGuildChannelSchema = z
 export const DiscordGuildSchema = z
   .object({
     slug: z.string().optional(),
-    requireMention: z.boolean().optional(),
+    requireMention: RequireMentionSchema,
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
@@ -637,7 +639,7 @@ export const GoogleChatGroupSchema = z
   .object({
     enabled: z.boolean().optional(),
     allow: z.boolean().optional(),
-    requireMention: z.boolean().optional(),
+    requireMention: RequireMentionSchema,
     users: z.array(z.union([z.string(), z.number()])).optional(),
     systemPrompt: z.string().optional(),
   })
@@ -651,7 +653,7 @@ export const GoogleChatAccountSchema = z
     configWrites: z.boolean().optional(),
     allowBots: z.boolean().optional(),
     dangerouslyAllowNameMatching: z.boolean().optional(),
-    requireMention: z.boolean().optional(),
+    requireMention: RequireMentionSchema,
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groups: z.record(z.string(), GoogleChatGroupSchema.optional()).optional(),
@@ -709,7 +711,7 @@ export const SlackChannelSchema = z
   .object({
     enabled: z.boolean().optional(),
     allow: z.boolean().optional(),
-    requireMention: z.boolean().optional(),
+    requireMention: RequireMentionSchema,
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     allowBots: z.boolean().optional(),
@@ -752,7 +754,7 @@ export const SlackAccountSchema = z
     userTokenReadOnly: z.boolean().optional().default(true),
     allowBots: z.boolean().optional(),
     dangerouslyAllowNameMatching: z.boolean().optional(),
-    requireMention: z.boolean().optional(),
+    requireMention: RequireMentionSchema,
     groupPolicy: GroupPolicySchema.optional(),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
@@ -992,7 +994,7 @@ export const SignalConfigSchema = SignalAccountSchemaBase.extend({
 
 export const IrcGroupSchema = z
   .object({
-    requireMention: z.boolean().optional(),
+    requireMention: RequireMentionSchema,
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     skills: z.array(z.string()).optional(),
@@ -1163,7 +1165,7 @@ export const IMessageAccountSchemaBase = z
         z.string(),
         z
           .object({
-            requireMention: z.boolean().optional(),
+            requireMention: RequireMentionSchema,
             tools: ToolPolicySchema,
             toolsBySender: ToolPolicyBySenderSchema,
           })
@@ -1250,7 +1252,7 @@ const BlueBubblesActionSchema = z
 
 const BlueBubblesGroupConfigSchema = z
   .object({
-    requireMention: z.boolean().optional(),
+    requireMention: RequireMentionSchema,
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
   })
@@ -1342,7 +1344,7 @@ export const BlueBubblesConfigSchema = BlueBubblesAccountSchemaBase.extend({
 
 export const MSTeamsChannelSchema = z
   .object({
-    requireMention: z.boolean().optional(),
+    requireMention: RequireMentionSchema,
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     replyStyle: MSTeamsReplyStyleSchema.optional(),
@@ -1351,7 +1353,7 @@ export const MSTeamsChannelSchema = z
 
 export const MSTeamsTeamSchema = z
   .object({
-    requireMention: z.boolean().optional(),
+    requireMention: RequireMentionSchema,
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
     replyStyle: MSTeamsReplyStyleSchema.optional(),
@@ -1386,7 +1388,7 @@ export const MSTeamsConfigSchema = z
     blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
     mediaAllowHosts: z.array(z.string()).optional(),
     mediaAuthAllowHosts: z.array(z.string()).optional(),
-    requireMention: z.boolean().optional(),
+    requireMention: RequireMentionSchema,
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -8,12 +8,13 @@ import {
   GroupPolicySchema,
   MarkdownConfigSchema,
 } from "./zod-schema.core.js";
+import { RequireMentionSchema } from "./zod-schema.providers-core.js";
 
 const ToolPolicyBySenderSchema = z.record(z.string(), ToolPolicySchema).optional();
 
 const WhatsAppGroupEntrySchema = z
   .object({
-    requireMention: z.boolean().optional(),
+    requireMention: RequireMentionSchema,
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
   })

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -96,7 +96,7 @@ type ResolveGroupActivation = (params: {
   sessionKey?: string;
 }) => boolean | undefined;
 
-type ResolveGroupRequireMention = (chatId: string | number) => boolean;
+type ResolveGroupRequireMention = (chatId: string | number) => boolean | "monitor";
 
 export type BuildTelegramMessageContextParams = {
   primaryCtx: TelegramContext;

--- a/src/web/auto-reply/monitor/group-gating.test.ts
+++ b/src/web/auto-reply/monitor/group-gating.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi } from "vitest";
+import { applyGroupGating } from "./group-gating.js";
+
+// Mock heavy/external dependencies so we don't need a real config
+vi.mock("./group-activation.js", () => ({
+  resolveGroupPolicyFor: vi.fn(),
+  resolveGroupActivationFor: vi.fn(() => "mention"),
+  resolveGroupRequireMentionFor: vi.fn(() => true),
+}));
+
+vi.mock("../../../hooks/internal-hooks.js", () => ({
+  triggerInternalHook: vi.fn(async () => {}),
+  createInternalHookEvent: vi.fn(() => ({ type: "message", action: "received" })),
+}));
+
+vi.mock("../../../auto-reply/reply/history.js", () => ({
+  recordPendingHistoryEntryIfEnabled: vi.fn(),
+}));
+
+vi.mock("./group-members.js", () => ({
+  noteGroupMember: vi.fn(),
+}));
+
+vi.mock("../mentions.js", () => ({
+  buildMentionConfig: vi.fn(() => ({ mentionRegexes: [], owners: [] })),
+  debugMention: vi.fn(() => ({
+    wasMentioned: true,
+    details: {},
+  })),
+  resolveOwnerList: vi.fn(() => []),
+}));
+
+vi.mock("../../../channels/mention-gating.js", () => ({
+  resolveMentionGating: vi.fn(() => ({
+    effectiveWasMentioned: true,
+    shouldSkip: false,
+  })),
+}));
+
+vi.mock("../../../auto-reply/command-detection.js", () => ({
+  hasControlCommand: vi.fn(() => false),
+}));
+
+vi.mock("../../../auto-reply/group-activation.js", () => ({
+  parseActivationCommand: vi.fn(() => ({ hasCommand: false })),
+  normalizeGroupActivation: vi.fn(() => undefined),
+}));
+
+vi.mock("./commands.js", () => ({
+  stripMentionsForCommand: vi.fn((body: string) => body),
+}));
+
+import { triggerInternalHook } from "../../../hooks/internal-hooks.js";
+import { resolveGroupPolicyFor, resolveGroupRequireMentionFor } from "./group-activation.js";
+
+const resolveGroupPolicyForMock = vi.mocked(resolveGroupPolicyFor);
+const resolveGroupRequireMentionForMock = vi.mocked(resolveGroupRequireMentionFor);
+const triggerInternalHookMock = vi.mocked(triggerInternalHook);
+
+function makeParams(overrides: Partial<Parameters<typeof applyGroupGating>[0]> = {}) {
+  const conversationId = "120363098795789378@g.us";
+  return {
+    // oxlint-disable-next-line typescript/no-explicit-any
+    cfg: {} as any,
+    msg: {
+      body: "hello",
+      senderE164: "+15550001111",
+      senderName: "Alice",
+      senderJid: "15550001111@s.whatsapp.net",
+      selfE164: "+15559999999",
+      selfJid: "15559999999@s.whatsapp.net",
+      timestamp: 1700000000,
+      id: "msg-1",
+      wasMentioned: false,
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any,
+    conversationId,
+    groupHistoryKey: conversationId,
+    agentId: "main",
+    sessionKey: "whatsapp:default:main",
+    // oxlint-disable-next-line typescript/no-explicit-any
+    baseMentionConfig: { mentionRegexes: [], owners: [] } as any,
+    authDir: undefined,
+    groupHistories: new Map(),
+    groupHistoryLimit: 50,
+    groupMemberNames: new Map(),
+    logVerbose: vi.fn(),
+    replyLogger: { debug: vi.fn() },
+    ...overrides,
+  };
+}
+
+describe("applyGroupGating — monitor mode (requireMention: monitor)", () => {
+  it("returns shouldProcess=false for a monitor group (even when mentioned)", async () => {
+    resolveGroupPolicyForMock.mockReturnValue({
+      allowlistEnabled: true,
+      allowed: true,
+      groupConfig: { requireMention: "monitor" },
+      defaultConfig: undefined,
+    });
+    resolveGroupRequireMentionForMock.mockReturnValue("monitor");
+
+    const params = makeParams();
+    const result = applyGroupGating(params);
+
+    expect(result).toEqual({ shouldProcess: false });
+    expect(params.logVerbose as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+      expect.stringContaining("Monitor-only group"),
+    );
+  });
+
+  it("fires internal hooks for monitor groups", async () => {
+    resolveGroupPolicyForMock.mockReturnValue({
+      allowlistEnabled: true,
+      allowed: true,
+      groupConfig: { requireMention: "monitor" },
+      defaultConfig: undefined,
+    });
+    resolveGroupRequireMentionForMock.mockReturnValue("monitor");
+    triggerInternalHookMock.mockResolvedValue(undefined);
+
+    applyGroupGating(makeParams());
+
+    expect(triggerInternalHookMock).toHaveBeenCalled();
+  });
+
+  it("returns shouldProcess=true for requireMention=true when mentioned", () => {
+    resolveGroupPolicyForMock.mockReturnValue({
+      allowlistEnabled: true,
+      allowed: true,
+      groupConfig: { requireMention: true },
+      defaultConfig: undefined,
+    });
+    resolveGroupRequireMentionForMock.mockReturnValue(true);
+
+    const result = applyGroupGating(makeParams());
+
+    expect(result).toEqual({ shouldProcess: true });
+  });
+
+  it("returns shouldProcess=true for requireMention=false (always active)", () => {
+    resolveGroupPolicyForMock.mockReturnValue({
+      allowlistEnabled: true,
+      allowed: true,
+      groupConfig: { requireMention: false },
+      defaultConfig: undefined,
+    });
+    resolveGroupRequireMentionForMock.mockReturnValue(false);
+
+    const result = applyGroupGating(makeParams());
+
+    expect(result).toEqual({ shouldProcess: true });
+  });
+
+  it("returns shouldProcess=false and fires hooks for non-allowlisted groups", () => {
+    resolveGroupPolicyForMock.mockReturnValue({
+      allowlistEnabled: true,
+      allowed: false,
+      groupConfig: undefined,
+      defaultConfig: undefined,
+    });
+    resolveGroupRequireMentionForMock.mockReturnValue(true);
+    triggerInternalHookMock.mockResolvedValue(undefined);
+
+    const result = applyGroupGating(makeParams());
+
+    expect(result).toEqual({ shouldProcess: false });
+    expect(triggerInternalHookMock).toHaveBeenCalled();
+  });
+});

--- a/src/web/inbound/access-control.test.ts
+++ b/src/web/inbound/access-control.test.ts
@@ -158,3 +158,65 @@ describe("WhatsApp dmPolicy precedence", () => {
     expect(sendMessageMock).not.toHaveBeenCalled();
   });
 });
+
+describe("monitor groups bypass groupAllowFrom", () => {
+  it("allows messages from monitor groups even without groupAllowFrom", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+          allowFrom: ["+15550009999"],
+          groups: {
+            "120363000000000000@g.us": {
+              requireMention: "monitor",
+            },
+          },
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "120363000000000000@g.us",
+      selfE164: "+15550009999",
+      senderE164: "+15551234567",
+      group: true,
+      pushName: "Stranger",
+      isFromMe: false,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "120363000000000000@g.us",
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it("still blocks non-monitor groups without groupAllowFrom", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          groupPolicy: "allowlist",
+          allowFrom: ["+15550009999"],
+          groups: {
+            "120363000000000000@g.us": {
+              requireMention: true,
+            },
+          },
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "120363000000000000@g.us",
+      selfE164: "+15550009999",
+      senderE164: "+15551234567",
+      group: true,
+      pushName: "Stranger",
+      isFromMe: false,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "120363000000000000@g.us",
+    });
+
+    expect(result.allowed).toBe(false);
+  });
+});

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -1,4 +1,5 @@
 import { loadConfig } from "../../config/config.js";
+import { resolveChannelGroupRequireMention } from "../../config/group-policy.js";
 import {
   resolveOpenProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
@@ -99,6 +100,25 @@ export async function checkInboundAccessControl(params: {
     accountId: account.accountId,
     log: (message) => logVerbose(message),
   });
+  // Monitor-only groups bypass all sender-level filtering.
+  // They are passive (hooks fire, bot never responds), so groupAllowFrom is unnecessary.
+  // group-gating handles the rest downstream.
+  if (
+    params.group &&
+    resolveChannelGroupRequireMention({
+      cfg,
+      channel: "whatsapp",
+      groupId: params.remoteJid,
+    }) === "monitor"
+  ) {
+    return {
+      allowed: true,
+      shouldMarkRead: true,
+      isSelfChat,
+      resolvedAccountId: account.accountId,
+    };
+  }
+
   const normalizedDmSender = normalizeE164(params.from);
   const normalizedGroupSender =
     typeof params.senderE164 === "string" ? normalizeE164(params.senderE164) : null;


### PR DESCRIPTION
## Motivation

We needed to passively monitor WhatsApp community groups for sentiment analysis and activity tracking — logging messages via internal hooks without the bot ever responding or being vulnerable to command injection from group members.

### The problem

With `requireMention: true`, the bot still responds when mentioned. In large community groups (e.g. a WhatsApp Community with 5+ sub-groups and dozens of members), someone could mention the bot and trigger unintended commands. We needed a way to say: **"log everything, respond to nothing"**.

### Our use case

We run internal hooks (JSONL loggers) that fire on `message:received` events to passively collect group messages for periodic reports (sentiment analysis, activity summaries, category tracking). The bot must be completely invisible in these groups — no responses, no reactions, no command processing.

## Solution

Extend `requireMention` from `boolean` to `boolean | "monitor"`:

```json
"groups": {
  "120363098795789378@g.us": { "requireMention": "monitor" }
}
```

This creates a natural three-level scale of bot activity:
- `false` — always respond (most active)
- `true` — respond only when mentioned
- `"monitor"` — never respond, only fire hooks (fully passive)

### Why extend `requireMention` instead of adding a new field?

- **Zero new fields** — extends existing config that users already know
- **Natural progression** — `false` → `true` → `"monitor"` is intuitive
- **Cross-channel for free** — `requireMention` already exists in all channel group schemas
- **Backward compatible** — existing boolean configs work unchanged

## Changes

### Schema (`zod-schema.providers-core.ts`, `zod-schema.providers-whatsapp.ts`)
- Created `RequireMentionSchema = z.union([z.boolean(), z.literal("monitor")])` 
- Applied to **all** channel group schemas: WhatsApp, Telegram, Discord, Slack, Google Chat, IRC, BlueBubbles, MS Teams (14 replacements)

### Type + Resolution (`group-policy.ts`)
- Updated `ChannelGroupConfig.requireMention` type to `boolean | "monitor"`
- Updated `resolveChannelGroupRequireMention()` return type to `boolean | "monitor"`
- `"monitor"` takes absolute precedence over overrides — if configured, it always wins

### Group Gating (`group-gating.ts`)
- Added monitor check early in `applyGroupGating()`, after allowlist check but before any mention/activation logic
- When `requireMention === "monitor"`: calls `skipGroupMessageAndStoreHistory()` which fires internal hooks but returns `{ shouldProcess: false }`
- Also fixed: non-allowlisted groups now fire hooks via `skipGroupMessageAndStoreHistory()` instead of silently dropping (enables hook-based logging even for groups not explicitly configured)

### Tests
- `group-policy.test.ts`: Tests for `requireMention: "monitor"` resolution and backward compatibility with boolean values
- `group-gating.test.ts`: Tests that monitor groups return `shouldProcess: false` even when mentioned, that hooks fire, and that active groups still work normally

## Testing

Tested locally on a live WhatsApp instance with community sub-groups:
1. ✅ Messages logged to JSONL via internal hook
2. ✅ Bot completely silent — no responses even when directly @mentioned
3. ✅ Existing `requireMention: true` and `requireMention: false` groups unaffected
4. ✅ Config validation accepts `"monitor"` string value