### PR TITLE
feat(googlechat): use gateway.displayName as bot name fallback

### DIFF
--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -384,6 +384,9 @@ function resolveBotDisplayName(params: {
   if (agent?.name?.trim()) {
     return agent.name.trim();
   }
+  if (config.gateway?.displayName?.trim()) {
+    return config.gateway.displayName.trim();
+  }
   return "OpenClaw";
 }
 

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -316,6 +316,12 @@ export type GatewayToolsConfig = {
 };
 
 export type GatewayConfig = {
+  /**
+   * Display name for the gateway (e.g. the bot/assistant name).
+   * Used as a fallback display name in channel typing indicators and other UI surfaces
+   * where no channel-specific or agent-specific name is configured.
+   */
+  displayName?: string;
   /** Single multiplexed port for Gateway WS + HTTP (default: 18789). */
   port?: number;
   /**

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -502,6 +502,7 @@ export const OpenClawSchema = z
         enabled: z.boolean().optional(),
         root: z.string().optional(),
         port: z.number().int().positive().optional(),
+        displayName: z.string().optional(),
         liveReload: z.boolean().optional(),
       })
       .strict()
@@ -535,6 +536,7 @@ export const OpenClawSchema = z
     gateway: z
       .object({
         port: z.number().int().positive().optional(),
+        displayName: z.string().optional(),
         mode: z.union([z.literal("local"), z.literal("remote")]).optional(),
         bind: z
           .union([


### PR DESCRIPTION
## Summary

Adds an optional `gateway.displayName` config field and uses it in the Google Chat bot display name resolution chain, so deployments with a custom bot name don't show "OpenClaw" in typing indicators.

## Changes

- `src/config/types.gateway.ts`: Added optional `displayName` field to `GatewayConfig`
- `extensions/googlechat/src/monitor.ts`: `resolveBotDisplayName` now checks `config.gateway?.displayName` before falling back to the hardcoded string

## Fallback chain (unchanged except step 3 added)

1. Account config `name`
2. Agent `name` from agents list
3. `gateway.displayName` ← **new**
4. `"OpenClaw"` (generic fallback)

## Usage

```json
{
  "gateway": {
    "displayName": "Slay"
  }
}
```

Closes #31236