### PR TITLE
feat(agents): support emoji field in agents.update

### DIFF
--- a/src/gateway/protocol/schema/agents-models-skills.ts
+++ b/src/gateway/protocol/schema/agents-models-skills.ts
@@ -70,6 +70,7 @@ export const AgentsUpdateParamsSchema = Type.Object(
     name: Type.Optional(NonEmptyString),
     workspace: Type.Optional(NonEmptyString),
     model: Type.Optional(NonEmptyString),
+    emoji: Type.Optional(Type.String()),
     avatar: Type.Optional(Type.String()),
   },
   { additionalProperties: false },

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -416,13 +416,14 @@ describe("agents.update", () => {
   });
 
   it("writes both emoji and avatar to IDENTITY.md when both provided", async () => {
-    const { promise } = makeCall("agents.update", {
+    const { respond, promise } = makeCall("agents.update", {
       agentId: "test-agent",
       emoji: "🤖",
       avatar: "https://example.com/avatar.png",
     });
     await promise;
 
+    expect(respond).toHaveBeenCalledWith(true, { ok: true, agentId: "test-agent" }, undefined);
     expect(mocks.fsAppendFile).toHaveBeenCalledWith(
       expect.stringContaining("IDENTITY.md"),
       expect.stringMatching(/- Emoji: 🤖[\s\S]*- Avatar:/),

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -399,6 +399,36 @@ describe("agents.update", () => {
 
     expect(mocks.ensureAgentWorkspace).not.toHaveBeenCalled();
   });
+
+  it("writes emoji to IDENTITY.md when provided", async () => {
+    const { respond, promise } = makeCall("agents.update", {
+      agentId: "test-agent",
+      emoji: "🦊",
+    });
+    await promise;
+
+    expect(respond).toHaveBeenCalledWith(true, { ok: true, agentId: "test-agent" }, undefined);
+    expect(mocks.fsAppendFile).toHaveBeenCalledWith(
+      expect.stringContaining("IDENTITY.md"),
+      expect.stringContaining("- Emoji: 🦊"),
+      "utf-8",
+    );
+  });
+
+  it("writes both emoji and avatar to IDENTITY.md when both provided", async () => {
+    const { promise } = makeCall("agents.update", {
+      agentId: "test-agent",
+      emoji: "🤖",
+      avatar: "https://example.com/avatar.png",
+    });
+    await promise;
+
+    expect(mocks.fsAppendFile).toHaveBeenCalledWith(
+      expect.stringContaining("IDENTITY.md"),
+      expect.stringMatching(/- Emoji: 🤖[\s\S]*- Avatar:/),
+      "utf-8",
+    );
+  });
 });
 
 describe("agents.delete", () => {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -466,6 +466,7 @@ export const agentsHandlers: GatewayRequestHandlers = {
         : undefined;
 
     const model = resolveOptionalStringParam(params.model);
+    const emoji = resolveOptionalStringParam(params.emoji);
     const avatar = resolveOptionalStringParam(params.avatar);
 
     const nextConfig = applyAgentConfig(cfg, {
@@ -484,11 +485,18 @@ export const agentsHandlers: GatewayRequestHandlers = {
       await ensureAgentWorkspace({ dir: workspaceDir, ensureBootstrapFiles: !skipBootstrap });
     }
 
-    if (avatar) {
+    if (emoji || avatar) {
       const workspace = workspaceDir ?? resolveAgentWorkspaceDir(nextConfig, agentId);
       await fs.mkdir(workspace, { recursive: true });
       const identityPath = path.join(workspace, DEFAULT_IDENTITY_FILENAME);
-      await fs.appendFile(identityPath, `\n- Avatar: ${sanitizeIdentityLine(avatar)}\n`, "utf-8");
+      const lines: string[] = [];
+      if (emoji) {
+        lines.push(`- Emoji: ${sanitizeIdentityLine(emoji)}`);
+      }
+      if (avatar) {
+        lines.push(`- Avatar: ${sanitizeIdentityLine(avatar)}`);
+      }
+      await fs.appendFile(identityPath, `\n${lines.join("\n")}\n`, "utf-8");
     }
 
     respond(true, { ok: true, agentId }, undefined);


### PR DESCRIPTION
## Summary

Add `emoji` as an optional parameter to `agents.update`. When provided, it is written to `IDENTITY.md` alongside `avatar`. Since we already support updating agent names, I thought it'd be more fun if agents could update their emoji too.

## Tests

Added 2 new test cases (emoji-only, emoji+avatar combo). All 27 existing tests pass.