### PR TITLE
fix(slack): disable draft preview when block streaming is offFix slack draft preview dup send

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.test.ts
+++ b/src/slack/monitor/message-handler/dispatch.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { isSlackDraftPreviewEnabled } from "./dispatch.js";
+
+describe("isSlackDraftPreviewEnabled", () => {
+  it("returns false when slack preview streaming is off", () => {
+    expect(
+      isSlackDraftPreviewEnabled({
+        mode: "off",
+        blockStreaming: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when block streaming is explicitly disabled", () => {
+    expect(
+      isSlackDraftPreviewEnabled({
+        mode: "partial",
+        blockStreaming: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps preview enabled when streaming is available and block streaming is allowed", () => {
+    expect(
+      isSlackDraftPreviewEnabled({
+        mode: "partial",
+        blockStreaming: true,
+      }),
+    ).toBe(true);
+    expect(
+      isSlackDraftPreviewEnabled({
+        mode: "progress",
+        blockStreaming: undefined,
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -36,6 +36,13 @@ export function isSlackStreamingEnabled(params: {
   return params.nativeStreaming;
 }
 
+export function isSlackDraftPreviewEnabled(params: {
+  mode: "off" | "partial" | "block" | "progress";
+  blockStreaming: boolean | undefined;
+}): boolean {
+  return params.mode !== "off" && params.blockStreaming !== false;
+}
+
 export function resolveSlackStreamingThreadHint(params: {
   replyToMode: "off" | "first" | "all";
   incomingThreadTs: string | undefined;
@@ -162,6 +169,13 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     nativeStreaming: account.config.nativeStreaming,
   });
   const previewStreamingEnabled = slackStreaming.mode !== "off";
+  const draftPreviewEnabled = isSlackDraftPreviewEnabled({
+    mode: slackStreaming.mode,
+    blockStreaming: account.config.blockStreaming,
+  });
+  if (previewStreamingEnabled && !draftPreviewEnabled) {
+    logVerbose("slack: draft preview disabled (blockStreaming=false)");
+  }
   const streamingEnabled = isSlackStreamingEnabled({
     mode: slackStreaming.mode,
     nativeStreaming: slackStreaming.nativeStreaming,
@@ -255,7 +269,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       const draftChannelId = draftStream?.channelId();
       const finalText = payload.text;
       const canFinalizeViaPreviewEdit =
-        previewStreamingEnabled &&
+        draftPreviewEnabled &&
         streamMode !== "status_final" &&
         mediaCount === 0 &&
         !payload.isError &&
@@ -279,7 +293,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             `slack: preview final edit failed; falling back to standard send (${String(err)})`,
           );
         }
-      } else if (previewStreamingEnabled && streamMode === "status_final" && hasStreamedMessage) {
+      } else if (draftPreviewEnabled && streamMode === "status_final" && hasStreamedMessage) {
         try {
           const statusChannelId = draftStream?.channelId();
           const statusMessageId = draftStream?.messageId();
@@ -358,7 +372,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     hasStreamedMessage = true;
   };
   const onDraftBoundary =
-    useStreaming || !previewStreamingEnabled
+    useStreaming || !draftPreviewEnabled
       ? undefined
       : async () => {
           if (hasStreamedMessage) {
@@ -386,7 +400,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       onModelSelected,
       onPartialReply: useStreaming
         ? undefined
-        : !previewStreamingEnabled
+        : !draftPreviewEnabled
           ? undefined
           : async (payload) => {
               updateDraftFromPartial(payload.text);


### PR DESCRIPTION
  ## Summary
  - disable Slack draft preview updates when `channels.slack.blockStreaming` is explicitly set to `false`
  - keep native streaming behavior unchanged and retain the existing final-delivery path
  - add a regression test for the preview enablement gate

  ## Root Cause
  Slack currently still enables the draft preview lane whenever the resolved Slack stream mode is not `off`. That means `onPartialReply`, draft
  preview edits, and the final `chat.update` path can still run even when `blockStreaming=false` is intended to disable block-style preview output.

  In practice this can surface as duplicate visible replies in Slack channels: one draft preview message and one final reply.

  ## Fix
  This PR introduces `isSlackDraftPreviewEnabled()` and makes draft-preview-only paths depend on that gate instead of the broader `mode !== "off"`
  check. When `blockStreaming=false`, the Slack draft preview lane is now disabled consistently.

  ## Notes
  - I did not run the full test suite in this environment; the PR includes a focused unit test for the new gate.