### PR TITLE
Discord: add id-based mention formatting and rewrite

### DIFF
--- a/src/discord/directory-cache.ts
+++ b/src/discord/directory-cache.ts
@@ -1,0 +1,111 @@
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/account-id.js";
+
+const DISCORD_DIRECTORY_CACHE_MAX_ENTRIES = 4000;
+const DISCORD_DISCRIMINATOR_SUFFIX = /#\d{4}$/;
+
+const DIRECTORY_HANDLE_CACHE = new Map<string, Map<string, string>>();
+
+function normalizeAccountCacheKey(accountId?: string | null): string {
+  const normalized = normalizeAccountId(accountId ?? DEFAULT_ACCOUNT_ID);
+  return normalized || DEFAULT_ACCOUNT_ID;
+}
+
+function normalizeSnowflake(value: string | number | bigint): string | null {
+  const text = String(value ?? "").trim();
+  if (!/^\d+$/.test(text)) {
+    return null;
+  }
+  return text;
+}
+
+function normalizeHandleKey(raw: string): string | null {
+  let handle = raw.trim();
+  if (!handle) {
+    return null;
+  }
+  if (handle.startsWith("@")) {
+    handle = handle.slice(1).trim();
+  }
+  if (!handle || /\s/.test(handle)) {
+    return null;
+  }
+  return handle.toLowerCase();
+}
+
+function ensureAccountCache(accountId?: string | null): Map<string, string> {
+  const cacheKey = normalizeAccountCacheKey(accountId);
+  const existing = DIRECTORY_HANDLE_CACHE.get(cacheKey);
+  if (existing) {
+    return existing;
+  }
+  const created = new Map<string, string>();
+  DIRECTORY_HANDLE_CACHE.set(cacheKey, created);
+  return created;
+}
+
+function setCacheEntry(cache: Map<string, string>, key: string, userId: string): void {
+  if (cache.has(key)) {
+    cache.delete(key);
+  }
+  cache.set(key, userId);
+  if (cache.size <= DISCORD_DIRECTORY_CACHE_MAX_ENTRIES) {
+    return;
+  }
+  const oldest = cache.keys().next();
+  if (!oldest.done) {
+    cache.delete(oldest.value);
+  }
+}
+
+export function rememberDiscordDirectoryUser(params: {
+  accountId?: string | null;
+  userId: string | number | bigint;
+  handles: Array<string | null | undefined>;
+}): void {
+  const userId = normalizeSnowflake(params.userId);
+  if (!userId) {
+    return;
+  }
+  const cache = ensureAccountCache(params.accountId);
+  for (const candidate of params.handles) {
+    if (typeof candidate !== "string") {
+      continue;
+    }
+    const handle = normalizeHandleKey(candidate);
+    if (!handle) {
+      continue;
+    }
+    setCacheEntry(cache, handle, userId);
+    const withoutDiscriminator = handle.replace(DISCORD_DISCRIMINATOR_SUFFIX, "");
+    if (withoutDiscriminator && withoutDiscriminator !== handle) {
+      setCacheEntry(cache, withoutDiscriminator, userId);
+    }
+  }
+}
+
+export function resolveDiscordDirectoryUserId(params: {
+  accountId?: string | null;
+  handle: string;
+}): string | undefined {
+  const cache = DIRECTORY_HANDLE_CACHE.get(normalizeAccountCacheKey(params.accountId));
+  if (!cache) {
+    return undefined;
+  }
+  const handle = normalizeHandleKey(params.handle);
+  if (!handle) {
+    return undefined;
+  }
+  const direct = cache.get(handle);
+  if (direct) {
+    return direct;
+  }
+  const withoutDiscriminator = handle.replace(DISCORD_DISCRIMINATOR_SUFFIX, "");
+  if (!withoutDiscriminator || withoutDiscriminator === handle) {
+    return undefined;
+  }
+  return cache.get(withoutDiscriminator);
+}
+
+export function __resetDiscordDirectoryCacheForTest(): void {
+  DIRECTORY_HANDLE_CACHE.clear();
+}

--- a/src/discord/directory-live.ts
+++ b/src/discord/directory-live.ts
@@ -2,6 +2,7 @@ import type { DirectoryConfigParams } from "../channels/plugins/directory-config
 import type { ChannelDirectoryEntry } from "../channels/plugins/types.js";
 import { resolveDiscordAccount } from "./accounts.js";
 import { fetchDiscord } from "./api.js";
+import { rememberDiscordDirectoryUser } from "./directory-cache.js";
 import { normalizeDiscordSlug } from "./monitor/allow-list.js";
 import { normalizeDiscordToken } from "./token.js";
 
@@ -102,6 +103,16 @@ export async function listDiscordDirectoryPeersLive(
       if (!user?.id) {
         continue;
       }
+      rememberDiscordDirectoryUser({
+        accountId: params.accountId,
+        userId: user.id,
+        handles: [
+          user.username,
+          user.global_name,
+          member.nick,
+          user.username ? `@${user.username}` : null,
+        ],
+      });
       const name = member.nick?.trim() || user.global_name?.trim() || user.username?.trim();
       rows.push({
         kind: "user",

--- a/src/discord/mentions.test.ts
+++ b/src/discord/mentions.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  __resetDiscordDirectoryCacheForTest,
+  rememberDiscordDirectoryUser,
+} from "./directory-cache.js";
+import { formatMention, rewriteDiscordKnownMentions } from "./mentions.js";
+
+describe("formatMention", () => {
+  it("formats user mentions from ids", () => {
+    expect(formatMention({ userId: "123456789" })).toBe("<@123456789>");
+  });
+
+  it("formats role mentions from ids", () => {
+    expect(formatMention({ roleId: "987654321" })).toBe("<@&987654321>");
+  });
+
+  it("formats channel mentions from ids", () => {
+    expect(formatMention({ channelId: "777555333" })).toBe("<#777555333>");
+  });
+
+  it("throws when no mention id is provided", () => {
+    expect(() => formatMention({})).toThrow(/exactly one/i);
+  });
+
+  it("throws when more than one mention id is provided", () => {
+    expect(() => formatMention({ userId: "1", roleId: "2" })).toThrow(/exactly one/i);
+  });
+});
+
+describe("rewriteDiscordKnownMentions", () => {
+  beforeEach(() => {
+    __resetDiscordDirectoryCacheForTest();
+  });
+
+  it("rewrites @name mentions when a cached user id exists", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789",
+      handles: ["Alice", "@alice_user", "alice#1234"],
+    });
+    const rewritten = rewriteDiscordKnownMentions("ping @Alice and @alice_user", {
+      accountId: "default",
+    });
+    expect(rewritten).toBe("ping <@123456789> and <@123456789>");
+  });
+
+  it("preserves unknown mentions and reserved mentions", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789",
+      handles: ["alice"],
+    });
+    const rewritten = rewriteDiscordKnownMentions("hello @unknown @everyone @here", {
+      accountId: "default",
+    });
+    expect(rewritten).toBe("hello @unknown @everyone @here");
+  });
+
+  it("does not rewrite mentions inside markdown code spans", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789",
+      handles: ["alice"],
+    });
+    const rewritten = rewriteDiscordKnownMentions(
+      "inline `@alice` fence ```\n@alice\n``` text @alice",
+      {
+        accountId: "default",
+      },
+    );
+    expect(rewritten).toBe("inline `@alice` fence ```\n@alice\n``` text <@123456789>");
+  });
+
+  it("is account-scoped", () => {
+    rememberDiscordDirectoryUser({
+      accountId: "ops",
+      userId: "999888777",
+      handles: ["alice"],
+    });
+    const defaultRewrite = rewriteDiscordKnownMentions("@alice", { accountId: "default" });
+    const opsRewrite = rewriteDiscordKnownMentions("@alice", { accountId: "ops" });
+    expect(defaultRewrite).toBe("@alice");
+    expect(opsRewrite).toBe("<@999888777>");
+  });
+});

--- a/src/discord/mentions.ts
+++ b/src/discord/mentions.ts
@@ -1,0 +1,83 @@
+import { resolveDiscordDirectoryUserId } from "./directory-cache.js";
+
+const MARKDOWN_CODE_SEGMENT_PATTERN = /```[\s\S]*?```|`[^`\n]*`/g;
+const MENTION_CANDIDATE_PATTERN = /(^|[\s([{"'.,;:!?])@([a-z0-9_.-]{2,32}(?:#[0-9]{4})?)/gi;
+const DISCORD_RESERVED_MENTIONS = new Set(["everyone", "here"]);
+
+function normalizeSnowflake(value: string | number | bigint): string | null {
+  const text = String(value ?? "").trim();
+  if (!/^\d+$/.test(text)) {
+    return null;
+  }
+  return text;
+}
+
+export function formatMention(params: {
+  userId?: string | number | bigint | null;
+  roleId?: string | number | bigint | null;
+  channelId?: string | number | bigint | null;
+}): string {
+  const userId = params.userId == null ? null : normalizeSnowflake(params.userId);
+  const roleId = params.roleId == null ? null : normalizeSnowflake(params.roleId);
+  const channelId = params.channelId == null ? null : normalizeSnowflake(params.channelId);
+  const values = [
+    userId ? { kind: "user" as const, id: userId } : null,
+    roleId ? { kind: "role" as const, id: roleId } : null,
+    channelId ? { kind: "channel" as const, id: channelId } : null,
+  ].filter((entry): entry is { kind: "user" | "role" | "channel"; id: string } => Boolean(entry));
+  if (values.length !== 1) {
+    throw new Error("formatMention requires exactly one of userId, roleId, or channelId");
+  }
+  const target = values[0];
+  if (target.kind === "user") {
+    return `<@${target.id}>`;
+  }
+  if (target.kind === "role") {
+    return `<@&${target.id}>`;
+  }
+  return `<#${target.id}>`;
+}
+
+function rewritePlainTextMentions(text: string, accountId?: string | null): string {
+  if (!text.includes("@")) {
+    return text;
+  }
+  return text.replace(MENTION_CANDIDATE_PATTERN, (match, prefix, rawHandle) => {
+    const handle = String(rawHandle ?? "").trim();
+    if (!handle) {
+      return match;
+    }
+    const lookup = handle.toLowerCase();
+    if (DISCORD_RESERVED_MENTIONS.has(lookup)) {
+      return match;
+    }
+    const userId = resolveDiscordDirectoryUserId({
+      accountId,
+      handle,
+    });
+    if (!userId) {
+      return match;
+    }
+    return `${String(prefix ?? "")}${formatMention({ userId })}`;
+  });
+}
+
+export function rewriteDiscordKnownMentions(
+  text: string,
+  params: { accountId?: string | null },
+): string {
+  if (!text.includes("@")) {
+    return text;
+  }
+  let rewritten = "";
+  let offset = 0;
+  MARKDOWN_CODE_SEGMENT_PATTERN.lastIndex = 0;
+  for (const match of text.matchAll(MARKDOWN_CODE_SEGMENT_PATTERN)) {
+    const matchIndex = match.index ?? 0;
+    rewritten += rewritePlainTextMentions(text.slice(offset, matchIndex), params.accountId);
+    rewritten += match[0];
+    offset = matchIndex + match[0].length;
+  }
+  rewritten += rewritePlainTextMentions(text.slice(offset), params.accountId);
+  return rewritten;
+}

--- a/src/discord/send.outbound.ts
+++ b/src/discord/send.outbound.ts
@@ -16,6 +16,7 @@ import { unlinkIfExists } from "../media/temp-files.js";
 import type { PollInput } from "../polls.js";
 import { loadWebMediaRaw } from "../web/media.js";
 import { resolveDiscordAccount } from "./accounts.js";
+import { rewriteDiscordKnownMentions } from "./mentions.js";
 import {
   buildDiscordMessagePayload,
   buildDiscordSendError,
@@ -144,6 +145,9 @@ export async function sendMessageDiscord(
   });
   const chunkMode = resolveChunkMode(cfg, "discord", accountInfo.accountId);
   const textWithTables = convertMarkdownTables(text ?? "", tableMode);
+  const textWithMentions = rewriteDiscordKnownMentions(textWithTables, {
+    accountId: accountInfo.accountId,
+  });
   const { token, rest, request } = createDiscordClient(opts, cfg);
   const recipient = await parseAndResolveRecipient(to, opts.accountId);
   const { channelId } = await resolveChannelId(rest, recipient, request);
@@ -153,7 +157,7 @@ export async function sendMessageDiscord(
 
   if (isForumLikeType(channelType)) {
     const threadName = deriveForumThreadName(textWithTables);
-    const chunks = buildDiscordTextChunks(textWithTables, {
+    const chunks = buildDiscordTextChunks(textWithMentions, {
       maxLinesPerMessage: accountInfo.config.maxLinesPerMessage,
       chunkMode,
     });
@@ -263,7 +267,7 @@ export async function sendMessageDiscord(
       result = await sendDiscordMedia(
         rest,
         channelId,
-        textWithTables,
+        textWithMentions,
         opts.mediaUrl,
         opts.mediaLocalRoots,
         opts.replyTo,
@@ -278,7 +282,7 @@ export async function sendMessageDiscord(
       result = await sendDiscordText(
         rest,
         channelId,
-        textWithTables,
+        textWithMentions,
         opts.replyTo,
         request,
         accountInfo.config.maxLinesPerMessage,
@@ -342,6 +346,9 @@ export async function sendWebhookMessageDiscord(
     throw new Error("Discord webhook id/token are required");
   }
 
+  const rewrittenText = rewriteDiscordKnownMentions(text, {
+    accountId: opts.accountId,
+  });
   const replyTo = typeof opts.replyTo === "string" ? opts.replyTo.trim() : "";
   const messageReference = replyTo ? { message_id: replyTo, fail_if_not_exists: false } : undefined;
 
@@ -358,7 +365,7 @@ export async function sendWebhookMessageDiscord(
         "content-type": "application/json",
       },
       body: JSON.stringify({
-        content: text,
+        content: rewrittenText,
         username: opts.username?.trim() || undefined,
         avatar_url: opts.avatarUrl?.trim() || undefined,
         ...(messageReference ? { message_reference: messageReference } : {}),
@@ -406,12 +413,17 @@ export async function sendStickerDiscord(
 ): Promise<DiscordSendResult> {
   const { rest, request, channelId } = await resolveDiscordSendTarget(to, opts);
   const content = opts.content?.trim();
+  const rewrittenContent = content
+    ? rewriteDiscordKnownMentions(content, {
+        accountId: opts.accountId,
+      })
+    : undefined;
   const stickers = normalizeStickerIds(stickerIds);
   const res = (await request(
     () =>
       rest.post(Routes.channelMessages(channelId), {
         body: {
-          content: content || undefined,
+          content: rewrittenContent || undefined,
           sticker_ids: stickers,
         },
       }) as Promise<{ id: string; channel_id: string }>,
@@ -427,6 +439,11 @@ export async function sendPollDiscord(
 ): Promise<DiscordSendResult> {
   const { rest, request, channelId } = await resolveDiscordSendTarget(to, opts);
   const content = opts.content?.trim();
+  const rewrittenContent = content
+    ? rewriteDiscordKnownMentions(content, {
+        accountId: opts.accountId,
+      })
+    : undefined;
   if (poll.durationSeconds !== undefined) {
     throw new Error("Discord polls do not support durationSeconds; use durationHours");
   }
@@ -436,7 +453,7 @@ export async function sendPollDiscord(
     () =>
       rest.post(Routes.channelMessages(channelId), {
         body: {
-          content: content || undefined,
+          content: rewrittenContent || undefined,
           poll: payload,
           ...(flags ? { flags } : {}),
         },

--- a/src/discord/send.sends-basic-channel-messages.test.ts
+++ b/src/discord/send.sends-basic-channel-messages.test.ts
@@ -1,6 +1,10 @@
 import { ChannelType, PermissionFlagsBits, Routes } from "discord-api-types/v10";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  __resetDiscordDirectoryCacheForTest,
+  rememberDiscordDirectoryUser,
+} from "./directory-cache.js";
+import {
   deleteMessageDiscord,
   editMessageDiscord,
   fetchChannelPermissionsDiscord,
@@ -62,6 +66,7 @@ describe("sendMessageDiscord", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetDiscordDirectoryCacheForTest();
   });
 
   it("sends basic channel messages", async () => {
@@ -80,6 +85,29 @@ describe("sendMessageDiscord", () => {
     expect(postMock).toHaveBeenCalledWith(
       Routes.channelMessages("789"),
       expect.objectContaining({ body: { content: "hello world" } }),
+    );
+  });
+
+  it("rewrites cached @username mentions to id-based mentions", async () => {
+    rememberDiscordDirectoryUser({
+      accountId: "default",
+      userId: "123456789012345678",
+      handles: ["Alice"],
+    });
+    const { rest, postMock, getMock } = makeDiscordRest();
+    getMock.mockResolvedValueOnce({ type: ChannelType.GuildText });
+    postMock.mockResolvedValue({
+      id: "msg1",
+      channel_id: "789",
+    });
+    await sendMessageDiscord("channel:789", "ping @Alice", {
+      rest,
+      token: "t",
+      accountId: "default",
+    });
+    expect(postMock).toHaveBeenCalledWith(
+      Routes.channelMessages("789"),
+      expect.objectContaining({ body: { content: "ping <@123456789012345678>" } }),
     );
   });
 

--- a/src/discord/targets.ts
+++ b/src/discord/targets.ts
@@ -7,6 +7,7 @@ import {
   type MessagingTargetKind,
   type MessagingTargetParseOptions,
 } from "../channels/targets.js";
+import { rememberDiscordDirectoryUser } from "./directory-cache.js";
 import { listDiscordDirectoryPeersLive } from "./directory-live.js";
 
 export type DiscordTargetKind = MessagingTargetKind;
@@ -99,6 +100,11 @@ export async function resolveDiscordTarget(
     if (match && match.kind === "user") {
       // Extract user ID from the directory entry (format: "user:<id>")
       const userId = match.id.replace(/^user:/, "");
+      rememberDiscordDirectoryUser({
+        accountId: options.accountId,
+        userId,
+        handles: [trimmed, match.name, match.handle],
+      });
       return buildMessagingTarget("user", userId, trimmed);
     }
   } catch {

--- a/src/discord/voice/command.ts
+++ b/src/discord/voice/command.ts
@@ -14,6 +14,7 @@ import { resolveCommandAuthorizedFromAuthorizers } from "../../channels/command-
 import type { OpenClawConfig } from "../../config/config.js";
 import { isDangerousNameMatchingEnabled } from "../../config/dangerous-name-matching.js";
 import type { DiscordAccountConfig } from "../../config/types.js";
+import { formatMention } from "../mentions.js";
 import {
   isDiscordGroupAllowedByPolicy,
   normalizeDiscordSlug,
@@ -139,7 +140,7 @@ async function authorizeVoiceCommand(
     channelConfig?.allowed === false
   ) {
     const channelId = channelOverride?.id ?? channel?.id;
-    const channelLabel = channelId ? `<#${channelId}>` : "This channel";
+    const channelLabel = channelId ? formatMention({ channelId }) : "This channel";
     return {
       ok: false,
       message: `${channelLabel} is not allowlisted for voice commands.`,
@@ -352,7 +353,9 @@ export function createDiscordVoiceCommand(params: VoiceCommandContext): CommandW
         await interaction.reply({ content: "No active voice sessions.", ephemeral: true });
         return;
       }
-      const lines = sessions.map((entry) => `• <#${entry.channelId}> (guild ${entry.guildId})`);
+      const lines = sessions.map(
+        (entry) => `• ${formatMention({ channelId: entry.channelId })} (guild ${entry.guildId})`,
+      );
       await interaction.reply({ content: lines.join("\n"), ephemeral: true });
     }
   }

--- a/src/discord/voice/manager.ts
+++ b/src/discord/voice/manager.ts
@@ -36,6 +36,7 @@ import { resolveAgentRoute } from "../../routing/resolve-route.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { parseTtsDirectives } from "../../tts/tts-core.js";
 import { resolveTtsConfig, textToSpeech, type ResolvedTtsConfig } from "../../tts/tts.js";
+import { formatMention } from "../mentions.js";
 import { resolveDiscordOwnerAccess } from "../monitor/allow-list.js";
 import { formatDiscordUserTag } from "../monitor/format.js";
 
@@ -378,7 +379,12 @@ export class DiscordVoiceManager {
     const existing = this.sessions.get(guildId);
     if (existing && existing.channelId === channelId) {
       logVoiceVerbose(`join: already connected to guild ${guildId} channel ${channelId}`);
-      return { ok: true, message: `Already connected to <#${channelId}>.`, guildId, channelId };
+      return {
+        ok: true,
+        message: `Already connected to ${formatMention({ channelId })}.`,
+        guildId,
+        channelId,
+      };
     }
     if (existing) {
       logVoiceVerbose(`join: replacing existing session for guild ${guildId}`);
@@ -518,7 +524,7 @@ export class DiscordVoiceManager {
     this.sessions.set(guildId, entry);
     return {
       ok: true,
-      message: `Joined <#${channelId}>.`,
+      message: `Joined ${formatMention({ channelId })}.`,
       guildId,
       channelId,
     };
@@ -539,7 +545,7 @@ export class DiscordVoiceManager {
     logVoiceVerbose(`leave: disconnected from guild ${guildId} channel ${entry.channelId}`);
     return {
       ok: true,
-      message: `Left <#${entry.channelId}>.`,
+      message: `Left ${formatMention({ channelId: entry.channelId })}.`,
       guildId,
       channelId: entry.channelId,
     };


### PR DESCRIPTION
• ## Summary

  Describe the problem and fix in 2–5 bullets:

  - Problem: Discord outbound text could include plain @Name mentions, which may not ping or may
    ping the wrong user.
  - Why it matters: mention correctness is critical for approvals/alerts/ops workflows; incorrect
    mentions reduce reliability and can notify the wrong person.
  - What changed: added formatMention({ userId | roleId | channelId }); added an account-scoped in-
    memory Discord directory handle cache; added safe outbound rewrite @name -> <@id> when a cached
    ID is known; updated Discord voice/status message strings to use helper-based channel mentions;
    added/updated tests.
  - What did NOT change (scope boundary): no inbound mention-gating behavior changes; no new config
    flags/default changes; no new Discord API endpoints; no role/channel auto-rewrite from free
    text (auto-rewrite is user-handle only).

  ## Change Type (select all)

  - [x] Bug fix
  - [x] Feature
  - [ ] Refactor
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [x] Memory / storage
  - [x] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## User-visible / Behavior Changes

  - Discord outbound sends now rewrite plain @username to <@userId> when that username is known in
    the per-account directory cache.
  - If a username is unknown, outbound text is unchanged.
  - @everyone and @here are not rewritten.
  - Mentions inside markdown code spans/fences are not rewritten.
  - Some voice command/status responses now use helper-generated channel mention formatting.

  ## Security Impact (required)

  - New permissions/capabilities? (Yes/No): No
  - Secrets/tokens handling changed? (Yes/No): No
  - New/changed network calls? (Yes/No): No
  - Command/tool execution surface changed? (Yes/No): No
  - Data access scope changed? (Yes/No): Yes
  - If any Yes, explain risk + mitigation:
      - Added in-memory, per-account cache of Discord handles -> user IDs derived from already-
        fetched directory/member data.
      - No persistent storage, no expanded API access, bounded size, and normalization-scoped
        lookups reduce cross-account leakage/misresolution risk.

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios: helper output for user/role/channel mention formats; known-user outbound
    rewrite; no rewrite for unknown users.
  - Edge cases checked: @everyone/@here preserved; markdown inline/fenced code preserved; cache is
    account-scoped.
  - What you did not verify: live Discord end-to-end behavior in a real guild/DM with production
    bot token.

  ## Compatibility / Migration

  - Backward compatible? (Yes/No): Yes
  - Config/env changes? (Yes/No): No
  - Migration needed? (Yes/No): No

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: revert commit e0b6cf232 (or remove outbound rewrite
    callsites in src/discord/send.outbound.ts).
  - Files/config to restore: src/discord/send.outbound.ts, src/discord/mentions.ts, src/discord/
    directory-cache.ts (and related imports/tests).
  - Known bad symptoms reviewers should watch for: unexpected <@id> substitution for a similarly
    named user due to stale/ambiguous cached handle.

  ## Risks and Mitigations

  - Risk: stale/ambiguous handle cache could rewrite @name to an unintended user ID.
  - Mitigation: rewrite only on exact cached hit, cache is per-account and bounded, unresolved
    handles are left untouched.
  - Risk: rewriting could alter literal examples/snippets in message content.
  - Mitigation: markdown inline and fenced code spans are excluded from rewrite logic.