### PR TITLE
fix(errors): prioritize billing error over rate-limit when provider returns 429

### DIFF
--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -529,6 +529,13 @@ export function formatAssistantErrorText(
     return `LLM request rejected: ${invalidRequest[1]}`;
   }
 
+  // Check billing before rate limit: some providers (e.g. Moonshot) return 429
+  // for account suspension / insufficient balance, which causes the rate limit
+  // pattern to match first. Billing errors should take priority.
+  if (isBillingErrorMessage(raw)) {
+    return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
+  }
+
   const transientCopy = formatRateLimitOrOverloadedErrorCopy(raw);
   if (transientCopy) {
     return transientCopy;
@@ -536,10 +543,6 @@ export function formatAssistantErrorText(
 
   if (isTimeoutErrorMessage(raw)) {
     return "LLM request timed out.";
-  }
-
-  if (isBillingErrorMessage(raw)) {
-    return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
   }
 
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {
@@ -652,6 +655,8 @@ const ERROR_PATTERNS = {
     "credit balance",
     "plans & billing",
     "insufficient balance",
+    "exceeded_current_quota_error", // Moonshot: account suspended/quota exceeded
+    "suspended due to", // Moonshot: account suspension message
   ],
   authPermanent: [
     /api[_ ]?key[_ ]?(?:revoked|invalid|deactivated|deleted)/i,
@@ -926,6 +931,11 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isJsonApiInternalServerError(raw)) {
     return "timeout";
   }
+  // Check billing before rate limit: some providers (e.g. Moonshot) use 429 for
+  // account suspension / insufficient balance — billing should take priority.
+  if (isBillingErrorMessage(raw)) {
+    return "billing";
+  }
   if (isRateLimitErrorMessage(raw)) {
     return "rate_limit";
   }
@@ -934,9 +944,6 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   }
   if (isCloudCodeAssistFormatError(raw)) {
     return "format";
-  }
-  if (isBillingErrorMessage(raw)) {
-    return "billing";
   }
   if (isTimeoutErrorMessage(raw)) {
     return "timeout";

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -656,7 +656,7 @@ const ERROR_PATTERNS = {
     "plans & billing",
     "insufficient balance",
     "exceeded_current_quota_error", // Moonshot: account suspended/quota exceeded
-    "suspended due to", // Moonshot: account suspension message
+    "suspended due to insufficient balance", // Moonshot: billing-specific suspension
   ],
   authPermanent: [
     /api[_ ]?key[_ ]?(?:revoked|invalid|deactivated|deleted)/i,


### PR DESCRIPTION
## Problem

Some providers (notably Moonshot/Kimi) return HTTP 429 with `exceeded_current_quota_error` type and an "insufficient balance" message when an account is suspended due to zero credits. Because the existing code checked rate-limit patterns **before** billing patterns, the `429` HTTP status caused the generic "⚠️ API rate limit reached. Please try again later." message to surface — even though the real issue is a billing/balance problem.

This is confusing for users because the fix for a rate limit (wait and retry) is completely different from the fix for a billing error (top up the account). A user seeing "rate limit" might wait indefinitely for a problem that will never self-resolve.

## Root Cause

In both `formatAssistantErrorText` and `classifyFailoverReason`, the rate-limit check ran before the billing check. Moonshot's 429 matched `/429/` in `ERROR_PATTERNS.rateLimit` before `isBillingErrorMessage` ever ran.

## Changes

1. **`ERROR_PATTERNS.billing`** — add `"exceeded_current_quota_error"` and `"suspended due to"` so Moonshot's error type string is unambiguously classified as a billing error regardless of HTTP status code.

2. **`formatAssistantErrorText`** — move `isBillingErrorMessage` check before `formatRateLimitOrOverloadedErrorCopy`. Billing errors should produce the actionable billing message (with provider name + link to billing dashboard) rather than the generic rate-limit message.

3. **`classifyFailoverReason`** — move `isBillingErrorMessage` check before `isRateLimitErrorMessage` so the failover system also correctly classifies billing vs. transient rate limiting.

## Before / After

**Before:** Moonshot account with zero balance → `⚠️ API rate limit reached. Please try again later.`

**After:** Moonshot account with zero balance → `⚠️ moonshot (kimi-k2.5) returned a billing error — your API key has run out of credits or has an insufficient balance. Check your moonshot billing dashboard and top up or switch to a different API key.`

## Test coverage

Existing tests in `pi-embedded-helpers.formatassistanterrortext.test.ts` cover billing error classification. The `exceeded_current_quota_error` pattern addition is consistent with existing billing pattern style.