### PR TITLE
Docs: add soft reset, permission presets, and orchestrator+workers guides

### DIFF
--- a/docs/gateway/permission-presets.md
+++ b/docs/gateway/permission-presets.md
@@ -1,0 +1,74 @@
+---
+summary: "Autonomy presets with explicit risk boundaries"
+title: "Permission presets"
+---
+
+# Permission presets
+
+Permission presets make autonomy explicit and reduce ambiguity in day-to-day operation.
+
+## SAFE
+
+Best for new deployments and sensitive contexts.
+
+### Allowed
+- Read-only analysis
+- Drafting docs/plans
+- Non-destructive local inspection
+
+### Approval required
+- External/public messaging
+- Destructive actions
+- Security/config changes
+
+## BALANCED (recommended default)
+
+Best for routine operations.
+
+### Allowed
+- SAFE actions
+- Routine local edits/commands
+- Monitoring and reporting loops
+
+### Approval required
+- Public/external sends
+- Credential/secret changes
+- High-impact automation changes
+
+## POWER
+
+Best for advanced operators with active oversight.
+
+### Allowed
+- BALANCED actions
+- Multi-step autonomous execution
+- Worker orchestration flows
+
+### Still gated
+- External/public actions
+- Broad destructive operations
+- Security posture changes
+
+## Selecting a preset
+
+Start with **BALANCED**. Move to **POWER** only when:
+- scope is explicit,
+- rollback path exists,
+- logging/audit is enabled,
+- escalation path is defined.
+
+## Oversight baseline (all presets)
+
+- Approval for external sends
+- Approval for destructive operations
+- Log major actions
+- Prefer reversible changes first
+
+## Example policy block
+
+```md
+Current preset: BALANCED
+Auto-allowed: local analysis, drafting, routine edits, monitoring loops
+Approval-required: external messaging, credential changes, destructive ops
+Escalation: notify owner before irreversible action
+```

--- a/docs/ops/soft-reset.md
+++ b/docs/ops/soft-reset.md
@@ -1,0 +1,73 @@
+---
+summary: "Reset mission/behavior without reinstalling integrations"
+title: "Soft reset"
+---
+
+# Soft reset
+
+A **soft reset** re-aligns assistant behavior (mission, tone, working style) without rebuilding channels, integrations, or local tooling.
+
+Use this when the assistant is off-target, too noisy/passive, or mismatched to current priorities.
+
+## Soft reset vs full reset
+
+### Soft reset
+- Rewrites behavior/context files
+- Keeps channels, skills, and environment setup
+- Usually takes 10–20 minutes
+
+### Full reset
+- Rebuilds setup from scratch
+- Reconnects channels/integrations
+- Use when environment/config itself is broken
+
+## What to rewrite vs keep
+
+### Rewrite (behavior-critical)
+- `SOUL.md`
+- `USER.md`
+- `WORKSTYLE.md`
+- `memory/YYYY-MM-DD.md` (add reset marker)
+
+### Usually keep
+- `TOOLS.md`
+- Channel/integration config
+- Installed skills
+- Service/environment setup
+
+### Optional cleanup
+- Prune outdated sections in `MEMORY.md`
+- Archive stale project notes
+
+## 10-minute checklist
+
+1. Rewrite `SOUL.md` for current mission/tone.
+2. Update `USER.md` with current goals and preferences.
+3. Update `WORKSTYLE.md` with current execution style.
+4. Add a dated reset note in today’s memory file.
+5. Run one real task as a validation pass.
+6. Tune once; avoid repeated micro-edits.
+
+## Validation
+
+- [ ] Tone matches expected vibe
+- [ ] Initiative level is appropriate
+- [ ] No breakage in channels/tools
+- [ ] First post-reset task needed less handholding
+
+## Common mistakes
+
+- Full reinstall for behavior-only issues
+- Editing many files before running one test task
+- Rotating tokens/channels unnecessarily
+
+## Reset note template
+
+```md
+Soft reset performed: YYYY-MM-DD
+Reason: [brief]
+New mission focus: [brief]
+Kept unchanged: integrations/channels/tools
+Validation task: [task]
+Outcome: [pass/fix needed]
+```

--- a/docs/tools/orchestrator-workers.md
+++ b/docs/tools/orchestrator-workers.md
@@ -1,0 +1,81 @@
+---
+summary: "Canonical multi-agent pattern for planning, execution, and validation"
+title: "Orchestrator + workers"
+---
+
+# Orchestrator + workers
+
+Use this pattern when one session is overloaded with planning, execution, and QA.
+
+## Roles
+
+### Orchestrator
+- Owns objective and priorities
+- Delegates scoped tasks
+- Merges worker outputs
+- Escalates only high-signal updates
+- Makes final go/no-go decisions
+
+### Workers
+- Handle one focused job each (research, implementation, validation)
+- Return structured outputs
+- Avoid side effects unless explicitly allowed
+
+## Minimal workflow
+
+1. Orchestrator writes task brief.
+2. Worker A gathers sources/facts.
+3. Worker B performs implementation/drafting.
+4. Worker C validates quality/risk.
+5. Orchestrator merges outputs, decides, logs.
+
+## Split vs single-session rule
+
+Split into separate worker sessions when:
+- tasks are independent,
+- expected runtime is >10 minutes,
+- tools differ significantly,
+- failure isolation matters.
+
+Keep in one session when:
+- work is short and linear,
+- risk is low,
+- parallelism adds little value.
+
+## Handoff contract
+
+Each worker should return:
+- `Summary:` 2–5 lines
+- `Artifacts:` files/links changed
+- `Risks:` uncertainties/blockers
+- `Next step:` one recommendation
+
+## Oversight defaults
+
+- Approval gate for external/public actions
+- Approval gate for destructive operations
+- One final owner (orchestrator) for merges
+- Log each worker cycle outcome
+
+## Starter template
+
+```md
+Objective:
+Constraints:
+Definition of done:
+
+Worker A (Research)
+- Scope:
+- Deliverable:
+
+Worker B (Implementation)
+- Scope:
+- Deliverable:
+
+Worker C (Validation)
+- Scope:
+- Deliverable:
+
+Merge rules:
+Approval required for:
+```


### PR DESCRIPTION
## PR summary (short)
This PR adds three operational docs to reduce recurring confusion in setup and scaling workflows:
- soft reset (behavior reset without reinstall)
- permission presets (SAFE/BALANCED/POWER)
- orchestrator + workers pattern (split rules + handoff contract)

The goal is faster self-serve onboarding and clearer autonomy/oversight boundaries.