### PR TITLE
fix: deduplicate memory bootstrap files by inode on case-insensitive filesystems

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -170,6 +170,27 @@ describe("loadWorkspaceBootstrapFiles", () => {
     expectSingleMemoryEntry(files, "alt");
   });
 
+  it("deduplicates when MEMORY.md and memory.md resolve to the same inode", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    await writeWorkspaceFile({ dir: tempDir, name: "MEMORY.md", content: "shared" });
+    // On case-insensitive FS (macOS APFS), memory.md already exists as the
+    // same file.  On case-sensitive FS (Linux), create a symlink so both
+    // names share an inode.
+    try {
+      await fs.symlink(path.join(tempDir, "MEMORY.md"), path.join(tempDir, "memory.md"));
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw err;
+      }
+    }
+
+    const files = await loadWorkspaceBootstrapFiles(tempDir);
+    expectSingleMemoryEntry(files, "shared");
+  });
+
   it("omits memory entries when no memory files exist", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
 

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -484,8 +484,13 @@ async function resolveMemoryBootstrapEntries(
   for (const entry of entries) {
     let key = entry.filePath;
     try {
-      key = await fs.realpath(entry.filePath);
-    } catch {}
+      const stat = await fs.stat(entry.filePath);
+      key = `${stat.dev}:${stat.ino}`;
+    } catch {
+      try {
+        key = await fs.realpath(entry.filePath);
+      } catch {}
+    }
     if (seen.has(key)) {
       continue;
     }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -186,12 +186,12 @@ export function buildGatewayCronService(params: {
       // fully resolved agent heartbeat config so cron-triggered heartbeats
       // respect agent-specific overrides (agents.list[].heartbeat) before
       // falling back to agents.defaults.heartbeat.
-      const agentEntry = Array.isArray(runtimeConfig.agents?.list)
-        ? runtimeConfig.agents.list.find(
-            (entry) =>
-              entry && typeof entry.id === "string" && normalizeAgentId(entry.id) === agentId,
-          )
-        : undefined;
+      const agentEntry =
+        Array.isArray(runtimeConfig.agents?.list) &&
+        runtimeConfig.agents.list.find(
+          (entry) =>
+            entry && typeof entry.id === "string" && normalizeAgentId(entry.id) === agentId,
+        );
       const baseHeartbeat = {
         ...runtimeConfig.agents?.defaults?.heartbeat,
         ...agentEntry?.heartbeat,

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -186,12 +186,12 @@ export function buildGatewayCronService(params: {
       // fully resolved agent heartbeat config so cron-triggered heartbeats
       // respect agent-specific overrides (agents.list[].heartbeat) before
       // falling back to agents.defaults.heartbeat.
-      const agentEntry =
-        Array.isArray(runtimeConfig.agents?.list) &&
-        runtimeConfig.agents.list.find(
-          (entry) =>
-            entry && typeof entry.id === "string" && normalizeAgentId(entry.id) === agentId,
-        );
+      const agentEntry = Array.isArray(runtimeConfig.agents?.list)
+        ? runtimeConfig.agents.list.find(
+            (entry) =>
+              entry && typeof entry.id === "string" && normalizeAgentId(entry.id) === agentId,
+          )
+        : undefined;
       const baseHeartbeat = {
         ...runtimeConfig.agents?.defaults?.heartbeat,
         ...agentEntry?.heartbeat,


### PR DESCRIPTION
## Summary

- **Bug**: On VirtioFS bind mounts (macOS case-insensitive APFS → Linux container), both `MEMORY.md` and `memory.md` pass `fs.access()` since the FS resolves them to the same file. The existing dedup logic used `fs.realpath()`, but Linux's `realpath` doesn't normalize case — it returns both paths as distinct strings, so both survive dedup and get loaded, doubling token usage.
- **Fix**: Replace `realpath`-based string comparison with `fs.stat()` inode comparison (`dev:ino`), which is the definitive same-file check on all POSIX systems regardless of filesystem case sensitivity. Falls back to `realpath` then raw path if `stat` fails.
- **Test**: Added test case that verifies dedup when both filenames resolve to the same inode (works on both case-insensitive macOS and case-sensitive Linux via symlink).

## Test plan

- [x] New unit test passes on macOS (case-insensitive FS — EEXIST path)
- [ ] New unit test passes on Linux CI (case-sensitive FS — symlink path)
- [x] All existing `workspace.test.ts` tests pass
- [x] `pnpm build` succeeds
- [x] `oxfmt --check` passes
- [ ] Rebuild with `./launch.sh` in openclaw-docker and confirm only one MEMORY.md appears in loaded context