### PR TITLE
feat(hooks): bridge after_tool_call to internal hook handlers

### DIFF
--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -1,4 +1,5 @@
 import type { AgentEvent } from "@mariozechner/pi-agent-core";
+import { createInternalHookEvent, triggerInternalHook } from "../hooks/internal-hooks.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { PluginHookAfterToolCallEvent } from "../plugins/types.js";
@@ -455,4 +456,15 @@ export async function handleToolExecutionEnd(
         ctx.log.warn(`after_tool_call hook failed: tool=${toolName} error=${String(err)}`);
       });
   }
+
+  // Bridge to internal hook system so ~/.openclaw/hooks/ handlers can observe tool calls
+  void triggerInternalHook(
+    createInternalHookEvent("tool", "after_call", ctx.params.sessionKey ?? "", {
+      toolName,
+      params: afterToolCallArgs && typeof afterToolCallArgs === "object" ? afterToolCallArgs : {},
+      result: sanitizedResult,
+      error: isToolError ? extractToolErrorMessage(sanitizedResult) : undefined,
+      durationMs: startData?.startTime != null ? Date.now() - startData.startTime : undefined,
+    }),
+  );
 }

--- a/src/agents/pi-tool-definition-adapter.ts
+++ b/src/agents/pi-tool-definition-adapter.ts
@@ -164,6 +164,7 @@ export function toToolDefinitions(tools: AnyAgentTool[]): ToolDefinition[] {
             toolName: normalizedName,
             result: rawResult,
           });
+
           return result;
         } catch (err) {
           if (signal?.aborted) {

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -10,7 +10,13 @@ import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
-export type InternalHookEventType = "command" | "session" | "agent" | "gateway" | "message";
+export type InternalHookEventType =
+  | "command"
+  | "session"
+  | "agent"
+  | "gateway"
+  | "message"
+  | "tool";
 
 export type AgentBootstrapHookContext = {
   workspaceDir: string;
@@ -312,6 +318,25 @@ export async function triggerInternalHook(event: InternalHookEvent): Promise<voi
       log.error(`Hook error [${event.type}:${event.action}]: ${message}`);
     }
   }
+}
+
+// ============================================================================
+// Tool Hook Events
+// ============================================================================
+export type ToolAfterCallHookContext = {
+  toolName: string;
+  params: Record<string, unknown>;
+  result?: unknown;
+  error?: string;
+  durationMs?: number;
+};
+export type ToolAfterCallHookEvent = InternalHookEvent & {
+  type: "tool";
+  action: "after_call";
+  context: ToolAfterCallHookContext;
+};
+export function isToolAfterCallEvent(event: InternalHookEvent): event is ToolAfterCallHookEvent {
+  return event.type === "tool" && event.action === "after_call";
 }
 
 /**


### PR DESCRIPTION
Adds tool:after_call to the internal hook system so hooks in ~/.openclaw/hooks/ can actually see tool executions.

Right now after_tool_call only fires in the plugin pipeline. External hook handlers have no visibility into tool calls at all. This fixes that. ~40 lines, 3 files.

Ref: Discussion #20575

## Summary

- **Problem:** `after_tool_call` fires in the plugin pipeline but never calls `triggerInternalHook`, so external handlers in `~/.openclaw/hooks/` are blind to tool execution
- **Why it matters:** memory, observability, and audit hooks need per tool call data (tool name, params, result, errors, duration) to be useful
- **What changed:** added `tool:after_call` event type to internal hooks, bridged it from `handleToolExecutionEnd` where `runAfterToolCall` already fires. Removed an earlier adapter bridge to avoid double firing in embedded runs where `splitSdkTools` routes through both paths.
- **What did NOT change (scope boundary):** no changes to the plugin hook system itself, no new dependencies, no config changes, bridge call is fire and forget matching existing patterns

## Change Type (select all)

- [x] Feature

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution

## Linked Issue/PR

Related #20575

## User-visible / Behavior Changes

Hooks registered for `tool:after_call` will now fire on every tool execution. No existing behavior changes. No config required.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: Node v22
- Model/provider: any
- Relevant config (redacted): internal hooks enabled

### Steps

1. Create a hook at `~/.openclaw/hooks/tool-logger/handler.ts` that listens for `tool:after_call`
2. Run any agent task that uses tools
3. Check that the hook fires with `toolName`, `params`, `result`, and `durationMs` in the context

### Expected

Hook fires once per tool call with full context

### Actual

- Before this PR: hook never fires for tool events
- After this PR: hook fires with complete tool execution data

## Evidence

Code review shows the bridge call mirrors the existing plugin hook pattern. The `triggerInternalHook` call is placed after `runAfterToolCall` in `handleToolExecutionEnd`. Uses `afterToolCallArgs` (the adjusted params from `before_tool_call`) so the internal hook matches what actually executed.

## Human Verification (required)

- Verified scenarios: confirmed the bridge fires after the plugin hook, confirmed the type additions follow the same pattern as `AgentBootstrapHookEvent` and `GatewayStartupHookEvent`
- Edge cases checked: error path gets `extractToolErrorMessage(sanitizedResult)` in the same bridge call
- What you did not verify: end to end with a running gateway (no local OpenClaw install, built from reading source)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit, the `triggerInternalHook` call is isolated and fire and forget
- Files/config to restore: `src/hooks/internal-hooks.ts`, `src/agents/pi-embedded-subscribe.handlers.tools.ts`
- Known bad symptoms reviewers should watch for: unexpected errors in gateway logs from `tool:after_call` handlers

## Risks and Mitigations

- **Risk:** a slow or throwing hook handler could log errors on every tool call
  - **Mitigation:** `triggerInternalHook` already catches and logs handler errors without blocking the agent pipeline, same as existing hook events

## Notes

AI-assisted (Claude). Tested by reading source and verifying patterns. No local OpenClaw gateway to test end to end.