### PR TITLE
fix: preserve webchat session-event replies via transcript mirror

### DIFF
--- a/src/auto-reply/reply/route-reply.test.ts
+++ b/src/auto-reply/reply/route-reply.test.ts
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   sendMessageTelegram: vi.fn(async () => ({ messageId: "m1", chatId: "c1" })),
   sendMessageWhatsApp: vi.fn(async () => ({ messageId: "m1", toJid: "jid" })),
   deliverOutboundPayloads: vi.fn(),
+  appendAssistantMessageToSessionTranscript: vi.fn(async () => ({ ok: true, sessionFile: "s" })),
 }));
 
 vi.mock("../../discord/send.js", () => ({
@@ -55,6 +56,9 @@ vi.mock("../../infra/outbound/deliver.js", async () => {
     deliverOutboundPayloads: mocks.deliverOutboundPayloads,
   };
 });
+vi.mock("../../config/sessions/transcript.js", () => ({
+  appendAssistantMessageToSessionTranscript: mocks.appendAssistantMessageToSessionTranscript,
+}));
 const actualDeliver = await vi.importActual<typeof import("../../infra/outbound/deliver.js")>(
   "../../infra/outbound/deliver.js",
 );
@@ -154,6 +158,24 @@ describe("routeReply", () => {
     });
     expect(res.ok).toBe(true);
     expect(mocks.sendMessageSlack).not.toHaveBeenCalled();
+  });
+
+  it("mirrors internal webchat replies into session transcript", async () => {
+    mocks.appendAssistantMessageToSessionTranscript.mockClear();
+    const res = await routeReply({
+      payload: { text: "hello webchat" },
+      channel: "webchat",
+      to: "webchat:user-1",
+      sessionKey: "main:webchat:user-1",
+      cfg: {} as never,
+    });
+    expect(res.ok).toBe(true);
+    expect(mocks.appendAssistantMessageToSessionTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionKey: "main:webchat:user-1",
+        text: "hello webchat",
+      }),
+    );
   });
 
   it("drops silent token payloads", async () => {

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -11,6 +11,7 @@ import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { resolveEffectiveMessagesConfig } from "../../agents/identity.js";
 import { normalizeChannelId } from "../../channels/plugins/index.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { appendAssistantMessageToSessionTranscript } from "../../config/sessions/transcript.js";
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
 import { INTERNAL_MESSAGE_CHANNEL, normalizeMessageChannel } from "../../utils/message-channel.js";
 import type { OriginatingChannelType } from "../templating.js";
@@ -100,10 +101,25 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
   }
 
   if (channel === INTERNAL_MESSAGE_CHANNEL) {
-    return {
-      ok: false,
-      error: "Webchat routing not supported for queued replies",
-    };
+    if (!params.sessionKey) {
+      return {
+        ok: false,
+        error: "Webchat routing requires sessionKey",
+      };
+    }
+    const mirrored = await appendAssistantMessageToSessionTranscript({
+      agentId: resolvedAgentId,
+      sessionKey: params.sessionKey,
+      text,
+      mediaUrls,
+    });
+    if (!mirrored.ok) {
+      return {
+        ok: false,
+        error: `Failed to mirror webchat reply: ${mirrored.reason}`,
+      };
+    }
+    return { ok: true };
   }
 
   const channelId = normalizeChannelId(channel) ?? null;


### PR DESCRIPTION
## Summary
Handle internal webchat reply routing in `routeReply` by mirroring assistant output into the session transcript instead of failing as unsupported.

## Problem
Session-event-triggered runs (for example exec-event wakes) can produce assistant output for webchat sessions, but `routeReply` previously returned:

- `Webchat routing not supported for queued replies`

This caused those responses to be dropped from the webchat-visible flow.

## Changes
- In `routeReply`:
  - for `channel === "webchat"`, require `sessionKey`
  - mirror reply payload into transcript via `appendAssistantMessageToSessionTranscript`
  - return success when mirror succeeds
- Added regression test:
  - `mirrors internal webchat replies into session transcript`

## Notes
This keeps behavior safe for non-routable internal webchat while preserving session-event outputs for webchat sessions.

Fixes openclaw/openclaw#31348