### PR TITLE
Agents: add explicit model identity to system prompt

### DIFF
--- a/src/agents/cli-runner.test.ts
+++ b/src/agents/cli-runner.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { runCliAgent } from "./cli-runner.js";
-import { resolveCliNoOutputTimeoutMs } from "./cli-runner/helpers.js";
+import { normalizeCliModel, resolveCliNoOutputTimeoutMs } from "./cli-runner/helpers.js";
 
 const supervisorSpawnMock = vi.fn();
 
@@ -261,5 +261,17 @@ describe("resolveCliNoOutputTimeoutMs", () => {
       useResume: true,
     });
     expect(timeoutMs).toBe(42_000);
+  });
+});
+
+describe("normalizeCliModel", () => {
+  it("resolves aliases to canonical model IDs", () => {
+    const backend = { modelAliases: { default: "claude-sonnet-4-20250514" } } as never;
+    expect(normalizeCliModel("default", backend)).toBe("claude-sonnet-4-20250514");
+  });
+
+  it("returns raw model ID when no alias matches", () => {
+    const backend = { modelAliases: {} } as never;
+    expect(normalizeCliModel("claude-opus-4-20250115", backend)).toBe("claude-opus-4-20250115");
   });
 });

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -76,7 +76,7 @@ export async function runCliAgent(params: {
   const backend = backendResolved.config;
   const modelId = (params.model ?? "default").trim() || "default";
   const normalizedModel = normalizeCliModel(modelId, backend);
-  const modelDisplay = `${params.provider}/${modelId}`;
+  const modelDisplay = `${params.provider}/${normalizedModel || modelId}`;
 
   const extraSystemPrompt = [
     params.extraSystemPrompt?.trim(),

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -559,6 +559,34 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("agent=work");
   });
 
+  it("includes explicit model identity in the prompt when runtimeInfo.model is set", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      runtimeInfo: {
+        host: "host",
+        os: "Linux",
+        arch: "x64",
+        node: "v22",
+        model: "minimax-portal/MiniMax-M2.5",
+      },
+    });
+
+    expect(prompt).toContain("currently powered by minimax-portal/MiniMax-M2.5");
+    expect(prompt).toContain(
+      "When asked what model you are, always answer: minimax-portal/MiniMax-M2.5",
+    );
+  });
+
+  it("uses generic identity line when runtimeInfo.model is not set", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+    });
+
+    expect(prompt).toContain("You are a personal assistant running inside OpenClaw.");
+    expect(prompt).not.toContain("currently powered by");
+    expect(prompt).not.toContain("When asked what model you are");
+  });
+
   it("includes reasoning visibility hint", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -587,6 +587,25 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).not.toContain("When asked what model you are");
   });
 
+  it("includes model identity in promptMode=none when runtimeInfo.model is set", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      promptMode: "none",
+      runtimeInfo: {
+        host: "host",
+        os: "Linux",
+        arch: "x64",
+        node: "v22",
+        model: "minimax-portal/MiniMax-M2.5",
+      },
+    });
+
+    expect(prompt).toContain("currently powered by minimax-portal/MiniMax-M2.5");
+    expect(prompt).toContain(
+      "When asked what model you are, always answer: minimax-portal/MiniMax-M2.5",
+    );
+  });
+
   it("includes reasoning visibility hint", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -414,8 +414,12 @@ export function buildAgentSystemPrompt(params: {
     return "You are a personal assistant running inside OpenClaw.";
   }
 
+  const modelIdentityLine = runtimeInfo?.model
+    ? `You are a personal assistant running inside OpenClaw, currently powered by ${runtimeInfo.model}. When asked what model you are, always answer: ${runtimeInfo.model}.`
+    : "You are a personal assistant running inside OpenClaw.";
+
   const lines = [
-    "You are a personal assistant running inside OpenClaw.",
+    modelIdentityLine,
     "",
     "## Tooling",
     "Tool availability (filtered by policy):",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -409,14 +409,14 @@ export function buildAgentSystemPrompt(params: {
   });
   const workspaceNotes = (params.workspaceNotes ?? []).map((note) => note.trim()).filter(Boolean);
 
-  // For "none" mode, return just the basic identity line
-  if (promptMode === "none") {
-    return "You are a personal assistant running inside OpenClaw.";
-  }
-
   const modelIdentityLine = runtimeInfo?.model
-    ? `You are a personal assistant running inside OpenClaw, currently powered by ${runtimeInfo.model}. When asked what model you are, always answer: ${runtimeInfo.model}.`
+    ? `You are a personal assistant running inside OpenClaw, currently powered by ${sanitizeForPromptLiteral(runtimeInfo.model)}. When asked what model you are, always answer: ${sanitizeForPromptLiteral(runtimeInfo.model)}.`
     : "You are a personal assistant running inside OpenClaw.";
+
+  // For "none" mode, return just the identity line (with model if available)
+  if (promptMode === "none") {
+    return modelIdentityLine;
+  }
 
   const lines = [
     modelIdentityLine,


### PR DESCRIPTION
## Summary

Fixes #32189 — Discord agent reports wrong model (says Haiku but running Minimax).

## Problem

The system prompt only included the model name in a dense `Runtime:` metadata line (`model=minimax-portal/MiniMax-M2.5 | default_model=...`). Non-frontier models don't parse this as their identity and hallucinate being Claude Haiku or GPT.

## Fix

Adds an explicit model identity instruction to the system prompt opening line:

> "You are a personal assistant running inside OpenClaw, **currently powered by minimax-portal/MiniMax-M2.5**. When asked what model you are, always answer: minimax-portal/MiniMax-M2.5."

When no model info is available, the prompt falls back to the existing generic identity line.

## Changes

- `src/agents/system-prompt.ts` — Inject model name into identity line when `runtimeInfo.model` is available
- `src/agents/system-prompt.test.ts` — 2 new tests covering both branches (model present / absent)

## Testing

- All 37 system prompt tests pass
- TypeScript typecheck clean (`pnpm tsgo`)
- Lint clean (`pnpm check`)
