### PR TITLE
fix(fs-safe): respect umask when mode is omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Infra/fs-safe default write mode: stop forcing `0600` in `openWritableFileWithinRoot` when no explicit `mode` is provided, so new files follow platform defaults (`0666 & umask`) and inherited ACL policies. (#32404) Thanks @jeanmonet.
 - Sessions/idle reset correctness: preserve existing `updatedAt` during inbound metadata-only writes so idle-reset boundaries are not unintentionally refreshed before actual user turns. (#32379) Thanks @romeodiaz.
 - Slack/socket auth failure handling: fail fast on non-recoverable auth errors (`account_inactive`, `invalid_auth`, etc.) during startup and reconnect instead of retry-looping indefinitely, including `unable_to_socket_mode_start` error payload propagation. (#32377) Thanks @scoootscooob.
 - CLI/installer Node preflight: enforce Node.js `v22.12+` consistently in both `openclaw.mjs` runtime bootstrap and installer active-shell checks, with actionable nvm recovery guidance for mismatched shell PATH/defaults. (#32356) Thanks @jasonhargrove.

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -251,18 +251,21 @@ describe("fs-safe", () => {
     const root = await tempDirs.make("openclaw-fs-safe-root-");
     const relativePath = path.join("nested", "default-mode.txt");
     const openSpy = vi.spyOn(fs, "open");
-    const opened = await openWritableFileWithinRoot({
-      rootDir: root,
-      relativePath,
-    });
-    await opened.handle.close();
+    try {
+      const opened = await openWritableFileWithinRoot({
+        rootDir: root,
+        relativePath,
+      });
+      await opened.handle.close();
 
-    const targetOpenCalls = openSpy.mock.calls.filter(([filePath]) =>
-      String(filePath).endsWith(relativePath),
-    );
-    expect(targetOpenCalls.length).toBeGreaterThan(0);
-    expect(targetOpenCalls.every((call) => call.length === 2)).toBe(true);
-    openSpy.mockRestore();
+      const targetOpenCalls = openSpy.mock.calls.filter(([filePath]) =>
+        String(filePath).endsWith(relativePath),
+      );
+      expect(targetOpenCalls.length).toBeGreaterThan(0);
+      expect(targetOpenCalls.every((call) => call.length === 2)).toBe(true);
+    } finally {
+      openSpy.mockRestore();
+    }
   });
 
   it("does not truncate existing target when atomic rename fails", async () => {

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -9,6 +9,7 @@ import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import {
   copyFileWithinRoot,
   createRootScopedReadFile,
+  openWritableFileWithinRoot,
   SafeOpenError,
   openFileWithinRoot,
   readFileWithinRoot,
@@ -244,6 +245,24 @@ describe("fs-safe", () => {
       data: "hello",
     });
     await expect(fs.readFile(path.join(root, "nested", "out.txt"), "utf8")).resolves.toBe("hello");
+  });
+
+  it("does not force 0o600 when write mode is not provided", async () => {
+    const root = await tempDirs.make("openclaw-fs-safe-root-");
+    const relativePath = path.join("nested", "default-mode.txt");
+    const openSpy = vi.spyOn(fs, "open");
+    const opened = await openWritableFileWithinRoot({
+      rootDir: root,
+      relativePath,
+    });
+    await opened.handle.close();
+
+    const targetOpenCalls = openSpy.mock.calls.filter(([filePath]) =>
+      String(filePath).endsWith(relativePath),
+    );
+    expect(targetOpenCalls.length).toBeGreaterThan(0);
+    expect(targetOpenCalls.every((call) => call.length === 2)).toBe(true);
+    openSpy.mockRestore();
   });
 
   it("does not truncate existing target when atomic rename fails", async () => {

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -406,18 +406,29 @@ export async function openWritableFileWithinRoot(params: {
     }
   }
 
-  const fileMode = params.mode ?? 0o600;
+  const fileMode = params.mode;
+
+  const openWritableHandle = async (
+    ioPathForOpen: string,
+    flags: number,
+    mode?: number,
+  ): Promise<FileHandle> => {
+    if (mode === undefined) {
+      return await fs.open(ioPathForOpen, flags);
+    }
+    return await fs.open(ioPathForOpen, flags, mode);
+  };
 
   let handle: FileHandle;
   let createdForWrite = false;
   try {
     try {
-      handle = await fs.open(ioPath, OPEN_WRITE_EXISTING_FLAGS, fileMode);
+      handle = await openWritableHandle(ioPath, OPEN_WRITE_EXISTING_FLAGS, fileMode);
     } catch (err) {
       if (!isNotFoundPathError(err)) {
         throw err;
       }
-      handle = await fs.open(ioPath, OPEN_WRITE_CREATE_FLAGS, fileMode);
+      handle = await openWritableHandle(ioPath, OPEN_WRITE_CREATE_FLAGS, fileMode);
       createdForWrite = true;
     }
   } catch (err) {


### PR DESCRIPTION
## Summary
- stop forcing `0o600` in `openWritableFileWithinRoot` when `mode` is not provided
- keep explicit mode behavior unchanged when callers pass `mode`
- add regression test to assert default-path `fs.open(...)` calls do not pass a mode argument
- add changelog entry under 2026.3.2 (Unreleased) Fixes

Fixes #32404.

## Testing
- `pnpm test src/infra/fs-safe.test.ts`
