### PR TITLE
fix(auth): grant owner-level tool access when ownerAllowFrom is wildcard

### DIFF
--- a/src/auto-reply/command-auth.ts
+++ b/src/auto-reply/command-auth.ts
@@ -341,7 +341,7 @@ export function resolveCommandAuthorization(params: {
   const senderId = matchedSender ?? senderCandidates[0];
 
   const enforceOwner = Boolean(dock?.commands?.enforceOwnerForCommands);
-  const senderIsOwner = Boolean(matchedSender);
+  const senderIsOwner = ownerAllowAll || Boolean(matchedSender);
   const ownerAllowlistConfigured = ownerAllowAll || explicitOwners.length > 0;
   const requireOwner = enforceOwner || ownerAllowlistConfigured;
   const isOwnerForCommands = !requireOwner


### PR DESCRIPTION
## Summary

- Fixes `ownerAllowFrom: ["*"]` not granting owner-level tool access (cron, gateway, whatsapp_login tools silently stripped)

**Root cause:** In `command-auth.ts`, the `ownerAllowAll` flag (from `"*"` in the allowlist) was used for `isOwnerForCommands` but not for `senderIsOwner`. When the allowlist is `["*"]`, the explicit owners list is empty, so `matchedSender` is always `undefined` and `senderIsOwner` is always `false`.

**Fix:** One-line change — include `ownerAllowAll` in the `senderIsOwner` check:
```typescript
const senderIsOwner = ownerAllowAll || Boolean(matchedSender);
```

## Changes

- `src/auto-reply/command-auth.ts`: Include `ownerAllowAll` in `senderIsOwner` derivation

## Test plan

- [ ] Configure `commands.ownerAllowFrom: ["*"]`
- [ ] Verify owner-only tools (cron, gateway) are available in the tool list
- [ ] Verify explicit owner IDs still work as before

Fixes #30233
Closes #30226