### PR TITLE
Telegram: honor NO_PROXY and env proxy precedence

### DIFF
--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -13,7 +13,7 @@ import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
-import { makeProxyFetch } from "./proxy.js";
+import { makeProxyFetch, resolveProxyUrlFromEnv, shouldBypassProxyForUrl } from "./proxy.js";
 import { readTelegramUpdateOffset, writeTelegramUpdateOffset } from "./update-offset-store.js";
 import { startTelegramWebhook } from "./webhook.js";
 
@@ -134,8 +134,11 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       );
     }
 
+    const resolvedProxyUrl = account.config.proxy?.trim() || resolveProxyUrlFromEnv();
+    const shouldBypassProxy = shouldBypassProxyForUrl("https://api.telegram.org");
     const proxyFetch =
-      opts.proxyFetch ?? (account.config.proxy ? makeProxyFetch(account.config.proxy) : undefined);
+      opts.proxyFetch ??
+      (resolvedProxyUrl && !shouldBypassProxy ? makeProxyFetch(resolvedProxyUrl) : undefined);
 
     let lastUpdateId = await readTelegramUpdateOffset({
       accountId: account.accountId,

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -1,6 +1,6 @@
 import type { BaseProbeResult } from "../channels/plugins/types.js";
 import { fetchWithTimeout } from "../utils/fetch-timeout.js";
-import { makeProxyFetch } from "./proxy.js";
+import { makeProxyFetch, resolveProxyUrlFromEnv, shouldBypassProxyForUrl } from "./proxy.js";
 
 const TELEGRAM_API_BASE = "https://api.telegram.org";
 
@@ -23,7 +23,9 @@ export async function probeTelegram(
   proxyUrl?: string,
 ): Promise<TelegramProbe> {
   const started = Date.now();
-  const fetcher = proxyUrl ? makeProxyFetch(proxyUrl) : fetch;
+  const resolvedProxyUrl = proxyUrl?.trim() || resolveProxyUrlFromEnv();
+  const shouldBypassProxy = shouldBypassProxyForUrl(TELEGRAM_API_BASE);
+  const fetcher = resolvedProxyUrl && !shouldBypassProxy ? makeProxyFetch(resolvedProxyUrl) : fetch;
   const base = `${TELEGRAM_API_BASE}/bot${token}`;
   const retryDelayMs = Math.max(50, Math.min(1000, timeoutMs));
 

--- a/src/telegram/proxy.test.ts
+++ b/src/telegram/proxy.test.ts
@@ -120,4 +120,11 @@ describe("shouldBypassProxyForUrl", () => {
     expect(shouldBypassProxyForUrl("https://api.telegram.org")).toBe(false);
     expect(shouldBypassProxyForUrl("https://api.telegram.org:8443")).toBe(true);
   });
+
+  it("matches IPv6 localhost entries with bracketed URL hostnames", () => {
+    process.env.NO_PROXY = "[::1], [::1]:443";
+    expect(shouldBypassProxyForUrl("https://[::1]")).toBe(true);
+    expect(shouldBypassProxyForUrl("https://[::1]:443")).toBe(true);
+    expect(shouldBypassProxyForUrl("https://[::1]:8443")).toBe(true);
+  });
 });

--- a/src/telegram/proxy.test.ts
+++ b/src/telegram/proxy.test.ts
@@ -114,4 +114,10 @@ describe("shouldBypassProxyForUrl", () => {
     expect(shouldBypassProxyForUrl("https://localhost:9000")).toBe(true);
     expect(shouldBypassProxyForUrl("https://example.org")).toBe(false);
   });
+
+  it("does not broaden port-scoped NO_PROXY entries", () => {
+    process.env.NO_PROXY = "api.telegram.org:8443";
+    expect(shouldBypassProxyForUrl("https://api.telegram.org")).toBe(false);
+    expect(shouldBypassProxyForUrl("https://api.telegram.org:8443")).toBe(true);
+  });
 });

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -13,3 +13,93 @@ export function makeProxyFetch(proxyUrl: string): typeof fetch {
   // should opt into resolveFetch/wrapFetchWithAbortSignal once at the edge.
   return fetcher;
 }
+
+/**
+ * Resolve proxy URL from standard environment variables.
+ * Precedence: HTTPS_PROXY > HTTP_PROXY > ALL_PROXY (case-insensitive).
+ */
+export function resolveProxyUrlFromEnv(): string | undefined {
+  const candidates = [
+    process.env.HTTPS_PROXY,
+    process.env.https_proxy,
+    process.env.HTTP_PROXY,
+    process.env.http_proxy,
+    process.env.ALL_PROXY,
+    process.env.all_proxy,
+  ];
+  for (const value of candidates) {
+    const trimmed = value?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return undefined;
+}
+
+function normalizeNoProxyEntry(value: string): string {
+  let normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return "";
+  }
+  if (normalized === "*") {
+    return normalized;
+  }
+  normalized = normalized.replace(/^[a-z][a-z0-9+.-]*:\/\//i, "");
+  normalized = normalized.split("/")[0] ?? normalized;
+  if (normalized.startsWith("[")) {
+    const end = normalized.indexOf("]");
+    if (end > 0) {
+      normalized = normalized.slice(1, end);
+    }
+  } else {
+    const match = normalized.match(/^(.*):\d+$/);
+    if (match?.[1]) {
+      normalized = match[1];
+    }
+  }
+  if (normalized.startsWith("*.")) {
+    normalized = normalized.slice(2);
+  }
+  return normalized;
+}
+
+function resolveNoProxyEntries(noProxy?: string | string[]): string[] {
+  const raw =
+    typeof noProxy === "undefined" ? (process.env.NO_PROXY ?? process.env.no_proxy ?? "") : noProxy;
+  const list = Array.isArray(raw) ? raw : raw.split(",");
+  return list.map(normalizeNoProxyEntry).filter(Boolean);
+}
+
+/**
+ * Return true when proxying should be bypassed for the given URL based on NO_PROXY.
+ * Supports exact host entries, leading-dot/suffix domains, and wildcard (*).
+ */
+export function shouldBypassProxyForUrl(url: string, noProxy?: string | string[]): boolean {
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname.trim().toLowerCase();
+  } catch {
+    return false;
+  }
+  if (!hostname) {
+    return false;
+  }
+
+  const entries = resolveNoProxyEntries(noProxy);
+  for (const entry of entries) {
+    if (entry === "*") {
+      return true;
+    }
+    if (entry.startsWith(".")) {
+      const suffix = entry.slice(1);
+      if (suffix && (hostname === suffix || hostname.endsWith(`.${suffix}`))) {
+        return true;
+      }
+      continue;
+    }
+    if (hostname === entry || hostname.endsWith(`.${entry}`)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -98,6 +98,14 @@ function resolveDefaultPort(protocol: string): string | null {
   }
 }
 
+function normalizeHostnameForNoProxy(hostname: string): string {
+  const trimmed = hostname.trim().toLowerCase();
+  if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
 /**
  * Return true when proxying should be bypassed for the given URL based on NO_PROXY.
  * Supports exact host entries, leading-dot/suffix domains, and wildcard (*).
@@ -107,7 +115,7 @@ export function shouldBypassProxyForUrl(url: string, noProxy?: string | string[]
   let port: string | null;
   try {
     const parsed = new URL(url);
-    hostname = parsed.hostname.trim().toLowerCase();
+    hostname = normalizeHostnameForNoProxy(parsed.hostname);
     port = parsed.port || resolveDefaultPort(parsed.protocol);
   } catch {
     return false;

--- a/src/telegram/proxy.ts
+++ b/src/telegram/proxy.ts
@@ -36,38 +36,66 @@ export function resolveProxyUrlFromEnv(): string | undefined {
   return undefined;
 }
 
-function normalizeNoProxyEntry(value: string): string {
+type NoProxyEntry = { wildcard: true } | { wildcard: false; host: string; port: string | null };
+
+function normalizeNoProxyEntry(value: string): NoProxyEntry | null {
   let normalized = value.trim().toLowerCase();
   if (!normalized) {
-    return "";
+    return null;
   }
   if (normalized === "*") {
-    return normalized;
+    return { wildcard: true };
   }
   normalized = normalized.replace(/^[a-z][a-z0-9+.-]*:\/\//i, "");
   normalized = normalized.split("/")[0] ?? normalized;
+
+  let host = normalized;
+  let port: string | null = null;
   if (normalized.startsWith("[")) {
     const end = normalized.indexOf("]");
     if (end > 0) {
-      normalized = normalized.slice(1, end);
+      host = normalized.slice(1, end);
+      const remainder = normalized.slice(end + 1);
+      const portMatch = remainder.match(/^:(\d+)$/);
+      if (portMatch?.[1]) {
+        port = portMatch[1];
+      }
     }
   } else {
-    const match = normalized.match(/^(.*):\d+$/);
-    if (match?.[1]) {
-      normalized = match[1];
+    const hostPortMatch = normalized.match(/^(.*):(\d+)$/);
+    if (hostPortMatch?.[1] && hostPortMatch[2]) {
+      host = hostPortMatch[1];
+      port = hostPortMatch[2];
     }
   }
-  if (normalized.startsWith("*.")) {
-    normalized = normalized.slice(2);
+
+  if (host.startsWith("*.")) {
+    host = host.slice(2);
   }
-  return normalized;
+  if (!host) {
+    return null;
+  }
+  return { wildcard: false, host, port };
 }
 
-function resolveNoProxyEntries(noProxy?: string | string[]): string[] {
+function resolveNoProxyEntries(noProxy?: string | string[]): NoProxyEntry[] {
   const raw =
     typeof noProxy === "undefined" ? (process.env.NO_PROXY ?? process.env.no_proxy ?? "") : noProxy;
   const list = Array.isArray(raw) ? raw : raw.split(",");
-  return list.map(normalizeNoProxyEntry).filter(Boolean);
+  return list.map(normalizeNoProxyEntry).filter((entry): entry is NoProxyEntry => entry !== null);
+}
+
+function resolveDefaultPort(protocol: string): string | null {
+  switch (protocol.toLowerCase()) {
+    case "http:":
+    case "ws:":
+      return "80";
+    case "https:":
+    case "wss:":
+      return "443";
+    default:
+      return null;
+  }
 }
 
 /**
@@ -76,8 +104,11 @@ function resolveNoProxyEntries(noProxy?: string | string[]): string[] {
  */
 export function shouldBypassProxyForUrl(url: string, noProxy?: string | string[]): boolean {
   let hostname: string;
+  let port: string | null;
   try {
-    hostname = new URL(url).hostname.trim().toLowerCase();
+    const parsed = new URL(url);
+    hostname = parsed.hostname.trim().toLowerCase();
+    port = parsed.port || resolveDefaultPort(parsed.protocol);
   } catch {
     return false;
   }
@@ -87,17 +118,20 @@ export function shouldBypassProxyForUrl(url: string, noProxy?: string | string[]
 
   const entries = resolveNoProxyEntries(noProxy);
   for (const entry of entries) {
-    if (entry === "*") {
+    if (entry.wildcard) {
       return true;
     }
-    if (entry.startsWith(".")) {
-      const suffix = entry.slice(1);
+    if (entry.port && port && entry.port !== port) {
+      continue;
+    }
+    if (entry.host.startsWith(".")) {
+      const suffix = entry.host.slice(1);
       if (suffix && (hostname === suffix || hostname.endsWith(`.${suffix}`))) {
         return true;
       }
       continue;
     }
-    if (hostname === entry || hostname.endsWith(`.${entry}`)) {
+    if (hostname === entry.host || hostname.endsWith(`.${entry.host}`)) {
       return true;
     }
   }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: multiple Telegram network paths accepted explicit `proxyUrl` but did not consistently honor standard proxy env vars and `NO_PROXY` bypass behavior.
- Why it matters: operators relying on environment-driven proxy policy can unintentionally route Telegram API calls through proxies that should be bypassed.
- What changed: added `resolveProxyUrlFromEnv()` (`HTTPS_PROXY` > `HTTP_PROXY` > `ALL_PROXY`, case-insensitive) and `shouldBypassProxyForUrl()` (`NO_PROXY` matching with exact/suffix/wildcard/port+scheme normalization), then wired probe/audit/monitor paths to use env-resolved proxy with bypass checks.
- What did NOT change (scope boundary): outbound Telegram request semantics and response parsing remain unchanged; this is transport selection hardening only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #26898

## User-visible / Behavior Changes

- Telegram probe/audit/monitor flows now automatically honor proxy env vars when explicit proxy config is absent.
- Telegram API calls now bypass proxying when `NO_PROXY` (or `no_proxy`) matches the destination host.

## Why

- Align Telegram transport behavior with standard operator proxy/no-proxy expectations.
- Reduce accidental proxying of sensitive Telegram bot traffic when bypass rules are configured.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): proxy env vars + NO_PROXY variants

### Steps

1. Set env proxy vars (`HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY`) and run Telegram proxy utilities.
2. Set `NO_PROXY` entries (`api.telegram.org`, `.telegram.org`, wildcard, scheme+port list entries) and evaluate bypass behavior.
3. Run Telegram probe/audit/monitor and proxy unit tests.

### Expected

- Proxy URL resolution follows precedence order and ignores blank env values.
- `NO_PROXY` host matches bypass proxy usage for Telegram API hosts.

### Actual

- Behavior matches expected and all targeted tests pass.

## Validation

- `pnpm exec vitest run src/telegram/proxy.test.ts src/telegram/probe.test.ts src/telegram/audit.test.ts src/telegram/monitor.test.ts src/telegram/send.proxy.test.ts`

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: env proxy precedence, blank filtering, exact/suffix/wildcard/normalized NO_PROXY matching.
- Edge cases checked: no partial host overmatch (`eviltelegram.org`), scheme+port NO_PROXY entries, and case-insensitive env var handling.
- What you did **not** verify: live Telegram API traffic behavior against external proxy infrastructure.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `cf4b62b188f47e6f6253fd060bbeb7426b39c4f0`.
- Files/config to restore: `src/telegram/proxy.ts`, `src/telegram/proxy.test.ts`, `src/telegram/probe.ts`, `src/telegram/audit.ts`, `src/telegram/monitor.ts`.
- Known bad symptoms reviewers should watch for: Telegram requests unexpectedly bypassing required corporate proxy or unexpectedly proxying despite explicit NO_PROXY configuration.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: NO_PROXY matching nuances (domain suffix vs exact host) can be interpreted differently across ecosystems.
  - Mitigation: explicit normalization/matching rules are covered by targeted tests for exact, suffix, wildcard, and list entries.
