### PR TITLE
fix(heartbeat): use retry reason after requests-in-flight backoff

### DIFF
--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -157,10 +157,16 @@ describe("startHeartbeatRunner", () => {
     // First heartbeat returns requests-in-flight
     await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
     expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(runSpy.mock.calls[0]?.[0]).toEqual(expect.objectContaining({ reason: "interval" }));
 
-    // Timer should be rescheduled; next heartbeat should still fire
-    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    // Retry wake should run quickly and bypass interval due-time checks.
+    await vi.advanceTimersByTimeAsync(1_000);
     expect(runSpy).toHaveBeenCalledTimes(2);
+    expect(runSpy.mock.calls[1]?.[0]).toEqual(expect.objectContaining({ reason: "retry" }));
+
+    // Regular interval schedule still fires after the original cadence.
+    await vi.advanceTimersByTimeAsync(30 * 60_000);
+    expect(runSpy).toHaveBeenCalledTimes(3);
 
     runner.stop();
   });

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -59,7 +59,7 @@ describe("heartbeat-wake", () => {
     expect(hasPendingHeartbeatWake()).toBe(false);
   });
 
-  it("retries requests-in-flight after the default retry delay", async () => {
+  it("retries interval requests-in-flight after the default retry delay with reason=retry", async () => {
     vi.useFakeTimers();
     const handler = vi
       .fn()
@@ -68,7 +68,7 @@ describe("heartbeat-wake", () => {
     await expectRetryAfterDefaultDelay({
       handler,
       initialReason: "interval",
-      expectedRetryReason: "interval",
+      expectedRetryReason: "retry",
     });
   });
 

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -106,6 +106,11 @@ function queuePendingWakeReason(params?: {
   }
 }
 
+function resolveRetryWakeReason(reason?: string): string {
+  const normalized = normalizeWakeReason(reason);
+  return resolveHeartbeatReasonKind(normalized) === "interval" ? "retry" : normalized;
+}
+
 function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
   const delay = Number.isFinite(coalesceMs) ? Math.max(0, coalesceMs) : DEFAULT_COALESCE_MS;
   const dueAt = Date.now() + delay;
@@ -156,7 +161,9 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
         if (res.status === "skipped" && res.reason === "requests-in-flight") {
           // The main lane is busy; retry this wake target soon.
           queuePendingWakeReason({
-            reason: pendingWake.reason ?? "retry",
+            // Interval retries must downgrade to `retry`; keeping `interval`
+            // can be filtered as "not due" by the scheduler.
+            reason: resolveRetryWakeReason(pendingWake.reason),
             agentId: pendingWake.agentId,
             sessionKey: pendingWake.sessionKey,
           });
@@ -167,7 +174,7 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
       // Error is already logged by the heartbeat runner; schedule a retry.
       for (const pendingWake of pendingBatch) {
         queuePendingWakeReason({
-          reason: pendingWake.reason ?? "retry",
+          reason: resolveRetryWakeReason(pendingWake.reason),
           agentId: pendingWake.agentId,
           sessionKey: pendingWake.sessionKey,
         });


### PR DESCRIPTION
## Summary
- when a wake request is skipped with `requests-in-flight`, keep target metadata but downgrade `interval` reason to `retry`
- prevents retry runs from being re-filtered as "not due" by interval scheduling logic
- add regression coverage in heartbeat wake + scheduler tests

## Why
For busy-lane heartbeat skips, retrying with `reason=interval` can be treated as not due yet and delay/skip execution, matching stuck queued-heartbeat behavior.

Addresses #31237.

## Testing
- `pnpm test src/infra/heartbeat-wake.test.ts src/infra/heartbeat-runner.scheduler.test.ts`
