### PR TITLE
fix(agents): suppress NO_REPLY and null-artifact leaks at channel delivery boundary

### DIFF
--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -511,6 +511,38 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("drops NO_REPLY payloads that leak through upstream normalization (#32403)", async () => {
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    const results = await deliverWhatsAppPayload({
+      sendWhatsApp,
+      payload: { text: "NO_REPLY" },
+    });
+    expect(sendWhatsApp).not.toHaveBeenCalled();
+    expect(results).toEqual([]);
+  });
+
+  it("drops None/null/undefined artifact payloads (#32403)", async () => {
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    for (const artifact of ["None", "null", "undefined"]) {
+      sendWhatsApp.mockClear();
+      const results = await deliverWhatsAppPayload({
+        sendWhatsApp,
+        payload: { text: artifact },
+      });
+      expect(sendWhatsApp).not.toHaveBeenCalled();
+      expect(results).toEqual([]);
+    }
+  });
+
+  it("preserves None/null in substantive text (#32403)", async () => {
+    const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
+    await deliverWhatsAppPayload({
+      sendWhatsApp,
+      payload: { text: "The result is None of the above" },
+    });
+    expect(sendWhatsApp).toHaveBeenCalledTimes(1);
+  });
+
   it("drops whitespace-only WhatsApp text payloads when no media is attached", async () => {
     const sendWhatsApp = vi.fn().mockResolvedValue({ messageId: "w1", toJid: "jid" });
     const results = await deliverWhatsAppPayload({

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -4,6 +4,7 @@ import {
   resolveChunkMode,
   resolveTextChunkLimit,
 } from "../../auto-reply/chunk.js";
+import { isSilentReplyText } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { resolveChannelMediaMaxBytes } from "../../channels/plugins/media-limits.js";
 import { loadChannelOutboundAdapter } from "../../channels/plugins/outbound/load.js";
@@ -255,6 +256,8 @@ function hasChannelDataPayload(payload: ReplyPayload): boolean {
   return Boolean(payload.channelData && Object.keys(payload.channelData).length > 0);
 }
 
+const NULL_ARTIFACT_RE = /^(?:None|null|undefined)$/;
+
 function normalizePayloadForChannelDelivery(
   payload: ReplyPayload,
   channelId: string,
@@ -262,6 +265,14 @@ function normalizePayloadForChannelDelivery(
   const hasMedia = hasMediaPayload(payload);
   const hasChannelData = hasChannelDataPayload(payload);
   const rawText = typeof payload.text === "string" ? payload.text : "";
+
+  if (!hasMedia && !hasChannelData) {
+    const trimmed = rawText.trim();
+    if (isSilentReplyText(trimmed) || NULL_ARTIFACT_RE.test(trimmed)) {
+      return null;
+    }
+  }
+
   const normalizedText =
     channelId === "whatsapp" ? rawText.replace(/^(?:[ \t]*\r?\n)+/, "") : rawText;
   if (!normalizedText.trim()) {


### PR DESCRIPTION
## Summary

- Problem: Upstream payload normalization (`parseReplyDirectives`) filters exact `NO_REPLY` tokens, but edge cases let the token or null-serialization artifacts (`None`, `null`, `undefined`) reach channel adapters. Only Slack and MSTeams had per-channel guards; Telegram, Discord, Signal, WhatsApp did not.
- Why it matters: Users see raw control tokens or Python/JS null-serialization strings as visible messages.
- What changed: Added a defense-in-depth guard in `normalizePayloadForChannelDelivery` (the last normalization step before adapter send) that drops text-only payloads matching `isSilentReplyText` or the regex `/^(?:None|null|undefined)$/`.
- What did NOT change (scope boundary): Upstream `parseReplyDirectives` logic is untouched. Channel-level guards in Slack/MSTeams remain. Payloads with media or channelData are never suppressed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32403

## User-visible / Behavior Changes

Users on Telegram, Discord, Signal, WhatsApp, and plugin channels no longer receive visible `NO_REPLY`, `None`, `null`, or `undefined` messages from the agent.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+

### Steps

1. Configure a memory-flush or maintenance cron that triggers `NO_REPLY`
2. Observe agent output on Telegram/Discord/Signal/WhatsApp

### Expected

- No visible control tokens or null-serialization strings

### Actual

- Before: `NO_REPLY`, `None`, or `null` appears as a visible message
- After: Payload is silently dropped

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `NO_REPLY`, `None`, `null`, `undefined` all dropped; substantive text like "The result is None of the above" preserved
- Edge cases checked: Payloads with media + `NO_REPLY` text are NOT dropped (media takes precedence); channelData-only payloads preserved
- What you did **not** verify: End-to-end on real channel adapters (tested via delivery mock)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Remove the `isSilentReplyText` and `NULL_ARTIFACT_RE` check block in `normalizePayloadForChannelDelivery`
- Files/config to restore: `src/infra/outbound/deliver.ts`

## Risks and Mitigations

- Risk: A model intentionally outputs the exact word `None` as a standalone reply and it gets suppressed
  - Mitigation: The check is case-sensitive and exact-match only (`/^(?:None|null|undefined)$/`); any surrounding text prevents suppression