### PR TITLE
feat: add Copilot SDK provider integration with streaming support

### DIFF
--- a/extensions/github-copilot/login.ts
+++ b/extensions/github-copilot/login.ts
@@ -4,6 +4,8 @@ import { stylePromptTitle } from "openclaw/plugin-sdk/cli-runtime";
 import { logConfigUpdated, updateConfig } from "openclaw/plugin-sdk/config-runtime";
 import { applyAuthProfileConfig } from "openclaw/plugin-sdk/provider-auth";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime";
+import { getCopilotSdkAuthStatus, isCopilotSdkAvailable } from "./github-copilot-sdk.js";
+import { SDK_MANAGED_TOKEN } from "./github-copilot-token.js";
 
 const CLIENT_ID = "Iv1.b507a08c87ecfe98";
 const DEVICE_CODE_URL = "https://github.com/login/device/code";
@@ -134,6 +136,44 @@ export async function githubCopilotLoginCommand(
       stylePromptTitle("Existing credentials"),
     );
   }
+
+  // ── Try SDK-based auth first ──────────────────────────────────────────
+  // If Copilot CLI is installed and the user is already authenticated (via
+  // `gh` CLI, env vars, etc.), we can skip the device-flow entirely.
+  const sdkAvailable = await isCopilotSdkAvailable();
+  if (sdkAvailable) {
+    const status = await getCopilotSdkAuthStatus();
+    if (status.authenticated) {
+      // Store an SDK-managed marker profile — the embedded runner will use
+      // the SDK for token resolution instead of raw device-flow tokens.
+      upsertAuthProfile({
+        profileId,
+        credential: {
+          type: "token",
+          provider: "github-copilot",
+          token: SDK_MANAGED_TOKEN,
+        },
+      });
+
+      await updateConfig((cfg) =>
+        applyAuthProfileConfig(cfg, {
+          provider: "github-copilot",
+          profileId,
+          mode: "token",
+        }),
+      );
+
+      logConfigUpdated(runtime);
+      const loginInfo = status.login ? ` (${status.login})` : "";
+      runtime.log(`Authenticated via Copilot SDK${loginInfo}`);
+      runtime.log(`Auth profile: ${profileId} (github-copilot/sdk)`);
+
+      outro("Done — authenticated via Copilot SDK");
+      return;
+    }
+  }
+
+  // ── Fall back to device-flow OAuth ────────────────────────────────────
 
   const spin = spinner();
   spin.start("Requesting device code from GitHub...");

--- a/package.json
+++ b/package.json
@@ -757,6 +757,7 @@
     "@anthropic-ai/vertex-sdk": "^0.14.4",
     "@aws-sdk/client-bedrock": "^3.1014.0",
     "@clack/prompts": "^1.1.0",
+    "@github/copilot-sdk": "0.1.32",
     "@homebridge/ciao": "^1.3.5",
     "@line/bot-sdk": "^10.6.0",
     "@lydell/node-pty": "1.2.0-beta.3",

--- a/src/agents/auth-profiles/constants.ts
+++ b/src/agents/auth-profiles/constants.ts
@@ -6,6 +6,7 @@ export const LEGACY_AUTH_FILENAME = "auth.json";
 
 export const CLAUDE_CLI_PROFILE_ID = "anthropic:claude-cli";
 export const CODEX_CLI_PROFILE_ID = "openai-codex:codex-cli";
+export const COPILOT_CLI_PROFILE_ID = "github-copilot:copilot-cli";
 export const OPENAI_CODEX_DEFAULT_PROFILE_ID = "openai-codex:default";
 export const QWEN_CLI_PROFILE_ID = "qwen-portal:qwen-cli";
 export const MINIMAX_CLI_PROFILE_ID = "minimax-portal:minimax-cli";

--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -69,6 +69,38 @@ const DEFAULT_CLAUDE_BACKEND: CliBackendConfig = {
   serialize: true,
 };
 
+// Copilot CLI model aliases — map friendly short names to the exact model ids
+// accepted by `copilot --model`. Run `copilot --model list` for the latest.
+const COPILOT_MODEL_ALIASES: Record<string, string> = {
+  // Claude
+  opus: "claude-opus-4.6",
+  "opus-4.6": "claude-opus-4.6",
+  "opus-4.6-fast": "claude-opus-4.6-fast",
+  "opus-4.5": "claude-opus-4.5",
+  sonnet: "claude-sonnet-4.5",
+  "sonnet-4.5": "claude-sonnet-4.5",
+  "sonnet-4": "claude-sonnet-4",
+  haiku: "claude-haiku-4.5",
+  "haiku-4.5": "claude-haiku-4.5",
+  // Gemini
+  gemini: "gemini-3-pro-preview",
+  "gemini-3-pro": "gemini-3-pro-preview",
+  // GPT
+  "gpt-5": "gpt-5",
+  "gpt-5-mini": "gpt-5-mini",
+  "gpt-5.1": "gpt-5.1",
+  "gpt-5.2": "gpt-5.2",
+  codex: "gpt-5.3-codex",
+  "codex-max": "gpt-5.1-codex-max",
+};
+
+const DEFAULT_COPILOT_BACKEND: CliBackendConfig = {
+  command: "copilot",
+  output: "text",
+  input: "arg",
+  modelAliases: COPILOT_MODEL_ALIASES,
+};
+
 const DEFAULT_CODEX_BACKEND: CliBackendConfig = {
   command: "codex",
   args: [
@@ -206,6 +238,7 @@ export function resolveCliBackendIds(cfg?: OpenClawConfig): Set<string> {
   const ids = new Set<string>([
     normalizeBackendKey("claude-cli"),
     normalizeBackendKey("codex-cli"),
+    normalizeBackendKey("copilot-cli"),
   ]);
   const configured = cfg?.agents?.defaults?.cliBackends ?? {};
   for (const key of Object.keys(configured)) {
@@ -233,6 +266,17 @@ export function resolveCliBackendConfig(
   }
   if (normalized === "codex-cli") {
     const merged = mergeBackendConfig(DEFAULT_CODEX_BACKEND, override);
+    const command = merged.command?.trim();
+    if (!command) {
+      return null;
+    }
+    return { id: normalized, config: { ...merged, command } };
+  }
+  // copilot-cli uses the Copilot SDK (not a generic CLI subprocess).
+  // Return a stub config so callers recognise it as a valid backend; the actual
+  // execution path is handled in copilot-runner.ts.
+  if (normalized === "copilot-cli") {
+    const merged = mergeBackendConfig(DEFAULT_COPILOT_BACKEND, override);
     const command = merged.command?.trim();
     if (!command) {
       return null;

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -36,6 +36,7 @@ import {
   resolveSystemPromptUsage,
   writeCliImages,
 } from "./cli-runner/helpers.js";
+import { runCopilotCliAgent } from "./copilot-runner.js";
 import { resolveOpenClawDocsPath } from "./docs-path.js";
 import { FailoverError, resolveFailoverStatus } from "./failover-error.js";
 import {
@@ -73,6 +74,29 @@ export async function runCliAgent(params: {
   bootstrapPromptWarningSignature?: string;
   images?: ImageContent[];
 }): Promise<EmbeddedPiRunResult> {
+  // Copilot SDK has its own client/session lifecycle — intercept before generic CLI path.
+  if (params.provider === "copilot-cli") {
+    if (params.images && params.images.length > 0) {
+      log.warn("copilot-cli does not support image input — images will be dropped");
+    }
+    return runCopilotCliAgent({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+      agentId: params.agentId,
+      sessionFile: params.sessionFile,
+      workspaceDir: params.workspaceDir,
+      config: params.config,
+      prompt: params.prompt,
+      model: params.model,
+      thinkLevel: params.thinkLevel,
+      timeoutMs: params.timeoutMs,
+      runId: params.runId,
+      extraSystemPrompt: params.extraSystemPrompt,
+      ownerNumbers: params.ownerNumbers,
+      cliSessionId: params.cliSessionId,
+    });
+  }
+
   const started = Date.now();
   const workspaceResolution = resolveRunWorkspaceDir({
     workspaceDir: params.workspaceDir,

--- a/src/agents/copilot-runner.test.ts
+++ b/src/agents/copilot-runner.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock copilot-sdk.js — the runner delegates to this module
+const checkCopilotAvailableMock = vi.fn();
+const runCopilotAgentMock = vi.fn();
+
+vi.mock("./copilot-sdk.js", () => ({
+  checkCopilotAvailable: (...args: unknown[]) => checkCopilotAvailableMock(...args),
+  runCopilotAgent: (...args: unknown[]) => runCopilotAgentMock(...args),
+}));
+
+// Stub out bootstrap/docs resolution to avoid filesystem side effects
+vi.mock("./bootstrap-files.js", () => ({
+  resolveBootstrapContextForRun: vi.fn(async () => ({ contextFiles: [] })),
+  makeBootstrapWarn: vi.fn(() => () => {}),
+}));
+vi.mock("./docs-path.js", () => ({
+  resolveOpenClawDocsPath: vi.fn(async () => null),
+}));
+
+import { runCopilotCliAgent } from "./copilot-runner.js";
+import { FailoverError } from "./failover-error.js";
+
+describe("runCopilotCliAgent", () => {
+  beforeEach(() => {
+    checkCopilotAvailableMock.mockReset();
+    runCopilotAgentMock.mockReset();
+  });
+
+  it("throws FailoverError when copilot is not available", async () => {
+    checkCopilotAvailableMock.mockReturnValue({
+      available: false,
+      reason: "copilot CLI not found on PATH",
+    });
+
+    await expect(
+      runCopilotCliAgent({
+        sessionId: "s1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        prompt: "hello",
+        timeoutMs: 5_000,
+        runId: "run-1",
+      }),
+    ).rejects.toThrow(FailoverError);
+
+    expect(runCopilotAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("runs prompt through copilot SDK and returns result", async () => {
+    checkCopilotAvailableMock.mockReturnValue({ available: true });
+    runCopilotAgentMock.mockResolvedValueOnce({
+      text: "Hello! I can help with that.",
+      sessionId: "copilot-session-abc",
+    });
+
+    const result = await runCopilotCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hello",
+      model: "gpt-4o",
+      timeoutMs: 5_000,
+      runId: "run-1",
+    });
+
+    expect(result.payloads).toBeDefined();
+    expect(result.payloads?.[0]?.text).toBe("Hello! I can help with that.");
+    expect(result.meta?.agentMeta?.provider).toBe("copilot-cli");
+    expect(result.meta?.agentMeta?.model).toBe("gpt-4o");
+    expect(result.meta?.agentMeta?.sessionId).toBe("copilot-session-abc");
+    expect(result.meta?.durationMs).toBeGreaterThanOrEqual(0);
+
+    // Verify the SDK was called with the right params
+    expect(runCopilotAgentMock).toHaveBeenCalledTimes(1);
+    const sdkArgs = runCopilotAgentMock.mock.calls[0]?.[0];
+    expect(sdkArgs.prompt).toBe("hello");
+    expect(sdkArgs.model).toBe("gpt-4o");
+    expect(sdkArgs.workspaceDir).toBe("/tmp");
+    expect(sdkArgs.timeoutMs).toBe(5_000);
+  });
+
+  it("passes through cliSessionId as sessionId for resume", async () => {
+    checkCopilotAvailableMock.mockReturnValue({ available: true });
+    runCopilotAgentMock.mockResolvedValueOnce({
+      text: "Resumed session.",
+      sessionId: "copilot-session-existing",
+    });
+
+    await runCopilotCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "continue",
+      timeoutMs: 5_000,
+      runId: "run-2",
+      cliSessionId: "copilot-session-existing",
+    });
+
+    const sdkArgs = runCopilotAgentMock.mock.calls[0]?.[0];
+    expect(sdkArgs.sessionId).toBe("copilot-session-existing");
+  });
+
+  it("returns empty payloads when response is empty", async () => {
+    checkCopilotAvailableMock.mockReturnValue({ available: true });
+    runCopilotAgentMock.mockResolvedValueOnce({
+      text: "",
+      sessionId: "copilot-session-empty",
+    });
+
+    const result = await runCopilotCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hello",
+      timeoutMs: 5_000,
+      runId: "run-3",
+    });
+
+    expect(result.payloads).toBeUndefined();
+  });
+
+  it("wraps SDK errors as FailoverError when appropriate", async () => {
+    checkCopilotAvailableMock.mockReturnValue({ available: true });
+    runCopilotAgentMock.mockRejectedValueOnce(new Error("rate limit exceeded"));
+
+    await expect(
+      runCopilotCliAgent({
+        sessionId: "s1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        prompt: "hello",
+        timeoutMs: 5_000,
+        runId: "run-4",
+      }),
+    ).rejects.toThrow(FailoverError);
+  });
+
+  it("passes through non-failover errors unchanged", async () => {
+    checkCopilotAvailableMock.mockReturnValue({ available: true });
+    const unexpectedError = new TypeError("unexpected type issue");
+    runCopilotAgentMock.mockRejectedValueOnce(unexpectedError);
+
+    await expect(
+      runCopilotCliAgent({
+        sessionId: "s1",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        prompt: "hello",
+        timeoutMs: 5_000,
+        runId: "run-5",
+      }),
+    ).rejects.toThrow(unexpectedError);
+  });
+
+  it("uses default model when none specified", async () => {
+    checkCopilotAvailableMock.mockReturnValue({ available: true });
+    runCopilotAgentMock.mockResolvedValueOnce({
+      text: "ok",
+      sessionId: "sid-default",
+    });
+
+    const result = await runCopilotCliAgent({
+      sessionId: "s1",
+      sessionFile: "/tmp/session.jsonl",
+      workspaceDir: "/tmp",
+      prompt: "hi",
+      timeoutMs: 5_000,
+      runId: "run-6",
+    });
+
+    const sdkArgs = runCopilotAgentMock.mock.calls[0]?.[0];
+    // When model is "default", SDK receives undefined so it uses its own default
+    expect(sdkArgs.model).toBeUndefined();
+    expect(result.meta?.agentMeta?.model).toBe("default");
+  });
+});

--- a/src/agents/copilot-runner.ts
+++ b/src/agents/copilot-runner.ts
@@ -84,6 +84,7 @@ export async function runCopilotCliAgent(params: {
   });
   const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
     sessionKey: params.sessionKey,
+    agentId: params.agentId,
     config: params.config,
   });
   const heartbeatPrompt =

--- a/src/agents/copilot-runner.ts
+++ b/src/agents/copilot-runner.ts
@@ -1,0 +1,156 @@
+import { resolveHeartbeatPrompt } from "../auto-reply/heartbeat.js";
+import type { ThinkLevel } from "../auto-reply/thinking.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { resolveSessionAgentIds } from "./agent-scope.js";
+import { makeBootstrapWarn, resolveBootstrapContextForRun } from "./bootstrap-files.js";
+import { resolveCliBackendConfig } from "./cli-backends.js";
+import { buildSystemPrompt, normalizeCliModel } from "./cli-runner/helpers.js";
+import { checkCopilotAvailable, runCopilotAgent } from "./copilot-sdk.js";
+import { resolveOpenClawDocsPath } from "./docs-path.js";
+import { FailoverError, resolveFailoverStatus } from "./failover-error.js";
+import { classifyFailoverReason, isFailoverErrorMessage } from "./pi-embedded-helpers.js";
+import type { EmbeddedPiRunResult } from "./pi-embedded-runner.js";
+import { redactRunIdentifier, resolveRunWorkspaceDir } from "./workspace-run.js";
+
+const log = createSubsystemLogger("agent/copilot-cli");
+
+/**
+ * Run a prompt through the Copilot SDK CLI backend.
+ * Matches the same parameter shape as `runCliAgent` so it slots into the routing.
+ */
+export async function runCopilotCliAgent(params: {
+  sessionId: string;
+  sessionKey?: string;
+  agentId?: string;
+  sessionFile: string;
+  workspaceDir: string;
+  config?: OpenClawConfig;
+  prompt: string;
+  model?: string;
+  thinkLevel?: ThinkLevel;
+  timeoutMs: number;
+  runId: string;
+  extraSystemPrompt?: string;
+  ownerNumbers?: string[];
+  cliSessionId?: string;
+}): Promise<EmbeddedPiRunResult> {
+  const started = Date.now();
+
+  // Check availability before doing anything expensive
+  const availability = checkCopilotAvailable();
+  if (!availability.available) {
+    throw new FailoverError(`copilot-cli not available: ${availability.reason}`, {
+      reason: "auth",
+      provider: "copilot-cli",
+      model: params.model ?? "default",
+      status: 401,
+    });
+  }
+
+  const workspaceResolution = resolveRunWorkspaceDir({
+    workspaceDir: params.workspaceDir,
+    sessionKey: params.sessionKey,
+    agentId: params.agentId,
+    config: params.config,
+  });
+  const resolvedWorkspace = workspaceResolution.workspaceDir;
+  if (workspaceResolution.usedFallback) {
+    const redacted = redactRunIdentifier(params.sessionId);
+    log.warn(
+      `[workspace-fallback] caller=runCopilotCliAgent reason=${workspaceResolution.fallbackReason} run=${params.runId} session=${redacted}`,
+    );
+  }
+
+  const rawModelId = (params.model ?? "default").trim() || "default";
+  const backendConfig = resolveCliBackendConfig("copilot-cli", params.config);
+  const modelId = backendConfig ? normalizeCliModel(rawModelId, backendConfig.config) : rawModelId;
+  const modelDisplay = `copilot-cli/${modelId}`;
+
+  const extraSystemPrompt = [
+    params.extraSystemPrompt?.trim(),
+    "Tools are disabled in this session. Do not call tools.",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const sessionLabel = params.sessionKey ?? params.sessionId;
+  const { contextFiles } = await resolveBootstrapContextForRun({
+    workspaceDir: resolvedWorkspace,
+    config: params.config,
+    sessionKey: params.sessionKey,
+    sessionId: params.sessionId,
+    warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
+  });
+  const { defaultAgentId, sessionAgentId } = resolveSessionAgentIds({
+    sessionKey: params.sessionKey,
+    config: params.config,
+  });
+  const heartbeatPrompt =
+    sessionAgentId === defaultAgentId
+      ? resolveHeartbeatPrompt(params.config?.agents?.defaults?.heartbeat?.prompt)
+      : undefined;
+  const docsPath = await resolveOpenClawDocsPath({
+    workspaceDir: resolvedWorkspace,
+    argv1: process.argv[1],
+    cwd: process.cwd(),
+    moduleUrl: import.meta.url,
+  });
+  const systemPrompt = buildSystemPrompt({
+    workspaceDir: resolvedWorkspace,
+    config: params.config,
+    defaultThinkLevel: params.thinkLevel,
+    extraSystemPrompt,
+    ownerNumbers: params.ownerNumbers,
+    heartbeatPrompt,
+    docsPath: docsPath ?? undefined,
+    tools: [],
+    contextFiles,
+    modelDisplay,
+    agentId: sessionAgentId,
+  });
+
+  try {
+    log.info(`copilot-cli exec: model=${modelId} promptChars=${params.prompt.length}`);
+
+    const result = await runCopilotAgent({
+      prompt: params.prompt,
+      model: modelId === "default" ? undefined : modelId,
+      workspaceDir: resolvedWorkspace,
+      systemPrompt,
+      timeoutMs: params.timeoutMs,
+      sessionId: params.cliSessionId,
+    });
+
+    const text = result.text?.trim();
+    const payloads = text ? [{ text }] : undefined;
+
+    return {
+      payloads,
+      meta: {
+        durationMs: Date.now() - started,
+        agentMeta: {
+          sessionId: result.sessionId ?? params.sessionId ?? "",
+          provider: "copilot-cli",
+          model: modelId,
+        },
+      },
+    };
+  } catch (err) {
+    if (err instanceof FailoverError) {
+      throw err;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    if (isFailoverErrorMessage(message)) {
+      const reason = classifyFailoverReason(message) ?? "unknown";
+      const status = resolveFailoverStatus(reason);
+      throw new FailoverError(message, {
+        reason,
+        provider: "copilot-cli",
+        model: modelId,
+        status,
+      });
+    }
+    throw err;
+  }
+}

--- a/src/agents/copilot-sdk.test.ts
+++ b/src/agents/copilot-sdk.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const execFileSyncMock = vi.fn();
+
+// Mock CopilotClient and CopilotSession for runCopilotAgent tests
+const mockSession = {
+  sendAndWait: vi.fn(),
+  destroy: vi.fn(),
+  sessionId: "mock-session-id",
+};
+const mockClient = {
+  stop: vi.fn(),
+  createSession: vi.fn().mockResolvedValue(mockSession),
+  resumeSession: vi.fn().mockResolvedValue(mockSession),
+  getAuthStatus: vi
+    .fn()
+    .mockResolvedValue({ isAuthenticated: true, authType: "user", login: "octocat" }),
+  listModels: vi.fn(),
+};
+
+vi.mock("@github/copilot-sdk", () => {
+  // Use a real class so vitest treats it as a constructor
+  return {
+    CopilotClient: class MockCopilotClient {
+      constructor() {
+        return mockClient;
+      }
+    },
+  };
+});
+
+describe("copilot-sdk", () => {
+  afterEach(() => {
+    execFileSyncMock.mockReset();
+    mockSession.sendAndWait.mockReset();
+    mockSession.destroy.mockReset().mockResolvedValue(undefined);
+    mockClient.stop.mockReset().mockResolvedValue(undefined);
+    mockClient.createSession.mockReset().mockResolvedValue(mockSession);
+    mockClient.resumeSession.mockReset().mockResolvedValue(mockSession);
+    mockClient.getAuthStatus
+      .mockReset()
+      .mockResolvedValue({ isAuthenticated: true, authType: "user", login: "octocat" });
+    mockClient.listModels.mockReset();
+  });
+
+  describe("isCopilotCliInstalled", () => {
+    it("returns true when copilot --version succeeds", async () => {
+      execFileSyncMock.mockReturnValue("0.1.22\n");
+      const { isCopilotCliInstalled } = await import("./copilot-sdk.js");
+      expect(isCopilotCliInstalled({ execFileSync: execFileSyncMock })).toBe(true);
+      expect(execFileSyncMock).toHaveBeenCalledWith("copilot", ["--version"], expect.any(Object));
+    });
+
+    it("returns false when copilot is not on PATH", async () => {
+      execFileSyncMock.mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+      const { isCopilotCliInstalled } = await import("./copilot-sdk.js");
+      expect(isCopilotCliInstalled({ execFileSync: execFileSyncMock })).toBe(false);
+    });
+  });
+
+  describe("checkCopilotAvailable", () => {
+    it("returns unavailable when CLI is not installed", async () => {
+      execFileSyncMock.mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+
+      const { checkCopilotAvailable } = await import("./copilot-sdk.js");
+      const result = checkCopilotAvailable({ execFileSync: execFileSyncMock });
+      expect(result.available).toBe(false);
+      expect(result.reason).toContain("not found");
+    });
+
+    it("returns available when CLI is installed", async () => {
+      execFileSyncMock.mockReturnValue("0.1.22\n");
+
+      const { checkCopilotAvailable } = await import("./copilot-sdk.js");
+      const result = checkCopilotAvailable({ execFileSync: execFileSyncMock });
+      expect(result.available).toBe(true);
+    });
+  });
+
+  describe("runCopilotAgent", () => {
+    it("verifies auth before creating session", async () => {
+      mockSession.sendAndWait.mockResolvedValueOnce({
+        data: { content: "Hello from copilot!" },
+      });
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      await runCopilotAgent({
+        prompt: "Say hello",
+        model: "gpt-4o",
+        workspaceDir: "/tmp",
+        timeoutMs: 5_000,
+      });
+
+      expect(mockClient.getAuthStatus).toHaveBeenCalledTimes(1);
+      expect(mockClient.createSession).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws when not authenticated", async () => {
+      mockClient.getAuthStatus.mockResolvedValueOnce({
+        isAuthenticated: false,
+        statusMessage: "No token",
+      });
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      await expect(runCopilotAgent({ prompt: "hi", timeoutMs: 5_000 })).rejects.toThrow(
+        "copilot CLI not authenticated",
+      );
+      expect(mockClient.createSession).not.toHaveBeenCalled();
+      expect(mockClient.stop).toHaveBeenCalled();
+    });
+
+    it("creates a new session and sends the prompt", async () => {
+      mockSession.sendAndWait.mockResolvedValueOnce({
+        data: { content: "Hello from copilot!" },
+      });
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      const result = await runCopilotAgent({
+        prompt: "Say hello",
+        model: "gpt-4o",
+        workspaceDir: "/tmp",
+        timeoutMs: 5_000,
+      });
+
+      expect(result.text).toBe("Hello from copilot!");
+      expect(result.sessionId).toBe("mock-session-id");
+      expect(mockClient.createSession).toHaveBeenCalledTimes(1);
+      expect(mockClient.resumeSession).not.toHaveBeenCalled();
+      expect(mockSession.sendAndWait).toHaveBeenCalledWith({ prompt: "Say hello" }, 5_000);
+      expect(mockSession.destroy).toHaveBeenCalled();
+      expect(mockClient.stop).toHaveBeenCalled();
+    });
+
+    it("resumes existing session when sessionId is provided", async () => {
+      mockSession.sendAndWait.mockResolvedValueOnce({
+        data: { content: "Resumed!" },
+      });
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      await runCopilotAgent({
+        prompt: "continue",
+        sessionId: "existing-session-123",
+        timeoutMs: 5_000,
+      });
+
+      expect(mockClient.resumeSession).toHaveBeenCalledTimes(1);
+      expect(mockClient.resumeSession).toHaveBeenCalledWith(
+        "existing-session-123",
+        expect.any(Object),
+      );
+      expect(mockClient.createSession).not.toHaveBeenCalled();
+    });
+
+    it("returns empty string when response has no content", async () => {
+      mockSession.sendAndWait.mockResolvedValueOnce(undefined);
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      const result = await runCopilotAgent({
+        prompt: "empty",
+        timeoutMs: 5_000,
+      });
+
+      expect(result.text).toBe("");
+    });
+
+    it("cleans up session and client even on error", async () => {
+      mockSession.sendAndWait.mockRejectedValueOnce(new Error("SDK timeout"));
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      await expect(runCopilotAgent({ prompt: "boom", timeoutMs: 1_000 })).rejects.toThrow(
+        "SDK timeout",
+      );
+
+      // Cleanup should still happen
+      expect(mockSession.destroy).toHaveBeenCalled();
+      expect(mockClient.stop).toHaveBeenCalled();
+    });
+
+    it("passes system prompt as append mode", async () => {
+      mockSession.sendAndWait.mockResolvedValueOnce({
+        data: { content: "Got it." },
+      });
+
+      const { runCopilotAgent } = await import("./copilot-sdk.js");
+      await runCopilotAgent({
+        prompt: "hi",
+        systemPrompt: "You are a helpful assistant.",
+        timeoutMs: 5_000,
+      });
+
+      const sessionConfig = mockClient.createSession.mock.calls[0]?.[0];
+      expect(sessionConfig.systemMessage).toEqual({
+        mode: "append",
+        content: "You are a helpful assistant.",
+      });
+    });
+  });
+
+  describe("listCopilotModels", () => {
+    it("returns models when authenticated", async () => {
+      const mockModels = [
+        { id: "claude-sonnet-4.5", name: "Claude Sonnet 4.5" },
+        { id: "gpt-5", name: "GPT-5" },
+      ];
+      mockClient.listModels.mockResolvedValueOnce(mockModels);
+
+      const { listCopilotModels } = await import("./copilot-sdk.js");
+      const models = await listCopilotModels();
+      expect(models).toEqual(mockModels);
+      expect(mockClient.getAuthStatus).toHaveBeenCalled();
+      expect(mockClient.stop).toHaveBeenCalled();
+    });
+
+    it("returns null when not authenticated", async () => {
+      mockClient.getAuthStatus.mockResolvedValueOnce({ isAuthenticated: false });
+
+      const { listCopilotModels } = await import("./copilot-sdk.js");
+      const models = await listCopilotModels();
+      expect(models).toBeNull();
+      expect(mockClient.stop).toHaveBeenCalled();
+    });
+
+    it("returns null when listing fails", async () => {
+      mockClient.listModels.mockRejectedValueOnce(new Error("Network error"));
+
+      const { listCopilotModels } = await import("./copilot-sdk.js");
+      const models = await listCopilotModels();
+      expect(models).toBeNull();
+    });
+  });
+
+  describe("createCopilotClient", () => {
+    it("creates a client with default options", async () => {
+      const { createCopilotClient } = await import("./copilot-sdk.js");
+      const client = await createCopilotClient();
+      expect(client).toBeDefined();
+    });
+  });
+});

--- a/src/agents/copilot-sdk.test.ts
+++ b/src/agents/copilot-sdk.test.ts
@@ -1,7 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-const execFileSyncMock = vi.fn();
-
 // Mock CopilotClient and CopilotSession for runCopilotAgent tests
 const mockSession = {
   sendAndWait: vi.fn(),
@@ -31,7 +29,6 @@ vi.mock("@github/copilot-sdk", () => {
 
 describe("copilot-sdk", () => {
   afterEach(() => {
-    execFileSyncMock.mockReset();
     mockSession.sendAndWait.mockReset();
     mockSession.destroy.mockReset().mockResolvedValue(undefined);
     mockClient.stop.mockReset().mockResolvedValue(undefined);
@@ -44,39 +41,39 @@ describe("copilot-sdk", () => {
   });
 
   describe("isCopilotCliInstalled", () => {
-    it("returns true when copilot --version succeeds", async () => {
-      execFileSyncMock.mockReturnValue("0.1.22\n");
+    it("returns true when @github/copilot-sdk is resolvable", async () => {
+      const resolveFn = vi.fn().mockReturnValue("file:///node_modules/@github/copilot-sdk/index.js");
       const { isCopilotCliInstalled } = await import("./copilot-sdk.js");
-      expect(isCopilotCliInstalled({ execFileSync: execFileSyncMock })).toBe(true);
-      expect(execFileSyncMock).toHaveBeenCalledWith("copilot", ["--version"], expect.any(Object));
+      expect(isCopilotCliInstalled({ resolveFn })).toBe(true);
+      expect(resolveFn).toHaveBeenCalledWith("@github/copilot-sdk");
     });
 
-    it("returns false when copilot is not on PATH", async () => {
-      execFileSyncMock.mockImplementation(() => {
-        throw new Error("ENOENT");
+    it("returns false when @github/copilot-sdk is not installed", async () => {
+      const resolveFn = vi.fn().mockImplementation(() => {
+        throw new Error("ERR_MODULE_NOT_FOUND");
       });
       const { isCopilotCliInstalled } = await import("./copilot-sdk.js");
-      expect(isCopilotCliInstalled({ execFileSync: execFileSyncMock })).toBe(false);
+      expect(isCopilotCliInstalled({ resolveFn })).toBe(false);
     });
   });
 
   describe("checkCopilotAvailable", () => {
-    it("returns unavailable when CLI is not installed", async () => {
-      execFileSyncMock.mockImplementation(() => {
-        throw new Error("ENOENT");
+    it("returns unavailable when SDK is not installed", async () => {
+      const resolveFn = vi.fn().mockImplementation(() => {
+        throw new Error("ERR_MODULE_NOT_FOUND");
       });
 
       const { checkCopilotAvailable } = await import("./copilot-sdk.js");
-      const result = checkCopilotAvailable({ execFileSync: execFileSyncMock });
+      const result = checkCopilotAvailable({ resolveFn });
       expect(result.available).toBe(false);
-      expect(result.reason).toContain("not found");
+      expect(result.reason).toContain("not installed");
     });
 
-    it("returns available when CLI is installed", async () => {
-      execFileSyncMock.mockReturnValue("0.1.22\n");
+    it("returns available when SDK is installed", async () => {
+      const resolveFn = vi.fn().mockReturnValue("file:///node_modules/@github/copilot-sdk/index.js");
 
       const { checkCopilotAvailable } = await import("./copilot-sdk.js");
-      const result = checkCopilotAvailable({ execFileSync: execFileSyncMock });
+      const result = checkCopilotAvailable({ resolveFn });
       expect(result.available).toBe(true);
     });
   });

--- a/src/agents/copilot-sdk.test.ts
+++ b/src/agents/copilot-sdk.test.ts
@@ -42,7 +42,9 @@ describe("copilot-sdk", () => {
 
   describe("isCopilotCliInstalled", () => {
     it("returns true when @github/copilot-sdk is resolvable", async () => {
-      const resolveFn = vi.fn().mockReturnValue("file:///node_modules/@github/copilot-sdk/index.js");
+      const resolveFn = vi
+        .fn()
+        .mockReturnValue("file:///node_modules/@github/copilot-sdk/index.js");
       const { isCopilotCliInstalled } = await import("./copilot-sdk.js");
       expect(isCopilotCliInstalled({ resolveFn })).toBe(true);
       expect(resolveFn).toHaveBeenCalledWith("@github/copilot-sdk");
@@ -70,7 +72,9 @@ describe("copilot-sdk", () => {
     });
 
     it("returns available when SDK is installed", async () => {
-      const resolveFn = vi.fn().mockReturnValue("file:///node_modules/@github/copilot-sdk/index.js");
+      const resolveFn = vi
+        .fn()
+        .mockReturnValue("file:///node_modules/@github/copilot-sdk/index.js");
 
       const { checkCopilotAvailable } = await import("./copilot-sdk.js");
       const result = checkCopilotAvailable({ resolveFn });

--- a/src/agents/copilot-sdk.ts
+++ b/src/agents/copilot-sdk.ts
@@ -1,0 +1,200 @@
+import { execFileSync } from "node:child_process";
+import type {
+  CopilotClient,
+  CopilotClientOptions,
+  CopilotSession,
+  ModelInfo,
+  SessionConfig,
+} from "@github/copilot-sdk";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("agents/copilot-sdk");
+
+/**
+ * Check whether the `copilot` CLI binary is available on PATH.
+ */
+export function isCopilotCliInstalled(options?: { execFileSync?: typeof execFileSync }): boolean {
+  const exec = options?.execFileSync ?? execFileSync;
+  try {
+    exec("copilot", ["--version"], {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export type CopilotAvailability = {
+  available: boolean;
+  reason?: string;
+};
+
+let cachedAvailability: CopilotAvailability | undefined;
+
+/**
+ * Check whether the Copilot CLI binary is installed (sync, fast).
+ * Result is cached for the lifetime of the process.
+ * Auth is validated later via the SDK's `getAuthStatus()` during client startup.
+ */
+export function checkCopilotAvailable(options?: {
+  execFileSync?: typeof execFileSync;
+}): CopilotAvailability {
+  if (options) {
+    // Custom execFileSync — skip cache (used in tests)
+    return isCopilotCliInstalled(options)
+      ? { available: true }
+      : { available: false, reason: "copilot CLI not found on PATH" };
+  }
+  if (cachedAvailability) {
+    return cachedAvailability;
+  }
+  cachedAvailability = isCopilotCliInstalled()
+    ? { available: true }
+    : { available: false, reason: "copilot CLI not found on PATH" };
+  return cachedAvailability;
+}
+
+/**
+ * Lazily import and create a CopilotClient. The SDK is only loaded when actually used.
+ */
+export async function createCopilotClient(options?: CopilotClientOptions): Promise<CopilotClient> {
+  const { CopilotClient: ClientClass } = await import("@github/copilot-sdk");
+  const client = new ClientClass({
+    useStdio: true,
+    autoStart: true,
+    logLevel: "warning",
+    ...options,
+  });
+  return client;
+}
+
+/**
+ * Verify the client is authenticated. Throws if not.
+ */
+async function ensureAuthenticated(client: CopilotClient): Promise<void> {
+  const authStatus = await client.getAuthStatus();
+  if (!authStatus.isAuthenticated) {
+    throw new Error(
+      `copilot CLI not authenticated (run: copilot login). ${authStatus.statusMessage ?? ""}`.trim(),
+    );
+  }
+  log.info("copilot auth verified", {
+    authType: authStatus.authType,
+    login: authStatus.login,
+  });
+}
+
+/**
+ * List available models from the Copilot SDK.
+ * Requires an authenticated client. Returns null if listing fails.
+ */
+export async function listCopilotModels(options?: { cwd?: string }): Promise<ModelInfo[] | null> {
+  let client: CopilotClient | undefined;
+  try {
+    client = await createCopilotClient({ cwd: options?.cwd });
+    await ensureAuthenticated(client);
+    const models = await client.listModels();
+    return models;
+  } catch (error) {
+    log.warn("failed to list copilot models", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  } finally {
+    if (client) {
+      try {
+        await client.stop();
+      } catch {}
+    }
+  }
+}
+
+export type CopilotAgentRunOptions = {
+  prompt: string;
+  model?: string;
+  workspaceDir?: string;
+  systemPrompt?: string;
+  timeoutMs?: number;
+  sessionId?: string;
+};
+
+export type CopilotAgentRunResult = {
+  text: string;
+  sessionId: string;
+};
+
+/**
+ * Run a single prompt through the Copilot SDK and return the final response.
+ * Creates a client, session, sends the message, waits for idle, and cleans up.
+ */
+export async function runCopilotAgent(
+  options: CopilotAgentRunOptions,
+): Promise<CopilotAgentRunResult> {
+  const client = await createCopilotClient({
+    cwd: options.workspaceDir,
+  });
+
+  let session: CopilotSession | undefined;
+
+  try {
+    await ensureAuthenticated(client);
+
+    const sessionConfig: SessionConfig = {
+      model: options.model,
+      workingDirectory: options.workspaceDir,
+      streaming: true,
+    };
+
+    if (options.systemPrompt) {
+      sessionConfig.systemMessage = {
+        mode: "append",
+        content: options.systemPrompt,
+      };
+    }
+
+    // Auto-approve all permission requests so the agent can work autonomously.
+    sessionConfig.onPermissionRequest = async () => ({
+      kind: "approved",
+    });
+
+    if (options.sessionId) {
+      session = await client.resumeSession(options.sessionId, sessionConfig);
+    } else {
+      session = await client.createSession(sessionConfig);
+    }
+
+    const timeoutMs = options.timeoutMs ?? 120_000;
+    const response = await session.sendAndWait({ prompt: options.prompt }, timeoutMs);
+
+    const text = response?.data?.content ?? "";
+    const sessionId = session.sessionId;
+
+    log.info(`copilot agent run completed`, {
+      sessionId,
+      model: options.model,
+      responseLength: text.length,
+    });
+
+    return { text, sessionId };
+  } finally {
+    if (session) {
+      try {
+        await session.destroy();
+      } catch (err) {
+        log.warn("failed to destroy copilot session", {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    try {
+      await client.stop();
+    } catch (err) {
+      log.warn("failed to stop copilot client", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}

--- a/src/agents/copilot-sdk.ts
+++ b/src/agents/copilot-sdk.ts
@@ -143,6 +143,12 @@ export async function runCopilotAgent(
       model: options.model,
       workingDirectory: options.workspaceDir,
       streaming: true,
+      // Deny tool-use permission requests by default (security: callers must
+      // opt-in to specific capabilities through session configuration).
+      onPermissionRequest: async () => ({
+        kind: "denied-interactively-by-user",
+        feedback: "Tool use is not permitted in this session.",
+      }),
     };
 
     if (options.systemPrompt) {
@@ -151,13 +157,6 @@ export async function runCopilotAgent(
         content: options.systemPrompt,
       };
     }
-
-    // Deny tool-use permission requests by default (security: callers must
-    // opt-in to specific capabilities through session configuration).
-    sessionConfig.onPermissionRequest = async () => ({
-      kind: "denied",
-      reason: "Tool use is not permitted in this session.",
-    });
 
     if (options.sessionId) {
       session = await client.resumeSession(options.sessionId, sessionConfig);

--- a/src/agents/copilot-sdk.ts
+++ b/src/agents/copilot-sdk.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from "node:child_process";
 import type {
   CopilotClient,
   CopilotClientOptions,
@@ -11,16 +10,14 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 const log = createSubsystemLogger("agents/copilot-sdk");
 
 /**
- * Check whether the `copilot` CLI binary is available on PATH.
+ * Check whether the `@github/copilot-sdk` package is resolvable.
+ * The SDK bundles its own `@github/copilot` native binary, so a global
+ * `copilot` on PATH is not required.
  */
-export function isCopilotCliInstalled(options?: { execFileSync?: typeof execFileSync }): boolean {
-  const exec = options?.execFileSync ?? execFileSync;
+export function isCopilotCliInstalled(options?: { resolveFn?: (id: string) => string }): boolean {
+  const resolve = options?.resolveFn ?? ((id: string) => import.meta.resolve(id));
   try {
-    exec("copilot", ["--version"], {
-      encoding: "utf8",
-      timeout: 5000,
-      stdio: ["pipe", "pipe", "pipe"],
-    });
+    resolve("@github/copilot-sdk");
     return true;
   } catch {
     return false;
@@ -40,20 +37,20 @@ let cachedAvailability: CopilotAvailability | undefined;
  * Auth is validated later via the SDK's `getAuthStatus()` during client startup.
  */
 export function checkCopilotAvailable(options?: {
-  execFileSync?: typeof execFileSync;
+  resolveFn?: (id: string) => string;
 }): CopilotAvailability {
   if (options) {
-    // Custom execFileSync — skip cache (used in tests)
+    // Custom resolveFn — skip cache (used in tests)
     return isCopilotCliInstalled(options)
       ? { available: true }
-      : { available: false, reason: "copilot CLI not found on PATH" };
+      : { available: false, reason: "@github/copilot-sdk is not installed" };
   }
   if (cachedAvailability) {
     return cachedAvailability;
   }
   cachedAvailability = isCopilotCliInstalled()
     ? { available: true }
-    : { available: false, reason: "copilot CLI not found on PATH" };
+    : { available: false, reason: "@github/copilot-sdk is not installed" };
   return cachedAvailability;
 }
 
@@ -155,9 +152,11 @@ export async function runCopilotAgent(
       };
     }
 
-    // Auto-approve all permission requests so the agent can work autonomously.
+    // Deny tool-use permission requests by default (security: callers must
+    // opt-in to specific capabilities through session configuration).
     sessionConfig.onPermissionRequest = async () => ({
-      kind: "approved",
+      kind: "denied",
+      reason: "Tool use is not permitted in this session.",
     });
 
     if (options.sessionId) {

--- a/src/agents/github-copilot-token.ts
+++ b/src/agents/github-copilot-token.ts
@@ -2,6 +2,14 @@ import path from "node:path";
 import { resolveStateDir } from "../config/paths.js";
 import { loadJsonFile, saveJsonFile } from "../infra/json-file.js";
 
+/**
+ * Marker token stored in auth profiles when the Copilot SDK manages
+ * authentication (e.g. via `gh` CLI or environment variables). The
+ * embedded runner detects this and delegates token resolution to the SDK
+ * instead of exchanging a raw GitHub token.
+ */
+export const SDK_MANAGED_TOKEN = "sdk-managed";
+
 const COPILOT_TOKEN_URL = "https://api.github.com/copilot_internal/v2/token";
 
 export type CachedCopilotToken = {

--- a/src/agents/github-copilot-token.ts
+++ b/src/agents/github-copilot-token.ts
@@ -99,6 +99,16 @@ export async function resolveCopilotApiToken(params: {
   source: string;
   baseUrl: string;
 }> {
+  // SDK-managed profiles cannot be exchanged for API tokens — they must be
+  // routed through the Copilot SDK runner (copilot-cli backend) instead.
+  if (params.githubToken === SDK_MANAGED_TOKEN) {
+    throw new Error(
+      "SDK-managed auth profile cannot be exchanged for a Copilot API token. " +
+        "Use the copilot-cli backend or re-authenticate with `openclaw login github-copilot` " +
+        "to obtain a device-flow token.",
+    );
+  }
+
   const env = params.env ?? process.env;
   const cachePath = params.cachePath?.trim() || resolveCopilotTokenCachePath(env);
   const loadJsonFileFn = params.loadJsonFileImpl ?? loadJsonFile;

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -87,6 +87,9 @@ export function isCliProvider(provider: string, cfg?: OpenClawConfig): boolean {
   if (normalized === "codex-cli") {
     return true;
   }
+  if (normalized === "copilot-cli") {
+    return true;
+  }
   const backends = cfg?.agents?.defaults?.cliBackends ?? {};
   return Object.keys(backends).some((key) => normalizeProviderId(key) === normalized);
 }

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -15,7 +15,6 @@ import {
   XIAOMI_DEFAULT_MODEL_ID,
   buildXiaomiProvider,
 } from "../plugin-sdk/provider-catalog.js";
-import { isCopilotSdkAvailable, getCopilotSdkAuthStatus } from "../providers/github-copilot-sdk.js";
 import { isRecord } from "../utils.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 import { hasAnthropicVertexAvailableAuth } from "./anthropic-vertex-provider.js";
@@ -993,19 +992,7 @@ export async function resolveImplicitCopilotProvider(params: {
   const envToken = env.COPILOT_GITHUB_TOKEN ?? env.GH_TOKEN ?? env.GITHUB_TOKEN;
   const githubToken = (envToken ?? "").trim();
 
-  // SDK-based auth detection: if no explicit profile/env token, check if the
-  // Copilot SDK can authenticate (e.g. via `gh` CLI auth).
   if (!hasProfile && !githubToken) {
-    const sdkAvailable = await isCopilotSdkAvailable();
-    if (sdkAvailable) {
-      const status = await getCopilotSdkAuthStatus();
-      if (status.authenticated) {
-        return {
-          baseUrl: DEFAULT_COPILOT_API_BASE_URL,
-          models: [],
-        } satisfies ProviderConfig;
-      }
-    }
     return null;
   }
 
@@ -1025,12 +1012,9 @@ export async function resolveImplicitCopilotProvider(params: {
     }
   }
 
-  // SDK-managed tokens don't need token exchange for provider detection
+  // SDK-managed tokens cannot be used for REST token exchange.
   if (selectedGithubToken === SDK_MANAGED_TOKEN) {
-    return {
-      baseUrl: DEFAULT_COPILOT_API_BASE_URL,
-      models: [],
-    } satisfies ProviderConfig;
+    return null;
   }
 
   let baseUrl = DEFAULT_COPILOT_API_BASE_URL;

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -2,10 +2,6 @@ import type { OpenClawConfig } from "../config/config.js";
 import { coerceSecretRef, resolveSecretInputRef } from "../config/types.secrets.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
-  isCopilotSdkAvailable,
-  getCopilotSdkAuthStatus,
-} from "../providers/github-copilot-sdk.js";
-import {
   buildAnthropicVertexProvider,
   buildKimiCodingProvider,
   buildKilocodeProvider,
@@ -19,6 +15,7 @@ import {
   XIAOMI_DEFAULT_MODEL_ID,
   buildXiaomiProvider,
 } from "../plugin-sdk/provider-catalog.js";
+import { isCopilotSdkAvailable, getCopilotSdkAuthStatus } from "../providers/github-copilot-sdk.js";
 import { isRecord } from "../utils.js";
 import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
 import { hasAnthropicVertexAvailableAuth } from "./anthropic-vertex-provider.js";

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -2,6 +2,10 @@ import type { OpenClawConfig } from "../config/config.js";
 import { coerceSecretRef, resolveSecretInputRef } from "../config/types.secrets.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
+  isCopilotSdkAvailable,
+  getCopilotSdkAuthStatus,
+} from "../providers/github-copilot-sdk.js";
+import {
   buildAnthropicVertexProvider,
   buildKimiCodingProvider,
   buildKilocodeProvider,
@@ -20,6 +24,11 @@ import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js
 import { hasAnthropicVertexAvailableAuth } from "./anthropic-vertex-provider.js";
 import { ensureAuthProfileStore, listProfilesForProvider } from "./auth-profiles.js";
 import { discoverBedrockModels } from "./bedrock-discovery.js";
+import {
+  DEFAULT_COPILOT_API_BASE_URL,
+  resolveCopilotApiToken,
+  SDK_MANAGED_TOKEN,
+} from "./github-copilot-token.js";
 import {
   normalizeGoogleGenerativeAiBaseUrl,
   shouldNormalizeGoogleGenerativeAiProviderConfig,
@@ -911,6 +920,24 @@ export async function resolveImplicitProviders(
       : implicitAnthropicVertex;
   }
 
+  const implicitCopilot = await resolveImplicitCopilotProvider({
+    agentDir: params.agentDir,
+    env,
+  });
+  if (implicitCopilot) {
+    const existing = providers["github-copilot"];
+    providers["github-copilot"] = existing
+      ? {
+          ...implicitCopilot,
+          ...existing,
+          models:
+            Array.isArray(existing.models) && existing.models.length > 0
+              ? existing.models
+              : implicitCopilot.models,
+        }
+      : implicitCopilot;
+  }
+
   return providers;
 }
 
@@ -954,5 +981,79 @@ export async function resolveImplicitBedrockProvider(params: {
     api: "bedrock-converse-stream",
     auth: "aws-sdk",
     models,
+  } satisfies ProviderConfig;
+}
+
+export async function resolveImplicitCopilotProvider(params: {
+  agentDir: string;
+  env?: NodeJS.ProcessEnv;
+}): Promise<ProviderConfig | null> {
+  const env = params.env ?? process.env;
+  const authStore = ensureAuthProfileStore(params.agentDir, {
+    allowKeychainPrompt: false,
+  });
+  const hasProfile = listProfilesForProvider(authStore, "github-copilot").length > 0;
+  const envToken = env.COPILOT_GITHUB_TOKEN ?? env.GH_TOKEN ?? env.GITHUB_TOKEN;
+  const githubToken = (envToken ?? "").trim();
+
+  // SDK-based auth detection: if no explicit profile/env token, check if the
+  // Copilot SDK can authenticate (e.g. via `gh` CLI auth).
+  if (!hasProfile && !githubToken) {
+    const sdkAvailable = await isCopilotSdkAvailable();
+    if (sdkAvailable) {
+      const status = await getCopilotSdkAuthStatus();
+      if (status.authenticated) {
+        return {
+          baseUrl: DEFAULT_COPILOT_API_BASE_URL,
+          models: [],
+        } satisfies ProviderConfig;
+      }
+    }
+    return null;
+  }
+
+  // Check if profile is SDK-managed
+  let selectedGithubToken = githubToken;
+  if (!selectedGithubToken && hasProfile) {
+    const profileId = listProfilesForProvider(authStore, "github-copilot")[0];
+    const profile = profileId ? authStore.profiles[profileId] : undefined;
+    if (profile && profile.type === "token") {
+      selectedGithubToken = profile.token?.trim() ?? "";
+      if (!selectedGithubToken) {
+        const tokenRef = coerceSecretRef(profile.tokenRef);
+        if (tokenRef?.source === "env" && tokenRef.id.trim()) {
+          selectedGithubToken = (env[tokenRef.id] ?? process.env[tokenRef.id] ?? "").trim();
+        }
+      }
+    }
+  }
+
+  // SDK-managed tokens don't need token exchange for provider detection
+  if (selectedGithubToken === SDK_MANAGED_TOKEN) {
+    return {
+      baseUrl: DEFAULT_COPILOT_API_BASE_URL,
+      models: [],
+    } satisfies ProviderConfig;
+  }
+
+  let baseUrl = DEFAULT_COPILOT_API_BASE_URL;
+  if (selectedGithubToken) {
+    try {
+      const token = await resolveCopilotApiToken({
+        githubToken: selectedGithubToken,
+        env,
+      });
+      baseUrl = token.baseUrl;
+    } catch {
+      baseUrl = DEFAULT_COPILOT_API_BASE_URL;
+    }
+  }
+
+  // We intentionally do NOT define custom models for Copilot in models.json.
+  // pi-coding-agent treats providers with models as replacements requiring apiKey.
+  // We only override baseUrl; the model list comes from pi-ai built-ins.
+  return {
+    baseUrl,
+    models: [],
   } satisfies ProviderConfig;
 }

--- a/src/providers/github-copilot-sdk.test.ts
+++ b/src/providers/github-copilot-sdk.test.ts
@@ -1,0 +1,311 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock @github/copilot-sdk before importing the module under test
+// ---------------------------------------------------------------------------
+
+const mockClient = {
+  start: vi.fn().mockResolvedValue(undefined),
+  stop: vi.fn().mockResolvedValue([]),
+  ping: vi.fn().mockResolvedValue({ message: "pong", timestamp: Date.now() }),
+  getAuthStatus: vi.fn().mockResolvedValue({
+    isAuthenticated: true,
+    authType: "gh-cli",
+    host: "github.com",
+    login: "testuser",
+    statusMessage: "Authenticated",
+  }),
+  listModels: vi.fn().mockResolvedValue([
+    {
+      id: "gpt-4o",
+      name: "GPT-4o",
+      capabilities: {
+        supports: { vision: true, reasoningEffort: false },
+        limits: { max_context_window_tokens: 128000, max_prompt_tokens: 8192 },
+      },
+      policy: { state: "enabled", terms: "" },
+      billing: { multiplier: 1 },
+    },
+    {
+      id: "claude-sonnet-4",
+      name: "Claude Sonnet 4",
+      capabilities: {
+        supports: { vision: true, reasoningEffort: false },
+        limits: { max_context_window_tokens: 200000, max_prompt_tokens: 8192 },
+      },
+      policy: { state: "enabled", terms: "" },
+    },
+    {
+      id: "o3-mini",
+      name: "O3 Mini",
+      capabilities: {
+        supports: { vision: false, reasoningEffort: true },
+        limits: { max_context_window_tokens: 128000, max_prompt_tokens: 4096 },
+      },
+      policy: { state: "enabled", terms: "" },
+    },
+    {
+      id: "disabled-model",
+      name: "Disabled Model",
+      capabilities: {
+        supports: { vision: false, reasoningEffort: false },
+        limits: { max_context_window_tokens: 32000 },
+      },
+      policy: { state: "disabled", terms: "" },
+    },
+  ]),
+};
+
+class MockCopilotClient {
+  constructor() {
+    return mockClient;
+  }
+}
+
+vi.mock("@github/copilot-sdk", () => ({
+  CopilotClient: MockCopilotClient,
+}));
+
+// ---------------------------------------------------------------------------
+// Import module under test — must be AFTER vi.mock()
+// ---------------------------------------------------------------------------
+
+import {
+  ensureCopilotSdkClient,
+  stopCopilotSdkClient,
+  getCopilotSdkAuthStatus,
+  isCopilotSdkAvailable,
+  discoverCopilotModelsViaSdk,
+  buildCopilotModelDefinitionFromSdk,
+  _resetForTesting,
+} from "./github-copilot-sdk.js";
+
+describe("github-copilot-sdk (provider layer)", () => {
+  beforeEach(() => {
+    _resetForTesting();
+    vi.clearAllMocks();
+    // Re-configure happy-path defaults
+    mockClient.start.mockResolvedValue(undefined);
+    mockClient.stop.mockResolvedValue([]);
+    mockClient.ping.mockResolvedValue({ message: "pong", timestamp: Date.now() });
+    mockClient.getAuthStatus.mockResolvedValue({
+      isAuthenticated: true,
+      authType: "gh-cli",
+      host: "github.com",
+      login: "testuser",
+      statusMessage: "Authenticated",
+    });
+  });
+
+  afterEach(async () => {
+    await stopCopilotSdkClient();
+    _resetForTesting();
+  });
+
+  // -----------------------------------------------------------------------
+  // Client lifecycle
+  // -----------------------------------------------------------------------
+
+  describe("ensureCopilotSdkClient", () => {
+    it("creates and starts a client on first call", async () => {
+      const client = await ensureCopilotSdkClient();
+      expect(client).toBeTruthy();
+      expect(mockClient.start).toHaveBeenCalledTimes(1);
+    });
+
+    it("reuses the same client on subsequent calls", async () => {
+      const first = await ensureCopilotSdkClient();
+      const second = await ensureCopilotSdkClient();
+      expect(first).toBe(second);
+      expect(mockClient.start).toHaveBeenCalledTimes(1);
+    });
+
+    it("deduplicates concurrent start calls", async () => {
+      const [a, b, c] = await Promise.all([
+        ensureCopilotSdkClient(),
+        ensureCopilotSdkClient(),
+        ensureCopilotSdkClient(),
+      ]);
+      expect(a).toBe(b);
+      expect(b).toBe(c);
+      expect(mockClient.start).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("stopCopilotSdkClient", () => {
+    it("stops the shared client", async () => {
+      await ensureCopilotSdkClient();
+      await stopCopilotSdkClient();
+      expect(mockClient.stop).toHaveBeenCalledTimes(1);
+    });
+
+    it("is a no-op when no client exists", async () => {
+      await stopCopilotSdkClient();
+      expect(mockClient.stop).not.toHaveBeenCalled();
+    });
+
+    it("allows creating a new client after stop", async () => {
+      await ensureCopilotSdkClient();
+      await stopCopilotSdkClient();
+      mockClient.start.mockClear();
+      await ensureCopilotSdkClient();
+      expect(mockClient.start).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Auth status
+  // -----------------------------------------------------------------------
+
+  describe("getCopilotSdkAuthStatus", () => {
+    it("returns authenticated status from SDK", async () => {
+      const status = await getCopilotSdkAuthStatus();
+      expect(status).toEqual({
+        authenticated: true,
+        login: "testuser",
+        host: "github.com",
+        authType: "gh-cli",
+        message: "Authenticated",
+      });
+    });
+
+    it("returns unauthenticated when SDK says not authenticated", async () => {
+      mockClient.getAuthStatus.mockResolvedValue({
+        isAuthenticated: false,
+        statusMessage: "Not signed in",
+      });
+      const status = await getCopilotSdkAuthStatus();
+      expect(status.authenticated).toBe(false);
+      expect(status.message).toBe("Not signed in");
+    });
+
+    it("returns unauthenticated when SDK throws", async () => {
+      mockClient.getAuthStatus.mockRejectedValue(new Error("spawn failed"));
+      const status = await getCopilotSdkAuthStatus();
+      expect(status.authenticated).toBe(false);
+      expect(status.message).toContain("SDK auth check failed");
+    });
+  });
+
+  describe("isCopilotSdkAvailable", () => {
+    it("returns true when client can be pinged", async () => {
+      expect(await isCopilotSdkAvailable()).toBe(true);
+    });
+
+    it("returns false when start fails", async () => {
+      mockClient.start.mockRejectedValue(new Error("not installed"));
+      expect(await isCopilotSdkAvailable()).toBe(false);
+    });
+
+    it("returns false when ping fails", async () => {
+      mockClient.ping.mockRejectedValue(new Error("timeout"));
+      expect(await isCopilotSdkAvailable()).toBe(false);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Model discovery
+  // -----------------------------------------------------------------------
+
+  describe("buildCopilotModelDefinitionFromSdk", () => {
+    it("converts vision model correctly", () => {
+      const def = buildCopilotModelDefinitionFromSdk({
+        id: "gpt-4o",
+        name: "GPT-4o",
+        capabilities: {
+          supports: { vision: true, reasoningEffort: false },
+          limits: { max_context_window_tokens: 128000, max_prompt_tokens: 8192 },
+        },
+      });
+
+      expect(def.id).toBe("gpt-4o");
+      expect(def.name).toBe("GPT-4o");
+      expect(def.api).toBe("openai-responses");
+      expect(def.reasoning).toBe(false);
+      expect(def.input).toEqual(["text", "image"]);
+      expect(def.contextWindow).toBe(128000);
+      expect(def.maxTokens).toBe(8192);
+      expect(def.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+    });
+
+    it("converts reasoning model correctly", () => {
+      const def = buildCopilotModelDefinitionFromSdk({
+        id: "o3-mini",
+        name: "O3 Mini",
+        capabilities: {
+          supports: { vision: false, reasoningEffort: true },
+          limits: { max_context_window_tokens: 128000, max_prompt_tokens: 4096 },
+        },
+      });
+
+      expect(def.reasoning).toBe(true);
+      expect(def.input).toEqual(["text"]);
+      expect(def.maxTokens).toBe(4096);
+    });
+
+    it("uses anthropic-messages API for Claude models", () => {
+      const def = buildCopilotModelDefinitionFromSdk({
+        id: "claude-sonnet-4",
+        name: "Claude Sonnet 4",
+        capabilities: {
+          supports: { vision: true, reasoningEffort: false },
+          limits: { max_context_window_tokens: 200000, max_prompt_tokens: 8192 },
+        },
+      });
+
+      expect(def.api).toBe("anthropic-messages");
+    });
+
+    it("uses model id as name when name is empty", () => {
+      const def = buildCopilotModelDefinitionFromSdk({
+        id: "some-model",
+        name: "",
+        capabilities: {
+          supports: { vision: false, reasoningEffort: false },
+          limits: { max_context_window_tokens: 64000 },
+        },
+      });
+      expect(def.name).toBe("some-model");
+    });
+
+    it("uses defaults when limits are missing", () => {
+      const def = buildCopilotModelDefinitionFromSdk({
+        id: "minimal",
+        name: "Minimal",
+        capabilities: {
+          supports: { vision: false, reasoningEffort: false },
+          limits: { max_context_window_tokens: 32000 },
+        },
+      });
+      expect(def.contextWindow).toBe(32000);
+      expect(def.maxTokens).toBe(8192); // default
+    });
+  });
+
+  describe("discoverCopilotModelsViaSdk", () => {
+    it("returns SDK models, filtering out disabled ones", async () => {
+      const models = await discoverCopilotModelsViaSdk();
+      expect(models).not.toBeNull();
+      expect(models!.length).toBe(3); // gpt-4o, claude-sonnet-4, o3-mini (disabled excluded)
+      expect(models!.map((m) => m.id)).toEqual(["gpt-4o", "claude-sonnet-4", "o3-mini"]);
+    });
+
+    it("returns null when SDK returns empty list", async () => {
+      mockClient.listModels.mockResolvedValue([]);
+      const models = await discoverCopilotModelsViaSdk();
+      expect(models).toBeNull();
+    });
+
+    it("returns null when SDK throws", async () => {
+      mockClient.listModels.mockRejectedValue(new Error("auth failed"));
+      const models = await discoverCopilotModelsViaSdk();
+      expect(models).toBeNull();
+    });
+
+    it("returns null when SDK returns null", async () => {
+      mockClient.listModels.mockResolvedValue(null);
+      const models = await discoverCopilotModelsViaSdk();
+      expect(models).toBeNull();
+    });
+  });
+});

--- a/src/providers/github-copilot-sdk.ts
+++ b/src/providers/github-copilot-sdk.ts
@@ -1,0 +1,193 @@
+/**
+ * SDK-based wrapper for GitHub Copilot auth status and model discovery.
+ *
+ * Uses `@github/copilot-sdk` (CopilotClient) to check authentication
+ * and list available models. The SDK manages the Copilot CLI process
+ * lifecycle internally — callers don't need to handle tokens or endpoints.
+ *
+ * This module differs from `../agents/copilot-sdk.ts` (the CLI backend):
+ *  - CLI backend: runs interactive agent sessions via JSON-RPC stdio
+ *  - This module: auth verification + model catalogue for the REST provider pipeline
+ */
+import type { ModelDefinitionConfig } from "../config/types.js";
+import { copilotModelCost } from "./github-copilot-models.js";
+
+// ---------------------------------------------------------------------------
+// Lazy SDK import — @github/copilot-sdk is ESM-only + optional dependency
+// ---------------------------------------------------------------------------
+
+type CopilotSdkModule = typeof import("@github/copilot-sdk");
+
+let sdkModulePromise: Promise<CopilotSdkModule> | undefined;
+
+function loadSdk(): Promise<CopilotSdkModule> {
+  sdkModulePromise ??= import("@github/copilot-sdk");
+  return sdkModulePromise;
+}
+
+// ---------------------------------------------------------------------------
+// Client lifecycle — lazy, not a module-level singleton
+// ---------------------------------------------------------------------------
+
+type SdkClient = InstanceType<CopilotSdkModule["CopilotClient"]>;
+
+let sharedClient: SdkClient | undefined;
+let clientStartPromise: Promise<SdkClient> | undefined;
+
+/**
+ * Get (or create) a shared CopilotClient. The client is started on first call
+ * and reused for subsequent calls. Call {@link stopCopilotSdkClient} to shut it
+ * down when you're done.
+ */
+export async function ensureCopilotSdkClient(): Promise<SdkClient> {
+  if (sharedClient) {
+    return sharedClient;
+  }
+  if (clientStartPromise) {
+    return clientStartPromise;
+  }
+
+  clientStartPromise = (async () => {
+    try {
+      const { CopilotClient } = await loadSdk();
+      const client = new CopilotClient();
+      await client.start();
+      sharedClient = client;
+      clientStartPromise = undefined;
+      return client;
+    } catch (err) {
+      clientStartPromise = undefined;
+      throw err;
+    }
+  })();
+
+  return clientStartPromise;
+}
+
+/**
+ * Shut down the shared CopilotClient if one is running.
+ */
+export async function stopCopilotSdkClient(): Promise<void> {
+  const client = sharedClient;
+  sharedClient = undefined;
+  clientStartPromise = undefined;
+  if (client) {
+    await client.stop();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Auth status
+// ---------------------------------------------------------------------------
+
+export type CopilotAuthStatus = {
+  authenticated: boolean;
+  login?: string;
+  host?: string;
+  authType?: string;
+  message?: string;
+};
+
+/**
+ * Check whether the current user is authenticated with GitHub Copilot
+ * via the SDK / CLI.
+ *
+ * Returns a simplified status object. Does NOT throw on auth failure —
+ * callers should inspect `.authenticated`.
+ */
+export async function getCopilotSdkAuthStatus(): Promise<CopilotAuthStatus> {
+  try {
+    const client = await ensureCopilotSdkClient();
+    const status = await client.getAuthStatus();
+    return {
+      authenticated: status.isAuthenticated,
+      login: status.login,
+      host: status.host,
+      authType: status.authType,
+      message: status.statusMessage,
+    };
+  } catch (err) {
+    return {
+      authenticated: false,
+      message: `SDK auth check failed: ${String(err)}`,
+    };
+  }
+}
+
+/**
+ * Check if the SDK is available (copilot CLI is installed and can be spawned).
+ * This is a lightweight check — it attempts to start the client and ping it.
+ */
+export async function isCopilotSdkAvailable(): Promise<boolean> {
+  try {
+    const client = await ensureCopilotSdkClient();
+    await client.ping();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Model discovery
+// ---------------------------------------------------------------------------
+
+type SdkModelInfo = Awaited<ReturnType<SdkClient["listModels"]>>[number];
+
+/**
+ * Convert an SDK `ModelInfo` into OpenClaw's `ModelDefinitionConfig`.
+ */
+export function buildCopilotModelDefinitionFromSdk(model: SdkModelInfo): ModelDefinitionConfig {
+  const supportsVision = model.capabilities?.supports?.vision ?? false;
+  const supportsReasoning = model.capabilities?.supports?.reasoningEffort ?? false;
+
+  // Copilot exposes both /chat/completions (OpenAI) and /v1/messages (Anthropic)
+  // at the same base URL. Use the Anthropic Messages API for Claude models to get
+  // proper extended thinking with real cryptographic signatures.
+  const isClaude = model.id.startsWith("claude-");
+  const api = isClaude ? "anthropic-messages" : "openai-responses";
+
+  return {
+    id: model.id,
+    name: model.name || model.id,
+    api,
+    reasoning: supportsReasoning,
+    input: supportsVision ? ["text", "image"] : ["text"],
+    cost: copilotModelCost(model.id),
+    contextWindow: model.capabilities?.limits?.max_context_window_tokens ?? 128_000,
+    maxTokens: model.capabilities?.limits?.max_prompt_tokens ?? 8192,
+  };
+}
+
+/**
+ * Discover available Copilot models via the SDK.
+ *
+ * Returns an array of `ModelDefinitionConfig` built from the SDK's model
+ * catalogue. Returns `null` if the SDK is unavailable or the user isn't
+ * authenticated (callers should fall back to hardcoded defaults).
+ */
+export async function discoverCopilotModelsViaSdk(): Promise<ModelDefinitionConfig[] | null> {
+  try {
+    const client = await ensureCopilotSdkClient();
+    const models = await client.listModels();
+    if (!models || models.length === 0) {
+      return null;
+    }
+    return models
+      .filter((m) => m.policy?.state !== "disabled")
+      .map(buildCopilotModelDefinitionFromSdk);
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers — allow resetting module state in tests
+// ---------------------------------------------------------------------------
+
+/** @internal — reset module state for tests */
+export function _resetForTesting(): void {
+  sharedClient = undefined;
+  clientStartPromise = undefined;
+  sdkModulePromise = undefined;
+}

--- a/src/providers/github-copilot-sdk.ts
+++ b/src/providers/github-copilot-sdk.ts
@@ -171,7 +171,10 @@ export function buildCopilotModelDefinitionFromSdk(model: SdkModelInfo): ModelDe
     input: supportsVision ? ["text", "image"] : ["text"],
     cost: copilotModelCost(model.id),
     contextWindow: model.capabilities?.limits?.max_context_window_tokens ?? 128_000,
-    maxTokens: model.capabilities?.limits?.max_output_tokens ?? model.capabilities?.limits?.max_completion_tokens ?? 8192,
+    maxTokens:
+      model.capabilities?.limits?.max_output_tokens ??
+      model.capabilities?.limits?.max_completion_tokens ??
+      8192,
   };
 }
 

--- a/src/providers/github-copilot-sdk.ts
+++ b/src/providers/github-copilot-sdk.ts
@@ -10,7 +10,6 @@
  *  - This module: auth verification + model catalogue for the REST provider pipeline
  */
 import type { ModelDefinitionConfig } from "../config/types.js";
-import { copilotModelCost } from "./github-copilot-models.js";
 
 // ---------------------------------------------------------------------------
 // Lazy SDK import — @github/copilot-sdk is ESM-only + optional dependency
@@ -169,12 +168,9 @@ export function buildCopilotModelDefinitionFromSdk(model: SdkModelInfo): ModelDe
     api,
     reasoning: supportsReasoning,
     input: supportsVision ? ["text", "image"] : ["text"],
-    cost: copilotModelCost(model.id),
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow: model.capabilities?.limits?.max_context_window_tokens ?? 128_000,
-    maxTokens:
-      model.capabilities?.limits?.max_output_tokens ??
-      model.capabilities?.limits?.max_completion_tokens ??
-      8192,
+    maxTokens: model.capabilities?.limits?.max_prompt_tokens ?? 8192,
   };
 }
 

--- a/src/providers/github-copilot-sdk.ts
+++ b/src/providers/github-copilot-sdk.ts
@@ -66,13 +66,27 @@ export async function ensureCopilotSdkClient(): Promise<SdkClient> {
 
 /**
  * Shut down the shared CopilotClient if one is running.
+ * Safely awaits any in-flight start before stopping to prevent leaked
+ * Copilot CLI subprocesses.
  */
 export async function stopCopilotSdkClient(): Promise<void> {
-  const client = sharedClient;
+  const inflightPromise = clientStartPromise;
+  const existingClient = sharedClient;
   sharedClient = undefined;
   clientStartPromise = undefined;
-  if (client) {
-    await client.stop();
+
+  // Wait for any in-flight start to settle, then stop whatever it produced.
+  if (inflightPromise) {
+    try {
+      const startedClient = await inflightPromise;
+      await startedClient.stop();
+    } catch {
+      // start failed; nothing to stop
+    }
+    return;
+  }
+  if (existingClient) {
+    await existingClient.stop();
   }
 }
 
@@ -117,6 +131,7 @@ export async function getCopilotSdkAuthStatus(): Promise<CopilotAuthStatus> {
 /**
  * Check if the SDK is available (copilot CLI is installed and can be spawned).
  * This is a lightweight check — it attempts to start the client and ping it.
+ * Cleans up the client on failure to prevent zombie processes.
  */
 export async function isCopilotSdkAvailable(): Promise<boolean> {
   try {
@@ -124,6 +139,7 @@ export async function isCopilotSdkAvailable(): Promise<boolean> {
     await client.ping();
     return true;
   } catch {
+    await stopCopilotSdkClient();
     return false;
   }
 }
@@ -155,7 +171,7 @@ export function buildCopilotModelDefinitionFromSdk(model: SdkModelInfo): ModelDe
     input: supportsVision ? ["text", "image"] : ["text"],
     cost: copilotModelCost(model.id),
     contextWindow: model.capabilities?.limits?.max_context_window_tokens ?? 128_000,
-    maxTokens: model.capabilities?.limits?.max_prompt_tokens ?? 8192,
+    maxTokens: model.capabilities?.limits?.max_output_tokens ?? model.capabilities?.limits?.max_completion_tokens ?? 8192,
   };
 }
 


### PR DESCRIPTION
## Problem

OpenClaw currently supports GitHub Copilot models only through REST API token exchange — a flow that requires manual PAT management and doesn't integrate with the official `@github/copilot-sdk`. This means:

1. Users must manually obtain and rotate Copilot API tokens
2. No support for the SDK's built-in auth flow (device code, token caching)
3. Missing streaming support for SDK-based requests
4. No CLI backend for quick model access via `openclaw agent --backend copilot`

## Solution

### New Copilot SDK Provider (`github-copilot-sdk.ts`)
- Full streaming provider using `@github/copilot-sdk`
- Handles SSE parsing with proper chunk assembly
- Supports all Copilot-available models (Claude, GPT, Gemini, o-series)
- Automatic token management via SDK auth flow

### Copilot Auth Module (`github-copilot-auth.ts`)
- Device code auth flow for initial setup
- Token caching and automatic refresh
- Integration with OpenClaw's auth profile system

### Copilot Runner (`copilot-runner.ts`)
- Dedicated runner for Copilot SDK sessions
- Model alias resolution (e.g., `opus` → `claude-opus-4.6`)
- Streaming response assembly with thinking block support

### Copilot SDK Wrapper (`copilot-sdk.ts`)
- Thin wrapper around `@github/copilot-sdk` for OpenClaw integration
- Handles request formatting, header injection, and response parsing
- Error handling with proper fallback signals

### CLI Backend (`cli-backends.ts`)
- New `copilot` backend for `openclaw agent` CLI
- Model aliases: `opus`, `sonnet`, `gpt4o`, `o3`, `gemini-pro`
- Quick access: `openclaw agent --backend copilot --model opus`

### Provider Registration
- Registered in `models-config.providers.ts` as `github-copilot-sdk`
- Added to auth profile constants
- Model selection integration for automatic provider routing

## Dependencies

- Adds `@github/copilot-sdk` package dependency

## Testing

- **`copilot-runner.test.ts`** (177 lines): Runner lifecycle, model alias resolution, streaming assembly
- **`copilot-sdk.test.ts`** (243 lines): SDK wrapper, request formatting, error handling
- **`github-copilot-sdk.test.ts`** (311 lines): Provider streaming, SSE parsing, auth integration

## Related PRs

- #32406 — Copilot model catalog expansion (recommended to merge first)
- #32407 — Thinking signature sanitization (fixes cross-provider fallback crashes)