### PR TITLE
[Feishu] 群消息 GroupSubject 传递实际群名而非 chat_id

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -13,6 +13,7 @@ import {
 } from "openclaw/plugin-sdk";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { getChatInfo } from "./chat.js";
 import { tryRecordMessage, tryRecordMessagePersistent } from "./dedup.js";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
 import { normalizeFeishuExternalKey } from "./external-keys.js";
@@ -1208,6 +1209,20 @@ export async function handleFeishuMessage(params: {
           }))
         : undefined;
 
+    // Resolve group name for better session labeling (best-effort)
+    let groupSubject: string | undefined = isGroup ? ctx.chatId : undefined;
+    if (isGroup && (feishuCfg?.resolveGroupNames ?? true)) {
+      try {
+        const client = createFeishuClient(account);
+        const chatInfo = await getChatInfo(client, ctx.chatId);
+        if (chatInfo?.name) {
+          groupSubject = chatInfo.name;
+        }
+      } catch {
+        // Fall back to chatId on error
+      }
+    }
+
     const ctxPayload = core.channel.reply.finalizeInboundContext({
       Body: combinedBody,
       BodyForAgent: messageBody,
@@ -1223,7 +1238,7 @@ export async function handleFeishuMessage(params: {
       SessionKey: route.sessionKey,
       AccountId: route.accountId,
       ChatType: isGroup ? "group" : "direct",
-      GroupSubject: isGroup ? ctx.chatId : undefined,
+      GroupSubject: groupSubject,
       SenderName: ctx.senderName ?? ctx.senderOpenId,
       SenderId: ctx.senderOpenId,
       Provider: "feishu" as const,

--- a/extensions/feishu/src/chat.ts
+++ b/extensions/feishu/src/chat.ts
@@ -12,7 +12,7 @@ function json(data: unknown) {
   };
 }
 
-async function getChatInfo(client: Lark.Client, chatId: string) {
+export async function getChatInfo(client: Lark.Client, chatId: string) {
   const res = await client.im.chat.get({ path: { chat_id: chatId } });
   if (res.code !== 0) {
     throw new Error(res.msg);


### PR DESCRIPTION
## 问题描述

当前飞书群消息的 `GroupSubject` 传递的是 `chat_id`（如 `oc_xxx`），而不是实际的群名称。这导致 OpenClaw 会话列表显示的是 ID 而非有意义的群名。

## 修复内容

1. **导出 getChatInfo 函数** (`chat.ts`)
   - 将 `getChatInfo` 函数从私有改为公开导出

2. **获取群名** (`bot.ts`)
   - 在处理群消息时调用 `getChatInfo` API 获取群信息
   - 将 `GroupSubject` 设置为实际的群名
   - 获取失败时回退到 `chatId`

3. **新增配置项**
   - `resolveGroupNames`：控制是否解析群名（默认 `true`）
   - 可通过设置 `channels.feishu.resolveGroupNames: false` 禁用以节省 API 配额

## 修改文件

- `extensions/feishu/src/chat.ts` - 导出 getChatInfo 函数
- `extensions/feishu/src/bot.ts` - 添加群名获取逻辑

## 测试

- 群消息会话将显示群名而非 chat_id
- 获取群名失败时回退到 chat_id（不影响消息处理）

Closes #32472