### PR TITLE
fix(cli-runner): preserve multi-block Claude text in parseCliJson

### DIFF
--- a/src/agents/cli-runner.helpers.parse-json.test.ts
+++ b/src/agents/cli-runner.helpers.parse-json.test.ts
@@ -8,7 +8,12 @@ describe("parseCliJson", () => {
         text: "Done! Saved the fix.",
         content: [
           { type: "text", text: "Let me investigate the logs...\n" },
-          { type: "tool_use", id: "call-1", name: "bash", input: { command: "tail -n 200 app.log" } },
+          {
+            type: "tool_use",
+            id: "call-1",
+            name: "bash",
+            input: { command: "tail -n 200 app.log" },
+          },
           { type: "text", text: "Found the issue! Here's what happened...\n" },
           { type: "tool_use", id: "call-2", name: "edit", input: { path: "src/app.ts" } },
           { type: "text", text: "Done! Saved the fix." },

--- a/src/agents/cli-runner.helpers.parse-json.test.ts
+++ b/src/agents/cli-runner.helpers.parse-json.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { parseCliJson } from "./cli-runner/helpers.js";
+
+describe("parseCliJson", () => {
+  it("keeps all assistant text blocks from message.content even when message.text is present", () => {
+    const payload = {
+      message: {
+        text: "Done! Saved the fix.",
+        content: [
+          { type: "text", text: "Let me investigate the logs...\n" },
+          { type: "tool_use", id: "call-1", name: "bash", input: { command: "tail -n 200 app.log" } },
+          { type: "text", text: "Found the issue! Here's what happened...\n" },
+          { type: "tool_use", id: "call-2", name: "edit", input: { path: "src/app.ts" } },
+          { type: "text", text: "Done! Saved the fix." },
+        ],
+      },
+    };
+
+    const parsed = parseCliJson(JSON.stringify(payload), { command: "claude" });
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.text).toContain("Let me investigate the logs...");
+    expect(parsed?.text).toContain("Found the issue! Here's what happened...");
+    expect(parsed?.text).toContain("Done! Saved the fix.");
+  });
+
+  it("falls back to message.text when no structured content blocks exist", () => {
+    const payload = {
+      message: {
+        text: "Single-block response",
+      },
+    };
+
+    const parsed = parseCliJson(JSON.stringify(payload), { command: "claude" });
+    expect(parsed?.text).toBe("Single-block response");
+  });
+});

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -151,17 +151,27 @@ function collectText(value: unknown): string {
   if (!isRecord(value)) {
     return "";
   }
-  if (typeof value.text === "string") {
-    return value.text;
+
+  // Prefer structured content/message blocks over a flat `text` field.
+  // Claude CLI can surface multi-block assistant output in `content[]` while also
+  // including the final block in `text`; picking `text` first drops earlier blocks.
+  if (Array.isArray(value.content)) {
+    const contentText = value.content.map((entry) => collectText(entry)).join("");
+    if (contentText.trim()) {
+      return contentText;
+    }
   }
-  if (typeof value.content === "string") {
+  if (typeof value.content === "string" && value.content.trim()) {
     return value.content;
   }
-  if (Array.isArray(value.content)) {
-    return value.content.map((entry) => collectText(entry)).join("");
-  }
   if (isRecord(value.message)) {
-    return collectText(value.message);
+    const messageText = collectText(value.message);
+    if (messageText.trim()) {
+      return messageText;
+    }
+  }
+  if (typeof value.text === "string") {
+    return value.text;
   }
   return "";
 }


### PR DESCRIPTION
## Summary
Fixes #31447.

When `parseCliJson()` receives Claude CLI output that includes both:
- `message.content` (multiple text/tool blocks), and
- `message.text` (often only the final text block),

we now prioritize the structured `content` blocks so earlier assistant text blocks are not dropped.

## What changed
- Updated `collectText()` in `src/agents/cli-runner/helpers.ts` to prefer:
  1. `content[]`
  2. `content` (string)
  3. nested `message`
  4. `text`
- Added regression tests in `src/agents/cli-runner.helpers.parse-json.test.ts`:
  - preserves all text blocks from `message.content` even when `message.text` exists
  - still falls back to `message.text` for single-block payloads

## Before / After
- **Before:** multi-block assistant responses could collapse to only the final block when `message.text` was present.
- **After:** all assistant text blocks from structured content are preserved in order.

## Validation
- `pnpm exec vitest run src/agents/cli-runner.helpers.parse-json.test.ts src/agents/cli-runner.test.ts`

## AI transparency
- [x] AI-assisted
- [x] Tested locally (targeted tests above)


AI-assisted contribution by @jlgrimes (Clawbot workflow).