### PR TITLE
fix(bluebubbles): coalesce text + URL balloon webhook events

### DIFF
--- a/extensions/bluebubbles/src/monitor.test.ts
+++ b/extensions/bluebubbles/src/monitor.test.ts
@@ -1877,6 +1877,122 @@ describe("BlueBubbles webhook monitor", () => {
         vi.useRealTimers();
       }
     });
+
+    it("coalesces text and URL-balloon events sharing the same logical message guid", async () => {
+      vi.useFakeTimers();
+      try {
+        const account = createMockAccount({ dmPolicy: "open" });
+        const config: OpenClawConfig = {};
+        const core = createMockRuntime();
+
+        // oxlint-disable-next-line typescript/no-explicit-any
+        core.channel.debounce.createInboundDebouncer = vi.fn((params: any) => {
+          // oxlint-disable-next-line typescript/no-explicit-any
+          type Item = any;
+          const buckets = new Map<
+            string,
+            { items: Item[]; timer: ReturnType<typeof setTimeout> | null }
+          >();
+
+          const flush = async (key: string) => {
+            const bucket = buckets.get(key);
+            if (!bucket) {
+              return;
+            }
+            if (bucket.timer) {
+              clearTimeout(bucket.timer);
+              bucket.timer = null;
+            }
+            const items = bucket.items;
+            bucket.items = [];
+            if (items.length > 0) {
+              await params.onFlush(items);
+            }
+          };
+
+          return {
+            enqueue: async (item: Item) => {
+              if (params.shouldDebounce && !params.shouldDebounce(item)) {
+                await params.onFlush([item]);
+                return;
+              }
+              const key = params.buildKey(item);
+              const bucket = buckets.get(key) ?? { items: [], timer: null };
+              bucket.items.push(item);
+              if (bucket.timer) {
+                clearTimeout(bucket.timer);
+              }
+              bucket.timer = setTimeout(async () => {
+                await flush(key);
+              }, params.debounceMs);
+              buckets.set(key, bucket);
+            },
+            flushKey: vi.fn(async (key: string) => {
+              await flush(key);
+            }),
+          };
+        }) as unknown as PluginRuntime["channel"]["debounce"]["createInboundDebouncer"];
+
+        setBlueBubblesRuntime(core);
+
+        unregister = registerBlueBubblesWebhookTarget({
+          account,
+          config,
+          runtime: { log: vi.fn(), error: vi.fn() },
+          core,
+          path: "/bluebubbles-webhook",
+        });
+
+        const messageId = "same-msg-guid-1";
+        const chatGuid = "iMessage;-;+15551234567";
+
+        const textPayload = {
+          type: "new-message",
+          data: {
+            text: "check this out https://example.com",
+            handle: { address: "+15551234567" },
+            isGroup: false,
+            isFromMe: false,
+            guid: messageId,
+            chatGuid,
+            date: Date.now(),
+          },
+        };
+
+        const balloonPayload = {
+          type: "new-message",
+          data: {
+            text: "https://example.com",
+            handle: { address: "+15551234567" },
+            isGroup: false,
+            isFromMe: false,
+            guid: "balloon-guid-1",
+            associatedMessageGuid: messageId,
+            balloonBundleId: "com.apple.messages.URLBalloonProvider",
+            chatGuid,
+            date: Date.now(),
+          },
+        };
+
+        await handleBlueBubblesWebhookRequest(
+          createMockRequest("POST", "/bluebubbles-webhook", textPayload),
+          createMockResponse(),
+        );
+        await vi.advanceTimersByTimeAsync(200);
+        await handleBlueBubblesWebhookRequest(
+          createMockRequest("POST", "/bluebubbles-webhook", balloonPayload),
+          createMockResponse(),
+        );
+
+        expect(mockDispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+
+        await vi.advanceTimersByTimeAsync(700);
+
+        expect(mockDispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("reply metadata", () => {

--- a/extensions/bluebubbles/src/monitor.ts
+++ b/extensions/bluebubbles/src/monitor.ts
@@ -157,13 +157,14 @@ function getOrCreateDebouncer(target: WebhookTarget) {
       // Prefer stable, shared identifiers to coalesce rapid-fire webhook events for the
       // same message (e.g., text-only then text+attachment).
       //
-      // For balloons (URL previews, stickers, etc), BlueBubbles often uses a different
-      // messageId than the originating text. When present, key by associatedMessageGuid
-      // to keep text + balloon coalescing working.
+      // For balloons (URL previews, stickers, etc), BlueBubbles often emits a separate
+      // webhook event with associatedMessageGuid pointing at the original text message.
+      // Use the same msg:* namespace as normal message IDs so text + balloon events
+      // for the same logical message coalesce into one debounce bucket.
       const balloonBundleId = msg.balloonBundleId?.trim();
       const associatedMessageGuid = msg.associatedMessageGuid?.trim();
       if (balloonBundleId && associatedMessageGuid) {
-        return `bluebubbles:${account.accountId}:balloon:${associatedMessageGuid}`;
+        return `bluebubbles:${account.accountId}:msg:${associatedMessageGuid}`;
       }
 
       const messageId = msg.messageId?.trim();


### PR DESCRIPTION
## Summary
- fix BlueBubbles inbound debounce keying so URL balloon events use the same `msg:*` key namespace as normal text messages
- ensure text and balloon webhook events sharing the same logical message GUID coalesce into a single debounce bucket
- add regression test coverage for text + URL balloon dual-webhook flow

## Root cause
`buildKey` used different namespaces for the same logical message:
- text event: `msg:<guid>`
- balloon event: `balloon:<associatedMessageGuid>`

Because the keys differed, the debouncer flushed twice and produced duplicate replies.

## Testing
- `pnpm exec vitest run --config vitest.extensions.config.ts extensions/bluebubbles/src/monitor.test.ts`

Closes #31823