### PR TITLE
feat(web-fetch): add ssrfPolicy config support for web_fetch tool

### DIFF
--- a/src/agents/tools/web-fetch.ssrf-firecrawl.test.ts
+++ b/src/agents/tools/web-fetch.ssrf-firecrawl.test.ts
@@ -1,0 +1,264 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as ssrf from "../../infra/net/ssrf.js";
+import { type FetchMock, withFetchPreconnect } from "../../test-utils/fetch-mock.js";
+
+const lookupMock = vi.fn();
+const resolvePinnedHostname = ssrf.resolvePinnedHostname;
+
+function makeHeaders(map: Record<string, string>): { get: (key: string) => string | null } {
+  return {
+    get: (key) => map[key.toLowerCase()] ?? null,
+  };
+}
+
+function textResponse(body: string): Response {
+  return {
+    ok: true,
+    status: 200,
+    headers: makeHeaders({ "content-type": "text/plain" }),
+    text: async () => body,
+  } as unknown as Response;
+}
+
+function errorResponse(status: number, body: string): Response {
+  return {
+    ok: false,
+    status,
+    statusText: "Server Error",
+    headers: makeHeaders({ "content-type": "text/plain" }),
+    text: async () => body,
+  } as unknown as Response;
+}
+
+function setMockFetch(
+  impl: FetchMock = async (_input: RequestInfo | URL, _init?: RequestInit) => textResponse(""),
+) {
+  const fetchSpy = vi.fn<FetchMock>(impl);
+  global.fetch = withFetchPreconnect(fetchSpy);
+  return fetchSpy;
+}
+
+async function createWebFetchToolForTest(params?: {
+  firecrawl?: { enabled?: boolean; apiKey?: string };
+  ssrfPolicy?: {
+    allowPrivateNetwork?: boolean;
+    dangerouslyAllowPrivateNetwork?: boolean;
+    allowRfc2544BenchmarkRange?: boolean;
+    allowedHostnames?: string[];
+    hostnameAllowlist?: string[];
+  };
+}) {
+  const { createWebFetchTool } = await import("./web-tools.js");
+  return createWebFetchTool({
+    config: {
+      tools: {
+        web: {
+          fetch: {
+            cacheTtlMinutes: 0,
+            firecrawl: params?.firecrawl ?? { enabled: false },
+            ssrfPolicy: params?.ssrfPolicy,
+          },
+        },
+      },
+    },
+  });
+}
+
+describe("web_fetch Firecrawl fallback suppression for private networks (P1)", () => {
+  const priorFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation((hostname) =>
+      resolvePinnedHostname(hostname, lookupMock),
+    );
+  });
+
+  afterEach(() => {
+    global.fetch = priorFetch;
+    lookupMock.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it("does not call Firecrawl for private IP URL when fetch errors and ssrfPolicy allows private", async () => {
+    // Allow the private IP through SSRF checks
+    vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockResolvedValue({
+      hostname: "10.0.0.5",
+      addresses: ["10.0.0.5"],
+      lookup: (() => {}) as unknown as ReturnType<typeof ssrf.createPinnedLookup>,
+    });
+
+    // First call (the direct fetch) throws a network error; second call would be Firecrawl.
+    const fetchSpy = setMockFetch().mockRejectedValueOnce(new Error("Connection refused"));
+    const tool = await createWebFetchToolForTest({
+      firecrawl: { enabled: true, apiKey: "fc-test-key" },
+      ssrfPolicy: { dangerouslyAllowPrivateNetwork: true },
+    });
+
+    // The tool should re-throw the original error, NOT attempt Firecrawl fallback.
+    await expect(tool?.execute?.("call", { url: "http://10.0.0.5/api/v1" })).rejects.toThrow(
+      "Connection refused",
+    );
+    // Only the direct fetch should have been called; no Firecrawl POST.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call Firecrawl for private IP URL on HTTP error and ssrfPolicy allows private", async () => {
+    vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockResolvedValue({
+      hostname: "192.168.1.100",
+      addresses: ["192.168.1.100"],
+      lookup: (() => {}) as unknown as ReturnType<typeof ssrf.createPinnedLookup>,
+    });
+
+    // Return a non-ok response so the error path fires (which normally tries Firecrawl).
+    const fetchSpy = setMockFetch().mockResolvedValueOnce(errorResponse(503, "unavailable"));
+    const tool = await createWebFetchToolForTest({
+      firecrawl: { enabled: true, apiKey: "fc-test-key" },
+      ssrfPolicy: { dangerouslyAllowPrivateNetwork: true },
+    });
+
+    await expect(tool?.execute?.("call", { url: "http://192.168.1.100/api/v1" })).rejects.toThrow(
+      /Web fetch failed \(503\)/,
+    );
+    // Only the direct fetch should have been called; Firecrawl must be skipped.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call Firecrawl for localhost when ssrfPolicy allows private", async () => {
+    vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockResolvedValue({
+      hostname: "localhost",
+      addresses: ["127.0.0.1"],
+      lookup: (() => {}) as unknown as ReturnType<typeof ssrf.createPinnedLookup>,
+    });
+
+    const fetchSpy = setMockFetch().mockRejectedValueOnce(new Error("ECONNREFUSED"));
+    const tool = await createWebFetchToolForTest({
+      firecrawl: { enabled: true, apiKey: "fc-test-key" },
+      ssrfPolicy: { dangerouslyAllowPrivateNetwork: true },
+    });
+
+    await expect(tool?.execute?.("call", { url: "http://localhost:8080/health" })).rejects.toThrow(
+      "ECONNREFUSED",
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call Firecrawl for allowedHostnames private host", async () => {
+    vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockResolvedValue({
+      hostname: "my-nas.local",
+      addresses: ["192.168.1.100"],
+      lookup: (() => {}) as unknown as ReturnType<typeof ssrf.createPinnedLookup>,
+    });
+
+    const fetchSpy = setMockFetch().mockRejectedValueOnce(new Error("timeout"));
+    const tool = await createWebFetchToolForTest({
+      firecrawl: { enabled: true, apiKey: "fc-test-key" },
+      ssrfPolicy: { allowedHostnames: ["my-nas.local"] },
+    });
+
+    await expect(tool?.execute?.("call", { url: "http://my-nas.local/files" })).rejects.toThrow(
+      "timeout",
+    );
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("still calls Firecrawl for public URLs when ssrfPolicy is set", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+
+    // Direct fetch fails, then Firecrawl succeeds
+    const fetchSpy = setMockFetch()
+      .mockRejectedValueOnce(new Error("Connection reset"))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          data: {
+            markdown: "# Firecrawl Result",
+            metadata: { statusCode: 200 },
+          },
+        }),
+      } as unknown as Response);
+
+    const tool = await createWebFetchToolForTest({
+      firecrawl: { enabled: true, apiKey: "fc-test-key" },
+      ssrfPolicy: { dangerouslyAllowPrivateNetwork: true },
+    });
+
+    const result = await tool?.execute?.("call", { url: "https://example.com/page" });
+    expect(result?.details).toMatchObject({ extractor: "firecrawl" });
+    // Both calls: direct fetch + Firecrawl
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("still calls Firecrawl for public URLs when no ssrfPolicy is set", async () => {
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+
+    const fetchSpy = setMockFetch()
+      .mockRejectedValueOnce(new Error("Connection reset"))
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          success: true,
+          data: {
+            markdown: "# Firecrawl Result",
+            metadata: { statusCode: 200 },
+          },
+        }),
+      } as unknown as Response);
+
+    const tool = await createWebFetchToolForTest({
+      firecrawl: { enabled: true, apiKey: "fc-test-key" },
+    });
+
+    const result = await tool?.execute?.("call", { url: "https://example.com/page" });
+    expect(result?.details).toMatchObject({ extractor: "firecrawl" });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("web_fetch SSRF policy cache partitioning (P2)", () => {
+  const priorFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.spyOn(ssrf, "resolvePinnedHostname").mockImplementation((hostname) =>
+      resolvePinnedHostname(hostname, lookupMock),
+    );
+    lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+  });
+
+  afterEach(() => {
+    global.fetch = priorFetch;
+    lookupMock.mockClear();
+    vi.restoreAllMocks();
+  });
+
+  it("does not serve stale cache across different ssrfPolicy configurations", async () => {
+    // Tool with no SSRF policy
+    setMockFetch().mockResolvedValue(textResponse("public-content"));
+    const toolNoPolicy = await createWebFetchToolForTest();
+
+    // Note: cache TTL is 0, so caching is disabled per-test. This test verifies
+    // the cache key contains policy info at the code level by testing that different
+    // policies produce distinct cache keys (no cross-contamination if TTL were > 0).
+    const result1 = await toolNoPolicy?.execute?.("call", { url: "https://example.com/cached" });
+    expect(result1?.details).toMatchObject({ status: 200 });
+
+    // With private-network policy — should NOT get cached result from above
+    vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockResolvedValue({
+      hostname: "example.com",
+      addresses: ["93.184.216.34"],
+      lookup: (() => {}) as unknown as ReturnType<typeof ssrf.createPinnedLookup>,
+    });
+
+    setMockFetch().mockResolvedValue(textResponse("policy-content"));
+    const toolWithPolicy = await createWebFetchToolForTest({
+      ssrfPolicy: { dangerouslyAllowPrivateNetwork: true },
+    });
+
+    const result2 = await toolWithPolicy?.execute?.("call", {
+      url: "https://example.com/cached",
+    });
+    expect(result2?.details).toMatchObject({ status: 200 });
+  });
+});

--- a/src/agents/tools/web-fetch.ssrf-firecrawl.test.ts
+++ b/src/agents/tools/web-fetch.ssrf-firecrawl.test.ts
@@ -161,6 +161,50 @@ describe("web_fetch Firecrawl fallback suppression for private networks (P1)", (
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
+  it("does not call Firecrawl for allowedHostnames non-local internal host (pre-DNS gap)", async () => {
+    // internal.company.com is not a .local/.internal hostname so isBlockedHostnameOrIp returns
+    // false for it — but it's in allowedHostnames, which means it's an internal target allowed
+    // only via policy.  Firecrawl must still be skipped.
+    vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockResolvedValue({
+      hostname: "internal.company.com",
+      addresses: ["10.10.10.10"],
+      lookup: (() => {}) as unknown as ReturnType<typeof ssrf.createPinnedLookup>,
+    });
+
+    const fetchSpy = setMockFetch().mockRejectedValueOnce(new Error("network error"));
+    const tool = await createWebFetchToolForTest({
+      firecrawl: { enabled: true, apiKey: "fc-test-key" },
+      ssrfPolicy: { allowedHostnames: ["internal.company.com"] },
+    });
+
+    await expect(
+      tool?.execute?.("call", { url: "http://internal.company.com/api" }),
+    ).rejects.toThrow("network error");
+    // Firecrawl must NOT be called — only the direct fetch.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call Firecrawl for hostnameAllowlist wildcard-matched internal host", async () => {
+    // *.corp.internal is a hostnameAllowlist pattern; the matched hostname is not a literal
+    // .local/.internal TLD but is treated as internal because it was explicitly allowlisted.
+    vi.spyOn(ssrf, "resolvePinnedHostnameWithPolicy").mockResolvedValue({
+      hostname: "api.corp.internal",
+      addresses: ["172.16.5.20"],
+      lookup: (() => {}) as unknown as ReturnType<typeof ssrf.createPinnedLookup>,
+    });
+
+    const fetchSpy = setMockFetch().mockRejectedValueOnce(new Error("ETIMEDOUT"));
+    const tool = await createWebFetchToolForTest({
+      firecrawl: { enabled: true, apiKey: "fc-test-key" },
+      ssrfPolicy: { hostnameAllowlist: ["*.corp.internal"] },
+    });
+
+    await expect(
+      tool?.execute?.("call", { url: "http://api.corp.internal/v1/data" }),
+    ).rejects.toThrow("ETIMEDOUT");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("still calls Firecrawl for public URLs when ssrfPolicy is set", async () => {
     lookupMock.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
 

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -155,6 +155,7 @@ function isPrivateNetworkUrl(url: string, policy?: SsrFPolicy): boolean {
   const hasRelaxedPolicy =
     policy.dangerouslyAllowPrivateNetwork === true ||
     policy.allowPrivateNetwork === true ||
+    policy.allowRfc2544BenchmarkRange === true ||
     (Array.isArray(policy.allowedHostnames) && policy.allowedHostnames.length > 0);
   if (!hasRelaxedPolicy) {
     return false;

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,6 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
-import { SsrFBlockedError, type SsrFPolicy } from "../../infra/net/ssrf.js";
+import { isBlockedHostnameOrIp, SsrFBlockedError, type SsrFPolicy } from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
 import { normalizeSecretInput } from "../../utils/normalize-secret-input.js";
@@ -140,6 +140,32 @@ function resolveFetchSsrFPolicy(fetch?: WebFetchConfig): SsrFPolicy | undefined 
     ...(allowedHostnames ? { allowedHostnames } : {}),
     ...(hostnameAllowlist ? { hostnameAllowlist } : {}),
   };
+}
+
+/**
+ * Returns true when the URL's hostname would be blocked by default SSRF checks
+ * (i.e. it's a private/internal address) but is only reachable because `ssrfPolicy`
+ * relaxes the restrictions.  In that case we must NOT forward the URL to external
+ * services like Firecrawl, since doing so would leak internal hostnames/paths.
+ */
+function isPrivateNetworkUrl(url: string, policy?: SsrFPolicy): boolean {
+  if (!policy) {
+    return false;
+  }
+  const hasRelaxedPolicy =
+    policy.dangerouslyAllowPrivateNetwork === true ||
+    policy.allowPrivateNetwork === true ||
+    (Array.isArray(policy.allowedHostnames) && policy.allowedHostnames.length > 0);
+  if (!hasRelaxedPolicy) {
+    return false;
+  }
+  try {
+    const parsed = new URL(url);
+    // Check whether the hostname would be blocked under the *default* (no-policy) SSRF rules.
+    return isBlockedHostnameOrIp(parsed.hostname);
+  } catch {
+    return false;
+  }
 }
 
 function resolveFetchMaxCharsCap(fetch?: WebFetchConfig): number {
@@ -518,6 +544,10 @@ async function maybeFetchFirecrawlWebFetchPayload(
     tookMs: number;
   },
 ): Promise<Record<string, unknown> | null> {
+  // Skip Firecrawl for private-network targets to avoid leaking internal URLs to third parties.
+  if (isPrivateNetworkUrl(params.urlToFetch, params.ssrfPolicy)) {
+    return null;
+  }
   const firecrawlParams = toFirecrawlContentParams({
     ...params,
     url: params.urlToFetch,
@@ -541,9 +571,34 @@ async function maybeFetchFirecrawlWebFetchPayload(
   return payload;
 }
 
+/** Stable, compact cache key fragment for the SSRF policy (empty string when no policy). */
+function ssrfPolicyCacheFragment(policy?: SsrFPolicy): string {
+  if (!policy) {
+    return "";
+  }
+  const parts: string[] = [];
+  if (policy.dangerouslyAllowPrivateNetwork) {
+    parts.push("priv");
+  }
+  if (policy.allowPrivateNetwork) {
+    parts.push("apriv");
+  }
+  if (policy.allowRfc2544BenchmarkRange) {
+    parts.push("rfc2544");
+  }
+  if (policy.allowedHostnames?.length) {
+    parts.push(`ah:${policy.allowedHostnames.toSorted().join(",")}`);
+  }
+  if (policy.hostnameAllowlist?.length) {
+    parts.push(`ha:${policy.hostnameAllowlist.toSorted().join(",")}`);
+  }
+  return parts.length > 0 ? parts.join("|") : "";
+}
+
 async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string, unknown>> {
+  const policyFragment = ssrfPolicyCacheFragment(params.ssrfPolicy);
   const cacheKey = normalizeCacheKey(
-    `fetch:${params.url}:${params.extractMode}:${params.maxChars}`,
+    `fetch:${params.url}:${params.extractMode}:${params.maxChars}${policyFragment ? `:${policyFragment}` : ""}`,
   );
   const cached = readCache(FETCH_CACHE, cacheKey);
   if (cached) {
@@ -721,8 +776,16 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
 }
 
 async function tryFirecrawlFallback(
-  params: FirecrawlRuntimeParams & { url: string; extractMode: ExtractMode },
+  params: FirecrawlRuntimeParams & {
+    url: string;
+    extractMode: ExtractMode;
+    ssrfPolicy?: SsrFPolicy;
+  },
 ): Promise<{ text: string; title?: string } | null> {
+  // Skip Firecrawl for private-network targets to avoid leaking internal URLs to third parties.
+  if (isPrivateNetworkUrl(params.url, params.ssrfPolicy)) {
+    return null;
+  }
   const firecrawlParams = toFirecrawlContentParams(params);
   if (!firecrawlParams) {
     return null;

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,5 +1,6 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
+import { normalizeHostname } from "../../infra/net/hostname.js";
 import { isBlockedHostnameOrIp, SsrFBlockedError, type SsrFPolicy } from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
@@ -147,26 +148,63 @@ function resolveFetchSsrFPolicy(fetch?: WebFetchConfig): SsrFPolicy | undefined 
  * (i.e. it's a private/internal address) but is only reachable because `ssrfPolicy`
  * relaxes the restrictions.  In that case we must NOT forward the URL to external
  * services like Firecrawl, since doing so would leak internal hostnames/paths.
+ *
+ * Detection is pre-DNS (hostname literal only).  Private-range checks cover literal IPs
+ * and well-known blocked hostnames.  Hostname allowlist entries are treated as
+ * potentially internal regardless of DNS resolution outcome, because they are added
+ * precisely to grant access to hosts that would otherwise be blocked.
  */
 function isPrivateNetworkUrl(url: string, policy?: SsrFPolicy): boolean {
   if (!policy) {
     return false;
   }
-  const hasRelaxedPolicy =
-    policy.dangerouslyAllowPrivateNetwork === true ||
-    policy.allowPrivateNetwork === true ||
-    policy.allowRfc2544BenchmarkRange === true ||
-    (Array.isArray(policy.allowedHostnames) && policy.allowedHostnames.length > 0);
-  if (!hasRelaxedPolicy) {
-    return false;
-  }
+  let hostname: string;
   try {
-    const parsed = new URL(url);
-    // Check whether the hostname would be blocked under the *default* (no-policy) SSRF rules.
-    return isBlockedHostnameOrIp(parsed.hostname);
+    hostname = normalizeHostname(new URL(url).hostname);
   } catch {
     return false;
   }
+  if (!hostname) {
+    return false;
+  }
+
+  // If the hostname is literally a private/blocked IP or known-blocked hostname under the
+  // default (no-policy) rules, it's private regardless of which policy flag allowed it.
+  if (isBlockedHostnameOrIp(hostname)) {
+    return true;
+  }
+
+  // Hostnames explicitly listed in allowedHostnames are whitelisted because they would
+  // otherwise fail SSRF checks — treat them as internal and never forward to Firecrawl.
+  if (Array.isArray(policy.allowedHostnames) && policy.allowedHostnames.length > 0) {
+    const normalizedAllowedHostnames = policy.allowedHostnames
+      .map((h) => normalizeHostname(h))
+      .filter(Boolean);
+    if (normalizedAllowedHostnames.includes(hostname)) {
+      return true;
+    }
+  }
+
+  // Hostnames matched by hostnameAllowlist patterns are similarly treated as internal.
+  if (Array.isArray(policy.hostnameAllowlist) && policy.hostnameAllowlist.length > 0) {
+    for (const pattern of policy.hostnameAllowlist) {
+      const normalizedPattern = normalizeHostname(pattern);
+      if (!normalizedPattern) {
+        continue;
+      }
+      if (normalizedPattern.startsWith("*.")) {
+        // Wildcard: *.example.com matches sub.example.com but not example.com itself.
+        const suffix = normalizedPattern.slice(2);
+        if (suffix && hostname !== suffix && hostname.endsWith(`.${suffix}`)) {
+          return true;
+        }
+      } else if (hostname === normalizedPattern) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 function resolveFetchMaxCharsCap(fetch?: WebFetchConfig): number {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -626,6 +626,18 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.fetch.userAgent": "Override User-Agent header for web_fetch requests.",
   "tools.web.fetch.readability":
     "Use Readability to extract main content from HTML (fallbacks to basic HTML cleanup).",
+  "tools.web.fetch.ssrfPolicy":
+    "Server-side request forgery guardrail settings for web_fetch requests. Keep restrictive defaults in production and open only explicitly approved targets.",
+  "tools.web.fetch.ssrfPolicy.allowPrivateNetwork":
+    "Legacy alias for tools.web.fetch.ssrfPolicy.dangerouslyAllowPrivateNetwork. Prefer the dangerously-named key so risk intent is explicit.",
+  "tools.web.fetch.ssrfPolicy.dangerouslyAllowPrivateNetwork":
+    "Allows web_fetch to reach private-network address ranges. Default is false (unlike browser which defaults to true). Enable for trusted-network setups.",
+  "tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange":
+    "Allows web_fetch to reach the RFC 2544 benchmarking range (198.18.0.0/15), commonly used by Clash/mihomo fake-ip mode. Default: false.",
+  "tools.web.fetch.ssrfPolicy.allowedHostnames":
+    "Explicit hostname allowlist exceptions for SSRF policy checks on web_fetch requests. Keep this list minimal.",
+  "tools.web.fetch.ssrfPolicy.hostnameAllowlist":
+    'Hostname allowlist patterns for web_fetch SSRF policy. Supports exact hosts and "*.example.com" wildcard subdomains.',
   "tools.web.fetch.firecrawl.enabled": "Enable Firecrawl fallback for web_fetch (if configured).",
   "tools.web.fetch.firecrawl.apiKey": "Firecrawl API key (fallback: FIRECRAWL_API_KEY env var).",
   "tools.web.fetch.firecrawl.baseUrl":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -228,6 +228,14 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.web.fetch.maxRedirects": "Web Fetch Max Redirects",
   "tools.web.fetch.userAgent": "Web Fetch User-Agent",
   "tools.web.fetch.readability": "Web Fetch Readability Extraction",
+  "tools.web.fetch.ssrfPolicy": "Web Fetch SSRF Policy",
+  "tools.web.fetch.ssrfPolicy.allowPrivateNetwork": "Web Fetch Allow Private Network",
+  "tools.web.fetch.ssrfPolicy.dangerouslyAllowPrivateNetwork":
+    "Web Fetch Dangerously Allow Private Network",
+  "tools.web.fetch.ssrfPolicy.allowRfc2544BenchmarkRange":
+    "Web Fetch Allow RFC 2544 Benchmark Range",
+  "tools.web.fetch.ssrfPolicy.allowedHostnames": "Web Fetch Allowed Hostnames",
+  "tools.web.fetch.ssrfPolicy.hostnameAllowlist": "Web Fetch Hostname Allowlist",
   "tools.web.fetch.firecrawl.enabled": "Enable Firecrawl Fallback",
   "tools.web.fetch.firecrawl.apiKey": "Firecrawl API Key",
   "tools.web.fetch.firecrawl.baseUrl": "Firecrawl Base URL",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -502,6 +502,19 @@ export type ToolsConfig = {
       userAgent?: string;
       /** Use Readability to extract main content (default: true). */
       readability?: boolean;
+      /** SSRF policy for web fetch requests. */
+      ssrfPolicy?: {
+        /** Legacy alias for private-network access. Prefer dangerouslyAllowPrivateNetwork. */
+        allowPrivateNetwork?: boolean;
+        /** If true, permit fetch to private/internal networks. Default: false */
+        dangerouslyAllowPrivateNetwork?: boolean;
+        /** If true, allow RFC 2544 benchmark range (198.18.0.0/15) used by Clash/mihomo fake-ip. */
+        allowRfc2544BenchmarkRange?: boolean;
+        /** Explicitly allowed hostnames (exact-match). */
+        allowedHostnames?: string[];
+        /** Hostname allowlist patterns (supports "*.example.com" wildcards). */
+        hostnameAllowlist?: string[];
+      };
       firecrawl?: {
         /** Enable Firecrawl fallback (default: true when apiKey is set). */
         enabled?: boolean;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -312,6 +312,16 @@ export const ToolsWebSearchSchema = z
   .strict()
   .optional();
 
+export const SsrFPolicySchema = z
+  .object({
+    allowPrivateNetwork: z.boolean().optional(),
+    dangerouslyAllowPrivateNetwork: z.boolean().optional(),
+    allowRfc2544BenchmarkRange: z.boolean().optional(),
+    allowedHostnames: z.array(z.string()).optional(),
+    hostnameAllowlist: z.array(z.string()).optional(),
+  })
+  .strict();
+
 export const ToolsWebFetchSchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -321,6 +331,7 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    ssrfPolicy: SsrFPolicySchema.optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

- Add `ssrfPolicy` config support to `tools.web.fetch` (parity with browser tool)
- Supports `dangerouslyAllowPrivateNetwork`, `allowPrivateNetwork` (legacy), `allowRfc2544BenchmarkRange`, `allowedHostnames`, and `hostnameAllowlist`
- Resolves web_fetch failures in environments where DNS resolves to special-use IP ranges (Clash/mihomo fake-ip mode with `198.18.0.0/15`)

## Changes

**Config schema** (`src/config/zod-schema.agent-runtime.ts`):
- Add `SsrFPolicySchema` (reusable) and wire `ssrfPolicy` into `ToolsWebFetchSchema`

**TypeScript types** (`src/config/types.tools.ts`):
- Add `ssrfPolicy` field to the web fetch config type with full JSDoc

**Implementation** (`src/agents/tools/web-fetch.ts`):
- Add `resolveFetchSsrFPolicy()` resolver (follows browser's pattern)
- Add `ssrfPolicy` to `WebFetchRuntimeParams` and pass it through to `fetchWithWebToolsNetworkGuard` as `policy`

**Config metadata** (`schema.help.ts`, `schema.labels.ts`):
- Add help text and labels for all 6 new ssrfPolicy config keys

**Tests** (`src/agents/tools/web-fetch.ssrf.test.ts`):
- 5 new tests: `dangerouslyAllowPrivateNetwork`, legacy `allowPrivateNetwork`, `allowRfc2544BenchmarkRange` allow/block, and default-block behavior

## Example config

```yaml
gateway:
  tools:
    web:
      fetch:
        ssrfPolicy:
          dangerouslyAllowPrivateNetwork: true
          # or for Clash/mihomo fake-ip only:
          # allowRfc2544BenchmarkRange: true
```

## Test plan

- [x] All existing web-fetch SSRF tests pass (5/5)
- [x] All new ssrfPolicy tests pass (5/5)
- [x] All broader web-fetch tests pass (49/49)
- [x] Config schema tests pass (24/24)
- [x] TypeScript type check passes
- [x] Lint/format checks pass

Closes #25322