### PR TITLE
fix(ui): auto-recover from small WebSocket event gaps instead of showing error

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -212,10 +212,6 @@ export function connectGateway(host: GatewayHost) {
         const app = host as unknown as OpenClawApp;
         void loadChatHistory(app);
         void loadDevices(app, { quiet: true });
-        if (app.chatRunId) {
-          app.chatRunId = null;
-          app.chatStream = null;
-        }
         return;
       }
       host.lastError = `event gap detected (expected seq ${expected}, got ${received}); refresh recommended`;

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -204,6 +204,14 @@ export function connectGateway(host: GatewayHost) {
       if (host.client !== client) {
         return;
       }
+      const gap = received - expected;
+      if (gap <= 3) {
+        console.debug(
+          `[gateway] small event gap (${gap} events), auto-recovering via history reload`,
+        );
+        void loadChatHistory(host as unknown as OpenClawApp);
+        return;
+      }
       host.lastError = `event gap detected (expected seq ${expected}, got ${received}); refresh recommended`;
       host.lastErrorCode = null;
     },

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -25,7 +25,6 @@ import {
   parseExecApprovalResolved,
   removeExecApproval,
 } from "./controllers/exec-approval.ts";
-import { loadExecApprovals } from "./controllers/exec-approvals.ts";
 import { loadNodes } from "./controllers/nodes.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import {
@@ -208,12 +207,15 @@ export function connectGateway(host: GatewayHost) {
       const gap = received - expected;
       if (gap <= 3) {
         console.debug(
-          `[gateway] small event gap (${gap} events), auto-recovering via full state refresh`,
+          `[gateway] small event gap (${gap} events), auto-recovering via state refresh`,
         );
         const app = host as unknown as OpenClawApp;
         void loadChatHistory(app);
-        void loadExecApprovals(app);
         void loadDevices(app, { quiet: true });
+        if (app.chatRunId) {
+          app.chatRunId = null;
+          app.chatStream = null;
+        }
         return;
       }
       host.lastError = `event gap detected (expected seq ${expected}, got ${received}); refresh recommended`;

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -25,6 +25,7 @@ import {
   parseExecApprovalResolved,
   removeExecApproval,
 } from "./controllers/exec-approval.ts";
+import { loadExecApprovals } from "./controllers/exec-approvals.ts";
 import { loadNodes } from "./controllers/nodes.ts";
 import { loadSessions } from "./controllers/sessions.ts";
 import {
@@ -207,9 +208,12 @@ export function connectGateway(host: GatewayHost) {
       const gap = received - expected;
       if (gap <= 3) {
         console.debug(
-          `[gateway] small event gap (${gap} events), auto-recovering via history reload`,
+          `[gateway] small event gap (${gap} events), auto-recovering via full state refresh`,
         );
-        void loadChatHistory(host as unknown as OpenClawApp);
+        const app = host as unknown as OpenClawApp;
+        void loadChatHistory(app);
+        void loadExecApprovals(app);
+        void loadDevices(app, { quiet: true });
         return;
       }
       host.lastError = `event gap detected (expected seq ${expected}, got ${received}); refresh recommended`;


### PR DESCRIPTION
## Summary

Fixes #25722 - Control UI shows persistent error for small WebSocket event gaps

Previously, any event gap (even a single missed event) would display a persistent error message asking users to refresh. This was disruptive for minor network hiccups that could be recovered automatically.

## Changes

- **Small gaps (≤3 events)**: Auto-recover by reloading chat history silently
- **Large gaps (>3 events)**: Show the existing error message recommending refresh

## Technical Details

When a small gap is detected:
1. Log debug message for troubleshooting
2. Call `loadChatHistory()` to refresh the chat state
3. Skip setting `lastError`, so no error banner is shown

The threshold of 3 events was chosen as a balance between:
- Recovering from common transient issues (1-2 missed events)
- Not masking serious connectivity problems

## Testing

- [x] TypeScript compilation passes
- [x] UI tests pass (`pnpm vitest run ui/src/ui`)
- [x] Lint passes

## AI Disclosure

This PR was developed with AI assistance. The code has been reviewed and tested locally.