### PR TITLE
fix(gateway): reset additionalProperties on channels node after applying channel schemas

### DIFF
--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -119,4 +119,31 @@ describe("config schema", () => {
     expect(defaultsHint?.help).toContain("last");
     expect(listHint?.help).toContain("bluebubbles");
   });
+
+  it("resets channels additionalProperties after applying channel schemas", () => {
+    const res = buildConfigSchema({
+      channels: [
+        {
+          id: "matrix",
+          label: "Matrix",
+          configSchema: {
+            type: "object",
+            properties: {
+              accessToken: { type: "string" },
+            },
+          },
+        },
+      ],
+    });
+
+    const schema = res.schema as {
+      properties?: Record<string, { additionalProperties?: unknown }>;
+    };
+    const channelsNode = schema.properties?.channels;
+    // stripChannelSchema sets additionalProperties = true so the base schema
+    // accepts any channel key.  applyChannelSchemas must reset it to false
+    // after merging concrete per-channel properties, otherwise the Control UI
+    // config-form analyzer flags the entire channels node as unsupported.
+    expect(channelsNode?.additionalProperties).toBe(false);
+  });
 });

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -293,6 +293,13 @@ function applyChannelSchemas(schema: ConfigSchema, channels: ChannelUiMetadata[]
     }
   }
 
+  // Once concrete per-channel properties are merged, close the object so
+  // the Control UI config-form analyzer can enumerate the properties
+  // instead of flagging the node as "unsupported" (additionalProperties was
+  // set to true by stripChannelSchema to accept any channel key before
+  // individual channel schemas were known).
+  channelsNode.additionalProperties = false;
+
   return next;
 }
 


### PR DESCRIPTION
## Summary

`stripChannelSchema()` sets `channels.additionalProperties = true` so the base schema
accepts any channel key before concrete channel plugins are known. `applyChannelSchemas()`
then merges per-channel property schemas back in — but never resets `additionalProperties`
to `false`. The result: the UI receives a channels object that has both explicit typed
properties AND `additionalProperties: true`, which the config form analyzer
(`config-form.analyze.ts` line ~81) flags as unsupported.

This one-line fix resets `additionalProperties = false` after channel schemas are applied,
since the node's properties now fully describe the registered channels.

## Relationship to existing work

This addresses the **gateway-side** root cause of #1749, which is distinct from the
**UI-side** improvements in #22809 and #29899:

| Aspect | This PR | #22809 | #29899 |
|--------|---------|--------|--------|
| Layer | Gateway (`schema.ts`) | UI (`config-form.analyze.ts`) | UI (`config-form.analyze.ts`) |
| Scope | Channels top-level node | Child→parent propagation | Complex unions + empty objects |
| Change size | 1 line + test | ~100 lines | ~200 lines |
| Conflict risk | None with #22809/#29899 | None with this PR | None with this PR |

These fixes are **complementary**:
- This PR fixes the top-level channels form rendering (the `additionalProperties: true` trigger)
- #22809 fixes nested accounts sections (child unsupported paths collapsing to parents)
- #29899 fixes complex union schemas (anyOf/oneOf with mixed types)

All three can land independently in any order.

## Test plan

- [x] Existing schema tests pass (`vitest run src/config/schema.test.ts` — 6/6 pass)
- [x] Broader config schema tests pass (48/48 across 4 test files)
- [x] New regression test verifies `additionalProperties` is `false` after `applyChannelSchemas`
- [x] Live verification: Control UI channels tab receives `additionalProperties: false` with
      concrete channel properties enumerated
- [ ] Manually adding an unknown channel key to config doesn't appear in the form
      (correct — it's not a registered plugin)
- [ ] Config save round-trips correctly (no fields lost)