### PR TITLE
feat(chrome-extension): group controlled tabs into red "OpenClaw" tab…

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -26,6 +26,9 @@ const tabBySession = new Map()
 /** @type {Map<string, number>} */
 const childSessionToTab = new Map()
 
+/** @type {number|null} */
+let openclawGroupId = null
+
 /** @type {Map<number, {resolve:(v:any)=>void, reject:(e:Error)=>void}>} */
 const pending = new Map()
 
@@ -107,6 +110,22 @@ async function rehydrateState() {
       })
       tabBySession.set(entry.sessionId, entry.tabId)
       setBadge(entry.tabId, 'on')
+    }
+    // Batch-group all rehydrated tabs into the OpenClaw group.
+    if (entries.length > 0) {
+      const tabIds = entries.map(e => e.tabId)
+      try {
+        const existing = await chrome.tabGroups.query({ title: 'OpenClaw' })
+        if (existing.length > 0) {
+          openclawGroupId = existing[0].id
+          await chrome.tabs.group({ tabIds, groupId: openclawGroupId })
+        } else {
+          openclawGroupId = await chrome.tabs.group({ tabIds })
+          await chrome.tabGroups.update(openclawGroupId, { title: 'OpenClaw', color: 'red' })
+        }
+      } catch {
+        // Grouping is cosmetic.
+      }
     }
     // Phase 2: validate asynchronously, remove dead tabs.
     for (const entry of entries) {
@@ -474,6 +493,43 @@ function getTabByTargetId(targetId) {
   return null
 }
 
+async function ensureTabInGroup(tabId) {
+  try {
+    if (openclawGroupId != null) {
+      try {
+        await chrome.tabs.group({ tabIds: [tabId], groupId: openclawGroupId })
+      } catch {
+        openclawGroupId = null
+      }
+    }
+    if (openclawGroupId == null) {
+      const existing = await chrome.tabGroups.query({ title: 'OpenClaw' })
+      if (existing.length > 0) {
+        openclawGroupId = existing[0].id
+        await chrome.tabs.group({ tabIds: [tabId], groupId: openclawGroupId })
+      }
+    }
+    if (openclawGroupId == null) {
+      openclawGroupId = await chrome.tabs.group({ tabIds: [tabId] })
+    }
+    // Chrome bug: update() writes data correctly but tab strip may not repaint
+    // until user interaction. No reliable workaround — keep the call so it works
+    // once Chrome fixes the rendering.
+    await chrome.tabGroups.update(openclawGroupId, { title: 'OpenClaw', color: 'red' })
+  } catch (e) {
+    // Grouping is cosmetic — never block attach.
+    console.warn('ensureTabInGroup failed:', e?.message || e)
+  }
+}
+
+async function removeTabFromGroup(tabId) {
+  try {
+    await chrome.tabs.ungroup(tabId)
+  } catch {
+    // Tab may already be closed or ungrouped.
+  }
+}
+
 async function attachTab(tabId, opts = {}) {
   const debuggee = { tabId }
   await chrome.debugger.attach(debuggee, '1.3')
@@ -512,6 +568,7 @@ async function attachTab(tabId, opts = {}) {
   }
 
   setBadge(tabId, 'on')
+  await ensureTabInGroup(tabId)
   await persistState()
 
   return { sessionId, targetId }
@@ -555,6 +612,7 @@ async function detachTab(tabId, reason) {
 
   if (tab?.sessionId) tabBySession.delete(tab.sessionId)
   tabs.delete(tabId)
+  await removeTabFromGroup(tabId)
 
   try {
     await chrome.debugger.detach({ tabId })
@@ -876,6 +934,7 @@ chrome.tabs.onReplaced.addListener((addedTabId, removedTabId) => void whenReady(
     }
   }
   setBadge(addedTabId, 'on')
+  void ensureTabInGroup(addedTabId)
   void persistState()
 }))
 

--- a/assets/chrome-extension/manifest.json
+++ b/assets/chrome-extension/manifest.json
@@ -9,7 +9,7 @@
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "permissions": ["debugger", "tabs", "activeTab", "storage", "alarms", "webNavigation"],
+  "permissions": ["debugger", "tabs", "tabGroups", "activeTab", "storage", "alarms", "webNavigation"],
   "host_permissions": ["http://127.0.0.1/*", "http://localhost/*"],
   "background": { "service_worker": "background.js", "type": "module" },
   "action": {


### PR DESCRIPTION
## Summary

  - **Problem:** OpenClaw-controlled tabs are visually indistinguishable from normal tabs, scattered across the tab strip
  - **Why it matters:** Users lose track of which tabs are under OpenClaw control, especially with many tabs open
  - **What changed:** Added `tabGroups` permission; on attach, tabs are grouped into a red "OpenClaw" Chrome Tab Group; on detach, tabs are ungrouped; on service worker rehydrate, all persisted tabs are batch-grouped in one IPC call
  - **What did NOT change (scope boundary):** Core attach/detach/relay logic untouched. Grouping is purely cosmetic — all errors are caught and never block any existing functionality

  ## Change Type (select all)

  - [ ] Bug fix
  - [x] Feature
  - [ ] Refactor
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [ ] API / contracts
  - [x] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - None

  ## User-visible / Behavior Changes

  - Attached tabs now appear inside a red "OpenClaw" Chrome Tab Group
  - Detaching a tab removes it from the group; detaching the last tab causes Chrome to auto-remove the group
  - Service worker restart preserves grouping via rehydrate

  ## Security Impact (required)

  - New permissions/capabilities? **Yes** — added `tabGroups` permission
  - Secrets/tokens handling changed? **No**
  - New/changed network calls? **No**
  - Command/tool execution surface changed? **No**
  - Data access scope changed? **No**
  - If any `Yes`, explain risk + mitigation: `tabGroups` is a low-privilege Chrome permission that only allows reading/modifying tab group metadata (title, color, collapsed state). It does not grant access to tab content, browsing
  history, or any user data.

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/container: Chrome (MV3 service worker)
  - Model/provider: N/A
  - Integration/channel: Chrome Extension
  - Relevant config: None

  ### Steps

  1. Load the modified extension via `chrome://extensions` → Developer Mode → Load Unpacked
  2. Click the OpenClaw icon to attach a tab
  3. Attach a second tab
  4. Detach one tab, then detach the last tab

  ### Expected

  - Step 2: Red "OpenClaw" tab group appears containing the tab
  - Step 3: Second tab joins the same group
  - Step 4: Tab leaves group; last detach causes group to disappear

  ### Actual

  - Grouping works correctly. Known Chrome rendering bug: on first group creation, title/color may not visually render until user clicks the group chip. The data is correctly written via `tabGroups.update()` — this is a Chrome tab strip
  repaint issue, not an extension bug.

  ## Evidence

  - [x] Trace/log snippets — `console.warn` in catch block confirms no errors on normal/incognito attach; `chrome.tabGroups.query()` in SW DevTools confirms title/color data is written correctly

  ## Human Verification (required)

  - **Verified scenarios:** Single tab attach/detach, multi-tab grouping, detach last tab (group auto-removed), service worker restart + rehydrate restores group
  - **Edge cases checked:** Incognito mode (grouping silently skipped, core functionality unaffected), `Target.createTarget` via relay (new tab enters group), `onReplaced` tab swap (new tab re-grouped)
  - **What you did not verify:** Behavior on Chrome versions older than 120; behavior when user manually moves tab out of group mid-session

  ## Compatibility / Migration

  - Backward compatible? **Yes**
  - Config/env changes? **No**
  - Migration needed? **No**

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: Remove `tabGroups` from `manifest.json` permissions and revert the 7 insertion points in `background.js`
  - Files/config to restore: `assets/chrome-extension/manifest.json`, `assets/chrome-extension/background.js`
  - Known bad symptoms reviewers should watch for: `ensureTabInGroup failed:` warnings in SW console indicate grouping API issues; should never affect attach/detach since all grouping code is wrapped in try/catch

  ## Risks and Mitigations

  - **Risk:** Chrome rendering bug causes title/color not to display on first group creation
    - **Mitigation:** `tabGroups.update()` correctly writes the data; display fixes itself on any user interaction with the group chip. This is a known Chrome issue, not solvable from extension side.
  - **Risk:** `chrome.tabs.group()` throws in incognito mode
    - **Mitigation:** Outer try/catch ensures grouping failure never blocks attach/detach. Logged via `console.warn` for diagnostics.
