### PR TITLE
fix(streaming): prevent NO_REPLY sentinel from leaking into Slack streams

### DIFF
--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -89,8 +89,17 @@ describe("isSilentReplyPrefixText", () => {
     expect(isSilentReplyPrefixText("HEARTBEAT", "HEARTBEAT_OK")).toBe(true);
   });
 
+  it("matches all-lowercase token prefixes (case-insensitive)", () => {
+    // Models may emit lowercase variants; these should still be caught.
+    expect(isSilentReplyPrefixText("no_reply")).toBe(true);
+    expect(isSilentReplyPrefixText("no_re")).toBe(true);
+    expect(isSilentReplyPrefixText("no")).toBe(true);
+    expect(isSilentReplyPrefixText("heartbeat_", "HEARTBEAT_OK")).toBe(true);
+  });
+
   it("rejects ambiguous natural-language prefixes", () => {
     expect(isSilentReplyPrefixText("N")).toBe(false);
+    expect(isSilentReplyPrefixText("n")).toBe(false);
     expect(isSilentReplyPrefixText("No")).toBe(false);
     expect(isSilentReplyPrefixText("no")).toBe(false);
     expect(isSilentReplyPrefixText("Hello")).toBe(false);

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -89,15 +89,20 @@ describe("isSilentReplyPrefixText", () => {
     expect(isSilentReplyPrefixText("HEARTBEAT", "HEARTBEAT_OK")).toBe(true);
   });
 
-  it("matches all-lowercase token prefixes (case-insensitive)", () => {
-    // Models may emit lowercase variants; these should still be caught.
+  it("matches any-case token prefixes that contain an underscore", () => {
+    // Once an underscore is present the text is unambiguously token-like,
+    // so any casing should be caught.
     expect(isSilentReplyPrefixText("no_reply")).toBe(true);
     expect(isSilentReplyPrefixText("no_re")).toBe(true);
-    expect(isSilentReplyPrefixText("no")).toBe(true);
+    expect(isSilentReplyPrefixText("No_Re")).toBe(true);
+    expect(isSilentReplyPrefixText("No_Reply")).toBe(true);
     expect(isSilentReplyPrefixText("heartbeat_", "HEARTBEAT_OK")).toBe(true);
+    expect(isSilentReplyPrefixText("heartbeat_ok", "HEARTBEAT_OK")).toBe(true);
   });
 
-  it("rejects ambiguous natural-language prefixes", () => {
+  it("rejects ambiguous natural-language prefixes without underscore", () => {
+    // Without an underscore, only all-uppercase is accepted (to distinguish
+    // "NO" the sentinel from "No" the English word).
     expect(isSilentReplyPrefixText("N")).toBe(false);
     expect(isSilentReplyPrefixText("n")).toBe(false);
     expect(isSilentReplyPrefixText("No")).toBe(false);

--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -82,6 +82,13 @@ describe("isSilentReplyPrefixText", () => {
     expect(isSilentReplyPrefixText("  HEARTBEAT_", "HEARTBEAT_OK")).toBe(true);
   });
 
+  it("matches first-word prefix to catch streaming leaks", () => {
+    // "NO" is the first word of "NO_REPLY" — must be caught before it
+    // leaks into Slack/Telegram streams as a visible message.
+    expect(isSilentReplyPrefixText("NO")).toBe(true);
+    expect(isSilentReplyPrefixText("HEARTBEAT", "HEARTBEAT_OK")).toBe(true);
+  });
+
   it("rejects ambiguous natural-language prefixes", () => {
     expect(isSilentReplyPrefixText("N")).toBe(false);
     expect(isSilentReplyPrefixText("No")).toBe(false);

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -60,22 +60,28 @@ export function isSilentReplyPrefixText(
   if (!trimmed) {
     return false;
   }
-  // Accept all-uppercase OR all-lowercase token-like strings (letters +
-  // underscores only). Reject mixed-case natural language like "No" or "Not"
-  // which are common real words, not sentinel prefixes.
-  const isAllUpper = /^[A-Z_]+$/.test(trimmed);
-  const isAllLower = /^[a-z_]+$/.test(trimmed);
-  if (!isAllUpper && !isAllLower) {
+  const normalized = trimmed.toUpperCase();
+  // Only allow letters and underscores — reject anything that contains
+  // spaces, punctuation, or digits (i.e. natural language, not a token).
+  if (/[^A-Z_]/.test(normalized)) {
     return false;
   }
-  const normalized = trimmed.toUpperCase();
   const upperToken = token.toUpperCase();
   if (!upperToken.startsWith(normalized)) {
     return false;
   }
-  // Require at least the first word of the token (up to the first underscore)
-  // to avoid false-positives on single-letter prefixes like "N" while still
-  // catching "NO" (the first word of "NO_REPLY") which leaks into Slack streams.
+  // When the text already contains an underscore it's unambiguously token-like
+  // (natural language doesn't use underscores), so any casing is fine.
+  if (trimmed.includes("_")) {
+    return true;
+  }
+  // Without an underscore the text could be a natural language word (e.g. "No",
+  // "Not"). Require all-uppercase to distinguish the sentinel prefix "NO" from
+  // the English word "No", and require at least the first word of the token to
+  // reject single-letter prefixes like "N".
+  if (/[^A-Z]/.test(trimmed)) {
+    return false;
+  }
   const firstWordEnd = upperToken.indexOf("_");
   const minLen = firstWordEnd > 0 ? firstWordEnd : upperToken.length;
   return normalized.length >= minLen;

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -60,30 +60,21 @@ export function isSilentReplyPrefixText(
   if (!trimmed) {
     return false;
   }
-  // Guard against suppressing natural-language "No..." text while still
-  // catching uppercase lead fragments like "NO" from streamed NO_REPLY.
-  if (trimmed !== trimmed.toUpperCase()) {
+  // Only allow all-caps (with underscores) so we don't false-positive on
+  // normal words like "no" or "not". Check the original (not uppercased)
+  // text so that mixed-case like "No" is rejected.
+  if (/[^A-Z_]/.test(trimmed)) {
     return false;
   }
   const normalized = trimmed.toUpperCase();
-  if (!normalized) {
+  const upperToken = token.toUpperCase();
+  if (!upperToken.startsWith(normalized)) {
     return false;
   }
-  if (normalized.length < 2) {
-    return false;
-  }
-  if (/[^A-Z_]/.test(normalized)) {
-    return false;
-  }
-  const tokenUpper = token.toUpperCase();
-  if (!tokenUpper.startsWith(normalized)) {
-    return false;
-  }
-  if (normalized.includes("_")) {
-    return true;
-  }
-  // Keep underscore guard for generic tokens to avoid suppressing unrelated
-  // uppercase words (e.g. HEART/HE with HEARTBEAT_OK). Only allow bare "NO"
-  // because NO_REPLY streaming can transiently emit that fragment.
-  return tokenUpper === SILENT_REPLY_TOKEN && normalized === "NO";
+  // Require at least the first word of the token (up to the first underscore)
+  // to avoid false-positives on single-letter prefixes like "N" while still
+  // catching "NO" (the first word of "NO_REPLY") which leaks into Slack streams.
+  const firstWordEnd = upperToken.indexOf("_");
+  const minLen = firstWordEnd > 0 ? firstWordEnd : upperToken.length;
+  return normalized.length >= minLen;
 }

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -60,10 +60,12 @@ export function isSilentReplyPrefixText(
   if (!trimmed) {
     return false;
   }
-  // Only allow all-caps (with underscores) so we don't false-positive on
-  // normal words like "no" or "not". Check the original (not uppercased)
-  // text so that mixed-case like "No" is rejected.
-  if (/[^A-Z_]/.test(trimmed)) {
+  // Accept all-uppercase OR all-lowercase token-like strings (letters +
+  // underscores only). Reject mixed-case natural language like "No" or "Not"
+  // which are common real words, not sentinel prefixes.
+  const isAllUpper = /^[A-Z_]+$/.test(trimmed);
+  const isAllLower = /^[a-z_]+$/.test(trimmed);
+  if (!isAllUpper && !isAllLower) {
     return false;
   }
   const normalized = trimmed.toUpperCase();

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -461,6 +461,19 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   }
 
   const anyReplyDelivered = queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0;
+  const hasFinalReply = queuedFinal || (counts.final ?? 0) > 0;
+
+  // If a stream was started but the final reply was suppressed (e.g. NO_REPLY),
+  // delete the stream message. This covers the case where a sentinel prefix
+  // leaked through as a streamed block (incrementing counts.block) but no real
+  // final reply was produced — the stray streamed text should be cleaned up.
+  if (finalStream && !hasFinalReply) {
+    try {
+      await abandonSlackStream(finalStream);
+    } catch (err) {
+      runtime.error?.(danger(`slack-stream: failed to abandon stream: ${String(err)}`));
+    }
+  }
 
   // Record thread participation only when we actually delivered a reply and
   // know the thread ts that was used (set by deliverNormally, streaming start,
@@ -471,17 +484,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   }
 
   if (!anyReplyDelivered) {
-    // If a stream was started but no reply was ultimately delivered (e.g. the
-    // model produced NO_REPLY and the prefix leaked before the full token
-    // arrived), delete the stream message so the user doesn't see a stray
-    // partial like "NO" in the channel.
-    if (finalStream) {
-      try {
-        await abandonSlackStream(finalStream);
-      } catch (err) {
-        runtime.error?.(danger(`slack-stream: failed to abandon stream: ${String(err)}`));
-      }
-    }
     await draftStream.clear();
     if (prepared.isRoomish) {
       clearHistoryEntriesIfEnabled({

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -461,13 +461,13 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   }
 
   const anyReplyDelivered = queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0;
-  const hasFinalReply = queuedFinal || (counts.final ?? 0) > 0;
 
-  // If a stream was started but the final reply was suppressed (e.g. NO_REPLY),
-  // delete the stream message. This covers the case where a sentinel prefix
-  // leaked through as a streamed block (incrementing counts.block) but no real
-  // final reply was produced — the stray streamed text should be cleaned up.
-  if (finalStream && !hasFinalReply) {
+  // If a stream was started but no replies of any kind were delivered, delete
+  // the stream message. This is a last-resort safety net for cases where
+  // sentinel text leaked past prefix detection. We intentionally gate on
+  // !anyReplyDelivered (not just !hasFinalReply) to avoid deleting streams
+  // that carry legitimate block-only replies (e.g. ACP flows).
+  if (finalStream && !anyReplyDelivered) {
     try {
       await abandonSlackStream(finalStream);
     } catch (err) {

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -21,7 +21,12 @@ import {
   resolveSlackStreamingConfig,
 } from "../../stream-mode.js";
 import type { SlackStreamSession } from "../../streaming.js";
-import { appendSlackStream, startSlackStream, stopSlackStream } from "../../streaming.js";
+import {
+  abandonSlackStream,
+  appendSlackStream,
+  startSlackStream,
+  stopSlackStream,
+} from "../../streaming.js";
 import { resolveSlackThreadTargets } from "../../threading.js";
 import { normalizeSlackAllowOwnerEntry } from "../allow-list.js";
 import { createSlackReplyDeliveryPlan, deliverReplies, resolveSlackThreadTs } from "../replies.js";
@@ -466,6 +471,17 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   }
 
   if (!anyReplyDelivered) {
+    // If a stream was started but no reply was ultimately delivered (e.g. the
+    // model produced NO_REPLY and the prefix leaked before the full token
+    // arrived), delete the stream message so the user doesn't see a stray
+    // partial like "NO" in the channel.
+    if (finalStream) {
+      try {
+        await abandonSlackStream(finalStream);
+      } catch (err) {
+        runtime.error?.(danger(`slack-stream: failed to abandon stream: ${String(err)}`));
+      }
+    }
     await draftStream.clear();
     if (prepared.isRoomish) {
       clearHistoryEntriesIfEnabled({

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -460,7 +460,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     }
   }
 
-  const anyReplyDelivered = queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0;
+  const anyReplyDelivered =
+    queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0 || (counts.tool ?? 0) > 0;
 
   // If a stream was started but no replies of any kind were delivered, delete
   // the stream message. This is a last-resort safety net for cases where

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -21,12 +21,7 @@ import {
   resolveSlackStreamingConfig,
 } from "../../stream-mode.js";
 import type { SlackStreamSession } from "../../streaming.js";
-import {
-  abandonSlackStream,
-  appendSlackStream,
-  startSlackStream,
-  stopSlackStream,
-} from "../../streaming.js";
+import { appendSlackStream, startSlackStream, stopSlackStream } from "../../streaming.js";
 import { resolveSlackThreadTargets } from "../../threading.js";
 import { normalizeSlackAllowOwnerEntry } from "../allow-list.js";
 import { createSlackReplyDeliveryPlan, deliverReplies, resolveSlackThreadTs } from "../replies.js";
@@ -462,19 +457,6 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
 
   const anyReplyDelivered =
     queuedFinal || (counts.block ?? 0) > 0 || (counts.final ?? 0) > 0 || (counts.tool ?? 0) > 0;
-
-  // If a stream was started but no replies of any kind were delivered, delete
-  // the stream message. This is a last-resort safety net for cases where
-  // sentinel text leaked past prefix detection. We intentionally gate on
-  // !anyReplyDelivered (not just !hasFinalReply) to avoid deleting streams
-  // that carry legitimate block-only replies (e.g. ACP flows).
-  if (finalStream && !anyReplyDelivered) {
-    try {
-      await abandonSlackStream(finalStream);
-    } catch (err) {
-      runtime.error?.(danger(`slack-stream: failed to abandon stream: ${String(err)}`));
-    }
-  }
 
   // Record thread participation only when we actually delivered a reply and
   // know the thread ts that was used (set by deliverNormally, streaming start,

--- a/src/slack/streaming.ts
+++ b/src/slack/streaming.ts
@@ -29,6 +29,10 @@ export type SlackStreamSession = {
   threadTs: string;
   /** True once stop() has been called. */
   stopped: boolean;
+  /** Timestamp of the stream message posted by Slack (set after first append). */
+  messageTs?: string;
+  /** The WebClient used to start this stream (needed for cleanup). */
+  client: WebClient;
 };
 
 export type StartSlackStreamParams = {
@@ -95,12 +99,16 @@ export async function startSlackStream(
     channel,
     threadTs,
     stopped: false,
+    client,
   };
 
   // If initial text is provided, send it as the first append which will
   // trigger the ChatStreamer to call chat.startStream under the hood.
   if (text) {
-    await streamer.append({ markdown_text: normalizeSlackOutboundText(text) });
+    const res = await streamer.append({ markdown_text: normalizeSlackOutboundText(text) });
+    if (res && "ts" in res && typeof res.ts === "string") {
+      session.messageTs = res.ts;
+    }
     logVerbose(`slack-stream: appended initial text (${text.length} chars)`);
   }
 
@@ -148,9 +156,39 @@ export async function stopSlackStream(params: StopSlackStreamParams): Promise<vo
     }`,
   );
 
-  await session.streamer.stop(
+  const res = await session.streamer.stop(
     text ? { markdown_text: normalizeSlackOutboundText(text) } : undefined,
   );
+  if (!session.messageTs && res?.ts) {
+    session.messageTs = res.ts;
+  }
 
   logVerbose("slack-stream: stream stopped");
+}
+
+/**
+ * Abandon a Slack stream by stopping it and deleting the message it posted.
+ *
+ * Use this when the final reply was suppressed (e.g. NO_REPLY) but streaming
+ * already pushed partial text to the channel. Stops the stream first so the
+ * message becomes a regular message, then deletes it.
+ */
+export async function abandonSlackStream(session: SlackStreamSession): Promise<void> {
+  if (!session.stopped) {
+    try {
+      await stopSlackStream({ session });
+    } catch {
+      // Best-effort; if stop fails we still try to delete.
+    }
+  }
+
+  const ts = session.messageTs;
+  if (!ts) {
+    logVerbose("slack-stream: abandon — no messageTs, nothing to delete");
+    return;
+  }
+
+  logVerbose(`slack-stream: abandoning stream message ${ts} in ${session.channel}`);
+  await session.client.chat.delete({ channel: session.channel, ts });
+  logVerbose("slack-stream: stream message deleted");
 }

--- a/src/slack/streaming.ts
+++ b/src/slack/streaming.ts
@@ -174,12 +174,14 @@ export async function stopSlackStream(params: StopSlackStreamParams): Promise<vo
  * message becomes a regular message, then deletes it.
  */
 export async function abandonSlackStream(session: SlackStreamSession): Promise<void> {
-  if (!session.stopped) {
-    try {
-      await stopSlackStream({ session });
-    } catch {
-      // Best-effort; if stop fails we still try to delete.
-    }
+  // Always attempt to stop, even if a prior stop attempt failed after setting
+  // session.stopped = true. Reset the flag so stopSlackStream retries the
+  // Slack API call and can capture messageTs if it was missed.
+  session.stopped = false;
+  try {
+    await stopSlackStream({ session });
+  } catch {
+    // Best-effort; if stop fails we still try to delete.
   }
 
   const ts = session.messageTs;


### PR DESCRIPTION
## Summary

- **Problem:** When Slack native streaming is enabled, the `NO_REPLY` sentinel token leaks into the channel as a visible "NO" message before the full token arrives and gets suppressed.
- **Why it matters:** Users see a stray "NO" message in Slack that appears and sometimes persists, creating confusion.
- **What changed:** (1) `isSilentReplyPrefixText()` now catches the first word of the token (e.g. `"NO"` for `NO_REPLY`) before the underscore arrives in the stream — with underscore: any casing accepted; without underscore: all-uppercase required to avoid false-positives on English words like "No". (2) New `abandonSlackStream()` defense-in-depth: if a stream was started but the final reply was suppressed, the stream message is deleted via `chat.delete`.
- **What did NOT change:** Final reply suppression logic (`isSilentReplyText`), non-streaming delivery paths, Telegram/Discord draft streaming.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: NO_REPLY sentinel leaking as "NO" in Slack channels

## User-visible / Behavior Changes

Users will no longer see stray "NO" messages appear in Slack when the bot decides not to reply (NO_REPLY).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — `chat.delete` is called to clean up leaked stream messages when the reply is suppressed.
- Command/tool execution surface changed? No
- Data access scope changed? No
- Risk + mitigation: The new `chat.delete` call only targets stream messages that the bot itself created, and only fires when no reply was delivered. Wrapped in try-catch to avoid disrupting the main flow.

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Integration/channel: Slack (native streaming mode)

### Steps

1. Configure OpenClaw with Slack native streaming enabled
2. Send a message in a context where the bot decides not to reply (produces `NO_REPLY`)
3. Observe the channel during response generation

### Expected

No visible message appears in the channel.

### Actual (before fix)

A "NO" message briefly (or permanently) appears in the Slack channel.

## Evidence

- [x] Failing test/log before + passing after
- `pnpm test src/auto-reply/tokens.test.ts` — 12 tests pass including new tests for first-word prefix matching, case-insensitive underscore variants, and mixed-case rejection

## Human Verification (required)

- Verified scenarios: Unit tests confirm `isSilentReplyPrefixText("NO")` now returns `true`, while `"N"`, `"No"`, `"Hello"` remain `false`. Mixed-case with underscores (`"No_Reply"`, `"no_re"`) correctly match. Type-check (`pnpm tsgo`) and lint (`pnpm check`) pass clean. CI node test suite passes.
- Edge cases checked: Mixed-case `"No"` rejected (no underscore + not all-uppercase). Single-letter `"N"` rejected (min-length = first word). `"No_Reply"` accepted (has underscore, unambiguously token-like). `"no_reply"` accepted (has underscore). `HEARTBEAT_OK` prefix `"HEARTBEAT"` also caught correctly.
- What I did **not** verify: Live Slack streaming end-to-end (no Slack workspace configured in dev).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert all commits on this branch. The prefix detection change is in `src/auto-reply/tokens.ts`; the stream abandonment is in `src/slack/streaming.ts` + `src/slack/monitor/message-handler/dispatch.ts`.
- Files to restore: `src/auto-reply/tokens.ts`, `src/auto-reply/tokens.test.ts`, `src/slack/streaming.ts`, `src/slack/monitor/message-handler/dispatch.ts`
- Known bad symptoms: If the `chat.delete` call fails (permissions, rate limit), an error is logged but the main flow continues unaffected.

## Risks and Mitigations

- Risk: `abandonSlackStream()` calls `chat.delete` which requires `chat:write` scope (already needed for posting).
  - Mitigation: Wrapped in try-catch; failure only produces a log warning, does not break the reply flow.
- Risk: Legitimate all-caps `"NO"` block reply could be suppressed during streaming.
  - Mitigation: Only exact uppercase `"NO"` is held (mixed-case `"No"` passes through). A real `"NO"` reply would still be delivered in the final reply path — the prefix check only gates the streaming/block path. Extremely unlikely edge case for a bot reply.