### PR TITLE
feat(commands): add textForce to enforce text disabling on non-native surfaces

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -33,6 +33,7 @@ They run immediately, are stripped before the model sees the message, and the re
     native: "auto",
     nativeSkills: "auto",
     text: true,
+    textForce: false,
     bash: false,
     bashForegroundMs: 2000,
     config: false,
@@ -48,7 +49,8 @@ They run immediately, are stripped before the model sees the message, and the re
 ```
 
 - `commands.text` (default `true`) enables parsing `/...` in chat messages.
-  - On surfaces without native commands (WhatsApp/WebChat/Signal/iMessage/Google Chat/MS Teams), text commands still work even if you set this to `false`.
+  - On surfaces without native commands (WhatsApp/WebChat/Signal/iMessage/Google Chat/MS Teams), text commands still work even if you set this to `false` — unless `commands.textForce` is also enabled.
+- `commands.textForce` (default `false`) enforces `commands.text: false` on **all** surfaces, including those without native command support. Use this in multi-tenant or white-label deployments where end users should not have access to `/model`, `/bash`, `/config`, or `/debug`. Native command sources (e.g., Discord slash commands) are always handled regardless of this setting.
 - `commands.native` (default `"auto"`) registers native commands.
   - Auto: on for Discord/Telegram; off for Slack (until you add slash commands); ignored for providers without native support.
   - Set `channels.discord.commands.native`, `channels.telegram.commands.native`, or `channels.slack.commands.native` to override per provider (bool or `"auto"`).

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -248,6 +248,57 @@ describe("commands registry", () => {
     ).toBe(true);
   });
 
+  it("textForce disables text commands on non-native surfaces", () => {
+    const cfg = { commands: { text: false, textForce: true } };
+    expect(
+      shouldHandleTextCommands({
+        cfg,
+        surface: "whatsapp",
+        commandSource: "text",
+      }),
+    ).toBe(false);
+    expect(
+      shouldHandleTextCommands({
+        cfg,
+        surface: "webchat",
+        commandSource: "text",
+      }),
+    ).toBe(false);
+  });
+
+  it("textForce still allows native command source", () => {
+    const cfg = { commands: { text: false, textForce: true } };
+    expect(
+      shouldHandleTextCommands({
+        cfg,
+        surface: "whatsapp",
+        commandSource: "native",
+      }),
+    ).toBe(true);
+  });
+
+  it("textForce without text:false has no effect", () => {
+    const cfg = { commands: { textForce: true } };
+    expect(
+      shouldHandleTextCommands({
+        cfg,
+        surface: "whatsapp",
+        commandSource: "text",
+      }),
+    ).toBe(true);
+  });
+
+  it("text:false without textForce preserves backward compat on non-native surfaces", () => {
+    const cfg = { commands: { text: false } };
+    expect(
+      shouldHandleTextCommands({
+        cfg,
+        surface: "whatsapp",
+        commandSource: "text",
+      }),
+    ).toBe(true);
+  });
+
   it("normalizes telegram-style command mentions for the current bot", () => {
     expect(normalizeCommandBody("/help@openclaw", { botUsername: "openclaw" })).toBe("/help");
     expect(

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -523,6 +523,9 @@ export function shouldHandleTextCommands(params: ShouldHandleTextCommandsParams)
   if (params.commandSource === "native") {
     return true;
   }
+  if (params.cfg.commands?.text === false && params.cfg.commands?.textForce) {
+    return false;
+  }
   if (params.cfg.commands?.text !== false) {
     return true;
   }

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -951,6 +951,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Registers native skill commands so users can invoke skills directly from provider command menus where supported. Keep aligned with your skill policy so exposed commands match what operators expect.",
   "commands.text":
     "Enables text-command parsing in chat input in addition to native command surfaces where available. Keep this enabled for compatibility across channels that do not support native command registration.",
+  "commands.textForce":
+    "When true, `commands.text: false` is enforced on ALL surfaces including those without native command support (WhatsApp, Slack, Signal, etc.). Use this in multi-tenant deployments where end users should not have access to text commands. Default: false.",
   "commands.bash":
     "Allow bash chat command (`!`; `/bash` alias) to run host shell commands (default: false; requires tools.elevated).",
   "commands.bashForegroundMs":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -430,6 +430,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "commands.native": "Native Commands",
   "commands.nativeSkills": "Native Skill Commands",
   "commands.text": "Text Commands",
+  "commands.textForce": "Enforce Text Command Disabling",
   "commands.bash": "Allow Bash Chat Command",
   "commands.bashForegroundMs": "Bash Foreground Window (ms)",
   "commands.config": "Allow /config",

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -141,6 +141,8 @@ export type CommandsConfig = {
   nativeSkills?: NativeCommandsSetting;
   /** Enable text command parsing (default: true). */
   text?: boolean;
+  /** When true, `commands.text: false` is enforced on ALL surfaces including those without native command support (default: false). */
+  textForce?: boolean;
   /** Allow bash chat command (`!`; `/bash` alias) (default: false). */
   bash?: boolean;
   /** How long bash waits before backgrounding (default: 2000; 0 backgrounds immediately). */

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -194,6 +194,7 @@ export const CommandsSchema = z
     native: NativeCommandsSettingSchema.optional().default("auto"),
     nativeSkills: NativeCommandsSettingSchema.optional().default("auto"),
     text: z.boolean().optional(),
+    textForce: z.boolean().optional(),
     bash: z.boolean().optional(),
     bashForegroundMs: z.number().int().min(0).max(30_000).optional(),
     config: z.boolean().optional(),


### PR DESCRIPTION
## Problem

OpenClaw is increasingly used to build **multi-tenant and white-label products** where the operator deploys one gateway serving many end users over WhatsApp, Slack, Signal, WebChat, iMessage, Google Chat, or MS Teams.

On these non-native surfaces, `commands.text: false` is deliberately ignored — the reasoning being that text commands are the only command mechanism available. This made sense for single-user/self-hosted setups, but it creates a **privilege escalation risk** in multi-tenant scenarios: any end user can type `/model`, `/bash`, `/config`, or `/debug` in a WhatsApp chat and access operator-level controls.

Today, the only way to close this gap is to patch the compiled bundle — which is fragile, breaks on every upgrade, and not a real solution.

## Solution

Add `commands.textForce` (boolean, default `false`). When set alongside `commands.text: false`, it enforces the disabling on **all** surfaces — including those without native command support.

```json5
{
  commands: {
    text: false,
    textForce: true,  // now text:false is respected everywhere
  }
}
```

This gives operators a clean, config-only way to lock down text commands for their end users without losing native command access (Discord slash commands, Telegram menus, etc.) for themselves.

### Who benefits
- **Multi-tenant operators** — can safely expose WhatsApp/Slack/Signal bots to thousands of end users without leaking admin commands
- **White-label builders** — can ship a polished product where `/debug` and `/bash` simply don't exist for the end user
- **Enterprise deployments** — satisfies security review requirements around command surface minimization

### Why not just use `allowFrom`?
`commands.allowFrom` gates *who* can run commands, but it still requires the operator to enumerate every allowed user. `textForce` is a blanket policy that says "text commands don't exist on this surface" — simpler, safer, and no user-list maintenance.

## Changes
- `src/config/types.messages.ts` — Added `textForce?: boolean` to `CommandsConfig`
- `src/config/zod-schema.session.ts` — Added Zod schema entry
- `src/config/schema.help.ts` — Added help text
- `src/config/schema.labels.ts` — Added field label
- `src/auto-reply/commands-registry.ts` — 3-line addition to `shouldHandleTextCommands`
- `src/auto-reply/commands-registry.test.ts` — 4 new test cases
- `docs/tools/slash-commands.md` — Updated documentation
- `CHANGELOG.md` — Unreleased entry

### Backward compatibility
- Default behavior is **identical** — `textForce` defaults to `false`
- Native command sources always handled regardless of this setting
- Existing `commands.text: false` behavior on native surfaces (Discord, Telegram) preserved
- Zero breaking changes

### AI-assisted
This PR was AI-assisted. All code reviewed and understood by contributor. Tests fully passing.

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm check` passes (Oxlint + Oxfmt)
- [x] `pnpm test:fast` passes — 4 new test cases for textForce behavior
- [x] Manual: `commands.text: false` + `textForce: true` disables `/help` on WhatsApp surface
- [x] Manual: native commands still work with textForce enabled