### PR TITLE
feat(cli): add sessions wrapup command for main-session rollover

### DIFF
--- a/src/cli/program/register.status-health-sessions.test.ts
+++ b/src/cli/program/register.status-health-sessions.test.ts
@@ -5,6 +5,7 @@ const statusCommand = vi.fn();
 const healthCommand = vi.fn();
 const sessionsCommand = vi.fn();
 const sessionsCleanupCommand = vi.fn();
+const sessionsWrapupCommand = vi.fn();
 const setVerbose = vi.fn();
 
 const runtime = {
@@ -27,6 +28,10 @@ vi.mock("../../commands/sessions.js", () => ({
 
 vi.mock("../../commands/sessions-cleanup.js", () => ({
   sessionsCleanupCommand,
+}));
+
+vi.mock("../../commands/sessions-wrapup.js", () => ({
+  sessionsWrapupCommand,
 }));
 
 vi.mock("../../globals.js", () => ({
@@ -56,6 +61,7 @@ describe("registerStatusHealthSessionsCommands", () => {
     healthCommand.mockResolvedValue(undefined);
     sessionsCommand.mockResolvedValue(undefined);
     sessionsCleanupCommand.mockResolvedValue(undefined);
+    sessionsWrapupCommand.mockResolvedValue(undefined);
   });
 
   it("runs status command with timeout and debug-derived verbose", async () => {
@@ -198,6 +204,30 @@ describe("registerStatusHealthSessionsCommands", () => {
     expect(sessionsCleanupCommand).toHaveBeenCalledWith(
       expect.objectContaining({
         allAgents: true,
+      }),
+      runtime,
+    );
+  });
+
+  it("runs sessions wrapup subcommand with forwarded options", async () => {
+    await runCli([
+      "sessions",
+      "wrapup",
+      "--agent",
+      "main",
+      "--summary",
+      "handoff summary",
+      "--timeout",
+      "15",
+      "--json",
+    ]);
+
+    expect(sessionsWrapupCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: "main",
+        summary: "handoff summary",
+        timeout: "15",
+        json: true,
       }),
       runtime,
     );

--- a/src/cli/program/register.status-health-sessions.ts
+++ b/src/cli/program/register.status-health-sessions.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { healthCommand } from "../../commands/health.js";
 import { sessionsCleanupCommand } from "../../commands/sessions-cleanup.js";
+import { sessionsWrapupCommand } from "../../commands/sessions-wrapup.js";
 import { sessionsCommand } from "../../commands/sessions.js";
 import { statusCommand } from "../../commands/status.js";
 import { setVerbose } from "../../globals.js";
@@ -154,6 +155,45 @@ export function registerStatusHealthSessionsCommands(program: Command) {
       );
     });
   sessionsCmd.enablePositionalOptions();
+
+  sessionsCmd
+    .command("wrapup")
+    .description(
+      "End an agent's current main session and seed the next session with a summary prompt",
+    )
+    .requiredOption("--summary <text>", "Summary/prompt to inject into the next session")
+    .option("--agent <id>", "Agent id to wrap up (default: configured default agent)")
+    .option("--timeout <seconds>", "Gateway wait timeout in seconds")
+    .option("--json", "Output JSON", false)
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.heading("Examples:")}\n${formatHelpExamples([
+          [
+            'openclaw sessions wrapup --agent main --summary "Summarize pending tasks and continue."',
+            "Roll over main session and start next session with a summary prompt.",
+          ],
+        ])}`,
+    )
+    .action(async (opts, command) => {
+      const parentOpts = command.parent?.opts() as
+        | {
+            agent?: string;
+            json?: boolean;
+          }
+        | undefined;
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        await sessionsWrapupCommand(
+          {
+            agent: (opts.agent as string | undefined) ?? parentOpts?.agent,
+            summary: opts.summary as string | undefined,
+            timeout: opts.timeout as string | undefined,
+            json: Boolean(opts.json || parentOpts?.json),
+          },
+          defaultRuntime,
+        );
+      });
+    });
 
   sessionsCmd
     .command("cleanup")

--- a/src/commands/sessions-wrapup.test.ts
+++ b/src/commands/sessions-wrapup.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  resolveDefaultAgentId: vi.fn(() => "main"),
+  agentViaGatewayCommand: vi.fn(),
+}));
+
+vi.mock("../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: mocks.resolveDefaultAgentId,
+}));
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({})),
+}));
+
+vi.mock("./agent-via-gateway.js", () => ({
+  agentViaGatewayCommand: mocks.agentViaGatewayCommand,
+}));
+
+import { sessionsWrapupCommand } from "./sessions-wrapup.js";
+
+function makeRuntime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn((code: number) => {
+      throw new Error(`exit ${code}`);
+    }),
+  };
+}
+
+describe("sessionsWrapupCommand", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.agentViaGatewayCommand.mockResolvedValue(undefined);
+  });
+
+  it("sends /new summary to gateway for the selected agent", async () => {
+    const runtime = makeRuntime();
+
+    await sessionsWrapupCommand(
+      {
+        agent: "main",
+        summary: "carry over this context",
+        timeout: "30",
+        json: true,
+      },
+      runtime,
+    );
+
+    expect(mocks.agentViaGatewayCommand).toHaveBeenCalledWith(
+      {
+        agent: "main",
+        message: "/new carry over this context",
+        json: true,
+        timeout: "30",
+      },
+      runtime,
+    );
+  });
+
+  it("uses default agent when --agent is omitted", async () => {
+    const runtime = makeRuntime();
+
+    await sessionsWrapupCommand({ summary: "hello" }, runtime);
+
+    expect(mocks.resolveDefaultAgentId).toHaveBeenCalled();
+    expect(mocks.agentViaGatewayCommand).toHaveBeenCalledWith(
+      {
+        agent: "main",
+        message: "/new hello",
+        json: false,
+        timeout: undefined,
+      },
+      runtime,
+    );
+  });
+
+  it("requires --summary", async () => {
+    const runtime = makeRuntime();
+
+    await expect(sessionsWrapupCommand({ summary: "  " }, runtime)).rejects.toThrow("exit 1");
+    expect(runtime.error).toHaveBeenCalledWith("--summary is required");
+    expect(mocks.agentViaGatewayCommand).not.toHaveBeenCalled();
+  });
+});

--- a/src/commands/sessions-wrapup.ts
+++ b/src/commands/sessions-wrapup.ts
@@ -1,0 +1,29 @@
+import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { loadConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
+import { agentViaGatewayCommand } from "./agent-via-gateway.js";
+
+export async function sessionsWrapupCommand(
+  opts: { agent?: string; summary?: string; json?: boolean; timeout?: string },
+  runtime: RuntimeEnv,
+) {
+  const summary = opts.summary?.trim() ?? "";
+  if (!summary) {
+    runtime.error("--summary is required");
+    runtime.exit(1);
+    return;
+  }
+
+  const cfg = loadConfig();
+  const agent = opts.agent?.trim() || resolveDefaultAgentId(cfg);
+
+  await agentViaGatewayCommand(
+    {
+      agent,
+      message: `/new ${summary}`,
+      json: Boolean(opts.json),
+      timeout: opts.timeout,
+    },
+    runtime,
+  );
+}


### PR DESCRIPTION
## Summary
This PR introduces a new CLI subcommand:

- `openclaw sessions wrapup --summary "..." [--agent <id>] [--timeout <seconds>] [--json]`

The command is designed for end-of-session handoff. It ends the current main conversation session for an agent and immediately seeds the next session with a user-provided summary/prompt.
By adding this feature, it allows agent itself to end the session in a ergonomic way, with a summary send to the new session. Useful when you need to automation the process of refreshing session, when you reach a milestone or ready to do something that requires fresh context but still need some conclusion from last session.

## Capability
- **Session rollover in one command**: avoids manually starting a new session and retyping context.
- **Summary injection into the next session**: the provided `--summary` text is carried into the first turn of the new session.
- **Agent targeting**: supports explicit `--agent`, otherwise falls back to configured default agent.
- **CLI-friendly output/timeout**: supports `--json` and `--timeout` passthrough.

## Architecture / Flow
1. `sessions wrapup` is registered under the existing `sessions` command tree.
2. Registration layer forwards normalized options to a dedicated command handler.
3. The handler validates `--summary` and resolves the effective agent id.
4. It reuses the existing gateway path by dispatching:
   - `message: /new <summary>`
   through `agentViaGatewayCommand(...)`.
5. Existing `/new` semantics remain the single source of truth for session reset behavior.

This keeps the change small and composable: no new session protocol is introduced; it is an ergonomic CLI wrapper over established agent command semantics.

## Code Architecture
- **CLI registration layer**: declares command shape and option parsing in `register.status-health-sessions.ts`.
- **Command handler layer**: encapsulates wrapup execution logic in `sessions-wrapup.ts`.
- **Gateway execution reuse**: delegates to existing `agentViaGatewayCommand` and `/new` path instead of adding a separate lifecycle path.

## Code Changes
### New files
- `src/commands/sessions-wrapup.ts`
  - Adds `sessionsWrapupCommand(...)`.
  - Validates summary, resolves agent (`resolveDefaultAgentId(loadConfig())` fallback), forwards `/new <summary>` to gateway agent command.

- `src/commands/sessions-wrapup.test.ts`
  - Unit tests for command behavior, default-agent resolution, and required-summary validation.

### Updated files
- `src/cli/program/register.status-health-sessions.ts`
  - Registers new `sessions wrapup` subcommand.
  - Adds help text/examples.
  - Forwards options to `sessionsWrapupCommand`.
  - Merges parent/session-level options where needed for robust subcommand option handling.

- `src/cli/program/register.status-health-sessions.test.ts`
  - Adds registration/wiring test coverage for `sessions wrapup` option forwarding.

## Unit Tests
### Added test file
- `src/commands/sessions-wrapup.test.ts`
  - Ensures `/new <summary>` is sent correctly.
  - Ensures default agent is used when `--agent` is omitted.
  - Ensures empty/blank `--summary` is rejected.

### Updated test file
- `src/cli/program/register.status-health-sessions.test.ts`
  - Verifies `sessions wrapup` option forwarding (`agent`, `summary`, `timeout`, `json`) from CLI registration to handler.

### Verified locally
- `CI=1 pnpm vitest src/commands/sessions-wrapup.test.ts src/cli/program/register.status-health-sessions.test.ts --run`
- `npm run build`

## Notes
- The implementation intentionally reuses existing `/new` behavior instead of introducing a parallel reset path.
- This minimizes risk and keeps future session lifecycle behavior centralized.
