### PR TITLE
fix(session): preserve session_status model overrides after same-session turns

### DIFF
--- a/src/commands/agent/session-store.test.ts
+++ b/src/commands/agent/session-store.test.ts
@@ -63,4 +63,63 @@ describe("updateSessionStoreAfterAgentRun", () => {
     expect(persisted?.acp).toBeDefined();
     expect(staleInMemory[sessionKey]?.acp).toBeDefined();
   });
+
+  it("preserves model overrides written by tools during the same run", async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-session-store-"));
+    const storePath = path.join(dir, "sessions.json");
+    const sessionKey = `agent:main:main`;
+    const sessionId = randomUUID();
+
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [sessionKey]: {
+            sessionId,
+            updatedAt: Date.now(),
+            providerOverride: "google",
+            modelOverride: "gemini-2.5-pro",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const staleInMemory: Record<string, SessionEntry> = {
+      [sessionKey]: {
+        sessionId,
+        updatedAt: Date.now(),
+        providerOverride: undefined,
+        modelOverride: undefined,
+      },
+    };
+
+    await updateSessionStoreAfterAgentRun({
+      cfg: {} as never,
+      sessionId,
+      sessionKey,
+      storePath,
+      sessionStore: staleInMemory,
+      defaultProvider: "openai",
+      defaultModel: "gpt-5.3-codex",
+      result: {
+        payloads: [],
+        meta: {
+          aborted: false,
+          agentMeta: {
+            provider: "openai",
+            model: "gpt-5.3-codex",
+          },
+        },
+      } as never,
+    });
+
+    const persisted = loadSessionStore(storePath, { skipCache: true })[sessionKey];
+    expect(persisted?.providerOverride).toBe("google");
+    expect(persisted?.modelOverride).toBe("gemini-2.5-pro");
+    expect(staleInMemory[sessionKey]?.providerOverride).toBe("google");
+    expect(staleInMemory[sessionKey]?.modelOverride).toBe("gemini-2.5-pro");
+  });
 });

--- a/src/commands/agent/session-store.ts
+++ b/src/commands/agent/session-store.ts
@@ -55,27 +55,13 @@ export async function updateSessionStoreAfterAgentRun(params: {
       fallbackContextTokens: DEFAULT_CONTEXT_TOKENS,
     }) ?? DEFAULT_CONTEXT_TOKENS;
 
-  const entry = sessionStore[sessionKey] ?? {
+  const now = Date.now();
+  const patch: Partial<SessionEntry> = {
     sessionId,
-    updatedAt: Date.now(),
-  };
-  const next: SessionEntry = {
-    ...entry,
-    sessionId,
-    updatedAt: Date.now(),
+    updatedAt: now,
     contextTokens,
+    abortedLastRun: result.meta.aborted ?? false,
   };
-  setSessionRuntimeModel(next, {
-    provider: providerUsed,
-    model: modelUsed,
-  });
-  if (isCliProvider(providerUsed, cfg)) {
-    const cliSessionId = result.meta.agentMeta?.sessionId?.trim();
-    if (cliSessionId) {
-      setCliSessionId(next, providerUsed, cliSessionId);
-    }
-  }
-  next.abortedLastRun = result.meta.aborted ?? false;
   if (hasNonzeroUsage(usage)) {
     const input = usage.input ?? 0;
     const output = usage.output ?? 0;
@@ -84,23 +70,42 @@ export async function updateSessionStoreAfterAgentRun(params: {
       contextTokens,
       promptTokens,
     });
-    next.inputTokens = input;
-    next.outputTokens = output;
+    patch.inputTokens = input;
+    patch.outputTokens = output;
     if (typeof totalTokens === "number" && Number.isFinite(totalTokens) && totalTokens > 0) {
-      next.totalTokens = totalTokens;
-      next.totalTokensFresh = true;
+      patch.totalTokens = totalTokens;
+      patch.totalTokensFresh = true;
     } else {
-      next.totalTokens = undefined;
-      next.totalTokensFresh = false;
+      patch.totalTokens = undefined;
+      patch.totalTokensFresh = false;
     }
-    next.cacheRead = usage.cacheRead ?? 0;
-    next.cacheWrite = usage.cacheWrite ?? 0;
+    patch.cacheRead = usage.cacheRead ?? 0;
+    patch.cacheWrite = usage.cacheWrite ?? 0;
   }
-  if (compactionsThisRun > 0) {
-    next.compactionCount = (entry.compactionCount ?? 0) + compactionsThisRun;
-  }
+
+  const cliSessionId =
+    isCliProvider(providerUsed, cfg) && result.meta.agentMeta?.sessionId?.trim()
+      ? result.meta.agentMeta.sessionId.trim()
+      : undefined;
+
   const persisted = await updateSessionStore(storePath, (store) => {
-    const merged = mergeSessionEntry(store[sessionKey], next);
+    const existing =
+      store[sessionKey] ??
+      sessionStore[sessionKey] ?? {
+        sessionId,
+        updatedAt: now,
+      };
+    const merged = mergeSessionEntry(existing, patch);
+    setSessionRuntimeModel(merged, {
+      provider: providerUsed,
+      model: modelUsed,
+    });
+    if (cliSessionId) {
+      setCliSessionId(merged, providerUsed, cliSessionId);
+    }
+    if (compactionsThisRun > 0) {
+      merged.compactionCount = (existing.compactionCount ?? 0) + compactionsThisRun;
+    }
     store[sessionKey] = merged;
     return merged;
   });


### PR DESCRIPTION
## Summary
- fix `updateSessionStoreAfterAgentRun` to merge a minimal runtime patch into the latest on-disk session entry instead of replaying a stale in-memory snapshot
- preserve model/provider overrides (and other externally-mutated fields) written mid-turn by tools like `session_status`
- add regression coverage for stale in-memory entries carrying explicit `undefined` override fields

## Before
When a run started with an in-memory session entry containing `modelOverride: undefined` / `providerOverride: undefined`, a same-session `session_status(model=...)` update could persist correctly mid-turn and then get clobbered at end-of-turn save.

## After
End-of-turn session persistence now merges runtime metrics into the freshest stored session entry, so tool-written model overrides survive the turn.

## Validation
- `pnpm exec vitest run src/commands/agent/session-store.test.ts`
- `pnpm exec vitest run src/agents/openclaw-tools.session-status.test.ts`

Fixes #31422
