### PR TITLE
feat(telegram): add inline button exec approvals

### DIFF
--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -1,6 +1,5 @@
 import crypto from "node:crypto";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
-import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import {
   addAllowlistEntry,
@@ -341,8 +340,10 @@ export async function processGatewayAllowlist(
     const interactiveApprovals = hasInteractiveExecApprovals(params.turnSourceChannel);
     const pendingText = interactiveApprovals
       ? `${warningText}Approval required (id ${approvalSlug}). ` +
-        `An interactive approval prompt with buttons has been sent to the user. ` +
-        `Reply with ONLY: ${SILENT_REPLY_TOKEN}`
+        `An interactive approval prompt with buttons has been sent to the user — ` +
+        `do not repeat the command or approval details. ` +
+        `The command will execute automatically once approved. ` +
+        `You will receive a system notification with the result — report it to the user at that time.`
       : `${warningText}Approval required (id ${approvalSlug}). ` +
         "Approve to run; updates will arrive after completion.";
 

--- a/src/agents/bash-tools.exec-host-gateway.ts
+++ b/src/agents/bash-tools.exec-host-gateway.ts
@@ -1,5 +1,7 @@
 import crypto from "node:crypto";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
+import { SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
+import { loadConfig } from "../config/config.js";
 import {
   addAllowlistEntry,
   type ExecAsk,
@@ -13,6 +15,7 @@ import {
 import { detectCommandObfuscation } from "../infra/exec-obfuscation-detect.js";
 import type { SafeBinProfile } from "../infra/exec-safe-bin-policy.js";
 import { logInfo } from "../logger.js";
+import { normalizeMessageChannel } from "../utils/message-channel.js";
 import { markBackgrounded, tail } from "./bash-process-registry.js";
 import {
   buildExecApprovalRequesterContext,
@@ -63,6 +66,46 @@ export type ProcessGatewayAllowlistResult = {
   execCommandOverride?: string;
   pendingResult?: AgentToolResult<ExecToolDetails>;
 };
+
+/**
+ * Checks whether the source channel has interactive (button-based) exec
+ * approvals configured.  When active, the agent tool result text should tell
+ * the LLM to emit NO_REPLY so the redundant text message is suppressed.
+ */
+function hasInteractiveExecApprovals(turnSourceChannel?: string): boolean {
+  if (!turnSourceChannel) {
+    return false;
+  }
+  const channel = normalizeMessageChannel(turnSourceChannel) ?? turnSourceChannel;
+  try {
+    const cfg = loadConfig();
+    type ChannelCfg = {
+      execApprovals?: { enabled?: boolean; approvers?: Array<string | number> };
+      accounts?: Record<
+        string,
+        { execApprovals?: { enabled?: boolean; approvers?: Array<string | number> } }
+      >;
+    };
+    const channelCfg = (cfg.channels as Record<string, unknown> | undefined)?.[channel] as
+      | ChannelCfg
+      | undefined;
+    if (!channelCfg) {
+      return false;
+    }
+    const ea = channelCfg.execApprovals;
+    if (ea?.enabled && (ea.approvers?.length ?? 0) > 0) {
+      return true;
+    }
+    if (channelCfg.accounts) {
+      return Object.values(channelCfg.accounts).some(
+        (acc) => acc.execApprovals?.enabled && (acc.execApprovals.approvers?.length ?? 0) > 0,
+      );
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
 
 export async function processGatewayAllowlist(
   params: ProcessGatewayAllowlistParams,
@@ -295,14 +338,20 @@ export async function processGatewayAllowlist(
       emitExecSystemEvent(summary, { sessionKey: params.notifySessionKey, contextKey });
     })();
 
+    const interactiveApprovals = hasInteractiveExecApprovals(params.turnSourceChannel);
+    const pendingText = interactiveApprovals
+      ? `${warningText}Approval required (id ${approvalSlug}). ` +
+        `An interactive approval prompt with buttons has been sent to the user. ` +
+        `Reply with ONLY: ${SILENT_REPLY_TOKEN}`
+      : `${warningText}Approval required (id ${approvalSlug}). ` +
+        "Approve to run; updates will arrive after completion.";
+
     return {
       pendingResult: {
         content: [
           {
             type: "text",
-            text:
-              `${warningText}Approval required (id ${approvalSlug}). ` +
-              "Approve to run; updates will arrive after completion.",
+            text: pendingText,
           },
         ],
         details: {

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -176,6 +176,24 @@ export type TelegramAccountConfig = {
    * Telegram expects unicode emoji (e.g., "👀") rather than shortcodes.
    */
   ackReaction?: string;
+  /** Exec approval forwarding with inline buttons (mirrors Discord exec approvals). */
+  execApprovals?: TelegramExecApprovalConfig;
+};
+
+export type TelegramExecApprovalConfig = {
+  /** Enable exec approval forwarding to Telegram with inline buttons. Default: false. */
+  enabled?: boolean;
+  /** Telegram user IDs (numeric) to receive approval prompts. Required if enabled. */
+  approvers?: Array<string | number>;
+  /** Only forward approvals for these agent IDs. Omit = all agents. */
+  agentFilter?: string[];
+  /** Only forward approvals matching these session key patterns (substring or regex). */
+  sessionFilter?: string[];
+  /** Delete approval messages after resolution. Default: false. */
+  cleanupAfterResolve?: boolean;
+  /** Where to send approval prompts. "dm" sends to approver DMs (default), "channel" sends to the
+   *  originating Telegram chat, "both" sends to both. */
+  target?: "dm" | "channel" | "both";
 };
 
 export type TelegramTopicConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -247,6 +247,17 @@ export const TelegramAccountSchemaBase = z
     linkPreview: z.boolean().optional(),
     responsePrefix: z.string().optional(),
     ackReaction: z.string().optional(),
+    execApprovals: z
+      .object({
+        enabled: z.boolean().optional(),
+        approvers: z.array(z.union([z.string(), z.number()])).optional(),
+        agentFilter: z.array(z.string()).optional(),
+        sessionFilter: z.array(z.string()).optional(),
+        cleanupAfterResolve: z.boolean().optional(),
+        target: z.enum(["dm", "channel", "both"]).optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 

--- a/src/infra/exec-approval-forwarder.ts
+++ b/src/infra/exec-approval-forwarder.ts
@@ -120,6 +120,33 @@ function resolveChannelAccountConfig<T>(
   return fallbackKey ? accounts[fallbackKey] : undefined;
 }
 
+// Telegram has inline-button-based exec approvals; skip text fallback only when
+// the Telegram-specific handler is enabled for the same target account.
+function shouldSkipTelegramForwarding(
+  target: ExecApprovalForwardTarget,
+  cfg: OpenClawConfig,
+): boolean {
+  const channel = normalizeMessageChannel(target.channel) ?? target.channel;
+  if (channel !== "telegram") {
+    return false;
+  }
+  const telegram = cfg.channels?.telegram as
+    | {
+        execApprovals?: { enabled?: boolean; approvers?: Array<string | number> };
+        accounts?: Record<
+          string,
+          { execApprovals?: { enabled?: boolean; approvers?: Array<string | number> } }
+        >;
+      }
+    | undefined;
+  if (!telegram) {
+    return false;
+  }
+  const account = resolveChannelAccountConfig(telegram.accounts, target.accountId);
+  const execApprovals = account?.execApprovals ?? telegram.execApprovals;
+  return Boolean(execApprovals?.enabled && (execApprovals.approvers?.length ?? 0) > 0);
+}
+
 // Discord has component-based exec approvals; skip text fallback only when the
 // Discord-specific handler is enabled for the same target account.
 function shouldSkipDiscordForwarding(
@@ -351,7 +378,10 @@ export function createExecApprovalForwarder(
       config,
       request,
       resolveSessionTarget,
-    }).filter((target) => !shouldSkipDiscordForwarding(target, cfg));
+    }).filter(
+      (target) =>
+        !shouldSkipDiscordForwarding(target, cfg) && !shouldSkipTelegramForwarding(target, cfg),
+    );
 
     if (filteredTargets.length === 0) {
       return false;
@@ -416,7 +446,10 @@ export function createExecApprovalForwarder(
           config,
           request,
           resolveSessionTarget,
-        }).filter((target) => !shouldSkipDiscordForwarding(target, cfg));
+        }).filter(
+          (target) =>
+            !shouldSkipDiscordForwarding(target, cfg) && !shouldSkipTelegramForwarding(target, cfg),
+        );
       }
     }
     if (!targets || targets.length === 0) {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -51,6 +51,7 @@ import {
 } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import { enforceTelegramDmAccess } from "./dm-access.js";
+import { parseExecApprovalCallbackData } from "./exec-approvals.js";
 import {
   evaluateTelegramGroupBaseAccess,
   evaluateTelegramGroupPolicyAccess,
@@ -119,6 +120,7 @@ export const registerTelegramHandlers = ({
   shouldSkipUpdate,
   processMessage,
   logger,
+  execApprovalHandler,
 }: RegisterTelegramHandlerParams) => {
   const DEFAULT_TEXT_FRAGMENT_MAX_GAP_MS = 1500;
   const TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS = 4000;
@@ -1084,6 +1086,26 @@ export const registerTelegramHandlers = ({
         }
         return await bot.api.sendMessage(callbackMessage.chat.id, text, params);
       };
+
+      // Exec approval callbacks have their own authorization (approvers list),
+      // independent of inline button scope, so check them first.
+      if (data.startsWith("ea:")) {
+        const parsed = parseExecApprovalCallbackData(data);
+        if (parsed && execApprovalHandler) {
+          const approvers = execApprovalHandler.getApprovers();
+          const senderId = callback.from?.id ? String(callback.from.id) : "";
+          if (!approvers.some((id) => String(id) === senderId)) {
+            return;
+          }
+          try {
+            await editCallbackMessage("Submitting decision...");
+          } catch {
+            // Message may have been deleted
+          }
+          await execApprovalHandler.resolveApproval(parsed.approvalId, parsed.action);
+        }
+        return;
+      }
 
       const inlineButtonsScope = resolveTelegramInlineButtonsScope({
         cfg,

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -35,6 +35,7 @@ import type {
   TelegramTopicConfig,
 } from "../config/types.js";
 import { danger, logVerbose } from "../globals.js";
+import type { ExecApprovalDecision } from "../infra/exec-approvals.js";
 import { getChildLogger } from "../logging.js";
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
 import {
@@ -116,6 +117,10 @@ export type RegisterTelegramHandlerParams = {
     replyMedia?: TelegramMediaRef[],
   ) => Promise<void>;
   logger: ReturnType<typeof getChildLogger>;
+  execApprovalHandler?: {
+    resolveApproval: (approvalId: string, decision: ExecApprovalDecision) => Promise<boolean>;
+    getApprovers: () => Array<string | number>;
+  } | null;
 };
 
 type RegisterTelegramNativeCommandsParams = {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -62,6 +62,7 @@ export type TelegramBotOptions = {
     mediaGroupFlushMs?: number;
     textFragmentGapMs?: number;
   };
+  execApprovalHandler?: import("./exec-approvals.js").TelegramExecApprovalHandler | null;
 };
 
 export { getTelegramSequentialKey };
@@ -404,6 +405,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     shouldSkipUpdate,
     processMessage,
     logger,
+    execApprovalHandler: opts.execApprovalHandler ?? null,
   });
 
   const originalStop = bot.stop.bind(bot);

--- a/src/telegram/exec-approvals.ts
+++ b/src/telegram/exec-approvals.ts
@@ -89,26 +89,125 @@ function formatCommandPreview(command: string, maxChars = 200): string {
   return command;
 }
 
+function describeCommand(command: string): string {
+  const trimmed = command.trim();
+  const binary = trimmed.split(/\s+/)[0] ?? trimmed;
+  const base = binary.split("/").pop() ?? binary;
+
+  // Provide human-readable descriptions for common commands
+  if (base === "rm" || base === "rmdir") {
+    return "Delete files or directories";
+  }
+  if (base === "mv") {
+    return "Move or rename files";
+  }
+  if (base === "cp") {
+    return "Copy files";
+  }
+  if (base === "chmod") {
+    return "Change file permissions";
+  }
+  if (base === "chown") {
+    return "Change file ownership";
+  }
+  if (base === "curl" || base === "wget") {
+    return "Download from the internet";
+  }
+  if (base === "pip" || base === "pip3") {
+    return "Install Python packages";
+  }
+  if (
+    base === "npm" ||
+    base === "npx" ||
+    base === "pnpm" ||
+    base === "yarn" ||
+    base === "bun" ||
+    base === "bunx"
+  ) {
+    return "Run a Node.js package manager command";
+  }
+  if (base === "git") {
+    return "Run a git version control command";
+  }
+  if (base === "docker" || base === "podman") {
+    return "Run a container command";
+  }
+  if (base === "ssh" || base === "scp") {
+    return "Connect to or transfer files with a remote host";
+  }
+  if (base === "sudo") {
+    return "Run a command with elevated privileges";
+  }
+  if (
+    base === "apt" ||
+    base === "apt-get" ||
+    base === "brew" ||
+    base === "dnf" ||
+    base === "yum" ||
+    base === "pacman"
+  ) {
+    return "Install or manage system packages";
+  }
+  if (base === "kill" || base === "pkill" || base === "killall") {
+    return "Terminate a running process";
+  }
+  if (base === "cat" || base === "less" || base === "head" || base === "tail") {
+    return "Read file contents";
+  }
+  if (base === "sed" || base === "awk") {
+    return "Transform text or file contents";
+  }
+  if (
+    base === "python" ||
+    base === "python3" ||
+    base === "node" ||
+    base === "ruby" ||
+    base === "perl"
+  ) {
+    return `Execute a ${base} script`;
+  }
+  if (base === "bash" || base === "sh" || base === "zsh") {
+    return "Run a shell script";
+  }
+  return `Run "${base}"`;
+}
+
 function buildRequestMessageText(request: ExecApprovalRequest, nowMs: number): string {
-  const lines: string[] = ["\u{1F512} Exec approval required"];
-  const command = formatCommandPreview(request.request.command);
-  lines.push(`Command: ${command}`);
+  const command = request.request.command;
+  const description = describeCommand(command);
+  const preview = formatCommandPreview(command, 300);
+  const expiresIn = Math.max(0, Math.round((request.expiresAtMs - nowMs) / 1000));
+
+  const lines: string[] = [
+    `\u{1F512} <b>Exec Approval Required</b>`,
+    "",
+    `<b>What:</b> ${description}`,
+    `<b>Command:</b> <code>${escapeHtml(preview)}</code>`,
+  ];
   if (request.request.cwd) {
-    lines.push(`CWD: ${request.request.cwd}`);
+    lines.push(`<b>Directory:</b> <code>${escapeHtml(request.request.cwd)}</code>`);
   }
   if (request.request.host) {
-    lines.push(`Host: ${request.request.host}`);
+    lines.push(`<b>Host:</b> ${escapeHtml(request.request.host)}`);
   }
   if (request.request.agentId) {
-    lines.push(`Agent: ${request.request.agentId}`);
+    lines.push(`<b>Agent:</b> ${escapeHtml(request.request.agentId)}`);
   }
   if (Array.isArray(request.request.envKeys) && request.request.envKeys.length > 0) {
-    lines.push(`Env: ${request.request.envKeys.join(", ")}`);
+    lines.push(`<b>Env overrides:</b> ${escapeHtml(request.request.envKeys.join(", "))}`);
   }
-  const expiresIn = Math.max(0, Math.round((request.expiresAtMs - nowMs) / 1000));
-  lines.push(`Expires in: ${expiresIn}s`);
-  lines.push(`ID: ${request.id}`);
+  lines.push("");
+  lines.push(
+    `\u26A0\uFE0F <i>Allow once</i> = run this command once. ` +
+      `<i>Always allow</i> = add to allowlist. ` +
+      `<i>Deny</i> = block execution.`,
+  );
+  lines.push(`\u23F3 Expires in ${expiresIn}s \u2022 ID: ${request.id}`);
   return lines.join("\n");
+}
+
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 function decisionLabel(decision: ExecApprovalDecision): string {
@@ -121,14 +220,29 @@ function decisionLabel(decision: ExecApprovalDecision): string {
   return "denied";
 }
 
-function buildResolvedMessageText(resolved: ExecApprovalResolved): string {
-  const base = `\u2705 Exec approval ${decisionLabel(resolved.decision)}.`;
-  const by = resolved.resolvedBy ? ` Resolved by ${resolved.resolvedBy}.` : "";
-  return `${base}${by} ID: ${resolved.id}`;
+function resolvedEmoji(decision: ExecApprovalDecision): string {
+  if (decision === "deny") {
+    return "\u274C";
+  }
+  return "\u2705";
+}
+
+function buildResolvedMessageText(
+  resolved: ExecApprovalResolved,
+  request?: ExecApprovalRequest,
+): string {
+  const emoji = resolvedEmoji(resolved.decision);
+  const label = decisionLabel(resolved.decision);
+  const by = resolved.resolvedBy ? ` by ${resolved.resolvedBy}` : "";
+  const commandInfo = request?.request.command
+    ? `\n<b>Command:</b> <code>${escapeHtml(formatCommandPreview(request.request.command, 200))}</code>`
+    : "";
+  return `${emoji} <b>Exec approval ${label}</b>${by}.${commandInfo}\nID: ${resolved.id}`;
 }
 
 function buildExpiredMessageText(request: ExecApprovalRequest): string {
-  return `\u23F1\uFE0F Exec approval expired. ID: ${request.id}`;
+  const preview = formatCommandPreview(request.request.command, 200);
+  return `\u23F1\uFE0F <b>Exec approval expired</b>\n<b>Command:</b> <code>${escapeHtml(preview)}</code>\nID: ${request.id}`;
 }
 
 // --- Chat ID extraction ---
@@ -395,7 +509,7 @@ export class TelegramExecApprovalHandler {
 
     logDebug(`telegram exec approvals: resolved ${resolved.id} with ${resolved.decision}`);
 
-    const text = buildResolvedMessageText(resolved);
+    const text = buildResolvedMessageText(resolved, entry.request);
     await this.updateOrDeleteMessages(entry, text);
   }
 

--- a/src/telegram/exec-approvals.ts
+++ b/src/telegram/exec-approvals.ts
@@ -1,0 +1,440 @@
+import type { OpenClawConfig } from "../config/config.js";
+import type { TelegramExecApprovalConfig } from "../config/types.telegram.js";
+import { buildGatewayConnectionDetails } from "../gateway/call.js";
+import { GatewayClient } from "../gateway/client.js";
+import type { EventFrame } from "../gateway/protocol/index.js";
+import type {
+  ExecApprovalDecision,
+  ExecApprovalRequest,
+  ExecApprovalResolved,
+} from "../infra/exec-approvals.js";
+import { logDebug, logError } from "../logger.js";
+import { compileSafeRegex } from "../security/safe-regex.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import type { TelegramInlineButtons } from "./button-types.js";
+import { editMessageTelegram, sendMessageTelegram } from "./send.js";
+
+// --- Callback data encoding ---
+// Telegram limits callback_data to 64 bytes.
+// Format: ea:<approvalId>:<actionCode>
+// Action codes: 1 = allow-once, 2 = allow-always, 3 = deny
+
+const ACTION_TO_CODE: Record<ExecApprovalDecision, string> = {
+  "allow-once": "1",
+  "allow-always": "2",
+  deny: "3",
+};
+
+const CODE_TO_ACTION: Record<string, ExecApprovalDecision> = {
+  "1": "allow-once",
+  "2": "allow-always",
+  "3": "deny",
+};
+
+export function buildExecApprovalCallbackData(
+  approvalId: string,
+  action: ExecApprovalDecision,
+): string {
+  return `ea:${approvalId}:${ACTION_TO_CODE[action]}`;
+}
+
+export function parseExecApprovalCallbackData(
+  data: string,
+): { approvalId: string; action: ExecApprovalDecision } | null {
+  if (!data.startsWith("ea:")) {
+    return null;
+  }
+  const parts = data.split(":");
+  if (parts.length !== 3) {
+    return null;
+  }
+  const approvalId = parts[1];
+  const action = CODE_TO_ACTION[parts[2]];
+  if (!approvalId || !action) {
+    return null;
+  }
+  return { approvalId, action };
+}
+
+// --- Button builder ---
+
+export function buildExecApprovalButtons(approvalId: string): TelegramInlineButtons {
+  return [
+    [
+      {
+        text: "\u2705 Allow once",
+        callback_data: buildExecApprovalCallbackData(approvalId, "allow-once"),
+        style: "success",
+      },
+      {
+        text: "\u{1F504} Always allow",
+        callback_data: buildExecApprovalCallbackData(approvalId, "allow-always"),
+        style: "primary",
+      },
+      {
+        text: "\u274C Deny",
+        callback_data: buildExecApprovalCallbackData(approvalId, "deny"),
+        style: "danger",
+      },
+    ],
+  ];
+}
+
+// --- Message formatting ---
+
+function formatCommandPreview(command: string, maxChars = 200): string {
+  if (command.length > maxChars) {
+    return `${command.slice(0, maxChars)}...`;
+  }
+  return command;
+}
+
+function buildRequestMessageText(request: ExecApprovalRequest, nowMs: number): string {
+  const lines: string[] = ["\u{1F512} Exec approval required"];
+  const command = formatCommandPreview(request.request.command);
+  lines.push(`Command: ${command}`);
+  if (request.request.cwd) {
+    lines.push(`CWD: ${request.request.cwd}`);
+  }
+  if (request.request.host) {
+    lines.push(`Host: ${request.request.host}`);
+  }
+  if (request.request.agentId) {
+    lines.push(`Agent: ${request.request.agentId}`);
+  }
+  if (Array.isArray(request.request.envKeys) && request.request.envKeys.length > 0) {
+    lines.push(`Env: ${request.request.envKeys.join(", ")}`);
+  }
+  const expiresIn = Math.max(0, Math.round((request.expiresAtMs - nowMs) / 1000));
+  lines.push(`Expires in: ${expiresIn}s`);
+  lines.push(`ID: ${request.id}`);
+  return lines.join("\n");
+}
+
+function decisionLabel(decision: ExecApprovalDecision): string {
+  if (decision === "allow-once") {
+    return "allowed once";
+  }
+  if (decision === "allow-always") {
+    return "allowed always";
+  }
+  return "denied";
+}
+
+function buildResolvedMessageText(resolved: ExecApprovalResolved): string {
+  const base = `\u2705 Exec approval ${decisionLabel(resolved.decision)}.`;
+  const by = resolved.resolvedBy ? ` Resolved by ${resolved.resolvedBy}.` : "";
+  return `${base}${by} ID: ${resolved.id}`;
+}
+
+function buildExpiredMessageText(request: ExecApprovalRequest): string {
+  return `\u23F1\uFE0F Exec approval expired. ID: ${request.id}`;
+}
+
+// --- Chat ID extraction ---
+
+export function extractTelegramChatId(sessionKey?: string | null): string | null {
+  if (!sessionKey) {
+    return null;
+  }
+  // Session key format: agent:<id>:telegram:dm:<chatId> or agent:<id>:telegram:group:<chatId>
+  const match = sessionKey.match(/telegram:(?:dm|group):(-?\d+)/);
+  return match ? match[1] : null;
+}
+
+// --- Pending approval tracking ---
+
+type PendingApproval = {
+  request: ExecApprovalRequest;
+  /** Map of target key -> { chatId, messageId } */
+  messages: Map<string, { chatId: string; messageId: string }>;
+  timeoutId: NodeJS.Timeout;
+};
+
+// --- Handler class ---
+
+export type TelegramExecApprovalHandlerOpts = {
+  accountId: string;
+  config: TelegramExecApprovalConfig;
+  gatewayUrl?: string;
+  cfg: OpenClawConfig;
+};
+
+export class TelegramExecApprovalHandler {
+  private gatewayClient: GatewayClient | null = null;
+  private pending = new Map<string, PendingApproval>();
+  private opts: TelegramExecApprovalHandlerOpts;
+  private started = false;
+
+  constructor(opts: TelegramExecApprovalHandlerOpts) {
+    this.opts = opts;
+  }
+
+  shouldHandle(request: ExecApprovalRequest): boolean {
+    const config = this.opts.config;
+    if (!config.enabled) {
+      return false;
+    }
+    if (!config.approvers || config.approvers.length === 0) {
+      return false;
+    }
+
+    // Check agent filter
+    if (config.agentFilter?.length) {
+      if (!request.request.agentId) {
+        return false;
+      }
+      if (!config.agentFilter.includes(request.request.agentId)) {
+        return false;
+      }
+    }
+
+    // Check session filter (substring or regex match)
+    if (config.sessionFilter?.length) {
+      const session = request.request.sessionKey;
+      if (!session) {
+        return false;
+      }
+      const matches = config.sessionFilter.some((p) => {
+        if (session.includes(p)) {
+          return true;
+        }
+        const regex = compileSafeRegex(p);
+        return regex ? regex.test(session) : false;
+      });
+      if (!matches) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  async start(): Promise<void> {
+    if (this.started) {
+      return;
+    }
+    this.started = true;
+
+    const config = this.opts.config;
+    if (!config.enabled) {
+      logDebug("telegram exec approvals: disabled");
+      return;
+    }
+
+    if (!config.approvers || config.approvers.length === 0) {
+      logDebug("telegram exec approvals: no approvers configured");
+      return;
+    }
+
+    logDebug("telegram exec approvals: starting handler");
+
+    const { url: gatewayUrl } = buildGatewayConnectionDetails({
+      config: this.opts.cfg,
+      url: this.opts.gatewayUrl,
+    });
+
+    this.gatewayClient = new GatewayClient({
+      url: gatewayUrl,
+      clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+      clientDisplayName: "Telegram Exec Approvals",
+      mode: GATEWAY_CLIENT_MODES.BACKEND,
+      scopes: ["operator.approvals"],
+      onEvent: (evt) => this.handleGatewayEvent(evt),
+      onHelloOk: () => {
+        logDebug("telegram exec approvals: connected to gateway");
+      },
+      onConnectError: (err) => {
+        logError(`telegram exec approvals: connect error: ${err.message}`);
+      },
+      onClose: (code, reason) => {
+        logDebug(`telegram exec approvals: gateway closed: ${code} ${reason}`);
+      },
+    });
+
+    this.gatewayClient.start();
+  }
+
+  async stop(): Promise<void> {
+    if (!this.started) {
+      return;
+    }
+    this.started = false;
+
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timeoutId);
+    }
+    this.pending.clear();
+
+    this.gatewayClient?.stop();
+    this.gatewayClient = null;
+
+    logDebug("telegram exec approvals: stopped");
+  }
+
+  async resolveApproval(approvalId: string, decision: ExecApprovalDecision): Promise<boolean> {
+    if (!this.gatewayClient) {
+      logError("telegram exec approvals: gateway client not connected");
+      return false;
+    }
+
+    logDebug(`telegram exec approvals: resolving ${approvalId} with ${decision}`);
+
+    try {
+      await this.gatewayClient.request("exec.approval.resolve", {
+        id: approvalId,
+        decision,
+      });
+      logDebug(`telegram exec approvals: resolved ${approvalId} successfully`);
+      return true;
+    } catch (err) {
+      logError(`telegram exec approvals: resolve failed: ${String(err)}`);
+      return false;
+    }
+  }
+
+  getApprovers(): Array<string | number> {
+    return this.opts.config.approvers ?? [];
+  }
+
+  private handleGatewayEvent(evt: EventFrame): void {
+    if (evt.event === "exec.approval.requested") {
+      const request = evt.payload as ExecApprovalRequest;
+      void this.handleApprovalRequested(request);
+    } else if (evt.event === "exec.approval.resolved") {
+      const resolved = evt.payload as ExecApprovalResolved;
+      void this.handleApprovalResolved(resolved);
+    }
+  }
+
+  private async handleApprovalRequested(request: ExecApprovalRequest): Promise<void> {
+    if (!this.shouldHandle(request)) {
+      return;
+    }
+
+    logDebug(`telegram exec approvals: received request ${request.id}`);
+
+    const buttons = buildExecApprovalButtons(request.id);
+    const text = buildRequestMessageText(request, Date.now());
+
+    const target = this.opts.config.target ?? "dm";
+    const sendToDm = target === "dm" || target === "both";
+    const sendToChannel = target === "channel" || target === "both";
+
+    const messages = new Map<string, { chatId: string; messageId: string }>();
+
+    // Send to originating channel if configured
+    if (sendToChannel) {
+      const chatId = extractTelegramChatId(request.request.sessionKey);
+      if (chatId) {
+        try {
+          const result = await sendMessageTelegram(chatId, text, {
+            accountId: this.opts.accountId,
+            buttons,
+            textMode: "html",
+          });
+          messages.set(`channel:${chatId}`, {
+            chatId,
+            messageId: result.messageId,
+          });
+          logDebug(`telegram exec approvals: sent approval ${request.id} to chat ${chatId}`);
+        } catch (err) {
+          logError(`telegram exec approvals: failed to send to channel: ${String(err)}`);
+        }
+      } else if (!sendToDm) {
+        logError(
+          `telegram exec approvals: target is "channel" but could not extract chat id from session key "${request.request.sessionKey ?? "(none)"}" — falling back to DM`,
+        );
+        // Fall through to DM below
+      }
+    }
+
+    // Send to approver DMs if configured
+    if (sendToDm || (sendToChannel && messages.size === 0)) {
+      const approvers = this.opts.config.approvers ?? [];
+      for (const approver of approvers) {
+        const userId = String(approver);
+        try {
+          const result = await sendMessageTelegram(userId, text, {
+            accountId: this.opts.accountId,
+            buttons,
+            textMode: "html",
+          });
+          messages.set(`dm:${userId}`, {
+            chatId: userId,
+            messageId: result.messageId,
+          });
+          logDebug(`telegram exec approvals: sent approval ${request.id} to user ${userId}`);
+        } catch (err) {
+          logError(`telegram exec approvals: failed to notify user ${userId}: ${String(err)}`);
+        }
+      }
+    }
+
+    if (messages.size === 0) {
+      return;
+    }
+
+    const timeoutMs = Math.max(0, request.expiresAtMs - Date.now());
+    const timeoutId = setTimeout(() => {
+      void this.handleApprovalTimeout(request.id);
+    }, timeoutMs);
+    timeoutId.unref?.();
+
+    this.pending.set(request.id, { request, messages, timeoutId });
+  }
+
+  private async handleApprovalResolved(resolved: ExecApprovalResolved): Promise<void> {
+    const entry = this.pending.get(resolved.id);
+    if (!entry) {
+      return;
+    }
+
+    clearTimeout(entry.timeoutId);
+    this.pending.delete(resolved.id);
+
+    logDebug(`telegram exec approvals: resolved ${resolved.id} with ${resolved.decision}`);
+
+    const text = buildResolvedMessageText(resolved);
+    await this.updateOrDeleteMessages(entry, text);
+  }
+
+  private async handleApprovalTimeout(approvalId: string): Promise<void> {
+    const entry = this.pending.get(approvalId);
+    if (!entry) {
+      return;
+    }
+
+    this.pending.delete(approvalId);
+
+    logDebug(`telegram exec approvals: timeout for ${approvalId}`);
+
+    const text = buildExpiredMessageText(entry.request);
+    await this.updateOrDeleteMessages(entry, text);
+  }
+
+  private async updateOrDeleteMessages(entry: PendingApproval, text: string): Promise<void> {
+    const cleanup = this.opts.config.cleanupAfterResolve === true;
+
+    for (const { chatId, messageId } of entry.messages.values()) {
+      try {
+        if (cleanup) {
+          const { deleteMessageTelegram } = await import("./send.js");
+          await deleteMessageTelegram(chatId, messageId, {
+            accountId: this.opts.accountId,
+          });
+        } else {
+          await editMessageTelegram(chatId, messageId, text, {
+            accountId: this.opts.accountId,
+            buttons: [], // Remove inline keyboard
+            textMode: "html",
+          });
+        }
+      } catch (err) {
+        logError(
+          `telegram exec approvals: failed to update message ${messageId} in ${chatId}: ${String(err)}`,
+        );
+      }
+    }
+  }
+}

--- a/src/telegram/exec-approvals.ts
+++ b/src/telegram/exec-approvals.ts
@@ -172,11 +172,22 @@ function describeCommand(command: string): string {
   return `Run "${base}"`;
 }
 
+function resolveAllowlistBinary(request: ExecApprovalRequest): string | null {
+  const resolvedPath = request.request.resolvedPath;
+  if (resolvedPath) {
+    return resolvedPath;
+  }
+  // Fall back to first token of the command
+  const first = request.request.command.trim().split(/\s+/)[0];
+  return first?.startsWith("/") ? first : null;
+}
+
 function buildRequestMessageText(request: ExecApprovalRequest, nowMs: number): string {
   const command = request.request.command;
   const description = describeCommand(command);
   const preview = formatCommandPreview(command, 300);
   const expiresIn = Math.max(0, Math.round((request.expiresAtMs - nowMs) / 1000));
+  const allowlistBinary = resolveAllowlistBinary(request);
 
   const lines: string[] = [
     `\u{1F512} <b>Exec Approval Required</b>`,
@@ -197,11 +208,17 @@ function buildRequestMessageText(request: ExecApprovalRequest, nowMs: number): s
     lines.push(`<b>Env overrides:</b> ${escapeHtml(request.request.envKeys.join(", "))}`);
   }
   lines.push("");
-  lines.push(
-    `\u26A0\uFE0F <i>Allow once</i> = run this command once. ` +
-      `<i>Always allow</i> = add to allowlist. ` +
-      `<i>Deny</i> = block execution.`,
-  );
+  lines.push(`<b>Allow once</b> = run this command only.`);
+  if (allowlistBinary) {
+    lines.push(
+      `<b>Always allow</b> = permanently allow <b>all</b> future ` +
+        `<code>${escapeHtml(allowlistBinary)}</code> commands without asking.`,
+    );
+  } else {
+    lines.push(`<b>Always allow</b> = permanently allow this binary for all future commands.`);
+  }
+  lines.push(`<b>Deny</b> = block execution.`);
+  lines.push("");
   lines.push(`\u23F3 Expires in ${expiresIn}s \u2022 ID: ${request.id}`);
   return lines.join("\n");
 }

--- a/src/telegram/exec-approvals.ts
+++ b/src/telegram/exec-approvals.ts
@@ -89,137 +89,48 @@ function formatCommandPreview(command: string, maxChars = 200): string {
   return command;
 }
 
-function describeCommand(command: string): string {
-  const trimmed = command.trim();
-  const binary = trimmed.split(/\s+/)[0] ?? trimmed;
-  const base = binary.split("/").pop() ?? binary;
-
-  // Provide human-readable descriptions for common commands
-  if (base === "rm" || base === "rmdir") {
-    return "Delete files or directories";
-  }
-  if (base === "mv") {
-    return "Move or rename files";
-  }
-  if (base === "cp") {
-    return "Copy files";
-  }
-  if (base === "chmod") {
-    return "Change file permissions";
-  }
-  if (base === "chown") {
-    return "Change file ownership";
-  }
-  if (base === "curl" || base === "wget") {
-    return "Download from the internet";
-  }
-  if (base === "pip" || base === "pip3") {
-    return "Install Python packages";
-  }
-  if (
-    base === "npm" ||
-    base === "npx" ||
-    base === "pnpm" ||
-    base === "yarn" ||
-    base === "bun" ||
-    base === "bunx"
-  ) {
-    return "Run a Node.js package manager command";
-  }
-  if (base === "git") {
-    return "Run a git version control command";
-  }
-  if (base === "docker" || base === "podman") {
-    return "Run a container command";
-  }
-  if (base === "ssh" || base === "scp") {
-    return "Connect to or transfer files with a remote host";
-  }
-  if (base === "sudo") {
-    return "Run a command with elevated privileges";
-  }
-  if (
-    base === "apt" ||
-    base === "apt-get" ||
-    base === "brew" ||
-    base === "dnf" ||
-    base === "yum" ||
-    base === "pacman"
-  ) {
-    return "Install or manage system packages";
-  }
-  if (base === "kill" || base === "pkill" || base === "killall") {
-    return "Terminate a running process";
-  }
-  if (base === "cat" || base === "less" || base === "head" || base === "tail") {
-    return "Read file contents";
-  }
-  if (base === "sed" || base === "awk") {
-    return "Transform text or file contents";
-  }
-  if (
-    base === "python" ||
-    base === "python3" ||
-    base === "node" ||
-    base === "ruby" ||
-    base === "perl"
-  ) {
-    return `Execute a ${base} script`;
-  }
-  if (base === "bash" || base === "sh" || base === "zsh") {
-    return "Run a shell script";
-  }
-  return `Run "${base}"`;
+/** Extract the short binary name from a command string (e.g. "python3" from "/usr/bin/python3 foo.py"). */
+function binaryName(command: string): string {
+  const first = command.trim().split(/\s+/)[0] ?? command;
+  return first.split("/").pop() ?? first;
 }
 
+/** Resolve the full path that "Always allow" would add to the permanent allowlist. */
 function resolveAllowlistBinary(request: ExecApprovalRequest): string | null {
   const resolvedPath = request.request.resolvedPath;
   if (resolvedPath) {
     return resolvedPath;
   }
-  // Fall back to first token of the command
   const first = request.request.command.trim().split(/\s+/)[0];
   return first?.startsWith("/") ? first : null;
 }
 
 function buildRequestMessageText(request: ExecApprovalRequest, nowMs: number): string {
   const command = request.request.command;
-  const description = describeCommand(command);
+  const name = binaryName(command);
   const preview = formatCommandPreview(command, 300);
   const expiresIn = Math.max(0, Math.round((request.expiresAtMs - nowMs) / 1000));
-  const allowlistBinary = resolveAllowlistBinary(request);
+  const allowlistPath = resolveAllowlistBinary(request);
+
+  // Plain-language description of what "Always allow" will do
+  const alwaysDesc = allowlistPath
+    ? `Let <code>${escapeHtml(name)}</code> run <b>any</b> command, <b>anywhere</b>, without asking again`
+    : `Let this program run without asking again`;
 
   const lines: string[] = [
-    `\u{1F512} <b>Exec Approval Required</b>`,
+    `<b>Allow ${escapeHtml(name)} to run?</b>`,
     "",
-    `<b>What:</b> ${description}`,
-    `<b>Command:</b> <code>${escapeHtml(preview)}</code>`,
+    `<code>${escapeHtml(preview)}</code>`,
   ];
   if (request.request.cwd) {
-    lines.push(`<b>Directory:</b> <code>${escapeHtml(request.request.cwd)}</code>`);
-  }
-  if (request.request.host) {
-    lines.push(`<b>Host:</b> ${escapeHtml(request.request.host)}`);
-  }
-  if (request.request.agentId) {
-    lines.push(`<b>Agent:</b> ${escapeHtml(request.request.agentId)}`);
-  }
-  if (Array.isArray(request.request.envKeys) && request.request.envKeys.length > 0) {
-    lines.push(`<b>Env overrides:</b> ${escapeHtml(request.request.envKeys.join(", "))}`);
+    lines.push(`in <code>${escapeHtml(request.request.cwd)}</code>`);
   }
   lines.push("");
-  lines.push(`<b>Allow once</b> = run this command only.`);
-  if (allowlistBinary) {
-    lines.push(
-      `<b>Always allow</b> = permanently allow <b>all</b> future ` +
-        `<code>${escapeHtml(allowlistBinary)}</code> commands without asking.`,
-    );
-  } else {
-    lines.push(`<b>Always allow</b> = permanently allow this binary for all future commands.`);
-  }
-  lines.push(`<b>Deny</b> = block execution.`);
+  lines.push(`\u2705 <b>Allow once</b> — run this specific command`);
+  lines.push(`\u{1F504} <b>Always allow</b> — ${alwaysDesc}`);
+  lines.push(`\u274C <b>Deny</b> — block it`);
   lines.push("");
-  lines.push(`\u23F3 Expires in ${expiresIn}s \u2022 ID: ${request.id}`);
+  lines.push(`\u23F3 ${expiresIn}s`);
   return lines.join("\n");
 }
 

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -12,6 +12,7 @@ import { resolveTelegramAccount } from "./accounts.js";
 import { resolveTelegramAllowedUpdates } from "./allowed-updates.js";
 import { withTelegramApiErrorLogging } from "./api-logging.js";
 import { createTelegramBot } from "./bot.js";
+import { TelegramExecApprovalHandler } from "./exec-approvals.js";
 import { isRecoverableTelegramNetworkError } from "./network-errors.js";
 import { makeProxyFetch } from "./proxy.js";
 import { readTelegramUpdateOffset, writeTelegramUpdateOffset } from "./update-offset-store.js";
@@ -97,6 +98,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
   const log = opts.runtime?.error ?? console.error;
   let activeRunner: ReturnType<typeof run> | undefined;
   let forceRestarted = false;
+  let execApprovalHandler: TelegramExecApprovalHandler | null = null;
 
   // Register handler for Grammy HttpError unhandled rejections.
   // This catches network errors that escape the polling loop's try-catch
@@ -136,6 +138,17 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
 
     const proxyFetch =
       opts.proxyFetch ?? (account.config.proxy ? makeProxyFetch(account.config.proxy) : undefined);
+
+    // Start exec approval handler if configured
+    const execApprovalsCfg = account.config.execApprovals;
+    if (execApprovalsCfg?.enabled && (execApprovalsCfg.approvers?.length ?? 0) > 0) {
+      execApprovalHandler = new TelegramExecApprovalHandler({
+        accountId: account.accountId,
+        config: execApprovalsCfg,
+        cfg,
+      });
+      void execApprovalHandler.start();
+    }
 
     let lastUpdateId = await readTelegramUpdateOffset({
       accountId: account.accountId,
@@ -224,6 +237,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
             lastUpdateId,
             onUpdateId: persistUpdateId,
           },
+          execApprovalHandler,
         });
       } catch (err) {
         const shouldRetry = await waitBeforeRetryOnRecoverableSetupError(
@@ -340,6 +354,9 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       }
     }
   } finally {
+    if (execApprovalHandler) {
+      void execApprovalHandler.stop();
+    }
     unregisterHandler();
   }
 }


### PR DESCRIPTION
## Summary

- Add interactive inline keyboard buttons for exec approval requests on Telegram, matching the existing Discord button-based UX
- Users can now tap **Allow once** / **Always allow** / **Deny** instead of typing `/approve <id> allow-once|allow-always|deny`
- Skip text-based forwarding when the native Telegram handler is enabled (mirrors the existing Discord skip logic)

### Files changed

- **NEW** `src/telegram/exec-approvals.ts` — `TelegramExecApprovalHandler` class with gateway client, button builder, callback data encoding, message formatting
- `src/config/types.telegram.ts` — `TelegramExecApprovalConfig` type + `execApprovals` field on `TelegramAccountConfig`
- `src/telegram/bot-handlers.ts` — `ea:` callback handling before `inlineButtonsScope` gate
- `src/telegram/bot-native-commands.ts` — `execApprovalHandler` on `RegisterTelegramHandlerParams`
- `src/telegram/bot.ts` — pass handler through `TelegramBotOptions` → `registerTelegramHandlers()`
- `src/telegram/monitor.ts` — create/start/stop handler lifecycle
- `src/infra/exec-approval-forwarder.ts` — `shouldSkipTelegramForwarding()` alongside Discord skip

## Test plan

- [ ] Add `execApprovals` config to a Telegram account in `openclaw.json`
- [ ] Trigger an exec approval (run a command that hits `ask: "on-miss"` with a non-allowlisted binary)
- [ ] Verify Telegram DM receives a message with three inline buttons
- [ ] Tap a button → verify command executes (or is denied)
- [ ] Verify the message updates to show the decision result
- [ ] Verify `pnpm build` passes (confirmed)
- [ ] Verify `pnpm check` passes (confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)