### PR TITLE
fix: reject leaked exec control metadata

### DIFF
--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -154,7 +154,7 @@ function binaryName(token: string | undefined): string | undefined {
     return undefined;
   }
   const cleaned = stripOuterQuotes(token) ?? token;
-  const segment = cleaned.split(/[/]/).at(-1) ?? cleaned;
+  const segment = cleaned.split(/[\\/]/).at(-1) ?? cleaned;
   return segment
     .trim()
     .toLowerCase()
@@ -568,6 +568,11 @@ export function createExecTool(
         applyPathPrepend(env, defaultPathPrepend);
       }
 
+      // Preflight: catch malformed exec control metadata before any approval or
+      // deferred gateway execution path can handle the command asynchronously.
+      assertNoInlineExecControlLeak(params.command);
+      await validateScriptFileForShellBleed({ command: params.command, workdir });
+
       if (host === "node") {
         return executeNodeHostCommand({
           command: params.command,
@@ -633,11 +638,6 @@ export function createExecTool(
         : (explicitTimeoutSec ?? defaultTimeoutSec);
       const getWarningText = () => (warnings.length ? `${warnings.join("\n")}\n\n` : "");
       const usePty = params.pty === true && !sandbox;
-
-      // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)
-      // before we execute and burn tokens in cron loops.
-      assertNoInlineExecControlLeak(params.command);
-      await validateScriptFileForShellBleed({ command: params.command, workdir });
 
       const run = await runExecProcess({
         command: params.command,

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -155,7 +155,10 @@ function binaryName(token: string | undefined): string | undefined {
   }
   const cleaned = stripOuterQuotes(token) ?? token;
   const segment = cleaned.split(/[/]/).at(-1) ?? cleaned;
-  return segment.trim().toLowerCase();
+  return segment
+    .trim()
+    .toLowerCase()
+    .replace(/\.exe$/i, "");
 }
 
 function parseInlineExecControlToken(
@@ -171,13 +174,14 @@ function parseInlineExecControlToken(
   }
   const name = match[1].toLowerCase() as InlineExecControlName;
   const rawValue = match[2]?.trim() ?? "";
+  const normalizedValue = rawValue.toLowerCase();
   if (name === "workdir") {
     return rawValue ? { name, value: rawValue } : null;
   }
-  if (rawValue === "true") {
+  if (normalizedValue === "true") {
     return { name, value: true };
   }
-  if (rawValue === "false") {
+  if (normalizedValue === "false") {
     return { name, value: false };
   }
   return null;

--- a/src/agents/bash-tools.exec.ts
+++ b/src/agents/bash-tools.exec.ts
@@ -77,6 +77,172 @@ function extractScriptTargetFromCommand(
   return null;
 }
 
+type InlineExecControlName = "pty" | "background" | "elevated" | "workdir";
+const INLINE_EXEC_SHELL_LAUNCHERS = new Set(["bash", "sh", "zsh"]);
+
+function splitShellWords(input: string | undefined, maxWords = 48): string[] {
+  if (!input) {
+    return [];
+  }
+
+  const words: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | undefined;
+  let escaped = false;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) {
+        quote = undefined;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (!current) {
+        continue;
+      }
+      words.push(current);
+      if (words.length >= maxWords) {
+        return words;
+      }
+      current = "";
+      continue;
+    }
+    current += char;
+  }
+
+  if (current) {
+    words.push(current);
+  }
+  return words;
+}
+
+function stripOuterQuotes(value: string | undefined): string | undefined {
+  if (!value) {
+    return value;
+  }
+  const trimmed = value.trim();
+  if (
+    trimmed.length >= 2 &&
+    ((trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'")))
+  ) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+function binaryName(token: string | undefined): string | undefined {
+  if (!token) {
+    return undefined;
+  }
+  const cleaned = stripOuterQuotes(token) ?? token;
+  const segment = cleaned.split(/[/]/).at(-1) ?? cleaned;
+  return segment.trim().toLowerCase();
+}
+
+function parseInlineExecControlToken(
+  token: string | undefined,
+): { name: InlineExecControlName; value: boolean | string } | null {
+  const trimmed = token?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const match = trimmed.match(/^(pty|background|elevated|workdir):(.*)$/i);
+  if (!match) {
+    return null;
+  }
+  const name = match[1].toLowerCase() as InlineExecControlName;
+  const rawValue = match[2]?.trim() ?? "";
+  if (name === "workdir") {
+    return rawValue ? { name, value: rawValue } : null;
+  }
+  if (rawValue === "true") {
+    return { name, value: true };
+  }
+  if (rawValue === "false") {
+    return { name, value: false };
+  }
+  return null;
+}
+
+function detectInlineExecControlLeak(command: string): {
+  controls: string[];
+  location: "prefix" | "shell-argv";
+} | null {
+  const words = splitShellWords(command, 12);
+  if (words.length === 0) {
+    return null;
+  }
+
+  const prefixControls: string[] = [];
+  let index = 0;
+  while (index < words.length) {
+    const parsed = parseInlineExecControlToken(words[index]);
+    if (!parsed) {
+      break;
+    }
+    prefixControls.push(words[index]);
+    index += 1;
+  }
+  if (prefixControls.length > 0) {
+    return { controls: prefixControls, location: "prefix" };
+  }
+
+  const launcher = binaryName(words[0]);
+  if (!launcher || !INLINE_EXEC_SHELL_LAUNCHERS.has(launcher)) {
+    return null;
+  }
+  const shellArgControls: string[] = [];
+  for (let i = 1; i < Math.min(words.length, 5); i += 1) {
+    const parsed = parseInlineExecControlToken(words[i]);
+    if (!parsed) {
+      break;
+    }
+    shellArgControls.push(words[i]);
+  }
+  if (shellArgControls.length > 0) {
+    return { controls: shellArgControls, location: "shell-argv" };
+  }
+  return null;
+}
+
+function assertNoInlineExecControlLeak(command: string): void {
+  const leak = detectInlineExecControlLeak(command);
+  if (!leak) {
+    return;
+  }
+  const controls = leak.controls.join(", ");
+  const location =
+    leak.location === "prefix"
+      ? "before the executable"
+      : "inside shell argv immediately after the executable";
+  throw new Error(
+    [
+      `exec preflight: detected leaked exec control metadata in command text (${controls}) ${location}.`,
+      "Keep exec controls structured and separate from the shell command.",
+      "Use tool parameters for pty/background/elevated/workdir instead of embedding them in command text.",
+    ].join("\n"),
+  );
+}
+
 async function validateScriptFileForShellBleed(params: {
   command: string;
   workdir: string;
@@ -466,6 +632,7 @@ export function createExecTool(
 
       // Preflight: catch a common model failure mode (shell syntax leaking into Python/JS sources)
       // before we execute and burn tokens in cron loops.
+      assertNoInlineExecControlLeak(params.command);
       await validateScriptFileForShellBleed({ command: params.command, workdir });
 
       const run = await runExecProcess({

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -586,4 +586,24 @@ describe("exec inline control metadata guard", () => {
       Use tool parameters for pty/background/elevated/workdir instead of embedding them in command text.]
     `);
   });
+
+  it("rejects leaked inline exec control metadata before gateway approval branching", async () => {
+    const approvalTool = createTestExecTool({ ask: "on" });
+    await expect(executeExecCommand(approvalTool, 'bash pty:true -lc "echo ok"')).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+      [Error: exec preflight: detected leaked exec control metadata in command text (pty:true) inside shell argv immediately after the executable.
+      Keep exec controls structured and separate from the shell command.
+      Use tool parameters for pty/background/elevated/workdir instead of embedding them in command text.]
+    `);
+  });
+
+  it("rejects leaked inline exec control metadata for windows path launcher names", async () => {
+    await expect(
+      executeExecCommand(execTool, 'C:\\\\Git\\\\bin\\\\bash.exe pty:true -lc "echo ok"'),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(`
+      [Error: exec preflight: detected leaked exec control metadata in command text (pty:true) inside shell argv immediately after the executable.
+      Keep exec controls structured and separate from the shell command.
+      Use tool parameters for pty/background/elevated/workdir instead of embedding them in command text.]
+    `);
+  });
 });

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -568,4 +568,22 @@ describe("exec inline control metadata guard", () => {
       Use tool parameters for pty/background/elevated/workdir instead of embedding them in command text.]
     `);
   });
+
+  it("rejects leaked inline exec control metadata with case-insensitive booleans", async () => {
+    await expect(executeExecCommand(execTool, "pty:True background:FALSE echo hello")).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+      [Error: exec preflight: detected leaked exec control metadata in command text (pty:True, background:FALSE) before the executable.
+      Keep exec controls structured and separate from the shell command.
+      Use tool parameters for pty/background/elevated/workdir instead of embedding them in command text.]
+    `);
+  });
+
+  it("rejects leaked inline exec control metadata for windows shell launcher names", async () => {
+    await expect(executeExecCommand(execTool, 'bash.exe pty:true -lc "echo ok"')).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+      [Error: exec preflight: detected leaked exec control metadata in command text (pty:true) inside shell argv immediately after the executable.
+      Keep exec controls structured and separate from the shell command.
+      Use tool parameters for pty/background/elevated/workdir instead of embedding them in command text.]
+    `);
+  });
 });

--- a/src/agents/bash-tools.test.ts
+++ b/src/agents/bash-tools.test.ts
@@ -547,3 +547,25 @@ describe("exec PATH handling", () => {
     }
   });
 });
+
+describe("exec inline control metadata guard", () => {
+  useCapturedEnv([...SHELL_ENV_KEYS], applyDefaultShellEnv);
+
+  it("rejects leaked inline exec control metadata before the executable", async () => {
+    await expect(executeExecCommand(execTool, "pty:true background:true echo hello")).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+      [Error: exec preflight: detected leaked exec control metadata in command text (pty:true, background:true) before the executable.
+      Keep exec controls structured and separate from the shell command.
+      Use tool parameters for pty/background/elevated/workdir instead of embedding them in command text.]
+    `);
+  });
+
+  it("rejects leaked inline exec control metadata in shell argv", async () => {
+    await expect(executeExecCommand(execTool, 'bash pty:true -lc "echo ok"')).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+      [Error: exec preflight: detected leaked exec control metadata in command text (pty:true) inside shell argv immediately after the executable.
+      Keep exec controls structured and separate from the shell command.
+      Use tool parameters for pty/background/elevated/workdir instead of embedding them in command text.]
+    `);
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: a real isolated cron `agentTurn` run could fail when structured exec control metadata leaked into raw shell command text, leading to malformed shell execution such as `bash pty:true ...` and then an embedded-run failure (`Cannot read properties of undefined (reading '0')`).
- Why it matters: this is not just a bad prompt example. It is a robustness and safety boundary issue. Exec controls such as `pty`, `background`, `elevated`, and `workdir` are structured tool parameters, not shell argv. When they leak into command text, the platform should fail closed with a clear tool error instead of handing the tokens to the shell and cascading into an internal runner failure.
- What changed: added an exec preflight guard in `src/agents/bash-tools.exec.ts` that detects leaked inline exec control metadata in command text and rejects it with a structured error before shell execution. Added focused regression tests covering both leading inline metadata and shell-argv leakage.
- What did NOT change (scope boundary): no provider/model logic, no cron scheduling semantics, no delivery semantics, and no session compaction behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None

## User-visible / Behavior Changes

- Exec/bash calls with leaked control metadata in raw command text now fail with a clear structured tool error.
- The platform no longer attempts to run malformed shell commands such as `bash pty:true ...`.
- This prevents a downstream embedded-run failure in cron/isolated agent flows.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Exec handling is now stricter. OpenClaw rejects mixed control-metadata/shell text instead of attempting best-effort execution. This reduces ambiguity at the structured-tool/raw-shell boundary and makes malformed commands fail closed.

## Repro + Verification

### Environment

- OS: Ubuntu
- Runtime/container: local git checkout
- Model/provider: provider-agnostic
- Integration/channel (if any): cron isolated-agent / exec tool path
- Relevant config (redacted): none

### Steps

1. Trigger an exec/bash call where control metadata leaks into the raw command string.
2. Example patterns:
   - `pty:true background:true echo hello`
   - `bash pty:true -lc "echo ok"`
3. Run through the exec tool path.

### Expected

- OpenClaw should reject the malformed command before shell execution.
- The failure should surface as a normal structured tool error.
- No internal runner crash should occur.

### Actual

- Before fix, malformed control metadata could reach the shell as argv.
- In the real cron case, that surfaced as `bash: pty:true: No such file or directory` followed by an embedded-run failure (`Cannot read properties of undefined (reading '0')`).

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - leaked inline metadata before the executable is rejected
  - leaked inline metadata in shell argv is rejected
  - existing PTY exec behavior still works
  - PTY fallback failure behavior still works
- Edge cases checked:
  - `pty:true background:true` prefix leakage
  - `bash pty:true -lc ...` shell-launcher leakage
- What you did **not** verify:
  - full repo test suite
  - full live cron end-to-end after this patch

## Compatibility / Migration

- Backward compatible? (`Yes, with stricter validation`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert commit `6c7f6dfa2`
- Files/config to restore:
  - `src/agents/bash-tools.exec.ts`
  - `src/agents/bash-tools.test.ts`
- Known bad symptoms reviewers should watch for:
  - false-positive rejection of valid shell commands containing `name:value` tokens at the start of the command

## Risks and Mitigations

- Risk:
  - the new preflight may reject some valid but unusual shell commands if they intentionally start with tokens matching exec control syntax.
  - Mitigation:
    - matching is intentionally narrow and focused on known control fields (`pty`, `background`, `elevated`, `workdir`)
    - shell-argv detection is limited to immediate post-launcher positions for `bash`/`sh`/`zsh`
    - focused tests cover the intended failure class

- Risk:
  - this addresses the malformed exec boundary but not every possible downstream bad result shape.
  - Mitigation:
    - this closes the real trigger observed in the cron failure and prevents the malformed shell execution from occurring in the first place.
