### PR TITLE
fix: add Ollama keep_alive + Cron ID prefix matching

### DIFF
--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -24,6 +24,7 @@ interface OllamaChatRequest {
   stream: boolean;
   tools?: OllamaTool[];
   options?: Record<string, unknown>;
+  keep_alive?: string | number;
 }
 
 interface OllamaChatMessage {
@@ -443,6 +444,10 @@ export function createOllamaStreamFn(baseUrl: string): StreamFn {
           stream: true,
           ...(ollamaTools.length > 0 ? { tools: ollamaTools } : {}),
           options: ollamaOptions,
+          // Keep model loaded if OLLAMA_KEEP_ALIVE env var is set.
+          // Format: "30m", "5m", 300000 (ms), etc.
+          // Helps with sequential cron jobs but increases RAM on memory-constrained hosts.
+          keep_alive: process.env.OLLAMA_KEEP_ALIVE,
         };
 
         const headers: Record<string, string> = {

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -190,7 +190,20 @@ export function registerCronEditCommand(cron: Command) {
             const listed = (await callGatewayFromCli("cron.list", opts, {
               includeDisabled: true,
             })) as { jobs?: CronJob[] } | null;
-            const existing = (listed?.jobs ?? []).find((job) => job.id === id);
+            const jobs = listed?.jobs ?? [];
+            // Try exact match first
+            let existing = jobs.find((job) => job.id === id);
+            // Try prefix match
+            if (!existing) {
+              const matches = jobs.filter((job) => job.id.startsWith(id));
+              if (matches.length === 1) {
+                existing = matches[0];
+              } else if (matches.length > 1) {
+                throw new Error(
+                  `Ambiguous cron job ID "${id}": ${matches.map((j) => j.id).join(", ")}`,
+                );
+              }
+            }
             if (!existing) {
               throw new Error(`unknown cron job id: ${id}`);
             }

--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -47,7 +47,21 @@ export class CronService {
   }
 
   getJob(id: string): CronJob | undefined {
-    return this.state.store?.jobs.find((job) => job.id === id);
+    const jobs = this.state.store?.jobs ?? [];
+    // Try exact match first
+    const exact = jobs.find((job) => job.id === id);
+    if (exact) {
+      return exact;
+    }
+    // Try prefix match (e.g., "0ed3cd30" matches "0ed3cd30-00a1-...")
+    const matches = jobs.filter((job) => job.id.startsWith(id));
+    if (matches.length === 1) {
+      return matches[0];
+    }
+    if (matches.length > 1) {
+      throw new Error(`Ambiguous cron job ID "${id}": ${matches.map((j) => j.id).join(", ")}`);
+    }
+    return undefined;
   }
 
   wake(opts: { mode: "now" | "next-heartbeat"; text: string }) {

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -152,11 +152,21 @@ function assertDeliverySupport(job: Pick<CronJob, "sessionTarget" | "delivery">)
 }
 
 export function findJobOrThrow(state: CronServiceState, id: string) {
-  const job = state.store?.jobs.find((j) => j.id === id);
-  if (!job) {
-    throw new Error(`unknown cron job id: ${id}`);
+  const jobs = state.store?.jobs ?? [];
+  // Try exact match first
+  const exact = jobs.find((j) => j.id === id);
+  if (exact) {
+    return exact;
   }
-  return job;
+  // Try prefix match (e.g., "0ed3cd30" matches "0ed3cd30-00a1-...")
+  const matches = jobs.filter((j) => j.id.startsWith(id));
+  if (matches.length === 1) {
+    return matches[0];
+  }
+  if (matches.length > 1) {
+    throw new Error(`Ambiguous cron job ID "${id}": ${matches.map((j) => j.id).join(", ")}`);
+  }
+  throw new Error(`unknown cron job id: ${id}`);
 }
 
 export function computeJobNextRunAtMs(job: CronJob, nowMs: number): number | undefined {

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -310,7 +310,7 @@ export async function update(state: CronServiceState, id: string, patch: CronJob
     await persist(state);
     armTimer(state);
     emit(state, {
-      jobId: id,
+      jobId: job.id,
       action: "updated",
       nextRunAtMs: job.state.nextRunAtMs,
     });


### PR DESCRIPTION
## Summary

### 1. Ollama keep_alive support (OLLAMA_KEEP_ALIVE env var)
Adds optional `keep_alive` parameter to Ollama /api/chat requests, controlled via `OLLAMA_KEEP_ALIVE` env var.

- Helps with sequential Ollama cron jobs (avoids cold start)
- Default unchanged when env var not set
- Users with sufficient RAM can enable: `export OLLAMA_KEEP_ALIVE="30m"`

### 2. Cron ID prefix matching
Supports short ID prefixes like git commit hashes.

- `openclaw cron edit 0ed3cd30` now works (matches `0ed3cd30-00a1-...`)
- Works for: edit, enable, disable, rm, run
- Throws "ambiguous" error if prefix matches multiple jobs

## Problem

1. Sequential Ollama cron jobs suffer from cold starts (30-60s per job)
2. Cron CLI requires full UUID - painful DX

## Solution

1. Add `keep_alive: process.env.OLLAMA_KEEP_ALIVE` to Ollama requests
2. Add prefix matching in CLI + service + ops layers

## Testing

- [x] TypeScript compiles
- [x] Code follows existing patterns

## Related

- #5769 (Ollama streaming)
- #22125 (Cron timeouts)