### PR TITLE
fix(agents): track tts tool media for deduplication to prevent duplicate voice notes

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.media.test.ts
@@ -9,6 +9,7 @@ import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handler
 function createMockContext(overrides?: {
   shouldEmitToolOutput?: boolean;
   onToolResult?: ReturnType<typeof vi.fn>;
+  toolResultFormat?: "markdown" | "plain";
 }): EmbeddedPiSubscribeContext {
   const onToolResult = overrides?.onToolResult ?? vi.fn();
   return {
@@ -16,6 +17,7 @@ function createMockContext(overrides?: {
       runId: "test-run",
       onToolResult,
       onAgentEvent: vi.fn(),
+      toolResultFormat: overrides?.toolResultFormat,
     },
     state: {
       toolMetaById: new Map(),
@@ -250,5 +252,51 @@ describe("handleToolExecutionEnd media emission", () => {
     expect(onToolResult).toHaveBeenCalledWith({
       mediaUrls: ["/tmp/canvas-output.png"],
     });
+  });
+});
+
+describe("handleToolExecutionEnd media dedup tracking (messagingToolSentMediaUrls)", () => {
+  it("tracks media URLs when verbose is off (direct delivery)", async () => {
+    const ctx = createMockContext({ shouldEmitToolOutput: false });
+    await emitPngMediaToolResult(ctx);
+    expect(ctx.state.messagingToolSentMediaUrls).toContain("/tmp/screenshot.png");
+  });
+
+  it("does NOT track media URLs when verbose=full + markdown (fenced output, MEDIA: skipped)", async () => {
+    // In verbose=full + markdown, emitToolOutput wraps output in ```txt fences.
+    // splitMediaFromOutput skips MEDIA: inside fences, so URLs are never delivered.
+    const ctx = createMockContext({ shouldEmitToolOutput: true, toolResultFormat: "markdown" });
+    await emitPngMediaToolResult(ctx);
+    expect(ctx.state.messagingToolSentMediaUrls).toHaveLength(0);
+  });
+
+  it("does NOT track media URLs when verbose=full + default format (markdown is default)", async () => {
+    // toolResultFormat defaults to "markdown" when not specified.
+    const ctx = createMockContext({ shouldEmitToolOutput: true });
+    await emitPngMediaToolResult(ctx);
+    expect(ctx.state.messagingToolSentMediaUrls).toHaveLength(0);
+  });
+
+  it("tracks media URLs when verbose=full + plain (emitToolOutput delivers MEDIA: without fencing)", async () => {
+    // In verbose=full + plain, emitToolOutput does not fence the output, so
+    // MEDIA: directives are extracted and delivered via onToolResult.
+    const ctx = createMockContext({ shouldEmitToolOutput: true, toolResultFormat: "plain" });
+    await emitPngMediaToolResult(ctx);
+    expect(ctx.state.messagingToolSentMediaUrls).toContain("/tmp/screenshot.png");
+  });
+
+  it("does NOT track media URLs when onToolResult is absent", async () => {
+    // Without onToolResult, no delivery occurs; tracking would cause false dedup.
+    const ctx = createMockContext({ shouldEmitToolOutput: false, onToolResult: undefined });
+    // Override to remove onToolResult
+    (ctx.params as Record<string, unknown>).onToolResult = undefined;
+    await emitPngMediaToolResult(ctx);
+    expect(ctx.state.messagingToolSentMediaUrls).toHaveLength(0);
+  });
+
+  it("does NOT track media URLs on tool error", async () => {
+    const ctx = createMockContext({ shouldEmitToolOutput: false });
+    await emitPngMediaToolResult(ctx, { isError: true });
+    expect(ctx.state.messagingToolSentMediaUrls).toHaveLength(0);
   });
 });

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -387,6 +387,37 @@ describe("messaging tool media URL tracking", () => {
     expect(ctx.state.messagingToolSentMediaUrls).toContain("/tmp/screenshot.png");
   });
 
+  it("does not track non-messaging tool media when shouldEmitToolOutput is true (verbose=full)", async () => {
+    const { ctx } = createTestContext();
+    // Simulate verbose=full mode where tool output is fenced and MEDIA: directives
+    // are skipped by splitMediaFromOutput, so media is never actually delivered.
+    ctx.shouldEmitToolOutput = () => true;
+
+    const startEvt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "tts",
+      toolCallId: "tool-tts-verbose",
+      args: { text: "Hello world" },
+    };
+    await handleToolExecutionStart(ctx, startEvt);
+
+    const endEvt: ToolExecutionEndEvent = {
+      type: "tool_execution_end",
+      toolName: "tts",
+      toolCallId: "tool-tts-verbose",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "[[audio_as_voice]]\nMEDIA:/tmp/tts-audio.ogg" }],
+        details: { audioPath: "/tmp/tts-audio.ogg", provider: "openai" },
+      },
+    };
+    await handleToolExecutionEnd(ctx, endEvt);
+
+    // Media should NOT be tracked because in verbose mode the output is wrapped
+    // in fenced blocks where MEDIA: directives are skipped.
+    expect(ctx.state.messagingToolSentMediaUrls).toHaveLength(0);
+  });
+
   it("discards pending media URL on tool error", async () => {
     const { ctx } = createTestContext();
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -308,6 +308,8 @@ describe("messaging tool media URL tracking", () => {
 
   it("tracks tts tool result media for deduplication", async () => {
     const { ctx } = createTestContext();
+    // onToolResult must be present for media to be tracked (delivery path active).
+    ctx.params.onToolResult = vi.fn();
 
     const startEvt: ToolExecutionStartEvent = {
       type: "tool_execution_start",
@@ -360,6 +362,8 @@ describe("messaging tool media URL tracking", () => {
 
   it("tracks browser tool MEDIA: result for deduplication", async () => {
     const { ctx } = createTestContext();
+    // onToolResult must be present for media to be tracked (delivery path active).
+    ctx.params.onToolResult = vi.fn();
 
     const startEvt: ToolExecutionStartEvent = {
       type: "tool_execution_start",
@@ -385,6 +389,41 @@ describe("messaging tool media URL tracking", () => {
     await handleToolExecutionEnd(ctx, endEvt);
 
     expect(ctx.state.messagingToolSentMediaUrls).toContain("/tmp/screenshot.png");
+  });
+
+  it("does not track non-messaging tool media when onToolResult is absent (follow-up runs)", async () => {
+    const { ctx } = createTestContext();
+    // createTestContext sets onToolResult to undefined, simulating follow-up runs
+    // where runEmbeddedPiAgent is invoked without onToolResult.
+    expect(ctx.params.onToolResult).toBeUndefined();
+
+    const startEvt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "browser",
+      toolCallId: "tool-br-no-cb",
+      args: { action: "screenshot" },
+    };
+    await handleToolExecutionStart(ctx, startEvt);
+
+    const endEvt: ToolExecutionEndEvent = {
+      type: "tool_execution_end",
+      toolName: "browser",
+      toolCallId: "tool-br-no-cb",
+      isError: false,
+      result: {
+        content: [
+          { type: "text", text: "MEDIA:/tmp/screenshot.png" },
+          { type: "image", data: "base64", mimeType: "image/png" },
+        ],
+        details: { path: "/tmp/screenshot.png" },
+      },
+    };
+    await handleToolExecutionEnd(ctx, endEvt);
+
+    // Media should NOT be tracked because without onToolResult the media is never
+    // delivered to the user; tracking it would cause the final reply's media
+    // attachment to be incorrectly stripped as a duplicate.
+    expect(ctx.state.messagingToolSentMediaUrls).toHaveLength(0);
   });
 
   it("does not track non-messaging tool media when shouldEmitToolOutput is true (verbose=full)", async () => {

--- a/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.test.ts
@@ -306,6 +306,87 @@ describe("messaging tool media URL tracking", () => {
     expect(ctx.state.messagingToolSentMediaUrls).not.toContain("file:///img-0.jpg");
   });
 
+  it("tracks tts tool result media for deduplication", async () => {
+    const { ctx } = createTestContext();
+
+    const startEvt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "tts",
+      toolCallId: "tool-tts-1",
+      args: { text: "Hello world" },
+    };
+    await handleToolExecutionStart(ctx, startEvt);
+
+    const endEvt: ToolExecutionEndEvent = {
+      type: "tool_execution_end",
+      toolName: "tts",
+      toolCallId: "tool-tts-1",
+      isError: false,
+      result: {
+        content: [{ type: "text", text: "[[audio_as_voice]]\nMEDIA:/tmp/tts-audio.ogg" }],
+        details: { audioPath: "/tmp/tts-audio.ogg", provider: "openai" },
+      },
+    };
+    await handleToolExecutionEnd(ctx, endEvt);
+
+    expect(ctx.state.messagingToolSentMediaUrls).toContain("/tmp/tts-audio.ogg");
+  });
+
+  it("does not track non-messaging tool media on error", async () => {
+    const { ctx } = createTestContext();
+
+    const startEvt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "tts",
+      toolCallId: "tool-tts-err",
+      args: { text: "Hello world" },
+    };
+    await handleToolExecutionStart(ctx, startEvt);
+
+    const endEvt: ToolExecutionEndEvent = {
+      type: "tool_execution_end",
+      toolName: "tts",
+      toolCallId: "tool-tts-err",
+      isError: true,
+      result: {
+        content: [{ type: "text", text: "MEDIA:/tmp/tts-audio.ogg" }],
+        details: { error: "TTS failed" },
+      },
+    };
+    await handleToolExecutionEnd(ctx, endEvt);
+
+    expect(ctx.state.messagingToolSentMediaUrls).toHaveLength(0);
+  });
+
+  it("tracks browser tool MEDIA: result for deduplication", async () => {
+    const { ctx } = createTestContext();
+
+    const startEvt: ToolExecutionStartEvent = {
+      type: "tool_execution_start",
+      toolName: "browser",
+      toolCallId: "tool-br-1",
+      args: { action: "screenshot" },
+    };
+    await handleToolExecutionStart(ctx, startEvt);
+
+    const endEvt: ToolExecutionEndEvent = {
+      type: "tool_execution_end",
+      toolName: "browser",
+      toolCallId: "tool-br-1",
+      isError: false,
+      result: {
+        content: [
+          { type: "text", text: "MEDIA:/tmp/screenshot.png" },
+          { type: "image", data: "base64", mimeType: "image/png" },
+        ],
+        details: { path: "/tmp/screenshot.png" },
+      },
+    };
+    await handleToolExecutionEnd(ctx, endEvt);
+
+    expect(ctx.state.messagingToolSentMediaUrls).toContain("/tmp/screenshot.png");
+  });
+
   it("discards pending media URL on tool error", async () => {
     const { ctx } = createTestContext();
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -402,10 +402,17 @@ export async function handleToolExecutionEnd(
   // - gate on onToolResult presence: media is only delivered when the callback
   //   exists; without it, tracking would cause the final reply's only media
   //   attachment to be incorrectly stripped as a duplicate.
+  // - skip when output is fenced (verbose=full + markdown): splitMediaFromOutput
+  //   ignores MEDIA: directives inside fenced blocks, so the URLs never reach
+  //   the user. In plain format, emitToolOutput does not fence, so MEDIA:
+  //   directives are still delivered via onToolResult and must be tracked.
+  const willFenceOutput =
+    ctx.shouldEmitToolOutput() && (ctx.params.toolResultFormat ?? "markdown") !== "plain";
   if (
     !isToolError &&
     !isMessagingSend &&
-    ctx.params.onToolResult
+    ctx.params.onToolResult &&
+    !willFenceOutput
   ) {
     const emittedMediaUrls = filterToolResultMediaUrls(
       toolName,

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -397,7 +397,10 @@ export async function handleToolExecutionEnd(
 
   // Track media emitted via tool results (e.g. tts, browser) so that
   // filterMessagingToolMediaDuplicates can strip duplicates from reply payloads.
-  if (!isToolError && !isMessagingSend) {
+  // Skip when shouldEmitToolOutput() is true (verbose=full): in that mode,
+  // emitToolResultOutput wraps output in fenced blocks where splitMediaFromOutput
+  // skips MEDIA: directives, so the media is never actually delivered to the user.
+  if (!isToolError && !isMessagingSend && !ctx.shouldEmitToolOutput()) {
     const emittedMediaUrls = filterToolResultMediaUrls(
       toolName,
       extractToolResultMediaPaths(result),

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -397,10 +397,19 @@ export async function handleToolExecutionEnd(
 
   // Track media emitted via tool results (e.g. tts, browser) so that
   // filterMessagingToolMediaDuplicates can strip duplicates from reply payloads.
-  // Skip when shouldEmitToolOutput() is true (verbose=full): in that mode,
-  // emitToolResultOutput wraps output in fenced blocks where splitMediaFromOutput
-  // skips MEDIA: directives, so the media is never actually delivered to the user.
-  if (!isToolError && !isMessagingSend && !ctx.shouldEmitToolOutput()) {
+  // Only track when the delivery path is actually active:
+  // - skip errors and messaging sends (handled above)
+  // - skip verbose=full mode (emitToolResultOutput wraps output in fenced blocks
+  //   where splitMediaFromOutput skips MEDIA: directives)
+  // - skip when onToolResult is absent (e.g. follow-up runs): emitToolResultOutput
+  //   returns early without delivering media, so tracking would cause the final
+  //   reply's only media attachment to be incorrectly stripped as a duplicate.
+  if (
+    !isToolError &&
+    !isMessagingSend &&
+    !ctx.shouldEmitToolOutput() &&
+    ctx.params.onToolResult
+  ) {
     const emittedMediaUrls = filterToolResultMediaUrls(
       toolName,
       extractToolResultMediaPaths(result),

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -399,15 +399,12 @@ export async function handleToolExecutionEnd(
   // filterMessagingToolMediaDuplicates can strip duplicates from reply payloads.
   // Only track when the delivery path is actually active:
   // - skip errors and messaging sends (handled above)
-  // - skip verbose=full mode (emitToolResultOutput wraps output in fenced blocks
-  //   where splitMediaFromOutput skips MEDIA: directives)
-  // - skip when onToolResult is absent (e.g. follow-up runs): emitToolResultOutput
-  //   returns early without delivering media, so tracking would cause the final
-  //   reply's only media attachment to be incorrectly stripped as a duplicate.
+  // - gate on onToolResult presence: media is only delivered when the callback
+  //   exists; without it, tracking would cause the final reply's only media
+  //   attachment to be incorrectly stripped as a duplicate.
   if (
     !isToolError &&
     !isMessagingSend &&
-    !ctx.shouldEmitToolOutput() &&
     ctx.params.onToolResult
   ) {
     const emittedMediaUrls = filterToolResultMediaUrls(

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -395,6 +395,19 @@ export async function handleToolExecutionEnd(
     }
   }
 
+  // Track media emitted via tool results (e.g. tts, browser) so that
+  // filterMessagingToolMediaDuplicates can strip duplicates from reply payloads.
+  if (!isToolError && !isMessagingSend) {
+    const emittedMediaUrls = filterToolResultMediaUrls(
+      toolName,
+      extractToolResultMediaPaths(result),
+    );
+    if (emittedMediaUrls.length > 0) {
+      ctx.state.messagingToolSentMediaUrls.push(...emittedMediaUrls);
+      ctx.trimMessagingToolSent();
+    }
+  }
+
   // Track committed reminders only when cron.add completed successfully.
   if (!isToolError && toolName === "cron" && isCronAddAction(startData?.args)) {
     ctx.state.successfulCronAdds += 1;

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -408,12 +408,7 @@ export async function handleToolExecutionEnd(
   //   directives are still delivered via onToolResult and must be tracked.
   const willFenceOutput =
     ctx.shouldEmitToolOutput() && (ctx.params.toolResultFormat ?? "markdown") !== "plain";
-  if (
-    !isToolError &&
-    !isMessagingSend &&
-    ctx.params.onToolResult &&
-    !willFenceOutput
-  ) {
+  if (!isToolError && !isMessagingSend && ctx.params.onToolResult && !willFenceOutput) {
     const emittedMediaUrls = filterToolResultMediaUrls(
       toolName,
       extractToolResultMediaPaths(result),

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -132,13 +132,7 @@ export type EmbeddedPiSubscribeContext = {
  */
 export type ToolHandlerParams = Pick<
   SubscribeEmbeddedPiSessionParams,
-  | "runId"
-  | "onBlockReplyFlush"
-  | "onAgentEvent"
-  | "onToolResult"
-  | "sessionKey"
-  | "sessionId"
-  | "agentId"
+  "runId" | "onBlockReplyFlush" | "onAgentEvent" | "onToolResult" | "toolResultFormat"
 >;
 
 export type ToolHandlerState = Pick<


### PR DESCRIPTION
## Summary
- Track media from non-messaging tools (tts, browser) in filterMessagingToolMediaDuplicates
- Prevents duplicate voice notes on Telegram and Discord
- Closes #21205

## Test plan
- Run pnpm vitest run src/agents/pi-embedded-subscribe.handlers.tools.test.ts
- Verify new dedup tracking tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)