### PR TITLE
fix(gateway): add handshake lock to prevent concurrent WS handshake race (#19168)

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -332,6 +332,13 @@ export function attachGatewayWsMessageHandler(params: {
     authRateLimiter,
   } = browserSecurity;
 
+  // Guard flag to prevent concurrent handshake attempts on the same connection.
+  // JavaScript is single-threaded, but async message handlers can interleave: if two
+  // connect frames arrive before the first handshake completes its async work,
+  // both see getClient() === null and attempt a parallel handshake. This flag
+  // serialises them so only one handshake can be in-flight at a time.
+  let handshakeInProgress = false;
+
   socket.on("message", async (data) => {
     if (isClosed()) {
       return;
@@ -363,6 +370,17 @@ export function attachGatewayWsMessageHandler(params: {
 
       const client = getClient();
       if (!client) {
+        // Reject concurrent handshake attempts. Two rapid connect frames can both
+        // observe getClient() === null before the first handshake's async work
+        // sets the client, causing a partial second handshake that leaves the
+        // connection in an inconsistent state. Serialise with handshakeInProgress.
+        if (handshakeInProgress) {
+          setCloseCause("handshake-race", { frameType, frameMethod, frameId });
+          close(1008, "handshake already in progress");
+          return;
+        }
+        handshakeInProgress = true;
+
         // Handshake must be a normal request:
         // { type:"req", method:"connect", params: ConnectParams }.
         const isRequestFrame = validateRequestFrame(parsed);


### PR DESCRIPTION
## Problem

A race condition exists in `src/gateway/server/ws-connection/message-handler.ts` (introduced in commit `bcbfb357be`, 2026-01-14). The `socket.on("message")` callback is `async`, so multiple invocations can be in-flight simultaneously. If two `connect` frames arrive in rapid succession, both can observe `getClient() === null` before the first handshake completes its async work (auth lookups, token validation, device pairing checks). Both handlers then proceed through the handshake path concurrently, producing a second incomplete handshake that leaves the connection in an inconsistent state — a non-null client with an uninitialized session sub-object. Downstream code calling `client.session.setSession(...)` then throws:

```
TypeError: Cannot read properties of null (reading setSession)
```

## Root Cause

`message-handler.ts:364` — no guard prevents two concurrent async handlers from both entering the `if (!client)` handshake branch at the same time.

## Fix

Add a `handshakeInProgress` boolean flag in the outer closure (shared across all handler invocations for a given connection). The first handler entering the `!client` branch sets the flag before its first `await`. Any subsequent handler that sees the flag set closes the connection with code `1008` (`handshake already in progress`) rather than starting a parallel handshake.

```ts
// Set before first async yield in the handshake path
handshakeInProgress = true;

// Guard at top of if (!client) block
if (handshakeInProgress) {
  setCloseCause("handshake-race", { frameType, frameMethod, frameId });
  close(1008, "handshake already in progress");
  return;
}
```

## Re-verify

Code-level check: confirmed the original `message-handler.ts` has no guard after `getClient() === null`, and the patched file introduces `handshakeInProgress` with the close-on-race path. The exact vulnerable pattern (`!client` → immediate `validateRequestFrame` with no concurrency guard) is gone in the fix.

Runtime repro was classified as `code-suspect` (pattern confirmed in source; live crash requires sub-millisecond frame timing not reliably triggered in lab). The fix directly addresses the confirmed code-level race.

Fixes #19168