### PR TITLE
fix(memory): narrow empty catch clauses and log sqlite-vec errors

### DIFF
--- a/src/memory/internal.ts
+++ b/src/memory/internal.ts
@@ -96,7 +96,11 @@ export async function listMemoryFiles(
         return;
       }
       result.push(absPath);
-    } catch {}
+    } catch (err) {
+      if (!isFileMissingError(err)) {
+        throw err;
+      }
+    }
   };
 
   await addMarkdownFile(memoryFile);
@@ -106,7 +110,11 @@ export async function listMemoryFiles(
     if (!dirStat.isSymbolicLink() && dirStat.isDirectory()) {
       await walkDir(memoryDir, result);
     }
-  } catch {}
+  } catch (err) {
+    if (!isFileMissingError(err)) {
+      throw err;
+    }
+  }
 
   const normalizedExtraPaths = normalizeExtraMemoryPaths(workspaceDir, extraPaths);
   if (normalizedExtraPaths.length > 0) {
@@ -123,7 +131,11 @@ export async function listMemoryFiles(
         if (stat.isFile() && inputPath.endsWith(".md")) {
           result.push(inputPath);
         }
-      } catch {}
+      } catch (err) {
+        if (!isFileMissingError(err)) {
+          throw err;
+        }
+      }
     }
   }
   if (result.length <= 1) {

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -729,7 +729,11 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           .run(entry.path, options.source);
       } catch (err) {
         // sqlite-vec extension may not be loaded; vector rows will be orphaned until next full reindex
-        log.debug("Failed to delete from vector table before reindex", { path: entry.path, source: options.source, err });
+        log.debug("Failed to delete from vector table before reindex", {
+          path: entry.path,
+          source: options.source,
+          err,
+        });
       }
     }
     if (this.fts.enabled && this.fts.available) {
@@ -738,7 +742,11 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
           .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
           .run(entry.path, options.source, this.provider.model);
       } catch (err) {
-        log.debug("Failed to delete from FTS table before reindex", { path: entry.path, source: options.source, err });
+        log.debug("Failed to delete from FTS table before reindex", {
+          path: entry.path,
+          source: options.source,
+          err,
+        });
       }
     }
     this.db

--- a/src/memory/manager-embedding-ops.ts
+++ b/src/memory/manager-embedding-ops.ts
@@ -727,14 +727,19 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
             `DELETE FROM ${VECTOR_TABLE} WHERE id IN (SELECT id FROM chunks WHERE path = ? AND source = ?)`,
           )
           .run(entry.path, options.source);
-      } catch {}
+      } catch (err) {
+        // sqlite-vec extension may not be loaded; vector rows will be orphaned until next full reindex
+        log.debug("Failed to delete from vector table before reindex", { path: entry.path, source: options.source, err });
+      }
     }
     if (this.fts.enabled && this.fts.available) {
       try {
         this.db
           .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
           .run(entry.path, options.source, this.provider.model);
-      } catch {}
+      } catch (err) {
+        log.debug("Failed to delete from FTS table before reindex", { path: entry.path, source: options.source, err });
+      }
     }
     this.db
       .prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`)
@@ -771,7 +776,10 @@ export abstract class MemoryManagerEmbeddingOps extends MemoryManagerSyncOps {
       if (vectorReady && embedding.length > 0) {
         try {
           this.db.prepare(`DELETE FROM ${VECTOR_TABLE} WHERE id = ?`).run(id);
-        } catch {}
+        } catch (err) {
+          // sqlite-vec extension may not be loaded; stale vector row will be replaced on insert
+          log.debug("Failed to delete stale vector row before upsert", { id, err });
+        }
         this.db
           .prepare(`INSERT INTO ${VECTOR_TABLE} (id, embedding) VALUES (?, ?)`)
           .run(id, vectorToBlob(embedding));

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -698,7 +698,10 @@ export abstract class MemoryManagerSyncOps {
           .run(stale.path, "memory");
       } catch (err) {
         // sqlite-vec extension may not be loaded; vector rows cleaned up with chunks below
-        log.debug("Failed to delete from vector table for stale memory file", { path: stale.path, err });
+        log.debug("Failed to delete from vector table for stale memory file", {
+          path: stale.path,
+          err,
+        });
       }
       this.db.prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`).run(stale.path, "memory");
       if (this.fts.enabled && this.fts.available) {
@@ -707,7 +710,10 @@ export abstract class MemoryManagerSyncOps {
             .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
             .run(stale.path, "memory", this.provider.model);
         } catch (err) {
-          log.debug("Failed to delete from FTS table for stale memory file", { path: stale.path, err });
+          log.debug("Failed to delete from FTS table for stale memory file", {
+            path: stale.path,
+            err,
+          });
         }
       }
     }
@@ -808,7 +814,10 @@ export abstract class MemoryManagerSyncOps {
           .run(stale.path, "sessions");
       } catch (err) {
         // sqlite-vec extension may not be loaded; vector rows cleaned up with chunks below
-        log.debug("Failed to delete from vector table for stale session file", { path: stale.path, err });
+        log.debug("Failed to delete from vector table for stale session file", {
+          path: stale.path,
+          err,
+        });
       }
       this.db
         .prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`)
@@ -819,7 +828,10 @@ export abstract class MemoryManagerSyncOps {
             .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
             .run(stale.path, "sessions", this.provider.model);
         } catch (err) {
-          log.debug("Failed to delete from FTS table for stale session file", { path: stale.path, err });
+          log.debug("Failed to delete from FTS table for stale session file", {
+            path: stale.path,
+            err,
+          });
         }
       }
     }

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -696,14 +696,19 @@ export abstract class MemoryManagerSyncOps {
             `DELETE FROM ${VECTOR_TABLE} WHERE id IN (SELECT id FROM chunks WHERE path = ? AND source = ?)`,
           )
           .run(stale.path, "memory");
-      } catch {}
+      } catch (err) {
+        // sqlite-vec extension may not be loaded; vector rows cleaned up with chunks below
+        log.debug("Failed to delete from vector table for stale memory file", { path: stale.path, err });
+      }
       this.db.prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`).run(stale.path, "memory");
       if (this.fts.enabled && this.fts.available) {
         try {
           this.db
             .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
             .run(stale.path, "memory", this.provider.model);
-        } catch {}
+        } catch (err) {
+          log.debug("Failed to delete from FTS table for stale memory file", { path: stale.path, err });
+        }
       }
     }
   }
@@ -801,7 +806,10 @@ export abstract class MemoryManagerSyncOps {
             `DELETE FROM ${VECTOR_TABLE} WHERE id IN (SELECT id FROM chunks WHERE path = ? AND source = ?)`,
           )
           .run(stale.path, "sessions");
-      } catch {}
+      } catch (err) {
+        // sqlite-vec extension may not be loaded; vector rows cleaned up with chunks below
+        log.debug("Failed to delete from vector table for stale session file", { path: stale.path, err });
+      }
       this.db
         .prepare(`DELETE FROM chunks WHERE path = ? AND source = ?`)
         .run(stale.path, "sessions");
@@ -810,7 +818,9 @@ export abstract class MemoryManagerSyncOps {
           this.db
             .prepare(`DELETE FROM ${FTS_TABLE} WHERE path = ? AND source = ? AND model = ?`)
             .run(stale.path, "sessions", this.provider.model);
-        } catch {}
+        } catch (err) {
+          log.debug("Failed to delete from FTS table for stale session file", { path: stale.path, err });
+        }
       }
     }
   }
@@ -1154,7 +1164,9 @@ export abstract class MemoryManagerSyncOps {
     if (this.fts.enabled && this.fts.available) {
       try {
         this.db.exec(`DELETE FROM ${FTS_TABLE}`);
-      } catch {}
+      } catch (err) {
+        log.debug("Failed to clear FTS table during index reset", { err });
+      }
     }
     this.dropVectorTable();
     this.vector.dims = undefined;

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -543,7 +543,11 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
               break;
             }
           }
-        } catch {}
+        } catch (err) {
+          if (!isFileMissingError(err)) {
+            throw err;
+          }
+        }
       }
     }
     if (!allowedWorkspace && !allowedAdditional) {


### PR DESCRIPTION
Titre :


fix(memory): narrow empty catch clauses and log sqlite-vec errors
Description :


## What

Narrow overly-broad `catch {}` blocks in the memory subsystem that were
silently swallowing all errors.

**`src/memory/internal.ts`** — 3 catch blocks now re-throw non-ENOENT
errors using the existing `isFileMissingError` helper (pattern already
used in `buildFileEntry` in the same file).

**`src/memory/manager.ts`** — Same fix for the `additionalPaths` lstat loop.

**`src/memory/manager-sync-ops.ts` + `manager-embedding-ops.ts`** —
sqlite-vec optional extension catch blocks now emit `log.debug` instead
of silently discarding the error, making failures visible without
changing behaviour.

## Why

Permission errors (EACCES) and unexpected I/O failures were
indistinguishable from normal file-not-found cases. The sqlite-vec
catches were completely invisible in logs, making it hard to debug
optional extension issues.

## Testing

- [x] AI-assisted (Claude Code)
- [ ] Lightly tested
- Existing memory tests cover the changed paths