### PR TITLE
fix(signal): ignore system messages (expiration timer, group permission changes)

### DIFF
--- a/extensions/signal/src/monitor/event-handler.system-messages.test.ts
+++ b/extensions/signal/src/monitor/event-handler.system-messages.test.ts
@@ -20,8 +20,8 @@ vi.mock("../send.js", () => ({
   sendReadReceiptSignal: sendReadReceiptMock,
 }));
 
-vi.mock("../../auto-reply/dispatch.js", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("../../auto-reply/dispatch.js")>();
+vi.mock("../../../../src/auto-reply/dispatch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../../src/auto-reply/dispatch.js")>();
   return {
     ...actual,
     dispatchInboundMessage: dispatchInboundMessageMock,
@@ -30,7 +30,7 @@ vi.mock("../../auto-reply/dispatch.js", async (importOriginal) => {
   };
 });
 
-vi.mock("../../pairing/pairing-store.js", () => ({
+vi.mock("../../../../src/pairing/pairing-store.js", () => ({
   readChannelAllowFromStore: vi.fn().mockResolvedValue([]),
   upsertChannelPairingRequest: vi.fn(),
 }));

--- a/extensions/signal/src/monitor/event-handler.system-messages.test.ts
+++ b/extensions/signal/src/monitor/event-handler.system-messages.test.ts
@@ -1,9 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createSignalEventHandler } from "./event-handler.js";
-import {
-  createBaseSignalEventHandlerDeps,
-  createSignalReceiveEvent,
-} from "./event-handler.test-harness.js";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { sendTypingMock, sendReadReceiptMock, dispatchInboundMessageMock } = vi.hoisted(() => ({
   sendTypingMock: vi.fn(),
@@ -35,6 +30,10 @@ vi.mock("../../../../src/pairing/pairing-store.js", () => ({
   upsertChannelPairingRequest: vi.fn(),
 }));
 
+let createSignalEventHandler: typeof import("./event-handler.js").createSignalEventHandler;
+let createBaseSignalEventHandlerDeps: typeof import("./event-handler.test-harness.js").createBaseSignalEventHandlerDeps;
+let createSignalReceiveEvent: typeof import("./event-handler.test-harness.js").createSignalReceiveEvent;
+
 function makeDeps() {
   return createBaseSignalEventHandlerDeps({
     // oxlint-disable-next-line typescript/no-explicit-any
@@ -44,6 +43,13 @@ function makeDeps() {
 }
 
 describe("signal system message filtering", () => {
+  beforeAll(async () => {
+    vi.resetModules();
+    ({ createSignalEventHandler } = await import("./event-handler.js"));
+    ({ createBaseSignalEventHandlerDeps, createSignalReceiveEvent } =
+      await import("./event-handler.test-harness.js"));
+  });
+
   beforeEach(() => {
     sendTypingMock.mockReset().mockResolvedValue(true);
     sendReadReceiptMock.mockReset().mockResolvedValue(true);

--- a/extensions/signal/src/monitor/event-handler.ts
+++ b/extensions/signal/src/monitor/event-handler.ts
@@ -562,6 +562,21 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
     const groupName = dataMessage.groupInfo?.groupName ?? undefined;
     const isGroup = Boolean(groupId);
 
+    // Skip signal-cli system messages that have no user-visible content
+    const isTimerUpdate =
+      !messageText &&
+      !quoteText &&
+      !dataMessage.attachments?.length &&
+      (dataMessage.isExpirationUpdate === true ||
+        (typeof dataMessage.expiresInSeconds === "number" && dataMessage.expiresInSeconds > 0));
+    const isGroupV2Change = Boolean(dataMessage.groupV2Change);
+    if (isTimerUpdate || isGroupV2Change) {
+      logVerbose(
+        `signal: skipping system message (isTimerUpdate=${isTimerUpdate}, isGroupV2Change=${isGroupV2Change})`,
+      );
+      return;
+    }
+
     if (!isGroup) {
       const allowedDirectMessage = await handleSignalDirectMessageAccess({
         dmPolicy: deps.dmPolicy,

--- a/extensions/signal/src/monitor/event-handler.types.ts
+++ b/extensions/signal/src/monitor/event-handler.types.ts
@@ -39,6 +39,9 @@ export type SignalDataMessage = {
   } | null;
   quote?: { text?: string | null } | null;
   reaction?: SignalReactionMessage | null;
+  expiresInSeconds?: number | null;
+  groupV2Change?: Record<string, unknown> | null;
+  isExpirationUpdate?: boolean | null;
 };
 
 export type SignalReactionMessage = {

--- a/src/signal/monitor/event-handler.system-messages.test.ts
+++ b/src/signal/monitor/event-handler.system-messages.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSignalEventHandler } from "./event-handler.js";
+import {
+  createBaseSignalEventHandlerDeps,
+  createSignalReceiveEvent,
+} from "./event-handler.test-harness.js";
+
+const { sendTypingMock, sendReadReceiptMock, dispatchInboundMessageMock } = vi.hoisted(() => ({
+  sendTypingMock: vi.fn(),
+  sendReadReceiptMock: vi.fn(),
+  dispatchInboundMessageMock: vi.fn(async () => ({
+    queuedFinal: false,
+    counts: { tool: 0, block: 0, final: 0 },
+  })),
+}));
+
+vi.mock("../send.js", () => ({
+  sendMessageSignal: vi.fn(),
+  sendTypingSignal: sendTypingMock,
+  sendReadReceiptSignal: sendReadReceiptMock,
+}));
+
+vi.mock("../../auto-reply/dispatch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../auto-reply/dispatch.js")>();
+  return {
+    ...actual,
+    dispatchInboundMessage: dispatchInboundMessageMock,
+    dispatchInboundMessageWithDispatcher: dispatchInboundMessageMock,
+    dispatchInboundMessageWithBufferedDispatcher: dispatchInboundMessageMock,
+  };
+});
+
+vi.mock("../../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore: vi.fn().mockResolvedValue([]),
+  upsertChannelPairingRequest: vi.fn(),
+}));
+
+function makeDeps() {
+  return createBaseSignalEventHandlerDeps({
+    // oxlint-disable-next-line typescript/no-explicit-any
+    cfg: { messages: { inbound: { debounceMs: 0 } } } as any,
+    historyLimit: 0,
+  });
+}
+
+describe("signal system message filtering", () => {
+  beforeEach(() => {
+    sendTypingMock.mockReset().mockResolvedValue(true);
+    sendReadReceiptMock.mockReset().mockResolvedValue(true);
+    dispatchInboundMessageMock.mockClear();
+  });
+
+  it("filters expiration timer update (expiresInSeconds, no text)", async () => {
+    const handler = createSignalEventHandler(makeDeps());
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: null,
+          attachments: [],
+          expiresInSeconds: 604800,
+          groupInfo: { groupId: "g1", groupName: "Test Group" },
+        },
+      }),
+    );
+    expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("filters expiration timer update with isExpirationUpdate flag", async () => {
+    const handler = createSignalEventHandler(makeDeps());
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: null,
+          attachments: [],
+          isExpirationUpdate: true,
+          expiresInSeconds: 604800,
+          groupInfo: { groupId: "g1", groupName: "Test Group" },
+        },
+      }),
+    );
+    expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("filters groupV2Change messages", async () => {
+    const handler = createSignalEventHandler(makeDeps());
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: null,
+          attachments: [],
+          groupV2Change: { editor: "+15550001111", changes: [] },
+          groupInfo: { groupId: "g1", groupName: "Test Group" },
+        },
+      }),
+    );
+    expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+  });
+
+  it("does NOT filter normal message with expiresInSeconds=0", async () => {
+    const handler = createSignalEventHandler(makeDeps());
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "hello",
+          attachments: [],
+          expiresInSeconds: 0,
+          groupInfo: { groupId: "g1", groupName: "Test Group" },
+        },
+      }),
+    );
+    expect(dispatchInboundMessageMock).toHaveBeenCalled();
+  });
+
+  it("does NOT filter message with text even if expiresInSeconds > 0", async () => {
+    const handler = createSignalEventHandler(makeDeps());
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "hello with timer",
+          attachments: [],
+          expiresInSeconds: 604800,
+          groupInfo: { groupId: "g1", groupName: "Test Group" },
+        },
+      }),
+    );
+    expect(dispatchInboundMessageMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

signal-cli sends `dataMessage` envelopes for system events (disappearing message timer changes, group permission updates) that contain no user-visible text. These fell through to the agent, which responded with a confused reply.

## Changes

- **`event-handler.types.ts`**: Added `expiresInSeconds`, `groupV2Change`, and `isExpirationUpdate` optional fields to `SignalDataMessage`
- **`event-handler.ts`**: Added early-return guard after groupId/groupName resolution that skips expiration timer updates and groupV2Change system messages before dispatch
- **`event-handler.system-messages.test.ts`**: 5 test cases covering both filtered and non-filtered scenarios

## Test coverage

1. Expiration timer update (expiresInSeconds=604800, no text) → filtered
2. Expiration timer update with isExpirationUpdate=true → filtered
3. groupV2Change present → filtered
4. Normal message with expiresInSeconds=0 → NOT filtered
5. Normal message with text + expiresInSeconds > 0 → NOT filtered (text takes priority)

Fixes #27615, Fixes #30981