### PR TITLE
fix(channels): suppress control token leakage at delivery layer

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -914,6 +914,80 @@ describe("deliverOutboundPayloads", () => {
       expect.objectContaining({ channelId: "whatsapp" }),
     );
   });
+
+  it("suppresses text-only NO_REPLY payload", async () => {
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    const results = await deliverWhatsAppPayload({
+      sendWhatsApp,
+      payload: { text: "NO_REPLY" },
+    });
+
+    expect(sendWhatsApp).not.toHaveBeenCalled();
+    expect(results).toEqual([]);
+  });
+
+  it("suppresses text-only HEARTBEAT_OK payload", async () => {
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    const results = await deliverWhatsAppPayload({
+      sendWhatsApp,
+      payload: { text: "HEARTBEAT_OK" },
+    });
+
+    expect(sendWhatsApp).not.toHaveBeenCalled();
+    expect(results).toEqual([]);
+  });
+
+  it("suppresses NO_REPLY with surrounding whitespace", async () => {
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    const results = await deliverWhatsAppPayload({
+      sendWhatsApp,
+      payload: { text: "  NO_REPLY  " },
+    });
+
+    expect(sendWhatsApp).not.toHaveBeenCalled();
+    expect(results).toEqual([]);
+  });
+
+  it("clears NO_REPLY text but still delivers media", async () => {
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    await deliverWhatsAppPayload({
+      sendWhatsApp,
+      payload: { text: "NO_REPLY", mediaUrl: "https://example.com/photo.png" },
+    });
+
+    expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+    expect(sendWhatsApp).toHaveBeenCalledWith(
+      "+1555",
+      "",
+      expect.objectContaining({
+        mediaUrl: "https://example.com/photo.png",
+      }),
+    );
+  });
+
+  it("does not suppress legitimate text containing NO_REPLY", async () => {
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    await deliverWhatsAppPayload({
+      sendWhatsApp,
+      payload: { text: "I will send NO_REPLY when done" },
+    });
+
+    expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses NO_REPLY on non-WhatsApp channels", async () => {
+    const sendSignal = vi.fn().mockResolvedValue({ messageId: "s1", toJid: "jid" });
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "signal",
+      to: "+1555",
+      payloads: [{ text: "NO_REPLY" }],
+      deps: { sendSignal },
+    });
+
+    expect(sendSignal).not.toHaveBeenCalled();
+    expect(results).toEqual([]);
+  });
 });
 
 const emptyRegistry = createTestRegistry([]);

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -4,6 +4,7 @@ import {
   resolveChunkMode,
   resolveTextChunkLimit,
 } from "../../auto-reply/chunk.js";
+import { HEARTBEAT_TOKEN, isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { resolveChannelMediaMaxBytes } from "../../channels/plugins/media-limits.js";
 import { loadChannelOutboundAdapter } from "../../channels/plugins/outbound/load.js";
@@ -255,6 +256,11 @@ function hasChannelDataPayload(payload: ReplyPayload): boolean {
   return Boolean(payload.channelData && Object.keys(payload.channelData).length > 0);
 }
 
+/** Defensive guard: detect control tokens that survived upstream normalization. */
+function isControlTokenText(text: string): boolean {
+  return isSilentReplyText(text, SILENT_REPLY_TOKEN) || isSilentReplyText(text, HEARTBEAT_TOKEN);
+}
+
 function normalizePayloadForChannelDelivery(
   payload: ReplyPayload,
   channelId: string,
@@ -265,6 +271,17 @@ function normalizePayloadForChannelDelivery(
   const normalizedText =
     channelId === "whatsapp" ? rawText.replace(/^(?:[ \t]*\r?\n)+/, "") : rawText;
   if (!normalizedText.trim()) {
+    if (!hasMedia && !hasChannelData) {
+      return null;
+    }
+    return {
+      ...payload,
+      text: "",
+    };
+  }
+  // Defensive: suppress control tokens (NO_REPLY, HEARTBEAT_OK) that
+  // survived upstream normalization. Text-only → drop; with media/channelData → clear text.
+  if (isControlTokenText(normalizedText)) {
     if (!hasMedia && !hasChannelData) {
       return null;
     }


### PR DESCRIPTION
## Summary

- Adds a defensive guard in `normalizePayloadForChannelDelivery()` to suppress `NO_REPLY` and `HEARTBEAT_OK` control tokens that survive upstream normalization
- Text-only payloads with control tokens are dropped; payloads with media/channelData have their text cleared so the token never reaches channel adapters
- Protects all channels uniformly (previously only Slack and MSTeams had per-adapter guards)

Fixes #32403

## Test plan

- [x] New tests: text-only `NO_REPLY` suppressed
- [x] New tests: text-only `HEARTBEAT_OK` suppressed
- [x] New tests: `NO_REPLY` with whitespace suppressed
- [x] New tests: `NO_REPLY` text cleared but media still delivered
- [x] New tests: legitimate text containing `NO_REPLY` is NOT suppressed
- [x] New tests: suppression works on non-WhatsApp channels (Signal)
- [x] All 41 existing + new tests pass
- [x] Build clean, format clean