### PR TITLE
fix(fs-safe): respect umask by defaulting to 0o666 instead of 0o600

### DIFF
--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -406,7 +406,7 @@ export async function openWritableFileWithinRoot(params: {
     }
   }
 
-  const fileMode = params.mode ?? 0o600;
+  const fileMode = params.mode ?? 0o666;
 
   let handle: FileHandle;
   let createdForWrite = false;
@@ -512,7 +512,7 @@ export async function writeFileWithinRoot(params: {
       tempPath,
       data: params.data,
       encoding: params.encoding,
-      mode: targetMode || 0o600,
+      mode: targetMode || 0o666,
     });
     await fs.rename(tempPath, destinationPath);
     tempPath = null;


### PR DESCRIPTION
Fixes #32404 - fs-safe previously hardcoded 0o600 file mode for all writes, bypassing both system umask and default POSIX ACLs on parent directories.

This change:
1. Defaults file mode to 0o666 (Node.js standard default) instead of 0o600
2. Still respects explicit mode parameter when provided
3. Maintains backward compatibility for explicit mode usage

Now umask works as expected:
- umask 0022 → 0o644 (rw-r--r--)
- umask 0002 → 0o664 (rw-rw-r--)
- Default ACLs on parent directories are also respected