### PR TITLE
fix(cron): narrow agentEntry type to fix TS2339

### DIFF
--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -250,14 +250,13 @@ export function buildGatewayCronService(params: {
       // fully resolved agent heartbeat config so cron-triggered heartbeats
       // respect agent-specific overrides (agents.list[].heartbeat) before
       // falling back to agents.defaults.heartbeat.
-      const agentEntry =
-        Array.isArray(runtimeConfig.agents?.list) &&
-        runtimeConfig.agents.list.find(
-          (entry) =>
-            entry && typeof entry.id === "string" && normalizeAgentId(entry.id) === agentId,
-        );
-      const agentHeartbeat =
-        agentEntry && typeof agentEntry === "object" ? agentEntry.heartbeat : undefined;
+      const agentEntry = Array.isArray(runtimeConfig.agents?.list)
+        ? runtimeConfig.agents.list.find(
+            (entry) =>
+              entry && typeof entry.id === "string" && normalizeAgentId(entry.id) === agentId,
+          )
+        : undefined;
+      const agentHeartbeat = agentEntry?.heartbeat;
       const baseHeartbeat = {
         ...runtimeConfig.agents?.defaults?.heartbeat,
         ...agentHeartbeat,


### PR DESCRIPTION
## Summary

- Replaces `&&` short-circuit with ternary when resolving `agentEntry` from `runtimeConfig.agents.list`, so TypeScript infers `AgentConfig | undefined` instead of `false | AgentConfig | undefined`
- Fixes TS2339 (`Property 'heartbeat' does not exist on type 'false'`) that breaks the `check` CI job on `main`

## Test plan

- [x] `pnpm tsgo` passes locally (server-cron.ts error gone)
- [ ] CI `check` job goes green