### PR TITLE
docs(community): add Monade Sales plugin listing

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,7 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+- **Monade Sales** — Security-first outbound calling and campaign operations with user-scoped SIP trunk management tools.
+  npm: `@openclaw/monade-sales`
+  repo: `https://github.com/monade-ai/livekit_depployment_voice_config/tree/dev/MCP/openclaw-monade-sales`
+  install: `openclaw plugins install @openclaw/monade-sales`

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -50,6 +50,6 @@ Use this format when adding entries:
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
 - **Monade Sales** — Security-first outbound calling and campaign operations with user-scoped SIP trunk management tools.
-  npm: `@openclaw/monade-sales`
+  npm: `@amolsoans/monade-sales`
   repo: `https://github.com/monade-ai/livekit_depployment_voice_config/tree/dev/MCP/openclaw-monade-sales`
-  install: `openclaw plugins install @openclaw/monade-sales`
+  install: `openclaw plugins install @amolsoans/monade-sales`


### PR DESCRIPTION
Adds a community plugin entry for Monade Sales in .

Entry includes:
- plugin name
- npm package spec
- source repository link
- install command

Note: npm publish is being finalized from the plugin source repo; this PR is opened as draft until package availability is confirmed.