### PR TITLE
fix(channels): bootstrap plugin registry in resolveMessageChannelSelection

### DIFF
--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -23,8 +23,15 @@ export function normalizeDeliverableOutboundChannel(
   return normalized;
 }
 
-function maybeBootstrapChannelPlugin(params: {
-  channel: DeliverableMessageChannel;
+/**
+ * Attempt to load channel plugins when the registry is empty.
+ * Unlike `resolveOutboundChannelPlugin`, this does not require the channel to
+ * already be recognized as deliverable — it bootstraps unconditionally when
+ * plugins have not been loaded yet. Useful when `isKnownChannel` fails for a
+ * channel name that *would* be valid after plugins are loaded.
+ */
+export function maybeBootstrapChannelPlugin(params: {
+  channel: string;
   cfg?: OpenClawConfig;
 }): void {
   const cfg = params.cfg;

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -1,19 +1,55 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+const TEST_WORKSPACE_ROOT = "/tmp/openclaw-test-workspace";
+
 const mocks = vi.hoisted(() => ({
   listChannelPlugins: vi.fn(),
+  loadOpenClawPlugins: vi.fn(),
 }));
 
 vi.mock("../../channels/plugins/index.js", () => ({
   listChannelPlugins: mocks.listChannelPlugins,
 }));
 
+vi.mock("../../plugins/loader.js", () => ({
+  loadOpenClawPlugins: mocks.loadOpenClawPlugins,
+}));
+
+vi.mock("../../agents/agent-scope.js", () => ({
+  resolveDefaultAgentId: () => "main",
+  resolveAgentWorkspaceDir: () => TEST_WORKSPACE_ROOT,
+}));
+
+vi.mock("../../config/plugin-auto-enable.js", () => ({
+  applyPluginAutoEnable(args: { config: unknown }) {
+    return { config: args.config, changes: [] };
+  },
+}));
+
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 import { resolveMessageChannelSelection } from "./channel-selection.js";
+
+function createExtensionPlugin(id: string) {
+  return createChannelTestPluginBase({
+    id: id as never,
+    label: id,
+    config: {
+      listAccountIds: () => ["default"],
+      resolveAccount: () => ({}),
+      isConfigured: async () => true,
+    },
+  });
+}
 
 describe("resolveMessageChannelSelection", () => {
   beforeEach(() => {
     mocks.listChannelPlugins.mockReset();
     mocks.listChannelPlugins.mockReturnValue([]);
+    mocks.loadOpenClawPlugins.mockReset();
   });
 
   it("keeps explicit known channels and marks source explicit", async () => {
@@ -87,5 +123,81 @@ describe("resolveMessageChannelSelection", () => {
         fallbackChannel: "not-a-channel",
       }),
     ).rejects.toThrow("Unknown channel: channel:c123");
+  });
+});
+
+describe("resolveMessageChannelSelection bootstrap recovery", () => {
+  let registrySeq = 0;
+
+  beforeEach(() => {
+    registrySeq += 1;
+    // Start with an empty registry (no channel plugins loaded).
+    setActivePluginRegistry(createTestRegistry([]), `sel-test-${registrySeq}`);
+    mocks.listChannelPlugins.mockReset();
+    mocks.listChannelPlugins.mockReturnValue([]);
+    mocks.loadOpenClawPlugins.mockReset();
+  });
+
+  it("bootstraps plugins when an extension channel is not yet in the registry", async () => {
+    const extensionPlugin = createExtensionPlugin("msteams");
+
+    // When loadOpenClawPlugins is called, populate the registry with the plugin.
+    mocks.loadOpenClawPlugins.mockImplementation(() => {
+      setActivePluginRegistry(
+        createTestRegistry([{ pluginId: "msteams", source: "test", plugin: extensionPlugin }]),
+        `sel-test-${registrySeq}`,
+      );
+    });
+
+    const result = await resolveMessageChannelSelection({
+      channel: "msteams",
+      cfg: { channels: { msteams: {} } } as never,
+    });
+
+    expect(result.channel).toBe("msteams");
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws Unknown channel when bootstrap does not resolve the channel", async () => {
+    // loadOpenClawPlugins is called but doesn't add the channel.
+    mocks.loadOpenClawPlugins.mockImplementation(() => {});
+
+    await expect(
+      resolveMessageChannelSelection({
+        channel: "nonexistent",
+        cfg: { channels: {} } as never,
+      }),
+    ).rejects.toThrow("Unknown channel: nonexistent");
+
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to fallbackChannel after bootstrap fails to resolve an opaque id", async () => {
+    mocks.loadOpenClawPlugins.mockImplementation(() => {});
+
+    const result = await resolveMessageChannelSelection({
+      channel: "C12345678",
+      fallbackChannel: "slack",
+      cfg: { channels: {} } as never,
+    });
+
+    expect(result).toMatchObject({
+      channel: "slack",
+      source: "tool-context-fallback",
+    });
+    // Bootstrap is attempted for the unrecognized channel before falling back.
+    expect(mocks.loadOpenClawPlugins).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips bootstrap when the channel is already known (built-in)", async () => {
+    // Built-in channels like "discord" are always in CHANNEL_IDS and don't
+    // need bootstrap. loadOpenClawPlugins should not be called.
+    const result = await resolveMessageChannelSelection({
+      channel: "discord",
+      cfg: { channels: { discord: {} } } as never,
+    });
+
+    expect(result.channel).toBe("discord");
+    expect(mocks.loadOpenClawPlugins).not.toHaveBeenCalled();
   });
 });

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -7,6 +7,7 @@ import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
+import { maybeBootstrapChannelPlugin } from "./channel-resolution.js";
 
 export type MessageChannelId = DeliverableMessageChannel;
 export type MessageChannelSelectionSource =
@@ -95,15 +96,21 @@ export async function resolveMessageChannelSelection(params: {
   const normalized = normalizeMessageChannel(params.channel);
   if (normalized) {
     if (!isKnownChannel(normalized)) {
-      const fallback = resolveKnownChannel(params.fallbackChannel);
-      if (fallback) {
-        return {
-          channel: fallback,
-          configured: await listConfiguredMessageChannels(params.cfg),
-          source: "tool-context-fallback",
-        };
+      // Bootstrap recovery: the plugin registry may not be loaded yet (e.g.
+      // after a provider restart or in an early outbound-only context).
+      // Trigger plugin loading, then re-check.
+      maybeBootstrapChannelPlugin({ channel: normalized, cfg: params.cfg });
+      if (!isKnownChannel(normalized)) {
+        const fallback = resolveKnownChannel(params.fallbackChannel);
+        if (fallback) {
+          return {
+            channel: fallback,
+            configured: await listConfiguredMessageChannels(params.cfg),
+            source: "tool-context-fallback",
+          };
+        }
+        throw new Error(`Unknown channel: ${String(normalized)}`);
       }
-      throw new Error(`Unknown channel: ${String(normalized)}`);
     }
     return {
       channel: normalized as MessageChannelId,


### PR DESCRIPTION
## Summary

- When an extension channel (e.g. `msteams`, `matrix`) is passed to `resolveMessageChannelSelection` and the plugin registry has not been loaded yet, `isKnownChannel` fails and throws `Unknown channel`. This adds bootstrap recovery: call `maybeBootstrapChannelPlugins` to load plugins when the registry is empty, then re-check before throwing.
- Widens `maybeBootstrapChannelPlugin` param type from `DeliverableMessageChannel` to `string` so the exported wrapper avoids an unsafe type cast.
- Follows up on 71cd33713 which landed the `toolContext` fallback and health-monitor startup grace from #32367.

Fixes #31476

## Why the previous approach was dead code

The original PR (#32367) attempted recovery via `resolveOutboundChannelPlugin`, but that function internally calls `normalizeDeliverableOutboundChannel` which gates on `isDeliverableMessageChannel` — the same check that already failed in `isKnownChannel`. The bootstrap (`maybeBootstrapChannelPlugin`) was never reached. This PR exports a new `maybeBootstrapChannelPlugins` that bypasses the deliverability gate.

## Test plan

- [x] New test: bootstrap succeeds for extension channel not yet in registry
- [x] New test: throws `Unknown channel` when bootstrap doesn't resolve the channel
- [x] New test: skips bootstrap for built-in channels (already known)
- [x] Existing upstream tests for fallback/source selection pass
- [x] `pnpm test` for channel-selection, message-action-runner, channel-health-monitor, targets.channel-resolution — all 69 tests pass
- [x] `pnpm tsgo --noEmit` — no new errors