### PR TITLE
feat: add announceReplyStyle for subagent announce passthrough

### DIFF
--- a/src/agents/subagent-announce.format.test.ts
+++ b/src/agents/subagent-announce.format.test.ts
@@ -1569,6 +1569,32 @@ describe("subagent announce formatting", () => {
     );
   });
 
+  it("uses passthrough reply instruction for nested subagent when announceReplyStyle is passthrough", async () => {
+    configOverride = {
+      agents: { defaults: { subagents: { announceReplyStyle: "passthrough" } } },
+    } as typeof configOverride;
+    embeddedRunMock.isEmbeddedPiRunActive.mockReturnValue(false);
+    embeddedRunMock.isEmbeddedPiRunStreaming.mockReturnValue(false);
+
+    const didAnnounce = await runSubagentAnnounceFlow({
+      childSessionKey: "agent:main:subagent:orchestrator:subagent:formatter",
+      childRunId: "run-formatter-passthrough",
+      requesterSessionKey: "agent:main:subagent:orchestrator",
+      requesterOrigin: { channel: "whatsapp", accountId: "acct-123", to: "+1555" },
+      requesterDisplayKey: "agent:main:subagent:orchestrator",
+      ...defaultOutcomeAnnounce,
+    });
+
+    expect(didAnnounce).toBe(true);
+    expect(sendSpy).not.toHaveBeenCalled();
+    const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+    expect(call?.params?.sessionKey).toBe("agent:main:subagent:orchestrator");
+    expect(call?.params?.deliver).toBe(false);
+    const message = typeof call?.params?.message === "string" ? call.params.message : "";
+    expect(message).toContain("Forward the subagent's result text above VERBATIM");
+    expect(message).not.toContain("Convert this completion into a concise internal orchestration");
+  });
+
   it("retries reading subagent output when early lifecycle completion had no text", async () => {
     embeddedRunMock.isEmbeddedPiRunActive.mockReturnValueOnce(true).mockReturnValue(false);
     embeddedRunMock.waitForEmbeddedPiRunEnd.mockResolvedValue(true);

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -65,6 +65,12 @@ function resolveSubagentAnnounceTimeoutMs(cfg: ReturnType<typeof loadConfig>): n
   return Math.min(Math.max(1, Math.floor(configured)), MAX_TIMER_SAFE_TIMEOUT_MS);
 }
 
+function resolveAnnounceReplyStyle(
+  cfg: ReturnType<typeof loadConfig>,
+): "synthesize" | "passthrough" {
+  return cfg.agents?.defaults?.subagents?.announceReplyStyle ?? "synthesize";
+}
+
 function buildCompletionDeliveryMessage(params: {
   findings: string;
   subagentName: string;
@@ -1041,12 +1047,16 @@ function buildAnnounceReplyInstruction(params: {
   requesterIsSubagent: boolean;
   announceType: SubagentAnnounceType;
   expectsCompletionMessage?: boolean;
+  announceReplyStyle?: "synthesize" | "passthrough";
 }): string {
   if (params.remainingActiveSubagentRuns > 0) {
     const activeRunsLabel = params.remainingActiveSubagentRuns === 1 ? "run" : "runs";
     return `There are still ${params.remainingActiveSubagentRuns} active subagent ${activeRunsLabel} for this session. If they are part of the same workflow, wait for the remaining results before sending a user update. If they are unrelated, respond normally using only the result above.`;
   }
   if (params.requesterIsSubagent) {
+    if (params.announceReplyStyle === "passthrough") {
+      return `Forward the subagent's result text above VERBATIM as your reply. Copy it exactly — do not summarize, rephrase, or add commentary. Do not output ${SILENT_REPLY_TOKEN}. The result IS your response.`;
+    }
     return `Convert this completion into a concise internal orchestration update for your parent agent in your own words. Keep this internal context private (don't mention system/log/stats/session details or announce type). If this result is duplicate or no update is needed, reply ONLY: ${SILENT_REPLY_TOKEN}.`;
   }
   if (params.expectsCompletionMessage) {
@@ -1267,11 +1277,13 @@ export async function runSubagentAnnounceFlow(params: {
     } catch {
       // Best-effort only; fall back to default announce instructions when unavailable.
     }
+    const announceCfg = loadConfig();
     const replyInstruction = buildAnnounceReplyInstruction({
       remainingActiveSubagentRuns,
       requesterIsSubagent,
       announceType,
       expectsCompletionMessage,
+      announceReplyStyle: resolveAnnounceReplyStyle(announceCfg),
     });
     const statsLine = await buildCompactAnnounceStatsLine({
       sessionKey: params.childSessionKey,

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -263,6 +263,13 @@ export type AgentDefaultsConfig = {
     runTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 60000). */
     announceTimeoutMs?: number;
+    /**
+     * How nested subagents handle announce replies from their children.
+     * - "synthesize" (default): the parent agent converts the child's result into an internal orchestration update.
+     * - "passthrough": the parent agent forwards the child's result verbatim without modification.
+     * Use "passthrough" for formatter/personality chains where the child's output IS the final response.
+     */
+    announceReplyStyle?: "synthesize" | "passthrough";
   };
   /** Optional sandbox settings for non-main sessions. */
   sandbox?: AgentSandboxConfig;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -160,6 +160,15 @@ export const AgentDefaultsSchema = z
         thinking: z.string().optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
+        announceReplyStyle: z
+          .enum(["synthesize", "passthrough"])
+          .optional()
+          .describe(
+            "How nested subagents handle announce replies from their children. " +
+              '"synthesize" (default): parent converts child result into an internal update. ' +
+              '"passthrough": parent forwards child result verbatim. ' +
+              "Use passthrough for formatter/personality chains where the child output IS the final response.",
+          ),
       })
       .strict()
       .optional(),


### PR DESCRIPTION
## Summary

- Adds `announceReplyStyle` config option to `agents.defaults.subagents`
- `"synthesize"` (default): current behavior — parent converts child result into an internal orchestration update
- `"passthrough"`: parent forwards child result verbatim — for formatter/personality chains where the child's output IS the final response

## Problem

When using `maxSpawnDepth: 2` for chains like `Router → Specialist → Formatter`, the announce mechanism tells the depth-1 agent to "Convert this completion into a concise internal orchestration update... reply ONLY: NO_REPLY." Models (tested with GPT-4o) consistently choose NO_REPLY over forwarding the formatted response, regardless of AGENTS.md instructions.

## Changes

- `src/config/types.agent-defaults.ts` — added `announceReplyStyle?: "synthesize" | "passthrough"` to subagents config
- `src/config/zod-schema.agent-defaults.ts` — added zod validation for the new field
- `src/agents/subagent-announce.ts` — added `resolveAnnounceReplyStyle()` resolver; updated `buildAnnounceReplyInstruction()` with passthrough branch
- `src/agents/subagent-announce.format.test.ts` — added test for passthrough behavior

## Testing

- All 52 existing tests pass + 1 new test
- Lightly tested end-to-end with a Telegram bot using Router → Movie Expert → Personality Formatter chain

## Discussion

Discussed in #30859

## AI Disclosure

Built with Claude Code. I understand what the code does and have tested it.