### PR TITLE
fix(cron): treat tool error payloads as recoverable when non-error output exists

### DIFF
--- a/src/cron/isolated-agent/run.tool-error-recovery.test.ts
+++ b/src/cron/isolated-agent/run.tool-error-recovery.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, type Mock } from "vitest";
+import {
+  makeIsolatedAgentTurnJob,
+  makeIsolatedAgentTurnParams,
+  setupRunCronIsolatedAgentTurnSuite,
+} from "./run.suite-helpers.js";
+import { loadRunCronIsolatedAgentTurn, runWithModelFallbackMock } from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+const helpers = await import("./helpers.js");
+const pickLastDeliverablePayloadMock = helpers.pickLastDeliverablePayload as unknown as Mock;
+
+describe("runCronIsolatedAgentTurn — tool error recovery (#32244)", () => {
+  setupRunCronIsolatedAgentTurnSuite();
+
+  it("reports ok when a non-error deliverable payload exists alongside a tool error", async () => {
+    const nonErrorPayload = { text: "Report written to ~/docs/report.md" };
+    const errorPayload = { text: "⚠️ Write failed", isError: true as const };
+
+    runWithModelFallbackMock.mockResolvedValue({
+      result: {
+        payloads: [nonErrorPayload, errorPayload],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      },
+      provider: "openai",
+      model: "gpt-4",
+    });
+    pickLastDeliverablePayloadMock.mockReturnValue(nonErrorPayload);
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob(),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+  });
+
+  it("still reports error when only error payloads exist (no non-error deliverable)", async () => {
+    const errorPayload = { text: "⚠️ Write failed", isError: true as const };
+
+    runWithModelFallbackMock.mockResolvedValue({
+      result: {
+        payloads: [errorPayload],
+        meta: { agentMeta: { usage: { input: 10, output: 20 } } },
+      },
+      provider: "openai",
+      model: "gpt-4",
+    });
+    pickLastDeliverablePayloadMock.mockReturnValue(errorPayload);
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob(),
+      }),
+    );
+
+    expect(result.status).toBe("error");
+  });
+
+  it("still reports error when there is a run-level error despite non-error deliverable", async () => {
+    const nonErrorPayload = { text: "Report written" };
+    const errorPayload = { text: "Context overflow", isError: true as const };
+
+    runWithModelFallbackMock.mockResolvedValue({
+      result: {
+        payloads: [nonErrorPayload, errorPayload],
+        meta: {
+          error: "context window exceeded",
+          agentMeta: { usage: { input: 10, output: 20 } },
+        },
+      },
+      provider: "openai",
+      model: "gpt-4",
+    });
+    pickLastDeliverablePayloadMock.mockReturnValue(nonErrorPayload);
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob(),
+      }),
+    );
+
+    expect(result.status).toBe("error");
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -625,7 +625,12 @@ export async function runCronIsolatedAgentTurn(params: {
   // Tool wrappers can emit transient/false-positive error payloads before a valid final
   // assistant payload.  Only treat payload errors as recoverable when (a) the run itself
   // did not report a model/context-level error and (b) a non-error payload follows.
-  const hasFatalErrorPayload = hasErrorPayload && !hasSuccessfulPayloadAfterLastError;
+  // Also treat errors as recoverable when the run produced a non-error deliverable
+  // payload — the agent completed its primary task despite a tool-level warning (#32244).
+  const hasNonErrorDeliverablePayload =
+    !runLevelError && deliveryPayload !== undefined && deliveryPayload.isError !== true;
+  const hasFatalErrorPayload =
+    hasErrorPayload && !hasSuccessfulPayloadAfterLastError && !hasNonErrorDeliverablePayload;
   const lastErrorPayloadText = [...payloads]
     .toReversed()
     .find((payload) => payload?.isError === true && Boolean(payload?.text?.trim()))


### PR DESCRIPTION
## Summary

- Problem: The cron status evaluator marked a run as `"error"` whenever the last payload had `isError: true`, even if the agent had already produced substantive non-error output earlier. This caused false positives when a tool (e.g. Write) emitted a transient error payload after the agent completed its primary task.
- Why it matters: Cron job dashboards show persistent error status for jobs that actually succeeded, causing alert fatigue and masking real failures.
- What changed: The `hasFatalErrorPayload` check now also considers whether the run produced a non-error deliverable payload. If such a payload exists and there is no run-level model/context error, tool-level error payloads are treated as recoverable.
- What did NOT change (scope boundary): Runs with only error payloads still report `"error"`. Runs with run-level errors (`meta.error`) still report `"error"` regardless of deliverable payloads.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32244

## User-visible / Behavior Changes

Cron jobs that produce valid output but also trigger a transient tool-level warning now report `lastRunStatus: "ok"` instead of `"error"`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+

### Steps

1. Create a cron job that writes a file using the Write tool
2. Trigger a scenario where the Write tool emits an `isError: true` payload but the file is actually written
3. Check `lastRunStatus` in the cron state

### Expected

- `lastRunStatus: "ok"` (the agent produced deliverable output)

### Actual

- Before: `lastRunStatus: "error"`, `lastError: "⚠️ ✍ Write: ... failed"`
- After: `lastRunStatus: "ok"`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Non-error payload before error → ok; only error payloads → error; run-level error with non-error payload → error
- Edge cases checked: `deliveryPayload.isError !== true` correctly distinguishes non-error deliverable content from error-only payloads
- What you did **not** verify: End-to-end with real tool execution (tested via mocked agent run)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Remove the `hasNonErrorDeliverablePayload` variable and the `&& !hasNonErrorDeliverablePayload` clause from `hasFatalErrorPayload`
- Files/config to restore: `src/cron/isolated-agent/run.ts`

## Risks and Mitigations

- Risk: A genuine tool failure is masked because the agent produced unrelated text output before the failure
  - Mitigation: Only applies when there is no run-level error (`meta.error`); the `hasSuccessfulPayloadAfterLastError` check still catches cases where a non-error payload follows the error