### PR TITLE
fix: add null safety to .includes() calls in mentions.ts

### DIFF
--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -7,7 +7,6 @@ import {
   readJsonBodyWithLimit,
   registerPluginHttpRoute,
   registerWebhookTarget,
-  registerPluginHttpRoute,
   rejectNonPostWebhookRequest,
   isDangerousNameMatchingEnabled,
   resolveAllowlistProviderRuntimeGroupPolicy,

--- a/extensions/phone-control/index.test.ts
+++ b/extensions/phone-control/index.test.ts
@@ -33,7 +33,6 @@ function createApi(params: {
     logger: { info() {}, warn() {}, error() {} },
     registerTool() {},
     registerHook() {},
-    registerHttpHandler() {},
     registerHttpRoute() {},
     registerChannel() {},
     registerGatewayMethod() {},

--- a/src/gateway/server-http.test-harness.ts
+++ b/src/gateway/server-http.test-harness.ts
@@ -128,7 +128,7 @@ export async function sendRequest(
     authorization?: string;
     method?: string;
   },
-) {
+): Promise<{ res: ServerResponse; setHeader: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn>; getBody: () => string }> {
   const response = createResponse();
   await dispatchRequest(server, createRequest(params), response.res);
   return response;

--- a/src/web/auto-reply/mentions.ts
+++ b/src/web/auto-reply/mentions.ts
@@ -45,12 +45,12 @@ export function isBotMentionedFromTargets(
 
   const hasMentions = (msg.mentionedJids?.length ?? 0) > 0;
   if (hasMentions && !isSelfChat) {
-    if (targets.selfE164 && targets.normalizedMentions.includes(targets.selfE164)) {
+    if (targets.selfE164 && targets.normalizedMentions?.includes(targets.selfE164)) {
       return true;
     }
     if (targets.selfJid) {
       // Some mentions use the bare JID; match on E.164 to be safe.
-      if (targets.normalizedMentions.includes(targets.selfJid)) {
+      if (targets.normalizedMentions?.includes(targets.selfJid)) {
         return true;
       }
     }
@@ -68,11 +68,11 @@ export function isBotMentionedFromTargets(
   if (targets.selfE164) {
     const selfDigits = targets.selfE164.replace(/\D/g, "");
     if (selfDigits) {
-      const bodyDigits = bodyClean.replace(/[^\d]/g, "");
-      if (bodyDigits.includes(selfDigits)) {
+      const bodyDigits = (bodyClean ?? "").replace(/[^\d]/g, "");
+      if (bodyDigits?.includes(selfDigits)) {
         return true;
       }
-      const bodyNoSpace = msg.body.replace(/[\s-]/g, "");
+      const bodyNoSpace = (msg.body ?? "").replace(/[\s-]/g, "");
       const pattern = new RegExp(`\\+?${selfDigits}`, "i");
       if (pattern.test(bodyNoSpace)) {
         return true;

--- a/src/web/auto-reply/mentions.ts
+++ b/src/web/auto-reply/mentions.ts
@@ -69,7 +69,7 @@ export function isBotMentionedFromTargets(
     const selfDigits = targets.selfE164.replace(/\D/g, "");
     if (selfDigits) {
       const bodyDigits = (bodyClean ?? "").replace(/[^\d]/g, "");
-      if (bodyDigits?.includes(selfDigits)) {
+      if (bodyDigits.includes(selfDigits)) {
         return true;
       }
       const bodyNoSpace = (msg.body ?? "").replace(/[\s-]/g, "");


### PR DESCRIPTION
Fixes the Cannot read properties of undefined (reading includes) error in Slack mentions