### PR TITLE
fix(security): enforce allowlist on message tool outbound sends

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -1,4 +1,5 @@
 import {
+  allowListMatches,
   applyAccountNameToChannelSection,
   buildChannelConfigSchema,
   buildTokenChannelStatusSummary,
@@ -14,8 +15,10 @@ import {
   listDiscordDirectoryGroupsFromConfig,
   listDiscordDirectoryPeersFromConfig,
   looksLikeDiscordTargetId,
+  missingTargetError,
   migrateBaseNameToDefaultAccount,
   normalizeAccountId,
+  normalizeDiscordAllowList,
   normalizeDiscordMessagingTarget,
   normalizeDiscordOutboundTarget,
   PAIRING_APPROVED_MESSAGE,
@@ -104,10 +107,11 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       configured: Boolean(account.token?.trim()),
       tokenSource: account.tokenSource,
     }),
-    resolveAllowFrom: ({ cfg, accountId }) =>
-      (resolveDiscordAccount({ cfg, accountId }).config.dm?.allowFrom ?? []).map((entry) =>
-        String(entry),
-      ),
+    resolveAllowFrom: ({ cfg, accountId }) => {
+      const config = resolveDiscordAccount({ cfg, accountId }).config;
+      // Use top-level allowFrom when set; fall back to dm.allowFrom for legacy configs.
+      return (config.allowFrom ?? config.dm?.allowFrom ?? []).map((entry) => String(entry));
+    },
     formatAllowFrom: ({ allowFrom }) =>
       allowFrom
         .map((entry) => String(entry).trim())
@@ -301,7 +305,32 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
     chunker: null,
     textChunkLimit: 2000,
     pollMaxOptions: 10,
-    resolveTarget: ({ to }) => normalizeDiscordOutboundTarget(to),
+    resolveTarget: ({ to, allowFrom }) => {
+      const normalized = normalizeDiscordOutboundTarget(to);
+      if (!normalized.ok) {
+        return normalized;
+      }
+      // Enforce allowFrom when a non-wildcard list is configured.
+      // allowFrom entries follow the same prefix conventions as the inbound
+      // allowlist ("user:<id>", "discord:<id>", bare IDs, channel slugs).
+      if (allowFrom && allowFrom.length > 0 && !allowFrom.includes("*")) {
+        const list = normalizeDiscordAllowList(allowFrom, ["discord:", "user:", "channel:", "pk:"]);
+        if (list) {
+          // Strip kind prefix ("user:", "channel:", "discord:") for comparison.
+          const rawId = normalized.to
+            .replace(/^(user|channel|discord):/i, "")
+            .trim()
+            .toLowerCase();
+          if (!allowListMatches(list, { id: rawId, name: rawId }, { allowNameMatching: true })) {
+            return {
+              ok: false,
+              error: missingTargetError("Discord", "user:<id> or channel:<id>"),
+            };
+          }
+        }
+      }
+      return normalized;
+    },
     sendText: async ({ cfg, to, text, accountId, deps, replyToId, silent }) => {
       const send = deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
       const result = await send(to, text, {
@@ -347,11 +376,6 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
     defaultRuntime: {
       accountId: DEFAULT_ACCOUNT_ID,
       running: false,
-      connected: false,
-      reconnectAttempts: 0,
-      lastConnectedAt: null,
-      lastDisconnect: null,
-      lastEventAt: null,
       lastStartAt: null,
       lastStopAt: null,
       lastError: null,
@@ -403,11 +427,6 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
         lastStartAt: runtime?.lastStartAt ?? null,
         lastStopAt: runtime?.lastStopAt ?? null,
         lastError: runtime?.lastError ?? null,
-        connected: runtime?.connected ?? false,
-        reconnectAttempts: runtime?.reconnectAttempts,
-        lastConnectedAt: runtime?.lastConnectedAt ?? null,
-        lastDisconnect: runtime?.lastDisconnect ?? null,
-        lastEventAt: runtime?.lastEventAt ?? null,
         application: app ?? undefined,
         bot: bot ?? undefined,
         probe,
@@ -459,7 +478,6 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
         abortSignal: ctx.abortSignal,
         mediaMaxMb: account.config.mediaMaxMb,
         historyLimit: account.config.historyLimit,
-        setStatus: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
       });
     },
   },

--- a/src/channels/plugins/outbound/discord.ts
+++ b/src/channels/plugins/outbound/discord.ts
@@ -1,5 +1,9 @@
 import type { OpenClawConfig } from "../../../config/config.js";
 import {
+  allowListMatches,
+  normalizeDiscordAllowList,
+} from "../../../discord/monitor/allow-list.js";
+import {
   getThreadBindingManager,
   type ThreadBindingRecord,
 } from "../../../discord/monitor/thread-bindings.js";
@@ -9,9 +13,9 @@ import {
   sendWebhookMessageDiscord,
 } from "../../../discord/send.js";
 import type { OutboundIdentity } from "../../../infra/outbound/identity.js";
+import { missingTargetError } from "../../../infra/outbound/target-errors.js";
 import { normalizeDiscordOutboundTarget } from "../normalize/discord.js";
 import type { ChannelOutboundAdapter } from "../types.js";
-import { sendTextMediaPayload } from "./direct-text-media.js";
 
 function resolveDiscordOutboundTarget(params: {
   to: string;
@@ -78,12 +82,43 @@ async function maybeSendDiscordWebhookText(params: {
   return result;
 }
 
+/**
+ * Extract the raw ID from a normalized Discord target for allowFrom comparison.
+ * Strips leading kind prefixes ("user:", "channel:", "discord:") so the ID
+ * can be matched against allowFrom entries that may or may not have prefixes.
+ */
+function extractDiscordTargetId(normalized: string): string {
+  return normalized
+    .replace(/^(user|channel|discord):/i, "")
+    .trim()
+    .toLowerCase();
+}
+
 export const discordOutbound: ChannelOutboundAdapter = {
   deliveryMode: "direct",
   chunker: null,
   textChunkLimit: 2000,
   pollMaxOptions: 10,
-  resolveTarget: ({ to }) => normalizeDiscordOutboundTarget(to),
+  resolveTarget: ({ to, allowFrom }) => {
+    const normalized = normalizeDiscordOutboundTarget(to);
+    if (!normalized.ok) {
+      return normalized;
+    }
+    // Enforce allowFrom when a non-wildcard list is configured.
+    // allowFrom entries use the same prefix conventions as the inbound
+    // allowlist (e.g. "user:<id>", "discord:<id>", bare IDs, or names).
+    if (allowFrom && allowFrom.length > 0 && !allowFrom.includes("*")) {
+      const list = normalizeDiscordAllowList(allowFrom, ["discord:", "user:", "channel:", "pk:"]);
+      if (list) {
+        const rawId = extractDiscordTargetId(normalized.to);
+        // Allow name-based matching so channel slugs in allowFrom work too.
+        if (!allowListMatches(list, { id: rawId, name: rawId }, { allowNameMatching: true })) {
+          return { ok: false, error: missingTargetError("Discord", "user:<id> or channel:<id>") };
+        }
+      }
+    }
+    return normalized;
+  },
   sendPayload: async (ctx) =>
     await sendTextMediaPayload({ channel: "discord", ctx, adapter: discordOutbound }),
   sendText: async ({ cfg, to, text, accountId, deps, replyToId, threadId, identity, silent }) => {

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -1081,3 +1081,135 @@ describe("runMessageAction accountId defaults", () => {
     expect(ctx.params.accountId).toBe("account-b");
   });
 });
+
+describe("runMessageAction outbound allowlist enforcement", () => {
+  // WhatsApp config with a restricted allowFrom — only +15551111111 is allowed.
+  const restrictedConfig = {
+    channels: {
+      whatsapp: {
+        allowFrom: ["+15551111111"],
+      },
+    },
+  } as OpenClawConfig;
+
+  // WhatsApp config with wildcard — all targets allowed.
+  const wildcardConfig = {
+    channels: {
+      whatsapp: {
+        allowFrom: ["*"],
+      },
+    },
+  } as OpenClawConfig;
+
+  // WhatsApp config with empty allowFrom — open access (no restriction).
+  const openConfig = {
+    channels: {
+      whatsapp: {},
+    },
+  } as OpenClawConfig;
+
+  beforeEach(() => {
+    installChannelRuntimes({ includeTelegram: false });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "whatsapp",
+          source: "test",
+          plugin: whatsappPlugin,
+        },
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
+  it("blocks send to a target not in the allowFrom list", async () => {
+    await expect(
+      runDrySend({
+        cfg: restrictedConfig,
+        actionParams: {
+          channel: "whatsapp",
+          target: "+15559999999",
+          message: "hello",
+        },
+      }),
+    ).rejects.toThrow(/Target not in allowlist/);
+  });
+
+  it("allows send to a target that is in the allowFrom list", async () => {
+    const result = await runDrySend({
+      cfg: restrictedConfig,
+      actionParams: {
+        channel: "whatsapp",
+        target: "+15551111111",
+        message: "hello",
+      },
+    });
+    expect(result.kind).toBe("send");
+  });
+
+  it("allows send when allowFrom contains wildcard", async () => {
+    const result = await runDrySend({
+      cfg: wildcardConfig,
+      actionParams: {
+        channel: "whatsapp",
+        target: "+15559999999",
+        message: "hello",
+      },
+    });
+    expect(result.kind).toBe("send");
+  });
+
+  it("allows send when allowFrom is empty (open access)", async () => {
+    const result = await runDrySend({
+      cfg: openConfig,
+      actionParams: {
+        channel: "whatsapp",
+        target: "+15559999999",
+        message: "hello",
+      },
+    });
+    expect(result.kind).toBe("send");
+  });
+
+  it("allows group JID targets regardless of allowlist", async () => {
+    const result = await runDrySend({
+      cfg: restrictedConfig,
+      actionParams: {
+        channel: "whatsapp",
+        target: "120363123456789@g.us",
+        message: "hello",
+      },
+    });
+    expect(result.kind).toBe("send");
+  });
+
+  it("blocks poll to a target not in the allowFrom list", async () => {
+    await expect(
+      runDryAction({
+        cfg: restrictedConfig,
+        action: "send" as const,
+        actionParams: {
+          channel: "whatsapp",
+          target: "+15559999999",
+          message: "hello",
+        },
+      }),
+    ).rejects.toThrow(/Target not in allowlist/);
+  });
+
+  it("provides clear error message for blocked targets", async () => {
+    await expect(
+      runDrySend({
+        cfg: restrictedConfig,
+        actionParams: {
+          channel: "whatsapp",
+          target: "+15559999999",
+          message: "hello",
+        },
+      }),
+    ).rejects.toThrow(/allowFrom/);
+  });
+});

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { discordPlugin } from "../../../extensions/discord/src/channel.js";
 import { slackPlugin } from "../../../extensions/slack/src/channel.js";
 import { telegramPlugin } from "../../../extensions/telegram/src/channel.js";
 import { whatsappPlugin } from "../../../extensions/whatsapp/src/channel.js";
@@ -114,13 +115,21 @@ function createAlwaysConfiguredPluginConfig(account: Record<string, unknown> = {
 }
 
 let createPluginRuntime: typeof import("../../plugins/runtime/index.js").createPluginRuntime;
+let setDiscordRuntime: typeof import("../../../extensions/discord/src/runtime.js").setDiscordRuntime;
 let setSlackRuntime: typeof import("../../../extensions/slack/src/runtime.js").setSlackRuntime;
 let setTelegramRuntime: typeof import("../../../extensions/telegram/src/runtime.js").setTelegramRuntime;
 let setWhatsAppRuntime: typeof import("../../../extensions/whatsapp/src/runtime.js").setWhatsAppRuntime;
 
-function installChannelRuntimes(params?: { includeTelegram?: boolean; includeWhatsApp?: boolean }) {
+function installChannelRuntimes(params?: {
+  includeDiscord?: boolean;
+  includeTelegram?: boolean;
+  includeWhatsApp?: boolean;
+}) {
   const runtime = createPluginRuntime();
   setSlackRuntime(runtime);
+  if (params?.includeDiscord) {
+    setDiscordRuntime(runtime);
+  }
   if (params?.includeTelegram !== false) {
     setTelegramRuntime(runtime);
   }
@@ -132,6 +141,7 @@ function installChannelRuntimes(params?: { includeTelegram?: boolean; includeWha
 describe("runMessageAction context isolation", () => {
   beforeAll(async () => {
     ({ createPluginRuntime } = await import("../../plugins/runtime/index.js"));
+    ({ setDiscordRuntime } = await import("../../../extensions/discord/src/runtime.js"));
     ({ setSlackRuntime } = await import("../../../extensions/slack/src/runtime.js"));
     ({ setTelegramRuntime } = await import("../../../extensions/telegram/src/runtime.js"));
     ({ setWhatsAppRuntime } = await import("../../../extensions/whatsapp/src/runtime.js"));
@@ -1373,5 +1383,115 @@ describe("runMessageAction allowlist enforcement for channels without resolveTar
       },
     });
     expect(result.kind).toBe("send");
+  });
+});
+
+describe("runMessageAction allowlist enforcement for Discord (plugin resolveTarget must check allowFrom)", () => {
+  // Discord has a plugin-level resolveTarget that normalizes targets but
+  // previously ignored allowFrom — verifying it now enforces the list.
+  const discordRestrictedConfig = {
+    channels: {
+      discord: {
+        allowFrom: ["111111111111111111"],
+      },
+    },
+  } as OpenClawConfig;
+
+  const discordWildcardConfig = {
+    channels: {
+      discord: {
+        allowFrom: ["*"],
+      },
+    },
+  } as OpenClawConfig;
+
+  const discordOpenConfig = {
+    channels: {
+      discord: {},
+    },
+  } as OpenClawConfig;
+
+  beforeEach(() => {
+    installChannelRuntimes({
+      includeDiscord: true,
+      includeTelegram: false,
+      includeWhatsApp: false,
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "discord",
+          source: "test",
+          plugin: discordPlugin,
+        },
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
+  it("blocks send to a discord user-DM target not in the allowFrom list", async () => {
+    await expect(
+      runDrySend({
+        cfg: discordRestrictedConfig,
+        actionParams: {
+          channel: "discord",
+          target: "user:999999999999999999",
+          message: "hello",
+        },
+      }),
+    ).rejects.toThrow(/Target not in allowlist/);
+  });
+
+  it("allows send to a discord target that is in the allowFrom list", async () => {
+    const result = await runDrySend({
+      cfg: discordRestrictedConfig,
+      actionParams: {
+        channel: "discord",
+        target: "user:111111111111111111",
+        message: "hello",
+      },
+    });
+    expect(result.kind).toBe("send");
+  });
+
+  it("allows send when discord allowFrom contains wildcard", async () => {
+    const result = await runDrySend({
+      cfg: discordWildcardConfig,
+      actionParams: {
+        channel: "discord",
+        target: "channel:999999999999999999",
+        message: "hello",
+      },
+    });
+    expect(result.kind).toBe("send");
+  });
+
+  it("allows send when discord allowFrom is empty (open access)", async () => {
+    const result = await runDrySend({
+      cfg: discordOpenConfig,
+      actionParams: {
+        channel: "discord",
+        target: "channel:999999999999999999",
+        message: "hello",
+      },
+    });
+    expect(result.kind).toBe("send");
+  });
+
+  it("normalizes bare numeric discord ID and enforces allowFrom", async () => {
+    // Bare numeric IDs are prefixed with "channel:" — allowFrom must still match.
+    await expect(
+      runDrySend({
+        cfg: discordRestrictedConfig,
+        actionParams: {
+          channel: "discord",
+          target: "999999999999999999",
+          message: "hello",
+        },
+      }),
+    ).rejects.toThrow(/Target not in allowlist/);
   });
 });

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -1202,6 +1202,57 @@ describe("runMessageAction outbound allowlist enforcement", () => {
     ).rejects.toThrow(/Target not in allowlist/);
   });
 
+  it("blocks sendAttachment to a target not in the allowFrom list", async () => {
+    await expect(
+      runMessageAction({
+        cfg: restrictedConfig,
+        action: "sendAttachment",
+        params: {
+          channel: "whatsapp",
+          target: "+15559999999",
+          media: "https://example.com/pic.png",
+          message: "caption",
+        },
+        dryRun: true,
+      }),
+    ).rejects.toThrow(/Target not in allowlist/);
+  });
+
+  it("blocks thread-reply to a target not in the allowFrom list", async () => {
+    await expect(
+      runDryAction({
+        cfg: restrictedConfig,
+        action: "thread-reply",
+        actionParams: {
+          channel: "whatsapp",
+          target: "+15559999999",
+          message: "reply text",
+        },
+      }),
+    ).rejects.toThrow(/Target not in allowlist/);
+  });
+
+  it("redacts phone numbers in allowlist error messages (PII)", async () => {
+    try {
+      await runDrySend({
+        cfg: restrictedConfig,
+        actionParams: {
+          channel: "whatsapp",
+          target: "+15559999999",
+          message: "hello",
+        },
+      });
+      throw new Error("expected rejection");
+    } catch (err) {
+      const message = (err as Error).message;
+      // The raw phone number should NOT appear in the error
+      expect(message).not.toContain("+15559999999");
+      // But the last 4 digits should be present (masked form)
+      expect(message).toContain("***9999");
+      expect(message).toContain("allowFrom");
+    }
+  });
+
   it("provides clear error message for blocked targets", async () => {
     await expect(
       runDrySend({

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -1283,3 +1283,95 @@ describe("runMessageAction outbound allowlist enforcement", () => {
     ).rejects.toThrow(/requires a target/);
   });
 });
+
+describe("runMessageAction allowlist enforcement for channels without resolveTarget", () => {
+  // Telegram has resolveAllowFrom but no outbound.resolveTarget,
+  // so the fallback allowlist check in resolveOutboundTarget must enforce.
+  const telegramRestrictedConfig = {
+    channels: {
+      telegram: {
+        allowFrom: ["111111111"],
+      },
+    },
+  } as OpenClawConfig;
+
+  const telegramWildcardConfig = {
+    channels: {
+      telegram: {
+        allowFrom: ["*"],
+      },
+    },
+  } as OpenClawConfig;
+
+  const telegramOpenConfig = {
+    channels: {
+      telegram: {},
+    },
+  } as OpenClawConfig;
+
+  beforeEach(() => {
+    installChannelRuntimes();
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "telegram",
+          source: "test",
+          plugin: telegramPlugin,
+        },
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry([]));
+  });
+
+  it("blocks send to a telegram target not in the allowFrom list", async () => {
+    await expect(
+      runDrySend({
+        cfg: telegramRestrictedConfig,
+        actionParams: {
+          channel: "telegram",
+          target: "999999999",
+          message: "hello",
+        },
+      }),
+    ).rejects.toThrow(/Target not in allowlist/);
+  });
+
+  it("allows send to a telegram target that is in the allowFrom list", async () => {
+    const result = await runDrySend({
+      cfg: telegramRestrictedConfig,
+      actionParams: {
+        channel: "telegram",
+        target: "111111111",
+        message: "hello",
+      },
+    });
+    expect(result.kind).toBe("send");
+  });
+
+  it("allows send when telegram allowFrom contains wildcard", async () => {
+    const result = await runDrySend({
+      cfg: telegramWildcardConfig,
+      actionParams: {
+        channel: "telegram",
+        target: "999999999",
+        message: "hello",
+      },
+    });
+    expect(result.kind).toBe("send");
+  });
+
+  it("allows send when telegram allowFrom is empty (open access)", async () => {
+    const result = await runDrySend({
+      cfg: telegramOpenConfig,
+      actionParams: {
+        channel: "telegram",
+        target: "999999999",
+        message: "hello",
+      },
+    });
+    expect(result.kind).toBe("send");
+  });
+});

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -1188,14 +1188,16 @@ describe("runMessageAction outbound allowlist enforcement", () => {
 
   it("blocks poll to a target not in the allowFrom list", async () => {
     await expect(
-      runDryAction({
+      runMessageAction({
         cfg: restrictedConfig,
-        action: "send" as const,
-        actionParams: {
+        action: "poll",
+        params: {
           channel: "whatsapp",
           target: "+15559999999",
-          message: "hello",
+          pollQuestion: "Favorite color?",
+          pollOption: ["Red", "Blue"],
         },
+        dryRun: true,
       }),
     ).rejects.toThrow(/Target not in allowlist/);
   });

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -1265,4 +1265,21 @@ describe("runMessageAction outbound allowlist enforcement", () => {
       }),
     ).rejects.toThrow(/allowFrom/);
   });
+
+  it("rejects guarded action when target is empty (no silent bypass)", async () => {
+    // Sending with an empty target on a guarded action must not silently
+    // skip the allowlist — it should throw a clear error.
+    await expect(
+      runMessageAction({
+        cfg: restrictedConfig,
+        action: "send",
+        params: {
+          channel: "whatsapp",
+          message: "hello",
+          // no target / to / channelId
+        },
+        dryRun: true,
+      }),
+    ).rejects.toThrow(/requires a target/);
+  });
 });

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -18,6 +18,7 @@ import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { type GatewayClientMode, type GatewayClientName } from "../../utils/message-channel.js";
 import { throwIfAborted } from "./abort.js";
+import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import {
   listConfiguredMessageChannels,
   resolveMessageChannelSelection,
@@ -83,6 +84,80 @@ function resolveAndApplyOutboundThreadId(
     params.threadId = resolved;
   }
   return resolved ?? undefined;
+}
+
+// Actions that deliver content to an explicit target and should be gated by the
+// channel's outbound allowlist.  Read-only or management actions (react, delete,
+// search, etc.) are excluded intentionally.
+// Note: "broadcast" is not listed because handleBroadcastAction returns early
+// and recurses into runMessageAction with action="send" per target — each
+// individual send is checked there.
+const ALLOWLIST_GUARDED_ACTIONS = new Set<ChannelMessageActionName>([
+  "send",
+  "poll",
+  "reply",
+  "sendWithEffect",
+  "sendAttachment",
+  "thread-create",
+  "thread-reply",
+  "sticker",
+]);
+
+/**
+ * Enforce the channel's outbound allowlist on the resolved target.
+ *
+ * Uses the same plugin allowFrom + resolveTarget mechanism that the
+ * CLI/heartbeat delivery path uses (via `resolveOutboundTarget`), so the
+ * behaviour stays consistent across all send surfaces.
+ */
+function enforceOutboundAllowlist(params: {
+  cfg: OpenClawConfig;
+  channel: ChannelId;
+  action: ChannelMessageActionName;
+  to: string;
+  accountId?: string | null;
+}): void {
+  if (!ALLOWLIST_GUARDED_ACTIONS.has(params.action)) {
+    return;
+  }
+
+  const plugin = resolveOutboundChannelPlugin({
+    channel: params.channel,
+    cfg: params.cfg,
+  });
+  if (!plugin) {
+    return;
+  }
+
+  const resolveAllowFrom = plugin.config.resolveAllowFrom;
+  const resolveTarget = plugin.outbound?.resolveTarget;
+  if (!resolveAllowFrom || !resolveTarget) {
+    // Channel has no allowlist enforcement capability — nothing to check.
+    return;
+  }
+
+  const allowFromRaw = resolveAllowFrom({
+    cfg: params.cfg,
+    accountId: params.accountId ?? undefined,
+  });
+  if (!allowFromRaw || allowFromRaw.length === 0) {
+    // No allowlist configured — open access.
+    return;
+  }
+
+  const allowFrom = allowFromRaw.map((entry) => String(entry));
+  const result = resolveTarget({
+    cfg: params.cfg,
+    to: params.to,
+    allowFrom,
+    accountId: params.accountId ?? undefined,
+    mode: "explicit",
+  });
+  if (!result.ok) {
+    throw new Error(
+      `Target not in allowlist. The message tool cannot send to "${params.to}" on ${params.channel} because it is not in the configured allowFrom list.`,
+    );
+  }
 }
 
 export type RunMessageActionParams = {
@@ -765,6 +840,20 @@ export async function runMessageAction(
     toolContext: input.toolContext,
     cfg,
   });
+
+  // Enforce outbound allowlist: reject sends to targets not in the configured
+  // allowFrom list for the channel.  Uses the resolved `to` from params
+  // (already written by resolveActionTarget / applyTargetToParams above).
+  const outboundTo = typeof params.to === "string" ? params.to.trim() : "";
+  if (outboundTo) {
+    enforceOutboundAllowlist({
+      cfg,
+      channel,
+      action,
+      to: outboundTo,
+      accountId,
+    });
+  }
 
   const gateway = resolveGateway(input);
 

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -18,7 +18,6 @@ import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { type GatewayClientMode, type GatewayClientName } from "../../utils/message-channel.js";
 import { throwIfAborted } from "./abort.js";
-import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import {
   listConfiguredMessageChannels,
   resolveMessageChannelSelection,
@@ -48,6 +47,7 @@ import {
 import { executePollAction, executeSendAction } from "./outbound-send-service.js";
 import { ensureOutboundSessionEntry, resolveOutboundSessionRoute } from "./outbound-session.js";
 import { resolveChannelTarget, type ResolvedMessagingTarget } from "./target-resolver.js";
+import { resolveOutboundTarget } from "./targets.js";
 import { extractToolPayload } from "./tool-payload.js";
 
 export type MessageActionRunnerGateway = {
@@ -103,12 +103,21 @@ const ALLOWLIST_GUARDED_ACTIONS = new Set<ChannelMessageActionName>([
   "sticker",
 ]);
 
+/** Mask a target identifier for error messages to avoid leaking PII (e.g. phone numbers). */
+function redactTarget(to: string): string {
+  // If it looks like a phone number (starts with + and has 7+ digits), mask all but last 4
+  const digits = to.replace(/\D/g, "");
+  if (/^\+?\d{7,}/.test(to) && digits.length >= 7) {
+    return `***${digits.slice(-4)}`;
+  }
+  return to;
+}
+
 /**
  * Enforce the channel's outbound allowlist on the resolved target.
  *
- * Uses the same plugin allowFrom + resolveTarget mechanism that the
- * CLI/heartbeat delivery path uses (via `resolveOutboundTarget`), so the
- * behaviour stays consistent across all send surfaces.
+ * Delegates to `resolveOutboundTarget` (the same path the CLI/heartbeat
+ * delivery uses) so the behaviour stays consistent across all send surfaces.
  */
 function enforceOutboundAllowlist(params: {
   cfg: OpenClawConfig;
@@ -121,41 +130,18 @@ function enforceOutboundAllowlist(params: {
     return;
   }
 
-  const plugin = resolveOutboundChannelPlugin({
+  const result = resolveOutboundTarget({
     channel: params.channel,
-    cfg: params.cfg,
-  });
-  if (!plugin) {
-    return;
-  }
-
-  const resolveAllowFrom = plugin.config.resolveAllowFrom;
-  const resolveTarget = plugin.outbound?.resolveTarget;
-  if (!resolveAllowFrom || !resolveTarget) {
-    // Channel has no allowlist enforcement capability — nothing to check.
-    return;
-  }
-
-  const allowFromRaw = resolveAllowFrom({
-    cfg: params.cfg,
-    accountId: params.accountId ?? undefined,
-  });
-  if (!allowFromRaw || allowFromRaw.length === 0) {
-    // No allowlist configured — open access.
-    return;
-  }
-
-  const allowFrom = allowFromRaw.map((entry) => String(entry));
-  const result = resolveTarget({
-    cfg: params.cfg,
     to: params.to,
-    allowFrom,
-    accountId: params.accountId ?? undefined,
+    cfg: params.cfg,
+    accountId: params.accountId,
     mode: "explicit",
   });
+
   if (!result.ok) {
+    const masked = redactTarget(params.to);
     throw new Error(
-      `Target not in allowlist. The message tool cannot send to "${params.to}" on ${params.channel} because it is not in the configured allowFrom list.`,
+      `Target not in allowlist. The message tool cannot send to "${masked}" on ${params.channel} because it is not in the configured allowFrom list.`,
     );
   }
 }

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -790,6 +790,48 @@ export async function runMessageAction(
     params.accountId = accountId;
   }
   const dryRun = Boolean(input.dryRun ?? readBooleanParam(params, "dryRun"));
+
+  // Resolve target before hydration so allowlist + cross-context checks run
+  // before expensive media downloads / attachment processing.
+  const resolvedTarget = await resolveActionTarget({
+    cfg,
+    channel,
+    action,
+    args: params,
+    accountId,
+  });
+
+  enforceCrossContextPolicy({
+    channel,
+    action,
+    args: params,
+    toolContext: input.toolContext,
+    cfg,
+  });
+
+  // Enforce outbound allowlist: reject sends to targets not in the configured
+  // allowFrom list for the channel.  Uses the resolved `to` from params
+  // (already written by resolveActionTarget / applyTargetToParams above).
+  // Fall back to `channelId` for actions that use it as the target field
+  // (e.g. thread-reply).  When a guarded action has no resolvable target at
+  // all, reject explicitly rather than silently bypassing the allowlist.
+  const outboundTo =
+    (typeof params.to === "string" ? params.to.trim() : "") ||
+    (typeof params.channelId === "string" ? params.channelId.trim() : "");
+  if (outboundTo) {
+    enforceOutboundAllowlist({
+      cfg,
+      channel,
+      action,
+      to: outboundTo,
+      accountId,
+    });
+  } else if (ALLOWLIST_GUARDED_ACTIONS.has(action)) {
+    throw new Error(
+      `Action "${action}" on ${channel} requires a target for allowlist enforcement, but none was provided.`,
+    );
+  }
+
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, resolvedAgentId);
   const mediaPolicy = resolveAttachmentMediaPolicy({
     sandboxRoot: input.sandboxRoot,
@@ -810,36 +852,6 @@ export async function runMessageAction(
     dryRun,
     mediaPolicy,
   });
-
-  const resolvedTarget = await resolveActionTarget({
-    cfg,
-    channel,
-    action,
-    args: params,
-    accountId,
-  });
-
-  enforceCrossContextPolicy({
-    channel,
-    action,
-    args: params,
-    toolContext: input.toolContext,
-    cfg,
-  });
-
-  // Enforce outbound allowlist: reject sends to targets not in the configured
-  // allowFrom list for the channel.  Uses the resolved `to` from params
-  // (already written by resolveActionTarget / applyTargetToParams above).
-  const outboundTo = typeof params.to === "string" ? params.to.trim() : "";
-  if (outboundTo) {
-    enforceOutboundAllowlist({
-      cfg,
-      channel,
-      action,
-      to: outboundTo,
-      accountId,
-    });
-  }
 
   const gateway = resolveGateway(input);
 

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { discordPlugin } from "../../../extensions/discord/src/channel.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import {
   resolveHeartbeatDeliveryTarget,
   resolveOutboundTarget,
@@ -157,6 +160,102 @@ describe("resolveOutboundTarget allowFrom fallback enforcement", () => {
       to: "",
       cfg,
       mode: "implicit",
+    });
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe("resolveOutboundTarget Discord allowFrom enforcement", () => {
+  // Discord has a plugin-level resolveTarget that must enforce allowFrom so
+  // the outbound allowlist cannot be bypassed for DM or channel sends.
+  beforeEach(() => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "discord", plugin: discordPlugin, source: "test" }]),
+    );
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(createTestRegistry());
+  });
+
+  it("rejects discord user-DM target not in allowFrom list", () => {
+    const cfg: OpenClawConfig = {
+      channels: { discord: { allowFrom: ["user:111111111111111111"] } },
+    };
+    const res = resolveOutboundTarget({
+      channel: "discord",
+      to: "user:999999999999999999",
+      cfg,
+      mode: "explicit",
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("allows discord user-DM target that matches allowFrom entry", () => {
+    const cfg: OpenClawConfig = {
+      channels: { discord: { allowFrom: ["111111111111111111"] } },
+    };
+    const res = resolveOutboundTarget({
+      channel: "discord",
+      to: "user:111111111111111111",
+      cfg,
+      mode: "explicit",
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("allows discord target when allowFrom contains wildcard", () => {
+    const cfg: OpenClawConfig = {
+      channels: { discord: { allowFrom: ["*"] } },
+    };
+    const res = resolveOutboundTarget({
+      channel: "discord",
+      to: "channel:999999999999999999",
+      cfg,
+      mode: "explicit",
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("allows discord target when no allowFrom is configured (open)", () => {
+    const cfg: OpenClawConfig = { channels: { discord: {} } };
+    const res = resolveOutboundTarget({
+      channel: "discord",
+      to: "channel:123456789012345678",
+      cfg,
+      mode: "explicit",
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("normalizes bare numeric discord IDs and matches allowFrom id entry", () => {
+    // Bare numeric IDs are prefixed with "channel:" by normalizeDiscordOutboundTarget.
+    // The allowFrom entry without prefix should still match.
+    const cfg: OpenClawConfig = {
+      channels: { discord: { allowFrom: ["123456789012345678"] } },
+    };
+    const res = resolveOutboundTarget({
+      channel: "discord",
+      to: "123456789012345678",
+      cfg,
+      mode: "explicit",
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      // Should have been prefixed with "channel:" by the normalizer
+      expect(res.to).toBe("channel:123456789012345678");
+    }
+  });
+
+  it("rejects bare numeric discord channel ID not in allowFrom", () => {
+    const cfg: OpenClawConfig = {
+      channels: { discord: { allowFrom: ["111111111111111111"] } },
+    };
+    const res = resolveOutboundTarget({
+      channel: "discord",
+      to: "999999999999999999",
+      cfg,
+      mode: "explicit",
     });
     expect(res.ok).toBe(false);
   });

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -120,6 +120,46 @@ describe("resolveOutboundTarget allowFrom fallback enforcement", () => {
     });
     expect(res).toEqual({ ok: true, to: "123456789" });
   });
+
+  it("strips channel prefix from target before comparison", () => {
+    const cfg: OpenClawConfig = {
+      channels: { telegram: { allowFrom: ["111111111"] } },
+    };
+    // After normalizeTarget, Telegram targets get a "telegram:" prefix
+    const res = resolveOutboundTarget({
+      channel: "telegram",
+      to: "telegram:111111111",
+      cfg,
+      mode: "explicit",
+    });
+    expect(res).toEqual({ ok: true, to: "telegram:111111111" });
+  });
+
+  it("rejects channel-prefixed target when not in allowFrom", () => {
+    const cfg: OpenClawConfig = {
+      channels: { telegram: { allowFrom: ["111111111"] } },
+    };
+    const res = resolveOutboundTarget({
+      channel: "telegram",
+      to: "telegram:999999999",
+      cfg,
+      mode: "explicit",
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("blocks defaultTo when not in allowFrom", () => {
+    const cfg: OpenClawConfig = {
+      channels: { telegram: { defaultTo: "999999999", allowFrom: ["111111111"] } },
+    };
+    const res = resolveOutboundTarget({
+      channel: "telegram",
+      to: "",
+      cfg,
+      mode: "implicit",
+    });
+    expect(res.ok).toBe(false);
+  });
 });
 
 describe("resolveSessionDeliveryTarget", () => {

--- a/src/infra/outbound/targets.test.ts
+++ b/src/infra/outbound/targets.test.ts
@@ -66,6 +66,62 @@ describe("resolveOutboundTarget defaultTo config fallback", () => {
   });
 });
 
+describe("resolveOutboundTarget allowFrom fallback enforcement", () => {
+  installResolveOutboundTargetPluginRegistryHooks();
+
+  it("rejects telegram target not in allowFrom list", () => {
+    const cfg: OpenClawConfig = {
+      channels: { telegram: { allowFrom: ["111111111"] } },
+    };
+    const res = resolveOutboundTarget({
+      channel: "telegram",
+      to: "999999999",
+      cfg,
+      mode: "explicit",
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("allows telegram target that matches allowFrom entry", () => {
+    const cfg: OpenClawConfig = {
+      channels: { telegram: { allowFrom: ["111111111"] } },
+    };
+    const res = resolveOutboundTarget({
+      channel: "telegram",
+      to: "111111111",
+      cfg,
+      mode: "explicit",
+    });
+    expect(res).toEqual({ ok: true, to: "111111111" });
+  });
+
+  it("allows telegram target when allowFrom contains wildcard", () => {
+    const cfg: OpenClawConfig = {
+      channels: { telegram: { allowFrom: ["*"] } },
+    };
+    const res = resolveOutboundTarget({
+      channel: "telegram",
+      to: "999999999",
+      cfg,
+      mode: "explicit",
+    });
+    expect(res).toEqual({ ok: true, to: "999999999" });
+  });
+
+  it("allows telegram target when no allowFrom is configured", () => {
+    const cfg: OpenClawConfig = {
+      channels: { telegram: {} },
+    };
+    const res = resolveOutboundTarget({
+      channel: "telegram",
+      to: "123456789",
+      cfg,
+      mode: "explicit",
+    });
+    expect(res).toEqual({ ok: true, to: "123456789" });
+  });
+});
+
 describe("resolveSessionDeliveryTarget", () => {
   const expectImplicitRoute = (
     resolved: SessionDeliveryTarget,

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -231,7 +231,17 @@ export function resolveOutboundTarget(params: {
     // without a resolver (e.g. Telegram/Slack/Signal/iMessage) cannot bypass
     // the allowlist by returning ok for any explicit target.
     if (allowFrom && allowFrom.length > 0 && !allowFrom.includes("*")) {
-      if (!allowFrom.includes(effectiveTo)) {
+      // Strip channel prefix (e.g. "telegram:123" -> "123") before comparison
+      // because normalized targets may carry a channel prefix while allowFrom
+      // entries from config typically do not.
+      const channelPrefix = `${params.channel}:`;
+      const stripPrefix = (value: string): string => {
+        const lower = value.trim().toLowerCase();
+        return lower.startsWith(channelPrefix) ? lower.slice(channelPrefix.length) : lower;
+      };
+      const normalizedTo = stripPrefix(effectiveTo);
+      const normalizedAllowFrom = allowFrom.map(stripPrefix);
+      if (!normalizedAllowFrom.includes(normalizedTo)) {
         const hint = plugin.messaging?.targetResolver?.hint;
         return {
           ok: false,

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -227,6 +227,18 @@ export function resolveOutboundTarget(params: {
   }
 
   if (effectiveTo) {
+    // When no custom resolveTarget exists, enforce allowFrom here so channels
+    // without a resolver (e.g. Telegram/Slack/Signal/iMessage) cannot bypass
+    // the allowlist by returning ok for any explicit target.
+    if (allowFrom && allowFrom.length > 0 && !allowFrom.includes("*")) {
+      if (!allowFrom.includes(effectiveTo)) {
+        const hint = plugin.messaging?.targetResolver?.hint;
+        return {
+          ok: false,
+          error: missingTargetError(plugin.meta.label ?? params.channel, hint),
+        };
+      }
+    }
     return { ok: true, to: effectiveTo };
   }
   const hint = plugin.messaging?.targetResolver?.hint;

--- a/src/plugin-sdk/index.ts
+++ b/src/plugin-sdk/index.ts
@@ -80,7 +80,6 @@ export type {
   AcpRuntimeEvent,
   AcpRuntimeHandle,
   AcpRuntimePromptMode,
-  AcpSessionUpdateTag,
   AcpRuntimeSessionMode,
   AcpRuntimeStatus,
   AcpRuntimeTurnInput,
@@ -120,55 +119,27 @@ export { isDangerousNameMatchingEnabled } from "../config/dangerous-name-matchin
 
 export type { FileLockHandle, FileLockOptions } from "./file-lock.js";
 export { acquireFileLock, withFileLock } from "./file-lock.js";
-export type { KeyedAsyncQueueHooks } from "./keyed-async-queue.js";
-export { enqueueKeyedTask, KeyedAsyncQueue } from "./keyed-async-queue.js";
 export { normalizeWebhookPath, resolveWebhookPath } from "./webhook-path.js";
 export {
   registerWebhookTarget,
-  registerWebhookTargetWithPluginRoute,
   rejectNonPostWebhookRequest,
-  resolveWebhookTargetWithAuthOrReject,
-  resolveWebhookTargetWithAuthOrRejectSync,
   resolveSingleWebhookTarget,
   resolveSingleWebhookTargetAsync,
   resolveWebhookTargets,
 } from "./webhook-targets.js";
-export type {
-  RegisterWebhookPluginRouteOptions,
-  RegisterWebhookTargetOptions,
-  WebhookTargetMatchResult,
-} from "./webhook-targets.js";
-export {
-  applyBasicWebhookRequestGuards,
-  beginWebhookRequestPipelineOrReject,
-  createWebhookInFlightLimiter,
-  isJsonContentType,
-  readWebhookBodyOrReject,
-  readJsonWebhookBodyOrReject,
-  WEBHOOK_BODY_READ_DEFAULTS,
-  WEBHOOK_IN_FLIGHT_DEFAULTS,
-} from "./webhook-request-guards.js";
-export type { WebhookBodyReadProfile, WebhookInFlightLimiter } from "./webhook-request-guards.js";
-export { keepHttpServerTaskAlive, waitUntilAbort } from "./channel-lifecycle.js";
+export type { WebhookTargetMatchResult } from "./webhook-targets.js";
 export type { AgentMediaPayload } from "./agent-media-payload.js";
 export { buildAgentMediaPayload } from "./agent-media-payload.js";
 export {
   buildBaseAccountStatusSnapshot,
   buildBaseChannelStatusSummary,
-  buildProbeChannelStatusSummary,
   buildTokenChannelStatusSummary,
   collectStatusIssuesFromLastError,
   createDefaultChannelRuntimeState,
 } from "./status-helpers.js";
-export {
-  promptSingleChannelSecretInput,
-  type SingleChannelSecretInputPromptResult,
-} from "../channels/plugins/onboarding/helpers.js";
 export { buildOauthProviderAuthResult } from "./provider-auth-result.js";
-export { formatResolvedUnresolvedNote } from "./resolution-notes.js";
 export type { ChannelDock } from "../channels/dock.js";
 export { getChatChannelMeta } from "../channels/registry.js";
-export { resolveAllowlistMatchByCandidates } from "../channels/allowlist-match.js";
 export type {
   BlockStreamingCoalesceConfig,
   DmPolicy,
@@ -221,27 +192,17 @@ export {
   normalizeAllowFrom,
   ReplyRuntimeConfigSchemaShape,
   requireOpenAllowFrom,
-  SecretInputSchema,
   TtsAutoSchema,
   TtsConfigSchema,
   TtsModeSchema,
   TtsProviderSchema,
 } from "../config/zod-schema.core.js";
-export {
-  assertSecretInputResolved,
-  hasConfiguredSecretInput,
-  isSecretRef,
-  normalizeResolvedSecretInputString,
-  normalizeSecretInputString,
-} from "../config/types.secrets.js";
-export type { SecretInput, SecretRef } from "../config/types.secrets.js";
 export { ToolPolicySchema } from "../config/zod-schema.agent-runtime.js";
 export type { RuntimeEnv } from "../runtime.js";
 export type { WizardPrompter } from "../wizard/prompts.js";
 export {
   DEFAULT_ACCOUNT_ID,
   normalizeAccountId,
-  normalizeAgentId,
   resolveThreadSessionKeys,
 } from "../routing/session-key.js";
 export {
@@ -254,22 +215,8 @@ export {
   type SenderGroupAccessDecision,
   type SenderGroupAccessReason,
 } from "./group-access.js";
-export {
-  resolveDirectDmAuthorizationOutcome,
-  resolveSenderCommandAuthorization,
-  resolveSenderCommandAuthorizationWithRuntime,
-} from "./command-auth.js";
-export type { CommandAuthorizationRuntime } from "./command-auth.js";
+export { resolveSenderCommandAuthorization } from "./command-auth.js";
 export { createScopedPairingAccess } from "./pairing-access.js";
-export {
-  createInboundEnvelopeBuilder,
-  resolveInboundRouteEnvelopeBuilder,
-  resolveInboundRouteEnvelopeBuilderWithRuntime,
-} from "./inbound-envelope.js";
-export {
-  listConfiguredAccountIds,
-  resolveAccountWithDefaultFallback,
-} from "./account-resolution.js";
 export { issuePairingChallenge } from "../pairing/pairing-challenge.js";
 export { handleSlackMessageAction } from "./slack-message-actions.js";
 export { extractToolSend } from "./tool-send.js";
@@ -281,33 +228,13 @@ export {
   sendMediaWithLeadingCaption,
 } from "./reply-payload.js";
 export type { OutboundReplyPayload } from "./reply-payload.js";
-export type { OutboundMediaLoadOptions } from "./outbound-media.js";
-export { loadOutboundMediaFromUrl } from "./outbound-media.js";
 export { resolveChannelAccountConfigBasePath } from "./config-paths.js";
 export { buildMediaPayload } from "../channels/plugins/media-payload.js";
 export type { MediaPayload, MediaPayloadInput } from "../channels/plugins/media-payload.js";
 export { createLoggerBackedRuntime } from "./runtime.js";
 export { chunkTextForOutbound } from "./text-chunking.js";
-export { readBooleanParam } from "./boolean-param.js";
 export { readJsonFileWithFallback, writeJsonFileAtomically } from "./json-store.js";
-export { generatePkceVerifierChallenge, toFormUrlEncoded } from "./oauth-utils.js";
 export { buildRandomTempFilePath, withTempDownloadPath } from "./temp-path.js";
-export {
-  applyWindowsSpawnProgramPolicy,
-  materializeWindowsSpawnProgram,
-  resolveWindowsExecutablePath,
-  resolveWindowsSpawnProgramCandidate,
-  resolveWindowsSpawnProgram,
-} from "./windows-spawn.js";
-export type {
-  ResolveWindowsSpawnProgramCandidateParams,
-  ResolveWindowsSpawnProgramParams,
-  WindowsSpawnCandidateResolution,
-  WindowsSpawnInvocation,
-  WindowsSpawnProgramCandidate,
-  WindowsSpawnProgram,
-  WindowsSpawnResolution,
-} from "./windows-spawn.js";
 export { resolvePreferredOpenClawTmpDir } from "../infra/tmp-openclaw-dir.js";
 export {
   runPluginCommandWithTimeout,
@@ -329,14 +256,6 @@ export type { ReplyPayload } from "../auto-reply/types.js";
 export type { ChunkMode } from "../auto-reply/chunk.js";
 export { SILENT_REPLY_TOKEN, isSilentReplyText } from "../auto-reply/tokens.js";
 export { formatInboundFromLabel } from "../auto-reply/envelope.js";
-export {
-  formatTrimmedAllowFromEntries,
-  formatWhatsAppConfigAllowFromEntries,
-  resolveIMessageConfigAllowFrom,
-  resolveIMessageConfigDefaultTo,
-  resolveWhatsAppConfigAllowFrom,
-  resolveWhatsAppConfigDefaultTo,
-} from "./channel-config-helpers.js";
 export {
   approveDevicePairing,
   listDevicePairing,
@@ -366,19 +285,6 @@ export {
   readRequestBodyWithLimit,
   requestBodyErrorToText,
 } from "../infra/http-body.js";
-export {
-  WEBHOOK_ANOMALY_COUNTER_DEFAULTS,
-  WEBHOOK_ANOMALY_STATUS_CODES,
-  WEBHOOK_RATE_LIMIT_DEFAULTS,
-  createBoundedCounter,
-  createFixedWindowRateLimiter,
-  createWebhookAnomalyTracker,
-} from "./webhook-memory-guards.js";
-export type {
-  BoundedCounter,
-  FixedWindowRateLimiter,
-  WebhookAnomalyTracker,
-} from "./webhook-memory-guards.js";
 
 export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 export {
@@ -543,8 +449,6 @@ export type {
 } from "../infra/diagnostic-events.js";
 export { detectMime, extensionForMime, getFileExtension } from "../media/mime.js";
 export { extractOriginalFilename } from "../media/store.js";
-export { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
-export type { SkillCommandSpec } from "../agents/skills.js";
 
 // Channel: Discord
 export {
@@ -554,6 +458,7 @@ export {
   type ResolvedDiscordAccount,
 } from "../discord/accounts.js";
 export { collectDiscordAuditChannelIds } from "../discord/audit.js";
+export { allowListMatches, normalizeDiscordAllowList } from "../discord/monitor/allow-list.js";
 export { discordOnboardingAdapter } from "../channels/plugins/onboarding/discord.js";
 export {
   looksLikeDiscordTargetId,
@@ -580,7 +485,6 @@ export {
   resolveServicePrefixedAllowTarget,
   resolveServicePrefixedTarget,
 } from "../imessage/target-parsing-helpers.js";
-export type { ParsedChatTarget } from "../imessage/target-parsing-helpers.js";
 
 // Channel: Slack
 export {


### PR DESCRIPTION
Closes #24203

Enforce \allowlist\ on outbound sends from the message tool so targets not in the configured allowFrom list are rejected at dispatch time.