### PR TITLE
fix(update): suppress false stable banner for prerelease-equivalent versions

### DIFF
--- a/src/infra/update-startup.stable-promotion.test.ts
+++ b/src/infra/update-startup.stable-promotion.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UpdateCheckResult } from "./update-check.js";
+
+vi.mock("./openclaw-root.js", () => ({
+  resolveOpenClawPackageRoot: vi.fn(),
+}));
+
+vi.mock("./update-check.js", async () => {
+  const actual = await vi.importActual<typeof import("./update-check.js")>("./update-check.js");
+  return {
+    ...actual,
+    checkUpdateStatus: vi.fn(),
+    resolveNpmChannelTag: vi.fn(),
+  };
+});
+
+vi.mock("../version.js", () => ({
+  VERSION: "2026.3.1-beta.1",
+}));
+
+describe("runGatewayUpdateCheck stable-promotion alias handling", () => {
+  let tempDir = "";
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-promotion-"));
+    process.env.OPENCLAW_STATE_DIR = tempDir;
+    delete process.env.VITEST;
+    process.env.NODE_ENV = "test";
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tempDir, { recursive: true, force: true });
+    delete process.env.OPENCLAW_STATE_DIR;
+  });
+
+  it("does not report update available when latest stable only drops prerelease suffix", async () => {
+    const { resolveOpenClawPackageRoot } = await import("./openclaw-root.js");
+    const { checkUpdateStatus, resolveNpmChannelTag } = await import("./update-check.js");
+    const { getUpdateAvailable, resetUpdateAvailableStateForTest, runGatewayUpdateCheck } =
+      await import("./update-startup.js");
+
+    resetUpdateAvailableStateForTest();
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue("/opt/openclaw");
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root: "/opt/openclaw",
+      installKind: "package",
+      packageManager: "npm",
+    } satisfies UpdateCheckResult);
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
+      tag: "latest",
+      version: "2026.3.1",
+    });
+
+    const onUpdateAvailableChange = vi.fn();
+    await runGatewayUpdateCheck({
+      cfg: { update: { channel: "stable" } },
+      log: { info: vi.fn() },
+      isNixMode: false,
+      allowInTests: true,
+      onUpdateAvailableChange,
+    });
+
+    expect(getUpdateAvailable()).toBeNull();
+    expect(onUpdateAvailableChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({ latestVersion: "2026.3.1" }),
+    );
+  });
+});

--- a/src/infra/update-startup.stable-promotion.test.ts
+++ b/src/infra/update-startup.stable-promotion.test.ts
@@ -70,6 +70,43 @@ describe("runGatewayUpdateCheck stable-promotion alias handling", () => {
     );
   });
 
+  it("still reports latest stable on beta channel for same base version", async () => {
+    const { resolveOpenClawPackageRoot } = await import("./openclaw-root.js");
+    const { checkUpdateStatus, resolveNpmChannelTag } = await import("./update-check.js");
+    const { getUpdateAvailable, resetUpdateAvailableStateForTest, runGatewayUpdateCheck } =
+      await import("./update-startup.js");
+
+    resetUpdateAvailableStateForTest();
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue("/opt/openclaw");
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root: "/opt/openclaw",
+      installKind: "package",
+      packageManager: "npm",
+    } satisfies UpdateCheckResult);
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
+      tag: "latest",
+      version: "2026.3.1",
+    });
+
+    const onUpdateAvailableChange = vi.fn();
+    await runGatewayUpdateCheck({
+      cfg: { update: { channel: "beta" } },
+      log: { info: vi.fn() },
+      isNixMode: false,
+      allowInTests: true,
+      onUpdateAvailableChange,
+    });
+
+    expect(getUpdateAvailable()).toEqual({
+      currentVersion: "2026.3.1-beta.1",
+      latestVersion: "2026.3.1",
+      channel: "latest",
+    });
+    expect(onUpdateAvailableChange).toHaveBeenCalledWith(
+      expect.objectContaining({ latestVersion: "2026.3.1" }),
+    );
+  });
+
   it("keeps persisted prerelease-equivalent update visible on beta channel", async () => {
     const { resolveOpenClawPackageRoot } = await import("./openclaw-root.js");
     const { checkUpdateStatus, resolveNpmChannelTag } = await import("./update-check.js");

--- a/src/infra/update-startup.stable-promotion.test.ts
+++ b/src/infra/update-startup.stable-promotion.test.ts
@@ -69,4 +69,52 @@ describe("runGatewayUpdateCheck stable-promotion alias handling", () => {
       expect.objectContaining({ latestVersion: "2026.3.1" }),
     );
   });
+
+  it("keeps persisted prerelease-equivalent update visible on beta channel", async () => {
+    const { resolveOpenClawPackageRoot } = await import("./openclaw-root.js");
+    const { checkUpdateStatus, resolveNpmChannelTag } = await import("./update-check.js");
+    const { getUpdateAvailable, resetUpdateAvailableStateForTest, runGatewayUpdateCheck } =
+      await import("./update-startup.js");
+
+    resetUpdateAvailableStateForTest();
+    const nowIso = new Date().toISOString();
+    await fs.writeFile(
+      path.join(tempDir, "update-check.json"),
+      JSON.stringify({
+        lastCheckedAt: nowIso,
+        lastAvailableVersion: "2026.3.1",
+        lastAvailableTag: "latest",
+      }),
+      "utf-8",
+    );
+
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue("/opt/openclaw");
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root: "/opt/openclaw",
+      installKind: "package",
+      packageManager: "npm",
+    } satisfies UpdateCheckResult);
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
+      tag: "beta",
+      version: "2026.3.1-beta.1",
+    });
+
+    const onUpdateAvailableChange = vi.fn();
+    await runGatewayUpdateCheck({
+      cfg: { update: { channel: "beta" } },
+      log: { info: vi.fn() },
+      isNixMode: false,
+      allowInTests: true,
+      onUpdateAvailableChange,
+    });
+
+    expect(getUpdateAvailable()).toEqual({
+      currentVersion: "2026.3.1-beta.1",
+      latestVersion: "2026.3.1",
+      channel: "latest",
+    });
+    expect(onUpdateAvailableChange).toHaveBeenCalledWith(
+      expect.objectContaining({ latestVersion: "2026.3.1" }),
+    );
+  });
 });

--- a/src/infra/update-startup.stable-promotion.test.ts
+++ b/src/infra/update-startup.stable-promotion.test.ts
@@ -25,6 +25,7 @@ describe("runGatewayUpdateCheck stable-promotion alias handling", () => {
   let tempDir = "";
 
   beforeEach(async () => {
+    vi.clearAllMocks();
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-promotion-"));
     process.env.OPENCLAW_STATE_DIR = tempDir;
     delete process.env.VITEST;
@@ -131,6 +132,8 @@ describe("runGatewayUpdateCheck stable-promotion alias handling", () => {
       installKind: "package",
       packageManager: "npm",
     } satisfies UpdateCheckResult);
+    // This test exercises persisted-state reuse (fresh check timestamp), so
+    // runGatewayUpdateCheck should not reach the live tag resolver path.
     vi.mocked(resolveNpmChannelTag).mockResolvedValue({
       tag: "beta",
       version: "2026.3.1-beta.1",
@@ -153,6 +156,7 @@ describe("runGatewayUpdateCheck stable-promotion alias handling", () => {
     expect(onUpdateAvailableChange).toHaveBeenCalledWith(
       expect.objectContaining({ latestVersion: "2026.3.1" }),
     );
+    expect(resolveNpmChannelTag).not.toHaveBeenCalled();
   });
 
   it("keeps persisted stable updates visible when base version differs", async () => {
@@ -179,6 +183,7 @@ describe("runGatewayUpdateCheck stable-promotion alias handling", () => {
       installKind: "package",
       packageManager: "npm",
     } satisfies UpdateCheckResult);
+    // This test also validates persisted-state behavior before the next live check window.
     vi.mocked(resolveNpmChannelTag).mockResolvedValue({
       tag: "latest",
       version: "2026.3.2",
@@ -201,5 +206,6 @@ describe("runGatewayUpdateCheck stable-promotion alias handling", () => {
     expect(onUpdateAvailableChange).toHaveBeenCalledWith(
       expect.objectContaining({ latestVersion: "2026.3.2" }),
     );
+    expect(resolveNpmChannelTag).not.toHaveBeenCalled();
   });
 });

--- a/src/infra/update-startup.stable-promotion.test.ts
+++ b/src/infra/update-startup.stable-promotion.test.ts
@@ -117,4 +117,52 @@ describe("runGatewayUpdateCheck stable-promotion alias handling", () => {
       expect.objectContaining({ latestVersion: "2026.3.1" }),
     );
   });
+
+  it("keeps persisted stable updates visible when base version differs", async () => {
+    const { resolveOpenClawPackageRoot } = await import("./openclaw-root.js");
+    const { checkUpdateStatus, resolveNpmChannelTag } = await import("./update-check.js");
+    const { getUpdateAvailable, resetUpdateAvailableStateForTest, runGatewayUpdateCheck } =
+      await import("./update-startup.js");
+
+    resetUpdateAvailableStateForTest();
+    const nowIso = new Date().toISOString();
+    await fs.writeFile(
+      path.join(tempDir, "update-check.json"),
+      JSON.stringify({
+        lastCheckedAt: nowIso,
+        lastAvailableVersion: "2026.3.2",
+        lastAvailableTag: "latest",
+      }),
+      "utf-8",
+    );
+
+    vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue("/opt/openclaw");
+    vi.mocked(checkUpdateStatus).mockResolvedValue({
+      root: "/opt/openclaw",
+      installKind: "package",
+      packageManager: "npm",
+    } satisfies UpdateCheckResult);
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
+      tag: "latest",
+      version: "2026.3.2",
+    });
+
+    const onUpdateAvailableChange = vi.fn();
+    await runGatewayUpdateCheck({
+      cfg: { update: { channel: "stable" } },
+      log: { info: vi.fn() },
+      isNixMode: false,
+      allowInTests: true,
+      onUpdateAvailableChange,
+    });
+
+    expect(getUpdateAvailable()).toEqual({
+      currentVersion: "2026.3.1-beta.1",
+      latestVersion: "2026.3.2",
+      channel: "latest",
+    });
+    expect(onUpdateAvailableChange).toHaveBeenCalledWith(
+      expect.objectContaining({ latestVersion: "2026.3.2" }),
+    );
+  });
 });

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -180,12 +180,16 @@ function setUpdateAvailableCache(params: {
   params.onUpdateAvailableChange?.(params.next);
 }
 
-function resolvePersistedUpdateAvailable(state: UpdateCheckState): UpdateAvailable | null {
+function resolvePersistedUpdateAvailable(params: {
+  state: UpdateCheckState;
+  channel: "stable" | "beta";
+}): UpdateAvailable | null {
+  const state = params.state;
   const latestVersion = state.lastAvailableVersion?.trim();
   if (!latestVersion) {
     return null;
   }
-  if (isStablePromotionAlias(VERSION, latestVersion)) {
+  if (params.channel === "stable" && isStablePromotionAlias(VERSION, latestVersion)) {
     return null;
   }
   const cmp = compareSemverStrings(VERSION, latestVersion);
@@ -355,8 +359,12 @@ export async function runGatewayUpdateCheck(params: {
   const state = await readState(statePath);
   const now = Date.now();
   const lastCheckedAt = state.lastCheckedAt ? Date.parse(state.lastCheckedAt) : null;
+  const channel = normalizeUpdateChannel(params.cfg.update?.channel) ?? DEFAULT_PACKAGE_CHANNEL;
   if (shouldRunUpdateHints) {
-    const persistedAvailable = resolvePersistedUpdateAvailable(state);
+    const persistedAvailable = resolvePersistedUpdateAvailable({
+      state,
+      channel,
+    });
     setUpdateAvailableCache({
       next: persistedAvailable,
       onUpdateAvailableChange: params.onUpdateAvailableChange,
@@ -403,7 +411,6 @@ export async function runGatewayUpdateCheck(params: {
     return;
   }
 
-  const channel = normalizeUpdateChannel(params.cfg.update?.channel) ?? DEFAULT_PACKAGE_CHANNEL;
   const resolved = await resolveNpmChannelTag({ channel, timeoutMs: 2500 });
   const tag = resolved.tag;
   if (!resolved.version) {

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -66,6 +66,33 @@ const AUTO_STABLE_DELAY_HOURS_DEFAULT = 6;
 const AUTO_STABLE_JITTER_HOURS_DEFAULT = 12;
 const AUTO_BETA_CHECK_INTERVAL_HOURS_DEFAULT = 1;
 
+function normalizeSemverForPromotionAlias(version: string): {
+  base: string;
+  hasPrerelease: boolean;
+} | null {
+  const normalized = version.trim().replace(/^v/i, "");
+  if (!normalized) {
+    return null;
+  }
+  const [core, ...rest] = normalized.split("-");
+  if (!core || !/^[0-9]+\.[0-9]+\.[0-9]+$/.test(core)) {
+    return null;
+  }
+  return {
+    base: core,
+    hasPrerelease: rest.length > 0,
+  };
+}
+
+function isStablePromotionAlias(currentVersion: string, latestVersion: string): boolean {
+  const current = normalizeSemverForPromotionAlias(currentVersion);
+  const latest = normalizeSemverForPromotionAlias(latestVersion);
+  if (!current || !latest) {
+    return false;
+  }
+  return current.base === latest.base && current.hasPrerelease && !latest.hasPrerelease;
+}
+
 function shouldSkipCheck(allowInTests: boolean): boolean {
   if (allowInTests) {
     return false;
@@ -156,6 +183,9 @@ function setUpdateAvailableCache(params: {
 function resolvePersistedUpdateAvailable(state: UpdateCheckState): UpdateAvailable | null {
   const latestVersion = state.lastAvailableVersion?.trim();
   if (!latestVersion) {
+    return null;
+  }
+  if (isStablePromotionAlias(VERSION, latestVersion)) {
     return null;
   }
   const cmp = compareSemverStrings(VERSION, latestVersion);
@@ -381,7 +411,9 @@ export async function runGatewayUpdateCheck(params: {
     return;
   }
 
-  const cmp = compareSemverStrings(VERSION, resolved.version);
+  const stablePromotionAlias =
+    channel === "stable" && isStablePromotionAlias(VERSION, resolved.version);
+  const cmp = stablePromotionAlias ? 0 : compareSemverStrings(VERSION, resolved.version);
   if (cmp != null && cmp < 0) {
     const nextAvailable: UpdateAvailable = {
       currentVersion: VERSION,


### PR DESCRIPTION
## Summary

- Problem: startup update checks treat `vX.Y.Z-beta.N` as behind `vX.Y.Z`, so installs running a prerelease-labeled binary from the same stable release show a persistent false “Update available” banner.
- Why it matters: Docker users can get stuck with a permanent false-positive update warning when stable/beta tags point to the same promoted artifact.
- What changed: update startup now suppresses update-available state when stable channel compares the same base version and only differs by prerelease suffix (for example `2026.3.1-beta.1` vs `2026.3.1`).
- What did NOT change (scope boundary): no update command/install flow changes, no semver comparator changes, no channel-tag resolution changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32488
- Related #32435

## User-visible / Behavior Changes

- Stable-channel installs no longer show update banners when current version is prerelease-only of the exact same stable base version.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm
- Model/provider: N/A
- Integration/channel (if any): Gateway startup update check
- Relevant config (redacted): `update.channel=stable`

### Steps

1. Mock runtime version as prerelease of a stable release (`2026.3.1-beta.1`).
2. Mock npm channel tag resolution to return stable `2026.3.1`.
3. Run `runGatewayUpdateCheck`.

### Expected

- No update-available state/banner because only prerelease suffix differs for same base stable version.

### Actual

- Before fix: `updateAvailable = { currentVersion: "2026.3.1-beta.1", latestVersion: "2026.3.1" }`.
- After fix: `updateAvailable = null`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added repro test (`src/infra/update-startup.stable-promotion.test.ts`) that failed before this change and passes after.
  - Ran existing startup update tests to ensure no regressions.
- Edge cases checked:
  - Suppression only applies for stable channel when versions share identical `major.minor.patch` and only current version is prerelease.
  - Persisted update state hydration also ignores this stable-promotion alias.
- What you did **not** verify:
  - Live Docker image digest/tag behavior against ghcr manifests.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR commit(s) touching `src/infra/update-startup.ts`.
- Files/config to restore:
  - `src/infra/update-startup.ts`
- Known bad symptoms reviewers should watch for:
  - stable users on genuine older prereleases no longer seeing update prompts (over-suppression).

## Risks and Mitigations

- Risk: over-suppressing valid updates for prerelease builds.
  - Mitigation: guard is narrow (stable channel only, same base semver only, current has prerelease and latest does not).
