### PR TITLE
feat(bedrock): add cost metadata support to bedrockDiscovery config

### DIFF
--- a/src/agents/bedrock-discovery.test.ts
+++ b/src/agents/bedrock-discovery.test.ts
@@ -139,4 +139,129 @@ describe("bedrock discovery", () => {
     });
     expect(sendMock).toHaveBeenCalledTimes(2);
   });
+
+  describe("cost metadata (bedrockDiscovery.costs)", () => {
+    it("defaults to zero cost when no costs config is provided", async () => {
+      const { discoverBedrockModels } = await loadDiscovery();
+      mockSingleActiveSummary();
+
+      const models = await discoverBedrockModels({ region: "us-east-1", clientFactory });
+      expect(models[0]?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+    });
+
+    it("applies cost override for a matching model ID", async () => {
+      const { discoverBedrockModels } = await loadDiscovery();
+      mockSingleActiveSummary();
+
+      const models = await discoverBedrockModels({
+        region: "us-east-1",
+        config: {
+          costs: {
+            "anthropic.claude-3-7-sonnet-20250219-v1:0": {
+              input: 3,
+              output: 15,
+              cacheRead: 0.3,
+              cacheWrite: 3.75,
+            },
+          },
+        },
+        clientFactory,
+      });
+
+      expect(models[0]?.cost).toEqual({ input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 });
+    });
+
+    it("uses zero cost for a model not present in the costs map", async () => {
+      const { discoverBedrockModels } = await loadDiscovery();
+      mockSingleActiveSummary();
+
+      const models = await discoverBedrockModels({
+        region: "us-east-1",
+        config: {
+          costs: {
+            "some.other.model-id": { input: 1, output: 5 },
+          },
+        },
+        clientFactory,
+      });
+
+      expect(models[0]?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+    });
+
+    it("fills missing cost fields with zero when only partial cost override is given", async () => {
+      const { discoverBedrockModels } = await loadDiscovery();
+      mockSingleActiveSummary();
+
+      const models = await discoverBedrockModels({
+        region: "us-east-1",
+        config: {
+          costs: {
+            "anthropic.claude-3-7-sonnet-20250219-v1:0": { input: 3, output: 15 },
+          },
+        },
+        clientFactory,
+      });
+
+      expect(models[0]?.cost).toEqual({ input: 3, output: 15, cacheRead: 0, cacheWrite: 0 });
+    });
+
+    it("applies cost overrides to multiple discovered models independently", async () => {
+      const { discoverBedrockModels } = await loadDiscovery();
+
+      sendMock.mockResolvedValueOnce({
+        modelSummaries: [
+          baseActiveAnthropicSummary,
+          {
+            modelId: "anthropic.claude-3-haiku-20240307-v1:0",
+            modelName: "Claude 3 Haiku",
+            providerName: "anthropic",
+            inputModalities: ["TEXT"],
+            outputModalities: ["TEXT"],
+            responseStreamingSupported: true,
+            modelLifecycle: { status: "ACTIVE" },
+          },
+        ],
+      });
+
+      const models = await discoverBedrockModels({
+        region: "us-east-1",
+        config: {
+          costs: {
+            "anthropic.claude-3-7-sonnet-20250219-v1:0": { input: 3, output: 15 },
+            "anthropic.claude-3-haiku-20240307-v1:0": { input: 0.25, output: 1.25 },
+          },
+        },
+        clientFactory,
+      });
+
+      const sonnet = models.find((m) => m.id === "anthropic.claude-3-7-sonnet-20250219-v1:0");
+      const haiku = models.find((m) => m.id === "anthropic.claude-3-haiku-20240307-v1:0");
+
+      expect(sonnet?.cost).toEqual({ input: 3, output: 15, cacheRead: 0, cacheWrite: 0 });
+      expect(haiku?.cost).toEqual({ input: 0.25, output: 1.25, cacheRead: 0, cacheWrite: 0 });
+    });
+
+    it("treats different costs maps as different cache keys", async () => {
+      const { discoverBedrockModels, resetBedrockDiscoveryCacheForTest } = await loadDiscovery();
+      resetBedrockDiscoveryCacheForTest();
+
+      sendMock
+        .mockResolvedValueOnce({ modelSummaries: [baseActiveAnthropicSummary] })
+        .mockResolvedValueOnce({ modelSummaries: [baseActiveAnthropicSummary] });
+
+      await discoverBedrockModels({
+        region: "us-east-1",
+        config: { costs: { "anthropic.claude-3-7-sonnet-20250219-v1:0": { input: 3 } } },
+        clientFactory,
+      });
+      await discoverBedrockModels({
+        region: "us-east-1",
+        config: { costs: { "anthropic.claude-3-7-sonnet-20250219-v1:0": { input: 5 } } },
+        clientFactory,
+      });
+
+      // Different costs = different cache keys = two separate API calls
+      expect(sendMock).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/src/agents/bedrock-discovery.ts
+++ b/src/agents/bedrock-discovery.ts
@@ -39,12 +39,22 @@ function normalizeProviderFilter(filter?: string[]): string[] {
   return Array.from(normalized).toSorted();
 }
 
+function normalizeCostsKey(costs?: Record<string, unknown>): string {
+  if (!costs || Object.keys(costs).length === 0) {
+    return "";
+  }
+  // Sort top-level model IDs for a stable, deterministic key
+  const sortedEntries = Object.entries(costs).toSorted(([a], [b]) => a.localeCompare(b));
+  return JSON.stringify(sortedEntries);
+}
+
 function buildCacheKey(params: {
   region: string;
   providerFilter: string[];
   refreshIntervalSeconds: number;
   defaultContextWindow: number;
   defaultMaxTokens: number;
+  costsKey: string;
 }): string {
   return JSON.stringify(params);
 }
@@ -124,9 +134,29 @@ function shouldIncludeSummary(summary: BedrockModelSummary, filter: string[]): b
   return true;
 }
 
+function resolveCostForModel(
+  modelId: string,
+  costs?: BedrockDiscoveryConfig["costs"],
+): typeof DEFAULT_COST {
+  if (!costs) {
+    return DEFAULT_COST;
+  }
+  const override = costs[modelId];
+  if (!override) {
+    return DEFAULT_COST;
+  }
+  return {
+    input: override.input ?? DEFAULT_COST.input,
+    output: override.output ?? DEFAULT_COST.output,
+    cacheRead: override.cacheRead ?? DEFAULT_COST.cacheRead,
+    cacheWrite: override.cacheWrite ?? DEFAULT_COST.cacheWrite,
+  };
+}
+
 function toModelDefinition(
   summary: BedrockModelSummary,
   defaults: { contextWindow: number; maxTokens: number },
+  costs?: BedrockDiscoveryConfig["costs"],
 ): ModelDefinitionConfig {
   const id = summary.modelId?.trim() ?? "";
   return {
@@ -134,7 +164,7 @@ function toModelDefinition(
     name: summary.modelName?.trim() || id,
     reasoning: inferReasoningSupport(summary),
     input: mapInputModalities(summary),
-    cost: DEFAULT_COST,
+    cost: resolveCostForModel(id, costs),
     contextWindow: defaults.contextWindow,
     maxTokens: defaults.maxTokens,
   };
@@ -158,12 +188,14 @@ export async function discoverBedrockModels(params: {
   const providerFilter = normalizeProviderFilter(params.config?.providerFilter);
   const defaultContextWindow = resolveDefaultContextWindow(params.config);
   const defaultMaxTokens = resolveDefaultMaxTokens(params.config);
+  const costsKey = normalizeCostsKey(params.config?.costs);
   const cacheKey = buildCacheKey({
     region: params.region,
     providerFilter,
     refreshIntervalSeconds,
     defaultContextWindow,
     defaultMaxTokens,
+    costsKey,
   });
   const now = params.now?.() ?? Date.now();
 
@@ -188,10 +220,11 @@ export async function discoverBedrockModels(params: {
         continue;
       }
       discovered.push(
-        toModelDefinition(summary, {
-          contextWindow: defaultContextWindow,
-          maxTokens: defaultMaxTokens,
-        }),
+        toModelDefinition(
+          summary,
+          { contextWindow: defaultContextWindow, maxTokens: defaultMaxTokens },
+          params.config?.costs,
+        ),
       );
     }
     return discovered.toSorted((a, b) => a.name.localeCompare(b.name));

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -678,6 +678,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Fallback context-window value applied to discovered models when provider metadata lacks explicit limits. Use realistic defaults to avoid oversized prompts that exceed true provider constraints.",
   "models.bedrockDiscovery.defaultMaxTokens":
     "Fallback max-token value applied to discovered models without explicit output token limits. Use conservative defaults to reduce truncation surprises and unexpected token spend.",
+  "models.bedrockDiscovery.costs":
+    'Per-model cost overrides for auto-discovered Bedrock models, keyed by exact model ID (e.g. "us.anthropic.claude-sonnet-4-6"). Values are cost-per-million-tokens for input, output, cacheRead, and cacheWrite. Omitting a field defaults it to zero. This is a pure metadata overlay — it does not affect model selection or request routing.',
   auth: "Authentication profile root used for multi-profile provider credentials and cooldown-based failover ordering. Keep profiles minimal and explicit so automatic failover behavior stays auditable.",
   "channels.slack.allowBots":
     "Allow bot-authored messages to trigger Slack replies (default: false).",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -396,6 +396,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "models.bedrockDiscovery.refreshInterval": "Bedrock Discovery Refresh Interval (s)",
   "models.bedrockDiscovery.defaultContextWindow": "Bedrock Default Context Window",
   "models.bedrockDiscovery.defaultMaxTokens": "Bedrock Default Max Tokens",
+  "models.bedrockDiscovery.costs": "Bedrock Discovery Cost Overrides",
   "auth.cooldowns.billingBackoffHours": "Billing Backoff (hours)",
   "auth.cooldowns.billingBackoffHoursByProvider": "Billing Backoff Overrides",
   "auth.cooldowns.billingMaxHours": "Billing Backoff Cap (hours)",

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -58,6 +58,13 @@ export type ModelProviderConfig = {
   models: ModelDefinitionConfig[];
 };
 
+export type BedrockModelCostConfig = {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+};
+
 export type BedrockDiscoveryConfig = {
   enabled?: boolean;
   region?: string;
@@ -65,6 +72,8 @@ export type BedrockDiscoveryConfig = {
   refreshInterval?: number;
   defaultContextWindow?: number;
   defaultMaxTokens?: number;
+  /** Per-model cost overrides keyed by model ID (e.g. "us.anthropic.claude-sonnet-4-6"). */
+  costs?: Record<string, BedrockModelCostConfig>;
 };
 
 export type ModelsConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -239,6 +239,15 @@ export const ModelProviderSchema = z
   })
   .strict();
 
+export const BedrockModelCostSchema = z
+  .object({
+    input: z.number().nonnegative().optional(),
+    output: z.number().nonnegative().optional(),
+    cacheRead: z.number().nonnegative().optional(),
+    cacheWrite: z.number().nonnegative().optional(),
+  })
+  .strict();
+
 export const BedrockDiscoverySchema = z
   .object({
     enabled: z.boolean().optional(),
@@ -247,6 +256,7 @@ export const BedrockDiscoverySchema = z
     refreshInterval: z.number().int().nonnegative().optional(),
     defaultContextWindow: z.number().int().positive().optional(),
     defaultMaxTokens: z.number().int().positive().optional(),
+    costs: z.record(z.string().min(1), BedrockModelCostSchema).optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

Fixes #29100

Add a `costs` map to `models.bedrockDiscovery` config keyed by model ID, allowing users to attach per-token cost metadata to auto-discovered Bedrock models without requiring a duplicate explicit provider block.

## Problem

When using `models.bedrockDiscovery` (IAM role-based auto-discovery), there was no way to attach cost metadata (input, output, cacheRead, cacheWrite) to discovered models. Cost config only worked via explicit `models.providers.<provider>.models[]` entries, which conflicts with the auto-discovery pattern. As a result, `/status` and `/usage` showed token counts with no USD estimates for Bedrock users on IAM auth.

## Solution

Add a `costs` map to `models.bedrockDiscovery` keyed by model ID:

```json5
{
  models: {
    bedrockDiscovery: {
      enabled: true,
      costs: {
        "us.anthropic.claude-sonnet-4-6": { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
        "us.anthropic.claude-haiku-4-5-20251001-v1:0": { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.25 }
      }
    }
  }
}
```

This is a pure metadata overlay — no behavioral changes to model selection or request routing.

## Changes

- **`src/config/types.models.ts`**: Add `BedrockModelCostConfig` type; add `costs` field to `BedrockDiscoveryConfig`
- **`src/config/zod-schema.core.ts`**: Add `BedrockModelCostSchema` and `costs` field to `BedrockDiscoverySchema` (fields validated as nonnegative numbers)
- **`src/agents/bedrock-discovery.ts`**: 
  - `resolveCostForModel()` — applies per-model cost overrides with zero fallback for unspecified fields
  - `normalizeCostsKey()` — stable serialization of the costs map for cache key inclusion (so different cost configs produce independent cache entries)
  - Wire costs through `toModelDefinition()` and `discoverBedrockModels()`
- **`src/config/schema.labels.ts`**: Add UI label for `models.bedrockDiscovery.costs`
- **`src/config/schema.help.ts`**: Add help text for `models.bedrockDiscovery.costs`
- **`src/agents/bedrock-discovery.test.ts`**: Add 6 new tests for cost metadata

## Tests

All existing tests pass. New tests cover:
- Zero default when no costs config provided
- Full cost override applied for matching model ID
- Partial override (unspecified fields default to zero)
- Multiple models with independent cost overrides
- Models not in the costs map fall back to zero
- Different costs maps produce separate cache entries