### PR TITLE
fix(bluebubbles): add staleness gate and GUID dedup for inbound messages

### DIFF
--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -82,6 +82,10 @@ const DEDUP_GUID_CACHE_MAX = 5000;
 const DEDUP_GUID_TTL_MS = 30 * 60 * 1000; // 30 minutes
 const _dedupGuidCache = new Map<string, number>();
 
+export function _resetBlueBubblesInboundDedupStateForTest(): void {
+  _dedupGuidCache.clear();
+}
+
 function _isStaleMessage(timestamp: number | undefined): boolean {
   if (typeof timestamp !== "number" || timestamp <= 0) return false;
   const age = Date.now() - timestamp;

--- a/extensions/bluebubbles/src/monitor-processing.ts
+++ b/extensions/bluebubbles/src/monitor-processing.ts
@@ -74,6 +74,34 @@ const invalidAckReactions = new Set<string>();
 const REPLY_DIRECTIVE_TAG_RE = /\[\[\s*(?:reply_to_current|reply_to\s*:\s*[^\]\n]+)\s*\]\]/gi;
 const PENDING_OUTBOUND_MESSAGE_ID_TTL_MS = 2 * 60 * 1000;
 
+// ── Staleness gate & GUID dedup (#19176, #12053) ──
+// BlueBubbles MessagePoller uses a 1-week lookback window and can re-fire
+// old messages as webhook events after restarts or reconnections.
+const STALE_MESSAGE_MAX_AGE_MS = 5 * 60 * 1000; // 5 minutes
+const DEDUP_GUID_CACHE_MAX = 5000;
+const DEDUP_GUID_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const _dedupGuidCache = new Map<string, number>();
+
+function _isStaleMessage(timestamp: number | undefined): boolean {
+  if (typeof timestamp !== "number" || timestamp <= 0) return false;
+  const age = Date.now() - timestamp;
+  return age > STALE_MESSAGE_MAX_AGE_MS;
+}
+
+function _isDuplicateGuid(guid: string | undefined): boolean {
+  if (!guid) return false;
+  const now = Date.now();
+  if (_dedupGuidCache.size > DEDUP_GUID_CACHE_MAX) {
+    for (const [k, v] of _dedupGuidCache) {
+      if (now - v > DEDUP_GUID_TTL_MS) _dedupGuidCache.delete(k);
+    }
+  }
+  if (_dedupGuidCache.has(guid)) return true;
+  _dedupGuidCache.set(guid, now);
+  return false;
+}
+// ── End staleness gate & GUID dedup ──
+
 type PendingOutboundMessageId = {
   id: number;
   accountId: string;
@@ -586,6 +614,22 @@ export async function processMessage(
   target: WebhookTarget,
 ): Promise<void> {
   const { account, config, runtime, core, statusSink } = target;
+
+  // ── Staleness gate: drop messages older than 5 minutes (#19176) ──
+  if (_isStaleMessage(message.timestamp)) {
+    logVerbose(
+      core,
+      runtime,
+      `drop: stale message age=${Math.round((Date.now() - (message.timestamp ?? 0)) / 1000)}s sender=${message.senderId} guid=${message.messageId ?? "?"}`,
+    );
+    return;
+  }
+  // ── GUID dedup: drop already-seen message GUIDs (#12053) ──
+  if (_isDuplicateGuid(message.messageId)) {
+    logVerbose(core, runtime, `drop: duplicate guid=${message.messageId} sender=${message.senderId}`);
+    return;
+  }
+
   const pairing = createChannelPairingController({
     core,
     channel: "bluebubbles",

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -3,7 +3,12 @@ import { safeEqualSecret } from "openclaw/plugin-sdk/browser-security-runtime";
 import { isPrivateNetworkOptInEnabled } from "openclaw/plugin-sdk/ssrf-runtime";
 import { createBlueBubblesDebounceRegistry } from "./monitor-debounce.js";
 import { normalizeWebhookMessage, normalizeWebhookReaction } from "./monitor-normalize.js";
-import { logVerbose, processMessage, processReaction } from "./monitor-processing.js";
+import {
+  _resetBlueBubblesInboundDedupStateForTest,
+  logVerbose,
+  processMessage,
+  processReaction,
+} from "./monitor-processing.js";
 import {
   _resetBlueBubblesShortIdState,
   resolveBlueBubblesMessageId,
@@ -366,4 +371,9 @@ export async function monitorBlueBubblesProvider(
   });
 }
 
-export { _resetBlueBubblesShortIdState, resolveBlueBubblesMessageId, resolveWebhookPathFromConfig };
+export {
+  _resetBlueBubblesInboundDedupStateForTest,
+  _resetBlueBubblesShortIdState,
+  resolveBlueBubblesMessageId,
+  resolveWebhookPathFromConfig,
+};

--- a/extensions/bluebubbles/src/test-support/monitor-test-support.ts
+++ b/extensions/bluebubbles/src/test-support/monitor-test-support.ts
@@ -2,6 +2,7 @@ import type { HistoryEntry, PluginRuntime } from "openclaw/plugin-sdk/bluebubble
 import { vi } from "vitest";
 import { createPluginRuntimeMock } from "../../../../test/helpers/plugins/plugin-runtime-mock.js";
 import {
+  _resetBlueBubblesInboundDedupStateForTest,
   _resetBlueBubblesShortIdState,
   clearBlueBubblesWebhookSecurityStateForTest,
 } from "../monitor.js";
@@ -117,6 +118,7 @@ export function resetBlueBubblesMonitorTestState(params: {
   extraReset?: () => void;
 }) {
   vi.clearAllMocks();
+  _resetBlueBubblesInboundDedupStateForTest();
   _resetBlueBubblesShortIdState();
   clearBlueBubblesWebhookSecurityStateForTest();
   params.extraReset?.();


### PR DESCRIPTION
## Summary

BlueBubbles MessagePoller uses a 1-week lookback window and can re-fire old messages as webhook events after server restarts or reconnections. OpenClaw currently has no protection against this, causing duplicate message processing and confusing replies to stale messages.

This PR adds two guards at the top of `processMessage()` in the BlueBubbles extension:

- **Staleness check**: drop inbound messages with timestamps older than 5 minutes
- **GUID dedup**: track recently processed message GUIDs in a TTL'd Map (30 min TTL, 5K entry cap) and drop duplicates

Both guards run before any other processing and log dropped messages via `logVerbose`.

## Context

- Issue #19176 requests a `maxMessageAge` filter for stale re-delivered webhooks
- Issue #12053 (closed) described the same problem with a real incident: 11x duplicate intro messages sent to a contact after BlueBubbles replayed 17-hour-old webhooks
- We've been running this exact patch in production on macOS 26 (Tahoe) since 2026-03-02 with no issues

## Design decisions

- **Hardcoded 5-min threshold** rather than configurable `maxMessageAgeSec` — simpler, and 5 minutes is generous enough for any legitimate delivery delay. A configurable option could be added later if needed.
- **GUID dedup is in-memory** — resets on gateway restart, but that's acceptable since the staleness gate catches old replays regardless. The dedup primarily protects against rapid duplicate webhook deliveries within a session.
- **Guards before `fromMe` check** — stale/duplicate `fromMe` messages should also be dropped to avoid unnecessary cache operations.

## Test plan

- [x] Tested on macOS 26.3 (Apple Silicon) with BlueBubbles Server
- [x] Gateway starts without TypeScript errors (Node.js 25.6.1 strip mode)
- [x] Normal messages are processed correctly
- [x] Stale messages (>5 min old) are dropped with verbose log
- [x] Duplicate GUIDs are dropped with verbose log
- [ ] Maintainer review

Fixes #19176
Ref #12053

🤖 Generated with [Claude Code](https://claude.com/claude-code)