### PR TITLE
plugin-sdk: Expose callGatewayTool, session APIs and Type

### DIFF
--- a/src/plugin-sdk/core.ts
+++ b/src/plugin-sdk/core.ts
@@ -24,7 +24,7 @@ import { createScopedDmSecurityResolver } from "./channel-config-helpers.js";
 import { createTextPairingAdapter } from "./channel-pairing.js";
 import { createAttachedChannelResultAdapter } from "./channel-send-result.js";
 import { definePluginEntry } from "./plugin-entry.js";
-
+export { Type } from "@sinclair/typebox";
 export type {
   AnyAgentTool,
   MediaUnderstandingProviderPlugin,
@@ -118,6 +118,9 @@ export {
 } from "../infra/secret-file.js";
 export type { SecretFileReadOptions, SecretFileReadResult } from "../infra/secret-file.js";
 
+export { callGatewayTool, readGatewayCallOptions } from "../agents/tools/gateway.js";
+export type { GatewayCallOptions } from "../agents/tools/gateway.js";
+
 export { resolveGatewayBindUrl } from "../shared/gateway-bind-url.js";
 export type { GatewayBindUrlResult } from "../shared/gateway-bind-url.js";
 export { resolveGatewayPort } from "../config/paths.js";
@@ -134,6 +137,9 @@ export {
   type RoutePeerKind,
 } from "../routing/resolve-route.js";
 export { resolveThreadSessionKeys } from "../routing/session-key.js";
+export { parseAgentSessionKey } from "../routing/session-key.js";
+export type { ParsedAgentSessionKey } from "../routing/session-key.js";
+export { extractDeliveryInfo } from "../config/sessions.js";
 
 export type ChannelOutboundSessionRouteParams = Parameters<
   NonNullable<ChannelMessagingAdapter["resolveOutboundSessionRoute"]>


### PR DESCRIPTION
## Summary

- **Problem**: Plugin authors who need to work with agent session keys, session delivery metadata, or gateway calls currently have to depend on internal modules or re-implement logic that already exists in core.
- **Why it matters**: Depending on internal paths is brittle/impossible and forces plugins to duplicate behavior (and bugs), while ad-hoc gateway calls can bypass least-privilege or safe URL handling.
- **What changed**: The `openclaw/plugin-sdk` now re-exports `parseAgentSessionKey`, `extractDeliveryInfo`, `callGatewayTool`, and the `Type` helper from `@sinclair/typebox`, exposing the same primitives core uses for session handling, delivery info, and gateway calls.
- **Why including Type?**: Because it would other require to re-declare and install the dependency in the plugin, or to emulate its behaviour.
- **What did NOT change (scope boundary)**: No changes were made to the implementations of these helpers, any existing call sites, gateway methods, session store behavior, or configuration formats.

## Change Type (select all)

- [ ] Bug fix  
- [x] Feature  
- [ ] Refactor  
- [ ] Docs  
- [ ] Security hardening  
- [ ] Chore/infra  

## Scope (select all touched areas)

- [x] Gateway / orchestration  
- [x] Skills / tool execution  
- [ ] Auth / tokens  
- [ ] Memory / storage  
- [x] Integrations  
- [ ] API / contracts  
- [ ] UI / DX  
- [ ] CI/CD / infra  
- [x] Plugin SDK

## Linked Issue/PR

N/A

## User-visible / Behavior Changes

- **None**. This is a pure API-surface expansion for the plugin SDK.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`): **No**  
- Secrets/tokens handling changed? (`Yes/No`): **No**  
- New/changed network calls? (`Yes/No`): **No** (reuses existing gateway client path)  
- Command/tool execution surface changed? (`Yes/No`): **No** (no new gateway methods; just exposes a helper)  
- Data access scope changed? (`Yes/No`): **No**  

## Repro + Verification

### Environment

- OS: `linux 6.14.0-37-generic`  
- Runtime/container: `Node 22+` (project baseline)  
- Model/provider: Not applicable (build-time/plugin SDK change only)  
- Integration/channel (if any): Not applicable  
- Relevant config (redacted): Standard local OpenClaw config with default gateway settings.

### Steps

Create an extension with:

```
import {
  callGatewayTool,
  extractDeliveryInfo,
  parseAgentSessionKey,
  type OpenClawPluginToolContext,
} from "openclaw/plugin-sdk";
```

### Expected

The libraries are exposed by the plugin-sdk.

### Actual

The libraries are not exposed.

## Evidence

- For this export-only change, the primary evidence is:
  - Existing unit tests for:
    - `parseAgentSessionKey` and related helpers in `src/sessions/session-key-utils.ts` / `src/routing/session-key.test.ts`.
    - `extractDeliveryInfo` in `src/config/sessions/delivery-info.test.ts`.
    - `callGatewayTool` usage via `src/agents/openclaw-gateway-tool.test.ts` and `src/agents/bash-tools.exec.approval-id.test.ts`.
  - Successful local/CI runs of `pnpm build`, `pnpm check`, and `pnpm test` (to be confirmed when the PR runs in CI).

## Human Verification (required)

- All tests passed.
- My [Custom plugin](https://github.com/FMCorz/openclaw-agent-cron/) ran successfully.

## Compatibility / Migration

- Backward compatible? (`Yes/No`): **Yes** — no existing exports or behaviors are changed.
- Config/env changes? (`Yes/No`): **No**.
- Migration needed? (`Yes/No`): **No**.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert the additional exports in `src/plugin-sdk/index.ts` to remove them from the public SDK surface.
- Files/config to restore:
  - `src/plugin-sdk/index.ts` only.

## Risks and Mitigations

- **Risk**: Exposing these helpers and `Type` via `openclaw/plugin-sdk` effectively promotes them to public, supported APIs, making future refactors of session key handling, delivery metadata lookup, and gateway calling more constrained.
  - **Mitigation**: These helpers are already the canonical utilities used across the codebase and backed by tests; their behavior is already de facto stable. If we need to change behavior, we can add new exports while preserving the old ones for a deprecation window.
- **Risk**: Plugins could call powerful gateway methods via `callGatewayTool**.
  - **Mitigation**: Plugins can already run commands and talk to the gateway (e.g. via existing tools or direct use of internal modules). This export only gives them a supported, canonical path. `callGatewayTool` still enforces least-privilege scopes via `resolveLeastPrivilegeOperatorScopesForMethod` and uses the same gateway auth and config as today, so no new capability or elevated permissions are introduced.

---

**AI-assisted note**

- This PR was drafted with AI assistance (Cursor agent).