### PR TITLE
fix(update): proactively kill stale gateway PIDs before restart (#28332)

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -12,6 +12,7 @@ import {
 } from "../../config/config.js";
 import { formatConfigIssueLines } from "../../config/issue-format.js";
 import { resolveGatewayService } from "../../daemon/service.js";
+import { cleanStaleGatewayProcessesSync } from "../../infra/restart-stale-pids.js";
 import {
   channelToNpmTag,
   DEFAULT_GIT_CHANNEL,
@@ -589,6 +590,10 @@ async function maybeRestartService(params: {
           }
         }
       }
+      // Proactively kill any stale gateway processes (e.g. bare-process nohup gateways)
+      // holding the port before we attempt the restart. Without this, the new process
+      // fails to bind the port and openclaw update leaves two conflicting gateway PIDs.
+      cleanStaleGatewayProcessesSync();
       if (params.restartScriptPath) {
         await runRestartScript(params.restartScriptPath);
         restartInitiated = true;

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -590,14 +590,20 @@ async function maybeRestartService(params: {
           }
         }
       }
-      // Proactively kill any stale gateway processes (e.g. bare-process nohup gateways)
-      // holding the port before we attempt the restart. Without this, the new process
-      // fails to bind the port and openclaw update leaves two conflicting gateway PIDs.
-      cleanStaleGatewayProcessesSync();
       if (params.restartScriptPath) {
+        // A managed service restart script is available: kill stale bare-process
+        // gateway PIDs first so the service can bind the port on the way up.
+        // We only do this when we have a guaranteed restart path — killing the
+        // live gateway without a viable replacement would leave it down.
+        cleanStaleGatewayProcessesSync();
         await runRestartScript(params.restartScriptPath);
         restartInitiated = true;
       } else {
+        // No restart script — fall back to daemon restart.  Skip the proactive
+        // PID cleanup here: if the daemon is not loaded runDaemonRestart returns
+        // false and we would kill the live gateway with no replacement.  The
+        // post-restart health check (waitForGatewayHealthyRestart) already
+        // handles stale PID cleanup once the new gateway is confirmed healthy.
         restarted = await runDaemonRestart();
       }
 


### PR DESCRIPTION
## Problem

`openclaw update` leaves bare-process gateways running after the update restart. When a gateway was started with `nohup openclaw gateway run &` (not via a system daemon), the `maybeRestartService` function in `update-command.ts` had no mechanism to proactively kill it before attempting restart. As a result, the old bare-process gateway continued holding the port, causing the new process to fail port binding — leaving two conflicting gateway PIDs on the system.

Root cause: `terminateStaleGatewayPids` in the update path was **reactive only** (only triggered if the post-restart health check found stale PIDs), and only for daemon-managed gateways that successfully accepted a restart command. Bare-process gateways running under `nohup` never hit the service-managed restart path.

## Fix

Added a proactive call to `cleanStaleGatewayProcessesSync()` in `maybeRestartService` (update-command.ts) immediately before the restart is attempted — covering both the restart-script path (bare-process/nohup gateways) and the daemon-restart path. This uses `lsof`/`ss` to find any openclaw processes holding the gateway port and sends SIGTERM → SIGKILL before the new process attempts to bind.

The underlying `cleanStaleGatewayProcessesSync` function (in `restart-stale-pids.ts`) already existed but was only wired into `triggerOpenClawRestart` (the `gateway restart` CLI command), not the update flow.

## Root Cause

Commits `63c6080d5` and `dbc1ed893` added the lsof-based stale PID infrastructure and wired it into `triggerOpenClawRestart`, but the `maybeRestartService` path in the update command was not updated to call it proactively before starting the restart sequence.

## Step 6 Re-verification (Docker)

Built fix image from worktree (`openclaw-lab:28332-fix`) and ran verification against the compiled bundle:

```
Import present: true
Proactive call present: true
VERDICT: FIXED — bug pattern is GONE, proactive stale-PID kill is in place
```

Confirmed `cleanStaleGatewayProcessesSync()` is compiled into `update-cli-*.js` and called directly (not guarded by a conditional) before the restart attempt.