### PR TITLE
fix(ui): clear stuck chat run on gateway disconnect (#32400)

### DIFF
--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -16,7 +16,11 @@ import { shouldReloadHistoryForFinalEvent } from "./chat-event-reload.ts";
 import { loadAgents, loadToolsCatalog } from "./controllers/agents.ts";
 import { loadAssistantIdentity } from "./controllers/assistant-identity.ts";
 import { loadChatHistory } from "./controllers/chat.ts";
-import { handleChatEvent, type ChatEventPayload } from "./controllers/chat.ts";
+import {
+  clearInFlightChatRun,
+  handleChatEvent,
+  type ChatEventPayload,
+} from "./controllers/chat.ts";
 import { loadDevices } from "./controllers/devices.ts";
 import type { ExecApprovalRequest } from "./controllers/exec-approval.ts";
 import {
@@ -179,16 +183,28 @@ export function connectGateway(host: GatewayHost) {
         return;
       }
       host.connected = false;
+      const hadActiveChatRun = clearInFlightChatRun(
+        host as unknown as {
+          chatRunId: string | null;
+          chatStream: string | null;
+          chatStreamStartedAt: number | null;
+        },
+      );
       // Code 1012 = Service Restart (expected during config saves, don't show as error)
       host.lastErrorCode =
         resolveGatewayErrorDetailCode(error) ??
         (typeof error?.code === "string" ? error.code : null);
       if (code !== 1012) {
         if (error?.message) {
-          host.lastError = error.message;
+          host.lastError = hadActiveChatRun
+            ? `Connection lost while waiting for the response. ${error.message}`
+            : error.message;
           return;
         }
-        host.lastError = `disconnected (${code}): ${reason || "no reason"}`;
+        const disconnectText = `disconnected (${code}): ${reason || "no reason"}`;
+        host.lastError = hadActiveChatRun
+          ? `Connection lost while waiting for the response. ${disconnectText}`
+          : disconnectText;
       } else {
         host.lastError = null;
         host.lastErrorCode = null;

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { handleChatEvent, loadChatHistory, type ChatEventPayload, type ChatState } from "./chat.ts";
+import {
+  clearInFlightChatRun,
+  handleChatEvent,
+  loadChatHistory,
+  type ChatEventPayload,
+  type ChatState,
+} from "./chat.ts";
 
 function createState(overrides: Partial<ChatState> = {}): ChatState {
   return {
@@ -19,6 +25,32 @@ function createState(overrides: Partial<ChatState> = {}): ChatState {
     ...overrides,
   };
 }
+
+describe("clearInFlightChatRun", () => {
+  it("clears run + stream state when run is active", () => {
+    const state = createState({
+      chatRunId: "run-1",
+      chatStream: "partial output",
+      chatStreamStartedAt: 123,
+    });
+    expect(clearInFlightChatRun(state)).toBe(true);
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe(null);
+    expect(state.chatStreamStartedAt).toBe(null);
+  });
+
+  it("returns false when no run is active", () => {
+    const state = createState({
+      chatRunId: null,
+      chatStream: "ignored",
+      chatStreamStartedAt: 123,
+    });
+    expect(clearInFlightChatRun(state)).toBe(false);
+    expect(state.chatRunId).toBe(null);
+    expect(state.chatStream).toBe("ignored");
+    expect(state.chatStreamStartedAt).toBe(123);
+  });
+});
 
 describe("handleChatEvent", () => {
   it("returns null when payload is missing", () => {

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -50,6 +50,20 @@ export type ChatEventPayload = {
   errorMessage?: string;
 };
 
+export function clearInFlightChatRun(state: {
+  chatRunId: string | null;
+  chatStream: string | null;
+  chatStreamStartedAt: number | null;
+}): boolean {
+  if (!state.chatRunId) {
+    return false;
+  }
+  state.chatRunId = null;
+  state.chatStream = null;
+  state.chatStreamStartedAt = null;
+  return true;
+}
+
 export async function loadChatHistory(state: ChatState) {
   if (!state.client || !state.connected) {
     return;


### PR DESCRIPTION
## **Summary**

- Problem: Control UI can get stuck in a “busy” state when the WebSocket drops mid-stream, because the UI never receives chat.final/chat.aborted and chatRunId remains set.
- Why it matters: Users can’t continue chatting after a network blip without refreshing the page.
- What changed: When the gateway WebSocket closes, the Control UI clears any in-flight chat run state and surfaces a clearer disconnect message if a response was in progress; added a small helper + regression tests.
- What did NOT change (scope boundary): No gateway/protocol changes; no attempt to resume streams after reconnect; only frontend state recovery.

## **Change Type (select all)**

- [x]  Bug fix
- [ ]  Feature
- [ ]  Refactor
- [ ]  Docs
- [ ]  Security hardening
- [ ]  Chore/infra

## **Scope (select all touched areas)**

- [ ]  Gateway / orchestration
- [ ]  Skills / tool execution
- [ ]  Auth / tokens
- [ ]  Memory / storage
- [ ]  Integrations
- [ ]  API / contracts
- [x]  UI / DX
- [ ]  CI/CD / infra

## **Linked Issue/PR**

- Closes #32400

## **User-visible / Behavior Changes**

- If the socket disconnects during a streaming response, the chat input is no longer blocked indefinitely; the UI clears the in-flight run state and shows a connection-lost message.

## **Security Impact (required)**

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## **Repro + Verification**

### **Environment**

- OS: macOS
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### **Steps**

1. Run pnpm test ui/src/ui/controllers/chat.test.ts
2. Run pnpm check

### **Expected**

- Tests pass; in-flight chat run state is cleared on disconnect.

### **Actual**

- Previously, chat could remain blocked because chatRunId was never cleared after a mid-stream disconnect.

## **Evidence**

- [x]  Passing after: targeted unit tests + pnpm check

## **Human Verification (required)**

- Verified scenarios: targeted unit tests; pnpm check
- Edge cases checked: N/A
- What you did **not** verify: manual repro in the browser with real disconnect toggling

## **Compatibility / Migration**

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)

## **Failure Recovery (if this breaks)**

- Revert this commit.

## **Risks and Mitigations**

None.