### PR TITLE
feat(ui): add file attachment button and drag-and-drop to WebUI

### DIFF
--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -176,10 +176,23 @@
   background: var(--bg);
 }
 
-.chat-attachment__img {
+.chat-attachment__img,
+.chat-attachment__file {
   width: 100%;
   height: 100%;
   object-fit: contain;
+}
+
+.chat-attachment__file {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-secondary);
+}
+
+.chat-attachment__file svg {
+  width: 32px;
+  height: 32px;
 }
 
 .chat-attachment__remove {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -168,21 +168,21 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
     return;
   }
 
-  const imageItems: DataTransferItem[] = [];
+  const fileItems: DataTransferItem[] = [];
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
-    if (item.type.startsWith("image/")) {
-      imageItems.push(item);
+    if (item.kind === "file") {
+      fileItems.push(item);
     }
   }
 
-  if (imageItems.length === 0) {
+  if (fileItems.length === 0) {
     return;
   }
 
   e.preventDefault();
 
-  for (const item of imageItems) {
+  for (const item of fileItems) {
     const file = item.getAsFile();
     if (!file) {
       continue;
@@ -194,13 +194,57 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
       const newAttachment: ChatAttachment = {
         id: generateAttachmentId(),
         dataUrl,
-        mimeType: file.type,
+        mimeType: file.type || "application/octet-stream",
       };
       const current = props.attachments ?? [];
       props.onAttachmentsChange?.([...current, newAttachment]);
     });
     reader.readAsDataURL(file);
   }
+}
+
+function handleDrop(e: DragEvent, props: ChatProps) {
+  e.preventDefault();
+  const items = e.dataTransfer?.items;
+  if (!items || !props.onAttachmentsChange) {
+    return;
+  }
+
+  const fileItems: DataTransferItem[] = [];
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (item.kind === "file") {
+      fileItems.push(item);
+    }
+  }
+
+  if (fileItems.length === 0) {
+    return;
+  }
+
+  for (const item of fileItems) {
+    const file = item.getAsFile();
+    if (!file) {
+      continue;
+    }
+
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+      const dataUrl = reader.result as string;
+      const newAttachment: ChatAttachment = {
+        id: generateAttachmentId(),
+        dataUrl,
+        mimeType: file.type || "application/octet-stream",
+      };
+      const current = props.attachments ?? [];
+      props.onAttachmentsChange?.([...current, newAttachment]);
+    });
+    reader.readAsDataURL(file);
+  }
+}
+
+function handleDragOver(e: DragEvent) {
+  e.preventDefault();
 }
 
 function renderAttachmentPreview(props: ChatProps) {
@@ -213,12 +257,16 @@ function renderAttachmentPreview(props: ChatProps) {
     <div class="chat-attachments">
       ${attachments.map(
         (att) => html`
-          <div class="chat-attachment">
-            <img
-              src=${att.dataUrl}
-              alt="Attachment preview"
-              class="chat-attachment__img"
-            />
+          <div class="chat-attachment" title="${att.mimeType}">
+            ${
+              att.mimeType.startsWith("image/")
+                ? html`<img
+                    src=${att.dataUrl}
+                    alt="Attachment preview"
+                    class="chat-attachment__img"
+                  />`
+                : html`<div class="chat-attachment__file">${icons.fileText}</div>`
+            }
             <button
               class="chat-attachment__remove"
               type="button"
@@ -315,7 +363,10 @@ export function renderChat(props: ChatProps) {
   `;
 
   return html`
-    <section class="card chat">
+    <section class="card chat"
+      @drop=${(e: DragEvent) => handleDrop(e, props)}
+      @dragover=${handleDragOver}
+    >
       ${props.disabledReason ? html`<div class="callout">${props.disabledReason}</div>` : nothing}
 
       ${props.error ? html`<div class="callout danger">${props.error}</div>` : nothing}
@@ -458,6 +509,56 @@ export function renderChat(props: ChatProps) {
             ></textarea>
           </label>
           <div class="chat-compose__actions">
+            <button
+              class="btn chat-compose__attach"
+              type="button"
+              aria-label="Attach file"
+              title="Attach file"
+              ?disabled=${!props.connected}
+              @click=${(e: Event) => {
+                const target = e.currentTarget as HTMLElement;
+                const input = target.nextElementSibling as HTMLInputElement;
+                input.click();
+              }}
+            >
+              ${icons.paperclip}
+            </button>
+            <input
+              type="file"
+              multiple
+              style="display: none"
+              @change=${(e: Event) => {
+                const input = e.target as HTMLInputElement;
+                if (!input.files || input.files.length === 0 || !props.onAttachmentsChange) {
+                  return;
+                }
+
+                let processed = 0;
+                const total = input.files.length;
+                const newAttachments: ChatAttachment[] = [];
+
+                const current = props.attachments ?? [];
+
+                for (let i = 0; i < input.files.length; i++) {
+                  const file = input.files[i];
+                  const reader = new FileReader();
+                  reader.addEventListener("load", () => {
+                    newAttachments.push({
+                      id: generateAttachmentId(),
+                      dataUrl: reader.result as string,
+                      mimeType: file.type || "application/octet-stream",
+                    });
+                    processed++;
+                    if (processed === total) {
+                      props.onAttachmentsChange?.([...current, ...newAttachments]);
+                    }
+                  });
+                  reader.readAsDataURL(file);
+                }
+                // Reset input so the same file can be selected again if removed
+                input.value = "";
+              }}
+            />
             <button
               class="btn"
               ?disabled=${!props.connected || (!canAbort && props.sending)}

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -182,22 +182,32 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
 
   e.preventDefault();
 
+  let processed = 0;
+  const total = fileItems.length;
+  const newAttachments: ChatAttachment[] = [];
+  const current = props.attachments ?? [];
+
   for (const item of fileItems) {
     const file = item.getAsFile();
     if (!file) {
+      processed++;
+      if (processed === total && newAttachments.length > 0) {
+        props.onAttachmentsChange?.([...current, ...newAttachments]);
+      }
       continue;
     }
 
     const reader = new FileReader();
     reader.addEventListener("load", () => {
-      const dataUrl = reader.result as string;
-      const newAttachment: ChatAttachment = {
+      newAttachments.push({
         id: generateAttachmentId(),
-        dataUrl,
+        dataUrl: reader.result as string,
         mimeType: file.type || "application/octet-stream",
-      };
-      const current = props.attachments ?? [];
-      props.onAttachmentsChange?.([...current, newAttachment]);
+      });
+      processed++;
+      if (processed === total) {
+        props.onAttachmentsChange?.([...current, ...newAttachments]);
+      }
     });
     reader.readAsDataURL(file);
   }
@@ -222,22 +232,32 @@ function handleDrop(e: DragEvent, props: ChatProps) {
     return;
   }
 
+  let processed = 0;
+  const total = fileItems.length;
+  const newAttachments: ChatAttachment[] = [];
+  const current = props.attachments ?? [];
+
   for (const item of fileItems) {
     const file = item.getAsFile();
     if (!file) {
+      processed++;
+      if (processed === total && newAttachments.length > 0) {
+        props.onAttachmentsChange?.([...current, ...newAttachments]);
+      }
       continue;
     }
 
     const reader = new FileReader();
     reader.addEventListener("load", () => {
-      const dataUrl = reader.result as string;
-      const newAttachment: ChatAttachment = {
+      newAttachments.push({
         id: generateAttachmentId(),
-        dataUrl,
+        dataUrl: reader.result as string,
         mimeType: file.type || "application/octet-stream",
-      };
-      const current = props.attachments ?? [];
-      props.onAttachmentsChange?.([...current, newAttachment]);
+      });
+      processed++;
+      if (processed === total) {
+        props.onAttachmentsChange?.([...current, ...newAttachments]);
+      }
     });
     reader.readAsDataURL(file);
   }


### PR DESCRIPTION
This PR adds a paperclip icon to the WebUI chat compose area allowing users to upload files via the file picker. It also implements drag-and-drop support over the chat container to accept generic files, replacing the previous image-only paste limitation. Non-image attachments now render with a generic file icon rather than a broken image preview.