### PR TITLE
fix(slack): emit manifest JSON unframed for copy/paste

### DIFF
--- a/src/channels/plugins/onboarding/slack.test.ts
+++ b/src/channels/plugins/onboarding/slack.test.ts
@@ -53,9 +53,19 @@ describe("noteSlackTokenHelp", () => {
     const prompter = createBasePrompter(async (message, title) => {
       notes.push({ message, title });
     });
+    const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    const ttyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+    Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
 
-    await noteSlackTokenHelp(prompter, "OpenClaw");
+    try {
+      await noteSlackTokenHelp(prompter, "OpenClaw");
+    } finally {
+      if (ttyDescriptor) {
+        Object.defineProperty(process.stdout, "isTTY", ttyDescriptor);
+      }
+    }
 
+    expect(writeSpy).not.toHaveBeenCalled();
     expect(notes).toHaveLength(2);
     expect(notes[1]?.message.startsWith("Manifest (JSON):\n")).toBe(true);
     const manifest = notes[1]?.message.replace("Manifest (JSON):\n", "") ?? "";

--- a/src/channels/plugins/onboarding/slack.test.ts
+++ b/src/channels/plugins/onboarding/slack.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WizardPrompter } from "../../../wizard/prompts.js";
 import { noteSlackTokenHelp } from "./slack.js";
 
 type NoteRecord = { message: string; title?: string };
+const originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 
 function createBasePrompter(note: WizardPrompter["note"]): WizardPrompter {
   return {
@@ -21,25 +22,30 @@ function createBasePrompter(note: WizardPrompter["note"]): WizardPrompter {
 }
 
 describe("noteSlackTokenHelp", () => {
-  it("emits manifest through codeBlock when prompter supports raw blocks", async () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalStdoutIsTTY) {
+      Object.defineProperty(process.stdout, "isTTY", originalStdoutIsTTY);
+    } else {
+      Reflect.deleteProperty(process.stdout, "isTTY");
+    }
+  });
+
+  it("prints manifest as raw JSON on TTY for copy/paste", async () => {
     const notes: NoteRecord[] = [];
-    const blocks: Array<{ code: string; language?: string; title?: string }> = [];
     const prompter = createBasePrompter(async (message, title) => {
       notes.push({ message, title });
     });
-    prompter.codeBlock = async (params) => {
-      blocks.push(params);
-    };
+    const writeSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
 
     await noteSlackTokenHelp(prompter, "Ops Bot");
 
     expect(notes).toHaveLength(1);
     expect(notes[0]?.message).toContain("use the JSON block shown after this note");
     expect(notes[0]?.message).not.toContain('"display_information"');
-    expect(blocks).toHaveLength(1);
-    expect(blocks[0]?.title).toBe("Manifest (JSON)");
-    expect(blocks[0]?.language).toBe("json");
-    const parsed = JSON.parse(blocks[0]?.code ?? "{}") as {
+    const writes = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join("");
+    const parsed = JSON.parse(writes) as {
       display_information?: { name?: string };
       features?: { slash_commands?: Array<{ command?: string }> };
     };
@@ -47,11 +53,12 @@ describe("noteSlackTokenHelp", () => {
     expect(parsed.features?.slash_commands?.[0]?.command).toBe("/openclaw");
   });
 
-  it("falls back to note-only output when codeBlock is unavailable", async () => {
+  it("falls back to note output for non-TTY prompters", async () => {
     const notes: NoteRecord[] = [];
     const prompter = createBasePrompter(async (message, title) => {
       notes.push({ message, title });
     });
+    Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
 
     await noteSlackTokenHelp(prompter, "OpenClaw");
 

--- a/src/channels/plugins/onboarding/slack.test.ts
+++ b/src/channels/plugins/onboarding/slack.test.ts
@@ -3,7 +3,6 @@ import type { WizardPrompter } from "../../../wizard/prompts.js";
 import { noteSlackTokenHelp } from "./slack.js";
 
 type NoteRecord = { message: string; title?: string };
-const originalStdoutIsTTY = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
 
 function createBasePrompter(note: WizardPrompter["note"]): WizardPrompter {
   return {
@@ -24,28 +23,24 @@ function createBasePrompter(note: WizardPrompter["note"]): WizardPrompter {
 describe("noteSlackTokenHelp", () => {
   afterEach(() => {
     vi.restoreAllMocks();
-    if (originalStdoutIsTTY) {
-      Object.defineProperty(process.stdout, "isTTY", originalStdoutIsTTY);
-    } else {
-      Reflect.deleteProperty(process.stdout, "isTTY");
-    }
   });
 
-  it("prints manifest as raw JSON on TTY for copy/paste", async () => {
+  it("prints manifest as raw JSON when prompter supports raw output", async () => {
     const notes: NoteRecord[] = [];
     const prompter = createBasePrompter(async (message, title) => {
       notes.push({ message, title });
     });
-    const writeSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
-    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    const rawSpy = vi.fn(async () => {});
+    prompter.raw = rawSpy;
 
     await noteSlackTokenHelp(prompter, "Ops Bot");
 
     expect(notes).toHaveLength(1);
     expect(notes[0]?.message).toContain("use the JSON block shown after this note");
     expect(notes[0]?.message).not.toContain('"display_information"');
-    const writes = writeSpy.mock.calls.map(([chunk]) => String(chunk)).join("");
-    const parsed = JSON.parse(writes) as {
+    expect(rawSpy).toHaveBeenCalledTimes(1);
+    const rawManifest = String(rawSpy.mock.calls[0]?.[0] ?? "");
+    const parsed = JSON.parse(rawManifest) as {
       display_information?: { name?: string };
       features?: { slash_commands?: Array<{ command?: string }> };
     };
@@ -58,13 +53,10 @@ describe("noteSlackTokenHelp", () => {
     const prompter = createBasePrompter(async (message, title) => {
       notes.push({ message, title });
     });
-    const writeSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
-    Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
 
     await noteSlackTokenHelp(prompter, "OpenClaw");
 
     expect(notes).toHaveLength(2);
-    expect(writeSpy).not.toHaveBeenCalled();
     expect(notes[1]?.message.startsWith("Manifest (JSON):\n")).toBe(true);
     const manifest = notes[1]?.message.replace("Manifest (JSON):\n", "") ?? "";
     const parsed = JSON.parse(manifest) as {

--- a/src/channels/plugins/onboarding/slack.test.ts
+++ b/src/channels/plugins/onboarding/slack.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { WizardPrompter } from "../../../wizard/prompts.js";
+import { noteSlackTokenHelp } from "./slack.js";
+
+type NoteRecord = { message: string; title?: string };
+
+function createBasePrompter(note: WizardPrompter["note"]): WizardPrompter {
+  return {
+    intro: async () => {},
+    outro: async () => {},
+    note,
+    select: async <T>() => "" as T,
+    multiselect: async <T>() => [] as T[],
+    text: async () => "",
+    confirm: async () => true,
+    progress: () => ({
+      update: () => {},
+      stop: () => {},
+    }),
+  };
+}
+
+describe("noteSlackTokenHelp", () => {
+  it("emits manifest through codeBlock when prompter supports raw blocks", async () => {
+    const notes: NoteRecord[] = [];
+    const blocks: Array<{ code: string; language?: string; title?: string }> = [];
+    const prompter = createBasePrompter(async (message, title) => {
+      notes.push({ message, title });
+    });
+    prompter.codeBlock = async (params) => {
+      blocks.push(params);
+    };
+
+    await noteSlackTokenHelp(prompter, "Ops Bot");
+
+    expect(notes).toHaveLength(1);
+    expect(notes[0]?.message).toContain("use the JSON block shown after this note");
+    expect(notes[0]?.message).not.toContain('"display_information"');
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.title).toBe("Manifest (JSON)");
+    expect(blocks[0]?.language).toBe("json");
+    const parsed = JSON.parse(blocks[0]?.code ?? "{}") as {
+      display_information?: { name?: string };
+      features?: { slash_commands?: Array<{ command?: string }> };
+    };
+    expect(parsed.display_information?.name).toBe("Ops Bot");
+    expect(parsed.features?.slash_commands?.[0]?.command).toBe("/openclaw");
+  });
+
+  it("falls back to note-only output when codeBlock is unavailable", async () => {
+    const notes: NoteRecord[] = [];
+    const prompter = createBasePrompter(async (message, title) => {
+      notes.push({ message, title });
+    });
+
+    await noteSlackTokenHelp(prompter, "OpenClaw");
+
+    expect(notes).toHaveLength(2);
+    expect(notes[1]?.message.startsWith("Manifest (JSON):\n")).toBe(true);
+    const manifest = notes[1]?.message.replace("Manifest (JSON):\n", "") ?? "";
+    const parsed = JSON.parse(manifest) as {
+      display_information?: { name?: string };
+    };
+    expect(parsed.display_information?.name).toBe("OpenClaw");
+  });
+});

--- a/src/channels/plugins/onboarding/slack.test.ts
+++ b/src/channels/plugins/onboarding/slack.test.ts
@@ -58,11 +58,13 @@ describe("noteSlackTokenHelp", () => {
     const prompter = createBasePrompter(async (message, title) => {
       notes.push({ message, title });
     });
+    const writeSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
     Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
 
     await noteSlackTokenHelp(prompter, "OpenClaw");
 
     expect(notes).toHaveLength(2);
+    expect(writeSpy).not.toHaveBeenCalled();
     expect(notes[1]?.message.startsWith("Manifest (JSON):\n")).toBe(true);
     const manifest = notes[1]?.message.replace("Manifest (JSON):\n", "") ?? "";
     const parsed = JSON.parse(manifest) as {

--- a/src/channels/plugins/onboarding/slack.test.ts
+++ b/src/channels/plugins/onboarding/slack.test.ts
@@ -62,6 +62,8 @@ describe("noteSlackTokenHelp", () => {
     } finally {
       if (ttyDescriptor) {
         Object.defineProperty(process.stdout, "isTTY", ttyDescriptor);
+      } else {
+        delete (process.stdout as { isTTY?: boolean }).isTTY;
       }
     }
 

--- a/src/channels/plugins/onboarding/slack.test.ts
+++ b/src/channels/plugins/onboarding/slack.test.ts
@@ -30,7 +30,7 @@ describe("noteSlackTokenHelp", () => {
     const prompter = createBasePrompter(async (message, title) => {
       notes.push({ message, title });
     });
-    const rawSpy = vi.fn(async () => {});
+    const rawSpy = vi.fn(async (_text: string) => {});
     prompter.raw = rawSpy;
 
     await noteSlackTokenHelp(prompter, "Ops Bot");
@@ -48,23 +48,18 @@ describe("noteSlackTokenHelp", () => {
     expect(parsed.features?.slash_commands?.[0]?.command).toBe("/openclaw");
   });
 
-  it("falls back to note output for non-TTY prompters", async () => {
+  it("falls back to note output when prompter raw output is unavailable", async () => {
     const notes: NoteRecord[] = [];
     const prompter = createBasePrompter(async (message, title) => {
       notes.push({ message, title });
     });
     const writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-    const ttyDescriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
-    Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
 
     try {
+      // No `raw` method means onboarding must emit manifest JSON via note output.
       await noteSlackTokenHelp(prompter, "OpenClaw");
     } finally {
-      if (ttyDescriptor) {
-        Object.defineProperty(process.stdout, "isTTY", ttyDescriptor);
-      } else {
-        delete (process.stdout as { isTTY?: boolean }).isTTY;
-      }
+      writeSpy.mockRestore();
     }
 
     expect(writeSpy).not.toHaveBeenCalled();

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -109,9 +109,9 @@ export async function noteSlackTokenHelp(prompter: WizardPrompter, botName: stri
     `Docs: ${formatDocsLink("/slack", "slack")}`,
   ];
   await prompter.note(setupLines.join("\n"), "Slack socket mode tokens");
-  if (process.stdout.isTTY) {
+  if (prompter.raw) {
     // Keep manifest unframed so users can copy/paste valid JSON directly.
-    process.stdout.write(`${manifest}\n`);
+    await prompter.raw(`${manifest}\n`);
     return;
   }
   await prompter.note(`Manifest (JSON):\n${manifest}`, "Slack socket mode tokens");

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -109,12 +109,9 @@ export async function noteSlackTokenHelp(prompter: WizardPrompter, botName: stri
     `Docs: ${formatDocsLink("/slack", "slack")}`,
   ];
   await prompter.note(setupLines.join("\n"), "Slack socket mode tokens");
-  if (prompter.codeBlock) {
-    await prompter.codeBlock({
-      title: "Manifest (JSON)",
-      language: "json",
-      code: manifest,
-    });
+  if (process.stdout.isTTY) {
+    // Keep manifest unframed so users can copy/paste valid JSON directly.
+    process.stdout.write(`${manifest}\n`);
     return;
   }
   await prompter.note(`Manifest (JSON):\n${manifest}`, "Slack socket mode tokens");

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -97,23 +97,27 @@ function buildSlackManifest(botName: string) {
   return JSON.stringify(manifest, null, 2);
 }
 
-async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Promise<void> {
+export async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Promise<void> {
   const manifest = buildSlackManifest(botName);
-  await prompter.note(
-    [
-      "1) Slack API → Create App → From scratch or From manifest (with the JSON below)",
-      "2) Add Socket Mode + enable it to get the app-level token (xapp-...)",
-      "3) Install App to workspace to get the xoxb- bot token",
-      "4) Enable Event Subscriptions (socket) for message events",
-      "5) App Home → enable the Messages tab for DMs",
-      "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
-      `Docs: ${formatDocsLink("/slack", "slack")}`,
-      "",
-      "Manifest (JSON):",
-      manifest,
-    ].join("\n"),
-    "Slack socket mode tokens",
-  );
+  const setupLines = [
+    "1) Slack API → Create App → From scratch or From manifest (use the JSON block shown after this note)",
+    "2) Add Socket Mode + enable it to get the app-level token (xapp-...)",
+    "3) Install App to workspace to get the xoxb- bot token",
+    "4) Enable Event Subscriptions (socket) for message events",
+    "5) App Home → enable the Messages tab for DMs",
+    "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
+    `Docs: ${formatDocsLink("/slack", "slack")}`,
+  ];
+  await prompter.note(setupLines.join("\n"), "Slack socket mode tokens");
+  if (prompter.codeBlock) {
+    await prompter.codeBlock({
+      title: "Manifest (JSON)",
+      language: "json",
+      code: manifest,
+    });
+    return;
+  }
+  await prompter.note(`Manifest (JSON):\n${manifest}`, "Slack socket mode tokens");
 }
 
 function setSlackChannelAllowlist(

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -62,6 +62,9 @@ export function createClackPrompter(): WizardPrompter {
     note: async (message, title) => {
       emitNote(message, title);
     },
+    raw: async (message) => {
+      process.stdout.write(message);
+    },
     select: async (params) =>
       guardCancel(
         await select({

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -62,6 +62,13 @@ export function createClackPrompter(): WizardPrompter {
     note: async (message, title) => {
       emitNote(message, title);
     },
+    codeBlock: async (params) => {
+      if (params.title?.trim()) {
+        emitNote("Copy/paste the block below exactly as shown.", params.title);
+      }
+      const code = String(params.code ?? "");
+      process.stdout.write(`${code}\n`);
+    },
     select: async (params) =>
       guardCancel(
         await select({

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -62,13 +62,6 @@ export function createClackPrompter(): WizardPrompter {
     note: async (message, title) => {
       emitNote(message, title);
     },
-    codeBlock: async (params) => {
-      if (params.title?.trim()) {
-        emitNote("Copy/paste the block below exactly as shown.", params.title);
-      }
-      const code = String(params.code ?? "");
-      process.stdout.write(`${code}\n`);
-    },
     select: async (params) =>
       guardCancel(
         await select({

--- a/src/wizard/prompts.ts
+++ b/src/wizard/prompts.ts
@@ -38,6 +38,7 @@ export type WizardPrompter = {
   intro: (title: string) => Promise<void>;
   outro: (message: string) => Promise<void>;
   note: (message: string, title?: string) => Promise<void>;
+  raw?: (message: string) => Promise<void>;
   select: <T>(params: WizardSelectParams<T>) => Promise<T>;
   multiselect: <T>(params: WizardMultiSelectParams<T>) => Promise<T[]>;
   text: (params: WizardTextParams) => Promise<string>;

--- a/src/wizard/prompts.ts
+++ b/src/wizard/prompts.ts
@@ -34,17 +34,10 @@ export type WizardProgress = {
   stop: (message?: string) => void;
 };
 
-export type WizardCodeBlockParams = {
-  code: string;
-  language?: string;
-  title?: string;
-};
-
 export type WizardPrompter = {
   intro: (title: string) => Promise<void>;
   outro: (message: string) => Promise<void>;
   note: (message: string, title?: string) => Promise<void>;
-  codeBlock?: (params: WizardCodeBlockParams) => Promise<void>;
   select: <T>(params: WizardSelectParams<T>) => Promise<T>;
   multiselect: <T>(params: WizardMultiSelectParams<T>) => Promise<T[]>;
   text: (params: WizardTextParams) => Promise<string>;

--- a/src/wizard/prompts.ts
+++ b/src/wizard/prompts.ts
@@ -34,10 +34,17 @@ export type WizardProgress = {
   stop: (message?: string) => void;
 };
 
+export type WizardCodeBlockParams = {
+  code: string;
+  language?: string;
+  title?: string;
+};
+
 export type WizardPrompter = {
   intro: (title: string) => Promise<void>;
   outro: (message: string) => Promise<void>;
   note: (message: string, title?: string) => Promise<void>;
+  codeBlock?: (params: WizardCodeBlockParams) => Promise<void>;
   select: <T>(params: WizardSelectParams<T>) => Promise<T>;
   multiselect: <T>(params: WizardMultiSelectParams<T>) => Promise<T[]>;
   text: (params: WizardTextParams) => Promise<string>;

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -69,13 +69,6 @@ class WizardSessionPrompter implements WizardPrompter {
     await this.prompt({ type: "note", title, message, executor: "client" });
   }
 
-  async codeBlock(params: { code: string; language?: string; title?: string }): Promise<void> {
-    const language = params.language?.trim() || "";
-    const fence = `\`\`\`${language}`;
-    const message = [fence, params.code, "```"].join("\n");
-    await this.note(message, params.title);
-  }
-
   async select<T>(params: {
     message: string;
     options: Array<{ value: T; label: string; hint?: string }>;

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -69,6 +69,13 @@ class WizardSessionPrompter implements WizardPrompter {
     await this.prompt({ type: "note", title, message, executor: "client" });
   }
 
+  async codeBlock(params: { code: string; language?: string; title?: string }): Promise<void> {
+    const language = params.language?.trim() || "";
+    const fence = `\`\`\`${language}`;
+    const message = [fence, params.code, "```"].join("\n");
+    await this.note(message, params.title);
+  }
+
   async select<T>(params: {
     message: string;
     options: Array<{ value: T; label: string; hint?: string }>;


### PR DESCRIPTION
## Summary

- Problem: Slack onboarding printed the app manifest inside a Clack note box, which wraps each line with border characters and breaks direct JSON copy/paste.
- Why it matters: users choosing “Create App from manifest” must manually strip border characters before Slack accepts the JSON.
- What changed: Slack onboarding now prints setup guidance in a note, then emits the manifest as raw JSON on TTY output (unframed); non-TTY/session flows keep the previous note fallback.
- What did NOT change (scope boundary): no Slack manifest schema changes, no token/config behavior changes, no onboarding flow step changes outside manifest rendering.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32493
- Related #32503

## User-visible / Behavior Changes

- In `openclaw channels add` Slack setup, the manifest JSON now prints as plain output (copy/paste ready) instead of inside the boxed note.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Slack onboarding
- Relevant config (redacted): default onboarding flow

### Steps

1. Run `openclaw channels add`.
2. Select Slack and proceed until the wizard prints the manifest guidance.
3. Copy the emitted manifest block and paste into Slack “Create App from manifest”.

### Expected

- Manifest is valid JSON with no framing characters.

### Actual

- Before fix: note framing characters were included around each line (`│ ... │`), so copy/pasted content was invalid JSON.
- After fix: manifest is emitted as raw JSON on TTY and pastes directly.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced note framing behavior locally via `pnpm tsx -e "import { note } from './src/terminal/note.ts'; note('{\n  \"a\":1\n}','Test');"` (shows `│` framing per line).
  - Verified Slack onboarding helper emits raw JSON on TTY and note fallback for non-TTY via new regression tests.
- Edge cases checked:
  - non-TTY/session path still receives manifest via note fallback.
  - manifest content remains valid JSON and still includes `/openclaw` slash command.
- What you did **not** verify:
  - Live Slack API app creation UI end-to-end with real workspace credentials.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR commit(s) on `src/channels/plugins/onboarding/slack.ts`.
- Files/config to restore:
  - `src/channels/plugins/onboarding/slack.ts`
- Known bad symptoms reviewers should watch for:
  - manifest no longer printed at all in Slack onboarding (TTY detection regression).

## Risks and Mitigations

- Risk: `process.stdout.isTTY` detection may differ in uncommon terminal wrappers.
  - Mitigation: explicit non-TTY fallback retains prior note behavior and regression tests cover both branches.
