### PR TITLE
fix(slack): use users.info for ID-based allowlist lookups to avoid rate-limit loop

### DIFF
--- a/src/slack/resolve-users.test.ts
+++ b/src/slack/resolve-users.test.ts
@@ -1,0 +1,214 @@
+import type { WebClient } from "@slack/web-api";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./client.js", () => ({
+  createSlackWebClient: () => ({}),
+}));
+
+const { resolveSlackUserAllowlist } = await import("./resolve-users.js");
+
+function makeMockClient(opts: {
+  usersInfo?: Record<
+    string,
+    {
+      id: string;
+      name: string;
+      deleted?: boolean;
+      is_bot?: boolean;
+      profile?: Record<string, string>;
+    }
+  >;
+  usersList?: Array<{
+    id: string;
+    name: string;
+    deleted?: boolean;
+    is_bot?: boolean;
+    profile?: Record<string, string>;
+  }>;
+}): WebClient {
+  return {
+    users: {
+      info: vi.fn(async (params: { user: string }) => {
+        const user = opts.usersInfo?.[params.user];
+        if (!user) {
+          throw new Error(`user_not_found`);
+        }
+        return { ok: true, user };
+      }),
+      list: vi.fn(async () => ({
+        members: opts.usersList ?? [],
+        response_metadata: { next_cursor: "" },
+      })),
+    },
+  } as unknown as WebClient;
+}
+
+describe("resolveSlackUserAllowlist", () => {
+  it("resolves ID-based entries via users.info without calling users.list", async () => {
+    const client = makeMockClient({
+      usersInfo: {
+        U123ABC: {
+          id: "U123ABC",
+          name: "alice",
+          profile: { display_name: "Alice Smith", email: "alice@example.com" },
+        },
+      },
+    });
+
+    const results = await resolveSlackUserAllowlist({
+      token: "xoxb-test",
+      entries: ["U123ABC"],
+      client,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual(
+      expect.objectContaining({
+        input: "U123ABC",
+        resolved: true,
+        id: "U123ABC",
+        name: "Alice Smith",
+        email: "alice@example.com",
+      }),
+    );
+    expect(client.users.info).toHaveBeenCalledWith({ user: "U123ABC" });
+    expect(client.users.list).not.toHaveBeenCalled();
+  });
+
+  it("resolves name-based entries via users.list", async () => {
+    const client = makeMockClient({
+      usersList: [{ id: "U999", name: "bob", profile: { display_name: "Bob Jones" } }],
+    });
+
+    const results = await resolveSlackUserAllowlist({
+      token: "xoxb-test",
+      entries: ["@bob"],
+      client,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual(
+      expect.objectContaining({ resolved: true, id: "U999", name: "Bob Jones" }),
+    );
+    expect(client.users.list).toHaveBeenCalled();
+    expect(client.users.info).not.toHaveBeenCalled();
+  });
+
+  it("resolves mixed ID and name entries using appropriate methods", async () => {
+    const client = makeMockClient({
+      usersInfo: {
+        U111: { id: "U111", name: "carol", profile: { display_name: "Carol" } },
+      },
+      usersList: [{ id: "U222", name: "dave", profile: { display_name: "Dave" } }],
+    });
+
+    const results = await resolveSlackUserAllowlist({
+      token: "xoxb-test",
+      entries: ["U111", "@dave"],
+      client,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual(expect.objectContaining({ id: "U111", name: "Carol" }));
+    expect(results[1]).toEqual(expect.objectContaining({ id: "U222", name: "Dave" }));
+    expect(client.users.info).toHaveBeenCalledTimes(1);
+    expect(client.users.list).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves original entry order in results", async () => {
+    const client = makeMockClient({
+      usersInfo: {
+        U111: { id: "U111", name: "first" },
+      },
+      usersList: [{ id: "U222", name: "second", profile: { display_name: "Second" } }],
+    });
+
+    const results = await resolveSlackUserAllowlist({
+      token: "xoxb-test",
+      entries: ["@second", "U111"],
+      client,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[0].input).toBe("@second");
+    expect(results[1].input).toBe("U111");
+  });
+
+  it("gracefully handles users.info failure for ID entries", async () => {
+    const client = makeMockClient({ usersInfo: {} });
+
+    const results = await resolveSlackUserAllowlist({
+      token: "xoxb-test",
+      entries: ["UNOTEXIST"],
+      client,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual(
+      expect.objectContaining({ input: "UNOTEXIST", resolved: true, id: "UNOTEXIST" }),
+    );
+    expect(client.users.list).not.toHaveBeenCalled();
+  });
+
+  it("resolves email-based entries via users.list", async () => {
+    const client = makeMockClient({
+      usersList: [
+        { id: "U333", name: "eve", profile: { email: "eve@co.com", display_name: "Eve" } },
+      ],
+    });
+
+    const results = await resolveSlackUserAllowlist({
+      token: "xoxb-test",
+      entries: ["eve@co.com"],
+      client,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual(
+      expect.objectContaining({ resolved: true, id: "U333", name: "Eve" }),
+    );
+    expect(client.users.list).toHaveBeenCalled();
+  });
+
+  it("skips users.list entirely when all entries are IDs", async () => {
+    const client = makeMockClient({
+      usersInfo: {
+        UAAA: { id: "UAAA", name: "a" },
+        UBBB: { id: "UBBB", name: "b" },
+      },
+    });
+
+    const results = await resolveSlackUserAllowlist({
+      token: "xoxb-test",
+      entries: ["UAAA", "UBBB"],
+      client,
+    });
+
+    expect(results).toHaveLength(2);
+    expect(results[0]).toEqual(expect.objectContaining({ id: "UAAA" }));
+    expect(results[1]).toEqual(expect.objectContaining({ id: "UBBB" }));
+    expect(client.users.list).not.toHaveBeenCalled();
+    expect(client.users.info).toHaveBeenCalledTimes(2);
+  });
+
+  it("resolves mention-format IDs via users.info", async () => {
+    const client = makeMockClient({
+      usersInfo: {
+        U123: { id: "U123", name: "mentioned", profile: { display_name: "Mentioned User" } },
+      },
+    });
+
+    const results = await resolveSlackUserAllowlist({
+      token: "xoxb-test",
+      entries: ["<@U123>"],
+      client,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual(
+      expect.objectContaining({ resolved: true, id: "U123", name: "Mentioned User" }),
+    );
+    expect(client.users.info).toHaveBeenCalledWith({ user: "U123" });
+    expect(client.users.list).not.toHaveBeenCalled();
+  });
+});

--- a/src/slack/resolve-users.test.ts
+++ b/src/slack/resolve-users.test.ts
@@ -191,6 +191,25 @@ describe("resolveSlackUserAllowlist", () => {
     expect(client.users.info).toHaveBeenCalledTimes(2);
   });
 
+  it("deduplicates users.info calls for repeated IDs", async () => {
+    const client = makeMockClient({
+      usersInfo: {
+        UDUPE: { id: "UDUPE", name: "dupeuser", profile: { display_name: "Dupe User" } },
+      },
+    });
+
+    const results = await resolveSlackUserAllowlist({
+      token: "xoxb-test",
+      entries: ["UDUPE", "UDUPE", "UDUPE"],
+      client,
+    });
+
+    expect(results).toHaveLength(3);
+    expect(results.every((r) => r.id === "UDUPE")).toBe(true);
+    expect(client.users.info).toHaveBeenCalledTimes(1);
+    expect(client.users.list).not.toHaveBeenCalled();
+  });
+
   it("resolves mention-format IDs via users.info", async () => {
     const client = makeMockClient({
       usersInfo: {

--- a/src/slack/resolve-users.ts
+++ b/src/slack/resolve-users.ts
@@ -160,8 +160,11 @@ async function lookupSlackUserById(
   try {
     const res = (await client.users.info({ user: userId })) as SlackUserInfoResponse;
     const member = res.user;
-    const id = member?.id?.trim();
-    const name = member?.name?.trim();
+    if (!member) {
+      return null;
+    }
+    const id = member.id?.trim();
+    const name = member.name?.trim();
     if (!id || !name) {
       return null;
     }

--- a/src/slack/resolve-users.ts
+++ b/src/slack/resolve-users.ts
@@ -136,52 +136,124 @@ function resolveSlackUserFromMatches(
   };
 }
 
+type SlackUserInfoResponse = {
+  ok?: boolean;
+  user?: {
+    id?: string;
+    name?: string;
+    deleted?: boolean;
+    is_bot?: boolean;
+    is_app_user?: boolean;
+    real_name?: string;
+    profile?: {
+      display_name?: string;
+      real_name?: string;
+      email?: string;
+    };
+  };
+};
+
+async function lookupSlackUserById(
+  client: WebClient,
+  userId: string,
+): Promise<SlackUserLookup | null> {
+  try {
+    const res = (await client.users.info({ user: userId })) as SlackUserInfoResponse;
+    const member = res.user;
+    const id = member?.id?.trim();
+    const name = member?.name?.trim();
+    if (!id || !name) {
+      return null;
+    }
+    const profile = member.profile ?? {};
+    return {
+      id,
+      name,
+      displayName: profile.display_name?.trim() || undefined,
+      realName: profile.real_name?.trim() || member.real_name?.trim() || undefined,
+      email: profile.email?.trim()?.toLowerCase() || undefined,
+      deleted: Boolean(member.deleted),
+      isBot: Boolean(member.is_bot),
+      isAppUser: Boolean(member.is_app_user),
+    };
+  } catch {
+    return null;
+  }
+}
+
 export async function resolveSlackUserAllowlist(params: {
   token: string;
   entries: string[];
   client?: WebClient;
 }): Promise<SlackUserResolution[]> {
   const client = params.client ?? createSlackWebClient(params.token);
-  const users = await listSlackUsers(client);
   const results: SlackUserResolution[] = [];
 
-  for (const input of params.entries) {
+  const idEntries: Array<{ index: number; input: string; id: string }> = [];
+  const otherEntries: Array<{
+    index: number;
+    input: string;
+    parsed: ReturnType<typeof parseSlackUserInput>;
+  }> = [];
+
+  for (let i = 0; i < params.entries.length; i++) {
+    const input = params.entries[i];
     const parsed = parseSlackUserInput(input);
     if (parsed.id) {
-      const match = users.find((user) => user.id === parsed.id);
-      results.push({
+      idEntries.push({ index: i, input, id: parsed.id });
+    } else {
+      otherEntries.push({ index: i, input, parsed });
+    }
+  }
+
+  const ordered: Array<{ index: number; result: SlackUserResolution }> = [];
+
+  for (const { index, input, id } of idEntries) {
+    const match = await lookupSlackUserById(client, id);
+    ordered.push({
+      index,
+      result: {
         input,
         resolved: true,
-        id: parsed.id,
+        id,
         name: match?.displayName ?? match?.realName ?? match?.name,
         email: match?.email,
         deleted: match?.deleted,
         isBot: match?.isBot,
-      });
-      continue;
-    }
-    if (parsed.email) {
-      const matches = users.filter((user) => user.email === parsed.email);
-      if (matches.length > 0) {
-        results.push(resolveSlackUserFromMatches(input, matches, parsed));
-        continue;
-      }
-    }
-    if (parsed.name) {
-      const target = parsed.name.toLowerCase();
-      const matches = users.filter((user) => {
-        const candidates = [user.name, user.displayName, user.realName]
-          .map((value) => value?.toLowerCase())
-          .filter(Boolean) as string[];
-        return candidates.includes(target);
-      });
-      if (matches.length > 0) {
-        results.push(resolveSlackUserFromMatches(input, matches, parsed));
-        continue;
-      }
-    }
+      },
+    });
+  }
 
-    results.push({ input, resolved: false });
+  if (otherEntries.length > 0) {
+    const users = await listSlackUsers(client);
+    for (const { index, input, parsed } of otherEntries) {
+      if (parsed.email) {
+        const matches = users.filter((user) => user.email === parsed.email);
+        if (matches.length > 0) {
+          ordered.push({ index, result: resolveSlackUserFromMatches(input, matches, parsed) });
+          continue;
+        }
+      }
+      if (parsed.name) {
+        const target = parsed.name.toLowerCase();
+        const matches = users.filter((user) => {
+          const candidates = [user.name, user.displayName, user.realName]
+            .map((value) => value?.toLowerCase())
+            .filter(Boolean) as string[];
+          return candidates.includes(target);
+        });
+        if (matches.length > 0) {
+          ordered.push({ index, result: resolveSlackUserFromMatches(input, matches, parsed) });
+          continue;
+        }
+      }
+      ordered.push({ index, result: { input, resolved: false } });
+    }
+  }
+
+  ordered.sort((a, b) => a.index - b.index);
+  for (const { result } of ordered) {
+    results.push(result);
   }
 
   return results;

--- a/src/slack/resolve-users.ts
+++ b/src/slack/resolve-users.ts
@@ -208,8 +208,13 @@ export async function resolveSlackUserAllowlist(params: {
 
   const ordered: Array<{ index: number; result: SlackUserResolution }> = [];
 
+  const idLookupCache = new Map<string, SlackUserLookup | null>();
   for (const { index, input, id } of idEntries) {
-    const match = await lookupSlackUserById(client, id);
+    let match = idLookupCache.get(id);
+    if (match === undefined) {
+      match = await lookupSlackUserById(client, id);
+      idLookupCache.set(id, match);
+    }
     ordered.push({
       index,
       result: {


### PR DESCRIPTION
## Summary

- **Problem:** `resolveSlackUserAllowlist` always calls `users.list` (Tier-2, paginated, enumerates entire workspace) even when all entries are user IDs. On large Slack workspaces (thousands of users), this causes rate-limit errors and loops.
- **Why it matters:** ID-based allowlist entries are common (e.g. `U12345`, `<@U12345>`). Hitting rate limits blocks the entire allowlist resolution flow, causing connection failures.
- **What changed:** Added a `lookupSlackUserById` helper that calls `users.info` (Tier-4, single-user, much higher rate limit). `resolveSlackUserAllowlist` now classifies entries upfront: ID-based entries use `users.info`; name/email-based entries still use `users.list`. `users.list` is only called when necessary. Original input order is preserved.
- **What did NOT change (scope boundary):** `listSlackUsers`, `parseSlackUserInput`, `resolveSlackUserFromMatches`, and all other Slack functions remain untouched. The matching logic for name/email entries is identical.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #31733

## User-visible / Behavior Changes

Slack allowlist resolution with ID-based entries is significantly faster and avoids rate-limit errors on large workspaces. No config changes needed.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` — calls `users.info` instead of `users.list` for ID entries
  - Risk + mitigation: `users.info` is a standard Slack Web API method, same auth scope (`users:read`). It returns less data (single user vs all users), reducing exposure.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime/container: Node.js
- Integration/channel: Slack

### Steps

1. Configure a Slack allowlist with ID-based entries (e.g. `U12345`)
2. Connect to a large Slack workspace (1000+ members)
3. Observe rate-limit errors during allowlist resolution

### Expected

- ID-based entries resolve instantly via `users.info` without hitting rate limits

### Actual (before fix)

- All entries trigger full `users.list` pagination, causing Tier-2 rate-limit errors

## Evidence

- [x] Failing test/log before + passing after
- 8 new test cases in `src/slack/resolve-users.test.ts`
- Tests verify: ID entries use `users.info` (not `users.list`), name entries use `users.list` (not `users.info`), mixed entries use both appropriately, order is preserved, error handling works

## Human Verification (required)

- Verified scenarios: Ran all 8 tests via `pnpm test -- --run src/slack/resolve-users.test.ts` — all pass
- Edge cases checked: `users.info` failure (graceful degradation), mention-format IDs (`<@U123>`), mixed ID + name entries, email-based entries, all-IDs skipping `users.list` entirely
- What I did **not** verify: Live Slack workspace end-to-end (no test instance available)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; `resolveSlackUserAllowlist` will fall back to the original `users.list`-only behavior
- Files/config to restore: `src/slack/resolve-users.ts`
- Known bad symptoms reviewers should watch for: ID-based entries resolving with missing `name`/`email` fields

## Risks and Mitigations

- Risk: `users.info` might return a different response shape than expected
  - Mitigation: Added defensive null checks on all fields; on failure, the entry still resolves with the known ID (graceful degradation)
- Risk: Behavior change for ID entries that were previously matched by name
  - Mitigation: `parseSlackUserInput` classification logic is unchanged; only entries explicitly parsed as IDs go through the new path

---

🤖 AI-assisted (Claude) · Fully tested · I understand what this code does.