### PR TITLE
Android: open Canvas external links in system browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Android/Canvas external link handling: open non-canvas WebView navigations in the system browser while keeping internal canvas host paths (`/__openclaw__/cap/`, `/__openclaw__/a2ui`, `/__openclaw__/canvas`) inside the in-app WebView, preventing users from getting stuck after tapping outbound links. Fixes #32319. Thanks @liuxiaopai-ai.
 - Feishu/Lark private DM routing: treat inbound `chat_type: "private"` as direct-message context for pairing/mention-forward/reaction synthetic handling so Lark private chats behave like Feishu p2p DMs. (#31400) Thanks @stakeswky.
 - Sandbox/workspace mount permissions: make primary `/workspace` bind mounts read-only whenever `workspaceAccess` is not `rw` (including `none`) across both core sandbox container and sandbox browser create flows. (#32227) Thanks @guanyu-zhang.
 - Signal/message actions: allow `react` to fall back to `toolContext.currentMessageId` when `messageId` is omitted, matching Telegram behavior and unblocking agent-initiated reactions on inbound turns. (#32217) Thanks @dunamismax.

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/CanvasScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/CanvasScreen.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.android.ui
 
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.util.Log
 import android.view.View
 import android.webkit.ConsoleMessage
@@ -22,6 +23,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewFeature
 import ai.openclaw.android.MainViewModel
+import java.net.URI
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -88,6 +90,25 @@ fun CanvasScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
               )
             }
 
+            override fun shouldOverrideUrlLoading(
+              view: WebView,
+              request: WebResourceRequest,
+            ): Boolean {
+              val requestedUrl = request.url?.toString()
+              if (!shouldOpenCanvasLinkInExternalBrowser(requestedUrl, request.isForMainFrame)) {
+                return false
+              }
+              return try {
+                context.startActivity(Intent(Intent.ACTION_VIEW, request.url))
+                true
+              } catch (err: Throwable) {
+                if (isDebuggable) {
+                  Log.w("OpenClawWebView", "failed to open external link: $requestedUrl", err)
+                }
+                false
+              }
+            }
+
             override fun onPageFinished(view: WebView, url: String?) {
               if (isDebuggable) {
                 Log.d("OpenClawWebView", "onPageFinished: $url")
@@ -146,5 +167,31 @@ private class CanvasA2UIActionBridge(private val onMessage: (String) -> Unit) {
 
   companion object {
     const val interfaceName: String = "openclawCanvasA2UIAction"
+  }
+}
+
+private val canvasInternalPathMarkers = listOf("/__openclaw__/cap/", "/__openclaw__/a2ui", "/__openclaw__/canvas")
+
+internal fun shouldOpenCanvasLinkInExternalBrowser(
+  requestedUrl: String?,
+  isMainFrame: Boolean,
+): Boolean {
+  if (!isMainFrame) return false
+  val raw = requestedUrl?.trim().orEmpty()
+  if (raw.isEmpty()) return false
+  val parsed = parseUriOrNull(raw) ?: return false
+  val scheme = parsed.scheme?.lowercase().orEmpty()
+  if (scheme == "about" || scheme == "javascript" || scheme == "data" || scheme == "file") return false
+  if (scheme != "http" && scheme != "https") return true
+  val path = parsed.path?.lowercase().orEmpty()
+  if (canvasInternalPathMarkers.any { path.contains(it) }) return false
+  return true
+}
+
+private fun parseUriOrNull(raw: String): URI? {
+  return try {
+    URI(raw)
+  } catch (_: Throwable) {
+    null
   }
 }

--- a/apps/android/app/src/test/java/ai/openclaw/android/ui/CanvasScreenExternalLinksTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/ui/CanvasScreenExternalLinksTest.kt
@@ -1,0 +1,49 @@
+package ai.openclaw.android.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CanvasScreenExternalLinksTest {
+  @Test
+  fun opensNormalHttpLinksInExternalBrowser() {
+    assertTrue(shouldOpenCanvasLinkInExternalBrowser("https://docs.openclaw.ai/channels/telegram", true))
+  }
+
+  @Test
+  fun keepsCanvasA2uiLinksInsideWebView() {
+    assertFalse(
+      shouldOpenCanvasLinkInExternalBrowser(
+        "http://127.0.0.1:18789/__openclaw__/cap/token-1/__openclaw__/a2ui/?platform=android",
+        true,
+      ),
+    )
+  }
+
+  @Test
+  fun keepsCanvasHostLinksInsideWebView() {
+    assertFalse(
+      shouldOpenCanvasLinkInExternalBrowser(
+        "http://127.0.0.1:18789/__openclaw__/canvas/index.html",
+        true,
+      ),
+    )
+  }
+
+  @Test
+  fun ignoresSpecialInlineSchemes() {
+    assertFalse(shouldOpenCanvasLinkInExternalBrowser("javascript:void(0)", true))
+    assertFalse(shouldOpenCanvasLinkInExternalBrowser("about:blank", true))
+    assertFalse(shouldOpenCanvasLinkInExternalBrowser("file:///android_asset/CanvasScaffold/scaffold.html", true))
+  }
+
+  @Test
+  fun opensCustomSchemesInExternalBrowser() {
+    assertTrue(shouldOpenCanvasLinkInExternalBrowser("mailto:support@example.com", true))
+  }
+
+  @Test
+  fun ignoresSubframeRequests() {
+    assertFalse(shouldOpenCanvasLinkInExternalBrowser("https://example.com", false))
+  }
+}


### PR DESCRIPTION
## Summary
- intercept main-frame Canvas WebView navigations and open non-canvas URLs with `Intent.ACTION_VIEW`
- keep internal canvas host paths inside the in-app WebView (`/__openclaw__/cap/`, `/__openclaw__/a2ui`, `/__openclaw__/canvas`)
- add JVM unit coverage for external/internal/scheme/subframe routing decisions

Fixes #32319

## Testing
- `cd apps/android && ./gradlew :app:testDebugUnitTest --tests ai.openclaw.android.ui.CanvasScreenExternalLinksTest --console=plain`
  - blocked in this environment: `Unable to locate a Java Runtime`
