### PR TITLE
fix(iris): force SMS delivery for DM replies + wire Ollama think parameter

### DIFF
--- a/extensions/imessage/src/monitor/inbound-processing.ts
+++ b/extensions/imessage/src/monitor/inbound-processing.ts
@@ -584,7 +584,9 @@ export function buildIMessageInboundContext(params: {
     });
   }
 
-  const imessageTo = (decision.isGroup ? chatTarget : undefined) || `imessage:${decision.sender}`;
+  // Force SMS for DM replies — "imessage:" hardcodes iMessage delivery,
+  // "sms:" guarantees SMS delivery for recipients without iMessage.
+  const imessageTo = (decision.isGroup ? chatTarget : undefined) || `sms:${decision.sender}`;
   const inboundHistory =
     decision.isGroup && decision.historyKey && params.historyLimit > 0
       ? (params.groupHistories.get(decision.historyKey) ?? []).map((entry) => ({


### PR DESCRIPTION
## Summary

Two independent bug fixes:

1. **SMS delivery for DM replies** (`src/imessage/monitor/inbound-processing.ts`): Change DM reply target prefix from `imessage:` to `sms:` — guarantees SMS delivery for recipients without iMessage. The old `imessage:` prefix hardcoded iMessage delivery, bypassing the channel's `service: "sms"` config.

2. **Ollama think parameter** (`src/agents/ollama-stream.ts`): Wire the `think` parameter through to Ollama API requests so extended thinking/reasoning models work correctly.

## Test plan

- [ ] DM reply to a non-iMessage recipient delivers via SMS
- [ ] Ollama models with thinking support receive the `think` parameter
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)