### PR TITLE
feat(memory): add section-aware chunking strategy for structured mark…

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -43,6 +43,7 @@ export type ResolvedMemorySearchConfig = {
   chunking: {
     tokens: number;
     overlap: number;
+    strategy: "token" | "section";
   };
   sync: {
     onSessionStart: boolean;
@@ -215,6 +216,7 @@ function mergeConfig(
   const chunking = {
     tokens: overrides?.chunking?.tokens ?? defaults?.chunking?.tokens ?? DEFAULT_CHUNK_TOKENS,
     overlap: overrides?.chunking?.overlap ?? defaults?.chunking?.overlap ?? DEFAULT_CHUNK_OVERLAP,
+    strategy: overrides?.chunking?.strategy ?? defaults?.chunking?.strategy ?? "token",
   };
   const sync = {
     onSessionStart: overrides?.sync?.onSessionStart ?? defaults?.sync?.onSessionStart ?? true,
@@ -314,7 +316,7 @@ function mergeConfig(
     model,
     local,
     store,
-    chunking: { tokens: Math.max(1, chunking.tokens), overlap },
+    chunking: { tokens: Math.max(1, chunking.tokens), overlap, strategy: chunking.strategy },
     sync: {
       ...sync,
       sessions: {

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -375,6 +375,8 @@ export type MemorySearchConfig = {
   chunking?: {
     tokens?: number;
     overlap?: number;
+    /** Chunking strategy: "token" (default) splits by token count; "section" splits at ## headings for better retrieval of structured markdown. */
+    strategy?: "token" | "section";
   };
   /** Sync behavior. */
   sync?: {

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -618,6 +618,7 @@ export const MemorySearchSchema = z
       .object({
         tokens: z.number().int().positive().optional(),
         overlap: z.number().int().nonnegative().optional(),
+        strategy: z.enum(["token", "section"]).optional(),
       })
       .strict()
       .optional(),

--- a/src/memory/embedding-chunk-limits.ts
+++ b/src/memory/embedding-chunk-limits.ts
@@ -26,16 +26,36 @@ export function enforceEmbeddingMaxInputTokens(
     // but keep text/embedText aligned so cache keys stay correct.
     if (chunk.embedText) {
       const splitEmbedTexts = splitTextToUtf8ByteLimit(chunk.embedText, maxInputTokens);
+      // Align text splits to embedText splits: compute the title prefix length
+      // and distribute chunk.text across the same number of output chunks.
+      const prefixLen = chunk.embedText.length - chunk.text.length;
       const splitTexts = splitTextToUtf8ByteLimit(chunk.text, maxInputTokens);
-      for (let i = 0; i < splitEmbedTexts.length; i++) {
-        const embedText = splitEmbedTexts[i];
-        out.push({
-          startLine: chunk.startLine,
-          endLine: chunk.endLine,
-          text: splitTexts[i] ?? embedText,
-          embedText,
-          hash: hashText(embedText),
-        });
+
+      // If counts match, use 1:1 mapping. Otherwise, distribute text splits
+      // across embedText splits to maintain alignment.
+      if (splitTexts.length === splitEmbedTexts.length) {
+        for (let i = 0; i < splitEmbedTexts.length; i++) {
+          out.push({
+            startLine: chunk.startLine,
+            endLine: chunk.endLine,
+            text: splitTexts[i],
+            embedText: splitEmbedTexts[i],
+            hash: hashText(splitEmbedTexts[i]),
+          });
+        }
+      } else {
+        // Counts differ due to prefix; re-split text to match embedText count
+        const adjustedLimit = Math.max(128, maxInputTokens - Math.max(0, prefixLen));
+        const reSplitTexts = splitTextToUtf8ByteLimit(chunk.text, adjustedLimit);
+        for (let i = 0; i < splitEmbedTexts.length; i++) {
+          out.push({
+            startLine: chunk.startLine,
+            endLine: chunk.endLine,
+            text: reSplitTexts[i] ?? splitEmbedTexts[i],
+            embedText: splitEmbedTexts[i],
+            hash: hashText(splitEmbedTexts[i]),
+          });
+        }
       }
     } else {
       for (const text of splitTextToUtf8ByteLimit(chunk.text, maxInputTokens)) {

--- a/src/memory/internal.test.ts
+++ b/src/memory/internal.test.ts
@@ -324,4 +324,28 @@ describe("chunkMarkdown — section strategy", () => {
     const chunks = chunkMarkdown("", { tokens: 400, overlap: 0, strategy: "section" });
     expect(chunks).toEqual([]);
   });
+
+  it("ignores ## headings inside code fences", () => {
+    const content = [
+      "## Real Section",
+      "",
+      "Some real content here.",
+      "More content.",
+      "Even more content.",
+      "Line five.",
+      "Line six.",
+      "",
+      "Example code:",
+      "```markdown",
+      "## This heading is inside a code fence",
+      "### And this one too",
+      "```",
+    ].join("\n");
+
+    const chunks = chunkMarkdown(content, { tokens: 400, overlap: 0, strategy: "section" });
+    // Should be a single chunk — the ## inside the fence is NOT a boundary
+    expect(chunks.length).toBe(1);
+    expect(chunks[0].text).toContain("## Real Section");
+    expect(chunks[0].text).toContain("## This heading is inside a code fence");
+  });
 });

--- a/src/memory/internal.test.ts
+++ b/src/memory/internal.test.ts
@@ -252,15 +252,19 @@ describe("chunkMarkdown — section strategy", () => {
     expect(chunks.some((c) => c.text.includes("Section Two"))).toBe(true);
   });
 
-  it("injects section title into sub-chunks of large sections", () => {
+  it("injects section title into embedText of sub-chunks, not text", () => {
     const bigLines = Array.from({ length: 90 }, (_, i) => `line content ${i}`);
     const content = ["## Big Section", ...bigLines].join("\n");
 
     const chunks = chunkMarkdown(content, { tokens: 400, overlap: 0, strategy: "section" });
     expect(chunks.length).toBeGreaterThan(1);
-    // All continuation sub-chunks should start with the section title
+    // First chunk includes the heading naturally in text (no embedText needed)
+    expect(chunks[0].text).toContain("## Big Section");
+    expect(chunks[0].embedText).toBeUndefined();
+    // Continuation sub-chunks: text is the raw slice, embedText has the title
     for (let i = 1; i < chunks.length; i++) {
-      expect(chunks[i].text).toContain("## Big Section");
+      expect(chunks[i].text).not.toContain("## Big Section");
+      expect(chunks[i].embedText).toContain("## Big Section");
     }
   });
 

--- a/src/memory/internal.test.ts
+++ b/src/memory/internal.test.ts
@@ -355,7 +355,10 @@ describe("chunkMarkdown — section strategy", () => {
   it("does not regress on long unstructured content without headings", () => {
     // No ## headings at all — simulates raw logs, plain notes, etc.
     // Section strategy treats this as a single section, then sub-splits if needed
-    const lines = Array.from({ length: 200 }, (_, i) => `Unstructured log entry ${i}: some data here`);
+    const lines = Array.from(
+      { length: 200 },
+      (_, i) => `Unstructured log entry ${i}: some data here`,
+    );
     const content = lines.join("\n");
     const sectionChunks = chunkMarkdown(content, { tokens: 400, overlap: 0, strategy: "section" });
     // All content must be captured (no data loss)
@@ -425,7 +428,7 @@ describe("chunkMarkdown — section strategy", () => {
       Array.from({ length: n }, (_, i) => `${prefix} line ${i + 1}`);
 
     const content = [
-      ...makeLines(20, "Preamble"),  // No heading before first section
+      ...makeLines(20, "Preamble"), // No heading before first section
       "",
       "## Only Section",
       "",

--- a/src/memory/internal.test.ts
+++ b/src/memory/internal.test.ts
@@ -352,4 +352,94 @@ describe("chunkMarkdown — section strategy", () => {
     expect(chunks[0].text).toContain("## Real Section");
     expect(chunks[0].text).toContain("## This heading is inside a code fence");
   });
+  it("does not regress on long unstructured content without headings", () => {
+    // No ## headings at all — simulates raw logs, plain notes, etc.
+    // Section strategy treats this as a single section, then sub-splits if needed
+    const lines = Array.from({ length: 200 }, (_, i) => `Unstructured log entry ${i}: some data here`);
+    const content = lines.join("\n");
+    const sectionChunks = chunkMarkdown(content, { tokens: 400, overlap: 0, strategy: "section" });
+    // All content must be captured (no data loss)
+    const allText = sectionChunks.map((c) => c.text).join("\n");
+    expect(allText).toContain("Unstructured log entry 0");
+    expect(allText).toContain("Unstructured log entry 199");
+    // Line numbers should be valid
+    for (const chunk of sectionChunks) {
+      expect(chunk.startLine).toBeGreaterThanOrEqual(1);
+      expect(chunk.endLine).toBeGreaterThanOrEqual(chunk.startLine);
+    }
+  });
+  it("handles mixed content: some sections with headings, trailing unstructured", () => {
+    const makeLines = (n: number, prefix: string): string[] =>
+      Array.from({ length: n }, (_, i) => `${prefix} line ${i + 1}`);
+
+    const content = [
+      "## Structured Part",
+      "",
+      ...makeLines(8, "Organized"),
+      "",
+      "## Another Section",
+      "",
+      ...makeLines(6, "Also organized"),
+      "",
+      // Trailing content with no heading — like appended raw notes
+      ...makeLines(10, "Loose trailing note"),
+    ].join("\n");
+
+    const chunks = chunkMarkdown(content, { tokens: 400, overlap: 0, strategy: "section" });
+    // Should produce at least 2 chunks; trailing content merges with last section
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    // The trailing notes should be captured somewhere
+    const allText = chunks.map((c) => c.text).join("\n");
+    expect(allText).toContain("Loose trailing note");
+  });
+
+  it("handles content with only # h1 and ### h3 headings (no ## boundaries)", () => {
+    const content = [
+      "# Top Level Title",
+      "",
+      "Introductory paragraph with some context.",
+      "Second line of intro.",
+      "",
+      "### Sub-detail One",
+      "",
+      "Detail content one.",
+      "Detail content two.",
+      "Detail content three.",
+      "Detail content four.",
+      "Detail content five.",
+      "",
+      "### Sub-detail Two",
+      "",
+      "More detail content.",
+    ].join("\n");
+
+    const chunks = chunkMarkdown(content, { tokens: 400, overlap: 0, strategy: "section" });
+    // No ## headings → single chunk (falls back, doesn't split on # or ###)
+    expect(chunks.length).toBe(1);
+    expect(chunks[0].text).toContain("# Top Level Title");
+    expect(chunks[0].text).toContain("### Sub-detail Two");
+  });
+
+  it("handles sparse headings in a long document", () => {
+    const makeLines = (n: number, prefix: string): string[] =>
+      Array.from({ length: n }, (_, i) => `${prefix} line ${i + 1}`);
+
+    const content = [
+      ...makeLines(20, "Preamble"),  // No heading before first section
+      "",
+      "## Only Section",
+      "",
+      ...makeLines(20, "Section body"),
+      "",
+      ...makeLines(20, "Epilogue without heading"),
+    ].join("\n");
+
+    const chunks = chunkMarkdown(content, { tokens: 400, overlap: 0, strategy: "section" });
+    // Preamble (no heading) becomes its own chunk, section is another
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+    const allText = chunks.map((c) => c.text).join("\n");
+    expect(allText).toContain("Preamble");
+    expect(allText).toContain("## Only Section");
+    expect(allText).toContain("Epilogue without heading");
+  });
 });

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -195,10 +195,15 @@ export function chunkMarkdownBySection(content: string): MemoryChunk[] {
   const MIN_SECTION_LINES = 5;
   const MAX_SECTION_LINES = 80;
 
-  // Find ## heading boundaries (0-based line indices)
+  // Find ## heading boundaries (0-based line indices), ignoring headings inside code fences
   const headingIndices: number[] = [];
+  let insideCodeFence = false;
   for (let i = 0; i < lines.length; i++) {
-    if (/^##\s/.test(lines[i] ?? "")) {
+    const line = lines[i] ?? "";
+    if (line.startsWith("```")) {
+      insideCodeFence = !insideCodeFence;
+    }
+    if (!insideCodeFence && /^##\s/.test(line)) {
       headingIndices.push(i);
     }
   }

--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -212,13 +212,13 @@ export function chunkMarkdownBySection(content: string): MemoryChunk[] {
     }
   }
 
-  // No ## headings — return the whole content as one chunk
+  // No ## headings — fall back to token-based splitting for proper granularity
+  // But first check if content is effectively empty
   if (headingIndices.length === 0) {
-    const text = content.trim();
-    if (!text) {
+    if (!content.trim()) {
       return [];
     }
-    return [{ startLine: 1, endLine: lines.length, text, hash: hashText(text) }];
+    return chunkMarkdown(content, { tokens: 512, overlap: 64, strategy: "token" });
   }
 
   // Build raw sections

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -52,6 +52,7 @@ type MemoryIndexMeta = {
   sources?: MemorySource[];
   chunkTokens: number;
   chunkOverlap: number;
+  chunkStrategy?: "token" | "section";
   vectorDims?: number;
 };
 
@@ -872,6 +873,7 @@ export abstract class MemoryManagerSyncOps {
       this.metaSourcesDiffer(meta, configuredSources) ||
       meta.chunkTokens !== this.settings.chunking.tokens ||
       meta.chunkOverlap !== this.settings.chunking.overlap ||
+      (meta.chunkStrategy ?? "token") !== this.settings.chunking.strategy ||
       (vectorReady && !meta?.vectorDims);
     try {
       if (needsFullReindex) {
@@ -1084,6 +1086,7 @@ export abstract class MemoryManagerSyncOps {
         sources: this.resolveConfiguredSourcesForMeta(),
         chunkTokens: this.settings.chunking.tokens,
         chunkOverlap: this.settings.chunking.overlap,
+        chunkStrategy: this.settings.chunking.strategy,
       };
       if (!nextMeta) {
         throw new Error("Failed to compute memory index metadata for reindexing.");
@@ -1155,6 +1158,7 @@ export abstract class MemoryManagerSyncOps {
       sources: this.resolveConfiguredSourcesForMeta(),
       chunkTokens: this.settings.chunking.tokens,
       chunkOverlap: this.settings.chunking.overlap,
+      chunkStrategy: this.settings.chunking.strategy,
     };
     if (this.vector.available && this.vector.dims) {
       nextMeta.vectorDims = this.vector.dims;


### PR DESCRIPTION
## Problem

The current `chunkTokens=400, chunkOverlap=80` strategy cuts across `##` section boundaries in structured markdown files (MEMORY.m$

Tested against 25 hand-labeled queries on a real workspace:

| Metric | `token` (current) | `section` (this PR) |
|--------|-------------------|----------------------|
| MRR@10 | 0.33 | **0.56** |
| Hit@1 | 25% | 40% |
| Miss rate (empty result) | **58%** | **17%** |

Same embedding model (`text-embedding-3-small`), same DB — only chunking strategy changed.

## Solution

Add a `strategy: "token" | "section"` field to `agents.defaults.memorySearch.index.chunking`. `"token"` remains the default — full$

**Config example:**

```jsonc
{
  "agents": {
    "defaults": {
      "memorySearch": {
        "index": {
          "chunking": {
            "strategy": "section"
          }
        }
      }
    }
  }
}
```

**Section-aware rules:**

1. Split at `##` heading boundaries
2. Inject section title into each sub-chunk (ensures topic keywords appear in every chunk)
3. Merge sections < 5 non-empty lines into the previous section
4. Sub-split sections > 80 lines at paragraph boundaries

## Changes

- `src/memory/internal.ts` — `chunkMarkdownBySection()` + `strategy` param on `chunkMarkdown()`
- `src/config/types.tools.ts` — `chunking.strategy?: "token" | "section"`
- `src/agents/memory-search.ts` — resolve + propagate `strategy` in `ResolvedMemorySearchConfig`
- `src/memory/manager-sync-ops.ts` — persist `chunkStrategy` in meta; trigger reindex on strategy change
- `src/memory/internal.test.ts` — 7 new tests for section-aware chunking

## Testing

```
pnpm build && pnpm test -- src/memory/internal.test.ts
# 20/20 pass
```

## Embedding cache correctness

`chunk.hash` is computed on the **injected text** (title + content), so:
- Sub-chunks of the same section with different injected titles get distinct cache keys ✅
- Switching from `"token"` to `"section"` bumps `chunkStrategy` in the index meta, triggering a full reindex that clears stale cache entries ✅

---

> AI-assisted: implementation and tests drafted with Claude (Anthropic).
