### PR TITLE
fix: retry failed session-event wake runs

### DIFF
--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -107,6 +107,19 @@ describe("heartbeat-wake", () => {
     });
   });
 
+  it("retries failed runs after the default retry delay", async () => {
+    vi.useFakeTimers();
+    const handler = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "failed", reason: "temporary error" })
+      .mockResolvedValueOnce({ status: "ran", durationMs: 1 });
+    await expectRetryAfterDefaultDelay({
+      handler,
+      initialReason: "exec-event",
+      expectedRetryReason: "exec-event",
+    });
+  });
+
   it("stale disposer does not clear a newer handler", async () => {
     vi.useFakeTimers();
     const handlerA = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -161,6 +161,16 @@ function schedule(coalesceMs: number, kind: WakeTimerKind = "normal") {
             sessionKey: pendingWake.sessionKey,
           });
           schedule(DEFAULT_RETRY_MS, "retry");
+          continue;
+        }
+        if (res.status === "failed") {
+          // Session-event runs should not be dropped on transient failures.
+          queuePendingWakeReason({
+            reason: pendingWake.reason ?? "retry",
+            agentId: pendingWake.agentId,
+            sessionKey: pendingWake.sessionKey,
+          });
+          schedule(DEFAULT_RETRY_MS, "retry");
         }
       }
     } catch {


### PR DESCRIPTION
## Summary
Retry failed heartbeat wake runs instead of dropping them.

## Problem
The wake scheduler already retries on:
- skipped reason requests-in-flight
- thrown handler errors

But when a handler returns `{ status: "failed" }`, the wake could be dropped with no retry.
That can cause session-event wake runs to be lost.

## Changes
- In `src/infra/heartbeat-wake.ts`:
  - keep existing retry behavior for `requests-in-flight`
  - add retry behavior for `res.status === "failed"`
- In `src/infra/heartbeat-wake.test.ts`:
  - add regression test `retries failed runs after the default retry delay`

Fixes openclaw/openclaw#31354