### PR TITLE
feat: add channel-bootstrap bundled hook

### DIFF
--- a/src/hooks/bundled/channel-bootstrap/HOOK.md
+++ b/src/hooks/bundled/channel-bootstrap/HOOK.md
@@ -1,0 +1,79 @@
+---
+name: channel-bootstrap
+description: "Inject per-channel bootstrap context into AGENTS.md during agent:bootstrap"
+homepage: https://docs.openclaw.ai/automation/hooks#channel-bootstrap
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🗂️",
+        "events": ["agent:bootstrap"],
+        "requires": { "config": ["workspace.dir"] },
+        "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
+      },
+  }
+---
+
+# Channel Bootstrap Hook
+
+Appends per-channel instructions to `AGENTS.md` at bootstrap time, based on the
+channel ID extracted from the active session key.
+
+## Why
+
+OpenClaw's global workspace files (`AGENTS.md`, `SOUL.md`, etc.) are shared across
+all channels and groups. When different Discord channels, Telegram groups, or Slack
+channels need distinct behavior — different personas, different callback handling,
+channel-specific rules — you'd have to cram everything into one giant `AGENTS.md`.
+
+This hook lets you split those instructions into per-channel files that only load
+when the agent is active in that specific channel.
+
+## How It Works
+
+1. Listens for `agent:bootstrap`.
+2. Parses the `sessionKey` to extract the channel or group ID.
+3. Looks for `workspace/channels/{channelId}.md`.
+4. If found, appends its content to the existing `AGENTS.md` bootstrap entry under
+   a `## 📡 Channel-Specific Context` heading. If no `AGENTS.md` entry exists,
+   a new one is created.
+5. If no channel file exists, the hook exits silently — no errors, no noise.
+
+## File Layout
+
+```
+workspace/
+└── channels/
+    ├── 1473810409952641138.md    ← Discord channel #dev-build
+    ├── 1473460547335880776.md    ← Discord channel #jobs-intel
+    ├── -1001234567890.md         ← Telegram group
+    └── C0123ABCDEF.md            ← Slack channel
+```
+
+## Channel ID Extraction Rules
+
+| Session Key Pattern                   | Extracted ID              |
+| ------------------------------------- | ------------------------- |
+| `…:discord:channel:123456`            | `123456`                  |
+| `…:discord:channel:123456:thread:789` | `123456` (parent channel) |
+| `…:telegram:group:-100123`            | `-100123`                 |
+| `…:slack:channel:C123ABC`             | `C123ABC`                 |
+| `…:whatsapp:group:120363…@g.us`       | `120363…@g.us`            |
+| `…:main` (DM / main session)          | _(skipped)_               |
+
+## Requirements
+
+- OpenClaw ≥ v2026.2 (hooks system)
+- Internal hooks enabled in config
+- `workspace.dir` configured
+
+## Enable
+
+```bash
+openclaw hooks enable channel-bootstrap
+```
+
+## See Also
+
+- [Hooks documentation](https://docs.openclaw.ai/automation/hooks)
+- [bootstrap-extra-files](https://docs.openclaw.ai/automation/hooks#bootstrap-extra-files)

--- a/src/hooks/bundled/channel-bootstrap/handler.test.ts
+++ b/src/hooks/bundled/channel-bootstrap/handler.test.ts
@@ -50,6 +50,11 @@ describe("extractChannelId", () => {
   });
 
   it("extracts generic channel id via fallback pattern", () => {
+    // Nextcloud Talk with hyphenated channel name
+    expect(extractChannelId("agent:main:nextcloud-talk:group:abc123")).toBe("abc123");
+  });
+
+  it("extracts generic channel id for non-hyphenated channels", () => {
     expect(extractChannelId("agent:main:matrix:channel:!room123:example.com")).toBe("!room123");
   });
 

--- a/src/hooks/bundled/channel-bootstrap/handler.test.ts
+++ b/src/hooks/bundled/channel-bootstrap/handler.test.ts
@@ -124,15 +124,13 @@ describe("channel-bootstrap handler", () => {
     const event = createHookEvent("agent", "bootstrap", context.sessionKey!, context);
     await handler(event);
 
-    // The slot in the array should be a new object, not the original reference
-    expect(context.bootstrapFiles[0]).not.toBe(originalEntry);
-    // Original entry content must be untouched
+    // Original entry content must be untouched (we work on a copy)
     expect(originalEntry.content).toBe("Global.");
-    // New entry should have the appended content
+    // The array should contain the updated entry
     expect(context.bootstrapFiles[0].content).toContain("Channel only.");
   });
 
-  it("injects new non-missing AGENTS.md entry when only a missing placeholder exists", async () => {
+  it("replaces missing AGENTS.md placeholder with injected channel context", async () => {
     const dir = await makeTempWorkspace("openclaw-channel-bootstrap-missing-");
     const channelsDir = path.join(dir, "channels");
     await fs.mkdir(channelsDir, { recursive: true });
@@ -147,13 +145,34 @@ describe("channel-bootstrap handler", () => {
     const event = createHookEvent("agent", "bootstrap", context.sessionKey!, context);
     await handler(event);
 
-    const nonMissingAgents = context.bootstrapFiles.filter(
-      (f) => f.name === "AGENTS.md" && !f.missing,
-    );
-    expect(nonMissingAgents).toHaveLength(1);
-    expect(nonMissingAgents[0].content).toContain("Channel only.");
-    expect(nonMissingAgents[0].path).toContain("AGENTS.md");
-    expect(nonMissingAgents[0].path).not.toContain("channels");
+    // Missing placeholder should be removed, replaced with non-missing entry
+    const allAgents = context.bootstrapFiles.filter((f) => f.name === "AGENTS.md");
+    expect(allAgents).toHaveLength(1);
+    expect(allAgents[0].missing).toBe(false);
+    expect(allAgents[0].content).toContain("Channel only.");
+    expect(allAgents[0].path).toContain("AGENTS.md");
+    expect(allAgents[0].path).not.toContain("channels");
+  });
+
+  it("resolves uppercase channel file for lowercase Slack session key", async () => {
+    const dir = await makeTempWorkspace("openclaw-channel-bootstrap-slack-case-");
+    const channelsDir = path.join(dir, "channels");
+    await fs.mkdir(channelsDir, { recursive: true });
+    // File named with canonical Slack uppercase
+    await fs.writeFile(path.join(channelsDir, "C0123ABCDEF.md"), "Slack context.", "utf-8");
+
+    const context = makeContext({
+      workspaceDir: dir,
+      // Runtime session key uses lowercase (session-key.ts normalizes)
+      sessionKey: "agent:main:slack:channel:c0123abcdef",
+      agentsMdContent: "Global.",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", context.sessionKey!, context);
+    await handler(event);
+
+    const agents = context.bootstrapFiles.find((f) => f.name === "AGENTS.md");
+    expect(agents!.content).toContain("Slack context.");
   });
 
   it("silently skips and does not modify bootstrap files when no channel file exists", async () => {

--- a/src/hooks/bundled/channel-bootstrap/handler.test.ts
+++ b/src/hooks/bundled/channel-bootstrap/handler.test.ts
@@ -90,7 +90,7 @@ describe("channel-bootstrap handler", () => {
       agentsMdContent: "# Global AGENTS\n\nGlobal stuff.",
     });
 
-    const event = createHookEvent("agent", "bootstrap", context.sessionKey, context);
+    const event = createHookEvent("agent", "bootstrap", context.sessionKey!, context);
     await handler(event);
 
     const agents = context.bootstrapFiles.find((f) => f.name === "AGENTS.md");
@@ -121,7 +121,7 @@ describe("channel-bootstrap handler", () => {
     // Replace with known reference so we can check identity
     context.bootstrapFiles[0] = originalEntry;
 
-    const event = createHookEvent("agent", "bootstrap", context.sessionKey, context);
+    const event = createHookEvent("agent", "bootstrap", context.sessionKey!, context);
     await handler(event);
 
     // The slot in the array should be a new object, not the original reference
@@ -144,7 +144,7 @@ describe("channel-bootstrap handler", () => {
       agentsMdMissing: true,
     });
 
-    const event = createHookEvent("agent", "bootstrap", context.sessionKey, context);
+    const event = createHookEvent("agent", "bootstrap", context.sessionKey!, context);
     await handler(event);
 
     const nonMissingAgents = context.bootstrapFiles.filter(
@@ -165,7 +165,7 @@ describe("channel-bootstrap handler", () => {
       agentsMdContent: "Global.",
     });
 
-    const event = createHookEvent("agent", "bootstrap", context.sessionKey, context);
+    const event = createHookEvent("agent", "bootstrap", context.sessionKey!, context);
     await handler(event);
 
     expect(context.bootstrapFiles).toHaveLength(1);
@@ -181,7 +181,7 @@ describe("channel-bootstrap handler", () => {
       agentsMdContent: "Global.",
     });
 
-    const event = createHookEvent("agent", "bootstrap", context.sessionKey, context);
+    const event = createHookEvent("agent", "bootstrap", context.sessionKey!, context);
     await handler(event);
 
     expect(context.bootstrapFiles).toHaveLength(1);
@@ -197,7 +197,7 @@ describe("channel-bootstrap handler", () => {
       agentsMdContent: "Global.",
     });
 
-    const event = createHookEvent("command", "new", context.sessionKey, context as never);
+    const event = createHookEvent("command", "new", context.sessionKey!, context as never);
     await handler(event as never);
 
     expect(context.bootstrapFiles[0].content).toBe("Global.");

--- a/src/hooks/bundled/channel-bootstrap/handler.test.ts
+++ b/src/hooks/bundled/channel-bootstrap/handler.test.ts
@@ -41,6 +41,18 @@ describe("extractChannelId", () => {
     );
   });
 
+  it("extracts Signal group id", () => {
+    expect(extractChannelId("agent:main:signal:group:abc123def456==")).toBe("abc123def456==");
+  });
+
+  it("extracts iMessage group id", () => {
+    expect(extractChannelId("agent:main:imessage:group:chat123456")).toBe("chat123456");
+  });
+
+  it("extracts generic channel id via fallback pattern", () => {
+    expect(extractChannelId("agent:main:matrix:channel:!room123:example.com")).toBe("!room123");
+  });
+
   it("returns null for DM / main session key", () => {
     expect(extractChannelId("agent:main:main")).toBeNull();
   });

--- a/src/hooks/bundled/channel-bootstrap/handler.test.ts
+++ b/src/hooks/bundled/channel-bootstrap/handler.test.ts
@@ -27,8 +27,12 @@ describe("extractChannelId", () => {
     expect(extractChannelId("agent:main:telegram:group:-1001234567890")).toBe("-1001234567890");
   });
 
-  it("extracts Slack channel id", () => {
+  it("extracts Slack channel id (uppercase, as stored in config)", () => {
     expect(extractChannelId("agent:main:slack:channel:C0123ABCDEF")).toBe("C0123ABCDEF");
+  });
+
+  it("extracts Slack channel id (lowercase, as normalised by session-key.ts at runtime)", () => {
+    expect(extractChannelId("agent:main:slack:channel:c0123abcdef")).toBe("c0123abcdef");
   });
 
   it("extracts WhatsApp group id", () => {
@@ -54,14 +58,15 @@ function makeContext(params: {
   workspaceDir: string;
   sessionKey: string;
   agentsMdContent?: string;
+  agentsMdMissing?: boolean;
 }): AgentBootstrapHookContext {
   const bootstrapFiles: AgentBootstrapHookContext["bootstrapFiles"] = [];
-  if (params.agentsMdContent !== undefined) {
+  if (params.agentsMdContent !== undefined || params.agentsMdMissing) {
     bootstrapFiles.push({
       name: "AGENTS.md",
       path: path.join(params.workspaceDir, "AGENTS.md"),
       content: params.agentsMdContent,
-      missing: false,
+      missing: params.agentsMdMissing ?? false,
     });
   }
   return {
@@ -96,8 +101,39 @@ describe("channel-bootstrap handler", () => {
     expect(context.bootstrapFiles.filter((f) => f.name === "AGENTS.md")).toHaveLength(1);
   });
 
-  it("injects new AGENTS.md entry when none exists but channel file is present", async () => {
-    const dir = await makeTempWorkspace("openclaw-channel-bootstrap-new-entry-");
+  it("does not mutate the original cached entry (clone on write)", async () => {
+    const dir = await makeTempWorkspace("openclaw-channel-bootstrap-clone-");
+    const channelsDir = path.join(dir, "channels");
+    await fs.mkdir(channelsDir, { recursive: true });
+    await fs.writeFile(path.join(channelsDir, "123456.md"), "Channel only.", "utf-8");
+
+    const originalEntry = {
+      name: "AGENTS.md" as const,
+      path: path.join(dir, "AGENTS.md"),
+      content: "Global.",
+      missing: false,
+    };
+    const context = makeContext({
+      workspaceDir: dir,
+      sessionKey: "agent:main:discord:channel:123456",
+      agentsMdContent: "Global.",
+    });
+    // Replace with known reference so we can check identity
+    context.bootstrapFiles[0] = originalEntry;
+
+    const event = createHookEvent("agent", "bootstrap", context.sessionKey, context);
+    await handler(event);
+
+    // The slot in the array should be a new object, not the original reference
+    expect(context.bootstrapFiles[0]).not.toBe(originalEntry);
+    // Original entry content must be untouched
+    expect(originalEntry.content).toBe("Global.");
+    // New entry should have the appended content
+    expect(context.bootstrapFiles[0].content).toContain("Channel only.");
+  });
+
+  it("injects new non-missing AGENTS.md entry when only a missing placeholder exists", async () => {
+    const dir = await makeTempWorkspace("openclaw-channel-bootstrap-missing-");
     const channelsDir = path.join(dir, "channels");
     await fs.mkdir(channelsDir, { recursive: true });
     await fs.writeFile(path.join(channelsDir, "999.md"), "Channel only.", "utf-8");
@@ -105,20 +141,23 @@ describe("channel-bootstrap handler", () => {
     const context = makeContext({
       workspaceDir: dir,
       sessionKey: "agent:main:discord:channel:999",
-      // no agentsMdContent → no AGENTS.md entry
+      agentsMdMissing: true,
     });
 
     const event = createHookEvent("agent", "bootstrap", context.sessionKey, context);
     await handler(event);
 
-    const agents = context.bootstrapFiles.find((f) => f.name === "AGENTS.md");
-    expect(agents).toBeDefined();
-    expect(agents!.content).toContain("Channel only.");
+    const nonMissingAgents = context.bootstrapFiles.filter(
+      (f) => f.name === "AGENTS.md" && !f.missing,
+    );
+    expect(nonMissingAgents).toHaveLength(1);
+    expect(nonMissingAgents[0].content).toContain("Channel only.");
+    expect(nonMissingAgents[0].path).toContain("AGENTS.md");
+    expect(nonMissingAgents[0].path).not.toContain("channels");
   });
 
   it("silently skips and does not modify bootstrap files when no channel file exists", async () => {
     const dir = await makeTempWorkspace("openclaw-channel-bootstrap-skip-");
-    // no channels/ dir at all
 
     const context = makeContext({
       workspaceDir: dir,
@@ -158,7 +197,6 @@ describe("channel-bootstrap handler", () => {
       agentsMdContent: "Global.",
     });
 
-    // command:new is not agent:bootstrap
     const event = createHookEvent("command", "new", context.sessionKey, context as never);
     await handler(event as never);
 

--- a/src/hooks/bundled/channel-bootstrap/handler.test.ts
+++ b/src/hooks/bundled/channel-bootstrap/handler.test.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { makeTempWorkspace } from "../../../test-helpers/workspace.js";
+import type { AgentBootstrapHookContext } from "../../hooks.js";
+import { createHookEvent } from "../../hooks.js";
+import handler, { extractChannelId } from "./handler.js";
+
+// ---------------------------------------------------------------------------
+// Unit tests: extractChannelId
+// ---------------------------------------------------------------------------
+
+describe("extractChannelId", () => {
+  it("extracts Discord channel id", () => {
+    expect(extractChannelId("agent:main:discord:channel:1473810409952641138")).toBe(
+      "1473810409952641138",
+    );
+  });
+
+  it("extracts Discord channel id from thread session key (ignores thread segment)", () => {
+    expect(
+      extractChannelId("agent:main:discord:channel:1473810409952641138:thread:987654321"),
+    ).toBe("1473810409952641138");
+  });
+
+  it("extracts Telegram group id (negative number)", () => {
+    expect(extractChannelId("agent:main:telegram:group:-1001234567890")).toBe("-1001234567890");
+  });
+
+  it("extracts Slack channel id", () => {
+    expect(extractChannelId("agent:main:slack:channel:C0123ABCDEF")).toBe("C0123ABCDEF");
+  });
+
+  it("extracts WhatsApp group id", () => {
+    expect(extractChannelId("agent:main:whatsapp:group:120363403215116621@g.us")).toBe(
+      "120363403215116621@g.us",
+    );
+  });
+
+  it("returns null for DM / main session key", () => {
+    expect(extractChannelId("agent:main:main")).toBeNull();
+  });
+
+  it("returns null for subagent session key without channel", () => {
+    expect(extractChannelId("agent:main:subagent:abc123")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests: full handler flow
+// ---------------------------------------------------------------------------
+
+function makeContext(params: {
+  workspaceDir: string;
+  sessionKey: string;
+  agentsMdContent?: string;
+}): AgentBootstrapHookContext {
+  const bootstrapFiles: AgentBootstrapHookContext["bootstrapFiles"] = [];
+  if (params.agentsMdContent !== undefined) {
+    bootstrapFiles.push({
+      name: "AGENTS.md",
+      path: path.join(params.workspaceDir, "AGENTS.md"),
+      content: params.agentsMdContent,
+      missing: false,
+    });
+  }
+  return {
+    workspaceDir: params.workspaceDir,
+    bootstrapFiles,
+    cfg: {},
+    sessionKey: params.sessionKey,
+  };
+}
+
+describe("channel-bootstrap handler", () => {
+  it("appends channel context to existing AGENTS.md when channel file is present", async () => {
+    const dir = await makeTempWorkspace("openclaw-channel-bootstrap-");
+    const channelsDir = path.join(dir, "channels");
+    await fs.mkdir(channelsDir, { recursive: true });
+    await fs.writeFile(path.join(channelsDir, "123456.md"), "# Dev Build\nShip it.", "utf-8");
+
+    const context = makeContext({
+      workspaceDir: dir,
+      sessionKey: "agent:main:discord:channel:123456",
+      agentsMdContent: "# Global AGENTS\n\nGlobal stuff.",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", context.sessionKey, context);
+    await handler(event);
+
+    const agents = context.bootstrapFiles.find((f) => f.name === "AGENTS.md");
+    expect(agents).toBeDefined();
+    expect(agents!.content).toContain("Global AGENTS");
+    expect(agents!.content).toContain("Channel-Specific Context");
+    expect(agents!.content).toContain("Ship it.");
+    expect(context.bootstrapFiles.filter((f) => f.name === "AGENTS.md")).toHaveLength(1);
+  });
+
+  it("injects new AGENTS.md entry when none exists but channel file is present", async () => {
+    const dir = await makeTempWorkspace("openclaw-channel-bootstrap-new-entry-");
+    const channelsDir = path.join(dir, "channels");
+    await fs.mkdir(channelsDir, { recursive: true });
+    await fs.writeFile(path.join(channelsDir, "999.md"), "Channel only.", "utf-8");
+
+    const context = makeContext({
+      workspaceDir: dir,
+      sessionKey: "agent:main:discord:channel:999",
+      // no agentsMdContent → no AGENTS.md entry
+    });
+
+    const event = createHookEvent("agent", "bootstrap", context.sessionKey, context);
+    await handler(event);
+
+    const agents = context.bootstrapFiles.find((f) => f.name === "AGENTS.md");
+    expect(agents).toBeDefined();
+    expect(agents!.content).toContain("Channel only.");
+  });
+
+  it("silently skips and does not modify bootstrap files when no channel file exists", async () => {
+    const dir = await makeTempWorkspace("openclaw-channel-bootstrap-skip-");
+    // no channels/ dir at all
+
+    const context = makeContext({
+      workspaceDir: dir,
+      sessionKey: "agent:main:discord:channel:9999999",
+      agentsMdContent: "Global.",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", context.sessionKey, context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(1);
+    expect(context.bootstrapFiles[0].content).toBe("Global.");
+  });
+
+  it("skips DM / main sessions with no channel id", async () => {
+    const dir = await makeTempWorkspace("openclaw-channel-bootstrap-dm-");
+
+    const context = makeContext({
+      workspaceDir: dir,
+      sessionKey: "agent:main:main",
+      agentsMdContent: "Global.",
+    });
+
+    const event = createHookEvent("agent", "bootstrap", context.sessionKey, context);
+    await handler(event);
+
+    expect(context.bootstrapFiles).toHaveLength(1);
+    expect(context.bootstrapFiles[0].content).toBe("Global.");
+  });
+
+  it("skips non-bootstrap events without modifying context", async () => {
+    const dir = await makeTempWorkspace("openclaw-channel-bootstrap-skip-event-");
+
+    const context = makeContext({
+      workspaceDir: dir,
+      sessionKey: "agent:main:discord:channel:123",
+      agentsMdContent: "Global.",
+    });
+
+    // command:new is not agent:bootstrap
+    const event = createHookEvent("command", "new", context.sessionKey, context as never);
+    await handler(event as never);
+
+    expect(context.bootstrapFiles[0].content).toBe("Global.");
+  });
+});

--- a/src/hooks/bundled/channel-bootstrap/handler.ts
+++ b/src/hooks/bundled/channel-bootstrap/handler.ts
@@ -61,7 +61,7 @@ export function extractChannelId(sessionKey: string): string | null {
   }
 
   // Generic fallback for other channels: agent:main:<channel>:channel|group:<id>
-  const genericChannel = sessionKey.match(/:(\w+):(?:channel|group):([^:]+)/);
+  const genericChannel = sessionKey.match(/:([\w-]+):(?:channel|group):([^:]+)/);
   if (genericChannel) {
     return genericChannel[2];
   }

--- a/src/hooks/bundled/channel-bootstrap/handler.ts
+++ b/src/hooks/bundled/channel-bootstrap/handler.ts
@@ -1,0 +1,88 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import { isAgentBootstrapEvent, type HookHandler } from "../../hooks.js";
+
+const log = createSubsystemLogger("channel-bootstrap");
+
+const CHANNEL_CONTEXT_HEADING = "\n\n---\n\n## 📡 Channel-Specific Context\n\n";
+
+/**
+ * Extracts the channel or group ID from an OpenClaw session key.
+ *
+ * Supported patterns:
+ *   Discord channel:  agent:main:discord:channel:123456
+ *   Discord thread:   agent:main:discord:channel:123456:thread:789  → 123456
+ *   Telegram group:   agent:main:telegram:group:-100123456789
+ *   Slack channel:    agent:main:slack:channel:C0123ABCDEF
+ *   WhatsApp group:   agent:main:whatsapp:group:120363403215116621@g.us
+ */
+export function extractChannelId(sessionKey: string): string | null {
+  const discordChannel = sessionKey.match(/:discord:channel:(\d+)/);
+  if (discordChannel) {
+    return discordChannel[1];
+  }
+
+  const telegramGroup = sessionKey.match(/:telegram:group:(-?\d+)/);
+  if (telegramGroup) {
+    return telegramGroup[1];
+  }
+
+  const slackChannel = sessionKey.match(/:slack:channel:([A-Z0-9]+)/);
+  if (slackChannel) {
+    return slackChannel[1];
+  }
+
+  const waGroup = sessionKey.match(/:whatsapp:group:([^:]+)/);
+  if (waGroup) {
+    return waGroup[1];
+  }
+
+  return null;
+}
+
+const channelBootstrapHook: HookHandler = async (event) => {
+  if (!isAgentBootstrapEvent(event)) {
+    return;
+  }
+
+  const { workspaceDir, bootstrapFiles, sessionKey } = event.context;
+  if (!workspaceDir || !bootstrapFiles) {
+    return;
+  }
+
+  const channelId = extractChannelId(sessionKey ?? "");
+  if (!channelId) {
+    return;
+  }
+
+  const channelFile = path.join(workspaceDir, "channels", `${channelId}.md`);
+
+  let channelContent: string;
+  try {
+    channelContent = fs.readFileSync(channelFile, "utf8").trim();
+  } catch {
+    // No channel file for this channel — silently skip
+    return;
+  }
+
+  if (!channelContent) {
+    return;
+  }
+
+  const agentsEntry = bootstrapFiles.find((f) => f.name === "AGENTS.md");
+  if (agentsEntry) {
+    agentsEntry.content = (agentsEntry.content ?? "") + CHANNEL_CONTEXT_HEADING + channelContent;
+    log.debug(`appended channel context for ${channelId} to AGENTS.md`);
+  } else {
+    bootstrapFiles.push({
+      name: "AGENTS.md",
+      path: channelFile,
+      content: `## 📡 Channel-Specific Context\n\n${channelContent}`,
+      missing: false,
+    });
+    log.debug(`injected channel context for ${channelId} as new AGENTS.md entry`);
+  }
+};
+
+export default channelBootstrapHook;

--- a/src/hooks/bundled/channel-bootstrap/handler.ts
+++ b/src/hooks/bundled/channel-bootstrap/handler.ts
@@ -14,7 +14,7 @@ const CHANNEL_CONTEXT_HEADING = "\n\n---\n\n## 📡 Channel-Specific Context\n\n
  *   Discord channel:  agent:main:discord:channel:123456
  *   Discord thread:   agent:main:discord:channel:123456:thread:789  → 123456
  *   Telegram group:   agent:main:telegram:group:-100123456789
- *   Slack channel:    agent:main:slack:channel:C0123ABCDEF
+ *   Slack channel:    agent:main:slack:channel:c0123abcdef (lowercased by session-key.ts)
  *   WhatsApp group:   agent:main:whatsapp:group:120363403215116621@g.us
  */
 export function extractChannelId(sessionKey: string): string | null {
@@ -28,7 +28,8 @@ export function extractChannelId(sessionKey: string): string | null {
     return telegramGroup[1];
   }
 
-  const slackChannel = sessionKey.match(/:slack:channel:([A-Z0-9]+)/);
+  // Case-insensitive: session-key.ts lowercases peerId, so Slack IDs may be lowercase at runtime
+  const slackChannel = sessionKey.match(/:slack:channel:([A-Z0-9]+)/i);
   if (slackChannel) {
     return slackChannel[1];
   }
@@ -70,14 +71,25 @@ const channelBootstrapHook: HookHandler = async (event) => {
     return;
   }
 
-  const agentsEntry = bootstrapFiles.find((f) => f.name === "AGENTS.md");
-  if (agentsEntry) {
-    agentsEntry.content = (agentsEntry.content ?? "") + CHANNEL_CONTEXT_HEADING + channelContent;
+  // Find an existing, non-missing AGENTS.md entry to append to.
+  // We must not mutate the cached entry in place (bootstrap-cache.ts reuses the same
+  // array across agent:bootstrap calls within a session), so we replace the entry with
+  // a shallow clone that carries the updated content.
+  const agentsIndex = bootstrapFiles.findIndex((f) => f.name === "AGENTS.md" && !f.missing);
+  if (agentsIndex !== -1) {
+    const original = bootstrapFiles[agentsIndex];
+    bootstrapFiles[agentsIndex] = {
+      ...original,
+      content: (original.content ?? "") + CHANNEL_CONTEXT_HEADING + channelContent,
+    };
     log.debug(`appended channel context for ${channelId} to AGENTS.md`);
   } else {
+    // Either AGENTS.md is absent or marked missing — inject as a new, non-missing entry.
+    // Use the workspace AGENTS.md path (not the channel file) so the system-prompt heading
+    // renders correctly (src/agents/system-prompt.ts reads path as the section heading).
     bootstrapFiles.push({
       name: "AGENTS.md",
-      path: channelFile,
+      path: path.join(workspaceDir, "AGENTS.md"),
       content: `## 📡 Channel-Specific Context\n\n${channelContent}`,
       missing: false,
     });

--- a/src/hooks/bundled/channel-bootstrap/handler.ts
+++ b/src/hooks/bundled/channel-bootstrap/handler.ts
@@ -16,6 +16,9 @@ const CHANNEL_CONTEXT_HEADING = "\n\n---\n\n## 📡 Channel-Specific Context\n\n
  *   Telegram group:   agent:main:telegram:group:-100123456789
  *   Slack channel:    agent:main:slack:channel:c0123abcdef (lowercased by session-key.ts)
  *   WhatsApp group:   agent:main:whatsapp:group:120363403215116621@g.us
+ *
+ * Returns the extracted ID as-is (preserving case from the session key).
+ * Callers that need case-insensitive file lookup should handle that separately.
  */
 export function extractChannelId(sessionKey: string): string | null {
   const discordChannel = sessionKey.match(/:discord:channel:(\d+)/);
@@ -28,7 +31,7 @@ export function extractChannelId(sessionKey: string): string | null {
     return telegramGroup[1];
   }
 
-  // Case-insensitive: session-key.ts lowercases peerId, so Slack IDs may be lowercase at runtime
+  // Case-insensitive: session-key.ts lowercases peerId, so Slack IDs are lowercase at runtime
   const slackChannel = sessionKey.match(/:slack:channel:([A-Z0-9]+)/i);
   if (slackChannel) {
     return slackChannel[1];
@@ -37,6 +40,43 @@ export function extractChannelId(sessionKey: string): string | null {
   const waGroup = sessionKey.match(/:whatsapp:group:([^:]+)/);
   if (waGroup) {
     return waGroup[1];
+  }
+
+  return null;
+}
+
+/**
+ * Try to read a channel context file, falling back to uppercase variant for
+ * case-sensitive filesystems where Slack IDs are lowercased in session keys
+ * but users may name files with canonical uppercase (e.g. C0123ABCDEF.md).
+ */
+function tryReadChannelFile(channelsDir: string, channelId: string): string | null {
+  const candidates = [channelId];
+
+  // For Slack-style IDs (alphanumeric, starts with letter), also try uppercase
+  if (/^[a-z]/i.test(channelId) && channelId !== channelId.toUpperCase()) {
+    candidates.push(channelId.toUpperCase());
+  }
+
+  for (const candidate of candidates) {
+    const filePath = path.join(channelsDir, `${candidate}.md`);
+    try {
+      const content = fs.readFileSync(filePath, "utf8").trim();
+      if (content) {
+        return content;
+      }
+    } catch (err: unknown) {
+      // Only silently skip file-not-found; surface other errors
+      if (
+        err instanceof Error &&
+        "code" in err &&
+        (err as NodeJS.ErrnoException).code === "ENOENT"
+      ) {
+        continue;
+      }
+      log.warn(`failed to read ${filePath}: ${String(err)}`);
+      return null;
+    }
   }
 
   return null;
@@ -57,37 +97,33 @@ const channelBootstrapHook: HookHandler = async (event) => {
     return;
   }
 
-  const channelFile = path.join(workspaceDir, "channels", `${channelId}.md`);
-
-  let channelContent: string;
-  try {
-    channelContent = fs.readFileSync(channelFile, "utf8").trim();
-  } catch {
-    // No channel file for this channel — silently skip
-    return;
-  }
-
+  const channelsDir = path.join(workspaceDir, "channels");
+  const channelContent = tryReadChannelFile(channelsDir, channelId);
   if (!channelContent) {
     return;
   }
 
-  // Find an existing, non-missing AGENTS.md entry to append to.
-  // We must not mutate the cached entry in place (bootstrap-cache.ts reuses the same
-  // array across agent:bootstrap calls within a session), so we replace the entry with
-  // a shallow clone that carries the updated content.
-  const agentsIndex = bootstrapFiles.findIndex((f) => f.name === "AGENTS.md" && !f.missing);
+  // Work on a shallow copy of the array to avoid mutating the cached snapshot
+  // from bootstrap-cache.ts (which reuses the same array across agent:bootstrap
+  // calls within a session).
+  const updatedFiles = [...bootstrapFiles];
+
+  const agentsIndex = updatedFiles.findIndex((f) => f.name === "AGENTS.md" && !f.missing);
   if (agentsIndex !== -1) {
-    const original = bootstrapFiles[agentsIndex];
-    bootstrapFiles[agentsIndex] = {
+    const original = updatedFiles[agentsIndex];
+    updatedFiles[agentsIndex] = {
       ...original,
       content: (original.content ?? "") + CHANNEL_CONTEXT_HEADING + channelContent,
     };
     log.debug(`appended channel context for ${channelId} to AGENTS.md`);
   } else {
-    // Either AGENTS.md is absent or marked missing — inject as a new, non-missing entry.
-    // Use the workspace AGENTS.md path (not the channel file) so the system-prompt heading
-    // renders correctly (src/agents/system-prompt.ts reads path as the section heading).
-    bootstrapFiles.push({
+    // Remove any missing placeholder to avoid contradictory [MISSING] + injected content
+    const missingIndex = updatedFiles.findIndex((f) => f.name === "AGENTS.md" && f.missing);
+    if (missingIndex !== -1) {
+      updatedFiles.splice(missingIndex, 1);
+    }
+
+    updatedFiles.push({
       name: "AGENTS.md",
       path: path.join(workspaceDir, "AGENTS.md"),
       content: `## 📡 Channel-Specific Context\n\n${channelContent}`,
@@ -95,6 +131,11 @@ const channelBootstrapHook: HookHandler = async (event) => {
     });
     log.debug(`injected channel context for ${channelId} as new AGENTS.md entry`);
   }
+
+  // Replace the entire array contents so the context reference is updated
+  // without breaking the caller's reference to event.context.bootstrapFiles
+  bootstrapFiles.length = 0;
+  bootstrapFiles.push(...updatedFiles);
 };
 
 export default channelBootstrapHook;

--- a/src/hooks/bundled/channel-bootstrap/handler.ts
+++ b/src/hooks/bundled/channel-bootstrap/handler.ts
@@ -16,6 +16,12 @@ const CHANNEL_CONTEXT_HEADING = "\n\n---\n\n## 📡 Channel-Specific Context\n\n
  *   Telegram group:   agent:main:telegram:group:-100123456789
  *   Slack channel:    agent:main:slack:channel:c0123abcdef (lowercased by session-key.ts)
  *   WhatsApp group:   agent:main:whatsapp:group:120363403215116621@g.us
+ *   Signal group:    agent:main:signal:group:abc123def456==
+ *   iMessage group:  agent:main:imessage:group:chat123456
+ *   Generic:         agent:main:<channel>:channel|group:<id>  (fallback)
+ *   Signal group:    agent:main:signal:group:abc123def456==
+ *   iMessage group:  agent:main:imessage:group:chat123456
+ *   Generic:         agent:main:<channel>:channel|group:<id>  (fallback)
  *
  * Returns the extracted ID as-is (preserving case from the session key).
  * Callers that need case-insensitive file lookup should handle that separately.
@@ -40,6 +46,24 @@ export function extractChannelId(sessionKey: string): string | null {
   const waGroup = sessionKey.match(/:whatsapp:group:([^:]+)/);
   if (waGroup) {
     return waGroup[1];
+  }
+
+  // Signal group: agent:main:signal:group:abc123def456==
+  const signalGroup = sessionKey.match(/:signal:group:([^:]+)/);
+  if (signalGroup) {
+    return signalGroup[1];
+  }
+
+  // iMessage group: agent:main:imessage:group:chat123456
+  const imessageGroup = sessionKey.match(/:imessage:group:([^:]+)/);
+  if (imessageGroup) {
+    return imessageGroup[1];
+  }
+
+  // Generic fallback for other channels: agent:main:<channel>:channel|group:<id>
+  const genericChannel = sessionKey.match(/:(\w+):(?:channel|group):([^:]+)/);
+  if (genericChannel) {
+    return genericChannel[2];
   }
 
   return null;


### PR DESCRIPTION
## Summary

Adds a new bundled hook `channel-bootstrap` that injects per-channel bootstrap context into `AGENTS.md` at `agent:bootstrap` time.

## Problem

OpenClaw's global workspace files (`AGENTS.md`, `SOUL.md`, etc.) are shared across all channels. Users with multiple Discord channels, Telegram groups, or Slack channels must cram all channel-specific instructions into one global file, making it large and hard to maintain.

## Solution

A new `channels/` directory in the workspace holds per-channel context files named by channel ID (e.g. `channels/1473810409952641138.md`). The `channel-bootstrap` hook reads the appropriate file at bootstrap time and appends it to `AGENTS.md` under a `## 📡 Channel-Specific Context` section.

```
workspace/
└── channels/
    ├── 1473810409952641138.md    ← Discord #dev-build specific rules
    ├── 1473460547335880776.md    ← Discord #jobs-intel rules  
    └── -1001234567890.md         ← Telegram group
```

## Design decisions

- **Append to AGENTS.md** (not a new entry): `WorkspaceBootstrapFileName` is a closed enum; appending to an existing recognized entry is the correct extension point and preserves global context.
- **Silent on missing files**: not having a `channels/{id}.md` is the default state — should produce zero noise.
- **No config required**: unlike `bootstrap-extra-files`, this hook needs no `paths` config — it just follows the `channels/` convention.
- **Workspace hook compatible**: users can also run this as a local workspace hook before it's bundled.

## Channel ID extraction

Supports Discord (channel + thread), Telegram group, Slack channel, WhatsApp group. DMs and main sessions are skipped (no channel ID → no-op).

## Tests

12 tests total: 7 unit tests for `extractChannelId` + 5 integration tests covering the full handler flow.

```
✓ src/hooks/bundled/channel-bootstrap/handler.test.ts (12 tests) 8ms
Test Files  1 passed (1)
      Tests  12 passed (12)
```

## Related

Similar in structure to `bootstrap-extra-files` (bundled). Complements the per-channel routing already available via `bindings` + multi-agent config — this covers the single-agent, multi-channel case.