### PR TITLE
agents: guard pre-send history against context overflow

### DIFF
--- a/src/agents/compaction.test.ts
+++ b/src/agents/compaction.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   estimateMessagesTokens,
   pruneHistoryForContextShare,
+  pruneHistoryToTokenBudget,
   splitMessagesByTokenShare,
 } from "./compaction.js";
 
@@ -262,5 +263,34 @@ describe("pruneHistoryForContextShare", () => {
     // droppedMessages = 1 (assistant) + 2 (orphaned tool_results) = 3
     // droppedMessagesList only has the assistant message
     expect(pruned.droppedMessages).toBe(pruned.droppedMessagesList.length + 2);
+  });
+});
+
+describe("pruneHistoryToTokenBudget", () => {
+  it("drops oldest messages until total tokens fit explicit budget", () => {
+    const messages = [makeMessage(1, 16_000), makeMessage(2, 1_000)];
+    const latestTokens = estimateMessagesTokens([messages[1]]);
+    const budgetTokens = latestTokens + 32;
+    const pruned = pruneHistoryToTokenBudget({
+      messages,
+      budgetTokens,
+      parts: 2,
+    });
+
+    expect(pruned.messages.map((msg) => msg.timestamp)).toEqual([2]);
+    expect(pruned.keptTokens).toBeLessThanOrEqual(budgetTokens);
+  });
+
+  it("can clear history entirely when budget is near zero", () => {
+    const messages = [makeMessage(1, 8_000)];
+    const pruned = pruneHistoryToTokenBudget({
+      messages,
+      budgetTokens: 0,
+      parts: 2,
+    });
+
+    expect(pruned.messages).toEqual([]);
+    expect(pruned.keptTokens).toBe(0);
+    expect(pruned.droppedMessages).toBeGreaterThan(0);
   });
 });

--- a/src/agents/compaction.ts
+++ b/src/agents/compaction.ts
@@ -448,6 +448,66 @@ export function pruneHistoryForContextShare(params: {
   };
 }
 
+export function pruneHistoryToTokenBudget(params: {
+  messages: AgentMessage[];
+  budgetTokens: number;
+  parts?: number;
+}): {
+  messages: AgentMessage[];
+  droppedMessagesList: AgentMessage[];
+  droppedChunks: number;
+  droppedMessages: number;
+  droppedTokens: number;
+  keptTokens: number;
+  budgetTokens: number;
+} {
+  const budgetTokens = Math.max(0, Math.floor(params.budgetTokens));
+  let keptMessages = params.messages;
+  const allDroppedMessages: AgentMessage[] = [];
+  let droppedChunks = 0;
+  let droppedMessages = 0;
+  let droppedTokens = 0;
+
+  const parts = normalizeParts(params.parts ?? DEFAULT_PARTS, keptMessages.length);
+
+  while (keptMessages.length > 0 && estimateMessagesTokens(keptMessages) > budgetTokens) {
+    let dropped: AgentMessage[] = [];
+    let nextKept: AgentMessage[] = [];
+    const chunks = splitMessagesByTokenShare(keptMessages, parts);
+    if (chunks.length <= 1) {
+      dropped = keptMessages.slice(0, 1);
+      nextKept = keptMessages.slice(1);
+    } else {
+      dropped = chunks[0] ?? [];
+      nextKept = chunks.slice(1).flat();
+    }
+
+    if (dropped.length === 0) {
+      break;
+    }
+
+    const repairReport = repairToolUseResultPairing(nextKept);
+    const repairedKept = repairReport.messages;
+    const orphanedCount = repairReport.droppedOrphanCount;
+
+    droppedChunks += 1;
+    droppedMessages += dropped.length + orphanedCount;
+    droppedTokens += estimateMessagesTokens(dropped);
+    allDroppedMessages.push(...dropped);
+    keptMessages = repairedKept;
+  }
+
+  return {
+    messages: keptMessages,
+    droppedMessagesList: allDroppedMessages,
+    droppedChunks,
+    droppedMessages,
+    droppedTokens,
+    keptTokens: estimateMessagesTokens(keptMessages),
+    budgetTokens,
+  };
+}
+
 export function resolveContextWindowTokens(model?: ExtensionContext["model"]): number {
   return Math.max(1, Math.floor(model?.contextWindow ?? DEFAULT_CONTEXT_TOKENS));
 }

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -5,6 +5,7 @@ import { streamSimple } from "@mariozechner/pi-ai";
 import {
   createAgentSession,
   DefaultResourceLoader,
+  estimateTokens,
   SessionManager,
 } from "@mariozechner/pi-coding-agent";
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
@@ -35,6 +36,7 @@ import {
   listChannelSupportedActions,
   resolveChannelMessageToolHints,
 } from "../../channel-tools.js";
+import { estimateMessagesTokens, pruneHistoryToTokenBudget } from "../../compaction.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { resolveOpenClawDocsPath } from "../../docs-path.js";
 import { isTimeoutError } from "../../failover-error.js";
@@ -421,6 +423,118 @@ function summarizeSessionContext(messages: AgentMessage[]): {
     totalTextChars,
     totalImageBlocks,
     maxMessageTextChars,
+  };
+}
+
+const PRE_SEND_INPUT_BUDGET_SAFETY_RATIO = 0.9;
+const PRE_SEND_RESPONSE_RESERVE_RATIO = 0.08;
+const PRE_SEND_RESPONSE_RESERVE_MIN_TOKENS = 1024;
+const PRE_SEND_RESPONSE_RESERVE_MAX_TOKENS = 8192;
+const PRE_SEND_PROMPT_IMAGE_TOKEN_PENALTY = 2048;
+
+function estimateTextMessageTokens(role: "system" | "user", text: string): number {
+  if (!text.trim()) {
+    return 0;
+  }
+  try {
+    return estimateTokens({
+      role,
+      content: text,
+      timestamp: Date.now(),
+    } as unknown as AgentMessage);
+  } catch {
+    // Conservative fallback for tokenizers that reject synthetic messages.
+    return Math.max(1, Math.ceil(text.length / 4));
+  }
+}
+
+function enforcePromptHistoryBudget(params: {
+  messages: AgentMessage[];
+  contextWindowTokens: number;
+  modelMaxTokens?: number;
+  systemPromptText: string;
+  promptText: string;
+  promptImageCount: number;
+}): {
+  didPrune: boolean;
+  messages: AgentMessage[];
+  historyTokensBefore: number;
+  historyTokensAfter: number;
+  historyBudgetTokens: number;
+  envelopeTokens: number;
+  inputBudgetTokens: number;
+  droppedMessages: number;
+} {
+  const historyTokensBefore = estimateMessagesTokens(params.messages);
+  const responseReserveUpper =
+    typeof params.modelMaxTokens === "number" && Number.isFinite(params.modelMaxTokens)
+      ? Math.max(
+          1,
+          Math.min(PRE_SEND_RESPONSE_RESERVE_MAX_TOKENS, Math.floor(params.modelMaxTokens)),
+        )
+      : PRE_SEND_RESPONSE_RESERVE_MAX_TOKENS;
+  const responseReserveTokens = Math.max(
+    1,
+    Math.min(
+      responseReserveUpper,
+      Math.max(
+        PRE_SEND_RESPONSE_RESERVE_MIN_TOKENS,
+        Math.floor(params.contextWindowTokens * PRE_SEND_RESPONSE_RESERVE_RATIO),
+      ),
+    ),
+  );
+  const inputBudgetTokens = Math.max(
+    1,
+    Math.floor(
+      (params.contextWindowTokens - responseReserveTokens) * PRE_SEND_INPUT_BUDGET_SAFETY_RATIO,
+    ),
+  );
+  const envelopeTokens =
+    estimateTextMessageTokens("system", params.systemPromptText) +
+    estimateTextMessageTokens("user", params.promptText) +
+    params.promptImageCount * PRE_SEND_PROMPT_IMAGE_TOKEN_PENALTY;
+  const historyBudgetTokens = Math.max(0, inputBudgetTokens - envelopeTokens);
+
+  if (historyTokensBefore <= historyBudgetTokens) {
+    return {
+      didPrune: false,
+      messages: params.messages,
+      historyTokensBefore,
+      historyTokensAfter: historyTokensBefore,
+      historyBudgetTokens,
+      envelopeTokens,
+      inputBudgetTokens,
+      droppedMessages: 0,
+    };
+  }
+
+  if (historyBudgetTokens <= 0) {
+    return {
+      didPrune: params.messages.length > 0,
+      messages: [],
+      historyTokensBefore,
+      historyTokensAfter: 0,
+      historyBudgetTokens,
+      envelopeTokens,
+      inputBudgetTokens,
+      droppedMessages: params.messages.length,
+    };
+  }
+
+  const pruned = pruneHistoryToTokenBudget({
+    messages: params.messages,
+    budgetTokens: historyBudgetTokens,
+    parts: 2,
+  });
+  return {
+    didPrune: pruned.messages !== params.messages,
+    messages: pruned.messages,
+    historyTokensBefore,
+    historyTokensAfter: pruned.keptTokens,
+    historyBudgetTokens,
+    envelopeTokens,
+    inputBudgetTokens,
+    droppedMessages: pruned.droppedMessages,
   };
 }
 
@@ -1262,6 +1376,32 @@ export async function runEmbeddedAttempt(
                 ? { root: sandbox.workspaceDir, bridge: sandbox.fsBridge }
                 : undefined,
           });
+
+          const contextWindowTokens = Math.max(
+            1,
+            Math.floor(
+              params.model.contextWindow ?? params.model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+            ),
+          );
+          const promptBudgetGuard = enforcePromptHistoryBudget({
+            messages: activeSession.messages,
+            contextWindowTokens,
+            modelMaxTokens: params.model.maxTokens,
+            systemPromptText,
+            promptText: effectivePrompt,
+            promptImageCount: imageResult.images.length,
+          });
+          if (promptBudgetGuard.didPrune) {
+            activeSession.agent.replaceMessages(promptBudgetGuard.messages);
+            log.warn(
+              `[context-budget-guard] pruned history before prompt: ` +
+                `sessionKey=${params.sessionKey ?? params.sessionId} ` +
+                `provider=${params.provider}/${params.modelId} ` +
+                `historyTokens=${promptBudgetGuard.historyTokensBefore}->${promptBudgetGuard.historyTokensAfter} ` +
+                `historyBudget=${promptBudgetGuard.historyBudgetTokens} inputBudget=${promptBudgetGuard.inputBudgetTokens} ` +
+                `envelopeTokens=${promptBudgetGuard.envelopeTokens} droppedMessages=${promptBudgetGuard.droppedMessages}`,
+            );
+          }
 
           cacheTrace?.recordStage("prompt:images", {
             prompt: effectivePrompt,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

I gave OpenClaw some requests via Telegram the other day and my machine started to overheat (A LOT), it never stopped, I had to stop it myself. The problem was that the local model I had installed was being thrown a bunch of context that exceeded the model limit, and somehow that went into a loop. I reversed engineered how we are doing it with codex and apply a similar fix for local models so that we can use it without crashing the local models. More specific:

- Problem: Long session history + system prompt + new prompt/images could exceed model context window before prompt send, causing context-overflow failures (local models).
- Why it matters: Users hit avoidable `400` context overflow errors and sessions became brittle after long chats.
- What changed: Added explicit history-pruning to token budget in `/src/agents/compaction.ts` and a pre-send budget guard in `/src/agents/pi-embedded-runner/run/attempt.ts` that reserves response headroom, accounts for prompt envelope tokens, and prunes oldest history only when needed.
- What did NOT change (scope boundary): No provider auth flow changes, no model catalog changes, no API contract/schema changes, no UI changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #N/A
- Related #N/A

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

- Long-running chats now prune oldest history before send when estimated input would overflow context window.
- New warning log when this happens: `[context-budget-guard] pruned history before prompt: ...`
- No config/default changes required.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): No
- Secrets/tokens handling changed? (`Yes/No`): No
- New/changed network calls? (`Yes/No`): No
- Command/tool execution surface changed? (`Yes/No`): No
- Data access scope changed? (`Yes/No`): No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (Apple Silicon)
- Runtime/container: Node.js + pnpm + Vitest (no container)
- Model/provider: Local small-context models (e.g. OpenAI-compatible local endpoints)
- Integration/channel (if any): Telegram
- Relevant config (redacted): Default embedded runner settings

### Steps

1. Build a session with large prior history.
2. Send a new prompt (optionally with images) on a smaller context-window model.
3. Observe whether prompt send overflows or is guarded.

### Expected

- Oldest history is pruned to fit budget and prompt send proceeds without immediate context overflow.

### Actual

- Before fix: prompt could fail immediately with context overflow, triggering the machine to extreme overheat, loops and crashes, it wold not end the session and switching models to let's say codex would not solve the issue since the session was "dirty".
- After fix: pre-send guard prunes history as needed, faster input/output since the LLM doesn't collapse in context; targeted tests pass.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Evidence snippet:
- `npm exec -- pnpm vitest run src/agents/compaction.test.ts src/agents/pi-embedded-runner/usage-reporting.test.ts`
- Result: `2 passed`, `13 passed`.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Added and executed tests for explicit token-budget pruning behavior; verified targeted runner-related tests still pass.
- Edge cases checked: Budget near zero clears history; constrained budget keeps newest messages and drops oldest.
- What you did **not** verify: Other providers than telegram, but since this affects only what you give to the local model it should be good.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): Yes
- Config/env changes? (`Yes/No`): No
- Migration needed? (`Yes/No`): No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit.
- Files/config to restore:
  - `/src/agents/compaction.ts`
  - `/src/agents/compaction.test.ts`
  - `/src/agents/pi-embedded-runner/run/attempt.ts`
- Known bad symptoms reviewers should watch for:
  - Excessive history drops on short prompts.
  - Frequent `[context-budget-guard]` warnings when not expected.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Over-pruning could remove useful older context in borderline sessions.
  - Mitigation: Guard only triggers when estimated budget is exceeded; keeps newest context.
- Risk: Token estimation is approximate and can vary by provider/tokenizer.
  - Mitigation: Uses safety ratio + response reserve + image penalty and keeps existing overflow handling as fallback.
