### PR TITLE
fix(android): open external Canvas links in system browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Android/Canvas WebView external links: open user-triggered cross-origin HTTP(S) main-frame navigations in the system browser (while keeping same-origin/in-canvas navigations inside WebView), so tapping docs/help links no longer traps users away from canvas content. Fixes #32319. Thanks @davelutztx.
 - OpenAI/Responses WebSocket tool-call id hygiene: normalize blank/whitespace streamed tool-call ids before persistence, and block empty `function_call_output.call_id` payloads in the WS conversion path to avoid OpenAI 400 errors (`Invalid 'input[n].call_id': empty string`), with regression coverage for both inbound stream normalization and outbound payload guards.
 - Gateway/Control UI basePath webhook passthrough: let non-read methods under configured `controlUiBasePath` fall through to plugin routes (instead of returning Control UI 405), restoring webhook handlers behind basePath mounts. (#32311) Thanks @ademczuk.
 - Models/config env propagation: apply `config.env.vars` before implicit provider discovery in models bootstrap so config-scoped credentials are visible to implicit provider resolution paths. (#32295) Thanks @hsiaoa.

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/CanvasScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/CanvasScreen.kt
@@ -101,15 +101,20 @@ fun CanvasScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
               view: WebView,
               request: WebResourceRequest,
             ): Boolean {
-              if (!request.isForMainFrame || !request.hasGesture()) return false
+              if (!request.isForMainFrame) return false
+              val userInitiatedOrRedirect = request.hasGesture() || request.isRedirect
+              if (!userInitiatedOrRedirect) return false
               val targetUrl = request.url?.toString().orEmpty()
               if (!shouldOpenCanvasNavigationInExternalBrowser(view.url, targetUrl)) return false
               return try {
                 val intent = Intent(Intent.ACTION_VIEW, request.url).addCategory(Intent.CATEGORY_BROWSABLE)
                 view.context.startActivity(intent)
                 true
-              } catch (_: Throwable) {
-                false
+              } catch (error: Throwable) {
+                if (isDebuggable) {
+                  Log.w("OpenClawWebView", "external navigation launch failed for $targetUrl", error)
+                }
+                true
               }
             }
 

--- a/apps/android/app/src/main/java/ai/openclaw/android/ui/CanvasScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/ui/CanvasScreen.kt
@@ -1,6 +1,7 @@
 package ai.openclaw.android.ui
 
 import android.annotation.SuppressLint
+import android.content.Intent
 import android.util.Log
 import android.view.View
 import android.webkit.ConsoleMessage
@@ -22,6 +23,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewFeature
 import ai.openclaw.android.MainViewModel
+import java.net.URI
 
 @SuppressLint("SetJavaScriptEnabled")
 @Composable
@@ -95,6 +97,22 @@ fun CanvasScreen(viewModel: MainViewModel, modifier: Modifier = Modifier) {
               viewModel.canvas.onPageFinished()
             }
 
+            override fun shouldOverrideUrlLoading(
+              view: WebView,
+              request: WebResourceRequest,
+            ): Boolean {
+              if (!request.isForMainFrame || !request.hasGesture()) return false
+              val targetUrl = request.url?.toString().orEmpty()
+              if (!shouldOpenCanvasNavigationInExternalBrowser(view.url, targetUrl)) return false
+              return try {
+                val intent = Intent(Intent.ACTION_VIEW, request.url).addCategory(Intent.CATEGORY_BROWSABLE)
+                view.context.startActivity(intent)
+                true
+              } catch (_: Throwable) {
+                false
+              }
+            }
+
             override fun onRenderProcessGone(
               view: WebView,
               detail: android.webkit.RenderProcessGoneDetail,
@@ -134,6 +152,44 @@ private fun disableForceDarkIfSupported(settings: WebSettings) {
   if (!WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) return
   @Suppress("DEPRECATION")
   WebSettingsCompat.setForceDark(settings, WebSettingsCompat.FORCE_DARK_OFF)
+}
+
+internal fun shouldOpenCanvasNavigationInExternalBrowser(currentUrl: String?, targetUrl: String): Boolean {
+  val target = parseUriOrNull(targetUrl) ?: return false
+  if (!target.isHttpLike()) return false
+
+  val current = parseUriOrNull(currentUrl) ?: return false
+  if (!current.isHttpLike()) return true
+
+  return current.originKey() != target.originKey()
+}
+
+private fun parseUriOrNull(raw: String?): URI? {
+  val value = raw?.trim().orEmpty()
+  if (value.isEmpty()) return null
+  return try {
+    URI(value)
+  } catch (_: Throwable) {
+    null
+  }
+}
+
+private fun URI.isHttpLike(): Boolean {
+  val normalized = scheme?.lowercase() ?: return false
+  return normalized == "http" || normalized == "https"
+}
+
+private fun URI.originKey(): String {
+  val normalizedScheme = scheme?.lowercase().orEmpty()
+  val normalizedHost = host?.lowercase().orEmpty()
+  val normalizedPort =
+    when {
+      port >= 0 -> port
+      normalizedScheme == "http" -> 80
+      normalizedScheme == "https" -> 443
+      else -> -1
+    }
+  return "$normalizedScheme|$normalizedHost|$normalizedPort"
 }
 
 private class CanvasA2UIActionBridge(private val onMessage: (String) -> Unit) {

--- a/apps/android/app/src/test/java/ai/openclaw/android/ui/CanvasScreenNavigationPolicyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/ui/CanvasScreenNavigationPolicyTest.kt
@@ -1,0 +1,47 @@
+package ai.openclaw.android.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CanvasScreenNavigationPolicyTest {
+  @Test
+  fun keepsSameOriginHttpNavigationInsideCanvas() {
+    assertFalse(
+      shouldOpenCanvasNavigationInExternalBrowser(
+        currentUrl = "https://canvas.example/page",
+        targetUrl = "https://canvas.example/docs",
+      ),
+    )
+  }
+
+  @Test
+  fun opensCrossOriginHttpNavigationInExternalBrowser() {
+    assertTrue(
+      shouldOpenCanvasNavigationInExternalBrowser(
+        currentUrl = "https://canvas.example/page",
+        targetUrl = "https://docs.example/help",
+      ),
+    )
+  }
+
+  @Test
+  fun opensHttpNavigationFromFileCanvasInExternalBrowser() {
+    assertTrue(
+      shouldOpenCanvasNavigationInExternalBrowser(
+        currentUrl = "file:///android_asset/CanvasScaffold/scaffold.html",
+        targetUrl = "https://example.com",
+      ),
+    )
+  }
+
+  @Test
+  fun keepsNonHttpTargetsInsideCanvas() {
+    assertFalse(
+      shouldOpenCanvasNavigationInExternalBrowser(
+        currentUrl = "https://canvas.example",
+        targetUrl = "javascript:void(0)",
+      ),
+    )
+  }
+}

--- a/apps/android/app/src/test/java/ai/openclaw/android/ui/CanvasScreenNavigationPolicyTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/android/ui/CanvasScreenNavigationPolicyTest.kt
@@ -26,6 +26,16 @@ class CanvasScreenNavigationPolicyTest {
   }
 
   @Test
+  fun opensCrossOriginMixedHttpSchemeNavigationInExternalBrowser() {
+    assertTrue(
+      shouldOpenCanvasNavigationInExternalBrowser(
+        currentUrl = "https://canvas.example/page",
+        targetUrl = "http://canvas.example/page",
+      ),
+    )
+  }
+
+  @Test
   fun opensHttpNavigationFromFileCanvasInExternalBrowser() {
     assertTrue(
       shouldOpenCanvasNavigationInExternalBrowser(
@@ -41,6 +51,26 @@ class CanvasScreenNavigationPolicyTest {
       shouldOpenCanvasNavigationInExternalBrowser(
         currentUrl = "https://canvas.example",
         targetUrl = "javascript:void(0)",
+      ),
+    )
+  }
+
+  @Test
+  fun keepsEquivalentDefaultHttpsPortNavigationInsideCanvas() {
+    assertFalse(
+      shouldOpenCanvasNavigationInExternalBrowser(
+        currentUrl = "https://canvas.example/page",
+        targetUrl = "https://canvas.example:443/help",
+      ),
+    )
+  }
+
+  @Test
+  fun keepsNavigationInsideCanvasWhenCurrentUrlIsMissing() {
+    assertFalse(
+      shouldOpenCanvasNavigationInExternalBrowser(
+        currentUrl = null,
+        targetUrl = "https://example.com",
       ),
     )
   }


### PR DESCRIPTION
## Summary
- fix Android Canvas WebView navigation so user-triggered cross-origin HTTP(S) main-frame links open in the system browser instead of replacing the in-app canvas page
- keep same-origin navigation in WebView, and keep non-HTTP(S) targets in WebView
- add unit tests for navigation policy decisions
- add changelog entry (Fixes #32319)

## Testing
- `bunx oxfmt --check apps/android/app/src/main/java/ai/openclaw/android/ui/CanvasScreen.kt apps/android/app/src/test/java/ai/openclaw/android/ui/CanvasScreenNavigationPolicyTest.kt CHANGELOG.md`
- `./gradlew :app:testDebugUnitTest --tests ai.openclaw.android.ui.CanvasScreenNavigationPolicyTest` *(fails locally: Java Runtime not available in this environment)*
