### PR TITLE
Reply: honor per-model context token overrides

### DIFF
--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -3,8 +3,6 @@ import {
   resolveDefaultAgentId,
   resolveSessionAgentId,
 } from "../../agents/agent-scope.js";
-import { lookupContextTokens } from "../../agents/context.js";
-import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import {
   buildModelAliasIndex,
   type ModelAliasIndex,
@@ -17,6 +15,7 @@ import { type SessionEntry, updateSessionStore } from "../../config/sessions.js"
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { applyVerboseOverride } from "../../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
+import { resolveContextTokens } from "./model-selection.js";
 import { resolveProfileOverride } from "./directive-handling.auth.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import { enqueueModeSwitchEvents } from "./directive-handling.shared.js";
@@ -213,7 +212,11 @@ export async function persistInlineDirectives(params: {
   return {
     provider,
     model,
-    contextTokens: agentCfg?.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS,
+    contextTokens: resolveContextTokens({
+      agentCfg,
+      provider,
+      model,
+    }),
   };
 }
 

--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -15,11 +15,11 @@ import { type SessionEntry, updateSessionStore } from "../../config/sessions.js"
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { applyVerboseOverride } from "../../sessions/level-overrides.js";
 import { applyModelOverrideToSessionEntry } from "../../sessions/model-overrides.js";
-import { resolveContextTokens } from "./model-selection.js";
 import { resolveProfileOverride } from "./directive-handling.auth.js";
 import type { InlineDirectives } from "./directive-handling.parse.js";
 import { enqueueModeSwitchEvents } from "./directive-handling.shared.js";
 import type { ElevatedLevel, ReasoningLevel } from "./directives.js";
+import { resolveContextTokens } from "./model-selection.js";
 
 export async function persistInlineDirectives(params: {
   directives: InlineDirectives;

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -407,6 +407,7 @@ export async function resolveReplyDirectives(params: {
 
   let contextTokens = resolveContextTokens({
     agentCfg,
+    provider,
     model,
   });
 

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -621,9 +621,7 @@ export function resolveContextTokens(params: {
       if (!parsed) {
         continue;
       }
-      if (
-        modelKey(normalizeProviderId(parsed.ref.provider), parsed.ref.model) === modelKeyValue
-      ) {
+      if (modelKey(normalizeProviderId(parsed.ref.provider), parsed.ref.model) === modelKeyValue) {
         return entry;
       }
     }

--- a/src/auto-reply/reply/model-selection.ts
+++ b/src/auto-reply/reply/model-selection.ts
@@ -627,7 +627,7 @@ export function resolveContextTokens(params: {
     }
     return undefined;
   })();
-  const modelParams = modelEntry?.params as Record<string, unknown> | undefined;
+  const modelParams = modelEntry?.params;
   const contextTokensFromParams =
     typeof modelParams?.contextTokens === "number" &&
     Number.isFinite(modelParams.contextTokens) &&


### PR DESCRIPTION
## Summary
- split from #26712 into a focused auto-reply token handling PR
- honor per-model context-token overrides during model selection
- include small follow-up cleanup/formatting from the original branch

## Validation
- `pnpm exec vitest run src/auto-reply/reply/model-selection.test.ts src/auto-reply/reply/directive-handling.model.test.ts`

## Context
This PR is one focused slice extracted from:
- https://github.com/openclaw/openclaw/pull/26712
