### PR TITLE
fix(slack): durable thread reply backfill with pagination + persisted cursor

### DIFF
--- a/src/slack/monitor/message-handler.test.ts
+++ b/src/slack/monitor/message-handler.test.ts
@@ -1,0 +1,238 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
+import type { ResolvedSlackAccount } from "../accounts.js";
+import type { SlackMessageEvent } from "../types.js";
+import { createSlackMessageHandler } from "./message-handler.js";
+
+const enqueueCalls: Array<{
+  message: SlackMessageEvent;
+  opts: { source: "message" | "app_mention" };
+}> = [];
+const prepareMock = vi.fn(async ({ message }: { message: SlackMessageEvent }) => ({
+  ctxPayload: {},
+  message,
+}));
+const dispatchMock = vi.fn(async () => {});
+
+vi.mock("../../auto-reply/inbound-debounce.js", () => ({
+  resolveInboundDebounceMs: () => 0,
+  createInboundDebouncer: (params: {
+    onFlush: (
+      entries: Array<{ message: SlackMessageEvent; opts: { source: "message" | "app_mention" } }>,
+    ) => Promise<void>;
+  }) => ({
+    enqueue: async (entry: {
+      message: SlackMessageEvent;
+      opts: { source: "message" | "app_mention" };
+    }) => {
+      enqueueCalls.push(entry);
+      await params.onFlush([entry]);
+    },
+  }),
+}));
+
+vi.mock("./message-handler/prepare.js", () => ({
+  prepareSlackMessage: (...args: unknown[]) => prepareMock(...args),
+}));
+
+vi.mock("./message-handler/dispatch.js", () => ({
+  dispatchPreparedSlackMessage: (...args: unknown[]) => dispatchMock(...args),
+}));
+
+function createCtx(params?: {
+  replies?: Array<{
+    messages?: Array<SlackMessageEvent>;
+    response_metadata?: { next_cursor?: string };
+  }>;
+}) {
+  const replyQueue = [...(params?.replies ?? [])];
+  const conversationsReplies = vi.fn(async () => replyQueue.shift() ?? { messages: [] });
+
+  return {
+    cfg: { channels: { slack: { enabled: true } } },
+    accountId: "default",
+    app: {
+      client: {
+        conversations: {
+          replies: conversationsReplies,
+        },
+      },
+    },
+    markMessageSeen: vi.fn(() => false),
+    runtime: {
+      error: vi.fn(),
+    },
+  } as unknown as Parameters<typeof createSlackMessageHandler>[0]["ctx"];
+}
+
+const account: ResolvedSlackAccount = {
+  accountId: "default",
+  enabled: true,
+  botTokenSource: "config",
+  appTokenSource: "config",
+  config: {},
+};
+
+describe("createSlackMessageHandler", () => {
+  beforeEach(() => {
+    enqueueCalls.length = 0;
+    prepareMock.mockClear();
+    dispatchMock.mockClear();
+  });
+
+  it("ignores message_changed/message_deleted even when thread_ts exists", async () => {
+    await withStateDirEnv("openclaw-slack-handler-", async () => {
+      const ctx = createCtx();
+      const handler = createSlackMessageHandler({ ctx, account });
+
+      await handler(
+        {
+          type: "message",
+          subtype: "message_changed",
+          channel: "D1",
+          thread_ts: "100.000",
+          ts: "101.000",
+          text: "edited",
+        } as SlackMessageEvent,
+        { source: "message" },
+      );
+
+      await handler(
+        {
+          type: "message",
+          subtype: "message_deleted",
+          channel: "D1",
+          thread_ts: "100.000",
+          ts: "101.001",
+          text: "deleted",
+        } as SlackMessageEvent,
+        { source: "message" },
+      );
+
+      expect(enqueueCalls).toHaveLength(0);
+      expect(prepareMock).not.toHaveBeenCalled();
+      expect(dispatchMock).not.toHaveBeenCalled();
+      expect(ctx.app.client.conversations.replies).not.toHaveBeenCalled();
+    });
+  });
+
+  it("backfills message_replied with pagination and ingests only plain user replies", async () => {
+    await withStateDirEnv("openclaw-slack-handler-", async () => {
+      const ctx = createCtx({
+        replies: [
+          {
+            messages: [
+              {
+                type: "message",
+                channel: "D1",
+                ts: "100.000",
+                thread_ts: "100.000",
+                text: "parent",
+              },
+              {
+                type: "message",
+                channel: "D1",
+                ts: "100.100",
+                thread_ts: "100.000",
+                user: "U1",
+                text: "reply one",
+              },
+              {
+                type: "message",
+                subtype: "message_deleted",
+                channel: "D1",
+                ts: "100.101",
+                thread_ts: "100.000",
+                text: "deleted",
+              },
+            ],
+            response_metadata: { next_cursor: "cursor-2" },
+          },
+          {
+            messages: [
+              {
+                type: "message",
+                channel: "D1",
+                ts: "100.200",
+                thread_ts: "100.000",
+                user: "U2",
+                text: "reply two",
+              },
+            ],
+            response_metadata: { next_cursor: "" },
+          },
+        ],
+      });
+      const handler = createSlackMessageHandler({ ctx, account });
+
+      await handler(
+        {
+          type: "message",
+          subtype: "message_replied",
+          channel: "D1",
+          ts: "100.150",
+          event_ts: "100.151",
+          message: {
+            type: "message",
+            channel: "D1",
+            ts: "100.150",
+            thread_ts: "100.000",
+            latest_reply: "100.200",
+          },
+        } as unknown as SlackMessageEvent,
+        { source: "message" },
+      );
+
+      expect(ctx.app.client.conversations.replies).toHaveBeenCalledTimes(2);
+      expect(ctx.app.client.conversations.replies).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ cursor: undefined, limit: 200 }),
+      );
+      expect(ctx.app.client.conversations.replies).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ cursor: "cursor-2", limit: 200 }),
+      );
+
+      expect(enqueueCalls).toHaveLength(2);
+      expect(enqueueCalls.map((entry) => entry.message.ts)).toEqual(["100.100", "100.200"]);
+      expect(dispatchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("uses persisted thread backfill cursor as oldest", async () => {
+    await withStateDirEnv("openclaw-slack-handler-", async ({ stateDir }) => {
+      const cursorPath = path.join(stateDir, "state", "slack-thread-backfill-cursors.json");
+      await fs.mkdir(path.dirname(cursorPath), { recursive: true });
+      await fs.writeFile(cursorPath, JSON.stringify({ "D1:100.000": "100.555" }, null, 2), "utf8");
+
+      const ctx = createCtx({
+        replies: [{ messages: [], response_metadata: { next_cursor: "" } }],
+      });
+      const handler = createSlackMessageHandler({ ctx, account });
+
+      await handler(
+        {
+          type: "message",
+          subtype: "message_replied",
+          channel: "D1",
+          ts: "100.700",
+          event_ts: "100.701",
+          message: {
+            type: "message",
+            channel: "D1",
+            ts: "100.700",
+            thread_ts: "100.000",
+            latest_reply: "100.700",
+          },
+        } as unknown as SlackMessageEvent,
+        { source: "message" },
+      );
+
+      expect(ctx.app.client.conversations.replies).toHaveBeenCalledWith(
+        expect.objectContaining({ oldest: "100.555" }),
+      );
+    });
+  });
+});

--- a/src/slack/monitor/message-handler.ts
+++ b/src/slack/monitor/message-handler.ts
@@ -1,8 +1,12 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFile } from "node:fs/promises";
+import path from "node:path";
 import { hasControlCommand } from "../../auto-reply/command-detection.js";
 import {
   createInboundDebouncer,
   resolveInboundDebounceMs,
 } from "../../auto-reply/inbound-debounce.js";
+import { resolveStateDir } from "../../config/paths.js";
 import type { ResolvedSlackAccount } from "../accounts.js";
 import type { SlackMessageEvent } from "../types.js";
 import { stripSlackMentionsForCommandDetection } from "./commands.js";
@@ -16,6 +20,12 @@ export type SlackMessageHandler = (
   opts: { source: "message" | "app_mention"; wasMentioned?: boolean },
 ) => Promise<void>;
 
+type SlackMessageRepliedEvent = SlackMessageEvent & {
+  subtype: "message_replied";
+  message?: SlackMessageEvent & { latest_reply?: string };
+  hidden?: boolean;
+};
+
 export function createSlackMessageHandler(params: {
   ctx: SlackMonitorContext;
   account: ResolvedSlackAccount;
@@ -23,6 +33,28 @@ export function createSlackMessageHandler(params: {
   const { ctx, account } = params;
   const debounceMs = resolveInboundDebounceMs({ cfg: ctx.cfg, channel: "slack" });
   const threadTsResolver = createSlackThreadTsResolver({ client: ctx.app.client });
+
+  const threadReplyBackfillCursor = loadThreadBackfillCursorStore();
+  const threadReplyBackfillInflight = new Map<string, Promise<boolean>>();
+  const threadReplyBackfillThrottleUntil = new Map<string, number>();
+  const THREAD_REPLY_BACKFILL_THROTTLE_MS = 1_500;
+  const slackThreadBackfillLogPath = path.join(
+    resolveStateDir(process.env),
+    "logs",
+    "slack-thread-backfill.log",
+  );
+
+  const logThreadBackfill = async (payload: Record<string, unknown>) => {
+    try {
+      await appendFile(
+        slackThreadBackfillLogPath,
+        `${JSON.stringify({ ts: new Date().toISOString(), ...payload })}\n`,
+        "utf8",
+      );
+    } catch {
+      // best effort
+    }
+  };
 
   const debouncer = createInboundDebouncer<{
     message: SlackMessageEvent;
@@ -98,22 +130,206 @@ export function createSlackMessageHandler(params: {
     },
   });
 
-  return async (message, opts) => {
-    if (opts.source === "message" && message.type !== "message") {
+  const enqueueSlackInboundMessage = async (
+    message: SlackMessageEvent,
+    opts: { source: "message" | "app_mention"; wasMentioned?: boolean },
+  ) => {
+    let normalizedMessage = message;
+    const candidate = message as SlackMessageRepliedEvent;
+    if (
+      opts.source === "message" &&
+      candidate.subtype === "message_replied" &&
+      candidate.message?.type === "message"
+    ) {
+      normalizedMessage = {
+        ...candidate.message,
+        channel: candidate.channel ?? candidate.message.channel,
+        event_ts: candidate.event_ts ?? candidate.message.event_ts,
+      };
+    }
+
+    if (opts.source === "message" && normalizedMessage.type !== "message") {
       return;
     }
     if (
       opts.source === "message" &&
-      message.subtype &&
-      message.subtype !== "file_share" &&
-      message.subtype !== "bot_message"
+      normalizedMessage.subtype &&
+      normalizedMessage.subtype !== "file_share" &&
+      normalizedMessage.subtype !== "bot_message"
     ) {
       return;
     }
-    if (ctx.markMessageSeen(message.channel, message.ts)) {
+    if (ctx.markMessageSeen(normalizedMessage.channel, normalizedMessage.ts)) {
       return;
     }
-    const resolvedMessage = await threadTsResolver.resolve({ message, source: opts.source });
+    const resolvedMessage = await threadTsResolver.resolve({
+      message: normalizedMessage,
+      source: opts.source,
+    });
     await debouncer.enqueue({ message: resolvedMessage, opts });
   };
+
+  return async (message, opts) => {
+    const candidate = message as SlackMessageRepliedEvent;
+
+    if (
+      opts.source === "message" &&
+      candidate.subtype === "message_replied" &&
+      candidate.message?.thread_ts
+    ) {
+      const channelId = candidate.channel ?? candidate.message.channel;
+      const threadTs = candidate.message.thread_ts;
+      if (channelId && threadTs) {
+        const cursorKey = `${channelId}:${threadTs}`;
+        const now = Date.now();
+        const throttleUntil = threadReplyBackfillThrottleUntil.get(cursorKey) ?? 0;
+        if (throttleUntil > now || threadReplyBackfillInflight.has(cursorKey)) {
+          return;
+        }
+
+        const oldest = threadReplyBackfillCursor.get(cursorKey) ?? threadTs;
+        const parentMessage = candidate.message;
+
+        const backfillPromise = (async () => {
+          threadReplyBackfillThrottleUntil.set(
+            cursorKey,
+            Date.now() + THREAD_REPLY_BACKFILL_THROTTLE_MS,
+          );
+          await logThreadBackfill({
+            event: "message_replied_parent",
+            channel: channelId,
+            thread_ts: threadTs,
+            ts: candidate.ts,
+            event_ts: candidate.event_ts,
+            oldest,
+          });
+
+          try {
+            const replies: SlackMessageEvent[] = [];
+            let cursor: string | undefined;
+            do {
+              const response = (await ctx.app.client.conversations.replies({
+                channel: channelId,
+                ts: threadTs,
+                oldest,
+                inclusive: false,
+                limit: 200,
+                cursor,
+              })) as {
+                messages?: Array<SlackMessageEvent | null | undefined>;
+                response_metadata?: { next_cursor?: string | null };
+              };
+
+              const pageReplies = (response.messages ?? []).filter(
+                (entry): entry is SlackMessageEvent => {
+                  if (!entry) {
+                    return false;
+                  }
+                  return (
+                    entry.type === "message" &&
+                    Boolean(entry.ts) &&
+                    entry.ts !== threadTs &&
+                    !entry.subtype
+                  );
+                },
+              );
+              replies.push(...pageReplies);
+              cursor = response.response_metadata?.next_cursor?.trim() || undefined;
+            } while (cursor);
+
+            for (const reply of replies) {
+              await enqueueSlackInboundMessage(
+                {
+                  ...reply,
+                  channel: channelId,
+                },
+                opts,
+              );
+            }
+
+            const lastTs =
+              replies.length > 0
+                ? replies[replies.length - 1]?.ts
+                : (parentMessage?.latest_reply ?? parentMessage?.ts);
+            if (lastTs) {
+              threadReplyBackfillCursor.set(cursorKey, lastTs);
+              persistThreadBackfillCursorStore(threadReplyBackfillCursor);
+            }
+
+            await logThreadBackfill({
+              event: "message_replied_backfill",
+              channel: channelId,
+              thread_ts: threadTs,
+              fetched: replies.length,
+              oldest,
+              newest: lastTs,
+            });
+            return true;
+          } catch (err) {
+            ctx.runtime.error?.(
+              `slack inbound: message_replied backfill failed channel=${channelId} thread_ts=${threadTs} error=${String(err)}`,
+            );
+            await logThreadBackfill({
+              event: "message_replied_backfill_error",
+              channel: channelId,
+              thread_ts: threadTs,
+              oldest,
+              error: String(err),
+            });
+            return false;
+          } finally {
+            threadReplyBackfillInflight.delete(cursorKey);
+          }
+        })();
+
+        threadReplyBackfillInflight.set(cursorKey, backfillPromise);
+        const handled = await backfillPromise;
+        if (handled) {
+          return;
+        }
+      }
+    }
+
+    await enqueueSlackInboundMessage(message, opts);
+  };
+}
+
+function getThreadBackfillCursorStorePath() {
+  return path.join(resolveStateDir(process.env), "state", "slack-thread-backfill-cursors.json");
+}
+
+function loadThreadBackfillCursorStore() {
+  const map = new Map<string, string>();
+  try {
+    const filePath = getThreadBackfillCursorStorePath();
+    if (!existsSync(filePath)) {
+      return map;
+    }
+    const parsed = JSON.parse(readFileSync(filePath, "utf8")) as Record<string, string>;
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === "string") {
+        map.set(key, value);
+      }
+    }
+  } catch {
+    // ignore corrupt/missing store
+  }
+  return map;
+}
+
+let persistThreadBackfillTimer: ReturnType<typeof setTimeout> | undefined;
+function persistThreadBackfillCursorStore(store: Map<string, string>) {
+  if (persistThreadBackfillTimer) {
+    clearTimeout(persistThreadBackfillTimer);
+  }
+  persistThreadBackfillTimer = setTimeout(() => {
+    persistThreadBackfillTimer = undefined;
+    try {
+      const filePath = getThreadBackfillCursorStorePath();
+      mkdirSync(path.dirname(filePath), { recursive: true });
+      writeFileSync(filePath, JSON.stringify(Object.fromEntries(store), null, 2), "utf8");
+    } catch {
+      // best-effort persistence
+    }
+  }, 100);
 }


### PR DESCRIPTION
## Summary
- handle Slack message_replied parent updates by backfilling replies via conversations.replies
- paginate backfill with next_cursor so >200 reply bursts are fully covered
- throttle + in-flight dedupe per channel:thread_ts to avoid API spam/rate-limit churn
- persist per-thread backfill cursor to state (~/.openclaw/state/slack-thread-backfill-cursors.json)
- keep subtype gate strict for inbound user messages (do not enqueue edit/delete subtypes)
- append minimal message_replied_parent + message_replied_backfill receipts into slack-thread-backfill.log

## Tests
- new src/slack/monitor/message-handler.test.ts covers:
  - ignore message_changed/message_deleted even with thread_ts
  - message_replied backfill ingestion path
  - pagination using mocked next_cursor
  - persisted cursor reuse as oldest across handler init

## Validation run
- pnpm vitest run src/slack/monitor/message-handler.test.ts src/slack/monitor/events/messages.test.ts
- pnpm build
