### PR TITLE
fix(telegram): inline model fallback notice in reply (AI-assisted)

### DIFF
--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -461,7 +461,11 @@ export async function runWithModelFallback<T>(params: {
       // throw, rethrow it immediately rather than trying a different model
       // that may have a smaller context window and fail worse.
       const errMessage = err instanceof Error ? err.message : String(err);
-      if (isLikelyContextOverflowError(errMessage)) {
+      const isSessionLimit =
+        /session limit|too many sessions|max(?:imum)? number of .*sessions|active sessions/i.test(
+          errMessage,
+        );
+      if (isLikelyContextOverflowError(errMessage) && !isSessionLimit) {
         throw err;
       }
       const normalized =

--- a/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.test.ts
@@ -738,6 +738,128 @@ describe("runReplyAgent typing (heartbeat)", () => {
     }
   });
 
+  it("inlines model fallback notice for Telegram when verbose is off", async () => {
+    const sessionEntry: SessionEntry = {
+      sessionId: "session",
+      updatedAt: Date.now(),
+    };
+    const sessionStore = { main: sessionEntry };
+
+    state.runEmbeddedPiAgentMock.mockResolvedValue({
+      payloads: [{ text: "final" }],
+      meta: {},
+    });
+
+    const fallbackSpy = vi
+      .spyOn(modelFallbackModule, "runWithModelFallback")
+      .mockImplementation(
+        async ({ run }: { run: (provider: string, model: string) => Promise<unknown> }) => ({
+          result: await run("deepinfra", "moonshotai/Kimi-K2.5"),
+          provider: "deepinfra",
+          model: "moonshotai/Kimi-K2.5",
+          attempts: [
+            {
+              provider: "fireworks",
+              model: "fireworks/minimax-m2p5",
+              error: "Provider fireworks is in cooldown (all profiles unavailable)",
+              reason: "rate_limit",
+            },
+          ],
+        }),
+      );
+
+    try {
+      const typing = createMockTypingController();
+      const sessionCtx = {
+        Provider: "telegram",
+        MessageSid: "msg",
+      } as unknown as TemplateContext;
+      const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+      const followupRun = {
+        prompt: "hello",
+        summaryLine: "hello",
+        enqueuedAt: Date.now(),
+        run: {
+          sessionId: "session",
+          sessionKey: "main",
+          messageProvider: "telegram",
+          sessionFile: "/tmp/session.jsonl",
+          workspaceDir: "/tmp",
+          config: {},
+          skillsSnapshot: {},
+          provider: "anthropic",
+          model: "claude",
+          thinkLevel: "low",
+          verboseLevel: "off",
+          elevatedLevel: "off",
+          bashElevated: {
+            enabled: false,
+            allowed: false,
+            defaultLevel: "off",
+          },
+          timeoutMs: 1_000,
+          blockReplyBreak: "message_end",
+        },
+      } as unknown as FollowupRun;
+
+      const runReplyAgent = await getRunReplyAgent();
+      const first = await runReplyAgent({
+        commandBody: "hello",
+        followupRun,
+        queueKey: "main",
+        resolvedQueue,
+        shouldSteer: false,
+        shouldFollowup: false,
+        isActive: false,
+        isStreaming: false,
+        typing,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        sessionCtx,
+        defaultModel: "anthropic/claude-opus-4-5",
+        resolvedVerboseLevel: "off",
+        isNewSession: false,
+        blockStreamingEnabled: false,
+        resolvedBlockStreamingBreak: "message_end",
+        shouldInjectGroupIntro: false,
+        typingMode: "instant",
+      });
+      const second = await runReplyAgent({
+        commandBody: "hello",
+        followupRun,
+        queueKey: "main",
+        resolvedQueue,
+        shouldSteer: false,
+        shouldFollowup: false,
+        isActive: false,
+        isStreaming: false,
+        typing,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        sessionCtx,
+        defaultModel: "anthropic/claude-opus-4-5",
+        resolvedVerboseLevel: "off",
+        isNewSession: false,
+        blockStreamingEnabled: false,
+        resolvedBlockStreamingBreak: "message_end",
+        shouldInjectGroupIntro: false,
+        typingMode: "instant",
+      });
+
+      const firstText = Array.isArray(first) ? first[0]?.text : first?.text;
+      const secondText = Array.isArray(second) ? second[0]?.text : second?.text;
+
+      expect(firstText).toContain("Model Fallback:");
+      expect(firstText).toContain("deepinfra/moonshotai/Kimi-K2.5");
+      expect(firstText).toContain("final");
+      expect(secondText).not.toContain("Model Fallback:");
+    } finally {
+      fallbackSpy.mockRestore();
+    }
+  });
+
   it("announces model fallback only once per active fallback state", async () => {
     const sessionEntry: SessionEntry = {
       sessionId: "session",

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -636,17 +636,38 @@ export async function runReplyAgent(params: {
           attempts: fallbackAttempts,
         },
       });
+      const fallbackNotice = buildFallbackNotice({
+        selectedProvider,
+        selectedModel,
+        activeProvider: providerUsed,
+        activeModel: modelUsed,
+        attempts: fallbackAttempts,
+      });
+
       if (verboseEnabled) {
-        const fallbackNotice = buildFallbackNotice({
-          selectedProvider,
-          selectedModel,
-          activeProvider: providerUsed,
-          activeModel: modelUsed,
-          attempts: fallbackAttempts,
-        });
         if (fallbackNotice) {
           verboseNotices.push({ text: fallbackNotice });
         }
+      } else if (!isHeartbeat && replyToChannel === "telegram" && fallbackNotice) {
+        // Less-chatty: inline the fallback notice into the eventual reply (Telegram) rather than
+        // sending a separate operational message.
+        const nextPayloads = [...finalPayloads];
+        const idx = nextPayloads.findIndex(
+          (p) => typeof p.text === "string" && p.text.trim().length > 0,
+        );
+        if (idx >= 0) {
+          const existing = nextPayloads[idx]?.text ?? "";
+          nextPayloads[idx] = {
+            ...nextPayloads[idx],
+            text: `${fallbackNotice}
+
+${existing}`,
+          };
+        } else {
+          // Media-only replies: fall back to a standalone notice payload.
+          nextPayloads.unshift({ text: fallbackNotice });
+        }
+        finalPayloads = nextPayloads;
       }
     }
     if (fallbackTransition.fallbackCleared) {


### PR DESCRIPTION
Summary
- Less-chatty model fallback UX for Telegram: when verbose is off and a fallback occurs, prepend the fallback notice into the eventual reply instead of emitting a separate operational message.
- Also treat session-limit-looking errors as non-context-overflow so model fallbacks can still be attempted.

Testing
- Lightly tested: `npx -y pnpm@10.23.0 -C /storage/share/projects/OpenClaw exec vitest run --config vitest.unit.config.ts src/auto-reply/reply/agent-runner.runreplyagent.test.ts`

AI assistance
- AI-assisted change.
- I understand the changes and verified via unit tests above.

Co-Authored-By: Oz <oz-agent@warp.dev>