### PR TITLE
fix: doctor --fix falls back to dmPolicy=pairing when allowlist has empty allowFrom

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -539,6 +539,32 @@ describe("doctor config flow", () => {
     expect(cfg.channels.telegram.allowFrom).toEqual(["12345"]);
   });
 
+  it('falls back dmPolicy="allowlist" to "pairing" when no pairing store exists on repair', async () => {
+    const result = await runDoctorConfigWithInput({
+      repair: true,
+      config: {
+        channels: {
+          telegram: {
+            botToken: "fake-token",
+            dmPolicy: "allowlist",
+          },
+        },
+      },
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    const cfg = result.cfg as {
+      channels: {
+        telegram: {
+          dmPolicy: string;
+          allowFrom?: string[];
+        };
+      };
+    };
+    expect(cfg.channels.telegram.dmPolicy).toBe("pairing");
+    expect(cfg.channels.telegram.allowFrom).toBeUndefined();
+  });
+
   it("migrates legacy toolsBySender keys to typed id entries on repair", async () => {
     const result = await runDoctorConfigWithInput({
       repair: true,

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1205,6 +1205,15 @@ async function maybeRepairAllowlistPolicyAllowFrom(cfg: OpenClawConfig): Promise
       Boolean,
     );
     if (recovered.length === 0) {
+      // No pairing store entries — fall back to dmPolicy="pairing" so DMs aren't silently blocked.
+      if (params.account.dmPolicy === "allowlist") {
+        params.account.dmPolicy = "pairing";
+      } else if (dm?.policy === "allowlist") {
+        dm.policy = "pairing";
+      }
+      changes.push(
+        `- ${params.prefix}: dmPolicy="allowlist" with empty allowFrom and no pairing store entries; falling back to dmPolicy="pairing".`,
+      );
       return;
     }
 

--- a/src/security/fix.test.ts
+++ b/src/security/fix.test.ts
@@ -255,4 +255,66 @@ describe("security fix", () => {
     expectPerms((await fs.stat(transcriptPath)).mode & 0o777, 0o600);
     expectPerms((await fs.stat(includePath)).mode & 0o777, 0o600);
   });
+
+  it('falls back to dmPolicy="pairing" when allowlist has empty allowFrom and no pairing store', async () => {
+    const stateDir = await createStateDir("allowlist-fallback");
+    const configPath = path.join(stateDir, "openclaw.json");
+    await writeJsonConfig(configPath, {
+      channels: {
+        telegram: { dmPolicy: "allowlist" },
+      },
+    });
+
+    const { res, channels } = await runFixAndReadChannels(stateDir, configPath);
+    expect(res.configWritten).toBe(true);
+    expect(res.changes).toEqual(
+      expect.arrayContaining([
+        "channels.telegram.dmPolicy=allowlist -> pairing (empty allowFrom, no store)",
+      ]),
+    );
+    expect(channels.telegram.dmPolicy).toBe("pairing");
+  });
+
+  it('seeds allowFrom from pairing store when dmPolicy="allowlist" and store has entries', async () => {
+    const stateDir = await createStateDir("allowlist-seed");
+    const configPath = path.join(stateDir, "openclaw.json");
+    await writeJsonConfig(configPath, {
+      channels: {
+        whatsapp: { dmPolicy: "allowlist" },
+      },
+    });
+    await writeWhatsAppAllowFromStore(stateDir, ["+15559990000"]);
+
+    const { res, channels } = await runFixAndReadChannels(stateDir, configPath);
+    expect(res.configWritten).toBe(true);
+    expect(res.changes).toEqual(
+      expect.arrayContaining(["channels.whatsapp.allowFrom: seeded 1 entry from pairing store"]),
+    );
+    expect(channels.whatsapp.dmPolicy).toBe("allowlist");
+    expect(channels.whatsapp.allowFrom).toEqual(["+15559990000"]);
+  });
+
+  it('falls back per-account dmPolicy="allowlist" to "pairing" with no pairing store', async () => {
+    const stateDir = await createStateDir("per-account-allowlist");
+    const configPath = path.join(stateDir, "openclaw.json");
+    await writeJsonConfig(configPath, {
+      channels: {
+        telegram: {
+          accounts: {
+            bot1: { dmPolicy: "allowlist" },
+          },
+        },
+      },
+    });
+
+    const { res, channels } = await runFixAndReadChannels(stateDir, configPath);
+    expect(res.configWritten).toBe(true);
+    expect(res.changes).toEqual(
+      expect.arrayContaining([
+        "channels.telegram.accounts.bot1.dmPolicy=allowlist -> pairing (empty allowFrom, no store)",
+      ]),
+    );
+    const accounts = channels.telegram.accounts as Record<string, Record<string, unknown>>;
+    expect(accounts.bot1.dmPolicy).toBe("pairing");
+  });
 });

--- a/src/security/fix.test.ts
+++ b/src/security/fix.test.ts
@@ -266,6 +266,7 @@ describe("security fix", () => {
     });
 
     const { res, channels } = await runFixAndReadChannels(stateDir, configPath);
+    expect(res.ok).toBe(true);
     expect(res.configWritten).toBe(true);
     expect(res.changes).toEqual(
       expect.arrayContaining([
@@ -286,6 +287,7 @@ describe("security fix", () => {
     await writeWhatsAppAllowFromStore(stateDir, ["+15559990000"]);
 
     const { res, channels } = await runFixAndReadChannels(stateDir, configPath);
+    expect(res.ok).toBe(true);
     expect(res.configWritten).toBe(true);
     expect(res.changes).toEqual(
       expect.arrayContaining(["channels.whatsapp.allowFrom: seeded 1 entry from pairing store"]),
@@ -308,6 +310,7 @@ describe("security fix", () => {
     });
 
     const { res, channels } = await runFixAndReadChannels(stateDir, configPath);
+    expect(res.ok).toBe(true);
     expect(res.configWritten).toBe(true);
     expect(res.changes).toEqual(
       expect.arrayContaining([

--- a/src/security/fix.ts
+++ b/src/security/fix.ts
@@ -1,13 +1,18 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { normalizeChatChannelId } from "../channels/registry.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { createConfigIO } from "../config/config.js";
 import { collectIncludePathsRecursive } from "../config/includes-scan.js";
 import { resolveConfigPath, resolveOAuthDir, resolveStateDir } from "../config/paths.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
 import { runExec } from "../process/exec.js";
-import { DEFAULT_ACCOUNT_ID, normalizeAgentId } from "../routing/session-key.js";
+import {
+  DEFAULT_ACCOUNT_ID,
+  normalizeAccountId,
+  normalizeAgentId,
+} from "../routing/session-key.js";
 import { createIcaclsResetCommand, formatIcaclsResetCommand, type ExecFn } from "./windows-acl.js";
 
 export type SecurityFixChmodAction = {
@@ -273,6 +278,109 @@ function setWhatsAppGroupAllowFromFromStore(params: {
   }
 }
 
+async function fixAllowlistDmPolicyEmptyAllowFrom(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+  changes: string[];
+}): Promise<void> {
+  const channels = params.cfg.channels;
+  if (!channels || typeof channels !== "object") {
+    return;
+  }
+
+  const hasEntries = (list: unknown): boolean =>
+    Array.isArray(list) &&
+    list.some((v) => {
+      const s = String(v).trim();
+      return s.length > 0;
+    });
+
+  const fixAccount = async (
+    channelName: string,
+    account: Record<string, unknown>,
+    prefix: string,
+    accountId?: string,
+  ) => {
+    const dmEntry = account.dm;
+    const dm =
+      dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)
+        ? (dmEntry as Record<string, unknown>)
+        : undefined;
+    const dmPolicy = (account.dmPolicy as string | undefined) ?? (dm?.policy as string | undefined);
+    if (dmPolicy !== "allowlist") {
+      return;
+    }
+    if (hasEntries(account.allowFrom) || hasEntries(dm?.allowFrom)) {
+      return;
+    }
+
+    const normalizedChannel = (normalizeChatChannelId(channelName) ?? channelName)
+      .trim()
+      .toLowerCase();
+    if (!normalizedChannel) {
+      return;
+    }
+    const normalizedAccountId = normalizeAccountId(accountId) || DEFAULT_ACCOUNT_ID;
+    const storeEntries = await readChannelAllowFromStore(
+      normalizedChannel,
+      params.env,
+      normalizedAccountId,
+    ).catch(() => []);
+    const recovered = Array.from(new Set(storeEntries.map((e) => String(e).trim()))).filter(
+      Boolean,
+    );
+
+    if (recovered.length > 0) {
+      // Respect channel-specific allowFrom placement (mirrors doctor-config-flow logic).
+      const useNested =
+        channelName === "googlechat" || channelName === "discord" || channelName === "slack";
+      if (useNested) {
+        const dmObj = dm ?? {};
+        dmObj.allowFrom = recovered;
+        account.dm = dmObj;
+      } else {
+        account.allowFrom = recovered;
+      }
+      params.changes.push(
+        `${prefix}.allowFrom: seeded ${recovered.length} ${recovered.length === 1 ? "entry" : "entries"} from pairing store`,
+      );
+    } else {
+      if (account.dmPolicy === "allowlist") {
+        account.dmPolicy = "pairing";
+      } else if (dm?.policy === "allowlist") {
+        dm.policy = "pairing";
+      }
+      params.changes.push(`${prefix}.dmPolicy=allowlist -> pairing (empty allowFrom, no store)`);
+    }
+  };
+
+  for (const [channelName, channelValue] of Object.entries(channels)) {
+    if (!channelValue || typeof channelValue !== "object") {
+      continue;
+    }
+    const section = channelValue as Record<string, unknown>;
+    // eslint-disable-next-line no-await-in-loop
+    await fixAccount(channelName, section, `channels.${channelName}`);
+
+    const accounts = section.accounts;
+    if (!accounts || typeof accounts !== "object") {
+      continue;
+    }
+    for (const [accountId, accountValue] of Object.entries(accounts)) {
+      if (!accountValue || typeof accountValue !== "object") {
+        continue;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await fixAccount(
+        channelName,
+        accountValue as Record<string, unknown>,
+        `channels.${channelName}.accounts.${accountId}`,
+        accountId,
+      );
+    }
+  }
+}
+
 function applyConfigFixes(params: { cfg: OpenClawConfig; env: NodeJS.ProcessEnv }): {
   cfg: OpenClawConfig;
   changes: string[];
@@ -426,9 +534,23 @@ export async function fixSecurityFootguns(opts?: {
       });
     }
 
+    await fixAllowlistDmPolicyEmptyAllowFrom({ cfg: fixed.cfg, env, changes });
+
     if (changes.length > 0) {
       try {
         await io.writeConfigFile(fixed.cfg);
+        configWritten = true;
+      } catch (err) {
+        errors.push(`writeConfigFile failed: ${String(err)}`);
+      }
+    }
+  } else if (snap.exists && snap.config && typeof snap.config === "object") {
+    const fixedCfg = structuredClone(snap.config);
+    await fixAllowlistDmPolicyEmptyAllowFrom({ cfg: fixedCfg, env, changes });
+
+    if (changes.length > 0) {
+      try {
+        await io.writeConfigFile(fixedCfg);
         configWritten = true;
       } catch (err) {
         errors.push(`writeConfigFile failed: ${String(err)}`);

--- a/src/security/fix.ts
+++ b/src/security/fix.ts
@@ -337,6 +337,11 @@ async function fixAllowlistDmPolicyEmptyAllowFrom(params: {
       if (useNested) {
         const dmObj = dm ?? {};
         dmObj.allowFrom = recovered;
+        // When policy lives at the top level, move it inside dm to keep the structure consistent.
+        if (account.dmPolicy === "allowlist" && !dmObj.policy) {
+          dmObj.policy = "allowlist";
+          delete account.dmPolicy;
+        }
         account.dm = dmObj;
       } else {
         account.allowFrom = recovered;
@@ -545,6 +550,7 @@ export async function fixSecurityFootguns(opts?: {
       }
     }
   } else if (snap.exists && snap.config && typeof snap.config === "object") {
+    const preFixErrorCount = errors.length;
     const fixedCfg = structuredClone(snap.config);
     await fixAllowlistDmPolicyEmptyAllowFrom({ cfg: fixedCfg, env, changes });
 
@@ -552,6 +558,8 @@ export async function fixSecurityFootguns(opts?: {
       try {
         await io.writeConfigFile(fixedCfg);
         configWritten = true;
+        // Config was repaired — clear the pre-fix validation errors that triggered this branch.
+        errors.splice(0, preFixErrorCount);
       } catch (err) {
         errors.push(`writeConfigFile failed: ${String(err)}`);
       }


### PR DESCRIPTION
## Summary

- **Problem:** In openclaw 2026.3.2, a new validation rule requires `allowFrom` to contain at least one entry when `dmPolicy="allowlist"`. Users who had `dmPolicy="allowlist"` with an empty or missing `allowFrom` (e.g., set by the setup wizard but never populated) now have an invalid config. `doctor --fix` tries to recover entries from the pairing store, but if the store file doesn't exist (common for users who never used the pairing flow), it does nothing and the config stays broken.
- **Why it matters:** The invalid config prevents the openclaw gateway from starting properly, leaving the user unable to use the application until manually fixed.
- **What changed:** When `dmPolicy="allowlist"` and `allowFrom` is empty and the pairing store has no entries, both `doctor --fix` and `security audit --fix` now fall back to `dmPolicy="pairing"` (the safe default). When store entries exist, they are seeded into `allowFrom`. The `security audit --fix` path also now handles invalid-but-parseable configs.
- **What did NOT change (scope boundary):** No changes to config validation, schema, or the pairing flow itself. Existing behavior for configs with populated `allowFrom` is untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: upgrade to 2026.3.2 breaking configs with empty allowFrom

## User-visible / Behavior Changes

- `openclaw doctor --fix` now auto-repairs `dmPolicy="allowlist"` with empty `allowFrom` by falling back to `dmPolicy="pairing"` when no pairing store entries are available.
- `openclaw security audit --fix` does the same, and now also works when the config is invalid (previously skipped entirely).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.4.0)
- Runtime/container: Node 22+, pnpm
- Model/provider: N/A
- Integration/channel (if any): All channels (telegram, whatsapp, discord, signal, etc.)
- Relevant config (redacted):

```json
{
  "channels": {
    "whatsapp": {
      "dmPolicy": "allowlist",
      "allowFrom": []
    }
  }
}
```

### Steps

1. Set `dmPolicy="allowlist"` with empty `allowFrom` in config
2. Ensure no pairing store file exists (e.g., no `credentials/whatsapp-allowFrom.json`)
3. Run `openclaw doctor --fix`

### Expected

- `dmPolicy` changed to `"pairing"`

### Actual (before fix)

- Config left unchanged, gateway cannot start due to invalid config

<img width="1102" height="597" alt="Openclaw-doctor-fix-issue" src="https://github.com/user-attachments/assets/30c9cca9-4691-42ba-9e50-b430079087d2" />

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

4 new tests added and passing (28 total across both test files):
- `fix.test.ts`: fallback to pairing (no store), seed from store, per-account fallback
- `doctor-config-flow.test.ts`: doctor repair fallback to pairing

## Human Verification (required)

- **Verified scenarios:** `pnpm build` passes, `pnpm check` passes (format + lint), all 28 tests pass. Manually tested on macOS — set `dmPolicy="allowlist"` with empty `allowFrom`, confirmed `doctor --fix` on `main` detects the issue but does not resolve it, then confirmed on the fix branch it correctly falls back to `dmPolicy="pairing"`.
- **Edge cases checked:** per-account dmPolicy, nested dm.policy, channel-aware allowFrom placement (googlechat/discord/slack write to dm.allowFrom), channel/account ID normalization, invalid-but-parseable config path
- **What you did not verify:** multi-channel config with mixed dmPolicy settings

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` — only auto-repairs broken configs
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit; manually set `dmPolicy` to desired value in config
- Files/config to restore: `~/.openclaw/openclaw.json`
- Known bad symptoms reviewers should watch for: `dmPolicy` unexpectedly changed to `"pairing"` for users who intentionally have empty allowFrom

## Risks and Mitigations

- **Risk:** A user intentionally sets `dmPolicy="allowlist"` with empty `allowFrom` to block all DMs, and the fix silently changes it to `"pairing"`.
- **Mitigation:** This configuration is already flagged as invalid by the schema validator. The fix only runs when the user explicitly invokes `doctor --fix` or `security audit --fix`, not automatically.