### PR TITLE
browser: accept bearer auth in extension relay endpoints

### DIFF
--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -615,6 +615,22 @@ describe("chrome extension relay server", () => {
     ext.close();
   });
 
+  it("accepts raw gateway bearer token for relay auth compatibility", async () => {
+    const sharedUrl = await ensureSharedRelayServer();
+    const sharedPort = new URL(sharedUrl).port;
+
+    const versionRes = await fetch(`${sharedUrl}/json/version`, {
+      headers: { Authorization: `Bearer ${TEST_GATEWAY_TOKEN}` },
+    });
+    expect(versionRes.status).toBe(200);
+
+    const cdp = new WebSocket(`ws://127.0.0.1:${sharedPort}/cdp`, {
+      headers: { Authorization: `Bearer ${TEST_GATEWAY_TOKEN}` },
+    });
+    await waitForOpen(cdp);
+    cdp.close();
+  });
+
   it(
     "tracks attached page targets and exposes them via CDP + /json/list",
     async () => {

--- a/src/browser/extension-relay.test.ts
+++ b/src/browser/extension-relay.test.ts
@@ -631,6 +631,30 @@ describe("chrome extension relay server", () => {
     cdp.close();
   });
 
+  it("accepts valid query token even when bearer header is unrelated", async () => {
+    const sharedUrl = await ensureSharedRelayServer();
+    const sharedPort = new URL(sharedUrl).port;
+    const token = relayAuthHeaders(sharedUrl)["x-openclaw-relay-token"];
+    expect(token).toBeTruthy();
+
+    const versionRes = await fetch(
+      `${sharedUrl}/json/version?token=${encodeURIComponent(String(token))}`,
+      {
+        headers: { Authorization: "Bearer unrelated-token" },
+      },
+    );
+    expect(versionRes.status).toBe(200);
+
+    const ext = new WebSocket(
+      `ws://127.0.0.1:${sharedPort}/extension?token=${encodeURIComponent(String(token))}`,
+      {
+        headers: { Authorization: "Bearer unrelated-token" },
+      },
+    );
+    await waitForOpen(ext);
+    ext.close();
+  });
+
   it(
     "tracks attached page targets and exposes them via CDP + /json/list",
     async () => {

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -99,10 +99,23 @@ function getHeader(req: IncomingMessage, name: string): string | undefined {
   return headerValue(req.headers[name.toLowerCase()]);
 }
 
+function parseBearerToken(value: string | undefined): string | undefined {
+  const raw = value?.trim() ?? "";
+  if (!raw.toLowerCase().startsWith("bearer ")) {
+    return undefined;
+  }
+  const token = raw.slice(7).trim();
+  return token || undefined;
+}
+
 function getRelayAuthTokenFromRequest(req: IncomingMessage, url?: URL): string | undefined {
   const headerToken = getHeader(req, RELAY_AUTH_HEADER)?.trim();
   if (headerToken) {
     return headerToken;
+  }
+  const bearerToken = parseBearerToken(getHeader(req, "authorization"));
+  if (bearerToken) {
+    return bearerToken;
   }
   const queryToken = url?.searchParams.get("token")?.trim();
   if (queryToken) {

--- a/src/browser/extension-relay.ts
+++ b/src/browser/extension-relay.ts
@@ -108,20 +108,21 @@ function parseBearerToken(value: string | undefined): string | undefined {
   return token || undefined;
 }
 
-function getRelayAuthTokenFromRequest(req: IncomingMessage, url?: URL): string | undefined {
+function getRelayAuthTokensFromRequest(req: IncomingMessage, url?: URL): string[] {
+  const candidates: string[] = [];
   const headerToken = getHeader(req, RELAY_AUTH_HEADER)?.trim();
   if (headerToken) {
-    return headerToken;
-  }
-  const bearerToken = parseBearerToken(getHeader(req, "authorization"));
-  if (bearerToken) {
-    return bearerToken;
+    candidates.push(headerToken);
   }
   const queryToken = url?.searchParams.get("token")?.trim();
   if (queryToken) {
-    return queryToken;
+    candidates.push(queryToken);
   }
-  return undefined;
+  const bearerToken = parseBearerToken(getHeader(req, "authorization"));
+  if (bearerToken) {
+    candidates.push(bearerToken);
+  }
+  return Array.from(new Set(candidates));
 }
 
 export type ChromeExtensionRelayServer = {
@@ -574,8 +575,8 @@ export async function ensureChromeExtensionRelayServer(opts: {
       }
 
       if (path.startsWith("/json")) {
-        const token = getRelayAuthTokenFromRequest(req, url);
-        if (!token || !relayAuthTokens.has(token)) {
+        const tokens = getRelayAuthTokensFromRequest(req, url);
+        if (!tokens.some((token) => relayAuthTokens.has(token))) {
           res.writeHead(401);
           res.end("Unauthorized");
           return;
@@ -707,8 +708,8 @@ export async function ensureChromeExtensionRelayServer(opts: {
       }
 
       if (pathname === "/extension") {
-        const token = getRelayAuthTokenFromRequest(req, url);
-        if (!token || !relayAuthTokens.has(token)) {
+        const tokens = getRelayAuthTokensFromRequest(req, url);
+        if (!tokens.some((token) => relayAuthTokens.has(token))) {
           rejectUpgrade(socket, 401, "Unauthorized");
           return;
         }
@@ -732,8 +733,8 @@ export async function ensureChromeExtensionRelayServer(opts: {
       }
 
       if (pathname === "/cdp") {
-        const token = getRelayAuthTokenFromRequest(req, url);
-        if (!token || !relayAuthTokens.has(token)) {
+        const tokens = getRelayAuthTokensFromRequest(req, url);
+        if (!tokens.some((token) => relayAuthTokens.has(token))) {
           rejectUpgrade(socket, 401, "Unauthorized");
           return;
         }


### PR DESCRIPTION
## Summary

- Problem: extension relay auth only accepted `x-openclaw-relay-token` (or `?token=`), so `Authorization: Bearer <gateway-token>` probe requests returned 401.
- Why it matters: operators commonly verify relay health with bearer curl/WebSocket clients; hard rejection makes diagnostics and compatibility brittle.
- What changed: relay auth token extraction now also accepts bearer tokens from `Authorization` header and validates them against the same accepted token set.
- What did NOT change (scope boundary): no token trust expansion beyond existing accepted tokens; no changes to auth derivation, relay token generation, or non-relay browser control auth.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32449
- Related #32331

## User-visible / Behavior Changes

- Extension relay `/json/*` and `/cdp`/`/extension` auth now accepts `Authorization: Bearer <token>` in addition to `x-openclaw-relay-token` and `?token=`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS/Linux (test harness)
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): browser extension relay
- Relevant config (redacted): relay enabled with gateway auth token

### Steps

1. Start extension relay server.
2. Request `/json/version` with `Authorization: Bearer <gateway-token>`.
3. Open `ws://127.0.0.1:<port>/cdp` with same bearer header.

### Expected

- Relay should authenticate with same accepted tokens regardless of whether token arrives via relay header or bearer header.

### Actual

- Before fix, bearer path returned 401 while relay-header/query-token path succeeded.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added regression test covering bearer token auth for HTTP `/json/version` and WebSocket `/cdp`.
  - Re-ran full extension relay test suite.
- Edge cases checked:
  - Existing relay-header and query-token auth behavior remains intact.
  - Bearer parsing still requires `Bearer ` prefix and non-empty token.
- What you did **not** verify:
  - Manual browser extension flow against a live desktop install.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `browser: accept bearer token in extension relay auth`.
- Files/config to restore:
  - `src/browser/extension-relay.ts`
  - `src/browser/extension-relay.test.ts`
- Known bad symptoms reviewers should watch for: unexpected acceptance of malformed `Authorization` values (covered by existing token-set checks).

## Risks and Mitigations

- Risk: broader header acceptance could unintentionally accept malformed auth headers.
  - Mitigation: strict bearer parsing + existing token-set membership check.
