### PR TITLE
fix: persist relative sessionFile paths instead of absolute

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import { lookupContextTokens } from "../../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
@@ -312,7 +313,9 @@ export async function runReplyAgent(params: {
       agentId,
       sessionCtx.MessageThreadId,
     );
-    nextEntry.sessionFile = nextSessionFile;
+    // Store only the filename — absolute paths in persisted entries break
+    // cross-agent path validation on restart (see #16090).
+    nextEntry.sessionFile = path.basename(nextSessionFile);
     activeSessionStore[sessionKey] = nextEntry;
     try {
       await updateSessionStore(storePath, (store) => {

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -521,7 +521,7 @@ export async function initSessionState(params: {
       if (forked) {
         sessionId = forked.sessionId;
         sessionEntry.sessionId = forked.sessionId;
-        sessionEntry.sessionFile = forked.sessionFile;
+        sessionEntry.sessionFile = path.basename(forked.sessionFile);
         sessionEntry.forkedFromParent = true;
         log.warn(`forked session created: file=${forked.sessionFile}`);
       }

--- a/src/config/sessions/session-file.ts
+++ b/src/config/sessions/session-file.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { resolveSessionFilePath } from "./paths.js";
 import { updateSessionStore } from "./store.js";
 import type { SessionEntry } from "./types.js";
@@ -25,13 +26,17 @@ export async function resolveAndPersistSessionFile(params: {
     agentId: params.agentId,
     sessionsDir: params.sessionsDir,
   });
+  // Persist only the filename (not the absolute path) so that session entries
+  // remain portable across agents and survive path-validation on restart.
+  // resolveSessionFilePath() reconstructs the full path from the filename + agentId.
+  const persistedSessionFile = path.basename(sessionFile);
   const persistedEntry: SessionEntry = {
     ...baseEntry,
     sessionId,
     updatedAt: Date.now(),
-    sessionFile,
+    sessionFile: persistedSessionFile,
   };
-  if (baseEntry.sessionId !== sessionId || baseEntry.sessionFile !== sessionFile) {
+  if (baseEntry.sessionId !== sessionId || baseEntry.sessionFile !== persistedSessionFile) {
     sessionStore[sessionKey] = persistedEntry;
     await updateSessionStore(
       storePath,


### PR DESCRIPTION
## Problem

Session entries in `sessions.json` store absolute paths in the `sessionFile` field (e.g. `/home/user/.openclaw/agents/my-agent/sessions/uuid.jsonl`). On restart, `resolvePathWithinSessionsDir` rejects these when the resolving agent's sessions directory differs from the stored absolute path, producing:

```
Session file path must be within sessions directory
```

This breaks **all non-main agent bindings** (Discord, Slack, BlueBubbles, etc.) — messages come in but never get routed to a reply.

Related to #16090 (closed as stale). The original `agentId` pass-through was fixed, but the persistence layer still stores the full absolute paths returned by `resolveSessionTranscriptPath()`.

## Root Cause

`resolveSessionTranscriptPath()` returns absolute paths (via `resolvePathWithinSessionsDir` → `path.resolve()`). These get stored directly into `sessionEntry.sessionFile` and persisted to `sessions.json`. On restart, the path validator rejects them because they don't resolve relative to the expected sessions directory.

## Fix

Use `path.basename()` when writing `sessionFile` to session entries. `resolveSessionFilePath()` already reconstructs the full path from a relative filename + `agentId`/`sessionsDir`, so only the filename is needed for persistence.

**Three sites fixed:**
- `src/config/sessions/session-file.ts` — `resolveAndPersistSessionFile()`: main persistence path
- `src/auto-reply/reply/agent-runner.ts` — session reset after failure
- `src/auto-reply/reply/session.ts` — forked session from parent

## Reproduction

1. Configure a non-main agent (e.g. `discord-opus`) with bindings to Discord/Slack
2. Use the system normally — sessions accumulate
3. Reboot or restart the gateway
4. Non-main agent stops responding to all bound channels
5. `sessions.json` contains absolute `sessionFile` paths
6. Gateway log shows `Session file path must be within sessions directory`

**Workaround (current):** Convert absolute paths to basenames in sessions.json and restart:
```bash
cd ~/.openclaw/agents
for f in */sessions/sessions.json; do
  python3 -c "import json,os;d=json.load(open('$f'));c=0
for v in d.values():
 if 'sessionFile' in v and os.path.isabs(v['sessionFile']):v['sessionFile']=os.path.basename(v['sessionFile']);c+=1
if c:json.dump(d,open('$f','w'),indent=2);print(f'Fixed {c} in $f')"
done
```

## Version

`2026.2.24` on macOS 26.3 (Apple Silicon)