### PR TITLE
docs(showcase): add Telegram /call community addon

### DIFF
--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -334,6 +334,12 @@ Watches company Slack channel, responds helpfully, and forwards notifications to
 Multi-lingual audio transcription via OpenRouter (Gemini, etc). Available on ClawHub.
 </Card>
 
+<Card title="Telegram /call Addon" icon="phone-volume" href="https://github.com/roshanis/openclaw-telegram-call-addon">
+  **@roshanis** • `telegram` `voice` `plugin`
+
+  Community addon that adds a `/call` command in Telegram and forwards to a Pipecat-compatible voice backend.
+</Card>
+
 </CardGroup>
 
 ## 🏗️ Infrastructure & Deployment

--- a/docs/start/showcase.md
+++ b/docs/start/showcase.md
@@ -337,7 +337,7 @@ Multi-lingual audio transcription via OpenRouter (Gemini, etc). Available on Cla
 <Card title="Telegram /call Addon" icon="phone-volume" href="https://github.com/roshanis/openclaw-telegram-call-addon">
   **@roshanis** • `telegram` `voice` `plugin`
 
-  Community addon that adds a `/call` command in Telegram and forwards to a Pipecat-compatible voice backend.
+Community plugin that adds a Telegram `/call` command and forwards calls to a Pipecat-compatible voice backend.
 </Card>
 
 </CardGroup>


### PR DESCRIPTION
## Summary
- add `openclaw-telegram-call-addon` to the Voice & Phone section in the community showcase
- include repo link and one-line description for Telegram `/call` workflow

## Why
- highlights an OpenClaw-focused community integration for phone workflows triggered from Telegram

## Scope
- docs only (`docs/start/showcase.md`)
- no code/runtime changes
- no image/assets added
