### PR TITLE
fix: emit message:sent hooks for channel reply dispatchers

### DIFF
--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -16,10 +16,32 @@ type ReplyDispatchSkipHandler = (
   info: { kind: ReplyDispatchKind; reason: NormalizeReplySkipReason },
 ) => void;
 
+type ReplyDispatchDeliverResult = {
+  delivered: boolean;
+  messageId?: string;
+};
+
 type ReplyDispatchDeliverer = (
   payload: ReplyPayload,
   info: { kind: ReplyDispatchKind },
-) => Promise<void>;
+) => Promise<ReplyDispatchDeliverResult | void>;
+
+type ReplyDispatchDeliveryHandler = (
+  payload: ReplyPayload,
+  info:
+    | {
+        kind: ReplyDispatchKind;
+        success: true;
+        delivered: boolean;
+        messageId?: string;
+      }
+    | {
+        kind: ReplyDispatchKind;
+        success: false;
+        delivered: false;
+        error: unknown;
+      },
+) => void;
 
 const DEFAULT_HUMAN_DELAY_MIN_MS = 800;
 const DEFAULT_HUMAN_DELAY_MAX_MS = 2500;
@@ -51,6 +73,7 @@ export type ReplyDispatcherOptions = {
   onHeartbeatStrip?: () => void;
   onIdle?: () => void;
   onError?: ReplyDispatchErrorHandler;
+  onDelivery?: ReplyDispatchDeliveryHandler;
   // AIDEV-NOTE: onSkip lets channels detect silent/empty drops (e.g. Telegram empty-response fallback).
   onSkip?: ReplyDispatchSkipHandler;
   /** Human-like delay between block replies for natural rhythm. */
@@ -155,9 +178,21 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         }
         // Safe: deliver is called inside an async .then() callback, so even a synchronous
         // throw becomes a rejection that flows through .catch()/.finally(), ensuring cleanup.
-        await options.deliver(normalized, { kind });
+        const deliveryResult = await options.deliver(normalized, { kind });
+        options.onDelivery?.(normalized, {
+          kind,
+          success: true,
+          delivered: deliveryResult?.delivered ?? true,
+          messageId: deliveryResult?.messageId,
+        });
       })
       .catch((err) => {
+        options.onDelivery?.(normalized, {
+          kind,
+          success: false,
+          delivered: false,
+          error: err,
+        });
         options.onError?.(err, { kind });
       })
       .finally(() => {

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -1200,6 +1200,54 @@ describe("createReplyDispatcher", () => {
     expect(onIdle).toHaveBeenCalledTimes(1);
   });
 
+  it("reports delivery outcomes via onDelivery", async () => {
+    const deliver = vi
+      .fn()
+      .mockResolvedValueOnce({ delivered: false })
+      .mockResolvedValueOnce({ delivered: true, messageId: "msg-1" });
+    const onDelivery = vi.fn();
+    const dispatcher = createReplyDispatcher({ deliver, onDelivery });
+
+    dispatcher.sendToolResult({ text: "tool" });
+    dispatcher.sendFinalReply({ text: "final" });
+
+    await dispatcher.waitForIdle();
+
+    expect(onDelivery).toHaveBeenCalledTimes(2);
+    expect(onDelivery.mock.calls[0]?.[1]).toMatchObject({
+      kind: "tool",
+      success: true,
+      delivered: false,
+    });
+    expect(onDelivery.mock.calls[1]?.[1]).toMatchObject({
+      kind: "final",
+      success: true,
+      delivered: true,
+      messageId: "msg-1",
+    });
+  });
+
+  it("reports delivery failures via onDelivery", async () => {
+    const err = new Error("boom");
+    const onError = vi.fn();
+    const onDelivery = vi.fn();
+    const deliver = vi.fn().mockRejectedValue(err);
+    const dispatcher = createReplyDispatcher({ deliver, onDelivery, onError });
+
+    dispatcher.sendFinalReply({ text: "final" });
+    await dispatcher.waitForIdle();
+
+    expect(onDelivery).toHaveBeenCalledTimes(1);
+    expect(onDelivery.mock.calls[0]?.[1]).toMatchObject({
+      kind: "final",
+      success: false,
+      delivered: false,
+      error: err,
+    });
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(err, { kind: "final" });
+  });
+
   it("delays block replies after the first when humanDelay is natural", async () => {
     vi.useFakeTimers();
     const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -969,7 +969,7 @@ async function dispatchDiscordComponentEvent(params: {
       humanDelay: resolveHumanDelayConfig(ctx.cfg, agentId),
       deliver: async (payload) => {
         const replyToId = replyReference.use();
-        await deliverDiscordReply({
+        const delivery = await deliverDiscordReply({
           replies: [payload],
           target: deliverTarget,
           token,
@@ -983,7 +983,10 @@ async function dispatchDiscordComponentEvent(params: {
           tableMode,
           chunkMode: resolveChunkMode(ctx.cfg, "discord", accountId),
         });
-        replyReference.markSent();
+        if (delivery.delivered) {
+          replyReference.markSent();
+        }
+        return delivery;
       },
       onReplyStart: async () => {
         try {

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -23,7 +23,7 @@ function createMockDraftStream() {
 
 const deliveryMocks = vi.hoisted(() => ({
   editMessageDiscord: vi.fn(async () => ({})),
-  deliverDiscordReply: vi.fn(async () => {}),
+  deliverDiscordReply: vi.fn(async () => ({ delivered: true })),
   createDiscordDraftStream: vi.fn(() => createMockDraftStream()),
 }));
 const editMessageDiscord = deliveryMocks.editMessageDiscord;

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -26,7 +26,11 @@ function createMockDraftStream() {
 
 const deliveryMocks = vi.hoisted(() => ({
   editMessageDiscord: vi.fn(async () => ({})),
-  deliverDiscordReply: vi.fn(async () => ({ delivered: true })),
+  deliverDiscordReply: vi.fn<
+    (
+      ...args: unknown[]
+    ) => Promise<{ delivered: boolean; messageId?: string; deliveredContent?: string }>
+  >(async () => ({ delivered: true })),
   createDiscordDraftStream: vi.fn(() => createMockDraftStream()),
 }));
 const editMessageDiscord = deliveryMocks.editMessageDiscord;
@@ -525,6 +529,36 @@ describe("processDiscordMessage draft streaming", () => {
         content: "Hello\nWorld",
         success: true,
         channelId: "discord",
+      }),
+    );
+  });
+
+  it("emits hook content from delivered metadata on normal send path", async () => {
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply({ text: "|A|B|   " });
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
+    deliverDiscordReply.mockResolvedValueOnce({
+      delivered: true,
+      messageId: "discord-msg-2",
+      deliveredContent: "A\tB",
+    });
+
+    const ctx = await createBaseContext({
+      discordConfig: { streamMode: "off", maxLinesPerMessage: 5 },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    expect(editMessageDiscord).not.toHaveBeenCalled();
+    expect(emitMessageSentHooks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "A\tB",
+        success: true,
+        channelId: "discord",
+        messageId: "discord-msg-2",
       }),
     );
   });

--- a/src/discord/monitor/message-handler.process.test.ts
+++ b/src/discord/monitor/message-handler.process.test.ts
@@ -10,6 +10,9 @@ const sendMocks = vi.hoisted(() => ({
   reactMessageDiscord: vi.fn(async () => {}),
   removeReactionDiscord: vi.fn(async () => {}),
 }));
+const hookMocks = vi.hoisted(() => ({
+  emitMessageSentHooks: vi.fn(),
+}));
 function createMockDraftStream() {
   return {
     update: vi.fn<(text: string) => void>(() => {}),
@@ -59,6 +62,7 @@ const configSessionsMocks = vi.hoisted(() => ({
 }));
 const readSessionUpdatedAt = configSessionsMocks.readSessionUpdatedAt;
 const resolveStorePath = configSessionsMocks.resolveStorePath;
+const emitMessageSentHooks = hookMocks.emitMessageSentHooks;
 
 vi.mock("../send.js", () => ({
   reactMessageDiscord: sendMocks.reactMessageDiscord,
@@ -82,16 +86,61 @@ vi.mock("../../auto-reply/dispatch.js", () => ({
 }));
 
 vi.mock("../../auto-reply/reply/reply-dispatcher.js", () => ({
+  // Match createReplyDispatcherWithTyping delivery semantics closely enough for hook assertions.
   createReplyDispatcherWithTyping: vi.fn(
-    (opts: { deliver: (payload: unknown, info: { kind: string }) => Promise<void> | void }) => ({
+    (opts: {
+      deliver: (
+        payload: unknown,
+        info: { kind: "block" | "final" },
+      ) =>
+        | Promise<{ delivered: boolean; messageId?: string } | void>
+        | { delivered: boolean; messageId?: string }
+        | void;
+      onDelivery?: (
+        payload: unknown,
+        info:
+          | { kind: "block" | "final"; success: true; delivered: boolean; messageId?: string }
+          | { kind: "block" | "final"; success: false; delivered: false; error: unknown },
+      ) => void;
+    }) => ({
       dispatcher: {
         sendToolResult: vi.fn(() => true),
-        sendBlockReply: vi.fn((payload: unknown) => {
-          void opts.deliver(payload as never, { kind: "block" });
+        sendBlockReply: vi.fn(async (payload: unknown) => {
+          try {
+            const delivery = await opts.deliver(payload, { kind: "block" });
+            opts.onDelivery?.(payload, {
+              kind: "block",
+              success: true,
+              delivered: delivery?.delivered ?? true,
+              messageId: delivery?.messageId,
+            });
+          } catch (error) {
+            opts.onDelivery?.(payload, {
+              kind: "block",
+              success: false,
+              delivered: false,
+              error,
+            });
+          }
           return true;
         }),
-        sendFinalReply: vi.fn((payload: unknown) => {
-          void opts.deliver(payload as never, { kind: "final" });
+        sendFinalReply: vi.fn(async (payload: unknown) => {
+          try {
+            const delivery = await opts.deliver(payload, { kind: "final" });
+            opts.onDelivery?.(payload, {
+              kind: "final",
+              success: true,
+              delivered: delivery?.delivered ?? true,
+              messageId: delivery?.messageId,
+            });
+          } catch (error) {
+            opts.onDelivery?.(payload, {
+              kind: "final",
+              success: false,
+              delivered: false,
+              error,
+            });
+          }
           return true;
         }),
         waitForIdle: vi.fn(async () => {}),
@@ -106,6 +155,10 @@ vi.mock("../../auto-reply/reply/reply-dispatcher.js", () => ({
 
 vi.mock("../../channels/session.js", () => ({
   recordInboundSession,
+}));
+
+vi.mock("../../hooks/message-sent.js", () => ({
+  emitMessageSentHooks: hookMocks.emitMessageSentHooks,
 }));
 
 vi.mock("../../config/sessions.js", () => ({
@@ -126,6 +179,7 @@ beforeEach(() => {
   createDiscordDraftStream.mockClear();
   dispatchInboundMessage.mockClear();
   recordInboundSession.mockClear();
+  emitMessageSentHooks.mockClear();
   readSessionUpdatedAt.mockClear();
   resolveStorePath.mockClear();
   dispatchInboundMessage.mockResolvedValue({
@@ -445,6 +499,34 @@ describe("processDiscordMessage draft streaming", () => {
       { rest: {} },
     );
     expect(deliverDiscordReply).not.toHaveBeenCalled();
+  });
+
+  it("emits hook content from finalized preview text", async () => {
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.dispatcher.sendFinalReply({ text: "Hello\nWorld   " });
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 0 } };
+    });
+
+    const ctx = await createBaseContext({
+      discordConfig: { streamMode: "partial", maxLinesPerMessage: 5 },
+    });
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await processDiscordMessage(ctx as any);
+
+    expect(editMessageDiscord).toHaveBeenCalledWith(
+      "c1",
+      "preview-1",
+      { content: "Hello\nWorld" },
+      { rest: {} },
+    );
+    expect(emitMessageSentHooks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "Hello\nWorld",
+        success: true,
+        channelId: "discord",
+      }),
+    );
   });
 
   it("accepts streaming=true alias for partial preview mode", async () => {

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -657,7 +657,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       }
 
       const replyToId = replyReference.use();
-      await deliverDiscordReply({
+      const delivery = await deliverDiscordReply({
         replies: [payload],
         target: deliverTarget,
         token,
@@ -673,8 +673,10 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
         sessionKey: ctxPayload.SessionKey,
         threadBindings,
       });
-      replyReference.markSent();
-      return { delivered: true };
+      if (delivery.delivered) {
+        replyReference.markSent();
+      }
+      return delivery;
     },
     onDelivery: (payload, deliveryInfo) => {
       if (deliveryInfo.success) {

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -679,7 +679,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       });
       if (delivery.delivered) {
         replyReference.markSent();
-        deliveredContentByPayload.set(payload, payload.text ?? "");
+        deliveredContentByPayload.set(payload, delivery.deliveredContent ?? payload.text ?? "");
       }
       return delivery;
     },

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -26,6 +26,7 @@ import { resolveDiscordPreviewStreamMode } from "../../config/discord-preview-st
 import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../globals.js";
+import { emitMessageSentHooks } from "../../hooks/message-sent.js";
 import { convertMarkdownTables } from "../../markdown/tables.js";
 import { buildAgentSessionKey } from "../../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../routing/session-key.js";
@@ -579,7 +580,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       const isFinal = info.kind === "final";
       if (payload.isReasoning) {
         // Reasoning/thinking payloads should not be delivered to Discord.
-        return;
+        return { delivered: false };
       }
       if (draftStream && isFinal) {
         await flushDraft();
@@ -607,7 +608,10 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
             );
             finalizedViaPreviewMessage = true;
             replyReference.markSent();
-            return;
+            return {
+              delivered: true,
+              messageId: previewMessageId,
+            };
           } catch (err) {
             logVerbose(
               `discord: preview final edit failed; falling back to standard send (${String(err)})`,
@@ -634,7 +638,10 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
               );
               finalizedViaPreviewMessage = true;
               replyReference.markSent();
-              return;
+              return {
+                delivered: true,
+                messageId: messageIdAfterStop,
+              };
             } catch (err) {
               logVerbose(
                 `discord: post-stop preview edit failed; falling back to standard send (${String(err)})`,
@@ -667,6 +674,38 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
         threadBindings,
       });
       replyReference.markSent();
+      return { delivered: true };
+    },
+    onDelivery: (payload, deliveryInfo) => {
+      if (deliveryInfo.success) {
+        if (!deliveryInfo.delivered) {
+          return;
+        }
+        emitMessageSentHooks({
+          to: deliverChannelId,
+          content: payload.text ?? "",
+          success: true,
+          channelId: "discord",
+          accountId,
+          conversationId: deliverChannelId,
+          sessionKey: ctxPayload.SessionKey,
+          messageId: deliveryInfo.messageId,
+        });
+        return;
+      }
+      emitMessageSentHooks({
+        to: deliverChannelId,
+        content: payload.text ?? "",
+        success: false,
+        error:
+          deliveryInfo.error instanceof Error
+            ? deliveryInfo.error.message
+            : String(deliveryInfo.error),
+        channelId: "discord",
+        accountId,
+        conversationId: deliverChannelId,
+        sessionKey: ctxPayload.SessionKey,
+      });
     },
     onError: (err, info) => {
       runtime.error?.(danger(`discord ${info.kind} reply failed: ${String(err)}`));

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -463,6 +463,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
   let draftText = "";
   let hasStreamedMessage = false;
   let finalizedViaPreviewMessage = false;
+  const deliveredContentByPayload = new WeakMap<ReplyPayload, string>();
 
   const resolvePreviewFinalText = (text?: string) => {
     if (typeof text !== "string") {
@@ -577,6 +578,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
     typingCallbacks,
     deliver: async (payload: ReplyPayload, info) => {
+      deliveredContentByPayload.delete(payload);
       const isFinal = info.kind === "final";
       if (payload.isReasoning) {
         // Reasoning/thinking payloads should not be delivered to Discord.
@@ -608,6 +610,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
             );
             finalizedViaPreviewMessage = true;
             replyReference.markSent();
+            deliveredContentByPayload.set(payload, previewFinalText);
             return {
               delivered: true,
               messageId: previewMessageId,
@@ -638,6 +641,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
               );
               finalizedViaPreviewMessage = true;
               replyReference.markSent();
+              deliveredContentByPayload.set(payload, previewFinalText);
               return {
                 delivered: true,
                 messageId: messageIdAfterStop,
@@ -675,17 +679,20 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       });
       if (delivery.delivered) {
         replyReference.markSent();
+        deliveredContentByPayload.set(payload, payload.text ?? "");
       }
       return delivery;
     },
     onDelivery: (payload, deliveryInfo) => {
+      const hookContent = deliveredContentByPayload.get(payload) ?? payload.text ?? "";
+      deliveredContentByPayload.delete(payload);
       if (deliveryInfo.success) {
         if (!deliveryInfo.delivered) {
           return;
         }
         emitMessageSentHooks({
           to: deliverChannelId,
-          content: payload.text ?? "",
+          content: hookContent,
           success: true,
           channelId: "discord",
           accountId,
@@ -697,7 +704,7 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
       }
       emitMessageSentHooks({
         to: deliverChannelId,
-        content: payload.text ?? "",
+        content: hookContent,
         success: false,
         error:
           deliveryInfo.error instanceof Error

--- a/src/discord/monitor/reply-delivery.test.ts
+++ b/src/discord/monitor/reply-delivery.test.ts
@@ -182,6 +182,24 @@ describe("deliverDiscordReply", () => {
     );
   });
 
+  it("returns delivered content and messageId for successful text sends", async () => {
+    const result = await deliverDiscordReply({
+      replies: [{ text: "|A|B|\n|-|-|\n|1|2|" }],
+      target: "channel:789",
+      token: "token",
+      runtime,
+      textLimit: 2000,
+    });
+
+    expect(sendMessageDiscordMock).toHaveBeenCalledTimes(1);
+    const sentText = sendMessageDiscordMock.mock.calls[0]?.[1];
+    expect(result).toEqual({
+      delivered: true,
+      messageId: "msg-1",
+      deliveredContent: sentText,
+    });
+  });
+
   it("sends bound-session text replies through webhook delivery", async () => {
     const threadBindings = await createBoundThreadBindings({ label: "codex-refactor" });
 
@@ -307,6 +325,10 @@ describe("deliverDiscordReply", () => {
     });
 
     expect(sendMessageDiscordMock).toHaveBeenCalledTimes(1);
-    expect(result).toEqual({ delivered: true });
+    expect(result).toMatchObject({
+      delivered: true,
+      messageId: "msg-1",
+      deliveredContent: "hello",
+    });
   });
 });

--- a/src/discord/monitor/reply-delivery.test.ts
+++ b/src/discord/monitor/reply-delivery.test.ts
@@ -281,4 +281,32 @@ describe("deliverDiscordReply", () => {
       expect.objectContaining({ token: "token", accountId: "default" }),
     );
   });
+
+  it("reports delivered=false when payload has no text or media", async () => {
+    const result = await deliverDiscordReply({
+      replies: [{ channelData: { traceId: "noop" } }],
+      target: "channel:noop",
+      token: "token",
+      runtime,
+      textLimit: 2000,
+    });
+
+    expect(sendWebhookMessageDiscordMock).not.toHaveBeenCalled();
+    expect(sendVoiceMessageDiscordMock).not.toHaveBeenCalled();
+    expect(sendMessageDiscordMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ delivered: false });
+  });
+
+  it("reports delivered=true when at least one outbound message is sent", async () => {
+    const result = await deliverDiscordReply({
+      replies: [{ text: "hello" }],
+      target: "channel:ok",
+      token: "token",
+      runtime,
+      textLimit: 2000,
+    });
+
+    expect(sendMessageDiscordMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ delivered: true });
+  });
 });

--- a/src/discord/monitor/reply-delivery.ts
+++ b/src/discord/monitor/reply-delivery.ts
@@ -148,7 +148,7 @@ export async function deliverDiscordReply(params: {
   chunkMode?: ChunkMode;
   sessionKey?: string;
   threadBindings?: DiscordThreadBindingLookup;
-}) {
+}): Promise<{ delivered: boolean; messageId?: string }> {
   const chunkLimit = Math.min(params.textLimit, 2000);
   const replyTo = params.replyToId?.trim() || undefined;
   const replyToMode = params.replyToMode ?? "all";
@@ -275,4 +275,5 @@ export async function deliverDiscordReply(params: {
   if (binding && deliveredAny) {
     params.threadBindings?.touchThread?.({ threadId: binding.threadId });
   }
+  return { delivered: deliveredAny };
 }

--- a/src/discord/monitor/reply-delivery.ts
+++ b/src/discord/monitor/reply-delivery.ts
@@ -83,7 +83,7 @@ async function sendDiscordChunkWithFallback(params: {
   binding?: DiscordThreadBindingLookupRecord;
   username?: string;
   avatarUrl?: string;
-}) {
+}): Promise<{ messageId?: string } | undefined> {
   if (!params.text.trim()) {
     return;
   }
@@ -91,7 +91,7 @@ async function sendDiscordChunkWithFallback(params: {
   const binding = params.binding;
   if (binding?.webhookId && binding?.webhookToken) {
     try {
-      await sendWebhookMessageDiscord(text, {
+      const sent = await sendWebhookMessageDiscord(text, {
         webhookId: binding.webhookId,
         webhookToken: binding.webhookToken,
         accountId: binding.accountId,
@@ -100,17 +100,18 @@ async function sendDiscordChunkWithFallback(params: {
         username: params.username,
         avatarUrl: params.avatarUrl,
       });
-      return;
+      return { messageId: sent.messageId };
     } catch {
       // Fall through to the standard bot sender path.
     }
   }
-  await sendMessageDiscord(params.target, text, {
+  const sent = await sendMessageDiscord(params.target, text, {
     token: params.token,
     rest: params.rest,
     accountId: params.accountId,
     replyTo: params.replyTo,
   });
+  return { messageId: sent.messageId };
 }
 
 async function sendAdditionalDiscordMedia(params: {
@@ -120,17 +121,22 @@ async function sendAdditionalDiscordMedia(params: {
   accountId?: string;
   mediaUrls: string[];
   resolveReplyTo: () => string | undefined;
-}) {
+}): Promise<{ messageId?: string }> {
+  let lastMessageId: string | undefined;
   for (const mediaUrl of params.mediaUrls) {
     const replyTo = params.resolveReplyTo();
-    await sendMessageDiscord(params.target, "", {
+    const sent = await sendMessageDiscord(params.target, "", {
       token: params.token,
       rest: params.rest,
       mediaUrl,
       accountId: params.accountId,
       replyTo,
     });
+    if (sent.messageId && sent.messageId !== "unknown") {
+      lastMessageId = sent.messageId;
+    }
   }
+  return { messageId: lastMessageId };
 }
 
 export async function deliverDiscordReply(params: {
@@ -148,7 +154,7 @@ export async function deliverDiscordReply(params: {
   chunkMode?: ChunkMode;
   sessionKey?: string;
   threadBindings?: DiscordThreadBindingLookup;
-}): Promise<{ delivered: boolean; messageId?: string }> {
+}): Promise<{ delivered: boolean; messageId?: string; deliveredContent?: string }> {
   const chunkLimit = Math.min(params.textLimit, 2000);
   const replyTo = params.replyToId?.trim() || undefined;
   const replyToMode = params.replyToMode ?? "all";
@@ -175,7 +181,10 @@ export async function deliverDiscordReply(params: {
   });
   const persona = resolveBindingPersona(binding);
   let deliveredAny = false;
+  let lastMessageId: string | undefined;
+  let lastDeliveredContent: string | undefined;
   for (const payload of params.replies) {
+    let deliveredThisPayload = false;
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
     const rawText = payload.text ?? "";
     const tableMode = params.tableMode ?? "code";
@@ -198,7 +207,7 @@ export async function deliverDiscordReply(params: {
           continue;
         }
         const replyTo = resolveReplyTo();
-        await sendDiscordChunkWithFallback({
+        const sent = await sendDiscordChunkWithFallback({
           target: params.target,
           text: chunk,
           token: params.token,
@@ -210,6 +219,13 @@ export async function deliverDiscordReply(params: {
           avatarUrl: persona.avatarUrl,
         });
         deliveredAny = true;
+        deliveredThisPayload = true;
+        if (sent?.messageId && sent.messageId !== "unknown") {
+          lastMessageId = sent.messageId;
+        }
+      }
+      if (deliveredThisPayload) {
+        lastDeliveredContent = text;
       }
       continue;
     }
@@ -222,15 +238,19 @@ export async function deliverDiscordReply(params: {
     // Voice message path: audioAsVoice flag routes through sendVoiceMessageDiscord.
     if (payload.audioAsVoice) {
       const replyTo = resolveReplyTo();
-      await sendVoiceMessageDiscord(params.target, firstMedia, {
+      const sent = await sendVoiceMessageDiscord(params.target, firstMedia, {
         token: params.token,
         rest: params.rest,
         accountId: params.accountId,
         replyTo,
       });
       deliveredAny = true;
+      deliveredThisPayload = true;
+      if (sent.messageId && sent.messageId !== "unknown") {
+        lastMessageId = sent.messageId;
+      }
       // Voice messages cannot include text; send remaining text separately if present.
-      await sendDiscordChunkWithFallback({
+      const textSent = await sendDiscordChunkWithFallback({
         target: params.target,
         text,
         token: params.token,
@@ -241,8 +261,11 @@ export async function deliverDiscordReply(params: {
         username: persona.username,
         avatarUrl: persona.avatarUrl,
       });
+      if (textSent?.messageId && textSent.messageId !== "unknown") {
+        lastMessageId = textSent.messageId;
+      }
       // Additional media items are sent as regular attachments (voice is single-file only).
-      await sendAdditionalDiscordMedia({
+      const additionalMedia = await sendAdditionalDiscordMedia({
         target: params.target,
         token: params.token,
         rest: params.rest,
@@ -250,11 +273,15 @@ export async function deliverDiscordReply(params: {
         mediaUrls: mediaList.slice(1),
         resolveReplyTo,
       });
+      if (additionalMedia.messageId) {
+        lastMessageId = additionalMedia.messageId;
+      }
+      lastDeliveredContent = text;
       continue;
     }
 
     const replyTo = resolveReplyTo();
-    await sendMessageDiscord(params.target, text, {
+    const sent = await sendMessageDiscord(params.target, text, {
       token: params.token,
       rest: params.rest,
       mediaUrl: firstMedia,
@@ -262,7 +289,11 @@ export async function deliverDiscordReply(params: {
       replyTo,
     });
     deliveredAny = true;
-    await sendAdditionalDiscordMedia({
+    deliveredThisPayload = true;
+    if (sent.messageId && sent.messageId !== "unknown") {
+      lastMessageId = sent.messageId;
+    }
+    const additionalMedia = await sendAdditionalDiscordMedia({
       target: params.target,
       token: params.token,
       rest: params.rest,
@@ -270,10 +301,20 @@ export async function deliverDiscordReply(params: {
       mediaUrls: mediaList.slice(1),
       resolveReplyTo,
     });
+    if (additionalMedia.messageId) {
+      lastMessageId = additionalMedia.messageId;
+    }
+    if (deliveredThisPayload) {
+      lastDeliveredContent = text;
+    }
   }
 
   if (binding && deliveredAny) {
     params.threadBindings?.touchThread?.({ threadId: binding.threadId });
   }
-  return { delivered: deliveredAny };
+  return {
+    delivered: deliveredAny,
+    ...(lastMessageId ? { messageId: lastMessageId } : {}),
+    ...(lastDeliveredContent !== undefined ? { deliveredContent: lastDeliveredContent } : {}),
+  };
 }

--- a/src/hooks/message-sent.test.ts
+++ b/src/hooks/message-sent.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const hookMocks = vi.hoisted(() => ({
+  runner: {
+    hasHooks: vi.fn(() => false),
+    runMessageSent: vi.fn(async () => {}),
+  },
+}));
+
+const internalHookMocks = vi.hoisted(() => ({
+  createInternalHookEvent: vi.fn(() => ({ type: "event" })),
+  triggerInternalHook: vi.fn(async () => {}),
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => hookMocks.runner,
+}));
+
+vi.mock("./internal-hooks.js", () => ({
+  createInternalHookEvent: internalHookMocks.createInternalHookEvent,
+  triggerInternalHook: internalHookMocks.triggerInternalHook,
+}));
+
+const { emitMessageSentHooks } = await import("./message-sent.js");
+
+describe("emitMessageSentHooks", () => {
+  beforeEach(() => {
+    hookMocks.runner.hasHooks.mockReset();
+    hookMocks.runner.hasHooks.mockReturnValue(false);
+    hookMocks.runner.runMessageSent.mockClear();
+    internalHookMocks.createInternalHookEvent.mockClear();
+    internalHookMocks.triggerInternalHook.mockClear();
+  });
+
+  it("emits plugin and internal hooks when sessionKey is present", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+
+    emitMessageSentHooks({
+      to: "chat-1",
+      content: "hello",
+      success: true,
+      channelId: "telegram",
+      accountId: "work",
+      sessionKey: "session-1",
+      messageId: "msg-1",
+    });
+
+    await Promise.resolve();
+
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      {
+        to: "chat-1",
+        content: "hello",
+        success: true,
+      },
+      {
+        channelId: "telegram",
+        accountId: "work",
+        conversationId: "chat-1",
+      },
+    );
+    expect(internalHookMocks.createInternalHookEvent).toHaveBeenCalledWith(
+      "message",
+      "sent",
+      "session-1",
+      {
+        to: "chat-1",
+        content: "hello",
+        success: true,
+        channelId: "telegram",
+        accountId: "work",
+        conversationId: "chat-1",
+        messageId: "msg-1",
+      },
+    );
+    expect(internalHookMocks.triggerInternalHook).toHaveBeenCalledWith({ type: "event" });
+  });
+
+  it("skips internal hook emission when sessionKey is missing", async () => {
+    hookMocks.runner.hasHooks.mockReturnValue(true);
+
+    emitMessageSentHooks({
+      to: "chat-2",
+      content: "hello",
+      success: false,
+      error: "send failed",
+      channelId: "slack",
+      accountId: "team",
+    });
+
+    await Promise.resolve();
+
+    expect(hookMocks.runner.runMessageSent).toHaveBeenCalledWith(
+      {
+        to: "chat-2",
+        content: "hello",
+        success: false,
+        error: "send failed",
+      },
+      {
+        channelId: "slack",
+        accountId: "team",
+        conversationId: "chat-2",
+      },
+    );
+    expect(internalHookMocks.createInternalHookEvent).not.toHaveBeenCalled();
+    expect(internalHookMocks.triggerInternalHook).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/message-sent.ts
+++ b/src/hooks/message-sent.ts
@@ -1,0 +1,52 @@
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { createInternalHookEvent, triggerInternalHook } from "./internal-hooks.js";
+
+export type EmitMessageSentHooksParams = {
+  to: string;
+  content: string;
+  success: boolean;
+  channelId: string;
+  accountId?: string;
+  conversationId?: string;
+  sessionKey?: string;
+  error?: string;
+  messageId?: string;
+};
+
+export function emitMessageSentHooks(params: EmitMessageSentHooksParams): void {
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner?.hasHooks("message_sent")) {
+    void hookRunner
+      .runMessageSent(
+        {
+          to: params.to,
+          content: params.content,
+          success: params.success,
+          ...(params.error ? { error: params.error } : {}),
+        },
+        {
+          channelId: params.channelId,
+          accountId: params.accountId,
+          conversationId: params.conversationId ?? params.to,
+        },
+      )
+      .catch(() => {});
+  }
+
+  if (!params.sessionKey) {
+    return;
+  }
+
+  void triggerInternalHook(
+    createInternalHookEvent("message", "sent", params.sessionKey, {
+      to: params.to,
+      content: params.content,
+      success: params.success,
+      ...(params.error ? { error: params.error } : {}),
+      channelId: params.channelId,
+      accountId: params.accountId,
+      conversationId: params.conversationId ?? params.to,
+      messageId: params.messageId,
+    }),
+  ).catch(() => {});
+}

--- a/src/imessage/monitor/deliver.test.ts
+++ b/src/imessage/monitor/deliver.test.ts
@@ -45,7 +45,7 @@ describe("deliverReplies", () => {
   it("propagates payload replyToId through all text chunks", async () => {
     chunkTextWithModeMock.mockImplementation((text: string) => text.split("|"));
 
-    await deliverReplies({
+    const result = await deliverReplies({
       replies: [{ text: "first|second", replyToId: "reply-1" }],
       target: "chat_id:10",
       client,
@@ -56,6 +56,7 @@ describe("deliverReplies", () => {
     });
 
     expect(sendMessageIMessageMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ delivered: true, messageId: "imsg-1" });
     expect(sendMessageIMessageMock).toHaveBeenNthCalledWith(
       1,
       "chat_id:10",
@@ -148,5 +149,20 @@ describe("deliverReplies", () => {
       text: "second",
       messageId: "imsg-1",
     });
+  });
+
+  it("reports delivered=false when payload has no text or media", async () => {
+    const result = await deliverReplies({
+      replies: [{ channelData: { traceId: "noop" } }],
+      target: "chat_id:40",
+      client,
+      accountId: "acct-4",
+      runtime,
+      maxBytes: 2048,
+      textLimit: 4000,
+    });
+
+    expect(sendMessageIMessageMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ delivered: false, messageId: undefined });
   });
 });

--- a/src/imessage/monitor/deliver.test.ts
+++ b/src/imessage/monitor/deliver.test.ts
@@ -56,7 +56,11 @@ describe("deliverReplies", () => {
     });
 
     expect(sendMessageIMessageMock).toHaveBeenCalledTimes(2);
-    expect(result).toEqual({ delivered: true, messageId: "imsg-1" });
+    expect(result).toEqual({
+      delivered: true,
+      messageId: "imsg-1",
+      deliveredContent: "first|second",
+    });
     expect(sendMessageIMessageMock).toHaveBeenNthCalledWith(
       1,
       "chat_id:10",
@@ -164,5 +168,32 @@ describe("deliverReplies", () => {
 
     expect(sendMessageIMessageMock).not.toHaveBeenCalled();
     expect(result).toEqual({ delivered: false, messageId: undefined });
+  });
+
+  it("returns deliveredContent from markdown-table-converted text", async () => {
+    convertMarkdownTablesMock.mockImplementation((text: string) => text.replace("|A|B|", "A\tB"));
+
+    const result = await deliverReplies({
+      replies: [{ text: "|A|B|" }],
+      target: "chat_id:50",
+      client,
+      accountId: "acct-5",
+      runtime,
+      maxBytes: 4096,
+      textLimit: 4000,
+    });
+
+    expect(sendMessageIMessageMock).toHaveBeenCalledWith(
+      "chat_id:50",
+      "A\tB",
+      expect.objectContaining({
+        accountId: "acct-5",
+      }),
+    );
+    expect(result).toEqual({
+      delivered: true,
+      messageId: "imsg-1",
+      deliveredContent: "A\tB",
+    });
   });
 });

--- a/src/imessage/monitor/deliver.ts
+++ b/src/imessage/monitor/deliver.ts
@@ -17,9 +17,11 @@ export async function deliverReplies(params: {
   maxBytes: number;
   textLimit: number;
   sentMessageCache?: Pick<SentMessageCache, "remember">;
-}) {
+}): Promise<{ delivered: boolean; messageId?: string }> {
   const { replies, target, client, runtime, maxBytes, textLimit, accountId, sentMessageCache } =
     params;
+  let delivered = false;
+  let lastMessageId: string | undefined;
   const scope = `${accountId ?? ""}:${target}`;
   const cfg = loadConfig();
   const tableMode = resolveMarkdownTableMode({
@@ -44,6 +46,10 @@ export async function deliverReplies(params: {
           accountId,
           replyToId: payload.replyToId,
         });
+        delivered = true;
+        if (sent.messageId && sent.messageId !== "unknown" && sent.messageId !== "ok") {
+          lastMessageId = sent.messageId;
+        }
         sentMessageCache?.remember(scope, { text: chunk, messageId: sent.messageId });
       }
     } else {
@@ -58,6 +64,10 @@ export async function deliverReplies(params: {
           accountId,
           replyToId: payload.replyToId,
         });
+        delivered = true;
+        if (sent.messageId && sent.messageId !== "unknown" && sent.messageId !== "ok") {
+          lastMessageId = sent.messageId;
+        }
         sentMessageCache?.remember(scope, {
           text: caption || undefined,
           messageId: sent.messageId,
@@ -66,4 +76,8 @@ export async function deliverReplies(params: {
     }
     runtime.log?.(`imessage: delivered reply to ${target}`);
   }
+  return {
+    delivered,
+    messageId: lastMessageId,
+  };
 }

--- a/src/imessage/monitor/deliver.ts
+++ b/src/imessage/monitor/deliver.ts
@@ -17,11 +17,12 @@ export async function deliverReplies(params: {
   maxBytes: number;
   textLimit: number;
   sentMessageCache?: Pick<SentMessageCache, "remember">;
-}): Promise<{ delivered: boolean; messageId?: string }> {
+}): Promise<{ delivered: boolean; messageId?: string; deliveredContent?: string }> {
   const { replies, target, client, runtime, maxBytes, textLimit, accountId, sentMessageCache } =
     params;
   let delivered = false;
   let lastMessageId: string | undefined;
+  let lastDeliveredContent: string | undefined;
   const scope = `${accountId ?? ""}:${target}`;
   const cfg = loadConfig();
   const tableMode = resolveMarkdownTableMode({
@@ -52,6 +53,7 @@ export async function deliverReplies(params: {
         }
         sentMessageCache?.remember(scope, { text: chunk, messageId: sent.messageId });
       }
+      lastDeliveredContent = text;
     } else {
       let first = true;
       for (const url of mediaList) {
@@ -73,11 +75,13 @@ export async function deliverReplies(params: {
           messageId: sent.messageId,
         });
       }
+      lastDeliveredContent = text;
     }
     runtime.log?.(`imessage: delivered reply to ${target}`);
   }
   return {
     delivered,
     messageId: lastMessageId,
+    ...(lastDeliveredContent !== undefined ? { deliveredContent: lastDeliveredContent } : {}),
   };
 }

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -364,7 +364,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           runtime.error?.(danger("imessage: missing delivery target"));
           return { delivered: false };
         }
-        await deliverReplies({
+        const delivery = await deliverReplies({
           replies: [payload],
           target,
           client,
@@ -374,7 +374,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           textLimit,
           sentMessageCache,
         });
-        return { delivered: true };
+        return delivery;
       },
       onDelivery: (payload, info) => {
         const target = ctxPayload.To;

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -23,6 +23,7 @@ import {
 } from "../../config/runtime-group-policy.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose, warn } from "../../globals.js";
+import { emitMessageSentHooks } from "../../hooks/message-sent.js";
 import { normalizeScpRemoteHost } from "../../infra/scp-host.js";
 import { waitForTransportReady } from "../../infra/transport-ready.js";
 import { mediaKindFromMime } from "../../media/constants.js";
@@ -361,7 +362,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         const target = ctxPayload.To;
         if (!target) {
           runtime.error?.(danger("imessage: missing delivery target"));
-          return;
+          return { delivered: false };
         }
         await deliverReplies({
           replies: [payload],
@@ -372,6 +373,39 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           maxBytes: mediaMaxBytes,
           textLimit,
           sentMessageCache,
+        });
+        return { delivered: true };
+      },
+      onDelivery: (payload, info) => {
+        const target = ctxPayload.To;
+        if (!target) {
+          return;
+        }
+        if (info.success) {
+          if (!info.delivered) {
+            return;
+          }
+          emitMessageSentHooks({
+            to: target,
+            content: payload.text ?? "",
+            success: true,
+            channelId: "imessage",
+            accountId: accountInfo.accountId,
+            conversationId: target,
+            sessionKey: ctxPayload.SessionKey,
+            messageId: info.messageId,
+          });
+          return;
+        }
+        emitMessageSentHooks({
+          to: target,
+          content: payload.text ?? "",
+          success: false,
+          error: info.error instanceof Error ? info.error.message : String(info.error),
+          channelId: "imessage",
+          accountId: accountInfo.accountId,
+          conversationId: target,
+          sessionKey: ctxPayload.SessionKey,
         });
       },
       onError: (err, info) => {

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -13,6 +13,7 @@ import {
   type HistoryEntry,
 } from "../../auto-reply/reply/history.js";
 import { createReplyDispatcher } from "../../auto-reply/reply/reply-dispatcher.js";
+import type { ReplyPayload } from "../../auto-reply/types.js";
 import { createReplyPrefixOptions } from "../../channels/reply-prefix.js";
 import { recordInboundSession } from "../../channels/session.js";
 import { loadConfig } from "../../config/config.js";
@@ -354,11 +355,13 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       channel: "imessage",
       accountId: decision.route.accountId,
     });
+    const deliveredContentByPayload = new WeakMap<ReplyPayload, string>();
 
     const dispatcher = createReplyDispatcher({
       ...prefixOptions,
       humanDelay: resolveHumanDelayConfig(cfg, decision.route.agentId),
       deliver: async (payload) => {
+        deliveredContentByPayload.delete(payload);
         const target = ctxPayload.To;
         if (!target) {
           runtime.error?.(danger("imessage: missing delivery target"));
@@ -374,6 +377,9 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           textLimit,
           sentMessageCache,
         });
+        if (delivery.delivered) {
+          deliveredContentByPayload.set(payload, delivery.deliveredContent ?? payload.text ?? "");
+        }
         return delivery;
       },
       onDelivery: (payload, info) => {
@@ -381,13 +387,15 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         if (!target) {
           return;
         }
+        const hookContent = deliveredContentByPayload.get(payload) ?? payload.text ?? "";
+        deliveredContentByPayload.delete(payload);
         if (info.success) {
           if (!info.delivered) {
             return;
           }
           emitMessageSentHooks({
             to: target,
-            content: payload.text ?? "",
+            content: hookContent,
             success: true,
             channelId: "imessage",
             accountId: accountInfo.accountId,
@@ -399,7 +407,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
         }
         emitMessageSentHooks({
           to: target,
-          content: payload.text ?? "",
+          content: hookContent,
           success: false,
           error: info.error instanceof Error ? info.error.message : String(info.error),
           channelId: "imessage",

--- a/src/signal/monitor.delivered-content.test.ts
+++ b/src/signal/monitor.delivered-content.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getSignalToolResultTestMocks,
+  installSignalToolResultTestHooks,
+} from "./monitor.tool-result.test-harness.js";
+import type { SignalEventHandlerDeps } from "./monitor/event-handler.types.js";
+
+const capturedEventHandlerDeps = vi.hoisted(() => ({
+  value: undefined as SignalEventHandlerDeps | undefined,
+}));
+
+vi.mock("./monitor/event-handler.js", () => ({
+  createSignalEventHandler: vi.fn((deps: SignalEventHandlerDeps) => {
+    capturedEventHandlerDeps.value = deps;
+    return async () => {};
+  }),
+}));
+
+installSignalToolResultTestHooks();
+
+const { monitorSignalProvider } = await import("./monitor.js");
+
+const { sendMock, streamMock } = getSignalToolResultTestMocks();
+
+describe("signal delivered content metadata", () => {
+  beforeEach(() => {
+    capturedEventHandlerDeps.value = undefined;
+  });
+
+  it("preserves chunk boundaries when building deliveredContent", async () => {
+    const abortController = new AbortController();
+    streamMock.mockImplementationOnce(async () => {
+      abortController.abort();
+    });
+
+    await monitorSignalProvider({
+      autoStart: false,
+      baseUrl: "http://127.0.0.1:8080",
+      abortSignal: abortController.signal,
+    });
+
+    const deps = capturedEventHandlerDeps.value;
+    expect(deps?.deliverReplies).toBeTypeOf("function");
+
+    sendMock.mockReset();
+    sendMock
+      .mockResolvedValueOnce({ messageId: "signal-msg-1" })
+      .mockResolvedValueOnce({ messageId: "signal-msg-2" });
+
+    const result = await deps!.deliverReplies({
+      replies: [{ text: "hello world" }],
+      target: "+15550001111",
+      baseUrl: "http://127.0.0.1:8080",
+      accountId: "default",
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: ((code: number): never => {
+          throw new Error(`exit ${code}`);
+        }) as (code: number) => never,
+      },
+      maxBytes: 8 * 1024 * 1024,
+      textLimit: 6,
+    });
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(sendMock.mock.calls[0]?.[1]).toBe("hello");
+    expect(sendMock.mock.calls[1]?.[1]).toBe("world");
+    expect(result).toMatchObject({
+      delivered: true,
+      messageId: "signal-msg-2",
+      deliveredContent: "hello\nworld",
+    });
+  });
+});

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -316,7 +316,8 @@ async function deliverReplies(params: {
         }
       }
       if (deliveredChunks.length > 0) {
-        lastDeliveredContent = deliveredChunks.join("");
+        // Preserve message boundaries when long replies are chunked into multiple sends.
+        lastDeliveredContent = deliveredChunks.join("\n");
       }
     } else {
       let first = true;

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -288,11 +288,12 @@ async function deliverReplies(params: {
   maxBytes: number;
   textLimit: number;
   chunkMode: "length" | "newline";
-}): Promise<{ delivered: boolean; messageId?: string }> {
+}): Promise<{ delivered: boolean; messageId?: string; deliveredContent?: string }> {
   const { replies, target, baseUrl, account, accountId, runtime, maxBytes, textLimit, chunkMode } =
     params;
   let delivered = false;
   let lastMessageId: string | undefined;
+  let lastDeliveredContent: string | undefined;
   for (const payload of replies) {
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
     const text = payload.text ?? "";
@@ -300,6 +301,7 @@ async function deliverReplies(params: {
       continue;
     }
     if (mediaList.length === 0) {
+      const deliveredChunks: string[] = [];
       for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
         const result = await sendMessageSignal(target, chunk, {
           baseUrl,
@@ -308,9 +310,13 @@ async function deliverReplies(params: {
           accountId,
         });
         delivered = true;
+        deliveredChunks.push(chunk);
         if (result.messageId && result.messageId !== "unknown") {
           lastMessageId = result.messageId;
         }
+      }
+      if (deliveredChunks.length > 0) {
+        lastDeliveredContent = deliveredChunks.join("");
       }
     } else {
       let first = true;
@@ -329,12 +335,14 @@ async function deliverReplies(params: {
           lastMessageId = result.messageId;
         }
       }
+      lastDeliveredContent = text;
     }
     runtime.log?.(`delivered reply to ${target}`);
   }
   return {
     delivered,
     messageId: lastMessageId,
+    ...(lastDeliveredContent !== undefined ? { deliveredContent: lastDeliveredContent } : {}),
   };
 }
 

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -288,9 +288,11 @@ async function deliverReplies(params: {
   maxBytes: number;
   textLimit: number;
   chunkMode: "length" | "newline";
-}) {
+}): Promise<{ delivered: boolean; messageId?: string }> {
   const { replies, target, baseUrl, account, accountId, runtime, maxBytes, textLimit, chunkMode } =
     params;
+  let delivered = false;
+  let lastMessageId: string | undefined;
   for (const payload of replies) {
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
     const text = payload.text ?? "";
@@ -299,29 +301,41 @@ async function deliverReplies(params: {
     }
     if (mediaList.length === 0) {
       for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
-        await sendMessageSignal(target, chunk, {
+        const result = await sendMessageSignal(target, chunk, {
           baseUrl,
           account,
           maxBytes,
           accountId,
         });
+        delivered = true;
+        if (result.messageId && result.messageId !== "unknown") {
+          lastMessageId = result.messageId;
+        }
       }
     } else {
       let first = true;
       for (const url of mediaList) {
         const caption = first ? text : "";
         first = false;
-        await sendMessageSignal(target, caption, {
+        const result = await sendMessageSignal(target, caption, {
           baseUrl,
           account,
           mediaUrl: url,
           maxBytes,
           accountId,
         });
+        delivered = true;
+        if (result.messageId && result.messageId !== "unknown") {
+          lastMessageId = result.messageId;
+        }
       }
     }
     runtime.log?.(`delivered reply to ${target}`);
   }
+  return {
+    delivered,
+    messageId: lastMessageId,
+  };
 }
 
 export async function monitorSignalProvider(opts: MonitorSignalOpts = {}): Promise<void> {

--- a/src/signal/monitor/event-handler.delivery-hooks.test.ts
+++ b/src/signal/monitor/event-handler.delivery-hooks.test.ts
@@ -113,4 +113,34 @@ describe("signal message:sent delivery hooks", () => {
       messageId: "signal-msg-1",
     });
   });
+
+  it("emits success hooks with deliveredContent when provided", async () => {
+    setDispatchPayload({ text: "|A|B|   " });
+    const deliverReplies = vi.fn<SignalEventHandlerDeps["deliverReplies"]>(async () => ({
+      delivered: true,
+      messageId: "signal-msg-2",
+      deliveredContent: "A\tB",
+    }));
+    const handler = createDeliveryHookHandler({ deliverReplies });
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "hello",
+          attachments: [],
+        },
+      }),
+    );
+
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
+    expect(emitMessageSentHooksMock).toHaveBeenCalledTimes(1);
+    expect(emitMessageSentHooksMock.mock.calls[0]?.[0]).toMatchObject({
+      to: "+15550001111",
+      content: "A\tB",
+      success: true,
+      channelId: "signal",
+      accountId: "default",
+      messageId: "signal-msg-2",
+    });
+  });
 });

--- a/src/signal/monitor/event-handler.delivery-hooks.test.ts
+++ b/src/signal/monitor/event-handler.delivery-hooks.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReplyPayload } from "../../auto-reply/types.js";
+import { createSignalEventHandler } from "./event-handler.js";
+import {
+  createBaseSignalEventHandlerDeps,
+  createSignalReceiveEvent,
+} from "./event-handler.test-harness.js";
+
+const { dispatchInboundMessageMock, emitMessageSentHooksMock, setDispatchPayload } = vi.hoisted(
+  () => {
+    let dispatchPayload: ReplyPayload = { text: "model reply" };
+    return {
+      setDispatchPayload: (payload: ReplyPayload) => {
+        dispatchPayload = payload;
+      },
+      dispatchInboundMessageMock: vi.fn(
+        async (params: {
+          dispatcher: {
+            sendFinalReply: (payload: ReplyPayload) => boolean;
+            waitForIdle: () => Promise<void>;
+          };
+        }) => {
+          params.dispatcher.sendFinalReply(dispatchPayload);
+          await params.dispatcher.waitForIdle();
+          return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+        },
+      ),
+      emitMessageSentHooksMock: vi.fn(),
+    };
+  },
+);
+
+vi.mock("../../auto-reply/dispatch.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../auto-reply/dispatch.js")>();
+  return {
+    ...actual,
+    dispatchInboundMessage: dispatchInboundMessageMock,
+  };
+});
+
+vi.mock("../../hooks/message-sent.js", () => ({
+  emitMessageSentHooks: emitMessageSentHooksMock,
+}));
+
+vi.mock("../../pairing/pairing-store.js", () => ({
+  readChannelAllowFromStore: vi.fn().mockResolvedValue([]),
+  upsertChannelPairingRequest: vi.fn(),
+}));
+
+function createDeliveryHookHandler(params: { deliverReplies: ReturnType<typeof vi.fn> }) {
+  return createSignalEventHandler(
+    createBaseSignalEventHandlerDeps({
+      cfg: { messages: { inbound: { debounceMs: 0 } } },
+      historyLimit: 0,
+      deliverReplies: params.deliverReplies,
+    }),
+  );
+}
+
+describe("signal message:sent delivery hooks", () => {
+  beforeEach(() => {
+    dispatchInboundMessageMock.mockClear();
+    emitMessageSentHooksMock.mockClear();
+    setDispatchPayload({ text: "model reply" });
+  });
+
+  it("does not emit success hooks when delivery reports delivered=false", async () => {
+    const deliverReplies = vi.fn(async () => ({ delivered: false }));
+    const handler = createDeliveryHookHandler({ deliverReplies });
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "hello",
+          attachments: [],
+        },
+      }),
+    );
+
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
+    expect(emitMessageSentHooksMock).not.toHaveBeenCalled();
+  });
+
+  it("emits success hooks with messageId when delivery reports delivered=true", async () => {
+    const deliverReplies = vi.fn(async () => ({
+      delivered: true,
+      messageId: "signal-msg-1",
+    }));
+    const handler = createDeliveryHookHandler({ deliverReplies });
+
+    await handler(
+      createSignalReceiveEvent({
+        dataMessage: {
+          message: "hello",
+          attachments: [],
+        },
+      }),
+    );
+
+    expect(deliverReplies).toHaveBeenCalledTimes(1);
+    expect(emitMessageSentHooksMock).toHaveBeenCalledTimes(1);
+    expect(emitMessageSentHooksMock.mock.calls[0]?.[0]).toMatchObject({
+      to: "+15550001111",
+      content: "model reply",
+      success: true,
+      channelId: "signal",
+      accountId: "default",
+      messageId: "signal-msg-1",
+    });
+  });
+});

--- a/src/signal/monitor/event-handler.delivery-hooks.test.ts
+++ b/src/signal/monitor/event-handler.delivery-hooks.test.ts
@@ -5,6 +5,7 @@ import {
   createBaseSignalEventHandlerDeps,
   createSignalReceiveEvent,
 } from "./event-handler.test-harness.js";
+import type { SignalEventHandlerDeps } from "./event-handler.types.js";
 
 const { dispatchInboundMessageMock, emitMessageSentHooksMock, setDispatchPayload } = vi.hoisted(
   () => {
@@ -47,7 +48,9 @@ vi.mock("../../pairing/pairing-store.js", () => ({
   upsertChannelPairingRequest: vi.fn(),
 }));
 
-function createDeliveryHookHandler(params: { deliverReplies: ReturnType<typeof vi.fn> }) {
+function createDeliveryHookHandler(params: {
+  deliverReplies: SignalEventHandlerDeps["deliverReplies"];
+}) {
   return createSignalEventHandler(
     createBaseSignalEventHandlerDeps({
       cfg: { messages: { inbound: { debounceMs: 0 } } },
@@ -65,7 +68,9 @@ describe("signal message:sent delivery hooks", () => {
   });
 
   it("does not emit success hooks when delivery reports delivered=false", async () => {
-    const deliverReplies = vi.fn(async () => ({ delivered: false }));
+    const deliverReplies = vi.fn<SignalEventHandlerDeps["deliverReplies"]>(async () => ({
+      delivered: false,
+    }));
     const handler = createDeliveryHookHandler({ deliverReplies });
 
     await handler(
@@ -82,7 +87,7 @@ describe("signal message:sent delivery hooks", () => {
   });
 
   it("emits success hooks with messageId when delivery reports delivered=true", async () => {
-    const deliverReplies = vi.fn(async () => ({
+    const deliverReplies = vi.fn<SignalEventHandlerDeps["deliverReplies"]>(async () => ({
       delivered: true,
       messageId: "signal-msg-1",
     }));

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -28,6 +28,7 @@ import { createTypingCallbacks } from "../../channels/typing.js";
 import { resolveChannelGroupRequireMention } from "../../config/group-policy.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../globals.js";
+import { emitMessageSentHooks } from "../../hooks/message-sent.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { mediaKindFromMime } from "../../media/constants.js";
 import { resolveAgentRoute } from "../../routing/resolve-route.js";
@@ -238,6 +239,36 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           runtime: deps.runtime,
           maxBytes: deps.mediaMaxBytes,
           textLimit: deps.textLimit,
+        });
+        return { delivered: true };
+      },
+      onDelivery: (payload, info) => {
+        const target = ctxPayload.To;
+        if (info.success) {
+          if (!info.delivered) {
+            return;
+          }
+          emitMessageSentHooks({
+            to: target,
+            content: payload.text ?? "",
+            success: true,
+            channelId: "signal",
+            accountId: deps.accountId,
+            conversationId: target,
+            sessionKey: ctxPayload.SessionKey,
+            messageId: info.messageId,
+          });
+          return;
+        }
+        emitMessageSentHooks({
+          to: target,
+          content: payload.text ?? "",
+          success: false,
+          error: info.error instanceof Error ? info.error.message : String(info.error),
+          channelId: "signal",
+          accountId: deps.accountId,
+          conversationId: target,
+          sessionKey: ctxPayload.SessionKey,
         });
       },
       onError: (err, info) => {

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -18,6 +18,7 @@ import {
 import { finalizeInboundContext } from "../../auto-reply/reply/inbound-context.js";
 import { buildMentionRegexes, matchesMentionPatterns } from "../../auto-reply/reply/mentions.js";
 import { createReplyDispatcherWithTyping } from "../../auto-reply/reply/reply-dispatcher.js";
+import type { ReplyPayload } from "../../auto-reply/types.js";
 import { resolveControlCommandGate } from "../../channels/command-gating.js";
 import { logInboundDrop, logTypingFailure } from "../../channels/logging.js";
 import { resolveMentionGatingWithBypass } from "../../channels/mention-gating.js";
@@ -224,12 +225,14 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         });
       },
     });
+    const deliveredContentByPayload = new WeakMap<ReplyPayload, string>();
 
     const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping({
       ...prefixOptions,
       humanDelay: resolveHumanDelayConfig(deps.cfg, route.agentId),
       typingCallbacks,
       deliver: async (payload) => {
+        deliveredContentByPayload.delete(payload);
         const result = await deps.deliverReplies({
           replies: [payload],
           target: ctxPayload.To,
@@ -240,6 +243,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           maxBytes: deps.mediaMaxBytes,
           textLimit: deps.textLimit,
         });
+        if (result?.delivered) {
+          deliveredContentByPayload.set(payload, result.deliveredContent ?? payload.text ?? "");
+        }
         return {
           delivered: result?.delivered ?? true,
           messageId: result?.messageId,
@@ -247,13 +253,15 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       },
       onDelivery: (payload, info) => {
         const target = ctxPayload.To;
+        const hookContent = deliveredContentByPayload.get(payload) ?? payload.text ?? "";
+        deliveredContentByPayload.delete(payload);
         if (info.success) {
           if (!info.delivered) {
             return;
           }
           emitMessageSentHooks({
             to: target,
-            content: payload.text ?? "",
+            content: hookContent,
             success: true,
             channelId: "signal",
             accountId: deps.accountId,
@@ -265,7 +273,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
         }
         emitMessageSentHooks({
           to: target,
-          content: payload.text ?? "",
+          content: hookContent,
           success: false,
           error: info.error instanceof Error ? info.error.message : String(info.error),
           channelId: "signal",

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -230,7 +230,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       humanDelay: resolveHumanDelayConfig(deps.cfg, route.agentId),
       typingCallbacks,
       deliver: async (payload) => {
-        await deps.deliverReplies({
+        const result = await deps.deliverReplies({
           replies: [payload],
           target: ctxPayload.To,
           baseUrl: deps.baseUrl,
@@ -240,7 +240,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           maxBytes: deps.mediaMaxBytes,
           textLimit: deps.textLimit,
         });
-        return { delivered: true };
+        return {
+          delivered: result?.delivered ?? true,
+          messageId: result?.messageId,
+        };
       },
       onDelivery: (payload, info) => {
         const target = ctxPayload.To;

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -105,7 +105,7 @@ export type SignalEventHandlerDeps = {
     runtime: RuntimeEnv;
     maxBytes: number;
     textLimit: number;
-  }) => Promise<{ delivered: boolean; messageId?: string } | void>;
+  }) => Promise<{ delivered: boolean; messageId?: string; deliveredContent?: string } | void>;
   resolveSignalReactionTargets: (reaction: SignalReactionMessage) => SignalReactionTarget[];
   isSignalReactionMessage: (
     reaction: SignalReactionMessage | null | undefined,

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -105,7 +105,7 @@ export type SignalEventHandlerDeps = {
     runtime: RuntimeEnv;
     maxBytes: number;
     textLimit: number;
-  }) => Promise<void>;
+  }) => Promise<{ delivered: boolean; messageId?: string } | void>;
   resolveSignalReactionTargets: (reaction: SignalReactionMessage) => SignalReactionTarget[];
   isSignalReactionMessage: (
     reaction: SignalReactionMessage | null | undefined,

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -9,6 +9,7 @@ import { createReplyPrefixOptions } from "../../../channels/reply-prefix.js";
 import { createTypingCallbacks } from "../../../channels/typing.js";
 import { resolveStorePath, updateLastRoute } from "../../../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../../globals.js";
+import { emitMessageSentHooks } from "../../../hooks/message-sent.js";
 import { resolveAgentOutboundIdentity } from "../../../infra/outbound/identity.js";
 import { removeSlackReaction } from "../../actions.js";
 import { createSlackDraftStream } from "../../draft-stream.js";
@@ -266,7 +267,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     deliver: async (payload) => {
       if (useStreaming) {
         await deliverWithStreaming(payload);
-        return;
+        return { delivered: true };
       }
 
       const mediaCount = payload.mediaUrls?.length ?? (payload.mediaUrl ? 1 : 0);
@@ -292,7 +293,10 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             ts: draftMessageId,
             text: finalText.trim(),
           });
-          return;
+          return {
+            delivered: true,
+            messageId: draftMessageId,
+          };
         } catch (err) {
           logVerbose(
             `slack: preview final edit failed; falling back to standard send (${String(err)})`,
@@ -319,6 +323,36 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       }
 
       await deliverNormally(payload);
+      return { delivered: true };
+    },
+    onDelivery: (payload, info) => {
+      const target = prepared.ctxPayload.To ?? message.channel;
+      if (info.success) {
+        if (!info.delivered) {
+          return;
+        }
+        emitMessageSentHooks({
+          to: target,
+          content: payload.text ?? "",
+          success: true,
+          channelId: "slack",
+          accountId: route.accountId,
+          conversationId: target,
+          sessionKey: prepared.ctxPayload.SessionKey,
+          messageId: info.messageId,
+        });
+        return;
+      }
+      emitMessageSentHooks({
+        to: target,
+        content: payload.text ?? "",
+        success: false,
+        error: info.error instanceof Error ? info.error.message : String(info.error),
+        channelId: "slack",
+        accountId: route.accountId,
+        conversationId: target,
+        sessionKey: prepared.ctxPayload.SessionKey,
+      });
     },
     onError: (err, info) => {
       runtime.error?.(danger(`slack ${info.kind} reply failed: ${String(err)}`));

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -216,7 +216,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         usedReplyThreadTs ??= replyThreadTs;
       }
       replyPlan.markSent();
-      deliveredContentByPayload.set(payload, payload.text ?? "");
+      deliveredContentByPayload.set(payload, delivery.deliveredContent ?? payload.text ?? "");
     }
     return delivery;
   };

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -193,9 +193,12 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let streamFailed = false;
   let usedReplyThreadTs: string | undefined;
 
-  const deliverNormally = async (payload: ReplyPayload, forcedThreadTs?: string): Promise<void> => {
+  const deliverNormally = async (
+    payload: ReplyPayload,
+    forcedThreadTs?: string,
+  ): Promise<{ delivered: boolean; messageId?: string }> => {
     const replyThreadTs = forcedThreadTs ?? replyPlan.nextThreadTs();
-    await deliverReplies({
+    const delivery = await deliverReplies({
       replies: [payload],
       target: prepared.replyTarget,
       token: ctx.botToken,
@@ -206,17 +209,21 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       replyToMode: prepared.replyToMode,
       ...(slackIdentity ? { identity: slackIdentity } : {}),
     });
-    // Record the thread ts only after confirmed delivery success.
-    if (replyThreadTs) {
-      usedReplyThreadTs ??= replyThreadTs;
+    // Record thread routing only after actual delivery.
+    if (delivery.delivered) {
+      if (replyThreadTs) {
+        usedReplyThreadTs ??= replyThreadTs;
+      }
+      replyPlan.markSent();
     }
-    replyPlan.markSent();
+    return delivery;
   };
 
-  const deliverWithStreaming = async (payload: ReplyPayload): Promise<void> => {
+  const deliverWithStreaming = async (
+    payload: ReplyPayload,
+  ): Promise<{ delivered: boolean; messageId?: string }> => {
     if (streamFailed || hasMedia(payload) || !payload.text?.trim()) {
-      await deliverNormally(payload, streamSession?.threadTs);
-      return;
+      return await deliverNormally(payload, streamSession?.threadTs);
     }
 
     const text = payload.text.trim();
@@ -230,8 +237,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             "slack-stream: no reply thread target for stream start, falling back to normal delivery",
           );
           streamFailed = true;
-          await deliverNormally(payload);
-          return;
+          return await deliverNormally(payload);
         }
 
         streamSession = await startSlackStream({
@@ -244,19 +250,20 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         });
         usedReplyThreadTs ??= streamThreadTs;
         replyPlan.markSent();
-        return;
+        return { delivered: true };
       }
 
       await appendSlackStream({
         session: streamSession,
         text: "\n" + text,
       });
+      return { delivered: true };
     } catch (err) {
       runtime.error?.(
         danger(`slack-stream: streaming API call failed: ${String(err)}, falling back`),
       );
       streamFailed = true;
-      await deliverNormally(payload, streamSession?.threadTs ?? plannedThreadTs);
+      return await deliverNormally(payload, streamSession?.threadTs ?? plannedThreadTs);
     }
   };
 
@@ -266,8 +273,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     typingCallbacks,
     deliver: async (payload) => {
       if (useStreaming) {
-        await deliverWithStreaming(payload);
-        return { delivered: true };
+        return await deliverWithStreaming(payload);
       }
 
       const mediaCount = payload.mediaUrls?.length ?? (payload.mediaUrl ? 1 : 0);
@@ -322,8 +328,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         hasStreamedMessage = false;
       }
 
-      await deliverNormally(payload);
-      return { delivered: true };
+      return await deliverNormally(payload);
     },
     onDelivery: (payload, info) => {
       const target = prepared.ctxPayload.To ?? message.channel;

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -192,6 +192,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
   let streamSession: SlackStreamSession | null = null;
   let streamFailed = false;
   let usedReplyThreadTs: string | undefined;
+  const deliveredContentByPayload = new WeakMap<ReplyPayload, string>();
 
   const deliverNormally = async (
     payload: ReplyPayload,
@@ -215,6 +216,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         usedReplyThreadTs ??= replyThreadTs;
       }
       replyPlan.markSent();
+      deliveredContentByPayload.set(payload, payload.text ?? "");
     }
     return delivery;
   };
@@ -250,6 +252,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         });
         usedReplyThreadTs ??= streamThreadTs;
         replyPlan.markSent();
+        deliveredContentByPayload.set(payload, text);
         return { delivered: true };
       }
 
@@ -257,6 +260,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         session: streamSession,
         text: "\n" + text,
       });
+      deliveredContentByPayload.set(payload, text);
       return { delivered: true };
     } catch (err) {
       runtime.error?.(
@@ -272,6 +276,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
     typingCallbacks,
     deliver: async (payload) => {
+      deliveredContentByPayload.delete(payload);
       if (useStreaming) {
         return await deliverWithStreaming(payload);
       }
@@ -299,6 +304,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             ts: draftMessageId,
             text: finalText.trim(),
           });
+          deliveredContentByPayload.set(payload, finalText.trim());
           return {
             delivered: true,
             messageId: draftMessageId,
@@ -332,13 +338,15 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
     },
     onDelivery: (payload, info) => {
       const target = prepared.ctxPayload.To ?? message.channel;
+      const hookContent = deliveredContentByPayload.get(payload) ?? payload.text ?? "";
+      deliveredContentByPayload.delete(payload);
       if (info.success) {
         if (!info.delivered) {
           return;
         }
         emitMessageSentHooks({
           to: target,
-          content: payload.text ?? "",
+          content: hookContent,
           success: true,
           channelId: "slack",
           accountId: route.accountId,
@@ -350,7 +358,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       }
       emitMessageSentHooks({
         to: target,
-        content: payload.text ?? "",
+        content: hookContent,
         success: false,
         error: info.error instanceof Error ? info.error.message : String(info.error),
         channelId: "slack",

--- a/src/slack/monitor/replies.test.ts
+++ b/src/slack/monitor/replies.test.ts
@@ -66,9 +66,13 @@ describe("deliverReplies identity passthrough", () => {
   it("reports delivered metadata from successful sends", async () => {
     sendMock.mockResolvedValueOnce({ messageId: "slack-msg-1", channelId: "C123" });
 
-    const result = await deliverReplies(baseParams({ replies: [{ text: "hello" }] }));
+    const result = await deliverReplies(baseParams({ replies: [{ text: "hello   " }] }));
 
     expect(sendMock).toHaveBeenCalledOnce();
-    expect(result).toEqual({ delivered: true, messageId: "slack-msg-1" });
+    expect(result).toEqual({
+      delivered: true,
+      messageId: "slack-msg-1",
+      deliveredContent: "hello",
+    });
   });
 });

--- a/src/slack/monitor/replies.test.ts
+++ b/src/slack/monitor/replies.test.ts
@@ -75,4 +75,30 @@ describe("deliverReplies identity passthrough", () => {
       deliveredContent: "hello",
     });
   });
+
+  it("keeps first caption as deliveredContent for multi-media payloads", async () => {
+    sendMock
+      .mockResolvedValueOnce({ messageId: "slack-media-1", channelId: "C123" })
+      .mockResolvedValueOnce({ messageId: "slack-media-2", channelId: "C123" });
+
+    const result = await deliverReplies(
+      baseParams({
+        replies: [
+          {
+            text: "primary caption",
+            mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+          },
+        ],
+      }),
+    );
+
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(sendMock.mock.calls[0]?.[1]).toBe("primary caption");
+    expect(sendMock.mock.calls[1]?.[1]).toBe("");
+    expect(result).toEqual({
+      delivered: true,
+      messageId: "slack-media-2",
+      deliveredContent: "primary caption",
+    });
+  });
 });

--- a/src/slack/monitor/replies.test.ts
+++ b/src/slack/monitor/replies.test.ts
@@ -22,9 +22,9 @@ function baseParams(overrides?: Record<string, unknown>) {
 describe("deliverReplies identity passthrough", () => {
   beforeEach(() => {
     sendMock.mockReset();
+    sendMock.mockResolvedValue({ messageId: "m-1", channelId: "C123" });
   });
   it("passes identity to sendMessageSlack for text replies", async () => {
-    sendMock.mockResolvedValue(undefined);
     const identity = { username: "Bot", iconEmoji: ":robot:" };
     await deliverReplies(baseParams({ identity }));
 
@@ -33,7 +33,6 @@ describe("deliverReplies identity passthrough", () => {
   });
 
   it("passes identity to sendMessageSlack for media replies", async () => {
-    sendMock.mockResolvedValue(undefined);
     const identity = { username: "Bot", iconUrl: "https://example.com/icon.png" };
     await deliverReplies(
       baseParams({
@@ -47,10 +46,29 @@ describe("deliverReplies identity passthrough", () => {
   });
 
   it("omits identity key when not provided", async () => {
-    sendMock.mockResolvedValue(undefined);
     await deliverReplies(baseParams());
 
     expect(sendMock).toHaveBeenCalledOnce();
     expect(sendMock.mock.calls[0][2]).not.toHaveProperty("identity");
+  });
+
+  it("reports delivered=false for channelData-only payloads", async () => {
+    const result = await deliverReplies(
+      baseParams({
+        replies: [{ channelData: { traceId: "noop" } }],
+      }),
+    );
+
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ delivered: false, messageId: undefined });
+  });
+
+  it("reports delivered metadata from successful sends", async () => {
+    sendMock.mockResolvedValueOnce({ messageId: "slack-msg-1", channelId: "C123" });
+
+    const result = await deliverReplies(baseParams({ replies: [{ text: "hello" }] }));
+
+    expect(sendMock).toHaveBeenCalledOnce();
+    expect(result).toEqual({ delivered: true, messageId: "slack-msg-1" });
   });
 });

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -18,9 +18,10 @@ export async function deliverReplies(params: {
   replyThreadTs?: string;
   replyToMode: "off" | "first" | "all";
   identity?: SlackSendIdentity;
-}): Promise<{ delivered: boolean; messageId?: string }> {
+}): Promise<{ delivered: boolean; messageId?: string; deliveredContent?: string }> {
   let delivered = false;
   let lastMessageId: string | undefined;
+  let lastDeliveredContent: string | undefined;
   for (const payload of params.replies) {
     // Keep reply tags opt-in: when replyToMode is off, explicit reply tags
     // must not force threading.
@@ -44,6 +45,7 @@ export async function deliverReplies(params: {
         ...(params.identity ? { identity: params.identity } : {}),
       });
       delivered = true;
+      lastDeliveredContent = trimmed;
       if (sent.messageId && sent.messageId !== "unknown" && sent.messageId !== "suppressed") {
         lastMessageId = sent.messageId;
       }
@@ -60,6 +62,7 @@ export async function deliverReplies(params: {
           ...(params.identity ? { identity: params.identity } : {}),
         });
         delivered = true;
+        lastDeliveredContent = caption;
         if (sent.messageId && sent.messageId !== "unknown" && sent.messageId !== "suppressed") {
           lastMessageId = sent.messageId;
         }
@@ -70,6 +73,7 @@ export async function deliverReplies(params: {
   return {
     delivered,
     messageId: lastMessageId,
+    ...(lastDeliveredContent !== undefined ? { deliveredContent: lastDeliveredContent } : {}),
   };
 }
 

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -53,6 +53,7 @@ export async function deliverReplies(params: {
       let first = true;
       for (const mediaUrl of mediaList) {
         const caption = first ? text : "";
+        const isFirstCaption = first;
         first = false;
         const sent = await sendMessageSlack(params.target, caption, {
           token: params.token,
@@ -62,7 +63,10 @@ export async function deliverReplies(params: {
           ...(params.identity ? { identity: params.identity } : {}),
         });
         delivered = true;
-        lastDeliveredContent = caption;
+        if (isFirstCaption) {
+          // Keep the primary caption text; later media messages intentionally use empty captions.
+          lastDeliveredContent = caption;
+        }
         if (sent.messageId && sent.messageId !== "unknown" && sent.messageId !== "suppressed") {
           lastMessageId = sent.messageId;
         }

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -18,7 +18,9 @@ export async function deliverReplies(params: {
   replyThreadTs?: string;
   replyToMode: "off" | "first" | "all";
   identity?: SlackSendIdentity;
-}) {
+}): Promise<{ delivered: boolean; messageId?: string }> {
+  let delivered = false;
+  let lastMessageId: string | undefined;
   for (const payload of params.replies) {
     // Keep reply tags opt-in: when replyToMode is off, explicit reply tags
     // must not force threading.
@@ -35,28 +37,40 @@ export async function deliverReplies(params: {
       if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
         continue;
       }
-      await sendMessageSlack(params.target, trimmed, {
+      const sent = await sendMessageSlack(params.target, trimmed, {
         token: params.token,
         threadTs,
         accountId: params.accountId,
         ...(params.identity ? { identity: params.identity } : {}),
       });
+      delivered = true;
+      if (sent.messageId && sent.messageId !== "unknown" && sent.messageId !== "suppressed") {
+        lastMessageId = sent.messageId;
+      }
     } else {
       let first = true;
       for (const mediaUrl of mediaList) {
         const caption = first ? text : "";
         first = false;
-        await sendMessageSlack(params.target, caption, {
+        const sent = await sendMessageSlack(params.target, caption, {
           token: params.token,
           mediaUrl,
           threadTs,
           accountId: params.accountId,
           ...(params.identity ? { identity: params.identity } : {}),
         });
+        delivered = true;
+        if (sent.messageId && sent.messageId !== "unknown" && sent.messageId !== "suppressed") {
+          lastMessageId = sent.messageId;
+        }
       }
     }
     params.runtime.log?.(`delivered reply to ${params.target}`);
   }
+  return {
+    delivered,
+    messageId: lastMessageId,
+  };
 }
 
 export type SlackRespondFn = (payload: {

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -9,6 +9,7 @@ const deliverReplies = vi.hoisted(() => vi.fn());
 const editMessageTelegram = vi.hoisted(() => vi.fn());
 const loadSessionStore = vi.hoisted(() => vi.fn());
 const resolveStorePath = vi.hoisted(() => vi.fn(() => "/tmp/sessions.json"));
+const emitMessageSentHooks = vi.hoisted(() => vi.fn());
 
 vi.mock("./draft-stream.js", () => ({
   createTelegramDraftStream,
@@ -31,6 +32,10 @@ vi.mock("../config/sessions.js", async () => ({
   resolveStorePath,
 }));
 
+vi.mock("../hooks/message-sent.js", () => ({
+  emitMessageSentHooks,
+}));
+
 vi.mock("./sticker-cache.js", () => ({
   cacheSticker: vi.fn(),
   describeStickerImage: vi.fn(),
@@ -46,6 +51,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     dispatchReplyWithBufferedBlockDispatcher.mockClear();
     deliverReplies.mockClear();
     editMessageTelegram.mockClear();
+    emitMessageSentHooks.mockClear();
     loadSessionStore.mockClear();
     resolveStorePath.mockClear();
     resolveStorePath.mockReturnValue("/tmp/sessions.json");
@@ -1062,6 +1068,41 @@ describe("dispatchTelegramMessage draft streaming", () => {
       }),
     );
     expect(editMessageTelegram).not.toHaveBeenCalled();
+  });
+
+  it("emits answer-only hook content when reasoning level is off", async () => {
+    loadSessionStore.mockReturnValue({
+      s1: { reasoningLevel: "off" },
+    });
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async ({ dispatcherOptions }) => {
+      dispatcherOptions.onDelivery?.(
+        {
+          text: "<think>should not leak</think>Visible answer",
+        },
+        {
+          kind: "final",
+          success: true,
+          delivered: true,
+          messageId: "telegram-msg-1",
+        },
+      );
+      return { queuedFinal: true };
+    });
+
+    await dispatchWithContext({
+      context: createContext({
+        ctxPayload: { SessionKey: "s1" } as unknown as TelegramMessageContext["ctxPayload"],
+      }),
+      streamMode: "partial",
+    });
+
+    expect(emitMessageSentHooks).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "Visible answer",
+        success: true,
+        messageId: "telegram-msg-1",
+      }),
+    );
   });
 
   it.each([undefined, null] as const)(

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -18,6 +18,7 @@ import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { loadSessionStore, resolveStorePath } from "../config/sessions.js";
 import type { OpenClawConfig, ReplyToMode, TelegramAccountConfig } from "../config/types.js";
 import { danger, logVerbose } from "../globals.js";
+import { emitMessageSentHooks } from "../hooks/message-sent.js";
 import { getAgentScopedMediaLocalRoots } from "../media/local-roots.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { TelegramMessageContext } from "./bot-message-context.js";
@@ -466,6 +467,7 @@ export const dispatchTelegramMessage = async ({
         ...prefixOptions,
         typingCallbacks,
         deliver: async (payload, info) => {
+          let delivered = false;
           const previewButtons = (
             payload.channelData?.telegram as { buttons?: TelegramInlineButtons } | undefined
           )?.buttons;
@@ -483,13 +485,16 @@ export const dispatchTelegramMessage = async ({
                 | { buttons?: TelegramInlineButtons }
                 | undefined
             )?.buttons;
-            await deliverLaneText({
+            const result = await deliverLaneText({
               laneName: "answer",
               text: buffered.text,
               payload: buffered.payload,
               infoKind: "final",
               previewButtons: bufferedButtons,
             });
+            if (result !== "skipped") {
+              delivered = true;
+            }
             reasoningStepState.resetForNextStep();
           };
 
@@ -513,6 +518,9 @@ export const dispatchTelegramMessage = async ({
               previewButtons,
               allowPreviewUpdateForNonFinal: segment.lane === "reasoning",
             });
+            if (result !== "skipped") {
+              delivered = true;
+            }
             if (segment.lane === "reasoning") {
               if (result !== "skipped") {
                 reasoningStepState.noteReasoningDelivered();
@@ -528,18 +536,21 @@ export const dispatchTelegramMessage = async ({
             }
           }
           if (segments.length > 0) {
-            return;
+            return { delivered };
           }
           if (split.suppressedReasoningOnly) {
             if (hasMedia) {
               const payloadWithoutSuppressedReasoning =
                 typeof payload.text === "string" ? { ...payload, text: "" } : payload;
-              await sendPayload(payloadWithoutSuppressedReasoning);
+              const mediaDelivered = await sendPayload(payloadWithoutSuppressedReasoning);
+              if (mediaDelivered) {
+                delivered = true;
+              }
             }
             if (info.kind === "final") {
               await flushBufferedFinalAnswer();
             }
-            return;
+            return { delivered };
           }
 
           if (info.kind === "final") {
@@ -553,12 +564,16 @@ export const dispatchTelegramMessage = async ({
             if (info.kind === "final") {
               await flushBufferedFinalAnswer();
             }
-            return;
+            return { delivered };
           }
-          await sendPayload(payload);
+          const payloadDelivered = await sendPayload(payload);
+          if (payloadDelivered) {
+            delivered = true;
+          }
           if (info.kind === "final") {
             await flushBufferedFinalAnswer();
           }
+          return { delivered };
         },
         onSkip: (_payload, info) => {
           if (info.reason !== "silent") {
@@ -568,6 +583,35 @@ export const dispatchTelegramMessage = async ({
         onError: (err, info) => {
           deliveryState.markNonSilentFailure();
           runtime.error?.(danger(`telegram ${info.kind} reply failed: ${String(err)}`));
+        },
+        onDelivery: (payload, info) => {
+          const target = String(chatId);
+          if (info.success) {
+            if (!info.delivered) {
+              return;
+            }
+            emitMessageSentHooks({
+              to: target,
+              content: payload.text ?? "",
+              success: true,
+              channelId: "telegram",
+              accountId: route.accountId,
+              conversationId: target,
+              sessionKey: ctxPayload.SessionKey,
+              messageId: info.messageId,
+            });
+            return;
+          }
+          emitMessageSentHooks({
+            to: target,
+            content: payload.text ?? "",
+            success: false,
+            error: info.error instanceof Error ? info.error.message : String(info.error),
+            channelId: "telegram",
+            accountId: route.accountId,
+            conversationId: target,
+            sessionKey: ctxPayload.SessionKey,
+          });
         },
       },
       replyOptions: {

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -254,6 +254,19 @@ export const dispatchTelegramMessage = async ({
         Boolean(split.reasoningText) && suppressReasoning && !split.answerText,
     };
   };
+  const deriveHookContent = (payload: ReplyPayload): string => {
+    if (resolvedReasoningLevel !== "off") {
+      return payload.text ?? "";
+    }
+    const split = splitTextIntoLaneSegments(payload.text);
+    if (split.suppressedReasoningOnly) {
+      return "";
+    }
+    if (split.segments.length === 0) {
+      return payload.text ?? "";
+    }
+    return split.segments.map((segment) => segment.text).join("\n\n");
+  };
   const resetDraftLaneState = (lane: DraftLaneState) => {
     lane.lastPartialText = "";
     lane.hasStreamedMessage = false;
@@ -586,13 +599,14 @@ export const dispatchTelegramMessage = async ({
         },
         onDelivery: (payload, info) => {
           const target = String(chatId);
+          const hookContent = deriveHookContent(payload);
           if (info.success) {
             if (!info.delivered) {
               return;
             }
             emitMessageSentHooks({
               to: target,
-              content: payload.text ?? "",
+              content: hookContent,
               success: true,
               channelId: "telegram",
               accountId: route.accountId,
@@ -604,7 +618,7 @@ export const dispatchTelegramMessage = async ({
           }
           emitMessageSentHooks({
             to: target,
-            content: payload.text ?? "",
+            content: hookContent,
             success: false,
             error: info.error instanceof Error ? info.error.message : String(info.error),
             channelId: "telegram",


### PR DESCRIPTION
## Summary
- add reply-dispatcher `onDelivery` callback with success/failure + delivered metadata
- add shared `emitMessageSentHooks` helper for plugin hook (`message_sent`) and internal hook (`message:sent`)
- wire message-sent hook emission into Telegram, Discord, Slack, Signal, and iMessage reply dispatchers
- keep hook emission gated on actual delivery (`delivered=true`) to avoid no-op payload events
- add regression tests for dispatcher delivery callbacks and new message-sent helper

## Testing
- pnpm test src/auto-reply/reply/reply-flow.test.ts src/hooks/message-sent.test.ts src/telegram/bot-message-dispatch.test.ts src/discord/monitor/message-handler.process.test.ts src/slack/monitor/message-handler/dispatch.streaming.test.ts src/signal/monitor/event-handler.inbound-contract.test.ts src/imessage/monitor/monitor-provider.echo-cache.test.ts
- pnpm exec oxlint src/auto-reply/reply/reply-dispatcher.ts src/auto-reply/reply/reply-flow.test.ts src/discord/monitor/message-handler.process.ts src/imessage/monitor/monitor-provider.ts src/signal/monitor/event-handler.ts src/slack/monitor/message-handler/dispatch.ts src/telegram/bot-message-dispatch.ts src/hooks/message-sent.ts src/hooks/message-sent.test.ts
- pnpm exec oxfmt --check src/auto-reply/reply/reply-dispatcher.ts src/auto-reply/reply/reply-flow.test.ts src/discord/monitor/message-handler.process.ts src/imessage/monitor/monitor-provider.ts src/signal/monitor/event-handler.ts src/slack/monitor/message-handler/dispatch.ts src/telegram/bot-message-dispatch.ts src/hooks/message-sent.ts src/hooks/message-sent.test.ts

Closes #31293
