### PR TITLE
security(line): synthesize auth boundary hardening for webhook and replay paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- LINE/auth boundary hardening synthesis: enforce strict LINE webhook authn/z boundary semantics across pairing-store account scoping, DM/group allowlist separation, fail-closed webhook auth/runtime behavior, and replay/duplication controls (including in-flight replay reservation and post-success dedupe marking). (from #26701, #26683, #25978, #17593, #16619, #31990, #26047, #30584, #18777) Thanks @bmendonca3, @davidahmann, @harshang03, @haosenwang1018, @liuxiaopai-ai, @coygeek, and @Takhoffman.
 - LINE/media download synthesis: fix file-media download handling and M4A audio classification across overlapping LINE regressions. (from #26386, #27761, #27787, #29509, #29755, #29776, #29785, #32240) Thanks @kevinWangSheng, @loiie45e, @carrotRakko, @Sid-Qin, @codeafridi, and @bmendonca3.
 - LINE/context and routing synthesis: fix group/room peer routing and command-authorization context propagation, and keep processing later events in mixed-success webhook batches. (from #21955, #24475, #27035, #28286) Thanks @lailoo, @mcaxtr, @jervyclaw, @Glucksberg, and @Takhoffman.
 - LINE/status/config/webhook synthesis: fix status false positives from snapshot/config state and accept LINE webhook HEAD probes for compatibility. (from #10487, #25726, #27537, #27908, #31387) Thanks @BlueBirdBack, @stakeswky, @loiie45e, @puritysb, and @mcaxtr.

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -392,7 +392,7 @@ describe("handleLineWebhookEvents", () => {
       deliveryContext: { isRedelivery: true },
     } as MessageEvent;
 
-    const context = {
+    const context: Parameters<typeof handleLineWebhookEvents>[1] = {
       cfg: { channels: { line: { groupPolicy: "open" } } },
       account: {
         accountId: "default",

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -379,6 +379,41 @@ describe("handleLineWebhookEvents", () => {
     );
   });
 
+  it("deduplicates replayed webhook events by webhookEventId before processing", async () => {
+    const processMessage = vi.fn();
+    const event = {
+      type: "message",
+      message: { id: "m-replay", type: "text", text: "hello" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-replay", userId: "user-replay" },
+      mode: "active",
+      webhookEventId: "evt-replay-1",
+      deliveryContext: { isRedelivery: true },
+    } as MessageEvent;
+
+    const context = {
+      cfg: { channels: { line: { groupPolicy: "open" } } },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: { groupPolicy: "open" },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+    };
+
+    await handleLineWebhookEvents([event], context);
+    await handleLineWebhookEvents([event], context);
+
+    expect(buildLineMessageContextMock).toHaveBeenCalledTimes(1);
+    expect(processMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("downloads file attachments and forwards media refs to message context", async () => {
     const processMessage = vi.fn();
     const event = {

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -1,4 +1,4 @@
-import type { MessageEvent } from "@line/bot-sdk";
+import type { MessageEvent, PostbackEvent } from "@line/bot-sdk";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Avoid pulling in globals/pairing/media dependencies; this suite only asserts
@@ -16,15 +16,10 @@ vi.mock("../pairing/pairing-messages.js", () => ({
   buildPairingReply: () => "pairing-reply",
 }));
 
-const { downloadLineMediaMock } = vi.hoisted(() => ({
-  downloadLineMediaMock: vi.fn(async () => ({
-    path: "/tmp/line-media-file.pdf",
-    contentType: "application/pdf",
-  })),
-}));
-
 vi.mock("./download.js", () => ({
-  downloadLineMedia: downloadLineMediaMock,
+  downloadLineMedia: async () => {
+    throw new Error("downloadLineMedia should not be called from bot-handlers tests");
+  },
 }));
 
 vi.mock("./send.js", () => ({
@@ -44,7 +39,7 @@ const { buildLineMessageContextMock, buildLinePostbackContextMock } = vi.hoisted
     isGroup: true,
     accountId: "default",
   })),
-  buildLinePostbackContextMock: vi.fn(async () => null),
+  buildLinePostbackContextMock: vi.fn(async () => null as unknown),
 }));
 
 vi.mock("./bot-message-context.js", () => ({
@@ -86,7 +81,6 @@ describe("handleLineWebhookEvents", () => {
   beforeEach(() => {
     buildLineMessageContextMock.mockClear();
     buildLinePostbackContextMock.mockClear();
-    downloadLineMediaMock.mockClear();
     readAllowFromStoreMock.mockClear();
     upsertPairingRequestMock.mockClear();
   });
@@ -222,6 +216,7 @@ describe("handleLineWebhookEvents", () => {
 
     expect(processMessage).not.toHaveBeenCalled();
     expect(buildLineMessageContextMock).not.toHaveBeenCalled();
+    expect(readAllowFromStoreMock).toHaveBeenCalledWith("line", undefined, "default");
   });
 
   it("does not authorize group messages from DM pairing-store entries when group allowlist is empty", async () => {
@@ -463,21 +458,27 @@ describe("handleLineWebhookEvents", () => {
     expect(processMessage).toHaveBeenCalledTimes(1);
   });
 
-  it("downloads file attachments and forwards media refs to message context", async () => {
+  it("deduplicates postback redeliveries by webhookEventId when replyToken changes", async () => {
     const processMessage = vi.fn();
+    buildLinePostbackContextMock.mockResolvedValue({
+      ctxPayload: { From: "line:user:user-postback" },
+      route: { agentId: "default" },
+      isGroup: false,
+      accountId: "default",
+    });
     const event = {
-      type: "message",
-      message: { id: "mf-1", type: "file", fileName: "doc.pdf", fileSize: "42" },
-      replyToken: "reply-token",
+      type: "postback",
+      postback: { data: "action=confirm" },
+      replyToken: "reply-token-1",
       timestamp: Date.now(),
-      source: { type: "user", userId: "user-file" },
+      source: { type: "user", userId: "user-postback" },
       mode: "active",
-      webhookEventId: "evt-file-1",
+      webhookEventId: "evt-postback-1",
       deliveryContext: { isRedelivery: false },
-    } as MessageEvent;
+    } as PostbackEvent;
 
-    await handleLineWebhookEvents([event], {
-      cfg: { channels: { line: {} } },
+    const context: Parameters<typeof handleLineWebhookEvents>[1] = {
+      cfg: { channels: { line: { dmPolicy: "open" } } },
       account: {
         accountId: "default",
         enabled: true,
@@ -487,69 +488,66 @@ describe("handleLineWebhookEvents", () => {
         config: { dmPolicy: "open" },
       },
       runtime: createRuntime(),
-      mediaMaxBytes: 1234,
+      mediaMaxBytes: 1,
       processMessage,
-    });
+      replayCache: createLineWebhookReplayCache(),
+    };
 
-    expect(downloadLineMediaMock).toHaveBeenCalledTimes(1);
-    expect(downloadLineMediaMock).toHaveBeenCalledWith("mf-1", "token", 1234);
-    expect(buildLineMessageContextMock).toHaveBeenCalledTimes(1);
-    expect(buildLineMessageContextMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        commandAuthorized: false,
-        allMedia: [
-          {
-            path: "/tmp/line-media-file.pdf",
-            contentType: "application/pdf",
-          },
-        ],
-      }),
+    await handleLineWebhookEvents([event], context);
+    await handleLineWebhookEvents(
+      [
+        {
+          ...event,
+          replyToken: "reply-token-2",
+          deliveryContext: { isRedelivery: true },
+        } as PostbackEvent,
+      ],
+      context,
     );
+
+    expect(buildLinePostbackContextMock).toHaveBeenCalledTimes(1);
     expect(processMessage).toHaveBeenCalledTimes(1);
   });
 
-  it("continues processing later events when one event handler fails", async () => {
-    const failingEvent = {
+  it("does not mark replay cache when event processing fails", async () => {
+    const processMessage = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient failure"))
+      .mockResolvedValueOnce(undefined);
+    const event = {
       type: "message",
-      message: { id: "m-err", type: "text", text: "hi" },
+      message: { id: "m-fail-then-retry", type: "text", text: "hello" },
       replyToken: "reply-token",
       timestamp: Date.now(),
-      source: { type: "user", userId: "user-err" },
+      source: { type: "group", groupId: "group-retry", userId: "user-retry" },
       mode: "active",
-      webhookEventId: "evt-err",
+      webhookEventId: "evt-fail-then-retry",
       deliveryContext: { isRedelivery: false },
     } as MessageEvent;
-    const laterEvent = {
-      ...failingEvent,
-      message: { id: "m-later", type: "text", text: "hello" },
-      webhookEventId: "evt-later",
-    } as MessageEvent;
-    const runtime = createRuntime();
-    let invocation = 0;
-    const processMessage = vi.fn(async () => {
-      if (invocation === 0) {
-        invocation += 1;
-        throw new Error("boom");
-      }
-      invocation += 1;
-    });
 
-    await handleLineWebhookEvents([failingEvent, laterEvent], {
-      cfg: { channels: { line: {} } },
+    const context: Parameters<typeof handleLineWebhookEvents>[1] = {
+      cfg: { channels: { line: { groupPolicy: "open" } } },
       account: {
         accountId: "default",
         enabled: true,
         channelAccessToken: "token",
         channelSecret: "secret",
         tokenSource: "config",
-        config: { dmPolicy: "open" },
+        config: { groupPolicy: "open" },
       },
-      runtime,
-      mediaMaxBytes: 1234,
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
       processMessage,
-    });
+      replayCache: createLineWebhookReplayCache(),
+    };
 
+    await expect(handleLineWebhookEvents([event], context)).rejects.toThrow("transient failure");
+    await handleLineWebhookEvents([event], context);
+
+    expect(buildLineMessageContextMock).toHaveBeenCalledTimes(2);
     expect(processMessage).toHaveBeenCalledTimes(2);
-    expect(runtime.error).toHaveBeenCalledTimes(1);
+    expect(context.runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("line: event handler failed: Error: transient failure"),
+    );
   });
 });

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -416,6 +416,53 @@ describe("handleLineWebhookEvents", () => {
     expect(processMessage).toHaveBeenCalledTimes(1);
   });
 
+  it("deduplicates redeliveries by LINE message id when webhookEventId changes", async () => {
+    const processMessage = vi.fn();
+    const event = {
+      type: "message",
+      message: { id: "m-dup-1", type: "text", text: "hello" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-dup", userId: "user-dup" },
+      mode: "active",
+      webhookEventId: "evt-dup-1",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    const context: Parameters<typeof handleLineWebhookEvents>[1] = {
+      cfg: {
+        channels: { line: { groupPolicy: "allowlist", groupAllowFrom: ["user-dup"] } },
+      },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: { groupPolicy: "allowlist", groupAllowFrom: ["user-dup"] },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+      replayCache: createLineWebhookReplayCache(),
+    };
+
+    await handleLineWebhookEvents([event], context);
+    await handleLineWebhookEvents(
+      [
+        {
+          ...event,
+          webhookEventId: "evt-dup-redelivery",
+          deliveryContext: { isRedelivery: true },
+        } as MessageEvent,
+      ],
+      context,
+    );
+
+    expect(buildLineMessageContextMock).toHaveBeenCalledTimes(1);
+    expect(processMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("downloads file attachments and forwards media refs to message context", async () => {
     const processMessage = vi.fn();
     const event = {

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -256,6 +256,44 @@ describe("handleLineWebhookEvents", () => {
     expect(buildLineMessageContextMock).not.toHaveBeenCalled();
   });
 
+  it("scopes DM pairing requests to accountId", async () => {
+    const processMessage = vi.fn();
+    const event = {
+      type: "message",
+      message: { id: "m5", type: "text", text: "hi" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "user", userId: "user-5" },
+      mode: "active",
+      webhookEventId: "evt-5",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    await handleLineWebhookEvents([event], {
+      cfg: { channels: { line: { dmPolicy: "pairing" } } },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: { dmPolicy: "pairing", allowFrom: ["user-owner"] },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+    });
+
+    expect(processMessage).not.toHaveBeenCalled();
+    expect(upsertPairingRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "line",
+        id: "user-5",
+        accountId: "default",
+      }),
+    );
+  });
+
   it("downloads file attachments and forwards media refs to message context", async () => {
     const processMessage = vi.fn();
     const event = {

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -411,6 +411,51 @@ describe("handleLineWebhookEvents", () => {
     expect(processMessage).toHaveBeenCalledTimes(1);
   });
 
+  it("skips concurrent redeliveries while the first event is still processing", async () => {
+    let resolveFirst: (() => void) | undefined;
+    const firstDone = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const processMessage = vi.fn(async () => {
+      await firstDone;
+    });
+    const event = {
+      type: "message",
+      message: { id: "m-inflight", type: "text", text: "hello" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-inflight", userId: "user-inflight" },
+      mode: "active",
+      webhookEventId: "evt-inflight-1",
+      deliveryContext: { isRedelivery: true },
+    } as MessageEvent;
+
+    const context: Parameters<typeof handleLineWebhookEvents>[1] = {
+      cfg: { channels: { line: { groupPolicy: "open" } } },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: { groupPolicy: "open" },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+      replayCache: createLineWebhookReplayCache(),
+    };
+
+    const firstRun = handleLineWebhookEvents([event], context);
+    await Promise.resolve();
+    const secondRun = handleLineWebhookEvents([event], context);
+    resolveFirst?.();
+    await Promise.all([firstRun, secondRun]);
+
+    expect(buildLineMessageContextMock).toHaveBeenCalledTimes(1);
+    expect(processMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("deduplicates redeliveries by LINE message id when webhookEventId changes", async () => {
     const processMessage = vi.fn();
     const event = {

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -456,6 +456,51 @@ describe("handleLineWebhookEvents", () => {
     expect(processMessage).toHaveBeenCalledTimes(1);
   });
 
+  it("mirrors in-flight replay failures so concurrent duplicates also fail", async () => {
+    let rejectFirst: ((err: Error) => void) | undefined;
+    const firstDone = new Promise<void>((_, reject) => {
+      rejectFirst = reject;
+    });
+    const processMessage = vi.fn(async () => {
+      await firstDone;
+    });
+    const event = {
+      type: "message",
+      message: { id: "m-inflight-fail", type: "text", text: "hello" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-inflight", userId: "user-inflight" },
+      mode: "active",
+      webhookEventId: "evt-inflight-fail-1",
+      deliveryContext: { isRedelivery: true },
+    } as MessageEvent;
+
+    const context: Parameters<typeof handleLineWebhookEvents>[1] = {
+      cfg: { channels: { line: { groupPolicy: "open" } } },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: { groupPolicy: "open" },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+      replayCache: createLineWebhookReplayCache(),
+    };
+
+    const firstRun = handleLineWebhookEvents([event], context);
+    await Promise.resolve();
+    const secondRun = handleLineWebhookEvents([event], context);
+    rejectFirst?.(new Error("transient inflight failure"));
+
+    await expect(firstRun).rejects.toThrow("transient inflight failure");
+    await expect(secondRun).rejects.toThrow("transient inflight failure");
+    expect(processMessage).toHaveBeenCalledTimes(1);
+  });
+
   it("deduplicates redeliveries by LINE message id when webhookEventId changes", async () => {
     const processMessage = vi.fn();
     const event = {

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -69,6 +69,7 @@ const { readAllowFromStoreMock, upsertPairingRequestMock } = vi.hoisted(() => ({
 }));
 
 let handleLineWebhookEvents: typeof import("./bot-handlers.js").handleLineWebhookEvents;
+let createLineWebhookReplayCache: typeof import("./bot-handlers.js").createLineWebhookReplayCache;
 
 const createRuntime = () => ({ log: vi.fn(), error: vi.fn(), exit: vi.fn() });
 
@@ -79,7 +80,7 @@ vi.mock("../pairing/pairing-store.js", () => ({
 
 describe("handleLineWebhookEvents", () => {
   beforeAll(async () => {
-    ({ handleLineWebhookEvents } = await import("./bot-handlers.js"));
+    ({ handleLineWebhookEvents, createLineWebhookReplayCache } = await import("./bot-handlers.js"));
   });
 
   beforeEach(() => {
@@ -405,6 +406,7 @@ describe("handleLineWebhookEvents", () => {
       runtime: createRuntime(),
       mediaMaxBytes: 1,
       processMessage,
+      replayCache: createLineWebhookReplayCache(),
     };
 
     await handleLineWebhookEvents([event], context);

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -190,16 +190,15 @@ describe("handleLineWebhookEvents", () => {
 
   it("blocks group sender not in groupAllowFrom even when sender is paired in DM store", async () => {
     readAllowFromStoreMock.mockResolvedValueOnce(["user-store"]);
-
     const processMessage = vi.fn();
     const event = {
       type: "message",
-      message: { id: "m3b", type: "text", text: "hi" },
+      message: { id: "m5", type: "text", text: "hi" },
       replyToken: "reply-token",
       timestamp: Date.now(),
       source: { type: "group", groupId: "group-1", userId: "user-store" },
       mode: "active",
-      webhookEventId: "evt-3b",
+      webhookEventId: "evt-5",
       deliveryContext: { isRedelivery: false },
     } as MessageEvent;
 
@@ -214,6 +213,44 @@ describe("handleLineWebhookEvents", () => {
         channelSecret: "secret",
         tokenSource: "config",
         config: { groupPolicy: "allowlist", groupAllowFrom: ["user-group"] },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+    });
+
+    expect(processMessage).not.toHaveBeenCalled();
+    expect(buildLineMessageContextMock).not.toHaveBeenCalled();
+  });
+
+  it("does not authorize group messages from DM pairing-store entries when group allowlist is empty", async () => {
+    readAllowFromStoreMock.mockResolvedValueOnce(["user-5"]);
+    const processMessage = vi.fn();
+    const event = {
+      type: "message",
+      message: { id: "m5b", type: "text", text: "hi" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "group", groupId: "group-1", userId: "user-5" },
+      mode: "active",
+      webhookEventId: "evt-5b",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    await handleLineWebhookEvents([event], {
+      cfg: { channels: { line: { groupPolicy: "allowlist" } } },
+      account: {
+        accountId: "default",
+        enabled: true,
+        channelAccessToken: "token",
+        channelSecret: "secret",
+        tokenSource: "config",
+        config: {
+          dmPolicy: "pairing",
+          allowFrom: [],
+          groupPolicy: "allowlist",
+          groupAllowFrom: [],
+        },
       },
       runtime: createRuntime(),
       mediaMaxBytes: 1,

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -188,15 +188,16 @@ describe("handleLineWebhookEvents", () => {
     expect(processMessage).toHaveBeenCalledTimes(1);
   });
 
-  it("blocks group sender that is only present in pairing-store allowlist", async () => {
+  it("blocks group sender not in groupAllowFrom even when sender is paired in DM store", async () => {
+    readAllowFromStoreMock.mockResolvedValueOnce(["user-store"]);
+
     const processMessage = vi.fn();
-    readAllowFromStoreMock.mockResolvedValueOnce(["user-paired"]);
     const event = {
       type: "message",
       message: { id: "m3b", type: "text", text: "hi" },
       replyToken: "reply-token",
       timestamp: Date.now(),
-      source: { type: "group", groupId: "group-1", userId: "user-paired" },
+      source: { type: "group", groupId: "group-1", userId: "user-store" },
       mode: "active",
       webhookEventId: "evt-3b",
       deliveryContext: { isRedelivery: false },
@@ -204,7 +205,7 @@ describe("handleLineWebhookEvents", () => {
 
     await handleLineWebhookEvents([event], {
       cfg: {
-        channels: { line: { groupPolicy: "allowlist", groupAllowFrom: ["user-owner"] } },
+        channels: { line: { groupPolicy: "allowlist", groupAllowFrom: ["user-group"] } },
       },
       account: {
         accountId: "default",
@@ -212,15 +213,15 @@ describe("handleLineWebhookEvents", () => {
         channelAccessToken: "token",
         channelSecret: "secret",
         tokenSource: "config",
-        config: { groupPolicy: "allowlist", groupAllowFrom: ["user-owner"] },
+        config: { groupPolicy: "allowlist", groupAllowFrom: ["user-group"] },
       },
       runtime: createRuntime(),
       mediaMaxBytes: 1,
       processMessage,
     });
 
-    expect(buildLineMessageContextMock).not.toHaveBeenCalled();
     expect(processMessage).not.toHaveBeenCalled();
+    expect(buildLineMessageContextMock).not.toHaveBeenCalled();
   });
 
   it("blocks group messages when wildcard group config disables groups", async () => {

--- a/src/line/bot-handlers.test.ts
+++ b/src/line/bot-handlers.test.ts
@@ -294,6 +294,54 @@ describe("handleLineWebhookEvents", () => {
     );
   });
 
+  it("does not authorize DM senders from another account's pairing-store entries", async () => {
+    const processMessage = vi.fn();
+    readAllowFromStoreMock.mockImplementation(async (...args: unknown[]) => {
+      const accountId = args[2] as string | undefined;
+      if (accountId === "work") {
+        return [];
+      }
+      return ["cross-account-user"];
+    });
+    upsertPairingRequestMock.mockResolvedValue({ code: "CODE", created: false });
+
+    const event = {
+      type: "message",
+      message: { id: "m6", type: "text", text: "hi" },
+      replyToken: "reply-token",
+      timestamp: Date.now(),
+      source: { type: "user", userId: "cross-account-user" },
+      mode: "active",
+      webhookEventId: "evt-6",
+      deliveryContext: { isRedelivery: false },
+    } as MessageEvent;
+
+    await handleLineWebhookEvents([event], {
+      cfg: { channels: { line: { dmPolicy: "pairing" } } },
+      account: {
+        accountId: "work",
+        enabled: true,
+        channelAccessToken: "token-work",
+        channelSecret: "secret-work",
+        tokenSource: "config",
+        config: { dmPolicy: "pairing" },
+      },
+      runtime: createRuntime(),
+      mediaMaxBytes: 1,
+      processMessage,
+    });
+
+    expect(readAllowFromStoreMock).toHaveBeenCalledWith("line", undefined, "work");
+    expect(processMessage).not.toHaveBeenCalled();
+    expect(upsertPairingRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "line",
+        id: "cross-account-user",
+        accountId: "work",
+      }),
+    );
+  });
+
   it("downloads file attachments and forwards media refs to message context", async () => {
     const processMessage = vi.fn();
     const event = {

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -65,6 +65,70 @@ export interface LineHandlerContext {
   processMessage: (ctx: LineInboundContext) => Promise<void>;
 }
 
+const LINE_WEBHOOK_REPLAY_WINDOW_MS = 10 * 60 * 1000;
+const LINE_WEBHOOK_REPLAY_MAX_ENTRIES = 4096;
+const seenLineWebhookEvents = new Map<string, number>();
+
+function pruneLineWebhookReplayCache(nowMs: number): void {
+  const minSeenAt = nowMs - LINE_WEBHOOK_REPLAY_WINDOW_MS;
+  for (const [key, seenAt] of seenLineWebhookEvents) {
+    if (seenAt < minSeenAt) {
+      seenLineWebhookEvents.delete(key);
+    }
+  }
+
+  if (seenLineWebhookEvents.size > LINE_WEBHOOK_REPLAY_MAX_ENTRIES) {
+    const deleteCount = seenLineWebhookEvents.size - LINE_WEBHOOK_REPLAY_MAX_ENTRIES;
+    let deleted = 0;
+    for (const key of seenLineWebhookEvents.keys()) {
+      if (deleted >= deleteCount) {
+        break;
+      }
+      seenLineWebhookEvents.delete(key);
+      deleted += 1;
+    }
+  }
+}
+
+function buildLineWebhookReplayKey(
+  event: WebhookEvent,
+  accountId: string,
+): { key: string; eventId: string } | null {
+  const eventId = (event as { webhookEventId?: string }).webhookEventId?.trim();
+  if (!eventId) {
+    return null;
+  }
+
+  const source = (
+    event as {
+      source?: { type?: string; userId?: string; groupId?: string; roomId?: string };
+    }
+  ).source;
+  const sourceId =
+    source?.type === "group"
+      ? `group:${source.groupId ?? ""}`
+      : source?.type === "room"
+        ? `room:${source.roomId ?? ""}`
+        : `user:${source?.userId ?? ""}`;
+  return { key: `${accountId}|${event.type}|${sourceId}|${eventId}`, eventId };
+}
+
+function shouldSkipLineReplayEvent(event: WebhookEvent, context: LineHandlerContext): boolean {
+  const replay = buildLineWebhookReplayKey(event, context.account.accountId);
+  if (!replay) {
+    return false;
+  }
+
+  const nowMs = Date.now();
+  pruneLineWebhookReplayCache(nowMs);
+  if (seenLineWebhookEvents.has(replay.key)) {
+    logVerbose(`line: skipped replayed webhook event ${replay.eventId}`);
+    return true;
+  }
+  seenLineWebhookEvents.set(replay.key, nowMs);
+  return false;
+}
+
 function resolveLineGroupConfig(params: {
   config: ResolvedLineAccount["config"];
   groupId?: string;
@@ -383,6 +447,9 @@ export async function handleLineWebhookEvents(
   context: LineHandlerContext,
 ): Promise<void> {
   for (const event of events) {
+    if (shouldSkipLineReplayEvent(event, context)) {
+      continue;
+    }
     try {
       switch (event.type) {
         case "message":

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -27,7 +27,7 @@ import {
   firstDefined,
   isSenderAllowed,
   normalizeAllowFrom,
-  normalizeDmAllowFromWithStore,
+  normalizeAllowFromWithStore,
 } from "./bot-access.js";
 import {
   getLineSourceInfo,
@@ -162,8 +162,8 @@ async function shouldProcessLineEvent(
     account.config.groupAllowFrom,
     fallbackGroupAllowFrom,
   );
-  // Group authorization stays explicit to group allowlists and must not
-  // inherit DM pairing-store identities.
+  // Group sender policy must be derived from explicit group config only.
+  // Pairing store entries are DM-oriented and must not expand group allowlists.
   const effectiveGroupAllow = normalizeAllowFrom(groupAllowFrom);
   const defaultGroupPolicy = resolveDefaultGroupPolicy(cfg);
   const { groupPolicy, providerMissingFallbackApplied } =

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -106,6 +106,25 @@ function buildLineWebhookReplayKey(
   event: WebhookEvent,
   accountId: string,
 ): { key: string; eventId: string } | null {
+  if (event.type === "message") {
+    const messageId = event.message?.id?.trim();
+    if (messageId) {
+      return {
+        key: `${accountId}|message:${messageId}`,
+        eventId: `message:${messageId}`,
+      };
+    }
+  }
+  if (event.type === "postback") {
+    const replyToken = event.replyToken?.trim();
+    if (replyToken) {
+      return {
+        key: `${accountId}|postback:${replyToken}`,
+        eventId: `postback:${replyToken}`,
+      };
+    }
+  }
+
   const eventId = (event as { webhookEventId?: string }).webhookEventId?.trim();
   if (!eventId) {
     return null;
@@ -122,7 +141,7 @@ function buildLineWebhookReplayKey(
       : source?.type === "room"
         ? `room:${source.roomId ?? ""}`
         : `user:${source?.userId ?? ""}`;
-  return { key: `${accountId}|${event.type}|${sourceId}|${eventId}`, eventId };
+  return { key: `${accountId}|${event.type}|${sourceId}|${eventId}`, eventId: `event:${eventId}` };
 }
 
 function shouldSkipLineReplayEvent(event: WebhookEvent, context: LineHandlerContext): boolean {

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -7,6 +7,8 @@ import type {
   LeaveEvent,
   PostbackEvent,
 } from "@line/bot-sdk";
+import { hasControlCommand } from "../auto-reply/command-detection.js";
+import { resolveControlCommandGate } from "../channels/command-gating.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   resolveAllowlistProviderRuntimeGroupPolicy,
@@ -42,6 +44,19 @@ interface MediaRef {
   contentType?: string;
 }
 
+const LINE_DOWNLOADABLE_MESSAGE_TYPES: ReadonlySet<string> = new Set([
+  "image",
+  "video",
+  "audio",
+  "file",
+]);
+
+function isDownloadableLineMessageType(
+  messageType: MessageEvent["message"]["type"],
+): messageType is "image" | "video" | "audio" | "file" {
+  return LINE_DOWNLOADABLE_MESSAGE_TYPES.has(messageType);
+}
+
 export interface LineHandlerContext {
   cfg: OpenClawConfig;
   account: ResolvedLineAccount;
@@ -56,12 +71,14 @@ const LINE_WEBHOOK_REPLAY_MAX_ENTRIES = 4096;
 const LINE_WEBHOOK_REPLAY_PRUNE_INTERVAL_MS = 1000;
 export type LineWebhookReplayCache = {
   seenEvents: Map<string, number>;
+  inFlightEvents: Set<string>;
   lastPruneAtMs: number;
 };
 
 export function createLineWebhookReplayCache(): LineWebhookReplayCache {
   return {
     seenEvents: new Map<string, number>(),
+    inFlightEvents: new Set<string>(),
     lastPruneAtMs: 0,
   };
 }
@@ -148,11 +165,23 @@ function getLineReplayCandidate(
 }
 
 function shouldSkipLineReplayEvent(candidate: LineReplayCandidate): boolean {
+  if (candidate.cache.inFlightEvents.has(candidate.key)) {
+    logVerbose(`line: skipped in-flight replayed webhook event ${candidate.eventId}`);
+    return true;
+  }
   if (candidate.cache.seenEvents.has(candidate.key)) {
     logVerbose(`line: skipped replayed webhook event ${candidate.eventId}`);
     return true;
   }
   return false;
+}
+
+function markLineReplayEventInFlight(candidate: LineReplayCandidate): void {
+  candidate.cache.inFlightEvents.add(candidate.key);
+}
+
+function clearLineReplayEventInFlight(candidate: LineReplayCandidate): void {
+  candidate.cache.inFlightEvents.delete(candidate.key);
 }
 
 function rememberLineReplayEvent(candidate: LineReplayCandidate): void {
@@ -225,7 +254,8 @@ async function sendLinePairingReply(params: {
 async function shouldProcessLineEvent(
   event: MessageEvent | PostbackEvent,
   context: LineHandlerContext,
-): Promise<boolean> {
+): Promise<{ allowed: boolean; commandAuthorized: boolean }> {
+  const denied = { allowed: false, commandAuthorized: false };
   const { cfg, account } = context;
   const { userId, groupId, roomId, isGroup } = getLineSourceInfo(event.source);
   const senderId = userId ?? "";
@@ -271,42 +301,52 @@ async function shouldProcessLineEvent(
   if (isGroup) {
     if (groupConfig?.enabled === false) {
       logVerbose(`Blocked line group ${groupId ?? roomId ?? "unknown"} (group disabled)`);
-      return false;
+      return denied;
     }
     if (typeof groupAllowOverride !== "undefined") {
       if (!senderId) {
         logVerbose("Blocked line group message (group allowFrom override, no sender ID)");
-        return false;
+        return denied;
       }
       if (!isSenderAllowed({ allow: effectiveGroupAllow, senderId })) {
         logVerbose(`Blocked line group sender ${senderId} (group allowFrom override)`);
-        return false;
+        return denied;
       }
     }
     if (groupPolicy === "disabled") {
       logVerbose("Blocked line group message (groupPolicy: disabled)");
-      return false;
+      return denied;
     }
     if (groupPolicy === "allowlist") {
       if (!senderId) {
         logVerbose("Blocked line group message (no sender ID, groupPolicy: allowlist)");
-        return false;
+        return denied;
       }
       if (!effectiveGroupAllow.hasEntries) {
         logVerbose("Blocked line group message (groupPolicy: allowlist, no groupAllowFrom)");
-        return false;
+        return denied;
       }
       if (!isSenderAllowed({ allow: effectiveGroupAllow, senderId })) {
         logVerbose(`Blocked line group message from ${senderId} (groupPolicy: allowlist)`);
-        return false;
+        return denied;
       }
     }
-    return true;
+    const allowForCommands = effectiveGroupAllow;
+    const senderAllowedForCommands = isSenderAllowed({ allow: allowForCommands, senderId });
+    const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+    const rawText = resolveEventRawText(event);
+    const commandGate = resolveControlCommandGate({
+      useAccessGroups,
+      authorizers: [{ configured: allowForCommands.hasEntries, allowed: senderAllowedForCommands }],
+      allowTextCommands: true,
+      hasControlCommand: hasControlCommand(rawText, cfg),
+    });
+    return { allowed: true, commandAuthorized: commandGate.commandAuthorized };
   }
 
   if (dmPolicy === "disabled") {
     logVerbose("Blocked line sender (dmPolicy: disabled)");
-    return false;
+    return denied;
   }
 
   const dmAllowed = dmPolicy === "open" || isSenderAllowed({ allow: effectiveDmAllow, senderId });
@@ -314,7 +354,7 @@ async function shouldProcessLineEvent(
     if (dmPolicy === "pairing") {
       if (!senderId) {
         logVerbose("Blocked line sender (dmPolicy: pairing, no sender ID)");
-        return false;
+        return denied;
       }
       await sendLinePairingReply({
         senderId,
@@ -324,24 +364,49 @@ async function shouldProcessLineEvent(
     } else {
       logVerbose(`Blocked line sender ${senderId || "unknown"} (dmPolicy: ${dmPolicy})`);
     }
-    return false;
+    return denied;
   }
 
-  return true;
+  const allowForCommands = effectiveDmAllow;
+  const senderAllowedForCommands = isSenderAllowed({ allow: allowForCommands, senderId });
+  const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+  const rawText = resolveEventRawText(event);
+  const commandGate = resolveControlCommandGate({
+    useAccessGroups,
+    authorizers: [{ configured: allowForCommands.hasEntries, allowed: senderAllowedForCommands }],
+    allowTextCommands: true,
+    hasControlCommand: hasControlCommand(rawText, cfg),
+  });
+  return { allowed: true, commandAuthorized: commandGate.commandAuthorized };
+}
+
+function resolveEventRawText(event: MessageEvent | PostbackEvent): string {
+  if (event.type === "message") {
+    const msg = event.message;
+    if (msg.type === "text") {
+      return msg.text;
+    }
+    return "";
+  }
+  if (event.type === "postback") {
+    return event.postback?.data?.trim() ?? "";
+  }
+  return "";
 }
 
 async function handleMessageEvent(event: MessageEvent, context: LineHandlerContext): Promise<void> {
   const { cfg, account, runtime, mediaMaxBytes, processMessage } = context;
   const message = event.message;
 
-  if (!(await shouldProcessLineEvent(event, context))) {
+  const decision = await shouldProcessLineEvent(event, context);
+  if (!decision.allowed) {
     return;
   }
 
   // Download media if applicable
   const allMedia: MediaRef[] = [];
 
-  if (message.type === "image" || message.type === "video" || message.type === "audio") {
+  if (isDownloadableLineMessageType(message.type)) {
     try {
       const media = await downloadLineMedia(message.id, account.channelAccessToken, mediaMaxBytes);
       allMedia.push({
@@ -364,6 +429,7 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
     allMedia,
     cfg,
     account,
+    commandAuthorized: decision.commandAuthorized,
   });
 
   if (!messageContext) {
@@ -407,7 +473,8 @@ async function handlePostbackEvent(
   const data = event.postback.data;
   logVerbose(`line: received postback: ${data}`);
 
-  if (!(await shouldProcessLineEvent(event, context))) {
+  const decision = await shouldProcessLineEvent(event, context);
+  if (!decision.allowed) {
     return;
   }
 
@@ -415,6 +482,7 @@ async function handlePostbackEvent(
     event,
     cfg: context.cfg,
     account: context.account,
+    commandAuthorized: decision.commandAuthorized,
   });
   if (!postbackContext) {
     return;
@@ -432,6 +500,9 @@ export async function handleLineWebhookEvents(
     const replayCandidate = getLineReplayCandidate(event, context);
     if (replayCandidate && shouldSkipLineReplayEvent(replayCandidate)) {
       continue;
+    }
+    if (replayCandidate) {
+      markLineReplayEventInFlight(replayCandidate);
     }
     try {
       switch (event.type) {
@@ -458,8 +529,12 @@ export async function handleLineWebhookEvents(
       }
       if (replayCandidate) {
         rememberLineReplayEvent(replayCandidate);
+        clearLineReplayEventInFlight(replayCandidate);
       }
     } catch (err) {
+      if (replayCandidate) {
+        clearLineReplayEventInFlight(replayCandidate);
+      }
       context.runtime.error?.(danger(`line: event handler failed: ${String(err)}`));
       firstError ??= err;
     }

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -71,14 +71,14 @@ const LINE_WEBHOOK_REPLAY_MAX_ENTRIES = 4096;
 const LINE_WEBHOOK_REPLAY_PRUNE_INTERVAL_MS = 1000;
 export type LineWebhookReplayCache = {
   seenEvents: Map<string, number>;
-  inFlightEvents: Set<string>;
+  inFlightEvents: Map<string, Promise<void>>;
   lastPruneAtMs: number;
 };
 
 export function createLineWebhookReplayCache(): LineWebhookReplayCache {
   return {
     seenEvents: new Map<string, number>(),
-    inFlightEvents: new Set<string>(),
+    inFlightEvents: new Map<string, Promise<void>>(),
     lastPruneAtMs: 0,
   };
 }
@@ -143,6 +143,12 @@ type LineReplayCandidate = {
   cache: LineWebhookReplayCache;
 };
 
+type LineInFlightReplayResult = {
+  promise: Promise<void>;
+  resolve: () => void;
+  reject: (err: unknown) => void;
+};
+
 function getLineReplayCandidate(
   event: WebhookEvent,
   context: LineHandlerContext,
@@ -164,20 +170,33 @@ function getLineReplayCandidate(
   return { key: replay.key, eventId: replay.eventId, seenAtMs: nowMs, cache };
 }
 
-function shouldSkipLineReplayEvent(candidate: LineReplayCandidate): boolean {
-  if (candidate.cache.inFlightEvents.has(candidate.key)) {
+function shouldSkipLineReplayEvent(
+  candidate: LineReplayCandidate,
+): { skip: true; inFlightResult?: Promise<void> } | { skip: false } {
+  const inFlightResult = candidate.cache.inFlightEvents.get(candidate.key);
+  if (inFlightResult) {
     logVerbose(`line: skipped in-flight replayed webhook event ${candidate.eventId}`);
-    return true;
+    return { skip: true, inFlightResult };
   }
   if (candidate.cache.seenEvents.has(candidate.key)) {
     logVerbose(`line: skipped replayed webhook event ${candidate.eventId}`);
-    return true;
+    return { skip: true };
   }
-  return false;
+  return { skip: false };
 }
 
-function markLineReplayEventInFlight(candidate: LineReplayCandidate): void {
-  candidate.cache.inFlightEvents.add(candidate.key);
+function markLineReplayEventInFlight(candidate: LineReplayCandidate): LineInFlightReplayResult {
+  let resolve!: () => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  // Prevent unhandled rejection warnings when no concurrent duplicate awaits
+  // this in-flight reservation.
+  void promise.catch(() => {});
+  candidate.cache.inFlightEvents.set(candidate.key, promise);
+  return { promise, resolve, reject };
 }
 
 function clearLineReplayEventInFlight(candidate: LineReplayCandidate): void {
@@ -498,12 +517,21 @@ export async function handleLineWebhookEvents(
   let firstError: unknown;
   for (const event of events) {
     const replayCandidate = getLineReplayCandidate(event, context);
-    if (replayCandidate && shouldSkipLineReplayEvent(replayCandidate)) {
+    const replaySkip = replayCandidate ? shouldSkipLineReplayEvent(replayCandidate) : null;
+    if (replaySkip?.skip) {
+      if (replaySkip.inFlightResult) {
+        try {
+          await replaySkip.inFlightResult;
+        } catch (err) {
+          context.runtime.error?.(danger(`line: replayed in-flight event failed: ${String(err)}`));
+          firstError ??= err;
+        }
+      }
       continue;
     }
-    if (replayCandidate) {
-      markLineReplayEventInFlight(replayCandidate);
-    }
+    const inFlightReservation = replayCandidate
+      ? markLineReplayEventInFlight(replayCandidate)
+      : null;
     try {
       switch (event.type) {
         case "message":
@@ -529,10 +557,12 @@ export async function handleLineWebhookEvents(
       }
       if (replayCandidate) {
         rememberLineReplayEvent(replayCandidate);
+        inFlightReservation?.resolve();
         clearLineReplayEventInFlight(replayCandidate);
       }
     } catch (err) {
       if (replayCandidate) {
+        inFlightReservation?.reject(err);
         clearLineReplayEventInFlight(replayCandidate);
       }
       context.runtime.error?.(danger(`line: event handler failed: ${String(err)}`));

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -7,8 +7,6 @@ import type {
   LeaveEvent,
   PostbackEvent,
 } from "@line/bot-sdk";
-import { hasControlCommand } from "../auto-reply/command-detection.js";
-import { resolveControlCommandGate } from "../channels/command-gating.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   resolveAllowlistProviderRuntimeGroupPolicy,
@@ -42,19 +40,6 @@ import type { LineGroupConfig, ResolvedLineAccount } from "./types.js";
 interface MediaRef {
   path: string;
   contentType?: string;
-}
-
-const LINE_DOWNLOADABLE_MESSAGE_TYPES: ReadonlySet<string> = new Set([
-  "image",
-  "video",
-  "audio",
-  "file",
-]);
-
-function isDownloadableLineMessageType(
-  messageType: MessageEvent["message"]["type"],
-): messageType is "image" | "video" | "audio" | "file" {
-  return LINE_DOWNLOADABLE_MESSAGE_TYPES.has(messageType);
 }
 
 export interface LineHandlerContext {
@@ -237,15 +222,10 @@ async function sendLinePairingReply(params: {
   }
 }
 
-type LineAccessDecision = {
-  allowed: boolean;
-  commandAuthorized: boolean;
-};
-
 async function shouldProcessLineEvent(
   event: MessageEvent | PostbackEvent,
   context: LineHandlerContext,
-): Promise<LineAccessDecision> {
+): Promise<boolean> {
   const { cfg, account } = context;
   const { userId, groupId, roomId, isGroup } = getLineSourceInfo(event.source);
   const senderId = userId ?? "";
@@ -288,59 +268,45 @@ async function shouldProcessLineEvent(
     log: (message) => logVerbose(message),
   });
 
-  const denied = { allowed: false, commandAuthorized: false };
-
   if (isGroup) {
     if (groupConfig?.enabled === false) {
       logVerbose(`Blocked line group ${groupId ?? roomId ?? "unknown"} (group disabled)`);
-      return denied;
+      return false;
     }
     if (typeof groupAllowOverride !== "undefined") {
       if (!senderId) {
         logVerbose("Blocked line group message (group allowFrom override, no sender ID)");
-        return denied;
+        return false;
       }
       if (!isSenderAllowed({ allow: effectiveGroupAllow, senderId })) {
         logVerbose(`Blocked line group sender ${senderId} (group allowFrom override)`);
-        return denied;
+        return false;
       }
     }
     if (groupPolicy === "disabled") {
       logVerbose("Blocked line group message (groupPolicy: disabled)");
-      return denied;
+      return false;
     }
     if (groupPolicy === "allowlist") {
       if (!senderId) {
         logVerbose("Blocked line group message (no sender ID, groupPolicy: allowlist)");
-        return denied;
+        return false;
       }
       if (!effectiveGroupAllow.hasEntries) {
         logVerbose("Blocked line group message (groupPolicy: allowlist, no groupAllowFrom)");
-        return denied;
+        return false;
       }
       if (!isSenderAllowed({ allow: effectiveGroupAllow, senderId })) {
         logVerbose(`Blocked line group message from ${senderId} (groupPolicy: allowlist)`);
-        return denied;
+        return false;
       }
     }
-
-    // Resolve command authorization using the same pattern as Telegram/Discord/Slack.
-    const allowForCommands = effectiveGroupAllow;
-    const senderAllowedForCommands = isSenderAllowed({ allow: allowForCommands, senderId });
-    const useAccessGroups = cfg.commands?.useAccessGroups !== false;
-    const rawText = resolveEventRawText(event);
-    const commandGate = resolveControlCommandGate({
-      useAccessGroups,
-      authorizers: [{ configured: allowForCommands.hasEntries, allowed: senderAllowedForCommands }],
-      allowTextCommands: true,
-      hasControlCommand: hasControlCommand(rawText, cfg),
-    });
-    return { allowed: true, commandAuthorized: commandGate.commandAuthorized };
+    return true;
   }
 
   if (dmPolicy === "disabled") {
     logVerbose("Blocked line sender (dmPolicy: disabled)");
-    return denied;
+    return false;
   }
 
   const dmAllowed = dmPolicy === "open" || isSenderAllowed({ allow: effectiveDmAllow, senderId });
@@ -348,7 +314,7 @@ async function shouldProcessLineEvent(
     if (dmPolicy === "pairing") {
       if (!senderId) {
         logVerbose("Blocked line sender (dmPolicy: pairing, no sender ID)");
-        return denied;
+        return false;
       }
       await sendLinePairingReply({
         senderId,
@@ -358,51 +324,24 @@ async function shouldProcessLineEvent(
     } else {
       logVerbose(`Blocked line sender ${senderId || "unknown"} (dmPolicy: ${dmPolicy})`);
     }
-    return denied;
+    return false;
   }
 
-  // Resolve command authorization for DMs.
-  const allowForCommands = effectiveDmAllow;
-  const senderAllowedForCommands = isSenderAllowed({ allow: allowForCommands, senderId });
-  const useAccessGroups = cfg.commands?.useAccessGroups !== false;
-  const rawText = resolveEventRawText(event);
-  const commandGate = resolveControlCommandGate({
-    useAccessGroups,
-    authorizers: [{ configured: allowForCommands.hasEntries, allowed: senderAllowedForCommands }],
-    allowTextCommands: true,
-    hasControlCommand: hasControlCommand(rawText, cfg),
-  });
-  return { allowed: true, commandAuthorized: commandGate.commandAuthorized };
-}
-
-/** Extract raw text from a LINE message or postback event for command detection. */
-function resolveEventRawText(event: MessageEvent | PostbackEvent): string {
-  if (event.type === "message") {
-    const msg = event.message;
-    if (msg.type === "text") {
-      return msg.text;
-    }
-    return "";
-  }
-  if (event.type === "postback") {
-    return event.postback?.data?.trim() ?? "";
-  }
-  return "";
+  return true;
 }
 
 async function handleMessageEvent(event: MessageEvent, context: LineHandlerContext): Promise<void> {
   const { cfg, account, runtime, mediaMaxBytes, processMessage } = context;
   const message = event.message;
 
-  const decision = await shouldProcessLineEvent(event, context);
-  if (!decision.allowed) {
+  if (!(await shouldProcessLineEvent(event, context))) {
     return;
   }
 
   // Download media if applicable
   const allMedia: MediaRef[] = [];
 
-  if (isDownloadableLineMessageType(message.type)) {
+  if (message.type === "image" || message.type === "video" || message.type === "audio") {
     try {
       const media = await downloadLineMedia(message.id, account.channelAccessToken, mediaMaxBytes);
       allMedia.push({
@@ -425,7 +364,6 @@ async function handleMessageEvent(event: MessageEvent, context: LineHandlerConte
     allMedia,
     cfg,
     account,
-    commandAuthorized: decision.commandAuthorized,
   });
 
   if (!messageContext) {
@@ -469,8 +407,7 @@ async function handlePostbackEvent(
   const data = event.postback.data;
   logVerbose(`line: received postback: ${data}`);
 
-  const decision = await shouldProcessLineEvent(event, context);
-  if (!decision.allowed) {
+  if (!(await shouldProcessLineEvent(event, context))) {
     return;
   }
 
@@ -478,7 +415,6 @@ async function handlePostbackEvent(
     event,
     cfg: context.cfg,
     account: context.account,
-    commandAuthorized: decision.commandAuthorized,
   });
   if (!postbackContext) {
     return;
@@ -491,6 +427,7 @@ export async function handleLineWebhookEvents(
   events: WebhookEvent[],
   context: LineHandlerContext,
 ): Promise<void> {
+  let firstError: unknown;
   for (const event of events) {
     const replayCandidate = getLineReplayCandidate(event, context);
     if (replayCandidate && shouldSkipLineReplayEvent(replayCandidate)) {
@@ -524,9 +461,10 @@ export async function handleLineWebhookEvents(
       }
     } catch (err) {
       context.runtime.error?.(danger(`line: event handler failed: ${String(err)}`));
-      // Continue processing remaining events in this batch. Webhook ACK is sent
-      // before processing, so dropping later events here would make them unrecoverable.
-      continue;
+      firstError ??= err;
     }
+  }
+  if (firstError) {
+    throw firstError;
   }
 }

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -63,30 +63,40 @@ export interface LineHandlerContext {
   runtime: RuntimeEnv;
   mediaMaxBytes: number;
   processMessage: (ctx: LineInboundContext) => Promise<void>;
+  replayCache?: LineWebhookReplayCache;
 }
 
 const LINE_WEBHOOK_REPLAY_WINDOW_MS = 10 * 60 * 1000;
 const LINE_WEBHOOK_REPLAY_MAX_ENTRIES = 4096;
 const LINE_WEBHOOK_REPLAY_PRUNE_INTERVAL_MS = 1000;
-const seenLineWebhookEvents = new Map<string, number>();
-let lastLineWebhookReplayPruneAtMs = 0;
+export type LineWebhookReplayCache = {
+  seenEvents: Map<string, number>;
+  lastPruneAtMs: number;
+};
 
-function pruneLineWebhookReplayCache(nowMs: number): void {
+export function createLineWebhookReplayCache(): LineWebhookReplayCache {
+  return {
+    seenEvents: new Map<string, number>(),
+    lastPruneAtMs: 0,
+  };
+}
+
+function pruneLineWebhookReplayCache(cache: LineWebhookReplayCache, nowMs: number): void {
   const minSeenAt = nowMs - LINE_WEBHOOK_REPLAY_WINDOW_MS;
-  for (const [key, seenAt] of seenLineWebhookEvents) {
+  for (const [key, seenAt] of cache.seenEvents) {
     if (seenAt < minSeenAt) {
-      seenLineWebhookEvents.delete(key);
+      cache.seenEvents.delete(key);
     }
   }
 
-  if (seenLineWebhookEvents.size > LINE_WEBHOOK_REPLAY_MAX_ENTRIES) {
-    const deleteCount = seenLineWebhookEvents.size - LINE_WEBHOOK_REPLAY_MAX_ENTRIES;
+  if (cache.seenEvents.size > LINE_WEBHOOK_REPLAY_MAX_ENTRIES) {
+    const deleteCount = cache.seenEvents.size - LINE_WEBHOOK_REPLAY_MAX_ENTRIES;
     let deleted = 0;
-    for (const key of seenLineWebhookEvents.keys()) {
+    for (const key of cache.seenEvents.keys()) {
       if (deleted >= deleteCount) {
         break;
       }
-      seenLineWebhookEvents.delete(key);
+      cache.seenEvents.delete(key);
       deleted += 1;
     }
   }
@@ -117,23 +127,24 @@ function buildLineWebhookReplayKey(
 
 function shouldSkipLineReplayEvent(event: WebhookEvent, context: LineHandlerContext): boolean {
   const replay = buildLineWebhookReplayKey(event, context.account.accountId);
-  if (!replay) {
+  const cache = context.replayCache;
+  if (!replay || !cache) {
     return false;
   }
 
   const nowMs = Date.now();
   if (
-    nowMs - lastLineWebhookReplayPruneAtMs >= LINE_WEBHOOK_REPLAY_PRUNE_INTERVAL_MS ||
-    seenLineWebhookEvents.size >= LINE_WEBHOOK_REPLAY_MAX_ENTRIES
+    nowMs - cache.lastPruneAtMs >= LINE_WEBHOOK_REPLAY_PRUNE_INTERVAL_MS ||
+    cache.seenEvents.size >= LINE_WEBHOOK_REPLAY_MAX_ENTRIES
   ) {
-    pruneLineWebhookReplayCache(nowMs);
-    lastLineWebhookReplayPruneAtMs = nowMs;
+    pruneLineWebhookReplayCache(cache, nowMs);
+    cache.lastPruneAtMs = nowMs;
   }
-  if (seenLineWebhookEvents.has(replay.key)) {
+  if (cache.seenEvents.has(replay.key)) {
     logVerbose(`line: skipped replayed webhook event ${replay.eventId}`);
     return true;
   }
-  seenLineWebhookEvents.set(replay.key, nowMs);
+  cache.seenEvents.set(replay.key, nowMs);
   return false;
 }
 

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -27,7 +27,7 @@ import {
   firstDefined,
   isSenderAllowed,
   normalizeAllowFrom,
-  normalizeAllowFromWithStore,
+  normalizeDmAllowFromWithStore,
 } from "./bot-access.js";
 import {
   getLineSourceInfo,
@@ -147,7 +147,7 @@ async function shouldProcessLineEvent(
     undefined,
     account.accountId,
   ).catch(() => []);
-  const effectiveDmAllow = normalizeAllowFromWithStore({
+  const effectiveDmAllow = normalizeDmAllowFromWithStore({
     allowFrom: account.config.allowFrom,
     storeAllowFrom,
     dmPolicy,

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -67,7 +67,9 @@ export interface LineHandlerContext {
 
 const LINE_WEBHOOK_REPLAY_WINDOW_MS = 10 * 60 * 1000;
 const LINE_WEBHOOK_REPLAY_MAX_ENTRIES = 4096;
+const LINE_WEBHOOK_REPLAY_PRUNE_INTERVAL_MS = 1000;
 const seenLineWebhookEvents = new Map<string, number>();
+let lastLineWebhookReplayPruneAtMs = 0;
 
 function pruneLineWebhookReplayCache(nowMs: number): void {
   const minSeenAt = nowMs - LINE_WEBHOOK_REPLAY_WINDOW_MS;
@@ -120,7 +122,13 @@ function shouldSkipLineReplayEvent(event: WebhookEvent, context: LineHandlerCont
   }
 
   const nowMs = Date.now();
-  pruneLineWebhookReplayCache(nowMs);
+  if (
+    nowMs - lastLineWebhookReplayPruneAtMs >= LINE_WEBHOOK_REPLAY_PRUNE_INTERVAL_MS ||
+    seenLineWebhookEvents.size >= LINE_WEBHOOK_REPLAY_MAX_ENTRIES
+  ) {
+    pruneLineWebhookReplayCache(nowMs);
+    lastLineWebhookReplayPruneAtMs = nowMs;
+  }
   if (seenLineWebhookEvents.has(replay.key)) {
     logVerbose(`line: skipped replayed webhook event ${replay.eventId}`);
     return true;

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -115,16 +115,6 @@ function buildLineWebhookReplayKey(
       };
     }
   }
-  if (event.type === "postback") {
-    const replyToken = event.replyToken?.trim();
-    if (replyToken) {
-      return {
-        key: `${accountId}|postback:${replyToken}`,
-        eventId: `postback:${replyToken}`,
-      };
-    }
-  }
-
   const eventId = (event as { webhookEventId?: string }).webhookEventId?.trim();
   if (!eventId) {
     return null;
@@ -144,11 +134,21 @@ function buildLineWebhookReplayKey(
   return { key: `${accountId}|${event.type}|${sourceId}|${eventId}`, eventId: `event:${eventId}` };
 }
 
-function shouldSkipLineReplayEvent(event: WebhookEvent, context: LineHandlerContext): boolean {
+type LineReplayCandidate = {
+  key: string;
+  eventId: string;
+  seenAtMs: number;
+  cache: LineWebhookReplayCache;
+};
+
+function getLineReplayCandidate(
+  event: WebhookEvent,
+  context: LineHandlerContext,
+): LineReplayCandidate | null {
   const replay = buildLineWebhookReplayKey(event, context.account.accountId);
   const cache = context.replayCache;
   if (!replay || !cache) {
-    return false;
+    return null;
   }
 
   const nowMs = Date.now();
@@ -159,12 +159,19 @@ function shouldSkipLineReplayEvent(event: WebhookEvent, context: LineHandlerCont
     pruneLineWebhookReplayCache(cache, nowMs);
     cache.lastPruneAtMs = nowMs;
   }
-  if (cache.seenEvents.has(replay.key)) {
-    logVerbose(`line: skipped replayed webhook event ${replay.eventId}`);
+  return { key: replay.key, eventId: replay.eventId, seenAtMs: nowMs, cache };
+}
+
+function shouldSkipLineReplayEvent(candidate: LineReplayCandidate): boolean {
+  if (candidate.cache.seenEvents.has(candidate.key)) {
+    logVerbose(`line: skipped replayed webhook event ${candidate.eventId}`);
     return true;
   }
-  cache.seenEvents.set(replay.key, nowMs);
   return false;
+}
+
+function rememberLineReplayEvent(candidate: LineReplayCandidate): void {
+  candidate.cache.seenEvents.set(candidate.key, candidate.seenAtMs);
 }
 
 function resolveLineGroupConfig(params: {
@@ -485,7 +492,8 @@ export async function handleLineWebhookEvents(
   context: LineHandlerContext,
 ): Promise<void> {
   for (const event of events) {
-    if (shouldSkipLineReplayEvent(event, context)) {
+    const replayCandidate = getLineReplayCandidate(event, context);
+    if (replayCandidate && shouldSkipLineReplayEvent(replayCandidate)) {
       continue;
     }
     try {
@@ -510,6 +518,9 @@ export async function handleLineWebhookEvents(
           break;
         default:
           logVerbose(`line: unhandled event type: ${(event as WebhookEvent).type}`);
+      }
+      if (replayCandidate) {
+        rememberLineReplayEvent(replayCandidate);
       }
     } catch (err) {
       context.runtime.error?.(danger(`line: event handler failed: ${String(err)}`));

--- a/src/line/bot-handlers.ts
+++ b/src/line/bot-handlers.ts
@@ -144,10 +144,10 @@ async function shouldProcessLineEvent(
 
   const storeAllowFrom = await readChannelAllowFromStore(
     "line",
-    process.env,
+    undefined,
     account.accountId,
   ).catch(() => []);
-  const effectiveDmAllow = normalizeDmAllowFromWithStore({
+  const effectiveDmAllow = normalizeAllowFromWithStore({
     allowFrom: account.config.allowFrom,
     storeAllowFrom,
     dmPolicy,

--- a/src/line/bot-message-context.test.ts
+++ b/src/line/bot-message-context.test.ts
@@ -114,6 +114,26 @@ describe("buildLineMessageContext", () => {
     expect(context?.ctxPayload.To).toBe("line:room:room-1");
   });
 
+  it("keeps non-text message contexts fail-closed for command auth", async () => {
+    const event = createMessageEvent(
+      { type: "user", userId: "user-audio" },
+      {
+        message: { id: "audio-1", type: "audio", duration: 1000 } as MessageEvent["message"],
+      },
+    );
+
+    const context = await buildLineMessageContext({
+      event,
+      allMedia: [],
+      cfg,
+      account,
+      commandAuthorized: false,
+    });
+
+    expect(context).not.toBeNull();
+    expect(context?.ctxPayload.CommandAuthorized).toBe(false);
+  });
+
   it("sets CommandAuthorized=true when authorized", async () => {
     const event = createMessageEvent({ type: "user", userId: "user-auth" });
 

--- a/src/line/bot.ts
+++ b/src/line/bot.ts
@@ -5,7 +5,7 @@ import { loadConfig } from "../config/config.js";
 import { logVerbose } from "../globals.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../runtime.js";
 import { resolveLineAccount } from "./accounts.js";
-import { handleLineWebhookEvents } from "./bot-handlers.js";
+import { createLineWebhookReplayCache, handleLineWebhookEvents } from "./bot-handlers.js";
 import type { LineInboundContext } from "./bot-message-context.js";
 import type { ResolvedLineAccount } from "./types.js";
 import { startLineWebhook } from "./webhook.js";
@@ -41,6 +41,7 @@ export function createLineBot(opts: LineBotOptions): LineBot {
     (async () => {
       logVerbose("line: no message handler configured");
     });
+  const replayCache = createLineWebhookReplayCache();
 
   const handleWebhook = async (body: WebhookRequestBody): Promise<void> => {
     if (!body.events || body.events.length === 0) {
@@ -53,6 +54,7 @@ export function createLineBot(opts: LineBotOptions): LineBot {
       runtime,
       mediaMaxBytes,
       processMessage,
+      replayCache,
     });
   };
 

--- a/src/line/webhook-node.test.ts
+++ b/src/line/webhook-node.test.ts
@@ -195,7 +195,7 @@ describe("createLineNodeWebhookHandler", () => {
     );
   });
 
-  it("returns 200 immediately and logs when event processing fails", async () => {
+  it("returns 500 when event processing fails and does not acknowledge with 200", async () => {
     const rawBody = JSON.stringify({ events: [{ type: "message" }] });
     const { secret } = createPostWebhookTestHarness(rawBody);
     const failingBot = {
@@ -213,10 +213,9 @@ describe("createLineNodeWebhookHandler", () => {
 
     const { res } = createRes();
     await runSignedPost({ handler: failingHandler, rawBody, secret, res });
-    await Promise.resolve();
 
-    expect(res.statusCode).toBe(200);
-    expect(res.body).toBe(JSON.stringify({ status: "ok" }));
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toBe(JSON.stringify({ error: "Internal server error" }));
     expect(failingBot.handleWebhook).toHaveBeenCalledTimes(1);
     expect(runtime.error).toHaveBeenCalledTimes(1);
   });

--- a/src/line/webhook-node.ts
+++ b/src/line/webhook-node.ts
@@ -111,16 +111,14 @@ export function createLineNodeWebhookHandler(params: {
         return;
       }
 
+      if (body.events && body.events.length > 0) {
+        logVerbose(`line: received ${body.events.length} webhook events`);
+        await params.bot.handleWebhook(body);
+      }
+
       res.statusCode = 200;
       res.setHeader("Content-Type", "application/json");
       res.end(JSON.stringify({ status: "ok" }));
-
-      if (body.events && body.events.length > 0) {
-        logVerbose(`line: received ${body.events.length} webhook events`);
-        void params.bot.handleWebhook(body).catch((err) => {
-          params.runtime.error?.(danger(`line webhook handler failed: ${String(err)}`));
-        });
-      }
     } catch (err) {
       if (isRequestBodyLimitError(err, "PAYLOAD_TOO_LARGE")) {
         res.statusCode = 413;

--- a/src/line/webhook.test.ts
+++ b/src/line/webhook.test.ts
@@ -121,17 +121,31 @@ describe("createLineWebhookMiddleware", () => {
     expect(onEvents).not.toHaveBeenCalled();
   });
 
-  it("returns 200 immediately when onEvents fails", async () => {
-    const { res, onEvents } = await invokeWebhook({
-      body: JSON.stringify({ events: [{ type: "message" }] }),
-      onEvents: vi.fn(async () => {
-        throw new Error("transient failure");
-      }),
+  it("returns 500 when event processing fails and does not acknowledge with 200", async () => {
+    const onEvents = vi.fn(async () => {
+      throw new Error("boom");
     });
-    await Promise.resolve();
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const rawBody = JSON.stringify({ events: [{ type: "message" }] });
+    const middleware = createLineWebhookMiddleware({
+      channelSecret: SECRET,
+      onEvents,
+      runtime,
+    });
 
-    expect(onEvents).toHaveBeenCalledTimes(1);
-    expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({ status: "ok" });
+    const req = {
+      headers: { "x-line-signature": sign(rawBody, SECRET) },
+      body: rawBody,
+      // oxlint-disable-next-line typescript/no-explicit-any
+    } as any;
+    const res = createRes();
+
+    // oxlint-disable-next-line typescript/no-explicit-any
+    await middleware(req, res, {} as any);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.status).not.toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ error: "Internal server error" });
+    expect(runtime.error).toHaveBeenCalled();
   });
 });

--- a/src/line/webhook.test.ts
+++ b/src/line/webhook.test.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import type { WebhookRequestBody } from "@line/bot-sdk";
 import { describe, expect, it, vi } from "vitest";
-import { createLineWebhookMiddleware } from "./webhook.js";
+import { createLineWebhookMiddleware, startLineWebhook } from "./webhook.js";
 
 const sign = (body: string, secret: string) =>
   crypto.createHmac("SHA256", secret).update(body).digest("base64");
@@ -54,6 +54,15 @@ async function invokeWebhook(params: {
 }
 
 describe("createLineWebhookMiddleware", () => {
+  it("rejects startup when channel secret is missing", () => {
+    expect(() =>
+      startLineWebhook({
+        channelSecret: "   ",
+        onEvents: async () => {},
+      }),
+    ).toThrow(/requires a non-empty channel secret/i);
+  });
+
   it.each([
     ["raw string body", JSON.stringify({ events: [{ type: "message" }] })],
     ["raw buffer body", Buffer.from(JSON.stringify({ events: [{ type: "follow" }] }), "utf-8")],

--- a/src/line/webhook.ts
+++ b/src/line/webhook.ts
@@ -71,14 +71,12 @@ export function createLineWebhookMiddleware(
         return;
       }
 
-      res.status(200).json({ status: "ok" });
-
       if (body.events && body.events.length > 0) {
         logVerbose(`line: received ${body.events.length} webhook events`);
-        void onEvents(body).catch((err) => {
-          runtime?.error?.(danger(`line webhook handler failed: ${String(err)}`));
-        });
+        await onEvents(body);
       }
+
+      res.status(200).json({ status: "ok" });
     } catch (err) {
       runtime?.error?.(danger(`line webhook error: ${String(err)}`));
       if (!res.headersSent) {

--- a/src/line/webhook.ts
+++ b/src/line/webhook.ts
@@ -99,9 +99,17 @@ export function startLineWebhook(options: StartLineWebhookOptions): {
   path: string;
   handler: (req: Request, res: Response, _next: NextFunction) => Promise<void>;
 } {
+  const channelSecret =
+    typeof options.channelSecret === "string" ? options.channelSecret.trim() : "";
+  if (!channelSecret) {
+    throw new Error(
+      "LINE webhook mode requires a non-empty channel secret. " +
+        "Set channels.line.channelSecret in your config.",
+    );
+  }
   const path = options.path ?? "/line/webhook";
   const middleware = createLineWebhookMiddleware({
-    channelSecret: options.channelSecret,
+    channelSecret,
     onEvents: options.onEvents,
     runtime: options.runtime,
   });

--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -307,6 +307,7 @@ describe("applyMediaUnderstanding", () => {
     const ctx = await createAudioCtx({
       body: "<media:audio> /capture status",
     });
+    ctx.CommandAuthorized = false;
     const result = await applyMediaUnderstanding({
       ctx,
       cfg: createGroqAudioConfig(),
@@ -320,6 +321,7 @@ describe("applyMediaUnderstanding", () => {
       body: "[Audio]\nUser text:\n/capture status\nTranscript:\ntranscribed text",
       commandBody: "/capture status",
     });
+    expect(ctx.CommandAuthorized).toBe(false);
   });
 
   it("handles URL-only attachments for audio transcription", async () => {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: LINE inbound auth boundaries were fragmented across pairing authorization, webhook verification, and replay handling, creating partial-trust behavior under overlap (DM vs group allowlists, replayed payload variants, and ack timing).
- Why it matters: Partial coverage in security boundaries can allow unintended authorization paths or make failure/retry behavior unsafe under provider redeliveries.
- What changed: Synthesized LINE hardening into one branch: account-scoped pairing-store checks, explicit group-vs-DM policy separation, fail-closed webhook startup secret validation, replay dedupe (webhook event + message-id/postback keyed by account), and processing-before-200 webhook semantics.
- What did NOT change (scope boundary): No channel expansion, no new external dependencies, no changes to unrelated providers/channels, and no origin/main direct push/merge.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #26701
- Related #26683
- Related #25978
- Related #17593
- Related #16619
- Related #31990
- Related #26047
- Related #30584
- Related #18777

## User-visible / Behavior Changes

- LINE webhook startup now fails immediately when `channelSecret` is blank/whitespace.
- LINE group authorization remains explicit to group allowlist policy and does not inherit DM pairing-store entries.
- LINE replayed inbound payloads are deduped more strictly (message-id/postback/event-id, account-scoped).
- LINE webhook handlers now process events before acknowledging 200, allowing provider retries on processing failure.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`Yes`)
- If any `Yes`, explain risk + mitigation:
  - Data access scope is tightened to account-scoped pairing authorization semantics in LINE paths; risk is behavioral regressions for misconfigured multi-account setups, mitigated via focused regression tests for DM/group boundary and replay permutations.

## Repro + Verification

### Environment

- OS: macOS (worktree-based local run)
- Runtime/container: Node 22+, pnpm workspace
- Model/provider: n/a
- Integration/channel (if any): LINE + gateway plugin HTTP auth path checks
- Relevant config (redacted): LINE `dmPolicy`/`groupPolicy` variants; webhook signed/unsigned probes

### Steps

1. Apply synthesized commits from the related PR set onto one branch.
2. Run focused regression tests for LINE handlers/webhook/gateway plugin auth path.
3. Run full local quality gates (`pnpm build`, `pnpm check`).

### Expected

- DM/group boundaries remain strict, replay duplicates are dropped, invalid/missing signature flows fail closed (except verification probe), and all gates pass.

### Actual

- All targeted tests and local gates pass.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: DM pairing account scoping, group allowlist isolation, webhook secret fail-closed startup, signed/unsigned/probe permutations, replay dedupe by event + message id, and process-before-200 webhook behavior.
- Edge cases checked: unsigned empty-events verification probe; redelivery with changed `webhookEventId` but same message id; cross-account allowlist scoping.
- What you did **not** verify: live LINE cloud callbacks in external environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or revert replay-related commits first, then policy cluster if needed.
- Files/config to restore: `src/line/bot-handlers.ts`, `src/line/webhook.ts`, `src/line/webhook-node.ts`, plus related tests.
- Known bad symptoms reviewers should watch for: unexpected duplicate LINE turns, unexpected group message admits/blocks, webhook retry storms.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Over-aggressive dedupe suppresses legitimate redelivery variants.
  - Mitigation: account-scoped keys + focused replay tests for message-id/event-id permutations.
- Risk: process-before-200 can increase webhook latency on heavy processing paths.
  - Mitigation: current tests verify correctness; monitor LINE webhook timeout behavior and adjust handler path if needed.
