### PR TITLE
fix(sessions): surface fire-and-forget delivery failures to requester

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Sessions/Agent-to-agent: `sessions_send` now notifies the requester session when a fire-and-forget (`timeoutSeconds=0`) target run fails (for example model-not-found/misconfigured target model), instead of silently dropping delivery in the background A2A announce flow. Fixes #25198.
 - Security/iOS deep links: require local confirmation (or trusted key) before forwarding `openclaw://agent` requests from iOS to gateway `agent.request`, and strip unkeyed delivery-routing fields to reduce exfiltration risk. This ships in the next npm release. Thanks @GCXWLP for reporting.
 - Security/Export session HTML: escape raw HTML markdown tokens in the exported session viewer, harden tree/header metadata rendering against HTML injection, and sanitize image data-URL MIME types in export output to prevent stored XSS when opening exported HTML files. This ships in the next npm release. Thanks @allsmog for reporting.
 - Security/Session export: harden exported HTML image rendering against data-URL attribute injection by validating image MIME/base64 fields, rejecting malformed base64 input in media ingestion paths, and dropping invalid tool-image payloads.

--- a/src/agents/tools/sessions-send-tool.a2a.model-failure.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.model-failure.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const callGatewayMock = vi.fn();
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+const runAgentStepMock = vi.fn();
+const readLatestAssistantReplyMock = vi.fn();
+vi.mock("./agent-step.js", () => ({
+  runAgentStep: (params: unknown) => runAgentStepMock(params),
+  readLatestAssistantReply: (params: unknown) => readLatestAssistantReplyMock(params),
+}));
+
+import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
+
+describe("runSessionsSendA2AFlow model failure handling", () => {
+  beforeEach(() => {
+    callGatewayMock.mockReset();
+    runAgentStepMock.mockReset();
+    readLatestAssistantReplyMock.mockReset();
+  });
+
+  it("notifies requester when agent.wait returns error", async () => {
+    callGatewayMock
+      .mockResolvedValueOnce({
+        status: "error",
+        error: "model not found: google/gemini-3-1-pro-preview",
+      })
+      .mockResolvedValueOnce({ runId: "notify-run-1", status: "accepted" });
+
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:target:telegram",
+      displayKey: "agent:target:telegram",
+      message: "hello",
+      announceTimeoutMs: 30_000,
+      maxPingPongTurns: 0,
+      requesterSessionKey: "agent:requester:whatsapp",
+      requesterChannel: "whatsapp",
+      waitRunId: "target-run-1",
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(2);
+    expect(callGatewayMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: "agent.wait",
+        params: expect.objectContaining({ runId: "target-run-1" }),
+      }),
+    );
+    expect(callGatewayMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: "agent",
+        params: expect.objectContaining({
+          sessionKey: "agent:requester:whatsapp",
+          channel: "webchat",
+          lane: "nested",
+          deliver: false,
+        }),
+      }),
+    );
+    expect(runAgentStepMock).not.toHaveBeenCalled();
+    expect(readLatestAssistantReplyMock).not.toHaveBeenCalled();
+  });
+
+  it("does not notify requester when requesterSessionKey is absent", async () => {
+    callGatewayMock.mockResolvedValueOnce({
+      status: "error",
+      error: "model not found",
+    });
+
+    await runSessionsSendA2AFlow({
+      targetSessionKey: "agent:target:telegram",
+      displayKey: "agent:target:telegram",
+      message: "hello",
+      announceTimeoutMs: 30_000,
+      maxPingPongTurns: 0,
+      waitRunId: "target-run-1",
+    });
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(1);
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "agent.wait",
+      }),
+    );
+    expect(runAgentStepMock).not.toHaveBeenCalled();
+  });
+
+  it("swallows requester-notification failures", async () => {
+    callGatewayMock
+      .mockResolvedValueOnce({ status: "error", error: "model not found" })
+      .mockRejectedValueOnce(new Error("notify failed"));
+
+    await expect(
+      runSessionsSendA2AFlow({
+        targetSessionKey: "agent:target:telegram",
+        displayKey: "agent:target:telegram",
+        message: "hello",
+        announceTimeoutMs: 30_000,
+        maxPingPongTurns: 0,
+        requesterSessionKey: "agent:requester:whatsapp",
+        requesterChannel: "whatsapp",
+        waitRunId: "target-run-1",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(callGatewayMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -2,7 +2,10 @@ import crypto from "node:crypto";
 import { callGateway } from "../../gateway/call.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import type { GatewayMessageChannel } from "../../utils/message-channel.js";
+import {
+  type GatewayMessageChannel,
+  INTERNAL_MESSAGE_CHANNEL,
+} from "../../utils/message-channel.js";
 import { AGENT_LANE_NESTED } from "../lanes.js";
 import { readLatestAssistantReply, runAgentStep } from "./agent-step.js";
 import { resolveAnnounceTarget } from "./sessions-announce-target.js";
@@ -32,7 +35,7 @@ export async function runSessionsSendA2AFlow(params: {
     let latestReply = params.roundOneReply;
     if (!primaryReply && params.waitRunId) {
       const waitMs = Math.min(params.announceTimeoutMs, 60_000);
-      const wait = await callGateway<{ status: string }>({
+      const wait = await callGateway<{ status?: string; error?: string }>({
         method: "agent.wait",
         params: {
           runId: params.waitRunId,
@@ -45,6 +48,36 @@ export async function runSessionsSendA2AFlow(params: {
           sessionKey: params.targetSessionKey,
         });
         latestReply = primaryReply;
+      } else if (wait?.status === "error") {
+        const waitError =
+          typeof wait.error === "string" && wait.error.trim() ? wait.error.trim() : "agent error";
+
+        if (params.requesterSessionKey) {
+          try {
+            await callGateway({
+              method: "agent",
+              params: {
+                message:
+                  `[sessions_send delivery failed]\n\n` +
+                  `Message sent to ${params.displayKey} could not be delivered: ${waitError}\n\n` +
+                  `The target agent model may be unavailable or misconfigured. Please verify model settings and retry.`,
+                sessionKey: params.requesterSessionKey,
+                idempotencyKey: crypto.randomUUID(),
+                deliver: false,
+                channel: INTERNAL_MESSAGE_CHANNEL,
+                lane: AGENT_LANE_NESTED,
+              },
+              timeoutMs: 10_000,
+            });
+          } catch (notifyErr) {
+            log.warn("sessions_send failed to notify requester of target failure", {
+              runId: runContextId,
+              targetSessionKey: params.targetSessionKey,
+              error: formatErrorMessage(notifyErr),
+            });
+          }
+        }
+        return;
       }
     }
     if (!latestReply) {


### PR DESCRIPTION
## Summary

- Problem: `sessions_send` fire-and-forget mode (`timeoutSeconds=0`) could silently drop delivery when the target run failed (for example invalid/unrecognized model on the target agent).
- Why it matters: multi-agent pipelines break invisibly because sender gets `accepted` but never sees target failure.
- What changed: `runSessionsSendA2AFlow` now checks `agent.wait` error status and notifies the requester session with a clear delivery-failed message.
- What did NOT change (scope boundary): no schema/tool API changes, no provider/model fallback policy changes, no wait-path (`timeoutSeconds>0`) behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #25198
- Related #19217 #21588

## User-visible / Behavior Changes

- In `sessions_send` fire-and-forget mode, if the target run fails, the sender now receives an internal delivery failure message instead of silent drop.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local dev runtime
- Model/provider: sessions_send A2A flow
- Integration/channel (if any): internal channel (`webchat`) for requester notification
- Relevant config (redacted): default tool routing

### Steps

1. Trigger `sessions_send` with `timeoutSeconds=0`.
2. Make target run fail (`agent.wait => status:error`, e.g. model not found).
3. Observe requester session behavior.

### Expected

- Requester receives explicit delivery-failed message with actionable hint.

### Actual

- Before: silent drop in background flow.
- After: requester notification is dispatched; flow exits cleanly.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - requester is notified when `agent.wait` returns `status:error`
  - no notification when requester session key is absent
  - notification-send failure is swallowed (no unhandled throw)
- Edge cases checked:
  - error string missing/blank falls back to generic text
- What you did **not** verify:
  - provider-level fallback billing warning UX (separate concern)

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/agents/tools/sessions-send-tool.a2a.ts`
  - `src/agents/tools/sessions-send-tool.a2a.model-failure.test.ts`
- Known bad symptoms reviewers should watch for:
  - duplicate requester notifications in fire-and-forget path.

## Risks and Mitigations

- Risk: requester receives additional internal message on target failure.
  - Mitigation: only triggers on explicit `agent.wait status:error` in fire-and-forget flow.
- Risk: notification send itself fails.
  - Mitigation: failure is caught/logged and does not crash sender flow.

## AI Transparency

- [x] AI-assisted
- Human reviewed and understood line-by-line.
- Testing done for this PR: targeted tests + `pnpm build` + `pnpm check`.