### PR TITLE
fix: reject delivery to unconfigured plugin channels in agent handler

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -6,6 +6,7 @@ import {
   resolveIngressWorkspaceOverrideForSpawnedRun,
 } from "../../agents/spawned-context.js";
 import { buildBareSessionResetPrompt } from "../../auto-reply/reply/session-reset-prompt.js";
+import { CHANNEL_IDS, type ChatChannelId } from "../../channels/registry.js";
 import { agentCommandFromIngress } from "../../commands/agent.js";
 import { loadConfig } from "../../config/config.js";
 import {
@@ -21,7 +22,10 @@ import {
   resolveAgentDeliveryPlan,
   resolveAgentOutboundTarget,
 } from "../../infra/outbound/agent-delivery.js";
-import { resolveMessageChannelSelection } from "../../infra/outbound/channel-selection.js";
+import {
+  listConfiguredMessageChannels,
+  resolveMessageChannelSelection,
+} from "../../infra/outbound/channel-selection.js";
 import { classifySessionKeyShape, normalizeAgentId } from "../../routing/session-key.js";
 import { defaultRuntime } from "../../runtime.js";
 import { normalizeInputProvenance, type InputProvenance } from "../../sessions/input-provenance.js";
@@ -595,6 +599,26 @@ export const agentHandlers: GatewayRequestHandlers = {
     let resolvedAccountId = deliveryPlan.resolvedAccountId;
     let resolvedTo = deliveryPlan.resolvedTo;
     let effectivePlan = deliveryPlan;
+
+    // A plugin channel may be registered but have no configured accounts,
+    // making it unusable for delivery.  Fall back to the
+    // INTERNAL_MESSAGE_CHANNEL path so the existing channel-selection
+    // logic can surface a proper error.  Built-in channels (in
+    // CHANNEL_IDS) are always considered available.
+    if (
+      wantsDelivery &&
+      resolvedChannel !== INTERNAL_MESSAGE_CHANNEL &&
+      isDeliverableMessageChannel(resolvedChannel) &&
+      !CHANNEL_IDS.includes(resolvedChannel as ChatChannelId)
+    ) {
+      const cfgResolved = cfgForAgent ?? cfg;
+      const configured = await listConfiguredMessageChannels(cfgResolved);
+      if (!configured.includes(resolvedChannel)) {
+        resolvedChannel = INTERNAL_MESSAGE_CHANNEL;
+        resolvedTo = undefined;
+        resolvedAccountId = undefined;
+      }
+    }
 
     if (wantsDelivery && resolvedChannel === INTERNAL_MESSAGE_CHANNEL) {
       const cfgResolved = cfgForAgent ?? cfg;


### PR DESCRIPTION
## Summary

When a session's `lastChannel` points to a plugin channel (e.g. msteams) that
has no configured accounts, the agent handler now falls back to the
`INTERNAL_MESSAGE_CHANNEL` path instead of silently accepting the delivery
request. This surfaces a proper "Channel is required" error.

Built-in channels (telegram, whatsapp, etc.) are always considered available
and skip this check.

**Root cause**: `isDeliverableMessageChannel()` only checks plugin registry
presence, not whether the plugin has configured accounts. The existing
`isPluginConfigured()` / `listConfiguredMessageChannels()` logic in
`channel-selection.ts` was only invoked in the webchat fallback path, never
for explicitly resolved plugin channels.

**Impact**: The gateway test "agent errors when deliver=true and last-channel
plugin is unavailable" (`server.agent.gateway-server-agent-b.test.ts`) tests
this exact scenario but passes on `main` only due to favorable test ordering
that sets up global state masking the bug. Running the test in isolation
reproduces the failure.

## Changes

Single file: `src/gateway/server-methods/agent.ts`

- Import `CHANNEL_IDS` (built-in channel list) and `listConfiguredMessageChannels`
- After `resolveAgentDeliveryPlan`, when `wantsDelivery` is true and the resolved
  channel is a non-built-in deliverable channel, check if it's among the configured
  channels. If not, fall back to `INTERNAL_MESSAGE_CHANNEL` so the existing
  `resolveMessageChannelSelection` error path is invoked.

## Test plan

- [x] `server.agent.gateway-server-agent-b.test.ts` — all 10 tests pass (including the previously-masked failure)
- [x] `server-methods/agent.test.ts` — all 13 tests pass (no regression for built-in channel delivery)