### PR TITLE
Status: cap cached percentage for stale totals

### DIFF
--- a/src/commands/status.format.test.ts
+++ b/src/commands/status.format.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { formatTokensCompact } from "./status.format.js";
+
+describe("formatTokensCompact", () => {
+  it("formats a standard cache percentage", () => {
+    const label = formatTokensCompact({
+      totalTokens: 5_000,
+      contextTokens: 20_000,
+      percentUsed: 25,
+      cacheRead: 2_000,
+      cacheWrite: 1_000,
+    });
+    expect(label).toContain("40% cached");
+  });
+
+  it("caps cache percentage at 100 when cacheRead exceeds session total", () => {
+    const label = formatTokensCompact({
+      totalTokens: 12_000,
+      contextTokens: 200_000,
+      percentUsed: 6,
+      cacheRead: 137_000,
+      cacheWrite: 0,
+    });
+    expect(label).toContain("100% cached");
+  });
+});

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -36,11 +36,11 @@ export const formatTokensCompact = (
 
   // Add cache hit rate if there are cached reads
   if (typeof cacheRead === "number" && cacheRead > 0) {
-    const total =
-      typeof used === "number"
-        ? used
-        : cacheRead + (typeof cacheWrite === "number" ? cacheWrite : 0);
-    const hitRate = Math.round((cacheRead / total) * 100);
+    const fallbackTotal = cacheRead + (typeof cacheWrite === "number" ? cacheWrite : 0);
+    const total = typeof used === "number" && used > 0 ? used : fallbackTotal;
+    // Session totals can be stale/misaligned for older entries; never show impossible cache rates.
+    const effectiveTotal = Math.max(total, fallbackTotal, cacheRead);
+    const hitRate = Math.min(100, Math.round((cacheRead / effectiveTotal) * 100));
     result += ` · 🗄️ ${hitRate}% cached`;
   }
 


### PR DESCRIPTION
## Summary
- split from #26712 into a focused status-formatting PR
- cap cached percentage display when totals are stale/inconsistent
- add status formatter test coverage for stale total edge cases

## Validation
- `pnpm exec vitest run src/commands/status.format.test.ts`

## Context
This PR is one focused slice extracted from:
- https://github.com/openclaw/openclaw/pull/26712
