### PR TITLE
fix(agents): improve bedrock-invoke code quality and add tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,3 +254,65 @@
   - `node --import tsx scripts/release-check.ts`
   - `pnpm release:check`
   - `pnpm test:install:smoke` or `OPENCLAW_INSTALL_SMOKE_SKIP_NONROOT=1 pnpm test:install:smoke` for non-root smoke path.
+
+## Corporate Bedrock Proxy (bedrock-invoke API mode)
+
+Custom `bedrock-invoke` API mode for corporate Bedrock proxies (e.g. Kong-based GenAI Nexus at `genai-nexus.int.api.corpinter.net`) that expose the Bedrock native invoke path with Bearer token auth.
+
+### How it works
+
+- Sends Anthropic Messages format request body (same as `anthropic-messages`)
+- Routes to `POST {baseUrl}/model/{modelId}/invoke-with-response-stream`
+- Body includes `anthropic_version: "bedrock-2023-05-31"`, excludes `model` and `stream` fields
+- Auth: sends both `Authorization: Bearer {token}` and `api-key: {token}` headers (Kong routing)
+- Parses AWS binary event stream (`application/vnd.amazon.eventstream`) response, where each frame contains base64-encoded Anthropic JSON events
+
+### Files
+
+- `src/config/types.models.ts` — `"bedrock-invoke"` in `MODEL_APIS`
+- `src/agents/bedrock-invoke-stream.ts` — StreamFn factory (AWS event stream parser + Anthropic message conversion)
+- `src/agents/pi-embedded-runner/run/attempt.ts` — wires `bedrock-invoke` StreamFn alongside Ollama
+- `src/agents/transcript-policy.ts` — `"bedrock-invoke"` in `isAnthropicApi()`
+
+### Config (`~/.openclaw/openclaw.json`)
+
+```json
+{
+  "models": {
+    "providers": {
+      "corp-bedrock": {
+        "baseUrl": "https://genai-nexus.int.api.corpinter.net",
+        "api": "bedrock-invoke",
+        "authHeader": true,
+        "apiKey": "${AWS_BEARER_TOKEN_BEDROCK}",
+        "models": [
+          {
+            "id": "claude-opus-4-6",
+            "name": "Claude Opus 4.6",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 200000,
+            "maxTokens": 8192
+          },
+          {
+            "id": "claude-sonnet-4-6",
+            "name": "Claude Sonnet 4.6",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 200000,
+            "maxTokens": 8192
+          }
+        ]
+      }
+    }
+  },
+  "agents": { "defaults": { "model": { "primary": "corp-bedrock/claude-opus-4-6" } } }
+}
+```
+
+### Notes
+
+- Model IDs use short Anthropic format (`claude-opus-4-6`), not Bedrock ARN format (`us.anthropic.claude-opus-4-6-v1`)
+- The proxy uses Kong API gateway; `api-key` header is required for route matching
+- Response is AWS binary event stream (not SSE); each frame wraps base64-encoded Anthropic JSON
+- Local dev CLI: run `pnpm build && npm link` to use `openclaw` globally from this repo

--- a/src/agents/bedrock-invoke-stream.test.ts
+++ b/src/agents/bedrock-invoke-stream.test.ts
@@ -1,0 +1,631 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  convertMessages,
+  extractTextFromContent,
+  convertTools,
+  parseAwsEventStream,
+  createBedrockInvokeStreamFn,
+  type SseEvent,
+} from "./bedrock-invoke-stream.js";
+
+// ── convertMessages ──────────────────────────────────────────────────────────
+
+describe("convertMessages", () => {
+  it("converts user text messages", () => {
+    const result = convertMessages([{ role: "user", content: "hello" }]);
+    expect(result).toEqual([{ role: "user", content: "hello" }]);
+  });
+
+  it("converts user multipart messages (text + image)", () => {
+    const result = convertMessages([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "describe this" },
+          { type: "image", data: "aW1hZ2VkYXRh", mimeType: "image/jpeg" },
+        ],
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "describe this" },
+          {
+            type: "image",
+            source: { type: "base64", media_type: "image/jpeg", data: "aW1hZ2VkYXRh" },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("defaults image mimeType to image/png", () => {
+    const result = convertMessages([{ role: "user", content: [{ type: "image", data: "abc" }] }]);
+    const block = (result[0].content as Array<Record<string, unknown>>)[0] as {
+      source: { media_type: string };
+    };
+    expect(block.source.media_type).toBe("image/png");
+  });
+
+  it("converts assistant text messages", () => {
+    const result = convertMessages([{ role: "assistant", content: "ok" }]);
+    expect(result).toEqual([{ role: "assistant", content: "ok" }]);
+  });
+
+  it("converts assistant toolCall content blocks to tool_use format", () => {
+    const result = convertMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me check." },
+          { type: "toolCall", id: "call_1", name: "bash", arguments: { command: "ls" } },
+        ],
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me check." },
+          { type: "tool_use", id: "call_1", name: "bash", input: { command: "ls" } },
+        ],
+      },
+    ]);
+  });
+
+  it("converts assistant tool_use content blocks (pass-through)", () => {
+    const result = convertMessages([
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tu_1", name: "read", input: { path: "/tmp" } }],
+      },
+    ]);
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tu_1", name: "read", input: { path: "/tmp" } }],
+      },
+    ]);
+  });
+
+  it("converts tool/toolResult role messages to user + tool_result block", () => {
+    const result = convertMessages([
+      { role: "tool", content: "file list output", toolCallId: "call_1" } as {
+        role: string;
+        content: unknown;
+      },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("user");
+    const blocks = result[0].content as Array<{
+      type: string;
+      tool_use_id: string;
+      content: string;
+    }>;
+    expect(blocks[0].type).toBe("tool_result");
+    expect(blocks[0].tool_use_id).toBe("call_1");
+    expect(blocks[0].content).toBe("file list output");
+  });
+
+  it("generates a random tool_use_id when toolCallId is missing", () => {
+    const result = convertMessages([{ role: "tool", content: "output" }]);
+    const blocks = result[0].content as Array<{ tool_use_id: string }>;
+    expect(blocks[0].tool_use_id).toMatch(/^tool_/);
+  });
+
+  it("returns empty array for empty messages", () => {
+    expect(convertMessages([])).toEqual([]);
+  });
+
+  it("falls back to empty content for non-string non-array user content", () => {
+    const result = convertMessages([{ role: "user", content: 42 }]);
+    expect(result).toEqual([{ role: "user", content: "" }]);
+  });
+});
+
+// ── extractTextFromContent ───────────────────────────────────────────────────
+
+describe("extractTextFromContent", () => {
+  it("returns string content directly", () => {
+    expect(extractTextFromContent("hello")).toBe("hello");
+  });
+
+  it("extracts text parts from an array", () => {
+    const content = [
+      { type: "text", text: "first" },
+      { type: "image", data: "x" },
+      { type: "text", text: "second" },
+    ];
+    expect(extractTextFromContent(content)).toBe("firstsecond");
+  });
+
+  it("returns empty string for non-array non-string", () => {
+    expect(extractTextFromContent(42)).toBe("");
+    expect(extractTextFromContent(null)).toBe("");
+    expect(extractTextFromContent(undefined)).toBe("");
+  });
+});
+
+// ── convertTools ─────────────────────────────────────────────────────────────
+
+describe("convertTools", () => {
+  it("converts name + description + parameters", () => {
+    const tools = [
+      {
+        name: "bash",
+        description: "Run commands",
+        parameters: { type: "object", properties: { cmd: { type: "string" } } },
+      },
+    ];
+    const result = convertTools(tools as never);
+    expect(result).toEqual([
+      {
+        name: "bash",
+        description: "Run commands",
+        input_schema: { type: "object", properties: { cmd: { type: "string" } } },
+      },
+    ]);
+  });
+
+  it("skips tools with empty name", () => {
+    const tools = [{ name: "", description: "no name" }];
+    expect(convertTools(tools as never)).toEqual([]);
+  });
+
+  it("uses default parameters when not provided", () => {
+    const tools = [{ name: "read", description: "Read files" }];
+    const result = convertTools(tools as never);
+    expect(result[0].input_schema).toEqual({ type: "object", properties: {} });
+  });
+
+  it("returns empty array for undefined input", () => {
+    expect(convertTools(undefined)).toEqual([]);
+  });
+
+  it("returns empty array for null-ish input", () => {
+    expect(convertTools(null as never)).toEqual([]);
+  });
+});
+
+// ── parseAwsEventStream ──────────────────────────────────────────────────────
+
+// Build a minimal AWS binary event stream frame for testing.
+// Frame layout: [4B total_len][4B headers_len][4B prelude_crc][payload][4B message_crc]
+function buildAwsFrame(payload: Uint8Array | string): Uint8Array {
+  const payloadBytes = typeof payload === "string" ? new TextEncoder().encode(payload) : payload;
+  const totalLength = 12 + payloadBytes.length + 4; // prelude(12) + payload + trailing CRC(4)
+  const frame = new Uint8Array(totalLength);
+  const view = new DataView(frame.buffer);
+  view.setUint32(0, totalLength); // total_len
+  view.setUint32(4, 0); // headers_len = 0
+  view.setUint32(8, 0); // prelude_crc = 0
+  frame.set(payloadBytes, 12);
+  view.setUint32(totalLength - 4, 0); // message_crc = 0
+  return frame;
+}
+
+function buildAwsEventFrame(event: SseEvent): Uint8Array {
+  const innerJson = JSON.stringify(event);
+  const base64 = Buffer.from(innerJson).toString("base64");
+  const envelope = JSON.stringify({ bytes: base64 });
+  return buildAwsFrame(envelope);
+}
+
+function mockAwsReader(frames: Uint8Array[]): ReadableStreamDefaultReader<Uint8Array> {
+  const combined = new Uint8Array(frames.reduce((sum, f) => sum + f.length, 0));
+  let offset = 0;
+  for (const f of frames) {
+    combined.set(f, offset);
+    offset += f.length;
+  }
+  let consumed = false;
+  return {
+    read: async () => {
+      if (consumed) {
+        return { done: true as const, value: undefined };
+      }
+      consumed = true;
+      return { done: false as const, value: combined };
+    },
+    releaseLock: () => {},
+    cancel: async () => {},
+    closed: Promise.resolve(undefined),
+  } as unknown as ReadableStreamDefaultReader<Uint8Array>;
+}
+
+async function collectEvents(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<SseEvent[]> {
+  const events: SseEvent[] = [];
+  for await (const event of parseAwsEventStream(reader)) {
+    events.push(event);
+  }
+  return events;
+}
+
+describe("parseAwsEventStream", () => {
+  it("parses message_start event", async () => {
+    const event: SseEvent = {
+      type: "message_start",
+      message: { id: "msg_1", usage: { input_tokens: 10, output_tokens: 0 } },
+    };
+    const reader = mockAwsReader([buildAwsEventFrame(event)]);
+    const events = await collectEvents(reader);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("message_start");
+  });
+
+  it("parses content_block_start + content_block_delta (text)", async () => {
+    const frames = [
+      buildAwsEventFrame({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+      buildAwsEventFrame({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "Hello world" },
+      }),
+    ];
+    const reader = mockAwsReader(frames);
+    const events = await collectEvents(reader);
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe("content_block_start");
+    expect(events[1].type).toBe("content_block_delta");
+    if (events[1].type === "content_block_delta") {
+      expect(events[1].delta).toEqual({ type: "text_delta", text: "Hello world" });
+    }
+  });
+
+  it("parses tool_use content block", async () => {
+    const frames = [
+      buildAwsEventFrame({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "tool_use", id: "tu_1", name: "bash", input: "" },
+      }),
+      buildAwsEventFrame({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '{"command":"ls"}' },
+      }),
+    ];
+    const reader = mockAwsReader(frames);
+    const events = await collectEvents(reader);
+    expect(events).toHaveLength(2);
+    if (events[0].type === "content_block_start") {
+      expect(events[0].content_block.type).toBe("tool_use");
+    }
+  });
+
+  it("parses thinking content block", async () => {
+    const frames = [
+      buildAwsEventFrame({
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "thinking", thinking: "" },
+      }),
+      buildAwsEventFrame({
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "thinking_delta", thinking: "Let me think..." },
+      }),
+    ];
+    const reader = mockAwsReader(frames);
+    const events = await collectEvents(reader);
+    expect(events).toHaveLength(2);
+    if (events[1].type === "content_block_delta") {
+      expect(events[1].delta).toEqual({ type: "thinking_delta", thinking: "Let me think..." });
+    }
+  });
+
+  it("skips frames with empty payload (no bytes field)", async () => {
+    // Frame whose payload JSON has no `bytes` key
+    const frame = buildAwsFrame(JSON.stringify({ noBytes: true }));
+    const reader = mockAwsReader([frame]);
+    const events = await collectEvents(reader);
+    expect(events).toHaveLength(0);
+  });
+
+  it("handles incomplete frame across chunks", async () => {
+    const fullFrame = buildAwsEventFrame({
+      type: "message_start",
+      message: { id: "msg_1" },
+    });
+    // Split the frame into two chunks
+    const split = Math.floor(fullFrame.length / 2);
+    const chunk1 = fullFrame.slice(0, split);
+    const chunk2 = fullFrame.slice(split);
+
+    let callCount = 0;
+    const reader = {
+      read: async () => {
+        callCount++;
+        if (callCount === 1) {
+          return { done: false as const, value: chunk1 };
+        }
+        if (callCount === 2) {
+          return { done: false as const, value: chunk2 };
+        }
+        return { done: true as const, value: undefined };
+      },
+      releaseLock: () => {},
+      cancel: async () => {},
+      closed: Promise.resolve(undefined),
+    } as unknown as ReadableStreamDefaultReader<Uint8Array>;
+
+    const events = await collectEvents(reader);
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe("message_start");
+  });
+});
+
+// ── createBedrockInvokeStreamFn ──────────────────────────────────────────────
+
+function buildFullAwsResponseBody(events: SseEvent[]): Uint8Array {
+  const frames = events.map(buildAwsEventFrame);
+  const total = frames.reduce((sum, f) => sum + f.length, 0);
+  const body = new Uint8Array(total);
+  let offset = 0;
+  for (const f of frames) {
+    body.set(f, offset);
+    offset += f.length;
+  }
+  return body;
+}
+
+async function withMockAwsFetch(
+  events: SseEvent[],
+  run: (fetchMock: ReturnType<typeof vi.fn>) => Promise<void>,
+  statusCode = 200,
+): Promise<void> {
+  const originalFetch = globalThis.fetch;
+  const body = buildFullAwsResponseBody(events);
+  const fetchMock = vi.fn(async () => {
+    if (statusCode !== 200) {
+      return new Response("Bad Request", { status: statusCode });
+    }
+    return new Response(Buffer.from(body), {
+      status: 200,
+      headers: { "Content-Type": "application/vnd.amazon.eventstream" },
+    });
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+  try {
+    await run(fetchMock);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+async function collectStreamEvents<T>(
+  stream: AsyncIterable<T> | Promise<AsyncIterable<T>>,
+): Promise<T[]> {
+  const resolved = await stream;
+  const events: T[] = [];
+  for await (const event of resolved) {
+    events.push(event);
+  }
+  return events;
+}
+
+const MODEL_INFO = {
+  id: "claude-sonnet-4-6",
+  api: "bedrock-invoke",
+  provider: "corp-bedrock",
+  contextWindow: 200000,
+  maxTokens: 8192,
+};
+
+describe("createBedrockInvokeStreamFn", () => {
+  it("sends correct URL and headers", async () => {
+    const events: SseEvent[] = [
+      { type: "message_start", message: { id: "msg_1", usage: { input_tokens: 5 } } },
+      { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hi" } },
+      { type: "content_block_stop", index: 0 },
+      { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 1 } },
+      { type: "message_stop" },
+    ];
+
+    await withMockAwsFetch(events, async (fetchMock) => {
+      const streamFn = createBedrockInvokeStreamFn("https://proxy.corp.net");
+      const stream = streamFn(
+        MODEL_INFO as never,
+        { messages: [{ role: "user", content: "hello" }] } as never,
+        { apiKey: "tok_123" } as never,
+      );
+      await collectStreamEvents(stream);
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe(
+        "https://proxy.corp.net/model/claude-sonnet-4-6/invoke-with-response-stream",
+      );
+      const headers = init.headers as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer tok_123");
+      expect(headers["api-key"]).toBe("tok_123");
+    });
+  });
+
+  it("request body includes anthropic_version and excludes model/stream", async () => {
+    const events: SseEvent[] = [
+      { type: "message_start", message: { id: "msg_1" } },
+      { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } },
+      { type: "content_block_stop", index: 0 },
+      { type: "message_delta", delta: { stop_reason: "end_turn" } },
+      { type: "message_stop" },
+    ];
+
+    await withMockAwsFetch(events, async (fetchMock) => {
+      const streamFn = createBedrockInvokeStreamFn("https://proxy.corp.net");
+      const stream = streamFn(
+        MODEL_INFO as never,
+        { messages: [{ role: "user", content: "hello" }] } as never,
+        { apiKey: "tok" } as never,
+      );
+      await collectStreamEvents(stream);
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+      expect(body.anthropic_version).toBe("bedrock-2023-05-31");
+      expect(body).not.toHaveProperty("model");
+      expect(body).not.toHaveProperty("stream");
+    });
+  });
+
+  it("happy path: text content yields done event", async () => {
+    const events: SseEvent[] = [
+      { type: "message_start", message: { id: "msg_1", usage: { input_tokens: 10 } } },
+      { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "Hello world" },
+      },
+      { type: "content_block_stop", index: 0 },
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn" },
+        usage: { output_tokens: 3 },
+      },
+      { type: "message_stop" },
+    ];
+
+    await withMockAwsFetch(events, async () => {
+      const streamFn = createBedrockInvokeStreamFn("https://proxy.corp.net");
+      const stream = streamFn(
+        MODEL_INFO as never,
+        { messages: [{ role: "user", content: "hello" }] } as never,
+        { apiKey: "tok" } as never,
+      );
+      const streamEvents = await collectStreamEvents(stream);
+      const done = streamEvents.find((e) => (e as { type: string }).type === "done") as {
+        type: "done";
+        message: {
+          content: Array<{ type: string; text?: string }>;
+          stopReason: string;
+          usage: { input: number; output: number };
+        };
+      };
+      expect(done).toBeDefined();
+      expect(done.message.content).toEqual([{ type: "text", text: "Hello world" }]);
+      expect(done.message.stopReason).toBe("stop");
+      expect(done.message.usage.input).toBe(10);
+      expect(done.message.usage.output).toBe(3);
+    });
+  });
+
+  it("tool_use flow yields stopReason toolUse", async () => {
+    const events: SseEvent[] = [
+      { type: "message_start", message: { id: "msg_1" } },
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "tool_use", id: "tu_1", name: "bash", input: "" },
+      },
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "input_json_delta", partial_json: '{"command":"ls"}' },
+      },
+      { type: "content_block_stop", index: 0 },
+      { type: "message_delta", delta: { stop_reason: "tool_use" } },
+      { type: "message_stop" },
+    ];
+
+    await withMockAwsFetch(events, async () => {
+      const streamFn = createBedrockInvokeStreamFn("https://proxy.corp.net");
+      const stream = streamFn(
+        MODEL_INFO as never,
+        { messages: [{ role: "user", content: "use bash" }] } as never,
+        { apiKey: "tok" } as never,
+      );
+      const streamEvents = await collectStreamEvents(stream);
+      const done = streamEvents.find((e) => (e as { type: string }).type === "done") as {
+        type: "done";
+        reason: string;
+        message: { stopReason: string; content: Array<{ type: string; name?: string }> };
+      };
+      expect(done).toBeDefined();
+      expect(done.reason).toBe("toolUse");
+      expect(done.message.stopReason).toBe("toolUse");
+      expect(done.message.content[0].type).toBe("toolCall");
+      expect(done.message.content[0].name).toBe("bash");
+    });
+  });
+
+  it("emits error event on non-200 response", async () => {
+    await withMockAwsFetch(
+      [],
+      async () => {
+        const streamFn = createBedrockInvokeStreamFn("https://proxy.corp.net");
+        const stream = streamFn(
+          MODEL_INFO as never,
+          { messages: [{ role: "user", content: "hello" }] } as never,
+          { apiKey: "tok" } as never,
+        );
+        const streamEvents = await collectStreamEvents(stream);
+        const error = streamEvents.find((e) => (e as { type: string }).type === "error") as {
+          type: "error";
+          error: { errorMessage: string };
+        };
+        expect(error).toBeDefined();
+        expect(error.error.errorMessage).toMatch(/400/);
+      },
+      400,
+    );
+  });
+
+  it("includes temperature in request body", async () => {
+    const events: SseEvent[] = [
+      { type: "message_start", message: { id: "msg_1" } },
+      { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } },
+      { type: "content_block_stop", index: 0 },
+      { type: "message_delta", delta: { stop_reason: "end_turn" } },
+      { type: "message_stop" },
+    ];
+
+    await withMockAwsFetch(events, async (fetchMock) => {
+      const streamFn = createBedrockInvokeStreamFn("https://proxy.corp.net");
+      const stream = streamFn(
+        MODEL_INFO as never,
+        { messages: [{ role: "user", content: "hello" }] } as never,
+        { apiKey: "tok", temperature: 0.7 } as never,
+      );
+      await collectStreamEvents(stream);
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string) as Record<string, unknown>;
+      expect(body.temperature).toBe(0.7);
+    });
+  });
+
+  it("trims trailing slash from baseUrl", async () => {
+    const events: SseEvent[] = [
+      { type: "message_start", message: { id: "msg_1" } },
+      { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "ok" } },
+      { type: "content_block_stop", index: 0 },
+      { type: "message_delta", delta: { stop_reason: "end_turn" } },
+      { type: "message_stop" },
+    ];
+
+    await withMockAwsFetch(events, async (fetchMock) => {
+      const streamFn = createBedrockInvokeStreamFn("https://proxy.corp.net///");
+      const stream = streamFn(
+        MODEL_INFO as never,
+        { messages: [{ role: "user", content: "hello" }] } as never,
+        { apiKey: "tok" } as never,
+      );
+      await collectStreamEvents(stream);
+
+      const [url] = fetchMock.mock.calls[0] as [string];
+      expect(url).toBe(
+        "https://proxy.corp.net/model/claude-sonnet-4-6/invoke-with-response-stream",
+      );
+    });
+  });
+});

--- a/src/agents/bedrock-invoke-stream.ts
+++ b/src/agents/bedrock-invoke-stream.ts
@@ -39,6 +39,7 @@ interface BedrockInvokeRequest {
   system?: string;
   messages: AnthropicMessage[];
   tools?: AnthropicTool[];
+  temperature?: number;
 }
 
 // ── SSE event types from Anthropic stream ───────────────────────────────────
@@ -84,7 +85,7 @@ interface SseMessageStop {
   type: "message_stop";
 }
 
-type SseEvent =
+export type SseEvent =
   | SseMessageStart
   | SseContentBlockStart
   | SseContentBlockDelta
@@ -102,7 +103,9 @@ type InputContentPart =
   | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
   | { type: "toolResult"; toolCallId: string; content: unknown };
 
-function convertMessages(messages: Array<{ role: string; content: unknown }>): AnthropicMessage[] {
+export function convertMessages(
+  messages: Array<{ role: string; content: unknown }>,
+): AnthropicMessage[] {
   const result: AnthropicMessage[] = [];
 
   for (const msg of messages) {
@@ -176,7 +179,7 @@ function convertMessages(messages: Array<{ role: string; content: unknown }>): A
   return result;
 }
 
-function extractTextFromContent(content: unknown): string {
+export function extractTextFromContent(content: unknown): string {
   if (typeof content === "string") {
     return content;
   }
@@ -189,7 +192,7 @@ function extractTextFromContent(content: unknown): string {
     .join("");
 }
 
-function convertTools(tools: Tool[] | undefined): AnthropicTool[] {
+export function convertTools(tools: Tool[] | undefined): AnthropicTool[] {
   if (!tools || !Array.isArray(tools)) {
     return [];
   }
@@ -230,10 +233,11 @@ const EVENT_STREAM_CRC_SIZE = 4;
  * Parse AWS binary event stream frames from a ReadableStream and yield
  * the decoded Anthropic JSON events.
  */
-async function* parseAwsEventStream(
+export async function* parseAwsEventStream(
   reader: ReadableStreamDefaultReader<Uint8Array>,
 ): AsyncGenerator<SseEvent> {
   let buffer = new Uint8Array(0);
+  const decoder = new TextDecoder();
 
   function appendToBuffer(chunk: Uint8Array): void {
     const next = new Uint8Array(buffer.length + chunk.length);
@@ -283,7 +287,6 @@ async function* parseAwsEventStream(
         continue;
       }
 
-      const decoder = new TextDecoder();
       const payloadStr = decoder.decode(payloadBytes);
 
       try {
@@ -337,7 +340,7 @@ export function createBedrockInvokeStreamFn(baseUrl: string): StreamFn {
         };
 
         if (typeof options?.temperature === "number") {
-          (body as unknown as Record<string, unknown>).temperature = options.temperature;
+          body.temperature = options.temperature;
         }
 
         const url = `${trimmedBase}/model/${model.id}/invoke-with-response-stream`;

--- a/src/agents/bedrock-invoke-stream.ts
+++ b/src/agents/bedrock-invoke-stream.ts
@@ -1,0 +1,535 @@
+import { randomUUID } from "node:crypto";
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type {
+  AssistantMessage,
+  StopReason,
+  TextContent,
+  ThinkingContent,
+  ToolCall,
+  Tool,
+  Usage,
+} from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("bedrock-invoke-stream");
+
+// ── Anthropic Messages request types (Bedrock subset) ───────────────────────
+
+interface AnthropicMessage {
+  role: "user" | "assistant";
+  content: string | AnthropicContentBlock[];
+}
+
+type AnthropicContentBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; source: { type: "base64"; media_type: string; data: string } }
+  | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
+  | { type: "tool_result"; tool_use_id: string; content: string };
+
+interface AnthropicTool {
+  name: string;
+  description: string;
+  input_schema: Record<string, unknown>;
+}
+
+interface BedrockInvokeRequest {
+  anthropic_version: string;
+  max_tokens: number;
+  system?: string;
+  messages: AnthropicMessage[];
+  tools?: AnthropicTool[];
+}
+
+// ── SSE event types from Anthropic stream ───────────────────────────────────
+
+interface SseMessageStart {
+  type: "message_start";
+  message: {
+    id: string;
+    usage?: { input_tokens?: number; output_tokens?: number };
+  };
+}
+
+interface SseContentBlockStart {
+  type: "content_block_start";
+  index: number;
+  content_block:
+    | { type: "text"; text: string }
+    | { type: "thinking"; thinking: string }
+    | { type: "tool_use"; id: string; name: string; input: string };
+}
+
+interface SseContentBlockDelta {
+  type: "content_block_delta";
+  index: number;
+  delta:
+    | { type: "text_delta"; text: string }
+    | { type: "thinking_delta"; thinking: string }
+    | { type: "input_json_delta"; partial_json: string };
+}
+
+interface SseContentBlockStop {
+  type: "content_block_stop";
+  index: number;
+}
+
+interface SseMessageDelta {
+  type: "message_delta";
+  delta: { stop_reason?: string };
+  usage?: { output_tokens?: number };
+}
+
+interface SseMessageStop {
+  type: "message_stop";
+}
+
+type SseEvent =
+  | SseMessageStart
+  | SseContentBlockStart
+  | SseContentBlockDelta
+  | SseContentBlockStop
+  | SseMessageDelta
+  | SseMessageStop
+  | { type: "ping" };
+
+// ── Message conversion ──────────────────────────────────────────────────────
+
+type InputContentPart =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType?: string }
+  | { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }
+  | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
+  | { type: "toolResult"; toolCallId: string; content: unknown };
+
+function convertMessages(messages: Array<{ role: string; content: unknown }>): AnthropicMessage[] {
+  const result: AnthropicMessage[] = [];
+
+  for (const msg of messages) {
+    const { role, content } = msg;
+
+    if (role === "user") {
+      if (typeof content === "string") {
+        result.push({ role: "user", content });
+      } else if (Array.isArray(content)) {
+        const blocks: AnthropicContentBlock[] = [];
+        for (const part of content as InputContentPart[]) {
+          if (part.type === "text") {
+            blocks.push({ type: "text", text: part.text });
+          } else if (part.type === "image") {
+            blocks.push({
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: part.mimeType ?? "image/png",
+                data: part.data,
+              },
+            });
+          }
+        }
+        result.push({ role: "user", content: blocks.length > 0 ? blocks : "" });
+      } else {
+        result.push({ role: "user", content: "" });
+      }
+    } else if (role === "assistant") {
+      if (typeof content === "string") {
+        result.push({ role: "assistant", content });
+      } else if (Array.isArray(content)) {
+        const blocks: AnthropicContentBlock[] = [];
+        for (const part of content as InputContentPart[]) {
+          if (part.type === "text") {
+            blocks.push({ type: "text", text: part.text });
+          } else if (part.type === "toolCall") {
+            blocks.push({
+              type: "tool_use",
+              id: part.id,
+              name: part.name,
+              input: part.arguments,
+            });
+          } else if (part.type === "tool_use") {
+            blocks.push({
+              type: "tool_use",
+              id: part.id,
+              name: part.name,
+              input: part.input,
+            });
+          }
+        }
+        result.push({ role: "assistant", content: blocks.length > 0 ? blocks : "" });
+      } else {
+        result.push({ role: "assistant", content: "" });
+      }
+    } else if (role === "tool" || role === "toolResult") {
+      // Tool results in Anthropic format go as user messages with tool_result blocks
+      const toolCallId =
+        typeof (msg as { toolCallId?: unknown }).toolCallId === "string"
+          ? ((msg as { toolCallId?: string }).toolCallId ?? `tool_${randomUUID()}`)
+          : `tool_${randomUUID()}`;
+      const text = typeof content === "string" ? content : extractTextFromContent(content);
+      result.push({
+        role: "user",
+        content: [{ type: "tool_result", tool_use_id: toolCallId, content: text }],
+      });
+    }
+  }
+
+  return result;
+}
+
+function extractTextFromContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return (content as Array<{ type: string; text?: string }>)
+    .filter((p) => p.type === "text" && typeof p.text === "string")
+    .map((p) => p.text!)
+    .join("");
+}
+
+function convertTools(tools: Tool[] | undefined): AnthropicTool[] {
+  if (!tools || !Array.isArray(tools)) {
+    return [];
+  }
+  const result: AnthropicTool[] = [];
+  for (const tool of tools) {
+    if (typeof tool.name !== "string" || !tool.name) {
+      continue;
+    }
+    result.push({
+      name: tool.name,
+      description: typeof tool.description === "string" ? tool.description : "",
+      input_schema: (tool.parameters ?? { type: "object", properties: {} }) as Record<
+        string,
+        unknown
+      >,
+    });
+  }
+  return result;
+}
+
+// ── AWS binary event stream parser ──────────────────────────────────────────
+//
+// The Bedrock invoke-with-response-stream endpoint returns
+// `application/vnd.amazon.eventstream` — a binary framing protocol.
+//
+// Each frame:
+//   [4B total_len] [4B headers_len] [4B prelude_crc]
+//   [headers...]   [payload...]     [4B message_crc]
+//
+// Headers are type-tagged key-value pairs; we only care about the payload.
+// For Bedrock, the payload is JSON: {"bytes":"<base64>"} where the base64
+// decodes to standard Anthropic JSON events (message_start, content_block_delta, etc.).
+
+const EVENT_STREAM_PRELUDE_SIZE = 12; // 4 + 4 + 4
+const EVENT_STREAM_CRC_SIZE = 4;
+
+/**
+ * Parse AWS binary event stream frames from a ReadableStream and yield
+ * the decoded Anthropic JSON events.
+ */
+async function* parseAwsEventStream(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+): AsyncGenerator<SseEvent> {
+  let buffer = new Uint8Array(0);
+
+  function appendToBuffer(chunk: Uint8Array): void {
+    const next = new Uint8Array(buffer.length + chunk.length);
+    next.set(buffer);
+    next.set(chunk, buffer.length);
+    buffer = next;
+  }
+
+  function readUint32(offset: number): number {
+    const view = new DataView(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+    return view.getUint32(offset);
+  }
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    appendToBuffer(value);
+
+    // Try to extract complete frames from the buffer
+    while (buffer.length >= EVENT_STREAM_PRELUDE_SIZE) {
+      const totalLength = readUint32(0);
+      const headersLength = readUint32(4);
+
+      if (totalLength < EVENT_STREAM_PRELUDE_SIZE + EVENT_STREAM_CRC_SIZE) {
+        // Malformed frame; skip 1 byte and resync
+        log.warn(`Malformed event stream frame (totalLength=${totalLength}), skipping`);
+        buffer = buffer.slice(1);
+        continue;
+      }
+
+      if (buffer.length < totalLength) {
+        // Incomplete frame; wait for more data
+        break;
+      }
+
+      // Extract payload (between headers and trailing CRC)
+      const payloadStart = EVENT_STREAM_PRELUDE_SIZE + headersLength;
+      const payloadEnd = totalLength - EVENT_STREAM_CRC_SIZE;
+      const payloadBytes = buffer.slice(payloadStart, payloadEnd);
+
+      // Advance buffer past this frame
+      buffer = buffer.slice(totalLength);
+
+      if (payloadBytes.length === 0) {
+        continue;
+      }
+
+      const decoder = new TextDecoder();
+      const payloadStr = decoder.decode(payloadBytes);
+
+      try {
+        const envelope = JSON.parse(payloadStr) as { bytes?: string };
+        if (!envelope.bytes) {
+          continue;
+        }
+
+        // Decode the base64 inner event
+        const innerJson = Buffer.from(envelope.bytes, "base64").toString("utf-8");
+        const event = JSON.parse(innerJson) as SseEvent;
+        yield event;
+      } catch {
+        // Some frames may be error events or non-JSON; log and skip
+        log.debug(`Skipping non-JSON event stream payload: ${payloadStr.slice(0, 120)}`);
+      }
+    }
+  }
+}
+
+// ── Accumulated content block tracking ──────────────────────────────────────
+
+interface ContentBlockAccumulator {
+  type: "text" | "thinking" | "tool_use";
+  text: string;
+  // For tool_use blocks
+  toolId?: string;
+  toolName?: string;
+  inputJson?: string;
+}
+
+// ── Main StreamFn factory ───────────────────────────────────────────────────
+
+export function createBedrockInvokeStreamFn(baseUrl: string): StreamFn {
+  const trimmedBase = baseUrl.trim().replace(/\/+$/, "");
+
+  return (model, context, options) => {
+    const stream = createAssistantMessageEventStream();
+
+    const run = async () => {
+      try {
+        const messages = convertMessages(context.messages ?? []);
+        const tools = convertTools(context.tools);
+
+        const body: BedrockInvokeRequest = {
+          anthropic_version: "bedrock-2023-05-31",
+          max_tokens: options?.maxTokens ?? model.maxTokens ?? 4096,
+          messages,
+          ...(context.systemPrompt ? { system: context.systemPrompt } : {}),
+          ...(tools.length > 0 ? { tools } : {}),
+        };
+
+        if (typeof options?.temperature === "number") {
+          (body as unknown as Record<string, unknown>).temperature = options.temperature;
+        }
+
+        const url = `${trimmedBase}/model/${model.id}/invoke-with-response-stream`;
+        log.debug(`POST ${url}`);
+
+        const headers: Record<string, string> = {
+          "Content-Type": "application/json",
+          ...options?.headers,
+        };
+        if (options?.apiKey) {
+          // Corporate Bedrock proxies (e.g. Kong-based) typically expect
+          // both Authorization and api-key headers for routing/auth.
+          headers.Authorization = `Bearer ${options.apiKey}`;
+          headers["api-key"] = options.apiKey;
+        }
+
+        const response = await fetch(url, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(body),
+          signal: options?.signal,
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => "unknown error");
+          throw new Error(`Bedrock invoke API error ${response.status}: ${errorText}`);
+        }
+
+        if (!response.body) {
+          throw new Error("Bedrock invoke API returned empty response body");
+        }
+
+        const reader = response.body.getReader();
+        const blocks: ContentBlockAccumulator[] = [];
+        let inputTokens = 0;
+        let outputTokens = 0;
+        let stopReason: string | undefined;
+
+        for await (const event of parseAwsEventStream(reader)) {
+          switch (event.type) {
+            case "message_start": {
+              const usage = event.message?.usage;
+              if (usage?.input_tokens) {
+                inputTokens = usage.input_tokens;
+              }
+              break;
+            }
+            case "content_block_start": {
+              const block = event.content_block;
+              if (block.type === "text") {
+                blocks[event.index] = { type: "text", text: block.text ?? "" };
+              } else if (block.type === "thinking") {
+                blocks[event.index] = { type: "thinking", text: block.thinking ?? "" };
+              } else if (block.type === "tool_use") {
+                blocks[event.index] = {
+                  type: "tool_use",
+                  text: "",
+                  toolId: block.id,
+                  toolName: block.name,
+                  inputJson: "",
+                };
+              }
+              break;
+            }
+            case "content_block_delta": {
+              const acc = blocks[event.index];
+              if (!acc) {
+                break;
+              }
+              if (event.delta.type === "text_delta") {
+                acc.text += event.delta.text;
+              } else if (event.delta.type === "thinking_delta") {
+                acc.text += event.delta.thinking;
+              } else if (event.delta.type === "input_json_delta") {
+                acc.inputJson = (acc.inputJson ?? "") + event.delta.partial_json;
+              }
+              break;
+            }
+            case "content_block_stop": {
+              // Block finalized; nothing extra needed
+              break;
+            }
+            case "message_delta": {
+              if (event.delta.stop_reason) {
+                stopReason = event.delta.stop_reason;
+              }
+              if (event.usage?.output_tokens) {
+                outputTokens = event.usage.output_tokens;
+              }
+              break;
+            }
+            case "message_stop": {
+              // Stream complete
+              break;
+            }
+          }
+        }
+
+        // Build AssistantMessage from accumulated blocks
+        const contentParts: (TextContent | ThinkingContent | ToolCall)[] = [];
+        for (const block of blocks) {
+          if (!block) {
+            continue;
+          }
+          if (block.type === "text" && block.text) {
+            contentParts.push({ type: "text", text: block.text });
+          } else if (block.type === "thinking" && block.text) {
+            contentParts.push({
+              type: "thinking",
+              thinking: block.text,
+            } as ThinkingContent);
+          } else if (block.type === "tool_use") {
+            let args: Record<string, unknown> = {};
+            if (block.inputJson) {
+              try {
+                args = JSON.parse(block.inputJson) as Record<string, unknown>;
+              } catch {
+                log.warn(`Failed to parse tool input JSON for ${block.toolName}`);
+              }
+            }
+            contentParts.push({
+              type: "toolCall",
+              id: block.toolId ?? `bedrock_call_${randomUUID()}`,
+              name: block.toolName ?? "unknown",
+              arguments: args,
+            });
+          }
+        }
+
+        const hasToolCalls = contentParts.some((p) => p.type === "toolCall");
+        const resolvedStopReason: StopReason =
+          stopReason === "tool_use" || hasToolCalls ? "toolUse" : "stop";
+
+        const usage: Usage = {
+          input: inputTokens,
+          output: outputTokens,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: inputTokens + outputTokens,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        };
+
+        const assistantMessage: AssistantMessage = {
+          role: "assistant",
+          content: contentParts,
+          stopReason: resolvedStopReason,
+          api: model.api,
+          provider: model.provider,
+          model: model.id,
+          usage,
+          timestamp: Date.now(),
+        };
+
+        const doneReason: Extract<StopReason, "stop" | "length" | "toolUse"> =
+          resolvedStopReason === "toolUse" ? "toolUse" : "stop";
+
+        stream.push({
+          type: "done",
+          reason: doneReason,
+          message: assistantMessage,
+        });
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        log.error(`Bedrock invoke stream error: ${errorMessage}`);
+        stream.push({
+          type: "error",
+          reason: "error",
+          error: {
+            role: "assistant" as const,
+            content: [],
+            stopReason: "error" as StopReason,
+            errorMessage,
+            api: model.api,
+            provider: model.provider,
+            model: model.id,
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+              totalTokens: 0,
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+            },
+            timestamp: Date.now(),
+          },
+        });
+      } finally {
+        stream.end();
+      }
+    };
+
+    queueMicrotask(() => void run());
+    return stream;
+  };
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -778,6 +778,11 @@ export async function runEmbeddedAttempt(
         const providerBaseUrl =
           typeof providerConfig?.baseUrl === "string" ? providerConfig.baseUrl.trim() : "";
         const bedrockBaseUrl = modelBaseUrl || providerBaseUrl || "";
+        if (!bedrockBaseUrl) {
+          log.warn(
+            `bedrock-invoke: no baseUrl configured for provider "${params.model.provider}"; requests will fail`,
+          );
+        }
         activeSession.agent.streamFn = createBedrockInvokeStreamFn(bedrockBaseUrl);
       } else {
         // Force a stable streamFn reference so vitest can reliably mock @mariozechner/pi-ai.

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -29,6 +29,7 @@ import { isReasoningTagProvider } from "../../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../../agent-paths.js";
 import { resolveSessionAgentIds } from "../../agent-scope.js";
 import { createAnthropicPayloadLogger } from "../../anthropic-payload-log.js";
+import { createBedrockInvokeStreamFn } from "../../bedrock-invoke-stream.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../../bootstrap-files.js";
 import { createCacheTrace } from "../../cache-trace.js";
 import {
@@ -768,6 +769,16 @@ export async function runEmbeddedAttempt(
           typeof providerConfig?.baseUrl === "string" ? providerConfig.baseUrl.trim() : "";
         const ollamaBaseUrl = modelBaseUrl || providerBaseUrl || OLLAMA_NATIVE_BASE_URL;
         activeSession.agent.streamFn = createOllamaStreamFn(ollamaBaseUrl);
+      } else if (params.model.api === "bedrock-invoke") {
+        // Bedrock native invoke: Anthropic Messages format routed to
+        // /model/{modelId}/invoke-with-response-stream (Bearer token auth).
+        const providerConfig = params.config?.models?.providers?.[params.model.provider];
+        const modelBaseUrl =
+          typeof params.model.baseUrl === "string" ? params.model.baseUrl.trim() : "";
+        const providerBaseUrl =
+          typeof providerConfig?.baseUrl === "string" ? providerConfig.baseUrl.trim() : "";
+        const bedrockBaseUrl = modelBaseUrl || providerBaseUrl || "";
+        activeSession.agent.streamFn = createBedrockInvokeStreamFn(bedrockBaseUrl);
       } else {
         // Force a stable streamFn reference so vitest can reliably mock @mariozechner/pi-ai.
         activeSession.agent.streamFn = streamSimple;

--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -66,6 +66,19 @@ describe("resolveTranscriptPolicy", () => {
     expect(policy.sanitizeMode).toBe("full");
   });
 
+  it("enables Anthropic-compatible policies for bedrock-invoke API", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "corp-bedrock",
+      modelId: "claude-opus-4-6",
+      modelApi: "bedrock-invoke",
+    });
+    expect(policy.repairToolUseResultPairing).toBe(true);
+    expect(policy.validateAnthropicTurns).toBe(true);
+    expect(policy.allowSyntheticToolResults).toBe(true);
+    expect(policy.sanitizeToolCallIds).toBe(true);
+    expect(policy.sanitizeMode).toBe("full");
+  });
+
   it("keeps OpenRouter on its existing turn-validation path", () => {
     const policy = resolveTranscriptPolicy({
       provider: "openrouter",

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -55,7 +55,11 @@ function isOpenAiProvider(provider?: string | null): boolean {
 }
 
 function isAnthropicApi(modelApi?: string | null, provider?: string | null): boolean {
-  if (modelApi === "anthropic-messages" || modelApi === "bedrock-converse-stream") {
+  if (
+    modelApi === "anthropic-messages" ||
+    modelApi === "bedrock-converse-stream" ||
+    modelApi === "bedrock-invoke"
+  ) {
     return true;
   }
   const normalized = normalizeProviderId(provider ?? "");

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -8,6 +8,7 @@ export const MODEL_APIS = [
   "google-generative-ai",
   "github-copilot",
   "bedrock-converse-stream",
+  "bedrock-invoke",
   "ollama",
 ] as const;
 


### PR DESCRIPTION
## Summary

- Export helper functions (`convertMessages`, `extractTextFromContent`, `convertTools`, `parseAwsEventStream`, `SseEvent`) from `bedrock-invoke-stream.ts` for testability (consistent with `ollama-stream.ts` pattern)
- Add `temperature` field to `BedrockInvokeRequest` interface, removing an unsafe double type cast
- Hoist `TextDecoder` out of inner loop in `parseAwsEventStream` to avoid per-frame allocation
- Add `log.warn()` in `attempt.ts` when `bedrockBaseUrl` is empty for bedrock-invoke provider
- Add comprehensive unit tests for `bedrock-invoke-stream.ts` (31 tests covering message conversion, tool conversion, AWS event stream parsing, and the full StreamFn factory)
- Add `bedrock-invoke` API test case to `transcript-policy.test.ts`

## Test plan

- [x] `pnpm tsgo` — type check passes
- [x] `pnpm check` — lint + format passes
- [x] `pnpm test -- --run src/agents/bedrock-invoke-stream.test.ts src/agents/transcript-policy.test.ts` — 39 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
