### PR TITLE
feat: add `gateway validate` for shadow config validation without gateway restart

### DIFF
--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -3,6 +3,7 @@ import { isRestartEnabled } from "../../config/commands.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveConfigSnapshotHash } from "../../config/io.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
+import { validateGatewayConfig } from "../../cli/gateway-cli/validate.js";
 import {
   formatDoctorNonInteractiveHint,
   type RestartSentinelPayload,
@@ -35,6 +36,7 @@ const GATEWAY_ACTIONS = [
   "restart",
   "config.get",
   "config.schema",
+  "config.validate",
   "config.apply",
   "config.patch",
   "update.run",
@@ -59,6 +61,8 @@ const GatewayToolSchema = Type.Object({
   sessionKey: Type.Optional(Type.String()),
   note: Type.Optional(Type.String()),
   restartDelayMs: Type.Optional(Type.Number()),
+  // config.validate
+  configPath: Type.Optional(Type.String()),
 });
 // NOTE: We intentionally avoid top-level `allOf`/`anyOf`/`oneOf` conditionals here:
 // - OpenAI rejects tool schemas that include these keywords at the *top-level*.
@@ -74,7 +78,7 @@ export function createGatewayTool(opts?: {
     name: "gateway",
     ownerOnly: true,
     description:
-      "Restart, apply config, or update the gateway in-place (SIGUSR1). Use config.patch for safe partial config updates (merges with existing). Use config.apply only when replacing entire config. Both trigger restart after writing. Always pass a human-readable completion message via the `note` parameter so the system can deliver it to the user after restart.",
+      "Restart, apply config, validate config, or update the gateway in-place (SIGUSR1). Use config.validate to check a config file for errors without touching the running gateway (pass optional configPath). Use config.patch for safe partial config updates (merges with existing). Use config.apply only when replacing entire config. Both trigger restart after writing. Always pass a human-readable completion message via the `note` parameter so the system can deliver it to the user after restart.",
     parameters: GatewayToolSchema,
     execute: async (_toolCallId, args) => {
       const params = args as Record<string, unknown>;
@@ -175,6 +179,14 @@ export function createGatewayTool(opts?: {
       if (action === "config.schema") {
         const result = await callGatewayTool("config.schema", gatewayOpts, {});
         return jsonResult({ ok: true, result });
+      }
+      if (action === "config.validate") {
+        const configPathOverride =
+          typeof params.configPath === "string" && params.configPath.trim()
+            ? params.configPath.trim()
+            : undefined;
+        const result = await validateGatewayConfig(configPathOverride);
+        return jsonResult({ ok: result.valid, result });
       }
       if (action === "config.apply") {
         const { raw, baseHash, sessionKey, note, restartDelayMs } =

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -25,6 +25,7 @@ import {
   renderBeaconLines,
 } from "./discover.js";
 import { addGatewayRunCommand } from "./run.js";
+import { addGatewayValidateCommand } from "./validate.js";
 
 function runGatewayCommand(action: () => Promise<void>, label?: string) {
   return runCommandWithRuntime(defaultRuntime, action, (err) => {
@@ -96,6 +97,7 @@ export function registerGatewayCli(program: Command) {
         () =>
           `\n${theme.heading("Examples:")}\n${formatHelpExamples([
             ["openclaw gateway run", "Run the gateway in the foreground."],
+            ["openclaw gateway validate", "Validate config without restarting the gateway."],
             ["openclaw gateway status", "Show service status and probe reachability."],
             ["openclaw gateway discover", "Find local and wide-area gateway beacons."],
             ["openclaw gateway call health", "Call a gateway RPC method directly."],
@@ -106,6 +108,8 @@ export function registerGatewayCli(program: Command) {
   addGatewayRunCommand(
     gateway.command("run").description("Run the WebSocket Gateway (foreground)"),
   );
+
+  addGatewayValidateCommand(gateway);
 
   addGatewayServiceCommands(gateway, {
     statusDescription: "Show gateway service status + probe the Gateway",

--- a/src/cli/gateway-cli/validate.ts
+++ b/src/cli/gateway-cli/validate.ts
@@ -1,0 +1,186 @@
+import path from "node:path";
+import type { Command } from "commander";
+import { CONFIG_PATH } from "../../config/config.js";
+import { createConfigIO } from "../../config/io.js";
+import type { AgentModelConfig } from "../../config/types.agents-shared.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { defaultRuntime } from "../../runtime.js";
+import { colorize, isRich, theme } from "../../terminal/theme.js";
+import { runCommandWithRuntime } from "../cli-utils.js";
+
+function resolveModelPrimary(model: AgentModelConfig | undefined): string {
+  if (!model) return "";
+  if (typeof model === "string") return model;
+  return model.primary ?? "";
+}
+
+function resolveModelFallbacks(model: AgentModelConfig | undefined): string[] {
+  if (!model || typeof model !== "object") return [];
+  return model.fallbacks ?? [];
+}
+
+function resolveChannelsSummary(cfg: OpenClawConfig): string[] {
+  const channels = cfg.channels;
+  if (!channels) return [];
+  const KNOWN_CHANNELS = [
+    "whatsapp",
+    "telegram",
+    "discord",
+    "slack",
+    "signal",
+    "irc",
+    "imessage",
+    "googlechat",
+    "msteams",
+  ] as const;
+  const active: string[] = [];
+  for (const ch of KNOWN_CHANNELS) {
+    const channelCfg = channels[ch] as Record<string, unknown> | undefined;
+    if (!channelCfg) continue;
+    if (channelCfg.enabled === false) continue;
+    const dmPolicy =
+      typeof channelCfg.dmPolicy === "string" && channelCfg.dmPolicy
+        ? channelCfg.dmPolicy
+        : undefined;
+    active.push(dmPolicy ? `${ch} (${dmPolicy})` : ch);
+  }
+  return active;
+}
+
+export type GatewayValidateResult =
+  | {
+      valid: true;
+      configPath: string;
+      model: string;
+      fallbacks: string[];
+      channels: string[];
+      warnings: string[];
+    }
+  | {
+      valid: false;
+      configPath: string;
+      issues: Array<{ path: string; message: string }>;
+    };
+
+/**
+ * Validate a gateway config file without touching the running gateway.
+ *
+ * Performs full Zod schema validation plus env-var substitution and $include
+ * resolution — the same pipeline used at gateway startup — but without
+ * binding any ports or connecting to any channels.
+ */
+export async function validateGatewayConfig(
+  configPathOverride?: string,
+): Promise<GatewayValidateResult> {
+  const configPath = configPathOverride
+    ? path.resolve(process.cwd(), configPathOverride)
+    : CONFIG_PATH;
+
+  const io = createConfigIO({ configPath });
+  const snapshot = await io.readConfigFileSnapshot();
+
+  if (!snapshot.exists) {
+    return {
+      valid: false,
+      configPath,
+      issues: [{ path: "", message: `Config file not found: ${configPath}` }],
+    };
+  }
+
+  if (!snapshot.valid) {
+    return {
+      valid: false,
+      configPath,
+      issues: snapshot.issues.map((issue) => ({
+        path: issue.path ?? "",
+        message: issue.message,
+      })),
+    };
+  }
+
+  const cfg = snapshot.config;
+  const agentDefaults = cfg.agents?.defaults;
+  const model = resolveModelPrimary(agentDefaults?.model);
+  const fallbacks = resolveModelFallbacks(agentDefaults?.model);
+  const channels = resolveChannelsSummary(cfg);
+  const warnings = (snapshot.warnings ?? []).map((w) => w.message);
+
+  return {
+    valid: true,
+    configPath,
+    model,
+    fallbacks,
+    channels,
+    warnings,
+  };
+}
+
+export function printGatewayValidateResult(result: GatewayValidateResult): void {
+  const rich = isRich();
+
+  if (!result.valid) {
+    defaultRuntime.log(colorize(rich, theme.error, "✗ Config invalid:"));
+    for (const issue of result.issues) {
+      const fieldPath = issue.path || "(root)";
+      defaultRuntime.log(`  ${colorize(rich, theme.muted, fieldPath)}: ${issue.message}`);
+    }
+    return;
+  }
+
+  defaultRuntime.log(
+    colorize(rich, theme.success, "✓ Config valid — gateway would start successfully"),
+  );
+
+  if (result.model) {
+    defaultRuntime.log(`  ${colorize(rich, theme.muted, "model:")} ${result.model}`);
+  }
+  if (result.channels.length > 0) {
+    defaultRuntime.log(
+      `  ${colorize(rich, theme.muted, "channels:")} ${result.channels.join(", ")}`,
+    );
+  }
+  if (result.fallbacks.length > 0) {
+    defaultRuntime.log(
+      `  ${colorize(rich, theme.muted, "fallbacks:")} ${result.fallbacks.join(", ")}`,
+    );
+  }
+  for (const warning of result.warnings) {
+    defaultRuntime.log(`  ${colorize(rich, theme.warn, "warn:")} ${warning}`);
+  }
+}
+
+export function addGatewayValidateCommand(cmd: Command): Command {
+  return cmd
+    .command("validate")
+    .description(
+      "Validate gateway config without restarting the running gateway (shadow validation)",
+    )
+    .option(
+      "--config <path>",
+      "Path to config file to validate (default: ~/.openclaw/openclaw.json)",
+    )
+    .option("--json", "Output result as JSON", false)
+    .action(async (opts: { config?: string; json?: boolean }) => {
+      await runCommandWithRuntime(
+        defaultRuntime,
+        async () => {
+          const result = await validateGatewayConfig(opts.config);
+          if (opts.json) {
+            defaultRuntime.log(JSON.stringify(result, null, 2));
+            if (!result.valid) {
+              defaultRuntime.exit(1);
+            }
+            return;
+          }
+          printGatewayValidateResult(result);
+          if (!result.valid) {
+            defaultRuntime.exit(1);
+          }
+        },
+        (err) => {
+          defaultRuntime.error(`Config validation failed: ${String(err)}`);
+          defaultRuntime.exit(1);
+        },
+      );
+    });
+}


### PR DESCRIPTION
## Problem
Changing gateway config (e.g. `dmPolicy`, model fallbacks, channel settings) requires editing `openclaw.json` and restarting the gateway. If the new config has an invalid value, the gateway crashes and goes offline until manually fixed.

There is currently no way to validate a config change before applying it.

## Solution
Add `openclaw gateway validate` — a shadow validation command that:
1. Runs the full config pipeline (JSON5 parse, $include resolution, env-var substitution, Zod schema validation) without touching the running gateway
2. Does NOT bind to any port or connect to any channels — the running gateway is completely unaffected
3. Exits with success/failure, printing exactly which field failed and what the valid options are
4. On success, summarizes key settings (model, channels + dmPolicy, fallbacks)

## Usage
```
# Validate current config
openclaw gateway validate

# Validate a proposed config before applying
openclaw gateway validate --config ./proposed.json

# Machine-readable output (CI/scripts)
openclaw gateway validate --json
```

## Output (success)
```
✓ Config valid — gateway would start successfully
  model: anthropic/claude-sonnet-4-6
  channels: whatsapp (allowlist), telegram
  fallbacks: google/gemini-3-pro-preview
```

## Output (failure)
```
✗ Config invalid:
  channels.whatsapp.dmPolicy: invalid value "ignore" — expected one of: allowlist, open, pairing
```

## Why in-process validation (not spawning a subprocess)?
The config pipeline — JSON5 parsing, `$include` resolution, environment variable substitution, and full Zod schema validation — is already fully encapsulated in `createConfigIO()`. Running it in-process is:
- **Faster**: no subprocess spawn overhead
- **More reliable**: no binary path resolution or port conflict issues
- **Safer**: no risk of accidentally affecting the running gateway
- **Richer errors**: Zod validation issues with exact field paths are returned directly

A future iteration could optionally spawn a real gateway process with `--validate-only` to also catch provider auth failures; the current implementation catches all schema-level errors (the most common failure mode).

## Changes
- **`src/cli/gateway-cli/validate.ts`** (new): `validateGatewayConfig()` core logic + `addGatewayValidateCommand()` CLI registration
- **`src/cli/gateway-cli/register.ts`**: wire in `validate` subcommand + add to help examples
- **`src/agents/tools/gateway-tool.ts`**: add `config.validate` action (accepts optional `configPath` param)

## Related
- Motivated by a real incident where `dmPolicy: "ignore"` (invalid value) crashed the gateway; valid values (`allowlist`, `open`, `pairing`) were only discoverable by reading source