### PR TITLE
fix(outbound): filter NO_REPLY/NO/None artifacts before channel delivery

### DIFF
--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -264,6 +264,10 @@ function normalizePayloadForChannelDelivery(
   const rawText = typeof payload.text === "string" ? payload.text : "";
   const normalizedText =
     channelId === "whatsapp" ? rawText.replace(/^(?:[ \t]*\r?\n)+/, "") : rawText;
+  const trimmedText = normalizedText.trim();
+  if (trimmedText === "NO_REPLY" || trimmedText === "NO" || trimmedText === "None") {
+    return null;
+  }
   if (!normalizedText.trim()) {
     if (!hasMedia && !hasChannelData) {
       return null;


### PR DESCRIPTION
Fixes #32403 - channel adapter leaks internal NO_REPLY/memory-flush artifacts as visible user messages.

This change adds explicit filtering in normalizePayloadForChannelDelivery():
1. Checks trimmed text for exact matches: NO_REPLY, NO, None
2. Returns null for those payloads, suppressing delivery entirely
3. Maintains existing behavior for all other payloads