### PR TITLE
fix: stop typing indicator from resetting TTL after run completes

### DIFF
--- a/src/auto-reply/reply/typing.test.ts
+++ b/src/auto-reply/reply/typing.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { createTypingController } from "./typing.js";
+
+describe("createTypingController", () => {
+  it("refreshTypingTtl is a no-op after markRunComplete", () => {
+    vi.useFakeTimers();
+    try {
+      const onCleanup = vi.fn();
+      const ctrl = createTypingController({
+        onReplyStart: vi.fn(),
+        onCleanup,
+        typingIntervalSeconds: 6,
+        typingTtlMs: 2 * 60_000,
+      });
+
+      // Start typing
+      void ctrl.startTypingLoop();
+      expect(ctrl.isActive()).toBe(true);
+
+      // Mark the run as complete — dispatcher not yet idle, so typing still active
+      ctrl.markRunComplete();
+
+      // Simulate a late callback calling refreshTypingTtl after run completed.
+      // Before the fix, this would reset the TTL timer and keep typing alive.
+      ctrl.refreshTypingTtl();
+
+      // Now mark dispatch idle — typing should stop immediately
+      ctrl.markDispatchIdle();
+      expect(ctrl.isActive()).toBe(false);
+      expect(onCleanup).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops typing when both markRunComplete and markDispatchIdle are called", () => {
+    vi.useFakeTimers();
+    try {
+      const onCleanup = vi.fn();
+      const ctrl = createTypingController({
+        onReplyStart: vi.fn(),
+        onCleanup,
+        typingIntervalSeconds: 6,
+        typingTtlMs: 2 * 60_000,
+      });
+
+      void ctrl.startTypingLoop();
+      expect(ctrl.isActive()).toBe(true);
+
+      ctrl.markRunComplete();
+      // Still active because dispatchIdle is false
+      expect(ctrl.isActive()).toBe(true);
+
+      ctrl.markDispatchIdle();
+      expect(ctrl.isActive()).toBe(false);
+      expect(onCleanup).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -78,6 +78,12 @@ export function createTypingController(params: {
     if (sealed) {
       return;
     }
+    // After the run completes, late callbacks (tool/block streaming) should not
+    // reset the TTL. Otherwise the typing indicator stays alive indefinitely.
+    // See: https://github.com/openclaw/openclaw/issues/26733
+    if (runComplete) {
+      return;
+    }
     if (!typingIntervalMs || typingIntervalMs <= 0) {
       return;
     }


### PR DESCRIPTION
## Summary

- Fixes typing indicator persisting for ~2 minutes after reply completes on Discord block streaming mode
- Adds `runComplete` guard to `refreshTypingTtl()` to prevent late callbacks from resetting the TTL timer
- Adds test coverage for the typing controller

Closes #26733

## Root Cause

In `createTypingController`, `refreshTypingTtl()` only checks `if (sealed)` before resetting the TTL timer. After `markRunComplete()` is called:

1. Late callbacks from tool/block streaming fire `refreshTypingTtl()` or `startTypingOnText()` → `refreshTypingTtl()`
2. This resets the 2-minute TTL timer, even though the run is already done
3. The typing indicator keeps running until the new TTL expires
4. If callbacks keep firing, the TTL keeps getting extended indefinitely

## Fix

Added `if (runComplete) return;` guard to `refreshTypingTtl()`, matching the existing pattern in `ensureStart()` (line 113) and `startTypingLoop()` (line 140). Once the run completes, no callback should be able to reset the typing TTL.

## Testing

- Added `typing.test.ts` with 2 test cases:
  1. `refreshTypingTtl` is a no-op after `markRunComplete` — verifies late callbacks don't extend typing
  2. Typing stops when both `markRunComplete` and `markDispatchIdle` are called — verifies normal flow