### PR TITLE
feat(hooks): add auth attribution metadata to agent_end llmCalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Docs: https://docs.openclaw.ai
 - Cron/Heartbeat light bootstrap context: add opt-in lightweight bootstrap mode for automation runs (`--light-context` for cron agent turns and `agents.*.heartbeat.lightContext` for heartbeat), keeping only `HEARTBEAT.md` for heartbeat runs and skipping bootstrap-file injection for cron lightweight runs. (#26064) Thanks @jose-velez.
 - OpenAI/WebSocket warm-up: add optional OpenAI Responses WebSocket warm-up (`response.create` with `generate:false`), enable it by default for `openai/*`, and expose `params.openaiWsWarmup` for per-model enable/disable control.
 - Agents/Subagents runtime events: replace ad-hoc subagent completion system-message handoff with typed internal completion events (`task_completion`) that are rendered consistently across direct and queued announce paths, with gateway/CLI plumbing for structured `internalEvents`.
+- Plugins/Hooks: add optional `agent_end.llmCalls[]` summaries with per-call auth attribution (`auth.method`: `oauth|api_key|none|unknown`) and non-secret profile/source metadata for usage analytics; existing `agent_end` payload fields remain unchanged and no credential secrets are emitted.
 
 ### Breaking
 

--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -84,7 +84,7 @@ These run inside the agent loop or gateway pipeline:
 - **`before_model_resolve`**: runs pre-session (no `messages`) to deterministically override provider/model before model resolution.
 - **`before_prompt_build`**: runs after session load (with `messages`) to inject `prependContext`/`systemPrompt` before prompt submission.
 - **`before_agent_start`**: legacy compatibility hook that may run in either phase; prefer the explicit hooks above.
-- **`agent_end`**: inspect the final message list and run metadata after completion.
+- **`agent_end`**: inspect the final message list and run metadata after completion, including optional `llmCalls` entries with per-call provider/model usage and auth metadata.
 - **`before_compaction` / `after_compaction`**: observe or annotate compaction cycles.
 - **`before_tool_call` / `after_tool_call`**: intercept tool params/results.
 - **`tool_result_persist`**: synchronously transform tool results before they are written to the session transcript.

--- a/docs/tools/plugin.md
+++ b/docs/tools/plugin.md
@@ -357,6 +357,35 @@ Notes:
 - Plugin-managed hooks show up in `openclaw hooks list` with `plugin:<id>`.
 - You cannot enable/disable plugin-managed hooks via `openclaw hooks`; enable/disable the plugin instead.
 
+### `agent_end` payload auth metadata
+
+`agent_end` hook events keep their existing fields and now optionally include:
+
+```ts
+type AuthMethod = "oauth" | "api_key" | "none" | "unknown";
+
+type AgentEndLlmCall = {
+  provider: string;
+  model: string;
+  usage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+  };
+  auth: {
+    method: AuthMethod;
+    profileId?: string;
+    profileType?: string;
+    source?: "auth_profile" | "env" | "inline" | "none" | "unknown";
+  };
+};
+```
+
+`llmCalls` is optional and additive for backward compatibility.
+
+Security note: this includes credential metadata only and never includes raw tokens, refresh tokens, client secrets, or full API keys.
+
 ## Provider plugins (model auth)
 
 Plugins can register **model provider auth** flows so users can run OAuth or

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -55,6 +55,7 @@ import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
 import { resolveModel } from "./model.js";
 import { runEmbeddedAttempt } from "./run/attempt.js";
+import { resolveLlmCallAuthInfo } from "./run/auth-attribution.js";
 import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import {
@@ -712,6 +713,18 @@ export async function runEmbeddedPiAgent(
           const prompt =
             provider === "anthropic" ? scrubAnthropicRefusalMagic(params.prompt) : params.prompt;
 
+          const authSnapshot = apiKeyInfo as ApiKeyInfo | null;
+          const llmCallAuth = resolveLlmCallAuthInfo({
+            provider,
+            resolvedAuth: authSnapshot
+              ? {
+                  mode: authSnapshot.mode,
+                  profileId: authSnapshot.profileId ?? lastProfileId,
+                  source: authSnapshot.source,
+                }
+              : undefined,
+          });
+
           const attempt = await runEmbeddedAttempt({
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
@@ -743,6 +756,7 @@ export async function runEmbeddedPiAgent(
             model,
             authStorage,
             modelRegistry,
+            llmCallAuth,
             agentId: workspaceResolution.agentId,
             legacyBeforeAgentStartResult,
             thinkLevel,

--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -1,6 +1,9 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/config.js";
 import {
+  buildAgentEndHookEvent,
+  buildAgentEndLlmCalls,
   isOllamaCompatProvider,
   resolveAttemptFsWorkspaceOnly,
   resolveOllamaBaseUrlForRun,
@@ -122,6 +125,93 @@ describe("resolveAttemptFsWorkspaceOnly", () => {
         sessionAgentId: "main",
       }),
     ).toBe(false);
+  });
+});
+
+describe("buildAgentEndLlmCalls", () => {
+  it("maps observed calls and injects normalized auth metadata", () => {
+    expect(
+      buildAgentEndLlmCalls({
+        observedCalls: [
+          {
+            provider: "openai",
+            model: "gpt-5",
+            usage: { input: 12, output: 7, cacheRead: 0, cacheWrite: 0, total: 19 },
+          },
+        ],
+        provider: "openai",
+        model: "gpt-5",
+        auth: {
+          method: "oauth",
+          profileId: "openai:work",
+          profileType: "oauth",
+          source: "auth_profile",
+        },
+      }),
+    ).toEqual([
+      {
+        provider: "openai",
+        model: "gpt-5",
+        usage: { input: 12, output: 7, cacheRead: 0, cacheWrite: 0 },
+        auth: {
+          method: "oauth",
+          profileId: "openai:work",
+          profileType: "oauth",
+          source: "auth_profile",
+        },
+      },
+    ]);
+  });
+
+  it("falls back to attempt usage when no observed calls were captured", () => {
+    expect(
+      buildAgentEndLlmCalls({
+        observedCalls: [],
+        provider: "openai",
+        model: "gpt-5",
+        auth: { method: "api_key", source: "env" },
+        usageFallback: { input: 1, output: 2 },
+      }),
+    ).toEqual([
+      {
+        provider: "openai",
+        model: "gpt-5",
+        usage: { input: 1, output: 2, cacheRead: undefined, cacheWrite: undefined },
+        auth: { method: "api_key", source: "env" },
+      },
+    ]);
+  });
+});
+
+describe("buildAgentEndHookEvent", () => {
+  it("keeps existing agent_end fields unchanged and adds optional llmCalls", () => {
+    expect(
+      buildAgentEndHookEvent({
+        messages: [{ role: "assistant", content: "done" }] as unknown as AgentMessage[],
+        success: true,
+        error: undefined,
+        durationMs: 42,
+        llmCalls: [
+          {
+            provider: "openai",
+            model: "gpt-5",
+            auth: { method: "none", source: "none" },
+          },
+        ],
+      }),
+    ).toEqual({
+      messages: [{ role: "assistant", content: "done" }],
+      success: true,
+      error: undefined,
+      durationMs: 42,
+      llmCalls: [
+        {
+          provider: "openai",
+          model: "gpt-5",
+          auth: { method: "none", source: "none" },
+        },
+      ],
+    });
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -15,8 +15,11 @@ import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
 import { getGlobalHookRunner } from "../../../plugins/hook-runner-global.js";
 import type {
   PluginHookAgentContext,
+  PluginHookAgentEndEvent,
   PluginHookBeforeAgentStartResult,
   PluginHookBeforePromptBuildResult,
+  PluginHookLlmCallAuthInfo,
+  PluginHookLlmCallSummary,
 } from "../../../plugins/types.js";
 import { isSubagentSessionKey } from "../../../routing/session-key.js";
 import { resolveSignalReactionLevel } from "../../../signal/reaction-level.js";
@@ -52,6 +55,7 @@ import {
   validateAnthropicTurns,
   validateGeminiTurns,
 } from "../../pi-embedded-helpers.js";
+import type { ObservedLlmCall } from "../../pi-embedded-subscribe.handlers.types.js";
 import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settings.js";
 import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
@@ -417,6 +421,82 @@ export function resolveAttemptFsWorkspaceOnly(params: {
     cfg: params.config,
     agentId: params.sessionAgentId,
   });
+}
+
+export function buildAgentEndLlmCalls(params: {
+  observedCalls: ObservedLlmCall[];
+  provider: string;
+  model: string;
+  auth: PluginHookLlmCallAuthInfo;
+  usageFallback?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+  };
+}): PluginHookLlmCallSummary[] | undefined {
+  const mapped = params.observedCalls.map((call) => ({
+    provider: call.provider ?? params.provider,
+    model: call.model ?? params.model,
+    usage: call.usage
+      ? {
+          input: call.usage.input,
+          output: call.usage.output,
+          cacheRead: call.usage.cacheRead,
+          cacheWrite: call.usage.cacheWrite,
+        }
+      : undefined,
+    auth: { ...params.auth },
+  }));
+
+  if (mapped.length > 0) {
+    return mapped;
+  }
+
+  if (!params.usageFallback) {
+    return undefined;
+  }
+
+  const hasUsage = [
+    params.usageFallback.input,
+    params.usageFallback.output,
+    params.usageFallback.cacheRead,
+    params.usageFallback.cacheWrite,
+  ].some((value) => typeof value === "number" && Number.isFinite(value) && value > 0);
+
+  if (!hasUsage) {
+    return undefined;
+  }
+
+  return [
+    {
+      provider: params.provider,
+      model: params.model,
+      usage: {
+        input: params.usageFallback.input,
+        output: params.usageFallback.output,
+        cacheRead: params.usageFallback.cacheRead,
+        cacheWrite: params.usageFallback.cacheWrite,
+      },
+      auth: { ...params.auth },
+    },
+  ];
+}
+
+export function buildAgentEndHookEvent(params: {
+  messages: AgentMessage[];
+  success: boolean;
+  error?: string;
+  durationMs?: number;
+  llmCalls?: PluginHookLlmCallSummary[];
+}): PluginHookAgentEndEvent {
+  return {
+    messages: params.messages,
+    success: params.success,
+    error: params.error,
+    durationMs: params.durationMs,
+    llmCalls: params.llmCalls,
+  };
 }
 
 function summarizeMessagePayload(msg: AgentMessage): { textChars: number; imageBlocks: number } {
@@ -1200,6 +1280,7 @@ export async function runEmbeddedAttempt(
         didSendViaMessagingTool,
         getLastToolError,
         getUsageTotals,
+        getLlmCalls,
         getCompactionCount,
       } = subscription;
 
@@ -1521,6 +1602,13 @@ export async function runEmbeddedAttempt(
               : undefined,
         });
         anthropicPayloadLogger?.recordUsage(messagesSnapshot, promptError);
+        const llmCalls = buildAgentEndLlmCalls({
+          observedCalls: getLlmCalls(),
+          provider: params.provider,
+          model: params.modelId,
+          auth: params.llmCallAuth,
+          usageFallback: getUsageTotals(),
+        });
 
         // Run agent_end hooks to allow plugins to analyze the conversation
         // This is fire-and-forget, so we don't await
@@ -1528,12 +1616,13 @@ export async function runEmbeddedAttempt(
         if (hookRunner?.hasHooks("agent_end")) {
           hookRunner
             .runAgentEnd(
-              {
+              buildAgentEndHookEvent({
                 messages: messagesSnapshot,
                 success: !aborted && !promptError,
                 error: promptError ? describeUnknownError(promptError) : undefined,
                 durationMs: Date.now() - promptStartedAt,
-              },
+                llmCalls,
+              }),
               {
                 agentId: hookAgentId,
                 sessionKey: params.sessionKey,

--- a/src/agents/pi-embedded-runner/run/auth-attribution.test.ts
+++ b/src/agents/pi-embedded-runner/run/auth-attribution.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { resolveLlmCallAuthInfo } from "./auth-attribution.js";
+
+describe("resolveLlmCallAuthInfo", () => {
+  it("classifies oauth profiles as oauth", () => {
+    expect(
+      resolveLlmCallAuthInfo({
+        provider: "openai",
+        resolvedAuth: {
+          mode: "oauth",
+          profileId: "openai:work",
+          source: "profile:openai:work",
+        },
+      }),
+    ).toEqual({
+      method: "oauth",
+      profileId: "openai:work",
+      profileType: "oauth",
+      source: "auth_profile",
+    });
+  });
+
+  it("classifies bearer token auth as api_key", () => {
+    expect(
+      resolveLlmCallAuthInfo({
+        provider: "github-copilot",
+        resolvedAuth: {
+          mode: "token",
+          profileId: "github-copilot:default",
+          source: "profile:github-copilot:default",
+        },
+      }),
+    ).toEqual({
+      method: "api_key",
+      profileId: "github-copilot:default",
+      profileType: "token",
+      source: "auth_profile",
+    });
+  });
+
+  it("classifies local no-auth providers as none", () => {
+    expect(
+      resolveLlmCallAuthInfo({
+        provider: "ollama",
+        resolvedAuth: {
+          mode: "api-key",
+          source: "env: OLLAMA_API_KEY",
+        },
+      }),
+    ).toEqual({
+      method: "none",
+      source: "none",
+    });
+  });
+
+  it("returns unknown when auth metadata is missing", () => {
+    expect(
+      resolveLlmCallAuthInfo({
+        provider: "openai",
+        resolvedAuth: {
+          mode: "api-key",
+          source: "",
+        },
+      }),
+    ).toEqual({
+      method: "unknown",
+      profileType: "api_key",
+      source: "unknown",
+    });
+  });
+});

--- a/src/agents/pi-embedded-runner/run/auth-attribution.ts
+++ b/src/agents/pi-embedded-runner/run/auth-attribution.ts
@@ -1,0 +1,98 @@
+import type { PluginHookLlmCallAuthInfo } from "../../../plugins/types.js";
+import type { ResolvedProviderAuth } from "../../model-auth.js";
+import { normalizeProviderId } from "../../model-selection.js";
+
+type ResolvedAuthSnapshot = Pick<ResolvedProviderAuth, "mode" | "profileId" | "source">;
+
+const LOCAL_NO_AUTH_PROVIDERS = new Set(["ollama"]);
+
+const normalizeProfileType = (mode: ResolvedProviderAuth["mode"]): string => {
+  switch (mode) {
+    case "api-key":
+      return "api_key";
+    case "aws-sdk":
+      return "aws_sdk";
+    default:
+      return mode;
+  }
+};
+
+const parseProfileIdFromSource = (source: string): string | undefined => {
+  if (!source.startsWith("profile:")) {
+    return undefined;
+  }
+  const value = source.slice("profile:".length).trim();
+  return value.length > 0 ? value : undefined;
+};
+
+const normalizeSource = (sourceRaw: string): PluginHookLlmCallAuthInfo["source"] => {
+  const source = sourceRaw.trim();
+  if (source.length === 0) {
+    return "unknown";
+  }
+  if (source.startsWith("profile:")) {
+    return "auth_profile";
+  }
+  if (source.startsWith("env:") || source.startsWith("shell env:") || source === "gcloud adc") {
+    return "env";
+  }
+  if (source === "models.json" || source.startsWith("inline:")) {
+    return "inline";
+  }
+  if (source.includes("aws-sdk")) {
+    return "unknown";
+  }
+  return "unknown";
+};
+
+export function resolveLlmCallAuthInfo(params: {
+  provider: string;
+  resolvedAuth?: ResolvedAuthSnapshot | null;
+}): PluginHookLlmCallAuthInfo {
+  const normalizedProvider = normalizeProviderId(params.provider);
+  if (LOCAL_NO_AUTH_PROVIDERS.has(normalizedProvider)) {
+    return { method: "none", source: "none" };
+  }
+
+  const resolvedAuth = params.resolvedAuth;
+  if (!resolvedAuth) {
+    return { method: "unknown", source: "unknown" };
+  }
+
+  const mode = resolvedAuth.mode;
+  const profileType = normalizeProfileType(mode);
+  const source = normalizeSource(resolvedAuth.source);
+  const profileIdFromSource = parseProfileIdFromSource(resolvedAuth.source);
+  const profileId = resolvedAuth.profileId?.trim() || profileIdFromSource;
+
+  if (mode === "oauth") {
+    if (!profileId && source === "unknown") {
+      return { method: "unknown", profileType, source };
+    }
+    return {
+      method: "oauth",
+      profileId: profileId || undefined,
+      profileType,
+      source,
+    };
+  }
+
+  if (mode === "api-key" || mode === "token") {
+    if (!profileId && source === "unknown") {
+      return { method: "unknown", profileType, source };
+    }
+    return {
+      method: "api_key",
+      profileId: profileId || undefined,
+      profileType,
+      source,
+    };
+  }
+
+  return {
+    method: "unknown",
+    profileId: profileId || undefined,
+    profileType,
+    source,
+  };
+}

--- a/src/agents/pi-embedded-runner/run/types.ts
+++ b/src/agents/pi-embedded-runner/run/types.ts
@@ -3,7 +3,10 @@ import type { Api, AssistantMessage, Model } from "@mariozechner/pi-ai";
 import type { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { ThinkLevel } from "../../../auto-reply/thinking.js";
 import type { SessionSystemPromptReport } from "../../../config/sessions/types.js";
-import type { PluginHookBeforeAgentStartResult } from "../../../plugins/types.js";
+import type {
+  PluginHookBeforeAgentStartResult,
+  PluginHookLlmCallAuthInfo,
+} from "../../../plugins/types.js";
 import type { MessagingToolSend } from "../../pi-embedded-messaging.js";
 import type { NormalizedUsage } from "../../usage.js";
 import type { RunEmbeddedPiAgentParams } from "./params.js";
@@ -19,6 +22,7 @@ export type EmbeddedRunAttemptParams = EmbeddedRunAttemptBase & {
   model: Model<Api>;
   authStorage: AuthStorage;
   modelRegistry: ModelRegistry;
+  llmCallAuth: PluginHookLlmCallAuthInfo;
   thinkLevel: ThinkLevel;
   legacyBeforeAgentStartResult?: PluginHookBeforeAgentStartResult;
 };

--- a/src/agents/pi-embedded-subscribe.handlers.messages.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.messages.ts
@@ -261,6 +261,7 @@ export function handleMessageEnd(
   const assistantMessage = msg;
   ctx.noteLastAssistant(assistantMessage);
   ctx.recordAssistantUsage((assistantMessage as { usage?: unknown }).usage);
+  ctx.recordLlmCall?.(assistantMessage);
   promoteThinkingTagsToBlocks(assistantMessage);
 
   const rawText = extractAssistantText(assistantMessage);

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -30,6 +30,12 @@ export type ToolCallSummary = {
   actionFingerprint?: string;
 };
 
+export type ObservedLlmCall = {
+  provider?: string;
+  model?: string;
+  usage?: NormalizedUsage;
+};
+
 export type EmbeddedPiSubscribeState = {
   assistantTexts: string[];
   toolMetas: Array<{ toolName?: string; meta?: string }>;
@@ -120,8 +126,10 @@ export type EmbeddedPiSubscribeContext = {
   resolveCompactionRetry: () => void;
   maybeResolveCompactionWait: () => void;
   recordAssistantUsage: (usage: unknown) => void;
+  recordLlmCall?: (message: AgentMessage) => void;
   incrementCompactionCount: () => void;
   getUsageTotals: () => NormalizedUsage | undefined;
+  getLlmCalls?: () => ObservedLlmCall[];
   getCompactionCount: () => number;
 };
 

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -14,6 +14,7 @@ import {
 import { createEmbeddedPiSessionEventHandler } from "./pi-embedded-subscribe.handlers.js";
 import type {
   EmbeddedPiSubscribeContext,
+  ObservedLlmCall,
   EmbeddedPiSubscribeState,
 } from "./pi-embedded-subscribe.handlers.types.js";
 import { filterToolResultMediaUrls } from "./pi-embedded-subscribe.tools.js";
@@ -86,6 +87,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     cacheWrite: 0,
     total: 0,
   };
+  const llmCalls: ObservedLlmCall[] = [];
   let compactionCount = 0;
 
   const assistantTexts = state.assistantTexts;
@@ -270,6 +272,26 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       (usage.input ?? 0) + (usage.output ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
     usageTotals.total += usageTotal;
   };
+  const recordLlmCall = (message: AgentMessage) => {
+    if (message?.role !== "assistant") {
+      return;
+    }
+    const provider =
+      typeof (message as { provider?: unknown }).provider === "string"
+        ? ((message as { provider?: string }).provider ?? undefined)
+        : undefined;
+    const model =
+      typeof (message as { model?: unknown }).model === "string"
+        ? ((message as { model?: string }).model ?? undefined)
+        : undefined;
+    const usage = normalizeUsage((message as { usage?: unknown }).usage as UsageLike | undefined);
+    llmCalls.push({
+      provider,
+      model,
+      usage: hasNonzeroUsage(usage) ? usage : undefined,
+    });
+  };
+  const getLlmCalls = () => llmCalls.slice();
   const getUsageTotals = () => {
     const hasUsage =
       usageTotals.input > 0 ||
@@ -622,8 +644,10 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     resolveCompactionRetry,
     maybeResolveCompactionWait,
     recordAssistantUsage,
+    recordLlmCall,
     incrementCompactionCount,
     getUsageTotals,
+    getLlmCalls,
     getCompactionCount: () => compactionCount,
   };
 
@@ -678,6 +702,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     didSendViaMessagingTool: () => messagingToolSentTexts.length > 0,
     getLastToolError: () => (state.lastToolError ? { ...state.lastToolError } : undefined),
     getUsageTotals,
+    getLlmCalls,
     getCompactionCount: () => compactionCount,
     waitForCompactionRetry: () => {
       // Reject after unsubscribe so callers treat it as cancellation, not success

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -399,12 +399,34 @@ export type PluginHookLlmOutputEvent = {
   };
 };
 
+export type PluginHookAuthMethod = "oauth" | "api_key" | "none" | "unknown";
+
+export type PluginHookLlmCallAuthInfo = {
+  method: PluginHookAuthMethod;
+  profileId?: string;
+  profileType?: string;
+  source?: "auth_profile" | "env" | "inline" | "none" | "unknown";
+};
+
+export type PluginHookLlmCallSummary = {
+  provider: string;
+  model: string;
+  usage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+  };
+  auth: PluginHookLlmCallAuthInfo;
+};
+
 // agent_end hook
 export type PluginHookAgentEndEvent = {
   messages: unknown[];
   success: boolean;
   error?: string;
   durationMs?: number;
+  llmCalls?: PluginHookLlmCallSummary[];
 };
 
 // Compaction hooks

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -308,6 +308,14 @@ type ExecRunResult = {
   termination: "exit" | "timeout" | "no-output-timeout";
 };
 
+function isBenignStdinWriteError(error: unknown): boolean {
+  if (!isRecord(error)) {
+    return false;
+  }
+  const code = typeof error.code === "string" ? error.code : "";
+  return code === "EPIPE" || code === "ERR_STREAM_DESTROYED";
+}
+
 async function runExecResolver(params: {
   command: string;
   args: string[];
@@ -390,6 +398,17 @@ async function runExecResolver(params: {
     });
     child.stdout?.on("data", (chunk) => append(chunk, "stdout"));
     child.stderr?.on("data", (chunk) => append(chunk, "stderr"));
+    child.stdin?.on("error", (error) => {
+      if (isBenignStdinWriteError(error)) {
+        return;
+      }
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimers();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    });
     child.on("close", (code, signal) => {
       if (settled) {
         return;
@@ -405,7 +424,19 @@ async function runExecResolver(params: {
       });
     });
 
-    child.stdin?.end(params.input);
+    try {
+      child.stdin?.end(params.input);
+    } catch (error) {
+      if (isBenignStdinWriteError(error)) {
+        return;
+      }
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimers();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    }
   });
 }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `agent_end` hooks expose conversation/messages and aggregate outcomes, but they do not include deterministic credential attribution per LLM call.
- Why it matters: downstream analytics (for example Manifest) cannot reliably distinguish OAuth vs API key usage without guesswork.
- What changed: added optional `agent_end.llmCalls[]` with normalized `auth.method` (`oauth|api_key|none|unknown`) plus optional non-secret metadata (`profileId`, `profileType`, `source`) for each call.
- What did NOT change (scope boundary): existing `agent_end` fields/semantics are unchanged; no secrets/tokens/client secrets/API key values are emitted.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #25532
- Related #26266

## User-visible / Behavior Changes

- `agent_end` hook payload now optionally includes `llmCalls[]` entries.
- Each entry includes `provider`, `model`, optional usage counters, and normalized `auth` metadata.
- Deterministic auth classification:
  - OAuth profile => `auth.method="oauth"`
  - API key/token path => `auth.method="api_key"`
  - no-auth local path (ollama) => `auth.method="none"`
  - insufficient metadata => `auth.method="unknown"`

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`Yes`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - Change is metadata-only attribution in hook payloads.
  - Risk: accidental credential leakage in telemetry.
  - Mitigation: payload includes only normalized non-secret fields; no raw access token, refresh token, client secret, or full API key value is included.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: unit-level coverage (openai/github-copilot/ollama classifications)
- Integration/channel (if any): N/A
- Relevant config (redacted): default test config

### Steps

1. Run `pnpm tsgo`.
2. Run `pnpm test -- --run src/agents/pi-embedded-runner/run/auth-attribution.test.ts src/agents/pi-embedded-runner/run/attempt.test.ts src/agents/pi-embedded-runner/usage-reporting.test.ts`.
3. Inspect `agent_end` payload construction and ensure existing fields are unchanged with optional additive `llmCalls`.

### Expected

- Typecheck passes.
- Tests pass.
- `agent_end` remains backward compatible and can include `llmCalls[].auth` attribution.

### Actual

- Passed locally.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - OAuth profile resolves to `auth.method="oauth"`.
  - token/API-key path resolves to `auth.method="api_key"`.
  - local no-auth ollama resolves to `auth.method="none"`.
  - missing metadata resolves to `auth.method="unknown"`.
  - `agent_end` contract remains additive and backward compatible.
- Edge cases checked:
  - no observed per-message LLM calls falls back to attempt usage summary.
  - missing usage does not force synthetic call records.
- What you did **not** verify:
  - full end-to-end plugin execution in a live external integration environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR commit; `agent_end` behavior returns to prior payload shape.
- Files/config to restore:
  - `src/plugins/types.ts`
  - `src/agents/pi-embedded-runner/run.ts`
  - `src/agents/pi-embedded-runner/run/attempt.ts`
  - `src/agents/pi-embedded-subscribe.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected `auth.method="unknown"` where deterministic profile metadata should exist.
  - any hook payload containing raw credential material (should never occur).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: provider-specific auth sources may map to `unknown` more often than expected.
  - Mitigation: mapping is explicit and deterministic; preserves safety and can be extended in follow-up without breaking schema.
