### PR TITLE
docs: add D-Chat/nMobile community plugin

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,6 +45,11 @@ Use this format when adding entries:
 
 ## Listed plugins
 
+- **D-Chat / nMobile** — Decentralized E2E encrypted messaging over the NKN relay network. Supports DM, topics, private groups, and IPFS media.
+  npm: `@zbruceli/openclaw-dchat`
+  repo: `https://github.com/zbruceli/openclaw-dchat`
+  install: `openclaw plugins install @zbruceli/openclaw-dchat`
+
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`


### PR DESCRIPTION
## Summary

- Adds **D-Chat / nMobile** to the community plugins listing page

## Plugin details

- npm: [`@zbruceli/openclaw-dchat`](https://www.npmjs.com/package/@zbruceli/openclaw-dchat)
- repo: https://github.com/zbruceli/openclaw-dchat
- Decentralized E2E encrypted messaging over the NKN relay network — supports DM, topics, private groups, and IPFS media
- Install: `openclaw plugins install @zbruceli/openclaw-dchat`