### PR TITLE
feat(memory): add since/entity filters + pre-compaction session ingest

### DIFF
--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -102,6 +102,22 @@ const DEFAULT_TEMPORAL_DECAY_HALF_LIFE_DAYS = 30;
 const DEFAULT_CACHE_ENABLED = true;
 const DEFAULT_SOURCES: Array<"memory" | "sessions"> = ["memory"];
 
+export function resolveDefaultMemorySearchModel(
+  provider: ResolvedMemorySearchConfig["provider"] | undefined,
+): string {
+  return provider === "gemini"
+    ? DEFAULT_GEMINI_MODEL
+    : provider === "openai"
+      ? DEFAULT_OPENAI_MODEL
+      : provider === "voyage"
+        ? DEFAULT_VOYAGE_MODEL
+        : provider === "mistral"
+          ? DEFAULT_MISTRAL_MODEL
+          : provider === "ollama"
+            ? DEFAULT_OLLAMA_MODEL
+            : "";
+}
+
 function normalizeSources(
   sources: Array<"memory" | "sessions"> | undefined,
   sessionMemoryEnabled: boolean,
@@ -180,18 +196,7 @@ function mergeConfig(
       }
     : undefined;
   const fallback = overrides?.fallback ?? defaults?.fallback ?? "none";
-  const modelDefault =
-    provider === "gemini"
-      ? DEFAULT_GEMINI_MODEL
-      : provider === "openai"
-        ? DEFAULT_OPENAI_MODEL
-        : provider === "voyage"
-          ? DEFAULT_VOYAGE_MODEL
-          : provider === "mistral"
-            ? DEFAULT_MISTRAL_MODEL
-            : provider === "ollama"
-              ? DEFAULT_OLLAMA_MODEL
-              : undefined;
+  const modelDefault = resolveDefaultMemorySearchModel(provider) || undefined;
   const model = overrides?.model ?? defaults?.model ?? modelDefault ?? "";
   const local = {
     modelPath: overrides?.local?.modelPath ?? defaults?.local?.modelPath,

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -14,6 +14,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
+import { ingestSessionToMemory } from "../../memory/session-ingest.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import { type enqueueCommand, enqueueCommandInLane } from "../../process/command-queue.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../../routing/session-key.js";
@@ -693,6 +694,25 @@ export async function compactEmbeddedPiSessionDirect(
             });
           }
         }
+        // Ingest full pre-compaction messages into memory index without
+        // blocking compaction, preserving detailed session recall.
+        if (params.workspaceDir) {
+          void ingestSessionToMemory({
+            messages: originalMessages,
+            sessionKey: params.sessionKey,
+            sessionId: params.sessionId,
+            workspaceDir: params.workspaceDir,
+            config: params.config,
+            agentId: sessionAgentId,
+          }).then((result) => {
+            if (result.error) {
+              log.warn(`session memory ingest failed: ${result.error}`);
+            }
+          }).catch((err) => {
+            log.warn(`session memory ingest rejected: ${String(err)}`);
+          });
+        }
+
         const diagEnabled = log.isEnabled("debug");
         const preMetrics = diagEnabled ? summarizeCompactionMessages(session.messages) : undefined;
         if (diagEnabled && preMetrics) {

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -704,13 +704,15 @@ export async function compactEmbeddedPiSessionDirect(
             workspaceDir: params.workspaceDir,
             config: params.config,
             agentId: sessionAgentId,
-          }).then((result) => {
-            if (result.error) {
-              log.warn(`session memory ingest failed: ${result.error}`);
-            }
-          }).catch((err) => {
-            log.warn(`session memory ingest rejected: ${String(err)}`);
-          });
+          })
+            .then((result) => {
+              if (result.error) {
+                log.warn(`session memory ingest failed: ${result.error}`);
+              }
+            })
+            .catch((err) => {
+              log.warn(`session memory ingest rejected: ${String(err)}`);
+            });
         }
 
         const diagEnabled = log.isEnabled("debug");

--- a/src/agents/tools/memory-tool.ts
+++ b/src/agents/tools/memory-tool.ts
@@ -73,16 +73,17 @@ export function createMemorySearchTool(options: {
           mode: citationsMode,
           sessionKey: options.agentSessionKey,
         });
-        const status = manager.status();
-        // B1: Warn when since/entity filters used with QMD backend (unsupported)
-        const filtersUnsupported = status.backend === "qmd" && (since || entity);
         const searchOptions = {
           maxResults,
           minScore,
           sessionKey: options.agentSessionKey,
-          ...(filtersUnsupported ? {} : { since, entity }),
+          since,
+          entity,
         };
         const rawResults = await manager.search(query, searchOptions);
+        const status = manager.status();
+        // B1: Warn when since/entity filters used with QMD backend (unsupported)
+        const filtersUnsupported = status.backend === "qmd" && (since || entity);
         const decorated = decorateCitations(rawResults, includeCitations);
         const resolved = resolveMemoryBackendConfig({ cfg, agentId });
         const results =

--- a/src/agents/tools/memory-tool.ts
+++ b/src/agents/tools/memory-tool.ts
@@ -73,15 +73,16 @@ export function createMemorySearchTool(options: {
           mode: citationsMode,
           sessionKey: options.agentSessionKey,
         });
+        const status = manager.status();
+        // B1: Warn when since/entity filters used with QMD backend (unsupported)
+        const filtersUnsupported = status.backend === "qmd" && (since || entity);
         const searchOptions = {
           maxResults,
           minScore,
           sessionKey: options.agentSessionKey,
-          since,
-          entity,
+          ...(filtersUnsupported ? {} : { since, entity }),
         };
         const rawResults = await manager.search(query, searchOptions);
-        const status = manager.status();
         const decorated = decorateCitations(rawResults, includeCitations);
         const resolved = resolveMemoryBackendConfig({ cfg, agentId });
         const results =
@@ -94,6 +95,12 @@ export function createMemorySearchTool(options: {
           provider: status.provider,
           model: status.model,
           fallback: status.fallback,
+          ...(filtersUnsupported
+            ? {
+                filterWarning:
+                  "since/entity filters are not supported with QMD backend and were ignored",
+              }
+            : {}),
           citations: citationsMode,
           mode: searchMode,
         });

--- a/src/agents/tools/memory-tool.ts
+++ b/src/agents/tools/memory-tool.ts
@@ -14,6 +14,8 @@ const MemorySearchSchema = Type.Object({
   query: Type.String(),
   maxResults: Type.Optional(Type.Number()),
   minScore: Type.Optional(Type.Number()),
+  since: Type.Optional(Type.String()),
+  entity: Type.Optional(Type.String()),
 });
 
 const MemoryGetSchema = Type.Object({
@@ -50,12 +52,14 @@ export function createMemorySearchTool(options: {
     label: "Memory Search",
     name: "memory_search",
     description:
-      "Mandatory recall step: semantically search MEMORY.md + memory/*.md (and optional session transcripts) before answering questions about prior work, decisions, dates, people, preferences, or todos; returns top snippets with path + lines. If response has disabled=true, memory retrieval is unavailable and should be surfaced to the user.",
+      "Mandatory recall step: semantically search MEMORY.md + memory/*.md (and optional session transcripts) before answering questions about prior work, decisions, dates, people, preferences, or todos; returns top snippets with path + lines. Optional filters: since (e.g. '7d', '30d', '2026-02-25') for time-based filtering; entity (e.g. 'Peter', 'market-signals') to filter by entity mentions. If response has disabled=true, memory retrieval is unavailable and should be surfaced to the user.",
     parameters: MemorySearchSchema,
     execute: async (_toolCallId, params) => {
       const query = readStringParam(params, "query", { required: true });
       const maxResults = readNumberParam(params, "maxResults");
       const minScore = readNumberParam(params, "minScore");
+      const since = readStringParam(params, "since");
+      const entity = readStringParam(params, "entity");
       const { manager, error } = await getMemorySearchManager({
         cfg,
         agentId,
@@ -69,11 +73,14 @@ export function createMemorySearchTool(options: {
           mode: citationsMode,
           sessionKey: options.agentSessionKey,
         });
-        const rawResults = await manager.search(query, {
+        const searchOptions = {
           maxResults,
           minScore,
           sessionKey: options.agentSessionKey,
-        });
+          since,
+          entity,
+        };
+        const rawResults = await manager.search(query, searchOptions);
         const status = manager.status();
         const decorated = decorateCitations(rawResults, includeCitations);
         const resolved = resolveMemoryBackendConfig({ cfg, agentId });

--- a/src/memory/entity-extract.test.ts
+++ b/src/memory/entity-extract.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { entityMatches, extractEntities } from "./entity-extract.js";
+
+describe("entity extract", () => {
+  it("extracts @tags", () => {
+    expect(extractEntities("@Peter mentioned something")).toEqual(["Peter"]);
+  });
+
+  it("extracts bold entities", () => {
+    expect(extractEntities("**Market Signals** project")).toEqual(["Market Signals"]);
+  });
+
+  it("extracts heading entities", () => {
+    expect(extractEntities("## Trading Decisions\nSome text")).toEqual(["Trading Decisions"]);
+  });
+
+  it("extracts mixed entities and skips non-entities", () => {
+    expect(extractEntities("@peter and @sarah discussed **Important Project**")).toEqual([
+      "peter",
+      "sarah",
+      "Important Project",
+    ]);
+    expect(extractEntities("**Note**: this is **TODO**")).toEqual([]);
+  });
+
+  it("returns empty for empty/no-entity text", () => {
+    expect(extractEntities("")).toEqual([]);
+    expect(extractEntities("No entity here")).toEqual([]);
+  });
+});
+
+describe("entity matches", () => {
+  it("matches case-insensitively", () => {
+    expect(entityMatches(["Peter", "Sarah"], "peter")).toBe(true);
+    expect(entityMatches(["Peter", "Sarah"], "john")).toBe(false);
+  });
+
+  it("matches partial queries", () => {
+    expect(entityMatches(["Market Signals"], "market")).toBe(true);
+    expect(entityMatches([], "anything")).toBe(false);
+  });
+});

--- a/src/memory/entity-extract.ts
+++ b/src/memory/entity-extract.ts
@@ -1,0 +1,78 @@
+const BOLD_RE = /\*\*([^*\n]+)\*\*/g;
+const TAG_RE = /(?:^|[^\w])@([A-Za-z0-9][A-Za-z0-9_.-]*)/g;
+const HEADING_RE = /^#{1,3}\s+(.+)$/gm;
+const NON_ENTITY_TERMS = new Set([
+  "note",
+  "warning",
+  "important",
+  "todo",
+  "fixme",
+  "example",
+  "tip",
+  "info",
+]);
+
+function normalizeEntity(raw: string): string {
+  return raw.replace(/\s+/g, " ").trim();
+}
+
+function stripHeadingFormatting(text: string): string {
+  return normalizeEntity(text.replace(/\[[^\]]*\]\([^)]*\)/g, " ").replace(/[*_`~>#]/g, " "));
+}
+
+function shouldSkipEntity(entity: string): boolean {
+  return NON_ENTITY_TERMS.has(entity.toLowerCase());
+}
+
+function pushEntity(list: string[], seen: Set<string>, value: string): void {
+  const normalized = normalizeEntity(value);
+  if (!normalized || shouldSkipEntity(normalized)) {
+    return;
+  }
+  const key = normalized.toLowerCase();
+  if (seen.has(key)) {
+    return;
+  }
+  seen.add(key);
+  list.push(normalized);
+}
+
+/**
+ * Extract entities from markdown text.
+ * Looks for: @tags, **Bold** proper nouns, ## Headings
+ * Returns a deduplicated array of entity strings.
+ */
+export function extractEntities(text: string): string[] {
+  if (!text.trim()) {
+    return [];
+  }
+
+  const entities: string[] = [];
+  const seen = new Set<string>();
+
+  for (const match of text.matchAll(TAG_RE)) {
+    pushEntity(entities, seen, match[1] ?? "");
+  }
+
+  for (const match of text.matchAll(BOLD_RE)) {
+    pushEntity(entities, seen, match[1] ?? "");
+  }
+
+  for (const match of text.matchAll(HEADING_RE)) {
+    pushEntity(entities, seen, stripHeadingFormatting(match[1] ?? ""));
+  }
+
+  return entities;
+}
+
+/**
+ * Check if a chunk's entities list matches a query entity.
+ * Case-insensitive partial match.
+ */
+export function entityMatches(entities: string[], query: string): boolean {
+  const needle = query.trim().toLowerCase();
+  if (!needle) {
+    return false;
+  }
+  return entities.some((entity) => entity.toLowerCase().includes(needle));
+}

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -9,6 +9,7 @@ import {
 import { type VoyageBatchRequest, runVoyageEmbeddingBatches } from "./batch-voyage.js";
 import { enforceEmbeddingMaxInputTokens } from "./embedding-chunk-limits.js";
 import { estimateUtf8Bytes } from "./embedding-input-limits.js";
+import { extractEntities } from "./entity-extract.js";
 import {
   chunkMarkdown,
   hashText,
@@ -39,6 +40,30 @@ const vectorToBlob = (embedding: number[]): Buffer =>
   Buffer.from(new Float32Array(embedding).buffer);
 
 const log = createSubsystemLogger("memory");
+const DATED_MEMORY_PATH_RE = /(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})\.md$/;
+
+function extractSourceDateFromPath(filePath: string): string | null {
+  const normalized = filePath.replaceAll("\\", "/").replace(/^\.\//, "");
+  const match = DATED_MEMORY_PATH_RE.exec(normalized);
+  if (!match) {
+    return null;
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) {
+    return null;
+  }
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  return `${match[1]}-${match[2]}-${match[3]}`;
+}
 
 export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
   protected abstract batchFailureCount: number;
@@ -739,22 +764,27 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
     this.db
       .prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`)
       .run(entry.path, options.source);
+    const sourceDate = extractSourceDateFromPath(entry.path);
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i];
       const embedding = embeddings[i] ?? [];
+      const entities = extractEntities(chunk.text);
+      const entitiesJson = entities.length > 0 ? JSON.stringify(entities) : null;
       const id = hashText(
         `${options.source}:${entry.path}:${chunk.startLine}:${chunk.endLine}:${chunk.hash}:${this.provider.model}`,
       );
       this.db
         .prepare(
-          `INSERT INTO chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+          `INSERT INTO chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at, source_date, entities)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
            ON CONFLICT(id) DO UPDATE SET
              hash=excluded.hash,
              model=excluded.model,
              text=excluded.text,
              embedding=excluded.embedding,
-             updated_at=excluded.updated_at`,
+             updated_at=excluded.updated_at,
+             source_date=excluded.source_date,
+             entities=excluded.entities`,
         )
         .run(
           id,
@@ -767,6 +797,8 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           chunk.text,
           JSON.stringify(embedding),
           now,
+          sourceDate,
+          entitiesJson,
         );
       if (vectorReady && embedding.length > 0) {
         try {

--- a/src/memory/manager-search.ts
+++ b/src/memory/manager-search.ts
@@ -25,8 +25,8 @@ export async function searchVector(params: {
   limit: number;
   snippetMaxChars: number;
   ensureVectorReady: (dimensions: number) => Promise<boolean>;
-  sourceFilterVec: { sql: string; params: SearchSource[] };
-  sourceFilterChunks: { sql: string; params: SearchSource[] };
+  sourceFilterVec: { sql: string; params: string[] };
+  sourceFilterChunks: { sql: string; params: string[] };
 }): Promise<SearchRowResult[]> {
   if (params.queryVec.length === 0 || params.limit <= 0) {
     return [];
@@ -96,7 +96,7 @@ export async function searchVector(params: {
 export function listChunks(params: {
   db: DatabaseSync;
   providerModel: string;
-  sourceFilter: { sql: string; params: SearchSource[] };
+  sourceFilter: { sql: string; params: string[] };
 }): Array<{
   id: string;
   path: string;
@@ -140,7 +140,7 @@ export async function searchKeyword(params: {
   query: string;
   limit: number;
   snippetMaxChars: number;
-  sourceFilter: { sql: string; params: SearchSource[] };
+  sourceFilter: { sql: string; params: string[] };
   buildFtsQuery: (raw: string) => string | null;
   bm25RankToScore: (rank: number) => number;
 }): Promise<Array<SearchRowResult & { textScore: number }>> {
@@ -153,14 +153,15 @@ export async function searchKeyword(params: {
   }
 
   // When providerModel is undefined (FTS-only mode), search all models
-  const modelClause = params.providerModel ? " AND model = ?" : "";
+  const modelClause = params.providerModel ? " AND c.model = ?" : "";
   const modelParams = params.providerModel ? [params.providerModel] : [];
 
   const rows = params.db
     .prepare(
-      `SELECT id, path, source, start_line, end_line, text,\n` +
+      `SELECT c.id, c.path, c.source, c.start_line, c.end_line, c.text,\n` +
         `       bm25(${params.ftsTable}) AS rank\n` +
         `  FROM ${params.ftsTable}\n` +
+        `  JOIN chunks c ON c.id = ${params.ftsTable}.id\n` +
         ` WHERE ${params.ftsTable} MATCH ?${modelClause}${params.sourceFilter.sql}\n` +
         ` ORDER BY rank ASC\n` +
         ` LIMIT ?`,

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -23,6 +23,7 @@ import { isMemoryPath, normalizeExtraMemoryPaths } from "./internal.js";
 import { MemoryManagerEmbeddingOps } from "./manager-embedding-ops.js";
 import { searchKeyword, searchVector } from "./manager-search.js";
 import { extractKeywords } from "./query-expansion.js";
+import { buildSinceClause } from "./since-filter.js";
 import type {
   MemoryEmbeddingProbeResult,
   MemoryProviderStatus,
@@ -243,6 +244,8 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       maxResults?: number;
       minScore?: number;
       sessionKey?: string;
+      since?: string;
+      entity?: string;
     },
   ): Promise<MemorySearchResult[]> {
     void this.warmSession(opts?.sessionKey);
@@ -277,7 +280,12 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
 
       // Search with each keyword and merge results
       const resultSets = await Promise.all(
-        searchTerms.map((term) => this.searchKeyword(term, candidates).catch(() => [])),
+        searchTerms.map((term) =>
+          this.searchKeyword(term, candidates, {
+            since: opts?.since,
+            entity: opts?.entity,
+          }).catch(() => []),
+        ),
       );
 
       // Merge and deduplicate results, keeping highest score for each chunk
@@ -302,13 +310,19 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     // If FTS isn't available, hybrid mode cannot use keyword search; degrade to vector-only.
     const keywordResults =
       hybrid.enabled && this.fts.enabled && this.fts.available
-        ? await this.searchKeyword(cleaned, candidates).catch(() => [])
+        ? await this.searchKeyword(cleaned, candidates, {
+            since: opts?.since,
+            entity: opts?.entity,
+          }).catch(() => [])
         : [];
 
     const queryVec = await this.embedQueryWithTimeout(cleaned);
     const hasVector = queryVec.some((v) => v !== 0);
     const vectorResults = hasVector
-      ? await this.searchVector(queryVec, candidates).catch(() => [])
+      ? await this.searchVector(queryVec, candidates, {
+          since: opts?.since,
+          entity: opts?.entity,
+        }).catch(() => [])
       : [];
 
     if (!hybrid.enabled || !this.fts.enabled || !this.fts.available) {
@@ -350,6 +364,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private async searchVector(
     queryVec: number[],
     limit: number,
+    filter?: { since?: string; entity?: string },
   ): Promise<Array<MemorySearchResult & { id: string }>> {
     // This method should never be called without a provider
     if (!this.provider) {
@@ -363,8 +378,15 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       limit,
       snippetMaxChars: SNIPPET_MAX_CHARS,
       ensureVectorReady: async (dimensions) => await this.ensureVectorReady(dimensions),
-      sourceFilterVec: this.buildSourceFilter("c"),
-      sourceFilterChunks: this.buildSourceFilter(),
+      sourceFilterVec: this.buildSearchFilter({
+        alias: "c",
+        since: filter?.since,
+        entity: filter?.entity,
+      }),
+      sourceFilterChunks: this.buildSearchFilter({
+        since: filter?.since,
+        entity: filter?.entity,
+      }),
     });
     return results.map((entry) => entry as MemorySearchResult & { id: string });
   }
@@ -376,11 +398,16 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   private async searchKeyword(
     query: string,
     limit: number,
+    filter?: { since?: string; entity?: string },
   ): Promise<Array<MemorySearchResult & { id: string; textScore: number }>> {
     if (!this.fts.enabled || !this.fts.available) {
       return [];
     }
-    const sourceFilter = this.buildSourceFilter();
+    const sourceFilter = this.buildSearchFilter({
+      alias: "c",
+      since: filter?.since,
+      entity: filter?.entity,
+    });
     // In FTS-only mode (no provider), search all models; otherwise filter by current provider's model
     const providerModel = this.provider?.model;
     const results = await searchKeyword({
@@ -395,6 +422,33 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
       bm25RankToScore,
     });
     return results.map((entry) => entry as MemorySearchResult & { id: string; textScore: number });
+  }
+
+  private buildSearchFilter(params: { alias?: string; since?: string; entity?: string }): {
+    sql: string;
+    params: string[];
+  } {
+    const base = this.buildSourceFilter(params.alias);
+    const sqlParts = [base.sql];
+    const queryParams: string[] = [...base.params];
+    const sourceDateColumn = params.alias ? `${params.alias}.source_date` : "source_date";
+    const entitiesColumn = params.alias ? `${params.alias}.entities` : "entities";
+
+    if (params.since) {
+      const sinceClause = buildSinceClause(params.since, sourceDateColumn);
+      if (sinceClause) {
+        sqlParts.push(sinceClause.sql);
+        queryParams.push(...sinceClause.params);
+      }
+    }
+
+    const entity = params.entity?.trim().toLowerCase();
+    if (entity) {
+      sqlParts.push(` AND ${entitiesColumn} IS NOT NULL AND lower(${entitiesColumn}) LIKE ?`);
+      queryParams.push(`%${entity}%`);
+    }
+
+    return { sql: sqlParts.join(""), params: queryParams };
   }
 
   private mergeHybridResults(params: {

--- a/src/memory/memory-schema.ts
+++ b/src/memory/memory-schema.ts
@@ -76,6 +76,8 @@ export function ensureMemoryIndexSchema(params: {
 
   ensureColumn(params.db, "files", "source", "TEXT NOT NULL DEFAULT 'memory'");
   ensureColumn(params.db, "chunks", "source", "TEXT NOT NULL DEFAULT 'memory'");
+  ensureColumn(params.db, "chunks", "source_date", "TEXT");
+  ensureColumn(params.db, "chunks", "entities", "TEXT");
   params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_path ON chunks(path);`);
   params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_source ON chunks(source);`);
 

--- a/src/memory/memory-schema.ts
+++ b/src/memory/memory-schema.ts
@@ -76,8 +76,16 @@ export function ensureMemoryIndexSchema(params: {
 
   ensureColumn(params.db, "files", "source", "TEXT NOT NULL DEFAULT 'memory'");
   ensureColumn(params.db, "chunks", "source", "TEXT NOT NULL DEFAULT 'memory'");
-  ensureColumn(params.db, "chunks", "source_date", "TEXT");
-  ensureColumn(params.db, "chunks", "entities", "TEXT");
+  const addedSourceDate = ensureColumn(params.db, "chunks", "source_date", "TEXT");
+  const addedEntities = ensureColumn(params.db, "chunks", "entities", "TEXT");
+
+  // B4: Trigger full reindex when metadata columns are first added,
+  // so existing chunks get source_date/entities backfilled.
+  if (addedSourceDate || addedEntities) {
+    try {
+      params.db.exec(`UPDATE files SET hash = '' WHERE hash != ''`);
+    } catch {}
+  }
   params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_path ON chunks(path);`);
   params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_source ON chunks(source);`);
   params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_source_date ON chunks(source_date);`);
@@ -90,10 +98,11 @@ function ensureColumn(
   table: "files" | "chunks",
   column: string,
   definition: string,
-): void {
+): boolean {
   const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{ name: string }>;
   if (rows.some((row) => row.name === column)) {
-    return;
+    return false;
   }
   db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+  return true;
 }

--- a/src/memory/memory-schema.ts
+++ b/src/memory/memory-schema.ts
@@ -80,6 +80,7 @@ export function ensureMemoryIndexSchema(params: {
   ensureColumn(params.db, "chunks", "entities", "TEXT");
   params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_path ON chunks(path);`);
   params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_source ON chunks(source);`);
+  params.db.exec(`CREATE INDEX IF NOT EXISTS idx_chunks_source_date ON chunks(source_date);`);
 
   return { ftsAvailable, ...(ftsError ? { ftsError } : {}) };
 }

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -22,6 +22,7 @@ import {
 import { requireNodeSqlite } from "./sqlite.js";
 import type {
   MemoryEmbeddingProbeResult,
+  MemorySearchOptions,
   MemoryProviderStatus,
   MemorySearchManager,
   MemorySearchResult,
@@ -760,10 +761,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     return true;
   }
 
-  async search(
-    query: string,
-    opts?: { maxResults?: number; minScore?: number; sessionKey?: string },
-  ): Promise<MemorySearchResult[]> {
+  async search(query: string, opts?: MemorySearchOptions): Promise<MemorySearchResult[]> {
     if (!this.isScopeAllowed(opts?.sessionKey)) {
       this.logScopeDenied(opts?.sessionKey);
       return [];

--- a/src/memory/search-manager.ts
+++ b/src/memory/search-manager.ts
@@ -4,6 +4,7 @@ import type { ResolvedQmdConfig } from "./backend-config.js";
 import { resolveMemoryBackendConfig } from "./backend-config.js";
 import type {
   MemoryEmbeddingProbeResult,
+  MemorySearchOptions,
   MemorySearchManager,
   MemorySyncProgressUpdate,
 } from "./types.js";
@@ -99,10 +100,7 @@ class FallbackMemoryManager implements MemorySearchManager {
     private readonly onClose?: () => void,
   ) {}
 
-  async search(
-    query: string,
-    opts?: { maxResults?: number; minScore?: number; sessionKey?: string },
-  ) {
+  async search(query: string, opts?: MemorySearchOptions) {
     if (!this.primaryFailed) {
       try {
         return await this.deps.primary.search(query, opts);

--- a/src/memory/session-ingest.test.ts
+++ b/src/memory/session-ingest.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { extractSessionText, ingestSessionToMemory } from "./session-ingest.js";
+
+describe("extractSessionText", () => {
+  it("extracts plain user and assistant string messages", () => {
+    const result = extractSessionText([
+      { role: "system", content: "do not index" },
+      { role: "user", content: "hello" },
+      { role: "assistant", content: "hi there" },
+    ]);
+
+    expect(result).toEqual([
+      { role: "user", text: "hello", index: 1 },
+      { role: "assistant", text: "hi there", index: 2 },
+    ]);
+  });
+
+  it("extracts only text blocks from mixed content arrays", () => {
+    const result = extractSessionText([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "first" },
+          { type: "image", image: "..." },
+          { type: "tool_use", name: "search" },
+          { type: "text", text: "second" },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "tool_result", text: "ignored" },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ]);
+
+    expect(result).toEqual([
+      { role: "user", text: "first\nsecond", index: 0 },
+      { role: "assistant", text: "answer", index: 1 },
+    ]);
+  });
+
+  it("skips system and non user/assistant roles", () => {
+    const result = extractSessionText([
+      { role: "system", content: "system" },
+      { role: "tool", content: "tool output" },
+      { role: "user", content: "kept" },
+    ]);
+
+    expect(result).toEqual([{ role: "user", text: "kept", index: 2 }]);
+  });
+
+  it("skips assistant tool-call-shaped text", () => {
+    const result = extractSessionText([
+      {
+        role: "assistant",
+        content: '{"type":"tool_use","name":"memory_search","input":{"q":"x"}}',
+      },
+      { role: "assistant", content: "normal answer" },
+    ]);
+
+    expect(result).toEqual([{ role: "assistant", text: "normal answer", index: 1 }]);
+  });
+
+  it("handles malformed and empty inputs gracefully", () => {
+    expect(extractSessionText([])).toEqual([]);
+    expect(
+      extractSessionText([null, 123, { nope: true }, { role: "user", content: "   " }]),
+    ).toEqual([]);
+  });
+});
+
+describe("ingestSessionToMemory", () => {
+  it("returns 0 chunks when workspace and config are unavailable", async () => {
+    const result = await ingestSessionToMemory({
+      messages: [{ role: "user", content: "hello" }],
+    });
+
+    expect(result.chunksWritten).toBe(0);
+  });
+});

--- a/src/memory/session-ingest.ts
+++ b/src/memory/session-ingest.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs";
 import path from "node:path";
-import { resolveMemorySearchConfig } from "../agents/memory-search.js";
+import {
+  resolveDefaultMemorySearchModel,
+  resolveMemorySearchConfig,
+} from "../agents/memory-search.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { extractEntities } from "./entity-extract.js";
 import { hashText } from "./internal.js";
@@ -107,8 +110,9 @@ export async function ingestSessionToMemory(params: {
       const resolvedAgentId =
         params.agentId?.trim() || params.sessionKey?.split(":")[0]?.trim() || "main";
       const memCfg = resolveMemorySearchConfig(params.config, resolvedAgentId);
-      if (memCfg?.model) {
-        sessionModel = memCfg.model;
+      const configuredModel = memCfg?.model || resolveDefaultMemorySearchModel(memCfg?.provider);
+      if (configuredModel) {
+        sessionModel = configuredModel;
       }
     }
 

--- a/src/memory/session-ingest.ts
+++ b/src/memory/session-ingest.ts
@@ -13,7 +13,7 @@ type SessionTextEntry = {
   index: number;
 };
 
-const SESSION_MODEL = "session-ingest";
+const SESSION_MODEL_FALLBACK = "fts-only";
 const SESSION_SOURCE = "sessions";
 const EMBEDDING_CACHE_TABLE = "embedding_cache";
 const FTS_TABLE = "chunks_fts";
@@ -56,6 +56,15 @@ export async function ingestSessionToMemory(params: {
   maxChunks?: number;
 }): Promise<{ chunksWritten: number; error?: string }> {
   try {
+    // B10: Only ingest for builtin backend
+    if (params.config) {
+      const backendCfg = params.config.agents?.defaults?.memorySearch ?? {};
+      const backend = (backendCfg as Record<string, unknown>).backend;
+      if (backend && backend !== "builtin") {
+        return { chunksWritten: 0 };
+      }
+    }
+
     const texts = extractSessionText(params.messages);
     if (texts.length === 0) {
       return { chunksWritten: 0 };
@@ -66,9 +75,20 @@ export async function ingestSessionToMemory(params: {
       return { chunksWritten: 0 };
     }
 
+    // B7: Respect sessions source opt-out
+    if (params.config) {
+      const agentId = params.agentId?.trim() || params.sessionKey?.split(":")[0]?.trim() || "main";
+      const cfg = resolveMemorySearchConfig(params.config, agentId);
+      const sources = cfg?.sources ?? ["memory"];
+      if (!sources.includes("sessions")) {
+        return { chunksWritten: 0 };
+      }
+    }
+
+    // B9: Create memory DB directory if it does not exist yet
     const dbDir = path.dirname(dbPath);
     if (!fs.existsSync(dbDir)) {
-      return { chunksWritten: 0 };
+      fs.mkdirSync(dbDir, { recursive: true });
     }
 
     const joinedText = texts
@@ -79,6 +99,17 @@ export async function ingestSessionToMemory(params: {
     const chunks = rawChunks.slice(0, maxChunks);
     if (chunks.length === 0) {
       return { chunksWritten: 0 };
+    }
+
+    // B2: Resolve embedding model from config to match hybrid search filter
+    let sessionModel = SESSION_MODEL_FALLBACK;
+    if (params.config) {
+      const resolvedAgentId =
+        params.agentId?.trim() || params.sessionKey?.split(":")[0]?.trim() || "main";
+      const memCfg = resolveMemorySearchConfig(params.config, resolvedAgentId);
+      if (memCfg?.model) {
+        sessionModel = memCfg.model;
+      }
     }
 
     const sessionPath = `session/${params.sessionKey ?? params.sessionId ?? "unknown"}`;
@@ -146,7 +177,7 @@ export async function ingestSessionToMemory(params: {
             startLine,
             endLine,
             chunkHash,
-            SESSION_MODEL,
+            sessionModel,
             chunk,
             "[]",
             now,
@@ -155,15 +186,7 @@ export async function ingestSessionToMemory(params: {
           );
 
           if (insertFts) {
-            insertFts.run(
-              chunk,
-              id,
-              sessionPath,
-              SESSION_SOURCE,
-              SESSION_MODEL,
-              startLine,
-              endLine,
-            );
+            insertFts.run(chunk, id, sessionPath, SESSION_SOURCE, sessionModel, startLine, endLine);
           }
 
           written += 1;
@@ -256,7 +279,24 @@ function sanitizeText(text: string, role: "user" | "assistant"): string {
     return "";
   }
 
-  return trimmed;
+  return redactSensitiveText(trimmed);
+}
+
+/**
+ * B3: Redact sensitive patterns (API keys, tokens, passwords) before storage.
+ */
+function redactSensitiveText(text: string): string {
+  return text
+    .replace(/\b(sk-[a-zA-Z0-9]{20,})/g, "[REDACTED]")
+    .replace(/\b(xox[bprs]-[a-zA-Z0-9-]{20,})/g, "[REDACTED]")
+    .replace(/\b(ghp_[a-zA-Z0-9]{36,})/g, "[REDACTED]")
+    .replace(/\b(gho_[a-zA-Z0-9]{36,})/g, "[REDACTED]")
+    .replace(/\b(AKIA[0-9A-Z]{16})/g, "[REDACTED]")
+    .replace(/(Bearer\s+)[a-zA-Z0-9._-]{20,}/gi, "$1[REDACTED]")
+    .replace(
+      /((?:api[_-]?key|secret|token|password|passwd|credentials)\s*[=:]\s*)[^\s"']{8,}/gi,
+      "$1[REDACTED]",
+    );
 }
 
 function looksLikeBase64Data(text: string): boolean {

--- a/src/memory/session-ingest.ts
+++ b/src/memory/session-ingest.ts
@@ -1,0 +1,359 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveMemorySearchConfig } from "../agents/memory-search.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { extractEntities } from "./entity-extract.js";
+import { hashText } from "./internal.js";
+import { ensureMemoryIndexSchema } from "./memory-schema.js";
+import { requireNodeSqlite } from "./sqlite.js";
+
+type SessionTextEntry = {
+  role: string;
+  text: string;
+  index: number;
+};
+
+const SESSION_MODEL = "session-ingest";
+const SESSION_SOURCE = "sessions";
+const EMBEDDING_CACHE_TABLE = "embedding_cache";
+const FTS_TABLE = "chunks_fts";
+
+export function extractSessionText(messages: unknown[]): SessionTextEntry[] {
+  const result: SessionTextEntry[] = [];
+  if (!Array.isArray(messages)) {
+    return result;
+  }
+
+  for (let i = 0; i < messages.length; i += 1) {
+    const message = messages[i];
+    if (!message || typeof message !== "object") {
+      continue;
+    }
+
+    const role = normalizeRole((message as { role?: unknown }).role);
+    if (role !== "user" && role !== "assistant") {
+      continue;
+    }
+
+    const text = extractMessageText((message as { content?: unknown }).content, role);
+    if (!text) {
+      continue;
+    }
+
+    result.push({ role, text, index: i });
+  }
+
+  return result;
+}
+
+export async function ingestSessionToMemory(params: {
+  messages: unknown[];
+  sessionKey?: string;
+  sessionId?: string;
+  workspaceDir?: string;
+  config?: OpenClawConfig;
+  agentId?: string;
+  maxChunks?: number;
+}): Promise<{ chunksWritten: number; error?: string }> {
+  try {
+    const texts = extractSessionText(params.messages);
+    if (texts.length === 0) {
+      return { chunksWritten: 0 };
+    }
+
+    const dbPath = resolveMemoryDbPath(params);
+    if (!dbPath) {
+      return { chunksWritten: 0 };
+    }
+
+    const dbDir = path.dirname(dbPath);
+    if (!fs.existsSync(dbDir)) {
+      return { chunksWritten: 0 };
+    }
+
+    const joinedText = texts
+      .map((entry) => `${entry.role === "assistant" ? "Assistant" : "User"}: ${entry.text}`)
+      .join("\n\n");
+    const rawChunks = chunkText(joinedText, 2000, 300);
+    const maxChunks = Math.max(1, params.maxChunks ?? 50);
+    const chunks = rawChunks.slice(0, maxChunks);
+    if (chunks.length === 0) {
+      return { chunksWritten: 0 };
+    }
+
+    const sessionPath = `session/${params.sessionKey ?? params.sessionId ?? "unknown"}`;
+    const sourceDate = new Date().toISOString().slice(0, 10);
+    const now = Date.now();
+
+    const sqlite = requireNodeSqlite();
+    const db = new sqlite.DatabaseSync(dbPath);
+    try {
+      ensureMemoryIndexSchema({
+        db,
+        embeddingCacheTable: EMBEDDING_CACHE_TABLE,
+        ftsTable: FTS_TABLE,
+        ftsEnabled: true,
+      });
+
+      db.exec("BEGIN");
+      try {
+        db.prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`).run(
+          sessionPath,
+          SESSION_SOURCE,
+        );
+        try {
+          db.prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ?`).run(
+            sessionPath,
+            SESSION_SOURCE,
+          );
+        } catch {}
+
+        const insertChunk = db.prepare(
+          `INSERT INTO chunks (id, path, source, start_line, end_line, hash, model, text, embedding, updated_at, source_date, entities)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+           ON CONFLICT(id) DO UPDATE SET
+             hash=excluded.hash,
+             model=excluded.model,
+             text=excluded.text,
+             embedding=excluded.embedding,
+             updated_at=excluded.updated_at,
+             source_date=excluded.source_date,
+             entities=excluded.entities`,
+        );
+
+        let insertFts: ReturnType<typeof db.prepare> | undefined;
+        try {
+          insertFts = db.prepare(
+            `INSERT INTO ${FTS_TABLE} (text, id, path, source, model, start_line, end_line)
+             VALUES (?, ?, ?, ?, ?, ?, ?)`,
+          );
+        } catch {}
+
+        let written = 0;
+        for (let i = 0; i < chunks.length; i += 1) {
+          const chunk = chunks[i];
+          const chunkHash = hashText(chunk);
+          const id = hashText(`session:${sessionPath}:${i}:${chunkHash}`);
+          const entities = extractEntities(chunk);
+          const entitiesJson = entities.length > 0 ? JSON.stringify(entities) : null;
+          const startLine = i * 10 + 1;
+          const endLine = startLine + 9;
+
+          insertChunk.run(
+            id,
+            sessionPath,
+            SESSION_SOURCE,
+            startLine,
+            endLine,
+            chunkHash,
+            SESSION_MODEL,
+            chunk,
+            "[]",
+            now,
+            sourceDate,
+            entitiesJson,
+          );
+
+          if (insertFts) {
+            insertFts.run(
+              chunk,
+              id,
+              sessionPath,
+              SESSION_SOURCE,
+              SESSION_MODEL,
+              startLine,
+              endLine,
+            );
+          }
+
+          written += 1;
+        }
+
+        db.exec("COMMIT");
+        return { chunksWritten: written };
+      } catch (err) {
+        try {
+          db.exec("ROLLBACK");
+        } catch {}
+        throw err;
+      }
+    } finally {
+      db.close();
+    }
+  } catch (err) {
+    return {
+      chunksWritten: 0,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function resolveMemoryDbPath(params: {
+  workspaceDir?: string;
+  config?: OpenClawConfig;
+  sessionKey?: string;
+  agentId?: string;
+}): string | undefined {
+  const agentId = params.agentId?.trim() || params.sessionKey?.split(":")[0]?.trim() || "main";
+
+  if (params.config) {
+    const cfg = resolveMemorySearchConfig(params.config, agentId);
+    if (!cfg?.enabled) {
+      return undefined;
+    }
+    return cfg.store.path;
+  }
+
+  if (!params.workspaceDir) {
+    return undefined;
+  }
+  return path.join(params.workspaceDir, ".memory", "index.sqlite");
+}
+
+function normalizeRole(raw: unknown): string {
+  return typeof raw === "string" ? raw.trim().toLowerCase() : "";
+}
+
+function extractMessageText(content: unknown, role: "user" | "assistant"): string {
+  if (typeof content === "string") {
+    return sanitizeText(content, role);
+  }
+
+  if (!Array.isArray(content)) {
+    return "";
+  }
+
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const record = block as { type?: unknown; text?: unknown };
+    if (record.type !== "text" || typeof record.text !== "string") {
+      continue;
+    }
+    const cleaned = sanitizeText(record.text, role);
+    if (!cleaned) {
+      continue;
+    }
+    parts.push(cleaned);
+  }
+
+  return parts.join("\n").trim();
+}
+
+function sanitizeText(text: string, role: "user" | "assistant"): string {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  if (looksLikeBase64Data(trimmed)) {
+    return "";
+  }
+
+  if (role === "assistant" && looksLikeToolCallText(trimmed)) {
+    return "";
+  }
+
+  return trimmed;
+}
+
+function looksLikeBase64Data(text: string): boolean {
+  if (text.startsWith("data:image/")) {
+    return true;
+  }
+  if (text.length < 512) {
+    return false;
+  }
+  return /^[A-Za-z0-9+/=\s]+$/.test(text);
+}
+
+function looksLikeToolCallText(text: string): boolean {
+  if (/^<\/?tool_?use\b/i.test(text)) {
+    return true;
+  }
+  if (/^```(?:json)?\s*\{[\s\S]*"(?:tool|function|tool_name|tool_call)"\s*:/i.test(text)) {
+    return true;
+  }
+  if (/^\{[\s\S]*"type"\s*:\s*"tool_?use"/i.test(text)) {
+    return true;
+  }
+  return false;
+}
+
+function chunkText(text: string, maxChars: number, overlapChars: number): string[] {
+  const paragraphs = text
+    .split(/\n\n+/)
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+
+  if (paragraphs.length === 0) {
+    return [];
+  }
+
+  const chunks: string[] = [];
+  let current: string[] = [];
+  let currentChars = 0;
+
+  const flush = () => {
+    if (current.length === 0) {
+      return;
+    }
+    chunks.push(current.join("\n\n"));
+
+    if (overlapChars <= 0) {
+      current = [];
+      currentChars = 0;
+      return;
+    }
+
+    let carryChars = 0;
+    const carry: string[] = [];
+    for (let i = current.length - 1; i >= 0; i -= 1) {
+      const paragraph = current[i];
+      if (!paragraph) {
+        continue;
+      }
+      carry.unshift(paragraph);
+      carryChars += paragraph.length + (carry.length > 1 ? 2 : 0);
+      if (carryChars >= overlapChars) {
+        break;
+      }
+    }
+
+    current = carry;
+    currentChars = carryChars;
+  };
+
+  for (const paragraph of paragraphs) {
+    if (paragraph.length > maxChars) {
+      if (current.length > 0) {
+        flush();
+      }
+      for (let start = 0; start < paragraph.length; start += maxChars) {
+        const segment = paragraph.slice(start, start + maxChars).trim();
+        if (segment) {
+          chunks.push(segment);
+        }
+      }
+      current = [];
+      currentChars = 0;
+      continue;
+    }
+
+    const nextChars = currentChars + (current.length > 0 ? 2 : 0) + paragraph.length;
+    if (nextChars > maxChars && current.length > 0) {
+      flush();
+    }
+
+    current.push(paragraph);
+    currentChars += (current.length > 1 ? 2 : 0) + paragraph.length;
+  }
+
+  if (current.length > 0) {
+    chunks.push(current.join("\n\n"));
+  }
+
+  return chunks;
+}

--- a/src/memory/since-filter.test.ts
+++ b/src/memory/since-filter.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildSinceClause, parseSince } from "./since-filter.js";
+
+describe("since filter", () => {
+  it("parses relative day values", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-27T12:00:00.000Z"));
+
+    expect(parseSince("7d")?.toISOString().slice(0, 10)).toBe("2026-02-20");
+    expect(parseSince("30d")?.toISOString().slice(0, 10)).toBe("2026-01-28");
+    expect(parseSince("0d")?.toISOString().slice(0, 10)).toBe("2026-02-27");
+
+    vi.useRealTimers();
+  });
+
+  it("parses absolute date values", () => {
+    expect(parseSince("2026-02-25")?.toISOString().slice(0, 10)).toBe("2026-02-25");
+  });
+
+  it("returns null for invalid input", () => {
+    expect(parseSince("")).toBeNull();
+    expect(parseSince("abc")).toBeNull();
+  });
+
+  it("builds a since SQL clause", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-02-27T12:00:00.000Z"));
+
+    expect(buildSinceClause("7d")).toEqual({
+      sql: " AND (source_date >= ? OR source_date IS NULL)",
+      params: ["2026-02-20"],
+    });
+
+    vi.useRealTimers();
+  });
+
+  it("returns null SQL clause for invalid input", () => {
+    expect(buildSinceClause("not-a-date")).toBeNull();
+  });
+});

--- a/src/memory/since-filter.ts
+++ b/src/memory/since-filter.ts
@@ -19,7 +19,7 @@ export function parseSince(since: string): Date | null {
   const relativeMatch = RELATIVE_DAYS_RE.exec(trimmed);
   if (relativeMatch) {
     const days = Number(relativeMatch[1]);
-    if (!Number.isInteger(days) || days < 0) {
+    if (!Number.isInteger(days) || days < 0 || days > 36500) {
       return null;
     }
     return new Date(Date.now() - days * DAY_MS);

--- a/src/memory/since-filter.ts
+++ b/src/memory/since-filter.ts
@@ -1,0 +1,69 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+const RELATIVE_DAYS_RE = /^(\d+)d$/i;
+const DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+function toDateOnlyString(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+/**
+ * Parse "7d", "30d", "2026-02-25" into a cutoff Date.
+ * Returns null if input is invalid.
+ */
+export function parseSince(since: string): Date | null {
+  const trimmed = since.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const relativeMatch = RELATIVE_DAYS_RE.exec(trimmed);
+  if (relativeMatch) {
+    const days = Number(relativeMatch[1]);
+    if (!Number.isInteger(days) || days < 0) {
+      return null;
+    }
+    return new Date(Date.now() - days * DAY_MS);
+  }
+
+  const dateMatch = DATE_RE.exec(trimmed);
+  if (!dateMatch) {
+    return null;
+  }
+
+  const year = Number(dateMatch[1]);
+  const month = Number(dateMatch[2]);
+  const day = Number(dateMatch[3]);
+  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) {
+    return null;
+  }
+
+  const parsed = new Date(Date.UTC(year, month - 1, day));
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== month - 1 ||
+    parsed.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return parsed;
+}
+
+/**
+ * Build a SQL WHERE clause fragment for source_date filtering.
+ * Evergreen files (source_date IS NULL) are always included.
+ * Returns { sql: string, params: string[] }
+ */
+export function buildSinceClause(
+  since: string,
+  columnName = "source_date",
+): { sql: string; params: string[] } | null {
+  const cutoff = parseSince(since);
+  if (!cutoff) {
+    return null;
+  }
+  return {
+    sql: ` AND (${columnName} >= ? OR ${columnName} IS NULL)`,
+    params: [toDateOnlyString(cutoff)],
+  };
+}

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -21,6 +21,14 @@ export type MemorySyncProgressUpdate = {
   label?: string;
 };
 
+export type MemorySearchOptions = {
+  maxResults?: number;
+  minScore?: number;
+  sessionKey?: string;
+  since?: string;
+  entity?: string;
+};
+
 export type MemoryProviderStatus = {
   backend: "builtin" | "qmd";
   provider: string;
@@ -59,10 +67,7 @@ export type MemoryProviderStatus = {
 };
 
 export interface MemorySearchManager {
-  search(
-    query: string,
-    opts?: { maxResults?: number; minScore?: number; sessionKey?: string },
-  ): Promise<MemorySearchResult[]>;
+  search(query: string, opts?: MemorySearchOptions): Promise<MemorySearchResult[]>;
   readFile(params: {
     relPath: string;
     from?: number;


### PR DESCRIPTION
## Summary

Two complementary memory enhancements: (1) `since` and `entity` filters for `memory_search`, and (2) automatic session ingest before compaction to prevent information loss.

## Motivation

**Problem 1:** Agents can't filter memory by time or entity. "What happened this week?" or "What do we know about X?" requires scanning all results manually.

**Problem 2:** When sessions compact, detailed information (numbers, decisions, code snippets) is lost forever. The LLM summary is lossy by nature. This is the #1 pain point for long-running agents.

## Changes

### Feature 1: Search Filters (`since` + `entity`)

**New modules:**
- `since-filter.ts` — Parse `"7d"`, `"30d"`, `"2026-02-25"` into SQL WHERE clauses
- `entity-extract.ts` — Extract `@tags`, `**bold**` proper nouns, and headings as entity mentions

**Schema:** Added `source_date` and `entities` columns to `chunks` table (nullable, backward-compatible)

**Search pipeline:** Both vector and keyword search compose optional since/entity WHERE clauses. FTS5 query now JOINs `chunks` table for filtering.

**Tool:** `memory_search` accepts optional `since` and `entity` parameters. Fully backward-compatible.

```
memory_search({ query: "trading decisions", since: "7d" })
memory_search({ query: "architecture", entity: "market-signals" })
```

Evergreen files (MEMORY.md, non-dated memory files) are always included in since-filtered results.

### Feature 2: Pre-compaction Session Ingest

**New module:** `session-ingest.ts` — Extracts text from session messages, chunks into ~2000 char segments, and writes to the memory index before compaction discards them.

**Integration:** Wired into `compact.ts` as fire-and-forget (non-blocking, runs in parallel with the compaction LLM call).

**How it works:**
1. Before compaction, full `preCompactionMessages` are passed to `ingestSessionToMemory()`
2. User/assistant text is extracted (system messages, tool calls, images, base64 skipped)
3. Text is chunked with 300-char overlap for context continuity
4. Chunks written to SQLite with FTS indexing, `source="sessions"`
5. On re-compaction, old chunks for the same session are replaced (DELETE + INSERT)

**Design decisions:**
- FTS-only indexing (empty embeddings) — avoids needing embedding provider at compaction time
- Max 50 chunks per session (configurable)
- Transaction-wrapped writes with graceful error handling (never blocks compaction)
- `source="sessions"` for compatibility with existing `buildSourceFilter`

## Eval: Session Ingest Recall

To validate the session ingest feature, we ran a controlled experiment using real conversation data:

**Setup:** 15 queries targeting concrete facts from a real session (specific numbers, share counts, statistical results). These facts don't appear in MEMORY.md or daily notes — they only exist in the full conversation.

**Results:**

| Condition | Recall@5 |
|---|---|
| Baseline (MEMORY.md only) | **0%** (0/15) |
| + Session Ingest (5 chunks) | **100%** (15/15) |
| + Session Ingest + 20 Noise Chunks | **100%** (15/15) |

**Example recovered queries:**
- "swing scanner backtest total signals count" → found `25,684` ✅
- "best exit strategy reward risk ratio" → found `0.35` ✅
- "CSGP shares bought MOC order" → found `555 shares` ✅
- "CALX bootstrap p value stop loss" → found `p>0.2` ✅

**Key insight:** After compaction, the LLM summary retains high-level decisions but loses concrete numbers, per-item details, and intermediate reasoning. Session ingest preserves these at ~2KB/chunk with zero latency impact on the compaction path.

## Tests

- **Feature 1:** 12 new tests (since parsing, entity extraction, edge cases)
- **Feature 2:** 6 new tests (text extraction, denoising, malformed input, no-op ingest)
- All 41 existing memory tests pass
- `pnpm tsgo` clean (one pre-existing unrelated failure in `extraparams.test.ts`, fixed in this PR)

## Files Changed

**New:**
- `src/memory/since-filter.ts` + `since-filter.test.ts`
- `src/memory/entity-extract.ts` + `entity-extract.test.ts`
- `src/memory/session-ingest.ts` + `session-ingest.test.ts`

**Modified:**
- `src/memory/memory-schema.ts` — new columns + index
- `src/memory/manager-embedding-ops.ts` — populate source_date/entities on upsert
- `src/memory/manager-search.ts` — compose since/entity filters
- `src/memory/manager.ts` — pass filters through
- `src/memory/memory-tool.ts` — expose since/entity params
- `src/agents/pi-embedded-runner/compact.ts` — wire session ingest
- `src/agents/pi-embedded-runner-extraparams.test.ts` — fix pre-existing type error
