### PR TITLE
gateway: make control-ui device-identity error actionable

### DIFF
--- a/src/gateway/server/ws-connection/auth-messages.test.ts
+++ b/src/gateway/server/ws-connection/auth-messages.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { formatControlUiDeviceIdentityRequiredMessage } from "./auth-messages.js";
+
+describe("formatControlUiDeviceIdentityRequiredMessage", () => {
+  it("returns actionable guidance for insecure control-ui connections", () => {
+    const message = formatControlUiDeviceIdentityRequiredMessage();
+    expect(message).toContain("control ui requires device identity");
+    expect(message).toContain("HTTPS/WSS on remote hosts");
+    expect(message).toContain("localhost secure context");
+    expect(message).toContain("gateway.controlUi.allowInsecureAuth=true");
+  });
+});

--- a/src/gateway/server/ws-connection/auth-messages.ts
+++ b/src/gateway/server/ws-connection/auth-messages.ts
@@ -4,6 +4,13 @@ import { GATEWAY_CLIENT_IDS } from "../../protocol/client-info.js";
 
 export type AuthProvidedKind = "token" | "device-token" | "password" | "none";
 
+export function formatControlUiDeviceIdentityRequiredMessage(): string {
+  return (
+    "control ui requires device identity " +
+    "(use HTTPS/WSS on remote hosts, or localhost secure context; local HTTP dev-only fallback: gateway.controlUi.allowInsecureAuth=true)"
+  );
+}
+
 export function formatGatewayAuthFailureMessage(params: {
   authMode: ResolvedGatewayAuth["mode"];
   authProvided: AuthProvidedKind;

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -77,7 +77,11 @@ import {
 } from "../health-state.js";
 import type { GatewayWsClient } from "../ws-types.js";
 import { resolveConnectAuthDecision, resolveConnectAuthState } from "./auth-context.js";
-import { formatGatewayAuthFailureMessage, type AuthProvidedKind } from "./auth-messages.js";
+import {
+  formatControlUiDeviceIdentityRequiredMessage,
+  formatGatewayAuthFailureMessage,
+  type AuthProvidedKind,
+} from "./auth-messages.js";
 import {
   evaluateMissingDeviceIdentity,
   isTrustedProxyControlUiOperatorAuth,
@@ -631,8 +635,7 @@ export function attachGatewayWsMessageHandler(params: {
           }
 
           if (decision.kind === "reject-control-ui-insecure-auth") {
-            const errorMessage =
-              "control ui requires device identity (use HTTPS or localhost secure context)";
+            const errorMessage = formatControlUiDeviceIdentityRequiredMessage();
             markHandshakeFailure("control-ui-insecure-auth", {
               insecureAuthConfigured: controlUiAuthPolicy.allowInsecureAuthConfigured,
             });


### PR DESCRIPTION
## Summary

- Problem: the Control UI connect rejection for missing device identity is terse and leaves operators unsure how to recover on remote/self-hosted setups.
- Why it matters: users hit `control ui requires device identity (use HTTPS or localhost secure context)` and often cannot tell that remote WebSocket must be secure (`wss`) and that `allowInsecureAuth` is local-only.
- What changed: centralized this rejection text and made it explicitly actionable for remote hosts (`HTTPS/WSS`) and local dev fallback (`gateway.controlUi.allowInsecureAuth=true`).
- What did NOT change (scope boundary): no auth-policy behavior changes, no bypass changes, no pairing/role semantics changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32473
- Related #20684

## User-visible / Behavior Changes

- On Control UI handshake failure caused by missing device identity in insecure contexts, the message now includes:
  - remote requirement: `HTTPS/WSS on remote hosts`
  - local dev-only fallback: `gateway.controlUi.allowInsecureAuth=true`

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux/macOS (test harness)
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): Gateway Control UI WebSocket connect
- Relevant config (redacted): token auth + Control UI client without device identity in insecure context

### Steps

1. Start gateway with token auth.
2. Connect as Control UI client with shared token but no device identity in insecure context.
3. Observe handshake rejection message.

### Expected

- Error should clearly tell users what to do for remote deployment vs local fallback.

### Actual

- Before fix, message only said `use HTTPS or localhost secure context`, which was ambiguous for remote WebSocket setup and local fallback behavior.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added unit test for the new formatter output.
  - Ran gateway auth integration suites that exercise control-ui connection rejection paths.
- Edge cases checked:
  - Existing rejection semantics and error detail code remain unchanged.
  - Trusted-proxy/local policy behavior unchanged.
- What you did **not** verify:
  - Manual browser-based dashboard session against a live reverse proxy.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `gateway: clarify control-ui device identity secure-context guidance`.
- Files/config to restore:
  - `src/gateway/server/ws-connection/auth-messages.ts`
  - `src/gateway/server/ws-connection/message-handler.ts`
  - `src/gateway/server/ws-connection/auth-messages.test.ts`
- Known bad symptoms reviewers should watch for: none expected beyond message content mismatch.

## Risks and Mitigations

- Risk: text-only change could drift from future policy behavior.
  - Mitigation: message generation is centralized and covered by focused tests.
