### PR TITLE
feat: configurable announceHeader for subagent completion messages

### DIFF
--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -1900,4 +1900,107 @@ describe("subagent announce formatting", () => {
       expect(call?.params?.channel, testCase.name).toBe(testCase.expectedChannel);
     }
   });
+
+  describe("announceHeader config", () => {
+    it("suppresses header when announceHeader is false", async () => {
+      configOverride = {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { subagents: { announceHeader: false } } },
+      } as typeof configOverride;
+      readLatestAssistantReplyMock.mockResolvedValue("Here is your data");
+
+      const didAnnounce = await runSubagentAnnounceFlow({
+        childSessionKey: "agent:main:subagent:test",
+        childRunId: "run-header-false",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
+        ...defaultOutcomeAnnounce,
+        expectsCompletionMessage: true,
+      });
+
+      expect(didAnnounce).toBe(true);
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+      const msg = typeof call?.params?.message === "string" ? call.params.message : "";
+      expect(msg).not.toContain("✅ Subagent");
+      expect(msg).not.toContain("finished");
+      expect(msg).toContain("Here is your data");
+    });
+
+    it("uses custom header template with {name} placeholder", async () => {
+      configOverride = {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { subagents: { announceHeader: "🎲 {name} says:" } } },
+      } as typeof configOverride;
+      readLatestAssistantReplyMock.mockResolvedValue("movie results");
+
+      const didAnnounce = await runSubagentAnnounceFlow({
+        childSessionKey: "agent:main:subagent:test",
+        childRunId: "run-header-custom",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
+        ...defaultOutcomeAnnounce,
+        expectsCompletionMessage: true,
+      });
+
+      expect(didAnnounce).toBe(true);
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+      const msg = typeof call?.params?.message === "string" ? call.params.message : "";
+      expect(msg).toContain("🎲 main says:");
+      expect(msg).not.toContain("✅ Subagent");
+    });
+
+    it("delivers body only when announceHeader is empty string", async () => {
+      configOverride = {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { subagents: { announceHeader: "" } } },
+      } as typeof configOverride;
+      readLatestAssistantReplyMock.mockResolvedValue("clean response");
+
+      const didAnnounce = await runSubagentAnnounceFlow({
+        childSessionKey: "agent:main:subagent:test",
+        childRunId: "run-header-empty",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
+        ...defaultOutcomeAnnounce,
+        expectsCompletionMessage: true,
+      });
+
+      expect(didAnnounce).toBe(true);
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+      const msg = typeof call?.params?.message === "string" ? call.params.message : "";
+      expect(msg).not.toContain("✅");
+      expect(msg).toContain("clean response");
+    });
+
+    it("preserves error/timeout headers even with custom announceHeader", async () => {
+      configOverride = {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { subagents: { announceHeader: "Custom: {name}" } } },
+      } as typeof configOverride;
+      readLatestAssistantReplyMock.mockResolvedValue("error details");
+
+      const didAnnounce = await runSubagentAnnounceFlow({
+        childSessionKey: "agent:main:subagent:test",
+        childRunId: "run-header-error",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
+        ...defaultOutcomeAnnounce,
+        outcome: { status: "error" },
+        expectsCompletionMessage: true,
+      });
+
+      expect(didAnnounce).toBe(true);
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+      const msg = typeof call?.params?.message === "string" ? call.params.message : "";
+      expect(msg).toContain("❌ Subagent main failed");
+    });
+  });
 });

--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -2002,5 +2002,57 @@ describe("subagent announce formatting", () => {
       const msg = typeof call?.params?.message === "string" ? call.params.message : "";
       expect(msg).toContain("❌ Subagent main failed");
     });
+
+    it("preserves error headers even when announceHeader is false", async () => {
+      configOverride = {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { subagents: { announceHeader: false } } },
+      } as typeof configOverride;
+      readLatestAssistantReplyMock.mockResolvedValue("error details");
+
+      const didAnnounce = await runSubagentAnnounceFlow({
+        childSessionKey: "agent:main:subagent:test",
+        childRunId: "run-header-false-error",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
+        ...defaultOutcomeAnnounce,
+        outcome: { status: "error" },
+        expectsCompletionMessage: true,
+      });
+
+      expect(didAnnounce).toBe(true);
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+      const msg = typeof call?.params?.message === "string" ? call.params.message : "";
+      expect(msg).toContain("❌ Subagent main failed");
+      expect(msg).toContain("error details");
+    });
+
+    it("preserves timeout headers even when announceHeader is false", async () => {
+      configOverride = {
+        session: { mainKey: "main", scope: "per-sender" },
+        agents: { defaults: { subagents: { announceHeader: false } } },
+      } as typeof configOverride;
+      readLatestAssistantReplyMock.mockResolvedValue("partial output");
+
+      const didAnnounce = await runSubagentAnnounceFlow({
+        childSessionKey: "agent:main:subagent:test",
+        childRunId: "run-header-false-timeout",
+        requesterSessionKey: "agent:main:main",
+        requesterDisplayKey: "main",
+        requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
+        ...defaultOutcomeAnnounce,
+        outcome: { status: "timeout" },
+        expectsCompletionMessage: true,
+      });
+
+      expect(didAnnounce).toBe(true);
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const call = sendSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+      const msg = typeof call?.params?.message === "string" ? call.params.message : "";
+      expect(msg).toContain("⏱️ Subagent main timed out");
+      expect(msg).toContain("partial output");
+    });
   });
 });

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -89,8 +89,10 @@ function buildCompletionDeliveryMessage(params: {
   const cfg = loadConfig();
   const customHeader = resolveAnnounceHeader(cfg);
 
-  // If announceHeader is false, suppress header entirely and deliver only the body.
-  if (customHeader === false) {
+  // If announceHeader is false, suppress header for non-error/timeout outcomes.
+  const isErrorOrTimeout =
+    params.outcome?.status === "error" || params.outcome?.status === "timeout";
+  if (customHeader === false && !isErrorOrTimeout) {
     return hasFindings ? findingsText : "";
   }
 

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -99,7 +99,7 @@ function buildCompletionDeliveryMessage(params: {
   const header = (() => {
     // Custom header template — only applies to success status.
     if (
-      customHeader != null &&
+      typeof customHeader === "string" &&
       params.outcome?.status !== "error" &&
       params.outcome?.status !== "timeout"
     ) {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -65,6 +65,10 @@ function resolveSubagentAnnounceTimeoutMs(cfg: ReturnType<typeof loadConfig>): n
   return Math.min(Math.max(1, Math.floor(configured)), MAX_TIMER_SAFE_TIMEOUT_MS);
 }
 
+function resolveAnnounceHeader(cfg: ReturnType<typeof loadConfig>): string | false | undefined {
+  return cfg.agents?.defaults?.subagents?.announceHeader;
+}
+
 function buildCompletionDeliveryMessage(params: {
   findings: string;
   subagentName: string;
@@ -81,7 +85,25 @@ function buildCompletionDeliveryMessage(params: {
   if (params.announceType === "cron job") {
     return hasFindings ? findingsText : "";
   }
+
+  const cfg = loadConfig();
+  const customHeader = resolveAnnounceHeader(cfg);
+
+  // If announceHeader is false, suppress header entirely and deliver only the body.
+  if (customHeader === false) {
+    return hasFindings ? findingsText : "";
+  }
+
   const header = (() => {
+    // Custom header template — only applies to success status.
+    if (
+      customHeader != null &&
+      params.outcome?.status !== "error" &&
+      params.outcome?.status !== "timeout"
+    ) {
+      return customHeader.replace(/\{name\}/g, params.subagentName);
+    }
+
     if (params.outcome?.status === "error") {
       return params.spawnMode === "session"
         ? `❌ Subagent ${params.subagentName} failed this task (session remains active)`
@@ -96,6 +118,12 @@ function buildCompletionDeliveryMessage(params: {
       ? `✅ Subagent ${params.subagentName} completed this task (session remains active)`
       : `✅ Subagent ${params.subagentName} finished`;
   })();
+
+  // Empty custom header (e.g., announceHeader: "") — deliver body only.
+  if (header === "") {
+    return hasFindings ? findingsText : "";
+  }
+
   if (!hasFindings) {
     return header;
   }

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -263,6 +263,13 @@ export type AgentDefaultsConfig = {
     runTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 60000). */
     announceTimeoutMs?: number;
+    /**
+     * Custom header for subagent announce messages. Use `{name}` as placeholder for the agent name.
+     * Set to `false` to suppress the header entirely and deliver only the response body.
+     * Set to `""` (empty string) for the same effect.
+     * Default: `"✅ Subagent {name} finished"`.
+     */
+    announceHeader?: string | false;
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -160,6 +160,14 @@ export const AgentDefaultsSchema = z
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
+        announceHeader: z
+          .union([z.string(), z.literal(false)])
+          .optional()
+          .describe(
+            'Custom header template for subagent announce messages. Use "{name}" as placeholder for the agent name. ' +
+              "Set to false to suppress the header entirely and deliver only the response body. " +
+              'Default: "✅ Subagent {name} finished".',
+          ),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

Adds a new `agents.defaults.subagents.announceHeader` config option to customize or suppress the status header prepended to subagent announce messages.

**Problem:** The current announce format always prepends `✅ Subagent {name} finished` to every subagent completion message. In multi-agent setups where subagents are used as response formatters (e.g., personality agents in a router → specialist → formatter chain), this prefix clutters the user-facing output on channels like Telegram and Discord. There is currently no way to customize or remove it.

**Solution:** A new config key that accepts:
- A **custom template string** with `{name}` placeholder (e.g., `"🎲 {name} says:"`)
- An **empty string** `""` to deliver only the response body (no header)
- **`false`** to suppress the header entirely
- Error/timeout headers (`❌`, `⏱️`) are always preserved regardless of config

### Config example

```json
{
  "agents": {
    "defaults": {
      "subagents": {
        "announceHeader": false
      }
    }
  }
}
```

## Changes

- `src/config/types.agent-defaults.ts` — add `announceHeader?: string | false` to subagents type
- `src/config/zod-schema.agent-defaults.ts` — add `announceHeader: z.union([z.string(), z.literal(false)]).optional()` to subagents schema
- `src/agents/subagent-announce.ts` — read config in `buildCompletionDeliveryMessage`, apply custom/suppressed header for success outcomes; narrowed type guard to fix TS2339
- `src/agents/subagent-announce.format.test.ts` — 6 new test cases covering `false`, custom template, empty string, error preservation, and error/timeout with `false`

## Test plan

- [x] All existing tests pass (no regressions)
- [x] New test: `announceHeader: false` → header suppressed, body only delivered
- [x] New test: `announceHeader: "🎲 {name} says:"` → custom header used with name substitution
- [x] New test: `announceHeader: ""` → empty header, body only
- [x] New test: error/timeout outcomes preserve default headers even with custom config
- [x] New test: `announceHeader: false` with error outcome → error header preserved
- [x] New test: `announceHeader: false` with timeout outcome → timeout header preserved

## End-to-end testing

Deployed a custom build with this patch to a production Telegram bot (Nylo) running on OpenClaw:
- `announceHeader: false` — header suppressed, clean responses delivered to Telegram users
- Error/timeout headers still appear correctly when subagents fail
- Tested across multiple agent chains (router → specialist, router → personality agent)
- Running in production for real users

## Discussion

#30863

## AI Disclosure

Built with Claude Code. We understand what the code does and have tested it end-to-end.