### PR TITLE
fix(daemon): fix backslash escape in systemd env parser

### DIFF
--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildSystemdUnit } from "./systemd-unit.js";
+import { buildSystemdUnit, parseSystemdEnvAssignment } from "./systemd-unit.js";
 
 describe("buildSystemdUnit", () => {
   it("quotes arguments with whitespace", () => {
@@ -22,5 +22,19 @@ describe("buildSystemdUnit", () => {
         },
       }),
     ).toThrow(/CR or LF/);
+  });
+});
+
+describe("parseSystemdEnvAssignment", () => {
+  it("unquotes simple assignment", () => {
+    expect(parseSystemdEnvAssignment('"FOO=bar"')).toEqual({ key: "FOO", value: "bar" });
+  });
+
+  it("handles backslash-escaped quotes in values", () => {
+    expect(parseSystemdEnvAssignment('"FOO=bar\\"baz"')).toEqual({ key: "FOO", value: 'bar"baz' });
+  });
+
+  it("returns null for empty input", () => {
+    expect(parseSystemdEnvAssignment("")).toBeNull();
   });
 });

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -34,6 +34,13 @@ describe("parseSystemdEnvAssignment", () => {
     expect(parseSystemdEnvAssignment('"FOO=bar\\"baz"')).toEqual({ key: "FOO", value: 'bar"baz' });
   });
 
+  it("handles backslash-escaped backslashes in values", () => {
+    expect(parseSystemdEnvAssignment('"FOO=bar\\\\baz"')).toEqual({
+      key: "FOO",
+      value: "bar\\baz",
+    });
+  });
+
   it("returns null for empty input", () => {
     expect(parseSystemdEnvAssignment("")).toBeNull();
   });

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -96,7 +96,7 @@ export function parseSystemdEnvAssignment(raw: string): { key: string; value: st
         escapeNext = false;
         continue;
       }
-      if (ch === "\\\\") {
+      if (ch === "\\") {
         escapeNext = true;
         continue;
       }


### PR DESCRIPTION
Fix `ch === "\\\\"" ` comparing single char against 2-char string — backslash escaping in parseSystemdEnvAssignment never triggered. Added test coverage.