### PR TITLE
feat(feishu): display voice message duration in Feishu

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -1,6 +1,8 @@
+import { execFile } from "child_process";
 import fs from "fs";
 import path from "path";
 import { Readable } from "stream";
+import { promisify } from "util";
 import { withTempDownloadPath, type ClawdbotConfig } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
@@ -8,6 +10,41 @@ import { normalizeFeishuExternalKey } from "./external-keys.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Get audio duration in milliseconds using ffprobe.
+ * Returns undefined if ffprobe is unavailable or the file cannot be probed.
+ */
+async function getAudioDurationMs(buffer: Buffer): Promise<number | undefined> {
+  const tmpDir = fs.mkdtempSync(
+    path.join(fs.realpathSync(require("os").tmpdir()), "feishu-audio-"),
+  );
+  const tmpFile = path.join(tmpDir, "probe.opus");
+  try {
+    fs.writeFileSync(tmpFile, buffer);
+    const { stdout } = await execFileAsync(
+      "ffprobe",
+      ["-v", "quiet", "-show_entries", "format=duration", "-of", "csv=p=0", tmpFile],
+      { timeout: 10_000 },
+    );
+    const seconds = parseFloat(stdout.trim());
+    if (Number.isFinite(seconds) && seconds > 0) {
+      return Math.round(seconds * 1000);
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  } finally {
+    try {
+      fs.unlinkSync(tmpFile);
+      fs.rmdirSync(tmpDir);
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+}
 
 export type DownloadImageResult = {
   buffer: Buffer;
@@ -440,11 +477,17 @@ export async function sendMediaFeishu(params: {
     return sendImageFeishu({ cfg, to, imageKey, replyToMessageId, replyInThread, accountId });
   } else {
     const fileType = detectFileType(name);
+    // For audio files, compute duration so Feishu displays playback time and enables STT
+    let duration: number | undefined;
+    if (fileType === "opus") {
+      duration = await getAudioDurationMs(buffer);
+    }
     const { fileKey } = await uploadFileFeishu({
       cfg,
       file: buffer,
       fileName: name,
       fileType,
+      duration,
       accountId,
     });
     // Feishu API: opus -> "audio", everything else (including video) -> "file"


### PR DESCRIPTION
## Summary

When sending voice messages via the Feishu plugin, the chat UI previously did not show the playback duration. This PR adds audio duration detection so Feishu can display the voice message length and enable speech-to-text (STT).

## Changes

- **`extensions/feishu/src/media.ts`**:
  - Added `getAudioDurationMs()` helper that uses `ffprobe` to detect the duration (in milliseconds) of audio buffers via a temporary file.
  - When uploading `opus` voice files, the computed duration is now passed to the Feishu upload API (`im.file.create`).
  - The duration is passed as the `duration` field which Feishu uses to display playback time in the chat.

## How it works

1. Before uploading an opus audio file, the buffer is written to a temp file.
2. `ffprobe` is called to extract the `format=duration` value.
3. The duration (in ms) is included in the upload request body.
4. If `ffprobe` is unavailable or fails, the upload proceeds without duration (graceful fallback).

## Testing

- Verified that voice messages sent via Feishu now show the correct playback duration.
- Verified graceful fallback when `ffprobe` is not installed.