### PR TITLE
fix(cli): guard service PATH entries with existsSync

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -1,6 +1,7 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveGatewayStateDir } from "./paths.js";
 import {
   buildMinimalServicePath,
@@ -11,7 +12,12 @@ import {
 } from "./service-env.js";
 
 describe("getMinimalServicePathParts - Linux user directories", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("includes user bin directories when HOME is set on Linux", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
     const result = getMinimalServicePathParts({
       platform: "linux",
       home: "/home/testuser",
@@ -45,6 +51,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
   });
 
   it("places user directories before system directories on Linux", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
     const result = getMinimalServicePathParts({
       platform: "linux",
       home: "/home/testuser",
@@ -59,6 +66,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
   });
 
   it("places extraDirs before user directories on Linux", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
     const result = getMinimalServicePathParts({
       platform: "linux",
       home: "/home/testuser",
@@ -74,6 +82,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
   });
 
   it("includes env-configured bin roots when HOME is set on Linux", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
     const result = getMinimalServicePathPartsFromEnv({
       platform: "linux",
       env: {
@@ -98,6 +107,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
   });
 
   it("includes version manager directories on macOS when HOME is set", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
     const result = getMinimalServicePathParts({
       platform: "darwin",
       home: "/Users/testuser",
@@ -124,6 +134,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
   });
 
   it("includes env-configured version manager dirs on macOS", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
     const result = getMinimalServicePathPartsFromEnv({
       platform: "darwin",
       env: {
@@ -143,6 +154,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
   });
 
   it("places version manager dirs before system dirs on macOS", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
     const result = getMinimalServicePathParts({
       platform: "darwin",
       home: "/Users/testuser",
@@ -159,6 +171,26 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     expect(fnmIndex).toBeLessThan(homebrewIndex);
   });
 
+  it("excludes non-existent user bin directories (#32448)", () => {
+    vi.spyOn(fs, "existsSync").mockImplementation((p) => {
+      const s = String(p);
+      return s === "/home/testuser/.local/bin" || s === "/home/testuser/.nvm/current/bin";
+    });
+    const result = getMinimalServicePathParts({
+      platform: "linux",
+      home: "/home/testuser",
+    });
+
+    expect(result).toContain("/home/testuser/.local/bin");
+    expect(result).toContain("/home/testuser/.nvm/current/bin");
+    expect(result).not.toContain("/home/testuser/.npm-global/bin");
+    expect(result).not.toContain("/home/testuser/.volta/bin");
+    expect(result).not.toContain("/home/testuser/.fnm/current/bin");
+    expect(result).not.toContain("/home/testuser/.bun/bin");
+    // System directories are always included (no existence check)
+    expect(result).toContain("/usr/local/bin");
+  });
+
   it("does not include Linux user directories on Windows", () => {
     const result = getMinimalServicePathParts({
       platform: "win32",
@@ -171,6 +203,10 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
 });
 
 describe("buildMinimalServicePath", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   const splitPath = (value: string, platform: NodeJS.Platform) =>
     value.split(platform === "win32" ? path.win32.delimiter : path.posix.delimiter);
 
@@ -194,6 +230,7 @@ describe("buildMinimalServicePath", () => {
   });
 
   it("includes Linux user directories when HOME is set in env", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
     const result = buildMinimalServicePath({
       platform: "linux",
       env: { HOME: "/home/alice" },
@@ -226,6 +263,7 @@ describe("buildMinimalServicePath", () => {
   });
 
   it("ensures user directories come before system directories on Linux", () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(true);
     const result = buildMinimalServicePath({
       platform: "linux",
       env: { HOME: "/home/bob" },

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { VERSION } from "../version.js";
@@ -77,13 +78,19 @@ function appendSubdir(base: string | undefined, subdir: string): string | undefi
   return base.endsWith(`/${subdir}`) ? base : path.posix.join(base, subdir);
 }
 
+function addDirIfExists(dirs: string[], dir: string): void {
+  if (fs.existsSync(dir)) {
+    dirs.push(dir);
+  }
+}
+
 function addCommonUserBinDirs(dirs: string[], home: string): void {
-  dirs.push(`${home}/.local/bin`);
-  dirs.push(`${home}/.npm-global/bin`);
-  dirs.push(`${home}/bin`);
-  dirs.push(`${home}/.volta/bin`);
-  dirs.push(`${home}/.asdf/shims`);
-  dirs.push(`${home}/.bun/bin`);
+  addDirIfExists(dirs, `${home}/.local/bin`);
+  addDirIfExists(dirs, `${home}/.npm-global/bin`);
+  addDirIfExists(dirs, `${home}/bin`);
+  addDirIfExists(dirs, `${home}/.volta/bin`);
+  addDirIfExists(dirs, `${home}/.asdf/shims`);
+  addDirIfExists(dirs, `${home}/.bun/bin`);
 }
 
 function addCommonEnvConfiguredBinDirs(
@@ -142,11 +149,11 @@ export function resolveDarwinUserBinDirs(
   // Node version managers - macOS specific paths
   // nvm: no stable default path, depends on user's shell configuration
   // fnm: macOS default is ~/Library/Application Support/fnm, not ~/.fnm
-  dirs.push(`${home}/Library/Application Support/fnm/aliases/default/bin`); // fnm default
-  dirs.push(`${home}/.fnm/aliases/default/bin`); // fnm if customized to ~/.fnm
+  addDirIfExists(dirs, `${home}/Library/Application Support/fnm/aliases/default/bin`); // fnm default
+  addDirIfExists(dirs, `${home}/.fnm/aliases/default/bin`); // fnm if customized to ~/.fnm
   // pnpm: macOS default is ~/Library/pnpm, not ~/.local/share/pnpm
-  dirs.push(`${home}/Library/pnpm`); // pnpm default
-  dirs.push(`${home}/.local/share/pnpm`); // pnpm XDG fallback
+  addDirIfExists(dirs, `${home}/Library/pnpm`); // pnpm default
+  addDirIfExists(dirs, `${home}/.local/share/pnpm`); // pnpm XDG fallback
 
   return dirs;
 }
@@ -173,10 +180,10 @@ export function resolveLinuxUserBinDirs(
   // Common user bin directories
   addCommonUserBinDirs(dirs, home);
 
-  // Node version managers
-  dirs.push(`${home}/.nvm/current/bin`); // nvm with current symlink
-  dirs.push(`${home}/.fnm/current/bin`); // fnm
-  dirs.push(`${home}/.local/share/pnpm`); // pnpm global bin
+  // Node version managers — only add if the directory/symlink actually exists
+  addDirIfExists(dirs, `${home}/.nvm/current/bin`); // nvm with current symlink
+  addDirIfExists(dirs, `${home}/.fnm/current/bin`); // fnm
+  addDirIfExists(dirs, `${home}/.local/share/pnpm`); // pnpm global bin
 
   return dirs;
 }


### PR DESCRIPTION
## Summary

- Problem: `addCommonUserBinDirs`, `resolveLinuxUserBinDirs`, and `resolveDarwinUserBinDirs` unconditionally pushed hardcoded directories (`~/.npm-global/bin`, `~/.nvm/current/bin`, etc.) into the generated service PATH without checking if they exist.
- Why it matters: `doctor --fix` writes stale/phantom paths into the service file. Commands that rely on node (exec tool, cron jobs) can fail with "No such file or directory" on minimal systems.
- What changed: Each candidate user-bin directory is now checked with `fs.existsSync` before being added to the PATH array. Added a new `addDirIfExists` helper.
- What did NOT change (scope boundary): System directories (`/usr/local/bin`, `/usr/bin`, `/bin`, `/opt/homebrew/bin`) remain unconditional. Env-configured dirs (PNPM_HOME, NVM_DIR, etc.) still use `addNonEmptyDir` (presence of env var implies intent).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #32448

## User-visible / Behavior Changes

`openclaw doctor --fix` no longer writes non-existent directories to the service PATH. Only directories that actually exist on the system are included.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux / macOS
- Runtime: Node.js 22+

### Steps

1. On a system without `~/.npm-global/bin` or `~/.nvm/current/bin`
2. Run `openclaw doctor --fix`
3. Inspect the generated service PATH

### Expected

- PATH only contains directories that actually exist

### Actual

- Before: PATH includes `~/.npm-global/bin`, `~/.nvm/current/bin` etc. even when absent
- After: Only existing directories appear in PATH

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Linux with selective directories present; macOS with all directories present; Windows (no-op); missing HOME
- Edge cases checked: `existsSync` mock selectively returns true for only 2 of 9 user dirs — only those 2 appear in result
- What you did **not** verify: Real system with actual directory presence (tested via mocked `existsSync`)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No — existing service files are regenerated on next `doctor --fix`

## Failure Recovery (if this breaks)

- How to disable/revert: Revert `addDirIfExists` to `dirs.push` (remove `fs.existsSync` guard)
- Files/config to restore: `src/daemon/service-env.ts`

## Risks and Mitigations

- Risk: A required binary lives in a directory that doesn't exist yet at service-file generation time but is created later
  - Mitigation: Re-running `doctor --fix` after installing the tool will pick up the new directory; env-configured dirs (NVM_DIR, PNPM_HOME, etc.) bypass the check