### PR TITLE
fix(macos): Prevent duplicate menu bar icons on macOS 26.3 when using wss: to gateway on local net with self-signed cert

### DIFF
--- a/apps/macos/Sources/OpenClaw/ControlChannel.swift
+++ b/apps/macos/Sources/OpenClaw/ControlChannel.swift
@@ -85,6 +85,50 @@ final class ControlChannel {
     private var recoveryTask: Task<Void, Never>?
     private var lastRecoveryAt: Date?
 
+    // FIX: Throttle rapid non-connected state transitions (macOS 26 icon storm).
+    // When the gateway connection bounces between connecting ↔ degraded rapidly,
+    // each state change triggers SwiftUI observation updates that can cause
+    // MenuBarExtra to recreate its NSStatusItem. By debouncing intermediate states,
+    // we prevent the UI from thrashing during connection instability.
+    private var pendingStateTask: Task<Void, Never>?
+    private var lastStateChangeAt: Date = .distantPast
+
+    /// Applies a state change with optional throttling for non-terminal transitions.
+    /// Transitions to/from `.connected` and `.disconnected` are applied immediately
+    /// so the user sees success/failure without delay. Rapid `.connecting` ↔ `.degraded`
+    /// oscillations are debounced with a 500ms window to prevent UI thrashing.
+    private func setStateThrottled(_ newState: ConnectionState) {
+        // Always apply terminal states immediately
+        if newState == .connected || newState == .disconnected
+            || self.state == .connected || self.state == .disconnected
+        {
+            self.pendingStateTask?.cancel()
+            self.pendingStateTask = nil
+            self.state = newState
+            self.lastStateChangeAt = Date()
+            return
+        }
+
+        // Throttle rapid non-terminal state changes (connecting ↔ degraded)
+        let now = Date()
+        let elapsed = now.timeIntervalSince(self.lastStateChangeAt)
+        if elapsed < 0.5 {
+            self.pendingStateTask?.cancel()
+            self.pendingStateTask = Task { [weak self] in
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                guard let self, !Task.isCancelled else { return }
+                self.state = newState
+                self.lastStateChangeAt = Date()
+            }
+            return
+        }
+
+        self.pendingStateTask?.cancel()
+        self.pendingStateTask = nil
+        self.state = newState
+        self.lastStateChangeAt = now
+    }
+
     private init() {
         self.startEventStream()
     }
@@ -105,11 +149,11 @@ final class ControlChannel {
                 self.logger.info(
                     "control channel configure mode=remote " +
                         "target=\(target, privacy: .public) identitySet=\(idSet, privacy: .public)")
-                self.state = .connecting
+                self.setStateThrottled(.connecting)
                 _ = try await GatewayEndpointStore.shared.ensureRemoteControlTunnel()
                 await self.refreshEndpoint(reason: "configure")
             } catch {
-                self.state = .degraded(error.localizedDescription)
+                self.setStateThrottled(.degraded(error.localizedDescription))
                 throw error
             }
         }
@@ -117,20 +161,20 @@ final class ControlChannel {
 
     func refreshEndpoint(reason: String) async {
         self.logger.info("control channel refresh endpoint reason=\(reason, privacy: .public)")
-        self.state = .connecting
+        self.setStateThrottled(.connecting)
         do {
             try await self.establishGatewayConnection()
-            self.state = .connected
+            self.setStateThrottled(.connected)
             PresenceReporter.shared.sendImmediate(reason: "connect")
         } catch {
             let message = self.friendlyGatewayMessage(error)
-            self.state = .degraded(message)
+            self.setStateThrottled(.degraded(message))
         }
     }
 
     func disconnect() async {
         await GatewayConnection.shared.shutdown()
-        self.state = .disconnected
+        self.setStateThrottled(.disconnected)
         self.lastPingMs = nil
         self.authSourceLabel = nil
     }
@@ -146,11 +190,11 @@ final class ControlChannel {
             let payload = try await self.request(method: "health", params: params, timeoutMs: timeoutMs)
             let ms = Date().timeIntervalSince(start) * 1000
             self.lastPingMs = ms
-            self.state = .connected
+            self.setStateThrottled(.connected)
             return payload
         } catch {
             let message = self.friendlyGatewayMessage(error)
-            self.state = .degraded(message)
+            self.setStateThrottled(.degraded(message))
             throw ControlChannelError.badResponse(message)
         }
     }
@@ -173,11 +217,11 @@ final class ControlChannel {
                 method: method,
                 params: rawParams,
                 timeoutMs: timeoutMs)
-            self.state = .connected
+            self.setStateThrottled(.connected)
             return data
         } catch {
             let message = self.friendlyGatewayMessage(error)
-            self.state = .degraded(message)
+            self.setStateThrottled(.degraded(message))
             throw ControlChannelError.badResponse(message)
         }
     }
@@ -366,9 +410,9 @@ final class ControlChannel {
                 NotificationCenter.default.post(name: .controlHeartbeat, object: data)
             }
         case let .event(evt) where evt.event == "shutdown":
-            self.state = .degraded("gateway shutdown")
+            self.setStateThrottled(.degraded("gateway shutdown"))
         case .snapshot:
-            self.state = .connected
+            self.setStateThrottled(.connected)
         default:
             break
         }

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -53,6 +53,21 @@ struct OpenClawApp: App {
         }
         .menuBarExtraStyle(.menu)
         .menuBarExtraAccess(isPresented: self.$isMenuPresented) { item in
+            // FIX: Guard against duplicate NSStatusItem creation (macOS 26 icon storm).
+            // During rapid gateway connection state changes, SwiftUI may re-evaluate
+            // the MenuBarExtra body and invoke this callback multiple times. Without
+            // this guard, each invocation can create a new menu bar icon, resulting in
+            // hundreds of duplicate icons flooding the menu bar.
+            //
+            // Three cases:
+            // 1. Same item we already have → skip (no-op)
+            // 2. New item while we have an existing one → remove old, adopt new
+            // 3. First item → adopt as normal
+            if let existing = self.statusItem, existing === item { return }
+            if let existing = self.statusItem, existing !== item {
+                Self.logger.warning("Duplicate NSStatusItem detected — removing previous instance")
+                NSStatusBar.system.removeStatusItem(existing)
+            }
             self.statusItem = item
             MenuSessionsInjector.shared.install(into: item)
             self.applyStatusItemAppearance(paused: self.state.isPaused, sleeping: self.isGatewaySleeping)


### PR DESCRIPTION
On macOS 26.3, when running the OpenClaw macOS app in remote mode with a gateway on the local network that it connects to via wss: and where the gateway is using a self-signed certificate (that has been added to the Apple keychain), I have observed two scenarios of duplications of the menu bar icon in recent weeks:

1. After the macOS app has been running for > 8 hours — and especially if the Mac laptop goes to sleep and wakes again — the menu bar icon will show 2-3 duplicates over time. After a few days there are maybe 4-5 duplicates.
2. Under certain conditions, especially when the gateway is slower to respond, the app can get into a state upon launch where it repeatedly has a connection state change during TLS negotiation, resulting in hundreds of duplicate menu bar icons flooding the menu bar.

The root cause of both behaviors appears to be the same: gateway connection state changes can cause SwiftUI to re-evaluate the MenuBarExtra body, invoking the menuBarExtraAccess callback multiple times. Each invocation creates a new NSStatusItem, resulting in duplicate menu bar icons added to the status bar.

The bug seems to be primarily occurring because I use a direct wss connection to a gateway running on VM in my basement and the gateway is using a self-signed certificate, which has also been added to the keychain on the Mac. Under these circumstances, TLS certificate validation (SecTrustEvaluateIfNecessary) triggers Security framework faults on macOS 26.3's stricter main-thread enforcement. When the connection state machine oscillates between connecting and degraded states, each transition fires SwiftUI observation updates that can recreate the status item.

I am proposing the following two defensive fixes, which have fixed both problems for me:

1. MenuBar.swift: Guard NSStatusItem creation in the menuBarExtraAccess callback. If the callback fires with the same item we already hold, skip re-setup. If it fires with a different item while we have an existing one, remove the old item from the status bar before adopting the new one.

2. ControlChannel.swift: Throttle rapid non-terminal state transitions (connecting ↔ degraded) with a 500ms debounce window. Terminal transitions to/from connected and disconnected are always applied immediately so the user sees connection success/failure without delay. Only intermediate oscillations are dampened.

Tested on macOS 26.3 with self-signed TLS gateway.

Debugging assistance and fix written by OpenClaw 2026.2.26 running Opus 4.6 on AWS Bedrock infra. Reviewed by me.

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: When using remode mode with a local network gateway connected via wss, the menu bar icon can get duplicated when the connection state fluctuates
- Why it matters: This happens frequently when the Mac laptop goes to sleep and wakes up; but can also cause major osciallations, which can create a menu bar icon storm
- What changed: Defensive changes to ensure that only one menu bar item is created
- What did NOT change (scope boundary): No other changes made

## Change Type (select all)

- [X] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [X] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: MacOS 26.3
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
4.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [X] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

 Console evidence (macOS 26.3, PID 30388, 2026-02-27):

 ```
   # 12 rapid Security framework faults within 4ms during TLS handshake:
   21:18:30.719  A  (Security) SecKeyVerifySignature
   21:18:30.719  A  (Security) SecKeyVerifySignature
   21:18:30.719  A  (Security) SecTrustEvaluateIfNecessary
   21:18:30.719  F  [com.apple.runtime-issues:Security] This method should not be called on the main thread...
   21:18:30.720  F  [com.apple.runtime-issues:Security] This method should not be called on the main thread...
   21:18:30.720  F  [com.apple.runtime-issues:Security] This method should not be called on the main thread...
   21:18:30.720  A  (Security) SecTrustSettingsXPCRead
   21:18:30.720  A  (Security) SecKeychainAddCallback
   21:18:30.721  A  (Security) SecTrustSettingsXPCRead
   21:18:30.722  F  [com.apple.runtime-issues:Security] This method should not be called on the main thread...
   21:18:30.722  A  (Security) SecKeyVerifySignature
   21:18:30.722  F  [com.apple.runtime-issues:Security] This method should not be called on the main thread...
   21:18:30.722  F  [com.apple.runtime-issues:Security] This method should not be called on the main thread...
   21:18:30.722  F  [com.apple.runtime-issues:Security] This method should not be called on the main thread...
   21:18:30.723  A  (Security) SecTrustEvaluateIfNecessary
   21:18:30.723  F  [com.apple.runtime-issues:Security] This method should not be called on the main thread...
 ```

 Environment: macOS 26.3, remote mode with self-signed TLS gateway (wss://), debug build (application.ai.openclaw.mac.debug).

 Symptoms: Hundreds of duplicate menu bar icons appearing in real-time. Gradual accumulation (2-5 extra icons) over days of normal use.
 Single process (no crash/relaunch loop), confirmed via ps aux.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Laptop sleep / wake up. Triggering gateway drops via stopping/restarting the gateway on the VM.
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: None
  - Mitigation:
