### PR TITLE
feat(discord): add default_auto_archive_duration support and channel/category CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Changes
+
+- Discord/Channel ops: support `default_auto_archive_duration` on `channel-create` and `channel-edit`, and add `--no-nsfw`, `--no-archived`, and `--no-locked` negation flags to `channel-edit` so boolean fields can be explicitly cleared from the CLI.
+
 ### Fixes
 
 - Cron/Failure alerts: add configurable repeated-failure alerting with per-job overrides and Web UI cron editor support (`inherit|disabled|custom` with threshold/cooldown/channel/target fields). (#24789) Thanks xbrak.

--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -160,7 +160,7 @@ Name lookup:
 - `channel info` (Discord): `--target`
 - `channel list` (Discord): `--guild-id`
 - `channel create` (Discord): `--guild-id`, `--name` (+ optional `--type`, `--parentId`, `--topic`, `--position`, `--nsfw`, `--default-auto-archive-duration`)
-- `channel edit` (Discord): `--target` (+ optional `--name`, `--topic`, `--position`, `--parentId`, `--clearParent`, `--nsfw`, `--rateLimitPerUser`, `--archived`, `--locked`, `--auto-archive-duration`, `--default-auto-archive-duration`)
+- `channel edit` (Discord): `--target` (+ optional `--name`, `--topic`, `--position`, `--parentId`, `--clearParent`, `--nsfw`, `--no-nsfw`, `--rateLimitPerUser`, `--archived`, `--no-archived`, `--locked`, `--no-locked`, `--auto-archive-duration`, `--default-auto-archive-duration`)
 - `channel delete` (Discord): `--target`
 - `channel move` (Discord): `--target`, `--guild-id` (+ optional `--parentId`, `--clearParent`, `--position`)
 - `category create` (Discord): `--guild-id`, `--name` (+ optional `--position`)

--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -159,6 +159,13 @@ Name lookup:
 - `role add` / `role remove` (Discord): `--guild-id`, `--user-id`, `--role-id`
 - `channel info` (Discord): `--target`
 - `channel list` (Discord): `--guild-id`
+- `channel create` (Discord): `--guild-id`, `--name` (+ optional `--type`, `--parentId`, `--topic`, `--position`, `--nsfw`, `--default-auto-archive-duration`)
+- `channel edit` (Discord): `--target` (+ optional `--name`, `--topic`, `--position`, `--parentId`, `--clearParent`, `--nsfw`, `--rateLimitPerUser`, `--archived`, `--locked`, `--auto-archive-duration`, `--default-auto-archive-duration`)
+- `channel delete` (Discord): `--target`
+- `channel move` (Discord): `--target`, `--guild-id` (+ optional `--parentId`, `--clearParent`, `--position`)
+- `category create` (Discord): `--guild-id`, `--name` (+ optional `--position`)
+- `category edit` (Discord): `--category-id` (+ optional `--name`, `--position`)
+- `category delete` (Discord): `--category-id`
 - `member info` (Discord/Slack): `--user-id` (+ `--guild-id` for Discord)
 - `voice status` (Discord): `--guild-id`, `--user-id`
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -414,13 +414,14 @@ Core actions:
 - `member-info` / `role-info`
 - `emoji-list` / `emoji-upload` / `sticker-upload`
 - `role-add` / `role-remove`
-- `channel-info` / `channel-list`
+- `channel-info` / `channel-list` / `channel-create` / `channel-edit`
 - `voice-status`
 - `event-list` / `event-create`
 - `timeout` / `kick` / `ban`
 
 Notes:
 
+- `channel-create` and `channel-edit` (Discord) support `autoArchiveDuration` (for threads) and `defaultAutoArchiveDuration` (for new threads in a channel).
 - `send` routes WhatsApp via the Gateway; other channels go direct.
 - `poll` uses the Gateway for WhatsApp and MS Teams; Discord polls go direct.
 - When a message tool call is bound to an active chat session, sends are constrained to that session’s target to avoid cross-context leaks.

--- a/src/agents/tools/discord-actions-guild.ts
+++ b/src/agents/tools/discord-actions-guild.ts
@@ -291,6 +291,9 @@ export async function handleDiscordGuildAction(
       const topic = readStringParam(params, "topic");
       const position = readNumberParam(params, "position", { integer: true });
       const nsfw = params.nsfw as boolean | undefined;
+      const defaultAutoArchiveDuration = readNumberParam(params, "defaultAutoArchiveDuration", {
+        integer: true,
+      });
       const channel = accountId
         ? await createChannelDiscord(
             {
@@ -301,6 +304,7 @@ export async function handleDiscordGuildAction(
               topic: topic ?? undefined,
               position: position ?? undefined,
               nsfw,
+              defaultAutoArchiveDuration: defaultAutoArchiveDuration ?? undefined,
             },
             { accountId },
           )
@@ -312,6 +316,7 @@ export async function handleDiscordGuildAction(
             topic: topic ?? undefined,
             position: position ?? undefined,
             nsfw,
+            defaultAutoArchiveDuration: defaultAutoArchiveDuration ?? undefined,
           });
       return jsonResult({ ok: true, channel });
     }
@@ -335,6 +340,9 @@ export async function handleDiscordGuildAction(
       const autoArchiveDuration = readNumberParam(params, "autoArchiveDuration", {
         integer: true,
       });
+      const defaultAutoArchiveDuration = readNumberParam(params, "defaultAutoArchiveDuration", {
+        integer: true,
+      });
       const availableTags = parseAvailableTags(params.availableTags);
       const channel = accountId
         ? await editChannelDiscord(
@@ -349,6 +357,7 @@ export async function handleDiscordGuildAction(
               archived,
               locked,
               autoArchiveDuration: autoArchiveDuration ?? undefined,
+              defaultAutoArchiveDuration: defaultAutoArchiveDuration ?? undefined,
               availableTags,
             },
             { accountId },
@@ -364,6 +373,7 @@ export async function handleDiscordGuildAction(
             archived,
             locked,
             autoArchiveDuration: autoArchiveDuration ?? undefined,
+            defaultAutoArchiveDuration: defaultAutoArchiveDuration ?? undefined,
             availableTags,
           });
       return jsonResult({ ok: true, channel });

--- a/src/agents/tools/discord-actions.test.ts
+++ b/src/agents/tools/discord-actions.test.ts
@@ -337,6 +337,7 @@ describe("handleDiscordGuildAction - channel management", () => {
         name: "test-channel",
         type: 0,
         topic: "Test topic",
+        defaultAutoArchiveDuration: 1440,
       },
       channelsEnabled,
     );
@@ -348,6 +349,7 @@ describe("handleDiscordGuildAction - channel management", () => {
       topic: "Test topic",
       position: undefined,
       nsfw: undefined,
+      defaultAutoArchiveDuration: 1440,
     });
     expect(result.details).toMatchObject({ ok: true });
   });
@@ -374,6 +376,7 @@ describe("handleDiscordGuildAction - channel management", () => {
         channelId: "C1",
         name: "new-name",
         topic: "new topic",
+        defaultAutoArchiveDuration: 4320,
       },
       channelsEnabled,
     );
@@ -388,6 +391,7 @@ describe("handleDiscordGuildAction - channel management", () => {
       archived: undefined,
       locked: undefined,
       autoArchiveDuration: undefined,
+      defaultAutoArchiveDuration: 4320,
     });
   });
 
@@ -413,6 +417,7 @@ describe("handleDiscordGuildAction - channel management", () => {
       archived: true,
       locked: false,
       autoArchiveDuration: 1440,
+      defaultAutoArchiveDuration: undefined,
     });
   });
 
@@ -439,6 +444,7 @@ describe("handleDiscordGuildAction - channel management", () => {
       archived: undefined,
       locked: undefined,
       autoArchiveDuration: undefined,
+      defaultAutoArchiveDuration: undefined,
     });
   });
 

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -382,6 +382,18 @@ function buildChannelManagementSchema() {
     position: Type.Optional(Type.Number()),
     nsfw: Type.Optional(Type.Boolean()),
     rateLimitPerUser: Type.Optional(Type.Number()),
+    autoArchiveDuration: Type.Optional(
+      Type.Number({
+        description:
+          "The duration in minutes to automatically archive the thread after recent activity. Valid: 60, 1440, 4320, 10080.",
+      }),
+    ),
+    defaultAutoArchiveDuration: Type.Optional(
+      Type.Number({
+        description:
+          "Default duration, in minutes, for threads in this channel to stay active. Valid: 60, 1440, 4320, 10080.",
+      }),
+    ),
     categoryId: Type.Optional(Type.String()),
     clearParent: Type.Optional(
       Type.Boolean({

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -382,11 +382,11 @@ function buildChannelManagementSchema() {
     position: Type.Optional(Type.Number()),
     nsfw: Type.Optional(Type.Boolean()),
     rateLimitPerUser: Type.Optional(Type.Number()),
-    autoArchiveDuration: optionalStringEnum("60", "1440", "4320", "10080", {
+    autoArchiveDuration: optionalStringEnum(["60", "1440", "4320", "10080"], {
       description:
         "The duration in minutes to automatically archive the thread after recent activity.",
     }),
-    defaultAutoArchiveDuration: optionalStringEnum("60", "1440", "4320", "10080", {
+    defaultAutoArchiveDuration: optionalStringEnum(["60", "1440", "4320", "10080"], {
       description: "Default duration, in minutes, for threads in this channel to stay active.",
     }),
     categoryId: Type.Optional(Type.String()),

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -21,7 +21,7 @@ import { stripReasoningTagsFromText } from "../../shared/text/reasoning-tags.js"
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { resolveSessionAgentId } from "../agent-scope.js";
 import { listChannelSupportedActions } from "../channel-tools.js";
-import { channelTargetSchema, channelTargetsSchema, stringEnum } from "../schema/typebox.js";
+import { channelTargetSchema, channelTargetsSchema, optionalStringEnum, stringEnum } from "../schema/typebox.js";
 import type { AnyAgentTool } from "./common.js";
 import { jsonResult, readNumberParam, readStringParam } from "./common.js";
 import { resolveGatewayOptions } from "./gateway.js";
@@ -382,18 +382,13 @@ function buildChannelManagementSchema() {
     position: Type.Optional(Type.Number()),
     nsfw: Type.Optional(Type.Boolean()),
     rateLimitPerUser: Type.Optional(Type.Number()),
-    autoArchiveDuration: Type.Optional(
-      Type.Number({
-        description:
-          "The duration in minutes to automatically archive the thread after recent activity. Valid: 60, 1440, 4320, 10080.",
-      }),
-    ),
-    defaultAutoArchiveDuration: Type.Optional(
-      Type.Number({
-        description:
-          "Default duration, in minutes, for threads in this channel to stay active. Valid: 60, 1440, 4320, 10080.",
-      }),
-    ),
+    autoArchiveDuration: optionalStringEnum("60", "1440", "4320", "10080", {
+      description:
+        "The duration in minutes to automatically archive the thread after recent activity.",
+    }),
+    defaultAutoArchiveDuration: optionalStringEnum("60", "1440", "4320", "10080", {
+      description: "Default duration, in minutes, for threads in this channel to stay active.",
+    }),
     categoryId: Type.Optional(Type.String()),
     clearParent: Type.Optional(
       Type.Boolean({

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -451,6 +451,48 @@ describe("handleDiscordMessageAction", () => {
       expect.objectContaining({ mediaLocalRoots: ["/tmp/agent-root"] }),
     );
   });
+
+  it.each([
+    ["archived=false (--no-archived)", { archived: false }, { archived: false }],
+    ["locked=false (--no-locked)", { locked: false }, { locked: false }],
+    ["nsfw=false (--no-nsfw)", { nsfw: false }, { nsfw: false }],
+    [
+      "archived=false and locked=false together",
+      { archived: false, locked: false },
+      { archived: false, locked: false },
+    ],
+  ])(
+    "channel-edit: forwards boolean false for %s",
+    async (_label, boolParams, expectedPartial) => {
+      await handleDiscordMessageAction({
+        action: "channel-edit",
+        params: { channelId: "C1", ...boolParams },
+        cfg: {} as OpenClawConfig,
+      });
+      const call = handleDiscordAction.mock.calls.at(-1);
+      expect(call?.[0]).toEqual(expect.objectContaining({ action: "channelEdit", ...expectedPartial }));
+    },
+  );
+
+  it("channel-edit: rejects invalid default-auto-archive-duration", async () => {
+    await expect(
+      handleDiscordMessageAction({
+        action: "channel-edit",
+        params: { channelId: "C1", defaultAutoArchiveDuration: 9999 },
+        cfg: {} as OpenClawConfig,
+      }),
+    ).rejects.toThrow(/Invalid default-auto-archive-duration: 9999/);
+  });
+
+  it("channel-create: rejects invalid default-auto-archive-duration", async () => {
+    await expect(
+      handleDiscordMessageAction({
+        action: "channel-create",
+        params: { guildId: "G1", name: "test", defaultAutoArchiveDuration: 30 },
+        cfg: {} as OpenClawConfig,
+      }),
+    ).rejects.toThrow(/Invalid default-auto-archive-duration: 30/);
+  });
 });
 
 describe("telegramMessageActions", () => {

--- a/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
+++ b/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
@@ -12,6 +12,20 @@ import {
 import { handleDiscordAction } from "../../../../agents/tools/discord-actions.js";
 import type { ChannelMessageActionContext } from "../../types.js";
 
+const VALID_AUTO_ARCHIVE_DURATIONS = [60, 1440, 4320, 10080] as const;
+
+/** Throws if value is set but not one of the Discord-allowed durations. */
+function validateAutoArchiveDuration(value: number | null | undefined, label: string): void {
+  if (value === undefined || value === null) {
+    return;
+  }
+  if (!(VALID_AUTO_ARCHIVE_DURATIONS as readonly number[]).includes(value)) {
+    throw new Error(
+      `Invalid ${label}: ${value}. Must be one of ${VALID_AUTO_ARCHIVE_DURATIONS.join(", ")}.`,
+    );
+  }
+}
+
 type Ctx = Pick<
   ChannelMessageActionContext,
   "action" | "params" | "cfg" | "accountId" | "requesterSenderId"
@@ -164,6 +178,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
     const defaultAutoArchiveDuration = readNumberParam(actionParams, "defaultAutoArchiveDuration", {
       integer: true,
     });
+    validateAutoArchiveDuration(defaultAutoArchiveDuration, "default-auto-archive-duration");
     return await handleDiscordAction(
       {
         action: "channelCreate",
@@ -203,6 +218,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
     const defaultAutoArchiveDuration = readNumberParam(actionParams, "defaultAutoArchiveDuration", {
       integer: true,
     });
+    validateAutoArchiveDuration(defaultAutoArchiveDuration, "default-auto-archive-duration");
     const availableTags = parseAvailableTags(actionParams.availableTags);
     return await handleDiscordAction(
       {

--- a/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
+++ b/src/channels/plugins/actions/discord/handle-action.guild-admin.ts
@@ -161,6 +161,9 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
       integer: true,
     });
     const nsfw = typeof actionParams.nsfw === "boolean" ? actionParams.nsfw : undefined;
+    const defaultAutoArchiveDuration = readNumberParam(actionParams, "defaultAutoArchiveDuration", {
+      integer: true,
+    });
     return await handleDiscordAction(
       {
         action: "channelCreate",
@@ -172,6 +175,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         topic: topic ?? undefined,
         position: position ?? undefined,
         nsfw,
+        defaultAutoArchiveDuration,
       },
       cfg,
     );
@@ -196,6 +200,9 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
     const autoArchiveDuration = readNumberParam(actionParams, "autoArchiveDuration", {
       integer: true,
     });
+    const defaultAutoArchiveDuration = readNumberParam(actionParams, "defaultAutoArchiveDuration", {
+      integer: true,
+    });
     const availableTags = parseAvailableTags(actionParams.availableTags);
     return await handleDiscordAction(
       {
@@ -211,6 +218,7 @@ export async function tryHandleDiscordMessageActionGuildAdmin(params: {
         archived,
         locked,
         autoArchiveDuration: autoArchiveDuration ?? undefined,
+        defaultAutoArchiveDuration,
         availableTags,
       },
       cfg,

--- a/src/cli/program/message/register.discord-admin.ts
+++ b/src/cli/program/message/register.discord-admin.ts
@@ -70,13 +70,18 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
     .option("--topic <text>", "Channel topic")
     .option("--position <n>", "Channel position")
     .option("--nsfw", "Mark as NSFW")
-    .option("--default-auto-archive-duration <n>", "Default auto-archive duration (60, 1440, 4320, 10080)")
+    .option(
+      "--default-auto-archive-duration <n>",
+      "Default auto-archive duration (60, 1440, 4320, 10080)",
+    )
     .action(async (opts) => {
       await helpers.runMessageAction("channel-create", opts);
     });
 
   helpers
-    .withMessageBase(helpers.withRequiredMessageTarget(channel.command("edit").description("Edit a channel")))
+    .withMessageBase(
+      helpers.withRequiredMessageTarget(channel.command("edit").description("Edit a channel")),
+    )
     .option("--name <text>", "Channel name")
     .option("--topic <text>", "Channel topic")
     .option("--position <n>", "Channel position")
@@ -87,13 +92,18 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
     .option("--archived", "Archive thread")
     .option("--locked", "Lock thread")
     .option("--auto-archive-duration <n>", "Auto-archive duration (60, 1440, 4320, 10080)")
-    .option("--default-auto-archive-duration <n>", "Default auto-archive duration (60, 1440, 4320, 10080)")
+    .option(
+      "--default-auto-archive-duration <n>",
+      "Default auto-archive duration (60, 1440, 4320, 10080)",
+    )
     .action(async (opts) => {
       await helpers.runMessageAction("channel-edit", opts);
     });
 
   helpers
-    .withMessageBase(helpers.withRequiredMessageTarget(channel.command("delete").description("Delete a channel")))
+    .withMessageBase(
+      helpers.withRequiredMessageTarget(channel.command("delete").description("Delete a channel")),
+    )
     .action(async (opts) => {
       await helpers.runMessageAction("channel-delete", opts);
     });

--- a/src/cli/program/message/register.discord-admin.ts
+++ b/src/cli/program/message/register.discord-admin.ts
@@ -57,6 +57,101 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
       await helpers.runMessageAction("channel-list", opts);
     });
 
+  helpers
+    .withMessageBase(
+      channel
+        .command("create")
+        .description("Create a channel")
+        .requiredOption("--guild-id <id>", "Guild id")
+        .requiredOption("--name <text>", "Channel name"),
+    )
+    .option("--type <n>", "Channel type (0: text, 2: voice, 5: announcement, 13: stage, 15: forum)")
+    .option("--parentId <id>", "Category/parent id")
+    .option("--topic <text>", "Channel topic")
+    .option("--position <n>", "Channel position")
+    .option("--nsfw", "Mark as NSFW")
+    .option("--default-auto-archive-duration <n>", "Default auto-archive duration (60, 1440, 4320, 10080)")
+    .action(async (opts) => {
+      await helpers.runMessageAction("channel-create", opts);
+    });
+
+  helpers
+    .withMessageBase(helpers.withRequiredMessageTarget(channel.command("edit").description("Edit a channel")))
+    .option("--name <text>", "Channel name")
+    .option("--topic <text>", "Channel topic")
+    .option("--position <n>", "Channel position")
+    .option("--parentId <id>", "Category/parent id")
+    .option("--clearParent", "Clear parent/category")
+    .option("--nsfw", "Mark as NSFW")
+    .option("--rateLimitPerUser <n>", "Slowmode in seconds")
+    .option("--archived", "Archive thread")
+    .option("--locked", "Lock thread")
+    .option("--auto-archive-duration <n>", "Auto-archive duration (60, 1440, 4320, 10080)")
+    .option("--default-auto-archive-duration <n>", "Default auto-archive duration (60, 1440, 4320, 10080)")
+    .action(async (opts) => {
+      await helpers.runMessageAction("channel-edit", opts);
+    });
+
+  helpers
+    .withMessageBase(helpers.withRequiredMessageTarget(channel.command("delete").description("Delete a channel")))
+    .action(async (opts) => {
+      await helpers.runMessageAction("channel-delete", opts);
+    });
+
+  helpers
+    .withMessageBase(
+      helpers.withRequiredMessageTarget(
+        channel
+          .command("move")
+          .description("Move a channel")
+          .requiredOption("--guild-id <id>", "Guild id"),
+      ),
+    )
+    .option("--parentId <id>", "Category/parent id")
+    .option("--clearParent", "Clear parent/category")
+    .option("--position <n>", "Channel position")
+    .action(async (opts) => {
+      await helpers.runMessageAction("channel-move", opts);
+    });
+
+  const category = message.command("category").description("Category actions");
+  helpers
+    .withMessageBase(
+      category
+        .command("create")
+        .description("Create a category")
+        .requiredOption("--guild-id <id>", "Guild id")
+        .requiredOption("--name <text>", "Category name"),
+    )
+    .option("--position <n>", "Category position")
+    .action(async (opts) => {
+      await helpers.runMessageAction("category-create", opts);
+    });
+
+  helpers
+    .withMessageBase(
+      category
+        .command("edit")
+        .description("Edit a category")
+        .requiredOption("--category-id <id>", "Category id"),
+    )
+    .option("--name <text>", "Category name")
+    .option("--position <n>", "Category position")
+    .action(async (opts) => {
+      await helpers.runMessageAction("category-edit", opts);
+    });
+
+  helpers
+    .withMessageBase(
+      category
+        .command("delete")
+        .description("Delete a category")
+        .requiredOption("--category-id <id>", "Category id"),
+    )
+    .action(async (opts) => {
+      await helpers.runMessageAction("category-delete", opts);
+    });
+
   const member = message.command("member").description("Member actions");
   helpers
     .withMessageBase(

--- a/src/cli/program/message/register.discord-admin.ts
+++ b/src/cli/program/message/register.discord-admin.ts
@@ -88,9 +88,12 @@ export function registerMessageDiscordAdminCommands(message: Command, helpers: M
     .option("--parentId <id>", "Category/parent id")
     .option("--clearParent", "Clear parent/category")
     .option("--nsfw", "Mark as NSFW")
+    .option("--no-nsfw", "Unmark as NSFW")
     .option("--rateLimitPerUser <n>", "Slowmode in seconds")
     .option("--archived", "Archive thread")
+    .option("--no-archived", "Unarchive thread")
     .option("--locked", "Lock thread")
+    .option("--no-locked", "Unlock thread")
     .option("--auto-archive-duration <n>", "Auto-archive duration (60, 1440, 4320, 10080)")
     .option(
       "--default-auto-archive-duration <n>",

--- a/src/discord/send.channels.ts
+++ b/src/discord/send.channels.ts
@@ -32,6 +32,9 @@ export async function createChannelDiscord(
   if (payload.nsfw !== undefined) {
     body.nsfw = payload.nsfw;
   }
+  if (payload.defaultAutoArchiveDuration !== undefined) {
+    body.default_auto_archive_duration = payload.defaultAutoArchiveDuration;
+  }
   return (await rest.post(Routes.guildChannels(payload.guildId), {
     body,
   })) as APIChannel;
@@ -69,6 +72,9 @@ export async function editChannelDiscord(
   }
   if (payload.autoArchiveDuration !== undefined) {
     body.auto_archive_duration = payload.autoArchiveDuration;
+  }
+  if (payload.defaultAutoArchiveDuration !== undefined) {
+    body.default_auto_archive_duration = payload.defaultAutoArchiveDuration;
   }
   if (payload.availableTags !== undefined) {
     body.available_tags = payload.availableTags.map((t) => ({

--- a/src/discord/send.types.ts
+++ b/src/discord/send.types.ts
@@ -132,6 +132,7 @@ export type DiscordChannelCreate = {
   topic?: string;
   position?: number;
   nsfw?: boolean;
+  defaultAutoArchiveDuration?: number;
 };
 
 export type DiscordForumTag = {
@@ -153,6 +154,7 @@ export type DiscordChannelEdit = {
   archived?: boolean;
   locked?: boolean;
   autoArchiveDuration?: number;
+  defaultAutoArchiveDuration?: number;
   availableTags?: DiscordForumTag[];
 };
 


### PR DESCRIPTION
I'm slowly getting used to the way this is coded. And this is an edge case I had because I like getting openclaw to setup new channels, but I dislike having to manually set the default archive days myself after the fact (especially when adding/editing/removing multiple channels at once). This adds support for setting thread auto-archive duration (60, 1440, 4320, 10080 minutes) when creating or editing Discord channels via the message tool, or via chat methods.

## Summary

- Problem: Discord `channel-create` and `channel-edit` actions did not support `default_auto_archive_duration`, forcing users to manually set thread auto-archive in Discord client
- Why it matters: When organizing channels programmatically, consistent thread auto-archive settings are important for workflow
- What changed: Added `defaultAutoArchiveDuration` parameter to `channel-create` and `channel-edit` actions; added full CLI commands for channel/category management
- What did NOT change: This is distinct from #28245 which sets auto_archive_duration on subagent threads at runtime. This PR exposes the channel-level setting to users via the message tool/CLI.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #25330
- Related #28245

## User-visible / Behavior Changes

- New `defaultAutoArchiveDuration` parameter for `channel-create` and `channel-edit` actions (valid: 60, 1440, 4320, 10080 minutes)
- New CLI commands: `message channel create`, `message channel edit`, `message channel delete`, `message channel move`
- New CLI commands: `message category create`, `message category edit`, `message category delete`
- Updated documentation in `docs/cli/message.md` and `docs/tools/index.md`

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No` - uses existing Discord API)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Docker (OpenClaw gateway)
- Model/provider: kimi 2.5
- Integration/channel: Discord
- Relevant config: `channels.discord.enabled: true`

### Steps
1. Create channel with auto-archive: `openclaw message channel create --guild-id GUILD --name test --default-auto-archive-duration 10080`
2. Edit channel auto-archive: `openclaw message channel edit --target CHANNEL --default-auto-archive-duration 4320`
3. Verify in Discord client that thread auto-archive is set correctly

### Expected

- Channel/thread created with specified default auto-archive duration
- Edit applies new duration without error

### Actual

- Channel/thread created with specified default auto-archive duration
- Edit works and show the correct default auto-archive duration too

## Evidence
- [x] Failing test/log before + passing after: Tests added in `discord-actions.test.ts` verify parameter is passed through correctly
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Asking openclaw to create a new channel with the specified default auto-archive duration, and the CLI.
- Edge cases checked: Optional parameter (undefined passes nothing), valid duration values (60, 1440, 4320, 10080)
- What you did **not** verify: Random number passed in outside of the regular range

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert PR, rebuild gateway
- Files/config to restore: None
- Known bad symptoms reviewers should watch for: Channel creation/editing fails with validation errors on `default_auto_archive_duration`

## Risks and Mitigations

- Risk: Discord API rejects invalid duration values
  - Mitigation: Schema validation accepts only valid values (60, 1440, 4320, 10080); parameter is optional