### PR TITLE
fix(windows): prevent conhost.exe zombie leak + fix agentEntry type narrowing

### DIFF
--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -53,6 +53,12 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
       env: process.env,
       detached: true,
       stdio: "inherit",
+      // On Windows, `stdio: "inherit"` causes Node to allocate a conhost.exe
+      // (Console Host) for each spawned child. These are never reaped when the
+      // child calls unref(), so they accumulate over time — one per cron run.
+      // `windowsHide: true` suppresses the console window allocation entirely,
+      // preventing the leak. No-op on macOS/Linux.
+      windowsHide: true,
     });
     child.unref();
     return { mode: "spawned", pid: child.pid ?? undefined };


### PR DESCRIPTION
## Changes

### 1. fix(windows): prevent conhost.exe zombie process leak

On Windows, the gateway accumulates hundreds of zombie \conhost.exe\ (Windows Console Host) processes over time, one per cron execution. These are never reaped and consume significant RAM.

**Root cause:** In \src/infra/process-respawn.ts\, \estartGatewayProcessWithFreshPid()\ spawns a detached child with \stdio: 'inherit'\. On Windows this causes Node.js to allocate a \conhost.exe\ for the child's console I/O. When \child.unref()\ is called, the Node event loop detaches from the child -- but the \conhost.exe\ stays alive as a zombie indefinitely.

**Observed impact (real production system, 9 cron jobs, ~7h uptime):**
- 404 zombie \conhost.exe\ processes
- 3.5 GB RAM consumed by zombies
- Periodic CPU spikes
- Gateway required manual restart to recover

**Fix:** Add \windowsHide: true\ to the \spawn()\ options. This suppresses console window (and \conhost.exe\) allocation on Windows entirely. No-op on macOS/Linux, zero cross-platform risk.

\\\	s
// src/infra/process-respawn.ts
const child = spawn(process.execPath, args, {
  env: process.env,
  detached: true,
  stdio: 'inherit',
  windowsHide: true,  // prevents conhost.exe allocation on Windows
});
\\\

---

### 2. fix(types): guard agentEntry against false before accessing heartbeat

Pre-existing TypeScript error caught by CI:

\\\
src/gateway/server-cron.ts(197,24): error TS2339: Property 'heartbeat' does not exist on type 'false | AgentConfig'
\\\

\gentEntry\ is the result of \Array.find()\ which can return \alse\ when no matching agent is found. The spread \...agentEntry?.heartbeat\ doesn't narrow the \alse\ case properly.

**Fix:** Explicit type guard before spreading:

\\\	s
// before
...agentEntry?.heartbeat,

// after
...(agentEntry && agentEntry !== false ? agentEntry.heartbeat : undefined),
\\\

---

## Tested on
- Windows 10 22H2, Node.js v24.13.0
- Before conhost fix: 404 zombies @ 3.5 GB after 7h with 9 active cron jobs
- After conhost fix: 0 \conhost.exe\ accumulation

## References
- [Node.js docs: child_process.spawn windowsHide](https://nodejs.org/api/child_process.html#optionswindowshide)