### PR TITLE
fix(ui): accept webchat image-only messages via opts.images

### DIFF
--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -327,6 +327,56 @@ describe("runPreparedReply media-only handling", () => {
     expect(call?.suppressTyping).toBe(true);
   });
 
+  it("allows webchat image-only messages via opts.images (#32474)", async () => {
+    const result = await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "",
+          RawBody: "",
+          CommandBody: "",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          Provider: "webchat",
+        },
+        opts: {
+          images: [
+            { type: "image", source: { type: "base64", data: "abc", media_type: "image/png" } },
+          ],
+        },
+      }),
+    );
+
+    expect(result).toEqual({ text: "ok" });
+    expect(vi.mocked(runReplyAgent)).toHaveBeenCalled();
+  });
+
+  it("rejects webchat messages with empty opts.images array and no text", async () => {
+    const result = await runPreparedReply(
+      baseParams({
+        ctx: {
+          Body: "",
+          RawBody: "",
+          CommandBody: "",
+        },
+        sessionCtx: {
+          Body: "",
+          BodyStripped: "",
+          Provider: "webchat",
+        },
+        opts: {
+          images: [],
+        },
+      }),
+    );
+
+    expect(result).toEqual({
+      text: "I didn't receive any text in your message. Please resend or add a caption.",
+    });
+    expect(vi.mocked(runReplyAgent)).not.toHaveBeenCalled();
+  });
+
   it("routes queued system events to system prompt context, not user prompt text", async () => {
     vi.mocked(buildQueuedSystemPrompt).mockResolvedValueOnce(
       "## Runtime System Events (gateway-generated)\n- [t] Model switched.",

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -306,7 +306,9 @@ export async function runPreparedReply(
     : [inboundUserContext, baseBodyFinal].filter(Boolean).join("\n\n");
   const baseBodyTrimmed = baseBodyForPrompt.trim();
   const hasMediaAttachment = Boolean(
-    sessionCtx.MediaPath || (sessionCtx.MediaPaths && sessionCtx.MediaPaths.length > 0),
+    sessionCtx.MediaPath ||
+    (sessionCtx.MediaPaths && sessionCtx.MediaPaths.length > 0) ||
+    (opts?.images && opts.images.length > 0),
   );
   if (!baseBodyTrimmed && !hasMediaAttachment) {
     await typing.onReplyStart();


### PR DESCRIPTION
## Summary

- Problem: Pasting a screenshot (without caption text) in the Control UI webchat results in an error: "I didn't receive any text in your message. Please resend or add a caption."
- Why it matters: Users cannot send image-only messages via paste in the webchat, forcing them to always include text captions for pasted screenshots.
- What changed: Extended the `hasMediaAttachment` guard in `runPreparedReply` to also check `opts?.images?.length > 0`. Webchat attachments arrive via `opts.images` (not `sessionCtx.MediaPath` which is set by external channels like Telegram).
- What did NOT change (scope boundary): External channel media handling is unchanged. The `sessionCtx.MediaPath` check remains intact. No frontend changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32474

## User-visible / Behavior Changes

Pasting screenshots in the Control UI webchat without caption text now works correctly — the image is sent to the agent instead of being rejected.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime: Node.js 22+

### Steps

1. Open Control UI (http://127.0.0.1:18789/)
2. Paste a screenshot into the chat input (Cmd+V)
3. Click send without typing any text

### Expected

- Image is sent to the agent and processed

### Actual

- Before: Error "I didn't receive any text in your message. Please resend or add a caption."
- After: Image is accepted and forwarded to the agent run

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: Image-only webchat message with opts.images accepted; empty opts.images array still rejected; existing MediaPath-based media detection unchanged
- Edge cases checked: Empty images array; undefined opts; undefined images property
- What you did **not** verify: Full browser paste interaction (requires browser environment)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; image-only webchat messages will be rejected again
- Files/config to restore: `src/auto-reply/reply/get-reply-run.ts`

## Risks and Mitigations

- Risk: None — this extends an existing guard to cover a previously missed input source
  - Mitigation: The downstream `effectiveBaseBody` fallback already handles empty text when media is present (line 321–323)