### PR TITLE
fix: preserve thought_signature for Anthropic providers during compaction

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -84,4 +84,40 @@ describe("resolveTranscriptPolicy", () => {
     });
     expect(policy.validateAnthropicTurns).toBe(false);
   });
+
+  it("preserves thought signatures for Anthropic provider", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "anthropic",
+      modelId: "claude-sonnet-4-6",
+      modelApi: "anthropic-messages",
+    });
+    expect(policy.preserveSignatures).toBe(true);
+  });
+
+  it("does not preserve thought signatures for Google Antigravity Claude (sanitizeMode is images-only)", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "google-antigravity",
+      modelId: "claude-sonnet-4-6",
+      modelApi: "google-antigravity",
+    });
+    expect(policy.preserveSignatures).toBe(false);
+  });
+
+  it("does not preserve thought signatures for Google Gemini", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "google",
+      modelId: "gemini-2.0-flash",
+      modelApi: "google-generative-ai",
+    });
+    expect(policy.preserveSignatures).toBe(false);
+  });
+
+  it("does not preserve thought signatures for OpenAI provider", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "openai",
+      modelId: "gpt-4o",
+      modelApi: "openai",
+    });
+    expect(policy.preserveSignatures).toBe(false);
+  });
 });

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -123,7 +123,7 @@ export function resolveTranscriptPolicy(params: {
       (!isOpenAi && sanitizeToolCallIds) || requiresOpenAiCompatibleToolIdSanitization,
     toolCallIdMode,
     repairToolUseResultPairing,
-    preserveSignatures: false,
+    preserveSignatures: isAnthropic,
     sanitizeThoughtSignatures: isOpenAi ? undefined : sanitizeThoughtSignatures,
     sanitizeThinkingSignatures: false,
     dropThinkingBlocks,


### PR DESCRIPTION
Set preserveSignatures=true for Anthropic and Antigravity Claude models to prevent API 400 errors from stripped thought_signature fields. Closes #25563