### PR TITLE
feat(typing): gateway-level TTL coordinator as backstop for stuck typing indicators

### DIFF
--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -118,8 +118,14 @@ export async function getReplyFromConfig(
     silentToken: SILENT_REPLY_TOKEN,
     log: defaultRuntime.log,
     // Register with the gateway-level TTL coordinator for defense-in-depth cleanup.
-    // Uses the session key as the unique identifier for this typing session.
-    coordinatorKey: agentSessionKey || undefined,
+    // Uses a composite key (session + channel/surface) to prevent collisions in
+    // multi-channel deployments where multiple channels share a canonical session key
+    // (e.g. direct chats collapsing to a main session key via resolveSessionKey).
+    coordinatorKey: agentSessionKey
+      ? (ctx.Surface ?? ctx.Provider)
+        ? `${agentSessionKey}::${ctx.Surface ?? ctx.Provider}`
+        : agentSessionKey
+      : undefined,
   });
   opts?.onTypingController?.(typing);
 

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -117,6 +117,9 @@ export async function getReplyFromConfig(
     typingIntervalSeconds,
     silentToken: SILENT_REPLY_TOKEN,
     log: defaultRuntime.log,
+    // Register with the gateway-level TTL coordinator for defense-in-depth cleanup.
+    // Uses the session key as the unique identifier for this typing session.
+    coordinatorKey: agentSessionKey || undefined,
   });
   opts?.onTypingController?.(typing);
 

--- a/src/auto-reply/reply/typing-coordinator-integration.test.ts
+++ b/src/auto-reply/reply/typing-coordinator-integration.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Integration tests: TypingController wired to TypingTtlCoordinator.
+ *
+ * These tests verify the gateway-level TTL coordinator correctly interacts
+ * with the typing controller lifecycle (start, clean stop, forced expiry).
+ *
+ * Relates to: #27138, #27011, #27053, #27690, #26961, #26733, #26751
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
+import { TypingTtlCoordinator } from "../../gateway/typing-ttl-coordinator.js";
+import { createTypingController } from "./typing.js";
+
+function makeController(params: {
+  coordinator: TypingTtlCoordinator;
+  coordinatorKey: string;
+  typingMaxTtlMs?: number;
+  onReplyStart?: Mock;
+  onCleanup?: Mock;
+}) {
+  const onReplyStart = params.onReplyStart ?? vi.fn();
+  const onCleanup = params.onCleanup ?? vi.fn();
+  const controller = createTypingController({
+    onReplyStart,
+    onCleanup,
+    typingIntervalSeconds: 6,
+    typingTtlMs: 300_000, // High internal TTL — we want coordinator to fire first
+    log: vi.fn(),
+    coordinatorKey: params.coordinatorKey,
+    coordinator: params.coordinator,
+    typingMaxTtlMs: params.typingMaxTtlMs,
+  });
+  return { controller, onReplyStart, onCleanup };
+}
+
+describe("TypingController + TypingTtlCoordinator integration", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // 1. Typing persists past TTL → coordinator fires cleanup
+  it("coordinator fires cleanup() when typing persists past TTL (missed cleanup)", async () => {
+    const warn = vi.fn();
+    const coordinator = new TypingTtlCoordinator({ defaultTtlMs: 5_000, warn });
+    const onCleanup = vi.fn();
+
+    // Create controller with a low coordinator TTL to simulate backstop behavior
+    const controller = createTypingController({
+      onReplyStart: vi.fn(),
+      onCleanup,
+      typingIntervalSeconds: 6,
+      typingTtlMs: 300_000, // Very high internal TTL — won't fire
+      log: vi.fn(),
+      coordinatorKey: "ch:stuck-session",
+      coordinator,
+      typingMaxTtlMs: 5_000, // Low coordinator TTL for the test
+    });
+
+    // Start typing (registers with coordinator)
+    await controller.startTypingLoop();
+    expect(coordinator.activeCount()).toBe(1);
+
+    // Simulate total hang: markRunComplete with no markDispatchIdle
+    // (in this typing.ts version, cleanup doesn't auto-fire without dispatchIdle)
+    controller.markRunComplete();
+    expect(onCleanup).not.toHaveBeenCalled(); // Not yet
+
+    // Advance past coordinator TTL
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    // Coordinator should have fired cleanup()
+    expect(onCleanup).toHaveBeenCalledTimes(1);
+    expect(coordinator.activeCount()).toBe(0);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("[typing-ttl] TTL expired"),
+      expect.objectContaining({ key: "ch:stuck-session" }),
+    );
+  });
+
+  // 2. Clean stop before TTL → coordinator does NOT fire
+  it("coordinator does NOT fire when typing stops cleanly before TTL", async () => {
+    const warn = vi.fn();
+    const coordinator = new TypingTtlCoordinator({ defaultTtlMs: 5_000, warn });
+    const { controller, onCleanup } = makeController({
+      coordinator,
+      coordinatorKey: "ch:clean-session",
+    });
+
+    await controller.startTypingLoop();
+    expect(coordinator.activeCount()).toBe(1);
+
+    // Normal clean stop: run completes + dispatch idle
+    controller.markRunComplete();
+    controller.markDispatchIdle();
+
+    expect(onCleanup).toHaveBeenCalledTimes(1);
+    expect(coordinator.activeCount()).toBe(0);
+
+    // Advance past TTL — coordinator should NOT fire a second cleanup
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(onCleanup).toHaveBeenCalledTimes(1); // Still only once
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  // 3. NO_REPLY path → typing is stopped before TTL
+  it("NO_REPLY path: coordinator deregisters when cleanup() is called externally", async () => {
+    const coordinator = new TypingTtlCoordinator({ defaultTtlMs: 30_000 });
+    const { controller, onCleanup } = makeController({
+      coordinator,
+      coordinatorKey: "ch:no-reply-session",
+    });
+
+    await controller.startTypingLoop();
+    expect(coordinator.activeCount()).toBe(1);
+
+    // Simulate NO_REPLY: typing.cleanup() called by the dispatcher
+    controller.cleanup();
+
+    expect(onCleanup).toHaveBeenCalledTimes(1);
+    expect(coordinator.activeCount()).toBe(0); // Deregistered on clean cleanup
+
+    // TTL should not fire
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(onCleanup).toHaveBeenCalledTimes(1);
+  });
+
+  // 4. Multiple overlapping sessions → each independently tracked
+  it("multiple overlapping sessions are tracked independently", async () => {
+    const coordinator = new TypingTtlCoordinator({ defaultTtlMs: 10_000 });
+    const onCleanup1 = vi.fn();
+    const onCleanup2 = vi.fn();
+    const onCleanup3 = vi.fn();
+
+    const ctrl1 = createTypingController({
+      onReplyStart: vi.fn(),
+      onCleanup: onCleanup1,
+      typingIntervalSeconds: 6,
+      log: vi.fn(),
+      coordinatorKey: "ch:sess1",
+      coordinator,
+      typingMaxTtlMs: 3_000,
+    });
+    const ctrl2 = createTypingController({
+      onReplyStart: vi.fn(),
+      onCleanup: onCleanup2,
+      typingIntervalSeconds: 6,
+      log: vi.fn(),
+      coordinatorKey: "ch:sess2",
+      coordinator,
+      typingMaxTtlMs: 6_000,
+    });
+    const ctrl3 = createTypingController({
+      onReplyStart: vi.fn(),
+      onCleanup: onCleanup3,
+      typingIntervalSeconds: 6,
+      log: vi.fn(),
+      coordinatorKey: "ch:sess3",
+      coordinator,
+      typingMaxTtlMs: 5_000,
+    });
+
+    await ctrl1.startTypingLoop();
+    await ctrl2.startTypingLoop();
+    await ctrl3.startTypingLoop();
+    expect(coordinator.activeCount()).toBe(3);
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(onCleanup1).toHaveBeenCalledTimes(1); // expired via coordinator
+    expect(onCleanup2).not.toHaveBeenCalled();
+    expect(onCleanup3).not.toHaveBeenCalled();
+
+    // Clean stop for sess3
+    ctrl3.markRunComplete();
+    ctrl3.markDispatchIdle();
+    expect(onCleanup3).toHaveBeenCalledTimes(1);
+    expect(coordinator.activeCount()).toBe(1); // only sess2 remains
+
+    await vi.advanceTimersByTimeAsync(3_000); // total 6s
+    expect(onCleanup2).toHaveBeenCalledTimes(1); // expired via coordinator
+    expect(coordinator.activeCount()).toBe(0);
+  });
+
+  // 5. Re-registration on interrupt → stale deregister doesn't break new session
+  it("stale deregister from interrupted session does not break a new session for same key", async () => {
+    const coordinator = new TypingTtlCoordinator({ defaultTtlMs: 10_000 });
+    const onCleanup1 = vi.fn();
+    const onCleanup2 = vi.fn();
+
+    // First session starts and is interrupted (cleanup called)
+    const ctrl1 = createTypingController({
+      onReplyStart: vi.fn(),
+      onCleanup: onCleanup1,
+      typingIntervalSeconds: 6,
+      log: vi.fn(),
+      coordinatorKey: "ch:shared-key",
+      coordinator,
+      typingMaxTtlMs: 5_000,
+    });
+    await ctrl1.startTypingLoop();
+    expect(coordinator.activeCount()).toBe(1);
+
+    // Interrupt ctrl1 (simulates session reset / NO_REPLY)
+    ctrl1.cleanup();
+    expect(coordinator.activeCount()).toBe(0);
+
+    // New session with same key starts
+    const ctrl2 = createTypingController({
+      onReplyStart: vi.fn(),
+      onCleanup: onCleanup2,
+      typingIntervalSeconds: 6,
+      log: vi.fn(),
+      coordinatorKey: "ch:shared-key",
+      coordinator,
+      typingMaxTtlMs: 5_000,
+    });
+    await ctrl2.startTypingLoop();
+    expect(coordinator.activeCount()).toBe(1);
+
+    // New session cleans up normally
+    ctrl2.markRunComplete();
+    ctrl2.markDispatchIdle();
+
+    expect(onCleanup2).toHaveBeenCalledTimes(1);
+    expect(coordinator.activeCount()).toBe(0);
+
+    // Advance past TTL — no spurious fire from stale first session
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(onCleanup1).toHaveBeenCalledTimes(1); // Only from the explicit ctrl1.cleanup()
+    expect(onCleanup2).toHaveBeenCalledTimes(1);
+  });
+
+  // 6. Coordinator error resilience → error in cleanup doesn't crash reply flow
+  it("coordinator error resilience: error in cleanup fn does not crash the coordinator", async () => {
+    const warn = vi.fn();
+    const coordinator = new TypingTtlCoordinator({ defaultTtlMs: 3_000, warn });
+    const onCleanup = vi.fn().mockImplementationOnce(() => {
+      throw new Error("cleanup blew up");
+    });
+
+    const controller = createTypingController({
+      onReplyStart: vi.fn(),
+      onCleanup,
+      typingIntervalSeconds: 6,
+      typingTtlMs: 300_000,
+      log: vi.fn(),
+      coordinatorKey: "ch:error-session",
+      coordinator,
+      typingMaxTtlMs: 3_000,
+    });
+
+    await controller.startTypingLoop();
+    expect(coordinator.activeCount()).toBe(1);
+
+    // Advance to TTL — coordinator fires cleanup which throws
+    expect(() => vi.advanceTimersByTime(3_000)).not.toThrow();
+
+    // Coordinator must have caught the error and logged it
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("[typing-ttl] cleanupFn threw"),
+      expect.objectContaining({ key: "ch:error-session" }),
+    );
+    expect(coordinator.activeCount()).toBe(0);
+  });
+});

--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -1,3 +1,5 @@
+import type { TypingTtlCoordinator } from "../../gateway/typing-ttl-coordinator.js";
+import { typingTtlCoordinator } from "../../gateway/typing-ttl-coordinator.js";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../tokens.js";
 
 export type TypingController = {
@@ -18,6 +20,23 @@ export function createTypingController(params: {
   typingTtlMs?: number;
   silentToken?: string;
   log?: (message: string) => void;
+  /**
+   * Unique key for this typing session (e.g. session key or channel+session).
+   * When provided, the session is registered with the gateway-level TTL coordinator
+   * as defense-in-depth against leaked typing indicators.
+   * If omitted, coordinator registration is skipped.
+   */
+  coordinatorKey?: string;
+  /**
+   * Gateway-level TTL coordinator. Defaults to the process singleton when
+   * `coordinatorKey` is provided. Override in tests to use an isolated instance.
+   */
+  coordinator?: TypingTtlCoordinator;
+  /**
+   * Hard TTL enforced by the gateway coordinator (ms). Defaults to coordinator default (120s).
+   * Only used when `coordinatorKey` is provided.
+   */
+  typingMaxTtlMs?: number;
 }): TypingController {
   const {
     onReplyStart,
@@ -26,6 +45,9 @@ export function createTypingController(params: {
     typingTtlMs = 2 * 60_000,
     silentToken = SILENT_REPLY_TOKEN,
     log,
+    coordinatorKey,
+    coordinator = coordinatorKey ? typingTtlCoordinator : undefined,
+    typingMaxTtlMs,
   } = params;
   let started = false;
   let active = false;
@@ -38,6 +60,9 @@ export function createTypingController(params: {
   let typingTimer: NodeJS.Timeout | undefined;
   let typingTtlTimer: NodeJS.Timeout | undefined;
   const typingIntervalMs = typingIntervalSeconds * 1000;
+
+  // Gateway-level coordinator deregister. Set when typing first starts; cleared on cleanup.
+  let coordinatorDeregister: (() => boolean) | undefined;
 
   const formatTypingTtl = (ms: number) => {
     if (ms % 60_000 === 0) {
@@ -64,6 +89,12 @@ export function createTypingController(params: {
     if (typingTimer) {
       clearInterval(typingTimer);
       typingTimer = undefined;
+    }
+    // Deregister from gateway-level coordinator on clean stop.
+    // This cancels the hard TTL so the coordinator won't fire a redundant forced cleanup.
+    if (coordinatorDeregister) {
+      coordinatorDeregister();
+      coordinatorDeregister = undefined;
     }
     // Notify the channel to stop its typing indicator (e.g., on NO_REPLY).
     // This fires only once (sealed prevents re-entry).
@@ -148,6 +179,13 @@ export function createTypingController(params: {
     }
     if (typingIntervalMs <= 0) {
       return;
+    }
+    // Register with the gateway-level TTL coordinator the first time typing starts.
+    // The coordinator is a defense-in-depth safety net: if all other cleanup paths fail
+    // (dispatcher hang, event-lane blockage, NO_REPLY path leak, etc.), the coordinator
+    // will unconditionally call cleanup() after the hard TTL and emit a diagnostic warning.
+    if (coordinator && coordinatorKey && !coordinatorDeregister) {
+      coordinatorDeregister = coordinator.register(coordinatorKey, cleanup, typingMaxTtlMs);
     }
     if (typingTimer) {
       return;

--- a/src/gateway/typing-ttl-coordinator.test.ts
+++ b/src/gateway/typing-ttl-coordinator.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TypingTtlCoordinator } from "./typing-ttl-coordinator.js";
+
+describe("TypingTtlCoordinator", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // 1. TTL expiry fires cleanupFn
+  it("fires cleanupFn after TTL expires", () => {
+    const warn = vi.fn();
+    const coordinator = new TypingTtlCoordinator({ defaultTtlMs: 5_000, warn });
+    const cleanupFn = vi.fn();
+
+    coordinator.register("ch:sess1", cleanupFn);
+    expect(coordinator.activeCount()).toBe(1);
+    expect(cleanupFn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(5_000);
+
+    expect(cleanupFn).toHaveBeenCalledTimes(1);
+    expect(coordinator.activeCount()).toBe(0);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("[typing-ttl] TTL expired for key ch:sess1"),
+      expect.objectContaining({ key: "ch:sess1" }),
+    );
+  });
+
+  // 2. Clean deregister cancels TTL (cleanup never fires)
+  it("deregister() cancels the TTL — cleanupFn never fires", () => {
+    const warn = vi.fn();
+    const coordinator = new TypingTtlCoordinator({ defaultTtlMs: 5_000, warn });
+    const cleanupFn = vi.fn();
+
+    const deregister = coordinator.register("ch:sess1", cleanupFn);
+    expect(coordinator.activeCount()).toBe(1);
+
+    // Clean stop before TTL elapses
+    deregister();
+    expect(coordinator.activeCount()).toBe(0);
+
+    // Advance well past TTL — cleanupFn must not fire
+    vi.advanceTimersByTime(10_000);
+    expect(cleanupFn).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  // 3. Stale deregister does NOT clear a newer registration for the same key
+  it("stale deregister does not clobber a newer registration for the same key", () => {
+    const coordinator = new TypingTtlCoordinator({ defaultTtlMs: 10_000 });
+    const cleanupFn1 = vi.fn();
+    const cleanupFn2 = vi.fn();
+
+    // First registration
+    const deregister1 = coordinator.register("ch:sess1", cleanupFn1, 3_000);
+    vi.advanceTimersByTime(1_000); // 1s elapsed
+
+    // Second registration for the same key (replaces first)
+    coordinator.register("ch:sess1", cleanupFn2, 5_000);
+    expect(coordinator.activeCount()).toBe(1);
+
+    // Stale deregister from first registration — must NOT clear the new one
+    deregister1();
+    expect(coordinator.activeCount()).toBe(1); // New registration still active
+
+    // Second cleanup fires at 5s from re-registration
+    vi.advanceTimersByTime(5_000);
+    expect(cleanupFn2).toHaveBeenCalledTimes(1);
+    expect(cleanupFn1).not.toHaveBeenCalled();
+    expect(coordinator.activeCount()).toBe(0);
+  });
+
+  // 4. Double-stop is idempotent (no throw, no extra calls)
+  it("calling deregister() twice is idempotent — no throw, no extra cleanup", () => {
+    const coordinator = new TypingTtlCoordinator({ defaultTtlMs: 5_000 });
+    const cleanupFn = vi.fn();
+
+    const deregister = coordinator.register("ch:sess1", cleanupFn);
+    deregister();
+    expect(() => deregister()).not.toThrow(); // Second call must not throw
+
+    vi.advanceTimersByTime(10_000);
+    expect(cleanupFn).not.toHaveBeenCalled();
+    expect(coordinator.activeCount()).toBe(0);
+  });
+
+  // 5. Re-registration after deregister works
+  it("re-registration after deregister creates a fresh TTL", () => {
+    const coordinator = new TypingTtlCoordinator({ defaultTtlMs: 5_000 });
+    const cleanupFn = vi.fn();
+
+    const deregister1 = coordinator.register("ch:sess1", cleanupFn);
+    deregister1(); // Clean stop
+    expect(coordinator.activeCount()).toBe(0);
+
+    // Re-register the same key
+    coordinator.register("ch:sess1", cleanupFn);
+    expect(coordinator.activeCount()).toBe(1);
+
+    vi.advanceTimersByTime(5_000);
+    expect(cleanupFn).toHaveBeenCalledTimes(1);
+    expect(coordinator.activeCount()).toBe(0);
+  });
+
+  // 6. Multi-session tracking is independent
+  it("tracks multiple sessions independently", () => {
+    const coordinator = new TypingTtlCoordinator({ defaultTtlMs: 10_000 });
+    const clean1 = vi.fn();
+    const clean2 = vi.fn();
+    const clean3 = vi.fn();
+
+    coordinator.register("ch:sess1", clean1, 3_000);
+    coordinator.register("ch:sess2", clean2, 6_000);
+    const deregister3 = coordinator.register("ch:sess3", clean3, 5_000);
+
+    expect(coordinator.activeCount()).toBe(3);
+
+    vi.advanceTimersByTime(3_000);
+    expect(clean1).toHaveBeenCalledTimes(1); // expired
+    expect(clean2).not.toHaveBeenCalled();
+    expect(clean3).not.toHaveBeenCalled();
+    expect(coordinator.activeCount()).toBe(2);
+
+    deregister3(); // clean stop for sess3
+    expect(coordinator.activeCount()).toBe(1);
+
+    vi.advanceTimersByTime(3_000); // total 6s
+    expect(clean2).toHaveBeenCalledTimes(1); // expired
+    expect(clean3).not.toHaveBeenCalled(); // was deregistered cleanly
+    expect(coordinator.activeCount()).toBe(0);
+  });
+
+  // 7. Error in cleanupFn is caught and logged, doesn't throw
+  it("error thrown by cleanupFn is caught and logged — does not propagate", () => {
+    const warn = vi.fn();
+    const coordinator = new TypingTtlCoordinator({ defaultTtlMs: 5_000, warn });
+    const cleanupFn = vi.fn().mockImplementation(() => {
+      throw new Error("already stopped");
+    });
+
+    coordinator.register("ch:sess1", cleanupFn);
+    expect(() => vi.advanceTimersByTime(5_000)).not.toThrow();
+
+    expect(cleanupFn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("[typing-ttl] cleanupFn threw"),
+      expect.objectContaining({ key: "ch:sess1" }),
+    );
+  });
+
+  // 8. Custom TTL is respected
+  it("respects per-call ttlMs override", () => {
+    const coordinator = new TypingTtlCoordinator({ defaultTtlMs: 30_000 });
+    const cleanupFn = vi.fn();
+
+    coordinator.register("ch:sess1", cleanupFn, 1_000); // override: 1s
+    vi.advanceTimersByTime(999);
+    expect(cleanupFn).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(cleanupFn).toHaveBeenCalledTimes(1);
+  });
+
+  // 9. deregister returns false when entry already cleared, true when it cleared it
+  it("deregister returns true when it cleared the entry, false when already cleared", () => {
+    const coordinator = new TypingTtlCoordinator({ defaultTtlMs: 5_000 });
+    const cleanupFn = vi.fn();
+
+    const deregister = coordinator.register("ch:sess1", cleanupFn);
+
+    // First call: should return true (successfully cancelled)
+    expect(deregister()).toBe(true);
+
+    // Second call: entry already cleared, should return false
+    expect(deregister()).toBe(false);
+
+    // Register again, let TTL fire, then try deregistering
+    const deregister2 = coordinator.register("ch:sess2", cleanupFn);
+    vi.advanceTimersByTime(5_000); // TTL fires
+    expect(deregister2()).toBe(false); // Already cleared by TTL
+  });
+});

--- a/src/gateway/typing-ttl-coordinator.ts
+++ b/src/gateway/typing-ttl-coordinator.ts
@@ -1,0 +1,115 @@
+/**
+ * Gateway-level typing indicator TTL coordinator.
+ *
+ * This is a defense-in-depth safety net for typing indicators. It operates independently
+ * of per-session TTL mechanisms already present in TypingController and TypingCallbacks.
+ *
+ * If all other cleanup mechanisms fail (e.g. dispatcher hangs, event-lane blockage,
+ * NO_REPLY path leak, block-streaming edge cases), this coordinator will unconditionally
+ * stop typing after a hard TTL and emit a structured warning for diagnostics.
+ *
+ * Related issues: #27138, #27690, #27011, #26961, #26733, #26751, #27053
+ */
+
+export type TypingTtlCoordinatorOptions = {
+  /** Hard TTL per session in milliseconds. Default: 120_000 (2 minutes). */
+  defaultTtlMs?: number;
+  /** Logger for forced-cleanup warnings. Default: console.warn */
+  warn?: (message: string, meta?: Record<string, unknown>) => void;
+};
+
+/**
+ * `TypingTtlCoordinator` class.
+ *
+ * Prefer the process-level singleton (`typingTtlCoordinator`) in production code.
+ * Export the class for isolated unit-testing.
+ */
+export class TypingTtlCoordinator {
+  private readonly defaultTtlMs: number;
+  private readonly warn: (message: string, meta?: Record<string, unknown>) => void;
+  private readonly sessions = new Map<string, ReturnType<typeof setTimeout>>();
+
+  constructor(options: TypingTtlCoordinatorOptions = {}) {
+    this.defaultTtlMs = options.defaultTtlMs ?? 120_000;
+    this.warn = options.warn ?? ((msg) => console.warn(msg));
+  }
+
+  /**
+   * Register a typing session.
+   *
+   * Returns a bound `deregister` callback that:
+   * - Is scoped to this specific registration (captures the timer ref)
+   * - Checks `sessions.get(key) === timerRef` before clearing to prevent
+   *   stale callbacks from clobbering a newer registration for the same key
+   * - Returns `true` if it successfully cancelled the TTL, `false` if already cleared
+   *
+   * @param key       - Unique session key (e.g. `${channelId}:${sessionKey}`)
+   * @param cleanupFn - Idempotent function to stop the typing indicator
+   * @param ttlMs     - Hard TTL in milliseconds (default: coordinator default)
+   * @returns deregister - call on clean stop to cancel the TTL; returns true if cancelled
+   */
+  register(key: string, cleanupFn: () => void, ttlMs?: number): () => boolean {
+    const resolvedTtlMs = ttlMs ?? this.defaultTtlMs;
+
+    // Cancel any previous registration for this key.
+    const existingTimer = this.sessions.get(key);
+    if (existingTimer !== undefined) {
+      clearTimeout(existingTimer);
+      this.sessions.delete(key);
+    }
+
+    if (resolvedTtlMs <= 0) {
+      // TTL disabled — skip scheduling, return a no-op deregister.
+      return () => false;
+    }
+
+    const timer = setTimeout(() => {
+      // Only fire if this timer is still the active registration for this key.
+      if (this.sessions.get(key) === timer) {
+        this.sessions.delete(key);
+        this.warn(`[typing-ttl] TTL expired for key ${key} — forced cleanup`, {
+          key,
+          ttlMs: resolvedTtlMs,
+        });
+        try {
+          cleanupFn();
+        } catch (err) {
+          this.warn(`[typing-ttl] cleanupFn threw for key ${key}: ${String(err)}`, { key });
+        }
+      }
+    }, resolvedTtlMs);
+
+    this.sessions.set(key, timer);
+
+    // Capture the timer ref at registration time so this deregister is
+    // bound exclusively to this registration, not any future one for the same key.
+    const timerRef = timer;
+
+    return (): boolean => {
+      // Guard: only clear if this registration's timer is still active for this key.
+      if (this.sessions.get(key) !== timerRef) {
+        // Already cleared (by TTL expiry or a prior deregister call) — no-op.
+        return false;
+      }
+      clearTimeout(timerRef);
+      this.sessions.delete(key);
+      return true;
+    };
+  }
+
+  /** Number of currently active (not yet deregistered or expired) sessions. */
+  activeCount(): number {
+    return this.sessions.size;
+  }
+}
+
+/**
+ * Process-level singleton typing TTL coordinator.
+ *
+ * Imported by `createTypingController` to register all active typing sessions.
+ * The default TTL is 120 seconds — well above any expected model-run duration,
+ * but short enough to prevent typing indicators from persisting indefinitely.
+ */
+export const typingTtlCoordinator: TypingTtlCoordinator = new TypingTtlCoordinator({
+  defaultTtlMs: 120_000,
+});


### PR DESCRIPTION
## Summary

Adds a process-level `TypingTtlCoordinator` singleton that acts as a hard defense-in-depth safety net for typing indicators that fail to clean up through all other normal paths.

Closes #30960 (replaces the dirty previous PR with a clean implementation from main).

## Problem

Typing indicators can leak indefinitely when:
- Dispatcher hangs (event-lane blockage)
- NO_REPLY path doesn't trigger cleanup
- Block-streaming edge cases leave the loop running
- Any other unexpected failure in the normal cleanup chain

## Solution

A gateway-level coordinator that:
1. Registers each typing session with a hard 120s TTL on `startTypingLoop()`
2. On clean stop (`markRunComplete` + `markDispatchIdle` or `cleanup()`), deregisters to cancel the TTL
3. If cleanup is missed: fires `cleanup()` unconditionally and emits a structured warning log `[typing-ttl] TTL expired for key %s — forced cleanup`

The coordinator is **stale-safe**: `deregister()` captures the timer ref at registration time and only clears the entry if it's still the active registration for that key, preventing stale callbacks from clobbering newer registrations when a session key is reused.

## Files Changed

| File | Change |
|------|--------|
| `src/gateway/typing-ttl-coordinator.ts` | NEW — `TypingTtlCoordinator` class + `typingTtlCoordinator` singleton |
| `src/gateway/typing-ttl-coordinator.test.ts` | NEW — 9 unit tests |
| `src/auto-reply/reply/typing.ts` | MODIFY — wire `coordinatorKey`/`coordinator`/`typingMaxTtlMs` options |
| `src/auto-reply/reply/get-reply.ts` | MODIFY — pass `agentSessionKey` as `coordinatorKey` |
| `src/auto-reply/reply/typing-coordinator-integration.test.ts` | NEW — 6 integration tests |

## Tests

```
pnpm vitest run src/gateway/typing-ttl-coordinator.test.ts src/auto-reply/reply/typing-coordinator-integration.test.ts
```

- ✅ 9 unit tests (TypingTtlCoordinator class)
- ✅ 6 integration tests (TypingController + coordinator wired together)

## Related Issues

Fixes #27138, #27011, #27053
Mitigates #27690, #26961, #26733, #26751