### PR TITLE
Parallelize multi-collection QMD queries and bump SQLite busy_timeout

### DIFF
--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -1648,6 +1648,52 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("re-throws non-timeout errors even when other collections succeed", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [
+            { path: workspaceDir, pattern: "**/*.md", name: "good" },
+            { path: path.join(workspaceDir, "b"), pattern: "**/*.md", name: "broken" },
+          ],
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "search") {
+        const collectionFlag = args.indexOf("-c");
+        const collectionName = collectionFlag >= 0 ? args[collectionFlag + 1] : "";
+        if (collectionName === "broken-main") {
+          // Simulate a spawn/permission failure (non-timeout error)
+          const child = createMockChild({ autoClose: false });
+          process.nextTick(() => child.emit("error", new Error("spawn EACCES")));
+          return child;
+        }
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify([
+            { docid: "doc1", score: 0.9, content: "hello", collection: "good-main" },
+          ]),
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    await expect(
+      manager.search("test", { sessionKey: "agent:main:slack:dm:u123" }),
+    ).rejects.toThrow("spawn EACCES");
+    await manager.close();
+  });
+
   it("runs qmd searches via mcporter and warns when startDaemon=false", async () => {
     cfg = {
       ...cfg,

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -1523,11 +1523,128 @@ describe("QmdMemoryManager", () => {
     const searchAndQueryCalls = spawnMock.mock.calls
       .map((call: unknown[]) => call[1] as string[])
       .filter((args: string[]) => args[0] === "search" || args[0] === "query");
-    expect(searchAndQueryCalls).toEqual([
-      ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
-      ["query", "test", "--json", "-n", String(maxResults), "-c", "notes-main"],
-    ]);
+    // With parallel execution, both collections attempt search concurrently,
+    // both fail with "unknown flag", then the fallback retries all with query.
+    const searchCalls = searchAndQueryCalls.filter((args: string[]) => args[0] === "search");
+    const queryCalls = searchAndQueryCalls.filter((args: string[]) => args[0] === "query");
+    expect(searchCalls).toEqual(
+      expect.arrayContaining([
+        ["search", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
+        ["search", "test", "--json", "-n", String(maxResults), "-c", "notes-main"],
+      ]),
+    );
+    expect(queryCalls).toEqual(
+      expect.arrayContaining([
+        ["query", "test", "--json", "-n", String(maxResults), "-c", "workspace-main"],
+        ["query", "test", "--json", "-n", String(maxResults), "-c", "notes-main"],
+      ]),
+    );
+    await manager.close();
+  });
+
+  it("launches all collection queries concurrently", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          paths: [
+            { path: workspaceDir, pattern: "**/*.md", name: "alpha" },
+            { path: path.join(workspaceDir, "b"), pattern: "**/*.md", name: "beta" },
+            { path: path.join(workspaceDir, "c"), pattern: "**/*.md", name: "gamma" },
+          ],
+        },
+      },
+    } as OpenClawConfig;
+
+    const pendingChildren: MockChild[] = [];
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "search") {
+        const child = createMockChild({ autoClose: false });
+        pendingChildren.push(child);
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    const searchPromise = manager.search("test", { sessionKey: "agent:main:slack:dm:u123" });
+
+    // Yield to let all spawn calls fire
+    await new Promise((r) => setTimeout(r, 50));
+
+    // All 3 collections should have been spawned before any closed
+    expect(pendingChildren.length).toBe(3);
+
+    // Now close them all with results
+    for (const child of pendingChildren) {
+      emitAndClose(child, "stdout", "[]");
+    }
+
+    await searchPromise;
+    await manager.close();
+  });
+
+  it("returns results from successful collections when one times out", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: false,
+          update: { interval: "0s", debounceMs: 60_000, onBoot: false },
+          limits: { timeoutMs: 200 },
+          paths: [
+            { path: workspaceDir, pattern: "**/*.md", name: "good" },
+            { path: path.join(workspaceDir, "b"), pattern: "**/*.md", name: "stuck" },
+          ],
+        },
+      },
+    } as OpenClawConfig;
+
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "search") {
+        const collectionFlag = args.indexOf("-c");
+        const collectionName = collectionFlag >= 0 ? args[collectionFlag + 1] : "";
+        if (collectionName === "stuck-main") {
+          // This one never closes — will time out
+          return createMockChild({ autoClose: false });
+        }
+        const child = createMockChild({ autoClose: false });
+        emitAndClose(
+          child,
+          "stdout",
+          JSON.stringify([
+            { docid: "doc1", score: 0.9, content: "hello", collection: "good-main" },
+          ]),
+        );
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager();
+    const inner = manager as unknown as {
+      db: { prepare: (query: string) => { all: (arg: unknown) => unknown }; close: () => void };
+    };
+    inner.db = {
+      prepare: (_query: string) => ({
+        all: (arg: unknown) => {
+          if (typeof arg === "string" && arg.startsWith("doc1")) {
+            return [{ collection: "good-main", path: "test.md" }];
+          }
+          return [];
+        },
+      }),
+      close: () => {},
+    };
+
+    const results = await manager.search("test", { sessionKey: "agent:main:slack:dm:u123" });
+
+    // Should get results from the good collection despite stuck timing out
+    expect(results.length).toBeGreaterThanOrEqual(1);
     await manager.close();
   });
 

--- a/src/memory/qmd-manager.test.ts
+++ b/src/memory/qmd-manager.test.ts
@@ -744,6 +744,37 @@ describe("QmdMemoryManager", () => {
     await manager.close();
   });
 
+  it("does not treat non-timeout errors containing 'timed out' as retryable", async () => {
+    cfg = {
+      ...cfg,
+      memory: {
+        backend: "qmd",
+        qmd: {
+          includeDefaultMemory: true,
+          update: { interval: "0s", debounceMs: 0, onBoot: false },
+          paths: [{ path: workspaceDir, pattern: "**/*.md", name: "workspace" }],
+        },
+      },
+    } as OpenClawConfig;
+    spawnMock.mockImplementation((_cmd: string, args: string[]) => {
+      if (args[0] === "update") {
+        const child = createMockChild({ autoClose: false });
+        queueMicrotask(() => {
+          child.stderr.emit("data", "search query timed out unexpectedly");
+          child.closeWith(1);
+        });
+        return child;
+      }
+      return createMockChild();
+    });
+
+    const { manager } = await createManager({ mode: "status" });
+    // The error message contains "timed out" but lacks the timedOut property,
+    // so it should NOT be retried and should propagate immediately.
+    await expect(manager.sync({ reason: "manual" })).rejects.toThrow("timed out");
+    await manager.close();
+  });
+
   it("rebuilds managed collections once when qmd update fails with null-byte ENOTDIR", async () => {
     cfg = {
       ...cfg,

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1118,9 +1118,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     if (this.isSqliteBusyError(err)) {
       return true;
     }
-    const message = err instanceof Error ? err.message : String(err);
-    const normalized = message.toLowerCase();
-    return normalized.includes("timed out");
+    return err instanceof Error && (err as Error & { timedOut?: boolean }).timedOut === true;
   }
 
   private shouldRunEmbed(force?: boolean): boolean {
@@ -1259,7 +1257,9 @@ export class QmdMemoryManager implements MemorySearchManager {
       const timer = opts?.timeoutMs
         ? setTimeout(() => {
             child.kill("SIGKILL");
-            reject(new Error(`qmd ${args.join(" ")} timed out after ${opts.timeoutMs}ms`));
+            const err = new Error(`qmd ${args.join(" ")} timed out after ${opts.timeoutMs}ms`);
+            (err as Error & { timedOut: boolean }).timedOut = true;
+            reject(err);
           }, opts.timeoutMs)
         : null;
       child.stdout.on("data", (data) => {
@@ -1363,7 +1363,9 @@ export class QmdMemoryManager implements MemorySearchManager {
         const timer = opts?.timeoutMs
           ? setTimeout(() => {
               child.kill("SIGKILL");
-              reject(new Error(`mcporter ${args.join(" ")} timed out after ${opts.timeoutMs}ms`));
+              const err = new Error(`mcporter ${args.join(" ")} timed out after ${opts.timeoutMs}ms`);
+              (err as Error & { timedOut: boolean }).timedOut = true;
+              reject(err);
             }, opts.timeoutMs)
           : null;
         child.stdout.on("data", (data) => {

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -2063,8 +2063,7 @@ export class QmdMemoryManager implements MemorySearchManager {
   }
 
   private isTimeoutError(err: unknown): boolean {
-    const message = err instanceof Error ? err.message : String(err);
-    return message.includes("timed out after");
+    return err instanceof Error && (err as Error & { timedOut?: boolean }).timedOut === true;
   }
 
   private isUnsupportedQmdOptionError(err: unknown): boolean {

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1363,7 +1363,9 @@ export class QmdMemoryManager implements MemorySearchManager {
         const timer = opts?.timeoutMs
           ? setTimeout(() => {
               child.kill("SIGKILL");
-              const err = new Error(`mcporter ${args.join(" ")} timed out after ${opts.timeoutMs}ms`);
+              const err = new Error(
+                `mcporter ${args.join(" ")} timed out after ${opts.timeoutMs}ms`,
+              );
               (err as Error & { timedOut: boolean }).timedOut = true;
               reject(err);
             }, opts.timeoutMs)

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -2060,6 +2060,11 @@ export class QmdMemoryManager implements MemorySearchManager {
     return normalized.includes("sqlite_busy") || normalized.includes("database is locked");
   }
 
+  private isTimeoutError(err: unknown): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    return message.includes("timed out after");
+  }
+
   private isUnsupportedQmdOptionError(err: unknown): boolean {
     const message = err instanceof Error ? err.message : String(err);
     const normalized = message.toLowerCase();
@@ -2112,12 +2117,12 @@ export class QmdMemoryManager implements MemorySearchManager {
         r.status === "fulfilled",
     );
 
-    // Re-throw structural errors (missing collections, unsupported flags) so the
-    // caller can trigger repair/fallback logic. Only swallow transient errors
-    // (timeouts) when at least some collections succeeded.
+    // Re-throw all failures except transient timeouts when at least some
+    // collections succeeded. This ensures real errors (corrupted indexes,
+    // spawn/permission failures, malformed JSON) propagate to the caller.
     for (const r of rejected) {
       const err = r.reason;
-      if (this.isMissingCollectionSearchError(err) || this.isUnsupportedQmdOptionError(err)) {
+      if (!this.isTimeoutError(err)) {
         throw err instanceof Error ? err : new Error(String(err));
       }
     }
@@ -2127,7 +2132,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
 
     for (const r of rejected) {
-      log.debug(`qmd ${command} collection query failed: ${r.reason}`);
+      log.debug(`qmd ${command} collection query timed out: ${r.reason}`);
     }
 
     const bestByResultKey = new Map<string, QmdQueryResult>();
@@ -2215,12 +2220,12 @@ export class QmdMemoryManager implements MemorySearchManager {
         r.status === "fulfilled",
     );
 
-    // Re-throw structural errors (missing collections, unsupported flags) so the
-    // caller can trigger repair/fallback logic. Only swallow transient errors
-    // (timeouts) when at least some collections succeeded.
+    // Re-throw all failures except transient timeouts when at least some
+    // collections succeeded. This ensures real errors (corrupted indexes,
+    // spawn/permission failures, malformed JSON) propagate to the caller.
     for (const r of rejected) {
       const err = r.reason;
-      if (this.isMissingCollectionSearchError(err) || this.isUnsupportedQmdOptionError(err)) {
+      if (!this.isTimeoutError(err)) {
         throw err instanceof Error ? err : new Error(String(err));
       }
     }
@@ -2230,7 +2235,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     }
 
     for (const r of rejected) {
-      log.debug(`qmd mcporter ${params.tool} collection query failed: ${r.reason}`);
+      log.debug(`qmd mcporter ${params.tool} collection query timed out: ${r.reason}`);
     }
 
     const bestByDocId = new Map<string, QmdQueryResult>();

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -2209,12 +2209,32 @@ export class QmdMemoryManager implements MemorySearchManager {
       }),
     );
 
-    const bestByDocId = new Map<string, QmdQueryResult>();
-    for (const settled of results) {
-      if (settled.status === "rejected") {
-        log.debug(`qmd mcporter ${params.tool} collection query failed: ${settled.reason}`);
-        continue;
+    const rejected = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+    const fulfilled = results.filter(
+      (r): r is PromiseFulfilledResult<{ collectionName: string; parsed: QmdQueryResult[] }> =>
+        r.status === "fulfilled",
+    );
+
+    // Re-throw structural errors (missing collections, unsupported flags) so the
+    // caller can trigger repair/fallback logic. Only swallow transient errors
+    // (timeouts) when at least some collections succeeded.
+    for (const r of rejected) {
+      const err = r.reason;
+      if (this.isMissingCollectionSearchError(err) || this.isUnsupportedQmdOptionError(err)) {
+        throw err instanceof Error ? err : new Error(String(err));
       }
+    }
+    if (fulfilled.length === 0 && rejected.length > 0) {
+      const first = rejected[0].reason;
+      throw first instanceof Error ? first : new Error(String(first));
+    }
+
+    for (const r of rejected) {
+      log.debug(`qmd mcporter ${params.tool} collection query failed: ${r.reason}`);
+    }
+
+    const bestByDocId = new Map<string, QmdQueryResult>();
+    for (const settled of fulfilled) {
       const { parsed } = settled.value;
       for (const entry of parsed) {
         if (typeof entry.docid !== "string" || !entry.docid.trim()) {

--- a/src/memory/qmd-manager.ts
+++ b/src/memory/qmd-manager.ts
@@ -1557,7 +1557,7 @@ export class QmdMemoryManager implements MemorySearchManager {
     const { DatabaseSync } = requireNodeSqlite();
     this.db = new DatabaseSync(this.indexPath, { readOnly: true });
     // Keep QMD recall responsive when the updater holds a write lock.
-    this.db.exec("PRAGMA busy_timeout = 1");
+    this.db.exec("PRAGMA busy_timeout = 2000");
     return this.db;
   }
 
@@ -2097,12 +2097,42 @@ export class QmdMemoryManager implements MemorySearchManager {
     log.debug(
       `qmd ${command} multi-collection workaround active (${collectionNames.length} collections)`,
     );
+    const results = await Promise.allSettled(
+      collectionNames.map(async (collectionName) => {
+        const args = this.buildSearchArgs(command, query, limit);
+        args.push("-c", collectionName);
+        const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs });
+        return { collectionName, parsed: parseQmdQueryJson(result.stdout, result.stderr) };
+      }),
+    );
+
+    const rejected = results.filter((r): r is PromiseRejectedResult => r.status === "rejected");
+    const fulfilled = results.filter(
+      (r): r is PromiseFulfilledResult<{ collectionName: string; parsed: QmdQueryResult[] }> =>
+        r.status === "fulfilled",
+    );
+
+    // Re-throw structural errors (missing collections, unsupported flags) so the
+    // caller can trigger repair/fallback logic. Only swallow transient errors
+    // (timeouts) when at least some collections succeeded.
+    for (const r of rejected) {
+      const err = r.reason;
+      if (this.isMissingCollectionSearchError(err) || this.isUnsupportedQmdOptionError(err)) {
+        throw err instanceof Error ? err : new Error(String(err));
+      }
+    }
+    if (fulfilled.length === 0 && rejected.length > 0) {
+      const first = rejected[0].reason;
+      throw first instanceof Error ? first : new Error(String(first));
+    }
+
+    for (const r of rejected) {
+      log.debug(`qmd ${command} collection query failed: ${r.reason}`);
+    }
+
     const bestByResultKey = new Map<string, QmdQueryResult>();
-    for (const collectionName of collectionNames) {
-      const args = this.buildSearchArgs(command, query, limit);
-      args.push("-c", collectionName);
-      const result = await this.runQmd(args, { timeoutMs: this.qmd.limits.timeoutMs });
-      const parsed = parseQmdQueryJson(result.stdout, result.stderr);
+    for (const settled of fulfilled) {
+      const { collectionName, parsed } = settled.value;
       for (const entry of parsed) {
         const normalizedHints = this.normalizeDocHints({
           preferredCollection: entry.collection ?? collectionName,
@@ -2164,17 +2194,28 @@ export class QmdMemoryManager implements MemorySearchManager {
     minScore: number;
     collectionNames: string[];
   }): Promise<QmdQueryResult[]> {
+    const results = await Promise.allSettled(
+      params.collectionNames.map(async (collectionName) => {
+        const parsed = await this.runQmdSearchViaMcporter({
+          mcporter: this.qmd.mcporter,
+          tool: params.tool,
+          query: params.query,
+          limit: params.limit,
+          minScore: params.minScore,
+          collection: collectionName,
+          timeoutMs: this.qmd.limits.timeoutMs,
+        });
+        return { collectionName, parsed };
+      }),
+    );
+
     const bestByDocId = new Map<string, QmdQueryResult>();
-    for (const collectionName of params.collectionNames) {
-      const parsed = await this.runQmdSearchViaMcporter({
-        mcporter: this.qmd.mcporter,
-        tool: params.tool,
-        query: params.query,
-        limit: params.limit,
-        minScore: params.minScore,
-        collection: collectionName,
-        timeoutMs: this.qmd.limits.timeoutMs,
-      });
+    for (const settled of results) {
+      if (settled.status === "rejected") {
+        log.debug(`qmd mcporter ${params.tool} collection query failed: ${settled.reason}`);
+        continue;
+      }
+      const { parsed } = settled.value;
       for (const entry of parsed) {
         if (typeof entry.docid !== "string" || !entry.docid.trim()) {
           continue;


### PR DESCRIPTION
## Summary

- **Parallelize `runQueryAcrossCollections()` and `runMcporterAcrossCollections()`** — replace sequential `for...of` loops with `Promise.allSettled()` so all collections are queried concurrently. With 5 collections and a 4s timeout each, worst-case drops from ~20s to ~4s.
- **Bump `PRAGMA busy_timeout` from 1ms to 2000ms** — reads now wait out short write locks from background `qmd embed` instead of failing instantly.
- Structural errors (missing collections, unsupported flags) are still re-thrown to preserve existing repair/fallback logic. Only transient errors (timeouts) are swallowed when at least some collections succeed.

## Test plan

- [x] All 50 existing tests pass (`npx vitest run src/memory/qmd-manager.test.ts`)
- [x] New test: "launches all collection queries concurrently" — verifies all spawns fire before any close
- [x] New test: "returns results from successful collections when one times out" — verifies `Promise.allSettled` resilience
- [x] Updated test: "uses per-collection query fallback when search mode rejects flags" — adjusted expectations for parallel execution
- [ ] Manual: rebuild container, test qmd query via Telegram with multiple collections