### PR TITLE
ui: add dismissible update banner per version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Control UI/update notice: add a dismiss button to the sticky update banner and persist dismissal per `latestVersion`, so users can hide the banner for the current release while automatically seeing it again when a newer version is published. (#32264) Thanks @deciia.
 - Feishu/Lark private DM routing: treat inbound `chat_type: "private"` as direct-message context for pairing/mention-forward/reaction synthetic handling so Lark private chats behave like Feishu p2p DMs. (#31400) Thanks @stakeswky.
 - Sandbox/workspace mount permissions: make primary `/workspace` bind mounts read-only whenever `workspaceAccess` is not `rw` (including `none`) across both core sandbox container and sandbox browser create flows. (#32227) Thanks @guanyu-zhang.
 - Signal/message actions: allow `react` to fall back to `toolContext.currentMessageId` when `messageId` is omitted, matching Telegram behavior and unblocking agent-initiated reactions on inbound turns. (#32217) Thanks @dunamismax.

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -10,7 +10,7 @@
   z-index: 10;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 8px;
   flex-wrap: wrap;
   margin: 0 calc(-1 * var(--shell-pad)) 0;
@@ -36,6 +36,7 @@
 .update-banner__dismiss {
   width: 28px;
   height: 28px;
+  margin-left: auto;
   border-color: transparent;
   color: var(--danger);
 }

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -8,6 +8,11 @@
   position: sticky;
   top: 0;
   z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  flex-wrap: wrap;
   margin: 0 calc(-1 * var(--shell-pad)) 0;
   border-radius: 0;
   border-left: none;
@@ -18,7 +23,6 @@
 }
 
 .update-banner__btn {
-  margin-left: 8px;
   border-color: var(--danger);
   color: var(--danger);
   font-size: 12px;
@@ -27,6 +31,13 @@
 
 .update-banner__btn:hover:not(:disabled) {
   background: rgba(239, 68, 68, 0.15);
+}
+
+.update-banner__dismiss {
+  width: 28px;
+  height: 28px;
+  border-color: transparent;
+  color: var(--danger);
 }
 
 /* ===========================================

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -317,4 +317,13 @@ describe("shouldRenderUpdateBanner", () => {
       ),
     ).toBe(true);
   });
+
+  it("returns true when update is available and not dismissed yet", () => {
+    expect(
+      shouldRenderUpdateBanner(
+        { latestVersion: "2026.3.2", currentVersion: "2026.2.26", channel: "latest" },
+        {},
+      ),
+    ).toBe(true);
+  });
 });

--- a/ui/src/ui/app-render.helpers.node.test.ts
+++ b/ui/src/ui/app-render.helpers.node.test.ts
@@ -3,6 +3,7 @@ import {
   isCronSessionKey,
   parseSessionKey,
   resolveSessionDisplayName,
+  shouldRenderUpdateBanner,
 } from "./app-render.helpers.ts";
 import type { SessionsListResult } from "./types.ts";
 
@@ -282,5 +283,38 @@ describe("isCronSessionKey", () => {
     expect(isCronSessionKey("main")).toBe(false);
     expect(isCronSessionKey("discord:group:eng")).toBe(false);
     expect(isCronSessionKey("agent:main:slack:cron:job:run:uuid")).toBe(false);
+  });
+});
+
+describe("shouldRenderUpdateBanner", () => {
+  it("returns false when update payload is missing", () => {
+    expect(shouldRenderUpdateBanner(null, {})).toBe(false);
+  });
+
+  it("returns false when latest version matches current version", () => {
+    expect(
+      shouldRenderUpdateBanner(
+        { latestVersion: "2026.3.1", currentVersion: "2026.3.1", channel: "latest" },
+        { dismissedUpdateVersion: undefined },
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false when user already dismissed the same latest version", () => {
+    expect(
+      shouldRenderUpdateBanner(
+        { latestVersion: "2026.3.1", currentVersion: "2026.2.26", channel: "latest" },
+        { dismissedUpdateVersion: "2026.3.1" },
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true for a new version when dismissal points to an older version", () => {
+    expect(
+      shouldRenderUpdateBanner(
+        { latestVersion: "2026.3.2", currentVersion: "2026.2.26", channel: "latest" },
+        { dismissedUpdateVersion: "2026.3.1" },
+      ),
+    ).toBe(true);
   });
 });

--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -8,9 +8,10 @@ import { OpenClawApp } from "./app.ts";
 import { ChatState, loadChatHistory } from "./controllers/chat.ts";
 import { icons } from "./icons.ts";
 import { iconForTab, pathForTab, titleForTab, type Tab } from "./navigation.ts";
+import type { UiSettings } from "./storage.ts";
 import type { ThemeTransitionContext } from "./theme-transition.ts";
 import type { ThemeMode } from "./theme.ts";
-import type { SessionsListResult } from "./types.ts";
+import type { SessionsListResult, UpdateAvailable } from "./types.ts";
 
 type SessionDefaultsSnapshot = {
   mainSessionKey?: string;
@@ -45,6 +46,19 @@ function resetChatStateForSessionSwitch(state: AppViewState, sessionKey: string)
     sessionKey,
     lastActiveSessionKey: sessionKey,
   });
+}
+
+export function shouldRenderUpdateBanner(
+  updateAvailable: UpdateAvailable | null,
+  settings: Pick<UiSettings, "dismissedUpdateVersion">,
+): boolean {
+  if (!updateAvailable) {
+    return false;
+  }
+  if (updateAvailable.latestVersion === updateAvailable.currentVersion) {
+    return false;
+  }
+  return settings.dismissedUpdateVersion !== updateAvailable.latestVersion;
 }
 
 export function renderTab(state: AppViewState, tab: Tab) {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -317,6 +317,11 @@ export function renderApp(state: AppViewState) {
                 (running v${availableUpdate.currentVersion}).
               </span>
               <button
+                class="btn btn--sm update-banner__btn"
+                ?disabled=${state.updateRunning || !state.connected}
+                @click=${() => runUpdate(state)}
+              >${state.updateRunning ? "Updating…" : "Update now"}</button>
+              <button
                 class="btn btn--sm btn--icon update-banner__dismiss"
                 @click=${() =>
                   state.applySettings({
@@ -328,11 +333,6 @@ export function renderApp(state: AppViewState) {
               >
                 ${icons.x}
               </button>
-              <button
-                class="btn btn--sm update-banner__btn"
-                ?disabled=${state.updateRunning || !state.connected}
-                @click=${() => runUpdate(state)}
-              >${state.updateRunning ? "Updating…" : "Update now"}</button>
             </div>`
             : nothing
         }

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -3,7 +3,12 @@ import { parseAgentSessionKey } from "../../../src/routing/session-key.js";
 import { t } from "../i18n/index.ts";
 import { refreshChatAvatar } from "./app-chat.ts";
 import { renderUsageTab } from "./app-render-usage-tab.ts";
-import { renderChatControls, renderTab, renderThemeToggle } from "./app-render.helpers.ts";
+import {
+  renderChatControls,
+  renderTab,
+  renderThemeToggle,
+  shouldRenderUpdateBanner,
+} from "./app-render.helpers.ts";
 import type { AppViewState } from "./app-view-state.ts";
 import { loadAgentFileContent, loadAgentFiles, saveAgentFile } from "./controllers/agent-files.ts";
 import { loadAgentIdentities, loadAgentIdentity } from "./controllers/agent-identity.ts";
@@ -143,11 +148,9 @@ export function renderApp(state: AppViewState) {
     (typeof state.hello?.server?.version === "string" && state.hello.server.version.trim()) ||
     state.updateAvailable?.currentVersion ||
     t("common.na");
-  const availableUpdate =
-    state.updateAvailable &&
-    state.updateAvailable.latestVersion !== state.updateAvailable.currentVersion
-      ? state.updateAvailable
-      : null;
+  const availableUpdate = shouldRenderUpdateBanner(state.updateAvailable, state.settings)
+    ? state.updateAvailable
+    : null;
   const versionStatusClass = availableUpdate ? "warn" : "ok";
   const presenceCount = state.presenceEntries.length;
   const sessionsCount = state.sessionsResult?.count ?? null;
@@ -309,8 +312,22 @@ export function renderApp(state: AppViewState) {
         ${
           availableUpdate
             ? html`<div class="update-banner callout danger" role="alert">
-              <strong>Update available:</strong> v${availableUpdate.latestVersion}
-              (running v${availableUpdate.currentVersion}).
+              <span>
+                <strong>Update available:</strong> v${availableUpdate.latestVersion}
+                (running v${availableUpdate.currentVersion}).
+              </span>
+              <button
+                class="btn btn--sm btn--icon update-banner__dismiss"
+                @click=${() =>
+                  state.applySettings({
+                    ...state.settings,
+                    dismissedUpdateVersion: availableUpdate.latestVersion,
+                  })}
+                title="Dismiss update notice"
+                aria-label="Dismiss update notice"
+              >
+                ${icons.x}
+              </button>
               <button
                 class="btn btn--sm update-banner__btn"
                 ?disabled=${state.updateRunning || !state.connected}

--- a/ui/src/ui/storage.node.test.ts
+++ b/ui/src/ui/storage.node.test.ts
@@ -60,4 +60,20 @@ describe("loadSettings default gateway URL derivation", () => {
     const { loadSettings } = await import("./storage.ts");
     expect(loadSettings().gatewayUrl).toBe("ws://gateway.example:18789/apps/openclaw");
   });
+
+  it("hydrates dismissed update version when persisted", async () => {
+    vi.stubGlobal("location", {
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/openclaw/chat",
+    } as Location);
+    vi.stubGlobal("window", {} as Window & typeof globalThis);
+    localStorage.setItem(
+      "openclaw.control.settings.v1",
+      JSON.stringify({ dismissedUpdateVersion: "2026.3.1" }),
+    );
+
+    const { loadSettings } = await import("./storage.ts");
+    expect(loadSettings().dismissedUpdateVersion).toBe("2026.3.1");
+  });
 });

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -15,6 +15,7 @@ export type UiSettings = {
   splitRatio: number; // Sidebar split ratio (0.4 to 0.7, default 0.6)
   navCollapsed: boolean; // Collapsible sidebar state
   navGroupsCollapsed: Record<string, boolean>; // Which nav groups are collapsed
+  dismissedUpdateVersion?: string;
   locale?: string;
 };
 
@@ -87,6 +88,11 @@ export function loadSettings(): UiSettings {
         typeof parsed.navGroupsCollapsed === "object" && parsed.navGroupsCollapsed !== null
           ? parsed.navGroupsCollapsed
           : defaults.navGroupsCollapsed,
+      dismissedUpdateVersion:
+        typeof parsed.dismissedUpdateVersion === "string" &&
+        parsed.dismissedUpdateVersion.trim().length > 0
+          ? parsed.dismissedUpdateVersion.trim()
+          : undefined,
       locale: isSupportedLocale(parsed.locale) ? parsed.locale : undefined,
     };
   } catch {


### PR DESCRIPTION
## Summary
- add a close button on the Control UI update banner
- persist `dismissedUpdateVersion` in UI settings so dismissals survive reloads
- re-show the banner automatically when a newer `latestVersion` appears
- add helper + tests for banner visibility logic and persisted settings hydration
- add changelog entry under 2026.3.2 fixes

Closes #32264

## Testing
- `pnpm exec oxfmt --check ui/src/ui/storage.ts ui/src/ui/app-render.helpers.ts ui/src/ui/app-render.ts ui/src/ui/app-render.helpers.node.test.ts ui/src/ui/storage.node.test.ts ui/src/styles/components.css`
- `pnpm tsgo` *(fails due pre-existing baseline issue: `src/browser/chrome.ts(137,29): TS2702`)*
- `pnpm --dir ui test -- src/ui/app-render.helpers.node.test.ts src/ui/storage.node.test.ts` *(UI suite currently has unrelated baseline failures; our changed helper test file passes in that run)*
