### PR TITLE
feat: warn on unrecognized primary/fallback model names at gateway startup

### DIFF
--- a/src/gateway/server-startup-model-validation.ts
+++ b/src/gateway/server-startup-model-validation.ts
@@ -1,0 +1,119 @@
+import { DEFAULT_PROVIDER } from "../agents/defaults.js";
+import type { ModelCatalogEntry } from "../agents/model-catalog.js";
+import { loadModelCatalog } from "../agents/model-catalog.js";
+import { resolveModelRefFromString } from "../agents/model-selection.js";
+import type { loadConfig } from "../config/config.js";
+import {
+  resolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue,
+} from "../config/model-input.js";
+
+/**
+ * Find the best matching model name suggestion for an unrecognized model,
+ * using prefix matching within the same provider.
+ */
+function findClosestModelSuggestion(
+  catalog: ModelCatalogEntry[],
+  provider: string,
+  modelId: string,
+): string | undefined {
+  const normalizedProvider = provider.toLowerCase().trim();
+  const normalizedModelId = modelId.toLowerCase().trim();
+
+  // Restrict candidates to the same provider first.
+  const providerModels = catalog.filter(
+    (entry) => entry.provider.toLowerCase() === normalizedProvider,
+  );
+
+  let bestMatch: ModelCatalogEntry | undefined;
+  let bestPrefixLen = 0;
+
+  for (const entry of providerModels) {
+    const entryId = entry.id.toLowerCase();
+    let prefixLen = 0;
+    const minLen = Math.min(normalizedModelId.length, entryId.length);
+    for (let i = 0; i < minLen; i++) {
+      if (normalizedModelId[i] === entryId[i]) {
+        prefixLen++;
+      } else {
+        break;
+      }
+    }
+    if (prefixLen > bestPrefixLen) {
+      bestPrefixLen = prefixLen;
+      bestMatch = entry;
+    }
+  }
+
+  // Only suggest if there's a meaningful prefix overlap (> 3 chars to avoid noise).
+  if (bestMatch && bestPrefixLen > 3) {
+    return `${bestMatch.provider}/${bestMatch.id}`;
+  }
+
+  return undefined;
+}
+
+/**
+ * Validate that primary and fallback model names in the config exist in the
+ * model catalog.  Emits a clear warning for each unrecognized model so the
+ * user can fix typos early (e.g. "google/gemini-3-pro" vs the real
+ * "google/gemini-3-pro-preview").
+ *
+ * This is intentionally non-fatal: custom / local model names that are not
+ * yet in the catalog should not break startup.
+ */
+export async function validateConfiguredModelNames(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  log: { warn: (msg: string) => void };
+}): Promise<void> {
+  try {
+    const catalog = await loadModelCatalog({ config: params.cfg });
+    if (catalog.length === 0) {
+      // Cannot validate without a populated catalog — skip silently.
+      return;
+    }
+
+    const agentModel = params.cfg.agents?.defaults?.model;
+    const primaryRaw = resolveAgentModelPrimaryValue(agentModel);
+    const fallbackRaws = resolveAgentModelFallbackValues(agentModel);
+
+    const modelsToCheck: Array<{ raw: string; role: string }> = [];
+    if (primaryRaw) {
+      modelsToCheck.push({ raw: primaryRaw, role: "Primary model" });
+    }
+    for (const fb of fallbackRaws) {
+      const trimmed = (fb ?? "").trim();
+      if (trimmed) {
+        modelsToCheck.push({ raw: trimmed, role: "Fallback model" });
+      }
+    }
+
+    for (const { raw, role } of modelsToCheck) {
+      const resolved = resolveModelRefFromString({
+        raw,
+        defaultProvider: DEFAULT_PROVIDER,
+      });
+      if (!resolved) {
+        continue;
+      }
+
+      const { provider, model: modelId } = resolved.ref;
+      const inCatalog = catalog.some(
+        (entry) =>
+          entry.provider.toLowerCase() === provider.toLowerCase() &&
+          entry.id.toLowerCase() === modelId.toLowerCase(),
+      );
+
+      if (!inCatalog) {
+        const suggestion = findClosestModelSuggestion(catalog, provider, modelId);
+        const suggestionText = suggestion ? ` Did you mean "${suggestion}"?` : "";
+        params.log.warn(
+          `[config-warn] ${role} "${provider}/${modelId}" is not recognized.${suggestionText} Run \`openclaw models list\` for valid names.`,
+        );
+      }
+    }
+  } catch (err) {
+    // Never let validation failures break startup.
+    params.log.warn(`[config-warn] Model name validation skipped: ${String(err)}`);
+  }
+}

--- a/src/gateway/server-startup.ts
+++ b/src/gateway/server-startup.ts
@@ -28,6 +28,7 @@ import {
   shouldWakeFromRestartSentinel,
 } from "./server-restart-sentinel.js";
 import { startGatewayMemoryBackend } from "./server-startup-memory.js";
+import { validateConfiguredModelNames } from "./server-startup-model-validation.js";
 
 const SESSION_LOCK_STALE_MS = 30 * 60 * 1000;
 
@@ -60,6 +61,9 @@ export async function startGatewaySidecars(params: {
   } catch (err) {
     params.log.warn(`session lock cleanup failed on startup: ${String(err)}`);
   }
+
+  // Validate primary and fallback model names against the model catalog.
+  await validateConfiguredModelNames({ cfg: params.cfg, log: params.log });
 
   // Start OpenClaw browser control server (unless disabled via config).
   let browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> = null;


### PR DESCRIPTION
## Problem

When a user configures an invalid fallback model name (e.g. `google/gemini-3-pro` instead of the correct `google/gemini-3-pro-preview`), the fallback silently fails at runtime with a confusing error like `All models failed (1)` — no indication that the model name itself is wrong.

## Solution

Add a `validateConfiguredModelNames()` function that runs once at gateway startup and checks all configured primary and fallback model names against the live model catalog.

- ✅ Warns clearly when a model name is unrecognized
- ✅ Suggests the closest available model name using prefix matching (e.g. _"Did you mean `google/gemini-3-pro-preview`?"_)
- ✅ Non-fatal — warning only, so custom/local models that aren't in the catalog don't break startup
- ✅ Gracefully skips validation if the catalog can't be loaded

## Example output

```
[config-warn] Fallback model "google/gemini-3-pro" is not recognized. Did you mean "google/gemini-3-pro-preview"? Run `openclaw models list` for valid names.
```

## Files changed

- `src/gateway/server-startup-model-validation.ts` — new validation module
- `src/gateway/server-startup.ts` — hooked into startup sequence