### PR TITLE
Add PIC Standard Guard to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,6 +45,11 @@ Use this format when adding entries:
 
 ## Listed plugins
 
+- **PIC Standard Guard** — Provenance & Intent Contract verification for OpenClaw tool calls. Enforces fail-closed governance on every tool call via a three-hook system (gate, init, audit).
+  npm: `pic-guard`
+  repo: `https://github.com/madeinplutofabio/pic-standard`
+  install: `openclaw plugins install pic-guard`
+
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`


### PR DESCRIPTION
## Summary
- Adds `pic-guard` to the community plugins listing
- Published on npm: https://www.npmjs.com/package/pic-guard
- Source: https://github.com/madeinplutofabio/pic-standard/tree/main/integrations/openclaw
- Follow-up from #14704, where maintainers suggested submitting as a community plugin

## What it does
PIC Standard Guard enforces Provenance & Intent Contract governance on OpenClaw tool calls through three lifecycle hooks:
- **pic-gate** (`before_tool_call`) — verifies `__pic` proposals before execution (fail-closed)
- **pic-init** (`before_agent_start`) — injects PIC awareness into sessions
- **pic-audit** (`tool_result_persist`) — logs structured audit records

## Checklist
- [x] Published on npm (`pic-guard@0.6.1`)
- [x] Public GitHub repo with issue tracking
- [x] Documentation (README, per-hook HOOK.md files, integration guide)
- [x] Tests (14 passing, CI via GitHub Actions)
- [x] Active maintenance (Dependabot, multiple releases)

## Change Type
- [x] Docs

## Scope
- [x] Integrations

## Security Impact
- All `No` — docs-only change, no code modified.