### PR TITLE
fix(reply): queue system-origin runs behind active user turns

### DIFF
--- a/src/auto-reply/reply/agent-runner.system-origin.test.ts
+++ b/src/auto-reply/reply/agent-runner.system-origin.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { isSystemOriginRun } from "./agent-runner.js";
+
+describe("isSystemOriginRun", () => {
+  it("treats rewritten messageProvider as system-origin when session provider is system", () => {
+    expect(
+      isSystemOriginRun({
+        messageProvider: "telegram",
+        sessionProvider: "system",
+      }),
+    ).toBe(true);
+  });
+
+  it("treats explicit system message providers as system-origin", () => {
+    expect(isSystemOriginRun({ messageProvider: "cron" })).toBe(true);
+    expect(isSystemOriginRun({ messageProvider: "hook" })).toBe(true);
+    expect(isSystemOriginRun({ messageProvider: "system" })).toBe(true);
+  });
+
+  it("does not classify normal channel providers as system-origin", () => {
+    expect(
+      isSystemOriginRun({
+        messageProvider: "telegram",
+        sessionProvider: "webchat",
+        sessionSurface: "webchat",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/agent-runner.system-origin.test.ts
+++ b/src/auto-reply/reply/agent-runner.system-origin.test.ts
@@ -11,6 +11,17 @@ describe("isSystemOriginRun", () => {
     ).toBe(true);
   });
 
+  it("treats rewritten messageProvider as system-origin when source provider is system", () => {
+    expect(
+      isSystemOriginRun({
+        messageProvider: "telegram",
+        sourceMessageProvider: "system",
+        sessionProvider: "telegram",
+        sessionSurface: "telegram",
+      }),
+    ).toBe(true);
+  });
+
   it("treats explicit system message providers as system-origin", () => {
     expect(isSystemOriginRun({ messageProvider: "cron" })).toBe(true);
     expect(isSystemOriginRun({ messageProvider: "hook" })).toBe(true);

--- a/src/auto-reply/reply/agent-runner.system-origin.test.ts
+++ b/src/auto-reply/reply/agent-runner.system-origin.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, it } from "vitest";
 import { isSystemOriginRun } from "./agent-runner.js";
 
 describe("isSystemOriginRun", () => {
-  it("treats rewritten messageProvider as system-origin when session provider is system", () => {
+  it("does not treat rewritten user messageProvider as system-origin via session fallback", () => {
     expect(
       isSystemOriginRun({
         messageProvider: "telegram",
         sessionProvider: "system",
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it("treats rewritten messageProvider as system-origin when source provider is system", () => {
@@ -26,6 +26,14 @@ describe("isSystemOriginRun", () => {
     expect(isSystemOriginRun({ messageProvider: "cron" })).toBe(true);
     expect(isSystemOriginRun({ messageProvider: "hook" })).toBe(true);
     expect(isSystemOriginRun({ messageProvider: "system" })).toBe(true);
+  });
+
+  it("falls back to session provider when message-level providers are missing", () => {
+    expect(
+      isSystemOriginRun({
+        sessionProvider: "system",
+      }),
+    ).toBe(true);
   });
 
   it("does not classify normal channel providers as system-origin", () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -60,9 +60,16 @@ import type { TypingController } from "./typing.js";
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
 const SYSTEM_MESSAGE_PROVIDERS = new Set(["cron", "hook", "system"]);
 
-function isSystemOriginRun(messageProvider: string | undefined): boolean {
-  const provider = messageProvider?.trim().toLowerCase();
-  return Boolean(provider && SYSTEM_MESSAGE_PROVIDERS.has(provider));
+export function isSystemOriginRun(params: {
+  messageProvider?: string;
+  sessionProvider?: string;
+  sessionSurface?: string;
+}): boolean {
+  const providers = [params.messageProvider, params.sessionProvider, params.sessionSurface];
+  return providers.some((provider) => {
+    const normalized = provider?.trim().toLowerCase();
+    return Boolean(normalized && SYSTEM_MESSAGE_PROVIDERS.has(normalized));
+  });
 }
 
 export async function runReplyAgent(params: {
@@ -206,7 +213,11 @@ export async function runReplyAgent(params: {
   const activeRunQueueAction = resolveActiveRunQueueAction({
     isActive,
     isHeartbeat,
-    isSystemRun: isSystemOriginRun(followupRun.run.messageProvider),
+    isSystemRun: isSystemOriginRun({
+      messageProvider: followupRun.run.messageProvider,
+      sessionProvider: sessionCtx.Provider,
+      sessionSurface: sessionCtx.Surface,
+    }),
     shouldFollowup,
     queueMode: resolvedQueue.mode,
   });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -58,6 +58,12 @@ import { createTypingSignaler } from "./typing-mode.js";
 import type { TypingController } from "./typing.js";
 
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
+const SYSTEM_MESSAGE_PROVIDERS = new Set(["cron", "hook", "system"]);
+
+function isSystemOriginRun(messageProvider: string | undefined): boolean {
+  const provider = messageProvider?.trim().toLowerCase();
+  return Boolean(provider && SYSTEM_MESSAGE_PROVIDERS.has(provider));
+}
 
 export async function runReplyAgent(params: {
   commandBody: string;
@@ -200,6 +206,7 @@ export async function runReplyAgent(params: {
   const activeRunQueueAction = resolveActiveRunQueueAction({
     isActive,
     isHeartbeat,
+    isSystemRun: isSystemOriginRun(followupRun.run.messageProvider),
     shouldFollowup,
     queueMode: resolvedQueue.mode,
   });

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -62,10 +62,16 @@ const SYSTEM_MESSAGE_PROVIDERS = new Set(["cron", "hook", "system"]);
 
 export function isSystemOriginRun(params: {
   messageProvider?: string;
+  sourceMessageProvider?: string;
   sessionProvider?: string;
   sessionSurface?: string;
 }): boolean {
-  const providers = [params.messageProvider, params.sessionProvider, params.sessionSurface];
+  const providers = [
+    params.messageProvider,
+    params.sourceMessageProvider,
+    params.sessionProvider,
+    params.sessionSurface,
+  ];
   return providers.some((provider) => {
     const normalized = provider?.trim().toLowerCase();
     return Boolean(normalized && SYSTEM_MESSAGE_PROVIDERS.has(normalized));
@@ -215,6 +221,7 @@ export async function runReplyAgent(params: {
     isHeartbeat,
     isSystemRun: isSystemOriginRun({
       messageProvider: followupRun.run.messageProvider,
+      sourceMessageProvider: followupRun.run.sourceMessageProvider,
       sessionProvider: sessionCtx.Provider,
       sessionSurface: sessionCtx.Surface,
     }),

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -66,16 +66,19 @@ export function isSystemOriginRun(params: {
   sessionProvider?: string;
   sessionSurface?: string;
 }): boolean {
-  const providers = [
-    params.messageProvider,
-    params.sourceMessageProvider,
-    params.sessionProvider,
-    params.sessionSurface,
-  ];
-  return providers.some((provider) => {
+  const normalizeProvider = (provider?: string): string | undefined => {
     const normalized = provider?.trim().toLowerCase();
-    return Boolean(normalized && SYSTEM_MESSAGE_PROVIDERS.has(normalized));
-  });
+    return normalized || undefined;
+  };
+  const messageProviders = [
+    normalizeProvider(params.messageProvider),
+    normalizeProvider(params.sourceMessageProvider),
+  ];
+  const hasMessageLevelProvider = messageProviders.some(Boolean);
+  const providers = hasMessageLevelProvider
+    ? messageProviders
+    : [normalizeProvider(params.sessionProvider), normalizeProvider(params.sessionSurface)];
+  return providers.some((provider) => Boolean(provider && SYSTEM_MESSAGE_PROVIDERS.has(provider)));
 }
 
 export async function runReplyAgent(params: {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -475,6 +475,7 @@ export async function runPreparedReply(
       agentDir,
       sessionId: sessionIdFinal,
       sessionKey,
+      sourceMessageProvider: ctx.Provider ?? ctx.Surface ?? sessionCtx.Provider,
       messageProvider: resolveOriginMessageProvider({
         originatingChannel: ctx.OriginatingChannel ?? sessionCtx.OriginatingChannel,
         // Prefer Provider over Surface for fallback channel identity.

--- a/src/auto-reply/reply/queue-policy.test.ts
+++ b/src/auto-reply/reply/queue-policy.test.ts
@@ -45,4 +45,16 @@ describe("resolveActiveRunQueueAction", () => {
       }),
     ).toBe("enqueue-followup");
   });
+
+  it("enqueues system-origin runs while active", () => {
+    expect(
+      resolveActiveRunQueueAction({
+        isActive: true,
+        isHeartbeat: false,
+        isSystemRun: true,
+        shouldFollowup: false,
+        queueMode: "interrupt",
+      }),
+    ).toBe("enqueue-followup");
+  });
 });

--- a/src/auto-reply/reply/queue-policy.test.ts
+++ b/src/auto-reply/reply/queue-policy.test.ts
@@ -57,4 +57,28 @@ describe("resolveActiveRunQueueAction", () => {
       }),
     ).toBe("enqueue-followup");
   });
+
+  it("still runs system-origin work immediately when no run is active", () => {
+    expect(
+      resolveActiveRunQueueAction({
+        isActive: false,
+        isHeartbeat: false,
+        isSystemRun: true,
+        shouldFollowup: false,
+        queueMode: "interrupt",
+      }),
+    ).toBe("run-now");
+  });
+
+  it("still drops heartbeat runs even when system-origin is marked", () => {
+    expect(
+      resolveActiveRunQueueAction({
+        isActive: true,
+        isHeartbeat: true,
+        isSystemRun: true,
+        shouldFollowup: false,
+        queueMode: "interrupt",
+      }),
+    ).toBe("drop");
+  });
 });

--- a/src/auto-reply/reply/queue-policy.ts
+++ b/src/auto-reply/reply/queue-policy.ts
@@ -5,6 +5,7 @@ export type ActiveRunQueueAction = "run-now" | "enqueue-followup" | "drop";
 export function resolveActiveRunQueueAction(params: {
   isActive: boolean;
   isHeartbeat: boolean;
+  isSystemRun?: boolean;
   shouldFollowup: boolean;
   queueMode: QueueSettings["mode"];
 }): ActiveRunQueueAction {
@@ -13,6 +14,9 @@ export function resolveActiveRunQueueAction(params: {
   }
   if (params.isHeartbeat) {
     return "drop";
+  }
+  if (params.isSystemRun) {
+    return "enqueue-followup";
   }
   if (params.shouldFollowup || params.queueMode === "steer") {
     return "enqueue-followup";

--- a/src/auto-reply/reply/queue/types.ts
+++ b/src/auto-reply/reply/queue/types.ts
@@ -47,6 +47,7 @@ export type FollowupRun = {
     sessionId: string;
     sessionKey?: string;
     messageProvider?: string;
+    sourceMessageProvider?: string;
     agentAccountId?: string;
     groupId?: string;
     groupChannel?: string;


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: while a user run is active, non-heartbeat system-origin turns (for example cron/hook/system provider runs) can still execute immediately.
- Why it matters: these system turns can preempt or interleave with user-facing processing, causing confusing response ordering and occasional NO_REPLY-style user impact under overlap.
- What changed: active-run queue policy now enqueues system-origin runs (`cron`, `hook`, `system`) instead of running them immediately.
- What did NOT change (scope boundary): user-origin runs and existing heartbeat-drop behavior are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32430
- Related #32062

## User-visible / Behavior Changes

- Under active-run overlap, system-origin turns are queued instead of preempting the current user run.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.7.x
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A (queue policy)
- Integration/channel (if any): system-origin runs (`cron`/`hook`/`system`) under active user run overlap
- Relevant config (redacted): queue mode where active run overlap can happen (`interrupt`/`collect` etc.)

### Steps

1. Keep a user run active.
2. Trigger a system-origin run with provider `cron`, `hook`, or `system`.
3. Observe queue action chosen while active.

### Expected

- System-origin run is enqueued and processed after active user run.

### Actual

- Before this fix, non-heartbeat system-origin runs could run immediately while active.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: queue-policy now returns `enqueue-followup` for active `isSystemRun=true`; existing non-system behavior remained stable in touched tests.
- Edge cases checked: heartbeat path still drops while active; non-heartbeat/non-system path unchanged.
- What you did **not** verify: live Discord end-to-end overlap with real cron traffic.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `4ac9c1a333`.
- Files/config to restore: `src/auto-reply/reply/queue-policy.ts`, `src/auto-reply/reply/queue-policy.test.ts`, `src/auto-reply/reply/agent-runner.ts`.
- Known bad symptoms reviewers should watch for: unexpected system followup queue depth growth under sustained system-event bursts.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: System events may queue longer in high-load sessions.
  - Mitigation: This only applies while an active run is in progress, and prevents user-turn preemption.
