### PR TITLE
Discord: keep slash interaction reply after message.send

### DIFF
--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -43,4 +43,30 @@ describe("buildReplyPayloads media filter integration", () => {
     // Text filter removes the payload entirely (text matched), so nothing remains.
     expect(replyPayloads).toHaveLength(0);
   });
+
+  it("suppresses same-target replies when messaging tool already sent", () => {
+    const { replyPayloads } = buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "done" }],
+      messageProvider: "discord",
+      originatingTo: "channel:C1",
+      messagingToolSentTargets: [{ tool: "message", provider: "discord", to: "channel:C1" }],
+    });
+
+    expect(replyPayloads).toHaveLength(0);
+  });
+
+  it("keeps same-target replies when suppression bypass is enabled", () => {
+    const { replyPayloads } = buildReplyPayloads({
+      ...baseParams,
+      payloads: [{ text: "done" }],
+      messageProvider: "discord",
+      originatingTo: "channel:C1",
+      messagingToolSentTargets: [{ tool: "message", provider: "discord", to: "channel:C1" }],
+      skipMessagingToolReplySuppression: true,
+    });
+
+    expect(replyPayloads).toHaveLength(1);
+    expect(replyPayloads[0]?.text).toBe("done");
+  });
 });

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -32,6 +32,7 @@ export function buildReplyPayloads(params: {
   messagingToolSentTargets?: Parameters<
     typeof shouldSuppressMessagingToolReplies
   >[0]["messagingToolSentTargets"];
+  skipMessagingToolReplySuppression?: boolean;
   originatingTo?: string;
   accountId?: string;
 }): { replyPayloads: ReplyPayload[]; didLogHeartbeatStrip: boolean } {
@@ -85,12 +86,14 @@ export function buildReplyPayloads(params: {
     !params.blockReplyPipeline?.isAborted();
   const messagingToolSentTexts = params.messagingToolSentTexts ?? [];
   const messagingToolSentTargets = params.messagingToolSentTargets ?? [];
-  const suppressMessagingToolReplies = shouldSuppressMessagingToolReplies({
-    messageProvider: params.messageProvider,
-    messagingToolSentTargets,
-    originatingTo: params.originatingTo,
-    accountId: params.accountId,
-  });
+  const suppressMessagingToolReplies = params.skipMessagingToolReplySuppression
+    ? false
+    : shouldSuppressMessagingToolReplies({
+        messageProvider: params.messageProvider,
+        messagingToolSentTargets,
+        originatingTo: params.originatingTo,
+        accountId: params.accountId,
+      });
   const dedupedPayloads = filterMessagingToolDuplicates({
     payloads: replyTaggedPayloads,
     sentTexts: messagingToolSentTexts,

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -457,6 +457,7 @@ export async function runReplyAgent(params: {
       messagingToolSentTexts: runResult.messagingToolSentTexts,
       messagingToolSentMediaUrls: runResult.messagingToolSentMediaUrls,
       messagingToolSentTargets: runResult.messagingToolSentTargets,
+      skipMessagingToolReplySuppression: Boolean(followupRun.skipMessagingToolReplySuppression),
       originatingTo: sessionCtx.OriginatingTo ?? sessionCtx.To,
       accountId: sessionCtx.AccountId,
     });

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -258,6 +258,29 @@ describe("createFollowupRunner messaging tool dedupe", () => {
     expect(onBlockReply).not.toHaveBeenCalled();
   });
 
+  it("does not suppress same-target replies when suppression bypass is enabled", async () => {
+    const onBlockReply = vi.fn(async () => {});
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "done" }],
+      messagingToolSentTargets: [{ tool: "slack", provider: "slack", to: "channel:C1" }],
+      meta: {},
+    });
+
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-5",
+    });
+
+    await runner({
+      ...baseQueuedRun("slack"),
+      skipMessagingToolReplySuppression: true,
+    });
+
+    expect(onBlockReply).toHaveBeenCalledTimes(1);
+  });
+
   it("drops media URL from payload when messaging tool already sent it", async () => {
     const onBlockReply = vi.fn(async () => {});
     runEmbeddedPiAgentMock.mockResolvedValueOnce({

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -256,12 +256,14 @@ export function createFollowupRunner(params: {
         payloads: dedupedPayloads,
         sentMediaUrls: runResult.messagingToolSentMediaUrls ?? [],
       });
-      const suppressMessagingToolReplies = shouldSuppressMessagingToolReplies({
-        messageProvider: queued.run.messageProvider,
-        messagingToolSentTargets: runResult.messagingToolSentTargets,
-        originatingTo: queued.originatingTo,
-        accountId: queued.run.agentAccountId,
-      });
+      const suppressMessagingToolReplies = queued.skipMessagingToolReplySuppression
+        ? false
+        : shouldSuppressMessagingToolReplies({
+            messageProvider: queued.run.messageProvider,
+            messagingToolSentTargets: runResult.messagingToolSentTargets,
+            originatingTo: queued.originatingTo,
+            accountId: queued.run.agentAccountId,
+          });
       const finalPayloads = suppressMessagingToolReplies ? [] : mediaFilteredPayloads;
 
       if (finalPayloads.length === 0) {

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -190,4 +190,35 @@ describe("runPreparedReply media-only handling", () => {
     });
     expect(vi.mocked(runReplyAgent)).not.toHaveBeenCalled();
   });
+
+  it("marks native slash runs to keep interaction reply delivery", async () => {
+    const result = await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "run slash command",
+          RawBody: "run slash command",
+          CommandBody: "run slash command",
+          ThreadHistoryBody: "Earlier message in this thread",
+          OriginatingChannel: "discord",
+          OriginatingTo: "channel:C123",
+          ChatType: "channel",
+          CommandSource: "native",
+          To: "slash:user-1",
+        },
+        sessionCtx: {
+          Body: "run slash command",
+          BodyStripped: "run slash command",
+          ThreadHistoryBody: "Earlier message in this thread",
+          Provider: "discord",
+          ChatType: "channel",
+          OriginatingChannel: "discord",
+          OriginatingTo: "channel:C123",
+        },
+      }),
+    );
+
+    expect(result).toEqual({ text: "ok" });
+    const call = vi.mocked(runReplyAgent).mock.calls[0]?.[0];
+    expect(call?.followupRun.skipMessagingToolReplySuppression).toBe(true);
+  });
 });

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -388,6 +388,12 @@ export async function runPreparedReply(
     messageId: sessionCtx.MessageSidFull ?? sessionCtx.MessageSid,
     summaryLine: baseBodyTrimmedRaw,
     enqueuedAt: Date.now(),
+    // Discord native slash interactions must always send an interaction response.
+    // Keep final payload delivery enabled even when message.send posts to same target.
+    skipMessagingToolReplySuppression:
+      ctx.CommandSource === "native" &&
+      typeof ctx.To === "string" &&
+      ctx.To.trim().toLowerCase().startsWith("slash:"),
     // Originating channel for reply routing.
     originatingChannel: ctx.OriginatingChannel,
     originatingTo: ctx.OriginatingTo,

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -25,6 +25,11 @@ export type FollowupRun = {
   summaryLine?: string;
   enqueuedAt: number;
   /**
+   * Preserve a reply payload even when a same-target messaging tool send happened.
+   * Used by native slash interactions that must send an interaction response.
+   */
+  skipMessagingToolReplySuppression?: boolean;
+  /**
    * Originating channel for reply routing.
    * When set, replies should be routed back to this provider
    * instead of using the session's lastChannel.


### PR DESCRIPTION
## Summary
- preserve interaction reply delivery for native slash command runs even when the message tool sends to the same provider+target
- thread that suppression bypass through followup run metadata into both inline and queued payload filtering paths
- add regression coverage for same-target suppression bypass and native slash followup-run tagging

## Root Cause
`message.send` to the same Discord target triggered the generic "suppress final reply" logic. In native slash flows this could remove the only interaction response payload, leaving Discord in a perpetual "Bot is responding..." state.

## Fix
- add `skipMessagingToolReplySuppression` to `FollowupRun`
- set it for native slash contexts (`CommandSource === "native"` and `To` starts with `slash:`)
- when set, bypass same-target message tool suppression while keeping existing dedupe behavior

## Testing
- `pnpm test src/auto-reply/reply/agent-runner-payloads.test.ts src/auto-reply/reply/followup-runner.test.ts src/auto-reply/reply/get-reply-run.media-only.test.ts src/discord/monitor/native-command.model-picker.test.ts`

Closes #31246
