### PR TITLE
Docs: add provider compatibility policy and lead-machine playbook

### DIFF
--- a/docs/playbooks/lead-machine.md
+++ b/docs/playbooks/lead-machine.md
@@ -1,0 +1,68 @@
+---
+summary: "Starter playbook for scout agents, warm-lead scoring, and human handoff"
+title: "Lead machine playbook"
+---
+
+# Lead machine playbook
+
+This playbook helps you run a lightweight scout + gatekeeper workflow and only escalate warm leads to a human.
+
+## Roles
+
+## Scout workers
+- Monitor target channels/communities
+- Engage with useful, non-spam responses
+- Capture lead context in structured notes
+
+## Gatekeeper (orchestrator)
+- Reviews scout summaries
+- Scores lead intent
+- Escalates only high-intent leads
+
+## Human closer
+- Handles final conversation/demo/booking
+- Can pause automation for a lead
+
+## Warm-lead scoring rubric (0–10)
+
+- Problem clarity (0–2)
+- Budget/authority signal (0–2)
+- Timeline urgency (0–2)
+- Response engagement (0–2)
+- Fit with offer/persona (0–2)
+
+Suggested threshold:
+- **0–4:** cold
+- **5–7:** monitor/nurture
+- **8–10:** escalate to human
+
+## Escalation template (Telegram/DM)
+
+```md
+Lead alert: WARM (score: 8/10)
+Source: <channel/thread>
+Summary: <2-3 lines>
+Signals: <budget/timeline/problem>
+Suggested action: <dm / call / demo>
+```
+
+## Pause/resume control per lead
+
+- `pause <lead-id>`: scout stops engagement for that lead
+- `resume <lead-id>`: scout resumes monitoring/engagement
+- Always pause when human takes direct ownership
+
+## Safety and compliance
+
+- Do not impersonate real individuals
+- Avoid deceptive claims
+- Respect platform terms and anti-spam rules
+- Keep approvals for high-risk or public actions
+
+## Starter implementation pattern
+
+1. Scout captures opportunities
+2. Gatekeeper scores leads
+3. Gatekeeper escalates only warm leads
+4. Human closes
+5. Outcome logged for rubric tuning

--- a/docs/policy/provider-compatibility.md
+++ b/docs/policy/provider-compatibility.md
@@ -1,0 +1,58 @@
+---
+summary: "Support tiers and risk boundaries for provider integrations"
+title: "Provider compatibility policy"
+---
+
+# Provider compatibility policy
+
+This policy defines how provider integrations are categorized and documented.
+
+## Support tiers
+
+## Tier 1 — Officially supported
+- Maintained in core docs and release flow
+- Covered by tests/validation expectations
+- Eligible for normal issue support
+
+## Tier 2 — Community-supported (use with caution)
+- May work reliably for some users
+- Not guaranteed across releases
+- Limited/no maintainer support commitment
+
+## Tier 3 — Not recommended
+- Conflicts with legal/ToS/security expectations, or
+- Requires fragile/unsafe workarounds
+
+## Evaluation criteria
+
+A provider/path is evaluated on:
+- Technical reliability
+- Security posture
+- Terms-of-service/legal clarity
+- Maintenance burden
+- User safety and supportability
+
+## PR acceptance guidance (provider-related)
+
+Maintainers should require:
+- Clear auth model and token handling
+- No bypass of existing safeguards
+- Explicit risk notes in docs
+- Testability or clear validation plan
+- Legal/ToS compatibility statement where relevant
+
+If legal/ToS status is unclear, prefer Tier 2 labeling or decline.
+
+## Documentation requirements
+
+Provider docs should always include:
+- Support tier label
+- Known limitations
+- Upgrade/breakage risk note
+- Rollback instructions
+
+## User-facing defaults
+
+- Recommend Tier 1 by default
+- Present Tier 2 as experimental
+- Avoid recommending Tier 3 paths


### PR DESCRIPTION
# PR Package — Follow-up Docs (Provider Policy + Lead Machine)

## PR title
Docs: add provider compatibility policy and lead-machine playbook

## PR body (copy/paste)
This PR adds two follow-up operational docs focused on support boundaries and practical business workflow automation.

### Added
- `docs/policy/provider-compatibility.md`
- `docs/playbooks/lead-machine.md`

### Why
After the core docs PR, the next recurring needs are:
1. Clear tiering for provider integrations (official/community/not recommended)
2. Practical starter guidance for scout → gatekeeper → human lead handoff

### Highlights
- Compatibility tier model with acceptance criteria
- PR guidance for provider-related contributions
- Lead scoring rubric + escalation template + pause/resume controls

### Acceptance criteria
- Users can distinguish safe/supported vs risky integration paths
- Non-coder operators can run a basic lead machine workflow
- Safety/oversight boundaries remain explicit
