### PR TITLE
feat(web-fetch): add ssrfPolicy.allowCidrs for custom CIDR allowlisting

### DIFF
--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -1,7 +1,7 @@
 import { Type } from "@sinclair/typebox";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
-import { SsrFBlockedError } from "../../infra/net/ssrf.js";
+import { SsrFBlockedError, type SsrFPolicy } from "../../infra/net/ssrf.js";
 import { logDebug } from "../../logger.js";
 import type { RuntimeWebFetchFirecrawlMetadata } from "../../secrets/runtime-web-tools.js";
 import { wrapExternalContent, wrapWebContent } from "../../security/external-content.js";
@@ -193,6 +193,25 @@ function resolveFirecrawlMaxAgeMsOrDefault(firecrawl?: FirecrawlFetchConfig): nu
     return resolved;
   }
   return DEFAULT_FIRECRAWL_MAX_AGE_MS;
+}
+
+function resolveSsrfPolicy(fetch?: WebFetchConfig): SsrFPolicy | undefined {
+  if (!fetch || typeof fetch !== "object") {
+    return undefined;
+  }
+  const raw = "ssrfPolicy" in fetch ? fetch.ssrfPolicy : undefined;
+  if (!raw || typeof raw !== "object") {
+    return undefined;
+  }
+  const policy = raw as { allowPrivateNetwork?: boolean; allowCidrs?: string[] };
+  const allowCidrs = Array.isArray(policy.allowCidrs) ? policy.allowCidrs : undefined;
+  if (!policy.allowPrivateNetwork && (!allowCidrs || allowCidrs.length === 0)) {
+    return undefined;
+  }
+  return {
+    ...(policy.allowPrivateNetwork ? { allowPrivateNetwork: true } : {}),
+    ...(allowCidrs && allowCidrs.length > 0 ? { allowCidrs } : {}),
+  };
 }
 
 function resolveMaxChars(value: unknown, fallback: number, cap: number): number {
@@ -452,6 +471,7 @@ type WebFetchRuntimeParams = FirecrawlRuntimeParams & {
   cacheTtlMs: number;
   userAgent: string;
   readabilityEnabled: boolean;
+  ssrfPolicy?: SsrFPolicy;
 };
 
 function toFirecrawlContentParams(
@@ -533,6 +553,7 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
       url: params.url,
       maxRedirects: params.maxRedirects,
       timeoutSeconds: params.timeoutSeconds,
+      policy: params.ssrfPolicy,
       init: {
         headers: {
           Accept: "text/markdown, text/html;q=0.9, */*;q=0.1",
@@ -745,6 +766,7 @@ export function createWebFetchTool(options?: {
     (fetch && "userAgent" in fetch && typeof fetch.userAgent === "string" && fetch.userAgent) ||
     DEFAULT_FETCH_USER_AGENT;
   const maxResponseBytes = resolveFetchMaxResponseBytes(fetch);
+  const ssrfPolicy = resolveSsrfPolicy(fetch);
   return {
     label: "Web Fetch",
     name: "web_fetch",
@@ -779,6 +801,7 @@ export function createWebFetchTool(options?: {
         firecrawlProxy: "auto",
         firecrawlStoreInCache: true,
         firecrawlTimeoutSeconds,
+        ssrfPolicy,
       });
       return jsonResult(result);
     },

--- a/src/agents/tools/web-guarded-fetch.test.ts
+++ b/src/agents/tools/web-guarded-fetch.test.ts
@@ -40,7 +40,6 @@ describe("web-guarded-fetch", () => {
         url: "https://example.com",
         policy: expect.objectContaining({
           dangerouslyAllowPrivateNetwork: true,
-          allowRfc2544BenchmarkRange: true,
         }),
         mode: GUARDED_FETCH_MODE.TRUSTED_ENV_PROXY,
       }),

--- a/src/agents/tools/web-guarded-fetch.ts
+++ b/src/agents/tools/web-guarded-fetch.ts
@@ -9,7 +9,6 @@ import type { SsrFPolicy } from "../../infra/net/ssrf.js";
 
 const WEB_TOOLS_TRUSTED_NETWORK_SSRF_POLICY: SsrFPolicy = {
   dangerouslyAllowPrivateNetwork: true,
-  allowRfc2544BenchmarkRange: true,
 };
 
 type WebToolGuardedFetchOptions = Omit<

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -701,6 +701,10 @@ export const FIELD_HELP: Record<string, string> = {
   "tools.web.fetch.firecrawl.maxAgeMs":
     "Firecrawl maxAge (ms) for cached results when supported by the API.",
   "tools.web.fetch.firecrawl.timeoutSeconds": "Timeout in seconds for Firecrawl requests.",
+  "tools.web.fetch.ssrfPolicy.allowPrivateNetwork":
+    "Allow web_fetch to access private/internal network addresses (default false). Use with caution.",
+  "tools.web.fetch.ssrfPolicy.allowCidrs":
+    "List of CIDR ranges (e.g. 198.18.0.0/15, 10.0.0.0/8) to allow through SSRF protection. Use for fake-IP proxy environments or trusted internal networks.",
   models:
     "Model catalog root for provider definitions, merge/replace behavior, and optional Bedrock discovery integration. Keep provider definitions explicit and validated before relying on production failover paths.",
   "models.mode":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -243,6 +243,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.web.fetch.firecrawl.onlyMainContent": "Firecrawl Main Content Only",
   "tools.web.fetch.firecrawl.maxAgeMs": "Firecrawl Cache Max Age (ms)",
   "tools.web.fetch.firecrawl.timeoutSeconds": "Firecrawl Timeout (sec)",
+  "tools.web.fetch.ssrfPolicy.allowPrivateNetwork": "Web Fetch Allow Private Network",
+  "tools.web.fetch.ssrfPolicy.allowCidrs": "Web Fetch Allowed CIDRs",
   "gateway.controlUi.basePath": "Control UI Base Path",
   "gateway.controlUi.root": "Control UI Assets Root",
   "gateway.controlUi.allowedOrigins": "Control UI Allowed Origins",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -538,6 +538,12 @@ export type ToolsConfig = {
         /** Timeout in seconds for Firecrawl requests. */
         timeoutSeconds?: number;
       };
+      ssrfPolicy?: {
+        /** Allow web_fetch to access private/internal network addresses (default: false). */
+        allowPrivateNetwork?: boolean;
+        /** CIDR ranges to allow through SSRF protection (e.g. '198.18.0.0/15', '10.0.0.0/8'). */
+        allowCidrs?: string[];
+      };
     };
   };
   media?: MediaToolsConfig;

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -327,6 +327,13 @@ export const ToolsWebFetchSchema = z
     cacheTtlMinutes: z.number().nonnegative().optional(),
     maxRedirects: z.number().int().nonnegative().optional(),
     userAgent: z.string().optional(),
+    ssrfPolicy: z
+      .object({
+        allowPrivateNetwork: z.boolean().optional(),
+        allowCidrs: z.array(z.string()).optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();

--- a/src/discord/monitor/message-utils.test.ts
+++ b/src/discord/monitor/message-utils.test.ts
@@ -40,7 +40,7 @@ const DISCORD_CDN_HOSTNAMES = [
 function expectDiscordCdnSsrFPolicy(policy: unknown) {
   expect(policy).toEqual(
     expect.objectContaining({
-      allowRfc2544BenchmarkRange: true,
+      allowCidrs: ["198.18.0.0/15"],
       hostnameAllowlist: expect.arrayContaining(DISCORD_CDN_HOSTNAMES),
     }),
   );
@@ -549,7 +549,7 @@ describe("Discord media SSRF policy", () => {
     expect(policy).toEqual(
       expect.objectContaining({
         allowPrivateNetwork: true,
-        allowRfc2544BenchmarkRange: true,
+        allowCidrs: expect.arrayContaining(["198.18.0.0/15"]),
         allowedHostnames: expect.arrayContaining(["assets.example.com"]),
         hostnameAllowlist: expect.arrayContaining(["assets.example.com", ...DISCORD_CDN_HOSTNAMES]),
       }),

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -16,7 +16,7 @@ const DISCORD_CDN_HOSTNAMES = [
 // Allow Discord CDN downloads when VPN/proxy DNS resolves to RFC2544 benchmark ranges.
 const DISCORD_MEDIA_SSRF_POLICY: SsrFPolicy = {
   hostnameAllowlist: DISCORD_CDN_HOSTNAMES,
-  allowRfc2544BenchmarkRange: true,
+  allowCidrs: ["198.18.0.0/15"],
 };
 
 function mergeHostnameList(...lists: Array<string[] | undefined>): string[] | undefined {
@@ -47,9 +47,7 @@ function resolveDiscordMediaSsrFPolicy(policy?: SsrFPolicy): SsrFPolicy {
     ...policy,
     ...(allowedHostnames ? { allowedHostnames } : {}),
     ...(hostnameAllowlist ? { hostnameAllowlist } : {}),
-    allowRfc2544BenchmarkRange:
-      Boolean(DISCORD_MEDIA_SSRF_POLICY.allowRfc2544BenchmarkRange) ||
-      Boolean(policy.allowRfc2544BenchmarkRange),
+    allowCidrs: [...(DISCORD_MEDIA_SSRF_POLICY.allowCidrs ?? []), ...(policy.allowCidrs ?? [])],
   };
 }
 

--- a/src/infra/net/fetch-guard.ssrf.test.ts
+++ b/src/infra/net/fetch-guard.ssrf.test.ts
@@ -105,7 +105,7 @@ describe("fetchWithSsrFGuard hardening", () => {
     const result = await fetchWithSsrFGuard({
       url: "http://198.18.0.153/file",
       fetchImpl,
-      policy: { allowRfc2544BenchmarkRange: true },
+      policy: { allowCidrs: ["198.18.0.0/15"] },
     });
     expect(result.response.status).toBe(200);
   });

--- a/src/infra/net/ssrf.pinning.test.ts
+++ b/src/infra/net/ssrf.pinning.test.ts
@@ -69,7 +69,7 @@ describe("ssrf pinning", () => {
 
     const pinned = await resolvePinnedHostnameWithPolicy("api.telegram.org", {
       lookupFn: lookup,
-      policy: { allowRfc2544BenchmarkRange: true },
+      policy: { allowCidrs: ["198.18.0.0/15"] },
     });
     expect(pinned.addresses).toContain("198.18.0.153");
   });

--- a/src/infra/net/ssrf.test.ts
+++ b/src/infra/net/ssrf.test.ts
@@ -1,3 +1,4 @@
+import ipaddr from "ipaddr.js";
 import { describe, expect, it } from "vitest";
 import { blockedIpv6MulticastLiterals } from "../../shared/net/ip-test-fixtures.js";
 import { normalizeFingerprint } from "../tls/fingerprint.js";
@@ -126,8 +127,8 @@ describe("isBlockedHostnameOrIp", () => {
     expect(isBlockedHostnameOrIp("198.20.0.1")).toBe(false);
   });
 
-  it("supports opt-in policy to allow RFC2544 benchmark range", () => {
-    const policy = { allowRfc2544BenchmarkRange: true };
+  it("supports opt-in policy to allow RFC2544 benchmark range via allowCidrs", () => {
+    const policy = { allowCidrs: [ipaddr.parseCIDR("198.18.0.0/15")] };
     expect(isBlockedHostnameOrIp("198.18.0.1")).toBe(true);
     expect(isBlockedHostnameOrIp("198.18.0.1", policy)).toBe(false);
     expect(isBlockedHostnameOrIp("::ffff:198.18.0.1", policy)).toBe(false);

--- a/src/infra/net/ssrf.ts
+++ b/src/infra/net/ssrf.ts
@@ -1,12 +1,12 @@
 import { lookup as dnsLookupCb, type LookupAddress } from "node:dns";
 import { lookup as dnsLookup } from "node:dns/promises";
+import ipaddr from "ipaddr.js";
 import { Agent, EnvHttpProxyAgent, ProxyAgent, type Dispatcher } from "undici";
 import {
   extractEmbeddedIpv4FromIpv6,
   isBlockedSpecialUseIpv4Address,
   isBlockedSpecialUseIpv6Address,
   isCanonicalDottedDecimalIPv4,
-  type Ipv4SpecialUseBlockOptions,
   isIpv4Address,
   isLegacyIpv4Literal,
   parseCanonicalIpAddress,
@@ -32,7 +32,7 @@ export type LookupFn = typeof dnsLookup;
 export type SsrFPolicy = {
   allowPrivateNetwork?: boolean;
   dangerouslyAllowPrivateNetwork?: boolean;
-  allowRfc2544BenchmarkRange?: boolean;
+  allowCidrs?: string[];
   allowedHostnames?: string[];
   hostnameAllowlist?: string[];
 };
@@ -42,6 +42,23 @@ const BLOCKED_HOSTNAMES = new Set([
   "localhost.localdomain",
   "metadata.google.internal",
 ]);
+
+type ParsedCidr = [ipaddr.IPv4 | ipaddr.IPv6, number];
+
+function parseCidrStrings(cidrs?: string[]): ParsedCidr[] {
+  if (!cidrs || cidrs.length === 0) {
+    return [];
+  }
+  const parsed: ParsedCidr[] = [];
+  for (const raw of cidrs) {
+    try {
+      parsed.push(ipaddr.parseCIDR(raw));
+    } catch {
+      console.warn(`[ssrf] invalid CIDR in allowCidrs, skipping: ${raw}`);
+    }
+  }
+  return parsed;
+}
 
 function normalizeHostnameSet(values?: string[]): Set<string> {
   if (!values || values.length === 0) {
@@ -65,12 +82,6 @@ function normalizeHostnameAllowlist(values?: string[]): string[] {
 
 export function isPrivateNetworkAllowedByPolicy(policy?: SsrFPolicy): boolean {
   return policy?.dangerouslyAllowPrivateNetwork === true || policy?.allowPrivateNetwork === true;
-}
-
-function resolveIpv4SpecialUseBlockOptions(policy?: SsrFPolicy): Ipv4SpecialUseBlockOptions {
-  return {
-    allowRfc2544BenchmarkRange: policy?.allowRfc2544BenchmarkRange === true,
-  };
 }
 
 function isHostnameAllowedByPattern(hostname: string, pattern: string): boolean {
@@ -105,7 +116,10 @@ function looksLikeUnsupportedIpv4Literal(address: string): boolean {
 }
 
 // Returns true for private/internal and special-use non-global addresses.
-export function isPrivateIpAddress(address: string, policy?: SsrFPolicy): boolean {
+export function isPrivateIpAddress(
+  address: string,
+  policy?: { allowCidrs?: ParsedCidr[] },
+): boolean {
   let normalized = address.trim().toLowerCase();
   if (normalized.startsWith("[") && normalized.endsWith("]")) {
     normalized = normalized.slice(1, -1);
@@ -113,19 +127,18 @@ export function isPrivateIpAddress(address: string, policy?: SsrFPolicy): boolea
   if (!normalized) {
     return false;
   }
-  const blockOptions = resolveIpv4SpecialUseBlockOptions(policy);
-
+  const cidrOpts = policy?.allowCidrs?.length ? { allowCidrs: policy.allowCidrs } : undefined;
   const strictIp = parseCanonicalIpAddress(normalized);
   if (strictIp) {
     if (isIpv4Address(strictIp)) {
-      return isBlockedSpecialUseIpv4Address(strictIp, blockOptions);
+      return isBlockedSpecialUseIpv4Address(strictIp, cidrOpts);
     }
     if (isBlockedSpecialUseIpv6Address(strictIp)) {
       return true;
     }
     const embeddedIpv4 = extractEmbeddedIpv4FromIpv6(strictIp);
     if (embeddedIpv4) {
-      return isBlockedSpecialUseIpv4Address(embeddedIpv4, blockOptions);
+      return isBlockedSpecialUseIpv4Address(embeddedIpv4, cidrOpts);
     }
     return false;
   }
@@ -163,7 +176,10 @@ function isBlockedHostnameNormalized(normalized: string): boolean {
   );
 }
 
-export function isBlockedHostnameOrIp(hostname: string, policy?: SsrFPolicy): boolean {
+export function isBlockedHostnameOrIp(
+  hostname: string,
+  policy?: { allowCidrs?: ParsedCidr[] },
+): boolean {
   const normalized = normalizeHostname(hostname);
   if (!normalized) {
     return false;
@@ -174,7 +190,10 @@ export function isBlockedHostnameOrIp(hostname: string, policy?: SsrFPolicy): bo
 const BLOCKED_HOST_OR_IP_MESSAGE = "Blocked hostname or private/internal/special-use IP address";
 const BLOCKED_RESOLVED_IP_MESSAGE = "Blocked: resolves to private/internal/special-use IP address";
 
-function assertAllowedHostOrIpOrThrow(hostnameOrIp: string, policy?: SsrFPolicy): void {
+function assertAllowedHostOrIpOrThrow(
+  hostnameOrIp: string,
+  policy?: { allowCidrs?: ParsedCidr[] },
+): void {
   if (isBlockedHostnameOrIp(hostnameOrIp, policy)) {
     throw new SsrFBlockedError(BLOCKED_HOST_OR_IP_MESSAGE);
   }
@@ -182,7 +201,7 @@ function assertAllowedHostOrIpOrThrow(hostnameOrIp: string, policy?: SsrFPolicy)
 
 function assertAllowedResolvedAddressesOrThrow(
   results: readonly LookupAddress[],
-  policy?: SsrFPolicy,
+  policy?: { allowCidrs?: ParsedCidr[] },
 ): void {
   for (const entry of results) {
     // Reuse the exact same host/IP classifier as the pre-DNS check to avoid drift.
@@ -299,10 +318,12 @@ export async function resolvePinnedHostnameWithPolicy(
   }
 
   const allowPrivateNetwork = isPrivateNetworkAllowedByPolicy(params.policy);
+  const parsedCidrs = parseCidrStrings(params.policy?.allowCidrs);
   const allowedHostnames = normalizeHostnameSet(params.policy?.allowedHostnames);
   const hostnameAllowlist = normalizeHostnameAllowlist(params.policy?.hostnameAllowlist);
   const isExplicitAllowed = allowedHostnames.has(normalized);
   const skipPrivateNetworkChecks = allowPrivateNetwork || isExplicitAllowed;
+  const cidrPolicy = parsedCidrs.length > 0 ? { allowCidrs: parsedCidrs } : undefined;
 
   if (!matchesHostnameAllowlist(normalized, hostnameAllowlist)) {
     throw new SsrFBlockedError(`Blocked hostname (not in allowlist): ${hostname}`);
@@ -310,7 +331,7 @@ export async function resolvePinnedHostnameWithPolicy(
 
   if (!skipPrivateNetworkChecks) {
     // Phase 1: fail fast for literal hosts/IPs before any DNS lookup side-effects.
-    assertAllowedHostOrIpOrThrow(normalized, params.policy);
+    assertAllowedHostOrIpOrThrow(normalized, cidrPolicy);
   }
 
   const lookupFn = params.lookupFn ?? dnsLookup;
@@ -321,7 +342,7 @@ export async function resolvePinnedHostnameWithPolicy(
 
   if (!skipPrivateNetworkChecks) {
     // Phase 2: re-check DNS answers so public hostnames cannot pivot to private targets.
-    assertAllowedResolvedAddressesOrThrow(results, params.policy);
+    assertAllowedResolvedAddressesOrThrow(results, cidrPolicy);
   }
 
   // Prefer addresses returned as IPv4 by DNS family metadata before other

--- a/src/shared/net/ip.ts
+++ b/src/shared/net/ip.ts
@@ -31,7 +31,7 @@ const BLOCKED_IPV6_SPECIAL_USE_RANGES = new Set<Ipv6Range>([
 ]);
 const RFC2544_BENCHMARK_PREFIX: [ipaddr.IPv4, number] = [ipaddr.IPv4.parse("198.18.0.0"), 15];
 export type Ipv4SpecialUseBlockOptions = {
-  allowRfc2544BenchmarkRange?: boolean;
+  allowCidrs?: Array<[ipaddr.IPv4 | ipaddr.IPv6, number]>;
 };
 
 const EMBEDDED_IPV4_SENTINEL_RULES: Array<{
@@ -257,13 +257,27 @@ export function isCarrierGradeNatIpv4Address(raw: string | undefined): boolean {
 
 export function isBlockedSpecialUseIpv4Address(
   address: ipaddr.IPv4,
-  options: Ipv4SpecialUseBlockOptions = {},
+  options?: Ipv4SpecialUseBlockOptions,
 ): boolean {
-  const inRfc2544BenchmarkRange = address.match(RFC2544_BENCHMARK_PREFIX);
-  if (inRfc2544BenchmarkRange && options.allowRfc2544BenchmarkRange === true) {
-    return false;
+  if (options?.allowCidrs) {
+    for (const cidr of options.allowCidrs) {
+      const [base, prefix] = cidr;
+      if (base.kind() !== "ipv4") {
+        continue;
+      }
+      try {
+        if (address.match([base as ipaddr.IPv4, prefix])) {
+          return false;
+        }
+      } catch {
+        // skip malformed CIDR
+      }
+    }
   }
-  return BLOCKED_IPV4_SPECIAL_USE_RANGES.has(address.range()) || inRfc2544BenchmarkRange;
+  if (BLOCKED_IPV4_SPECIAL_USE_RANGES.has(address.range())) {
+    return true;
+  }
+  return address.match(RFC2544_BENCHMARK_PREFIX);
 }
 
 function decodeIpv4FromHextets(high: number, low: number): ipaddr.IPv4 {

--- a/src/slack/monitor/media.test.ts
+++ b/src/slack/monitor/media.test.ts
@@ -487,7 +487,7 @@ describe("Slack media SSRF policy", () => {
     vi.restoreAllMocks();
   });
 
-  it("passes ssrfPolicy with Slack CDN allowedHostnames and allowRfc2544BenchmarkRange to file downloads", async () => {
+  it("passes ssrfPolicy with Slack CDN allowedHostnames and allowCidrs to file downloads", async () => {
     vi.spyOn(mediaStore, "saveMediaBuffer").mockResolvedValue(
       createSavedMedia("/tmp/test.jpg", "image/jpeg"),
     );
@@ -505,7 +505,7 @@ describe("Slack media SSRF policy", () => {
 
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({
-        ssrfPolicy: expect.objectContaining({ allowRfc2544BenchmarkRange: true }),
+        ssrfPolicy: expect.objectContaining({ allowCidrs: ["198.18.0.0/15"] }),
       }),
     );
 
@@ -541,7 +541,7 @@ describe("Slack media SSRF policy", () => {
 
     expect(spy).toHaveBeenCalledWith(
       expect.objectContaining({
-        ssrfPolicy: expect.objectContaining({ allowRfc2544BenchmarkRange: true }),
+        ssrfPolicy: expect.objectContaining({ allowCidrs: ["198.18.0.0/15"] }),
       }),
     );
   });

--- a/src/slack/monitor/media.ts
+++ b/src/slack/monitor/media.ts
@@ -110,7 +110,7 @@ export async function fetchWithSlackAuth(url: string, token: string): Promise<Re
 
 const SLACK_MEDIA_SSRF_POLICY = {
   allowedHostnames: ["*.slack.com", "*.slack-edge.com", "*.slack-files.com"],
-  allowRfc2544BenchmarkRange: true,
+  allowCidrs: ["198.18.0.0/15"],
 };
 
 /**

--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -25,7 +25,7 @@ import { resolveSlackBotToken } from "./token.js";
 const SLACK_TEXT_LIMIT = 4000;
 const SLACK_UPLOAD_SSRF_POLICY = {
   allowedHostnames: ["*.slack.com", "*.slack-edge.com", "*.slack-files.com"],
-  allowRfc2544BenchmarkRange: true,
+  allowCidrs: ["198.18.0.0/15"],
 };
 
 type SlackRecipient =

--- a/src/telegram/bot/delivery.resolve-media-retry.test.ts
+++ b/src/telegram/bot/delivery.resolve-media-retry.test.ts
@@ -151,7 +151,7 @@ async function expectTransientGetFileRetrySuccess() {
     expect.objectContaining({
       url: `https://api.telegram.org/file/bot${BOT_TOKEN}/voice/file_0.oga`,
       ssrfPolicy: {
-        allowRfc2544BenchmarkRange: true,
+        allowCidrs: ["198.18.0.0/15"],
         allowedHostnames: ["api.telegram.org"],
       },
     }),

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -14,7 +14,7 @@ const TELEGRAM_MEDIA_SSRF_POLICY = {
   // Telegram file downloads should trust api.telegram.org even when DNS/proxy
   // resolution maps to private/internal ranges in restricted networks.
   allowedHostnames: ["api.telegram.org"],
-  allowRfc2544BenchmarkRange: true,
+  allowCidrs: ["198.18.0.0/15"],
 };
 
 /**


### PR DESCRIPTION
## Summary

- **Problem:** `web_fetch` is completely broken in fake-IP proxy environments (Surge Enhanced Mode, Clash fake-ip, Quantumult X, etc.) because the SSRF guard blocks RFC 2544 benchmark range (`198.18.0.0/15`) addresses used for DNS interception. There is no config path to opt out. Internal network fetching (e.g. local docs servers) is also impossible.
- **Why it matters:** Every user running Surge, Clash, Shadowrocket, or similar tools in fake-IP/TUN mode cannot use `web_fetch` at all. Users wanting to access internal documentation servers are also blocked.
- **What changed:** Added `tools.web.fetch.ssrfPolicy.allowCidrs` — an array of CIDR strings that should be allowed through SSRF protection. This is a generic approach: instead of adding specific booleans for each IP range (like `allowRfc2544BenchmarkRange`), users specify exactly which CIDRs they trust.
- **What did NOT change:** Default behavior remains fully restrictive (no CIDRs allowed). The existing `dangerouslyAllowPrivateNetwork` nuclear option is untouched. Browser SSRF policy is unaffected.

**Config example:**
```json
{
  "tools": {
    "web": {
      "fetch": {
        "ssrfPolicy": {
          "allowCidrs": ["198.18.0.0/15"]
        }
      }
    }
  }
}
```

**More examples:**
```json
// Allow fake-IP proxy range
{ "allowCidrs": ["198.18.0.0/15"] }

// Allow internal docs server
{ "allowCidrs": ["10.0.0.0/8"] }

// Multiple ranges
{ "allowCidrs": ["198.18.0.0/15", "172.16.0.0/12"] }
```

## Change Type (select all)

- [x] Bug fix
- [x] Feature

## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] API / contracts

## Linked Issue/PR

- Closes #28271
- Closes #26945
- Related #28349 (specific `allowRfc2544BenchmarkRange` approach — this PR is a more generic alternative)
- Related #25229 (specific `allowPrivateNetwork` approach — complementary, this adds fine-grained control)

## User-visible / Behavior Changes

- New config: `tools.web.fetch.ssrfPolicy.allowCidrs` (string array, optional, default empty)
- When set, IP addresses matching any listed CIDR bypass SSRF blocking for `web_fetch`
- Invalid CIDR strings are warned and skipped (no crash)
- Schema labels and help text added for UI discoverability

## Security Impact (required)

- New permissions/capabilities? **Yes** — opt-in capability to bypass SSRF protection for specific CIDR ranges
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No** (same fetch surface; destination allowlist is relaxed only when opted in)
- Command/tool execution surface changed? **No**
- Data access scope changed? **Yes** — when allowCidrs is set, tool can reach specified IP ranges
- **Risk + mitigation:** Users could allowlist dangerous ranges. Mitigation: (1) default is empty (fully restrictive), (2) explicit opt-in required, (3) each CIDR must be individually listed — no wildcards, (4) consistent with existing patterns (`browser.ssrfPolicy.allowPrivateNetwork`, `dangerouslyAllowPrivateNetwork`)

## Repro + Verification

### Environment

- OS: macOS 15.x (Apple Silicon)
- Runtime: Node.js v22.22.0
- Proxy: Surge Enhanced Mode (fake-IP to 198.18.0.0/15)
- Config: `{ "tools": { "web": { "fetch": { "ssrfPolicy": { "allowCidrs": ["198.18.0.0/15"] } } } } }`

### Steps

1. Run OpenClaw behind Surge Enhanced Mode (or any fake-IP proxy)
2. Use `web_fetch` to access any public URL (e.g. `https://example.com`)
3. DNS resolves to `198.18.x.x` (fake-IP range) → SSRF guard blocks it

### Expected

With `allowCidrs: ["198.18.0.0/15"]`, `web_fetch` should succeed.

### Actual (before fix)

`Blocked: resolves to private/internal/special-use IP address` for every URL.

### Actual (after fix)

`web_fetch` succeeds for all public URLs, including `cursor.com`, `baidu.com`, etc.

## Evidence

- [x] `npx vitest run src/infra/net/fetch-guard.ssrf.test.ts` — 8/8 passed (including updated RFC2544 opt-in test)
- [x] `npx vitest run src/shared/net/ip.test.ts` — 4/4 passed
- [x] `npm run build` — clean, no type errors
- [x] `npx oxfmt --check` — clean
- [x] Live testing: `web_fetch https://cursor.com/pricing` succeeds with `allowCidrs: ["198.18.0.0/15"]` behind Surge

## Human Verification (required)

- Verified scenarios: (1) web_fetch blocked without config, (2) web_fetch works with allowCidrs for fake-IP proxy, (3) invalid CIDRs logged as warning and skipped, (4) empty allowCidrs = default restrictive behavior
- Edge cases checked: IPv6 CIDRs gracefully skipped for IPv4 addresses, malformed CIDR strings, empty array
- What you did **not** verify: IPv6-only proxy environments, performance under very large CIDR lists (>100)

## Compatibility / Migration

- Backward compatible? **Yes** — new config is optional, defaults maintain current restrictive behavior
- Config/env changes? New optional `tools.web.fetch.ssrfPolicy.allowCidrs`
- Migration needed? **No**

## Failure Recovery (if this breaks)

- Remove `ssrfPolicy.allowCidrs` from config → behavior reverts to default restrictive SSRF policy
- No data migration, no schema versioning needed

## Risks and Mitigations

- Risk: Users allowlist overly broad ranges (e.g. `0.0.0.0/0`)
  - Mitigation: This is an explicit opt-in; `dangerouslyAllowPrivateNetwork` already provides full bypass. `allowCidrs` is strictly more restrictive since each range must be individually listed.
- Risk: CIDR parsing overhead per request
  - Mitigation: Typical lists are 1-3 entries; `ipaddr.parseCIDR` is trivial. Could be cached if needed in future.