### PR TITLE
fix(ui): notify UI when agent times out instead of showing perpetual thinking state

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
+import { emitAgentEvent } from "../../infra/agent-events.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { PluginHookBeforeAgentStartResult } from "../../plugins/types.js";
@@ -1247,28 +1248,37 @@ export async function runEmbeddedPiAgent(
           // Timeout aborts can leave the run without any assistant payloads.
           // Emit an explicit timeout error instead of silently completing, so
           // callers do not lose the turn as an orphaned user message.
-          if (timedOut && !timedOutDuringCompaction && payloads.length === 0) {
-            return {
-              payloads: [
-                {
-                  text:
-                    "Request timed out before a response was generated. " +
-                    "Please try again, or increase `agents.defaults.timeoutSeconds` in your config.",
-                  isError: true,
-                },
-              ],
-              meta: {
-                durationMs: Date.now() - started,
-                agentMeta,
-                aborted,
-                systemPromptReport: attempt.systemPromptReport,
+          if (timedOut && !timedOutDuringCompaction) {
+            const timeoutErrorMessage =
+              payloads.length === 0
+                ? "Request timed out before a response was generated. " +
+                  "Please try again, or increase `agents.defaults.timeoutSeconds` in your config."
+                : "Request timed out. The response may be incomplete.";
+            emitAgentEvent({
+              runId: params.runId,
+              stream: "lifecycle",
+              data: {
+                phase: "error",
+                error: timeoutErrorMessage,
+                endedAt: Date.now(),
               },
-              didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-              messagingToolSentTexts: attempt.messagingToolSentTexts,
-              messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
-              messagingToolSentTargets: attempt.messagingToolSentTargets,
-              successfulCronAdds: attempt.successfulCronAdds,
-            };
+            });
+            if (payloads.length === 0) {
+              return {
+                payloads: [{ text: timeoutErrorMessage, isError: true }],
+                meta: {
+                  durationMs: Date.now() - started,
+                  agentMeta,
+                  aborted,
+                  systemPromptReport: attempt.systemPromptReport,
+                },
+                didSendViaMessagingTool: attempt.didSendViaMessagingTool,
+                messagingToolSentTexts: attempt.messagingToolSentTexts,
+                messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
+                messagingToolSentTargets: attempt.messagingToolSentTargets,
+                successfulCronAdds: attempt.successfulCronAdds,
+              };
+            }
           }
 
           log.debug(


### PR DESCRIPTION
## Summary

Fixes #24903 - Agent timeout leaves UI in perpetual 'thinking' state

Previously, when an agent timed out, the UI would continue showing 'thinking...' indefinitely because no error event was sent to the UI.

## Root Cause

When a timeout occurs:
1. `abortRun(true)` is called, setting `timedOut=true`
2. The agent is aborted, but `lastAssistant.stopReason` is not `'error'`
3. `handleAgentEnd` sends `phase:'end'` instead of `phase:'error'`
4. UI receives `state:'final'` with no error indication

## Fix

Emit a `lifecycle:error` event explicitly when timeout occurs (and not during compaction). This ensures the UI receives `state:'error'` with a clear timeout message, regardless of whether the agent produced any output before timing out.

The error message varies based on whether any output was generated:
- **No output**: `'Request timed out before a response was generated. Please try again, or increase agents.defaults.timeoutSeconds in your config.'`
- **Partial output**: `'Request timed out. The response may be incomplete.'`

## Changes

- `src/agents/pi-embedded-runner/run.ts`: Emit `lifecycle:error` event when `timedOut && !timedOutDuringCompaction`

## Testing

- [x] All existing tests pass (326 tests in pi-embedded-runner)
- [x] TypeScript compilation passes
- [x] Lint passes

## AI Disclosure

This PR was developed with AI assistance. The code has been reviewed and tested locally.