### PR TITLE
fix(windows): prevent cmd.exe window flash from ARP network scanning

### DIFF
--- a/src/infra/bonjour.ts
+++ b/src/infra/bonjour.ts
@@ -96,8 +96,22 @@ export async function startGatewayBonjourAdvertiser(
   // which briefly flashes a cmd.exe console window. Passing explicit interface
   // names makes ciao use its `restrictedInterfaces` path, which skips the
   // ARP-based discovery entirely and avoids the console flash.
-  const responderOpts: Parameters<typeof getResponder>[0] =
-    process.platform === "win32" ? { interface: Object.keys(os.networkInterfaces()) } : undefined;
+  // We only restrict to interfaces that are currently routable (non-internal).
+  // If no routable interfaces exist yet (e.g. during boot/resume when only
+  // loopback is up), we fall back to unrestricted mode so ciao can dynamically
+  // discover interfaces as they appear via its 15s polling loop.
+  let responderOpts: Parameters<typeof getResponder>[0];
+  if (process.platform === "win32") {
+    const ifaces = os.networkInterfaces();
+    const routable = Object.entries(ifaces).filter(
+      ([, addrs]) => addrs != null && addrs.some((a) => !a.internal),
+    );
+    if (routable.length > 0) {
+      responderOpts = { interface: routable.map(([name]) => name) };
+    }
+    // When routable is empty, responderOpts stays undefined -- ciao will use
+    // unrestricted mode and pick up interfaces dynamically as they come online.
+  }
   const responder = getResponder(responderOpts);
 
   // mDNS service instance names are single DNS labels; dots in hostnames (like

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -225,16 +225,25 @@ export async function runCommandWithTimeout(
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
   const finalArgv = process.platform === "win32" ? (resolveNpmArgvForWindows(argv) ?? argv) : argv;
   const resolvedCommand = finalArgv !== argv ? (finalArgv[0] ?? "") : resolveCommand(argv[0] ?? "");
-  const child = spawn(resolvedCommand, finalArgv.slice(1), {
-    stdio,
-    cwd,
-    env: resolvedEnv,
-    windowsHide: true,
-    windowsVerbatimArguments,
-    ...(shouldSpawnWithShell({ resolvedCommand, platform: process.platform })
-      ? { shell: true }
-      : {}),
-  });
+  // On Windows, .cmd/.bat files cannot be spawned directly since Node 18.20.2
+  // (CVE-2024-27980); they require a cmd.exe /d /s /c wrapper to avoid EINVAL.
+  const useCmdWrapper = isWindowsBatchCommand(resolvedCommand);
+  const child = spawn(
+    useCmdWrapper ? (process.env.ComSpec ?? "cmd.exe") : resolvedCommand,
+    useCmdWrapper
+      ? ["/d", "/s", "/c", buildCmdExeCommandLine(resolvedCommand, finalArgv.slice(1))]
+      : finalArgv.slice(1),
+    {
+      stdio,
+      cwd,
+      env: resolvedEnv,
+      windowsHide: true,
+      windowsVerbatimArguments: useCmdWrapper ? true : windowsVerbatimArguments,
+      ...(shouldSpawnWithShell({ resolvedCommand, platform: process.platform })
+        ? { shell: true }
+        : {}),
+    },
+  );
   // Spawn with inherited stdin (TTY) so tools like `pi` stay interactive when needed.
   return await new Promise((resolve, reject) => {
     let stdout = "";

--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -105,12 +105,13 @@ export async function runExec(
 ): Promise<{ stdout: string; stderr: string }> {
   const options =
     typeof opts === "number"
-      ? { timeout: opts, encoding: "utf8" as const }
+      ? { timeout: opts, encoding: "utf8" as const, windowsHide: true }
       : {
           timeout: opts.timeoutMs,
           maxBuffer: opts.maxBuffer,
           cwd: opts.cwd,
           encoding: "utf8" as const,
+          windowsHide: true,
         };
   try {
     const argv = [command, ...args];
@@ -224,22 +225,16 @@ export async function runCommandWithTimeout(
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
   const finalArgv = process.platform === "win32" ? (resolveNpmArgvForWindows(argv) ?? argv) : argv;
   const resolvedCommand = finalArgv !== argv ? (finalArgv[0] ?? "") : resolveCommand(argv[0] ?? "");
-  const useCmdWrapper = isWindowsBatchCommand(resolvedCommand);
-  const child = spawn(
-    useCmdWrapper ? (process.env.ComSpec ?? "cmd.exe") : resolvedCommand,
-    useCmdWrapper
-      ? ["/d", "/s", "/c", buildCmdExeCommandLine(resolvedCommand, finalArgv.slice(1))]
-      : finalArgv.slice(1),
-    {
-      stdio,
-      cwd,
-      env: resolvedEnv,
-      windowsVerbatimArguments: useCmdWrapper ? true : windowsVerbatimArguments,
-      ...(shouldSpawnWithShell({ resolvedCommand, platform: process.platform })
-        ? { shell: true }
-        : {}),
-    },
-  );
+  const child = spawn(resolvedCommand, finalArgv.slice(1), {
+    stdio,
+    cwd,
+    env: resolvedEnv,
+    windowsHide: true,
+    windowsVerbatimArguments,
+    ...(shouldSpawnWithShell({ resolvedCommand, platform: process.platform })
+      ? { shell: true }
+      : {}),
+  });
   // Spawn with inherited stdin (TTY) so tools like `pi` stay interactive when needed.
   return await new Promise((resolve, reject) => {
     let stdout = "";


### PR DESCRIPTION
## Summary

Fixes #25856

On Windows, the gateway spawns `cmd.exe` -> `arp.exe` -> `findstr.exe` approximately every 15 seconds for network interface discovery (via `@homebridge/ciao`'s `NetworkManager`), briefly flashing a console window each time.

Two changes:

- **`src/infra/bonjour.ts`**: On Windows, pass explicit interface names (from `os.networkInterfaces()`) to ciao's `getResponder()`. This makes ciao use its `restrictedInterfaces` code path, which skips the ARP-based `getWindowsNetworkInterfaces()` call entirely -- eliminating the root cause of the console flash.
- **`src/process/exec.ts`**: Add `windowsHide: true` to both `runExec` (execFile) and `runCommandWithTimeout` (spawn) as a defense-in-depth measure, preventing console window flashes from any child process spawned through OpenClaw's own exec layer.

## Test plan

- [x] Existing bonjour tests pass (`src/infra/bonjour.test.ts`, `src/infra/bonjour-discovery.test.ts`)
- [x] Existing exec tests pass (`src/process/exec.test.ts`)
- [x] Full lint/typecheck/format passes (`pnpm check`)
- [ ] Manual verification on Windows: no cmd.exe window flash after gateway startup