### PR TITLE
fix(browser): harden chrome shutdown across SIGUSR1 restarts

### DIFF
--- a/src/browser/chrome.test.ts
+++ b/src/browser/chrome.test.ts
@@ -350,8 +350,8 @@ describe("browser chrome helpers", () => {
     });
   });
 
-  it("stopOpenClawChrome no-ops when process is already killed", async () => {
-    const proc = makeChromeTestProc({ killed: true });
+  it("stopOpenClawChrome no-ops when process already exited", async () => {
+    const proc = makeChromeTestProc({ killed: true, exitCode: 0 });
     await stopChromeWithProc(proc, 10);
     expect(proc.kill).not.toHaveBeenCalled();
   });
@@ -372,6 +372,20 @@ describe("browser chrome helpers", () => {
       } as unknown as Response),
     );
     const proc = makeChromeTestProc();
+    await stopChromeWithProc(proc, 1);
+    expect(proc.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
+    expect(proc.kill).toHaveBeenNthCalledWith(2, "SIGKILL");
+  });
+
+  it("stopOpenClawChrome retries kill when proc.killed is true but still running", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ webSocketDebuggerUrl: "ws://127.0.0.1/devtools" }),
+      } as unknown as Response),
+    );
+    const proc = makeChromeTestProc({ killed: true, exitCode: null });
     await stopChromeWithProc(proc, 1);
     expect(proc.kill).toHaveBeenNthCalledWith(1, "SIGTERM");
     expect(proc.kill).toHaveBeenNthCalledWith(2, "SIGKILL");

--- a/src/browser/chrome.test.ts
+++ b/src/browser/chrome.test.ts
@@ -90,10 +90,17 @@ async function stopChromeWithProc(proc: ReturnType<typeof makeChromeTestProc>, t
   );
 }
 
-function makeChromeTestProc(overrides?: Partial<{ killed: boolean; exitCode: number | null }>) {
+function makeChromeTestProc(
+  overrides?: Partial<{
+    killed: boolean;
+    exitCode: number | null;
+    signalCode: NodeJS.Signals | null;
+  }>,
+) {
   return {
     killed: overrides?.killed ?? false,
     exitCode: overrides?.exitCode ?? null,
+    signalCode: overrides?.signalCode ?? null,
     kill: vi.fn(),
   };
 }
@@ -352,6 +359,12 @@ describe("browser chrome helpers", () => {
 
   it("stopOpenClawChrome no-ops when process already exited", async () => {
     const proc = makeChromeTestProc({ killed: true, exitCode: 0 });
+    await stopChromeWithProc(proc, 10);
+    expect(proc.kill).not.toHaveBeenCalled();
+  });
+
+  it("stopOpenClawChrome no-ops when process exited by signal", async () => {
+    const proc = makeChromeTestProc({ signalCode: "SIGTERM" });
     await stopChromeWithProc(proc, 10);
     expect(proc.kill).not.toHaveBeenCalled();
   });

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -78,6 +78,10 @@ function cdpUrlForPort(cdpPort: number) {
   return `http://127.0.0.1:${cdpPort}`;
 }
 
+function isProcessExited(proc: Pick<ChildProcessWithoutNullStreams, "exitCode" | "signalCode">) {
+  return proc.exitCode !== null || proc.signalCode !== null;
+}
+
 export async function isChromeReachable(
   cdpUrl: string,
   timeoutMs = CHROME_REACHABILITY_TIMEOUT_MS,
@@ -399,7 +403,7 @@ export async function stopOpenClawChrome(
   timeoutMs = CHROME_STOP_TIMEOUT_MS,
 ) {
   const proc = running.proc;
-  if (proc.exitCode !== null) {
+  if (isProcessExited(proc)) {
     return;
   }
   try {
@@ -410,7 +414,7 @@ export async function stopOpenClawChrome(
 
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    if (proc.exitCode !== null) {
+    if (isProcessExited(proc)) {
       return;
     }
     if (!(await isChromeReachable(cdpUrlForPort(running.cdpPort), CHROME_STOP_PROBE_TIMEOUT_MS))) {
@@ -419,7 +423,7 @@ export async function stopOpenClawChrome(
     await new Promise((r) => setTimeout(r, 100));
   }
 
-  if (proc.exitCode !== null) {
+  if (isProcessExited(proc)) {
     return;
   }
   try {

--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -399,7 +399,7 @@ export async function stopOpenClawChrome(
   timeoutMs = CHROME_STOP_TIMEOUT_MS,
 ) {
   const proc = running.proc;
-  if (proc.killed) {
+  if (proc.exitCode !== null) {
     return;
   }
   try {
@@ -410,8 +410,8 @@ export async function stopOpenClawChrome(
 
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
-    if (!proc.exitCode && proc.killed) {
-      break;
+    if (proc.exitCode !== null) {
+      return;
     }
     if (!(await isChromeReachable(cdpUrlForPort(running.cdpPort), CHROME_STOP_PROBE_TIMEOUT_MS))) {
       return;
@@ -419,6 +419,9 @@ export async function stopOpenClawChrome(
     await new Promise((r) => setTimeout(r, 100));
   }
 
+  if (proc.exitCode !== null) {
+    return;
+  }
   try {
     proc.kill("SIGKILL");
   } catch {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: soft restart paths can leave a previously-launched browser process alive, so a later restart can inherit a stale `proc.killed=true` state and skip real shutdown work.
- Why it matters: stale browser processes can conflict with fresh restarts and lead to unreliable CDP behavior after restart.
- What changed: hardened `stopOpenClawChrome()` to key shutdown on `exitCode` (actual process exit) instead of `proc.killed` (signal attempt flag), and to continue TERM/KILL escalation when `killed===true` but the process is still running.
- What did NOT change (scope boundary): no changes to browser launch flags, profile selection, or gateway restart orchestration logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32458
- Related #

## User-visible / Behavior Changes

- Browser teardown during restart is more reliable when prior stop attempts already marked `proc.killed=true` but the process has not actually exited.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS/Linux (unit-level validation)
- Runtime/container: Node + Vitest
- Model/provider: N/A
- Integration/channel (if any): Browser control / CDP
- Relevant config (redacted): default browser control settings

### Steps

1. Start browser control and launch a local browser profile.
2. Trigger stop/restart sequences where process signaling may set `proc.killed=true` before actual process exit.
3. Observe teardown behavior for subsequent stop attempts.

### Expected

- Stop logic should only no-op when process already exited (`exitCode !== null`).
- Stop should continue TERM/KILL escalation when process is still running even if `proc.killed === true`.

### Actual

- Previous logic returned early when `proc.killed === true`, which can skip shutdown work for still-running processes.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm vitest run src/browser/chrome.test.ts` passes with updated stop semantics and new regression case.
- Edge cases checked: already-exited process no-op, CDP-down fast return, CDP-still-reachable SIGKILL escalation, and `killed=true + exitCode=null` retry path.
- What you did **not** verify: full live SIGUSR1 restart on an external host with real Chrome process table inspection.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Browser: harden SIGUSR1 chrome shutdown`.
- Files/config to restore: `src/browser/chrome.ts`, `src/browser/chrome.test.ts`.
- Known bad symptoms reviewers should watch for: browser process not receiving SIGTERM/SIGKILL in tests or unexpected stop-time hangs.

## Risks and Mitigations

- Risk: stricter reliance on `exitCode` could behave differently on unusual process wrappers.
  - Mitigation: retained existing CDP reachability checks and SIGKILL fallback; added regression coverage for the key stale-killed state.
