### PR TITLE
fix(cli): print Slack manifest as raw JSON outside note box

### DIFF
--- a/src/channels/plugins/onboarding/slack.test.ts
+++ b/src/channels/plugins/onboarding/slack.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { buildSlackManifest } from "./slack.js";
+
+describe("buildSlackManifest", () => {
+  it("returns valid JSON that can be parsed without error (#32493)", () => {
+    const manifest = buildSlackManifest("TestBot");
+    expect(() => JSON.parse(manifest)).not.toThrow();
+  });
+
+  it("uses the provided bot name in the manifest", () => {
+    const parsed = JSON.parse(buildSlackManifest("MyAgent"));
+    expect(parsed.display_information.name).toBe("MyAgent");
+    expect(parsed.features.bot_user.display_name).toBe("MyAgent");
+  });
+
+  it("falls back to OpenClaw when bot name is empty or whitespace", () => {
+    const parsed = JSON.parse(buildSlackManifest("   "));
+    expect(parsed.display_information.name).toBe("OpenClaw");
+
+    const parsed2 = JSON.parse(buildSlackManifest(""));
+    expect(parsed2.display_information.name).toBe("OpenClaw");
+  });
+
+  it("output does not contain box-drawing or pipe framing characters (#32493)", () => {
+    const manifest = buildSlackManifest("TestBot");
+    expect(manifest).not.toMatch(/[│┌┐└┘─|]/);
+  });
+
+  it("includes required Slack manifest structure", () => {
+    const parsed = JSON.parse(buildSlackManifest("Bot"));
+    expect(parsed).toHaveProperty("display_information");
+    expect(parsed).toHaveProperty("features.bot_user");
+    expect(parsed).toHaveProperty("oauth_config.scopes.bot");
+    expect(parsed).toHaveProperty("settings.socket_mode_enabled", true);
+    expect(parsed).toHaveProperty("settings.event_subscriptions.bot_events");
+    expect(Array.isArray(parsed.oauth_config.scopes.bot)).toBe(true);
+  });
+});

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -28,7 +28,7 @@ import {
 
 const channel = "slack" as const;
 
-function buildSlackManifest(botName: string) {
+export function buildSlackManifest(botName: string) {
   const safeName = botName.trim() || "OpenClaw";
   const manifest = {
     display_information: {
@@ -101,19 +101,19 @@ async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Pr
   const manifest = buildSlackManifest(botName);
   await prompter.note(
     [
-      "1) Slack API → Create App → From scratch or From manifest (with the JSON below)",
+      "1) Slack API → Create App → From scratch or From manifest (printed below)",
       "2) Add Socket Mode + enable it to get the app-level token (xapp-...)",
       "3) Install App to workspace to get the xoxb- bot token",
       "4) Enable Event Subscriptions (socket) for message events",
       "5) App Home → enable the Messages tab for DMs",
       "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
       `Docs: ${formatDocsLink("/slack", "slack")}`,
-      "",
-      "Manifest (JSON):",
-      manifest,
     ].join("\n"),
     "Slack socket mode tokens",
   );
+  console.log("\nManifest (JSON) — copy the block below:\n");
+  console.log(manifest);
+  console.log();
 }
 
 function setSlackChannelAllowlist(


### PR DESCRIPTION
## Summary

- Problem: The Slack JSON manifest output during `openclaw channels add` is rendered inside a `@clack/prompts` note box, wrapping every line in box-drawing characters (`│`, `─`, `┌`, `┐`, etc.). Users cannot copy valid JSON from the CLI output — they must manually strip the framing characters.
- Why it matters: This completely breaks the copy-paste workflow for Slack app manifest setup, which is the primary recommended path for configuring Slack integration.
- What changed: Split `noteSlackTokenHelp` so the setup instructions remain inside the boxed note, while the JSON manifest is printed via `console.log()` as raw, unframed text that can be directly copied.
- What did NOT change (scope boundary): The manifest content itself is unchanged. The boxed note still shows all setup instructions. No other channel onboarding flows are affected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32493

## User-visible / Behavior Changes

The Slack JSON manifest is now printed as raw text below the boxed setup instructions. Users can copy-paste it directly without stripping box-drawing characters.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22+

### Steps

1. Run `openclaw channels add`
2. Select Slack
3. Enter a bot name
4. Observe the manifest output

### Expected

- Raw JSON manifest printed outside the note box, directly copyable

### Actual

- Before: JSON wrapped in box-drawing characters (│, ─), invalid when copied
- After: JSON printed as raw text via console.log, valid when copied

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `buildSlackManifest` returns valid JSON; output contains no box-drawing characters; bot name substitution works; empty name falls back to "OpenClaw"
- Edge cases checked: Empty/whitespace bot name; manifest structure completeness
- What you did **not** verify: Full interactive CLI flow (requires terminal interaction)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; the manifest will again render inside the note box
- Files/config to restore: `src/channels/plugins/onboarding/slack.ts`

## Risks and Mitigations

- Risk: `console.log` output interleaves with `@clack/prompts` rendering in edge cases
  - Mitigation: The manifest is printed immediately after the note completes (await), so ordering is deterministic