### PR TITLE
fix: correct crossContext config path in FAQ (#24936)

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -2922,23 +2922,18 @@ Enable cross-provider messaging for the agent:
 
 ```json5
 {
-  agents: {
-    defaults: {
-      tools: {
-        message: {
-          crossContext: {
-            allowAcrossProviders: true,
-            marker: { enabled: true, prefix: "[from {channel}] " },
-          },
-        },
+  tools: {
+    message: {
+      crossContext: {
+        allowAcrossProviders: true,
+        marker: { enabled: true, prefix: "[from {channel}] " },
       },
     },
   },
 }
 ```
 
-Restart the gateway after editing config. If you only want this for a single
-agent, set it under `agents.list[].tools.message` instead.
+Restart the gateway after editing config.
 
 ### Why does it feel like the bot ignores rapidfire messages
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: The FAQ entry for enabling cross-provider messaging showed the config nested under `agents.defaults.tools.message.crossContext`, which is not a valid schema path and causes a schema validation error when users apply it.
- Why it matters: Users following the FAQ verbatim would get a silent config rejection, leaving the feature non-functional with no clear error pointing to the doc.
- What changed: Corrected the JSON5 example to use the actual top-level `tools.message.crossContext` path. Removed the incorrect per-agent alternative (`agents.list[].tools.message`) that also pointed to a non-existent nesting.
- What did NOT change (scope boundary): No code, schema, or runtime behavior changed — documentation only.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24936
- Related #

## User-visible / Behavior Changes

Users who follow the FAQ to enable cross-provider messaging will now apply a config that actually validates and takes effect. Previously the doc example was silently rejected by schema validation.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: N/A (docs-only change)
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Open `docs/help/faq.md` and find the "How do I enable cross-provider messaging?" section.
2. Compare the JSON5 example before and after this PR.
3. Confirm the corrected path `tools.message.crossContext` matches the config schema accepted by the gateway.

### Expected

- The JSON5 snippet under "How do I enable cross-provider messaging?" uses `tools.message.crossContext` at the top level.

### Actual

- Before this fix: the snippet used `agents.defaults.tools.message.crossContext`, which is not a valid path and is rejected by schema validation.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Diff shows removal of the invalid nested path and replacement with the correct top-level `tools.message.crossContext` structure. The correct path is confirmed by the config schema in the codebase.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Confirmed the correct config key `tools.message.crossContext` is present in the codebase schema and that the old nesting `agents.defaults.tools.message` does not exist as a valid path. Read the schema definition to confirm `tools.message` sits at top level, not under `agents.defaults`.
- Edge cases checked: Confirmed the removed per-agent alternative (`agents.list[].tools.message`) is also not a valid schema path — no valid per-agent override path exists for this setting.
- What you did **not** verify: Live gateway restart behavior with the corrected config (runtime behavior is unchanged; only the doc example is corrected).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `f943725b1` in `docs/help/faq.md`.
- Files/config to restore: `docs/help/faq.md` only.
- Known bad symptoms reviewers should watch for: None — docs-only change with no runtime impact.

## Risks and Mitigations

None.