### PR TITLE
fix(reply): preserve queued exec lifecycle events during active runs

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -66,6 +66,7 @@ export async function runReplyAgent(params: {
   resolvedQueue: QueueSettings;
   shouldSteer: boolean;
   shouldFollowup: boolean;
+  hasQueuedSystemPrompt?: boolean;
   isActive: boolean;
   isStreaming: boolean;
   opts?: GetReplyOptions;
@@ -97,6 +98,7 @@ export async function runReplyAgent(params: {
     resolvedQueue,
     shouldSteer,
     shouldFollowup,
+    hasQueuedSystemPrompt,
     isActive,
     isStreaming,
     opts,
@@ -200,6 +202,7 @@ export async function runReplyAgent(params: {
   const activeRunQueueAction = resolveActiveRunQueueAction({
     isActive,
     isHeartbeat,
+    hasQueuedSystemPrompt,
     shouldFollowup,
     queueMode: resolvedQueue.mode,
   });

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -524,6 +524,7 @@ export async function runPreparedReply(
     resolvedQueue,
     shouldSteer,
     shouldFollowup,
+    hasQueuedSystemPrompt: Boolean(queuedSystemPrompt),
     isActive,
     isStreaming,
     opts,

--- a/src/auto-reply/reply/queue-policy.test.ts
+++ b/src/auto-reply/reply/queue-policy.test.ts
@@ -13,6 +13,18 @@ describe("resolveActiveRunQueueAction", () => {
     ).toBe("run-now");
   });
 
+  it("runs heartbeat system-prompt work immediately when inactive", () => {
+    expect(
+      resolveActiveRunQueueAction({
+        isActive: false,
+        isHeartbeat: true,
+        hasQueuedSystemPrompt: true,
+        shouldFollowup: false,
+        queueMode: "interrupt",
+      }),
+    ).toBe("run-now");
+  });
+
   it("drops heartbeat runs while another run is active", () => {
     expect(
       resolveActiveRunQueueAction({
@@ -33,6 +45,18 @@ describe("resolveActiveRunQueueAction", () => {
         hasQueuedSystemPrompt: true,
         shouldFollowup: true,
         queueMode: "collect",
+      }),
+    ).toBe("enqueue-followup");
+  });
+
+  it("enqueues heartbeat system-prompt runs even in interrupt mode while active", () => {
+    expect(
+      resolveActiveRunQueueAction({
+        isActive: true,
+        isHeartbeat: true,
+        hasQueuedSystemPrompt: true,
+        shouldFollowup: false,
+        queueMode: "interrupt",
       }),
     ).toBe("enqueue-followup");
   });

--- a/src/auto-reply/reply/queue-policy.test.ts
+++ b/src/auto-reply/reply/queue-policy.test.ts
@@ -18,10 +18,23 @@ describe("resolveActiveRunQueueAction", () => {
       resolveActiveRunQueueAction({
         isActive: true,
         isHeartbeat: true,
+        hasQueuedSystemPrompt: false,
         shouldFollowup: true,
         queueMode: "collect",
       }),
     ).toBe("drop");
+  });
+
+  it("enqueues heartbeat runs with queued system events while active", () => {
+    expect(
+      resolveActiveRunQueueAction({
+        isActive: true,
+        isHeartbeat: true,
+        hasQueuedSystemPrompt: true,
+        shouldFollowup: true,
+        queueMode: "collect",
+      }),
+    ).toBe("enqueue-followup");
   });
 
   it("enqueues followups for non-heartbeat active runs", () => {

--- a/src/auto-reply/reply/queue-policy.ts
+++ b/src/auto-reply/reply/queue-policy.ts
@@ -5,6 +5,7 @@ export type ActiveRunQueueAction = "run-now" | "enqueue-followup" | "drop";
 export function resolveActiveRunQueueAction(params: {
   isActive: boolean;
   isHeartbeat: boolean;
+  hasQueuedSystemPrompt?: boolean;
   shouldFollowup: boolean;
   queueMode: QueueSettings["mode"];
 }): ActiveRunQueueAction {
@@ -12,6 +13,11 @@ export function resolveActiveRunQueueAction(params: {
     return "run-now";
   }
   if (params.isHeartbeat) {
+    // Preserve heartbeat-triggered runs when they carry queued system events
+    // (for example exec approval terminal outcomes) so they are not lost.
+    if (params.hasQueuedSystemPrompt) {
+      return "enqueue-followup";
+    }
     return "drop";
   }
   if (params.shouldFollowup || params.queueMode === "steer") {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: heartbeat-triggered runs are dropped whenever another run is active.
- Why it matters: exec approval terminal outcomes (finished/denied/timeout) are delivered via queued system events + heartbeat wake; dropping that heartbeat can delay visibility until an operator sends a nudge.
- What changed: when an active run exists, heartbeat runs that carry queued system prompt content are now enqueued as followups instead of dropped.
- What did NOT change (scope boundary): normal heartbeat noise behavior is unchanged (heartbeats without queued system prompt are still dropped during active runs).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32062
- Related #14191

## User-visible / Behavior Changes

- Exec approval lifecycle outcomes queued as runtime system events are no longer dropped when a heartbeat wake happens during another active run; they are enqueued and delivered when the active run clears.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.7.x
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A (queue policy behavior)
- Integration/channel (if any): heartbeat + queued system events (exec lifecycle path)
- Relevant config (redacted): queue mode with active run overlap (collect/steer scenario)

### Steps

1. Trigger an exec approval lifecycle event that enqueues a system event and heartbeat wake.
2. Keep another run active at wake time.
3. Observe queue action chosen for the heartbeat-triggered run.

### Expected

- Heartbeat run carrying queued runtime system events should not be dropped under active-run overlap.

### Actual

- Before this fix, heartbeat was dropped unconditionally during active runs.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `resolveActiveRunQueueAction` now returns `enqueue-followup` for `isHeartbeat=true`, `isActive=true`, `hasQueuedSystemPrompt=true`; unchanged drop behavior for heartbeat with no queued system prompt.
- Edge cases checked: non-heartbeat active-run behavior and queue mode behavior unchanged in touched tests.
- What you did **not** verify: full end-to-end Discord operator workflow with live approvals.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `039c8bb3f1`.
- Files/config to restore: `src/auto-reply/reply/queue-policy.ts`, `src/auto-reply/reply/agent-runner.ts`, `src/auto-reply/reply/get-reply-run.ts`.
- Known bad symptoms reviewers should watch for: heartbeat followup backlog growth if repeated queued-system heartbeat runs accumulate under sustained long-running active turns.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: More heartbeat followups can queue during long active runs.
  - Mitigation: Scope is narrow to heartbeat runs with queued system prompt content only; heartbeat noise remains dropped.
