### PR TITLE
fix(config): default group/thread sessions to idle reset mode

### DIFF
--- a/src/config/sessions/reset.ts
+++ b/src/config/sessions/reset.ts
@@ -19,6 +19,14 @@ export type SessionFreshness = {
 
 export const DEFAULT_RESET_MODE: SessionResetMode = "daily";
 export const DEFAULT_RESET_AT_HOUR = 4;
+export const DEFAULT_GROUP_IDLE_MINUTES = 10080; // 7 days
+
+function resolveDefaultResetMode(resetType: SessionResetType): SessionResetMode {
+  if (resetType === "group" || resetType === "thread") {
+    return "idle";
+  }
+  return DEFAULT_RESET_MODE;
+}
 
 const THREAD_SESSION_MARKERS = [":thread:", ":topic:"];
 const GROUP_SESSION_MARKERS = [":group:", ":channel:"];
@@ -97,10 +105,11 @@ export function resolveSessionResetPolicy(params: {
         : undefined));
   const hasExplicitReset = Boolean(baseReset || sessionCfg?.resetByType);
   const legacyIdleMinutes = params.resetOverride ? undefined : sessionCfg?.idleMinutes;
+  const defaultMode = resolveDefaultResetMode(params.resetType);
   const mode =
     typeReset?.mode ??
     baseReset?.mode ??
-    (!hasExplicitReset && legacyIdleMinutes != null ? "idle" : DEFAULT_RESET_MODE);
+    (!hasExplicitReset && legacyIdleMinutes != null ? "idle" : defaultMode);
   const atHour = normalizeResetAtHour(
     typeReset?.atHour ?? baseReset?.atHour ?? DEFAULT_RESET_AT_HOUR,
   );
@@ -113,7 +122,8 @@ export function resolveSessionResetPolicy(params: {
       idleMinutes = Math.max(normalized, 1);
     }
   } else if (mode === "idle") {
-    idleMinutes = DEFAULT_IDLE_MINUTES;
+    const isGroupLike = params.resetType === "group" || params.resetType === "thread";
+    idleMinutes = isGroupLike ? DEFAULT_GROUP_IDLE_MINUTES : DEFAULT_IDLE_MINUTES;
   }
 
   return { mode, atHour, idleMinutes };

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -141,7 +141,62 @@ describe("resolveSessionResetPolicy", () => {
         resetType: "group",
       });
 
-      expect(groupPolicy.mode).toBe("daily");
+      // dm config does not leak to group; group uses its own default (idle)
+      expect(groupPolicy.mode).toBe("idle");
+      expect(groupPolicy.idleMinutes).not.toBe(45);
+    });
+  });
+
+  describe("group/thread sessions default to idle (#32109)", () => {
+    it("group defaults to idle with 7-day timeout when unconfigured", () => {
+      const policy = resolveSessionResetPolicy({ resetType: "group" });
+      expect(policy.mode).toBe("idle");
+      expect(policy.idleMinutes).toBe(10080);
+    });
+
+    it("thread defaults to idle with 7-day timeout when unconfigured", () => {
+      const policy = resolveSessionResetPolicy({ resetType: "thread" });
+      expect(policy.mode).toBe("idle");
+      expect(policy.idleMinutes).toBe(10080);
+    });
+
+    it("direct sessions still default to daily", () => {
+      const policy = resolveSessionResetPolicy({ resetType: "direct" });
+      expect(policy.mode).toBe("daily");
+      expect(policy.idleMinutes).toBeUndefined();
+    });
+
+    it("explicit daily override for group is honored", () => {
+      const sessionCfg = {
+        resetByType: {
+          group: { mode: "daily" as const, atHour: 6 },
+        },
+      } as unknown as SessionConfig;
+
+      const policy = resolveSessionResetPolicy({ sessionCfg, resetType: "group" });
+      expect(policy.mode).toBe("daily");
+      expect(policy.atHour).toBe(6);
+    });
+
+    it("explicit base reset.mode overrides group default", () => {
+      const sessionCfg = {
+        reset: { mode: "daily" as const },
+      } as unknown as SessionConfig;
+
+      const policy = resolveSessionResetPolicy({ sessionCfg, resetType: "group" });
+      expect(policy.mode).toBe("daily");
+    });
+
+    it("group respects custom idleMinutes when explicitly set", () => {
+      const sessionCfg = {
+        resetByType: {
+          group: { mode: "idle" as const, idleMinutes: 1440 },
+        },
+      } as unknown as SessionConfig;
+
+      const policy = resolveSessionResetPolicy({ sessionCfg, resetType: "group" });
+      expect(policy.mode).toBe("idle");
+      expect(policy.idleMinutes).toBe(1440);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Problem: Group chat and forum topic sessions default to `daily` reset mode (reset at 4 AM), causing complete conversation context loss every morning. This is unintuitive for topic-based workflows where a topic represents an ongoing project/discussion.
- Why it matters: Users in Telegram forum groups, Discord threads, and Slack channels lose conversation history daily, requiring them to re-explain context every morning.
- What changed: `resolveSessionResetPolicy` now uses type-aware defaults — `group` and `thread` sessions default to `idle` mode with a 7-day (10080 minute) timeout. `direct`/DM sessions retain the existing `daily` default.
- What did NOT change (scope boundary): Users who have explicitly configured `reset.mode` or `resetByType` in their config are unaffected. The `evaluateSessionFreshness`, `resolveSessionResetType`, and session key parsing logic are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32109

## User-visible / Behavior Changes

- Group and thread sessions no longer reset at 4 AM by default
- They now use idle-based reset with a 7-day window (conversations stay alive for 7 days of inactivity)
- Direct/DM sessions are unchanged (still reset daily at 4 AM)
- Users can override by setting `session.resetByType.group.mode: "daily"` in config

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Create a Telegram group with forum topics enabled
2. Send messages in a topic
3. Wait past 4 AM (or verify via `evaluateSessionFreshness`)

### Expected

- Session remains fresh unless idle for 7 days

### Actual

- Before: Session resets at 4 AM daily, losing all context
- After: Session stays active for 7 days of inactivity

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: group defaults to idle/10080min; thread defaults to idle/10080min; direct defaults to daily; explicit daily override for group honored; explicit base reset.mode overrides group default; custom idleMinutes honored
- Edge cases checked: resetByType.dm does not leak to group; legacy idleMinutes compatibility preserved
- What you did **not** verify: Live multi-day session persistence (requires real deployment)

## Compatibility / Migration

- Backward compatible? Yes — existing explicit configs override the new defaults
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Set `session.resetByType.group.mode: "daily"` and `session.resetByType.thread.mode: "daily"` in config, or revert this commit
- Files/config to restore: `src/config/sessions/reset.ts`

## Risks and Mitigations

- Risk: Longer session lifetime increases transcript file sizes on disk
  - Mitigation: Memory compaction already handles long sessions; the 7-day window is bounded and configurable
- Risk: Users expecting daily group resets may be surprised
  - Mitigation: This matches user expectations from the issue; explicit config overrides still work