### PR TITLE
feat(telegram): add sendMessageDraft raw API fallback for Bot API 9.3+

### DIFF
--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -51,9 +51,10 @@ function resolveSendMessageDraftApi(api: Bot["api"]): TelegramSendMessageDraft |
   // Fall back to raw API call for Bot API 9.3+ (sendMessageDraft)
   // Grammy exposes `api.raw` as a Proxy that forwards any method call to the Bot API.
   // This allows using new Bot API methods before Grammy adds typed wrappers.
-  // The raw proxy is always present in Grammy >= 1.0, so we just need to check it exists.
+  // Guard: ensure rawApi exists and sendMessageDraft is callable (may not be if Grammy's
+  // raw API is a typed interface rather than a Proxy in some edge configurations).
   const rawApi = (api as Bot["api"] & { raw?: GrammyRawApiProxy }).raw;
-  if (!rawApi) {
+  if (!rawApi || typeof rawApi.sendMessageDraft !== "function") {
     return undefined;
   }
 

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -27,13 +27,52 @@ function allocateTelegramDraftId(): number {
   return nextDraftId;
 }
 
+type SendMessageDraftPayload = {
+  chat_id: number;
+  draft_id: number;
+  text: string;
+  message_thread_id?: number;
+  parse_mode?: string;
+  entities?: unknown[];
+};
+
+type GrammyRawApiProxy = {
+  sendMessageDraft: (payload: SendMessageDraftPayload) => Promise<boolean>;
+};
+
 function resolveSendMessageDraftApi(api: Bot["api"]): TelegramSendMessageDraft | undefined {
-  const sendMessageDraft = (api as Bot["api"] & { sendMessageDraft?: TelegramSendMessageDraft })
+  // First check if Grammy has native sendMessageDraft method
+  const nativeMethod = (api as Bot["api"] & { sendMessageDraft?: TelegramSendMessageDraft })
     .sendMessageDraft;
-  if (typeof sendMessageDraft !== "function") {
+  if (typeof nativeMethod === "function") {
+    return nativeMethod.bind(api as object);
+  }
+
+  // Fall back to raw API call for Bot API 9.3+ (sendMessageDraft)
+  // Grammy exposes `api.raw` as a Proxy that forwards any method call to the Bot API.
+  // This allows using new Bot API methods before Grammy adds typed wrappers.
+  // The raw proxy is always present in Grammy >= 1.0, so we just need to check it exists.
+  const rawApi = (api as Bot["api"] & { raw?: GrammyRawApiProxy }).raw;
+  if (!rawApi) {
     return undefined;
   }
-  return sendMessageDraft.bind(api as object);
+
+  return async (
+    chatId: number,
+    draftId: number,
+    text: string,
+    params?: { message_thread_id?: number; parse_mode?: "HTML" },
+  ): Promise<unknown> => {
+    return rawApi.sendMessageDraft({
+      chat_id: chatId,
+      draft_id: draftId,
+      text,
+      ...(params?.message_thread_id != null
+        ? { message_thread_id: params.message_thread_id }
+        : {}),
+      ...(params?.parse_mode ? { parse_mode: params.parse_mode } : {}),
+    });
+  };
 }
 
 function shouldFallbackFromDraftTransport(err: unknown): boolean {


### PR DESCRIPTION
## Summary

Add support for Telegram's `sendMessageDraft` API (Bot API 9.3, December 2025) to enable real-time streaming of AI responses.

## Changes

- Modified `resolveSendMessageDraftApi()` in `src/telegram/draft-stream.ts` to fall back to Grammy's `api.raw` proxy when native `sendMessageDraft` method is unavailable
- This allows streaming draft previews (typing animation effect) in Telegram DMs before Grammy officially adds typed wrappers

## How it works

1. First checks if Grammy has native `api.sendMessageDraft()` method
2. If not, uses Grammy's `api.raw.sendMessageDraft()` proxy to call the Bot API directly
3. Existing fallback to `sendMessage` + `editMessageText` remains as final fallback if API rejects

## References

- [Telegram Bot API 9.3 - sendMessageDraft](https://core.telegram.org/bots/api#sendmessagedraft)
- Real-time streaming enables ChatGPT-like typing animation for AI bot responses