### PR TITLE
Gateway: allow webchat session label updates

### DIFF
--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -27,6 +27,7 @@ import { GATEWAY_CLIENT_IDS } from "../protocol/client-info.js";
 import {
   ErrorCodes,
   errorShape,
+  type SessionsPatchParams,
   validateSessionsCompactParams,
   validateSessionsDeleteParams,
   validateSessionsListParams,
@@ -99,6 +100,14 @@ function rejectWebchatSessionMutation(params: {
     ),
   );
   return true;
+}
+
+function isWebchatLabelOnlyPatch(patch: SessionsPatchParams): boolean {
+  const keys = Object.keys(patch).filter((key) => key !== "key");
+  if (keys.length !== 1 || keys[0] !== "label") {
+    return false;
+  }
+  return Object.hasOwn(patch, "label");
 }
 
 function migrateAndPruneSessionStoreKey(params: {
@@ -411,7 +420,12 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     if (!key) {
       return;
     }
-    if (rejectWebchatSessionMutation({ action: "patch", client, isWebchatConnect, respond })) {
+    const allowWebchatLabelPatch =
+      client?.connect && isWebchatConnect(client.connect) && isWebchatLabelOnlyPatch(p);
+    if (
+      !allowWebchatLabelPatch &&
+      rejectWebchatSessionMutation({ action: "patch", client, isWebchatConnect, respond })
+    ) {
       return;
     }
 

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1239,12 +1239,22 @@ describe("gateway server sessions", () => {
       scopes: ["operator.admin"],
     });
 
-    const patched = await rpcReq(ws, "sessions.patch", {
+    const patchedLabel = await rpcReq<{
+      ok: true;
+      entry: { label?: string };
+    }>(ws, "sessions.patch", {
       key: "agent:main:discord:group:dev",
-      label: "should-fail",
+      label: "should-pass",
     });
-    expect(patched.ok).toBe(false);
-    expect(patched.error?.message ?? "").toMatch(/webchat clients cannot patch sessions/i);
+    expect(patchedLabel.ok).toBe(true);
+    expect(patchedLabel.payload?.entry.label).toBe("should-pass");
+
+    const patchedThinking = await rpcReq(ws, "sessions.patch", {
+      key: "agent:main:discord:group:dev",
+      thinkingLevel: "high",
+    });
+    expect(patchedThinking.ok).toBe(false);
+    expect(patchedThinking.error?.message ?? "").toMatch(/webchat clients cannot patch sessions/i);
 
     const deleted = await rpcReq(ws, "sessions.delete", {
       key: "agent:main:discord:group:dev",


### PR DESCRIPTION
## Summary
- split from #26712 into a focused gateway sessions PR
- allow webchat session label updates through gateway sessions methods
- add/update gateway session tests for label-update behavior

## Validation
- `pnpm exec vitest run src/gateway/server.sessions.gateway-server-sessions-a.test.ts`

## Context
This PR is one focused slice extracted from:
- https://github.com/openclaw/openclaw/pull/26712
