### PR TITLE
fix(config): deduplicate repeated config warnings on reload

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -736,8 +736,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         const details = validated.warnings
           .map((iss) => `- ${iss.path || "<root>"}: ${iss.message}`)
           .join("\n");
-        if (!loggedConfigWarnings.has(details)) {
-          loggedConfigWarnings.add(details);
+        const warnKey = `${configPath}:${details}`;
+        if (!loggedConfigWarnings.has(warnKey)) {
+          loggedConfigWarnings.add(warnKey);
           deps.logger.warn(`Config warnings:\\n${details}`);
         }
       }
@@ -1087,8 +1088,9 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       const details = validated.warnings
         .map((warning) => `- ${warning.path}: ${warning.message}`)
         .join("\n");
-      if (!loggedConfigWarnings.has(details)) {
-        loggedConfigWarnings.add(details);
+      const warnKey = `${configPath}:${details}`;
+      if (!loggedConfigWarnings.has(warnKey)) {
+        loggedConfigWarnings.add(warnKey);
         deps.logger.warn(`Config warnings:\n${details}`);
       }
     }

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -82,6 +82,8 @@ const OPEN_DM_POLICY_ALLOW_FROM_RE =
 
 const CONFIG_AUDIT_LOG_FILENAME = "config-audit.jsonl";
 const loggedInvalidConfigs = new Set<string>();
+// Deduplicate config warnings so repeated reloads don't spam the log
+const loggedConfigWarnings = new Set<string>();
 
 type ConfigWriteAuditResult = "rename" | "copy-fallback" | "failed";
 
@@ -553,9 +555,12 @@ function warnOnConfigMiskeys(raw: unknown, logger: Pick<typeof console, "warn">)
     return;
   }
   if ("token" in (gateway as Record<string, unknown>)) {
-    logger.warn(
-      'Config uses "gateway.token". This key is ignored; use "gateway.auth.token" instead.',
-    );
+    const msg =
+      'Config uses "gateway.token". This key is ignored; use "gateway.auth.token" instead.';
+    if (!loggedConfigWarnings.has(msg)) {
+      loggedConfigWarnings.add(msg);
+      logger.warn(msg);
+    }
   }
 }
 
@@ -581,9 +586,11 @@ function warnIfConfigFromFuture(cfg: OpenClawConfig, logger: Pick<typeof console
     return;
   }
   if (cmp < 0) {
-    logger.warn(
-      `Config was last written by a newer OpenClaw (${touched}); current version is ${VERSION}.`,
-    );
+    const msg = `Config was last written by a newer OpenClaw (${touched}); current version is ${VERSION}.`;
+    if (!loggedConfigWarnings.has(msg)) {
+      loggedConfigWarnings.add(msg);
+      logger.warn(msg);
+    }
   }
 }
 
@@ -729,7 +736,10 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         const details = validated.warnings
           .map((iss) => `- ${iss.path || "<root>"}: ${iss.message}`)
           .join("\n");
-        deps.logger.warn(`Config warnings:\\n${details}`);
+        if (!loggedConfigWarnings.has(details)) {
+          loggedConfigWarnings.add(details);
+          deps.logger.warn(`Config warnings:\\n${details}`);
+        }
       }
       warnIfConfigFromFuture(validated.config, deps.logger);
       const cfg = applyTalkConfigNormalization(
@@ -1077,7 +1087,10 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       const details = validated.warnings
         .map((warning) => `- ${warning.path}: ${warning.message}`)
         .join("\n");
-      deps.logger.warn(`Config warnings:\n${details}`);
+      if (!loggedConfigWarnings.has(details)) {
+        loggedConfigWarnings.add(details);
+        deps.logger.warn(`Config warnings:\n${details}`);
+      }
     }
 
     // Restore ${VAR} env var references that were resolved during config loading.

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -546,7 +546,11 @@ export type ConfigIoDeps = {
   logger?: Pick<typeof console, "error" | "warn">;
 };
 
-function warnOnConfigMiskeys(raw: unknown, logger: Pick<typeof console, "warn">): void {
+function warnOnConfigMiskeys(
+  raw: unknown,
+  logger: Pick<typeof console, "warn">,
+  configPath?: string,
+): void {
   if (!raw || typeof raw !== "object") {
     return;
   }
@@ -557,8 +561,9 @@ function warnOnConfigMiskeys(raw: unknown, logger: Pick<typeof console, "warn">)
   if ("token" in (gateway as Record<string, unknown>)) {
     const msg =
       'Config uses "gateway.token". This key is ignored; use "gateway.auth.token" instead.';
-    if (!loggedConfigWarnings.has(msg)) {
-      loggedConfigWarnings.add(msg);
+    const key = configPath ? `${configPath}:${msg}` : msg;
+    if (!loggedConfigWarnings.has(key)) {
+      loggedConfigWarnings.add(key);
       logger.warn(msg);
     }
   }
@@ -576,7 +581,11 @@ function stampConfigVersion(cfg: OpenClawConfig): OpenClawConfig {
   };
 }
 
-function warnIfConfigFromFuture(cfg: OpenClawConfig, logger: Pick<typeof console, "warn">): void {
+function warnIfConfigFromFuture(
+  cfg: OpenClawConfig,
+  logger: Pick<typeof console, "warn">,
+  configPath?: string,
+): void {
   const touched = cfg.meta?.lastTouchedVersion;
   if (!touched) {
     return;
@@ -587,8 +596,9 @@ function warnIfConfigFromFuture(cfg: OpenClawConfig, logger: Pick<typeof console
   }
   if (cmp < 0) {
     const msg = `Config was last written by a newer OpenClaw (${touched}); current version is ${VERSION}.`;
-    if (!loggedConfigWarnings.has(msg)) {
-      loggedConfigWarnings.add(msg);
+    const key = configPath ? `${configPath}:${msg}` : msg;
+    if (!loggedConfigWarnings.has(key)) {
+      loggedConfigWarnings.add(key);
       logger.warn(msg);
     }
   }
@@ -707,7 +717,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         resolveConfigIncludesForRead(parsed, configPath, deps),
         deps.env,
       );
-      warnOnConfigMiskeys(resolvedConfig, deps.logger);
+      warnOnConfigMiskeys(resolvedConfig, deps.logger, configPath);
       if (typeof resolvedConfig !== "object" || resolvedConfig === null) {
         return {};
       }
@@ -742,7 +752,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           deps.logger.warn(`Config warnings:\\n${details}`);
         }
       }
-      warnIfConfigFromFuture(validated.config, deps.logger);
+      warnIfConfigFromFuture(validated.config, deps.logger, configPath);
       const cfg = applyTalkConfigNormalization(
         applyModelDefaults(
           applyCompactionDefaults(
@@ -959,7 +969,7 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         };
       }
 
-      warnIfConfigFromFuture(validated.config, deps.logger);
+      warnIfConfigFromFuture(validated.config, deps.logger, configPath);
       const snapshotConfig = normalizeConfigPaths(
         applyTalkApiKey(
           applyTalkConfigNormalization(


### PR DESCRIPTION
Add warning deduplication to prevent thousands of duplicate warning messages flooding logs on config reload. Mirrors existing error dedup pattern.