### PR TITLE
fix(tui): preserve streamed text across tool-call continuation deltas

### DIFF
--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -176,6 +176,28 @@ describe("TuiStreamAssembler", () => {
     expect(expanded).toBe("Before tool call\nAfter tool call (expanded)");
   });
 
+  it("keeps pre-tool text when continuation snapshots partially overlap", () => {
+    const assembler = new TuiStreamAssembler();
+
+    assembler.ingestDelta(
+      "run-post-tool-overlap",
+      messageWithContent([text("Before tool call")]),
+      false,
+    );
+    assembler.ingestDelta(
+      "run-post-tool-overlap",
+      messageWithContent([toolUse(), text("After 1")]),
+      false,
+    );
+
+    const overlap = assembler.ingestDelta(
+      "run-post-tool-overlap",
+      messageWithContent([toolUse(), text("After 1"), text("After 2")]),
+      false,
+    );
+    expect(overlap).toBe("Before tool call\nAfter 1\nAfter 2");
+  });
+
   for (const testCase of FINALIZE_BOUNDARY_CASES) {
     it(testCase.name, () => {
       const assembler = new TuiStreamAssembler();

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -274,6 +274,33 @@ describe("TuiStreamAssembler", () => {
     expect(fullSnapshot).toBe("Before tool call\nAfter 1\nAfter 2\nAfter 3");
   });
 
+  it("does not retain stale continuation blocks during finalize snapshots", () => {
+    const assembler = new TuiStreamAssembler();
+
+    assembler.ingestDelta(
+      "run-post-tool-finalize-snapshot",
+      messageWithContent([text("Before tool call")]),
+      false,
+    );
+    assembler.ingestDelta(
+      "run-post-tool-finalize-snapshot",
+      messageWithContent([toolUse(), text("After 1")]),
+      false,
+    );
+    assembler.ingestDelta(
+      "run-post-tool-finalize-snapshot",
+      messageWithContent([toolUse(), text("After 2")]),
+      false,
+    );
+
+    const finalText = assembler.finalize(
+      "run-post-tool-finalize-snapshot",
+      messageWithContent([toolUse(), text("After 2"), text("After 3")]),
+      false,
+    );
+    expect(finalText).toBe("After 2\nAfter 3");
+  });
+
   for (const testCase of FINALIZE_BOUNDARY_CASES) {
     it(testCase.name, () => {
       const assembler = new TuiStreamAssembler();

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -247,6 +247,33 @@ describe("TuiStreamAssembler", () => {
     expect(fullSnapshot).toBe("Before tool call\nAfter 1\nAfter 2");
   });
 
+  it("keeps continuation anchor across appended post-tool chunks", () => {
+    const assembler = new TuiStreamAssembler();
+
+    assembler.ingestDelta(
+      "run-post-tool-anchor",
+      messageWithContent([text("Before tool call")]),
+      false,
+    );
+    assembler.ingestDelta(
+      "run-post-tool-anchor",
+      messageWithContent([toolUse(), text("After 1")]),
+      false,
+    );
+    assembler.ingestDelta(
+      "run-post-tool-anchor",
+      messageWithContent([toolUse(), text("After 2")]),
+      false,
+    );
+
+    const fullSnapshot = assembler.ingestDelta(
+      "run-post-tool-anchor",
+      messageWithContent([toolUse(), text("After 1"), text("After 2"), text("After 3")]),
+      false,
+    );
+    expect(fullSnapshot).toBe("Before tool call\nAfter 1\nAfter 2\nAfter 3");
+  });
+
   for (const testCase of FINALIZE_BOUNDARY_CASES) {
     it(testCase.name, () => {
       const assembler = new TuiStreamAssembler();

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -154,6 +154,28 @@ describe("TuiStreamAssembler", () => {
     expect(finalText).toBe("Before tool call\nAfter tool call");
   });
 
+  it("replaces post-tool continuation snapshots instead of duplicating them", () => {
+    const assembler = new TuiStreamAssembler();
+
+    assembler.ingestDelta(
+      "run-post-tool-expand",
+      messageWithContent([text("Before tool call")]),
+      false,
+    );
+    assembler.ingestDelta(
+      "run-post-tool-expand",
+      messageWithContent([toolUse(), text("After tool call")]),
+      false,
+    );
+
+    const expanded = assembler.ingestDelta(
+      "run-post-tool-expand",
+      messageWithContent([toolUse(), text("After tool call (expanded)")]),
+      false,
+    );
+    expect(expanded).toBe("Before tool call\nAfter tool call (expanded)");
+  });
+
   for (const testCase of FINALIZE_BOUNDARY_CASES) {
     it(testCase.name, () => {
       const assembler = new TuiStreamAssembler();

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -198,6 +198,33 @@ describe("TuiStreamAssembler", () => {
     expect(overlap).toBe("Before tool call\nAfter 1\nAfter 2");
   });
 
+  it("preserves pre-tool text on mixed-overlap continuation updates", () => {
+    const assembler = new TuiStreamAssembler();
+
+    assembler.ingestDelta(
+      "run-post-tool-mixed-overlap",
+      messageWithContent([text("Before tool call")]),
+      false,
+    );
+    assembler.ingestDelta(
+      "run-post-tool-mixed-overlap",
+      messageWithContent([toolUse(), text("After 1")]),
+      false,
+    );
+    assembler.ingestDelta(
+      "run-post-tool-mixed-overlap",
+      messageWithContent([toolUse(), text("After 1"), text("After 2")]),
+      false,
+    );
+
+    const revised = assembler.ingestDelta(
+      "run-post-tool-mixed-overlap",
+      messageWithContent([toolUse(), text("After 1 revised"), text("After 2")]),
+      false,
+    );
+    expect(revised).toBe("Before tool call\nAfter 1 revised\nAfter 2");
+  });
+
   for (const testCase of FINALIZE_BOUNDARY_CASES) {
     it(testCase.name, () => {
       const assembler = new TuiStreamAssembler();

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -225,6 +225,28 @@ describe("TuiStreamAssembler", () => {
     expect(revised).toBe("Before tool call\nAfter 1 revised\nAfter 2");
   });
 
+  it("replaces continuation with full snapshot without duplicating pre-tool prefix", () => {
+    const assembler = new TuiStreamAssembler();
+
+    assembler.ingestDelta(
+      "run-post-tool-full-snapshot",
+      messageWithContent([text("Before tool call")]),
+      false,
+    );
+    assembler.ingestDelta(
+      "run-post-tool-full-snapshot",
+      messageWithContent([toolUse(), text("After 1")]),
+      false,
+    );
+
+    const fullSnapshot = assembler.ingestDelta(
+      "run-post-tool-full-snapshot",
+      messageWithContent([text("Before tool call"), text("After 1"), text("After 2")]),
+      false,
+    );
+    expect(fullSnapshot).toBe("Before tool call\nAfter 1\nAfter 2");
+  });
+
   for (const testCase of FINALIZE_BOUNDARY_CASES) {
     it(testCase.name, () => {
       const assembler = new TuiStreamAssembler();

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -136,6 +136,27 @@ function isSnapshotCompatibleContinuation(params: {
   });
 }
 
+function mergeContinuationWithOverlap(params: {
+  previousBlocks: string[];
+  nextBlocks: string[];
+}): string[] | null {
+  const { previousBlocks, nextBlocks } = params;
+  if (previousBlocks.length === 0 || nextBlocks.length === 0) {
+    return null;
+  }
+  const maxOverlap = Math.min(previousBlocks.length, nextBlocks.length);
+  for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {
+    const previousSlice = previousBlocks.slice(previousBlocks.length - overlap);
+    const nextSlice = nextBlocks.slice(0, overlap);
+    const matches = previousSlice.every((block, index) => block === nextSlice[index]);
+    if (!matches) {
+      continue;
+    }
+    return [...previousBlocks, ...nextBlocks.slice(overlap)];
+  }
+  return null;
+}
+
 export class TuiStreamAssembler {
   private runs = new Map<string, RunStreamState>();
 
@@ -185,9 +206,24 @@ export class TuiStreamAssembler {
         streamedTextBlocks: state.contentBlocks,
         nextContentBlocks,
       });
+      const continuationStart = state.postBoundaryContinuationStart;
+      const overlapMergedContinuation =
+        continuationStart != null &&
+        continuationStart >= 0 &&
+        continuationStart <= state.contentBlocks.length
+          ? mergeContinuationWithOverlap({
+              previousBlocks: state.contentBlocks.slice(continuationStart),
+              nextBlocks: nextContentBlocks,
+            })
+          : null;
 
-      if (shouldAppendContinuation) {
-        const continuationStart = state.postBoundaryContinuationStart;
+      if (overlapMergedContinuation && continuationStart != null) {
+        state.contentBlocks = [
+          ...state.contentBlocks.slice(0, continuationStart),
+          ...overlapMergedContinuation,
+        ];
+        state.contentText = state.contentBlocks.join("\n");
+      } else if (shouldAppendContinuation) {
         const canReplacePriorContinuation =
           continuationStart != null &&
           continuationStart >= 0 &&

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -252,7 +252,9 @@ export class TuiStreamAssembler {
             ...nextContentBlocks,
           ];
         } else {
-          state.postBoundaryContinuationStart = state.contentBlocks.length;
+          if (continuationStart == null) {
+            state.postBoundaryContinuationStart = state.contentBlocks.length;
+          }
           state.contentBlocks = [...state.contentBlocks, ...nextContentBlocks];
         }
         state.contentText = state.contentBlocks.join("\n");

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -231,7 +231,11 @@ export class TuiStreamAssembler {
         existingContinuation.length > 0 &&
         nextContentBlocks.some((block) => existingContinuation.includes(block));
 
-      if (overlapMergedContinuation && continuationStart != null) {
+      if (
+        overlapMergedContinuation &&
+        continuationStart != null &&
+        boundaryDropMode === "streamed-or-incoming"
+      ) {
         state.contentBlocks = [
           ...state.contentBlocks.slice(0, continuationStart),
           ...overlapMergedContinuation,

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -207,6 +207,12 @@ export class TuiStreamAssembler {
         nextContentBlocks,
       });
       const continuationStart = state.postBoundaryContinuationStart;
+      const priorBoundaryPrefix =
+        continuationStart != null &&
+        continuationStart >= 0 &&
+        continuationStart <= state.contentBlocks.length
+          ? state.contentBlocks.slice(0, continuationStart)
+          : [];
       const existingContinuation =
         continuationStart != null &&
         continuationStart >= 0 &&
@@ -256,10 +262,13 @@ export class TuiStreamAssembler {
         hasContinuationBlockOverlap &&
         continuationStart != null
       ) {
-        state.contentBlocks = [
-          ...state.contentBlocks.slice(0, continuationStart),
-          ...nextContentBlocks,
-        ];
+        const nextIncludesBoundaryPrefix =
+          priorBoundaryPrefix.length > 0 &&
+          nextContentBlocks.length >= priorBoundaryPrefix.length &&
+          priorBoundaryPrefix.every((block, index) => nextContentBlocks[index] === block);
+        state.contentBlocks = nextIncludesBoundaryPrefix
+          ? nextContentBlocks
+          : [...priorBoundaryPrefix, ...nextContentBlocks];
         state.contentText = state.contentBlocks.join("\n");
       } else if (!shouldKeepStreamedBoundaryText) {
         state.contentText = contentText;

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -10,6 +10,7 @@ type RunStreamState = {
   contentText: string;
   contentBlocks: string[];
   sawNonTextContentBlocks: boolean;
+  postBoundaryContinuationStart: number | null;
   displayText: string;
 };
 
@@ -119,6 +120,22 @@ function shouldAppendPostBoundaryContinuation(params: {
   return params.nextContentBlocks.every((block) => !params.streamedTextBlocks.includes(block));
 }
 
+function isSnapshotCompatibleContinuation(params: {
+  previousBlocks: string[];
+  nextBlocks: string[];
+}): boolean {
+  if (params.previousBlocks.length === 0 || params.nextBlocks.length === 0) {
+    return false;
+  }
+  if (params.previousBlocks.length !== params.nextBlocks.length) {
+    return false;
+  }
+  return params.nextBlocks.every((block, index) => {
+    const previous = params.previousBlocks[index] ?? "";
+    return block === previous || block.startsWith(previous) || previous.startsWith(block);
+  });
+}
+
 export class TuiStreamAssembler {
   private runs = new Map<string, RunStreamState>();
 
@@ -130,6 +147,7 @@ export class TuiStreamAssembler {
         contentText: "",
         contentBlocks: [],
         sawNonTextContentBlocks: false,
+        postBoundaryContinuationStart: null,
         displayText: "",
       };
       this.runs.set(runId, state);
@@ -169,11 +187,29 @@ export class TuiStreamAssembler {
       });
 
       if (shouldAppendContinuation) {
-        state.contentBlocks = [...state.contentBlocks, ...nextContentBlocks];
+        const continuationStart = state.postBoundaryContinuationStart;
+        const canReplacePriorContinuation =
+          continuationStart != null &&
+          continuationStart >= 0 &&
+          continuationStart <= state.contentBlocks.length &&
+          isSnapshotCompatibleContinuation({
+            previousBlocks: state.contentBlocks.slice(continuationStart),
+            nextBlocks: nextContentBlocks,
+          });
+        if (canReplacePriorContinuation && continuationStart != null) {
+          state.contentBlocks = [
+            ...state.contentBlocks.slice(0, continuationStart),
+            ...nextContentBlocks,
+          ];
+        } else {
+          state.postBoundaryContinuationStart = state.contentBlocks.length;
+          state.contentBlocks = [...state.contentBlocks, ...nextContentBlocks];
+        }
         state.contentText = state.contentBlocks.join("\n");
       } else if (!shouldKeepStreamedBoundaryText) {
         state.contentText = contentText;
         state.contentBlocks = nextContentBlocks;
+        state.postBoundaryContinuationStart = null;
       }
     }
     if (sawNonTextContentBlocks) {

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -207,15 +207,23 @@ export class TuiStreamAssembler {
         nextContentBlocks,
       });
       const continuationStart = state.postBoundaryContinuationStart;
-      const overlapMergedContinuation =
+      const existingContinuation =
         continuationStart != null &&
         continuationStart >= 0 &&
         continuationStart <= state.contentBlocks.length
+          ? state.contentBlocks.slice(continuationStart)
+          : [];
+      const overlapMergedContinuation =
+        continuationStart != null && existingContinuation.length > 0
           ? mergeContinuationWithOverlap({
-              previousBlocks: state.contentBlocks.slice(continuationStart),
+              previousBlocks: existingContinuation,
               nextBlocks: nextContentBlocks,
             })
           : null;
+      const hasContinuationBlockOverlap =
+        continuationStart != null &&
+        existingContinuation.length > 0 &&
+        nextContentBlocks.some((block) => existingContinuation.includes(block));
 
       if (overlapMergedContinuation && continuationStart != null) {
         state.contentBlocks = [
@@ -229,7 +237,7 @@ export class TuiStreamAssembler {
           continuationStart >= 0 &&
           continuationStart <= state.contentBlocks.length &&
           isSnapshotCompatibleContinuation({
-            previousBlocks: state.contentBlocks.slice(continuationStart),
+            previousBlocks: existingContinuation,
             nextBlocks: nextContentBlocks,
           });
         if (canReplacePriorContinuation && continuationStart != null) {
@@ -241,6 +249,17 @@ export class TuiStreamAssembler {
           state.postBoundaryContinuationStart = state.contentBlocks.length;
           state.contentBlocks = [...state.contentBlocks, ...nextContentBlocks];
         }
+        state.contentText = state.contentBlocks.join("\n");
+      } else if (
+        !shouldKeepStreamedBoundaryText &&
+        boundaryDropMode === "streamed-or-incoming" &&
+        hasContinuationBlockOverlap &&
+        continuationStart != null
+      ) {
+        state.contentBlocks = [
+          ...state.contentBlocks.slice(0, continuationStart),
+          ...nextContentBlocks,
+        ];
         state.contentText = state.contentBlocks.join("\n");
       } else if (!shouldKeepStreamedBoundaryText) {
         state.contentText = contentText;


### PR DESCRIPTION
## Summary
- preserve previously streamed TUI text when a later delta crosses a tool boundary and only carries the continuation block
- add regression coverage for the live-stream erase case and for repeated continuation deltas

Fixes #28180.

## Why This Fits The Project
From `VISION.md`:
> - Bug fixes and stability
> - One PR = one issue/topic. Do not bundle multiple unrelated fixes/features.

From `CONTRIBUTING.md`:
> - Keep PRs focused (one thing per PR; do not mix unrelated concerns)
> - Describe what & why

This PR is a focused TUI stability fix for one reproducible regression.

## What Changed
- teach `TuiStreamAssembler` to append non-overlapping post-tool continuation text during streaming instead of replacing already-rendered pre-tool text
- keep the existing finalize behavior for real boundary-drop/subset cases
- add targeted tests for the tool-boundary continuation regression

## Testing
- `pnpm vitest run src/tui/tui-stream-assembler.test.ts`

## AI Transparency
- AI-assisted: yes
- Testing: fully tested for the changed path
- I reviewed the diff and verified the added regression cases match the reported bug
