### PR TITLE
feat: add interruptPriority field to CronJob

### DIFF
--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -116,6 +116,16 @@ export type CronJob = {
   description?: string;
   enabled: boolean;
   deleteAfterRun?: boolean;
+  /**
+   * Execution priority hint for time-sensitive jobs.
+   * - "normal" (default): job runs in standard queue order.
+   * - "interrupt": job bypasses normal queue ordering and runs immediately
+   *   when triggered. Use only for irreversible, time-windowed actions
+   *   (e.g. responding to a verification challenge with a 5-minute window).
+   *
+   * Most jobs should use "normal". Overusing "interrupt" defeats its purpose.
+   */
+  interruptPriority?: "normal" | "interrupt";
   createdAtMs: number;
   updatedAtMs: number;
   schedule: CronSchedule;


### PR DESCRIPTION
## Summary

Adds an optional `interruptPriority` field to `CronJob` to distinguish time-sensitive irreversible jobs from normal background jobs.

## Motivation

From the reflections: *'interrupt tax'* — irreversible operations with short time windows (verification challenges, publish actions) must be treated differently from reversible background tasks. Without this field, all cron jobs are treated equally by the scheduler.

## Changes (`src/cron/types.ts`)

```ts
interruptPriority?: 'normal' | 'interrupt';
```

- `'normal'` (default): standard queue ordering
- `'interrupt'`: bypass queue, run immediately when triggered

## Non-breaking

Optional field, defaults to `'normal'`. No existing behavior changes. Scheduler implementations can read this field to prioritize time-critical jobs.