### PR TITLE
Build: harden A2UI bundle for Windows+WSL shell path(AI-assisted:Codex)

### DIFF
--- a/scripts/bundle-a2ui.mjs
+++ b/scripts/bundle-a2ui.mjs
@@ -42,11 +42,40 @@ function resolveLocalBin(name) {
   return path.join(rootDir, "node_modules", ".bin", `${name}${ext}`);
 }
 
+function resolveExecutableCandidate(executable) {
+  if (process.platform !== "win32" || !executable.toLowerCase().endsWith(".cmd")) {
+    return executable;
+  }
+
+  if (path.isAbsolute(executable)) {
+    return existsSync(executable) ? executable : null;
+  }
+
+  const whereResult = spawnSync("where", [executable], {
+    cwd: rootDir,
+    stdio: ["ignore", "pipe", "ignore"],
+    encoding: "utf8",
+  });
+  if (whereResult.error || whereResult.status !== 0) {
+    return null;
+  }
+
+  const resolved = whereResult.stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find((line) => line.length > 0);
+  return resolved ?? null;
+}
+
 function runCommand(command, args) {
   const executables = resolveExecutables(command);
   for (const executable of executables) {
-    const useShell = process.platform === "win32" && executable.toLowerCase().endsWith(".cmd");
-    const result = spawnSync(executable, args, {
+    const candidate = resolveExecutableCandidate(executable);
+    if (!candidate) {
+      continue;
+    }
+    const useShell = process.platform === "win32" && candidate.toLowerCase().endsWith(".cmd");
+    const result = spawnSync(candidate, args, {
       cwd: rootDir,
       stdio: "inherit",
       shell: useShell,
@@ -72,8 +101,12 @@ function hasRolldown() {
   }
   const executables = resolveExecutables("rolldown");
   for (const executable of executables) {
-    const useShell = process.platform === "win32" && executable.toLowerCase().endsWith(".cmd");
-    const result = spawnSync(executable, ["--version"], {
+    const candidate = resolveExecutableCandidate(executable);
+    if (!candidate) {
+      continue;
+    }
+    const useShell = process.platform === "win32" && candidate.toLowerCase().endsWith(".cmd");
+    const result = spawnSync(candidate, ["--version"], {
       cwd: rootDir,
       stdio: "ignore",
       shell: useShell,

--- a/scripts/bundle-a2ui.mjs
+++ b/scripts/bundle-a2ui.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(scriptDir, "..");
+const hashFile = path.join(rootDir, "src", "canvas-host", "a2ui", ".bundle.hash");
+const outputFile = path.join(rootDir, "src", "canvas-host", "a2ui", "a2ui.bundle.js");
+const a2uiRendererDir = path.join(rootDir, "vendor", "a2ui", "renderers", "lit");
+const a2uiAppDir = path.join(rootDir, "apps", "shared", "OpenClawKit", "Tools", "CanvasA2UI");
+const inputPaths = [
+  path.join(rootDir, "package.json"),
+  path.join(rootDir, "pnpm-lock.yaml"),
+  a2uiRendererDir,
+  a2uiAppDir,
+];
+
+function resolveExecutables(command) {
+  if (process.platform !== "win32") {
+    return [command];
+  }
+  if (command === "pnpm") {
+    const executables = [];
+    if (process.env.OPENCLAW_PNPM_CMD) {
+      executables.push(process.env.OPENCLAW_PNPM_CMD);
+    }
+    if (process.env.APPDATA) {
+      executables.push(path.join(process.env.APPDATA, "npm", "pnpm.cmd"));
+    }
+    if (process.env.USERPROFILE) {
+      executables.push(path.join(process.env.USERPROFILE, "AppData", "Roaming", "npm", "pnpm.cmd"));
+    }
+    executables.push("pnpm.cmd", "pnpm");
+    return executables;
+  }
+  if (command === "rolldown") {
+    return ["rolldown.cmd", "rolldown"];
+  }
+  return [command];
+}
+
+function resolveLocalBin(name) {
+  const ext = process.platform === "win32" ? ".cmd" : "";
+  return path.join(rootDir, "node_modules", ".bin", `${name}${ext}`);
+}
+
+function runCommand(command, args) {
+  const executables = resolveExecutables(command);
+  for (const executable of executables) {
+    const useShell = process.platform === "win32" && executable.toLowerCase().endsWith(".cmd");
+    const result = spawnSync(executable, args, {
+      cwd: rootDir,
+      stdio: "inherit",
+      shell: useShell,
+    });
+    if (!result.error) {
+      if (result.status !== 0) {
+        const printable = [command, ...args].join(" ");
+        throw new Error(`Command failed: ${printable}`);
+      }
+      return;
+    }
+    if (result.error.code !== "ENOENT" && result.error.code !== "EINVAL") {
+      throw result.error;
+    }
+  }
+  throw new Error(`Command not found: ${command}`);
+}
+
+function hasRolldown() {
+  const localRolldown = resolveLocalBin("rolldown");
+  if (existsSync(localRolldown)) {
+    return true;
+  }
+  const executables = resolveExecutables("rolldown");
+  for (const executable of executables) {
+    const useShell = process.platform === "win32" && executable.toLowerCase().endsWith(".cmd");
+    const result = spawnSync(executable, ["--version"], {
+      cwd: rootDir,
+      stdio: "ignore",
+      shell: useShell,
+    });
+    if (!result.error) {
+      return result.status === 0;
+    }
+    if (result.error.code !== "ENOENT" && result.error.code !== "EINVAL") {
+      return false;
+    }
+  }
+  return false;
+}
+
+async function walk(entryPath, files) {
+  const stat = await fs.stat(entryPath);
+  if (stat.isDirectory()) {
+    const entries = await fs.readdir(entryPath);
+    for (const entry of entries) {
+      await walk(path.join(entryPath, entry), files);
+    }
+    return;
+  }
+  files.push(entryPath);
+}
+
+function normalizePath(filePath) {
+  return filePath.split(path.sep).join("/");
+}
+
+async function computeHash() {
+  const files = [];
+  for (const inputPath of inputPaths) {
+    await walk(inputPath, files);
+  }
+  files.sort((a, b) => normalizePath(a).localeCompare(normalizePath(b)));
+
+  const hash = createHash("sha256");
+  for (const filePath of files) {
+    const relativePath = normalizePath(path.relative(rootDir, filePath));
+    hash.update(relativePath);
+    hash.update("\0");
+    hash.update(await fs.readFile(filePath));
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+function printFailureAndExit(err) {
+  if (err instanceof Error && err.message) {
+    console.error(err.message);
+  }
+  console.error("A2UI bundling failed. Re-run with: pnpm canvas:a2ui:bundle");
+  console.error("If this persists, verify pnpm deps and try again.");
+  process.exit(1);
+}
+
+async function main() {
+  if (!existsSync(a2uiRendererDir) || !existsSync(a2uiAppDir)) {
+    if (existsSync(outputFile)) {
+      console.log("A2UI sources missing; keeping prebuilt bundle.");
+      return;
+    }
+    throw new Error(`A2UI sources missing and no prebuilt bundle found at: ${outputFile}`);
+  }
+
+  const currentHash = await computeHash();
+  if (existsSync(hashFile) && existsSync(outputFile)) {
+    const previousHash = (await fs.readFile(hashFile, "utf8")).trim();
+    if (previousHash === currentHash) {
+      console.log("A2UI bundle up to date; skipping.");
+      return;
+    }
+  }
+
+  const localTsc = resolveLocalBin("tsc");
+  if (!existsSync(localTsc)) {
+    throw new Error(`Local TypeScript binary missing: ${localTsc}`);
+  }
+  runCommand(localTsc, ["-p", path.join(a2uiRendererDir, "tsconfig.json")]);
+
+  const rolldownConfig = path.join(a2uiAppDir, "rolldown.config.mjs");
+  const localRolldown = resolveLocalBin("rolldown");
+  if (existsSync(localRolldown)) {
+    runCommand(localRolldown, ["-c", rolldownConfig]);
+  } else if (hasRolldown()) {
+    runCommand("rolldown", ["-c", rolldownConfig]);
+  } else {
+    runCommand("pnpm", ["-s", "dlx", "rolldown", "-c", rolldownConfig]);
+  }
+
+  await fs.writeFile(hashFile, `${currentHash}\n`);
+}
+
+main().catch(printFailureAndExit);

--- a/scripts/bundle-a2ui.mjs
+++ b/scripts/bundle-a2ui.mjs
@@ -69,6 +69,7 @@ function resolveExecutableCandidate(executable) {
 
 function runCommand(command, args) {
   const executables = resolveExecutables(command);
+  let lastNonZero = null;
   for (const executable of executables) {
     const candidate = resolveExecutableCandidate(executable);
     if (!candidate) {
@@ -82,14 +83,23 @@ function runCommand(command, args) {
     });
     if (!result.error) {
       if (result.status !== 0) {
-        const printable = [command, ...args].join(" ");
-        throw new Error(`Command failed: ${printable}`);
+        lastNonZero = {
+          candidate,
+          status: result.status ?? "unknown",
+        };
+        continue;
       }
       return;
     }
     if (result.error.code !== "ENOENT" && result.error.code !== "EINVAL") {
       throw result.error;
     }
+  }
+  if (lastNonZero) {
+    const printable = [command, ...args].join(" ");
+    throw new Error(
+      `Command failed after trying executable fallbacks: ${printable} (last candidate: ${lastNonZero.candidate}, exit: ${lastNonZero.status})`,
+    );
   }
   throw new Error(`Command not found: ${command}`);
 }

--- a/scripts/bundle-a2ui.mjs
+++ b/scripts/bundle-a2ui.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { existsSync } from "node:fs";
 import { promises as fs } from "node:fs";
 import path from "node:path";

--- a/scripts/bundle-a2ui.mjs
+++ b/scripts/bundle-a2ui.mjs
@@ -19,6 +19,18 @@ const inputPaths = [
   a2uiAppDir,
 ];
 
+function isWindowsUncPath(filePath) {
+  return process.platform === "win32" && filePath.startsWith("\\\\");
+}
+
+function resolveCommandCwd(useShell) {
+  if (useShell && isWindowsUncPath(rootDir)) {
+    const drive = process.env.SystemDrive || "C:";
+    return `${drive}\\`;
+  }
+  return rootDir;
+}
+
 function resolveExecutables(command) {
   if (process.platform !== "win32") {
     return [command];
@@ -77,7 +89,7 @@ function runCommand(command, args) {
     }
     const useShell = process.platform === "win32" && candidate.toLowerCase().endsWith(".cmd");
     const result = spawnSync(candidate, args, {
-      cwd: rootDir,
+      cwd: resolveCommandCwd(useShell),
       stdio: "inherit",
       shell: useShell,
     });
@@ -117,7 +129,7 @@ function hasRolldown() {
     }
     const useShell = process.platform === "win32" && candidate.toLowerCase().endsWith(".cmd");
     const result = spawnSync(candidate, ["--version"], {
-      cwd: rootDir,
+      cwd: resolveCommandCwd(useShell),
       stdio: "ignore",
       shell: useShell,
     });

--- a/scripts/bundle-a2ui.mjs
+++ b/scripts/bundle-a2ui.mjs
@@ -28,12 +28,6 @@ function resolveExecutables(command) {
     if (process.env.OPENCLAW_PNPM_CMD) {
       executables.push(process.env.OPENCLAW_PNPM_CMD);
     }
-    if (process.env.APPDATA) {
-      executables.push(path.join(process.env.APPDATA, "npm", "pnpm.cmd"));
-    }
-    if (process.env.USERPROFILE) {
-      executables.push(path.join(process.env.USERPROFILE, "AppData", "Roaming", "npm", "pnpm.cmd"));
-    }
     executables.push("pnpm.cmd", "pnpm");
     return executables;
   }

--- a/scripts/bundle-a2ui.mjs
+++ b/scripts/bundle-a2ui.mjs
@@ -112,10 +112,13 @@ function hasRolldown() {
       shell: useShell,
     });
     if (!result.error) {
-      return result.status === 0;
+      if (result.status === 0) {
+        return true;
+      }
+      continue;
     }
     if (result.error.code !== "ENOENT" && result.error.code !== "EINVAL") {
-      return false;
+      continue;
     }
   }
   return false;

--- a/scripts/bundle-a2ui.sh
+++ b/scripts/bundle-a2ui.sh
@@ -4,13 +4,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT_PATH="$ROOT_DIR/scripts/bundle-a2ui.mjs"
 
-if command -v node >/dev/null 2>&1; then
-  exec node "$SCRIPT_PATH"
-fi
-
-if command -v node.exe >/dev/null 2>&1; then
+run_windows_node() {
+  local node_bin="$1"
   if command -v wslpath >/dev/null 2>&1; then
-    node_exe_path="$(command -v node.exe)"
     script_windows_path="$(wslpath -w "$SCRIPT_PATH")"
     if command -v cmd.exe >/dev/null 2>&1; then
       windows_path="$(cmd.exe /c echo %PATH% | tr -d '\r')"
@@ -18,10 +14,22 @@ if command -v node.exe >/dev/null 2>&1; then
         export PATH="$windows_path"
       fi
     fi
-    exec "$node_exe_path" "$script_windows_path"
+    exec "$node_bin" "$script_windows_path"
   fi
   echo "wslpath is required to run node.exe from WSL." >&2
   exit 1
+}
+
+if command -v node >/dev/null 2>&1; then
+  node_path="$(command -v node)"
+  if [[ "$node_path" == *.exe ]]; then
+    run_windows_node "$node_path"
+  fi
+  exec "$node_path" "$SCRIPT_PATH"
+fi
+
+if command -v node.exe >/dev/null 2>&1; then
+  run_windows_node "$(command -v node.exe)"
 fi
 
 echo "Node.js not found in PATH. Install Node 22+ to run A2UI bundling." >&2

--- a/scripts/bundle-a2ui.sh
+++ b/scripts/bundle-a2ui.sh
@@ -1,95 +1,28 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-on_error() {
-  echo "A2UI bundling failed. Re-run with: pnpm canvas:a2ui:bundle" >&2
-  echo "If this persists, verify pnpm deps and try again." >&2
-}
-trap on_error ERR
-
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-HASH_FILE="$ROOT_DIR/src/canvas-host/a2ui/.bundle.hash"
-OUTPUT_FILE="$ROOT_DIR/src/canvas-host/a2ui/a2ui.bundle.js"
-A2UI_RENDERER_DIR="$ROOT_DIR/vendor/a2ui/renderers/lit"
-A2UI_APP_DIR="$ROOT_DIR/apps/shared/OpenClawKit/Tools/CanvasA2UI"
+SCRIPT_PATH="$ROOT_DIR/scripts/bundle-a2ui.mjs"
 
-# Docker builds exclude vendor/apps via .dockerignore.
-# In that environment we can keep a prebuilt bundle only if it exists.
-if [[ ! -d "$A2UI_RENDERER_DIR" || ! -d "$A2UI_APP_DIR" ]]; then
-  if [[ -f "$OUTPUT_FILE" ]]; then
-    echo "A2UI sources missing; keeping prebuilt bundle."
-    exit 0
+if command -v node >/dev/null 2>&1; then
+  exec node "$SCRIPT_PATH"
+fi
+
+if command -v node.exe >/dev/null 2>&1; then
+  if command -v wslpath >/dev/null 2>&1; then
+    node_exe_path="$(command -v node.exe)"
+    script_windows_path="$(wslpath -w "$SCRIPT_PATH")"
+    if command -v cmd.exe >/dev/null 2>&1; then
+      windows_path="$(cmd.exe /c echo %PATH% | tr -d '\r')"
+      if [[ -n "$windows_path" ]]; then
+        export PATH="$windows_path"
+      fi
+    fi
+    exec "$node_exe_path" "$script_windows_path"
   fi
-  echo "A2UI sources missing and no prebuilt bundle found at: $OUTPUT_FILE" >&2
+  echo "wslpath is required to run node.exe from WSL." >&2
   exit 1
 fi
 
-INPUT_PATHS=(
-  "$ROOT_DIR/package.json"
-  "$ROOT_DIR/pnpm-lock.yaml"
-  "$A2UI_RENDERER_DIR"
-  "$A2UI_APP_DIR"
-)
-
-compute_hash() {
-  ROOT_DIR="$ROOT_DIR" node --input-type=module - "${INPUT_PATHS[@]}" <<'NODE'
-import { createHash } from "node:crypto";
-import { promises as fs } from "node:fs";
-import path from "node:path";
-
-const rootDir = process.env.ROOT_DIR ?? process.cwd();
-const inputs = process.argv.slice(2);
-const files = [];
-
-async function walk(entryPath) {
-  const st = await fs.stat(entryPath);
-  if (st.isDirectory()) {
-    const entries = await fs.readdir(entryPath);
-    for (const entry of entries) {
-      await walk(path.join(entryPath, entry));
-    }
-    return;
-  }
-  files.push(entryPath);
-}
-
-for (const input of inputs) {
-  await walk(input);
-}
-
-function normalize(p) {
-  return p.split(path.sep).join("/");
-}
-
-files.sort((a, b) => normalize(a).localeCompare(normalize(b)));
-
-const hash = createHash("sha256");
-for (const filePath of files) {
-  const rel = normalize(path.relative(rootDir, filePath));
-  hash.update(rel);
-  hash.update("\0");
-  hash.update(await fs.readFile(filePath));
-  hash.update("\0");
-}
-
-process.stdout.write(hash.digest("hex"));
-NODE
-}
-
-current_hash="$(compute_hash)"
-if [[ -f "$HASH_FILE" ]]; then
-  previous_hash="$(cat "$HASH_FILE")"
-  if [[ "$previous_hash" == "$current_hash" && -f "$OUTPUT_FILE" ]]; then
-    echo "A2UI bundle up to date; skipping."
-    exit 0
-  fi
-fi
-
-pnpm -s exec tsc -p "$A2UI_RENDERER_DIR/tsconfig.json"
-if command -v rolldown >/dev/null 2>&1; then
-  rolldown -c "$A2UI_APP_DIR/rolldown.config.mjs"
-else
-  pnpm -s dlx rolldown -c "$A2UI_APP_DIR/rolldown.config.mjs"
-fi
-
-echo "$current_hash" > "$HASH_FILE"
+echo "Node.js not found in PATH. Install Node 22+ to run A2UI bundling." >&2
+exit 1


### PR DESCRIPTION
## Summary
- add a Node-based A2UI bundling entry at `scripts/bundle-a2ui.mjs`
- keep `scripts/bundle-a2ui.sh` as a thin launcher, with Windows+WSL handling for `node.exe`
- make bundling command execution resilient to Windows/WSL path and executable resolution differences

## Why
`pnpm build` could fail on Windows when `canvas:a2ui:bundle` was executed through `bash`, because the mixed WSL shell + Windows Node environment could not reliably resolve downstream commands.

## Validation
- pnpm canvas:a2ui:bundle
- pnpm build

## AI-assisted
- AI-assisted: Codex
- Testing: locally ran `pnpm canvas:a2ui:bundle` + `pnpm build`; CI covers `pnpm check` + `pnpm test` (including Windows shards).
- Understanding: `scripts/bundle-a2ui.sh` is a launcher for mixed WSL bash + Windows `node.exe`. `scripts/bundle-a2ui.mjs` performs hash-based incremental bundling, runs `tsc`, and invokes `rolldown` with robust Windows/WSL executable fallback logic (including `.cmd` shims and UNC/WSL path edge cases).

## Key Review Fixes
- Continue fallback candidates when a `.cmd` probe exits non-zero under `shell: true` (don’t fail-fast; try later candidates).
- Keep probing `rolldown` candidates after a failed `--version` probe before falling back to `pnpm dlx`.
- Avoid running `.cmd` tools with a UNC working directory (e.g. `\\wsl.localhost\...`) to prevent `cmd.exe` cwd failures.
