### PR TITLE
fix(hooks): emit internal message:sent for dispatcher-only reply paths

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1430,7 +1430,11 @@ describe("dispatchReplyFromConfig", () => {
         }),
       }),
     );
-    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
+    // message:received + message:sent
+    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(2);
+    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "message", action: "sent" }),
+    );
   });
 
   it("skips internal message:received hook when session key is unavailable", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1430,11 +1430,7 @@ describe("dispatchReplyFromConfig", () => {
         }),
       }),
     );
-    // message:received + message:sent
-    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(2);
-    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "message", action: "sent" }),
-    );
+    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledTimes(1);
   });
 
   it("skips internal message:received hook when session key is unavailable", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -570,6 +570,28 @@ export async function dispatchReplyFromConfig(params: {
     const counts = dispatcher.getQueuedCounts();
     counts.final += routedFinalCount;
     recordProcessed("completed");
+
+    // Emit message:sent internal hook after successful dispatch.
+    // This fires regardless of whether the channel plugin uses the standard
+    // deliverOutboundPayloads path (which has its own emitMessageSent) or a
+    // custom deliver callback (e.g., Feishu's streaming card sender).
+    // Channels using deliverOutboundPayloads will fire message:sent twice
+    // (once per-payload in deliver, once here); hooks should be idempotent.
+    if (sessionKey && (queuedFinal || routedFinalCount > 0)) {
+      void triggerInternalHook(
+        createInternalHookEvent("message", "sent", sessionKey, {
+          to: ctx.To ?? ctx.From ?? "",
+          content: "",
+          success: true,
+          channelId: channel,
+          accountId: ctx.AccountId,
+          conversationId: chatId,
+        }),
+      ).catch((err) => {
+        logVerbose(`dispatch-from-config: message_sent internal hook failed: ${String(err)}`);
+      });
+    }
+
     markIdle("message_completed");
     return { queuedFinal, counts };
   } catch (err) {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -575,9 +575,10 @@ export async function dispatchReplyFromConfig(params: {
     // This fires regardless of whether the channel plugin uses the standard
     // deliverOutboundPayloads path (which has its own emitMessageSent) or a
     // custom deliver callback (e.g., Feishu's streaming card sender).
-    // Channels using deliverOutboundPayloads will fire message:sent twice
-    // (once per-payload in deliver, once here); hooks should be idempotent.
-    if (sessionKey && (queuedFinal || routedFinalCount > 0)) {
+    // Channels using deliverOutboundPayloads may fire message:sent more than once;
+    // hooks should be idempotent.
+    const deliveredCount = counts.tool + counts.block + counts.final;
+    if (sessionKey && deliveredCount > 0) {
       void triggerInternalHook(
         createInternalHookEvent("message", "sent", sessionKey, {
           to: ctx.To ?? ctx.From ?? "",

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -455,4 +455,18 @@ describe("hooks", () => {
       expect(keys).toEqual([]);
     });
   });
+
+  describe("global singleton registry", () => {
+    it("stores handlers in globalThis via Symbol.for", () => {
+      const key = Symbol.for("openclaw.internal-hooks.handlers");
+      const g = globalThis as Record<symbol, unknown>;
+
+      const handler = vi.fn();
+      registerInternalHook("message:sent", handler);
+
+      const map = g[key] as Map<string, unknown[]>;
+      expect(map).toBeInstanceOf(Map);
+      expect(map.get("message:sent")).toContain(handler);
+    });
+  });
 });

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -110,8 +110,23 @@ export interface InternalHookEvent {
 
 export type InternalHookHandler = (event: InternalHookEvent) => Promise<void> | void;
 
-/** Registry of hook handlers by event key */
-const handlers = new Map<string, InternalHookHandler[]>();
+/**
+ * Registry of hook handlers by event key.
+ *
+ * Use a global singleton so register/trigger share one Map even when
+ * bundling splits code across multiple chunks/entrypoints.
+ */
+const HOOK_REGISTRY_KEY = Symbol.for("openclaw.internal-hooks.handlers");
+
+function getHandlers(): Map<string, InternalHookHandler[]> {
+  const g = globalThis as Record<symbol, unknown>;
+  if (!g[HOOK_REGISTRY_KEY]) {
+    g[HOOK_REGISTRY_KEY] = new Map<string, InternalHookHandler[]>();
+  }
+  return g[HOOK_REGISTRY_KEY] as Map<string, InternalHookHandler[]>;
+}
+
+const handlers = getHandlers();
 const log = createSubsystemLogger("internal-hooks");
 
 /**


### PR DESCRIPTION
## Summary

This fixes missing `message:sent` internal hook events for reply paths that use channel-provided dispatchers (not the standard `deliverOutboundPayloads` flow).

In practice, Feishu uses a custom dispatcher deliver callback for streaming/card/direct sends, so `deliverOutboundPayloads`-level `emitMessageSent` is bypassed and internal hooks never see `message:sent`.

## Root cause

- `message:sent` internal hooks were emitted from delivery plumbing that is only exercised by `deliverOutboundPayloads`/`deliverOutboundPayloadsCore`.
- Dispatcher-only paths (e.g. Feishu custom deliver callback) successfully send messages but skip that emission point.
- Additionally, the hook handler registry (`Map`) was module-scoped, so when bundling splits code across multiple chunks, `registerInternalHook` and `triggerInternalHook` could reference different Map instances — register succeeds but trigger finds no handlers.

## Changes

### 1. Emit `message:sent` at dispatch layer (`dispatch-from-config.ts`)
After successful completion (`recordProcessed("completed")`), emit an internal `message:sent` hook when:
- `sessionKey` is present, and
- at least one payload was delivered (`counts.tool + counts.block + counts.final > 0`).

### 2. Global singleton hook registry (`internal-hooks.ts`)
Use `Symbol.for("openclaw.internal-hooks.handlers")` on `globalThis` so that `registerInternalHook` and `triggerInternalHook` always share one Map, even across bundled chunks.

## Why `dispatch-from-config.ts`

`dispatchReplyFromConfig` is the common orchestration point across both:
- routed deliveries (`routeReply`), and
- dispatcher-driven deliveries (`dispatcher.sendFinalReply`).

Emitting here ensures internal hooks observe completion in both paths.

## Validation

- **Unit tests**: 64 passed (internal-hooks + dispatch-from-config)
- **Live Feishu e2e**: Consecutive messages all show:
  - `message:received` → 👏 CLAP reaction added
  - `message:sent` → ✅ OK reaction added
  - 3/3 consecutive passes confirmed by end user

## Related

- Issue: https://github.com/openclaw/openclaw/issues/30624