### PR TITLE
fix(gateway): prevent sessions_send from corrupting target session channel

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -20,7 +20,11 @@ import {
 import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
 import { classifySessionKeyShape, normalizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
-import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
+import {
+  normalizeInputProvenance,
+  isInterSessionInputProvenance,
+  type InputProvenance,
+} from "../../sessions/input-provenance.js";
 import { resolveSendPolicy } from "../../sessions/send-policy.js";
 import { normalizeSessionDeliveryFields } from "../../utils/delivery-context.js";
 import {
@@ -421,7 +425,14 @@ export const agentHandlers: GatewayRequestHandlers = {
         label: labelValue,
         spawnedBy: spawnedByValue,
         spawnDepth: entry?.spawnDepth,
-        channel: entry?.channel ?? request.channel?.trim(),
+        // Preserve the session's real channel when the message arrives via inter-session
+        // transport (sessions_send). The request.channel is "webchat" (INTERNAL_MESSAGE_CHANNEL)
+        // in that case — it's just the transport, not the session's actual channel identity.
+        // Without this guard, a sessions_send call overwrites the target session's channel
+        // from e.g. "telegram" to "webchat", breaking subsequent message delivery (#31671).
+        channel:
+          entry?.channel ??
+          (isInterSessionInputProvenance(inputProvenance) ? undefined : request.channel?.trim()),
         groupId: resolvedGroupId ?? entry?.groupId,
         groupChannel: resolvedGroupChannel ?? entry?.groupChannel,
         space: resolvedGroupSpace ?? entry?.space,
@@ -508,8 +519,12 @@ export const agentHandlers: GatewayRequestHandlers = {
       typeof request.threadId === "string" && request.threadId.trim()
         ? request.threadId.trim()
         : undefined;
+    // For inter-session messages, the request.channel is just the internal transport
+    // ("webchat"). Don't propagate it as the turn's source channel — it would pollute
+    // delivery routing and lastChannel tracking.
+    const isInterSession = isInterSessionInputProvenance(inputProvenance);
     const turnSourceChannel =
-      typeof request.channel === "string" && request.channel.trim()
+      !isInterSession && typeof request.channel === "string" && request.channel.trim()
         ? request.channel.trim()
         : undefined;
     const turnSourceTo =

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -430,9 +430,14 @@ export const agentHandlers: GatewayRequestHandlers = {
         // in that case — it's just the transport, not the session's actual channel identity.
         // Without this guard, a sessions_send call overwrites the target session's channel
         // from e.g. "telegram" to "webchat", breaking subsequent message delivery (#31671).
-        channel:
-          entry?.channel ??
-          (isInterSessionInputProvenance(inputProvenance) ? undefined : request.channel?.trim()),
+        // When inter-session and no existing channel, omit the key entirely so
+        // mergeSessionEntry ({...existing, ...patch}) does not clobber a
+        // concurrently written channel with undefined.
+        ...(isInterSessionInputProvenance(inputProvenance)
+          ? entry?.channel
+            ? { channel: entry.channel }
+            : {}
+          : { channel: entry?.channel ?? request.channel?.trim() }),
         groupId: resolvedGroupId ?? entry?.groupId,
         groupChannel: resolvedGroupChannel ?? entry?.groupChannel,
         space: resolvedGroupSpace ?? entry?.space,


### PR DESCRIPTION
## Summary

Fixes #31671 — `sessions_send` overwrites the target session's `channel` field from `"telegram"` to `"webchat"`, breaking subsequent Telegram message delivery.

## Root Cause

`sessions_send` dispatches messages via the gateway using `channel: INTERNAL_MESSAGE_CHANNEL` (`"webchat"`) as the transport. In `server-methods/agent.ts`, the session entry patch was built with:

```typescript
channel: entry?.channel ?? request.channel?.trim(),
```

When `entry.channel` was undefined (e.g. race condition, fresh entry lookup), this fell back to `request.channel` = `"webchat"`, overwriting the session's real channel identity.

Additionally, the `turnSourceChannel` used for delivery routing was set to `"webchat"`, polluting `lastChannel` tracking and delivery context.

## Fix

Two changes in `server-methods/agent.ts`:

1. **Session channel field**: When `inputProvenance.kind === "inter_session"`, the request's transport channel is excluded from the fallback chain. The session channel only gets set from the request for real inbound messages (Telegram, Discord, etc.), never from internal transport.

2. **Turn source channel**: Inter-session messages no longer propagate the transport channel as `turnSourceChannel`, preventing `lastChannel` and `deliveryContext` from being overwritten.

Both changes use the existing `isInterSessionInputProvenance()` utility — no new dependencies.

## Verification

```
✓ src/gateway/server-methods/agent.test.ts (11 tests) 58ms
  TypeScript: 0 errors
```