### PR TITLE
fix(imessage): strip reply tags before announcement delivery

### DIFF
--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -118,18 +118,14 @@ vi.mock("./tools/agent-step.js", () => ({
   readLatestAssistantReply: readLatestAssistantReplyMock,
 }));
 
-vi.mock("../config/sessions.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../config/sessions.js")>();
-  return {
-    ...actual,
-    loadSessionStore: vi.fn(() => loadSessionStoreFixture()),
-    resolveAgentIdFromSessionKey: () => "main",
-    resolveStorePath: () => "/tmp/sessions.json",
-    resolveMainSessionKey: () => "agent:main:main",
-    readSessionUpdatedAt: vi.fn(() => undefined),
-    recordSessionMetaFromInbound: vi.fn().mockResolvedValue(undefined),
-  };
-});
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: vi.fn(() => loadSessionStoreFixture()),
+  resolveAgentIdFromSessionKey: () => "main",
+  resolveStorePath: () => "/tmp/sessions.json",
+  resolveMainSessionKey: () => "agent:main:main",
+  readSessionUpdatedAt: vi.fn(() => undefined),
+  recordSessionMetaFromInbound: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock("./pi-embedded.js", () => embeddedRunMock);
 
@@ -518,6 +514,60 @@ describe("subagent announce formatting", () => {
     expect(didAnnounce).toBe(true);
     expect(sendSpy).not.toHaveBeenCalled();
     expect(agentSpy).not.toHaveBeenCalled();
+  });
+
+  it("strips reply tags from completion delivery message (#24600)", async () => {
+    sessionStore = {
+      "agent:main:subagent:test": { sessionId: "child-session-reply-tags" },
+      "agent:main:main": { sessionId: "requester-session-reply-tags" },
+    };
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-direct-completion-reply-tags",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: { channel: "imessage", to: "+15550001234", accountId: "acct-1" },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      roundOneReply: "[[reply_to:6100]] Got it. This is a test message.",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    const msg = typeof call?.params?.message === "string" ? call.params.message : "";
+    // Reply directive tag must be stripped before delivery.
+    expect(msg).not.toContain("[[reply_to:");
+    // Actual message text must be preserved.
+    expect(msg).toContain("Got it. This is a test message.");
+  });
+
+  it("preserves MEDIA: directives when stripping reply tags from completion message (#24600)", async () => {
+    sessionStore = {
+      "agent:main:subagent:test": { sessionId: "child-session-media-directives" },
+      "agent:main:main": { sessionId: "requester-session-media-directives" },
+    };
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:test",
+      childRunId: "run-direct-completion-media-directives",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      requesterOrigin: { channel: "imessage", to: "+15550001234", accountId: "acct-1" },
+      ...defaultOutcomeAnnounce,
+      expectsCompletionMessage: true,
+      roundOneReply: "[[reply_to:6100]] Here is your image.\nMEDIA:/tmp/result.png",
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    const msg = typeof call?.params?.message === "string" ? call.params.message : "";
+    // Reply directive tag must be stripped.
+    expect(msg).not.toContain("[[reply_to:");
+    // MEDIA: directive must be preserved in the text for downstream delivery to resolve.
+    expect(msg).toContain("MEDIA:/tmp/result.png");
+    // Human-readable text must be preserved too.
+    expect(msg).toContain("Here is your image.");
   });
 
   it("retries completion direct send on transient channel-unavailable errors", async () => {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,5 +1,5 @@
 import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
-import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
+import { parseInlineDirectives } from "../utils/directive-tags.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { loadConfig } from "../config/config.js";
@@ -83,8 +83,12 @@ function buildCompletionDeliveryMessage(params: {
   outcome?: SubagentRunOutcome;
   announceType?: SubagentAnnounceType;
 }): string {
-  // Strip reply directive tags (e.g. [[reply_to:6100]]) before delivery (#24600)
-  const findingsText = parseReplyDirectives(params.findings).text.trim();
+  // Strip only [[reply_to:...]] tags; preserve MEDIA: lines and [[audio_as_voice]]
+  // so the downstream send path can parse them for attachments/voice flags (#24600)
+  const findingsText = parseInlineDirectives(params.findings, {
+    stripReplyTags: true,
+    stripAudioTag: false,
+  }).text.trim();
   if (isAnnounceSkip(findingsText)) {
     return "";
   }

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,4 +1,5 @@
 import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
+import { parseReplyDirectives } from "../auto-reply/reply/reply-directives.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { loadConfig } from "../config/config.js";
@@ -82,7 +83,8 @@ function buildCompletionDeliveryMessage(params: {
   outcome?: SubagentRunOutcome;
   announceType?: SubagentAnnounceType;
 }): string {
-  const findingsText = params.findings.trim();
+  // Strip reply directive tags (e.g. [[reply_to:6100]]) before delivery (#24600)
+  const findingsText = parseReplyDirectives(params.findings).text.trim();
   if (isAnnounceSkip(findingsText)) {
     return "";
   }

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -1,5 +1,4 @@
 import { resolveQueueSettings } from "../auto-reply/reply/queue.js";
-import { parseInlineDirectives } from "../utils/directive-tags.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { loadConfig } from "../config/config.js";
@@ -22,6 +21,7 @@ import {
   mergeDeliveryContext,
   normalizeDeliveryContext,
 } from "../utils/delivery-context.js";
+import { parseInlineDirectives } from "../utils/directive-tags.js";
 import { isDeliverableMessageChannel, isInternalMessageChannel } from "../utils/message-channel.js";
 import {
   buildAnnounceIdFromChildRun,


### PR DESCRIPTION
## Summary

- Strip `[[reply_to:NNNN]]` and `[[reply_to_current]]` reply directive tags from the completion delivery message before sending to channels (iMessage, Slack, etc.)
- Use `parseInlineDirectives()` (not `parseReplyDirectives()`) so that `MEDIA:` lines and `[[audio_as_voice]]` directives are preserved in the text for downstream delivery to parse — calling `parseReplyDirectives()` would extract media into a separate `mediaUrls` field that `buildCompletionDeliveryMessage` cannot pass through
- Restore `subagent-announce.format.e2e.test.ts` which was accidentally deleted in an earlier commit, plus add two regression tests

Fixes #24600

## Test plan

- [x] Added test "strips reply tags from completion delivery message (#24600)" — verifies `[[reply_to:6100]]` tags are removed
- [x] Added test "preserves MEDIA: directives when stripping reply tags from completion message (#24600)" — verifies `MEDIA:/tmp/result.png` is preserved alongside stripped tags
- [x] All 55 subagent announce format e2e tests pass
- [x] TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)