### PR TITLE
fix(agents): suppress streaming partial leak of NO_REPLY prefixes

### DIFF
--- a/src/auto-reply/tokens.test.ts
+++ b/src/auto-reply/tokens.test.ts
@@ -81,10 +81,19 @@ describe("isSilentReplyPrefixText", () => {
     expect(isSilentReplyPrefixText("  HEARTBEAT_", "HEARTBEAT_OK")).toBe(true);
   });
 
-  it("rejects ambiguous natural-language prefixes", () => {
-    expect(isSilentReplyPrefixText("N")).toBe(false);
-    expect(isSilentReplyPrefixText("No")).toBe(false);
+  it("matches pure-alpha prefixes before the underscore arrives (#32168)", () => {
+    expect(isSilentReplyPrefixText("N")).toBe(true);
+    expect(isSilentReplyPrefixText("NO")).toBe(true);
+    expect(isSilentReplyPrefixText("No")).toBe(true);
+    expect(isSilentReplyPrefixText("  NO")).toBe(true);
+    expect(isSilentReplyPrefixText("H", "HEARTBEAT_OK")).toBe(true);
+    expect(isSilentReplyPrefixText("HEART", "HEARTBEAT_OK")).toBe(true);
+  });
+
+  it("rejects non-prefix alpha strings", () => {
     expect(isSilentReplyPrefixText("Hello")).toBe(false);
+    expect(isSilentReplyPrefixText("X")).toBe(false);
+    expect(isSilentReplyPrefixText("Not")).toBe(false);
   });
 
   it("rejects non-prefixes and mixed characters", () => {

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -60,9 +60,6 @@ export function isSilentReplyPrefixText(
   if (!normalized) {
     return false;
   }
-  if (!normalized.includes("_")) {
-    return false;
-  }
   if (/[^A-Z_]/.test(normalized)) {
     return false;
   }


### PR DESCRIPTION
## Summary

- Problem: `isSilentReplyPrefixText` had an early-exit `includes('_')` guard that rejected pure-alpha prefixes like `"NO"`, causing them to leak through as visible typing deltas during streaming before the full `NO_REPLY` token arrived.
- Why it matters: Users on all channels see a brief flash of `"NO"` in the typing bubble, which is confusing and exposes an internal control token.
- What changed: Removed the `includes('_')` guard so all uppercase-only prefixes of the token (e.g. `N`, `NO`, `NO_`, `NO_RE`) are correctly suppressed.
- What did NOT change (scope boundary): Final message delivery is unaffected; `isSilentReplyText` (exact-match for completed tokens) and `stripSilentToken` remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32168

## User-visible / Behavior Changes

Users no longer see a brief `"NO"` flash in the typing indicator when the agent decides to respond with `NO_REPLY`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+

### Steps

1. Send a message that the agent decides not to reply to (triggers `NO_REPLY`)
2. Watch the typing indicator during streaming

### Expected

- No visible text leaks during streaming

### Actual

- Before: `"NO"` appears briefly in typing bubble
- After: Nothing visible until real content arrives

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `"N"`, `"NO"`, `"NO_"`, `"NO_RE"`, `"NO_REPLY"` all correctly suppressed; `"Hello"`, `"X"`, `"Not"` correctly pass through
- Edge cases checked: Mixed-case `"No"` normalizes to `"NO"` and is correctly treated as a prefix (acceptable for typing-indicator-only suppression)
- What you did **not** verify: End-to-end with real streaming provider; logic is pure function tested via unit tests

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the single guard removal in `src/auto-reply/tokens.ts` (re-add the `includes('_')` check)
- Files/config to restore: `src/auto-reply/tokens.ts`

## Risks and Mitigations

- Risk: Single-character prefixes like `"N"` cause a very brief delay in the typing indicator for replies starting with "N"
  - Mitigation: The delay is one streaming delta (~50ms); the typing indicator catches up on the next delta when the text is no longer a valid prefix