### PR TITLE
fix(exec-approval): support safe slug prefix resolution for /approve

### DIFF
--- a/src/gateway/exec-approval-manager.ts
+++ b/src/gateway/exec-approval-manager.ts
@@ -97,7 +97,11 @@ export class ExecApprovalManager {
   }
 
   resolve(recordId: string, decision: ExecApprovalDecision, resolvedBy?: string | null): boolean {
-    const pending = this.pending.get(recordId);
+    const fullId = this.resolveCanonicalId(recordId);
+    if (!fullId) {
+      return false;
+    }
+    const pending = this.pending.get(fullId);
     if (!pending) {
       return false;
     }
@@ -114,11 +118,29 @@ export class ExecApprovalManager {
     pending.resolve(decision);
     setTimeout(() => {
       // Only delete if the entry hasn't been replaced
-      if (this.pending.get(recordId) === pending) {
-        this.pending.delete(recordId);
+      if (this.pending.get(fullId) === pending) {
+        this.pending.delete(fullId);
       }
     }, RESOLVED_ENTRY_GRACE_MS);
     return true;
+  }
+
+  private resolveCanonicalId(input: string): string | null {
+    // Exact match first
+    if (this.pending.has(input)) {
+      return input;
+    }
+    // Prefix match fallback
+    const matches: string[] = [];
+    for (const key of this.pending.keys()) {
+      if (key.startsWith(input)) {
+        matches.push(key);
+        if (matches.length > 1) {
+          return null; // ambiguous → hard fail
+        }
+      }
+    }
+    return matches.length === 1 ? matches[0] : null;
   }
 
   expire(recordId: string, resolvedBy?: string | null): boolean {


### PR DESCRIPTION
## Summary

- **Problem:** `/approve <slug> allow-once` fails with `unknown approval id` because `ExecApprovalManager` stores approvals keyed by full UUID, while the exec tool displays an 8-char slug.
- **Why it matters:** Users can’t approve exec requests using the ID they’re shown, forcing them to hunt down the full UUID in logs; this is especially painful on chat-forwarded approvals (e.g., Telegram).
- **What changed:** `ExecApprovalManager.resolve()` now attempts exact UUID lookup first, then falls back to **safe prefix matching** (only succeeds when the prefix matches **exactly one** pending approval). Internals normalize to the **canonical full UUID** for state mutation/cleanup.
- **What did NOT change (scope boundary):** No changes to approval record format, storage model (still keyed by full UUID), decision semantics (`allow-once`, etc.), timeout/expiry behavior, or request/forwarder plumbing beyond using the resolved canonical ID internally.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #9591

## User-visible / Behavior Changes

- Users can approve pending exec approvals using the short slug displayed by the exec tool (e.g., `/approve c937dad1 allow-once`), as long as the slug uniquely matches a pending approval ID.
- If the slug matches **multiple** pending approvals (ambiguous), approval is rejected (same user-facing failure mode as “unknown approval id”).

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No (approvals were already required; this only fixes ID matching)
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS / Linux (dev)
- Runtime/container: Node.js (gateway runtime)
- Model/provider: N/A
- Integration/channel (if any): Telegram (reported), also applies to any chat-forwarded approvals
- Relevant config (redacted):
  - `approvals.exec.enabled: true`
  - `approvals.exec.mode: session`
  - `approvals.exec.forward_to_chat: true` (or equivalent)
  - `/elevated ask` configured to require approval for exec commands

### Steps

1. Enable exec approvals forwarding to chat (`approvals.exec.enabled: true`, forward approvals to chat).
2. Configure `/elevated ask` (or equivalent) so exec commands require approval.
3. Trigger an exec that requires approval.
4. Observe chat message displaying short approval slug (e.g., `Approval required (id c937dad1)`).
5. Run `/approve c937dad1 allow-once`.

### Expected

- Approval is resolved successfully and the exec proceeds (for allow-once).

### Actual

- Before: `❌ Failed to submit approval: Error: unknown approval id`
- After: Approval resolves successfully when the slug uniquely matches a pending approval.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - Approving with **full UUID** still succeeds (no regression).
  - Approving with **8-char slug** succeeds when it uniquely matches a pending approval.
  - Unknown slug still fails cleanly.
- Edge cases checked:
  - Prefix lookup path does **not** mutate state using the slug (cleanup uses canonical UUID).
  - Ambiguous prefix is rejected (does not pick first match).
- What you did **not** verify:
  - I did not verify behavior across every chat forwarder/channel implementation (assumed they use the same underlying resolve path).
  - I did not run long-duration soak testing for pending-entry expiry under heavy concurrency beyond basic local checks.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this commit (restores exact-match-only behavior).
- Files/config to restore:
  - `src/gateway/exec-approval-manager.ts` (or equivalent file path)
- Known bad symptoms reviewers should watch for:
  - `/approve <slug>` unexpectedly approving the wrong request (should not happen; ambiguous prefixes are rejected).
  - Stuck pending approvals due to cleanup using the wrong key (should not happen; cleanup uses canonical UUID).

## Risks and Mitigations

- Risk: Ambiguous slug prefix could match multiple pending approvals, leading to wrong approval if implemented naively.
  - Mitigation: Require exactly one prefix match; otherwise fail without resolving.
- Risk: Event/audit inconsistency if downstream code uses user-provided slug instead of canonical UUID.
  - Mitigation: Normalize to canonical UUID inside `resolve()` before any state mutation/cleanup; exact-match behavior remains unchanged.