### PR TITLE
fix(daemon): include WorkingDirectory in LaunchAgent plist

### DIFF
--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -2,6 +2,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { collectConfigServiceEnvVars } from "../config/env-vars.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { resolveGatewayLaunchAgentLabel } from "../daemon/constants.js";
+import { resolveGatewayStateDir } from "../daemon/paths.js";
 import { resolveGatewayProgramArguments } from "../daemon/program-args.js";
 import { resolvePreferredNodePath } from "../daemon/runtime-paths.js";
 import { buildServiceEnvironment } from "../daemon/service-env.js";
@@ -71,7 +72,11 @@ export async function buildGatewayInstallPlan(params: {
   };
   Object.assign(environment, serviceEnvironment);
 
-  return { programArguments, workingDirectory, environment };
+  // Default working directory to the OpenClaw state dir (e.g. ~/.openclaw) so the
+  // daemon does not run with `/` as cwd when launched by launchd/systemd.
+  const resolvedWorkingDirectory = workingDirectory || resolveGatewayStateDir(params.env);
+
+  return { programArguments, workingDirectory: resolvedWorkingDirectory, environment };
 }
 
 export function gatewayInstallErrorHint(platform = process.platform): string {

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { formatCliCommand } from "../cli/command-format.js";
 import { collectConfigServiceEnvVars } from "../config/env-vars.js";
 import type { OpenClawConfig } from "../config/types.js";
@@ -75,6 +76,8 @@ export async function buildGatewayInstallPlan(params: {
   // Default working directory to the OpenClaw state dir (e.g. ~/.openclaw) so the
   // daemon does not run with `/` as cwd when launched by launchd/systemd.
   const resolvedWorkingDirectory = workingDirectory ?? resolveGatewayStateDir(params.env);
+  // Ensure the working directory exists so launchd/systemd can CHDIR into it on first install.
+  fs.mkdirSync(resolvedWorkingDirectory, { recursive: true, mode: 0o700 });
 
   return { programArguments, workingDirectory: resolvedWorkingDirectory, environment };
 }

--- a/src/commands/daemon-install-helpers.ts
+++ b/src/commands/daemon-install-helpers.ts
@@ -74,7 +74,7 @@ export async function buildGatewayInstallPlan(params: {
 
   // Default working directory to the OpenClaw state dir (e.g. ~/.openclaw) so the
   // daemon does not run with `/` as cwd when launched by launchd/systemd.
-  const resolvedWorkingDirectory = workingDirectory || resolveGatewayStateDir(params.env);
+  const resolvedWorkingDirectory = workingDirectory ?? resolveGatewayStateDir(params.env);
 
   return { programArguments, workingDirectory: resolvedWorkingDirectory, environment };
 }

--- a/src/commands/node-daemon-install-helpers.ts
+++ b/src/commands/node-daemon-install-helpers.ts
@@ -1,4 +1,5 @@
 import { formatNodeServiceDescription } from "../daemon/constants.js";
+import { resolveGatewayStateDir } from "../daemon/paths.js";
 import { resolveNodeProgramArguments } from "../daemon/program-args.js";
 import { resolvePreferredNodePath } from "../daemon/runtime-paths.js";
 import { buildNodeServiceEnvironment } from "../daemon/service-env.js";
@@ -61,5 +62,9 @@ export async function buildNodeInstallPlan(params: {
     version: environment.OPENCLAW_SERVICE_VERSION,
   });
 
-  return { programArguments, workingDirectory, environment, description };
+  // Default working directory to the OpenClaw state dir (e.g. ~/.openclaw) so the
+  // daemon does not run with `/` as cwd when launched by launchd/systemd.
+  const resolvedWorkingDirectory = workingDirectory || resolveGatewayStateDir(params.env);
+
+  return { programArguments, workingDirectory: resolvedWorkingDirectory, environment, description };
 }

--- a/src/commands/node-daemon-install-helpers.ts
+++ b/src/commands/node-daemon-install-helpers.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { formatNodeServiceDescription } from "../daemon/constants.js";
 import { resolveGatewayStateDir } from "../daemon/paths.js";
 import { resolveNodeProgramArguments } from "../daemon/program-args.js";
@@ -65,6 +66,8 @@ export async function buildNodeInstallPlan(params: {
   // Default working directory to the OpenClaw state dir (e.g. ~/.openclaw) so the
   // daemon does not run with `/` as cwd when launched by launchd/systemd.
   const resolvedWorkingDirectory = workingDirectory ?? resolveGatewayStateDir(params.env);
+  // Ensure the working directory exists so launchd/systemd can CHDIR into it on first install.
+  fs.mkdirSync(resolvedWorkingDirectory, { recursive: true, mode: 0o700 });
 
   return { programArguments, workingDirectory: resolvedWorkingDirectory, environment, description };
 }

--- a/src/commands/node-daemon-install-helpers.ts
+++ b/src/commands/node-daemon-install-helpers.ts
@@ -64,7 +64,7 @@ export async function buildNodeInstallPlan(params: {
 
   // Default working directory to the OpenClaw state dir (e.g. ~/.openclaw) so the
   // daemon does not run with `/` as cwd when launched by launchd/systemd.
-  const resolvedWorkingDirectory = workingDirectory || resolveGatewayStateDir(params.env);
+  const resolvedWorkingDirectory = workingDirectory ?? resolveGatewayStateDir(params.env);
 
   return { programArguments, workingDirectory: resolvedWorkingDirectory, environment, description };
 }


### PR DESCRIPTION
Default WorkingDirectory to OpenClaw state dir when program-args resolver does not provide one, so gateway does not run with / as cwd. Closes #25562