### PR TITLE
feat: add rejection log and confidence fields to CronRunTelemetry

### DIFF
--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -38,10 +38,33 @@ export type CronUsageSummary = {
   cache_write_tokens?: number;
 };
 
+/**
+ * An action the agent evaluated but chose not to take during a cron run.
+ * Recording rejections turns the run log into a judgment ledger, not just
+ * an output ledger — making agent reasoning auditable over time.
+ */
+export type CronRejection = {
+  /** Brief description of the action that was considered. */
+  action: string;
+  /** Why the agent decided not to take it. */
+  reason: string;
+};
+
 export type CronRunTelemetry = {
   model?: string;
   provider?: string;
   usage?: CronUsageSummary;
+  /**
+   * Actions the agent evaluated but chose not to take, with brief reasons.
+   * Populated by the isolated agent when it decides to skip an opportunity.
+   * Example: [{ action: "submit OpenWork task", reason: "142 existing submissions, win odds < 1%" }]
+   */
+  rejections?: CronRejection[];
+  /**
+   * Agent's self-reported confidence in this run's output (0–1).
+   * 1.0 = high confidence; 0.0 = uncertain/fallback output.
+   */
+  confidence?: number;
 };
 
 export type CronRunOutcome = {


### PR DESCRIPTION
## Summary

The cron run log currently only records what the agent *did* — not what it considered and decided against. This makes it impossible to audit judgment quality over time.

## Changes (`src/cron/types.ts`)

New type:
```ts
export type CronRejection = {
  action: string;  // what was considered
  reason: string;  // why it was skipped
};
```

New fields on `CronRunTelemetry`:
- `rejections?: CronRejection[]` — actions evaluated but not taken
- `confidence?: number` — agent self-reported confidence (0–1)

## Motivation

From the reflections: *'rejection log 是大多数 agent 跳过的，但它是信任的证据'*. An agent that records why it didn't act is more auditable than one that only records what it did.

Example: an openwork-job-hunt run that found tasks but skipped them can now record:
```json
{
  "rejections": [
    { "action": "submit OpenWork task X", "reason": "142 existing submissions, win odds < 1%" },
    { "action": "post to MoltBook", "reason": "requires human authorization" }
  ],
  "confidence": 0.9
}
```

## Non-breaking

All fields are optional. No existing behavior changes. Isolated agents can populate these fields at their discretion.