### PR TITLE
fix(feishu): extend sendText auto-detection to support document and media files

### DIFF
--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -69,15 +69,15 @@ export const feishuOutbound: ChannelOutboundAdapter = {
   textChunkLimit: 4000,
   sendText: async ({ cfg, to, text, accountId }) => {
     // Scheme A compatibility shim:
-    // when upstream accidentally returns a local image path as plain text,
-    // auto-upload and send as Feishu image message instead of leaking path text.
-    const localImagePath = normalizePossibleLocalFilePath(text);
-    if (localImagePath) {
+    // when upstream accidentally returns a local file path as plain text,
+    // auto-upload and send as Feishu file/image message instead of leaking path text.
+    const localFilePath = normalizePossibleLocalFilePath(text);
+    if (localFilePath) {
       try {
         const result = await sendMediaFeishu({
           cfg,
           to,
-          mediaUrl: localImagePath,
+          mediaUrl: localFilePath,
           accountId: accountId ?? undefined,
         });
         return { channel: "feishu", ...result };

--- a/extensions/feishu/src/outbound.ts
+++ b/extensions/feishu/src/outbound.ts
@@ -5,7 +5,34 @@ import { sendMediaFeishu } from "./media.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMessageFeishu } from "./send.js";
 
-function normalizePossibleLocalImagePath(text: string | undefined): string | null {
+/**
+ * Supported file extensions for auto-detecting local file paths in plain text.
+ * Includes images and common document/media types supported by Feishu upload API.
+ */
+const AUTO_SEND_EXTENSIONS = new Set([
+  // Images
+  ".jpg",
+  ".jpeg",
+  ".png",
+  ".gif",
+  ".webp",
+  ".bmp",
+  ".ico",
+  ".tiff",
+  // Documents
+  ".pdf",
+  ".doc",
+  ".docx",
+  ".xls",
+  ".xlsx",
+  ".ppt",
+  ".pptx",
+  // Audio/Video
+  ".opus",
+  ".mp4",
+]);
+
+function normalizePossibleLocalFilePath(text: string | undefined): string | null {
   const raw = text?.trim();
   if (!raw) return null;
 
@@ -18,10 +45,7 @@ function normalizePossibleLocalImagePath(text: string | undefined): string | nul
   if (/^(https?:\/\/|data:|file:\/\/)/i.test(raw)) return null;
 
   const ext = path.extname(raw).toLowerCase();
-  const isImageExt = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".ico", ".tiff"].includes(
-    ext,
-  );
-  if (!isImageExt) return null;
+  if (!AUTO_SEND_EXTENSIONS.has(ext)) return null;
 
   if (!path.isAbsolute(raw)) return null;
   if (!fs.existsSync(raw)) return null;
@@ -47,7 +71,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
     // Scheme A compatibility shim:
     // when upstream accidentally returns a local image path as plain text,
     // auto-upload and send as Feishu image message instead of leaking path text.
-    const localImagePath = normalizePossibleLocalImagePath(text);
+    const localImagePath = normalizePossibleLocalFilePath(text);
     if (localImagePath) {
       try {
         const result = await sendMediaFeishu({
@@ -58,7 +82,7 @@ export const feishuOutbound: ChannelOutboundAdapter = {
         });
         return { channel: "feishu", ...result };
       } catch (err) {
-        console.error(`[feishu] local image path auto-send failed:`, err);
+        console.error(`[feishu] local file path auto-send failed:`, err);
         // fall through to plain text as last resort
       }
     }


### PR DESCRIPTION
## Summary

- Problem: `normalizePossibleLocalImagePath()` in `extensions/feishu/src/outbound.ts` only recognizes image extensions (`.jpg`, `.png`, `.gif`, etc.). When the AI agent returns a local document path (e.g. `/home/user/resume.pdf`) as plain text via `sendText`, the raw filesystem path is sent to the end user — leaking internal server paths.
- Why it matters: Users receive raw filesystem paths instead of actual files, and internal directory structures are exposed.
- What changed: Renamed `normalizePossibleLocalImagePath` → `normalizePossibleLocalFilePath`, expanded supported extensions to include documents (`.pdf`, `.doc`, `.docx`, `.xls`, `.xlsx`, `.ppt`, `.pptx`) and media (`.opus`, `.mp4`), and switched from `Array.includes` to `Set.has` for O(1) lookup.
- What did NOT change (scope boundary): The `sendMedia` path is unaffected. The detection logic (whitespace check, URL exclusion, absolute path requirement, existence check, race-condition guard) is preserved exactly as-is.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #30646

## User-visible / Behavior Changes

- When the agent returns a local file path (PDF, DOC, XLS, PPT, MP4, OPUS) as plain text via the Feishu channel, the file is now automatically uploaded and sent as a proper Feishu file message instead of leaking the raw path string.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` (uses existing `sendMediaFeishu`)
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux 6.17.0-14-generic (x64)
- Runtime/container: Node.js v24.13.0
- Model/provider: github-copilot/claude-opus-4.6

### Steps

1. Configure the Feishu channel with a paired user
2. Ask the agent to send a local PDF file (e.g. a generated resume)
3. The agent returns the file path as plain text in `sendText`

### Expected

- The file is uploaded via `sendMediaFeishu` and delivered as a Feishu file message

### Actual (before fix)

- The raw filesystem path (e.g. `/home/user/resume/resume.pdf`) is sent as plain text

## Evidence

- [x] Manually verified on local OpenClaw deployment with Feishu channel: PDF files are now correctly uploaded and delivered as file messages

## Human Verification (required)

- Verified scenarios: Sending PDF files via Feishu channel — file is uploaded and received correctly
- Edge cases checked: Image files still work as before (backward compatible); non-existent paths still fall through to plain text; paths with whitespace are not matched; URLs are excluded
- What you did **not** verify: Automated test suite (no existing test infrastructure for outbound.ts)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit
- Files/config to restore: `extensions/feishu/src/outbound.ts`
- Known bad symptoms reviewers should watch for: If a plain text message happens to be exactly a file path with a matching extension, it would be auto-uploaded instead of sent as text (same existing behavior as image paths)

## Risks and Mitigations

- Risk: False positive detection on plain text that looks like a file path
  - Mitigation: Same guards as the original image-only implementation — must be absolute path, no whitespace, must exist on disk, must be a regular file