### PR TITLE
fix: filter heartbeat tokens in outbound delivery

### DIFF
--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { HEARTBEAT_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { typedCases } from "../../test-utils/typed-cases.js";
@@ -35,6 +36,7 @@ import { resolveOutboundSessionRoute } from "./outbound-session.js";
 import {
   formatOutboundPayloadLog,
   normalizeOutboundPayloads,
+  normalizeReplyPayloadsForDelivery,
   normalizeOutboundPayloadsForJson,
 } from "./payloads.js";
 import { runResolveOutboundTargetCoreTests } from "./targets.shared-test.js";
@@ -1116,6 +1118,26 @@ describe("normalizeOutboundPayloads", () => {
       { text: "final answer" },
     ]);
     expect(normalized).toEqual([{ text: "final answer", mediaUrls: [] }]);
+  });
+});
+
+describe("normalizeReplyPayloadsForDelivery", () => {
+  it("filters heartbeat-only and silent-only payloads before channel delivery", () => {
+    expect(
+      normalizeReplyPayloadsForDelivery([{ text: HEARTBEAT_TOKEN }, { text: "NO_REPLY" }]),
+    ).toEqual([]);
+  });
+
+  it("strips heartbeat text and preserves media-only payloads", () => {
+    expect(
+      normalizeReplyPayloadsForDelivery([
+        { text: HEARTBEAT_TOKEN, mediaUrl: "https://x.test/a.png" },
+        { text: `${HEARTBEAT_TOKEN} hello`, mediaUrl: "https://x.test/b.png" },
+      ]),
+    ).toMatchObject([
+      { text: "", mediaUrl: "https://x.test/a.png", mediaUrls: ["https://x.test/a.png"] },
+      { text: "hello", mediaUrl: "https://x.test/b.png", mediaUrls: ["https://x.test/b.png"] },
+    ]);
   });
 });
 

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -1,8 +1,10 @@
+import { stripHeartbeatToken } from "../../auto-reply/heartbeat.js";
 import { parseReplyDirectives } from "../../auto-reply/reply/reply-directives.js";
 import {
   isRenderablePayload,
   shouldSuppressReasoningPayload,
 } from "../../auto-reply/reply/reply-payloads.js";
+import { HEARTBEAT_TOKEN, isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 
 export type NormalizedOutboundPayload = {
@@ -56,9 +58,30 @@ export function normalizeReplyPayloadsForDelivery(
     );
     const hasMultipleMedia = (explicitMediaUrls?.length ?? 0) > 1;
     const resolvedMediaUrl = hasMultipleMedia ? undefined : explicitMediaUrl;
+    const hasMedia = mergedMedia.length > 0;
+    const hasChannelData = Boolean(
+      payload.channelData && Object.keys(payload.channelData).length > 0,
+    );
+    let text = parsed.text ?? "";
+
+    if (text && isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
+      if (!hasMedia && !hasChannelData) {
+        return [];
+      }
+      text = "";
+    }
+
+    if (text.includes(HEARTBEAT_TOKEN)) {
+      const stripped = stripHeartbeatToken(text, { mode: "message" });
+      if (stripped.shouldSkip && !hasMedia && !hasChannelData) {
+        return [];
+      }
+      text = stripped.text;
+    }
+
     const next: ReplyPayload = {
       ...payload,
-      text: parsed.text ?? "",
+      text,
       mediaUrls: mergedMedia.length ? mergedMedia : undefined,
       mediaUrl: resolvedMediaUrl,
       replyToId: payload.replyToId ?? parsed.replyToId,


### PR DESCRIPTION
## Summary

- Problem: outbound delivery could send `HEARTBEAT_OK` and `NO_REPLY` to end users because `normalizeReplyPayloadsForDelivery()` did not apply the silent-token filtering already present in `normalizeReplyPayload()`.
- Why it matters: cron/isolated-agent replies travel through the outbound delivery pipeline, so heartbeat/silent markers could leak into Telegram or other channels as visible user text.
- What changed: added heartbeat and silent-token filtering to `src/infra/outbound/payloads.ts`, preserving media/channel payloads while suppressing marker-only text.
- What did NOT change (scope boundary): no provider logic, no gateway auth, no session compaction behavior, no model/tool execution semantics.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None

## User-visible / Behavior Changes

- `HEARTBEAT_OK` is no longer delivered as visible channel text.
- `NO_REPLY` is no longer delivered as visible channel text.
- If a payload contains media or channel data plus a silent/heartbeat marker, the marker text is stripped while the non-text payload is preserved.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu
- Runtime/container: local git checkout
- Model/provider: provider-agnostic
- Integration/channel (if any): outbound channel delivery path
- Relevant config (redacted): none

### Steps

1. Produce a reply payload that contains only `HEARTBEAT_OK` or `NO_REPLY`.
2. Send it through the outbound delivery normalization path.
3. Repeat with marker text plus media/channel payload.

### Expected

- Marker-only payloads should be dropped before delivery.
- Marker text should be stripped from mixed payloads, while media/channel data remains deliverable.

### Actual

- Before fix, `normalizeReplyPayloadsForDelivery()` did not apply heartbeat/silent-token filtering.
- The equivalent filtering already existed in `normalizeReplyPayload()`, so behavior diverged between the auto-reply path and the outbound delivery path.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - marker-only `HEARTBEAT_OK` payload is filtered
  - marker-only `NO_REPLY` payload is filtered
  - heartbeat marker is stripped while media payload is preserved
  - heartbeat marker is stripped while remaining visible text is preserved
- Edge cases checked:
  - no media / no channel data
  - media with empty text after stripping
  - silent token handling and heartbeat handling through the same outbound path
- What you did **not** verify:
  - full repo test suite
  - live channel end-to-end against Telegram after this patch

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert commit `a2e9c866f`
- Files/config to restore:
  - `src/infra/outbound/payloads.ts`
  - `src/infra/outbound/outbound.test.ts`
- Known bad symptoms reviewers should watch for:
  - media payloads unexpectedly dropped when heartbeat markers are present
  - visible delivery of heartbeat/silent markers returning

## Risks and Mitigations

- Risk:
  - duplicated filtering behavior still exists across `normalizeReplyPayload()` and `normalizeReplyPayloadsForDelivery()`, so future drift is still possible.
  - Mitigation:
    - this patch aligns the outbound path now and adds focused regression coverage; a later shared-helper refactor can remove duplication without blocking the bug fix.
