### PR TITLE
fix(control-ui): prevent infinite render loop in cron form name field

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -477,6 +477,10 @@ export function renderApp(state: AppViewState) {
                 timezoneSuggestions: CRON_TIMEZONE_SUGGESTIONS,
                 deliveryToSuggestions,
                 onFormChange: (patch) => {
+                  const keys = Object.keys(patch) as Array<keyof typeof patch>;
+                  if (keys.every((k) => state.cronForm[k] === patch[k])) {
+                    return;
+                  }
                   state.cronForm = normalizeCronFormState({ ...state.cronForm, ...patch });
                   state.cronFieldErrors = validateCronForm(state.cronForm);
                 },


### PR DESCRIPTION
## Summary

- Adds a shallow equality check in the cron form `onFormChange` handler to prevent infinite reactive render loops when clicking an empty input field

**Root cause:** The `@input` handler fires when clicking an empty field (value `""` → `""`). The spread operator `{ ...state.cronForm, ...patch }` always creates a new object reference, which Lit detects as a change and triggers a re-render, causing an infinite loop that spikes CPU to ~100%.

**Fix:** Compare patch values against current form state before creating a new object. If nothing changed, bail out early.

## Changes

- `ui/src/ui/app-render.ts`: Add shallow equality check before reassigning `cronForm`

## Test plan

- [ ] Open Control UI → Cron Jobs tab → click the empty "Name" input field
- [ ] Verify the UI remains responsive (no CPU spike, no frozen tab)
- [ ] Verify typing in the field still works and form validation triggers correctly

Fixes #30208