### PR TITLE
fix: skip last assistant message in sanitizeToolCallInputs when it contains thinking blocks

### DIFF
--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -314,4 +314,78 @@ describe("sanitizeToolCallInputs", () => {
       : [];
     expect(types).toEqual(["text", "toolUse"]);
   });
+
+  it("preserves last assistant message with thinking blocks even if tool name is not allowed", () => {
+    const thinkingAssistant = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "let me think..." },
+        { type: "toolCall", id: "call_exec", name: "exec", arguments: { command: "ls" } },
+        { type: "text", text: "done" },
+      ],
+    };
+    const input = [
+      { role: "user", content: "hello" },
+      thinkingAssistant,
+    ] as unknown as AgentMessage[];
+
+    // allowedToolNames does NOT include "exec" — normally it would be dropped
+    const out = sanitizeToolCallInputs(input, { allowedToolNames: ["read"] });
+
+    // The last assistant message must be preserved unchanged because it has thinking blocks
+    expect(out).toHaveLength(2);
+    expect(out[1]).toBe(thinkingAssistant);
+  });
+
+  it("preserves last assistant message with redacted_thinking blocks", () => {
+    const thinkingAssistant = {
+      role: "assistant",
+      content: [
+        { type: "redacted_thinking", data: "AQID" },
+        { type: "toolCall", id: "call_exec", name: "exec", arguments: { command: "ls" } },
+        { type: "text", text: "result" },
+      ],
+    };
+    const input = [
+      { role: "user", content: "hello" },
+      thinkingAssistant,
+    ] as unknown as AgentMessage[];
+
+    const out = sanitizeToolCallInputs(input, { allowedToolNames: ["read"] });
+
+    expect(out).toHaveLength(2);
+    expect(out[1]).toBe(thinkingAssistant);
+  });
+
+  it("still filters non-last assistant messages with thinking blocks", () => {
+    const input = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "thought" },
+          { type: "toolCall", id: "call_exec", name: "exec", arguments: { command: "ls" } },
+          { type: "text", text: "first" },
+        ],
+      },
+      { role: "user", content: "next" },
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "last response" },
+        ],
+      },
+    ] as unknown as AgentMessage[];
+
+    // The first assistant message is NOT the last, so its exec tool call should be dropped
+    const out = sanitizeToolCallInputs(input, { allowedToolNames: ["read"] });
+
+    const firstAssistant = out[0] as Extract<AgentMessage, { role: "assistant" }>;
+    const toolCalls = Array.isArray(firstAssistant.content)
+      ? firstAssistant.content.filter((b) => {
+          const t = (b as { type?: unknown }).type;
+          return t === "toolCall" || t === "toolUse" || t === "functionCall";
+        })
+      : [];
+    expect(toolCalls).toHaveLength(0);
+  });
 });

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -370,9 +370,7 @@ describe("sanitizeToolCallInputs", () => {
       { role: "user", content: "next" },
       {
         role: "assistant",
-        content: [
-          { type: "text", text: "last response" },
-        ],
+        content: [{ type: "text", text: "last response" }],
       },
     ] as unknown as AgentMessage[];
 

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -132,13 +132,44 @@ export function repairToolCallInputs(
   const out: AgentMessage[] = [];
   const allowedToolNames = normalizeAllowedToolNames(options?.allowedToolNames);
 
-  for (const msg of messages) {
+  // Find the last assistant message index. If it contains thinking or
+  // redacted_thinking blocks, we must skip it from tool call filtering —
+  // Anthropic requires the latest assistant message to be byte-for-byte identical
+  // to the original response when it contains thinking blocks.
+  // See: https://github.com/openclaw/openclaw/issues/28414
+  let lastAssistantIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i];
+    if (m && typeof m === "object" && m.role === "assistant" && Array.isArray(m.content)) {
+      lastAssistantIdx = i;
+      break;
+    }
+  }
+  const skipLastAssistant =
+    lastAssistantIdx >= 0 &&
+    Array.isArray((messages[lastAssistantIdx] as Extract<AgentMessage, { role: "assistant" }>).content) &&
+    (messages[lastAssistantIdx] as Extract<AgentMessage, { role: "assistant" }>).content.some(
+      (block) => {
+        const t = block && typeof block === "object" ? (block as { type?: unknown }).type : undefined;
+        return t === "thinking" || t === "redacted_thinking";
+      },
+    );
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
     if (!msg || typeof msg !== "object") {
       out.push(msg);
       continue;
     }
 
     if (msg.role !== "assistant" || !Array.isArray(msg.content)) {
+      out.push(msg);
+      continue;
+    }
+
+    // Skip the last assistant message when it contains thinking blocks —
+    // Anthropic requires it to be unmodified.
+    if (skipLastAssistant && i === lastAssistantIdx) {
       out.push(msg);
       continue;
     }

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -147,10 +147,13 @@ export function repairToolCallInputs(
   }
   const skipLastAssistant =
     lastAssistantIdx >= 0 &&
-    Array.isArray((messages[lastAssistantIdx] as Extract<AgentMessage, { role: "assistant" }>).content) &&
+    Array.isArray(
+      (messages[lastAssistantIdx] as Extract<AgentMessage, { role: "assistant" }>).content,
+    ) &&
     (messages[lastAssistantIdx] as Extract<AgentMessage, { role: "assistant" }>).content.some(
       (block) => {
-        const t = block && typeof block === "object" ? (block as { type?: unknown }).type : undefined;
+        const t =
+          block && typeof block === "object" ? (block as { type?: unknown }).type : undefined;
         return t === "thinking" || t === "redacted_thinking";
       },
     );


### PR DESCRIPTION
## Summary

- Fixes `sanitizeToolCallInputs` dropping owner-only `tool_use` blocks from the **latest** assistant message, which breaks Anthropic's thinking block contract
- Adds 3 test cases covering thinking, redacted_thinking, and non-last assistant message behavior

Closes #28414

## Root Cause

When extended thinking is enabled and a shared session (e.g., Discord guild) is used:

1. Owner's assistant message contains `[thinking, exec_tool_use, text]`
2. Non-owner sends next message → `allowedToolNames` excludes owner-only tools like `exec`
3. `sanitizeToolCallInputs` → `repairToolCallInputs` iterates **all** messages including the latest assistant message
4. Drops the `exec` tool_use block because it's not in `allowedToolNames`
5. Anthropic API rejects: "thinking or redacted_thinking blocks in the latest assistant message cannot be modified"

## Fix

In `repairToolCallInputs()`, before the main filtering loop:

1. Find the index of the **last** assistant message in the array
2. Check if it contains any `thinking` or `redacted_thinking` content blocks
3. If yes, skip that message entirely during tool call filtering (push it unchanged)

This is safe because:
- `dropThinkingBlocks` only runs for `copilotClaude`, not standard Anthropic — so thinking blocks are present when `sanitizeToolCallInputs` runs
- Only the **last** assistant message is protected — earlier messages with thinking blocks are still filtered normally
- The `session-tool-result-guard.ts` call site passes single messages, so it's unaffected

## Testing

- Added test: last assistant with `thinking` blocks + disallowed tool name → message preserved unchanged
- Added test: last assistant with `redacted_thinking` blocks → message preserved unchanged
- Added test: non-last assistant with thinking blocks → tool calls still filtered (no regression)
- All 16 tests pass