### PR TITLE
fix(status): show per-agent model in Dashboard Sessions table (#23295)

### DIFF
--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const AGENT_OVERRIDE_MODEL = "custom-agent-model";
+const DEFAULT_MODEL = "default-model";
+
+const mocks = vi.hoisted(() => ({
+  loadConfig: vi.fn(),
+  loadSessionStore: vi.fn(),
+  resolveMainSessionKey: vi.fn().mockReturnValue("agent:main:work"),
+  resolveStorePath: vi.fn().mockReturnValue("/tmp/sessions.json"),
+  resolveFreshSessionTotalTokens: vi.fn(() => undefined),
+  resolveSessionModelRef: vi.fn(),
+  listAgentsForGateway: vi.fn(),
+  classifySessionKey: vi.fn().mockReturnValue("direct"),
+  buildChannelSummary: vi.fn().mockResolvedValue([]),
+  resolveHeartbeatSummaryForAgent: vi.fn().mockReturnValue({
+    enabled: false,
+    every: "5m",
+    everyMs: 300_000,
+  }),
+  peekSystemEvents: vi.fn().mockReturnValue([]),
+  resolveLinkChannelContext: vi.fn().mockResolvedValue(null),
+  resolveConfiguredModelRef: vi.fn(),
+  resolveContextTokensForModel: vi.fn().mockReturnValue(128_000),
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: mocks.loadConfig,
+}));
+
+vi.mock("../config/sessions.js", () => ({
+  loadSessionStore: mocks.loadSessionStore,
+  resolveMainSessionKey: mocks.resolveMainSessionKey,
+  resolveStorePath: mocks.resolveStorePath,
+  resolveFreshSessionTotalTokens: mocks.resolveFreshSessionTotalTokens,
+}));
+
+vi.mock("../gateway/session-utils.js", () => ({
+  classifySessionKey: mocks.classifySessionKey,
+  listAgentsForGateway: mocks.listAgentsForGateway,
+  resolveSessionModelRef: mocks.resolveSessionModelRef,
+}));
+
+vi.mock("../infra/channel-summary.js", () => ({
+  buildChannelSummary: mocks.buildChannelSummary,
+}));
+
+vi.mock("../infra/heartbeat-runner.js", () => ({
+  resolveHeartbeatSummaryForAgent: mocks.resolveHeartbeatSummaryForAgent,
+}));
+
+vi.mock("../infra/system-events.js", () => ({
+  peekSystemEvents: mocks.peekSystemEvents,
+}));
+
+vi.mock("./status.link-channel.js", () => ({
+  resolveLinkChannelContext: mocks.resolveLinkChannelContext,
+}));
+
+vi.mock("../agents/model-selection.js", () => ({
+  resolveConfiguredModelRef: mocks.resolveConfiguredModelRef,
+}));
+
+vi.mock("../agents/context.js", () => ({
+  resolveContextTokensForModel: mocks.resolveContextTokensForModel,
+}));
+
+vi.mock("../agents/defaults.js", () => ({
+  DEFAULT_CONTEXT_TOKENS: 128_000,
+  DEFAULT_MODEL: "default-model",
+  DEFAULT_PROVIDER: "default-provider",
+}));
+
+describe("getStatusSummary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.loadConfig.mockReturnValue({
+      agents: { defaults: { model: { primary: DEFAULT_MODEL } } },
+    });
+
+    mocks.resolveConfiguredModelRef.mockReturnValue({
+      provider: "default-provider",
+      model: DEFAULT_MODEL,
+    });
+
+    mocks.listAgentsForGateway.mockReturnValue({
+      defaultId: "main",
+      mainKey: "agent:main:work",
+      scope: "per-sender",
+      agents: [{ id: "research", name: "Research" }],
+    });
+
+    mocks.loadSessionStore.mockReturnValue({
+      "agent:research:work": {
+        updatedAt: Date.now() - 60_000,
+        sessionId: "sess-1",
+      },
+    });
+  });
+
+  it("uses per-agent model for sessions in the allSessions (recent) list", async () => {
+    // resolveSessionModelRef should receive the agent ID parsed from the key
+    // even when buildSessionRows is called without agentIdOverride (the allSessions path).
+    mocks.resolveSessionModelRef.mockImplementation(
+      (_cfg: unknown, _entry: unknown, agentId?: string) => {
+        if (agentId === "research") {
+          return { provider: "custom-provider", model: AGENT_OVERRIDE_MODEL };
+        }
+        return { provider: "default-provider", model: DEFAULT_MODEL };
+      },
+    );
+
+    const { getStatusSummary } = await import("./status.summary.js");
+    const summary = await getStatusSummary();
+
+    // The "recent" list comes from the allSessions path (no agentIdOverride).
+    // Before the fix, agentId was computed AFTER resolveSessionModelRef, so
+    // the model would incorrectly be the global default.
+    const recentSession = summary.sessions.recent[0];
+    expect(recentSession).toBeDefined();
+    expect(recentSession?.model).toBe(AGENT_OVERRIDE_MODEL);
+
+    // Verify resolveSessionModelRef was called with the agent ID parsed from the key.
+    // It's called twice: once for byAgent (with agentIdOverride) and once for allSessions.
+    // Both should pass "research" as the agentId.
+    const calls = mocks.resolveSessionModelRef.mock.calls;
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    // Every call should include "research" as the agentId argument.
+    for (const call of calls) {
+      expect(call[2]).toBe("research");
+    }
+  });
+});

--- a/src/commands/status.summary.ts
+++ b/src/commands/status.summary.ts
@@ -134,7 +134,9 @@ export async function getStatusSummary(
       .map(([key, entry]) => {
         const updatedAt = entry?.updatedAt ?? null;
         const age = updatedAt ? now - updatedAt : null;
-        const resolvedModel = resolveSessionModelRef(cfg, entry, opts.agentIdOverride);
+        const parsedAgentId = parseAgentSessionKey(key)?.agentId;
+        const agentId = opts.agentIdOverride ?? parsedAgentId;
+        const resolvedModel = resolveSessionModelRef(cfg, entry, agentId);
         const model = resolvedModel.model ?? configModel ?? null;
         const contextTokens =
           resolveContextTokensForModel({
@@ -153,8 +155,6 @@ export async function getStatusSummary(
           contextTokens && contextTokens > 0 && total !== undefined
             ? Math.min(999, Math.round((total / contextTokens) * 100))
             : null;
-        const parsedAgentId = parseAgentSessionKey(key)?.agentId;
-        const agentId = opts.agentIdOverride ?? parsedAgentId;
 
         return {
           agentId,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: The Dashboard Sessions table (`/status recent` list) showed the global default model for all sessions, even when an agent had a per-agent model override configured. Sessions belonging to non-default agents (e.g., `agent:research:work`) appeared with the wrong model name.
- Why it matters: Users with multiple agents using different models cannot verify which model a session actually ran on from the status table, making multi-agent setups misleading and harder to debug.
- What changed: In `buildSessionRows` (the code path used by `allSessions`/`recent`), moved `parsedAgentId`/`agentId` computation to occur **before** the `resolveSessionModelRef` call. Previously, `agentId` was computed after the model resolution call, so it was always `undefined` on that path—causing `resolveSessionModelRef` to fall back to the global default model regardless of which agent the session key belonged to.
- What did NOT change (scope boundary): The `byAgent` path (which uses `agentIdOverride`) was already correct. No changes to model resolution logic, config schema, or any channel/gateway code.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #23295
- Related #

## User-visible / Behavior Changes

The `model` column in the Dashboard Sessions table (and the `sessions.recent` list in `/status --all` output) now correctly reflects the per-agent model override for each session, rather than always showing the global default model.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 24.04)
- Runtime/container: Node 22 / Bun
- Model/provider: Any (reproducible with any per-agent model override)
- Integration/channel (if any): N/A
- Relevant config (redacted): `agents.research.model.primary = "custom-agent-model"`

### Steps

1. Configure two agents (`main` and `research`) where `research` has a different model override.
2. Send a message in the `research` agent session.
3. Run `openclaw status --all` or open the Dashboard Sessions table.

### Expected

- The `research` session row shows the per-agent model (e.g., `custom-agent-model`).

### Actual

- Before the fix: the `research` session row shows the global default model instead of the per-agent override.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test in `src/commands/status.summary.test.ts` (`"uses per-agent model for sessions in the allSessions (recent) list"`) fails on `main` and passes after the fix. The test asserts that `resolveSessionModelRef` is called with the correct `agentId` parsed from the session key on the `allSessions` path, and that `summary.sessions.recent[0].model` equals the per-agent override model.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Read `buildSessionRows` call sites for both `byAgent` and `allSessions` paths; confirmed `parsedAgentId`/`agentId` is now computed before `resolveSessionModelRef` on both paths.
- Edge cases checked: Session keys that do not parse to a known agent (e.g., `global`, `unknown`) are excluded by the `.filter()` above the map; keys without an agent segment return `undefined` from `parseAgentSessionKey`, so `agentId` falls back to `undefined` (same as before for plain/non-agent-scoped sessions).
- What you did **not** verify: Live multi-agent gateway with actual hardware or external API calls.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the two moved lines in `src/commands/status.summary.ts` (move `parsedAgentId`/`agentId` back to after the `resolveSessionModelRef` call).
- Files/config to restore: `src/commands/status.summary.ts`
- Known bad symptoms reviewers should watch for: Sessions in the `recent` list showing unexpected models (would indicate a regression in `parseAgentSessionKey` returning wrong agent IDs).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: If `parseAgentSessionKey` returns an incorrect `agentId` for some session key format, the wrong per-agent config could be used for model resolution.
  - Mitigation: `parseAgentSessionKey` is a pure key-parsing function with existing coverage. The fix only moves when it is called (earlier in the same map callback), not how it is called. The `byAgent` path already used the same function correctly with the same logic.