### PR TITLE
fix(tui): prevent /compact from crashing terminal session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- TUI//compact crash: prevent `/compact` from corrupting the parent shell (zsh/bash) with `command not found: ^[]7 file://...` OSC-escape errors when the TUI exits during or after compaction. Fixes: (1) wrap `tui.stop()` inside `requestExit` with `try/finally` so `process.exit(0)` is guaranteed even when `tui.stop()` throws; (2) add a `process.once('exit', ...)` safety-net that calls `setRawMode(false)` on every exit path — including uncaught exceptions and unhandled rejections — so the kernel TTY input buffer is never left in raw mode where subsequent shell prompts would be interpreted as commands; (3) add a dedicated `/compact` command case that shows "compacting…" activity status before forwarding to the gateway. (#30421) Thanks @Meisenburg.
 - Config/Memory: allow `"mistral"` in `agents.defaults.memorySearch.provider` and `agents.defaults.memorySearch.fallback` schema validation. (#14934) Thanks @ThomsenDrake.
 - Security/Feishu: enforce ID-only allowlist matching for DM/group sender authorization, normalize Feishu ID prefixes during checks, and ignore mutable display names so display-name collisions cannot satisfy allowlist entries. This ships in the next npm release. Thanks @jiseoung for reporting.
 - Feishu/Commands: in group chats, command authorization now falls back to top-level `channels.feishu.allowFrom` when per-group `allowFrom` is not set, so `/command` no longer gets blocked by an unintended empty allowlist. (#23756)

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -129,4 +129,25 @@ describe("tui command handlers", () => {
     expect(addSystem).toHaveBeenCalledWith("send failed: Error: gateway down");
     expect(setActivityStatus).toHaveBeenLastCalledWith("error");
   });
+
+  // Regression test for issue #30421: /compact must be forwarded to the gateway
+  // AND must show a "compacting…" status before sending so the user knows the
+  // TUI has not frozen during the (potentially long) compaction operation.
+  it("/compact forwards to gateway and shows compacting status first", async () => {
+    const { handleCommand, sendChat, addUser, requestRender, setActivityStatus } = createHarness();
+
+    await handleCommand("/compact");
+
+    // Must be forwarded as a chat message
+    expect(addUser).toHaveBeenCalledWith("/compact");
+    expect(sendChat).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "/compact" }),
+    );
+    // "compacting…" must have appeared in the activity status calls
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const statusValues = setActivityStatus.mock.calls.map((args: any[]) => args[0] as string);
+    expect(statusValues).toContain("compacting…");
+    // A render must have been requested
+    expect(requestRender).toHaveBeenCalled();
+  });
 });

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -444,6 +444,14 @@ export function createCommandHandlers(context: CommandHandlerContext) {
       case "settings":
         openSettings();
         break;
+      case "compact":
+        // Forward /compact to the gateway as a control command.
+        // Show an explicit activity status while the (potentially long-running)
+        // compaction is in progress so the user knows the TUI hasn't frozen.
+        setActivityStatus("compacting…");
+        tui.requestRender();
+        await sendMessage(raw);
+        break;
       case "exit":
       case "quit":
         requestExit();

--- a/src/tui/tui.test.ts
+++ b/src/tui/tui.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getSlashCommands, parseCommand } from "./commands.js";
 import {
   createBackspaceDeduper,
+  forceRestoreTty,
   resolveCtrlCAction,
   resolveFinalAssistantText,
   resolveGatewayDisconnectState,
@@ -148,5 +149,41 @@ describe("resolveCtrlCAction", () => {
       action: "warn",
       nextLastCtrlCAt: 3501,
     });
+  });
+});
+
+describe("TUI terminal safety (issue #30421)", () => {
+  // forceRestoreTty() is the last-resort safety net called from requestExit()
+  // and from the process 'exit' listener to ensure the parent shell is never
+  // left in raw mode after a /compact crash or any other unexpected exit.
+
+  it("forceRestoreTty does not throw when stdin has no setRawMode", () => {
+    // Simulate an environment where stdin.isTTY is false (e.g. piped input)
+    const orig = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+    expect(() => forceRestoreTty()).not.toThrow();
+    Object.defineProperty(process.stdin, "isTTY", { value: orig, configurable: true });
+  });
+
+  it("forceRestoreTty does not throw when setRawMode throws", () => {
+    // Temporarily install a setRawMode that throws, simulating EBADF on a
+    // closed terminal fd.  forceRestoreTty must swallow the error.
+    const orig = process.stdin.isTTY;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const origSetRaw = (process.stdin as any).setRawMode;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    Object.defineProperty(process.stdin, "setRawMode", {
+      value: () => { throw Object.assign(new Error("EBADF"), { code: "EBADF" }); },
+      configurable: true,
+      writable: true,
+    });
+    expect(() => forceRestoreTty()).not.toThrow();
+    // Restore original state
+    Object.defineProperty(process.stdin, "setRawMode", {
+      value: origSetRaw,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(process.stdin, "isTTY", { value: orig, configurable: true });
   });
 });

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -246,6 +246,28 @@ export function createBackspaceDeduper(params?: { dedupeWindowMs?: number; now?:
   };
 }
 
+/**
+ * Best-effort last-resort TTY cleanup.  Called from the process 'exit'
+ * safety-net and from error-path shutdowns so the parent shell is never left
+ * with a corrupted raw-mode terminal (issue #30421).
+ */
+export function forceRestoreTty(): void {
+  try {
+    if (process.stdin.isTTY && typeof process.stdin.setRawMode === "function") {
+      process.stdin.setRawMode(false);
+    }
+  } catch {
+    // nothing we can do
+  }
+  try {
+    // Re-enable cursor and disable bracketed-paste in case tui.stop() was
+    // interrupted before writing these sequences.
+    process.stdout.write("\x1b[?25h\x1b[?2004l");
+  } catch {
+    // nothing we can do
+  }
+}
+
 type CtrlCAction = "clear" | "warn" | "exit";
 
 export function resolveCtrlCAction(params: {
@@ -770,8 +792,14 @@ export async function runTui(opts: TuiOptions) {
     }
     exitRequested = true;
     client.stop();
-    tui.stop();
-    process.exit(0);
+    try {
+      tui.stop();
+    } finally {
+      // Guarantee process.exit(0) is always reached — even when tui.stop()
+      // throws — so the process never hangs and the parent shell is not left
+      // with a corrupted raw-mode terminal (#30421).
+      process.exit(0);
+    }
   };
 
   const { handleCommand, sendMessage, openModelSelector, openAgentSelector, openSessionSelector } =
@@ -924,6 +952,18 @@ export async function runTui(opts: TuiOptions) {
   const sigtermHandler = () => {
     requestExit();
   };
+  // Safety-net: ensure the terminal is always restored to a usable state even
+  // when the process exits unexpectedly (uncaught exception, unhandled promise
+  // rejection, SIGTERM received while /compact is running, etc.).
+  // Without this guard the parent shell is left in raw mode and OSC escape
+  // sequences queued in the kernel TTY input buffer get interpreted as shell
+  // commands, e.g.:
+  //   command not found: ^[]7 file://hostname/path^G   (issue #30421)
+  const tuiExitCleanup = () => {
+    forceRestoreTty();
+  };
+  process.once("exit", tuiExitCleanup);
+
   process.on("SIGINT", sigintHandler);
   process.on("SIGTERM", sigtermHandler);
   tui.start();
@@ -932,6 +972,7 @@ export async function runTui(opts: TuiOptions) {
     const finish = () => {
       process.removeListener("SIGINT", sigintHandler);
       process.removeListener("SIGTERM", sigtermHandler);
+      process.removeListener("exit", tuiExitCleanup);
       resolve();
     };
     process.once("exit", finish);


### PR DESCRIPTION
## Summary

Fixes **#30421** — When `/compact` is typed in the TUI, the parent shell (zsh/bash) is left with a corrupted raw-mode terminal after the TUI exits, producing errors like:

```
command not found: ^[]7 file://hostname/path^G
no such file or directory: file://hostname/path
```

## Root Cause

The TUI puts the terminal in raw mode via `setRawMode(true)`. To restore the terminal on exit, `tui.stop()` must complete and call `setRawMode(false)`. Before this fix there were two code paths that could skip this restoration:

1. **`requestExit()` didn't guarantee `process.exit(0)`** — if `tui.stop()` threw any exception (e.g. `EPIPE`/`EIO`/`ENOTTY` when the user closes the terminal window while compaction is running), the `process.exit(0)` call that followed was never reached. The process then exited via the uncaught-exception path, leaving the kernel TTY input buffer in raw mode.

2. **No process-level safety net** — if the TUI process crashed for any other reason (unhandled promise rejection, etc.) while `/compact` was running, there was nothing to restore raw mode. The parent shell then read any OSC escape sequences queued in the TTY input buffer as shell commands, producing the errors in the issue.

## Changes

| File | Change |
|------|--------|
| `src/tui/tui.ts` | Add `forceRestoreTty()` helper; wrap `tui.stop()` in `requestExit()` with `try/finally` so `process.exit(0)` is always reached; register `process.once('exit', forceRestoreTty)` as a last-resort safety net |
| `src/tui/tui-command-handlers.ts` | Add dedicated `compact` case that sets `'compacting…'` activity status before forwarding to gateway, giving the user immediate visual feedback during the long-running operation |
| `src/tui/tui.test.ts` | Add `forceRestoreTty` safety tests |
| `src/tui/tui-command-handlers.test.ts` | Add `/compact` forwarding regression test |
| `CHANGELOG.md` | Add entry |

## Testing

```
npx vitest run src/tui/tui.test.ts src/tui/tui-command-handlers.test.ts
# 22 tests pass
```

### Manual Repro Steps (pre-fix)
1. Run `openclaw tui`
2. Type `/compact` and press Enter
3. While compaction is running (or immediately), close the terminal tab
4. In a new shell: observe `command not found: ^[]7 file://...` errors

Post-fix: the `process.once('exit')` handler calls `setRawMode(false)` and shows the cursor regardless of how the process exits, so the parent shell always starts with a clean terminal state.