### PR TITLE
fix: auto auth profile override should not bias profile ordering

### DIFF
--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -50,4 +50,152 @@ describe("resolveSessionAuthProfileOverride", () => {
       expect(sessionEntry.authProfileOverride).toBe("zai:work");
     });
   });
+
+  it("re-selects higher-priority profile when it exits cooldown", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      const now = Date.now();
+      await fs.writeFile(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "anth:oauth": { type: "token", provider: "anthropic", token: "tok-oauth" },
+            "anth:default": { type: "api_key", provider: "anthropic", key: "sk-test" },
+          },
+          order: { anthropic: ["anth:oauth", "anth:default"] },
+          usageStats: {
+            "anth:oauth": {
+              lastUsed: now - 120_000,
+              cooldownUntil: now - 1_000,
+            },
+            "anth:default": { lastUsed: now - 60_000 },
+          },
+        }),
+        "utf-8",
+      );
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s1",
+        updatedAt: now - 30_000,
+        authProfileOverride: "anth:default",
+        authProfileOverrideSource: "auto",
+        authProfileOverrideCompactionCount: 0,
+      };
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "anthropic",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: false,
+      });
+
+      expect(resolved).toBe("anth:oauth");
+    });
+  });
+
+  it("keeps intentional new-session rotation to the next healthy profile", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      await fs.writeFile(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "anth:oauth": { type: "token", provider: "anthropic", token: "tok-oauth" },
+            "anth:default": { type: "api_key", provider: "anthropic", key: "sk-test" },
+          },
+          order: { anthropic: ["anth:oauth", "anth:default"] },
+          usageStats: {
+            "anth:oauth": { lastUsed: Date.now() - 120_000 },
+            "anth:default": { lastUsed: Date.now() - 60_000 },
+          },
+        }),
+        "utf-8",
+      );
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s1",
+        updatedAt: Date.now() - 30_000,
+        authProfileOverride: "anth:oauth",
+        authProfileOverrideSource: "auto",
+        authProfileOverrideCompactionCount: 0,
+      };
+      const sessionStore = { "agent:main:main": sessionEntry };
+      const current = sessionEntry.authProfileOverride;
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "anthropic",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: true,
+      });
+
+      expect(resolved).not.toBe(current);
+      expect(resolved).toBe("anth:default");
+    });
+  });
+  it("stays on current profile when higher-priority profiles are still in cooldown", async () => {
+    await withStateDirEnv("openclaw-auth-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      const authPath = path.join(agentDir, "auth-profiles.json");
+      const now = Date.now();
+      await fs.writeFile(
+        authPath,
+        JSON.stringify({
+          version: 1,
+          profiles: {
+            "anth:oauth": { type: "token", provider: "anthropic", token: "tok-oauth" },
+            "anth:default": { type: "api_key", provider: "anthropic", key: "sk-test" },
+          },
+          order: { anthropic: ["anth:oauth", "anth:default"] },
+          usageStats: {
+            "anth:oauth": {
+              lastUsed: now - 10_000,
+              consecutiveErrors: 3,
+              cooldownUntil: now + 300_000,
+            },
+            "anth:default": { lastUsed: now - 5_000 },
+          },
+        }),
+        "utf-8",
+      );
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s1",
+        updatedAt: now - 5_000,
+        authProfileOverride: "anth:default",
+        authProfileOverrideSource: "auto",
+        authProfileOverrideCompactionCount: 0,
+      };
+      const sessionStore = { "agent:main:main": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "anthropic",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:main",
+        storePath: undefined,
+        isNewSession: false,
+      });
+
+      expect(resolved).toBe("anth:default");
+    });
+  });
 });

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -63,6 +63,7 @@ export async function resolveSessionAuthProfileOverride(params: {
   }
 
   const store = ensureAuthProfileStore(agentDir, { allowKeychainPrompt: false });
+
   const order = resolveAuthProfileOrder({ cfg, store, provider });
   let current = sessionEntry.authProfileOverride?.trim();
 
@@ -125,6 +126,11 @@ export async function resolveSessionAuthProfileOverride(params: {
     next = pickNextAvailable(current);
   } else if (!current || isProfileInCooldown(store, current)) {
     next = pickFirstAvailable();
+  } else if (source === "auto") {
+    const best = pickFirstAvailable();
+    if (best && order.indexOf(best) < order.indexOf(current)) {
+      next = best;
+    }
   }
 
   if (!next) {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,9 +1,11 @@
 import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
+import type { PluginHookBeforeAgentStartResult } from "../../plugins/types.js";
+import type { RunEmbeddedPiAgentParams } from "./run/params.js";
+import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import type { PluginHookBeforeAgentStartResult } from "../../plugins/types.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
@@ -55,13 +57,11 @@ import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
 import { resolveModel } from "./model.js";
 import { runEmbeddedAttempt } from "./run/attempt.js";
-import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import {
   truncateOversizedToolResultsInSession,
   sessionLikelyHasOversizedToolResults,
 } from "./tool-result-truncation.js";
-import type { EmbeddedPiAgentMeta, EmbeddedPiRunResult } from "./types.js";
 import { describeUnknownError } from "./utils.js";
 
 type ApiKeyInfo = ResolvedProviderAuth;
@@ -348,7 +348,11 @@ export async function runEmbeddedPiAgent(
         cfg: params.config,
         store: authStore,
         provider,
-        preferredProfile: preferredProfileId,
+        preferredProfile:
+          params.authProfileIdSource === "user" ||
+          (params.authProfileIdSource === undefined && preferredProfileId)
+            ? preferredProfileId
+            : undefined,
       });
       if (lockedProfileId && !profileOrder.includes(lockedProfileId)) {
         throw new Error(`Auth profile "${lockedProfileId}" is not configured for ${provider}.`);


### PR DESCRIPTION
## Summary

Two related bugs in auth profile rotation that cause auto-selected fallback profiles (e.g., API key) to be used instead of higher-priority profiles (e.g., OAuth) even when those profiles are available.

### Bug 1: preferredProfile passed for auto overrides (run.ts)

`resolveAuthProfileOrder()` received `preferredProfile: preferredProfileId` regardless of whether the source was `user` or `auto`. When set, `resolveAuthProfileOrder` moves the preferred profile to the front of the candidate list. This means an auto-selected `anthropic:default` (API key) gets front-of-queue treatment, bypassing OAuth profiles.

**Fix:** Only pass `preferredProfile` when the override source is `user`.

### Bug 2: No re-evaluation when higher-priority profiles exit cooldown (session-override.ts)

`resolveSessionAuthProfileOverride()` kept the current auto-selected profile as long as it wasn't in cooldown itself. It never checked whether a higher-priority profile had exited cooldown and become available again.

**Fix:** When the current auto-selected profile is not the highest-priority in the order, scan for any higher-priority profile that's now available.

### Tests

Added 2 new test cases to `session-override.test.ts`:
- Re-selects higher-priority profile when it exits cooldown
- Stays on current profile when higher-priority profiles are still in cooldown

Fixes #25510
Replaces #25534 (which had merge conflicts)