### PR TITLE
feat: add {modelEmoji} and {thinkEmoji} template variables for responsePrefix

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1431,7 +1431,14 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
 ```json5
 {
   messages: {
-    responsePrefix: "🦞", // or "auto"
+    responsePrefix: "{modelEmoji}{thinkEmoji}", // or "🦞", or "auto", or "[{model} | think:{thinkingLevel}]"
+    modelEmojiMap: {
+      "claude-opus-4-6": "🧠",
+      "claude-sonnet-4-5": "🎵",
+      "gpt-5.3-codex": "🤖",
+      "kimi-k2.5": "🌙",
+    },
+    thinkEmoji: ["💭", ""], // [active, inactive]
     ackReaction: "👀",
     ackReactionScope: "group-mentions", // group-mentions | group-all | direct | all
     removeAckAfterReply: false,
@@ -1464,15 +1471,28 @@ Resolution (most specific wins): account → channel → global. `""` disables a
 
 **Template variables:**
 
-| Variable          | Description            | Example                     |
-| ----------------- | ---------------------- | --------------------------- |
-| `{model}`         | Short model name       | `claude-opus-4-6`           |
-| `{modelFull}`     | Full model identifier  | `anthropic/claude-opus-4-6` |
-| `{provider}`      | Provider name          | `anthropic`                 |
-| `{thinkingLevel}` | Current thinking level | `high`, `low`, `off`        |
-| `{identity.name}` | Agent identity name    | (same as `"auto"`)          |
+| Variable          | Description                       | Example                     |
+| ----------------- | --------------------------------- | --------------------------- |
+| `{model}`         | Short model name                  | `claude-opus-4-6`           |
+| `{modelFull}`     | Full model identifier             | `anthropic/claude-opus-4-6` |
+| `{provider}`      | Provider name                     | `anthropic`                 |
+| `{thinkingLevel}` | Current thinking level            | `high`, `low`, `off`        |
+| `{identity.name}` | Agent identity name               | (same as `"auto"`)          |
+| `{modelEmoji}`    | Emoji from `modelEmojiMap` lookup | `🧠`, `🎵`, `🤖`            |
+| `{thinkEmoji}`    | Emoji from `thinkEmoji` pair      | `💭` or `""`                |
 
 Variables are case-insensitive. `{think}` is an alias for `{thinkingLevel}`.
+
+### Model emoji map
+
+Maps model names, provider names, or substrings to emoji for the `{modelEmoji}` variable.
+
+Keys are matched case-insensitively in order: exact short model name → exact full model ID → exact provider → substring match. First match wins. If no match, `{modelEmoji}` resolves to empty string.
+
+### Think emoji pair
+
+A two-element array `[activeEmoji, inactiveEmoji]` for the `{thinkEmoji}` variable.
+When thinking is `"high"` or `"low"`, the first emoji is used. Otherwise the second (typically `""`).
 
 ### Ack reaction
 

--- a/src/agents/identity.ts
+++ b/src/agents/identity.ts
@@ -141,7 +141,12 @@ export function resolveEffectiveMessagesConfig(
     channel?: string;
     accountId?: string;
   },
-): { messagePrefix: string; responsePrefix?: string } {
+): {
+  messagePrefix: string;
+  responsePrefix?: string;
+  modelEmojiMap?: Record<string, string>;
+  thinkEmoji?: [string, string];
+} {
   return {
     messagePrefix: resolveMessagePrefix(cfg, agentId, {
       hasAllowFrom: opts?.hasAllowFrom,
@@ -151,6 +156,8 @@ export function resolveEffectiveMessagesConfig(
       channel: opts?.channel,
       accountId: opts?.accountId,
     }),
+    modelEmojiMap: cfg.messages?.modelEmojiMap,
+    thinkEmoji: cfg.messages?.thinkEmoji,
   };
 }
 

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -8,7 +8,9 @@ import { createReplyReferencePlanner } from "./reply-reference.js";
 import {
   extractShortModelName,
   hasTemplateVariables,
+  resolveModelEmoji,
   resolveResponsePrefixTemplate,
+  resolveThinkEmoji,
 } from "./response-prefix-template.js";
 import { createStreamingDirectiveAccumulator } from "./streaming-directives.js";
 import { createMockTypingController } from "./test-helpers.js";
@@ -789,5 +791,93 @@ describe("hasTemplateVariables", () => {
     expect(hasTemplateVariables("[{model}]")).toBe(true);
     expect(hasTemplateVariables("[{model}]")).toBe(true);
     expect(hasTemplateVariables("[Claude]")).toBe(false);
+  });
+});
+
+describe("resolveModelEmoji", () => {
+  const map = {
+    "claude-opus-4-6": "🧠",
+    "claude-sonnet-4-5": "🎵",
+    "gpt-5.3-codex": "🤖",
+    "kimi-k2.5": "🌙",
+    anthropic: "🦞",
+  };
+
+  it("matches exact short model name", () => {
+    expect(resolveModelEmoji(map, "claude-opus-4-6")).toBe("🧠");
+    expect(resolveModelEmoji(map, "gpt-5.3-codex")).toBe("🤖");
+  });
+
+  it("matches case-insensitively", () => {
+    expect(resolveModelEmoji(map, "Claude-Opus-4-6")).toBe("🧠");
+  });
+
+  it("matches provider name as fallback", () => {
+    expect(resolveModelEmoji(map, "claude-haiku-4-5", undefined, "anthropic")).toBe("🦞");
+  });
+
+  it("matches full model ID", () => {
+    const fullMap = { "anthropic/claude-opus-4-6": "🧬" };
+    expect(resolveModelEmoji(fullMap, "other", "anthropic/claude-opus-4-6")).toBe("🧬");
+  });
+
+  it("matches substring in model name", () => {
+    const subMap = { opus: "🧠" };
+    expect(resolveModelEmoji(subMap, "claude-opus-4-6")).toBe("🧠");
+  });
+
+  it("returns empty string for no match", () => {
+    expect(resolveModelEmoji(map, "unknown-model")).toBe("");
+  });
+
+  it("returns empty string for undefined/empty map", () => {
+    expect(resolveModelEmoji(undefined, "claude-opus-4-6")).toBe("");
+    expect(resolveModelEmoji({}, "claude-opus-4-6")).toBe("");
+  });
+});
+
+describe("resolveThinkEmoji", () => {
+  it("returns active emoji for high/low thinking", () => {
+    expect(resolveThinkEmoji(["💭", ""], "high")).toBe("💭");
+    expect(resolveThinkEmoji(["💭", ""], "low")).toBe("💭");
+  });
+
+  it("returns inactive emoji for off thinking", () => {
+    expect(resolveThinkEmoji(["💭", "💤"], "off")).toBe("💤");
+  });
+
+  it("returns inactive emoji for undefined thinking level", () => {
+    expect(resolveThinkEmoji(["💭", ""], undefined)).toBe("");
+  });
+
+  it("returns empty string for undefined/invalid pair", () => {
+    expect(resolveThinkEmoji(undefined, "high")).toBe("");
+  });
+});
+
+describe("resolveResponsePrefixTemplate with emoji variables", () => {
+  it("resolves {modelEmoji} and {thinkEmoji} from context", () => {
+    const result = resolveResponsePrefixTemplate("{modelEmoji}{thinkEmoji}", {
+      model: "claude-opus-4-6",
+      modelEmoji: "🧠",
+      thinkEmoji: "💭",
+    });
+    expect(result).toBe("🧠💭");
+  });
+
+  it("resolves {modelEmoji} to empty string when not set", () => {
+    const result = resolveResponsePrefixTemplate("{modelEmoji} hello", {
+      model: "claude-opus-4-6",
+    });
+    expect(result).toBe(" hello");
+  });
+
+  it("resolves mixed emoji and text variables", () => {
+    const result = resolveResponsePrefixTemplate("{modelEmoji} [{model}]{thinkEmoji}", {
+      model: "claude-opus-4-6",
+      modelEmoji: "🧠",
+      thinkEmoji: "💭",
+    });
+    expect(result).toBe("🧠 [claude-opus-4-6]💭");
   });
 });

--- a/src/auto-reply/reply/response-prefix-template.ts
+++ b/src/auto-reply/reply/response-prefix-template.ts
@@ -16,6 +16,10 @@ export type ResponsePrefixContext = {
   thinkingLevel?: string;
   /** Agent identity name */
   identityName?: string;
+  /** Resolved emoji from modelEmojiMap (pre-resolved by the caller) */
+  modelEmoji?: string;
+  /** Resolved thinking emoji (pre-resolved by the caller) */
+  thinkEmoji?: string;
 };
 
 // Regex pattern for template variables: {variableName} or {variable.name}
@@ -59,6 +63,10 @@ export function resolveResponsePrefixTemplate(
       case "identity.name":
       case "identityname":
         return context.identityName ?? match;
+      case "modelemoji":
+        return context.modelEmoji ?? "";
+      case "thinkemoji":
+        return context.thinkEmoji ?? "";
       default:
         // Leave unrecognized variables as-is
         return match;
@@ -86,6 +94,91 @@ export function extractShortModelName(fullModel: string): string {
 
   // Strip date suffixes (YYYYMMDD format)
   return modelPart.replace(/-\d{8}$/, "").replace(/-latest$/, "");
+}
+
+/**
+ * Resolve model emoji from a map by matching against model name, provider, alias, or partial match.
+ *
+ * Match order (first wins, case-insensitive):
+ * 1. Exact short model name (e.g., "claude-opus-4-6")
+ * 2. Full model ID (e.g., "anthropic/claude-opus-4-6")
+ * 3. Provider name (e.g., "anthropic")
+ * 4. Substring match on short model name (e.g., "opus" matches "claude-opus-4-6")
+ *
+ * @returns The matched emoji, or empty string if no match
+ */
+export function resolveModelEmoji(
+  map: Record<string, string> | undefined,
+  model?: string,
+  modelFull?: string,
+  provider?: string,
+): string {
+  if (!map || Object.keys(map).length === 0) {
+    return "";
+  }
+
+  // Build a lowercase lookup
+  const entries = Object.entries(map).map(([k, v]) => [k.toLowerCase(), v] as const);
+
+  const modelLower = model?.toLowerCase();
+  const modelFullLower = modelFull?.toLowerCase();
+  const providerLower = provider?.toLowerCase();
+
+  // 1. Exact short model name
+  if (modelLower) {
+    for (const [key, emoji] of entries) {
+      if (key === modelLower) {
+        return emoji;
+      }
+    }
+  }
+
+  // 2. Exact full model ID
+  if (modelFullLower) {
+    for (const [key, emoji] of entries) {
+      if (key === modelFullLower) {
+        return emoji;
+      }
+    }
+  }
+
+  // 3. Exact provider name
+  if (providerLower) {
+    for (const [key, emoji] of entries) {
+      if (key === providerLower) {
+        return emoji;
+      }
+    }
+  }
+
+  // 4. Substring match on model name (e.g., "opus" matches "claude-opus-4-6")
+  if (modelLower) {
+    for (const [key, emoji] of entries) {
+      if (modelLower.includes(key) || key.includes(modelLower)) {
+        return emoji;
+      }
+    }
+  }
+
+  return "";
+}
+
+/**
+ * Resolve thinking emoji from a pair based on current thinking level.
+ *
+ * @param pair - [activeEmoji, inactiveEmoji]
+ * @param thinkingLevel - Current thinking level ("high", "low", "off", etc.)
+ * @returns The appropriate emoji
+ */
+export function resolveThinkEmoji(
+  pair: [string, string] | undefined,
+  thinkingLevel?: string,
+): string {
+  if (!pair || pair.length < 2) {
+    return "";
+  }
+  const isActive = thinkingLevel === "high" || thinkingLevel === "low";
+  return isActive ? pair[0] : pair[1];
 }
 
 /**

--- a/src/channels/reply-prefix.ts
+++ b/src/channels/reply-prefix.ts
@@ -1,6 +1,8 @@
 import { resolveEffectiveMessagesConfig, resolveIdentityName } from "../agents/identity.js";
 import {
   extractShortModelName,
+  resolveModelEmoji,
+  resolveThinkEmoji,
   type ResponsePrefixContext,
 } from "../auto-reply/reply/response-prefix-template.js";
 import type { GetReplyOptions } from "../auto-reply/types.js";
@@ -31,20 +33,31 @@ export function createReplyPrefixContext(params: {
     identityName: resolveIdentityName(cfg, agentId),
   };
 
+  const effectiveMessages = resolveEffectiveMessagesConfig(cfg, agentId, {
+    channel: params.channel,
+    accountId: params.accountId,
+  });
+
   const onModelSelected = (ctx: ModelSelectionContext) => {
+    const shortModel = extractShortModelName(ctx.model);
+    const thinkLevel = ctx.thinkLevel ?? "off";
     // Mutate the object directly instead of reassigning to ensure closures see updates.
     prefixContext.provider = ctx.provider;
-    prefixContext.model = extractShortModelName(ctx.model);
+    prefixContext.model = shortModel;
     prefixContext.modelFull = `${ctx.provider}/${ctx.model}`;
-    prefixContext.thinkingLevel = ctx.thinkLevel ?? "off";
+    prefixContext.thinkingLevel = thinkLevel;
+    prefixContext.modelEmoji = resolveModelEmoji(
+      effectiveMessages.modelEmojiMap,
+      shortModel,
+      `${ctx.provider}/${ctx.model}`,
+      ctx.provider,
+    );
+    prefixContext.thinkEmoji = resolveThinkEmoji(effectiveMessages.thinkEmoji, thinkLevel);
   };
 
   return {
     prefixContext,
-    responsePrefix: resolveEffectiveMessagesConfig(cfg, agentId, {
-      channel: params.channel,
-      accountId: params.accountId,
-    }).responsePrefix,
+    responsePrefix: effectiveMessages.responsePrefix,
     responsePrefixContextProvider: () => prefixContext,
     onModelSelected,
   };

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -614,6 +614,8 @@ export const FIELD_LABELS: Record<string, string> = {
   messages: "Messages",
   "messages.messagePrefix": "Inbound Message Prefix",
   "messages.responsePrefix": "Outbound Response Prefix",
+  "messages.modelEmojiMap": "Model Emoji Map",
+  "messages.thinkEmoji": "Thinking Emoji Pair",
   "messages.groupChat": "Group Chat Rules",
   "messages.groupChat.mentionPatterns": "Group Mention Patterns",
   "messages.groupChat.historyLimit": "Group History Limit",

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -82,6 +82,8 @@ export type StatusReactionsConfig = {
   timing?: StatusReactionsTimingConfig;
 };
 
+export type ModelEmojiMap = Record<string, string>;
+
 export type MessagesConfig = {
   /** @deprecated Use `whatsapp.messagePrefix` (WhatsApp-only inbound prefix). */
   messagePrefix?: string;
@@ -97,14 +99,48 @@ export type MessagesConfig = {
    * - `{provider}` - provider name (e.g., `anthropic`, `openai`)
    * - `{thinkingLevel}` or `{think}` - current thinking level (`high`, `low`, `off`)
    * - `{identity.name}` or `{identityName}` - agent identity name
+   * - `{modelEmoji}` - emoji resolved from `modelEmojiMap` by matching model/provider/alias
+   * - `{thinkEmoji}` - emoji for thinking state: first entry when thinking is active, second when off
    *
-   * Example: `"[{model} | think:{thinkingLevel}]"` → `"[claude-opus-4-6 | think:high]"`
+   * Example: `"{modelEmoji}{thinkEmoji}"` → `"🧠💭"` (Opus with thinking on)
    *
    * Unresolved variables remain as literal text (e.g., `{model}` if context unavailable).
    *
    * Default: none
    */
   responsePrefix?: string;
+  /**
+   * Map model names, provider names, or aliases to emoji strings for `{modelEmoji}`.
+   *
+   * Keys are matched case-insensitively against (in order):
+   * 1. Short model name (e.g., `claude-opus-4-6`)
+   * 2. Provider name (e.g., `anthropic`)
+   * 3. Model alias (e.g., `opus`)
+   *
+   * First match wins. If no match, `{modelEmoji}` resolves to empty string.
+   *
+   * Example:
+   * ```json5
+   * {
+   *   "claude-opus-4-6": "🧠",
+   *   "claude-sonnet-4-5": "🎵",
+   *   "gpt-5.3-codex": "🤖",
+   *   "kimi-k2.5": "🌙",
+   * }
+   * ```
+   */
+  modelEmojiMap?: ModelEmojiMap;
+  /**
+   * Emoji pair for `{thinkEmoji}` — [active, inactive].
+   *
+   * When thinking level is "high" or "low", the first emoji is used.
+   * When thinking is "off" or unavailable, the second emoji is used (or empty string if not set).
+   *
+   * Example: `["💭", ""]` → shows 💭 when thinking, nothing when not.
+   *
+   * Default: none (variable resolves to empty string)
+   */
+  thinkEmoji?: [string, string];
   groupChat?: GroupChatConfig;
   queue?: QueueConfig;
   /** Debounce rapid inbound messages per sender (global + per-channel overrides). */

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -331,6 +331,8 @@ export const ReplyRuntimeConfigSchemaShape = {
   blockStreaming: z.boolean().optional(),
   blockStreamingCoalesce: BlockStreamingCoalesceSchema.optional(),
   responsePrefix: z.string().optional(),
+  modelEmojiMap: z.record(z.string(), z.string()).optional(),
+  thinkEmoji: z.tuple([z.string(), z.string()]).optional(),
   mediaMaxMb: z.number().positive().optional(),
 };
 

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -185,6 +185,8 @@ export const MessagesSchema = z
       .optional(),
     suppressToolErrors: z.boolean().optional(),
     tts: TtsConfigSchema,
+    modelEmojiMap: z.record(z.string(), z.string()).optional(),
+    thinkEmoji: z.tuple([z.string(), z.string()]).optional(),
   })
   .strict()
   .optional();


### PR DESCRIPTION
## Summary

Adds two new template variables for `responsePrefix`:

- **`{modelEmoji}`** — resolves from a configurable `modelEmojiMap` that maps model names, providers, or substrings to emoji strings
- **`{thinkEmoji}`** — resolves from a `thinkEmoji` `[active, inactive]` pair based on the current thinking level

## New config options

```json5
{
  messages: {
    responsePrefix: "{modelEmoji}{thinkEmoji}",
    modelEmojiMap: {
      "claude-opus-4-6": "🧠",
      "claude-sonnet-4-5": "🎵",
      "gpt-5.3-codex": "🤖",
      "kimi-k2.5": "🌙",
    },
    thinkEmoji: ["💭", ""],  // [active, inactive]
  },
}
```

**Result:** Opus+thinking → `🧠💭` · Codex → `🤖` · Sonnet → `🎵` · Kimi → `🌙`

## modelEmojiMap matching

Keys are matched case-insensitively in order (first match wins):
1. Exact short model name (e.g., `claude-opus-4-6`)
2. Exact full model ID (e.g., `anthropic/claude-opus-4-6`)
3. Exact provider name (e.g., `anthropic`)
4. Substring match on model name (e.g., `opus` matches `claude-opus-4-6`)

## Changes

- `src/auto-reply/reply/response-prefix-template.ts` — new `resolveModelEmoji()`, `resolveThinkEmoji()` helpers + `{modelEmoji}`/`{thinkEmoji}` in template resolution
- `src/channels/reply-prefix.ts` — wire up emoji resolution in `onModelSelected` callback
- `src/agents/identity.ts` — pass through `modelEmojiMap` and `thinkEmoji` from config
- `src/config/types.messages.ts` — new `ModelEmojiMap` type, `modelEmojiMap` + `thinkEmoji` on `MessagesConfig`
- `src/config/zod-schema.core.ts` — validation schema for new fields
- `src/config/schema.labels.ts` — UI labels
- `docs/gateway/configuration-reference.md` — docs for new variables + config
- `src/auto-reply/reply/reply-utils.test.ts` — 14 new test cases

## Testing

- All 47 tests in `reply-utils.test.ts` pass
- TypeScript typecheck clean (`tsc --noEmit`)
