### PR TITLE
fix: register OpenResponses runId in chatAbortControllers for chat.abort support

### DIFF
--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -32,6 +32,8 @@ import { defaultRuntime } from "../runtime.js";
 import { resolveAssistantStreamDeltaText } from "./agent-event-assistant-text.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
+import type { ChatAbortControllerEntry } from "./chat-abort.js";
+import { resolveChatRunExpiresAtMs } from "./chat-abort.js";
 import { sendJson, setSseHeaders, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import { resolveAgentIdForRequest, resolveSessionKey } from "./http-utils.js";
@@ -52,6 +54,7 @@ type OpenResponsesHttpOptions = {
   trustedProxies?: string[];
   allowRealIpFallback?: boolean;
   rateLimiter?: AuthRateLimiter;
+  chatAbortControllers?: Map<string, ChatAbortControllerEntry>;
 };
 
 const DEFAULT_BODY_BYTES = 20 * 1024 * 1024;
@@ -449,6 +452,23 @@ export async function handleOpenResponsesHttpRequest(
       ? { maxTokens: payload.max_output_tokens }
       : undefined;
 
+  // Register abort controller so chat.abort can find this run
+  const abortController = new AbortController();
+  if (opts.chatAbortControllers) {
+    const now = Date.now();
+    const timeoutMs = 10 * 60_000; // 10 minute default
+    opts.chatAbortControllers.set(responseId, {
+      controller: abortController,
+      sessionId: responseId,
+      sessionKey,
+      startedAtMs: now,
+      expiresAtMs: resolveChatRunExpiresAtMs({ now, timeoutMs }),
+    });
+  }
+  const cleanupAbortController = () => {
+    opts.chatAbortControllers?.delete(responseId);
+  };
+
   if (!stream) {
     try {
       const result = await runResponsesAgentCommand({
@@ -525,6 +545,8 @@ export async function handleOpenResponsesHttpRequest(
         error: { code: "api_error", message: "internal error" },
       });
       sendJson(res, 500, response);
+    } finally {
+      cleanupAbortController();
     }
     return true;
   }
@@ -603,6 +625,7 @@ export async function handleOpenResponsesHttpRequest(
       return;
     }
     finalizeRequested = { status, text };
+    cleanupAbortController();
     maybeFinalize();
   };
 
@@ -679,6 +702,7 @@ export async function handleOpenResponsesHttpRequest(
   req.on("close", () => {
     closed = true;
     unsubscribe();
+    cleanupAbortController();
   });
 
   void (async () => {
@@ -819,6 +843,7 @@ export async function handleOpenResponsesHttpRequest(
         usage: finalUsage,
       });
 
+      cleanupAbortController();
       writeSseEvent(res, { type: "response.failed", response: errorResponse });
       emitAgentEvent({
         runId: responseId,

--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -245,6 +245,7 @@ async function runResponsesAgentCommand(params: {
   sessionKey: string;
   runId: string;
   deps: ReturnType<typeof createDefaultDeps>;
+  abortSignal?: AbortSignal;
 }) {
   return agentCommand(
     {
@@ -258,6 +259,7 @@ async function runResponsesAgentCommand(params: {
       deliver: false,
       messageChannel: "webchat",
       bestEffortDeliver: false,
+      abortSignal: params.abortSignal,
     },
     defaultRuntime,
     params.deps,
@@ -480,6 +482,7 @@ export async function handleOpenResponsesHttpRequest(
         sessionKey,
         runId: responseId,
         deps,
+        abortSignal: abortController.signal,
       });
 
       const payloads = (result as { payloads?: Array<{ text?: string }> } | null)?.payloads;
@@ -716,6 +719,7 @@ export async function handleOpenResponsesHttpRequest(
         sessionKey,
         runId: responseId,
         deps,
+        abortSignal: abortController.signal,
       });
 
       finalUsage = extractUsageFromResult(result);

--- a/src/gateway/server-http.ts
+++ b/src/gateway/server-http.ts
@@ -32,6 +32,7 @@ import {
   type ResolvedGatewayAuth,
 } from "./auth.js";
 import { CANVAS_CAPABILITY_TTL_MS, normalizeCanvasScopedUrl } from "./canvas-capability.js";
+import type { ChatAbortControllerEntry } from "./chat-abort.js";
 import {
   handleControlUiAvatarRequest,
   handleControlUiHttpRequest,
@@ -463,6 +464,7 @@ export function createGatewayHttpServer(opts: {
   resolvedAuth: ResolvedGatewayAuth;
   /** Optional rate limiter for auth brute-force protection. */
   rateLimiter?: AuthRateLimiter;
+  chatAbortControllers?: Map<string, ChatAbortControllerEntry>;
   tlsOptions?: TlsOptions;
 }): HttpServer {
   const {
@@ -479,6 +481,7 @@ export function createGatewayHttpServer(opts: {
     handlePluginRequest,
     resolvedAuth,
     rateLimiter,
+    chatAbortControllers,
   } = opts;
   const httpServer: HttpServer = opts.tlsOptions
     ? createHttpsServer(opts.tlsOptions, (req, res) => {
@@ -555,6 +558,7 @@ export function createGatewayHttpServer(opts: {
             trustedProxies,
             allowRealIpFallback,
             rateLimiter,
+            chatAbortControllers,
           })
         ) {
           return;

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -125,6 +125,7 @@ export async function createGatewayRuntimeState(params: {
   }
   const httpServers: HttpServer[] = [];
   const httpBindHosts: string[] = [];
+  const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
   for (const host of bindHosts) {
     const httpServer = createGatewayHttpServer({
       canvasHost,
@@ -140,6 +141,7 @@ export async function createGatewayRuntimeState(params: {
       handlePluginRequest,
       resolvedAuth: params.resolvedAuth,
       rateLimiter: params.rateLimiter,
+      chatAbortControllers,
       tlsOptions: params.gatewayTls?.enabled ? params.gatewayTls.tlsOptions : undefined,
     });
     try {
@@ -187,7 +189,6 @@ export async function createGatewayRuntimeState(params: {
   const chatDeltaSentAt = chatRunState.deltaSentAt;
   const addChatRun = chatRunRegistry.add;
   const removeChatRun = chatRunRegistry.remove;
-  const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
   const toolEventRecipients = createToolEventRecipientRegistry();
 
   return {


### PR DESCRIPTION
## Summary

OpenResponses HTTP API tasks (`resp_xxx`) were not registered in the Gateway's `chatAbortControllers` Map, causing `chat.abort` requests to silently return `aborted: false` while the task continued executing.

## Root Cause

When a task is started via the OpenResponses `/v1/responses` endpoint, the generated `responseId` was never added to `chatAbortControllers`. The Gateway RPC WebSocket (`chat.send`) correctly registers run IDs, but the HTTP path was missing this registration.

## Changes

- **`openresponses-http.ts`**: Create an `AbortController` for each request, register it in `chatAbortControllers` with the `responseId` as key before running the agent command. Clean up on completion (`finally` block for non-streaming, `requestFinalize`/error/close handlers for streaming).
- **`server-http.ts`**: Thread `chatAbortControllers` through `createGatewayHttpServer` options to the OpenResponses handler.
- **`server-runtime-state.ts`**: Pass the existing `chatAbortControllers` Map to `createGatewayHttpServer`, moved declaration before the bind-host loop.

## Testing

- TypeScript compilation passes (no new errors)
- Minimal, focused change — only adds registration/cleanup logic

Fixes #30558