### PR TITLE
fix: prevent HEARTBEAT_OK discard from swallowing steered user responses

### DIFF
--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -163,6 +163,42 @@ describe("stripHeartbeatToken", () => {
       didStrip: true,
     });
   });
+
+  it("preserves multi-sentence response after HEARTBEAT_OK in heartbeat mode (steered user message fix)", () => {
+    // When a steered user message produces "HEARTBEAT_OK. Here is the answer to your question."
+    // the response after stripping HEARTBEAT_OK should NOT be swallowed even if it's short.
+    const response = "Sure! Here is the answer to your question. Let me know if you need more details.";
+    expect(
+      stripHeartbeatToken(`${HEARTBEAT_TOKEN} ${response}`, { mode: "heartbeat" }),
+    ).toEqual({
+      shouldSkip: false,
+      text: response,
+      didStrip: true,
+    });
+  });
+
+  it("still suppresses single-fragment acks in heartbeat mode", () => {
+    // A brief ack like "Nothing to report" should still be suppressed
+    expect(
+      stripHeartbeatToken(`${HEARTBEAT_TOKEN} Nothing to report`, { mode: "heartbeat" }),
+    ).toEqual({
+      shouldSkip: true,
+      text: "",
+      didStrip: true,
+    });
+  });
+
+  it("preserves response with question/answer pattern after HEARTBEAT_OK", () => {
+    // Steered message response that addresses a user question
+    const response = "The server is running fine. Your deployment completed at 3:42 PM with no errors.";
+    expect(
+      stripHeartbeatToken(`${HEARTBEAT_TOKEN} ${response}`, { mode: "heartbeat" }),
+    ).toEqual({
+      shouldSkip: false,
+      text: response,
+      didStrip: true,
+    });
+  });
 });
 
 describe("isHeartbeatContentEffectivelyEmpty", () => {

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -163,7 +163,20 @@ export function stripHeartbeatToken(
   const rest = picked.text.trim();
   if (mode === "heartbeat") {
     if (rest.length <= maxAckChars) {
-      return { shouldSkip: true, text: "", didStrip: true };
+      // When the remaining text after stripping HEARTBEAT_OK is short,
+      // check whether it looks like a substantive response rather than a
+      // brief status ack.  A steered user message may produce a combined
+      // "HEARTBEAT_OK. <actual answer>" reply where the answer portion is
+      // under maxAckChars but should still be delivered.
+      //
+      // Heuristic: if the text contains sentence-ending punctuation followed
+      // by more content (multi-sentence), or starts with common response
+      // patterns, treat it as a real response and do NOT skip.
+      const hasMultipleSentences = /[.!?]\s+\S/.test(rest);
+      const hasSubstantiveContent = rest.length > 0 && hasMultipleSentences;
+      if (!hasSubstantiveContent) {
+        return { shouldSkip: true, text: "", didStrip: true };
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fix a bug where user messages sent during an active heartbeat run get silently swallowed when `queue.mode` is set to `steer`.

## Problem

When `steer` mode injects a user message into a heartbeat run, the agent produces a combined response like:

```
HEARTBEAT_OK. Sure! Here is the answer to your question. Let me know if you need more details.
```

The current `stripHeartbeatToken()` logic strips `HEARTBEAT_OK` and then checks if the remaining text is ≤ `maxAckChars` (default: 300). Since many user responses are under 300 characters, the entire response is treated as a brief heartbeat ack and suppressed — the user never receives their answer.

### Before (broken)

```
User sends message during heartbeat → Agent responds with HEARTBEAT_OK + answer
→ stripHeartbeatToken strips token, remaining text ≤ 300 chars
→ shouldSkip = true → delivery suppressed → user gets nothing
```

### After (fixed)

```
User sends message during heartbeat → Agent responds with HEARTBEAT_OK + answer
→ stripHeartbeatToken strips token, remaining text ≤ 300 chars
→ BUT remaining text has multi-sentence structure → recognized as substantive response
→ shouldSkip = false → delivery proceeds → user gets their answer
```

## Root Cause

In `stripHeartbeatToken()` (`src/auto-reply/heartbeat.ts`), the `maxAckChars` check does not distinguish between:
- A brief heartbeat ack: `"Nothing to report"` (single fragment, no sentence structure)
- A real user response: `"Sure! Here is the answer. Let me know if you need more."` (multi-sentence, addresses user)

## Fix

Added a heuristic in the `maxAckChars` check: after stripping `HEARTBEAT_OK`, if the remaining text contains multi-sentence structure (sentence-ending punctuation `[.!?]` followed by more content), it is recognized as a substantive response and NOT suppressed.

### Backward Compatibility

| Input | Before | After |
|-------|--------|-------|
| `HEARTBEAT_OK` | suppressed | suppressed |
| `HEARTBEAT_OK 🦞` | suppressed | suppressed |
| `HEARTBEAT_OK Nothing to report` | suppressed | suppressed |
| `HEARTBEAT_OK Sure! Here is the answer.` | suppressed | **delivered** |
| `HEARTBEAT_OK The server is fine. Deploy at 3:42.` | suppressed | **delivered** |

## Files Changed

| File | Description |
|------|-------------|
| `src/auto-reply/heartbeat.ts` | Added multi-sentence heuristic in `stripHeartbeatToken()` |
| `src/auto-reply/heartbeat.test.ts` | 3 new test cases for steered response scenarios |

## Test Cases Added

1. Multi-sentence steered response → preserved (not suppressed)
2. Single-fragment ack → still correctly suppressed
3. Question/answer pattern → preserved

Fixes #30197
