### PR TITLE
google-gemini-cli-auth: respect env proxy in OAuth fetches

### DIFF
--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -243,6 +243,7 @@ async function fetchWithTimeout(
     url,
     init,
     timeoutMs,
+    proxy: "env",
   });
   try {
     const body = await response.arrayBuffer();

--- a/scripts/check-no-raw-channel-fetch.mjs
+++ b/scripts/check-no-raw-channel-fetch.mjs
@@ -35,7 +35,7 @@ const allowedRawFetchCallsites = new Set([
   "extensions/googlechat/src/api.ts:22",
   "extensions/googlechat/src/api.ts:43",
   "extensions/googlechat/src/api.ts:63",
-  "extensions/googlechat/src/api.ts:184",
+  "extensions/googlechat/src/api.ts:188",
   "extensions/googlechat/src/auth.ts:82",
   "extensions/matrix/src/directory-live.ts:41",
   "extensions/matrix/src/matrix/client/config.ts:171",


### PR DESCRIPTION
## Summary
Enable environment proxy usage during Gemini CLI OAuth network calls.

## Changes
- In `extensions/google-gemini-cli-auth/oauth.ts`, pass `proxy: "env"` to `fetchWithSsrFGuard` inside `fetchWithTimeout`.
- Fix stale allowlist line in `scripts/check-no-raw-channel-fetch.mjs` for Google Chat upload callsite (`api.ts:184` -> `api.ts:188`) so CI `pnpm check` matches current source lines.

## Why
In restricted networks where direct access to `oauth2.googleapis.com` is blocked, token exchange fails with `TypeError: fetch failed` even when HTTP(S)_PROXY is configured. The proxy change makes OAuth token exchange follow env proxy settings.

The CI adjustment is required because the raw-fetch allowlist currently references an outdated line number for an existing legacy callsite.

## Scope
- Small, targeted changes.
- Gemini CLI OAuth plugin network path + lint allowlist maintenance.
