### PR TITLE
fix(ui): keep pasted image attachments when data URL omits mime

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -570,6 +570,28 @@ describe("sendChatMessage", () => {
       },
     ]);
   });
+
+  it("drops non-base64 data URLs from attachment payloads", async () => {
+    const request = vi.fn().mockResolvedValue({});
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    await sendChatMessage(state, "", [
+      {
+        id: "att-1",
+        mimeType: "image/png",
+        dataUrl: "data:text/plain,hello",
+      },
+    ]);
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const payload = request.mock.calls[0]?.[1] as {
+      attachments?: Array<{ mimeType: string; content: string; type: string }>;
+    };
+    expect(payload.attachments).toEqual([]);
+  });
 });
 
 describe("loadChatHistory", () => {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { handleChatEvent, loadChatHistory, type ChatEventPayload, type ChatState } from "./chat.ts";
+import {
+  handleChatEvent,
+  loadChatHistory,
+  sendChatMessage,
+  type ChatEventPayload,
+  type ChatState,
+} from "./chat.ts";
 
 function createState(overrides: Partial<ChatState> = {}): ChatState {
   return {
@@ -533,6 +539,36 @@ describe("loadChatHistory", () => {
 
     // text takes precedence — "real reply" is NOT silent, so message is kept.
     expect(state.chatMessages).toHaveLength(1);
+  });
+});
+
+describe("sendChatMessage", () => {
+  it("keeps pasted image attachments when data URL has no mime prefix", async () => {
+    const request = vi.fn().mockResolvedValue({});
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+    });
+
+    await sendChatMessage(state, "", [
+      {
+        id: "att-1",
+        mimeType: "image/png",
+        dataUrl: "data:;base64,aGVsbG8=",
+      },
+    ]);
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const payload = request.mock.calls[0]?.[1] as {
+      attachments?: Array<{ mimeType: string; content: string; type: string }>;
+    };
+    expect(payload.attachments).toEqual([
+      {
+        type: "image",
+        mimeType: "image/png",
+        content: "aGVsbG8=",
+      },
+    ]);
   });
 });
 

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -74,12 +74,27 @@ export async function loadChatHistory(state: ChatState) {
   }
 }
 
-function dataUrlToBase64(dataUrl: string): { content: string; mimeType: string } | null {
-  const match = /^data:([^;]+);base64,(.+)$/.exec(dataUrl);
+function dataUrlToBase64(
+  dataUrl: string,
+  fallbackMimeType?: string,
+): { content: string; mimeType: string } | null {
+  const match = /^data:([^,]*),(.+)$/.exec(dataUrl);
   if (!match) {
     return null;
   }
-  return { mimeType: match[1], content: match[2] };
+  const metadata = match[1] ?? "";
+  const content = match[2] ?? "";
+  if (!metadata.toLowerCase().includes(";base64")) {
+    return null;
+  }
+  const metadataParts = metadata.split(";");
+  const metadataMime = metadataParts[0]?.trim() ?? "";
+  const trimmedFallback = fallbackMimeType?.trim() ?? "";
+  const mimeType = metadataMime || trimmedFallback || "image/png";
+  if (!content) {
+    return null;
+  }
+  return { mimeType, content };
 }
 
 type AssistantMessageNormalizationOptions = {
@@ -182,7 +197,7 @@ export async function sendChatMessage(
   const apiAttachments = hasAttachments
     ? attachments
         .map((att) => {
-          const parsed = dataUrlToBase64(att.dataUrl);
+          const parsed = dataUrlToBase64(att.dataUrl, att.mimeType);
           if (!parsed) {
             return null;
           }

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -78,22 +78,14 @@ function dataUrlToBase64(
   dataUrl: string,
   fallbackMimeType?: string,
 ): { content: string; mimeType: string } | null {
-  const match = /^data:([^,]*),(.+)$/.exec(dataUrl);
+  const match = /^data:([^;,]*)(?:;[^,]*)?;base64,(.+)$/i.exec(dataUrl);
   if (!match) {
     return null;
   }
-  const metadata = match[1] ?? "";
   const content = match[2] ?? "";
-  if (!metadata.toLowerCase().includes(";base64")) {
-    return null;
-  }
-  const metadataParts = metadata.split(";");
-  const metadataMime = metadataParts[0]?.trim() ?? "";
+  const metadataMime = (match[1] ?? "").trim();
   const trimmedFallback = fallbackMimeType?.trim() ?? "";
   const mimeType = metadataMime || trimmedFallback || "image/png";
-  if (!content) {
-    return null;
-  }
   return { mimeType, content };
 }
 


### PR DESCRIPTION
## Summary

- Problem: Pasted images in Control UI can arrive as `data:;base64,...`, and UI attachment serialization currently drops those attachments.
- Why it matters: attachment-only sends become empty-message sends and trigger `I didn't receive any text in your message. Please resend or add a caption.`
- What changed: relaxed data URL parsing to accept empty mime metadata, require `;base64`, and fall back to attachment mime (or `image/png`) when missing.
- What did NOT change (scope boundary): no gateway/server attachment parsing changes, no channel-specific delivery changes, no config/schema changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32474
- Related #32471

## User-visible / Behavior Changes

- Control UI now keeps pasted image attachments even when the browser clipboard produces `data:;base64,...` without an explicit mime prefix.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS / Linux (logic-level repro)
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): Control UI (webchat)
- Relevant config (redacted): default Control UI chat send path

### Steps

1. Create a chat attachment payload where the pasted image data URL is `data:;base64,aGVsbG8=` and `mimeType` is `image/png`.
2. Call `sendChatMessage(state, "", [attachment])`.
3. Inspect outbound `chat.send` request payload.

### Expected

- Outbound `attachments` includes one image with `mimeType: image/png` and base64 `content`.

### Actual

- Before fix, outbound `attachments` became `[]`, so the send had no text and no usable media.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced pre-fix behavior with `pnpm -s tsx -e '...sendChatMessage(...)...'` and confirmed payload `attachments: []`.
  - Added regression test in `ui/src/ui/controllers/chat.test.ts` and confirmed it passes after fix.
- Edge cases checked:
  - Parser still requires `;base64` metadata.
  - Missing mime now falls back safely instead of dropping the image.
- What you did **not** verify:
  - Manual browser E2E run against a live gateway instance.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `ui: preserve pasted image attachments without data-url mime`.
- Files/config to restore: `ui/src/ui/controllers/chat.ts`, `ui/src/ui/controllers/chat.test.ts`.
- Known bad symptoms reviewers should watch for: malformed non-base64 data URLs should remain rejected.

## Risks and Mitigations

- Risk: accepting broader data URL metadata could permit malformed payloads.
  - Mitigation: parser still requires `;base64`, non-matching data URLs are dropped, and tests cover the intended fallback path.
