### PR TITLE
feat: fire message_sending/message_sent hooks on outbound replies

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -199,7 +199,7 @@ export async function dispatchReplyFromConfig(params: {
             senderUsername: ctx.SenderUsername,
             senderE164: ctx.SenderE164,
             guildId: ctx.GroupSpace,
-            channelName: ctx.GroupChannel,
+            channelName: ctx.GroupChannel ?? ctx.GroupSubject,
           },
         },
         {
@@ -234,7 +234,7 @@ export async function dispatchReplyFromConfig(params: {
           senderUsername: ctx.SenderUsername,
           senderE164: ctx.SenderE164,
           guildId: ctx.GroupSpace,
-          channelName: ctx.GroupChannel,
+          channelName: ctx.GroupChannel ?? ctx.GroupSubject,
         },
       }),
     ).catch((err) => {

--- a/src/signal/monitor.outbound-hooks.test.ts
+++ b/src/signal/monitor.outbound-hooks.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  flush,
+  getSignalToolResultTestMocks,
+  installSignalToolResultTestHooks,
+} from "./monitor.tool-result.test-harness.js";
+
+installSignalToolResultTestHooks();
+
+// ---------------------------------------------------------------------------
+// Hook-runner mock – must be declared before `await import("./monitor.js")` so
+// that the module loads with our mock already in place.
+// ---------------------------------------------------------------------------
+
+// Mutable state: each test swaps in its own fake runner via `setFakeRunner`.
+let currentRunner: {
+  hasHooks: ReturnType<typeof vi.fn>;
+  runMessageSending: ReturnType<typeof vi.fn>;
+  runMessageSent: ReturnType<typeof vi.fn>;
+} | null = null;
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => currentRunner,
+}));
+
+// Import monitor AFTER harness mocks + hook-runner mock are wired.
+await import("./monitor.js");
+
+const { sendMock, streamMock } = getSignalToolResultTestMocks();
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SIGNAL_BASE_URL = "http://127.0.0.1:8080";
+const SENDER = "+15550001111";
+const REPLY_TEXT = "outbound hook reply";
+
+/** Hook names this test cares about for outbound hooks. */
+const OUTBOUND_HOOKS = new Set(["message_sending", "message_sent"]);
+
+/**
+ * Build a minimal fake HookRunner.
+ *
+ * By default `hasHooks` only reports true for `message_sending` / `message_sent`
+ * so that other hooks (e.g. `message_received`) don't attempt to call methods
+ * that aren't on this stub.
+ */
+function makeRunner(opts: {
+  hasHooksFn?: (name: string) => boolean;
+  sendingResult?: { cancel?: boolean } | null;
+  sendingError?: Error;
+}) {
+  return {
+    hasHooks: vi.fn(
+      (name: string) => opts.hasHooksFn?.(name) ?? OUTBOUND_HOOKS.has(name),
+    ),
+    runMessageSending: vi.fn(() =>
+      opts.sendingError
+        ? Promise.reject(opts.sendingError)
+        : Promise.resolve(opts.sendingResult ?? undefined),
+    ),
+    runMessageSent: vi.fn(() => Promise.resolve(undefined)),
+  };
+}
+
+async function receiveSignalPayloads(params: {
+  payloads: unknown[];
+  opts?: Partial<Parameters<(typeof import("./monitor.js"))["monitorSignalProvider"]>[0]>;
+}) {
+  const { monitorSignalProvider } = await import("./monitor.js");
+  const abortController = new AbortController();
+  streamMock.mockImplementation(async ({ onEvent }: { onEvent: (e: unknown) => unknown }) => {
+    for (const payload of params.payloads) {
+      await onEvent({ event: "receive", data: JSON.stringify(payload) });
+    }
+    abortController.abort();
+  });
+  await monitorSignalProvider({
+    autoStart: false,
+    baseUrl: SIGNAL_BASE_URL,
+    abortSignal: abortController.signal,
+    ...params.opts,
+  });
+  await flush();
+}
+
+function inboundPayload(text: string) {
+  return {
+    envelope: {
+      sourceNumber: SENDER,
+      sourceName: "Ada",
+      timestamp: Date.now(),
+      dataMessage: { message: text },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("monitorSignalProvider – outbound message_sending / message_sent hooks", () => {
+  it("fires message_sending with correct payload and context before sendMessageSignal", async () => {
+    const runner = makeRunner({});
+    currentRunner = runner;
+
+    sendMock.mockResolvedValue(undefined);
+    const { replyMock } = getSignalToolResultTestMocks();
+    replyMock.mockResolvedValue({ text: REPLY_TEXT });
+
+    await receiveSignalPayloads({ payloads: [inboundPayload("ping")] });
+
+    expect(runner.runMessageSending).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: SENDER,
+        content: expect.stringContaining(REPLY_TEXT),
+        metadata: expect.objectContaining({ channel: "signal" }),
+      }),
+      expect.objectContaining({ channelId: "signal" }),
+    );
+    expect(sendMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call sendMessageSignal when message_sending returns { cancel: true }", async () => {
+    const runner = makeRunner({ sendingResult: { cancel: true } });
+    currentRunner = runner;
+
+    const { replyMock } = getSignalToolResultTestMocks();
+    replyMock.mockResolvedValue({ text: REPLY_TEXT });
+
+    await receiveSignalPayloads({ payloads: [inboundPayload("ping")] });
+
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+
+  it("fires message_sent with success: true after successful send", async () => {
+    const runner = makeRunner({});
+    currentRunner = runner;
+
+    sendMock.mockResolvedValue(undefined);
+    const { replyMock } = getSignalToolResultTestMocks();
+    replyMock.mockResolvedValue({ text: REPLY_TEXT });
+
+    await receiveSignalPayloads({ payloads: [inboundPayload("ping")] });
+
+    expect(runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: SENDER,
+        content: expect.stringContaining(REPLY_TEXT),
+        success: true,
+      }),
+      expect.objectContaining({ channelId: "signal" }),
+    );
+  });
+
+  it("fires message_sent with success: false and error when sendMessageSignal throws", async () => {
+    const runner = makeRunner({});
+    currentRunner = runner;
+
+    const errorMsg = "signal send failure";
+    sendMock.mockRejectedValue(new Error(errorMsg));
+    const { replyMock } = getSignalToolResultTestMocks();
+    replyMock.mockResolvedValue({ text: REPLY_TEXT });
+
+    // The error is caught by the event handler, so monitor doesn't reject.
+    await receiveSignalPayloads({ payloads: [inboundPayload("ping")] });
+
+    expect(runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: SENDER,
+        success: false,
+        error: errorMsg,
+      }),
+      expect.objectContaining({ channelId: "signal" }),
+    );
+  });
+});

--- a/src/telegram/bot/delivery.hooks.test.ts
+++ b/src/telegram/bot/delivery.hooks.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Bot } from "grammy";
+import { deliverReplies } from "./delivery.js";
+
+// --- mock hook runner ---
+const getGlobalHookRunnerMock = vi.fn();
+
+vi.mock("../../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => getGlobalHookRunnerMock(),
+}));
+
+// --- other mocks required by delivery.ts ---
+vi.mock("../../web/media.js", () => ({
+  loadWebMedia: vi.fn(),
+}));
+
+vi.mock("grammy", () => ({
+  InputFile: class {
+    constructor(
+      public buffer: Buffer,
+      public fileName?: string,
+    ) {}
+  },
+  GrammyError: class GrammyError extends Error {
+    description = "";
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CHAT_ID = "99999";
+const TEXT = "Hello, hook world!";
+
+const flush = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+function createRuntime() {
+  return { error: vi.fn(), log: vi.fn() };
+}
+
+function createBot(api: Record<string, unknown> = {}): Bot {
+  return { api } as unknown as Bot;
+}
+
+type FakeRunner = {
+  hasHooks: ReturnType<typeof vi.fn>;
+  runMessageSending: ReturnType<typeof vi.fn>;
+  runMessageSent: ReturnType<typeof vi.fn>;
+};
+
+function createFakeRunner(opts: {
+  hasHooksFn?: (name: string) => boolean;
+  sendingResult?: { cancel?: boolean } | null;
+  sendingError?: Error;
+}): FakeRunner {
+  return {
+    hasHooks: vi.fn((name: string) => opts.hasHooksFn?.(name) ?? true),
+    runMessageSending: vi.fn(() =>
+      opts.sendingError
+        ? Promise.reject(opts.sendingError)
+        : Promise.resolve(opts.sendingResult ?? undefined),
+    ),
+    runMessageSent: vi.fn(() => Promise.resolve(undefined)),
+  };
+}
+
+async function deliver(bot: Bot, runner: FakeRunner | null, text = TEXT) {
+  getGlobalHookRunnerMock.mockReturnValue(runner);
+  return deliverReplies({
+    replies: [{ text }],
+    chatId: CHAT_ID,
+    token: "tok",
+    runtime: createRuntime(),
+    bot,
+    replyToMode: "off",
+    textLimit: 4000,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("deliverReplies – message_sending / message_sent hooks", () => {
+  beforeEach(() => {
+    getGlobalHookRunnerMock.mockReset();
+  });
+
+  it("fires message_sending with correct payload and channel context before send", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 1, chat: { id: CHAT_ID } });
+    const bot = createBot({ sendMessage });
+    const runner = createFakeRunner({});
+
+    await deliver(bot, runner);
+
+    expect(runner.runMessageSending).toHaveBeenCalledWith(
+      { to: CHAT_ID, content: TEXT, metadata: { channel: "telegram" } },
+      { channelId: "telegram" },
+    );
+    // send happened after hook
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call sendMessage or message_sent when message_sending returns { cancel: true }", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 1, chat: { id: CHAT_ID } });
+    const bot = createBot({ sendMessage });
+    const runner = createFakeRunner({ sendingResult: { cancel: true } });
+
+    await deliver(bot, runner);
+    await flush();
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(runner.runMessageSent).not.toHaveBeenCalled();
+  });
+
+  it("fires message_sent with { to, content, success: true } after successful send", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 1, chat: { id: CHAT_ID } });
+    const bot = createBot({ sendMessage });
+    const runner = createFakeRunner({});
+
+    await deliver(bot, runner);
+    await flush();
+
+    expect(runner.runMessageSent).toHaveBeenCalledWith(
+      { to: CHAT_ID, content: TEXT, success: true },
+      { channelId: "telegram" },
+    );
+  });
+
+  it("proceeds normally (send is called) when message_sending hook is absent", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 1, chat: { id: CHAT_ID } });
+    const bot = createBot({ sendMessage });
+    const runner = createFakeRunner({ hasHooksFn: () => false });
+
+    await deliver(bot, runner);
+
+    expect(runner.runMessageSending).not.toHaveBeenCalled();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT block delivery when message_sending hook throws", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 1, chat: { id: CHAT_ID } });
+    const bot = createBot({ sendMessage });
+    const runner = createFakeRunner({ sendingError: new Error("hook kaboom") });
+
+    await expect(deliver(bot, runner)).resolves.toBeDefined();
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/telegram/bot/delivery.hooks.test.ts
+++ b/src/telegram/bot/delivery.hooks.test.ts
@@ -147,4 +147,19 @@ describe("deliverReplies – message_sending / message_sent hooks", () => {
     await expect(deliver(bot, runner)).resolves.toBeDefined();
     expect(sendMessage).toHaveBeenCalledTimes(1);
   });
+
+  it("fires message_sent with success: false and error when sendMessage throws", async () => {
+    const errorMsg = "telegram send failure";
+    const sendMessage = vi.fn().mockRejectedValue(new Error(errorMsg));
+    const bot = createBot({ sendMessage });
+    const runner = createFakeRunner({});
+
+    await expect(deliver(bot, runner)).rejects.toThrow();
+    await flush();
+
+    expect(runner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({ to: CHAT_ID, success: false, error: errorMsg }),
+      { channelId: "telegram" },
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- **Signal**: Fire `message_sending` and `message_sent` plugin hooks when the agent sends replies via Signal, matching the existing pattern for other providers.
- **Telegram**: Fire `message_sending` and `message_sent` plugin hooks on delivery, enabling plugins to intercept or log outbound messages.
- Exports `resolveReplyFromConfig` helper to support hook integration in dispatch logic.

## Test plan
- [x] Unit tests added for Signal outbound hooks (`monitor.outbound-hooks.test.ts`)
- [x] Unit tests added for Telegram delivery hooks (`delivery.hooks.test.ts`)
- [ ] Verify existing Signal/Telegram message flows still work end-to-end
- [ ] Verify plugin hooks fire correctly with real plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)