### PR TITLE
fix(discord): ignore wildcard key in unresolved audit channels

### DIFF
--- a/src/discord/audit.test.ts
+++ b/src/discord/audit.test.ts
@@ -53,4 +53,33 @@ describe("discord audit", () => {
     expect(audit.channels[0]?.channelId).toBe("111");
     expect(audit.channels[0]?.missing).toContain("SendMessages");
   });
+
+  it("does not count wildcard guild channel keys as unresolved", async () => {
+    const { collectDiscordAuditChannelIds } = await import("./audit.js");
+
+    const cfg = {
+      channels: {
+        discord: {
+          enabled: true,
+          token: "t",
+          groupPolicy: "allowlist",
+          guilds: {
+            "123": {
+              channels: {
+                "*": { allow: true },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as import("../config/config.js").OpenClawConfig;
+
+    const collected = collectDiscordAuditChannelIds({
+      cfg,
+      accountId: "default",
+    });
+
+    expect(collected.channelIds).toEqual([]);
+    expect(collected.unresolvedChannels).toBe(0);
+  });
 });

--- a/src/discord/audit.ts
+++ b/src/discord/audit.ts
@@ -22,6 +22,7 @@ export type DiscordChannelPermissionsAudit = {
 };
 
 const REQUIRED_CHANNEL_PERMISSIONS = ["ViewChannel", "SendMessages"] as const;
+const DISCORD_CHANNEL_WILDCARD_KEY = "*";
 
 function shouldAuditChannelConfig(config: DiscordGuildChannelConfig | undefined) {
   if (!config) {
@@ -75,7 +76,9 @@ export function collectDiscordAuditChannelIds(params: {
   });
   const keys = listConfiguredGuildChannelKeys(account.config.guilds);
   const channelIds = keys.filter((key) => /^\d+$/.test(key));
-  const unresolvedChannels = keys.length - channelIds.length;
+  const unresolvedChannels = keys.filter(
+    (key) => key !== DISCORD_CHANNEL_WILDCARD_KEY && !/^\d+$/.test(key),
+  ).length;
   return { channelIds, unresolvedChannels };
 }
 


### PR DESCRIPTION
## Summary

- Problem: `openclaw doctor` / `channels status --probe` reports `unresolvedChannels=1` for valid Discord guild channel wildcard config (`channels.discord.guilds.<id>.channels."*"`).
- Why it matters: this creates false-positive audit warnings for valid allow-all guild channel configuration.
- What changed: Discord audit channel collection now excludes the `*` wildcard key from unresolved-channel counting, and a regression test covers wildcard-only guild config.
- What did NOT change (scope boundary): allowlist matching, guild/channel routing, and channel permission probing behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32517
- Related #32520

## User-visible / Behavior Changes

- `openclaw doctor` and `openclaw channels status --probe` no longer count Discord channel wildcard keys (`*`) as unresolved channel IDs.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (Darwin arm64)
- Runtime/container: Node 22 + pnpm workspace tests
- Model/provider: N/A
- Integration/channel (if any): Discord
- Relevant config (redacted):

```json
{
  "channels": {
    "discord": {
      "guilds": {
        "1478116902202114240": {
          "channels": {
            "*": { "allow": true }
          }
        }
      }
    }
  }
}
```

### Steps

1. Configure Discord guild channel allowlist with wildcard-only entry (`channels.discord.guilds.<guildId>.channels."*"`).
2. Run Discord audit collection (`collectDiscordAuditChannelIds`) via doctor/status flows.
3. Observe unresolved channel count.

### Expected

- Wildcard key is treated as valid config and does not increment `unresolvedChannels`.

### Actual

- `*` was treated as unresolved/non-numeric and incremented `unresolvedChannels` by 1.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm vitest run src/discord/audit.test.ts` passes, including new wildcard regression case.
  - Existing numeric/non-numeric unresolved counting case still passes.
- Edge cases checked:
  - Wildcard-only channel map returns `channelIds=[]` and `unresolvedChannels=0`.
- What you did **not** verify:
  - Full end-to-end Discord live API permission probing in a real guild.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/discord/audit.ts`, `src/discord/audit.test.ts`.
- Known bad symptoms reviewers should watch for: wildcard keys wrongly reappear in unresolved count.

## Risks and Mitigations

- Risk: non-numeric keys other than wildcard could be accidentally excluded from unresolved count.
  - Mitigation: logic excludes only exact `*`; all other non-numeric keys remain unresolved and existing test coverage is retained.
