### PR TITLE
feishu: honor configured default account in outbound resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/default account resolution: always honor explicit `channels.feishu.defaultAccount` during outbound account selection (including top-level-credential setups where the preferred id is not present in `accounts`), instead of silently falling back to another account id. (#32253) Thanks @bmendonca3.
 - Gemini schema sanitization: coerce malformed JSON Schema `properties` values (`null`, arrays, primitives) to `{}` before provider validation, preventing downstream strict-validator crashes on invalid plugin/tool schemas. (#32332) Thanks @webdevtodayjason.
 - OpenAI/Responses WebSocket tool-call id hygiene: normalize blank/whitespace streamed tool-call ids before persistence, and block empty `function_call_output.call_id` payloads in the WS conversion path to avoid OpenAI 400 errors (`Invalid 'input[n].call_id': empty string`), with regression coverage for both inbound stream normalization and outbound payload guards.
 - Gateway/Control UI basePath webhook passthrough: let non-read methods under configured `controlUiBasePath` fall through to plugin routes (instead of returning Control UI 405), restoring webhook handlers behind basePath mounts. (#32311) Thanks @ademczuk.

--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -66,6 +66,26 @@ describe("resolveDefaultFeishuAccountId", () => {
 });
 
 describe("resolveFeishuAccount", () => {
+  it("uses top-level credentials with configured default account id even without account map entry", () => {
+    const cfg = {
+      channels: {
+        feishu: {
+          defaultAccount: "router-d",
+          appId: "top_level_app",
+          appSecret: "top_level_secret",
+          accounts: {
+            default: { appId: "cli_default", appSecret: "secret_default" },
+          },
+        },
+      },
+    };
+
+    const account = resolveFeishuAccount({ cfg: cfg as never, accountId: undefined });
+    expect(account.accountId).toBe("router-d");
+    expect(account.configured).toBe(true);
+    expect(account.appId).toBe("top_level_app");
+  });
+
   it("uses configured default account when accountId is omitted", () => {
     const cfg = {
       channels: {

--- a/extensions/feishu/src/accounts.test.ts
+++ b/extensions/feishu/src/accounts.test.ts
@@ -33,11 +33,26 @@ describe("resolveDefaultFeishuAccountId", () => {
     expect(resolveDefaultFeishuAccountId(cfg as never)).toBe("router-d");
   });
 
-  it("falls back to literal default account id when preferred is missing", () => {
+  it("keeps configured defaultAccount even when not present in accounts map", () => {
     const cfg = {
       channels: {
         feishu: {
-          defaultAccount: "missing",
+          defaultAccount: "router-d",
+          accounts: {
+            default: { appId: "cli_default", appSecret: "secret_default" },
+            zeta: { appId: "cli_zeta", appSecret: "secret_zeta" },
+          },
+        },
+      },
+    };
+
+    expect(resolveDefaultFeishuAccountId(cfg as never)).toBe("router-d");
+  });
+
+  it("falls back to literal default account id when present", () => {
+    const cfg = {
+      channels: {
+        feishu: {
           accounts: {
             default: { appId: "cli_default", appSecret: "secret_default" },
             zeta: { appId: "cli_zeta", appSecret: "secret_zeta" },

--- a/extensions/feishu/src/accounts.ts
+++ b/extensions/feishu/src/accounts.ts
@@ -37,10 +37,10 @@ export function listFeishuAccountIds(cfg: ClawdbotConfig): string[] {
 export function resolveDefaultFeishuAccountId(cfg: ClawdbotConfig): string {
   const preferredRaw = (cfg.channels?.feishu as FeishuConfig | undefined)?.defaultAccount?.trim();
   const preferred = preferredRaw ? normalizeAccountId(preferredRaw) : undefined;
-  const ids = listFeishuAccountIds(cfg);
-  if (preferred && ids.includes(preferred)) {
+  if (preferred) {
     return preferred;
   }
+  const ids = listFeishuAccountIds(cfg);
   if (ids.includes(DEFAULT_ACCOUNT_ID)) {
     return DEFAULT_ACCOUNT_ID;
   }


### PR DESCRIPTION
## Summary

- Problem: Feishu defaultAccount preference can be ignored when the preferred id is not present in accounts map.
- Why it matters: outbound account resolution can route through an unintended account.
- What changed: default account resolution now honors configured defaultAccount directly, with normalization and regression coverage.
- What did NOT change: no changes to credential loading semantics beyond account selection precedence.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Feishu account selection now respects configured defaultAccount even when account entries are sparse.

## Security Impact (required)

- New permissions/capabilities? (Yes/No) No
- Secrets/tokens handling changed? (Yes/No) No
- New/changed network calls? (Yes/No) No
- Command/tool execution surface changed? (Yes/No) No
- Data access scope changed? (Yes/No) No

## Repro + Verification

### Steps

1. Configure channels.feishu.defaultAccount to a value not present in channels.feishu.accounts keys.
2. Resolve default Feishu account id and run account resolution without explicit accountId.
3. Verify preferred defaultAccount is used.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: pnpm -s vitest run extensions/feishu/src/accounts.test.ts
- Edge cases checked: normalization and missing-account-map preference behavior.
- What you did not verify: live Feishu API call path.

## Compatibility / Migration

- Backward compatible? (Yes/No) Yes
- Config/env changes? (Yes/No) No
- Migration needed? (Yes/No) No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: extensions/feishu/src/accounts.ts, extensions/feishu/src/accounts.test.ts
- Known bad symptoms reviewers should watch for: wrong Feishu account selected for outbound actions.

## Risks and Mitigations

- Risk: behavior shift for configurations that relied on previous fallback selection.
  - Mitigation: explicit regression tests document and lock expected precedence.
