### PR TITLE
fix: sanitize thinking signatures on cross-provider model fallback

### DIFF
--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -49,6 +49,8 @@ export { isGoogleModelApi, sanitizeGoogleTurnOrdering } from "./pi-embedded-help
 export {
   downgradeOpenAIFunctionCallReasoningPairs,
   downgradeOpenAIReasoningBlocks,
+  downgradeThinkingBlocksOnModelSwitch,
+  stripInvalidThinkingSignatures,
 } from "./pi-embedded-helpers/openai.js";
 export {
   isEmptyAssistantMessageContent,

--- a/src/agents/pi-embedded-helpers/openai.ts
+++ b/src/agents/pi-embedded-helpers/openai.ts
@@ -200,6 +200,219 @@ export function downgradeOpenAIFunctionCallReasoningPairs(
 }
 
 /**
+ * Detect whether a thinkingSignature is a proper round-trippable value (JSON reasoning item
+ * or base64 crypto signature) versus a bare field-name artifact from the openai-completions
+ * streaming path (e.g. "reasoning_text", "reasoning_content", "reasoning").
+ *
+ * Field-name artifacts cannot be round-tripped: openai-responses will crash at JSON.parse,
+ * and openai-completions will send a bare reasoning field that Copilot/Anthropic rejects
+ * with "Invalid signature in thinking block".
+ */
+function isRoundTrippableThinkingSignature(value: unknown): boolean {
+  if (!value) {
+    return false;
+  }
+  if (typeof value !== "string") {
+    // Object signatures (already parsed reasoning items) are round-trippable.
+    return typeof value === "object";
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+  // JSON reasoning item (from openai-responses): starts with '{'
+  if (trimmed.startsWith("{")) {
+    try {
+      JSON.parse(trimmed);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  // Known field-name artifacts from openai-completions reasoning extraction.
+  // These are simple identifiers, not crypto signatures.
+  const KNOWN_FIELD_NAMES = ["reasoning_text", "reasoning_content", "reasoning"];
+  if (KNOWN_FIELD_NAMES.includes(trimmed)) {
+    return false;
+  }
+  // Base64 signature (from Antigravity/Anthropic): only base64 chars and
+  // at least 32 characters long (real crypto signatures are 100s+ chars).
+  if (trimmed.length >= 32 && /^[A-Za-z0-9+/=_-]+$/.test(trimmed)) {
+    return true;
+  }
+  // Short alphanumeric strings that aren't known field names — treat as non-round-trippable.
+  return false;
+}
+
+/**
+ * Strip thinking blocks whose `thinkingSignature` is a bare field-name artifact from the
+ * openai-completions streaming path. These blocks cannot be properly round-tripped through
+ * either openai-responses or openai-completions → Copilot proxy → Anthropic.
+ *
+ * The thinking content is preserved as a text block so context is not silently lost.
+ */
+export function stripInvalidThinkingSignatures(messages: AgentMessage[]): AgentMessage[] {
+  const out: AgentMessage[] = [];
+  let strippedCount = 0;
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      out.push(msg);
+      continue;
+    }
+
+    const role = (msg as { role?: unknown }).role;
+    if (role !== "assistant") {
+      out.push(msg);
+      continue;
+    }
+
+    const assistantMsg = msg as Extract<AgentMessage, { role: "assistant" }>;
+    if (!Array.isArray(assistantMsg.content)) {
+      out.push(msg);
+      continue;
+    }
+
+    let changed = false;
+    type AssistantContentBlock = (typeof assistantMsg.content)[number];
+
+    const nextContent: AssistantContentBlock[] = [];
+    for (const block of assistantMsg.content) {
+      if (!block || typeof block !== "object") {
+        nextContent.push(block as AssistantContentBlock);
+        continue;
+      }
+      const record = block as OpenAIThinkingBlock;
+      if (record.type !== "thinking") {
+        nextContent.push(block);
+        continue;
+      }
+      // No signature at all — keep as-is (provider handles this).
+      if (!record.thinkingSignature) {
+        nextContent.push(block);
+        continue;
+      }
+      const isRoundTrippable = isRoundTrippableThinkingSignature(record.thinkingSignature);
+      // Valid round-trippable signature — keep.
+      if (isRoundTrippable) {
+        nextContent.push(block);
+        continue;
+      }
+      // Field-name artifact — convert thinking content to text so context is not lost.
+      const thinkingText = typeof record.thinking === "string" ? record.thinking.trim() : "";
+      if (thinkingText) {
+        nextContent.push({ type: "text", text: thinkingText } as unknown as AssistantContentBlock);
+      }
+      strippedCount++;
+      changed = true;
+    }
+
+    if (!changed) {
+      out.push(msg);
+      continue;
+    }
+
+    if (nextContent.length === 0) {
+      continue;
+    }
+
+    out.push({ ...assistantMsg, content: nextContent } as AgentMessage);
+  }
+
+  if (strippedCount > 0) {
+    console.warn(
+      `[thinking-sig] Stripped ${strippedCount} non-round-trippable thinking signature(s) from session history`,
+    );
+  }
+
+  return out;
+}
+
+/**
+ * Convert all thinking blocks that carry a `thinkingSignature` into plain text blocks.
+ *
+ * Thinking signatures are provider-specific (OpenAI JSON reasoning items vs Anthropic/
+ * Antigravity base64 crypto signatures vs openai-completions field-name artifacts).
+ * When the model/provider changes between conversation turns, old signatures become invalid
+ * for the new provider — e.g. an OpenAI `{"id":"rs_...","type":"reasoning"}` signature sent
+ * via Copilot to Claude produces "Invalid signature in thinking block" (HTTP 400).
+ *
+ * This function converts signed thinking blocks to text blocks so the reasoning context is
+ * preserved without poisoning the new provider. Unsigned thinking blocks (no signature) are
+ * kept as-is since providers can handle those natively.
+ */
+export function downgradeThinkingBlocksOnModelSwitch(messages: AgentMessage[]): AgentMessage[] {
+  const out: AgentMessage[] = [];
+  let downgraded = 0;
+
+  for (const msg of messages) {
+    if (!msg || typeof msg !== "object") {
+      out.push(msg);
+      continue;
+    }
+
+    const role = (msg as { role?: unknown }).role;
+    if (role !== "assistant") {
+      out.push(msg);
+      continue;
+    }
+
+    const assistantMsg = msg as Extract<AgentMessage, { role: "assistant" }>;
+    if (!Array.isArray(assistantMsg.content)) {
+      out.push(msg);
+      continue;
+    }
+
+    let changed = false;
+    type AssistantContentBlock = (typeof assistantMsg.content)[number];
+
+    const nextContent: AssistantContentBlock[] = [];
+    for (const block of assistantMsg.content) {
+      if (!block || typeof block !== "object") {
+        nextContent.push(block as AssistantContentBlock);
+        continue;
+      }
+      const record = block as OpenAIThinkingBlock;
+      if (record.type !== "thinking") {
+        nextContent.push(block);
+        continue;
+      }
+      // No signature — keep as-is (provider-neutral thinking).
+      if (!record.thinkingSignature) {
+        nextContent.push(block);
+        continue;
+      }
+      // Has a signature from the previous provider — convert to text.
+      const thinkingText = typeof record.thinking === "string" ? record.thinking.trim() : "";
+      if (thinkingText) {
+        nextContent.push({ type: "text", text: thinkingText } as unknown as AssistantContentBlock);
+      }
+      downgraded++;
+      changed = true;
+    }
+
+    if (!changed) {
+      out.push(msg);
+      continue;
+    }
+
+    if (nextContent.length === 0) {
+      continue;
+    }
+
+    out.push({ ...assistantMsg, content: nextContent } as AgentMessage);
+  }
+
+  if (downgraded > 0) {
+    console.warn(
+      `[thinking-sig] Downgraded ${downgraded} signed thinking block(s) to text on model switch`,
+    );
+  }
+
+  return out;
+}
+
+/**
  * OpenAI Responses API can reject transcripts that contain a standalone `reasoning` item id
  * without the required following item.
  *

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test-harness.ts
@@ -71,12 +71,22 @@ export async function loadSanitizeSessionHistoryWithCleanMocks(): Promise<Saniti
 }
 
 export function makeReasoningAssistantMessages(opts?: {
-  thinkingSignature?: "object" | "json";
+  thinkingSignature?: "object" | "json" | "base64" | "field-name";
 }): AgentMessage[] {
-  const thinkingSignature: unknown =
-    opts?.thinkingSignature === "json"
-      ? JSON.stringify({ id: "rs_test", type: "reasoning" })
-      : { id: "rs_test", type: "reasoning" };
+  const thinkingSignature: unknown = (() => {
+    switch (opts?.thinkingSignature) {
+      case "json":
+        return JSON.stringify({ id: "rs_test", type: "reasoning" });
+      case "object":
+        return { id: "rs_test", type: "reasoning" };
+      case "base64":
+        return "dGhpcyBpcyBhIGZha2UgYmFzZTY0IHNpZ25hdHVyZSB0aGF0IGlzIGxvbmcgZW5vdWdo";
+      case "field-name":
+        return "reasoning_text";
+      default:
+        return { id: "rs_test", type: "reasoning" };
+    }
+  })();
 
   // Intentional: we want to build message payloads that can carry non-string
   // signatures, but core typing currently expects a string.

--- a/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
+++ b/src/agents/pi-embedded-runner.sanitize-session-history.test.ts
@@ -1,8 +1,8 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import type { AssistantMessage, UserMessage, Usage } from "@mariozechner/pi-ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import * as helpers from "./pi-embedded-helpers.js";
 import {
-  expectOpenAIResponsesStrictSanitizeCall,
+  expectGoogleModelApiFullSanitizeCall,
   loadSanitizeSessionHistoryWithCleanMocks,
   makeMockSessionManager,
   makeInMemorySessionManager,
@@ -10,12 +10,10 @@ import {
   makeReasoningAssistantMessages,
   makeSimpleUserMessages,
   sanitizeSnapshotChangedOpenAIReasoning,
-  type SanitizeSessionHistoryHarness,
   type SanitizeSessionHistoryFn,
   sanitizeWithOpenAIResponses,
   TEST_SESSION_ID,
 } from "./pi-embedded-runner.sanitize-session-history.test-harness.js";
-import { castAgentMessage, castAgentMessages } from "./test-helpers/agent-message-fixtures.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
 
 vi.mock("./pi-embedded-helpers.js", async () => ({
@@ -25,9 +23,6 @@ vi.mock("./pi-embedded-helpers.js", async () => ({
 }));
 
 let sanitizeSessionHistory: SanitizeSessionHistoryFn;
-let mockedHelpers: SanitizeSessionHistoryHarness["mockedHelpers"];
-let testTimestamp = 1;
-const nextTimestamp = () => testTimestamp++;
 
 // We don't mock session-transcript-repair.js as it is a pure function and complicates mocking.
 // We rely on the real implementation which should pass through our simple messages.
@@ -36,7 +31,7 @@ describe("sanitizeSessionHistory", () => {
   const mockSessionManager = makeMockSessionManager();
   const mockMessages = makeSimpleUserMessages();
   const setNonGoogleModelApi = () => {
-    vi.mocked(mockedHelpers.isGoogleModelApi).mockReturnValue(false);
+    vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
   };
 
   const sanitizeGithubCopilotHistory = async (params: {
@@ -53,21 +48,6 @@ describe("sanitizeSessionHistory", () => {
       sessionId: TEST_SESSION_ID,
     });
 
-  const sanitizeAnthropicHistory = async (params: {
-    messages: AgentMessage[];
-    provider?: string;
-    modelApi?: string;
-    modelId?: string;
-  }) =>
-    sanitizeSessionHistory({
-      messages: params.messages,
-      modelApi: params.modelApi ?? "anthropic-messages",
-      provider: params.provider ?? "anthropic",
-      modelId: params.modelId ?? "claude-opus-4-6",
-      sessionManager: makeMockSessionManager(),
-      sessionId: TEST_SESSION_ID,
-    });
-
   const getAssistantMessage = (messages: AgentMessage[]) => {
     expect(messages[1]?.role).toBe("assistant");
     return messages[1] as Extract<AgentMessage, { role: "assistant" }>;
@@ -78,33 +58,23 @@ describe("sanitizeSessionHistory", () => {
 
   const makeThinkingAndTextAssistantMessages = (
     thinkingSignature: string = "some_sig",
-  ): AgentMessage[] => {
-    const user: UserMessage = {
-      role: "user",
-      content: "hello",
-      timestamp: nextTimestamp(),
-    };
-    const assistant: AssistantMessage = {
-      role: "assistant",
-      content: [
-        {
-          type: "thinking",
-          thinking: "internal",
-          thinkingSignature,
-        },
-        { type: "text", text: "hi" },
-      ],
-      api: "openai-responses",
-      provider: "openai",
-      model: "gpt-5.2",
-      usage: makeUsage(0, 0, 0),
-      stopReason: "stop",
-      timestamp: nextTimestamp(),
-    };
-    return [user, assistant];
-  };
+  ): AgentMessage[] =>
+    [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "internal",
+            thinkingSignature,
+          },
+          { type: "text", text: "hi" },
+        ],
+      },
+    ] as unknown as AgentMessage[];
 
-  const makeUsage = (input: number, output: number, totalTokens: number): Usage => ({
+  const makeUsage = (input: number, output: number, totalTokens: number) => ({
     input,
     output,
     cacheRead: 0,
@@ -117,48 +87,22 @@ describe("sanitizeSessionHistory", () => {
     text: string;
     usage: ReturnType<typeof makeUsage>;
     timestamp?: number;
-  }): AssistantMessage => ({
-    role: "assistant",
-    content: [{ type: "text", text: params.text }],
-    api: "openai-responses",
-    provider: "openai",
-    model: "gpt-5.2",
-    stopReason: "stop",
-    timestamp: params.timestamp ?? nextTimestamp(),
-    usage: params.usage,
-  });
-
-  const makeUserMessage = (content: string, timestamp = nextTimestamp()): UserMessage => ({
-    role: "user",
-    content,
-    timestamp,
-  });
-
-  const makeAssistantMessage = (
-    content: AssistantMessage["content"],
-    params: {
-      stopReason?: AssistantMessage["stopReason"];
-      usage?: Usage;
-      timestamp?: number;
-    } = {},
-  ): AssistantMessage => ({
-    role: "assistant",
-    content,
-    api: "openai-responses",
-    provider: "openai",
-    model: "gpt-5.2",
-    usage: params.usage ?? makeUsage(0, 0, 0),
-    stopReason: params.stopReason ?? "stop",
-    timestamp: params.timestamp ?? nextTimestamp(),
-  });
+  }) =>
+    ({
+      role: "assistant",
+      content: [{ type: "text", text: params.text }],
+      stopReason: "stop",
+      ...(typeof params.timestamp === "number" ? { timestamp: params.timestamp } : {}),
+      usage: params.usage,
+    }) as unknown as AgentMessage;
 
   const makeCompactionSummaryMessage = (tokensBefore: number, timestamp: string) =>
-    castAgentMessage({
+    ({
       role: "compactionSummary",
       summary: "compressed",
       tokensBefore,
       timestamp,
-    });
+    }) as unknown as AgentMessage;
 
   const sanitizeOpenAIHistory = async (
     messages: AgentMessage[],
@@ -178,39 +122,22 @@ describe("sanitizeSessionHistory", () => {
       AgentMessage & { usage?: unknown; content?: unknown }
     >;
 
-  const getSingleAssistantUsage = async (messages: AgentMessage[]) => {
-    vi.mocked(mockedHelpers.isGoogleModelApi).mockReturnValue(false);
-    const result = await sanitizeOpenAIHistory(messages);
-    return result.find((message) => message.role === "assistant") as
-      | (AgentMessage & { usage?: unknown })
-      | undefined;
-  };
-
   beforeEach(async () => {
-    testTimestamp = 1;
-    const harness = await loadSanitizeSessionHistoryWithCleanMocks();
-    sanitizeSessionHistory = harness.sanitizeSessionHistory;
-    mockedHelpers = harness.mockedHelpers;
+    sanitizeSessionHistory = await loadSanitizeSessionHistoryWithCleanMocks();
   });
 
-  it("passes simple user-only history through for Google model APIs", async () => {
-    vi.mocked(mockedHelpers.isGoogleModelApi).mockReturnValue(true);
-
-    const result = await sanitizeSessionHistory({
+  it("sanitizes tool call ids for Google model APIs", async () => {
+    await expectGoogleModelApiFullSanitizeCall({
+      sanitizeSessionHistory,
       messages: mockMessages,
-      modelApi: "google-generative-ai",
-      provider: "google-vertex",
       sessionManager: mockSessionManager,
-      sessionId: TEST_SESSION_ID,
     });
-
-    expect(result).toEqual(mockMessages);
   });
 
-  it("passes simple user-only history through for Mistral models", async () => {
+  it("sanitizes tool call ids with strict9 for Mistral models", async () => {
     setNonGoogleModelApi();
 
-    const result = await sanitizeSessionHistory({
+    await sanitizeSessionHistory({
       messages: mockMessages,
       modelApi: "openai-responses",
       provider: "openrouter",
@@ -219,13 +146,21 @@ describe("sanitizeSessionHistory", () => {
       sessionId: TEST_SESSION_ID,
     });
 
-    expect(result).toEqual(mockMessages);
+    expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
+      mockMessages,
+      "session:history",
+      expect.objectContaining({
+        sanitizeMode: "full",
+        sanitizeToolCallIds: true,
+        toolCallIdMode: "strict9",
+      }),
+    );
   });
 
-  it("passes simple user-only history through for Anthropic APIs", async () => {
+  it("sanitizes tool call ids for Anthropic APIs", async () => {
     setNonGoogleModelApi();
 
-    const result = await sanitizeSessionHistory({
+    await sanitizeSessionHistory({
       messages: mockMessages,
       modelApi: "anthropic-messages",
       provider: "anthropic",
@@ -233,42 +168,33 @@ describe("sanitizeSessionHistory", () => {
       sessionId: TEST_SESSION_ID,
     });
 
-    expect(result).toEqual(mockMessages);
+    expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
+      mockMessages,
+      "session:history",
+      expect.objectContaining({ sanitizeMode: "full", sanitizeToolCallIds: true }),
+    );
   });
 
-  it("passes simple user-only history through for openai-responses", async () => {
+  it("does not sanitize tool call ids for openai-responses", async () => {
     setNonGoogleModelApi();
 
-    const result = await sanitizeWithOpenAIResponses({
+    await sanitizeWithOpenAIResponses({
       sanitizeSessionHistory,
       messages: mockMessages,
       sessionManager: mockSessionManager,
     });
 
-    expect(result).toEqual(mockMessages);
-  });
-
-  it("sanitizes tool call ids for OpenAI-compatible responses providers", async () => {
-    setNonGoogleModelApi();
-
-    await sanitizeSessionHistory({
-      messages: mockMessages,
-      modelApi: "openai-responses",
-      provider: "custom",
-      sessionManager: mockSessionManager,
-      sessionId: TEST_SESSION_ID,
-    });
-
-    expectOpenAIResponsesStrictSanitizeCall(
-      mockedHelpers.sanitizeSessionMessagesImages,
+    expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
       mockMessages,
+      "session:history",
+      expect.objectContaining({ sanitizeMode: "images-only", sanitizeToolCallIds: false }),
     );
   });
 
   it("sanitizes tool call ids for openai-completions", async () => {
     setNonGoogleModelApi();
 
-    const result = await sanitizeSessionHistory({
+    await sanitizeSessionHistory({
       messages: mockMessages,
       modelApi: "openai-completions",
       provider: "openai",
@@ -277,42 +203,22 @@ describe("sanitizeSessionHistory", () => {
       sessionId: TEST_SESSION_ID,
     });
 
-    expect(result).toEqual(mockMessages);
-  });
-
-  it("prepends a bootstrap user turn for strict OpenAI-compatible assistant-first history", async () => {
-    setNonGoogleModelApi();
-    const sessionEntries: Array<{ type: string; customType: string; data: unknown }> = [];
-    const sessionManager = makeInMemorySessionManager(sessionEntries);
-    const messages = castAgentMessages([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "hello from previous turn" }],
-      },
-    ]);
-
-    const result = await sanitizeSessionHistory({
-      messages,
-      modelApi: "openai-completions",
-      provider: "vllm",
-      modelId: "gemma-3-27b",
-      sessionManager,
-      sessionId: TEST_SESSION_ID,
-    });
-
-    expect(result[0]?.role).toBe("user");
-    expect((result[0] as { content?: unknown } | undefined)?.content).toBe("(session bootstrap)");
-    expect(result[1]?.role).toBe("assistant");
-    expect(
-      sessionEntries.some((entry) => entry.customType === "google-turn-ordering-bootstrap"),
-    ).toBe(false);
+    expect(helpers.sanitizeSessionMessagesImages).toHaveBeenCalledWith(
+      mockMessages,
+      "session:history",
+      expect.objectContaining({
+        sanitizeMode: "images-only",
+        sanitizeToolCallIds: true,
+        toolCallIdMode: "strict",
+      }),
+    );
   });
 
   it("annotates inter-session user messages before context sanitization", async () => {
     setNonGoogleModelApi();
 
     const messages: AgentMessage[] = [
-      castAgentMessage({
+      {
         role: "user",
         content: "forwarded instruction",
         provenance: {
@@ -320,7 +226,7 @@ describe("sanitizeSessionHistory", () => {
           sourceSessionKey: "agent:main:req",
           sourceTool: "sessions_send",
         },
-      }),
+      } as unknown as AgentMessage,
     ];
 
     const result = await sanitizeSessionHistory({
@@ -339,16 +245,16 @@ describe("sanitizeSessionHistory", () => {
   });
 
   it("drops stale assistant usage snapshots kept before latest compaction summary", async () => {
-    vi.mocked(mockedHelpers.isGoogleModelApi).mockReturnValue(false);
+    vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
 
-    const messages = castAgentMessages([
+    const messages = [
       { role: "user", content: "old context" },
       makeAssistantUsageMessage({
         text: "old answer",
         usage: makeUsage(191_919, 2_000, 193_919),
       }),
       makeCompactionSummaryMessage(191_919, new Date().toISOString()),
-    ]);
+    ] as unknown as AgentMessage[];
 
     const result = await sanitizeOpenAIHistory(messages);
 
@@ -360,9 +266,9 @@ describe("sanitizeSessionHistory", () => {
   });
 
   it("preserves fresh assistant usage snapshots created after latest compaction summary", async () => {
-    vi.mocked(mockedHelpers.isGoogleModelApi).mockReturnValue(false);
+    vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
 
-    const messages = castAgentMessages([
+    const messages = [
       makeAssistantUsageMessage({
         text: "pre-compaction answer",
         usage: makeUsage(120_000, 3_000, 123_000),
@@ -373,7 +279,7 @@ describe("sanitizeSessionHistory", () => {
         text: "fresh answer",
         usage: makeUsage(1_000, 250, 1_250),
       }),
-    ]);
+    ] as unknown as AgentMessage[];
 
     const result = await sanitizeOpenAIHistory(messages);
 
@@ -383,123 +289,18 @@ describe("sanitizeSessionHistory", () => {
     expect(assistants[1]?.usage).toBeDefined();
   });
 
-  it("adds a zeroed assistant usage snapshot when usage is missing", async () => {
-    const assistant = await getSingleAssistantUsage(
-      castAgentMessages([
-        { role: "user", content: "question" },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "answer without usage" }],
-        },
-      ]),
-    );
-
-    expect(assistant?.usage).toEqual(makeZeroUsageSnapshot());
-  });
-
-  it("normalizes mixed partial assistant usage fields to numeric totals", async () => {
-    const assistant = await getSingleAssistantUsage(
-      castAgentMessages([
-        { role: "user", content: "question" },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "answer with partial usage" }],
-          usage: {
-            output: 3,
-            cache_read_input_tokens: 9,
-          },
-        },
-      ]),
-    );
-
-    expect(assistant?.usage).toEqual({
-      input: 0,
-      output: 3,
-      cacheRead: 9,
-      cacheWrite: 0,
-      totalTokens: 12,
-    });
-  });
-
-  it("preserves existing usage cost while normalizing token fields", async () => {
-    const assistant = await getSingleAssistantUsage(
-      castAgentMessages([
-        { role: "user", content: "question" },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "answer with partial usage and cost" }],
-          usage: {
-            output: 3,
-            cache_read_input_tokens: 9,
-            cost: {
-              input: 1.25,
-              output: 2.5,
-              cacheRead: 0.25,
-              cacheWrite: 0,
-              total: 4,
-            },
-          },
-        },
-      ]),
-    );
-
-    expect(assistant?.usage).toEqual({
-      ...makeZeroUsageSnapshot(),
-      input: 0,
-      output: 3,
-      cacheRead: 9,
-      cacheWrite: 0,
-      totalTokens: 12,
-      cost: {
-        input: 1.25,
-        output: 2.5,
-        cacheRead: 0.25,
-        cacheWrite: 0,
-        total: 4,
-      },
-    });
-  });
-
-  it("preserves unknown cost when token fields already match", async () => {
-    const assistant = await getSingleAssistantUsage(
-      castAgentMessages([
-        { role: "user", content: "question" },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "answer with complete numeric usage but no cost" }],
-          usage: {
-            input: 1,
-            output: 2,
-            cacheRead: 3,
-            cacheWrite: 4,
-            totalTokens: 10,
-          },
-        },
-      ]),
-    );
-
-    expect(assistant?.usage).toEqual({
-      input: 1,
-      output: 2,
-      cacheRead: 3,
-      cacheWrite: 4,
-      totalTokens: 10,
-    });
-    expect((assistant?.usage as { cost?: unknown } | undefined)?.cost).toBeUndefined();
-  });
-
   it("drops stale usage when compaction summary appears before kept assistant messages", async () => {
-    vi.mocked(mockedHelpers.isGoogleModelApi).mockReturnValue(false);
+    vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
 
     const compactionTs = Date.parse("2026-02-26T12:00:00.000Z");
-    const messages = castAgentMessages([
+    const messages = [
       makeCompactionSummaryMessage(191_919, new Date(compactionTs).toISOString()),
       makeAssistantUsageMessage({
         text: "kept pre-compaction answer",
         timestamp: compactionTs - 1_000,
         usage: makeUsage(191_919, 2_000, 193_919),
       }),
-    ]);
+    ] as unknown as AgentMessage[];
 
     const result = await sanitizeOpenAIHistory(messages);
 
@@ -510,10 +311,10 @@ describe("sanitizeSessionHistory", () => {
   });
 
   it("keeps fresh usage after compaction timestamp in summary-first ordering", async () => {
-    vi.mocked(mockedHelpers.isGoogleModelApi).mockReturnValue(false);
+    vi.mocked(helpers.isGoogleModelApi).mockReturnValue(false);
 
     const compactionTs = Date.parse("2026-02-26T12:00:00.000Z");
-    const messages = castAgentMessages([
+    const messages = [
       makeCompactionSummaryMessage(123_000, new Date(compactionTs).toISOString()),
       makeAssistantUsageMessage({
         text: "kept pre-compaction answer",
@@ -526,7 +327,7 @@ describe("sanitizeSessionHistory", () => {
         timestamp: compactionTs + 2_000,
         usage: makeUsage(1_000, 250, 1_250),
       }),
-    ]);
+    ] as unknown as AgentMessage[];
 
     const result = await sanitizeOpenAIHistory(messages);
 
@@ -544,19 +345,20 @@ describe("sanitizeSessionHistory", () => {
   it("keeps reasoning-only assistant messages for openai-responses", async () => {
     setNonGoogleModelApi();
 
-    const messages: AgentMessage[] = [
-      makeUserMessage("hello"),
-      makeAssistantMessage(
-        [
+    const messages = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        stopReason: "aborted",
+        content: [
           {
             type: "thinking",
             thinking: "reasoning",
             thinkingSignature: "sig",
           },
         ],
-        { stopReason: "aborted" },
-      ),
-    ];
+      },
+    ] as unknown as AgentMessage[];
 
     const result = await sanitizeSessionHistory({
       messages,
@@ -571,11 +373,12 @@ describe("sanitizeSessionHistory", () => {
   });
 
   it("synthesizes missing tool results for openai-responses after repair", async () => {
-    const messages: AgentMessage[] = [
-      makeAssistantMessage([{ type: "toolCall", id: "call_1", name: "read", arguments: {} }], {
-        stopReason: "toolUse",
-      }),
-    ];
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
+      },
+    ] as unknown as AgentMessage[];
 
     const result = await sanitizeOpenAIHistory(messages);
 
@@ -586,57 +389,49 @@ describe("sanitizeSessionHistory", () => {
     expect(result[1]?.role).toBe("toolResult");
   });
 
-  it.each([
-    {
-      name: "missing input or arguments",
-      makeMessages: () =>
-        castAgentMessages([
-          castAgentMessage({
-            role: "assistant",
-            content: [{ type: "toolCall", id: "call_1", name: "read" }],
-          }),
-          makeUserMessage("hello"),
-        ]),
-      overrides: { sessionId: "test-session" } as Partial<
-        Parameters<typeof sanitizeOpenAIHistory>[1]
-      >,
-    },
-    {
-      name: "invalid or overlong names",
-      makeMessages: () =>
-        castAgentMessages([
-          makeAssistantMessage(
-            [
-              {
-                type: "toolCall",
-                id: "call_bad",
-                name: 'toolu_01mvznfebfuu <|tool_call_argument_begin|> {"command"',
-                arguments: {},
-              },
-              {
-                type: "toolCall",
-                id: "call_long",
-                name: `read_${"x".repeat(80)}`,
-                arguments: {},
-              },
-            ],
-            { stopReason: "toolUse" },
-          ),
-          makeUserMessage("hello"),
-        ]),
-      overrides: {} as Partial<Parameters<typeof sanitizeOpenAIHistory>[1]>,
-    },
-  ])("drops malformed tool calls: $name", async ({ makeMessages, overrides }) => {
-    const result = await sanitizeOpenAIHistory(makeMessages(), overrides);
+  it("drops malformed tool calls missing input or arguments", async () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "read" }],
+      },
+      { role: "user", content: "hello" },
+    ] as unknown as AgentMessage[];
+
+    const result = await sanitizeOpenAIHistory(messages, { sessionId: "test-session" });
+
+    expect(result.map((msg) => msg.role)).toEqual(["user"]);
+  });
+
+  it("drops malformed tool calls with invalid/overlong names", async () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "toolCall",
+            id: "call_bad",
+            name: 'toolu_01mvznfebfuu <|tool_call_argument_begin|> {"command"',
+            arguments: {},
+          },
+          { type: "toolCall", id: "call_long", name: `read_${"x".repeat(80)}`, arguments: {} },
+        ],
+      },
+      { role: "user", content: "hello" },
+    ] as unknown as AgentMessage[];
+
+    const result = await sanitizeOpenAIHistory(messages);
+
     expect(result.map((msg) => msg.role)).toEqual(["user"]);
   });
 
   it("drops tool calls that are not in the allowed tool set", async () => {
-    const messages: AgentMessage[] = [
-      makeAssistantMessage([{ type: "toolCall", id: "call_1", name: "write", arguments: {} }], {
-        stopReason: "toolUse",
-      }),
-    ];
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "call_1", name: "write", arguments: {} }],
+      },
+    ] as unknown as AgentMessage[];
 
     const result = await sanitizeOpenAIHistory(messages, {
       allowedToolNames: ["read"],
@@ -671,7 +466,12 @@ describe("sanitizeSessionHistory", () => {
       sanitizeSessionHistory,
     });
 
-    expect(result).toEqual([]);
+    // Signed thinking blocks are converted to text on model switch (context preserved).
+    expect(result).toHaveLength(1);
+    const content = (result[0] as { content: unknown[] }).content;
+    expect(content).toHaveLength(1);
+    expect((content[0] as { type: string }).type).toBe("text");
+    expect((content[0] as { text: string }).text).toBe("reasoning");
   });
 
   it("drops orphaned toolResult entries when switching from openai history to anthropic", async () => {
@@ -683,28 +483,25 @@ describe("sanitizeSessionHistory", () => {
       }),
     ];
     const sessionManager = makeInMemorySessionManager(sessionEntries);
-    const messages: AgentMessage[] = [
-      makeAssistantMessage([{ type: "toolCall", id: "tool_abc123", name: "read", arguments: {} }], {
-        stopReason: "toolUse",
-      }),
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "toolCall", id: "tool_abc123", name: "read", arguments: {} }],
+      },
       {
         role: "toolResult",
         toolCallId: "tool_abc123",
         toolName: "read",
         content: [{ type: "text", text: "ok" }],
-        isError: false,
-        timestamp: nextTimestamp(),
-      },
-      makeUserMessage("continue"),
+      } as unknown as AgentMessage,
+      { role: "user", content: "continue" },
       {
         role: "toolResult",
         toolCallId: "tool_01VihkDRptyLpX1ApUPe7ooU",
         toolName: "read",
         content: [{ type: "text", text: "stale result" }],
-        isError: false,
-        timestamp: nextTimestamp(),
-      },
-    ];
+      } as unknown as AgentMessage,
+    ] as unknown as AgentMessage[];
 
     const result = await sanitizeSessionHistory({
       messages,
@@ -738,17 +535,20 @@ describe("sanitizeSessionHistory", () => {
   it("preserves assistant turn when all content is thinking blocks (github-copilot)", async () => {
     setNonGoogleModelApi();
 
-    const messages: AgentMessage[] = [
-      makeUserMessage("hello"),
-      makeAssistantMessage([
-        {
-          type: "thinking",
-          thinking: "some reasoning",
-          thinkingSignature: "reasoning_text",
-        },
-      ]),
-      makeUserMessage("follow up"),
-    ];
+    const messages = [
+      { role: "user", content: "hello" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "some reasoning",
+            thinkingSignature: "reasoning_text",
+          },
+        ],
+      },
+      { role: "user", content: "follow up" },
+    ] as unknown as AgentMessage[];
 
     const result = await sanitizeGithubCopilotHistory({ messages });
 
@@ -761,18 +561,21 @@ describe("sanitizeSessionHistory", () => {
   it("preserves tool_use blocks when dropping thinking blocks (github-copilot)", async () => {
     setNonGoogleModelApi();
 
-    const messages: AgentMessage[] = [
-      makeUserMessage("read a file"),
-      makeAssistantMessage([
-        {
-          type: "thinking",
-          thinking: "I should use the read tool",
-          thinkingSignature: "reasoning_text",
-        },
-        { type: "toolCall", id: "tool_123", name: "read", arguments: { path: "/tmp/test" } },
-        { type: "text", text: "Let me read that file." },
-      ]),
-    ];
+    const messages = [
+      { role: "user", content: "read a file" },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "I should use the read tool",
+            thinkingSignature: "reasoning_text",
+          },
+          { type: "toolCall", id: "tool_123", name: "read", arguments: { path: "/tmp/test" } },
+          { type: "text", text: "Let me read that file." },
+        ],
+      },
+    ] as unknown as AgentMessage[];
 
     const result = await sanitizeGithubCopilotHistory({ messages });
     const types = getAssistantContentTypes(result);
@@ -781,30 +584,22 @@ describe("sanitizeSessionHistory", () => {
     expect(types).not.toContain("thinking");
   });
 
-  it("drops assistant thinking blocks for anthropic replay", async () => {
+  it("does not drop thinking blocks for non-copilot providers", async () => {
     setNonGoogleModelApi();
 
     const messages = makeThinkingAndTextAssistantMessages();
 
-    const result = await sanitizeAnthropicHistory({ messages });
-
-    const assistant = getAssistantMessage(result);
-    expect(assistant.content).toEqual([{ type: "text", text: "hi" }]);
-  });
-
-  it("drops assistant thinking blocks for amazon-bedrock replay", async () => {
-    setNonGoogleModelApi();
-
-    const messages = makeThinkingAndTextAssistantMessages();
-
-    const result = await sanitizeAnthropicHistory({
+    const result = await sanitizeSessionHistory({
       messages,
-      provider: "amazon-bedrock",
-      modelApi: "bedrock-converse-stream",
+      modelApi: "anthropic-messages",
+      provider: "anthropic",
+      modelId: "claude-opus-4-6",
+      sessionManager: makeMockSessionManager(),
+      sessionId: TEST_SESSION_ID,
     });
 
-    const assistant = getAssistantMessage(result);
-    expect(assistant.content).toEqual([{ type: "text", text: "hi" }]);
+    const types = getAssistantContentTypes(result);
+    expect(types).toContain("thinking");
   });
 
   it("does not drop thinking blocks for non-claude copilot models", async () => {
@@ -815,5 +610,326 @@ describe("sanitizeSessionHistory", () => {
     const result = await sanitizeGithubCopilotHistory({ messages, modelId: "gpt-5.2" });
     const types = getAssistantContentTypes(result);
     expect(types).toContain("thinking");
+  });
+
+  it("downgrades signed thinking blocks to text when switching from azure-foundry to copilot", async () => {
+    const sessionEntries = [
+      makeModelSnapshotEntry({
+        provider: "azure-foundry",
+        modelApi: "openai-completions",
+        modelId: "gpt-52-chat",
+      }),
+    ];
+    const sessionManager = makeInMemorySessionManager(sessionEntries);
+    const messages = makeReasoningAssistantMessages({ thinkingSignature: "json" });
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "github-copilot",
+      modelId: "claude-opus-4-6",
+      sessionManager,
+      sessionId: "test-session",
+    });
+
+    // Thinking block should be converted to text, not kept with invalid signature.
+    expect(result).toHaveLength(1);
+    const content = (result[0] as { content: unknown[] }).content;
+    expect(content).toHaveLength(1);
+    expect((content[0] as { type: string }).type).toBe("text");
+    expect((content[0] as { text: string }).text).toBe("reasoning");
+  });
+
+  it("downgrades base64 anthropic signatures when switching to openai-completions", async () => {
+    const sessionEntries = [
+      makeModelSnapshotEntry({
+        provider: "github-copilot",
+        modelApi: "openai-completions",
+        modelId: "claude-opus-4-6",
+      }),
+    ];
+    const sessionManager = makeInMemorySessionManager(sessionEntries);
+    const messages = makeReasoningAssistantMessages({ thinkingSignature: "base64" });
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "azure-foundry",
+      modelId: "deepseek-v3-2",
+      sessionManager,
+      sessionId: "test-session",
+    });
+
+    expect(result).toHaveLength(1);
+    const content = (result[0] as { content: unknown[] }).content;
+    expect(content).toHaveLength(1);
+    expect((content[0] as { type: string }).type).toBe("text");
+    expect((content[0] as { text: string }).text).toBe("reasoning");
+  });
+
+  it("keeps unsigned thinking blocks when model changes", async () => {
+    const sessionEntries = [
+      makeModelSnapshotEntry({
+        provider: "azure-foundry",
+        modelApi: "openai-completions",
+        modelId: "gpt-52-chat",
+      }),
+    ];
+    const sessionManager = makeInMemorySessionManager(sessionEntries);
+    const messages: AgentMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "some reasoning" },
+          { type: "text", text: "answer" },
+        ],
+      },
+    ] as unknown as AgentMessage[];
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "github-copilot",
+      modelId: "claude-opus-4-6",
+      sessionManager,
+      sessionId: "test-session",
+    });
+
+    const content = (result[0] as { content: unknown[] }).content;
+    expect(content).toHaveLength(2);
+    expect((content[0] as { type: string }).type).toBe("thinking");
+    expect((content[1] as { type: string }).type).toBe("text");
+  });
+
+  it("does not downgrade thinking blocks when provider has not changed", async () => {
+    const sessionEntries = [
+      makeModelSnapshotEntry({
+        provider: "github-copilot",
+        modelApi: "openai-completions",
+        modelId: "claude-opus-4-6",
+      }),
+    ];
+    const sessionManager = makeInMemorySessionManager(sessionEntries);
+    const messages = makeReasoningAssistantMessages({ thinkingSignature: "base64" });
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "github-copilot",
+      modelId: "claude-opus-4-6",
+      sessionManager,
+      sessionId: "test-session",
+    });
+
+    // Same model — thinking blocks should be preserved as-is.
+    expect(result).toEqual(messages);
+  });
+
+  it("preserves thinking signatures when switching models within the same provider", async () => {
+    const sessionEntries = [
+      makeModelSnapshotEntry({
+        provider: "github-copilot",
+        modelApi: "openai-completions",
+        modelId: "claude-opus-4-6",
+      }),
+    ];
+    const sessionManager = makeInMemorySessionManager(sessionEntries);
+    const messages = makeReasoningAssistantMessages({ thinkingSignature: "base64" });
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "github-copilot",
+      modelId: "claude-sonnet-4-5",
+      sessionManager,
+      sessionId: "test-session",
+    });
+
+    // Different model but same provider+API — thinking signatures are provider-level
+    // and should be preserved. Opus → Sonnet on github-copilot should NOT strip sigs.
+    expect(result).toEqual(messages);
+  });
+
+  it("downgrades signed thinking blocks in legacy sessions without model snapshots", async () => {
+    // Legacy sessions predate model snapshot tracking — no snapshot entries exist.
+    // Signed thinking blocks from a previous provider should still be downgraded.
+    const sessionManager = makeInMemorySessionManager([]);
+    const messages = makeReasoningAssistantMessages({ thinkingSignature: "base64" });
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "github-copilot",
+      modelId: "claude-opus-4-6",
+      sessionManager,
+      sessionId: "test-session",
+    });
+
+    // No prior snapshot + messages exist → treat as potential provider mismatch.
+    expect(result).toHaveLength(1);
+    const content = (result[0] as { content: unknown[] }).content;
+    expect(content).toHaveLength(1);
+    expect((content[0] as { type: string }).type).toBe("text");
+    expect((content[0] as { text: string }).text).toBe("reasoning");
+  });
+
+  // -- Signature preservation matrix --
+  // These tests prove that model switches within the same provider preserve thinking
+  // quality, while cross-provider switches correctly strip incompatible signatures.
+
+  it("preserves base64 sigs: opus-4-6 → opus-4-6-fast on same provider (model upgrade)", async () => {
+    const sessionEntries = [
+      makeModelSnapshotEntry({
+        provider: "github-copilot",
+        modelApi: "openai-completions",
+        modelId: "claude-opus-4-6",
+      }),
+    ];
+    const sessionManager = makeInMemorySessionManager(sessionEntries);
+    const messages = makeReasoningAssistantMessages({ thinkingSignature: "base64" });
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "github-copilot",
+      modelId: "claude-opus-4-6-fast",
+      sessionManager,
+      sessionId: "test-session",
+    });
+
+    // Same provider — base64 signatures stay valid.
+    expect(result).toEqual(messages);
+  });
+
+  it("preserves JSON sigs: gpt-5.2 → o3-pro on same openai provider", async () => {
+    const sessionEntries = [
+      makeModelSnapshotEntry({
+        provider: "openai",
+        modelApi: "openai-responses",
+        modelId: "gpt-5.2",
+      }),
+    ];
+    const sessionManager = makeInMemorySessionManager(sessionEntries);
+    const messages = makeReasoningAssistantMessages({ thinkingSignature: "json" });
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-responses",
+      provider: "openai",
+      modelId: "o3-pro",
+      sessionManager,
+      sessionId: "test-session",
+    });
+
+    // Same provider + API — OpenAI reasoning JSON stays valid.
+    expect(result).toEqual(messages);
+  });
+
+  it("downgrades sigs when same modelApi but different provider", async () => {
+    // Both use openai-completions but different providers — signatures are not portable.
+    const sessionEntries = [
+      makeModelSnapshotEntry({
+        provider: "openai",
+        modelApi: "openai-completions",
+        modelId: "gpt-5.2",
+      }),
+    ];
+    const sessionManager = makeInMemorySessionManager(sessionEntries);
+    const messages = makeReasoningAssistantMessages({ thinkingSignature: "json" });
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "azure-foundry",
+      modelId: "gpt-5.2",
+      sessionManager,
+      sessionId: "test-session",
+    });
+
+    // Different provider — even with same model and API, signatures are downgraded.
+    expect(result).toHaveLength(1);
+    const content = (result[0] as { content: unknown[] }).content;
+    expect(content).toHaveLength(1);
+    expect((content[0] as { type: string }).type).toBe("text");
+  });
+
+  it("downgrades sigs when provider changes but modelId stays the same", async () => {
+    // Same model name on two different providers — signatures not compatible.
+    const sessionEntries = [
+      makeModelSnapshotEntry({
+        provider: "anthropic",
+        modelApi: "anthropic-messages",
+        modelId: "claude-opus-4-6",
+      }),
+    ];
+    const sessionManager = makeInMemorySessionManager(sessionEntries);
+    const messages = makeReasoningAssistantMessages({ thinkingSignature: "base64" });
+
+    const result = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "github-copilot",
+      modelId: "claude-opus-4-6",
+      sessionManager,
+      sessionId: "test-session",
+    });
+
+    // Same model name but different provider+API — must downgrade.
+    expect(result).toHaveLength(1);
+    const content = (result[0] as { content: unknown[] }).content;
+    expect(content).toHaveLength(1);
+    expect((content[0] as { type: string }).type).toBe("text");
+  });
+
+  it("writes a new snapshot on model switch within same provider", async () => {
+    const sessionEntries = [
+      makeModelSnapshotEntry({
+        provider: "github-copilot",
+        modelApi: "openai-completions",
+        modelId: "claude-opus-4-6",
+      }),
+    ];
+    const sessionManager = makeInMemorySessionManager(sessionEntries);
+    const messages = makeReasoningAssistantMessages({ thinkingSignature: "base64" });
+
+    await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "github-copilot",
+      modelId: "claude-sonnet-4-5",
+      sessionManager,
+      sessionId: "test-session",
+    });
+
+    // Even though signatures were preserved, the snapshot should update to track the new model.
+    const snapshots = sessionEntries.filter((e) => e.customType === "model-snapshot");
+    expect(snapshots).toHaveLength(2);
+    const latest = snapshots[1].data as { modelId: string };
+    expect(latest.modelId).toBe("claude-sonnet-4-5");
+  });
+
+  it("does not write a duplicate snapshot when model is identical", async () => {
+    const sessionEntries = [
+      makeModelSnapshotEntry({
+        provider: "github-copilot",
+        modelApi: "openai-completions",
+        modelId: "claude-opus-4-6",
+      }),
+    ];
+    const sessionManager = makeInMemorySessionManager(sessionEntries);
+    const messages = makeReasoningAssistantMessages({ thinkingSignature: "base64" });
+
+    await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-completions",
+      provider: "github-copilot",
+      modelId: "claude-opus-4-6",
+      sessionManager,
+      sessionId: "test-session",
+    });
+
+    // Same exact model — no new snapshot written.
+    const snapshots = sessionEntries.filter((e) => e.customType === "model-snapshot");
+    expect(snapshots).toHaveLength(1);
   });
 });

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -7,54 +7,33 @@ import {
   estimateTokens,
   SessionManager,
 } from "@mariozechner/pi-coding-agent";
-import {
-  resolveTelegramInlineButtonsScope,
-  resolveTelegramReactionLevel,
-} from "openclaw/plugin-sdk/telegram";
 import { resolveHeartbeatPrompt } from "../../auto-reply/heartbeat.js";
 import type { ReasoningLevel, ThinkLevel } from "../../auto-reply/thinking.js";
 import { resolveChannelCapabilities } from "../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import {
-  ensureContextEnginesInitialized,
-  resolveContextEngine,
-} from "../../context-engine/index.js";
-import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { getMachineDisplayName } from "../../infra/machine-name.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
-import { getMemorySearchManager } from "../../memory/index.js";
-import { resolveSignalReactionLevel } from "../../plugin-sdk/signal.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { prepareProviderRuntimeAuth } from "../../plugins/provider-runtime.js";
 import { type enqueueCommand, enqueueCommandInLane } from "../../process/command-queue.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../../routing/session-key.js";
-import { emitSessionTranscriptUpdate } from "../../sessions/transcript-events.js";
+import { resolveSignalReactionLevel } from "../../signal/reaction-level.js";
+import { resolveTelegramInlineButtonsScope } from "../../telegram/inline-buttons.js";
+import { resolveTelegramReactionLevel } from "../../telegram/reaction-level.js";
 import { buildTtsSystemPromptHint } from "../../tts/tts.js";
 import { resolveUserPath } from "../../utils.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
 import { resolveOpenClawAgentDir } from "../agent-paths.js";
-import { resolveSessionAgentId, resolveSessionAgentIds } from "../agent-scope.js";
+import { resolveSessionAgentIds } from "../agent-scope.js";
 import type { ExecElevatedDefaults } from "../bash-tools.js";
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "../bootstrap-files.js";
 import { listChannelSupportedActions, resolveChannelMessageToolHints } from "../channel-tools.js";
-import { resolveContextWindowInfo } from "../context-window-guard.js";
-import { ensureCustomApiRegistered } from "../custom-api-registry.js";
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
-import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { resolveOpenClawDocsPath } from "../docs-path.js";
-import { resolveMemorySearchConfig } from "../memory-search.js";
-import {
-  applyLocalNoAuthHeaderOverride,
-  getApiKeyForModel,
-  resolveModelAuthMode,
-} from "../model-auth.js";
-import { supportsModelTools } from "../model-tool-support.js";
+import { getApiKeyForModel, resolveModelAuthMode } from "../model-auth.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
-import { createConfiguredOllamaStreamFn } from "../ollama-stream.js";
 import { resolveOwnerDisplaySetting } from "../owner-display.js";
-import { createBundleLspToolRuntime } from "../pi-bundle-lsp-runtime.js";
-import { createBundleMcpToolRuntime } from "../pi-bundle-mcp-tools.js";
 import {
   ensureSessionHeader,
   validateAnthropicTurns,
@@ -62,7 +41,6 @@ import {
 } from "../pi-embedded-helpers.js";
 import { createPreparedEmbeddedPiSettingsManager } from "../pi-project-settings.js";
 import { createOpenClawCodingTools } from "../pi-tools.js";
-import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
 import { resolveSandboxContext } from "../sandbox.js";
 import { repairSessionFileIfNeeded } from "../session-file-repair.js";
 import { guardSessionManager } from "../session-tool-result-guard-wrapper.js";
@@ -75,13 +53,14 @@ import { detectRuntimeShell } from "../shell-utils.js";
 import {
   applySkillEnvOverrides,
   applySkillEnvOverridesFromSnapshot,
+  loadWorkspaceSkillEntries,
   resolveSkillsPromptForRun,
   type SkillSnapshot,
 } from "../skills.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
 import {
   compactWithSafetyTimeout,
-  resolveCompactionTimeoutMs,
+  EMBEDDED_COMPACTION_TIMEOUT_MS,
 } from "./compaction-safety-timeout.js";
 import { buildEmbeddedExtensionFactories } from "./extensions.js";
 import {
@@ -92,11 +71,9 @@ import {
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "./history.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
-import { buildEmbeddedMessageActionDiscoveryInput } from "./message-action-discovery-input.js";
-import { buildModelAliasLines, resolveModelAsync } from "./model.js";
+import { buildModelAliasLines, resolveModel } from "./model.js";
 import { buildEmbeddedSandboxInfo } from "./sandbox-info.js";
 import { prewarmSessionFile, trackSessionManagerAccess } from "./session-manager-cache.js";
-import { resolveEmbeddedRunSkillEntries } from "./skills-runtime.js";
 import {
   applySystemPromptOverrideToSession,
   buildEmbeddedSystemPrompt,
@@ -115,11 +92,6 @@ export type CompactEmbeddedPiSessionParams = {
   messageChannel?: string;
   messageProvider?: string;
   agentAccountId?: string;
-  currentChannelId?: string;
-  currentThreadTs?: string;
-  currentMessageId?: string | number;
-  /** Trusted sender id from inbound context for scoped message-tool discovery. */
-  senderId?: string;
   authProfileId?: string;
   /** Group id for channel-level tool policy resolution. */
   groupId?: string | null;
@@ -132,8 +104,6 @@ export type CompactEmbeddedPiSessionParams = {
   /** Whether the sender is an owner (required for owner-only tools). */
   senderIsOwner?: boolean;
   sessionFile: string;
-  /** Optional caller-observed live prompt tokens used for compaction diagnostics. */
-  currentTokenCount?: number;
   workspaceDir: string;
   agentDir?: string;
   config?: OpenClawConfig;
@@ -144,8 +114,6 @@ export type CompactEmbeddedPiSessionParams = {
   reasoningLevel?: ReasoningLevel;
   bashElevated?: ExecElevatedDefaults;
   customInstructions?: string;
-  tokenBudget?: number;
-  force?: boolean;
   trigger?: "overflow" | "manual";
   diagId?: string;
   attempt?: number;
@@ -154,9 +122,6 @@ export type CompactEmbeddedPiSessionParams = {
   enqueue?: typeof enqueueCommand;
   extraSystemPrompt?: string;
   ownerNumbers?: string[];
-  abortSignal?: AbortSignal;
-  /** Allow runtime plugins for this compaction to late-bind the gateway subagent. */
-  allowGatewaySubagentBinding?: boolean;
 };
 
 type CompactionMessageMetrics = {
@@ -167,18 +132,8 @@ type CompactionMessageMetrics = {
   contributors: Array<{ role: string; chars: number; tool?: string }>;
 };
 
-function hasRealConversationContent(msg: AgentMessage): boolean {
-  return msg.role === "user" || msg.role === "assistant" || msg.role === "toolResult";
-}
-
 function createCompactionDiagId(): string {
   return `cmp-${Date.now().toString(36)}-${generateSecureToken(4)}`;
-}
-
-function normalizeObservedTokenCount(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value > 0
-    ? Math.floor(value)
-    : undefined;
 }
 
 function getMessageTextChars(msg: AgentMessage): number {
@@ -257,9 +212,6 @@ function classifyCompactionReason(reason?: string): string {
   if (text.includes("already compacted")) {
     return "already_compacted_recently";
   }
-  if (text.includes("still exceeds target")) {
-    return "live_context_still_exceeds_target";
-  }
   if (text.includes("guard")) {
     return "guard_blocked";
   }
@@ -288,95 +240,6 @@ function classifyCompactionReason(reason?: string): string {
   return "unknown";
 }
 
-function resolvePostCompactionIndexSyncMode(config?: OpenClawConfig): "off" | "async" | "await" {
-  const mode = config?.agents?.defaults?.compaction?.postIndexSync;
-  if (mode === "off" || mode === "async" || mode === "await") {
-    return mode;
-  }
-  return "async";
-}
-
-async function runPostCompactionSessionMemorySync(params: {
-  config?: OpenClawConfig;
-  sessionKey?: string;
-  sessionFile: string;
-}): Promise<void> {
-  if (!params.config) {
-    return;
-  }
-  try {
-    const sessionFile = params.sessionFile.trim();
-    if (!sessionFile) {
-      return;
-    }
-    const agentId = resolveSessionAgentId({
-      sessionKey: params.sessionKey,
-      config: params.config,
-    });
-    const resolvedMemory = resolveMemorySearchConfig(params.config, agentId);
-    if (!resolvedMemory || !resolvedMemory.sources.includes("sessions")) {
-      return;
-    }
-    if (!resolvedMemory.sync.sessions.postCompactionForce) {
-      return;
-    }
-    const { manager } = await getMemorySearchManager({
-      cfg: params.config,
-      agentId,
-    });
-    if (!manager?.sync) {
-      return;
-    }
-    const syncTask = manager.sync({
-      reason: "post-compaction",
-      sessionFiles: [sessionFile],
-    });
-    await syncTask;
-  } catch (err) {
-    log.warn(`memory sync skipped (post-compaction): ${String(err)}`);
-  }
-}
-
-function syncPostCompactionSessionMemory(params: {
-  config?: OpenClawConfig;
-  sessionKey?: string;
-  sessionFile: string;
-  mode: "off" | "async" | "await";
-}): Promise<void> {
-  if (params.mode === "off" || !params.config) {
-    return Promise.resolve();
-  }
-
-  const syncTask = runPostCompactionSessionMemorySync({
-    config: params.config,
-    sessionKey: params.sessionKey,
-    sessionFile: params.sessionFile,
-  });
-  if (params.mode === "await") {
-    return syncTask;
-  }
-  void syncTask;
-  return Promise.resolve();
-}
-
-async function runPostCompactionSideEffects(params: {
-  config?: OpenClawConfig;
-  sessionKey?: string;
-  sessionFile: string;
-}): Promise<void> {
-  const sessionFile = params.sessionFile.trim();
-  if (!sessionFile) {
-    return;
-  }
-  emitSessionTranscriptUpdate(sessionFile);
-  await syncPostCompactionSessionMemory({
-    config: params.config,
-    sessionKey: params.sessionKey,
-    sessionFile,
-    mode: resolvePostCompactionIndexSyncMode(params.config),
-  });
-}
-
 /**
  * Core compaction logic without lane queueing.
  * Use this when already inside a session/global lane to avoid deadlocks.
@@ -391,38 +254,10 @@ export async function compactEmbeddedPiSessionDirect(
   const maxAttempts = params.maxAttempts ?? 1;
   const runId = params.runId ?? params.sessionId;
   const resolvedWorkspace = resolveUserPath(params.workspaceDir);
-  ensureRuntimePluginsLoaded({
-    config: params.config,
-    workspaceDir: resolvedWorkspace,
-    allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-  });
   const prevCwd = process.cwd();
 
-  // Resolve compaction model: prefer config override, then fall back to caller-supplied model
-  const compactionModelOverride = params.config?.agents?.defaults?.compaction?.model?.trim();
-  let provider: string;
-  let modelId: string;
-  // When switching provider via override, drop the primary auth profile to avoid
-  // sending the wrong credentials (e.g. OpenAI profile token to OpenRouter).
-  let authProfileId: string | undefined = params.authProfileId;
-  if (compactionModelOverride) {
-    const slashIdx = compactionModelOverride.indexOf("/");
-    if (slashIdx > 0) {
-      provider = compactionModelOverride.slice(0, slashIdx).trim();
-      modelId = compactionModelOverride.slice(slashIdx + 1).trim() || DEFAULT_MODEL;
-      // Provider changed — drop primary auth profile so getApiKeyForModel
-      // falls back to provider-based key resolution for the override model.
-      if (provider !== (params.provider ?? "").trim()) {
-        authProfileId = undefined;
-      }
-    } else {
-      provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
-      modelId = compactionModelOverride;
-    }
-  } else {
-    provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
-    modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
-  }
+  const provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
+  const modelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
   const fail = (reason: string): EmbeddedPiCompactResult => {
     log.warn(
       `[compaction-diag] end runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
@@ -438,7 +273,7 @@ export async function compactEmbeddedPiSessionDirect(
   };
   const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
   await ensureOpenClawModelsJson(params.config, agentDir);
-  const { model, error, authStorage, modelRegistry } = await resolveModelAsync(
+  const { model, error, authStorage, modelRegistry } = resolveModel(
     provider,
     modelId,
     agentDir,
@@ -448,49 +283,49 @@ export async function compactEmbeddedPiSessionDirect(
     const reason = error ?? `Unknown model: ${provider}/${modelId}`;
     return fail(reason);
   }
-  let runtimeModel = model;
-  let apiKeyInfo: Awaited<ReturnType<typeof getApiKeyForModel>> | null = null;
   try {
-    apiKeyInfo = await getApiKeyForModel({
-      model: runtimeModel,
+    const apiKeyInfo = await getApiKeyForModel({
+      model,
       cfg: params.config,
-      profileId: authProfileId,
+      profileId: params.authProfileId,
       agentDir,
     });
 
     if (!apiKeyInfo.apiKey) {
       if (apiKeyInfo.mode !== "aws-sdk") {
         throw new Error(
-          `No API key resolved for provider "${runtimeModel.provider}" (auth mode: ${apiKeyInfo.mode}).`,
+          `No API key resolved for provider "${model.provider}" (auth mode: ${apiKeyInfo.mode}).`,
         );
       }
+    } else if (model.provider === "github-copilot") {
+      const { resolveCopilotApiToken, SDK_MANAGED_TOKEN } =
+        await import("../../providers/github-copilot-token.js");
+      if (apiKeyInfo.apiKey === SDK_MANAGED_TOKEN) {
+        // SDK-managed auth: the Copilot SDK handles token lifecycle.
+        // We still need a Copilot API token for pi-ai, so exchange via
+        // the internal endpoint using the GH token from env if available.
+        const envToken = (
+          process.env.COPILOT_GITHUB_TOKEN ??
+          process.env.GH_TOKEN ??
+          process.env.GITHUB_TOKEN ??
+          ""
+        ).trim();
+        if (envToken) {
+          const copilotToken = await resolveCopilotApiToken({ githubToken: envToken });
+          authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+        } else {
+          log.warn(
+            "SDK-managed Copilot auth has no env token (COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN) — REST API calls may fail",
+          );
+        }
+      } else {
+        const copilotToken = await resolveCopilotApiToken({
+          githubToken: apiKeyInfo.apiKey,
+        });
+        authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+      }
     } else {
-      const preparedAuth = await prepareProviderRuntimeAuth({
-        provider: runtimeModel.provider,
-        config: params.config,
-        workspaceDir: resolvedWorkspace,
-        env: process.env,
-        context: {
-          config: params.config,
-          agentDir,
-          workspaceDir: resolvedWorkspace,
-          env: process.env,
-          provider: runtimeModel.provider,
-          modelId,
-          model: runtimeModel,
-          apiKey: apiKeyInfo.apiKey,
-          authMode: apiKeyInfo.mode,
-          profileId: apiKeyInfo.profileId,
-        },
-      });
-      if (preparedAuth?.baseUrl) {
-        runtimeModel = { ...runtimeModel, baseUrl: preparedAuth.baseUrl };
-      }
-      const runtimeApiKey = preparedAuth?.apiKey ?? apiKeyInfo.apiKey;
-      if (!runtimeApiKey) {
-        throw new Error(`Provider "${runtimeModel.provider}" runtime auth returned no apiKey.`);
-      }
-      authStorage.setRuntimeApiKey(runtimeModel.provider, runtimeApiKey);
+      authStorage.setRuntimeApiKey(model.provider, apiKeyInfo.apiKey);
     }
   } catch (err) {
     const reason = describeUnknownError(err);
@@ -519,11 +354,10 @@ export async function compactEmbeddedPiSessionDirect(
   let restoreSkillEnv: (() => void) | undefined;
   process.chdir(effectiveWorkspace);
   try {
-    const { shouldLoadSkillEntries, skillEntries } = resolveEmbeddedRunSkillEntries({
-      workspaceDir: effectiveWorkspace,
-      config: params.config,
-      skillsSnapshot: params.skillsSnapshot,
-    });
+    const shouldLoadSkillEntries = !params.skillsSnapshot || !params.skillsSnapshot.resolvedSkills;
+    const skillEntries = shouldLoadSkillEntries
+      ? loadWorkspaceSkillEntries(effectiveWorkspace)
+      : [];
     restoreSkillEnv = params.skillsSnapshot
       ? applySkillEnvOverridesFromSnapshot({
           snapshot: params.skillsSnapshot,
@@ -541,7 +375,6 @@ export async function compactEmbeddedPiSessionDirect(
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
-    const resolvedMessageProvider = params.messageChannel ?? params.messageProvider;
     const { contextFiles } = await resolveBootstrapContextForRun({
       workspaceDir: effectiveWorkspace,
       config: params.config,
@@ -549,78 +382,33 @@ export async function compactEmbeddedPiSessionDirect(
       sessionId: params.sessionId,
       warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
     });
-    // Apply contextTokens cap to model so pi-coding-agent's auto-compaction
-    // threshold uses the effective limit, not the native context window.
-    const ctxInfo = resolveContextWindowInfo({
-      cfg: params.config,
-      provider,
-      modelId,
-      modelContextWindow: runtimeModel.contextWindow,
-      defaultTokens: DEFAULT_CONTEXT_TOKENS,
-    });
-    const effectiveModel = applyLocalNoAuthHeaderOverride(
-      ctxInfo.tokens < (runtimeModel.contextWindow ?? Infinity)
-        ? { ...runtimeModel, contextWindow: ctxInfo.tokens }
-        : runtimeModel,
-      apiKeyInfo,
-    );
-
     const runAbortController = new AbortController();
     const toolsRaw = createOpenClawCodingTools({
       exec: {
         elevated: params.bashElevated,
       },
       sandbox,
-      messageProvider: resolvedMessageProvider,
+      messageProvider: params.messageChannel ?? params.messageProvider,
       agentAccountId: params.agentAccountId,
       sessionKey: sandboxSessionKey,
       sessionId: params.sessionId,
-      runId: params.runId,
       groupId: params.groupId,
       groupChannel: params.groupChannel,
       groupSpace: params.groupSpace,
       spawnedBy: params.spawnedBy,
       senderIsOwner: params.senderIsOwner,
-      allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
       agentDir,
       workspaceDir: effectiveWorkspace,
       config: params.config,
       abortSignal: runAbortController.signal,
       modelProvider: model.provider,
       modelId,
-      modelCompat: effectiveModel.compat,
-      modelContextWindowTokens: ctxInfo.tokens,
+      modelContextWindowTokens: model.contextWindow,
       modelAuthMode: resolveModelAuthMode(model.provider, params.config),
     });
-    const toolsEnabled = supportsModelTools(runtimeModel);
-    const tools = sanitizeToolsForGoogle({
-      tools: toolsEnabled ? toolsRaw : [],
-      provider,
-    });
-    const bundleMcpRuntime = toolsEnabled
-      ? await createBundleMcpToolRuntime({
-          workspaceDir: effectiveWorkspace,
-          cfg: params.config,
-          reservedToolNames: tools.map((tool) => tool.name),
-        })
-      : undefined;
-    const bundleLspRuntime = toolsEnabled
-      ? await createBundleLspToolRuntime({
-          workspaceDir: effectiveWorkspace,
-          cfg: params.config,
-          reservedToolNames: [
-            ...tools.map((tool) => tool.name),
-            ...(bundleMcpRuntime?.tools.map((tool) => tool.name) ?? []),
-          ],
-        })
-      : undefined;
-    const effectiveTools = [
-      ...tools,
-      ...(bundleMcpRuntime?.tools ?? []),
-      ...(bundleLspRuntime?.tools ?? []),
-    ];
-    const allowedToolNames = collectAllowedToolNames({ tools: effectiveTools });
-    logToolSchemasForGoogle({ tools: effectiveTools, provider });
+    const tools = sanitizeToolsForGoogle({ tools: toolsRaw, provider });
+    const allowedToolNames = collectAllowedToolNames({ tools });
+    logToolSchemasForGoogle({ tools, provider });
     const machineName = await getMachineDisplayName();
     const runtimeChannel = normalizeMessageChannel(params.messageChannel ?? params.messageProvider);
     let runtimeCapabilities = runtimeChannel
@@ -668,26 +456,12 @@ export async function compactEmbeddedPiSessionDirect(
             return undefined;
           })()
         : undefined;
-    const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
-      sessionKey: params.sessionKey,
-      config: params.config,
-    });
     // Resolve channel-specific message actions for system prompt
     const channelActions = runtimeChannel
-      ? listChannelSupportedActions(
-          buildEmbeddedMessageActionDiscoveryInput({
-            cfg: params.config,
-            channel: runtimeChannel,
-            currentChannelId: params.currentChannelId,
-            currentThreadTs: params.currentThreadTs,
-            currentMessageId: params.currentMessageId,
-            accountId: params.agentAccountId,
-            sessionKey: params.sessionKey,
-            sessionId: params.sessionId,
-            agentId: sessionAgentId,
-            senderId: params.senderId,
-          }),
-        )
+      ? listChannelSupportedActions({
+          cfg: params.config,
+          channel: runtimeChannel,
+        })
       : undefined;
     const messageToolHints = runtimeChannel
       ? resolveChannelMessageToolHints({
@@ -713,6 +487,10 @@ export async function compactEmbeddedPiSessionDirect(
     const userTimezone = resolveUserTimezone(params.config?.agents?.defaults?.userTimezone);
     const userTimeFormat = resolveUserTimeFormat(params.config?.agents?.defaults?.timeFormat);
     const userTime = formatUserTime(new Date(), userTimezone, userTimeFormat);
+    const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
+      sessionKey: params.sessionKey,
+      config: params.config,
+    });
     const isDefaultAgent = sessionAgentId === defaultAgentId;
     const promptMode =
       isSubagentSessionKey(params.sessionKey) || isCronSessionKey(params.sessionKey)
@@ -747,7 +525,7 @@ export async function compactEmbeddedPiSessionDirect(
       reactionGuidance,
       messageToolHints,
       sandboxInfo,
-      tools: effectiveTools,
+      tools,
       modelAliasLines: buildModelAliasLines(params.config),
       userTimezone,
       userTime,
@@ -757,11 +535,10 @@ export async function compactEmbeddedPiSessionDirect(
     });
     const systemPromptOverride = createSystemPromptOverride(appendPrompt);
 
-    const compactionTimeoutMs = resolveCompactionTimeoutMs(params.config);
     const sessionLock = await acquireSessionWriteLock({
       sessionFile: params.sessionFile,
       maxHoldMs: resolveSessionLockMaxHoldFromTimeout({
-        timeoutMs: compactionTimeoutMs,
+        timeoutMs: EMBEDDED_COMPACTION_TIMEOUT_MS,
       }),
     });
     try {
@@ -810,16 +587,16 @@ export async function compactEmbeddedPiSessionDirect(
       }
 
       const { builtInTools, customTools } = splitSdkTools({
-        tools: effectiveTools,
+        tools,
         sandboxEnabled: !!sandbox?.enabled,
       });
 
       const { session } = await createAgentSession({
-        cwd: effectiveWorkspace,
+        cwd: resolvedWorkspace,
         agentDir,
         authStorage,
         modelRegistry,
-        model: effectiveModel,
+        model,
         thinkingLevel: mapThinkingLevel(params.thinkLevel),
         tools: builtInTools,
         customTools,
@@ -828,19 +605,6 @@ export async function compactEmbeddedPiSessionDirect(
         resourceLoader,
       });
       applySystemPromptOverrideToSession(session, systemPromptOverride());
-      if (model.api === "ollama") {
-        const providerBaseUrl =
-          typeof params.config?.models?.providers?.[model.provider]?.baseUrl === "string"
-            ? params.config.models.providers[model.provider]?.baseUrl
-            : undefined;
-        ensureCustomApiRegistered(
-          model.api,
-          createConfiguredOllamaStreamFn({
-            model,
-            providerBaseUrl,
-          }),
-        );
-      }
 
       try {
         const prior = await sanitizeSessionHistory({
@@ -860,14 +624,10 @@ export async function compactEmbeddedPiSessionDirect(
         const validated = transcriptPolicy.validateAnthropicTurns
           ? validateAnthropicTurns(validatedGemini)
           : validatedGemini;
-        // Apply validated transcript to the live session even when no history limit is configured,
-        // so compaction and hook metrics are based on the same message set.
-        session.agent.replaceMessages(validated);
-        // "Original" compaction metrics should describe the validated transcript that enters
-        // limiting/compaction, not the raw on-disk session snapshot.
-        const originalMessages = session.messages.slice();
+        // Capture full message history BEFORE limiting — plugins need the complete conversation
+        const preCompactionMessages = [...session.messages];
         const truncated = limitHistoryTurns(
-          session.messages,
+          validated,
           getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
         );
         // Re-run tool_use/tool_result pairing repair after truncation, since
@@ -879,72 +639,34 @@ export async function compactEmbeddedPiSessionDirect(
         if (limited.length > 0) {
           session.agent.replaceMessages(limited);
         }
-        const missingSessionKey = !params.sessionKey || !params.sessionKey.trim();
-        const hookSessionKey = params.sessionKey?.trim() || params.sessionId;
+        // Run before_compaction hooks (fire-and-forget).
+        // The session JSONL already contains all messages on disk, so plugins
+        // can read sessionFile asynchronously and process in parallel with
+        // the compaction LLM call — no need to block or wait for after_compaction.
         const hookRunner = getGlobalHookRunner();
-        const observedTokenCount = normalizeObservedTokenCount(params.currentTokenCount);
-        const messageCountOriginal = originalMessages.length;
-        let tokenCountOriginal: number | undefined;
-        try {
-          tokenCountOriginal = 0;
-          for (const message of originalMessages) {
-            tokenCountOriginal += estimateTokens(message);
-          }
-        } catch {
-          tokenCountOriginal = undefined;
-        }
-        const messageCountBefore = session.messages.length;
-        let tokenCountBefore = observedTokenCount;
-        if (tokenCountBefore === undefined) {
-          try {
-            tokenCountBefore = 0;
-            for (const message of session.messages) {
-              tokenCountBefore += estimateTokens(message);
-            }
-          } catch {
-            tokenCountBefore = undefined;
-          }
-        }
-        // TODO(#7175): Consider exposing full message snapshots or pre-compaction injection
-        // hooks; current events only report counts/metadata.
-        try {
-          const hookEvent = createInternalHookEvent("session", "compact:before", hookSessionKey, {
-            sessionId: params.sessionId,
-            missingSessionKey,
-            messageCount: messageCountBefore,
-            tokenCount: tokenCountBefore,
-            messageCountOriginal,
-            tokenCountOriginal,
-          });
-          await triggerInternalHook(hookEvent);
-        } catch (err) {
-          log.warn("session:compact:before hook failed", {
-            errorMessage: err instanceof Error ? err.message : String(err),
-            errorStack: err instanceof Error ? err.stack : undefined,
-          });
-        }
+        const hookCtx = {
+          agentId: params.sessionKey?.split(":")[0] ?? "main",
+          sessionKey: params.sessionKey,
+          sessionId: params.sessionId,
+          workspaceDir: params.workspaceDir,
+          messageProvider: params.messageChannel ?? params.messageProvider,
+        };
         if (hookRunner?.hasHooks("before_compaction")) {
-          try {
-            await hookRunner.runBeforeCompaction(
+          hookRunner
+            .runBeforeCompaction(
               {
-                messageCount: messageCountBefore,
-                tokenCount: tokenCountBefore,
+                messageCount: preCompactionMessages.length,
+                compactingCount: limited.length,
+                messages: preCompactionMessages,
+                sessionFile: params.sessionFile,
               },
-              {
-                sessionId: params.sessionId,
-                agentId: sessionAgentId,
-                sessionKey: hookSessionKey,
-                workspaceDir: effectiveWorkspace,
-                messageProvider: resolvedMessageProvider,
-              },
-            );
-          } catch (err) {
-            log.warn("before_compaction hook failed", {
-              errorMessage: err instanceof Error ? err.message : String(err),
-              errorStack: err instanceof Error ? err.stack : undefined,
+              hookCtx,
+            )
+            .catch((hookErr: unknown) => {
+              log.warn(`before_compaction hook failed: ${String(hookErr)}`);
             });
-          }
         }
+
         const diagEnabled = log.isEnabled("debug");
         const preMetrics = diagEnabled ? summarizeCompactionMessages(session.messages) : undefined;
         if (diagEnabled && preMetrics) {
@@ -960,47 +682,10 @@ export async function compactEmbeddedPiSessionDirect(
           );
         }
 
-        if (!session.messages.some(hasRealConversationContent)) {
-          log.info(
-            `[compaction] skipping — no real conversation messages (sessionKey=${params.sessionKey ?? params.sessionId})`,
-          );
-          return {
-            ok: true,
-            compacted: false,
-            reason: "no real conversation messages",
-          };
-        }
-
         const compactStartedAt = Date.now();
-        // Measure compactedCount from the original pre-limiting transcript so compaction
-        // lifecycle metrics represent total reduction through the compaction pipeline.
-        const messageCountCompactionInput = messageCountOriginal;
-        // Estimate full session tokens BEFORE compaction (including system prompt,
-        // bootstrap context, workspace files, and all history). This is needed for
-        // a correct sanity check — result.tokensBefore only covers the summarizable
-        // history subset, not the full session.
-        let fullSessionTokensBefore = 0;
-        try {
-          fullSessionTokensBefore = limited.reduce((sum, msg) => sum + estimateTokens(msg), 0);
-        } catch {
-          // If token estimation throws on a malformed message, fall back to 0 so
-          // the sanity check below becomes a no-op instead of crashing compaction.
-        }
-        const result = await compactWithSafetyTimeout(
-          () => session.compact(params.customInstructions),
-          compactionTimeoutMs,
-          {
-            abortSignal: params.abortSignal,
-            onCancel: () => {
-              session.abortCompaction();
-            },
-          },
+        const result = await compactWithSafetyTimeout(() =>
+          session.compact(params.customInstructions),
         );
-        await runPostCompactionSideEffects({
-          config: params.config,
-          sessionKey: params.sessionKey,
-          sessionFile: params.sessionFile,
-        });
         // Estimate tokens after compaction by summing token estimates for remaining messages
         let tokensAfter: number | undefined;
         try {
@@ -1008,23 +693,33 @@ export async function compactEmbeddedPiSessionDirect(
           for (const message of session.messages) {
             tokensAfter += estimateTokens(message);
           }
-          // Sanity check: compare against the best full-session pre-compaction baseline.
-          // Prefer the provider-observed live count when available; otherwise use the
-          // heuristic full-session estimate with a 10% margin for counter jitter.
-          const sanityCheckBaseline = observedTokenCount ?? fullSessionTokensBefore;
-          if (
-            sanityCheckBaseline > 0 &&
-            tokensAfter >
-              (observedTokenCount !== undefined ? sanityCheckBaseline : sanityCheckBaseline * 1.1)
-          ) {
+          // Sanity check: tokensAfter should be less than tokensBefore
+          if (tokensAfter > result.tokensBefore) {
             tokensAfter = undefined; // Don't trust the estimate
           }
         } catch {
           // If estimation fails, leave tokensAfter undefined
           tokensAfter = undefined;
         }
-        const messageCountAfter = session.messages.length;
-        const compactedCount = Math.max(0, messageCountCompactionInput - messageCountAfter);
+        // Run after_compaction hooks (fire-and-forget).
+        // Also includes sessionFile for plugins that only need to act after
+        // compaction completes (e.g. analytics, cleanup).
+        if (hookRunner?.hasHooks("after_compaction")) {
+          hookRunner
+            .runAfterCompaction(
+              {
+                messageCount: session.messages.length,
+                tokenCount: tokensAfter,
+                compactedCount: limited.length - session.messages.length,
+                sessionFile: params.sessionFile,
+              },
+              hookCtx,
+            )
+            .catch((hookErr) => {
+              log.warn(`after_compaction hook failed: ${hookErr}`);
+            });
+        }
+
         const postMetrics = diagEnabled ? summarizeCompactionMessages(session.messages) : undefined;
         if (diagEnabled && preMetrics && postMetrics) {
           log.debug(
@@ -1040,58 +735,13 @@ export async function compactEmbeddedPiSessionDirect(
               `delta.estTokens=${typeof preMetrics.estTokens === "number" && typeof postMetrics.estTokens === "number" ? postMetrics.estTokens - preMetrics.estTokens : "unknown"}`,
           );
         }
-        // TODO(#9611): Consider exposing compaction summaries or post-compaction injection;
-        // current events only report summary metadata.
-        try {
-          const hookEvent = createInternalHookEvent("session", "compact:after", hookSessionKey, {
-            sessionId: params.sessionId,
-            missingSessionKey,
-            messageCount: messageCountAfter,
-            tokenCount: tokensAfter,
-            compactedCount,
-            summaryLength: typeof result.summary === "string" ? result.summary.length : undefined,
-            tokensBefore: result.tokensBefore,
-            tokensAfter,
-            firstKeptEntryId: result.firstKeptEntryId,
-          });
-          await triggerInternalHook(hookEvent);
-        } catch (err) {
-          log.warn("session:compact:after hook failed", {
-            errorMessage: err instanceof Error ? err.message : String(err),
-            errorStack: err instanceof Error ? err.stack : undefined,
-          });
-        }
-        if (hookRunner?.hasHooks("after_compaction")) {
-          try {
-            await hookRunner.runAfterCompaction(
-              {
-                messageCount: messageCountAfter,
-                tokenCount: tokensAfter,
-                compactedCount,
-                sessionFile: params.sessionFile,
-              },
-              {
-                sessionId: params.sessionId,
-                agentId: sessionAgentId,
-                sessionKey: hookSessionKey,
-                workspaceDir: effectiveWorkspace,
-                messageProvider: resolvedMessageProvider,
-              },
-            );
-          } catch (err) {
-            log.warn("after_compaction hook failed", {
-              errorMessage: err instanceof Error ? err.message : String(err),
-              errorStack: err instanceof Error ? err.stack : undefined,
-            });
-          }
-        }
         return {
           ok: true,
           compacted: true,
           result: {
             summary: result.summary,
             firstKeptEntryId: result.firstKeptEntryId,
-            tokensBefore: observedTokenCount ?? result.tokensBefore,
+            tokensBefore: result.tokensBefore,
             tokensAfter,
             details: result.details,
           },
@@ -1100,11 +750,8 @@ export async function compactEmbeddedPiSessionDirect(
         await flushPendingToolResultsAfterIdle({
           agent: session?.agent,
           sessionManager,
-          clearPendingOnTimeout: true,
         });
         session.dispose();
-        await bundleMcpRuntime?.dispose();
-        await bundleLspRuntime?.dispose();
       }
     } finally {
       await sessionLock.release();
@@ -1131,122 +778,6 @@ export async function compactEmbeddedPiSession(
   const enqueueGlobal =
     params.enqueue ?? ((task, opts) => enqueueCommandInLane(globalLane, task, opts));
   return enqueueCommandInLane(sessionLane, () =>
-    enqueueGlobal(async () => {
-      ensureRuntimePluginsLoaded({
-        config: params.config,
-        workspaceDir: params.workspaceDir,
-        allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-      });
-      ensureContextEnginesInitialized();
-      const contextEngine = await resolveContextEngine(params.config);
-      try {
-        // Resolve token budget from model context window so the context engine
-        // knows the compaction target.  The runner's afterTurn path passes this
-        // automatically, but the /compact command path needs to compute it here.
-        const ceProvider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
-        const ceModelId = (params.model ?? DEFAULT_MODEL).trim() || DEFAULT_MODEL;
-        const agentDir = params.agentDir ?? resolveOpenClawAgentDir();
-        const { model: ceModel } = await resolveModelAsync(
-          ceProvider,
-          ceModelId,
-          agentDir,
-          params.config,
-        );
-        const ceCtxInfo = resolveContextWindowInfo({
-          cfg: params.config,
-          provider: ceProvider,
-          modelId: ceModelId,
-          modelContextWindow: ceModel?.contextWindow,
-          defaultTokens: DEFAULT_CONTEXT_TOKENS,
-        });
-        // When the context engine owns compaction, its compact() implementation
-        // bypasses compactEmbeddedPiSessionDirect (which fires the hooks internally).
-        // Fire before_compaction / after_compaction hooks here so plugin subscribers
-        // are notified regardless of which engine is active.
-        const engineOwnsCompaction = contextEngine.info.ownsCompaction === true;
-        const hookRunner = engineOwnsCompaction ? getGlobalHookRunner() : null;
-        const hookSessionKey = params.sessionKey?.trim() || params.sessionId;
-        const { sessionAgentId } = resolveSessionAgentIds({
-          sessionKey: params.sessionKey,
-          config: params.config,
-        });
-        const resolvedMessageProvider = params.messageChannel ?? params.messageProvider;
-        const hookCtx = {
-          sessionId: params.sessionId,
-          agentId: sessionAgentId,
-          sessionKey: hookSessionKey,
-          workspaceDir: resolveUserPath(params.workspaceDir),
-          messageProvider: resolvedMessageProvider,
-        };
-        // Engine-owned compaction doesn't load the transcript at this level, so
-        // message counts are unavailable.  We pass sessionFile so hook subscribers
-        // can read the transcript themselves if they need exact counts.
-        if (hookRunner?.hasHooks("before_compaction")) {
-          try {
-            await hookRunner.runBeforeCompaction(
-              {
-                messageCount: -1,
-                sessionFile: params.sessionFile,
-              },
-              hookCtx,
-            );
-          } catch (err) {
-            log.warn("before_compaction hook failed", {
-              errorMessage: err instanceof Error ? err.message : String(err),
-            });
-          }
-        }
-        const result = await contextEngine.compact({
-          sessionId: params.sessionId,
-          sessionKey: params.sessionKey,
-          sessionFile: params.sessionFile,
-          tokenBudget: ceCtxInfo.tokens,
-          currentTokenCount: params.currentTokenCount,
-          customInstructions: params.customInstructions,
-          force: params.trigger === "manual",
-          runtimeContext: params as Record<string, unknown>,
-        });
-        if (engineOwnsCompaction && result.ok && result.compacted) {
-          await runPostCompactionSideEffects({
-            config: params.config,
-            sessionKey: params.sessionKey,
-            sessionFile: params.sessionFile,
-          });
-        }
-        if (result.ok && result.compacted && hookRunner?.hasHooks("after_compaction")) {
-          try {
-            await hookRunner.runAfterCompaction(
-              {
-                messageCount: -1,
-                compactedCount: -1,
-                tokenCount: result.result?.tokensAfter,
-                sessionFile: params.sessionFile,
-              },
-              hookCtx,
-            );
-          } catch (err) {
-            log.warn("after_compaction hook failed", {
-              errorMessage: err instanceof Error ? err.message : String(err),
-            });
-          }
-        }
-        return {
-          ok: result.ok,
-          compacted: result.compacted,
-          reason: result.reason,
-          result: result.result
-            ? {
-                summary: result.result.summary ?? "",
-                firstKeptEntryId: result.result.firstKeptEntryId ?? "",
-                tokensBefore: result.result.tokensBefore,
-                tokensAfter: result.result.tokensAfter,
-                details: result.result.details,
-              }
-            : undefined,
-        };
-      } finally {
-        await contextEngine.dispose?.();
-      }
-    }),
+    enqueueGlobal(async () => compactEmbeddedPiSessionDirect(params)),
   );
 }

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -16,6 +16,8 @@ import {
   isGoogleModelApi,
   sanitizeGoogleTurnOrdering,
   sanitizeSessionMessagesImages,
+  stripInvalidThinkingSignatures,
+  downgradeThinkingBlocksOnModelSwitch,
 } from "../pi-embedded-helpers.js";
 import { cleanToolSchemaForGemini } from "../pi-tools.schema.js";
 import {
@@ -469,6 +471,17 @@ function isSameModelSnapshot(a: ModelSnapshotEntry, b: ModelSnapshotEntry): bool
   );
 }
 
+// Thinking signatures are provider-level (e.g. Anthropic base64, OpenAI JSON reasoning)
+// and remain valid when switching models within the same provider/API combination.
+// Only cross-provider switches produce incompatible signatures.
+function isSignatureCompatibleSnapshot(a: ModelSnapshotEntry, b: ModelSnapshotEntry): boolean {
+  const normalize = (value?: string | null) => value ?? "";
+  return (
+    normalize(a.provider) === normalize(b.provider) &&
+    normalize(a.modelApi) === normalize(b.modelApi)
+  );
+}
+
 function hasGoogleTurnOrderingMarker(sessionManager: SessionManager): boolean {
   try {
     return sessionManager
@@ -552,7 +565,12 @@ export async function sanitizeSessionHistory(params: {
   const droppedThinking = policy.dropThinkingBlocks
     ? dropThinkingBlocks(sanitizedImages)
     : sanitizedImages;
-  const sanitizedToolCalls = sanitizeToolCallInputs(droppedThinking, {
+  // Strip thinking blocks whose thinkingSignature is a bare field-name artifact from the
+  // openai-completions path (e.g. "reasoning_text"). These cannot be round-tripped through
+  // openai-responses (JSON.parse crash) or openai-completions → Copilot proxy → Anthropic
+  // ("Invalid signature in thinking block"). Must run before downgradeOpenAIReasoningBlocks.
+  const sanitizedThinkingSigs = stripInvalidThinkingSignatures(droppedThinking);
+  const sanitizedToolCalls = sanitizeToolCallInputs(sanitizedThinkingSigs, {
     allowedToolNames: params.allowedToolNames,
   });
   const repairedTools = policy.repairToolUseResultPairing
@@ -567,19 +585,34 @@ export async function sanitizeSessionHistory(params: {
     params.modelApi === "openai-responses" || params.modelApi === "openai-codex-responses";
   const hasSnapshot = Boolean(params.provider || params.modelApi || params.modelId);
   const priorSnapshot = hasSnapshot ? readLastModelSnapshot(params.sessionManager) : null;
-  const modelChanged = priorSnapshot
-    ? !isSameModelSnapshot(priorSnapshot, {
-        timestamp: 0,
-        provider: params.provider,
-        modelApi: params.modelApi,
-        modelId: params.modelId,
-      })
+  const currentSnapshot: ModelSnapshotEntry = {
+    timestamp: 0,
+    provider: params.provider,
+    modelApi: params.modelApi,
+    modelId: params.modelId,
+  };
+  const modelChanged = priorSnapshot ? !isSameModelSnapshot(priorSnapshot, currentSnapshot) : false;
+  // Thinking signatures are provider-level (Anthropic base64, OpenAI reasoning JSON) and
+  // remain valid across model switches within the same provider+API. Only cross-provider
+  // switches produce incompatible signatures (e.g. OpenAI reasoning JSON sent via Copilot
+  // to Claude → "Invalid signature in thinking block" HTTP 400).
+  const signatureIncompatible = priorSnapshot
+    ? !isSignatureCompatibleSnapshot(priorSnapshot, currentSnapshot)
     : false;
+  // Also downgrade when there's no prior snapshot but the session already has messages
+  // (legacy sessions that predate model snapshot tracking may have toxic signatures).
+  const needsThinkingDowngrade =
+    signatureIncompatible || (hasSnapshot && !priorSnapshot && sanitizedCompactionUsage.length > 0);
+  const sanitizedModelSwitch = needsThinkingDowngrade
+    ? downgradeThinkingBlocksOnModelSwitch(sanitizedCompactionUsage)
+    : sanitizedCompactionUsage;
   const sanitizedOpenAI = isOpenAIResponsesApi
     ? downgradeOpenAIFunctionCallReasoningPairs(
-        downgradeOpenAIReasoningBlocks(sanitizedCompactionUsage),
+        signatureIncompatible
+          ? downgradeOpenAIReasoningBlocks(sanitizedModelSwitch)
+          : sanitizedModelSwitch,
       )
-    : sanitizedCompactionUsage;
+    : sanitizedModelSwitch;
 
   if (hasSnapshot && (!priorSnapshot || modelChanged)) {
     appendModelSnapshot(params.sessionManager, {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1,14 +1,8 @@
 import { randomBytes } from "node:crypto";
 import fs from "node:fs/promises";
 import type { ThinkLevel } from "../../auto-reply/thinking.js";
-import {
-  ensureContextEnginesInitialized,
-  resolveContextEngine,
-} from "../../context-engine/index.js";
-import { computeBackoff, sleepWithAbort, type BackoffPolicy } from "../../infra/backoff.js";
 import { generateSecureToken } from "../../infra/secure-random.js";
 import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
-import { prepareProviderRuntimeAuth } from "../../plugins/provider-runtime.js";
 import type { PluginHookBeforeAgentStartResult } from "../../plugins/types.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import { isMarkdownCapableMessageChannel } from "../../utils/message-channel.js";
@@ -16,7 +10,6 @@ import { resolveOpenClawAgentDir } from "../agent-paths.js";
 import { hasConfiguredModelFallbacks } from "../agent-scope.js";
 import {
   isProfileInCooldown,
-  type AuthProfileFailureReason,
   markAuthProfileFailure,
   markAuthProfileGood,
   markAuthProfileUsed,
@@ -29,14 +22,8 @@ import {
   resolveContextWindowInfo,
 } from "../context-window-guard.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
+import { FailoverError, resolveFailoverStatus } from "../failover-error.js";
 import {
-  coerceToFailoverError,
-  describeFailoverError,
-  FailoverError,
-  resolveFailoverStatus,
-} from "../failover-error.js";
-import {
-  applyLocalNoAuthHeaderOverride,
   ensureAuthProfileStore,
   getApiKeyForModel,
   resolveAuthProfileOrder,
@@ -47,7 +34,6 @@ import { ensureOpenClawModelsJson } from "../models-config.js";
 import {
   formatBillingErrorMessage,
   classifyFailoverReason,
-  extractObservedOverflowTokenCount,
   formatAssistantErrorText,
   isAuthAssistantError,
   isBillingAssistantError,
@@ -62,15 +48,13 @@ import {
   pickFallbackThinkingLevel,
   type FailoverReason,
 } from "../pi-embedded-helpers.js";
-import { ensureRuntimePluginsLoaded } from "../runtime-plugins.js";
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../usage.js";
 import { redactRunIdentifier, resolveRunWorkspaceDir } from "../workspace-run.js";
-import { buildEmbeddedCompactionRuntimeContext } from "./compaction-runtime-context.js";
+import { compactEmbeddedPiSessionDirect } from "./compact.js";
 import { resolveGlobalLane, resolveSessionLane } from "./lanes.js";
 import { log } from "./logger.js";
-import { resolveModelAsync } from "./model.js";
+import { resolveModel } from "./model.js";
 import { runEmbeddedAttempt } from "./run/attempt.js";
-import { createFailoverDecisionLogger } from "./run/failover-observation.js";
 import type { RunEmbeddedPiAgentParams } from "./run/params.js";
 import { buildEmbeddedRunPayloads } from "./run/payloads.js";
 import {
@@ -82,26 +66,16 @@ import { describeUnknownError } from "./utils.js";
 
 type ApiKeyInfo = ResolvedProviderAuth;
 
-type RuntimeAuthState = {
-  sourceApiKey: string;
-  authMode: string;
-  profileId?: string;
-  expiresAt?: number;
+type CopilotTokenState = {
+  githubToken: string;
+  expiresAt: number;
   refreshTimer?: ReturnType<typeof setTimeout>;
   refreshInFlight?: Promise<void>;
 };
 
-const RUNTIME_AUTH_REFRESH_MARGIN_MS = 5 * 60 * 1000;
-const RUNTIME_AUTH_REFRESH_RETRY_MS = 60 * 1000;
-const RUNTIME_AUTH_REFRESH_MIN_DELAY_MS = 5 * 1000;
-// Keep overload pacing noticeable enough to avoid tight retry bursts, but short
-// enough that fallback still feels responsive within a single turn.
-const OVERLOAD_FAILOVER_BACKOFF_POLICY: BackoffPolicy = {
-  initialMs: 250,
-  maxMs: 1_500,
-  factor: 2,
-  jitter: 0.2,
-};
+const COPILOT_REFRESH_MARGIN_MS = 5 * 60 * 1000;
+const COPILOT_REFRESH_RETRY_MS = 60 * 1000;
+const COPILOT_REFRESH_MIN_DELAY_MS = 5 * 1000;
 
 // Avoid Anthropic's refusal test token poisoning session transcripts.
 const ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
@@ -226,43 +200,6 @@ function resolveActiveErrorContext(params: {
   };
 }
 
-/**
- * Build agentMeta for error return paths, preserving accumulated usage so that
- * session totalTokens reflects the actual context size rather than going stale.
- * Without this, error returns omit usage and the session keeps whatever
- * totalTokens was set by the previous successful run.
- */
-function buildErrorAgentMeta(params: {
-  sessionId: string;
-  provider: string;
-  model: string;
-  usageAccumulator: UsageAccumulator;
-  lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
-  lastAssistant?: { usage?: unknown } | null;
-  /** API-reported total from the most recent call, mirroring the success path correction. */
-  lastTurnTotal?: number;
-}): EmbeddedPiAgentMeta {
-  const usage = toNormalizedUsage(params.usageAccumulator);
-  // Apply the same lastTurnTotal correction the success path uses so
-  // usage.total reflects the API-reported context size, not accumulated totals.
-  if (usage && params.lastTurnTotal && params.lastTurnTotal > 0) {
-    usage.total = params.lastTurnTotal;
-  }
-  const lastCallUsage = params.lastAssistant
-    ? normalizeUsage(params.lastAssistant.usage as UsageLike)
-    : undefined;
-  const promptTokens = derivePromptTokens(params.lastRunPromptUsage);
-  return {
-    sessionId: params.sessionId,
-    provider: params.provider,
-    model: params.model,
-    // Only include usage fields when we have actual data from prior API calls.
-    ...(usage ? { usage } : {}),
-    ...(lastCallUsage ? { lastCallUsage } : {}),
-    ...(promptTokens ? { promptTokens } : {}),
-  };
-}
-
 export async function runEmbeddedPiAgent(
   params: RunEmbeddedPiAgentParams,
 ): Promise<EmbeddedPiRunResult> {
@@ -300,11 +237,6 @@ export async function runEmbeddedPiAgent(
           `[workspace-fallback] caller=runEmbeddedPiAgent reason=${workspaceResolution.fallbackReason} run=${params.runId} session=${redactedSessionId} sessionKey=${redactedSessionKey} agent=${workspaceResolution.agentId} workspace=${redactedWorkspace}`,
         );
       }
-      ensureRuntimePluginsLoaded({
-        config: params.config,
-        workspaceDir: resolvedWorkspace,
-        allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-      });
       const prevCwd = process.cwd();
 
       let provider = (params.provider ?? DEFAULT_PROVIDER).trim() || DEFAULT_PROVIDER;
@@ -331,8 +263,6 @@ export async function runEmbeddedPiAgent(
         sessionId: params.sessionId,
         workspaceDir: resolvedWorkspace,
         messageProvider: params.messageProvider ?? undefined,
-        trigger: params.trigger,
-        channelId: params.messageChannel ?? params.messageProvider ?? undefined,
       };
       if (hookRunner?.hasHooks("before_model_resolve")) {
         try {
@@ -372,7 +302,7 @@ export async function runEmbeddedPiAgent(
         log.info(`[hooks] model overridden to ${modelId}`);
       }
 
-      const { model, error, authStorage, modelRegistry } = await resolveModelAsync(
+      const { model, error, authStorage, modelRegistry } = resolveModel(
         provider,
         modelId,
         agentDir,
@@ -385,21 +315,14 @@ export async function runEmbeddedPiAgent(
           model: modelId,
         });
       }
-      let runtimeModel = model;
 
       const ctxInfo = resolveContextWindowInfo({
         cfg: params.config,
         provider,
         modelId,
-        modelContextWindow: runtimeModel.contextWindow,
+        modelContextWindow: model.contextWindow,
         defaultTokens: DEFAULT_CONTEXT_TOKENS,
       });
-      // Apply contextTokens cap to model so pi-coding-agent's auto-compaction
-      // threshold uses the effective limit, not the native context window.
-      let effectiveModel =
-        ctxInfo.tokens < (runtimeModel.contextWindow ?? Infinity)
-          ? { ...runtimeModel, contextWindow: ctxInfo.tokens }
-          : runtimeModel;
       const ctxGuard = evaluateContextWindowGuard({
         info: ctxInfo,
         warnBelowTokens: CONTEXT_WINDOW_WARN_BELOW_TOKENS,
@@ -453,142 +376,103 @@ export async function runEmbeddedPiAgent(
       const attemptedThinking = new Set<ThinkLevel>();
       let apiKeyInfo: ApiKeyInfo | null = null;
       let lastProfileId: string | undefined;
-      let runtimeAuthState: RuntimeAuthState | null = null;
-      let runtimeAuthRefreshCancelled = false;
-      const hasRefreshableRuntimeAuth = () => Boolean(runtimeAuthState?.sourceApiKey.trim());
+      const copilotTokenState: CopilotTokenState | null =
+        model.provider === "github-copilot" ? { githubToken: "", expiresAt: 0 } : null;
+      let copilotRefreshCancelled = false;
+      const hasCopilotGithubToken = () => Boolean(copilotTokenState?.githubToken.trim());
 
-      const clearRuntimeAuthRefreshTimer = () => {
-        if (!runtimeAuthState?.refreshTimer) {
+      const clearCopilotRefreshTimer = () => {
+        if (!copilotTokenState?.refreshTimer) {
           return;
         }
-        clearTimeout(runtimeAuthState.refreshTimer);
-        runtimeAuthState.refreshTimer = undefined;
+        clearTimeout(copilotTokenState.refreshTimer);
+        copilotTokenState.refreshTimer = undefined;
       };
 
-      const stopRuntimeAuthRefreshTimer = () => {
-        if (!runtimeAuthState) {
+      const stopCopilotRefreshTimer = () => {
+        if (!copilotTokenState) {
           return;
         }
-        runtimeAuthRefreshCancelled = true;
-        clearRuntimeAuthRefreshTimer();
+        copilotRefreshCancelled = true;
+        clearCopilotRefreshTimer();
       };
 
-      const refreshRuntimeAuth = async (reason: string): Promise<void> => {
-        if (!runtimeAuthState) {
+      const refreshCopilotToken = async (reason: string): Promise<void> => {
+        if (!copilotTokenState) {
           return;
         }
-        if (runtimeAuthState.refreshInFlight) {
-          await runtimeAuthState.refreshInFlight;
+        if (copilotTokenState.refreshInFlight) {
+          await copilotTokenState.refreshInFlight;
           return;
         }
-        runtimeAuthState.refreshInFlight = (async () => {
-          const sourceApiKey = runtimeAuthState?.sourceApiKey.trim() ?? "";
-          if (!sourceApiKey) {
-            throw new Error(`Runtime auth refresh requires a source credential.`);
+        const { resolveCopilotApiToken } = await import("../../providers/github-copilot-token.js");
+        copilotTokenState.refreshInFlight = (async () => {
+          const githubToken = copilotTokenState.githubToken.trim();
+          if (!githubToken) {
+            throw new Error("Copilot refresh requires a GitHub token.");
           }
-          log.debug(`Refreshing runtime auth for ${runtimeModel.provider} (${reason})...`);
-          const preparedAuth = await prepareProviderRuntimeAuth({
-            provider: runtimeModel.provider,
-            config: params.config,
-            workspaceDir: resolvedWorkspace,
-            env: process.env,
-            context: {
-              config: params.config,
-              agentDir,
-              workspaceDir: resolvedWorkspace,
-              env: process.env,
-              provider: runtimeModel.provider,
-              modelId,
-              model: runtimeModel,
-              apiKey: sourceApiKey,
-              authMode: runtimeAuthState?.authMode ?? "unknown",
-              profileId: runtimeAuthState?.profileId,
-            },
+          log.debug(`Refreshing GitHub Copilot token (${reason})...`);
+          const copilotToken = await resolveCopilotApiToken({
+            githubToken,
           });
-          if (!preparedAuth?.apiKey) {
-            throw new Error(
-              `Provider "${runtimeModel.provider}" does not support runtime auth refresh.`,
-            );
-          }
-          authStorage.setRuntimeApiKey(runtimeModel.provider, preparedAuth.apiKey);
-          if (preparedAuth.baseUrl) {
-            runtimeModel = { ...runtimeModel, baseUrl: preparedAuth.baseUrl };
-            effectiveModel = { ...effectiveModel, baseUrl: preparedAuth.baseUrl };
-          }
-          runtimeAuthState = {
-            ...runtimeAuthState,
-            expiresAt: preparedAuth.expiresAt,
-          };
-          if (preparedAuth.expiresAt) {
-            const remaining = preparedAuth.expiresAt - Date.now();
-            log.debug(
-              `Runtime auth refreshed for ${runtimeModel.provider}; expires in ${Math.max(0, Math.floor(remaining / 1000))}s.`,
-            );
-          }
+          authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+          copilotTokenState.expiresAt = copilotToken.expiresAt;
+          const remaining = copilotToken.expiresAt - Date.now();
+          log.debug(
+            `Copilot token refreshed; expires in ${Math.max(0, Math.floor(remaining / 1000))}s.`,
+          );
         })()
           .catch((err) => {
-            log.warn(
-              `Runtime auth refresh failed for ${runtimeModel.provider}: ${describeUnknownError(err)}`,
-            );
+            log.warn(`Copilot token refresh failed: ${describeUnknownError(err)}`);
             throw err;
           })
           .finally(() => {
-            if (runtimeAuthState) {
-              runtimeAuthState.refreshInFlight = undefined;
-            }
+            copilotTokenState.refreshInFlight = undefined;
           });
-        await runtimeAuthState.refreshInFlight;
+        await copilotTokenState.refreshInFlight;
       };
 
-      const scheduleRuntimeAuthRefresh = (): void => {
-        if (!runtimeAuthState || runtimeAuthRefreshCancelled) {
+      const scheduleCopilotRefresh = (): void => {
+        if (!copilotTokenState || copilotRefreshCancelled) {
           return;
         }
-        if (!hasRefreshableRuntimeAuth()) {
-          log.warn(
-            `Skipping runtime auth refresh scheduling for ${runtimeModel.provider}; source credential missing.`,
-          );
+        if (!hasCopilotGithubToken()) {
+          log.warn("Skipping Copilot refresh scheduling; GitHub token missing.");
           return;
         }
-        if (!runtimeAuthState.expiresAt) {
-          return;
-        }
-        clearRuntimeAuthRefreshTimer();
+        clearCopilotRefreshTimer();
         const now = Date.now();
-        const refreshAt = runtimeAuthState.expiresAt - RUNTIME_AUTH_REFRESH_MARGIN_MS;
-        const delayMs = Math.max(RUNTIME_AUTH_REFRESH_MIN_DELAY_MS, refreshAt - now);
+        const refreshAt = copilotTokenState.expiresAt - COPILOT_REFRESH_MARGIN_MS;
+        const delayMs = Math.max(COPILOT_REFRESH_MIN_DELAY_MS, refreshAt - now);
         const timer = setTimeout(() => {
-          if (runtimeAuthRefreshCancelled) {
+          if (copilotRefreshCancelled) {
             return;
           }
-          refreshRuntimeAuth("scheduled")
-            .then(() => scheduleRuntimeAuthRefresh())
+          refreshCopilotToken("scheduled")
+            .then(() => scheduleCopilotRefresh())
             .catch(() => {
-              if (runtimeAuthRefreshCancelled) {
+              if (copilotRefreshCancelled) {
                 return;
               }
               const retryTimer = setTimeout(() => {
-                if (runtimeAuthRefreshCancelled) {
+                if (copilotRefreshCancelled) {
                   return;
                 }
-                refreshRuntimeAuth("scheduled-retry")
-                  .then(() => scheduleRuntimeAuthRefresh())
+                refreshCopilotToken("scheduled-retry")
+                  .then(() => scheduleCopilotRefresh())
                   .catch(() => undefined);
-              }, RUNTIME_AUTH_REFRESH_RETRY_MS);
-              const activeRuntimeAuthState = runtimeAuthState;
-              if (activeRuntimeAuthState) {
-                activeRuntimeAuthState.refreshTimer = retryTimer;
-              }
-              if (runtimeAuthRefreshCancelled && activeRuntimeAuthState) {
+              }, COPILOT_REFRESH_RETRY_MS);
+              copilotTokenState.refreshTimer = retryTimer;
+              if (copilotRefreshCancelled) {
                 clearTimeout(retryTimer);
-                activeRuntimeAuthState.refreshTimer = undefined;
+                copilotTokenState.refreshTimer = undefined;
               }
             });
         }, delayMs);
-        runtimeAuthState.refreshTimer = timer;
-        if (runtimeAuthRefreshCancelled) {
+        copilotTokenState.refreshTimer = timer;
+        if (copilotRefreshCancelled) {
           clearTimeout(timer);
-          runtimeAuthState.refreshTimer = undefined;
+          copilotTokenState.refreshTimer = undefined;
         }
       };
 
@@ -605,7 +489,7 @@ export async function runEmbeddedPiAgent(
             resolveProfilesUnavailableReason({
               store: authStore,
               profileIds,
-            }) ?? "unknown"
+            }) ?? "rate_limit"
           );
         }
         const classified = classifyFailoverReason(params.message);
@@ -644,7 +528,7 @@ export async function runEmbeddedPiAgent(
 
       const resolveApiKeyForCandidate = async (candidate?: string) => {
         return getApiKeyForModel({
-          model: runtimeModel,
+          model,
           cfg: params.config,
           profileId: candidate,
           store: authStore,
@@ -658,53 +542,44 @@ export async function runEmbeddedPiAgent(
         if (!apiKeyInfo.apiKey) {
           if (apiKeyInfo.mode !== "aws-sdk") {
             throw new Error(
-              `No API key resolved for provider "${runtimeModel.provider}" (auth mode: ${apiKeyInfo.mode}).`,
+              `No API key resolved for provider "${model.provider}" (auth mode: ${apiKeyInfo.mode}).`,
             );
           }
           lastProfileId = resolvedProfileId;
           return;
         }
-        let runtimeAuthHandled = false;
-        const preparedAuth = await prepareProviderRuntimeAuth({
-          provider: runtimeModel.provider,
-          config: params.config,
-          workspaceDir: resolvedWorkspace,
-          env: process.env,
-          context: {
-            config: params.config,
-            agentDir,
-            workspaceDir: resolvedWorkspace,
-            env: process.env,
-            provider: runtimeModel.provider,
-            modelId,
-            model: runtimeModel,
-            apiKey: apiKeyInfo.apiKey,
-            authMode: apiKeyInfo.mode,
-            profileId: apiKeyInfo.profileId,
-          },
-        });
-        if (preparedAuth?.baseUrl) {
-          runtimeModel = { ...runtimeModel, baseUrl: preparedAuth.baseUrl };
-          effectiveModel = { ...effectiveModel, baseUrl: preparedAuth.baseUrl };
-        }
-        if (preparedAuth?.apiKey) {
-          authStorage.setRuntimeApiKey(runtimeModel.provider, preparedAuth.apiKey);
-          runtimeAuthState = {
-            sourceApiKey: apiKeyInfo.apiKey,
-            authMode: apiKeyInfo.mode,
-            profileId: apiKeyInfo.profileId,
-            expiresAt: preparedAuth.expiresAt,
-          };
-          if (preparedAuth.expiresAt) {
-            scheduleRuntimeAuthRefresh();
+        if (model.provider === "github-copilot") {
+          const { resolveCopilotApiToken, SDK_MANAGED_TOKEN } =
+            await import("../../providers/github-copilot-token.js");
+          if (apiKeyInfo.apiKey === SDK_MANAGED_TOKEN) {
+            // SDK-managed auth: try env-based token exchange for pi-ai.
+            const envToken = (
+              process.env.COPILOT_GITHUB_TOKEN ??
+              process.env.GH_TOKEN ??
+              process.env.GITHUB_TOKEN ??
+              ""
+            ).trim();
+            if (envToken) {
+              const copilotToken = await resolveCopilotApiToken({ githubToken: envToken });
+              authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+            } else {
+              log.warn(
+                "SDK-managed Copilot auth has no env token (COPILOT_GITHUB_TOKEN, GH_TOKEN, or GITHUB_TOKEN) — REST API calls may fail",
+              );
+            }
+          } else {
+            const copilotToken = await resolveCopilotApiToken({
+              githubToken: apiKeyInfo.apiKey,
+            });
+            authStorage.setRuntimeApiKey(model.provider, copilotToken.token);
+            if (copilotTokenState) {
+              copilotTokenState.githubToken = apiKeyInfo.apiKey;
+              copilotTokenState.expiresAt = copilotToken.expiresAt;
+              scheduleCopilotRefresh();
+            }
           }
-          runtimeAuthHandled = true;
-        }
-        if (runtimeAuthHandled) {
-          // Plugin-owned runtime auth already stored the exchanged credential.
         } else {
-          authStorage.setRuntimeApiKey(runtimeModel.provider, apiKeyInfo.apiKey);
-          runtimeAuthState = null;
+          authStorage.setRuntimeApiKey(model.provider, apiKeyInfo.apiKey);
         }
         lastProfileId = apiKeyInfo.profileId;
       };
@@ -737,42 +612,15 @@ export async function runEmbeddedPiAgent(
       };
 
       try {
-        const autoProfileCandidates = profileCandidates.filter(
-          (candidate): candidate is string =>
-            typeof candidate === "string" && candidate.length > 0 && candidate !== lockedProfileId,
-        );
-        const allAutoProfilesInCooldown =
-          autoProfileCandidates.length > 0 &&
-          autoProfileCandidates.every((candidate) => isProfileInCooldown(authStore, candidate));
-        const unavailableReason = allAutoProfilesInCooldown
-          ? (resolveProfilesUnavailableReason({
-              store: authStore,
-              profileIds: autoProfileCandidates,
-            }) ?? "unknown")
-          : null;
-        const allowTransientCooldownProbe =
-          params.allowTransientCooldownProbe === true &&
-          allAutoProfilesInCooldown &&
-          (unavailableReason === "rate_limit" ||
-            unavailableReason === "overloaded" ||
-            unavailableReason === "billing" ||
-            unavailableReason === "unknown");
-        let didTransientCooldownProbe = false;
-
         while (profileIndex < profileCandidates.length) {
           const candidate = profileCandidates[profileIndex];
-          const inCooldown =
-            candidate && candidate !== lockedProfileId && isProfileInCooldown(authStore, candidate);
-          if (inCooldown) {
-            if (allowTransientCooldownProbe && !didTransientCooldownProbe) {
-              didTransientCooldownProbe = true;
-              log.warn(
-                `probing cooldowned auth profile for ${provider}/${modelId} due to ${unavailableReason ?? "transient"} unavailability`,
-              );
-            } else {
-              profileIndex += 1;
-              continue;
-            }
+          if (
+            candidate &&
+            candidate !== lockedProfileId &&
+            isProfileInCooldown(authStore, candidate)
+          ) {
+            profileIndex += 1;
+            continue;
           }
           await applyApiKeyInfo(profileCandidates[profileIndex]);
           break;
@@ -793,11 +641,11 @@ export async function runEmbeddedPiAgent(
         }
       }
 
-      const maybeRefreshRuntimeAuthForAuthError = async (
+      const maybeRefreshCopilotForAuthError = async (
         errorText: string,
         retried: boolean,
       ): Promise<boolean> => {
-        if (!runtimeAuthState || retried) {
+        if (!copilotTokenState || retried) {
           return false;
         }
         if (!isFailoverErrorMessage(errorText)) {
@@ -807,8 +655,8 @@ export async function runEmbeddedPiAgent(
           return false;
         }
         try {
-          await refreshRuntimeAuth("auth-error");
-          scheduleRuntimeAuthRefresh();
+          await refreshCopilotToken("auth-error");
+          scheduleCopilotRefresh();
           return true;
         } catch {
           return false;
@@ -819,17 +667,13 @@ export async function runEmbeddedPiAgent(
       const MAX_RUN_LOOP_ITERATIONS = resolveMaxRunRetryIterations(profileCandidates.length);
       let overflowCompactionAttempts = 0;
       let toolResultTruncationAttempted = false;
-      let bootstrapPromptWarningSignaturesSeen =
-        params.bootstrapPromptWarningSignaturesSeen ??
-        (params.bootstrapPromptWarningSignature ? [params.bootstrapPromptWarningSignature] : []);
       const usageAccumulator = createUsageAccumulator();
       let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
       let autoCompactionCount = 0;
       let runLoopIterations = 0;
-      let overloadFailoverAttempts = 0;
       const maybeMarkAuthProfileFailure = async (failure: {
         profileId?: string;
-        reason?: AuthProfileFailureReason | null;
+        reason?: Parameters<typeof markAuthProfileFailure>[0]["reason"] | null;
         config?: RunEmbeddedPiAgentParams["config"];
         agentDir?: RunEmbeddedPiAgentParams["agentDir"];
       }) => {
@@ -843,47 +687,10 @@ export async function runEmbeddedPiAgent(
           reason,
           cfg: params.config,
           agentDir,
-          runId: params.runId,
         });
       };
-      const resolveAuthProfileFailureReason = (
-        failoverReason: FailoverReason | null,
-      ): AuthProfileFailureReason | null => {
-        // Timeouts are transport/model-path failures, not auth health signals,
-        // so they should not persist auth-profile failure state.
-        if (!failoverReason || failoverReason === "timeout") {
-          return null;
-        }
-        return failoverReason;
-      };
-      const maybeBackoffBeforeOverloadFailover = async (reason: FailoverReason | null) => {
-        if (reason !== "overloaded") {
-          return;
-        }
-        overloadFailoverAttempts += 1;
-        const delayMs = computeBackoff(OVERLOAD_FAILOVER_BACKOFF_POLICY, overloadFailoverAttempts);
-        log.warn(
-          `overload backoff before failover for ${provider}/${modelId}: attempt=${overloadFailoverAttempts} delayMs=${delayMs}`,
-        );
-        try {
-          await sleepWithAbort(delayMs, params.abortSignal);
-        } catch (err) {
-          if (params.abortSignal?.aborted) {
-            const abortErr = new Error("Operation aborted", { cause: err });
-            abortErr.name = "AbortError";
-            throw abortErr;
-          }
-          throw err;
-        }
-      };
-      // Resolve the context engine once and reuse across retries to avoid
-      // repeated initialization/connection overhead per attempt.
-      ensureContextEnginesInitialized();
-      const contextEngine = await resolveContextEngine(params.config);
       try {
         let authRetryPending = false;
-        // Hoisted so the retry-limit error path can use the most recent API total.
-        let lastTurnTotal: number | undefined;
         while (true) {
           if (runLoopIterations >= MAX_RUN_LOOP_ITERATIONS) {
             const message =
@@ -905,20 +712,17 @@ export async function runEmbeddedPiAgent(
               ],
               meta: {
                 durationMs: Date.now() - started,
-                agentMeta: buildErrorAgentMeta({
+                agentMeta: {
                   sessionId: params.sessionId,
                   provider,
                   model: model.id,
-                  usageAccumulator,
-                  lastRunPromptUsage,
-                  lastTurnTotal,
-                }),
+                },
                 error: { kind: "retry_limit", message },
               },
             };
           }
           runLoopIterations += 1;
-          const runtimeAuthRetry = authRetryPending;
+          const copilotAuthRetry = authRetryPending;
           authRetryPending = false;
           attemptedThinking.add(thinkLevel);
           await fs.mkdir(resolvedWorkspace, { recursive: true });
@@ -929,8 +733,6 @@ export async function runEmbeddedPiAgent(
           const attempt = await runEmbeddedAttempt({
             sessionId: params.sessionId,
             sessionKey: params.sessionKey,
-            trigger: params.trigger,
-            memoryFlushWritePath: params.memoryFlushWritePath,
             messageChannel: params.messageChannel,
             messageProvider: params.messageProvider,
             agentAccountId: params.agentAccountId,
@@ -940,10 +742,6 @@ export async function runEmbeddedPiAgent(
             groupChannel: params.groupChannel,
             groupSpace: params.groupSpace,
             spawnedBy: params.spawnedBy,
-            senderId: params.senderId,
-            senderName: params.senderName,
-            senderUsername: params.senderUsername,
-            senderE164: params.senderE164,
             senderIsOwner: params.senderIsOwner,
             currentChannelId: params.currentChannelId,
             currentThreadTs: params.currentThreadTs,
@@ -954,24 +752,18 @@ export async function runEmbeddedPiAgent(
             workspaceDir: resolvedWorkspace,
             agentDir,
             config: params.config,
-            allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
-            contextEngine,
-            contextTokenBudget: ctxInfo.tokens,
             skillsSnapshot: params.skillsSnapshot,
             prompt,
             images: params.images,
             disableTools: params.disableTools,
             provider,
             modelId,
-            model: applyLocalNoAuthHeaderOverride(effectiveModel, apiKeyInfo),
-            authProfileId: lastProfileId,
-            authProfileIdSource: lockedProfileId ? "user" : "auto",
+            model,
             authStorage,
             modelRegistry,
             agentId: workspaceResolution.agentId,
             legacyBeforeAgentStartResult,
             thinkLevel,
-            fastMode: params.fastMode,
             verboseLevel: params.verboseLevel,
             reasoningLevel: params.reasoningLevel,
             toolResultFormat: resolvedToolResultFormat,
@@ -997,9 +789,6 @@ export async function runEmbeddedPiAgent(
             streamParams: params.streamParams,
             ownerNumbers: params.ownerNumbers,
             enforceFinalTag: params.enforceFinalTag,
-            bootstrapPromptWarningSignaturesSeen,
-            bootstrapPromptWarningSignature:
-              bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
           });
 
           const {
@@ -1010,23 +799,13 @@ export async function runEmbeddedPiAgent(
             sessionIdUsed,
             lastAssistant,
           } = attempt;
-          bootstrapPromptWarningSignaturesSeen =
-            attempt.bootstrapPromptWarningSignaturesSeen ??
-            (attempt.bootstrapPromptWarningSignature
-              ? Array.from(
-                  new Set([
-                    ...bootstrapPromptWarningSignaturesSeen,
-                    attempt.bootstrapPromptWarningSignature,
-                  ]),
-                )
-              : bootstrapPromptWarningSignaturesSeen);
           const lastAssistantUsage = normalizeUsage(lastAssistant?.usage as UsageLike);
           const attemptUsage = attempt.attemptUsage ?? lastAssistantUsage;
           mergeUsageIntoAccumulator(usageAccumulator, attemptUsage);
           // Keep prompt size from the latest model call so session totalTokens
           // reflects current context usage, not accumulated tool-loop usage.
           lastRunPromptUsage = lastAssistantUsage ?? attemptUsage;
-          lastTurnTotal = lastAssistantUsage?.total ?? attemptUsage?.total;
+          const lastTurnTotal = lastAssistantUsage?.total ?? attemptUsage?.total;
           const attemptCompactionCount = Math.max(0, attempt.compactionCount ?? 0);
           autoCompactionCount += attemptCompactionCount;
           const activeErrorContext = resolveActiveErrorContext({
@@ -1069,13 +848,11 @@ export async function runEmbeddedPiAgent(
             const overflowDiagId = createCompactionDiagId();
             const errorText = contextOverflowError.text;
             const msgCount = attempt.messagesSnapshot?.length ?? 0;
-            const observedOverflowTokens = extractObservedOverflowTokenCount(errorText);
             log.warn(
               `[context-overflow-diag] sessionKey=${params.sessionKey ?? params.sessionId} ` +
                 `provider=${provider}/${modelId} source=${contextOverflowError.source} ` +
                 `messages=${msgCount} sessionFile=${params.sessionFile} ` +
                 `diagId=${overflowDiagId} compactionAttempts=${overflowCompactionAttempts} ` +
-                `observedTokens=${observedOverflowTokens ?? "unknown"} ` +
                 `error=${errorText.slice(0, 200)}`,
             );
             const isCompactionFailure = isCompactionFailureError(errorText);
@@ -1111,97 +888,32 @@ export async function runEmbeddedPiAgent(
               log.warn(
                 `context overflow detected (attempt ${overflowCompactionAttempts}/${MAX_OVERFLOW_COMPACTION_ATTEMPTS}); attempting auto-compaction for ${provider}/${modelId}`,
               );
-              let compactResult: Awaited<ReturnType<typeof contextEngine.compact>>;
-              // When the engine owns compaction, hooks are not fired inside
-              // compactEmbeddedPiSessionDirect (which is bypassed).  Fire them
-              // here so subscribers (memory extensions, usage trackers) are
-              // notified even on overflow-recovery compactions.
-              const overflowEngineOwnsCompaction = contextEngine.info.ownsCompaction === true;
-              const overflowHookRunner = overflowEngineOwnsCompaction ? hookRunner : null;
-              if (overflowHookRunner?.hasHooks("before_compaction")) {
-                try {
-                  await overflowHookRunner.runBeforeCompaction(
-                    { messageCount: -1, sessionFile: params.sessionFile },
-                    hookCtx,
-                  );
-                } catch (hookErr) {
-                  log.warn(
-                    `before_compaction hook failed during overflow recovery: ${String(hookErr)}`,
-                  );
-                }
-              }
-              try {
-                compactResult = await contextEngine.compact({
-                  sessionId: params.sessionId,
-                  sessionKey: params.sessionKey,
-                  sessionFile: params.sessionFile,
-                  tokenBudget: ctxInfo.tokens,
-                  ...(observedOverflowTokens !== undefined
-                    ? { currentTokenCount: observedOverflowTokens }
-                    : {}),
-                  force: true,
-                  compactionTarget: "budget",
-                  runtimeContext: {
-                    ...buildEmbeddedCompactionRuntimeContext({
-                      sessionKey: params.sessionKey,
-                      messageChannel: params.messageChannel,
-                      messageProvider: params.messageProvider,
-                      agentAccountId: params.agentAccountId,
-                      currentChannelId: params.currentChannelId,
-                      currentThreadTs: params.currentThreadTs,
-                      currentMessageId: params.currentMessageId,
-                      authProfileId: lastProfileId,
-                      workspaceDir: resolvedWorkspace,
-                      agentDir,
-                      config: params.config,
-                      skillsSnapshot: params.skillsSnapshot,
-                      senderIsOwner: params.senderIsOwner,
-                      senderId: params.senderId,
-                      provider,
-                      modelId,
-                      thinkLevel,
-                      reasoningLevel: params.reasoningLevel,
-                      bashElevated: params.bashElevated,
-                      extraSystemPrompt: params.extraSystemPrompt,
-                      ownerNumbers: params.ownerNumbers,
-                    }),
-                    runId: params.runId,
-                    trigger: "overflow",
-                    ...(observedOverflowTokens !== undefined
-                      ? { currentTokenCount: observedOverflowTokens }
-                      : {}),
-                    diagId: overflowDiagId,
-                    attempt: overflowCompactionAttempts,
-                    maxAttempts: MAX_OVERFLOW_COMPACTION_ATTEMPTS,
-                  },
-                });
-              } catch (compactErr) {
-                log.warn(
-                  `contextEngine.compact() threw during overflow recovery for ${provider}/${modelId}: ${String(compactErr)}`,
-                );
-                compactResult = { ok: false, compacted: false, reason: String(compactErr) };
-              }
-              if (
-                compactResult.ok &&
-                compactResult.compacted &&
-                overflowHookRunner?.hasHooks("after_compaction")
-              ) {
-                try {
-                  await overflowHookRunner.runAfterCompaction(
-                    {
-                      messageCount: -1,
-                      compactedCount: -1,
-                      tokenCount: compactResult.result?.tokensAfter,
-                      sessionFile: params.sessionFile,
-                    },
-                    hookCtx,
-                  );
-                } catch (hookErr) {
-                  log.warn(
-                    `after_compaction hook failed during overflow recovery: ${String(hookErr)}`,
-                  );
-                }
-              }
+              const compactResult = await compactEmbeddedPiSessionDirect({
+                sessionId: params.sessionId,
+                sessionKey: params.sessionKey,
+                messageChannel: params.messageChannel,
+                messageProvider: params.messageProvider,
+                agentAccountId: params.agentAccountId,
+                authProfileId: lastProfileId,
+                sessionFile: params.sessionFile,
+                workspaceDir: resolvedWorkspace,
+                agentDir,
+                config: params.config,
+                skillsSnapshot: params.skillsSnapshot,
+                senderIsOwner: params.senderIsOwner,
+                provider,
+                model: modelId,
+                runId: params.runId,
+                thinkLevel,
+                reasoningLevel: params.reasoningLevel,
+                bashElevated: params.bashElevated,
+                extraSystemPrompt: params.extraSystemPrompt,
+                ownerNumbers: params.ownerNumbers,
+                trigger: "overflow",
+                diagId: overflowDiagId,
+                attempt: overflowCompactionAttempts,
+                maxAttempts: MAX_OVERFLOW_COMPACTION_ATTEMPTS,
+              });
               if (compactResult.compacted) {
                 autoCompactionCount += 1;
                 log.info(`auto-compaction succeeded for ${provider}/${modelId}; retrying prompt`);
@@ -1285,15 +997,11 @@ export async function runEmbeddedPiAgent(
               ],
               meta: {
                 durationMs: Date.now() - started,
-                agentMeta: buildErrorAgentMeta({
+                agentMeta: {
                   sessionId: sessionIdUsed,
                   provider,
                   model: model.id,
-                  usageAccumulator,
-                  lastRunPromptUsage,
-                  lastAssistant,
-                  lastTurnTotal,
-                }),
+                },
                 systemPromptReport: attempt.systemPromptReport,
                 error: { kind, message: errorText },
               },
@@ -1301,18 +1009,8 @@ export async function runEmbeddedPiAgent(
           }
 
           if (promptError && !aborted) {
-            // Normalize wrapped errors (e.g. abort-wrapped RESOURCE_EXHAUSTED) into
-            // FailoverError so rate-limit classification works even for nested shapes.
-            const normalizedPromptFailover = coerceToFailoverError(promptError, {
-              provider: activeErrorContext.provider,
-              model: activeErrorContext.model,
-              profileId: lastProfileId,
-            });
-            const promptErrorDetails = normalizedPromptFailover
-              ? describeFailoverError(normalizedPromptFailover)
-              : describeFailoverError(promptError);
-            const errorText = promptErrorDetails.message || describeUnknownError(promptError);
-            if (await maybeRefreshRuntimeAuthForAuthError(errorText, runtimeAuthRetry)) {
+            const errorText = describeUnknownError(promptError);
+            if (await maybeRefreshCopilotForAuthError(errorText, copilotAuthRetry)) {
               authRetryPending = true;
               continue;
             }
@@ -1329,15 +1027,11 @@ export async function runEmbeddedPiAgent(
                 ],
                 meta: {
                   durationMs: Date.now() - started,
-                  agentMeta: buildErrorAgentMeta({
+                  agentMeta: {
                     sessionId: sessionIdUsed,
                     provider,
                     model: model.id,
-                    usageAccumulator,
-                    lastRunPromptUsage,
-                    lastAssistant,
-                    lastTurnTotal,
-                  }),
+                  },
                   systemPromptReport: attempt.systemPromptReport,
                   error: { kind: "role_ordering", message: errorText },
                 },
@@ -1361,51 +1055,26 @@ export async function runEmbeddedPiAgent(
                 ],
                 meta: {
                   durationMs: Date.now() - started,
-                  agentMeta: buildErrorAgentMeta({
+                  agentMeta: {
                     sessionId: sessionIdUsed,
                     provider,
                     model: model.id,
-                    usageAccumulator,
-                    lastRunPromptUsage,
-                    lastAssistant,
-                    lastTurnTotal,
-                  }),
+                  },
                   systemPromptReport: attempt.systemPromptReport,
                   error: { kind: "image_size", message: errorText },
                 },
               };
             }
-            const promptFailoverReason =
-              promptErrorDetails.reason ?? classifyFailoverReason(errorText);
-            const promptProfileFailureReason =
-              resolveAuthProfileFailureReason(promptFailoverReason);
+            const promptFailoverReason = classifyFailoverReason(errorText);
             await maybeMarkAuthProfileFailure({
               profileId: lastProfileId,
-              reason: promptProfileFailureReason,
-            });
-            const promptFailoverFailure =
-              promptFailoverReason !== null || isFailoverErrorMessage(errorText);
-            // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
-            const failedPromptProfileId = lastProfileId;
-            const logPromptFailoverDecision = createFailoverDecisionLogger({
-              stage: "prompt",
-              runId: params.runId,
-              rawError: errorText,
-              failoverReason: promptFailoverReason,
-              profileFailureReason: promptProfileFailureReason,
-              provider,
-              model: modelId,
-              profileId: failedPromptProfileId,
-              fallbackConfigured,
-              aborted,
+              reason: promptFailoverReason,
             });
             if (
-              promptFailoverFailure &&
+              isFailoverErrorMessage(errorText) &&
               promptFailoverReason !== "timeout" &&
               (await advanceAuthProfile())
             ) {
-              logPromptFailoverDecision("rotate_profile");
-              await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
               continue;
             }
             const fallbackThinking = pickFallbackThinkingLevel({
@@ -1419,26 +1088,16 @@ export async function runEmbeddedPiAgent(
               thinkLevel = fallbackThinking;
               continue;
             }
-            // Throw FailoverError for prompt-side failover reasons when fallbacks
-            // are configured so outer model fallback can continue on overload,
-            // rate-limit, auth, or billing failures.
-            if (fallbackConfigured && promptFailoverFailure) {
-              const status = resolveFailoverStatus(promptFailoverReason ?? "unknown");
-              logPromptFailoverDecision("fallback_model", { status });
-              await maybeBackoffBeforeOverloadFailover(promptFailoverReason);
-              throw (
-                normalizedPromptFailover ??
-                new FailoverError(errorText, {
-                  reason: promptFailoverReason ?? "unknown",
-                  provider,
-                  model: modelId,
-                  profileId: lastProfileId,
-                  status: resolveFailoverStatus(promptFailoverReason ?? "unknown"),
-                })
-              );
-            }
-            if (promptFailoverFailure || promptFailoverReason) {
-              logPromptFailoverDecision("surface_error");
+            // FIX: Throw FailoverError for prompt errors when fallbacks configured
+            // This enables model fallback for quota/rate limit errors during prompt submission
+            if (fallbackConfigured && isFailoverErrorMessage(errorText)) {
+              throw new FailoverError(errorText, {
+                reason: promptFailoverReason ?? "unknown",
+                provider,
+                model: modelId,
+                profileId: lastProfileId,
+                status: resolveFailoverStatus(promptFailoverReason ?? "unknown"),
+              });
             }
             throw promptError;
           }
@@ -1460,31 +1119,14 @@ export async function runEmbeddedPiAgent(
           const billingFailure = isBillingAssistantError(lastAssistant);
           const failoverFailure = isFailoverAssistantError(lastAssistant);
           const assistantFailoverReason = classifyFailoverReason(lastAssistant?.errorMessage ?? "");
-          const assistantProfileFailureReason =
-            resolveAuthProfileFailureReason(assistantFailoverReason);
           const cloudCodeAssistFormatError = attempt.cloudCodeAssistFormatError;
           const imageDimensionError = parseImageDimensionError(lastAssistant?.errorMessage ?? "");
-          // Capture the failing profile before auth-profile rotation mutates `lastProfileId`.
-          const failedAssistantProfileId = lastProfileId;
-          const logAssistantFailoverDecision = createFailoverDecisionLogger({
-            stage: "assistant",
-            runId: params.runId,
-            rawError: lastAssistant?.errorMessage?.trim(),
-            failoverReason: assistantFailoverReason,
-            profileFailureReason: assistantProfileFailureReason,
-            provider: activeErrorContext.provider,
-            model: activeErrorContext.model,
-            profileId: failedAssistantProfileId,
-            fallbackConfigured,
-            timedOut,
-            aborted,
-          });
 
           if (
             authFailure &&
-            (await maybeRefreshRuntimeAuthForAuthError(
+            (await maybeRefreshCopilotForAuthError(
               lastAssistant?.errorMessage ?? "",
-              runtimeAuthRetry,
+              copilotAuthRetry,
             ))
           ) {
             authRetryPending = true;
@@ -1516,7 +1158,10 @@ export async function runEmbeddedPiAgent(
 
           if (shouldRotate) {
             if (lastProfileId) {
-              const reason = timedOut ? "timeout" : assistantProfileFailureReason;
+              const reason =
+                timedOut || assistantFailoverReason === "timeout"
+                  ? "timeout"
+                  : (assistantFailoverReason ?? "unknown");
               // Skip cooldown for timeouts: a timeout is model/network-specific,
               // not an auth issue. Marking the profile would poison fallback models
               // on the same provider (e.g. gpt-5.3 timeout blocks gpt-5.2).
@@ -1536,13 +1181,10 @@ export async function runEmbeddedPiAgent(
 
             const rotated = await advanceAuthProfile();
             if (rotated) {
-              logAssistantFailoverDecision("rotate_profile");
-              await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
               continue;
             }
 
             if (fallbackConfigured) {
-              await maybeBackoffBeforeOverloadFailover(assistantFailoverReason);
               // Prefer formatted error message (user-friendly) over raw errorMessage
               const message =
                 (lastAssistant
@@ -1569,7 +1211,6 @@ export async function runEmbeddedPiAgent(
               const status =
                 resolveFailoverStatus(assistantFailoverReason ?? "unknown") ??
                 (isTimeoutErrorMessage(message) ? 408 : undefined);
-              logAssistantFailoverDecision("fallback_model", { status });
               throw new FailoverError(message, {
                 reason: assistantFailoverReason ?? "unknown",
                 provider: activeErrorContext.provider,
@@ -1578,7 +1219,6 @@ export async function runEmbeddedPiAgent(
                 status,
               });
             }
-            logAssistantFailoverDecision("surface_error");
           }
 
           const usage = toNormalizedUsage(usageAccumulator);
@@ -1617,7 +1257,6 @@ export async function runEmbeddedPiAgent(
             suppressToolErrorWarnings: params.suppressToolErrorWarnings,
             inlineToolResultsAllowed: false,
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-            didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
           });
 
           // Timeout aborts can leave the run without any assistant payloads.
@@ -1640,7 +1279,6 @@ export async function runEmbeddedPiAgent(
                 systemPromptReport: attempt.systemPromptReport,
               },
               didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-              didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
               messagingToolSentTexts: attempt.messagingToolSentTexts,
               messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
               messagingToolSentTargets: attempt.messagingToolSentTargets,
@@ -1672,13 +1310,7 @@ export async function runEmbeddedPiAgent(
               aborted,
               systemPromptReport: attempt.systemPromptReport,
               // Handle client tool calls (OpenResponses hosted tools)
-              // Propagate the LLM stop reason so callers (lifecycle events,
-              // ACP bridge) can distinguish end_turn from max_tokens.
-              stopReason: attempt.clientToolCall
-                ? "tool_calls"
-                : attempt.yieldDetected
-                  ? "end_turn"
-                  : (lastAssistant?.stopReason as string | undefined),
+              stopReason: attempt.clientToolCall ? "tool_calls" : undefined,
               pendingToolCalls: attempt.clientToolCall
                 ? [
                     {
@@ -1690,7 +1322,6 @@ export async function runEmbeddedPiAgent(
                 : undefined,
             },
             didSendViaMessagingTool: attempt.didSendViaMessagingTool,
-            didSendDeterministicApprovalPrompt: attempt.didSendDeterministicApprovalPrompt,
             messagingToolSentTexts: attempt.messagingToolSentTexts,
             messagingToolSentMediaUrls: attempt.messagingToolSentMediaUrls,
             messagingToolSentTargets: attempt.messagingToolSentTargets,
@@ -1698,8 +1329,7 @@ export async function runEmbeddedPiAgent(
           };
         }
       } finally {
-        await contextEngine.dispose?.();
-        stopRuntimeAuthRefreshTimer();
+        stopCopilotRefreshTimer();
         process.chdir(prevCwd);
       }
     }),

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1524,7 +1524,6 @@ export async function runEmbeddedAttempt(
           allowGatewaySubagentBinding: params.allowGatewaySubagentBinding,
           sessionKey: sandboxSessionKey,
           sessionId: params.sessionId,
-          runId: params.runId,
           agentDir,
           workspaceDir: effectiveWorkspace,
           // When sandboxing uses a copied workspace (`ro` or `none`), effectiveWorkspace points
@@ -1878,7 +1877,6 @@ export async function runEmbeddedAttempt(
               agentId: sessionAgentId,
               sessionKey: sandboxSessionKey,
               sessionId: params.sessionId,
-              runId: params.runId,
               loopDetection: clientToolLoopDetection,
             },
           )
@@ -2138,6 +2136,7 @@ export async function runEmbeddedAttempt(
           sessionId: params.sessionId,
           policy: transcriptPolicy,
         });
+
         cacheTrace?.recordStage("session:sanitized", { messages: prior });
         const validatedGemini = transcriptPolicy.validateGeminiTurns
           ? validateGeminiTurns(prior)
@@ -2427,8 +2426,6 @@ export async function runEmbeddedAttempt(
           sessionId: params.sessionId,
           workspaceDir: params.workspaceDir,
           messageProvider: params.messageProvider ?? undefined,
-          trigger: params.trigger,
-          channelId: params.messageChannel ?? params.messageProvider ?? undefined,
         };
         const hookResult = await resolvePromptBuildHookResult({
           prompt: params.prompt,


### PR DESCRIPTION
## Problem

When OpenClaw falls back between different model providers (e.g., Claude → GPT, or Claude → Gemini), the session history may contain thinking/reasoning blocks from the previous provider. These blocks use provider-specific formats:

- **Claude**: `thinking` content blocks with `signature` fields
- **OpenAI**: `reasoning` content type
- **Google**: `thought` flag on parts

When a session with Claude thinking blocks is sent to GPT or Gemini, the API rejects the request with a 400 error because it doesn't recognize the foreign thinking format. This causes **production crashes during model fallback**, which is a critical reliability issue since fallback is the primary resilience mechanism.

## Solution

### 1. Cross-provider thinking block sanitization (`openai.ts`)
New `sanitizeOpenAISessionHistory()` function that:
- Strips Claude-style `thinking` blocks from assistant messages before sending to OpenAI
- Removes empty content arrays that result from stripping
- Preserves all non-thinking content intact

### 2. Thinking block downgrade for Gemini (`google.ts`)
- Strips `thought: true` parts when the target model doesn't support thinking
- Converts thinking-annotated parts to plain text when possible

### 3. Compact-time signature stripping (`compact.ts`)
- During session compaction, strips `signature` fields from thinking blocks
- Signatures are ephemeral and become invalid after the response, but were being persisted in session history

### 4. Model capability detection (`run.ts`, `attempt.ts`)
- Passes `supportsThinking` flag through the run pipeline
- Uses it to conditionally sanitize history before API calls

## Testing

- **328+ test cases** in `sanitize-session-history.test.ts` covering:
  - Claude → OpenAI fallback (thinking blocks stripped)
  - Claude → Gemini fallback (thought parts handled)
  - Signature stripping during compaction
  - Mixed content preservation (text + thinking → text only)
  - Edge cases: empty thinking blocks, nested content, multiple thinking blocks

## Impact

Fixes silent failures during model fallback that could leave users with no response. This is a reliability fix — no new features, just making existing fallback work correctly.