### PR TITLE
Daemon/Usage: normalize token values and clamp invalid counters

### DIFF
--- a/src/agents/usage.normalization.test.ts
+++ b/src/agents/usage.normalization.test.ts
@@ -38,6 +38,23 @@ describe("normalizeUsage", () => {
     expect(normalizeUsage({})).toBeUndefined();
   });
 
+  it("ignores negative usage counters", () => {
+    const usage = normalizeUsage({
+      input_tokens: -100,
+      output_tokens: 250,
+      cache_read_input_tokens: -10,
+      cache_creation_input_tokens: 50,
+      total_tokens: -1,
+    });
+    expect(usage).toEqual({
+      input: undefined,
+      output: 250,
+      cacheRead: undefined,
+      cacheWrite: 50,
+      total: undefined,
+    });
+  });
+
   it("guards against empty/zero usage overwrites", () => {
     expect(hasNonzeroUsage(undefined)).toBe(false);
     expect(hasNonzeroUsage(null)).toBe(false);

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -73,6 +73,9 @@ const asFiniteNumber = (value: unknown): number | undefined => {
   if (!Number.isFinite(value)) {
     return undefined;
   }
+  if (value < 0) {
+    return undefined;
+  }
   return value;
 };
 

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -100,6 +100,42 @@ describe("auditGatewayServiceConfig", () => {
       audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayTokenMismatch),
     ).toBe(false);
   });
+
+  it("does not flag gateway token mismatch when service token is double-quoted", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "linux",
+      expectedGatewayToken: "new-token",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: {
+          PATH: "/usr/local/bin:/usr/bin:/bin",
+          OPENCLAW_GATEWAY_TOKEN: '"new-token"',
+        },
+      },
+    });
+    expect(
+      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayTokenMismatch),
+    ).toBe(false);
+  });
+
+  it("does not flag gateway token mismatch when service token is single-quoted", async () => {
+    const audit = await auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "linux",
+      expectedGatewayToken: "new-token",
+      command: {
+        programArguments: ["/usr/bin/node", "gateway"],
+        environment: {
+          PATH: "/usr/local/bin:/usr/bin:/bin",
+          OPENCLAW_GATEWAY_TOKEN: "'new-token'",
+        },
+      },
+    });
+    expect(
+      audit.issues.some((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayTokenMismatch),
+    ).toBe(false);
+  });
 });
 
 describe("checkTokenDrift", () => {

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -118,6 +118,22 @@ describe("checkTokenDrift", () => {
     expect(result).toBeNull();
   });
 
+  it("returns null when service token is wrapped in quotes", () => {
+    const result = checkTokenDrift({
+      serviceToken: '"same-token"',
+      configToken: "same-token",
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when tokens only differ by surrounding whitespace", () => {
+    const result = checkTokenDrift({
+      serviceToken: " same-token ",
+      configToken: "same-token",
+    });
+    expect(result).toBeNull();
+  });
+
   it("detects drift when config has token but service has different token", () => {
     const result = checkTokenDrift({ serviceToken: "old-token", configToken: "new-token" });
     expect(result).not.toBeNull();

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -226,11 +226,11 @@ function auditGatewayToken(
   issues: ServiceConfigIssue[],
   expectedGatewayToken?: string,
 ) {
-  const expectedToken = expectedGatewayToken?.trim();
+  const expectedToken = normalizeGatewayToken(expectedGatewayToken);
   if (!expectedToken) {
     return;
   }
-  const serviceToken = command?.environment?.OPENCLAW_GATEWAY_TOKEN?.trim();
+  const serviceToken = normalizeGatewayToken(command?.environment?.OPENCLAW_GATEWAY_TOKEN);
   if (serviceToken === expectedToken) {
     return;
   }

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -47,6 +47,24 @@ export const SERVICE_AUDIT_CODES = {
   systemdWantsNetworkOnline: "systemd-wants-network-online",
 } as const;
 
+function normalizeGatewayToken(value: string | undefined): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    const inner = trimmed.slice(1, -1).trim();
+    return inner || undefined;
+  }
+  return trimmed;
+}
+
 export function needsNodeRuntimeMigration(issues: ServiceConfigIssue[]): boolean {
   return issues.some(
     (issue) =>
@@ -360,7 +378,8 @@ export function checkTokenDrift(params: {
   serviceToken: string | undefined;
   configToken: string | undefined;
 }): ServiceConfigIssue | null {
-  const { serviceToken, configToken } = params;
+  const serviceToken = normalizeGatewayToken(params.serviceToken);
+  const configToken = normalizeGatewayToken(params.configToken);
 
   // No drift if both are undefined/empty
   if (!serviceToken && !configToken) {


### PR DESCRIPTION
## Summary
- split from #26712 into a focused token-normalization PR
- normalize gateway service token values before drift comparison in daemon audit
- handle quoted token values in service/env comparisons
- ignore negative provider token counters in usage normalization

## Validation
- `pnpm exec vitest run src/daemon/service-audit.test.ts src/agents/usage.normalization.test.ts`

## Context
This PR is one focused slice extracted from:
- https://github.com/openclaw/openclaw/pull/26712
