### PR TITLE
CLI: fall back when nodes omit system.run.prepare

### DIFF
--- a/src/cli/nodes-cli/register.invoke.nodes-run-prepare-fallback.test.ts
+++ b/src/cli/nodes-cli/register.invoke.nodes-run-prepare-fallback.test.ts
@@ -173,7 +173,7 @@ describe("nodes run prepare fallback (#29171)", () => {
       caps: [],
       connected: true,
       permissions: { screenRecording: true },
-    };
+    } as (typeof nodeListResponse.nodes)[number];
 
     const program = new Command();
     program.exitOverride();
@@ -201,7 +201,7 @@ describe("nodes run prepare fallback (#29171)", () => {
       caps: [],
       connected: true,
       permissions: { screenRecording: true },
-    };
+    } as (typeof nodeListResponse.nodes)[number];
 
     const program = new Command();
     program.exitOverride();
@@ -228,7 +228,7 @@ describe("nodes run prepare fallback (#29171)", () => {
       caps: [],
       connected: true,
       permissions: { screenRecording: true },
-    };
+    } as (typeof nodeListResponse.nodes)[number];
 
     const program = new Command();
     program.exitOverride();

--- a/src/cli/nodes-cli/register.invoke.nodes-run-prepare-fallback.test.ts
+++ b/src/cli/nodes-cli/register.invoke.nodes-run-prepare-fallback.test.ts
@@ -1,0 +1,153 @@
+import { Command } from "commander";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+type GatewayCall = {
+  method?: string;
+  params?: {
+    id?: string;
+    command?: string;
+    commandArgv?: string[];
+    systemRunPlanV2?: unknown;
+    host?: string;
+    agentId?: string;
+    params?: Record<string, unknown>;
+  };
+};
+
+const callGateway = vi.fn(async (opts: GatewayCall) => {
+  if (opts.method === "node.list") {
+    return {
+      nodes: [
+        {
+          nodeId: "mac-1",
+          displayName: "Mac",
+          platform: "macos",
+          caps: [],
+          commands: ["system.run"],
+          connected: true,
+          permissions: { screenRecording: true },
+        },
+      ],
+    };
+  }
+  if (opts.method === "node.invoke") {
+    if (opts.params?.command === "system.run.prepare") {
+      throw new Error(
+        'node command not allowed: the node (platform: macos) does not support "system.run.prepare"',
+      );
+    }
+    return {
+      payload: {
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        success: true,
+        timedOut: false,
+      },
+    };
+  }
+  if (opts.method === "exec.approvals.node.get") {
+    return {
+      file: {
+        version: 1,
+        defaults: {
+          security: "allowlist",
+          ask: "off",
+          askFallback: "deny",
+        },
+        agents: {},
+      },
+    };
+  }
+  if (opts.method === "exec.approval.request") {
+    return { decision: "allow-once" };
+  }
+  return { ok: true };
+});
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: (opts: GatewayCall) => callGateway(opts),
+  randomIdempotencyKey: () => "mock-key",
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("../../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: vi.fn(() => ({})),
+  };
+});
+
+describe("nodes run prepare fallback (#29171)", () => {
+  let registerNodesCli: (program: Command) => void;
+
+  beforeAll(async () => {
+    ({ registerNodesCli } = await import("../nodes-cli.js"));
+  });
+
+  beforeEach(() => {
+    callGateway.mockClear();
+  });
+
+  it("falls back to system.run when the node does not advertise system.run.prepare", async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerNodesCli(program);
+
+    await program.parseAsync(["nodes", "run", "--node", "mac-1", "echo", "hi"], {
+      from: "user",
+    });
+
+    const invokeCommands = callGateway.mock.calls
+      .map((call) => call[0])
+      .filter((entry) => entry.method === "node.invoke")
+      .map((entry) => entry.params?.command);
+
+    expect(invokeCommands).toEqual(["system.run"]);
+  });
+
+  it("requests approval without systemRunPlanV2 when it falls back to system.run", async () => {
+    const program = new Command();
+    program.exitOverride();
+    registerNodesCli(program);
+
+    await program.parseAsync(
+      ["nodes", "run", "--node", "mac-1", "--ask", "on-miss", "echo", "hi"],
+      { from: "user" },
+    );
+
+    const approvalRequest = callGateway.mock.calls
+      .map((call) => call[0])
+      .find((entry) => entry.method === "exec.approval.request");
+
+    expect(approvalRequest?.params).toMatchObject({
+      command: "echo hi",
+      commandArgv: ["echo", "hi"],
+      host: "node",
+      agentId: "main",
+    });
+    expect(approvalRequest?.params?.systemRunPlanV2).toBeUndefined();
+
+    const invokeRequest = callGateway.mock.calls
+      .map((call) => call[0])
+      .find((entry) => entry.method === "node.invoke");
+
+    expect(invokeRequest?.params?.params).toMatchObject({
+      command: ["echo", "hi"],
+      rawCommand: null,
+      agentId: "main",
+      approved: true,
+      approvalDecision: "allow-once",
+      runId: expect.any(String),
+    });
+  });
+});

--- a/src/cli/nodes-cli/register.invoke.nodes-run-prepare-fallback.test.ts
+++ b/src/cli/nodes-cli/register.invoke.nodes-run-prepare-fallback.test.ts
@@ -109,7 +109,7 @@ describe("nodes run prepare fallback (#29171)", () => {
       commands: ["system.run"],
       connected: true,
       permissions: { screenRecording: true },
-    };
+    } as (typeof nodeListResponse.nodes)[number];
   });
 
   it("falls back to system.run when the node does not advertise system.run.prepare", async () => {
@@ -275,6 +275,33 @@ describe("nodes run prepare fallback (#29171)", () => {
 
   it("does not fallback when generic unsupported-command errors omit the command", async () => {
     prepareErrorMessage = "command not supported";
+    nodeListResponse.nodes[0] = {
+      nodeId: "mac-1",
+      displayName: "Mac",
+      platform: "macos",
+      caps: [],
+      connected: true,
+      permissions: { screenRecording: true },
+    } as (typeof nodeListResponse.nodes)[number];
+
+    const program = new Command();
+    program.exitOverride();
+    registerNodesCli(program);
+
+    await program.parseAsync(["nodes", "run", "--node", "mac-1", "echo", "hi"], {
+      from: "user",
+    });
+
+    const invokeCommands = callGateway.mock.calls
+      .map((call) => call[0])
+      .filter((entry) => entry.method === "node.invoke")
+      .map((entry) => entry.params?.command);
+
+    expect(invokeCommands).toEqual(["system.run.prepare"]);
+  });
+
+  it("does not fallback when system.run.prepare is denied by allowlist policy", async () => {
+    prepareErrorMessage = 'node command not allowed: "system.run.prepare" is not in the allowlist';
     nodeListResponse.nodes[0] = {
       nodeId: "mac-1",
       displayName: "Mac",

--- a/src/cli/nodes-cli/register.invoke.nodes-run-prepare-fallback.test.ts
+++ b/src/cli/nodes-cli/register.invoke.nodes-run-prepare-fallback.test.ts
@@ -126,7 +126,7 @@ describe("nodes run prepare fallback (#29171)", () => {
       .filter((entry) => entry.method === "node.invoke")
       .map((entry) => entry.params?.command);
 
-    expect(invokeCommands).toEqual(["system.run"]);
+    expect(invokeCommands).toEqual(["system.run.prepare", "system.run"]);
   });
 
   it("requests approval without systemRunPlanV2 when it falls back to system.run", async () => {
@@ -153,7 +153,7 @@ describe("nodes run prepare fallback (#29171)", () => {
 
     const invokeRequest = callGateway.mock.calls
       .map((call) => call[0])
-      .find((entry) => entry.method === "node.invoke");
+      .find((entry) => entry.method === "node.invoke" && entry.params?.command === "system.run");
 
     expect(invokeRequest?.params?.params).toMatchObject({
       command: ["echo", "hi"],

--- a/src/cli/nodes-cli/register.invoke.nodes-run-prepare-fallback.test.ts
+++ b/src/cli/nodes-cli/register.invoke.nodes-run-prepare-fallback.test.ts
@@ -219,6 +219,33 @@ describe("nodes run prepare fallback (#29171)", () => {
     expect(invokeCommands).toEqual(["system.run.prepare", "system.run"]);
   });
 
+  it("does not fallback when node advertises neither system.run.prepare nor system.run", async () => {
+    nodeListResponse.nodes[0] = {
+      nodeId: "mac-1",
+      displayName: "Mac",
+      platform: "macos",
+      caps: [],
+      commands: ["system.describe"],
+      connected: true,
+      permissions: { screenRecording: true },
+    };
+
+    const program = new Command();
+    program.exitOverride();
+    registerNodesCli(program);
+
+    await program.parseAsync(["nodes", "run", "--node", "mac-1", "echo", "hi"], {
+      from: "user",
+    });
+
+    const invokeCommands = callGateway.mock.calls
+      .map((call) => call[0])
+      .filter((entry) => entry.method === "node.invoke")
+      .map((entry) => entry.params?.command);
+
+    expect(invokeCommands).toEqual(["system.run.prepare"]);
+  });
+
   it("falls back when the node host returns a generic unsupported-command error", async () => {
     prepareErrorMessage = "command not supported";
     nodeListResponse.nodes[0] = {

--- a/src/cli/nodes-cli/register.invoke.nodes-run-prepare-fallback.test.ts
+++ b/src/cli/nodes-cli/register.invoke.nodes-run-prepare-fallback.test.ts
@@ -246,8 +246,8 @@ describe("nodes run prepare fallback (#29171)", () => {
     expect(invokeCommands).toEqual(["system.run.prepare"]);
   });
 
-  it("falls back when the node host returns a generic unsupported-command error", async () => {
-    prepareErrorMessage = "command not supported";
+  it("falls back when unsupported-command errors mention system.run.prepare", async () => {
+    prepareErrorMessage = 'command not supported: "system.run.prepare"';
     nodeListResponse.nodes[0] = {
       nodeId: "mac-1",
       displayName: "Mac",
@@ -271,5 +271,32 @@ describe("nodes run prepare fallback (#29171)", () => {
       .map((entry) => entry.params?.command);
 
     expect(invokeCommands).toEqual(["system.run.prepare", "system.run"]);
+  });
+
+  it("does not fallback when generic unsupported-command errors omit the command", async () => {
+    prepareErrorMessage = "command not supported";
+    nodeListResponse.nodes[0] = {
+      nodeId: "mac-1",
+      displayName: "Mac",
+      platform: "macos",
+      caps: [],
+      connected: true,
+      permissions: { screenRecording: true },
+    } as (typeof nodeListResponse.nodes)[number];
+
+    const program = new Command();
+    program.exitOverride();
+    registerNodesCli(program);
+
+    await program.parseAsync(["nodes", "run", "--node", "mac-1", "echo", "hi"], {
+      from: "user",
+    });
+
+    const invokeCommands = callGateway.mock.calls
+      .map((call) => call[0])
+      .filter((entry) => entry.method === "node.invoke")
+      .map((entry) => entry.params?.command);
+
+    expect(invokeCommands).toEqual(["system.run.prepare"]);
   });
 });

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -171,9 +171,19 @@ function toPreparedNodesRunContext(
 
 function isUnsupportedNodeCommandError(error: unknown, command: string): boolean {
   const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  const normalized = message.toLowerCase();
+  if (normalized.includes("command not supported")) {
+    return true;
+  }
+  if (!normalized.includes("node command not allowed")) {
+    return false;
+  }
+  if (normalized.includes("did not declare any supported commands")) {
+    return true;
+  }
   return (
-    message.includes("node command not allowed") &&
-    message.includes(`does not support "${command}"`)
+    normalized.includes(command.toLowerCase()) &&
+    (normalized.includes("does not support") || normalized.includes("not in the allowlist"))
   );
 }
 

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -181,10 +181,7 @@ function isUnsupportedNodeCommandError(error: unknown, command: string): boolean
   if (normalized.includes("did not declare any supported commands")) {
     return true;
   }
-  return (
-    normalized.includes(command.toLowerCase()) &&
-    (normalized.includes("does not support") || normalized.includes("not in the allowlist"))
-  );
+  return normalized.includes(command.toLowerCase()) && normalized.includes("does not support");
 }
 
 function resolveNodesRunPolicy(opts: NodesRunOpts, execDefaults: ExecDefaults | undefined) {

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -235,16 +235,7 @@ async function prepareNodesRunContext(params: {
     });
 
   const advertisedCommands = Array.isArray(nodeInfo?.commands) ? nodeInfo.commands : null;
-  const advertisedSupportsPrepare = advertisedCommands?.includes("system.run.prepare") ?? false;
   const advertisedSupportsRun = advertisedCommands?.includes("system.run") ?? false;
-  if (advertisedCommands && !advertisedSupportsPrepare && advertisedSupportsRun) {
-    return {
-      prepared: fallbackPrepared(),
-      nodeEnv,
-      timeoutMs,
-      invokeTimeout,
-    };
-  }
 
   try {
     const prepareResponse = (await callGatewayCli("node.invoke", params.opts, {

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -238,7 +238,9 @@ async function prepareNodesRunContext(params: {
     });
 
   const advertisedCommands = Array.isArray(nodeInfo?.commands) ? nodeInfo.commands : null;
-  if (advertisedCommands && !advertisedCommands.includes("system.run.prepare")) {
+  const advertisedSupportsPrepare = advertisedCommands?.includes("system.run.prepare") ?? false;
+  const advertisedSupportsRun = advertisedCommands?.includes("system.run") ?? false;
+  if (advertisedCommands && !advertisedSupportsPrepare && advertisedSupportsRun) {
     return {
       prepared: fallbackPrepared(),
       nodeEnv,
@@ -268,6 +270,9 @@ async function prepareNodesRunContext(params: {
     };
   } catch (error) {
     if (!isUnsupportedNodeCommandError(error, "system.run.prepare")) {
+      throw error;
+    }
+    if (advertisedCommands && !advertisedSupportsRun) {
       throw error;
     }
     return {

--- a/src/cli/nodes-cli/register.invoke.ts
+++ b/src/cli/nodes-cli/register.invoke.ts
@@ -173,7 +173,7 @@ function isUnsupportedNodeCommandError(error: unknown, command: string): boolean
   const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
   const normalized = message.toLowerCase();
   if (normalized.includes("command not supported")) {
-    return true;
+    return normalized.includes(command.toLowerCase());
   }
   if (!normalized.includes("node command not allowed")) {
     return false;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw nodes run` always sent `system.run.prepare`, even when the selected node only advertised `system.run`.
- Why it matters: mixed-version gateway/app installs fail with `node command not allowed ... does not support "system.run.prepare"`, while the agent exec path keeps working.
- What changed: `nodes run` now skips `system.run.prepare` when the node explicitly omits it, falls back to a direct `system.run` approval/invoke flow, and keeps the existing prepared-plan path for nodes that do advertise `system.run.prepare`.
- What did NOT change (scope boundary): no gateway protocol changes, no node-host command changes, and no changes to the existing `system.run.prepare` behavior on newer nodes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #29171
- Related #

## User-visible / Behavior Changes

`openclaw nodes run` now works against nodes that advertise `system.run` but not `system.run.prepare`. Approval prompts still work on the fallback path, but the CLI no longer sends the unsupported prepare command first.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) Yes
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  The CLI now chooses between the existing prepared-plan path and the pre-existing direct `system.run` path based on the node's advertised commands. Coverage keeps the prepared-plan flow intact for newer nodes, and the new regression test covers the fallback path plus approval forwarding without `systemRunPlanV2`.

## Repro + Verification

### Environment

- OS: macOS Sequoia 15.x
- Runtime/container: Node 22 + pnpm workspace tests
- Model/provider: N/A
- Integration/channel (if any): nodes CLI
- Relevant config (redacted): mocked node list with `commands: ["system.run"]`

### Steps

1. Mock a connected node that advertises `commands: ["system.run"]` and rejects `node.invoke` `system.run.prepare` with `node command not allowed ... does not support "system.run.prepare"`.
2. Run `openclaw nodes run --node <id> echo hi`.
3. Observe the CLI behavior before and after this patch.

### Expected

- `nodes run` should invoke `system.run` directly when the node does not advertise `system.run.prepare`.
- Approval requests should still carry `command`/`commandArgv` on the fallback path.

### Actual

- Before this patch, `nodes run` always attempted `system.run.prepare` first and failed before it could invoke `system.run`.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced the failure locally with a focused Vitest harness that advertises only `system.run` and rejects `system.run.prepare`.
  - Verified `nodes run` now invokes only `system.run` on that node.
  - Verified approval requests on the fallback path omit `systemRunPlanV2` and still carry `command` and `commandArgv`.
  - Verified the existing prepared-plan coverage still passes for nodes that do not publish a command list.
- Edge cases checked:
  - Nodes with no advertised `commands` list still use the existing `system.run.prepare` path.
  - Nodes that unexpectedly reject `system.run.prepare` still fall back cleanly.
- What you did **not** verify:
  - A live mixed-version gateway/app pair outside the local mocked repro.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR to restore the prior always-prepare behavior.
- Files/config to restore: `src/cli/nodes-cli/register.invoke.ts`
- Known bad symptoms reviewers should watch for: missing `systemRunPlanV2` on nodes that do advertise `system.run.prepare`, or approval requests no longer carrying `commandArgv` on the fallback path.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: the CLI could skip `system.run.prepare` too aggressively and regress newer nodes.
  - Mitigation: it only skips prepare when the node explicitly advertises a commands list that omits `system.run.prepare`; otherwise the existing prepare path is unchanged, and the existing coverage suite still exercises that path.
- Risk: fallback approvals could lose context without `systemRunPlanV2`.
  - Mitigation: the new regression test asserts the fallback approval request still sends `command`, `commandArgv`, and the expected approval metadata.
