### PR TITLE
docs(plugins): add @cyzlmh/openclaw-sms to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,8 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **SMS (Aliyun + Tencent)** — Outbound SMS channel plugin for mainland-friendly delivery through Aliyun SMS or Tencent Cloud SMS templates.
+  npm: `@cyzlmh/openclaw-sms`
+  repo: `https://github.com/cyzlmh/openclaw-sms`
+  install: `openclaw plugins install @cyzlmh/openclaw-sms`


### PR DESCRIPTION
## Summary
Add the new community-maintained SMS plugin entry:
- npm: `@cyzlmh/openclaw-sms`
- repo: https://github.com/cyzlmh/openclaw-sms
- install: `openclaw plugins install @cyzlmh/openclaw-sms`

## Context
This follows guidance from closed PR #24202 to maintain the SMS integration as a third-party plugin in its own repository and then submit a community listing update.
