### PR TITLE
fix: add "none" tool profile to suppress tool schemas for tool-free agents

### DIFF
--- a/changelog/fragments/pr-30004.md
+++ b/changelog/fragments/pr-30004.md
@@ -1,0 +1,1 @@
+- Add `none` tool profile to disable tool schemas for agents that don't need tools (#30004)

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -56,6 +56,7 @@ import { subscribeEmbeddedPiSession } from "../../pi-embedded-subscribe.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../../pi-project-settings.js";
 import { toClientToolDefinitions } from "../../pi-tool-definition-adapter.js";
 import { createOpenClawCodingTools, resolveToolLoopDetectionConfig } from "../../pi-tools.js";
+import { resolveEffectiveToolPolicy } from "../../pi-tools.policy.js";
 import { resolveSandboxContext } from "../../sandbox.js";
 import { resolveSandboxRuntimeStatus } from "../../sandbox/runtime-status.js";
 import { repairSessionFileIfNeeded } from "../../session-file-repair.js";
@@ -562,48 +563,55 @@ export async function runEmbeddedAttempt(
     });
     // Check if the model supports native image input
     const modelHasVision = params.model.input?.includes("image") ?? false;
-    const toolsRaw = params.disableTools
-      ? []
-      : createOpenClawCodingTools({
-          agentId: sessionAgentId,
-          exec: {
-            ...params.execOverrides,
-            elevated: params.bashElevated,
-          },
-          sandbox,
-          messageProvider: params.messageChannel ?? params.messageProvider,
-          agentAccountId: params.agentAccountId,
-          messageTo: params.messageTo,
-          messageThreadId: params.messageThreadId,
-          groupId: params.groupId,
-          groupChannel: params.groupChannel,
-          groupSpace: params.groupSpace,
-          spawnedBy: params.spawnedBy,
-          senderId: params.senderId,
-          senderName: params.senderName,
-          senderUsername: params.senderUsername,
-          senderE164: params.senderE164,
-          senderIsOwner: params.senderIsOwner,
-          sessionKey: sandboxSessionKey,
-          sessionId: params.sessionId,
-          agentDir,
-          workspaceDir: effectiveWorkspace,
-          config: params.config,
-          abortSignal: runAbortController.signal,
-          modelProvider: params.model.provider,
-          modelId: params.modelId,
-          modelContextWindowTokens: params.model.contextWindow,
-          modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
-          currentChannelId: params.currentChannelId,
-          currentThreadTs: params.currentThreadTs,
-          currentMessageId: params.currentMessageId,
-          replyToMode: params.replyToMode,
-          hasRepliedRef: params.hasRepliedRef,
-          modelHasVision,
-          requireExplicitMessageTarget:
-            params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
-          disableMessageTool: params.disableMessageTool,
-        });
+    const effectiveToolProfile = resolveEffectiveToolPolicy({
+      config: params.config,
+      agentId: sessionAgentId,
+      modelProvider: params.model.provider,
+      modelId: params.modelId,
+    }).profile;
+    const toolsRaw =
+      params.disableTools || effectiveToolProfile === "none"
+        ? []
+        : createOpenClawCodingTools({
+            agentId: sessionAgentId,
+            exec: {
+              ...params.execOverrides,
+              elevated: params.bashElevated,
+            },
+            sandbox,
+            messageProvider: params.messageChannel ?? params.messageProvider,
+            agentAccountId: params.agentAccountId,
+            messageTo: params.messageTo,
+            messageThreadId: params.messageThreadId,
+            groupId: params.groupId,
+            groupChannel: params.groupChannel,
+            groupSpace: params.groupSpace,
+            spawnedBy: params.spawnedBy,
+            senderId: params.senderId,
+            senderName: params.senderName,
+            senderUsername: params.senderUsername,
+            senderE164: params.senderE164,
+            senderIsOwner: params.senderIsOwner,
+            sessionKey: sandboxSessionKey,
+            sessionId: params.sessionId,
+            agentDir,
+            workspaceDir: effectiveWorkspace,
+            config: params.config,
+            abortSignal: runAbortController.signal,
+            modelProvider: params.model.provider,
+            modelId: params.modelId,
+            modelContextWindowTokens: params.model.contextWindow,
+            modelAuthMode: resolveModelAuthMode(params.model.provider, params.config),
+            currentChannelId: params.currentChannelId,
+            currentThreadTs: params.currentThreadTs,
+            currentMessageId: params.currentMessageId,
+            replyToMode: params.replyToMode,
+            hasRepliedRef: params.hasRepliedRef,
+            modelHasVision,
+            requireExplicitMessageTarget:
+              params.requireExplicitMessageTarget ?? isSubagentSessionKey(params.sessionKey),
+            disableMessageTool: params.disableMessageTool,
+          });
     const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider: params.provider });
     const allowedToolNames = collectAllowedToolNames({
       tools,

--- a/src/agents/pi-tools.none-profile.test.ts
+++ b/src/agents/pi-tools.none-profile.test.ts
@@ -1,0 +1,35 @@
+import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import { Type } from "@sinclair/typebox";
+import { describe, expect, it } from "vitest";
+import { filterToolsByPolicy } from "./pi-tools.policy.js";
+import { resolveCoreToolProfilePolicy } from "./tool-catalog.js";
+
+function createStubTool(name: string): AgentTool {
+  return {
+    name,
+    label: name,
+    description: "",
+    parameters: Type.Object({}),
+    execute: async () => ({}) as AgentToolResult<unknown>,
+  };
+}
+
+describe('tool profile "none"', () => {
+  it("resolves to a deny-all policy", () => {
+    const policy = resolveCoreToolProfilePolicy("none");
+    expect(policy).toBeDefined();
+    expect(policy!.deny).toEqual(["*"]);
+  });
+
+  it("filters out all tools when applied", () => {
+    const tools = [
+      createStubTool("read"),
+      createStubTool("write"),
+      createStubTool("exec"),
+      createStubTool("browser"),
+    ];
+    const policy = resolveCoreToolProfilePolicy("none")!;
+    const filtered = filterToolsByPolicy(tools, policy);
+    expect(filtered).toEqual([]);
+  });
+});

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -1,4 +1,4 @@
-export type ToolProfileId = "minimal" | "coding" | "messaging" | "full";
+export type ToolProfileId = "none" | "minimal" | "coding" | "messaging" | "full";
 
 type ToolProfilePolicy = {
   allow?: string[];
@@ -246,6 +246,7 @@ function listCoreToolIdsForProfile(profile: ToolProfileId): string[] {
 }
 
 const CORE_TOOL_PROFILES: Record<ToolProfileId, ToolProfilePolicy> = {
+  none: { deny: ["*"] },
   minimal: {
     allow: listCoreToolIdsForProfile("minimal"),
   },
@@ -278,6 +279,7 @@ function buildCoreToolGroupMap() {
 export const CORE_TOOL_GROUPS = buildCoreToolGroupMap();
 
 export const PROFILE_OPTIONS = [
+  { id: "none", label: "None" },
   { id: "minimal", label: "Minimal" },
   { id: "coding", label: "Coding" },
   { id: "messaging", label: "Messaging" },

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -138,7 +138,7 @@ export type MediaToolsConfig = {
   video?: MediaUnderstandingConfig;
 };
 
-export type ToolProfileId = "minimal" | "coding" | "messaging" | "full";
+export type ToolProfileId = "none" | "minimal" | "coding" | "messaging" | "full";
 
 export type ToolLoopDetectionDetectorConfig = {
   /** Enable warning/blocking for repeated identical calls to the same tool/params. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -331,7 +331,13 @@ export const ToolsWebSchema = z
   .optional();
 
 export const ToolProfileSchema = z
-  .union([z.literal("minimal"), z.literal("coding"), z.literal("messaging"), z.literal("full")])
+  .union([
+    z.literal("none"),
+    z.literal("minimal"),
+    z.literal("coding"),
+    z.literal("messaging"),
+    z.literal("full"),
+  ])
   .optional();
 
 type AllowlistPolicy = {

--- a/src/gateway/protocol/schema/agents-models-skills.ts
+++ b/src/gateway/protocol/schema/agents-models-skills.ts
@@ -219,6 +219,7 @@ export const ToolsCatalogParamsSchema = Type.Object(
 export const ToolCatalogProfileSchema = Type.Object(
   {
     id: Type.Union([
+      Type.Literal("none"),
       Type.Literal("minimal"),
       Type.Literal("coding"),
       Type.Literal("messaging"),

--- a/src/gateway/server-methods/tools-catalog.ts
+++ b/src/gateway/server-methods/tools-catalog.ts
@@ -26,7 +26,7 @@ type ToolCatalogEntry = {
   source: "core" | "plugin";
   pluginId?: string;
   optional?: boolean;
-  defaultProfiles: Array<"minimal" | "coding" | "messaging" | "full">;
+  defaultProfiles: Array<"none" | "minimal" | "coding" | "messaging" | "full">;
 };
 
 type ToolCatalogGroup = {


### PR DESCRIPTION
## Summary

- Adds a `"none"` tool profile (`deny: ["*"]`) so agents can explicitly opt out of tool schemas entirely
- Adds an early-out in the runner to skip tool construction when the effective profile is `"none"`, avoiding unnecessary overhead
- Fixes #30004 where small local models (e.g. 3B params via Ollama) fail because the gateway sends tool/function schemas even when the agent has no tools configured

## Problem

When an agent has no `tools` configured (e.g. a simple heartbeat bot), `createOpenClawCodingTools()` is still called unconditionally, building the full tool set. The tool policy pipeline skips agent-level filtering when `agentTools` is undefined, so all built-in tools are sent to the model. Small local models choke on these schemas.

## Solution

Add a `"none"` tool profile that denies all tools via the existing `deny: ["*"]` pattern (already tested in `pi-tools.policy.test.ts`). Users set `tools: { profile: "none" }` on agents that should be tool-free.

### Changes

| File | Change |
|------|--------|
| `src/config/types.tools.ts` | Add `"none"` to `ToolProfileId` union |
| `src/agents/tool-catalog.ts` | Add `none` profile to `CORE_TOOL_PROFILES` and `PROFILE_OPTIONS` |
| `src/agents/pi-embedded-runner/run/attempt.ts` | Early-out: skip `createOpenClawCodingTools` when profile is `"none"` |
| `src/agents/pi-tools.none-profile.test.ts` | New: tests that `"none"` resolves to deny-all and filters out all tools |
| `changelog/fragments/pr-30004.md` | Changelog entry |

## Test plan

- [x] New test: `"none"` profile resolves to a deny-all policy
- [x] New test: `filterToolsByPolicy` with the `"none"` profile returns empty array
- [x] Existing 46 policy tests still pass
- [x] Full unit test suite (747 files, 6002 tests) passes
- [x] `oxfmt --check` passes on all changed files
- [ ] Manual: configure an agent with `tools: { profile: "none" }` and verify no tool schemas are sent to the model

Closes #30004

Made with [Cursor](https://cursor.com)