### PR TITLE
Typing: stabilize keepalive and suppress silent-run indicator

### DIFF
--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -592,6 +592,29 @@ describe("runReplyAgent typing (heartbeat)", () => {
     }
   });
 
+  it("does not start message-mode typing from tool events on silent runs", async () => {
+    state.runEmbeddedPiAgentMock.mockImplementationOnce(async (params: AgentRunParams) => {
+      params.onAgentEvent?.({
+        stream: "tool",
+        data: { phase: "start", name: "reaction" },
+      });
+      params.onAgentEvent?.({
+        stream: "tool",
+        data: { phase: "update", name: "reaction" },
+      });
+      return { payloads: [{ text: "NO_REPLY" }], meta: {} };
+    });
+
+    const { run, typing } = createMinimalRun({
+      typingMode: "message",
+    });
+    const result = await run();
+
+    expect(result).toBeUndefined();
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).not.toHaveBeenCalled();
+  });
+
   it("retries transient HTTP failures once with timer-driven backoff", async () => {
     vi.useFakeTimers();
     let calls = 0;

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -517,7 +517,7 @@ describe("createTypingSignaler", () => {
     expect(typing.startTypingOnText).not.toHaveBeenCalled();
   });
 
-  it("handles tool-start typing before and after active text mode", async () => {
+  it("does not start typing from tool events before renderable text in message mode", async () => {
     const typing = createMockTypingController();
     const signaler = createTypingSignaler({
       typing,
@@ -527,16 +527,35 @@ describe("createTypingSignaler", () => {
 
     await signaler.signalToolStart();
 
-    expect(typing.startTypingLoop).toHaveBeenCalled();
-    expect(typing.refreshTypingTtl).toHaveBeenCalled();
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).not.toHaveBeenCalled();
     expect(typing.startTypingOnText).not.toHaveBeenCalled();
+
+    await signaler.signalTextDelta("hello");
+    expect(typing.startTypingOnText).toHaveBeenCalledWith("hello");
+
     (typing.isActive as ReturnType<typeof vi.fn>).mockReturnValue(true);
     (typing.startTypingLoop as ReturnType<typeof vi.fn>).mockClear();
     (typing.refreshTypingTtl as ReturnType<typeof vi.fn>).mockClear();
+
     await signaler.signalToolStart();
 
     expect(typing.refreshTypingTtl).toHaveBeenCalled();
     expect(typing.startTypingLoop).not.toHaveBeenCalled();
+  });
+
+  it("starts typing from tool events in instant mode", async () => {
+    const typing = createMockTypingController();
+    const signaler = createTypingSignaler({
+      typing,
+      mode: "instant",
+      isHeartbeat: false,
+    });
+
+    await signaler.signalToolStart();
+
+    expect(typing.startTypingLoop).toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).toHaveBeenCalled();
   });
 
   it("suppresses typing when disabled", async () => {

--- a/src/auto-reply/reply/typing-mode.ts
+++ b/src/auto-reply/reply/typing-mode.ts
@@ -128,7 +128,12 @@ export function createTypingSignaler(params: {
     if (disabled) {
       return;
     }
-    // Start typing as soon as tools begin executing, even before the first text delta.
+    // In message/thinking modes, don't light up typing on tool-only silent runs.
+    // We only start from tool events when typing is already active or mode is instant.
+    if (!shouldStartImmediately && !typing.isActive() && !hasRenderableText) {
+      return;
+    }
+    // Instant mode may need to start from tool execution even before text deltas.
     if (!typing.isActive()) {
       await typing.startTypingLoop();
       typing.refreshTypingTtl();

--- a/src/channels/typing.test.ts
+++ b/src/channels/typing.test.ts
@@ -164,6 +164,37 @@ describe("createTypingCallbacks", () => {
     });
   });
 
+  it("does not re-arm keepalive when idle fires during an in-flight start", async () => {
+    vi.useFakeTimers();
+    try {
+      let resolveStart: (() => void) | undefined;
+      const start = vi.fn().mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveStart = resolve;
+          }),
+      );
+      const stop = vi.fn().mockResolvedValue(undefined);
+      const onStartError = vi.fn();
+      const callbacks = createTypingCallbacks({ start, stop, onStartError });
+
+      const inFlightStart = callbacks.onReplyStart();
+      expect(start).toHaveBeenCalledTimes(1);
+
+      callbacks.onIdle?.();
+      await flushMicrotasks();
+      expect(stop).toHaveBeenCalledTimes(1);
+
+      resolveStart?.();
+      await inFlightStart;
+
+      await vi.advanceTimersByTimeAsync(9_000);
+      expect(start).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("deduplicates stop across idle and cleanup", async () => {
     const { stop, callbacks } = createTypingHarness();
 

--- a/src/channels/typing.ts
+++ b/src/channels/typing.ts
@@ -77,7 +77,7 @@ export function createTypingCallbacks(params: CreateTypingCallbacksParams): Typi
     keepaliveLoop.stop();
     clearTtlTimer();
     await fireStart();
-    if (startGuard.isTripped()) {
+    if (startGuard.isTripped() || closed) {
       return;
     }
     keepaliveLoop.start();


### PR DESCRIPTION
## Summary
- split from #26712 into a focused typing-behavior PR
- suppress tool-start typing indicator on silent message runs
- prevent typing keepalive re-arm if idle/cleanup closes while start is in-flight
- include tests for idle-during-inflight-start behavior

## Validation
- `pnpm exec vitest run src/channels/typing.test.ts src/auto-reply/reply/reply-utils.test.ts`

## Context
This PR is one focused slice extracted from:
- https://github.com/openclaw/openclaw/pull/26712
