### PR TITLE
Plugins: suppress duplicate id warnings for same source paths

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PluginCandidate } from "./discovery.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 
@@ -206,6 +206,39 @@ describe("loadPluginManifestRegistry", () => {
     ];
 
     expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
+  });
+
+  it("suppresses duplicate warning when source path matches but realpath is unavailable", () => {
+    const dir = makeTempDir();
+    const manifest = { id: "same-source-plugin", configSchema: { type: "object" } };
+    writeManifest(dir, manifest);
+
+    const source = path.join(dir, "index.ts");
+    fs.writeFileSync(source, "export default {};\n", "utf-8");
+
+    const candidates: PluginCandidate[] = [
+      {
+        idHint: "same-source-plugin",
+        source,
+        rootDir: dir,
+        origin: "bundled",
+      },
+      {
+        idHint: "same-source-plugin",
+        source,
+        rootDir: path.join(dir, "sub", ".."),
+        origin: "global",
+      },
+    ];
+
+    const realpathSpy = vi.spyOn(fs, "realpathSync").mockImplementation(() => {
+      throw new Error("realpath unavailable");
+    });
+    try {
+      expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
+    } finally {
+      realpathSpy.mockRestore();
+    }
   });
 
   it("prefers higher-precedence origins for the same physical directory (config > workspace > global > bundled)", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveUserPath } from "../utils.js";
 import { normalizePluginsConfig, type NormalizedPluginsConfig } from "./config-state.js";
@@ -47,6 +48,10 @@ export type PluginManifestRegistry = {
 const registryCache = new Map<string, { expiresAt: number; registry: PluginManifestRegistry }>();
 
 const DEFAULT_MANIFEST_CACHE_MS = 200;
+
+function pathsMatch(a: string, b: string): boolean {
+  return path.resolve(a) === path.resolve(b);
+}
 
 export function clearPluginManifestRegistryCache(): void {
   registryCache.clear();
@@ -204,7 +209,9 @@ export function loadPluginManifestRegistry(params: {
       // Check whether both candidates point to the same physical directory
       // (e.g. via symlinks or different path representations). If so, this
       // is a false-positive duplicate and can be silently skipped.
-      const samePath = existing.candidate.rootDir === candidate.rootDir;
+      const samePath =
+        pathsMatch(existing.candidate.rootDir, candidate.rootDir) ||
+        pathsMatch(existing.candidate.source, candidate.source);
       const samePlugin = (() => {
         if (samePath) {
           return true;


### PR DESCRIPTION
## Summary
- split from #26712 into a focused plugin-manifest PR
- suppress duplicate plugin-id warnings when candidates resolve to the same source/root path
- preserve duplicate warnings for truly distinct plugin roots
- add regression tests for same-path and precedence scenarios

## Validation
- `pnpm exec vitest run src/plugins/manifest-registry.test.ts`

## Context
This PR is one focused slice extracted from:
- https://github.com/openclaw/openclaw/pull/26712
