### PR TITLE
security: detect injection patterns in memory files before indexing

### DIFF
--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -11,6 +11,7 @@ import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.j
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { onSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { resolveUserPath } from "../utils.js";
+import { detectSuspiciousPatterns } from "../security/external-content.js";
 import { DEFAULT_GEMINI_EMBEDDING_MODEL } from "./embeddings-gemini.js";
 import { DEFAULT_MISTRAL_EMBEDDING_MODEL } from "./embeddings-mistral.js";
 import { DEFAULT_OPENAI_EMBEDDING_MODEL } from "./embeddings-openai.js";
@@ -670,6 +671,16 @@ export abstract class MemoryManagerSyncOps {
           });
         }
         return;
+      }
+      // Scan memory file content for injection patterns before indexing
+      if (entry.content) {
+        const suspicious = detectSuspiciousPatterns(entry.content);
+        if (suspicious.length > 0) {
+          log.warn("suspicious patterns detected in memory file", {
+            path: entry.path,
+            patternCount: suspicious.length,
+          });
+        }
       }
       await this.indexFile(entry, { source: "memory" });
       if (params.progress) {


### PR DESCRIPTION
## Summary

Memory files (MEMORY.md, memory/*.md) are the most trusted context source for agents, yet had zero injection detection. External content (webhooks, emails) already uses `detectSuspiciousPatterns()` from `external-content.ts` — this extends the same protection to memory files.

## Change

In `manager-sync-ops.ts`, call `detectSuspiciousPatterns()` on file content before `indexFile()` for memory-source files. Logs a `warn` with path + pattern count if suspicious content is found. Non-blocking — does not prevent indexing.

## Why this matters

The attack surface for agent identity manipulation is highest in files the agent trusts most. An attacker who can write to MEMORY.md can inject instructions that feel like the agent's own thoughts. This change ensures every memory file sync triggers a pattern scan, creating an audit trail even when the agent doesn't notice the injection.

## Non-breaking

- Warn-only, no behavior change
- 11 lines added, zero new dependencies (reuses existing `detectSuspiciousPatterns`)