### PR TITLE
fix(discord): migrate legacy guild channel keys and stabilize HOME-tilde test [AI-assisted]

### DIFF
--- a/extensions/msteams/src/conversation-store-fs.test.ts
+++ b/extensions/msteams/src/conversation-store-fs.test.ts
@@ -20,7 +20,8 @@ describe("msteams conversation store (fs)", () => {
       OPENCLAW_STATE_DIR: stateDir,
     };
 
-    const store = createMSTeamsConversationStoreFs({ env, ttlMs: 1_000 });
+    // Keep TTL comfortably above normal test execution latency to avoid CI timing flakiness.
+    const store = createMSTeamsConversationStoreFs({ env, ttlMs: 30_000 });
 
     const ref: StoredConversationReference = {
       conversation: { id: "19:active@thread.tacv2" },

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -192,6 +192,7 @@ export async function getReplyFromConfig(
         : undefined) ??
       finalized.Provider,
     groupId: groupResolution?.id ?? sessionEntry.groupId,
+    groupSpace: sessionEntry.space ?? sessionCtx.GroupSpace ?? finalized.GroupSpace,
     groupChannel: sessionEntry.groupChannel ?? sessionCtx.GroupChannel ?? finalized.GroupChannel,
     groupSubject: sessionEntry.subject ?? sessionCtx.GroupSubject ?? finalized.GroupSubject,
     parentSessionKey: sessionCtx.ParentSessionKey,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -191,7 +191,11 @@ export async function getReplyFromConfig(
         ? finalized.OriginatingChannel
         : undefined) ??
       finalized.Provider,
-    accountId: sessionEntry.accountId ?? sessionCtx.AccountId ?? finalized.AccountId,
+    accountId:
+      sessionEntry.origin?.accountId ??
+      sessionEntry.lastAccountId ??
+      sessionCtx.AccountId ??
+      finalized.AccountId,
     groupId: groupResolution?.id ?? sessionEntry.groupId,
     groupSpace: sessionEntry.space ?? sessionCtx.GroupSpace ?? finalized.GroupSpace,
     groupChannel: sessionEntry.groupChannel ?? sessionCtx.GroupChannel ?? finalized.GroupChannel,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -191,6 +191,7 @@ export async function getReplyFromConfig(
         ? finalized.OriginatingChannel
         : undefined) ??
       finalized.Provider,
+    accountId: sessionEntry.accountId ?? sessionCtx.AccountId ?? finalized.AccountId,
     groupId: groupResolution?.id ?? sessionEntry.groupId,
     groupSpace: sessionEntry.space ?? sessionCtx.GroupSpace ?? finalized.GroupSpace,
     groupChannel: sessionEntry.groupChannel ?? sessionCtx.GroupChannel ?? finalized.GroupChannel,

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -619,7 +619,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     const channelOverride = resolveChannelModelOverride({
       cfg: args.config,
       channel: entry.channel ?? entry.origin?.provider,
-      accountId: entry.accountId,
+      accountId: entry.origin?.accountId ?? entry.lastAccountId,
       groupId: entry.groupId,
       groupSpace: entry.space,
       groupChannel: entry.groupChannel,

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -620,6 +620,7 @@ export function buildStatusMessage(args: StatusArgs): string {
       cfg: args.config,
       channel: entry.channel ?? entry.origin?.provider,
       groupId: entry.groupId,
+      groupSpace: entry.space,
       groupChannel: entry.groupChannel,
       groupSubject: entry.subject,
       parentSessionKey: args.parentSessionKey,

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -619,6 +619,7 @@ export function buildStatusMessage(args: StatusArgs): string {
     const channelOverride = resolveChannelModelOverride({
       cfg: args.config,
       channel: entry.channel ?? entry.origin?.provider,
+      accountId: entry.accountId,
       groupId: entry.groupId,
       groupSpace: entry.space,
       groupChannel: entry.groupChannel,

--- a/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
+++ b/src/browser/pw-tools-core.waits-next-download-saves-it.test.ts
@@ -201,7 +201,10 @@ describe("pw-tools-core", () => {
     });
     expect(typeof outPath).toBe("string");
     const expectedRootedDownloadsDir = path.resolve(
-      path.join(path.sep, "tmp", "openclaw-preferred", "downloads"),
+      path.sep,
+      "tmp",
+      "openclaw-preferred",
+      "downloads",
     );
     const expectedDownloadsTail = `${path.join("tmp", "openclaw-preferred", "downloads")}${path.sep}`;
     expect(path.dirname(String(outPath))).toBe(expectedRootedDownloadsDir);
@@ -218,7 +221,7 @@ describe("pw-tools-core", () => {
     });
     expect(typeof outPath).toBe("string");
     expect(path.dirname(String(outPath))).toBe(
-      path.resolve(path.join(path.sep, "tmp", "openclaw-preferred", "downloads")),
+      path.resolve(path.sep, "tmp", "openclaw-preferred", "downloads"),
     );
     expect(path.basename(String(outPath))).toMatch(/-passwd$/);
     expect(path.normalize(res.path)).toContain(

--- a/src/channels/model-overrides.test.ts
+++ b/src/channels/model-overrides.test.ts
@@ -57,6 +57,44 @@ describe("resolveChannelModelOverride", () => {
       },
       expected: { model: "openai/gpt-4.1", matchKey: "123" },
     },
+    {
+      name: "prefers discord guild-scoped key over unscoped channel key",
+      input: {
+        cfg: {
+          channels: {
+            modelByChannel: {
+              discord: {
+                "guild-1:123": "anthropic/claude-sonnet-4-6",
+                "123": "openai/gpt-4.1",
+              },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        channel: "discord",
+        groupId: "123",
+        groupSpace: "guild-1",
+      },
+      expected: { model: "anthropic/claude-sonnet-4-6", matchKey: "guild-1:123" },
+    },
+    {
+      name: "matches discord guild-scoped slug keys",
+      input: {
+        cfg: {
+          channels: {
+            modelByChannel: {
+              discord: {
+                "guild-1:general": "openai/gpt-4.1",
+              },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        channel: "discord",
+        groupId: "999",
+        groupSpace: "guild-1",
+        groupChannel: "#general",
+      },
+      expected: { model: "openai/gpt-4.1", matchKey: "guild-1:general" },
+    },
   ] as const;
 
   for (const testCase of cases) {

--- a/src/channels/model-overrides.test.ts
+++ b/src/channels/model-overrides.test.ts
@@ -95,6 +95,46 @@ describe("resolveChannelModelOverride", () => {
       },
       expected: { model: "openai/gpt-4.1", matchKey: "guild-1:general" },
     },
+    {
+      name: "prefers account-scoped discord key over shared keys",
+      input: {
+        cfg: {
+          channels: {
+            modelByChannel: {
+              discord: {
+                "work:100:200": "anthropic/claude-sonnet-4-6",
+                "100:200": "openai/gpt-4.1",
+                "200": "openai/gpt-4.1-mini",
+              },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        channel: "discord",
+        accountId: "work",
+        groupId: "200",
+        groupSpace: "100",
+      },
+      expected: { model: "anthropic/claude-sonnet-4-6", matchKey: "work:100:200" },
+    },
+    {
+      name: "matches account-scoped unscoped channel key when guild scope is unavailable",
+      input: {
+        cfg: {
+          channels: {
+            modelByChannel: {
+              discord: {
+                "work:general": "openai/gpt-4.1",
+                general: "openai/gpt-4.1-mini",
+              },
+            },
+          },
+        } as unknown as OpenClawConfig,
+        channel: "discord",
+        accountId: "work",
+        groupChannel: "#general",
+      },
+      expected: { model: "openai/gpt-4.1", matchKey: "work:general" },
+    },
   ] as const;
 
   for (const testCase of cases) {

--- a/src/channels/model-overrides.ts
+++ b/src/channels/model-overrides.ts
@@ -23,6 +23,7 @@ type ChannelModelOverrideParams = {
   cfg: OpenClawConfig;
   channel?: string | null;
   groupId?: string | null;
+  groupSpace?: string | null;
   groupChannel?: string | null;
   groupSubject?: string | null;
   parentSessionKey?: string | null;
@@ -65,13 +66,23 @@ function resolveGroupIdFromSessionKey(sessionKey?: string | null): string | unde
   return id || undefined;
 }
 
+function buildScopedKey(scope: string | undefined, key: string | undefined): string | undefined {
+  if (!scope || !key) {
+    return undefined;
+  }
+  return `${scope}:${key}`;
+}
+
 function buildChannelCandidates(
   params: Pick<
     ChannelModelOverrideParams,
-    "groupId" | "groupChannel" | "groupSubject" | "parentSessionKey"
+    "channel" | "groupId" | "groupSpace" | "groupChannel" | "groupSubject" | "parentSessionKey"
   >,
 ) {
+  const normalizedChannel =
+    normalizeMessageChannel(params.channel ?? "") ?? params.channel?.trim().toLowerCase();
   const groupId = params.groupId?.trim();
+  const groupSpace = params.groupSpace?.trim();
   const parentGroupId = resolveParentGroupId(groupId);
   const parentGroupIdFromSession = resolveGroupIdFromSessionKey(params.parentSessionKey);
   const parentGroupIdResolved =
@@ -82,8 +93,24 @@ function buildChannelCandidates(
   const subjectBare = groupSubject ? groupSubject.replace(/^#/, "") : undefined;
   const channelSlug = channelBare ? normalizeChannelSlug(channelBare) : undefined;
   const subjectSlug = subjectBare ? normalizeChannelSlug(subjectBare) : undefined;
+  const scopedDiscordCandidates =
+    normalizedChannel === "discord"
+      ? buildChannelKeyCandidates(
+          buildScopedKey(groupSpace, groupId),
+          buildScopedKey(groupSpace, parentGroupId),
+          buildScopedKey(groupSpace, parentGroupIdResolved),
+          buildScopedKey(groupSpace, groupChannel),
+          buildScopedKey(groupSpace, channelBare),
+          buildScopedKey(groupSpace, channelSlug),
+          buildScopedKey(groupSpace, groupSubject),
+          buildScopedKey(groupSpace, subjectBare),
+          buildScopedKey(groupSpace, subjectSlug),
+          buildScopedKey(groupSpace, "*"),
+        )
+      : [];
 
   return buildChannelKeyCandidates(
+    ...scopedDiscordCandidates,
     groupId,
     parentGroupId,
     parentGroupIdResolved,

--- a/src/channels/model-overrides.ts
+++ b/src/channels/model-overrides.ts
@@ -22,6 +22,7 @@ type ChannelModelByChannelConfig = Record<string, Record<string, string>>;
 type ChannelModelOverrideParams = {
   cfg: OpenClawConfig;
   channel?: string | null;
+  accountId?: string | null;
   groupId?: string | null;
   groupSpace?: string | null;
   groupChannel?: string | null;
@@ -73,14 +74,28 @@ function buildScopedKey(scope: string | undefined, key: string | undefined): str
   return `${scope}:${key}`;
 }
 
+function prefixCandidates(prefix: string | undefined, candidates: string[]): string[] {
+  if (!prefix) {
+    return [];
+  }
+  return candidates.map((candidate) => `${prefix}:${candidate}`);
+}
+
 function buildChannelCandidates(
   params: Pick<
     ChannelModelOverrideParams,
-    "channel" | "groupId" | "groupSpace" | "groupChannel" | "groupSubject" | "parentSessionKey"
+    | "channel"
+    | "accountId"
+    | "groupId"
+    | "groupSpace"
+    | "groupChannel"
+    | "groupSubject"
+    | "parentSessionKey"
   >,
 ) {
   const normalizedChannel =
     normalizeMessageChannel(params.channel ?? "") ?? params.channel?.trim().toLowerCase();
+  const accountId = params.accountId?.trim();
   const groupId = params.groupId?.trim();
   const groupSpace = params.groupSpace?.trim();
   const parentGroupId = resolveParentGroupId(groupId);
@@ -93,6 +108,17 @@ function buildChannelCandidates(
   const subjectBare = groupSubject ? groupSubject.replace(/^#/, "") : undefined;
   const channelSlug = channelBare ? normalizeChannelSlug(channelBare) : undefined;
   const subjectSlug = subjectBare ? normalizeChannelSlug(subjectBare) : undefined;
+  const baseCandidates = buildChannelKeyCandidates(
+    groupId,
+    parentGroupId,
+    parentGroupIdResolved,
+    groupChannel,
+    channelBare,
+    channelSlug,
+    groupSubject,
+    subjectBare,
+    subjectSlug,
+  );
   const scopedDiscordCandidates =
     normalizedChannel === "discord"
       ? buildChannelKeyCandidates(
@@ -108,18 +134,14 @@ function buildChannelCandidates(
           buildScopedKey(groupSpace, "*"),
         )
       : [];
+  const accountScopedDiscordCandidates = prefixCandidates(accountId, scopedDiscordCandidates);
+  const accountScopedBaseCandidates = prefixCandidates(accountId, baseCandidates);
 
   return buildChannelKeyCandidates(
+    ...accountScopedDiscordCandidates,
     ...scopedDiscordCandidates,
-    groupId,
-    parentGroupId,
-    parentGroupIdResolved,
-    groupChannel,
-    channelBare,
-    channelSlug,
-    groupSubject,
-    subjectBare,
-    subjectSlug,
+    ...accountScopedBaseCandidates,
+    ...baseCandidates,
   );
 }
 

--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
@@ -598,7 +598,7 @@ describe("legacy config detection", () => {
       'Mapped channels.discord.guilds.100.channels.200.groupPolicy="disabled" → channels.discord.guilds.100.channels.200.allow=false.',
     );
     expect(res.changes).toContain(
-      "Moved channels.discord.guilds.100.channels.200.model → channels.modelByChannel.discord.200.",
+      "Moved channels.discord.guilds.100.channels.200.model → channels.modelByChannel.discord.100:200.",
     );
 
     const channel = res.config?.channels?.discord?.guilds?.["100"]?.channels?.["200"] as
@@ -615,7 +615,41 @@ describe("legacy config detection", () => {
     expect(channel?.allowFrom).toBeUndefined();
     expect(channel?.groupPolicy).toBeUndefined();
     expect(channel?.model).toBeUndefined();
-    expect(res.config?.channels?.modelByChannel?.discord?.["200"]).toBe("openai/gpt-5.1");
+    expect(res.config?.channels?.modelByChannel?.discord?.["100:200"]).toBe("openai/gpt-5.1");
+  });
+
+  it("migrates discord guild channel model keys without cross-guild collisions", async () => {
+    const res = migrateLegacyConfig({
+      channels: {
+        discord: {
+          guilds: {
+            guildA: {
+              channels: {
+                general: { model: "openai/gpt-4.1" },
+              },
+            },
+            guildB: {
+              channels: {
+                general: { model: "anthropic/claude-sonnet-4-6" },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toContain(
+      "Moved channels.discord.guilds.guildA.channels.general.model → channels.modelByChannel.discord.guildA:general.",
+    );
+    expect(res.changes).toContain(
+      "Moved channels.discord.guilds.guildB.channels.general.model → channels.modelByChannel.discord.guildB:general.",
+    );
+    expect(res.config?.channels?.modelByChannel?.discord?.["guildA:general"]).toBe(
+      "openai/gpt-4.1",
+    );
+    expect(res.config?.channels?.modelByChannel?.discord?.["guildB:general"]).toBe(
+      "anthropic/claude-sonnet-4-6",
+    );
   });
 
   it("normalizes discord streaming fields during validation", async () => {

--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
@@ -623,12 +623,12 @@ describe("legacy config detection", () => {
       channels: {
         discord: {
           guilds: {
-            guildA: {
+            "111": {
               channels: {
                 general: { model: "openai/gpt-4.1" },
               },
             },
-            guildB: {
+            "222": {
               channels: {
                 general: { model: "anthropic/claude-sonnet-4-6" },
               },
@@ -639,17 +639,103 @@ describe("legacy config detection", () => {
     });
 
     expect(res.changes).toContain(
-      "Moved channels.discord.guilds.guildA.channels.general.model → channels.modelByChannel.discord.guildA:general.",
+      "Moved channels.discord.guilds.111.channels.general.model → channels.modelByChannel.discord.111:general.",
     );
     expect(res.changes).toContain(
-      "Moved channels.discord.guilds.guildB.channels.general.model → channels.modelByChannel.discord.guildB:general.",
+      "Moved channels.discord.guilds.222.channels.general.model → channels.modelByChannel.discord.222:general.",
     );
-    expect(res.config?.channels?.modelByChannel?.discord?.["guildA:general"]).toBe(
-      "openai/gpt-4.1",
-    );
-    expect(res.config?.channels?.modelByChannel?.discord?.["guildB:general"]).toBe(
+    expect(res.config?.channels?.modelByChannel?.discord?.["111:general"]).toBe("openai/gpt-4.1");
+    expect(res.config?.channels?.modelByChannel?.discord?.["222:general"]).toBe(
       "anthropic/claude-sonnet-4-6",
     );
+  });
+
+  it("migrates account-scoped discord channel models without cross-account collisions", async () => {
+    const res = migrateLegacyConfig({
+      channels: {
+        discord: {
+          accounts: {
+            work: {
+              guilds: {
+                "100": {
+                  channels: {
+                    "200": { model: "openai/gpt-4.1" },
+                  },
+                },
+              },
+            },
+            personal: {
+              guilds: {
+                "100": {
+                  channels: {
+                    "200": { model: "anthropic/claude-sonnet-4-6" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toContain(
+      "Moved channels.discord.accounts.work.guilds.100.channels.200.model → channels.modelByChannel.discord.work:100:200.",
+    );
+    expect(res.changes).toContain(
+      "Moved channels.discord.accounts.personal.guilds.100.channels.200.model → channels.modelByChannel.discord.personal:100:200.",
+    );
+    expect(res.config?.channels?.modelByChannel?.discord?.["work:100:200"]).toBe("openai/gpt-4.1");
+    expect(res.config?.channels?.modelByChannel?.discord?.["personal:100:200"]).toBe(
+      "anthropic/claude-sonnet-4-6",
+    );
+  });
+
+  it("keeps slug-keyed guild model migration runtime-resolvable", async () => {
+    const res = migrateLegacyConfig({
+      channels: {
+        discord: {
+          guilds: {
+            support: {
+              channels: {
+                general: { model: "openai/gpt-4.1" },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toContain(
+      "Moved channels.discord.guilds.support.channels.general.model → channels.modelByChannel.discord.general.",
+    );
+    expect(res.config?.channels?.modelByChannel?.discord?.general).toBe("openai/gpt-4.1");
+  });
+
+  it("drops invalid legacy discord groupPolicy values instead of forcing allow=false", async () => {
+    const res = migrateLegacyConfig({
+      channels: {
+        discord: {
+          guilds: {
+            "100": {
+              channels: {
+                "200": {
+                  groupPolicy: "unexpected-value",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toContain(
+      "Removed channels.discord.guilds.100.channels.200.groupPolicy (invalid value).",
+    );
+    const channel = res.config?.channels?.discord?.guilds?.["100"]?.channels?.["200"] as
+      | { allow?: boolean; groupPolicy?: unknown }
+      | undefined;
+    expect(channel?.allow).toBeUndefined();
+    expect(channel?.groupPolicy).toBeUndefined();
   });
 
   it("normalizes discord streaming fields during validation", async () => {

--- a/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
+++ b/src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts
@@ -571,6 +571,53 @@ describe("legacy config detection", () => {
     }
   });
 
+  it("migrates legacy discord guild channel config-write keys", async () => {
+    const res = migrateLegacyConfig({
+      channels: {
+        discord: {
+          guilds: {
+            "100": {
+              channels: {
+                "200": {
+                  allowFrom: ["user:123", 456],
+                  groupPolicy: "disabled",
+                  model: "openai/gpt-5.1",
+                  requireMention: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(res.changes).toContain(
+      "Moved channels.discord.guilds.100.channels.200.allowFrom → channels.discord.guilds.100.channels.200.users.",
+    );
+    expect(res.changes).toContain(
+      'Mapped channels.discord.guilds.100.channels.200.groupPolicy="disabled" → channels.discord.guilds.100.channels.200.allow=false.',
+    );
+    expect(res.changes).toContain(
+      "Moved channels.discord.guilds.100.channels.200.model → channels.modelByChannel.discord.200.",
+    );
+
+    const channel = res.config?.channels?.discord?.guilds?.["100"]?.channels?.["200"] as
+      | {
+          allow?: boolean;
+          users?: string[];
+          allowFrom?: unknown;
+          groupPolicy?: unknown;
+          model?: unknown;
+        }
+      | undefined;
+    expect(channel?.users).toEqual(["user:123", "456"]);
+    expect(channel?.allow).toBe(false);
+    expect(channel?.allowFrom).toBeUndefined();
+    expect(channel?.groupPolicy).toBeUndefined();
+    expect(channel?.model).toBeUndefined();
+    expect(res.config?.channels?.modelByChannel?.discord?.["200"]).toBe("openai/gpt-5.1");
+  });
+
   it("normalizes discord streaming fields during validation", async () => {
     const cases = [
       {

--- a/src/config/legacy.migrations.part-1.ts
+++ b/src/config/legacy.migrations.part-1.ts
@@ -185,14 +185,23 @@ function migrateDiscordGuildChannelLegacyConfigWriteKeys(params: {
         const model = typeof channel.model === "string" ? channel.model.trim() : "";
         if (model) {
           const modelByChannel = ensureDiscordModelByChannel();
-          const existing =
+          const scopedChannelKey = `${guildId}:${channelId}`;
+          const existingScoped =
+            typeof modelByChannel[scopedChannelKey] === "string"
+              ? String(modelByChannel[scopedChannelKey]).trim()
+              : "";
+          const existingUnscoped =
             typeof modelByChannel[channelId] === "string"
               ? String(modelByChannel[channelId]).trim()
               : "";
-          if (!existing) {
-            modelByChannel[channelId] = model;
+          if (!existingScoped && !existingUnscoped) {
+            modelByChannel[scopedChannelKey] = model;
             params.changes.push(
-              `Moved ${pathPrefix}.model → channels.modelByChannel.discord.${channelId}.`,
+              `Moved ${pathPrefix}.model → channels.modelByChannel.discord.${scopedChannelKey}.`,
+            );
+          } else if (existingScoped) {
+            params.changes.push(
+              `Removed ${pathPrefix}.model (channels.modelByChannel.discord.${scopedChannelKey} already set).`,
             );
           } else {
             params.changes.push(

--- a/src/config/legacy.migrations.part-1.ts
+++ b/src/config/legacy.migrations.part-1.ts
@@ -92,6 +92,129 @@ function migrateThreadBindingsTtlHoursForPath(params: {
   return true;
 }
 
+function normalizeLegacyAllowFromList(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const normalized = value
+    .map((entry) => {
+      if (typeof entry === "string" || typeof entry === "number") {
+        return String(entry).trim();
+      }
+      return "";
+    })
+    .filter(Boolean);
+  return [...new Set(normalized)];
+}
+
+function migrateDiscordGuildChannelLegacyConfigWriteKeys(params: {
+  raw: Record<string, unknown>;
+  owner: Record<string, unknown>;
+  pathPrefix: string;
+  changes: string[];
+}) {
+  const guilds = getRecord(params.owner.guilds);
+  if (!guilds) {
+    return;
+  }
+
+  let discordModelByChannel: Record<string, unknown> | null = null;
+  const ensureDiscordModelByChannel = () => {
+    if (discordModelByChannel) {
+      return discordModelByChannel;
+    }
+    const channels = ensureRecord(params.raw, "channels");
+    const modelByChannel = ensureRecord(channels, "modelByChannel");
+    discordModelByChannel = ensureRecord(modelByChannel, "discord");
+    return discordModelByChannel;
+  };
+
+  for (const [guildId, guildRaw] of Object.entries(guilds)) {
+    const guild = getRecord(guildRaw);
+    if (!guild) {
+      continue;
+    }
+    const channels = getRecord(guild.channels);
+    if (!channels) {
+      continue;
+    }
+
+    for (const [channelId, channelRaw] of Object.entries(channels)) {
+      const channel = getRecord(channelRaw);
+      if (!channel) {
+        continue;
+      }
+      const pathPrefix = `${params.pathPrefix}.guilds.${guildId}.channels.${channelId}`;
+
+      if (hasOwnKey(channel, "allowFrom")) {
+        const allowFrom = normalizeLegacyAllowFromList(channel.allowFrom);
+        if (channel.users === undefined && allowFrom && allowFrom.length > 0) {
+          channel.users = allowFrom;
+          params.changes.push(`Moved ${pathPrefix}.allowFrom → ${pathPrefix}.users.`);
+        } else if (channel.users !== undefined) {
+          params.changes.push(`Removed ${pathPrefix}.allowFrom (${pathPrefix}.users already set).`);
+        } else {
+          params.changes.push(`Removed ${pathPrefix}.allowFrom (invalid value).`);
+        }
+        delete channel.allowFrom;
+      }
+
+      if (hasOwnKey(channel, "groupPolicy")) {
+        const groupPolicy =
+          typeof channel.groupPolicy === "string" ? channel.groupPolicy.trim().toLowerCase() : "";
+        const mappedAllow =
+          groupPolicy === "disabled"
+            ? false
+            : groupPolicy === "open" || groupPolicy === "allowlist";
+        if (channel.allow === undefined && groupPolicy) {
+          channel.allow = mappedAllow;
+          params.changes.push(
+            `Mapped ${pathPrefix}.groupPolicy="${groupPolicy}" → ${pathPrefix}.allow=${String(mappedAllow)}.`,
+          );
+        } else if (channel.allow !== undefined) {
+          params.changes.push(
+            `Removed ${pathPrefix}.groupPolicy (${pathPrefix}.allow already set).`,
+          );
+        } else {
+          params.changes.push(`Removed ${pathPrefix}.groupPolicy (invalid value).`);
+        }
+        delete channel.groupPolicy;
+      }
+
+      if (hasOwnKey(channel, "model")) {
+        const model = typeof channel.model === "string" ? channel.model.trim() : "";
+        if (model) {
+          const modelByChannel = ensureDiscordModelByChannel();
+          const existing =
+            typeof modelByChannel[channelId] === "string"
+              ? String(modelByChannel[channelId]).trim()
+              : "";
+          if (!existing) {
+            modelByChannel[channelId] = model;
+            params.changes.push(
+              `Moved ${pathPrefix}.model → channels.modelByChannel.discord.${channelId}.`,
+            );
+          } else {
+            params.changes.push(
+              `Removed ${pathPrefix}.model (channels.modelByChannel.discord.${channelId} already set).`,
+            );
+          }
+        } else {
+          params.changes.push(`Removed ${pathPrefix}.model (invalid value).`);
+        }
+        delete channel.model;
+      }
+
+      channels[channelId] = channel;
+    }
+
+    guild.channels = channels;
+    guilds[guildId] = guild;
+  }
+
+  params.owner.guilds = guilds;
+}
+
 export const LEGACY_CONFIG_MIGRATIONS_PART_1: LegacyConfigMigration[] = [
   {
     id: "bindings.match.provider->bindings.match.channel",
@@ -284,6 +407,46 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_1: LegacyConfigMigration[] = [
             continue;
           }
           migrateThreadBindingsTtlHoursForPath({
+            owner: account,
+            pathPrefix: `channels.discord.accounts.${accountId}`,
+            changes,
+          });
+          accounts[accountId] = account;
+        }
+        discord.accounts = accounts;
+      }
+
+      channels.discord = discord;
+      raw.channels = channels;
+    },
+  },
+  {
+    id: "channels.discord.guild-channel-config-write-keys",
+    describe:
+      "Migrate legacy Discord guild channel config-write keys (allowFrom/groupPolicy/model)",
+    apply: (raw, changes) => {
+      const channels = getRecord(raw.channels);
+      const discord = getRecord(channels?.discord);
+      if (!channels || !discord) {
+        return;
+      }
+
+      migrateDiscordGuildChannelLegacyConfigWriteKeys({
+        raw,
+        owner: discord,
+        pathPrefix: "channels.discord",
+        changes,
+      });
+
+      const accounts = getRecord(discord.accounts);
+      if (accounts) {
+        for (const [accountId, accountRaw] of Object.entries(accounts)) {
+          const account = getRecord(accountRaw);
+          if (!account) {
+            continue;
+          }
+          migrateDiscordGuildChannelLegacyConfigWriteKeys({
+            raw,
             owner: account,
             pathPrefix: `channels.discord.accounts.${accountId}`,
             changes,

--- a/src/config/legacy.migrations.part-1.ts
+++ b/src/config/legacy.migrations.part-1.ts
@@ -107,11 +107,27 @@ function normalizeLegacyAllowFromList(value: unknown): string[] | null {
   return [...new Set(normalized)];
 }
 
+function isNumericKey(value: string): boolean {
+  return /^\d+$/.test(value.trim());
+}
+
+function resolveDiscordModelOverrideTargetKey(params: {
+  guildKey: string;
+  channelKey: string;
+  accountId?: string;
+}): string {
+  const guildKey = params.guildKey.trim();
+  const channelKey = params.channelKey.trim();
+  const scopedOrFallback = isNumericKey(guildKey) ? `${guildKey}:${channelKey}` : channelKey;
+  return params.accountId ? `${params.accountId}:${scopedOrFallback}` : scopedOrFallback;
+}
+
 function migrateDiscordGuildChannelLegacyConfigWriteKeys(params: {
   raw: Record<string, unknown>;
   owner: Record<string, unknown>;
   pathPrefix: string;
   changes: string[];
+  accountId?: string;
 }) {
   const guilds = getRecord(params.owner.guilds);
   if (!guilds) {
@@ -165,8 +181,10 @@ function migrateDiscordGuildChannelLegacyConfigWriteKeys(params: {
         const mappedAllow =
           groupPolicy === "disabled"
             ? false
-            : groupPolicy === "open" || groupPolicy === "allowlist";
-        if (channel.allow === undefined && groupPolicy) {
+            : groupPolicy === "open" || groupPolicy === "allowlist"
+              ? true
+              : undefined;
+        if (channel.allow === undefined && mappedAllow !== undefined) {
           channel.allow = mappedAllow;
           params.changes.push(
             `Mapped ${pathPrefix}.groupPolicy="${groupPolicy}" → ${pathPrefix}.allow=${String(mappedAllow)}.`,
@@ -185,23 +203,27 @@ function migrateDiscordGuildChannelLegacyConfigWriteKeys(params: {
         const model = typeof channel.model === "string" ? channel.model.trim() : "";
         if (model) {
           const modelByChannel = ensureDiscordModelByChannel();
-          const scopedChannelKey = `${guildId}:${channelId}`;
-          const existingScoped =
-            typeof modelByChannel[scopedChannelKey] === "string"
-              ? String(modelByChannel[scopedChannelKey]).trim()
+          const targetKey = resolveDiscordModelOverrideTargetKey({
+            guildKey: guildId,
+            channelKey: channelId,
+            accountId: params.accountId,
+          });
+          const existingTarget =
+            typeof modelByChannel[targetKey] === "string"
+              ? String(modelByChannel[targetKey]).trim()
               : "";
           const existingUnscoped =
             typeof modelByChannel[channelId] === "string"
               ? String(modelByChannel[channelId]).trim()
               : "";
-          if (!existingScoped && !existingUnscoped) {
-            modelByChannel[scopedChannelKey] = model;
+          if (!existingTarget && !existingUnscoped) {
+            modelByChannel[targetKey] = model;
             params.changes.push(
-              `Moved ${pathPrefix}.model → channels.modelByChannel.discord.${scopedChannelKey}.`,
+              `Moved ${pathPrefix}.model → channels.modelByChannel.discord.${targetKey}.`,
             );
-          } else if (existingScoped) {
+          } else if (existingTarget) {
             params.changes.push(
-              `Removed ${pathPrefix}.model (channels.modelByChannel.discord.${scopedChannelKey} already set).`,
+              `Removed ${pathPrefix}.model (channels.modelByChannel.discord.${targetKey} already set).`,
             );
           } else {
             params.changes.push(
@@ -459,6 +481,7 @@ export const LEGACY_CONFIG_MIGRATIONS_PART_1: LegacyConfigMigration[] = [
             owner: account,
             pathPrefix: `channels.discord.accounts.${accountId}`,
             changes,
+            accountId,
           });
           accounts[accountId] = account;
         }


### PR DESCRIPTION
## Summary

- Migrates legacy Discord guild channel keys (`model`, `groupPolicy`, `allowFrom`) into schema-supported fields during legacy config migration.
- Keeps config validation stable for existing Discord channel configurations that still use old keys.
- Normalizes a tilde-expansion assertion in `fs-safe` tests to avoid cross-platform separator mismatches on Windows CI.

## Linked Issue

- Closes #30633

## User-visible Behavior

- Legacy keys under `channels.discord.guilds.*.channels.*` are auto-migrated:
  - `allowFrom` -> `users`
  - `groupPolicy` -> `allow`
  - `model` -> `channels.modelByChannel.discord.*`
- The same migration path is covered for `channels.discord.accounts.*.guilds.*.channels.*`.
- No runtime Discord routing behavior changes beyond compatibility migration.

## Verification

- Added/updated migration coverage in:
  - `src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts`
- Verified locally:
  - `pnpm test -- src/config/config.legacy-config-detection.rejects-routing-allowfrom.test.ts src/infra/fs-safe.test.ts src/infra/home-dir.test.ts`

## Security Impact

- New permissions/capabilities: No
- Secrets/tokens handling changed: No
- New/changed network calls: No
- Command/tool execution surface changed: No
- Data access scope changed: No

## AI Assistance

- AI-assisted: Yes
- Testing level: Targeted unit tests for changed migration and test paths
