### PR TITLE
browser: report extension profile running when relay is reachable

### DIFF
--- a/src/browser/routes/basic.status-running.test.ts
+++ b/src/browser/routes/basic.status-running.test.ts
@@ -12,6 +12,16 @@ describe("resolveBrowserStatusRunning", () => {
     ).toBe(true);
   });
 
+  it("reports extension profiles as not running when relay HTTP is unreachable", () => {
+    expect(
+      resolveBrowserStatusRunning({
+        driver: "extension",
+        cdpHttp: false,
+        cdpReady: false,
+      }),
+    ).toBe(false);
+  });
+
   it("uses CDP websocket readiness for openclaw profiles", () => {
     expect(
       resolveBrowserStatusRunning({
@@ -20,5 +30,15 @@ describe("resolveBrowserStatusRunning", () => {
         cdpReady: false,
       }),
     ).toBe(false);
+  });
+
+  it("reports openclaw profiles as running when CDP websocket is ready", () => {
+    expect(
+      resolveBrowserStatusRunning({
+        driver: "openclaw",
+        cdpHttp: false,
+        cdpReady: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/src/browser/routes/basic.status-running.test.ts
+++ b/src/browser/routes/basic.status-running.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { resolveBrowserStatusRunning } from "./basic.js";
+
+describe("resolveBrowserStatusRunning", () => {
+  it("uses relay HTTP reachability for extension profiles", () => {
+    expect(
+      resolveBrowserStatusRunning({
+        driver: "extension",
+        cdpHttp: true,
+        cdpReady: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("uses CDP websocket readiness for openclaw profiles", () => {
+    expect(
+      resolveBrowserStatusRunning({
+        driver: "openclaw",
+        cdpHttp: true,
+        cdpReady: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/browser/routes/basic.ts
+++ b/src/browser/routes/basic.ts
@@ -5,6 +5,16 @@ import { resolveProfileContext } from "./agent.shared.js";
 import type { BrowserRequest, BrowserResponse, BrowserRouteRegistrar } from "./types.js";
 import { getProfileContext, jsonError, toStringOrEmpty } from "./utils.js";
 
+export function resolveBrowserStatusRunning(params: {
+  driver: "openclaw" | "extension";
+  cdpHttp: boolean;
+  cdpReady: boolean;
+}): boolean {
+  // Extension profiles are healthy when relay HTTP is reachable.
+  // Tab-level CDP readiness remains exposed via cdpReady.
+  return params.driver === "extension" ? params.cdpHttp : params.cdpReady;
+}
+
 async function withBasicProfileRoute(params: {
   req: BrowserRequest;
   res: BrowserResponse;
@@ -71,7 +81,11 @@ export function registerBrowserBasicRoutes(app: BrowserRouteRegistrar, ctx: Brow
     res.json({
       enabled: current.resolved.enabled,
       profile: profileCtx.profile.name,
-      running: cdpReady,
+      running: resolveBrowserStatusRunning({
+        driver: profileCtx.profile.driver,
+        cdpHttp,
+        cdpReady,
+      }),
       cdpReady,
       cdpHttp,
       pid: profileState?.running?.pid ?? null,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: extension profiles reported `running=false` unless a tab was already attached.
- Why it matters: operators interpret `browser start` as failed/deadlocked even when relay server is healthy, because status uses tab-level readiness instead of relay availability.
- What changed: browser status now reports `running` from relay HTTP reachability for extension profiles; `cdpReady` remains exposed for tab-level readiness.
- What did NOT change (scope boundary): no change to tab-attachment requirements or extension relay startup logic.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32532
- Related #23914

## User-visible / Behavior Changes

- `openclaw browser status` / browser status API now shows extension profile `running=true` when relay HTTP is reachable, even before any tab is attached.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 15.7.x
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Browser extension relay profile (`driver=extension`)
- Relevant config (redacted): profile with `driver: extension` and relay `cdpUrl`

### Steps

1. Start extension profile relay with no attached extension tab.
2. Query browser status.
3. Compare `running` semantics for extension vs openclaw profile.

### Expected

- Extension profile should report running when relay server is up, independent of attached tab state.

### Actual

- Before fix, `running` tracked `cdpReady`, which is false until a tab attaches.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: unit test confirms extension profile running derives from `cdpHttp`; openclaw profile still derives from `cdpReady`.
- Edge cases checked: existing server-lifecycle relay tests still pass.
- What you did **not** verify: live Chrome extension attach flow on a full desktop session.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `a39d4e0c25`.
- Files/config to restore: `src/browser/routes/basic.ts`, `src/browser/routes/basic.status-running.test.ts`.
- Known bad symptoms reviewers should watch for: extension status shown as running when relay endpoint is up but no tabs are attached (tab readiness still visible via `cdpReady=false`).

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Operators might conflate `running` with tab attachment state.
  - Mitigation: `cdpReady` remains in response and continues to reflect tab-level readiness.
