### PR TITLE
feat(whatsapp): add group metadata service for runtime group name resolution

### DIFF
--- a/src/agents/tools/whatsapp-actions.ts
+++ b/src/agents/tools/whatsapp-actions.ts
@@ -2,6 +2,7 @@ import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { OpenClawConfig } from "../../config/config.js";
 import { sendReactionWhatsApp } from "../../web/outbound.js";
 import { createActionGate, jsonResult, readReactionParams, readStringParam } from "./common.js";
+import { handleWhatsAppListGroups } from "./whatsapp-groups.js";
 import { resolveAuthorizedWhatsAppOutboundTarget } from "./whatsapp-target-auth.js";
 
 export async function handleWhatsAppAction(
@@ -10,6 +11,10 @@ export async function handleWhatsAppAction(
 ): Promise<AgentToolResult<unknown>> {
   const action = readStringParam(params, "action", { required: true });
   const isActionEnabled = createActionGate(cfg.channels?.whatsapp?.actions);
+
+  if (action === "listGroups") {
+    return await handleWhatsAppListGroups(params, cfg);
+  }
 
   if (action === "react") {
     if (!isActionEnabled("reactions")) {

--- a/src/agents/tools/whatsapp-groups.ts
+++ b/src/agents/tools/whatsapp-groups.ts
@@ -1,0 +1,26 @@
+import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import type { OpenClawConfig } from "../../config/config.js";
+import { listGroups, searchGroups } from "../../web/group-metadata.js";
+import { jsonResult, readStringParam } from "./common.js";
+
+export async function handleWhatsAppListGroups(
+  params: Record<string, unknown>,
+  cfg: OpenClawConfig,
+): Promise<AgentToolResult<unknown>> {
+  const query = readStringParam(params, "query");
+  const groups = query ? await searchGroups(query) : await listGroups();
+  const configuredGroups = cfg.channels?.whatsapp?.groups ?? {};
+
+  const result = Array.from(groups.entries()).map(([jid, meta]) => {
+    const groupCfg = configuredGroups[jid];
+    return {
+      jid,
+      name: groupCfg?.name ?? meta.subject,
+      isCommunity: meta.isCommunity,
+      linkedParent: meta.linkedParent,
+      configuredAs: groupCfg?.requireMention,
+    };
+  });
+
+  return jsonResult(result);
+}

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -15,6 +15,8 @@ export type WhatsAppActionConfig = {
 };
 
 export type WhatsAppGroupConfig = {
+  /** Human-readable group name (resolved automatically or set manually). */
+  name?: string;
   requireMention?: boolean;
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -13,6 +13,7 @@ const ToolPolicyBySenderSchema = z.record(z.string(), ToolPolicySchema).optional
 
 const WhatsAppGroupEntrySchema = z
   .object({
+    name: z.string().optional(),
     requireMention: z.boolean().optional(),
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,

--- a/src/web/group-metadata.test.ts
+++ b/src/web/group-metadata.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearGroupMetadataProvider,
+  getGroupMetadata,
+  listGroups,
+  searchGroups,
+  setGroupMetadataProvider,
+} from "./group-metadata.js";
+
+const makeProvider = (
+  data: Record<string, { subject?: string; isCommunity?: boolean; linkedParent?: string }>,
+) => ({
+  groupFetchAllParticipating: vi.fn().mockResolvedValue(data),
+});
+
+afterEach(() => {
+  clearGroupMetadataProvider();
+});
+
+describe("group-metadata", () => {
+  it("returns empty map when no provider registered", async () => {
+    const groups = await listGroups();
+    expect(groups.size).toBe(0);
+  });
+
+  it("getGroupMetadata returns null when no provider registered", async () => {
+    const result = await getGroupMetadata("123@g.us");
+    expect(result).toBeNull();
+  });
+
+  it("lists groups from provider", async () => {
+    const provider = makeProvider({
+      "111@g.us": { subject: "Family", isCommunity: false },
+      "222@g.us": { subject: "Work", isCommunity: true, linkedParent: "333@g.us" },
+    });
+    setGroupMetadataProvider(provider);
+
+    const groups = await listGroups();
+    expect(groups.size).toBe(2);
+    expect(groups.get("111@g.us")).toEqual({
+      subject: "Family",
+      isCommunity: false,
+      linkedParent: undefined,
+    });
+    expect(groups.get("222@g.us")).toEqual({
+      subject: "Work",
+      isCommunity: true,
+      linkedParent: "333@g.us",
+    });
+  });
+
+  it("caches data on second call", async () => {
+    const provider = makeProvider({
+      "111@g.us": { subject: "Family" },
+    });
+    setGroupMetadataProvider(provider);
+
+    await listGroups();
+    await listGroups();
+    expect(provider.groupFetchAllParticipating).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-fetches after TTL expires", async () => {
+    const provider = makeProvider({
+      "111@g.us": { subject: "Family" },
+    });
+    setGroupMetadataProvider(provider);
+
+    await listGroups();
+    expect(provider.groupFetchAllParticipating).toHaveBeenCalledTimes(1);
+
+    // Advance time past TTL (5 minutes)
+    vi.useFakeTimers();
+    vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+    await listGroups();
+    expect(provider.groupFetchAllParticipating).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  it("getGroupMetadata returns entry for known jid", async () => {
+    setGroupMetadataProvider(
+      makeProvider({
+        "111@g.us": { subject: "Family", isCommunity: false },
+      }),
+    );
+
+    const meta = await getGroupMetadata("111@g.us");
+    expect(meta).toEqual({
+      subject: "Family",
+      isCommunity: false,
+      linkedParent: undefined,
+    });
+  });
+
+  it("getGroupMetadata returns null for unknown jid", async () => {
+    setGroupMetadataProvider(
+      makeProvider({
+        "111@g.us": { subject: "Family" },
+      }),
+    );
+
+    const meta = await getGroupMetadata("999@g.us");
+    expect(meta).toBeNull();
+  });
+
+  it("searchGroups matches by subject", async () => {
+    setGroupMetadataProvider(
+      makeProvider({
+        "111@g.us": { subject: "Family Chat" },
+        "222@g.us": { subject: "Work Team" },
+        "333@g.us": { subject: "Family Photos" },
+      }),
+    );
+
+    const results = await searchGroups("family");
+    expect(results.size).toBe(2);
+    expect(results.has("111@g.us")).toBe(true);
+    expect(results.has("333@g.us")).toBe(true);
+  });
+
+  it("searchGroups matches by jid", async () => {
+    setGroupMetadataProvider(
+      makeProvider({
+        "111@g.us": { subject: "Group A" },
+        "222@g.us": { subject: "Group B" },
+      }),
+    );
+
+    const results = await searchGroups("222");
+    expect(results.size).toBe(1);
+    expect(results.has("222@g.us")).toBe(true);
+  });
+
+  it("searchGroups returns empty for no matches", async () => {
+    setGroupMetadataProvider(
+      makeProvider({
+        "111@g.us": { subject: "Family" },
+      }),
+    );
+
+    const results = await searchGroups("nonexistent");
+    expect(results.size).toBe(0);
+  });
+
+  it("clearGroupMetadataProvider clears cache", async () => {
+    const provider = makeProvider({
+      "111@g.us": { subject: "Family" },
+    });
+    setGroupMetadataProvider(provider);
+
+    await listGroups();
+    clearGroupMetadataProvider();
+
+    const groups = await listGroups();
+    expect(groups.size).toBe(0);
+  });
+
+  it("defaults subject to jid when missing", async () => {
+    setGroupMetadataProvider(
+      makeProvider({
+        "111@g.us": {},
+      }),
+    );
+
+    const meta = await getGroupMetadata("111@g.us");
+    expect(meta?.subject).toBe("111@g.us");
+  });
+});

--- a/src/web/group-metadata.ts
+++ b/src/web/group-metadata.ts
@@ -1,0 +1,87 @@
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("gateway/channels/whatsapp").child("group-metadata");
+
+export type GroupMetadataEntry = {
+  subject: string;
+  isCommunity: boolean;
+  linkedParent?: string;
+};
+
+export type GroupMetadataProvider = {
+  groupFetchAllParticipating: () => Promise<
+    Record<string, { subject?: string; isCommunity?: boolean; linkedParent?: string }>
+  >;
+};
+
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+let provider: GroupMetadataProvider | null = null;
+let cache: Map<string, GroupMetadataEntry> | null = null;
+let cacheTimestamp = 0;
+
+export function setGroupMetadataProvider(p: GroupMetadataProvider): void {
+  provider = p;
+  cache = null;
+  cacheTimestamp = 0;
+  log.debug("Group metadata provider registered");
+}
+
+export function clearGroupMetadataProvider(): void {
+  provider = null;
+  cache = null;
+  cacheTimestamp = 0;
+  log.debug("Group metadata provider cleared");
+}
+
+async function fetchAndCache(): Promise<Map<string, GroupMetadataEntry>> {
+  if (!provider) {
+    return new Map();
+  }
+  try {
+    const raw = await provider.groupFetchAllParticipating();
+    const map = new Map<string, GroupMetadataEntry>();
+    for (const [jid, meta] of Object.entries(raw)) {
+      map.set(jid, {
+        subject: meta.subject ?? jid,
+        isCommunity: meta.isCommunity === true,
+        linkedParent: meta.linkedParent ?? undefined,
+      });
+    }
+    cache = map;
+    cacheTimestamp = Date.now();
+    log.debug(`Cached metadata for ${map.size} groups`);
+    return map;
+  } catch (err) {
+    log.warn(`Failed to fetch group metadata: ${String(err)}`);
+    return cache ?? new Map();
+  }
+}
+
+function isCacheStale(): boolean {
+  return !cache || Date.now() - cacheTimestamp > CACHE_TTL_MS;
+}
+
+export async function listGroups(): Promise<Map<string, GroupMetadataEntry>> {
+  if (isCacheStale()) {
+    return await fetchAndCache();
+  }
+  return cache!;
+}
+
+export async function getGroupMetadata(jid: string): Promise<GroupMetadataEntry | null> {
+  const groups = await listGroups();
+  return groups.get(jid) ?? null;
+}
+
+export async function searchGroups(query: string): Promise<Map<string, GroupMetadataEntry>> {
+  const groups = await listGroups();
+  const lower = query.toLowerCase();
+  const results = new Map<string, GroupMetadataEntry>();
+  for (const [jid, meta] of groups) {
+    if (meta.subject.toLowerCase().includes(lower) || jid.toLowerCase().includes(lower)) {
+      results.set(jid, meta);
+    }
+  }
+  return results;
+}

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -8,6 +8,7 @@ import { getChildLogger } from "../../logging/logger.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { saveMediaBuffer } from "../../media/store.js";
 import { jidToE164, resolveJidToE164 } from "../../utils.js";
+import { clearGroupMetadataProvider, setGroupMetadataProvider } from "../group-metadata.js";
 import { createWaSocket, getStatusCode, waitForWaConnection } from "../session.js";
 import { checkInboundAccessControl } from "./access-control.js";
 import { isRecentInboundMessage } from "./dedupe.js";
@@ -41,6 +42,9 @@ export async function monitorWebInbox(options: {
     authDir: options.authDir,
   });
   await waitForWaConnection(sock);
+  setGroupMetadataProvider({
+    groupFetchAllParticipating: () => sock.groupFetchAllParticipating(),
+  });
   const connectedAtMs = Date.now();
 
   let onCloseResolve: ((reason: WebListenerCloseReason) => void) | null = null;
@@ -431,6 +435,7 @@ export async function monitorWebInbox(options: {
   ) => {
     try {
       if (update.connection === "close") {
+        clearGroupMetadataProvider();
         const status = getStatusCode(update.lastDisconnect?.error);
         resolveClose({
           status,


### PR DESCRIPTION
## Summary

Adds a WhatsApp group metadata resolution layer so agents can query group names at runtime without restarts.

### Problem

WhatsApp groups in config are identified by JID only (`120363000000001234@g.us`) which is meaningless to admins. When asked "add the Book Club group to the allowlist", the agent has no way to look up which JID corresponds to which group name.

### Solution

A lightweight singleton service that wraps Baileys' `groupFetchAllParticipating()` with a lazy 5-minute TTL cache, following the same pattern as `ActiveWebListener`.

### Changes

**New files:**
- `src/web/group-metadata.ts` — Singleton service (~87 lines). Decoupled from Baileys via `GroupMetadataProvider` interface. Lazy fetch + TTL cache, no timers.
- `src/agents/tools/whatsapp-groups.ts` — Tool handler for `action: "listGroups"` with optional `query` filtering
- `src/web/group-metadata.test.ts` — 12 unit tests

**Modified:**
- `src/web/inbound/monitor.ts` — Registers/clears provider on connect/disconnect
- `src/config/types.whatsapp.ts` — Added optional `name` field to `WhatsAppGroupConfig`
- `src/config/zod-schema.providers-whatsapp.ts` — Added `name` to Zod schema
- `src/agents/tools/whatsapp-actions.ts` — Routes `listGroups` action

### Design decisions
- **No new dependencies** — pure TypeScript
- **Follows ActiveWebListener pattern** — singleton set/clear lifecycle
- **Lazy, not eager** — no boot-time fetch, no background timers
- **Agent decides** — service provides data, agent uses config.patch to persist names
- **Backward compatible** — `name` field is optional, existing configs unchanged