### PR TITLE
docs: fix sub-agent bootstrap file list to match source code (5 files, not 2)

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -595,7 +595,7 @@ Injects additional bootstrap files (for example monorepo-local `AGENTS.md` / `TO
 - Paths are resolved relative to workspace.
 - Files must stay inside workspace (realpath-checked).
 - Only recognized bootstrap basenames are loaded.
-- Subagent allowlist is preserved (`AGENTS.md` and `TOOLS.md` only).
+- Subagent allowlist is preserved (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, and `USER.md`).
 
 **Enable**:
 

--- a/docs/concepts/system-prompt.md
+++ b/docs/concepts/system-prompt.md
@@ -75,7 +75,7 @@ Large files are truncated with a marker. The max per-file size is controlled by
 content across files is capped by `agents.defaults.bootstrapTotalMaxChars`
 (default: 150000). Missing files inject a short missing-file marker.
 
-Sub-agent sessions only inject `AGENTS.md` and `TOOLS.md` (other bootstrap files
+Sub-agent sessions inject `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, and `USER.md` (other bootstrap files
 are filtered out to keep the sub-agent context small).
 
 Internal hooks can intercept this step via `agent:bootstrap` to mutate or replace

--- a/docs/start/openclaw.md
+++ b/docs/start/openclaw.md
@@ -71,7 +71,7 @@ When onboarding finishes, we auto-open the dashboard and print a clean (non-toke
 
 OpenClaw reads operating instructions and “memory” from its workspace directory.
 
-By default, OpenClaw uses `~/.openclaw/workspace` as the agent workspace, and will create it (plus starter `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`) automatically on setup/first agent run. `BOOTSTRAP.md` is only created when the workspace is brand new (it should not come back after you delete it). `MEMORY.md` is optional (not auto-created); when present, it is loaded for normal sessions. Subagent sessions only inject `AGENTS.md` and `TOOLS.md`.
+By default, OpenClaw uses `~/.openclaw/workspace` as the agent workspace, and will create it (plus starter `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`) automatically on setup/first agent run. `BOOTSTRAP.md` is only created when the workspace is brand new (it should not come back after you delete it). `MEMORY.md` is optional (not auto-created); when present, it is loaded for normal sessions. Subagent sessions inject `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, and `USER.md`.
 
 Tip: treat this folder like OpenClaw’s “memory” and make it a git repo (ideally private) so your `AGENTS.md` + memory files are backed up. If git is installed, brand-new workspaces are auto-initialized.
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -277,6 +277,6 @@ Sub-agents use a dedicated in-process queue lane:
 - Sub-agent announce is **best-effort**. If the gateway restarts, pending "announce back" work is lost.
 - Sub-agents still share the same gateway process resources; treat `maxConcurrent` as a safety valve.
 - `sessions_spawn` is always non-blocking: it returns `{ status: "accepted", runId, childSessionKey }` immediately.
-- Sub-agent context only injects `AGENTS.md` + `TOOLS.md` (no `SOUL.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, or `BOOTSTRAP.md`).
+- Sub-agent context injects `AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, and `USER.md` (no `HEARTBEAT.md` or `BOOTSTRAP.md`).
 - Maximum nesting depth is 5 (`maxSpawnDepth` range: 1–5). Depth 2 is recommended for most use cases.
 - `maxChildrenPerAgent` caps active children per session (default: 5, range: 1–20).

--- a/docs/zh-CN/tools/subagents.md
+++ b/docs/zh-CN/tools/subagents.md
@@ -164,4 +164,4 @@ x-i18n:
 - 子智能体通告是**尽力而为**的。如果 Gateway 网关重启，待处理的"通告回复"工作会丢失。
 - 子智能体仍然共享相同的 Gateway 网关进程资源；将 `maxConcurrent` 视为安全阀。
 - `sessions_spawn` 始终是非阻塞的：它立即返回 `{ status: "accepted", runId, childSessionKey }`。
-- 子智能体上下文仅注入 `AGENTS.md` + `TOOLS.md`（无 `SOUL.md`、`IDENTITY.md`、`USER.md`、`HEARTBEAT.md` 或 `BOOTSTRAP.md`）。
+- 子智能体上下文注入 `AGENTS.md`、`SOUL.md`、`TOOLS.md`、`IDENTITY.md` 和 `USER.md`（无 `HEARTBEAT.md` 或 `BOOTSTRAP.md`）。


### PR DESCRIPTION
The English docs incorrectly said sub-agent sessions only inject AGENTS.md and TOOLS.md, but the actual source code injects 5 files: AGENTS.md, TOOLS.md, SOUL.md, IDENTITY.md, USER.md. The Chinese docs didn't mention this at all.

This fix updates both English and Chinese documentation to correctly list all 5 injected files.

Fixes #30658