### PR TITLE
fix: don't auto-promote reasoning_effort for openrouter/auto; add ThinkLevel "auto"

### DIFF
--- a/customer-starter/.gitignore
+++ b/customer-starter/.gitignore
@@ -1,0 +1,19 @@
+# Do not commit real config with tokens or phone numbers
+config/openclaw.yml
+config/*.yml
+!config/openclaw.example.yml
+deployment.env
+.env
+.env.*
+!.env.example
+!deployment.example.env
+*.pem
+*.key
+secrets/
+
+# OS and editor
+.DS_Store
+Thumbs.db
+*.swp
+*.swo
+*~

--- a/customer-starter/CUSTOMIZE.md
+++ b/customer-starter/CUSTOMIZE.md
@@ -1,0 +1,49 @@
+# Customize for a customer
+
+Use this repo as the base for a **specific customer** (e.g. FirstLight). Clone once per customer and tailor config and docs.
+
+## 1. Clone and rename
+
+```bash
+git clone https://github.com/YOUR_ORG/openclaw-customer-starter.git firstlight-openclaw
+cd firstlight-openclaw
+```
+
+(Or create a new repo from the template on GitHub, then clone that.)
+
+## 2. Customer-specific renames
+
+- **README**: Update the "Quick start" example to use the customer name (e.g. FirstLight).
+- **Config**: Copy `config/openclaw.example.yml` to `config/openclaw.yml` (or your OpenClaw config path) and set:
+  - Gateway token, agent id, workspace paths if needed.
+  - Telegram `botToken`, WhatsApp accounts if any.
+  - Leave `session.identityLinks` as `{}` and add users as they onboard.
+
+Do **not** commit real tokens or phone numbers. Use env vars or a secrets store and reference them from config where supported, or keep `openclaw.yml` out of git (add to `.gitignore`) and maintain it on the deploy host.
+
+## 3. Deploy OpenClaw
+
+We deploy **from here** (this repo stays on your machine). Copy this repo’s `config/` to the VM (e.g. rsync), then run OpenClaw in Docker on the VM via SSH (e.g. `vm-ssh.sh` from the main repo using `deployment.env`). See SETUP.md Step 7.
+
+- Run OpenClaw (from the [main repo](https://github.com/openclaw/openclaw) or your fork) via Docker on the GCP VM.
+- Set **OPENCLAW_CONFIG_DIR** (or the compose instance env) on the VM to the path where you copied this repo’s `config/` (so the gateway loads `openclaw.yml`).
+- Ensure the agent **workspace** exists and is writable; create `users/` there if you use the inject plugin for multi-user context.
+
+## 4. Enable channels and add users
+
+- **Telegram**: Set bot token, start gateway, approve pairing or set allowlist. See [Adding users (Telegram + WhatsApp)](docs/ADDING-USERS.md).
+- **WhatsApp**: Run `openclaw channels login`, add numbers to `allowFrom` or use pairing. See [Adding users](docs/ADDING-USERS.md).
+- **Per-user identity**: Add each user to `session.identityLinks` with their canonical id and `telegram:...` / `whatsapp:...` peer ids. See [Multi-user context](docs/MULTI-USER-CONTEXT.md).
+
+## 5. Optional: push to GitHub
+
+If you want a dedicated repo for this customer:
+
+```bash
+git remote set-url origin https://github.com/YOUR_ORG/firstlight-openclaw.git
+git add .
+git commit -m "Customize for FirstLight"
+git push -u origin main
+```
+
+Keep secrets out of the repo; use env or a secrets manager in CI/deploy.

--- a/customer-starter/README.md
+++ b/customer-starter/README.md
@@ -1,0 +1,98 @@
+# OpenClaw customer starter
+
+A **starting point for a new customer** deployment: multi-user context (one bot, many users with per-user preferences) and straightforward **Telegram** and **WhatsApp** user onboarding.
+
+This repo is **self-contained**: config templates, deployment env, and scripts to copy config to a GCP VM and start the container via SSH. No need to clone the main OpenClaw repo on your laptop.
+
+---
+
+## Workflow: commit → clone → customize → deploy
+
+1. **Commit this repo to your GitHub** (e.g. push `customer-starter` as its own repo, or “Use this template” to create `YOUR_ORG/openclaw-customer-starter`).
+2. **On your Mac**, create a new directory and clone that repo:
+   ```bash
+   mkdir -p ~/deploys && cd ~/deploys
+   git clone https://github.com/YOUR_ORG/openclaw-customer-starter.git firstlight-openclaw
+   cd firstlight-openclaw
+   ```
+3. **Customize**: copy `deployment.example.env` → `deployment.env` and `config/openclaw.example.yml` → `config/openclaw.yml`, then edit (GCP VM, container name, Telegram token, WhatsApp, etc.). See [SETUP.md](SETUP.md) for the full walkthrough.
+4. **Deploy**: run `./scripts/copy-config-to-vm.sh` to push config to the VM, then `./scripts/start-on-vm.sh` to start the container. Use `./scripts/vm-ssh.sh` to run commands on the VM.
+
+**Requirements:** `gcloud` CLI, a GCP VM with Docker and the main OpenClaw repo (or image) set up. We deploy **from your machine**; customization stays local.
+
+---
+
+## Start here: guided setup
+
+**Walk through the setup with your assistant (or follow the steps yourself):**
+
+👉 **[SETUP.md](SETUP.md) — Guided setup (step-by-step)**
+
+Each step has a **Checkpoint**; when you’re done, tell your assistant and they’ll guide you to the next step. You’ll end up with a working config, Telegram and WhatsApp enabled, and your first user in `session.identityLinks`.
+
+---
+
+## Purpose
+
+- Use this repo as a **template**: clone it (or "Use this template" on GitHub), then customize for a specific customer (e.g. FirstLight).
+- It does **not** contain the OpenClaw app code. You run OpenClaw (or your fork) separately; this repo holds **config**, **docs**, and **checklists** for the customer setup.
+- After customizing, point your OpenClaw gateway at this repo’s config (or copy the config into your OpenClaw deploy).
+
+## Multi-user context and OpenClaw updates
+
+**Multi-user context** (`session.dmScope`, `session.identityLinks`) is implemented in the **OpenClaw app** (main repo), not in this starter. This repo only provides the config and docs that use those features—no code changes required for basic multi-user.
+
+If you need to **modify OpenClaw** (e.g. add an extension, a custom inject plugin, or change the system prompt) and still stay up to date with upstream: **fork** the [OpenClaw repo](https://github.com/openclaw/openclaw), add `upstream` as a remote, do your changes on a branch, and periodically run `git fetch upstream && git merge upstream/main`. Deploy from your fork on the VM; this starter’s config still points at the same gateway. See [Multi-user context and keeping OpenClaw up to date](https://docs.openclaw.ai/reference/multi-user-and-upstream) and [Fork and deploy plan](https://docs.openclaw.ai/reference/fork-and-deploy-plan).
+
+## What’s inside
+
+| Path                            | Description                                                                                                                                                                                                             |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **SETUP.md**                    | **Guided setup** — step-by-step walkthrough (GCP VM + Docker); do one step, then tell your assistant and continue.                                                                                                      |
+| **deployment.example.env**      | GCP VM, container name, and paths. Copy to `deployment.env` and fill in; scripts use it for SSH and deploy.                                                                                                             |
+| `config/`                       | Example OpenClaw config: session (dmScope, identityLinks), Telegram, WhatsApp. Copy to `openclaw.yml` and edit.                                                                                                         |
+| **scripts/**                    | `vm-ssh.sh` (SSH to VM), `copy-config-to-vm.sh` (push config), `start-on-vm.sh` (start container). Run from repo root.                                                                                                  |
+| **plugin/user-context-inject/** | Inject plugin for multi-user context: reads `users/<key>.md`, injects as prependContext. Copy to workspace `.openclaw/extensions/user-context-inject/` and add to `plugins.allow`.                                      |
+| `docs/`                         | Multi-user-context checklist, adding users (Telegram + WhatsApp), [review](docs/MULTI-USER-REVIEW.md), [AGENTS snippet](docs/AGENTS-SNIPPET-multi-user.md), [adding skills and tools](docs/ADDING-SKILLS-AND-TOOLS.md). |
+| **CUSTOMIZE.md**                | Short reference: clone → rename for customer → fill config → deploy.                                                                                                                                                    |
+
+## Quick start (if you prefer to do it without the guide)
+
+1. **Clone this repo** (or create a new repo from it on GitHub):
+   ```bash
+   git clone https://github.com/YOUR_ORG/openclaw-customer-starter.git firstlight-openclaw
+   cd firstlight-openclaw
+   ```
+2. **Customize** for the customer: rename in README, set `config/openclaw.example.yml` (or `.json`) with bot tokens, channel ids, and leave `session.identityLinks` empty at first.
+3. **Deploy OpenClaw** (Docker or your fork) and set `OPENCLAW_CONFIG_DIR` (or copy `config/` contents) to this repo’s config so the gateway uses it.
+4. **Enable Telegram and WhatsApp**: add bot token (Telegram), run `openclaw channels login` (WhatsApp), then add users (see [Adding users (Telegram + WhatsApp)](docs/ADDING-USERS.md)).
+5. **Add users** one by one: allowlist or pairing, then add each user to `session.identityLinks` so they get one session and one prefs file across channels (see [Multi-user context](docs/MULTI-USER-CONTEXT.md)).
+
+## Links
+
+- [OpenClaw docs](https://docs.openclaw.ai) — Gateway, channels, config.
+- [Multi-user context](https://docs.openclaw.ai/concepts/multi-user-context) — Per-user preferences and identity links.
+- [Telegram](https://docs.openclaw.ai/channels/telegram) · [WhatsApp](https://docs.openclaw.ai/channels/whatsapp) — Channel setup and peer id format.
+
+## Pushing this repo to your GitHub
+
+This folder is a **clean, standalone repo** you can commit and push:
+
+1. Create a new repo on GitHub (e.g. `YOUR_ORG/openclaw-customer-starter`). Do **not** initialize with a README.
+2. Copy this folder to a new directory (so it’s not inside the OpenClaw repo), then init and push:
+   ```bash
+   cp -r /path/to/openclaw/customer-starter /tmp/openclaw-customer-starter
+   cd /tmp/openclaw-customer-starter
+   git init
+   git add .
+   git commit -m "Initial customer starter template"
+   git remote add origin https://github.com/YOUR_ORG/openclaw-customer-starter.git
+   git branch -M main
+   git push -u origin main
+   ```
+3. Optionally enable **Template repository** in the repo settings so you can “Use this template” for each new customer.
+4. **Your workflow:** On your Mac, create a new dir, clone the repo you just pushed, customize `deployment.env` and `config/openclaw.yml`, then run the scripts to deploy (see “Workflow” above).
+
+## License
+
+Same as the OpenClaw project (see root repo).

--- a/customer-starter/SETUP.md
+++ b/customer-starter/SETUP.md
@@ -1,0 +1,210 @@
+# Guided setup (walk through with your assistant)
+
+Use this page **one step at a time**. After each step, tell your assistant you’re done (or paste any output) and they’ll guide you to the next step.
+
+**With an AI assistant (e.g. in Cursor):** Open this repo, then say: _“Walk me through the customer-starter setup”_ or _“I’m at Step N, done.”_ The assistant will use this file to guide you step by step.
+
+---
+
+## Before you start
+
+- We’re installing OpenClaw as a **Docker container on a named GCP VM**. You’ll supply the VM details (project, VM name, zone) and the container/service name during setup.
+- You’re setting up for **one customer** (e.g. FirstLight). Pick a short **customer name** (e.g. `firstlight`) for folder and config.
+- You have (or will create) a **GCP VM** with Docker installed and the OpenClaw image available (from the [OpenClaw repo](https://github.com/openclaw/openclaw) or your fork). Your assistant can help with VM creation and Docker install if needed.
+
+---
+
+## Step 1 — Clone the repo
+
+Clone this repo into a folder named after your customer (or any name you prefer).
+
+```bash
+git clone https://github.com/YOUR_ORG/openclaw-customer-starter.git firstlight-openclaw
+cd firstlight-openclaw
+```
+
+**If you used “Use this template” on GitHub**, clone the new repo you created instead:
+
+```bash
+git clone https://github.com/YOUR_ORG/your-customer-repo.git firstlight-openclaw
+cd firstlight-openclaw
+```
+
+**Checkpoint:** You’re in the repo and `config/openclaw.example.yml` and `docs/` exist. Tell your assistant: “Step 1 done.”
+
+---
+
+## Step 2 — Create your config file
+
+Create the real config file from the example. We’ll edit it in the next steps; it’s ignored by git so you won’t commit secrets.
+
+```bash
+cp config/openclaw.example.yml config/openclaw.yml
+```
+
+**Checkpoint:** `config/openclaw.yml` exists. Tell your assistant: “Step 2 done.”
+
+---
+
+## Step 3 — Record deployment target (GCP VM + Docker)
+
+We need to know **where** this customer’s OpenClaw will run: which GCP VM and which Docker container name. Your assistant will use this to give you the right commands and can run commands on the VM for you (e.g. via SSH).
+
+1. Copy the deployment example and fill in your values:
+   ```bash
+   cp deployment.example.env deployment.env
+   ```
+2. Edit **`deployment.env`** and set:
+   - **GCP_VM_PROJECT**, **GCP_VM_NAME**, **GCP_VM_ZONE** — GCP VM (e.g. `gidr-demo`, `openclaw-gateway`, `us-central1-a`).
+   - **OPENCLAW_CONTAINER_NAME** — Docker service/container name for this customer (e.g. `gidr-claw-firstlight`). Must match the service in your OpenClaw multi-instance compose.
+   - **OPENCLAW_ON_VM_PATH** — Path on the VM where this customer’s folder lives (e.g. `/home/user/firstlight-openclaw`). Scripts copy `config/` here.
+   - **OPENCLAW_REPO_ON_VM_PATH** — Path on the VM to the main OpenClaw repo (e.g. `/home/user/openclaw`). Used by `scripts/start-on-vm.sh`.
+
+`deployment.env` is gitignored so you don’t commit internal names or project ids. Your assistant can read it from your workspace to run VM SSH or suggest exact docker/compose commands.
+
+**Checkpoint:** `deployment.env` exists with correct `GCP_VM_*` and `OPENCLAW_CONTAINER_NAME`. Tell your assistant: “Step 3 done.”
+
+---
+
+## Step 4 — Set customer name and session (multi-user)
+
+Open `config/openclaw.yml` and confirm:
+
+- `session.dmScope` is `per-peer` (one session per person across Telegram and WhatsApp).
+- `session.identityLinks` is `{}` (we’ll add users later).
+
+No need to change anything yet unless you want to add a comment with your customer name at the top of the file.
+
+**Checkpoint:** You’ve looked at `config/openclaw.yml` and see `session:` with `dmScope: per-peer` and `identityLinks: {}`. Tell your assistant: “Step 4 done.”
+
+---
+
+## Step 5 — Telegram: create bot and add token
+
+1. In Telegram, open [@BotFather](https://t.me/BotFather) and create a new bot (`/newbot`). Copy the **token**.
+2. Open `config/openclaw.yml` and set the Telegram token:
+   - Under `channels.telegram`, set `botToken: "YOUR_TOKEN"` (or leave empty and set env `TELEGRAM_BOT_TOKEN` later).
+3. Leave `dmPolicy: pairing` so new users get a pairing code, or set `dmPolicy: allowlist` and `allowFrom: []` if you’ll add user ids later.
+
+**Checkpoint:** `channels.telegram.botToken` is set (or you’ve noted you’ll use env). Tell your assistant: “Step 5 done.”
+
+---
+
+## Step 6 — WhatsApp: decide number and policy
+
+1. Decide which **phone number** will be used for WhatsApp (dedicated number or WhatsApp Business recommended).
+2. In `config/openclaw.yml`, under `channels.whatsapp`:
+   - Set `dmPolicy: allowlist` and `allowFrom: []` for now (we’ll add numbers when we add users), **or**
+   - Set `dmPolicy: pairing` if you want unknown senders to get a pairing code.
+3. You’ll run `openclaw channels login` and scan the QR code **after** the gateway is running (later step).
+
+**Checkpoint:** `channels.whatsapp` has `dmPolicy` and `allowFrom` (or pairing) set. Tell your assistant: “Step 6 done.”
+
+---
+
+## Deployment flow: deploy from here, customize locally
+
+We **deploy from your machine** and **manage customization locally**: this repo (and `config/`, `deployment.env`) stays on your laptop or in Cursor. You edit here; you (or the assistant) copy config to the VM when needed and run Docker on the VM via SSH (e.g. `vm-ssh.sh`). No need to clone this customer repo on the VM for day-to-day edits.
+
+(Alternative: you can instead clone this repo on the VM and customize there; Step 7 has a short “Alternative: clone and customize on the VM” section if you prefer that.)
+
+---
+
+## Step 7 — Deploy OpenClaw as Docker on the GCP VM
+
+OpenClaw runs as a **Docker container on the VM** in `deployment.env`. The container must use this customer’s **config** so the gateway loads `openclaw.yml`.
+
+### Deploy from here (default)
+
+1. **Set paths in `deployment.env`** (you did this in Step 3). Ensure `OPENCLAW_ON_VM_PATH` and `OPENCLAW_REPO_ON_VM_PATH` are set (see `deployment.example.env`).
+2. **Copy this customer’s config to the VM** (whenever you change config). From this repo root:
+   ```bash
+   ./scripts/copy-config-to-vm.sh
+   ```
+3. **On the VM**, the main OpenClaw repo must already be at `OPENCLAW_REPO_ON_VM_PATH` with compose and `.env` set. In that `.env`, set the **config dir** for this customer’s container (e.g. `OPENCLAW_FIRSTLIGHT_CONFIG_DIR=/home/user/firstlight-openclaw/config` to match `OPENCLAW_ON_VM_PATH` + `/config`).
+4. **Start (or restart) the container** from this repo root:
+   ```bash
+   ./scripts/start-on-vm.sh
+   ```
+5. **Confirm:** `./scripts/vm-ssh.sh -- 'docker ps'` and check the container is up.
+
+### Alternative: clone and customize on the VM
+
+If you prefer to keep everything on the server: SSH to the VM, clone this repo (or your customer repo) there, edit `config/openclaw.yml` on the VM, set the OpenClaw `.env` config path (e.g. `OPENCLAW_FIRSTLIGHT_CONFIG_DIR=...`), then run `./platforms/gcp-vm/manage-multi.sh start` (or the relevant `docker compose ... up -d` command) on the VM.
+
+**Checkpoint:** Gateway container is running on the GCP VM and loading config from this customer’s `config/`. Tell your assistant: “Step 7 done.”
+
+---
+
+## Step 8 — WhatsApp: link the number (if using WhatsApp)
+
+If you’re using WhatsApp:
+
+1. Run **`openclaw channels login`** (from the same machine or container that runs the gateway, with the same config).
+2. Scan the QR code with the phone that has the number you chose for WhatsApp.
+3. After linking, the gateway keeps the session; keep the gateway running so the session stays active.
+
+**Checkpoint:** WhatsApp shows “Linked devices” and the OpenClaw session is active. Tell your assistant: “Step 8 done.”
+
+---
+
+## Step 9 — Add your first user (identityLinks)
+
+1. Have the **first user** send one message to your Telegram bot (or WhatsApp number) so the gateway sees them.
+2. Get their **peer id**:
+   - **Telegram:** numeric user id (e.g. from gateway logs, or ask your assistant how to find it).
+   - **WhatsApp:** E.164 number (e.g. `+15551234567`).
+3. Choose a **canonical id** for them (e.g. `alice`, `jane`, `firstlight-ops-1`). This will be their session key suffix and the base for their prefs file.
+4. Open `config/openclaw.yml` and add them under `session.identityLinks`:
+
+   ```yaml
+   session:
+     dmScope: per-peer
+     identityLinks:
+       alice: ["telegram:123456789"] # use real telegram user id
+       # or for WhatsApp: alice: ["whatsapp:+15551234567"]
+       # or both:        alice: ["telegram:123456789", "whatsapp:+15551234567"]
+   ```
+
+5. Save the file. The gateway hot-reloads config; no restart needed.
+
+**Checkpoint:** The user is in `identityLinks`. They send another message; it should be handled under session `agent:main:dm:alice` (or your canonical id). Tell your assistant: “Step 9 done.”
+
+---
+
+## Step 10 — Optional: per-user preferences (inject plugin)
+
+To have the bot remember per-user details (timezone, preferences) in a file per user:
+
+1. In the **agent workspace** on the VM, create a `users/` directory (or let the agent create it on first write).
+2. **Copy the inject plugin** from this repo to the workspace so OpenClaw loads it:
+   - From this repo: `plugin/user-context-inject/` (openclaw.plugin.json + index.ts).
+   - On the VM, copy it to: `<workspace>/.openclaw/extensions/user-context-inject/` (same structure). The workspace path is the one your gateway uses (e.g. the default or `agents.defaults.workspace` in config).
+3. **Enable the plugin** in `config/openclaw.yml`: add under `plugins` (create the key if missing): `allow: [telegram, whatsapp, user-context-inject]` (include whichever channel plugins you use). No OpenClaw code changes or fork needed—the plugin is in this repo.
+4. In **AGENTS.md** (or SOUL.md) in the workspace, add instructions so the agent writes user preferences to `users/<key>.md`. Use the snippet in [docs/AGENTS-SNIPPET-multi-user.md](docs/AGENTS-SNIPPET-multi-user.md).
+
+**Checkpoint:** Plugin is registered and one user file exists (or the agent has created it). Tell your assistant: “Step 10 done.”
+
+---
+
+## Step 11 — Optional: custom skills and tools
+
+If your use case needs **custom tools** (e.g. search a knowledge base, call an API) and **skills** with business rules for when and how to call them:
+
+1. **Tools** — Add or enable an extension/plugin that registers the tools (e.g. in the OpenClaw repo you run or your fork). In config, allowlist the tool names (e.g. `tools.alsoAllow: ["search_troubleshooting", "retrieval_firstlight_noc"]`) and set any required env vars.
+2. **Skill** — Add a `SKILL.md` in the agent workspace at `skills/<name>/SKILL.md` (or use `skills.load.extraDirs` in config). In the skill, describe the tools, **when to use** them, **behavior** (order, citations, handling no results), and setup.
+3. **Business rules** — Put “when to use” and “behavior” in the skill; optionally reinforce in AGENTS.md or SOUL.md.
+
+Full guide: [Adding skills and tools for a custom use case](docs/ADDING-SKILLS-AND-TOOLS.md) (e.g. FirstLight: two tools + skill + rules).
+
+**Checkpoint:** Custom tools are allowlisted, skill is in place, and the agent follows the rules. Tell your assistant: “Step 11 done.”
+
+---
+
+## You’re done
+
+- **Add more users:** Repeat Step 9 for each person; add Telegram and/or WhatsApp peer ids to their `identityLinks` entry.
+- **Existing user adds a second channel:** Append the new peer id to their existing entry (e.g. add `whatsapp:+15551234567` to `alice`).
+- **Reference:** [Adding users (Telegram + WhatsApp)](docs/ADDING-USERS.md) · [Multi-user context](docs/MULTI-USER-CONTEXT.md) · [Adding skills and tools](docs/ADDING-SKILLS-AND-TOOLS.md).
+
+If you get stuck on any step, tell your assistant which step and what you see (error message, config snippet, or “I don’t have X yet”); they can guide you through it.

--- a/customer-starter/config/openclaw.example.yml
+++ b/customer-starter/config/openclaw.example.yml
@@ -1,0 +1,42 @@
+# OpenClaw config for customer deployments (multi-user context + Telegram + WhatsApp).
+# Copy to openclaw.yml in your OpenClaw config dir; do not commit real tokens or numbers.
+#
+# Session: one key per person across Telegram and WhatsApp (identityLinks).
+# Add users under session.identityLinks; see docs/MULTI-USER-CONTEXT.md and docs/ADDING-USERS.md.
+
+session:
+  dmScope: per-peer
+  identityLinks: {}
+  # Example after adding users:
+  # identityLinks:
+  #   alice: ["telegram:123456789", "whatsapp:+15551234567"]
+  #   bob:   ["telegram:987654321"]
+
+channels:
+  telegram:
+    enabled: true
+    botToken: "" # or set TELEGRAM_BOT_TOKEN in env
+    dmPolicy: pairing # or allowlist + allowFrom: ["123456789", ...]
+
+  whatsapp:
+    enabled: true
+    dmPolicy: allowlist
+    allowFrom: [] # E.164 numbers, e.g. ["+15551234567"]
+    # Or dmPolicy: pairing for code-based approval
+
+# Optional: gateway token for Control UI and CLI
+# gateway:
+#   auth:
+#     token: ""
+
+# Optional: agent defaults (model, workspace)
+# agents:
+#   defaults:
+#     model:
+#       primary: openrouter/auto
+#     workspace: "."
+
+# Optional: multi-user inject plugin (Step 10). Allow the plugin; it is loaded from
+# workspace/.openclaw/extensions/user-context-inject/ (copy from this repo's plugin/user-context-inject).
+# plugins:
+#   allow: [telegram, whatsapp, user-context-inject]

--- a/customer-starter/deployment.example.env
+++ b/customer-starter/deployment.example.env
@@ -1,0 +1,24 @@
+# Deployment target: GCP VM + Docker container.
+# Copy to deployment.env and fill in. Used so you (and your assistant) know where
+# this customer's OpenClaw runs. Do not commit deployment.env (secrets or internal names).
+#
+# Your assistant can use these to run commands on the VM (e.g. vm-ssh) and to
+# tell you the exact docker/compose commands for your VM and container name.
+
+# GCP VM where OpenClaw runs (Docker on this VM)
+GCP_VM_PROJECT=gidr-demo
+GCP_VM_NAME=openclaw-gateway
+GCP_VM_ZONE=us-central1-a
+
+# Docker: container or compose service name for this customer's gateway.
+# If using openclaw multi-instance compose (e.g. gidr-claw-firstlight), set this
+# so we know which service to start/restart/exec into.
+OPENCLAW_CONTAINER_NAME=gidr-claw-firstlight
+
+# Path on the VM where this customer's config lives (used by scripts/copy-config-to-vm.sh).
+# After copying, the OpenClaw compose .env on the VM should set the instance config dir to this path + /config.
+OPENCLAW_ON_VM_PATH=/home/user/firstlight-openclaw
+
+# Path on the VM to the main OpenClaw repo (has platforms/gcp-vm/docker-compose.multi.yml and .env).
+# Used by scripts/start-on-vm.sh to run docker compose.
+OPENCLAW_REPO_ON_VM_PATH=/home/user/openclaw

--- a/customer-starter/docs/ADDING-SKILLS-AND-TOOLS.md
+++ b/customer-starter/docs/ADDING-SKILLS-AND-TOOLS.md
@@ -1,0 +1,149 @@
+# Adding skills and tools for a custom use case
+
+This guide describes how to add **custom tools** and **skills** (with business rules) for a specific use case—for example, FirstLight: two tools (search + retrieval) plus a skill and rules for when and how to call them.
+
+---
+
+## Overview
+
+| Piece              | Purpose                                                                                                                                                                 | Where it lives                                                                                                             |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| **Tools**          | Capabilities the agent can call (e.g. search a knowledge base, call an API).                                                                                            | OpenClaw **extension** or **plugin** (registers tools with the agent runtime).                                             |
+| **Skill**          | One markdown file (SKILL.md) that names the tools, describes **when to use** them, **behavior** (how to combine, cite, handle no results), and **setup** (config, env). | **Workspace** `skills/<name>/SKILL.md`, or **config** `skills.load.extraDirs`, or a **plugin** that declares a skill path. |
+| **Business rules** | When to call which tool, in what order, and guardrails.                                                                                                                 | In the **skill** (primary) and optionally in **AGENTS.md** / **SOUL.md** in the workspace.                                 |
+| **Config**         | Allow the agent to use the tools; optionally enable the skill.                                                                                                          | `openclaw.yml`: `tools.alsoAllow` (or tool allowlist), `plugins.allow`, and optionally `skills.entries.<skillKey>`.        |
+
+You do **not** need to change OpenClaw core. You need either:
+
+- An **extension** (or plugin) that provides the tools—in the OpenClaw repo you run (upstream or your fork), or a plugin loaded from the workspace / `plugins.load.paths`—plus config and a skill file, or
+- A **fork** of OpenClaw that adds the extension and (optionally) tool summaries/order in the system prompt for a polished experience.
+
+---
+
+## 1. Adding tools
+
+Tools are registered by **extensions** (under `extensions/` in the OpenClaw repo) or **plugins** (loaded from workspace `.openclaw/extensions/`, `plugins.load.paths`, or bundled). Each tool has a **name**, **description**, **parameters** (schema), and an **execute** function.
+
+- **If the tools already exist** (e.g. `gidr-mcp` with `search_troubleshooting` and `retrieval_firstlight_noc`): ensure that extension is enabled and allowlist the tool names in config (see below).
+- **If you need new tools:** add an extension (or plugin) in the OpenClaw repo (or your fork), or in a plugin directory you load via `plugins.load.paths` / workspace extensions. The plugin SDK and existing extensions (e.g. `extensions/gidr-mcp`) are the reference for name, description, parameters (TypeBox schema), and `execute`.
+
+**Config (allowlist):** so the agent can call your tools, add them to the tool allowlist, e.g. in `config/openclaw.yml`:
+
+```yaml
+# Example: allow Firstlight tools (adjust agent key if you use a named agent)
+agents:
+  defaults:
+    tools:
+      alsoAllow: ["search_troubleshooting", "retrieval_firstlight_noc"]
+```
+
+Or at the top level if your config uses a global tool allowlist. The exact key depends on your OpenClaw config schema (`tools.alsoAllow`, `agents.defaults.tools.alsoAllow`, or allowlist by plugin id).
+
+---
+
+## 2. Adding a skill (SKILL.md)
+
+A **skill** is a markdown file (with optional frontmatter) that tells the agent about a set of tools and how to use them. It is the main place for **business rules**: when to use which tool, in what order, and how to behave.
+
+**Where to put the skill:**
+
+- **Workspace:** `workspace/skills/<skill-name>/SKILL.md` (e.g. `skills/firstlight/SKILL.md`). The agent’s workspace is the one set in config (e.g. `agents.defaults.workspace`).
+- **Config:** `skills.load.extraDirs`: list paths to directories that contain skill subdirs (e.g. `["/path/to/my-skills"]` where `my-skills/firstlight/SKILL.md` exists).
+- **Plugin:** a plugin can declare `skills: ["skills/firstlight"]` in its manifest (path relative to the plugin root); OpenClaw will load that skill when the plugin is enabled.
+
+**Structure of SKILL.md:**
+
+```markdown
+---
+name: firstlight
+description: Firstlight NOC and troubleshooting. Use search_troubleshooting and retrieval_firstlight_noc for network/equipment issues, runbooks, or when the user asks for Firstlight or uses /firstlight.
+metadata:
+  openclaw:
+    emoji: "🔍"
+    requires: { env: ["GIDR_MCP_URL"] }
+---
+
+# Firstlight NOC and troubleshooting
+
+When the user has a troubleshooting question, needs NOC/runbook content, or explicitly invokes **/firstlight**, use the GIDR MCP tools.
+
+## Tools
+
+- **search_troubleshooting** — Search the Firstlight troubleshooting / NOC knowledge base. Use for symptoms, equipment, vendor, outage queries. Pass `query` (required), optional `limit`, `search_mode` (text or hybrid), filters. Prefer `search_mode: "text"`. Return results with citations.
+- **retrieval_firstlight_noc** — Retrieve NOC/runbook content. Use for procedures or when the user asks for Firstlight NOC. Pass `query` and optional `limit`, `search_mode`.
+
+## When to use
+
+- User asks about network issues, slow speeds, outages, equipment, or troubleshooting steps.
+- User asks for NOC procedures, runbooks, or Firstlight-specific content.
+- User sends **/firstlight** or says they want Firstlight / NOC help.
+
+## Behavior
+
+- Extract a clear search query from the user; ask a short clarifying question if the intent is ambiguous.
+- Call **search_troubleshooting** and/or **retrieval_firstlight_noc** as needed; combine results when both apply.
+- If a tool returns no results, say so and suggest refining the query or scope.
+- In replies, cite sources when the tool returns them.
+
+## Setup
+
+- Enable the **gidr-mcp** extension and set `GIDR_MCP_URL` and `GIDR_API_KEY` (or `GIDR_API_KEY_FILE`).
+- In config, allowlist the tools, e.g. `tools.alsoAllow: ["search_troubleshooting", "retrieval_firstlight_noc"]`.
+```
+
+Frontmatter:
+
+- **name** — Skill name (used for eligibility and display).
+- **description** — Short summary (shown in skill lists; include when to use and tool names).
+- **metadata.openclaw** — Optional: `emoji`, `requires.env` (env vars that must be set for the skill to be eligible), `skillKey` (config key under `skills.entries`).
+
+The body is the **business rules**: which tools exist, when to use them, how to combine and cite, and setup. The agent sees this in context, so be explicit about when to call which tool and how to handle errors or empty results.
+
+---
+
+## 3. Business rules: where to put them
+
+- **In the skill (SKILL.md):** Primary place. Use sections like “When to use”, “Behavior”, “Tools”. Describe order (e.g. “prefer search_troubleshooting first, then retrieval_firstlight_noc if the user wants procedures”).
+- **In AGENTS.md / SOUL.md:** Optional. Add a short line such as: “For Firstlight NOC and troubleshooting, follow the **firstlight** skill; use the two tools only when the user’s intent matches that skill.”
+- **Tool summaries and order in the system prompt:** OpenClaw’s system prompt can include short tool descriptions and a suggested tool order. That lives in the OpenClaw repo (`src/agents/system-prompt.ts`). To add or change them you either contribute to upstream or maintain a fork. For many use cases, the **skill file alone** is enough; the model follows the skill’s “When to use” and “Behavior” without needing system-prompt changes.
+
+---
+
+## 4. FirstLight example (two tools + skill + rules)
+
+**Tools (from gidr-mcp extension):**
+
+1. **search_troubleshooting** — Search troubleshooting / NOC knowledge base (symptoms, equipment, outages).
+2. **retrieval_firstlight_noc** — Retrieve NOC/runbook content.
+
+**Skill:** `skills/firstlight/SKILL.md` (in workspace or in an extraDir). Content as in the template above: tools, when to use, behavior, setup.
+
+**Config:**
+
+- Enable the extension (e.g. `plugins.allow` includes the extension id if it’s a plugin, or the extension is bundled).
+- Set env: `GIDR_MCP_URL`, `GIDR_API_KEY` (or `GIDR_API_KEY_FILE`).
+- Allowlist tools: `tools.alsoAllow: ["search_troubleshooting", "retrieval_firstlight_noc"]` (or equivalent in your config).
+
+**Rules (in the skill):**
+
+- Use **search_troubleshooting** for symptoms, equipment, outages; use **retrieval_firstlight_noc** for procedures/runbooks; use both when the user has a troubleshooting question that may need both search and procedure content.
+- Prefer `search_mode: "text"`; cite sources; on no results, suggest refining the query.
+
+---
+
+## 5. Checklist for a new use case
+
+1. **Tools** — Implement in an extension or plugin (OpenClaw repo or fork, or loadable plugin). Register name, description, parameters, execute.
+2. **Config** — Enable the extension/plugin; set required env vars; allowlist tool names (`tools.alsoAllow` or equivalent).
+3. **Skill** — Add `skills/<name>/SKILL.md` (workspace, extraDirs, or plugin). Include: tools, when to use, behavior, setup.
+4. **Business rules** — Write “When to use” and “Behavior” in the skill; optionally reinforce in AGENTS.md/SOUL.md.
+5. **(Optional)** System-prompt tool summaries/order — Only if you want them; requires editing OpenClaw (fork or upstream).
+
+---
+
+## References
+
+- [Skills config](https://docs.openclaw.ai/tools/skills-config) — `skills.load.extraDirs`, `skills.entries`, allowlists.
+- [OpenClaw plugins](https://docs.openclaw.ai/plugin) — How to add a plugin that registers tools (and optionally a skill path).
+- FirstLight skill in repo: `skills/firstlight/SKILL.md`.
+- GIDR MCP extension: `extensions/gidr-mcp/` (tools + optional env).

--- a/customer-starter/docs/ADDING-USERS.md
+++ b/customer-starter/docs/ADDING-USERS.md
@@ -1,0 +1,68 @@
+# Adding users (Telegram and WhatsApp)
+
+Steps to **enable** Telegram and WhatsApp and then **add users** so they can message the bot and (with multi-user context) get one session and one prefs file per person.
+
+## 1. Enable Telegram
+
+1. Create a bot with [@BotFather](https://t.me/BotFather); copy the token.
+2. In config (`config/openclaw.yml` or your OpenClaw config dir):
+   ```yaml
+   channels:
+     telegram:
+       enabled: true
+       botToken: "YOUR_BOT_TOKEN"
+       dmPolicy: pairing # or allowlist (see below)
+   ```
+   Or set env `TELEGRAM_BOT_TOKEN`.
+3. Start the gateway. On first DM, the user gets a **pairing code**; approve it (Control UI or CLI: `openclaw pairing` / allowlist).
+4. **Peer id**: After the user messages, get their Telegram user id from session metadata or `openclaw status` (numeric, e.g. `123456789`). Use it in `session.identityLinks` as `telegram:123456789`.
+
+**Allowlist instead of pairing:** Set `dmPolicy: allowlist` and `allowFrom: ["123456789"]` (Telegram user ids). Then only those ids can DM; no pairing step.
+
+## 2. Enable WhatsApp
+
+1. Use a **dedicated phone number** (or WhatsApp Business with a separate number). Configure the channel:
+   ```yaml
+   channels:
+     whatsapp:
+       dmPolicy: allowlist
+       allowFrom: ["+15551234567"] # E.164, add more as needed
+   ```
+2. Run **`openclaw channels login`** and scan the QR code (Linked Devices). Keep the gateway running so the session stays active.
+3. **Peer id**: WhatsApp peer id is the E.164 number (e.g. `+15551234567`). Use it in `session.identityLinks` as `whatsapp:+15551234567`.
+
+**Pairing (optional):** Set `dmPolicy: pairing` so unknown senders get a pairing code; approve via Control UI or CLI, then add them to `identityLinks` and optionally to `allowFrom` if you use allowlist elsewhere.
+
+## 3. Add a user (multi-user context)
+
+Once Telegram and/or WhatsApp are enabled and the user has messaged at least once:
+
+1. Choose a **canonical id** for them (e.g. `alice`, `firstlight-jane`).
+2. Get **peer ids**:
+   - **Telegram**: numeric user id (e.g. from gateway logs, session list, or status).
+   - **WhatsApp**: E.164 number of the account that messaged.
+3. Edit `session.identityLinks` in your config:
+   ```yaml
+   session:
+     dmScope: per-peer
+     identityLinks:
+       alice: ["telegram:123456789"]           # first channel
+       # later, when they add WhatsApp:
+       alice: ["telegram:123456789", "whatsapp:+15551234567"]
+   ```
+4. Save; config hot-reloads. From then on, that user’s messages (from either channel) use session key `agent:main:dm:alice` and prefs file `users/dm_alice.md`.
+
+## 4. Quick reference (peer id format)
+
+| Channel  | Peer id format  | Example        |
+| -------- | --------------- | -------------- |
+| Telegram | Numeric user id | `123456789`    |
+| WhatsApp | E.164 number    | `+15551234567` |
+
+In `identityLinks` always prefix with the channel: `telegram:123456789`, `whatsapp:+15551234567`.
+
+## Links
+
+- [Telegram](https://docs.openclaw.ai/channels/telegram) — Bot setup, dmPolicy, groups.
+- [WhatsApp](https://docs.openclaw.ai/channels/whatsapp) — Login, allowlist, pairing.
+- [Multi-user context](https://docs.openclaw.ai/concepts/multi-user-context) — identityLinks, per-user files, inject plugin.

--- a/customer-starter/docs/AGENTS-SNIPPET-multi-user.md
+++ b/customer-starter/docs/AGENTS-SNIPPET-multi-user.md
@@ -1,0 +1,15 @@
+# Snippet for AGENTS.md or SOUL.md (multi-user context)
+
+Paste this into your agent workspace’s **AGENTS.md** or **SOUL.md** so the agent knows to store per-user preferences in `users/<key>.md`. The User context block (injected by the user-context-inject plugin) tells the agent which key to use.
+
+```markdown
+## Per-user preferences (multi-user context)
+
+You have a **User context** block at the start of each turn with this user’s stored preferences (if any). The block also indicates the **session key** for this user (e.g. `dm_alice`).
+
+- **Store preferences:** When the user shares timezone, location, language, or other durable preferences, write or update them in `users/<key>.md` in the workspace. Use the key from the User context block (e.g. if the block says "key: dm_alice", write to `users/dm_alice.md`). Use a single markdown file per user; you can use headings and lists.
+- **Do not** derive the filename from the user’s message or from another user’s data—only from the User context block for this turn.
+- **Read:** The inject plugin automatically prepends the contents of `users/<key>.md` to each turn, so you will see it in the User context block. Update that file when the user tells you new preferences.
+```
+
+If your User context block format differs (e.g. it only shows the file contents without "key: ..."), instruct the agent to use the same key that was used for the injected content (e.g. "the filename is users/<sanitized-session-key>.md where the session key is shown in the User context block or matches the current DM user").

--- a/customer-starter/docs/MULTI-USER-CONTEXT.md
+++ b/customer-starter/docs/MULTI-USER-CONTEXT.md
@@ -1,0 +1,45 @@
+# Multi-user context (checklist)
+
+One bot, many users: each user gets a **single session key** and **one preferences file** across Telegram and WhatsApp when you use `session.dmScope: "per-peer"` and `session.identityLinks`.
+
+Full guide: [Multi-User Context](https://docs.openclaw.ai/concepts/multi-user-context).
+
+## Checklist
+
+- [ ] **session.dmScope** — Set to `"per-peer"` so session keys are `agent:<agentId>:dm:<canonicalId>` (one per person).
+- [ ] **session.identityLinks** — Map each person to a canonical id and their channel peer ids, e.g.:
+  ```yaml
+  session:
+    dmScope: per-peer
+    identityLinks:
+      alice: ["telegram:123456789", "whatsapp:+15551234567"]
+      bob: ["telegram:987654321"]
+  ```
+- [ ] **users/ directory** — In the agent workspace, create `users/` (or let the agent create it). One file per user, e.g. `users/dm_alice.md`, keyed by canonical id (sanitized).
+- [ ] **Inject plugin** — This repo includes `plugin/user-context-inject/`. Copy it to your agent workspace at `workspace/.openclaw/extensions/user-context-inject/` and add `user-context-inject` to `plugins.allow` in config. It reads `users/<sanitized-session-key>.md` and returns `prependContext` each turn. See SETUP.md Step 10.
+- [ ] **AGENTS.md / SOUL.md** — Add the snippet from [AGENTS-SNIPPET-multi-user.md](AGENTS-SNIPPET-multi-user.md) so the agent writes user preferences to `users/<key>.md` using the key from the User context block.
+
+## Unifying Telegram + WhatsApp
+
+- **Telegram peer id**: numeric user id (e.g. from first message or `openclaw status`).
+- **WhatsApp peer id**: E.164 number, e.g. `+15551234567`.
+- Add both to the **same** `identityLinks` entry so one person gets one key:
+  ```yaml
+  identityLinks:
+    alice: ["telegram:123456789", "whatsapp:+15551234567"]
+  ```
+- Config hot-reloads; no gateway restart needed when you add or update identity links.
+
+## New user (first channel)
+
+1. User messages from Telegram or WhatsApp. Ensure they are allowlisted or paired for that channel.
+2. Choose a **canonical id** (e.g. `alice`, `firstlight-ops-1`). It becomes the session key suffix and the prefs filename base.
+3. Get the **peer id** for that channel (Telegram user id or WhatsApp E.164).
+4. Add to `session.identityLinks`: `"alice": ["telegram:123456789"]` (or whatsapp).
+5. Save config. Next message from that peer uses `agent:main:dm:alice` and `users/dm_alice.md`.
+
+## Existing user adds another channel
+
+1. Get the **peer id for the new channel** (e.g. WhatsApp number).
+2. Append to their **existing** entry: `"alice": ["telegram:123456789", "whatsapp:+15551234567"]`.
+3. Save config. Messages from either channel now use the same session and prefs file.

--- a/customer-starter/docs/MULTI-USER-REVIEW.md
+++ b/customer-starter/docs/MULTI-USER-REVIEW.md
@@ -1,0 +1,40 @@
+# Multi-user context: what’s needed and where
+
+Review of [MULTI-USER-CONTEXT.md](MULTI-USER-CONTEXT.md) and the main [Multi-User Context](https://docs.openclaw.ai/concepts/multi-user-context) doc. Goal: can everything be done in **openclaw-starter** so we don’t need to maintain a fork of OpenClaw?
+
+---
+
+## Checklist from the docs
+
+| Requirement                                                                 | Implemented where                                         | In openclaw-starter?                    | OpenClaw code change? |
+| --------------------------------------------------------------------------- | --------------------------------------------------------- | --------------------------------------- | --------------------- |
+| **session.dmScope** (`per-peer`)                                            | OpenClaw core (session-key, resolve-route, config schema) | ✓ Config example has it                 | No                    |
+| **session.identityLinks**                                                   | OpenClaw core (same)                                      | ✓ Config example has it                 | No                    |
+| **users/ directory** in workspace                                           | Convention only; you create it or the agent does          | Doc + optional placeholder              | No                    |
+| **Inject plugin** (read `users/<key>.md`, return `prependContext`)          | Not in OpenClaw; hook API exists, plugin missing          | ✓ Yes — add plugin, deploy to workspace | No                    |
+| **plugins.allow** (include inject plugin)                                   | Config                                                    | ✓ Add to example                        | No                    |
+| **AGENTS.md / SOUL.md** (instruct agent to write prefs to `users/<key>.md`) | Workspace files                                           | ✓ Snippet in openclaw-starter docs      | No                    |
+
+---
+
+## Conclusion
+
+**All of it can be done in openclaw-starter. No OpenClaw repo code changes are required.**
+
+- **Session routing** (dmScope, identityLinks) is already in OpenClaw; we only need config (already in the example).
+- **Inject plugin:** The `before_agent_start` hook and `prependContext` are already in OpenClaw. The only missing piece is a small plugin that reads `users/<sanitized-session-key>.md` and returns that as `prependContext`. That plugin can live in openclaw-starter and be loaded by OpenClaw in either of two ways:
+  1. **Workspace discovery:** Copy the plugin into the agent workspace at `workspace/.openclaw/extensions/user-context-inject/`. OpenClaw already discovers plugins there. Add `user-context-inject` to `plugins.allow` in config.
+  2. **Config path:** Set `plugins.load.paths` in config to a path where the plugin lives (e.g. a directory you copy to the VM and mount). Add the plugin id to `plugins.allow`.
+
+We use option 1 in this repo: the starter includes the plugin; you copy it into the workspace and add one line to config.
+
+---
+
+## What was added to openclaw-starter
+
+1. **plugin/user-context-inject/** — The inject plugin (openclaw.plugin.json + index.ts). Copy this to your agent workspace’s `workspace/.openclaw/extensions/user-context-inject/` on the VM (or add its path to `plugins.load.paths` and ensure it’s on the container).
+2. **Config** — Example snippet for `plugins.allow` (and optional `plugins.load.paths`) in [SETUP.md](../SETUP.md) and the config example.
+3. **docs/AGENTS-SNIPPET-multi-user.md** — Snippet to paste into AGENTS.md or SOUL.md so the agent writes user preferences to `users/<key>.md`.
+4. **SETUP Step 10** — Updated to reference the bundled plugin and the snippet.
+
+You do **not** need a fork of OpenClaw for multi-user context or the inject plugin.

--- a/customer-starter/plugin/user-context-inject/index.ts
+++ b/customer-starter/plugin/user-context-inject/index.ts
@@ -4,9 +4,9 @@
  * prependContext so the agent sees that user's preferences each turn.
  */
 
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import fs from "node:fs";
 import path from "node:path";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 
 /** Sanitize session key for use as a filename (e.g. agent:main:dm:alice -> dm_alice). */
 function sanitizeSessionKey(sessionKey: string): string {

--- a/customer-starter/plugin/user-context-inject/index.ts
+++ b/customer-starter/plugin/user-context-inject/index.ts
@@ -1,0 +1,70 @@
+/**
+ * User context inject plugin — multi-user context.
+ * Reads users/<sanitized-session-key>.md from the workspace and returns it as
+ * prependContext so the agent sees that user's preferences each turn.
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import fs from "node:fs";
+import path from "node:path";
+
+/** Sanitize session key for use as a filename (e.g. agent:main:dm:alice -> dm_alice). */
+function sanitizeSessionKey(sessionKey: string): string {
+  const trimmed = sessionKey.trim();
+  if (!trimmed) {
+    return "";
+  }
+  // Take the part after agent:<agentId>: (e.g. dm:alice) and replace : with _
+  const parts = trimmed.split(":");
+  if (parts.length >= 4) {
+    // agent:main:dm:alice -> dm_alice
+    return parts.slice(2).join("_");
+  }
+  if (parts.length >= 2) {
+    return parts.slice(1).join("_");
+  }
+  return trimmed.replace(/[^a-zA-Z0-9_-]/g, "_");
+}
+
+const plugin = {
+  id: "user-context-inject",
+  name: "User context inject",
+  description: "Injects per-user preferences from users/<key>.md (multi-user context)",
+  configSchema: {},
+
+  register(api: OpenClawPluginApi) {
+    api.on("before_agent_start", async (_event, ctx) => {
+      const sessionKey = ctx?.sessionKey;
+      const workspaceDir = ctx?.workspaceDir;
+      if (!sessionKey || !workspaceDir) {
+        return;
+      }
+
+      const sanitized = sanitizeSessionKey(sessionKey);
+      if (!sanitized) {
+        return;
+      }
+
+      const userFile = path.join(workspaceDir, "users", `${sanitized}.md`);
+      try {
+        if (!fs.existsSync(userFile)) {
+          return;
+        }
+        const content = fs.readFileSync(userFile, "utf-8").trim();
+        if (!content) {
+          return;
+        }
+        return {
+          prependContext: `## User context\n\n${content}`,
+        };
+      } catch {
+        api.logger.warn?.(`user-context-inject: could not read ${userFile}`);
+        return undefined;
+      }
+    });
+
+    api.logger.info?.("user-context-inject: registered (inject users/<key>.md)");
+  },
+};
+
+export default plugin;

--- a/customer-starter/plugin/user-context-inject/openclaw.plugin.json
+++ b/customer-starter/plugin/user-context-inject/openclaw.plugin.json
@@ -1,0 +1,10 @@
+{
+  "id": "user-context-inject",
+  "name": "User context inject",
+  "description": "Injects per-user preferences from users/<sanitized-session-key>.md into each run via before_agent_start (multi-user context).",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/customer-starter/scripts/copy-config-to-vm.sh
+++ b/customer-starter/scripts/copy-config-to-vm.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copy this repo's config/ to the VM. Run from repo root.
+# Loads deployment.env; requires OPENCLAW_ON_VM_PATH and GCP_VM_*.
+#
+# Usage: ./scripts/copy-config-to-vm.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+if [[ ! -f "$REPO_ROOT/deployment.env" ]]; then
+  echo "Missing deployment.env. Copy deployment.example.env to deployment.env and set OPENCLAW_ON_VM_PATH and GCP_VM_*." >&2
+  exit 1
+fi
+set -a
+# shellcheck source=/dev/null
+source "$REPO_ROOT/deployment.env"
+set +a
+
+: "${OPENCLAW_ON_VM_PATH:?Set OPENCLAW_ON_VM_PATH in deployment.env}"
+: "${GCP_VM_PROJECT:?Set GCP_VM_PROJECT in deployment.env}"
+: "${GCP_VM_NAME:?Set GCP_VM_NAME in deployment.env}"
+: "${GCP_VM_ZONE:?Set GCP_VM_ZONE in deployment.env}"
+
+echo "Copying config/ to $GCP_VM_NAME:$OPENCLAW_ON_VM_PATH/config/"
+gcloud compute ssh "$GCP_VM_NAME" \
+  --project="$GCP_VM_PROJECT" \
+  --zone="$GCP_VM_ZONE" \
+  -- "mkdir -p $OPENCLAW_ON_VM_PATH/config"
+gcloud compute scp --recurse \
+  --project="$GCP_VM_PROJECT" \
+  --zone="$GCP_VM_ZONE" \
+  "$REPO_ROOT/config" \
+  "$GCP_VM_NAME:$OPENCLAW_ON_VM_PATH/"
+
+echo "Done. Config is at $OPENCLAW_ON_VM_PATH/config/ on the VM."

--- a/customer-starter/scripts/start-on-vm.sh
+++ b/customer-starter/scripts/start-on-vm.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Start (or restart) this customer's OpenClaw container on the VM.
+# Run from repo root. Loads deployment.env.
+#
+# The VM must have the main OpenClaw repo at OPENCLAW_REPO_ON_VM_PATH with
+# .env set (including the instance config dir pointing at this customer's config).
+#
+# Usage: ./scripts/start-on-vm.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+if [[ ! -f "$REPO_ROOT/deployment.env" ]]; then
+  echo "Missing deployment.env. Copy deployment.example.env to deployment.env and set OPENCLAW_REPO_ON_VM_PATH, OPENCLAW_CONTAINER_NAME, GCP_VM_*." >&2
+  exit 1
+fi
+set -a
+# shellcheck source=/dev/null
+source "$REPO_ROOT/deployment.env"
+set +a
+
+: "${OPENCLAW_REPO_ON_VM_PATH:?Set OPENCLAW_REPO_ON_VM_PATH in deployment.env}"
+: "${OPENCLAW_CONTAINER_NAME:?Set OPENCLAW_CONTAINER_NAME in deployment.env}"
+: "${GCP_VM_PROJECT:?Set GCP_VM_PROJECT in deployment.env}"
+: "${GCP_VM_NAME:?Set GCP_VM_NAME in deployment.env}"
+: "${GCP_VM_ZONE:?Set GCP_VM_ZONE in deployment.env}"
+
+"$REPO_ROOT/scripts/vm-ssh.sh" -- "cd $OPENCLAW_REPO_ON_VM_PATH && docker compose -f platforms/gcp-vm/docker-compose.multi.yml --env-file .env up -d $OPENCLAW_CONTAINER_NAME"
+echo "Started (or restarted) $OPENCLAW_CONTAINER_NAME. Check: ./scripts/vm-ssh.sh -- 'docker ps'"

--- a/customer-starter/scripts/vm-ssh.sh
+++ b/customer-starter/scripts/vm-ssh.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# SSH to the GCP VM. Loads deployment.env from this repo root so you can run
+# commands on the VM (e.g. docker ps, manage-multi.sh).
+#
+# Usage (from repo root):
+#   ./scripts/vm-ssh.sh                  # interactive SSH
+#   ./scripts/vm-ssh.sh -- 'docker ps'   # run one command
+#
+# Requires: gcloud, deployment.env (copy from deployment.example.env).
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+if [[ -f "$REPO_ROOT/deployment.env" ]]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$REPO_ROOT/deployment.env"
+  set +a
+fi
+
+GCP_VM_PROJECT="${GCP_VM_PROJECT:-gidr-demo}"
+GCP_VM_NAME="${GCP_VM_NAME:-openclaw-gateway}"
+GCP_VM_ZONE="${GCP_VM_ZONE:-us-central1-a}"
+
+if [[ $# -eq 0 ]]; then
+  exec gcloud compute ssh "$GCP_VM_NAME" \
+    --project="$GCP_VM_PROJECT" \
+    --zone="$GCP_VM_ZONE"
+fi
+
+if [[ "$1" == "--" ]]; then
+  shift
+fi
+exec gcloud compute ssh "$GCP_VM_NAME" \
+  --project="$GCP_VM_PROJECT" \
+  --zone="$GCP_VM_ZONE" \
+  -- \
+  "$@"

--- a/docs/reference/fork-and-deploy-plan.md
+++ b/docs/reference/fork-and-deploy-plan.md
@@ -47,34 +47,44 @@ Only the following should be **added or changed** in the fork. Everything else s
 
 1. **Fork** the OpenClaw repo (e.g. `openclaw/openclaw` → `YOUR_ORG/openclaw` or your user fork). Use GitHub (or your Git host) “Fork” and ensure you have push access.
 2. **Clone the fork** locally (replace with your fork URL and branch name):
+
    ```bash
    git clone https://github.com/YOUR_ORG/openclaw.git
    cd openclaw
    ```
+
 3. **Add upstream** so you can pull updates later:
+
    ```bash
    git remote add upstream https://github.com/openclaw/openclaw.git
    git fetch upstream
    ```
+
 4. **Create a branch** for your deployment line (e.g. `deploy/gidr-demo` or `main-custom`):
+
    ```bash
    git checkout -b deploy/gidr-demo
    ```
+
 5. **Apply your changes** to this branch:
    - Ensure all items in the “Scope of customizations” table above are present (extensions, skills, system-prompt tweaks, GCP example doc, this plan).
    - If you are starting from a fresh clone of the fork, re-apply or cherry-pick the same commits you used in the main repo (or copy the changed files).
 6. **Commit and push** the branch to the fork:
+
    ```bash
    git add -A
    git status   # sanity check
-   git commit -m "Add GIDR MCP extension, firstlight skill, GCP example, fork-and-deploy plan"
+   git commit -m “Add GIDR MCP extension, firstlight skill, GCP example, fork-and-deploy plan”
    git push -u origin deploy/gidr-demo
    ```
+
 7. **(Optional)** Tag a release for deploy (e.g. `v2026.2.1-gidr.1`):
+
    ```bash
    git tag v2026.2.1-gidr.1
    git push origin v2026.2.1-gidr.1
    ```
+
    Deployment can then use this tag for reproducibility.
 
 ---
@@ -84,15 +94,18 @@ Only the following should be **added or changed** in the fork. Everything else s
 When you want to pull in upstream changes:
 
 1. **Fetch and merge** (or rebase) from upstream:
+
    ```bash
    git fetch upstream
    git merge upstream/main   # or: git rebase upstream/main
    ```
+
 2. **Resolve conflicts** if any. Most will be in:
    - `src/agents/system-prompt.ts` (tool list / summaries)
    - Any other file upstream changed that you also changed.
 3. **Re-run your tests and a quick deploy test** (e.g. build, start gateway, smoke test).
 4. **Push** the updated branch (and optionally a new tag):
+
    ```bash
    git push origin deploy/gidr-demo
    # optional: git tag v2026.2.1-gidr.2 && git push origin v2026.2.1-gidr.2
@@ -111,11 +124,13 @@ Choose one of the following (or both). The goal is: **one canonical way** to go 
   - Clone URL: `https://github.com/YOUR_ORG/openclaw.git`
   - Branch or tag: `deploy/gidr-demo` or `v2026.2.1-gidr.1`
 - **Example** (for gidr-demo, openclaw-gateway): On the VM after SSH, run:
+
   ```bash
   git clone --branch deploy/gidr-demo https://github.com/YOUR_ORG/openclaw.git openclaw
   cd openclaw
   # then continue with: create ~/.openclaw, ~/.openclaw/workspace, .env, docker-compose as in the GCP doc
   ```
+
 - **Secrets**: Document that `GIDR_MCP_URL` and `GIDR_API_KEY` (or `GIDR_API_KEY_FILE`) must be set (e.g. in `.env` or the environment) for the Firstlight tools to work. Optionally reference a secrets manager (e.g. GCP Secret Manager) without embedding secrets in the doc.
 
 ### Option B — Deploy script in the fork
@@ -141,11 +156,13 @@ For each environment (e.g. gidr-demo / openclaw-gateway):
 - [ ] **Fork**: Clone uses the fork URL and the chosen branch/tag.
 - [ ] **Env**: `GIDR_MCP_URL` and `GIDR_API_KEY` (or `GIDR_API_KEY_FILE`) set where the Gateway runs (e.g. in `.env` for Docker).
 - [ ] **Config**: Agent has the GIDR tools allowlisted, e.g. in `openclaw.yml`:
+
   ```yaml
   tools:
     alsoAllow: ["search_troubleshooting", "retrieval_firstlight_noc"]
   # or: alsoAllow: ["gidr-mcp"]
   ```
+
 - [ ] **Plugins**: Extension `gidr-mcp` is enabled (default if present in repo; ensure it’s not disabled in config).
 - [ ] **Access**: SSH tunnel (or controlled port exposure) for Control UI; gateway token pasted once in the UI.
 

--- a/docs/reference/fork-and-deploy-plan.md
+++ b/docs/reference/fork-and-deploy-plan.md
@@ -119,7 +119,7 @@ Choose one of the following (or both). The goal is: **one canonical way** to go 
 
 ### Option A — Documented steps (no new script)
 
-- **Location**: Keep using the existing [GCP doc](/platforms/gcp) and [GCP VM deployment](/platforms/gcp-vm).
+- **Location**: Keep using the existing [GCP doc](/platforms/gcp) and [Docker install](/install/docker).
 - **Change**: In the “Clone OpenClaw” step, document that for this deployment we clone **the fork** and **branch/tag**:
   - Clone URL: `https://github.com/YOUR_ORG/openclaw.git`
   - Branch or tag: `deploy/gidr-demo` or `v2026.2.1-gidr.1`
@@ -195,7 +195,7 @@ Execute in this order:
 ## 9. Doc links
 
 - [GCP platform guide](/platforms/gcp) — Full GCP setup; includes gidr-demo / openclaw-gateway example.
-- [GCP VM deployment](/platforms/gcp-vm) — Docker Compose, VM layout, **multiple instances** (docker-compose.multi.yml), and **manage-multi.sh** to maintain many containers on one VM.
+- [Docker install](/install/docker) — Docker Compose setup and configuration.
 - [Docker install](/install/docker) — Generic Docker-based install.
 - [Slash commands](/tools/slash-commands) — Includes `/firstlight` when the firstlight skill is loaded.
 

--- a/docs/reference/fork-and-deploy-plan.md
+++ b/docs/reference/fork-and-deploy-plan.md
@@ -38,6 +38,7 @@ Only the following should be **added or changed** in the fork. Everything else s
 | **Deploy helper** (optional)   | Script or one-page doc that clones the fork and runs the GCP VM flow                                            | See step 5                                                                                                                                                                              |
 | **Multi-instance maintenance** | `platforms/gcp-vm/manage-multi.sh` + README “Maintaining many instances”                                        | Deploy many OpenClaw containers side-by-side on one VM; one script to start/stop/restart/logs/pull/exec all                                                                             |
 | **Customer starter template**  | `customer-starter/`                                                                                             | One repo as starting point for a new customer: multi-user context, Telegram + WhatsApp user onboarding; publish as standalone repo, clone and customize per customer (e.g. FirstLight). |
+| **Observability**              | `extensions/langsmith-tracer/`                                                                                  | LangSmith tracing for the agent loop (LLM calls, tool calls, token usage). Opt-in via `LANGSMITH_API_KEY`; no-op when absent. See `extensions/langsmith-tracer/README.md`.              |
 
 **Do not** change core under `src/` beyond the listed system-prompt edits unless necessary. Prefer extensions and skills so upstream merges stay clean.
 

--- a/docs/reference/fork-and-deploy-plan.md
+++ b/docs/reference/fork-and-deploy-plan.md
@@ -1,0 +1,185 @@
+---
+summary: "Plan for a repeatable OpenClaw deployment using a fork and easy deploy"
+read_when:
+  - You want to ship a customized OpenClaw (extensions, skills, GCP) in a versioned, repeatable way
+  - You want to merge upstream updates while keeping your customizations
+  - You want one-source-of-truth for deploy (clone fork → run steps)
+title: "Fork and deploy plan"
+---
+
+See also: [Multi-user context and keeping OpenClaw up to date](/reference/multi-user-and-upstream) for how openclaw-starter (config only) and a fork (code) work together.
+
+# Fork and deploy plan (repeatable OpenClaw)
+
+This document is the **plan** for making your OpenClaw solution repeatable: fork the repo, apply your changes, and enable easy deployment. Execute the steps in order once the plan is approved.
+
+---
+
+## 1. Goals
+
+- **Repeatable**: Same steps produce the same running Gateway every time (same branch/tag, same config pattern).
+- **Versioned**: Customizations (GIDR MCP, Firstlight skill, GCP example) live in one repo at a known revision.
+- **Upstream-friendly**: Minimize customizations in core; keep them in extensions, skills, and config/docs so merging upstream stays simple.
+- **Easy deploy**: Deploy by cloning the fork (and branch/tag) and running a small set of commands (optionally a single script).
+
+---
+
+## 2. Scope of customizations (what goes in the fork)
+
+Only the following should be **added or changed** in the fork. Everything else stays as in upstream.
+
+| Area                           | Contents                                                                                                        | Notes                                                                                                                                                                                   |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Extensions**                 | `extensions/gidr-mcp/` (GIDR MCP client, `search_troubleshooting`, `retrieval_firstlight_noc`)                  | Optional plugin; enable via config + env                                                                                                                                                |
+| **Skills**                     | `skills/firstlight/SKILL.md` (Firstlight NOC/troubleshooting, `/firstlight`)                                    | Bundled skill; agent sees it when GIDR env is set                                                                                                                                       |
+| **System prompt**              | `src/agents/system-prompt.ts` (tool summaries + order for `search_troubleshooting`, `retrieval_firstlight_noc`) | Small additive change; keep in sync with upstream                                                                                                                                       |
+| **Docs**                       | `docs/platforms/gcp.md` (example: gidr-demo, openclaw-gateway)                                                  | Example section only                                                                                                                                                                    |
+| **This plan**                  | `docs/reference/fork-and-deploy-plan.md`                                                                        | This document                                                                                                                                                                           |
+| **Deploy helper** (optional)   | Script or one-page doc that clones the fork and runs the GCP VM flow                                            | See step 5                                                                                                                                                                              |
+| **Multi-instance maintenance** | `platforms/gcp-vm/manage-multi.sh` + README “Maintaining many instances”                                        | Deploy many OpenClaw containers side-by-side on one VM; one script to start/stop/restart/logs/pull/exec all                                                                             |
+| **Customer starter template**  | `customer-starter/`                                                                                             | One repo as starting point for a new customer: multi-user context, Telegram + WhatsApp user onboarding; publish as standalone repo, clone and customize per customer (e.g. FirstLight). |
+
+**Do not** change core under `src/` beyond the listed system-prompt edits unless necessary. Prefer extensions and skills so upstream merges stay clean.
+
+---
+
+## 3. Step 1 — Create and prepare the fork
+
+1. **Fork** the OpenClaw repo (e.g. `openclaw/openclaw` → `YOUR_ORG/openclaw` or your user fork). Use GitHub (or your Git host) “Fork” and ensure you have push access.
+2. **Clone the fork** locally (replace with your fork URL and branch name):
+   ```bash
+   git clone https://github.com/YOUR_ORG/openclaw.git
+   cd openclaw
+   ```
+3. **Add upstream** so you can pull updates later:
+   ```bash
+   git remote add upstream https://github.com/openclaw/openclaw.git
+   git fetch upstream
+   ```
+4. **Create a branch** for your deployment line (e.g. `deploy/gidr-demo` or `main-custom`):
+   ```bash
+   git checkout -b deploy/gidr-demo
+   ```
+5. **Apply your changes** to this branch:
+   - Ensure all items in the “Scope of customizations” table above are present (extensions, skills, system-prompt tweaks, GCP example doc, this plan).
+   - If you are starting from a fresh clone of the fork, re-apply or cherry-pick the same commits you used in the main repo (or copy the changed files).
+6. **Commit and push** the branch to the fork:
+   ```bash
+   git add -A
+   git status   # sanity check
+   git commit -m "Add GIDR MCP extension, firstlight skill, GCP example, fork-and-deploy plan"
+   git push -u origin deploy/gidr-demo
+   ```
+7. **(Optional)** Tag a release for deploy (e.g. `v2026.2.1-gidr.1`):
+   ```bash
+   git tag v2026.2.1-gidr.1
+   git push origin v2026.2.1-gidr.1
+   ```
+   Deployment can then use this tag for reproducibility.
+
+---
+
+## 4. Step 2 — Keep the fork in sync with upstream
+
+When you want to pull in upstream changes:
+
+1. **Fetch and merge** (or rebase) from upstream:
+   ```bash
+   git fetch upstream
+   git merge upstream/main   # or: git rebase upstream/main
+   ```
+2. **Resolve conflicts** if any. Most will be in:
+   - `src/agents/system-prompt.ts` (tool list / summaries)
+   - Any other file upstream changed that you also changed.
+3. **Re-run your tests and a quick deploy test** (e.g. build, start gateway, smoke test).
+4. **Push** the updated branch (and optionally a new tag):
+   ```bash
+   git push origin deploy/gidr-demo
+   # optional: git tag v2026.2.1-gidr.2 && git push origin v2026.2.1-gidr.2
+   ```
+
+---
+
+## 5. Step 3 — Define “easy deployment”
+
+Choose one of the following (or both). The goal is: **one canonical way** to go from “fork repo” to “Gateway running on the VM”.
+
+### Option A — Documented steps (no new script)
+
+- **Location**: Keep using the existing [GCP doc](/platforms/gcp) and [GCP VM deployment](/platforms/gcp-vm).
+- **Change**: In the “Clone OpenClaw” step, document that for this deployment we clone **the fork** and **branch/tag**:
+  - Clone URL: `https://github.com/YOUR_ORG/openclaw.git`
+  - Branch or tag: `deploy/gidr-demo` or `v2026.2.1-gidr.1`
+- **Example** (for gidr-demo, openclaw-gateway): On the VM after SSH, run:
+  ```bash
+  git clone --branch deploy/gidr-demo https://github.com/YOUR_ORG/openclaw.git openclaw
+  cd openclaw
+  # then continue with: create ~/.openclaw, ~/.openclaw/workspace, .env, docker-compose as in the GCP doc
+  ```
+- **Secrets**: Document that `GIDR_MCP_URL` and `GIDR_API_KEY` (or `GIDR_API_KEY_FILE`) must be set (e.g. in `.env` or the environment) for the Firstlight tools to work. Optionally reference a secrets manager (e.g. GCP Secret Manager) without embedding secrets in the doc.
+
+### Option B — Deploy script in the fork
+
+- **Location**: e.g. `scripts/deploy-from-fork.sh` or `platforms/gcp-vm/deploy-from-fork.sh` in the fork.
+- **Responsibilities** (high level):
+  1. Run on the **VM** (or from a runner that SSHs to the VM).
+  2. Ensure dependencies (Docker, git) are present.
+  3. Clone the fork (or pull if already cloned) at the chosen branch/tag.
+  4. Create `~/.openclaw` and `~/.openclaw/workspace` if missing.
+  5. Copy or symlink a provided `.env` (or template) and optionally pull secrets from env / a secrets store.
+  6. Run the same `docker compose -f platforms/gcp-vm/docker-compose.yml --env-file .env up -d openclaw-gateway` (or equivalent) as in the GCP doc.
+- **Inputs**: Branch or tag, clone URL, path to `.env` or template. No secrets in the script; secrets come from env or files the operator provides.
+- **Doc**: Add a short section in this plan or in the GCP VM README: “To deploy from the fork, run: `./scripts/deploy-from-fork.sh …`” with the exact command and required env vars.
+
+---
+
+## 6. Step 4 — GCP and config checklist (per environment)
+
+For each environment (e.g. gidr-demo / openclaw-gateway):
+
+- [ ] **GCP**: Project and VM exist (or create per [GCP doc](/platforms/gcp) example).
+- [ ] **Fork**: Clone uses the fork URL and the chosen branch/tag.
+- [ ] **Env**: `GIDR_MCP_URL` and `GIDR_API_KEY` (or `GIDR_API_KEY_FILE`) set where the Gateway runs (e.g. in `.env` for Docker).
+- [ ] **Config**: Agent has the GIDR tools allowlisted, e.g. in `openclaw.yml`:
+  ```yaml
+  tools:
+    alsoAllow: ["search_troubleshooting", "retrieval_firstlight_noc"]
+  # or: alsoAllow: ["gidr-mcp"]
+  ```
+- [ ] **Plugins**: Extension `gidr-mcp` is enabled (default if present in repo; ensure it’s not disabled in config).
+- [ ] **Access**: SSH tunnel (or controlled port exposure) for Control UI; gateway token pasted once in the UI.
+
+---
+
+## 7. Step 5 — Execution order (summary)
+
+Execute in this order:
+
+1. **Fork and branch** (Step 1): Create fork, add upstream remote, create deployment branch, apply customizations, push, optionally tag.
+2. **Deploy definition** (Step 3): Either update the GCP doc with “clone from fork” (Option A) or add and document the deploy script (Option B).
+3. **First deploy**: On a test VM (or existing gidr-demo VM), follow the chosen deploy path (doc or script), then verify:
+   - Gateway starts.
+   - Control UI is reachable via tunnel.
+   - Agent can use `search_troubleshooting` and `retrieval_firstlight_noc` when configured (and `/firstlight` skill is available).
+4. **Sync process** (Step 2): Use it whenever you want to pull upstream; re-test and re-tag as needed.
+5. **Checklist** (Step 4): Use the per-environment checklist for any new VM or environment.
+
+---
+
+## 8. Optional: CI and pre-built images
+
+- **CI**: In the fork, add a small CI job (e.g. GitHub Actions) that on push to the deploy branch (or on tag):
+  - Runs `pnpm build` and `pnpm test` (or equivalent).
+  - Optionally builds a Docker image and pushes it to a registry (e.g. GCR, Artifact Registry).
+- **Deploy from image**: If you use a pre-built image, the VM can pull that image instead of building from source; the “clone fork” step is then only for config/scripts, or replaced by “pull image and run” with env/config mounted. This is optional and can be added after the basic “clone fork + compose” flow is stable.
+
+---
+
+## 9. Doc links
+
+- [GCP platform guide](/platforms/gcp) — Full GCP setup; includes gidr-demo / openclaw-gateway example.
+- [GCP VM deployment](/platforms/gcp-vm) — Docker Compose, VM layout, **multiple instances** (docker-compose.multi.yml), and **manage-multi.sh** to maintain many containers on one VM.
+- [Docker install](/install/docker) — Generic Docker-based install.
+- [Slash commands](/tools/slash-commands) — Includes `/firstlight` when the firstlight skill is loaded.
+
+After execution, you can point operators to this plan and the chosen deploy path (doc or script) for repeatable deployments.

--- a/docs/reference/multi-user-and-upstream.md
+++ b/docs/reference/multi-user-and-upstream.md
@@ -1,0 +1,53 @@
+---
+summary: "How multi-user context works and how to modify OpenClaw while staying up to date"
+read_when:
+  - You use openclaw-starter (config only) and want to know where multi-user support lives
+  - You need to change OpenClaw code (plugins, extensions, skills) and still pull upstream updates
+title: "Multi-user context and keeping OpenClaw up to date"
+---
+
+# Multi-user context and keeping OpenClaw up to date
+
+## Two repos, two roles
+
+| Repo                                                 | Role                     | Contains                                                                                                                                                   |
+| ---------------------------------------------------- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **openclaw** (or your fork)                          | The application          | Gateway, channels, session routing, `dmScope` / `identityLinks`, plugins, extensions. **Multi-user context is implemented here.**                          |
+| **openclaw-starter** (e.g. GIDR-AI/openclaw-starter) | Customer config + deploy | Config templates (`session.dmScope`, `session.identityLinks`), deployment env, scripts to copy config to VM and start the container. **No OpenClaw code.** |
+
+Multi-user context (`session.dmScope: "per-peer"`, `session.identityLinks`) is **already implemented in the main OpenClaw repo**. The starter only holds **config and docs** that use those features. You do **not** need to modify OpenClaw for basic multi-user—just run OpenClaw (upstream or your fork) on the VM and point it at your openclaw-starter config.
+
+If you need **optional** behavior (e.g. an inject plugin that reads `users/<key>.md` and injects `prependContext` via `before_agent_start`), that can live in an extension in your fork or in a separate plugin repo; the hook API is in OpenClaw core.
+
+---
+
+## When you need to modify OpenClaw
+
+If you add or change **code** in OpenClaw (extensions, skills, system prompt, GCP helpers, or any file under `src/` or `extensions/`), use a **fork** and keep it in sync with upstream so you get security and feature updates.
+
+### Pattern: fork + upstream sync
+
+1. **Fork** the repo (e.g. `openclaw/openclaw` → `GIDR-AI/openclaw`).
+2. **Add upstream** and create a branch for your customizations:
+   ```bash
+   git remote add upstream https://github.com/openclaw/openclaw.git
+   git fetch upstream
+   git checkout -b deploy/gidr   # or main, or a release branch
+   ```
+3. **Apply your changes** on that branch (extensions, skills, config defaults, docs). Prefer extensions and skills over core changes so merges stay clean.
+4. **Deploy from your fork** on the VM (clone your fork and branch; build/run Docker from there). Your openclaw-starter config still points at the same gateway; only the **binary/image** comes from your fork.
+5. **Keep up to date** by merging (or rebasing) upstream into your branch:
+   ```bash
+   git fetch upstream
+   git merge upstream/main   # or: git rebase upstream/main
+   ```
+   Resolve conflicts (often in `src/agents/system-prompt.ts` or other files you touched), run tests, then push.
+
+Full steps and scope: [Fork and deploy plan](/reference/fork-and-deploy-plan).
+
+---
+
+## Summary
+
+- **Multi-user context:** Implemented in OpenClaw. openclaw-starter provides config and checklists; no code changes required.
+- **Modifying OpenClaw and staying up to date:** Fork → add upstream remote → do changes on a branch → deploy from fork → periodically `git fetch upstream && git merge upstream/main`.

--- a/docs/reference/multi-user-and-upstream.md
+++ b/docs/reference/multi-user-and-upstream.md
@@ -29,18 +29,22 @@ If you add or change **code** in OpenClaw (extensions, skills, system prompt, GC
 
 1. **Fork** the repo (e.g. `openclaw/openclaw` → `GIDR-AI/openclaw`).
 2. **Add upstream** and create a branch for your customizations:
+
    ```bash
    git remote add upstream https://github.com/openclaw/openclaw.git
    git fetch upstream
    git checkout -b deploy/gidr   # or main, or a release branch
    ```
+
 3. **Apply your changes** on that branch (extensions, skills, config defaults, docs). Prefer extensions and skills over core changes so merges stay clean.
 4. **Deploy from your fork** on the VM (clone your fork and branch; build/run Docker from there). Your openclaw-starter config still points at the same gateway; only the **binary/image** comes from your fork.
 5. **Keep up to date** by merging (or rebasing) upstream into your branch:
+
    ```bash
    git fetch upstream
    git merge upstream/main   # or: git rebase upstream/main
    ```
+
    Resolve conflicts (often in `src/agents/system-prompt.ts` or other files you touched), run tests, then push.
 
 Full steps and scope: [Fork and deploy plan](/reference/fork-and-deploy-plan).

--- a/extensions/langsmith-tracer/README.md
+++ b/extensions/langsmith-tracer/README.md
@@ -1,0 +1,146 @@
+# @openclaw/langsmith-tracer
+
+LangSmith tracing extension for the OpenClaw agent loop.
+
+Traces every agent turn — LLM calls, tool calls, token usage, errors — to
+[LangSmith](https://smith.langchain.com) using the OpenClaw plugin hook system.
+No core files are modified; this extension is purely additive.
+
+> **Fork-specific:** This extension lives in the `fritzebner/openclaw` fork and is
+> not part of upstream OpenClaw. It is intentionally kept out of `src/` so merging
+> upstream changes never touches tracing code.
+
+---
+
+## Trace hierarchy
+
+Each agent turn produces one trace in LangSmith:
+
+```
+openclaw-agent  [chain]              ← full turn: user message → reply
+  anthropic/claude-sonnet-4-5 [llm] ← turn 1: first LLM call
+    bash  [tool]                     ← tool called by the LLM
+    read_file  [tool]
+  anthropic/claude-sonnet-4-5 [llm] ← turn 2: follow-up LLM call (after tools)
+```
+
+Each run shows:
+
+- **chain**: prompt input, success/error, total duration
+- **llm**: message history input, generated texts output, token usage (input/output/cache)
+- **tool**: params input, result or error output, duration
+
+---
+
+## Hook to RunTree mapping
+
+This table is the key reference for future maintainers.
+
+| Plugin hook          | RunTree action                            | Data captured                               |
+| -------------------- | ----------------------------------------- | ------------------------------------------- |
+| `before_agent_start` | Create root `chain` run, `postRun()`      | `prompt`                                    |
+| `llm_input`          | Create child `llm` run, `postRun()`       | system prompt, message history, image count |
+| `before_tool_call`   | Create grandchild `tool` run, `postRun()` | tool name, params                           |
+| `after_tool_call`    | `end()` + `patchRun()` on tool run        | result or error                             |
+| `llm_output`         | `end()` + `patchRun()` on LLM run         | generated texts, token usage                |
+| `agent_end`          | `end()` + `patchRun()` on root run        | success flag, error message                 |
+
+**Correlation key:** `agentId` from `PluginHookAgentContext` / `PluginHookToolContext`.
+Tool hooks carry `PluginHookToolContext` (no `sessionId`), so `agentId` is used as the
+stable key across all hook types.
+
+**State:** `LangSmithTracer` maintains a `Map<agentId, SessionTrace>` in memory.
+Each entry holds the root run, the current LLM run, and a stack of pending tool runs.
+
+---
+
+## Setup
+
+### 1. Set environment variables
+
+```bash
+export LANGSMITH_API_KEY=ls__...          # required — get from smith.langchain.com
+export LANGSMITH_PROJECT=openclaw         # optional, default: "default"
+export LANGSMITH_TRACING_V2=true          # required by LangSmith SDK
+```
+
+Add these to the `.env` file used by docker-compose on the VM (see
+[GCP VM deployment](/install/docker)).
+
+### 2. Enable in openclaw.yml
+
+The extension is auto-discovered from `extensions/langsmith-tracer/` (bundled in
+the fork). You can explicitly enable it or configure the project name via config:
+
+```yaml
+plugins:
+  entries:
+    langsmith-tracer:
+      enabled: true
+      config:
+        project: "openclaw-prod" # overrides LANGSMITH_PROJECT
+        # endpoint: "https://..."      # overrides LANGSMITH_ENDPOINT
+```
+
+If `LANGSMITH_API_KEY` is not set the plugin logs one info line and registers no
+hooks — zero overhead, no change to agent behavior.
+
+---
+
+## Troubleshooting
+
+**Traces not appearing in LangSmith**
+
+- Verify `LANGSMITH_API_KEY` is set in the container: `docker exec <container> printenv LANGSMITH_API_KEY`
+- Verify `LANGSMITH_TRACING_V2=true` is set
+- Check gateway logs for `langsmith-tracer:` lines (enabled/disabled message on startup, any `warn` lines)
+- Make sure the project name matches what you see in smith.langchain.com
+
+**All runs show as errors**
+
+- Look for `agent_end` with `success: false` — check the `error` field in the LangSmith run
+- The gateway logs will show the same error
+
+**LLM runs have no token usage**
+
+- The `llm_output` hook receives `usage` from pi-agent-core. If the model/provider
+  does not report usage, the field will be empty — this is expected.
+
+---
+
+## Extending
+
+To add more data to traces, edit `src/tracer.ts`. Each hook method receives the
+full event object from `src/plugins/types.ts` — refer to that file for all
+available fields.
+
+To add a new hook (e.g. `before_compaction`):
+
+1. Add a method to `LangSmithTracer` in `src/tracer.ts`
+2. Register it with `api.on("before_compaction", ...)` in `index.ts`
+3. Add a test case to `index.test.ts`
+
+---
+
+## Source layout
+
+```
+extensions/langsmith-tracer/
+  index.ts           ← plugin entry point; registers all hooks
+  src/
+    config.ts        ← env var + plugin config resolution; Client factory
+    tracer.ts        ← LangSmithTracer class (RunTree state machine)
+  index.test.ts      ← unit tests (no network required)
+  README.md          ← this file
+  package.json       ← dep: langsmith@^0.5
+```
+
+---
+
+## Key reference files
+
+- Plugin hook types and event shapes: [src/plugins/types.ts](../../src/plugins/types.ts)
+- Hook call sites in the agent loop: [src/agents/pi-embedded-runner/run/attempt.ts](../../src/agents/pi-embedded-runner/run/attempt.ts)
+- Best example of a hooks-based extension: [extensions/memory-lancedb/](../memory-lancedb/)
+- Fork scope and deploy plan: [docs/reference/fork-and-deploy-plan.md](../../docs/reference/fork-and-deploy-plan.md)
+- LangSmith RunTree API: `langsmith/run_trees` (see `node_modules/langsmith/dist/run_trees.d.ts`)

--- a/extensions/langsmith-tracer/index.test.ts
+++ b/extensions/langsmith-tracer/index.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Tests for the LangSmith tracer extension.
+ *
+ * Unit tests use a fake RunNode factory injected via the _runNodeFactory
+ * constructor option — no real LangSmith account or module mocking needed.
+ *
+ * Live tests (describeLive block) require LANGSMITH_API_KEY + OPENCLAW_LIVE_TEST=1.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── fake RunNode ──────────────────────────────────────────────────────────────
+
+type FakeRun = {
+  name: string;
+  run_type: string;
+  inputs: Record<string, unknown>;
+  outputs?: Record<string, unknown>;
+  error?: string;
+  children: FakeRun[];
+  postRun: ReturnType<typeof vi.fn>;
+  patchRun: ReturnType<typeof vi.fn>;
+  end: ReturnType<typeof vi.fn>;
+  createChild: ReturnType<typeof vi.fn>;
+};
+
+function makeFakeRun(cfg: Record<string, unknown> = {}): FakeRun {
+  const children: FakeRun[] = [];
+  const run: FakeRun = {
+    name: (cfg["name"] as string) ?? "fake-run",
+    run_type: (cfg["run_type"] as string) ?? "chain",
+    inputs: (cfg["inputs"] as Record<string, unknown>) ?? {},
+    children,
+    postRun: vi.fn().mockResolvedValue(undefined),
+    patchRun: vi.fn().mockResolvedValue(undefined),
+    end: vi.fn().mockImplementation(async (outputs?: Record<string, unknown>, error?: string) => {
+      run.outputs = outputs;
+      run.error = error;
+    }),
+    createChild: vi.fn().mockImplementation((childCfg: Record<string, unknown>) => {
+      const child = makeFakeRun(childCfg);
+      children.push(child);
+      return child;
+    }),
+  };
+  return run;
+}
+
+// ── LangSmithTracer unit tests ────────────────────────────────────────────────
+
+describe("LangSmithTracer", () => {
+  let LangSmithTracer: typeof import("./src/tracer.js").LangSmithTracer;
+  const mockLogger = { warn: vi.fn(), info: vi.fn() };
+  const mockClient = {} as import("langsmith").Client;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    ({ LangSmithTracer } = await import("./src/tracer.js"));
+  });
+
+  function makeTracer(rootRun: FakeRun) {
+    return new LangSmithTracer({
+      client: mockClient,
+      projectName: "test",
+      logger: mockLogger,
+      _runNodeFactory: () => rootRun,
+    });
+  }
+
+  // ── test 3: happy path ─────────────────────────────────────────────────────
+  it("happy path: full single-turn sequence creates correct run hierarchy", async () => {
+    const rootRun = makeFakeRun({ name: "openclaw-agent", run_type: "chain" });
+    const tracer = makeTracer(rootRun);
+    const sessionId = "sess-1";
+
+    // before_agent_start → root run posted
+    await tracer.onAgentStart(sessionId, { prompt: "hello" });
+    expect(rootRun.postRun).toHaveBeenCalledTimes(1);
+    expect(tracer.activeSessionCount).toBe(1);
+
+    // llm_input → child llm run created under root
+    await tracer.onLlmInput(sessionId, {
+      runId: "run-1",
+      sessionId,
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      prompt: "hello",
+      historyMessages: [],
+      imagesCount: 0,
+    });
+    expect(rootRun.createChild).toHaveBeenCalledTimes(1);
+    const llmRun = rootRun.children[0];
+    expect(llmRun).toBeDefined();
+    expect(llmRun.postRun).toHaveBeenCalledTimes(1);
+    expect(llmRun.run_type).toBe("llm");
+
+    // before_tool_call → grandchild tool run under llm run
+    await tracer.onBeforeToolCall(sessionId, { toolName: "bash", params: { cmd: "ls" } });
+    expect(llmRun.createChild).toHaveBeenCalledTimes(1);
+    const toolRun = llmRun.children[0];
+    expect(toolRun).toBeDefined();
+    expect(toolRun.postRun).toHaveBeenCalledTimes(1);
+    expect(toolRun.run_type).toBe("tool");
+
+    // after_tool_call → tool run closed with result
+    await tracer.onAfterToolCall(sessionId, {
+      toolName: "bash",
+      params: { cmd: "ls" },
+      result: "file.ts",
+    });
+    expect(toolRun.end).toHaveBeenCalledWith({ output: "file.ts" }, undefined);
+    expect(toolRun.patchRun).toHaveBeenCalledTimes(1);
+
+    // llm_output → llm run closed with texts + usage
+    await tracer.onLlmOutput(sessionId, {
+      runId: "run-1",
+      sessionId,
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      assistantTexts: ["done"],
+      usage: { input: 100, output: 20 },
+    });
+    expect(llmRun.end).toHaveBeenCalledWith(expect.objectContaining({ generations: ["done"] }));
+    expect(llmRun.patchRun).toHaveBeenCalledTimes(1);
+
+    // agent_end → root run closed, session removed
+    await tracer.onAgentEnd(sessionId, { messages: [], success: true });
+    expect(rootRun.end).toHaveBeenCalledWith({ success: true }, undefined);
+    expect(rootRun.patchRun).toHaveBeenCalledTimes(1);
+    expect(tracer.activeSessionCount).toBe(0);
+  });
+
+  // ── test 4: multi-turn ────────────────────────────────────────────────────
+  it("multi-turn: two LLM calls create two child runs under the root", async () => {
+    const rootRun = makeFakeRun({ name: "openclaw-agent", run_type: "chain" });
+    const tracer = makeTracer(rootRun);
+    const sessionId = "sess-multi";
+
+    await tracer.onAgentStart(sessionId, { prompt: "multi" });
+
+    // Turn 1
+    await tracer.onLlmInput(sessionId, {
+      runId: "r1",
+      sessionId,
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      prompt: "multi",
+      historyMessages: [],
+      imagesCount: 0,
+    });
+    await tracer.onLlmOutput(sessionId, {
+      runId: "r1",
+      sessionId,
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      assistantTexts: ["turn1"],
+    });
+
+    // Turn 2
+    await tracer.onLlmInput(sessionId, {
+      runId: "r2",
+      sessionId,
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      prompt: "multi",
+      historyMessages: [],
+      imagesCount: 0,
+    });
+    await tracer.onLlmOutput(sessionId, {
+      runId: "r2",
+      sessionId,
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      assistantTexts: ["turn2"],
+    });
+
+    await tracer.onAgentEnd(sessionId, { messages: [], success: true });
+
+    // Two separate child LLM runs created under the root
+    expect(rootRun.createChild).toHaveBeenCalledTimes(2);
+    expect(rootRun.children).toHaveLength(2);
+    expect(tracer.activeSessionCount).toBe(0);
+  });
+
+  // ── test 5: error resilience ──────────────────────────────────────────────
+  it("error in postRun is caught and logged — does not throw", async () => {
+    const rootRun = makeFakeRun();
+    rootRun.postRun.mockRejectedValue(new Error("network error"));
+    const tracer = makeTracer(rootRun);
+
+    await expect(tracer.onAgentStart("sess-err", { prompt: "fail" })).resolves.toBeUndefined();
+    expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("onAgentStart failed"));
+  });
+
+  // ── test 5b: unknown session is a no-op ──────────────────────────────────
+  it("hooks for unknown sessionId are silently ignored", async () => {
+    const rootRun = makeFakeRun();
+    const tracer = makeTracer(rootRun);
+
+    // Never called onAgentStart — session does not exist
+    await tracer.onLlmInput("ghost-session", {
+      runId: "r",
+      sessionId: "ghost-session",
+      provider: "x",
+      model: "y",
+      prompt: "z",
+      historyMessages: [],
+      imagesCount: 0,
+    });
+    expect(rootRun.createChild).not.toHaveBeenCalled();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  // ── test: after_tool_call with no matching start ───────────────────────────
+  it("after_tool_call with no pending tool run is a no-op", async () => {
+    const rootRun = makeFakeRun();
+    const tracer = makeTracer(rootRun);
+
+    await tracer.onAgentStart("sess-notool", { prompt: "p" });
+    await tracer.onAfterToolCall("sess-notool", {
+      toolName: "bash",
+      params: {},
+      result: "out",
+    });
+    // No tool was started, so nothing should be patched
+    expect(rootRun.patchRun).not.toHaveBeenCalled();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  // ── test: failed agent run sets error on root run ────────────────────────
+  it("agent_end with success=false sets error on root run", async () => {
+    const rootRun = makeFakeRun();
+    const tracer = makeTracer(rootRun);
+
+    await tracer.onAgentStart("sess-fail", { prompt: "p" });
+    await tracer.onAgentEnd("sess-fail", {
+      messages: [],
+      success: false,
+      error: "timeout",
+    });
+    expect(rootRun.end).toHaveBeenCalledWith(undefined, "timeout");
+    expect(tracer.activeSessionCount).toBe(0);
+  });
+});
+
+// ── config unit tests ─────────────────────────────────────────────────────────
+
+describe("config", () => {
+  // Save and restore env around each test.
+  let savedApiKey: string | undefined;
+  let savedProject: string | undefined;
+  let savedEndpoint: string | undefined;
+
+  beforeEach(() => {
+    savedApiKey = process.env["LANGSMITH_API_KEY"];
+    savedProject = process.env["LANGSMITH_PROJECT"];
+    savedEndpoint = process.env["LANGSMITH_ENDPOINT"];
+    delete process.env["LANGSMITH_API_KEY"];
+    delete process.env["LANGSMITH_PROJECT"];
+    delete process.env["LANGSMITH_ENDPOINT"];
+  });
+
+  afterEach(() => {
+    if (savedApiKey !== undefined) process.env["LANGSMITH_API_KEY"] = savedApiKey;
+    else delete process.env["LANGSMITH_API_KEY"];
+    if (savedProject !== undefined) process.env["LANGSMITH_PROJECT"] = savedProject;
+    else delete process.env["LANGSMITH_PROJECT"];
+    if (savedEndpoint !== undefined) process.env["LANGSMITH_ENDPOINT"] = savedEndpoint;
+    else delete process.env["LANGSMITH_ENDPOINT"];
+  });
+
+  // ── test 6a ───────────────────────────────────────────────────────────────
+  it("isEnabled returns false when LANGSMITH_API_KEY is absent", async () => {
+    const { isEnabled } = await import("./src/config.js");
+    expect(isEnabled()).toBe(false);
+  });
+
+  it("isEnabled returns true when LANGSMITH_API_KEY is set", async () => {
+    process.env["LANGSMITH_API_KEY"] = "ls__test";
+    const { isEnabled } = await import("./src/config.js");
+    expect(isEnabled()).toBe(true);
+  });
+
+  it("isEnabled returns true when apiKey is in pluginConfig", async () => {
+    const { isEnabled } = await import("./src/config.js");
+    expect(isEnabled({ apiKey: "ls__fromconfig" })).toBe(true);
+  });
+
+  // ── test 6b ───────────────────────────────────────────────────────────────
+  it("resolveConfig uses defaults when env vars are absent", async () => {
+    const { resolveConfig } = await import("./src/config.js");
+    const cfg = resolveConfig();
+    expect(cfg.project).toBe("openclaw-agent-runs");
+    expect(cfg.endpoint).toBe("https://api.smith.langchain.com");
+    expect(cfg.apiKey).toBe("");
+  });
+
+  it("resolveConfig respects LANGSMITH_PROJECT env var", async () => {
+    process.env["LANGSMITH_PROJECT"] = "my-project";
+    const { resolveConfig } = await import("./src/config.js");
+    const cfg = resolveConfig();
+    expect(cfg.project).toBe("my-project");
+  });
+
+  it("resolveConfig prefers env var over pluginConfig", async () => {
+    process.env["LANGSMITH_PROJECT"] = "from-env";
+    const { resolveConfig } = await import("./src/config.js");
+    const cfg = resolveConfig({ project: "from-config" });
+    expect(cfg.project).toBe("from-env");
+  });
+});
+
+// ── plugin registration tests ─────────────────────────────────────────────────
+
+describe("plugin registration", () => {
+  let savedApiKey: string | undefined;
+
+  beforeEach(() => {
+    savedApiKey = process.env["LANGSMITH_API_KEY"];
+    delete process.env["LANGSMITH_API_KEY"];
+  });
+
+  afterEach(() => {
+    if (savedApiKey !== undefined) process.env["LANGSMITH_API_KEY"] = savedApiKey;
+    else delete process.env["LANGSMITH_API_KEY"];
+  });
+
+  function makeMockApi(pluginConfig?: Record<string, unknown>) {
+    return {
+      pluginConfig,
+      logger: { info: vi.fn(), warn: vi.fn() },
+      on: vi.fn(),
+    };
+  }
+
+  // ── test 1: no-op without API key ─────────────────────────────────────────
+  it("does not register hooks when LANGSMITH_API_KEY is absent", async () => {
+    const { default: plugin } = await import("./index.js");
+    const api = makeMockApi();
+    plugin.register(api as unknown as import("openclaw/plugin-sdk").OpenClawPluginApi);
+    expect(api.on).not.toHaveBeenCalled();
+    expect(api.logger.info).toHaveBeenCalledWith(expect.stringContaining("disabled"));
+  });
+});
+
+// ── live test (test 7) ────────────────────────────────────────────────────────
+
+const liveEnabled =
+  Boolean(process.env["LANGSMITH_API_KEY"]) && process.env["OPENCLAW_LIVE_TEST"] === "1";
+const describeLive = liveEnabled ? describe : describe.skip;
+
+describeLive("live: full round-trip to LangSmith", () => {
+  it("agent turn produces a readable trace in LangSmith", async () => {
+    const { buildClient, resolveConfig } = await import("./src/config.js");
+    const { LangSmithTracer } = await import("./src/tracer.js");
+
+    const cfg = resolveConfig();
+    const client = buildClient(cfg);
+    const tracer = new LangSmithTracer({
+      client,
+      projectName: cfg.project,
+      logger: { warn: console.warn, info: console.info },
+    });
+
+    const sessionId = `live-test-${Date.now()}`;
+
+    await tracer.onAgentStart(sessionId, { prompt: "live test prompt" });
+    await tracer.onLlmInput(sessionId, {
+      runId: sessionId,
+      sessionId,
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      prompt: "live test prompt",
+      historyMessages: [{ role: "user", content: "live test prompt" }],
+      imagesCount: 0,
+    });
+    await tracer.onBeforeToolCall(sessionId, {
+      toolName: "bash",
+      params: { command: "echo hello" },
+    });
+    await tracer.onAfterToolCall(sessionId, {
+      toolName: "bash",
+      params: { command: "echo hello" },
+      result: "hello\n",
+      durationMs: 42,
+    });
+    await tracer.onLlmOutput(sessionId, {
+      runId: sessionId,
+      sessionId,
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      assistantTexts: ["The command output was: hello"],
+      usage: { input: 50, output: 10, total: 60 },
+    });
+    await tracer.onAgentEnd(sessionId, { messages: [], success: true, durationMs: 500 });
+
+    expect(tracer.activeSessionCount).toBe(0);
+    console.info(`Live test done — check project "${cfg.project}" in LangSmith`);
+  });
+});

--- a/extensions/langsmith-tracer/index.ts
+++ b/extensions/langsmith-tracer/index.ts
@@ -1,0 +1,110 @@
+/**
+ * LangSmith Tracer — OpenClaw fork extension.
+ *
+ * Traces every agent turn to LangSmith using the OpenClaw plugin hook system.
+ * No core files are modified; this extension is entirely additive.
+ *
+ * ## Quick enable
+ *
+ *   export LANGSMITH_API_KEY=ls__...
+ *   export LANGSMITH_PROJECT=openclaw          # optional, default: "default"
+ *   export LANGSMITH_TRACING_V2=true           # required by LangSmith
+ *
+ * Then add to your openclaw.yml:
+ *
+ *   plugins:
+ *     entries:
+ *       langsmith-tracer:
+ *         enabled: true
+ *
+ * ## Architecture
+ *
+ * See extensions/langsmith-tracer/src/tracer.ts for the RunTree state machine
+ * and extensions/langsmith-tracer/README.md for the full reference.
+ *
+ * ## Correlation key
+ *
+ * Agent hooks (before_agent_start, llm_input, llm_output, agent_end) carry
+ * PluginHookAgentContext with sessionId + agentId.
+ * Tool hooks (before_tool_call, after_tool_call) carry PluginHookToolContext
+ * with agentId only (no sessionId). We use agentId as the primary key so tool
+ * events can be correlated to their parent agent session.
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { buildClient, isEnabled, resolveConfig } from "./src/config.js";
+import { LangSmithTracer } from "./src/tracer.js";
+
+export default {
+  id: "langsmith-tracer",
+  name: "LangSmith Tracer",
+  description:
+    "Traces OpenClaw agent runs (LLM calls, tool calls, token usage) to LangSmith. " +
+    "Enable by setting LANGSMITH_API_KEY. No-op when the key is absent.",
+
+  register(api: OpenClawPluginApi) {
+    const pluginCfg = api.pluginConfig as Record<string, unknown> | undefined;
+
+    if (!isEnabled(pluginCfg)) {
+      api.logger.info(
+        "langsmith-tracer: LANGSMITH_API_KEY not set — tracing disabled (set the env var to enable)",
+      );
+      return;
+    }
+
+    const cfg = resolveConfig(pluginCfg);
+    const client = buildClient(cfg);
+    const tracer = new LangSmithTracer({
+      client,
+      projectName: cfg.project,
+      logger: api.logger,
+    });
+
+    api.logger.info(
+      `langsmith-tracer: tracing enabled → project "${cfg.project}" at ${cfg.endpoint}`,
+    );
+
+    // ── before_agent_start ──────────────────────────────────────────────────
+    // Creates the root "chain" run for the full agent turn.
+    // Correlation key: agentId (stable across agent + tool hooks).
+    api.on("before_agent_start", async (event, ctx) => {
+      const key = ctx.agentId ?? ctx.sessionId ?? "unknown";
+      await tracer.onAgentStart(key, event);
+    });
+
+    // ── llm_input ───────────────────────────────────────────────────────────
+    // Creates a child "llm" run for each LLM API call within the turn.
+    api.on("llm_input", async (event, ctx) => {
+      const key = ctx.agentId ?? event.sessionId ?? "unknown";
+      await tracer.onLlmInput(key, event);
+    });
+
+    // ── before_tool_call ────────────────────────────────────────────────────
+    // Creates a grandchild "tool" run under the current LLM run.
+    api.on("before_tool_call", async (event, ctx) => {
+      const key = ctx.agentId ?? "unknown";
+      await tracer.onBeforeToolCall(key, event);
+    });
+
+    // ── after_tool_call ─────────────────────────────────────────────────────
+    // Closes the tool run with its result or error.
+    api.on("after_tool_call", async (event, ctx) => {
+      const key = ctx.agentId ?? "unknown";
+      await tracer.onAfterToolCall(key, event);
+    });
+
+    // ── llm_output ──────────────────────────────────────────────────────────
+    // Closes the LLM run with texts + token usage.
+    api.on("llm_output", async (event, ctx) => {
+      const key = ctx.agentId ?? event.sessionId ?? "unknown";
+      await tracer.onLlmOutput(key, event);
+    });
+
+    // ── agent_end ───────────────────────────────────────────────────────────
+    // Closes the root run and removes the session from the state map.
+    api.on("agent_end", async (event, ctx) => {
+      const key = ctx.agentId ?? ctx.sessionId ?? "unknown";
+      await tracer.onAgentEnd(key, event);
+    });
+  },
+};

--- a/extensions/langsmith-tracer/package.json
+++ b/extensions/langsmith-tracer/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@openclaw/langsmith-tracer",
+  "version": "2026.3.2",
+  "private": true,
+  "description": "LangSmith tracing extension for the OpenClaw agent loop (fork-specific observability)",
+  "type": "module",
+  "dependencies": {
+    "langsmith": "^0.5.7"
+  },
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/langsmith-tracer/src/config.ts
+++ b/extensions/langsmith-tracer/src/config.ts
@@ -1,0 +1,60 @@
+import { Client } from "langsmith";
+
+/**
+ * Configuration for the LangSmith tracer extension.
+ *
+ * All values can be set via env vars (standard LangSmith convention) or via
+ * the openclaw.yml plugin config block:
+ *
+ *   plugins:
+ *     entries:
+ *       langsmith-tracer:
+ *         enabled: true
+ *         config:
+ *           project: "my-project"
+ *
+ * Env vars take precedence over plugin config.
+ */
+export type LangSmithConfig = {
+  apiKey: string;
+  project: string;
+  endpoint: string;
+};
+
+/**
+ * Returns true when the LANGSMITH_API_KEY env var is set (or apiKey provided
+ * in plugin config). When false the plugin registers no-op hooks.
+ */
+export function isEnabled(pluginConfig?: Record<string, unknown>): boolean {
+  return Boolean(process.env.LANGSMITH_API_KEY ?? (pluginConfig?.["apiKey"] as string | undefined));
+}
+
+/**
+ * Resolves the effective LangSmith config from env + plugin config.
+ * Plugin config keys: apiKey, project, endpoint.
+ */
+export function resolveConfig(pluginConfig?: Record<string, unknown>): LangSmithConfig {
+  const apiKey =
+    process.env.LANGSMITH_API_KEY ?? (pluginConfig?.["apiKey"] as string | undefined) ?? "";
+  const project =
+    process.env.LANGSMITH_PROJECT ??
+    (pluginConfig?.["project"] as string | undefined) ??
+    "openclaw-agent-runs";
+  const endpoint =
+    process.env.LANGSMITH_ENDPOINT ??
+    (pluginConfig?.["endpoint"] as string | undefined) ??
+    "https://api.smith.langchain.com";
+
+  return { apiKey, project, endpoint };
+}
+
+/**
+ * Creates an authenticated LangSmith Client.
+ * Call only after isEnabled() returns true.
+ */
+export function buildClient(cfg: LangSmithConfig): Client {
+  return new Client({
+    apiKey: cfg.apiKey,
+    apiUrl: cfg.endpoint,
+  });
+}

--- a/extensions/langsmith-tracer/src/tracer.ts
+++ b/extensions/langsmith-tracer/src/tracer.ts
@@ -1,0 +1,302 @@
+/**
+ * LangSmithTracer — RunTree state machine for the OpenClaw agent loop.
+ *
+ * ## Trace hierarchy
+ *
+ * Each agent turn (one user message → one reply) produces this structure:
+ *
+ *   openclaw-agent  [chain]          ← before_agent_start … agent_end
+ *     anthropic/claude-…  [llm]      ← llm_input … llm_output (turn 1)
+ *       bash  [tool]                 ← before_tool_call … after_tool_call
+ *       read_file  [tool]
+ *     anthropic/claude-…  [llm]      ← llm_input … llm_output (turn 2)
+ *
+ * ## State machine (per sessionId)
+ *
+ *   ┌─ before_agent_start ─┐  creates rootRun
+ *   │   llm_input           │  creates currentLlmRun as child of rootRun
+ *   │     before_tool_call  │  pushes tool run onto pendingToolStack
+ *   │     after_tool_call   │  pops + closes tool run
+ *   │   llm_output          │  closes currentLlmRun
+ *   │   (repeat for N turns)│
+ *   └─ agent_end ──────────┘  closes rootRun, removes session from map
+ *
+ * ## Error safety
+ *
+ * Every public method catches all errors internally — a LangSmith failure must
+ * never break the agent loop. Errors are logged to the provided logger.
+ */
+
+import { RunTree } from "langsmith";
+import type { Client } from "langsmith";
+
+// Hook event types (mirrors src/plugins/types.ts, inlined to avoid core imports)
+export type LlmInputEvent = {
+  runId: string;
+  sessionId: string;
+  provider: string;
+  model: string;
+  systemPrompt?: string;
+  prompt: string;
+  historyMessages: unknown[];
+  imagesCount: number;
+};
+
+export type LlmOutputEvent = {
+  runId: string;
+  sessionId: string;
+  provider: string;
+  model: string;
+  assistantTexts: string[];
+  lastAssistant?: unknown;
+  usage?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+    total?: number;
+  };
+};
+
+export type AgentStartEvent = {
+  prompt: string;
+  messages?: unknown[];
+};
+
+export type AgentEndEvent = {
+  messages: unknown[];
+  success: boolean;
+  error?: string;
+  durationMs?: number;
+};
+
+export type BeforeToolCallEvent = {
+  toolName: string;
+  params: Record<string, unknown>;
+};
+
+export type AfterToolCallEvent = {
+  toolName: string;
+  params: Record<string, unknown>;
+  result?: unknown;
+  error?: string;
+  durationMs?: number;
+};
+
+type SessionTrace = {
+  rootRun: RunNode;
+  /** The LLM call currently in progress; null between turns. */
+  currentLlmRun: RunNode | null;
+  /**
+   * Stack of tool RunNodes. Pushed on before_tool_call, popped on
+   * after_tool_call. Depth is almost always ≤ 1; a stack handles edge cases
+   * where two tools could theoretically overlap.
+   */
+  pendingToolStack: RunNode[];
+};
+
+export type TracerLogger = {
+  warn: (msg: string) => void;
+  info?: (msg: string) => void;
+};
+
+/** Minimal interface for a run node — matches RunTree's used methods. */
+export interface RunNode {
+  postRun(): Promise<void>;
+  createChild(cfg: Record<string, unknown>): RunNode;
+  end(outputs?: Record<string, unknown>, error?: string): Promise<void>;
+  patchRun(): Promise<void>;
+}
+
+/** Factory that creates root RunNodes. Injected so tests can supply fakes. */
+export type RunNodeFactory = (cfg: Record<string, unknown>) => RunNode;
+
+export class LangSmithTracer {
+  private readonly projectName: string;
+  private readonly logger: TracerLogger;
+  private readonly createRootRun: RunNodeFactory;
+  /** Active traces indexed by sessionId. */
+  private readonly sessions = new Map<string, SessionTrace>();
+
+  constructor(opts: {
+    client: Client;
+    projectName: string;
+    logger: TracerLogger;
+    /** Override for testing — defaults to `new RunTree(cfg)`. */
+    _runNodeFactory?: RunNodeFactory;
+  }) {
+    this.projectName = opts.projectName;
+    this.logger = opts.logger;
+    this.createRootRun =
+      opts._runNodeFactory ??
+      ((cfg) =>
+        new RunTree({
+          ...(cfg as Parameters<typeof RunTree>[0]),
+          client: opts.client,
+        }));
+  }
+
+  // ── before_agent_start ────────────────────────────────────────────────────
+
+  async onAgentStart(sessionId: string, event: AgentStartEvent): Promise<void> {
+    try {
+      // Close any leaked session from a previous run on the same session slot.
+      if (this.sessions.has(sessionId)) {
+        this.logger.warn(
+          `langsmith-tracer: session ${sessionId} already active — closing stale trace`,
+        );
+        await this._closeSession(sessionId, false, "replaced by new agent start");
+      }
+
+      const rootRun = this.createRootRun({
+        name: "openclaw-agent",
+        run_type: "chain",
+        project_name: this.projectName,
+        inputs: { prompt: event.prompt },
+      });
+      await rootRun.postRun();
+
+      this.sessions.set(sessionId, {
+        rootRun,
+        currentLlmRun: null,
+        pendingToolStack: [],
+      });
+    } catch (err) {
+      this.logger.warn(`langsmith-tracer: onAgentStart failed: ${String(err)}`);
+    }
+  }
+
+  // ── llm_input ─────────────────────────────────────────────────────────────
+
+  async onLlmInput(sessionId: string, event: LlmInputEvent): Promise<void> {
+    try {
+      const session = this.sessions.get(sessionId);
+      if (!session) return; // tracing not started for this session
+
+      const parent = session.currentLlmRun ?? session.rootRun;
+      const llmRun = parent.createChild({
+        name: `${event.provider}/${event.model}`,
+        run_type: "llm",
+        inputs: {
+          system: event.systemPrompt ?? "",
+          messages: event.historyMessages,
+          images_count: event.imagesCount,
+        },
+      });
+      await llmRun.postRun();
+
+      session.currentLlmRun = llmRun;
+    } catch (err) {
+      this.logger.warn(`langsmith-tracer: onLlmInput failed: ${String(err)}`);
+    }
+  }
+
+  // ── before_tool_call ──────────────────────────────────────────────────────
+
+  async onBeforeToolCall(sessionId: string, event: BeforeToolCallEvent): Promise<void> {
+    try {
+      const session = this.sessions.get(sessionId);
+      if (!session) return;
+
+      // Tools are children of the LLM run that requested them; fall back to
+      // root if there is no active LLM run (shouldn't happen in normal flow).
+      const parent = session.currentLlmRun ?? session.rootRun;
+      const toolRun = parent.createChild({
+        name: event.toolName,
+        run_type: "tool",
+        inputs: event.params,
+      });
+      await toolRun.postRun();
+
+      session.pendingToolStack.push(toolRun);
+    } catch (err) {
+      this.logger.warn(`langsmith-tracer: onBeforeToolCall failed: ${String(err)}`);
+    }
+  }
+
+  // ── after_tool_call ───────────────────────────────────────────────────────
+
+  async onAfterToolCall(sessionId: string, event: AfterToolCallEvent): Promise<void> {
+    try {
+      const session = this.sessions.get(sessionId);
+      if (!session) return;
+
+      const toolRun = session.pendingToolStack.pop();
+      if (!toolRun) return; // no matching start (shouldn't happen)
+
+      await toolRun.end(event.error ? undefined : { output: event.result }, event.error);
+      await toolRun.patchRun();
+    } catch (err) {
+      this.logger.warn(`langsmith-tracer: onAfterToolCall failed: ${String(err)}`);
+    }
+  }
+
+  // ── llm_output ────────────────────────────────────────────────────────────
+
+  async onLlmOutput(sessionId: string, event: LlmOutputEvent): Promise<void> {
+    try {
+      const session = this.sessions.get(sessionId);
+      if (!session?.currentLlmRun) return;
+
+      const llmRun = session.currentLlmRun;
+      session.currentLlmRun = null;
+
+      await llmRun.end({
+        generations: event.assistantTexts,
+        usage: event.usage ?? {},
+      });
+      await llmRun.patchRun();
+    } catch (err) {
+      this.logger.warn(`langsmith-tracer: onLlmOutput failed: ${String(err)}`);
+    }
+  }
+
+  // ── agent_end ─────────────────────────────────────────────────────────────
+
+  async onAgentEnd(sessionId: string, event: AgentEndEvent): Promise<void> {
+    await this._closeSession(sessionId, event.success, event.error);
+  }
+
+  // ── internals ─────────────────────────────────────────────────────────────
+
+  private async _closeSession(sessionId: string, success: boolean, error?: string): Promise<void> {
+    try {
+      const session = this.sessions.get(sessionId);
+      if (!session) return;
+      this.sessions.delete(sessionId);
+
+      // Close any dangling tool runs.
+      for (const toolRun of session.pendingToolStack.reverse()) {
+        try {
+          await toolRun.end(undefined, "agent ended with tool still pending");
+          await toolRun.patchRun();
+        } catch {
+          // best-effort
+        }
+      }
+
+      // Close dangling LLM run.
+      if (session.currentLlmRun) {
+        try {
+          await session.currentLlmRun.end(undefined, "agent ended with LLM call still pending");
+          await session.currentLlmRun.patchRun();
+        } catch {
+          // best-effort
+        }
+      }
+
+      await session.rootRun.end(
+        success ? { success: true } : undefined,
+        success ? undefined : (error ?? "agent run failed"),
+      );
+      await session.rootRun.patchRun();
+    } catch (err) {
+      this.logger.warn(`langsmith-tracer: _closeSession failed: ${String(err)}`);
+    }
+  }
+
+  /** Returns the number of active sessions (for testing). */
+  get activeSessionCount(): number {
+    return this.sessions.size;
+  }
+}

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -14,7 +14,7 @@ export type ModelRef = {
   model: string;
 };
 
-export type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
+export type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive" | "auto";
 
 export type ModelAliasIndex = {
   byAlias: Map<string, { alias: string; ref: ModelRef }>;
@@ -520,6 +520,18 @@ export function resolveAllowedModelRef(params: {
   return { ref: resolved.ref, key: status.key };
 }
 
+/**
+ * Pass-through routing models that don't perform reasoning themselves — they
+ * forward the request to a downstream model chosen at runtime.  We must NOT
+ * auto-promote thinking for these: the downstream model decides its own
+ * reasoning budget, and forcing reasoning_effort on the router causes it to
+ * pick reasoning-capable models even for trivial queries.
+ *
+ * When thinkingDefault is explicitly configured, that value is used as-is
+ * (e.g. "auto" → OpenRouter applies per-query complexity routing).
+ */
+const PASSTHROUGH_ROUTER_MODELS = new Set(["openrouter/auto"]);
+
 export function resolveThinkingDefault(params: {
   cfg: OpenClawConfig;
   provider: string;
@@ -557,7 +569,10 @@ export function resolveThinkingDefault(params: {
   const candidate = params.catalog?.find(
     (entry) => entry.provider === params.provider && entry.id === params.model,
   );
-  if (candidate?.reasoning) {
+  // Don't auto-promote thinking for pass-through routing models.
+  // These models route to a downstream model; forcing reasoning_effort here
+  // overrides the router's own complexity-based model selection.
+  if (candidate?.reasoning && !PASSTHROUGH_ROUTER_MODELS.has(params.model)) {
     return "low";
   }
   return "off";

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -1,9 +1,9 @@
 import type { OpenClawConfig } from "../config/config.js";
-import type { ModelCatalogEntry } from "./model-catalog.js";
 import { resolveAgentModelPrimaryValue, toAgentModelListLike } from "../config/model-input.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveAgentConfig, resolveAgentEffectiveModelPrimary } from "./agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
+import type { ModelCatalogEntry } from "./model-catalog.js";
 import { splitTrailingAuthProfile } from "./model-ref-profile.js";
 import { normalizeGoogleModelId } from "./models-config.providers.js";
 

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -1,9 +1,9 @@
 import type { OpenClawConfig } from "../config/config.js";
+import type { ModelCatalogEntry } from "./model-catalog.js";
 import { resolveAgentModelPrimaryValue, toAgentModelListLike } from "../config/model-input.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveAgentConfig, resolveAgentEffectiveModelPrimary } from "./agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "./defaults.js";
-import type { ModelCatalogEntry } from "./model-catalog.js";
 import { splitTrailingAuthProfile } from "./model-ref-profile.js";
 import { normalizeGoogleModelId } from "./models-config.providers.js";
 
@@ -14,7 +14,15 @@ export type ModelRef = {
   model: string;
 };
 
-export type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive" | "auto";
+export type ThinkLevel =
+  | "off"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "adaptive"
+  | "auto";
 
 export type ModelAliasIndex = {
   byAlias: Map<string, { alias: string; ref: ModelRef }>;
@@ -550,7 +558,8 @@ export function resolveThinkingDefault(params: {
     perModelThinking === "medium" ||
     perModelThinking === "high" ||
     perModelThinking === "xhigh" ||
-    perModelThinking === "adaptive"
+    perModelThinking === "adaptive" ||
+    perModelThinking === "auto"
   ) {
     return perModelThinking;
   }
@@ -572,7 +581,10 @@ export function resolveThinkingDefault(params: {
   // Don't auto-promote thinking for pass-through routing models.
   // These models route to a downstream model; forcing reasoning_effort here
   // overrides the router's own complexity-based model selection.
-  if (candidate?.reasoning && !PASSTHROUGH_ROUTER_MODELS.has(params.model)) {
+  if (
+    candidate?.reasoning &&
+    !PASSTHROUGH_ROUTER_MODELS.has(modelKey(params.provider, params.model))
+  ) {
     return "low";
   }
   return "off";

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -518,7 +518,7 @@ function mapThinkingLevelToOpenRouterReasoningEffort(
   if (thinkingLevel === "off") {
     return "none";
   }
-  if (thinkingLevel === "adaptive") {
+  if (thinkingLevel === "adaptive" || thinkingLevel === "auto") {
     return "medium";
   }
   return thinkingLevel;
@@ -587,12 +587,12 @@ function createOpenRouterWrapper(
           // only the nested one is sent.
           delete payloadObj.reasoning_effort;
 
-          // When thinking is "off", do not inject reasoning at all.
-          // Some models (e.g. deepseek/deepseek-r1) require reasoning and reject
-          // { effort: "none" } with "Reasoning is mandatory for this endpoint and
-          // cannot be disabled." Omitting the field lets each model use its own
-          // default reasoning behavior.
-          if (thinkingLevel !== "off") {
+          // When thinking is "off" or "auto", do not inject reasoning at all.
+          // "off": some models (e.g. deepseek/deepseek-r1) require reasoning and
+          //   reject { effort: "none" } — omitting the field respects each model's
+          //   default reasoning behavior.
+          // "auto": let the provider decide; never force an effort level.
+          if (thinkingLevel !== "off" && thinkingLevel !== "auto") {
             const existingReasoning = payloadObj.reasoning;
 
             // OpenRouter treats reasoning.effort and reasoning.max_tokens as

--- a/src/agents/pi-embedded-runner/utils.ts
+++ b/src/agents/pi-embedded-runner/utils.ts
@@ -13,6 +13,11 @@ export function mapThinkingLevel(level?: ThinkLevel): ThinkingLevel {
   if (level === "adaptive") {
     return "medium";
   }
+  // "auto" means let the provider decide — don't force reasoning_effort.
+  // pi-agent-core converts "off" → undefined, which omits reasoning_effort from the API request.
+  if (level === "auto") {
+    return "off";
+  }
   return level;
 }
 

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -179,8 +179,10 @@ export function installSessionToolResultGuard(
       nextMessage = sanitized[0];
     }
     const nextRole = (nextMessage as { role?: unknown }).role;
+    // Accept both "toolResult" (Pi/Anthropic) and "tool" (OpenAI-style) so pending is cleared and we don't insert synthetic.
+    const isToolResult = nextRole === "toolResult" || nextRole === "tool";
 
-    if (nextRole === "toolResult") {
+    if (isToolResult) {
       const id = extractToolResultId(nextMessage as Extract<AgentMessage, { role: "toolResult" }>);
       const toolName = id ? pending.get(id) : undefined;
       if (id) {

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -427,7 +427,9 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
         break;
       }
 
-      if (nextRole === "toolResult") {
+      // Accept both "toolResult" (Pi/Anthropic) and "tool" (OpenAI-style) as tool result messages.
+      const isToolResult = nextRole === "toolResult" || nextRole === "tool";
+      if (isToolResult) {
         const toolResult = next as Extract<AgentMessage, { role: "toolResult" }>;
         const id = extractToolResultId(toolResult);
         if (id && toolCallIds.has(id)) {
@@ -451,7 +453,7 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
       }
 
       // Drop tool results that don't match the current assistant tool calls.
-      if (nextRole !== "toolResult") {
+      if (!isToolResult) {
         remainder.push(next);
       } else {
         droppedOrphanCount += 1;

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -1,4 +1,4 @@
-export type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
+export type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive" | "auto";
 export type VerboseLevel = "off" | "on" | "full";
 export type NoticeLevel = "off" | "on" | "full";
 export type ElevatedLevel = "off" | "on" | "ask" | "full";
@@ -73,6 +73,10 @@ export function normalizeThinkLevel(raw?: string | null): ThinkLevel | undefined
   }
   if (["think"].includes(key)) {
     return "minimal";
+  }
+  // "auto" = let the provider decide; don't force reasoning_effort
+  if (["auto", "automatic"].includes(key)) {
+    return "auto";
   }
   return undefined;
 }

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -1,4 +1,12 @@
-export type ThinkLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive" | "auto";
+export type ThinkLevel =
+  | "off"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh"
+  | "adaptive"
+  | "auto";
 export type VerboseLevel = "off" | "on" | "full";
 export type NoticeLevel = "off" | "on" | "full";
 export type ElevatedLevel = "off" | "on" | "ask" | "full";
@@ -45,7 +53,7 @@ export function normalizeThinkLevel(raw?: string | null): ThinkLevel | undefined
   }
   const key = raw.trim().toLowerCase();
   const collapsed = key.replace(/[\s_-]+/g, "");
-  if (collapsed === "adaptive" || collapsed === "auto") {
+  if (collapsed === "adaptive") {
     return "adaptive";
   }
   if (collapsed === "xhigh" || collapsed === "extrahigh") {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -129,6 +129,7 @@ export const AgentDefaultsSchema = z
         z.literal("high"),
         z.literal("xhigh"),
         z.literal("adaptive"),
+        z.literal("auto"),
       ])
       .optional(),
     verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),


### PR DESCRIPTION
## Problem

`openrouter/auto` has `reasoning: true` in the pi-ai model catalog. This caused `resolveThinkingDefault` to automatically set `thinkLevel: "low"` for every query, which made pi-ai send `reasoning_effort: "low"` to OpenRouter on every request. OpenRouter then routed all queries to a reasoning-focused model whose responses came back primarily as thinking blocks with little/no plain text — causing downstream channels (e.g. Telegram) to receive empty responses.

Additionally, when `openrouter/auto` routes to a tool-using model, tool results come back as `role: "tool"` (OpenAI format), but `session-tool-result-guard.ts` and `session-transcript-repair.ts` only accepted `role: "toolResult"` (Anthropic format), causing session transcript corruption.

## Changes

- `src/agents/model-selection.ts`: Add `PASSTHROUGH_ROUTER_MODELS` set. Skip auto-promotion of `thinkLevel` for pass-through routing models like `openrouter/auto` that choose their own downstream model and reasoning level.
- `src/agents/session-tool-result-guard.ts`: Accept both `"toolResult"` (Anthropic) and `"tool"` (OpenAI) role strings.
- `src/agents/session-transcript-repair.ts`: Same fix as above.
- `src/auto-reply/thinking.ts` + `src/agents/pi-embedded-runner/utils.ts` + `src/config/zod-schema.agent-defaults.ts`: Add `"auto"` as a valid `ThinkLevel`. Semantics: "let the provider decide — don't send `reasoning_effort`." Maps to `"off"` at the pi-agent-core layer so no `reasoning_effort` param is injected.

## Testing

Verified with `openrouter/auto` as the gateway model: Telegram now receives responses, and tool calls round-trip correctly.