### PR TITLE
Disable tool calls for Ollama provider

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -384,9 +384,12 @@ export async function compactEmbeddedPiSessionDirect(
       modelContextWindowTokens: model.contextWindow,
       modelAuthMode: resolveModelAuthMode(model.provider, params.config),
     });
-    const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider });
-    const allowedToolNames = collectAllowedToolNames({ tools });
-    logToolSchemasForGoogle({ tools, provider });
+    const disableTools = provider.trim().toLowerCase() === "ollama";
+    const tools = disableTools ? [] : sanitizeToolsForGoogle({ tools: toolsRaw, provider });
+    const allowedToolNames = disableTools ? [] : collectAllowedToolNames({ tools });
+    if (!disableTools) {
+      logToolSchemasForGoogle({ tools, provider });
+    }
     const machineName = await getMachineDisplayName();
     const runtimeChannel = normalizeMessageChannel(params.messageChannel ?? params.messageProvider);
     let runtimeCapabilities = runtimeChannel

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -585,12 +585,19 @@ export async function runEmbeddedAttempt(
             params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
           disableMessageTool: params.disableMessageTool,
         });
-    const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider: params.provider });
-    const allowedToolNames = collectAllowedToolNames({
-      tools,
-      clientTools: params.clientTools,
-    });
-    logToolSchemasForGoogle({ tools, provider: params.provider });
+    const disableTools = (params.provider ?? "").trim().toLowerCase() === "ollama";
+    const tools = disableTools
+      ? []
+      : sanitizeToolsForGoogle({ tools: toolsRaw, provider: params.provider });
+    const allowedToolNames = disableTools
+      ? new Set<string>()
+      : collectAllowedToolNames({
+          tools,
+          clientTools: params.clientTools,
+        });
+    if (!disableTools) {
+      logToolSchemasForGoogle({ tools, provider: params.provider });
+    }
 
     const machineName = await getMachineDisplayName();
     const runtimeChannel = normalizeMessageChannel(params.messageChannel ?? params.messageProvider);


### PR DESCRIPTION
## Summary
- Ollama models return `400 … does not support tools` whenever we send tool payloads.
- Short-circuit tool generation/logging in `pi-embedded-runner` when `provider === 'ollama'`, so Ollama sessions stay text-only.

## Testing
- Built OpenClaw locally (`npm run build`, `npm install -g .`).
- Verified Local Phi (Ollama) in webchat responds without the 400 error and still handles normal prompts.