### PR TITLE
fix: align hook status with loader by checking events (#24981)

### DIFF
--- a/src/cli/hooks-cli.test.ts
+++ b/src/cli/hooks-cli.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { HookStatusReport } from "../hooks/hooks-status.js";
-import { formatHooksCheck, formatHooksList } from "./hooks-cli.js";
+import { formatHookInfo, formatHooksCheck, formatHooksList } from "./hooks-cli.js";
 import { createEmptyInstallChecks } from "./requirements-test-fixtures.js";
 
 const report: HookStatusReport = {
@@ -71,6 +71,9 @@ describe("hooks cli formatting", () => {
 
     const checkOutput = formatHooksCheck(noEventsReport, {});
     expect(checkOutput).toContain("no events defined");
+
+    const infoOutput = formatHookInfo(noEventsReport, "empty-hook", {});
+    expect(infoOutput).toContain("No events defined");
   });
 
   it("labels plugin-managed hooks with plugin id", () => {

--- a/src/cli/hooks-cli.test.ts
+++ b/src/cli/hooks-cli.test.ts
@@ -40,6 +40,39 @@ describe("hooks cli formatting", () => {
     expect(output).toContain("Hooks Status");
   });
 
+  it("shows no-events status for hooks without events", () => {
+    const noEventsReport: HookStatusReport = {
+      workspaceDir: "/tmp/workspace",
+      managedHooksDir: "/tmp/hooks",
+      hooks: [
+        {
+          name: "empty-hook",
+          description: "Hook with no events",
+          source: "openclaw-managed",
+          pluginId: undefined,
+          filePath: "/tmp/hooks/empty-hook/HOOK.md",
+          baseDir: "/tmp/hooks/empty-hook",
+          handlerPath: "/tmp/hooks/empty-hook/handler.js",
+          hookKey: "empty-hook",
+          emoji: "🔗",
+          homepage: undefined,
+          events: [],
+          always: false,
+          disabled: false,
+          eligible: false,
+          managedByPlugin: false,
+          ...createEmptyInstallChecks(),
+        },
+      ],
+    };
+
+    const listOutput = formatHooksList(noEventsReport, {});
+    expect(listOutput).toContain("no events");
+
+    const checkOutput = formatHooksCheck(noEventsReport, {});
+    expect(checkOutput).toContain("no events defined");
+  });
+
   it("labels plugin-managed hooks with plugin id", () => {
     const pluginReport: HookStatusReport = {
       workspaceDir: "/tmp/workspace",

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -123,6 +123,9 @@ function formatHookStatus(hook: HookStatusEntry): string {
   if (hook.disabled) {
     return theme.warn("⏸ disabled");
   }
+  if (hook.events.length === 0) {
+    return theme.warn("⚠ no events");
+  }
   return theme.error("✗ missing");
 }
 
@@ -336,7 +339,9 @@ export function formatHookInfo(
     ? theme.success("✓ Ready")
     : hook.disabled
       ? theme.warn("⏸ Disabled")
-      : theme.error("✗ Missing requirements");
+      : hook.events.length === 0
+        ? theme.warn("⚠ No events defined")
+        : theme.error("✗ Missing requirements");
 
   lines.push(`${emoji} ${theme.heading(hook.name)} ${status}`);
   lines.push("");
@@ -454,6 +459,9 @@ export function formatHooksCheck(report: HookStatusReport, opts: HooksCheckOptio
       const reasons = [];
       if (hook.disabled) {
         reasons.push("disabled");
+      }
+      if (hook.events.length === 0) {
+        reasons.push("no events defined");
       }
       if (hook.missing.bins.length > 0) {
         reasons.push(`bins: ${hook.missing.bins.join(", ")}`);

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -463,8 +463,11 @@ export function formatHooksCheck(report: HookStatusReport, opts: HooksCheckOptio
       if (hook.disabled) {
         reasons.push("disabled");
       } else if (hook.events.length === 0) {
-        // Mirrors exclusive-priority logic in formatHookStatus / formatHookInfo
+        // Sole reason — missing-requirement details would mislead the user
+        // into fixing the wrong thing when the real issue is no events defined.
         reasons.push("no events defined");
+        lines.push(`  ${hook.emoji ?? "🔗"} ${hook.name} - ${reasons.join("; ")}`);
+        continue;
       }
       if (hook.missing.bins.length > 0) {
         reasons.push(`bins: ${hook.missing.bins.join(", ")}`);

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -462,8 +462,8 @@ export function formatHooksCheck(report: HookStatusReport, opts: HooksCheckOptio
       const reasons = [];
       if (hook.disabled) {
         reasons.push("disabled");
-      }
-      if (hook.events.length === 0) {
+      } else if (hook.events.length === 0) {
+        // Mirrors exclusive-priority logic in formatHookStatus / formatHookInfo
         reasons.push("no events defined");
       }
       if (hook.missing.bins.length > 0) {

--- a/src/cli/hooks-cli.ts
+++ b/src/cli/hooks-cli.ts
@@ -87,7 +87,9 @@ function resolveHookForToggle(
     );
   }
   if (opts?.requireEligible && !hook.eligible) {
-    throw new Error(`Hook "${hookName}" is not eligible (missing requirements)`);
+    // Surface the most specific reason so users understand why enable was rejected
+    const reason = hook.events.length === 0 ? "no events defined" : "missing requirements";
+    throw new Error(`Hook "${hookName}" is not eligible (${reason})`);
   }
   return hook;
 }
@@ -433,6 +435,7 @@ export function formatHooksCheck(report: HookStatusReport, opts: HooksCheckOptio
           eligible: eligible.map((h) => h.name),
           notEligible: notEligible.map((h) => ({
             name: h.name,
+            events: h.events,
             missing: h.missing,
           })),
         },

--- a/src/hooks/hooks-status.test.ts
+++ b/src/hooks/hooks-status.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { buildWorkspaceHookStatus } from "./hooks-status.js";
+import type { HookEntry } from "./types.js";
+
+function createHookEntry(overrides?: Partial<HookEntry> & { events?: string[] }): HookEntry {
+  const events = overrides?.events ?? ["command:new"];
+  return {
+    hook: {
+      name: "test-hook",
+      description: "A test hook",
+      source: "openclaw-bundled",
+      filePath: "/tmp/hooks/test-hook/HOOK.md",
+      baseDir: "/tmp/hooks/test-hook",
+      handlerPath: "/tmp/hooks/test-hook/handler.js",
+      ...overrides?.hook,
+    },
+    frontmatter: overrides?.frontmatter ?? {},
+    metadata: {
+      events,
+      ...overrides?.metadata,
+    },
+  };
+}
+
+describe("buildWorkspaceHookStatus", () => {
+  it("marks hook with events as eligible", () => {
+    const entry = createHookEntry({ events: ["command:new"] });
+    const report = buildWorkspaceHookStatus("/tmp/workspace", { entries: [entry] });
+
+    expect(report.hooks).toHaveLength(1);
+    expect(report.hooks[0].eligible).toBe(true);
+  });
+
+  it("marks hook with no events as not eligible", () => {
+    const entry = createHookEntry({ events: [] });
+    const report = buildWorkspaceHookStatus("/tmp/workspace", { entries: [entry] });
+
+    expect(report.hooks).toHaveLength(1);
+    expect(report.hooks[0].eligible).toBe(false);
+  });
+
+  it("marks hook with undefined metadata as not eligible", () => {
+    const entry: HookEntry = {
+      hook: {
+        name: "no-metadata-hook",
+        description: "Hook with no metadata",
+        source: "openclaw-bundled",
+        filePath: "/tmp/hooks/no-metadata/HOOK.md",
+        baseDir: "/tmp/hooks/no-metadata",
+        handlerPath: "/tmp/hooks/no-metadata/handler.js",
+      },
+      frontmatter: {},
+      metadata: undefined,
+    };
+    const report = buildWorkspaceHookStatus("/tmp/workspace", { entries: [entry] });
+
+    expect(report.hooks).toHaveLength(1);
+    // metadata?.events ?? [] yields [], so eligible should be false
+    expect(report.hooks[0].eligible).toBe(false);
+  });
+});

--- a/src/hooks/hooks-status.ts
+++ b/src/hooks/hooks-status.ts
@@ -101,7 +101,8 @@ function buildHookStatus(
       isConfigSatisfied,
     });
 
-  const eligible = !disabled && requirementsSatisfied;
+  // Match loader behavior: hooks with no events are not loaded (loader.ts:109-113)
+  const eligible = !disabled && requirementsSatisfied && events.length > 0;
 
   return {
     name: entry.hook.name,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `buildHookStatus()` in `hooks-status.ts` computed `eligible` without checking `events.length`, so a managed hook with no events configured was reported as `ready` even though the hook loader (`loader.ts:109-113`) skips such hooks.
- Why it matters: Users running `openclaw hooks list` or `openclaw hooks info` would see a hook displayed as "ready" or "✓ Ready" while the hook runner silently never loaded it — a silent misconfiguration with no actionable signal.
- What changed: Added `events.length > 0` to the `eligible` computation in `hooks-status.ts`, and added matching display branches in `hooks-cli.ts` ("⚠ no events" in list view, "⚠ No events defined" in info view, "no events defined" reason in check output).
- What did NOT change (scope boundary): The hook loader, hook runner, plugin system, and all other channels/commands are untouched. This is a status-display alignment fix only.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24981
- Related #

## User-visible / Behavior Changes

`openclaw hooks list`: hooks with no events now show `⚠ no events` instead of `✗ missing`.
`openclaw hooks info <name>`: status line now reads `⚠ No events defined` instead of `✗ Missing requirements` when events is empty.
`openclaw hooks check`: not-ready hooks now include `"no events defined"` in the reasons list when applicable.
The `eligible` field on hook status entries is now `false` when `events` is empty, matching actual loader behavior.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 24.04)
- Runtime/container: Node 22 / Bun
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Hook with `events: []` in metadata

### Steps

1. Create or install a managed hook whose `HOOK.md` metadata defines no events (or `events: []`).
2. Run `openclaw hooks list` — the hook shows `ready` (bug).
3. Run `openclaw hooks info <hook-name>` — status reads "✓ Ready" (bug).

### Expected

- Hook with no events listed shows `⚠ no events` in `hooks list` output.
- `hooks info` status reads `⚠ No events defined`.
- `hooks check` includes `"no events defined"` in the reasons for that hook.

### Actual (before fix)

- Hook with no events shows `ready` / `✓ Ready` — same as a fully functional hook.
- `hooks check` gives no hint that events are missing.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New unit tests in `src/hooks/hooks-status.test.ts` cover: hook with events (eligible=true), hook with empty events (eligible=false), hook with undefined metadata (eligible=false). New tests in `src/cli/hooks-cli.test.ts` cover the three display branches in `formatHookStatus` and `formatHookInfo`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Traced `loader.ts:109-113` to confirm the loader skips hooks where `events.length === 0`; confirmed `buildHookStatus` did not have the same guard before this fix; confirmed all four display paths in `hooks-cli.ts` now consistently reflect the no-events state.
- Edge cases checked: `metadata === undefined` (defaults `events` to `[]` via `??`, so `eligible` is correctly `false`); hook that is both disabled and has no events (disabled check fires first, no-events branch is unreachable but harmless).
- What you did **not** verify: Live end-to-end with a real managed hook plugin on a gateway instance; macOS app hook status surface (if any).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `c93182fe4` (`git revert c93182fe4`).
- Files/config to restore: `src/hooks/hooks-status.ts`, `src/cli/hooks-cli.ts`
- Known bad symptoms reviewers should watch for: Any hook that previously showed `ready` and is now shown as `⚠ no events` — that is the correct new behavior, not a regression.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: A hook author who relied on an events-less hook being reported as "ready" (e.g. for scripting/parsing `hooks list` output) will now see a different status string.
  - Mitigation: The hook was never actually loaded by the runner in this state; the new output is more accurate. No behavior change to the hook runner itself.