### PR TITLE
feat(feishu): add message retrieval and chat search tools

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -5,6 +5,7 @@ import { feishuPlugin } from "./src/channel.js";
 import { registerFeishuChatTools } from "./src/chat.js";
 import { registerFeishuDocTools } from "./src/docx.js";
 import { registerFeishuDriveTools } from "./src/drive.js";
+import { registerFeishuMessageTools } from "./src/message.js";
 import { registerFeishuPermTools } from "./src/perm.js";
 import { setFeishuRuntime } from "./src/runtime.js";
 import { registerFeishuWikiTools } from "./src/wiki.js";
@@ -55,6 +56,7 @@ const plugin = {
     api.registerChannel({ plugin: feishuPlugin });
     registerFeishuDocTools(api);
     registerFeishuChatTools(api);
+    registerFeishuMessageTools(api);
     registerFeishuWikiTools(api);
     registerFeishuDriveTools(api);
     registerFeishuPermTools(api);

--- a/extensions/feishu/skills/feishu-message/SKILL.md
+++ b/extensions/feishu/skills/feishu-message/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: feishu-message
+description: |
+  Feishu message history and retrieval. Activate when user asks about chat history, past messages, or specific message lookup.
+---
+
+# Feishu Message Tool
+
+Single tool `feishu_message` with action parameter for message operations.
+
+## Actions
+
+### List Messages (Chat History)
+
+```json
+{ "action": "list", "chat_id": "oc_xxx" }
+```
+
+Returns recent messages from the specified chat. The bot must be a member of the chat.
+
+Optional parameters:
+
+- `start_time`: Start timestamp in seconds (Unix epoch)
+- `end_time`: End timestamp in seconds (Unix epoch)
+- `sort_type`: `"ByCreateTimeAsc"` or `"ByCreateTimeDesc"` (default: desc)
+- `page_size`: 1-50 (default: 20)
+- `page_token`: For pagination (from previous response)
+
+Response fields per message:
+
+- `message_id`: Unique message identifier
+- `msg_type`: Message type (text, image, file, etc.)
+- `body.content`: JSON-encoded message content
+- `sender`: Sender info (id, id_type, sender_type)
+- `create_time`: Unix timestamp string
+- `chat_id`: Chat the message belongs to
+- `mentions`: Mentioned users (if any)
+
+### Get Single Message
+
+```json
+{ "action": "get", "message_id": "om_xxx" }
+```
+
+Returns a single message by its ID.
+
+## Message Content Format
+
+The `body.content` field is JSON-encoded. For text messages:
+
+```json
+{ "text": "Hello world" }
+```
+
+For rich text, images, files, etc., the structure varies by `msg_type`.
+
+## Pagination
+
+When `has_more` is `true` in the response, pass the returned `page_token` to fetch the next page:
+
+```json
+{ "action": "list", "chat_id": "oc_xxx", "page_token": "returned_token" }
+```
+
+## Permissions
+
+Requires Feishu app permissions:
+
+- `im:message` or `im:message:readonly` (read messages the bot can access)
+
+The bot can only read messages from chats it has joined.
+
+## Configuration
+
+Enable/disable in `channels.feishu.tools`:
+
+```json
+{ "tools": { "message": true } }
+```
+
+Enabled by default.

--- a/extensions/feishu/src/chat-schema.ts
+++ b/extensions/feishu/src/chat-schema.ts
@@ -1,15 +1,16 @@
 import { Type, type Static } from "@sinclair/typebox";
 
-const CHAT_ACTION_VALUES = ["members", "info"] as const;
+const CHAT_ACTION_VALUES = ["members", "info", "search"] as const;
 const MEMBER_ID_TYPE_VALUES = ["open_id", "user_id", "union_id"] as const;
 
 export const FeishuChatSchema = Type.Object({
   action: Type.Unsafe<(typeof CHAT_ACTION_VALUES)[number]>({
     type: "string",
     enum: [...CHAT_ACTION_VALUES],
-    description: "Action to run: members | info",
+    description: "Action: members | info | search (find chats by name)",
   }),
-  chat_id: Type.String({ description: "Chat ID (from URL or event payload)" }),
+  chat_id: Type.Optional(Type.String({ description: "Chat ID (required for members/info)" })),
+  query: Type.Optional(Type.String({ description: "Search keyword (required for search)" })),
   page_size: Type.Optional(Type.Number({ description: "Page size (1-100, default 50)" })),
   page_token: Type.Optional(Type.String({ description: "Pagination token" })),
   member_id_type: Type.Optional(

--- a/extensions/feishu/src/chat.test.ts
+++ b/extensions/feishu/src/chat.test.ts
@@ -9,20 +9,21 @@ vi.mock("./client.js", () => ({
 
 describe("registerFeishuChatTools", () => {
   const chatGetMock = vi.hoisted(() => vi.fn());
+  const chatSearchMock = vi.hoisted(() => vi.fn());
   const chatMembersGetMock = vi.hoisted(() => vi.fn());
 
   beforeEach(() => {
     vi.clearAllMocks();
     createFeishuClientMock.mockReturnValue({
       im: {
-        chat: { get: chatGetMock },
+        chat: { get: chatGetMock, search: chatSearchMock },
         chatMembers: { get: chatMembersGetMock },
       },
     });
   });
 
-  it("registers feishu_chat and handles info/members actions", async () => {
-    const registerTool = vi.fn();
+  function registerTool() {
+    const fn = vi.fn();
     registerFeishuChatTools({
       config: {
         channels: {
@@ -35,22 +36,26 @@ describe("registerFeishuChatTools", () => {
         },
       } as any,
       logger: { debug: vi.fn(), info: vi.fn() } as any,
-      registerTool,
+      registerTool: fn,
     } as any);
+    expect(fn).toHaveBeenCalledTimes(1);
+    return fn.mock.calls[0]?.[0];
+  }
 
-    expect(registerTool).toHaveBeenCalledTimes(1);
-    const tool = registerTool.mock.calls[0]?.[0];
-    expect(tool?.name).toBe("feishu_chat");
-
+  it("handles info action", async () => {
+    const tool = registerTool();
     chatGetMock.mockResolvedValueOnce({
       code: 0,
       data: { name: "group name", user_count: 3 },
     });
-    const infoResult = await tool.execute("tc_1", { action: "info", chat_id: "oc_1" });
-    expect(infoResult.details).toEqual(
+    const result = await tool.execute("tc_1", { action: "info", chat_id: "oc_1" });
+    expect(result.details).toEqual(
       expect.objectContaining({ chat_id: "oc_1", name: "group name", user_count: 3 }),
     );
+  });
 
+  it("handles members action", async () => {
+    const tool = registerTool();
     chatMembersGetMock.mockResolvedValueOnce({
       code: 0,
       data: {
@@ -59,8 +64,8 @@ describe("registerFeishuChatTools", () => {
         items: [{ member_id: "ou_1", name: "member1", member_id_type: "open_id" }],
       },
     });
-    const membersResult = await tool.execute("tc_2", { action: "members", chat_id: "oc_1" });
-    expect(membersResult.details).toEqual(
+    const result = await tool.execute("tc_2", { action: "members", chat_id: "oc_1" });
+    expect(result.details).toEqual(
       expect.objectContaining({
         chat_id: "oc_1",
         members: [expect.objectContaining({ member_id: "ou_1", name: "member1" })],
@@ -68,8 +73,53 @@ describe("registerFeishuChatTools", () => {
     );
   });
 
+  it("handles search action", async () => {
+    const tool = registerTool();
+    chatSearchMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        has_more: false,
+        page_token: "",
+        items: [
+          {
+            chat_id: "oc_100",
+            name: "Project Alpha",
+            description: "Alpha team chat",
+            chat_type: "group",
+            user_count: "5",
+          },
+        ],
+      },
+    });
+    const result = await tool.execute("tc_3", { action: "search", query: "Alpha" });
+    expect(result.details).toEqual(
+      expect.objectContaining({
+        items: [
+          expect.objectContaining({
+            chat_id: "oc_100",
+            name: "Project Alpha",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("returns error when search is called without query", async () => {
+    const tool = registerTool();
+    const result = await tool.execute("tc_4", { action: "search" });
+    expect(result.details).toEqual({ error: "query is required for search action" });
+  });
+
+  it("returns error when info/members called without chat_id", async () => {
+    const tool = registerTool();
+    const r1 = await tool.execute("tc_5", { action: "info" });
+    expect(r1.details).toEqual({ error: "chat_id is required for info action" });
+    const r2 = await tool.execute("tc_6", { action: "members" });
+    expect(r2.details).toEqual({ error: "chat_id is required for members action" });
+  });
+
   it("skips registration when chat tool is disabled", () => {
-    const registerTool = vi.fn();
+    const fn = vi.fn();
     registerFeishuChatTools({
       config: {
         channels: {
@@ -82,8 +132,8 @@ describe("registerFeishuChatTools", () => {
         },
       } as any,
       logger: { debug: vi.fn(), info: vi.fn() } as any,
-      registerTool,
+      registerTool: fn,
     } as any);
-    expect(registerTool).not.toHaveBeenCalled();
+    expect(fn).not.toHaveBeenCalled();
   });
 });

--- a/extensions/feishu/src/chat.ts
+++ b/extensions/feishu/src/chat.ts
@@ -71,6 +71,42 @@ async function getChatMembers(
   };
 }
 
+async function searchChats(
+  client: Lark.Client,
+  query: string,
+  pageSize?: number,
+  pageToken?: string,
+) {
+  const page_size = pageSize ? Math.max(1, Math.min(100, pageSize)) : 20;
+  const res = await client.im.chat.search({
+    params: {
+      query,
+      page_size,
+      page_token: pageToken,
+    },
+  });
+
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    has_more: res.data?.has_more,
+    page_token: res.data?.page_token,
+    items:
+      res.data?.items?.map((item) => ({
+        chat_id: item.chat_id,
+        name: item.name,
+        description: item.description,
+        owner_id: item.owner_id,
+        avatar: item.avatar,
+        external: item.external,
+        tenant_key: item.tenant_key,
+        labels: item.labels,
+      })) ?? [],
+  };
+}
+
 export function registerFeishuChatTools(api: OpenClawPluginApi) {
   if (!api.config) {
     api.logger.debug?.("feishu_chat: No config available, skipping chat tools");
@@ -96,14 +132,24 @@ export function registerFeishuChatTools(api: OpenClawPluginApi) {
     {
       name: "feishu_chat",
       label: "Feishu Chat",
-      description: "Feishu chat operations. Actions: members, info",
+      description:
+        "Feishu chat operations. Actions: search (find chats by name), info (chat details), members (list members)",
       parameters: FeishuChatSchema,
       async execute(_toolCallId, params) {
         const p = params as FeishuChatParams;
         try {
           const client = getClient();
           switch (p.action) {
-            case "members":
+            case "search": {
+              if (!p.query) {
+                return json({ error: "query is required for search action" });
+              }
+              return json(await searchChats(client, p.query, p.page_size, p.page_token));
+            }
+            case "members": {
+              if (!p.chat_id) {
+                return json({ error: "chat_id is required for members action" });
+              }
               return json(
                 await getChatMembers(
                   client,
@@ -113,8 +159,13 @@ export function registerFeishuChatTools(api: OpenClawPluginApi) {
                   p.member_id_type,
                 ),
               );
-            case "info":
+            }
+            case "info": {
+              if (!p.chat_id) {
+                return json({ error: "chat_id is required for info action" });
+              }
               return json(await getChatInfo(client, p.chat_id));
+            }
             default:
               return json({ error: `Unknown action: ${String(p.action)}` });
           }

--- a/extensions/feishu/src/message-schema.ts
+++ b/extensions/feishu/src/message-schema.ts
@@ -1,0 +1,27 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+const MESSAGE_ACTION_VALUES = ["list", "get"] as const;
+const SORT_TYPE_VALUES = ["ByCreateTimeAsc", "ByCreateTimeDesc"] as const;
+
+export const FeishuMessageSchema = Type.Object({
+  action: Type.Unsafe<(typeof MESSAGE_ACTION_VALUES)[number]>({
+    type: "string",
+    enum: [...MESSAGE_ACTION_VALUES],
+    description: "Action: list (chat history) | get (single message)",
+  }),
+  chat_id: Type.Optional(Type.String({ description: "Chat ID (required for list)" })),
+  message_id: Type.Optional(Type.String({ description: "Message ID (required for get)" })),
+  start_time: Type.Optional(Type.String({ description: "Start timestamp in seconds (for list)" })),
+  end_time: Type.Optional(Type.String({ description: "End timestamp in seconds (for list)" })),
+  sort_type: Type.Optional(
+    Type.Unsafe<(typeof SORT_TYPE_VALUES)[number]>({
+      type: "string",
+      enum: [...SORT_TYPE_VALUES],
+      description: "Sort order (default: ByCreateTimeDesc)",
+    }),
+  ),
+  page_size: Type.Optional(Type.Number({ description: "Page size (1-50, default 20)" })),
+  page_token: Type.Optional(Type.String({ description: "Pagination token" })),
+});
+
+export type FeishuMessageParams = Static<typeof FeishuMessageSchema>;

--- a/extensions/feishu/src/message.test.ts
+++ b/extensions/feishu/src/message.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerFeishuMessageTools } from "./message.js";
+
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: createFeishuClientMock,
+}));
+
+describe("registerFeishuMessageTools", () => {
+  const messageListMock = vi.hoisted(() => vi.fn());
+  const messageGetMock = vi.hoisted(() => vi.fn());
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createFeishuClientMock.mockReturnValue({
+      im: {
+        message: { list: messageListMock, get: messageGetMock },
+      },
+    });
+  });
+
+  it("registers feishu_message and handles list/get actions", async () => {
+    const registerTool = vi.fn();
+    registerFeishuMessageTools({
+      config: {
+        channels: {
+          feishu: {
+            enabled: true,
+            appId: "app_id",
+            appSecret: "app_secret",
+            tools: { message: true },
+          },
+        },
+      } as any,
+      logger: { debug: vi.fn(), info: vi.fn() } as any,
+      registerTool,
+    } as any);
+
+    expect(registerTool).toHaveBeenCalledTimes(1);
+    const tool = registerTool.mock.calls[0]?.[0];
+    expect(tool?.name).toBe("feishu_message");
+
+    messageListMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        has_more: false,
+        page_token: "",
+        items: [
+          {
+            message_id: "om_1",
+            msg_type: "text",
+            create_time: "1700000000",
+            chat_id: "oc_1",
+            sender: { id: "ou_1", id_type: "open_id", sender_type: "user" },
+            body: { content: '{"text":"hello"}' },
+          },
+        ],
+      },
+    });
+    const listResult = await tool.execute("tc_1", { action: "list", chat_id: "oc_1" });
+    expect(listResult.details).toEqual(
+      expect.objectContaining({
+        chat_id: "oc_1",
+        has_more: false,
+        items: [
+          expect.objectContaining({
+            message_id: "om_1",
+            msg_type: "text",
+            sender: expect.objectContaining({ id: "ou_1" }),
+          }),
+        ],
+      }),
+    );
+
+    messageGetMock.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_2",
+            msg_type: "text",
+            create_time: "1700000001",
+            chat_id: "oc_1",
+            sender: { id: "ou_2", id_type: "open_id", sender_type: "user" },
+            body: { content: '{"text":"world"}' },
+          },
+        ],
+      },
+    });
+    const getResult = await tool.execute("tc_2", { action: "get", message_id: "om_2" });
+    expect(getResult.details).toEqual(
+      expect.objectContaining({
+        message_id: "om_2",
+        msg_type: "text",
+        body: { content: '{"text":"world"}' },
+      }),
+    );
+  });
+
+  it("returns error when chat_id missing for list", async () => {
+    const registerTool = vi.fn();
+    registerFeishuMessageTools({
+      config: {
+        channels: {
+          feishu: {
+            enabled: true,
+            appId: "app_id",
+            appSecret: "app_secret",
+            tools: { message: true },
+          },
+        },
+      } as any,
+      logger: { debug: vi.fn(), info: vi.fn() } as any,
+      registerTool,
+    } as any);
+
+    const tool = registerTool.mock.calls[0]?.[0];
+    const result = await tool.execute("tc_3", { action: "list" });
+    expect(result.details).toEqual({ error: "chat_id is required for list action" });
+  });
+
+  it("skips registration when message tool is disabled", () => {
+    const registerTool = vi.fn();
+    registerFeishuMessageTools({
+      config: {
+        channels: {
+          feishu: {
+            enabled: true,
+            appId: "app_id",
+            appSecret: "app_secret",
+            tools: { message: false },
+          },
+        },
+      } as any,
+      logger: { debug: vi.fn(), info: vi.fn() } as any,
+      registerTool,
+    } as any);
+    expect(registerTool).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/feishu/src/message.ts
+++ b/extensions/feishu/src/message.ts
@@ -1,0 +1,157 @@
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { listEnabledFeishuAccounts } from "./accounts.js";
+import { createFeishuClient } from "./client.js";
+import { FeishuMessageSchema, type FeishuMessageParams } from "./message-schema.js";
+import { resolveToolsConfig } from "./tools-config.js";
+
+function json(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    details: data,
+  };
+}
+
+type MessageItem = {
+  message_id?: string;
+  msg_type?: string;
+  create_time?: string;
+  update_time?: string;
+  chat_id?: string;
+  deleted?: boolean;
+  sender?: { id: string; id_type: string; sender_type: string; tenant_key?: string };
+  body?: { content: string };
+  mentions?: { key: string; id: string; id_type: string; name: string }[];
+};
+
+function pickMessageFields(item: MessageItem) {
+  return {
+    message_id: item.message_id,
+    msg_type: item.msg_type,
+    create_time: item.create_time,
+    chat_id: item.chat_id,
+    sender: item.sender,
+    body: item.body,
+    mentions: item.mentions,
+  };
+}
+
+async function listMessages(
+  client: Lark.Client,
+  chatId: string,
+  opts: {
+    startTime?: string;
+    endTime?: string;
+    sortType?: string;
+    pageSize?: number;
+    pageToken?: string;
+  },
+) {
+  const page_size = opts.pageSize ? Math.max(1, Math.min(50, opts.pageSize)) : 20;
+  const res = await client.im.message.list({
+    params: {
+      container_id_type: "chat",
+      container_id: chatId,
+      start_time: opts.startTime,
+      end_time: opts.endTime,
+      sort_type: opts.sortType as "ByCreateTimeAsc" | "ByCreateTimeDesc" | undefined,
+      page_size,
+      page_token: opts.pageToken,
+    },
+  });
+
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  return {
+    chat_id: chatId,
+    has_more: res.data?.has_more,
+    page_token: res.data?.page_token,
+    items: res.data?.items?.map((item) => pickMessageFields(item as MessageItem)) ?? [],
+  };
+}
+
+async function getMessage(client: Lark.Client, messageId: string) {
+  const res = await client.im.message.get({
+    path: { message_id: messageId },
+  });
+
+  if (res.code !== 0) {
+    throw new Error(res.msg);
+  }
+
+  const items = res.data?.items;
+  if (!items || items.length === 0) {
+    throw new Error(`Message not found: ${messageId}`);
+  }
+
+  return pickMessageFields(items[0] as MessageItem);
+}
+
+export function registerFeishuMessageTools(api: OpenClawPluginApi) {
+  if (!api.config) {
+    api.logger.debug?.("feishu_message: No config available, skipping message tools");
+    return;
+  }
+
+  const accounts = listEnabledFeishuAccounts(api.config);
+  if (accounts.length === 0) {
+    api.logger.debug?.("feishu_message: No Feishu accounts configured, skipping message tools");
+    return;
+  }
+
+  const firstAccount = accounts[0];
+  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
+  if (!toolsCfg.message) {
+    api.logger.debug?.("feishu_message: message tool disabled in config");
+    return;
+  }
+
+  const getClient = () => createFeishuClient(firstAccount);
+
+  api.registerTool(
+    {
+      name: "feishu_message",
+      label: "Feishu Message",
+      description:
+        "Feishu message operations. Actions: list (chat history), get (single message by ID)",
+      parameters: FeishuMessageSchema,
+      async execute(_toolCallId, params) {
+        const p = params as FeishuMessageParams;
+        try {
+          const client = getClient();
+          switch (p.action) {
+            case "list": {
+              if (!p.chat_id) {
+                return json({ error: "chat_id is required for list action" });
+              }
+              return json(
+                await listMessages(client, p.chat_id, {
+                  startTime: p.start_time,
+                  endTime: p.end_time,
+                  sortType: p.sort_type,
+                  pageSize: p.page_size,
+                  pageToken: p.page_token,
+                }),
+              );
+            }
+            case "get": {
+              if (!p.message_id) {
+                return json({ error: "message_id is required for get action" });
+              }
+              return json(await getMessage(client, p.message_id));
+            }
+            default:
+              return json({ error: `Unknown action: ${String(p.action)}` });
+          }
+        } catch (err) {
+          return json({ error: err instanceof Error ? err.message : String(err) });
+        }
+      },
+    },
+    { name: "feishu_message" },
+  );
+
+  api.logger.info?.("feishu_message: Registered feishu_message tool");
+}

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -52,6 +52,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
   const merged: Required<FeishuToolsConfig> = {
     doc: false,
     chat: false,
+    message: false,
     wiki: false,
     drive: false,
     perm: false,

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -8,6 +8,7 @@ import type { FeishuToolsConfig } from "./types.js";
 export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   doc: true,
   chat: true,
+  message: true,
   wiki: true,
   drive: true,
   perm: false,

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -68,6 +68,7 @@ export type FeishuMediaInfo = {
 export type FeishuToolsConfig = {
   doc?: boolean;
   chat?: boolean;
+  message?: boolean;
   wiki?: boolean;
   drive?: boolean;
   perm?: boolean;


### PR DESCRIPTION
## Summary

- Add new `feishu_message` tool with `list` (chat history with time-range filtering, sort, pagination) and `get` (single message by ID) actions
- Add `search` action to existing `feishu_chat` tool so agents can discover chats by name before fetching messages
- Includes skill documentation (`feishu-message/SKILL.md`), unit tests for both tools, and schema/config wiring

Together these enable a complete workflow: search chat by name -> list messages with time range -> LLM analyzes content.

## Test plan

- [x] `pnpm tsgo` passes
- [x] `pnpm test -- extensions/feishu/src/chat.test.ts` — 6 tests pass
- [x] `pnpm test -- extensions/feishu/src/message.test.ts` — 5 tests pass
- [x] `pnpm check` passes
- [x] Manual testing: `feishu_message list` retrieves messages from a Feishu chat (bot must be a member)
- [x] Manual testing: `feishu_chat search` finds chats by keyword
