### PR TITLE
fix(gateway): scope chat event broadcasts to session-associated clients

### DIFF
--- a/src/gateway/server-broadcast.session-scoping.test.ts
+++ b/src/gateway/server-broadcast.session-scoping.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from "vitest";
+import { createGatewayBroadcaster } from "./server-broadcast.js";
+import type { GatewayWsClient } from "./server/ws-types.js";
+
+function createMockClient(overrides: {
+  connId: string;
+  scopes?: string[];
+  chatSessionKeys?: Set<string>;
+}): GatewayWsClient {
+  const sent: string[] = [];
+  return {
+    connId: overrides.connId,
+    socket: {
+      send: vi.fn((data: string) => sent.push(data)),
+      close: vi.fn(),
+      bufferedAmount: 0,
+    } as unknown as GatewayWsClient["socket"],
+    connect: {
+      minProtocol: 3,
+      maxProtocol: 3,
+      client: {
+        id: "openclaw-control-ui",
+        version: "test",
+        platform: "test",
+        mode: "webchat",
+      },
+      role: "operator",
+      scopes: overrides.scopes ?? [],
+    } as unknown as GatewayWsClient["connect"],
+    chatSessionKeys: overrides.chatSessionKeys,
+  };
+}
+
+function getSentPayloads(client: GatewayWsClient): unknown[] {
+  return (client.socket.send as ReturnType<typeof vi.fn>).mock.calls.map(
+    ([raw]: [string]) => JSON.parse(raw).payload,
+  );
+}
+
+describe("chat broadcast session scoping", () => {
+  it("delivers chat events to all clients when none have declared session interest", () => {
+    const clientA = createMockClient({ connId: "a" });
+    const clientB = createMockClient({ connId: "b" });
+    const clients = new Set([clientA, clientB]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("chat", { sessionKey: "session-1", text: "hello" });
+
+    expect(getSentPayloads(clientA)).toHaveLength(1);
+    expect(getSentPayloads(clientB)).toHaveLength(1);
+  });
+
+  it("scopes chat events to clients that have interacted with the session", () => {
+    const clientA = createMockClient({
+      connId: "a",
+      chatSessionKeys: new Set(["session-1"]),
+    });
+    const clientB = createMockClient({
+      connId: "b",
+      chatSessionKeys: new Set(["session-2"]),
+    });
+    const clients = new Set([clientA, clientB]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("chat", { sessionKey: "session-1", text: "hello" });
+
+    // Client A subscribed to session-1 → receives event
+    expect(getSentPayloads(clientA)).toHaveLength(1);
+    // Client B subscribed to session-2 only → does NOT receive event
+    expect(getSentPayloads(clientB)).toHaveLength(0);
+  });
+
+  it("always delivers chat events to admin-scoped clients regardless of session tracking", () => {
+    const adminClient = createMockClient({
+      connId: "admin",
+      scopes: ["operator.admin"],
+      chatSessionKeys: new Set(["session-2"]), // subscribed to different session
+    });
+    const regularClient = createMockClient({
+      connId: "regular",
+      chatSessionKeys: new Set(["session-2"]),
+    });
+    const clients = new Set([adminClient, regularClient]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("chat", { sessionKey: "session-1", text: "hello" });
+
+    // Admin always receives all chat events
+    expect(getSentPayloads(adminClient)).toHaveLength(1);
+    // Regular client subscribed to session-2 → does NOT receive session-1 events
+    expect(getSentPayloads(regularClient)).toHaveLength(0);
+  });
+
+  it("delivers to clients with empty chatSessionKeys (backward compat)", () => {
+    const legacyClient = createMockClient({ connId: "legacy" }); // no chatSessionKeys
+    const scopedClient = createMockClient({
+      connId: "scoped",
+      chatSessionKeys: new Set(["session-1"]),
+    });
+    const clients = new Set([legacyClient, scopedClient]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("chat", { sessionKey: "session-2", text: "hello" });
+
+    // Legacy client (no session tracking) gets everything
+    expect(getSentPayloads(legacyClient)).toHaveLength(1);
+    // Scoped client subscribed to session-1 → does NOT get session-2
+    expect(getSentPayloads(scopedClient)).toHaveLength(0);
+  });
+
+  it("does NOT scope non-chat events", () => {
+    const clientA = createMockClient({
+      connId: "a",
+      chatSessionKeys: new Set(["session-1"]),
+    });
+    const clients = new Set([clientA]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("agent", { sessionKey: "session-2", data: "tool output" });
+
+    // Agent events are NOT session-scoped — client receives it regardless
+    expect(getSentPayloads(clientA)).toHaveLength(1);
+  });
+
+  it("delivers chat events with no sessionKey to all clients", () => {
+    const scopedClient = createMockClient({
+      connId: "scoped",
+      chatSessionKeys: new Set(["session-1"]),
+    });
+    const clients = new Set([scopedClient]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("chat", { text: "no session key" }); // no sessionKey in payload
+
+    // Cannot scope without sessionKey → deliver to all
+    expect(getSentPayloads(scopedClient)).toHaveLength(1);
+  });
+
+  it("client tracking multiple sessions receives events from all of them", () => {
+    const multiClient = createMockClient({
+      connId: "multi",
+      chatSessionKeys: new Set(["session-1", "session-2"]),
+    });
+    const clients = new Set([multiClient]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("chat", { sessionKey: "session-1", text: "msg1" });
+    broadcast("chat", { sessionKey: "session-2", text: "msg2" });
+    broadcast("chat", { sessionKey: "session-3", text: "msg3" });
+
+    // Receives session-1 and session-2, not session-3
+    expect(getSentPayloads(multiClient)).toHaveLength(2);
+  });
+});

--- a/src/gateway/server-broadcast.session-scoping.test.ts
+++ b/src/gateway/server-broadcast.session-scoping.test.ts
@@ -33,7 +33,7 @@ function createMockClient(overrides: {
 
 function getSentPayloads(client: GatewayWsClient): unknown[] {
   return (client.socket.send as ReturnType<typeof vi.fn>).mock.calls.map(
-    ([raw]: [string]) => JSON.parse(raw).payload,
+    (args: unknown[]) => JSON.parse(args[0] as string).payload,
   );
 }
 
@@ -106,6 +106,23 @@ describe("chat broadcast session scoping", () => {
     expect(getSentPayloads(legacyClient)).toHaveLength(1);
     // Scoped client subscribed to session-1 → does NOT get session-2
     expect(getSentPayloads(scopedClient)).toHaveLength(0);
+  });
+
+  it("does NOT treat admin scope on non-operator role as admin", () => {
+    const nodeClient = createMockClient({
+      connId: "node",
+      scopes: ["operator.admin"],
+      chatSessionKeys: new Set(["session-2"]),
+    });
+    // Override role to "node" — admin scope should not apply
+    (nodeClient.connect as Record<string, unknown>).role = "node";
+    const clients = new Set([nodeClient]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    broadcast("chat", { sessionKey: "session-1", text: "hello" });
+
+    // Non-operator role with admin scope should NOT bypass session scoping
+    expect(getSentPayloads(nodeClient)).toHaveLength(0);
   });
 
   it("does NOT scope non-chat events", () => {

--- a/src/gateway/server-broadcast.session-scoping.test.ts
+++ b/src/gateway/server-broadcast.session-scoping.test.ts
@@ -2,6 +2,20 @@ import { describe, it, expect, vi } from "vitest";
 import { createGatewayBroadcaster } from "./server-broadcast.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
 
+// Mock session-utils so we can control canonical key resolution in tests.
+vi.mock("./session-utils.js", () => ({
+  resolveSessionStoreKey: vi.fn(({ sessionKey }: { sessionKey: string }) => {
+    // Simulate canonical resolution: "main" → "agent:main:main"
+    const aliases: Record<string, string> = {
+      main: "agent:main:main",
+    };
+    return aliases[sessionKey] ?? sessionKey;
+  }),
+}));
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({})),
+}));
+
 function createMockClient(overrides: {
   connId: string;
   scopes?: string[];
@@ -151,6 +165,36 @@ describe("chat broadcast session scoping", () => {
 
     // Cannot scope without sessionKey → deliver to all
     expect(getSentPayloads(scopedClient)).toHaveLength(1);
+  });
+
+  it("matches chat events via canonical key when raw alias differs", () => {
+    // Client tracked the canonical key "agent:main:main" via chat.send
+    const client = createMockClient({
+      connId: "a",
+      chatSessionKeys: new Set(["agent:main:main"]),
+    });
+    const clients = new Set([client]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    // Event producer emits raw alias "main" — resolveSessionStoreKey maps
+    // it to "agent:main:main", so the client should still receive the event.
+    broadcast("chat", { sessionKey: "main", text: "via alias" });
+
+    expect(getSentPayloads(client)).toHaveLength(1);
+  });
+
+  it("does NOT deliver when neither raw nor canonical key matches", () => {
+    const client = createMockClient({
+      connId: "a",
+      chatSessionKeys: new Set(["agent:main:main"]),
+    });
+    const clients = new Set([client]);
+    const { broadcast } = createGatewayBroadcaster({ clients });
+
+    // "other-session" is not an alias for "agent:main:main"
+    broadcast("chat", { sessionKey: "other-session", text: "nope" });
+
+    expect(getSentPayloads(client)).toHaveLength(0);
   });
 
   it("client tracking multiple sessions receives events from all of them", () => {

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -38,6 +38,11 @@ export type GatewayBroadcastToConnIdsFn = (
   opts?: GatewayBroadcastOpts,
 ) => void;
 
+function hasAdminScope(client: GatewayWsClient): boolean {
+  const scopes = Array.isArray(client.connect.scopes) ? client.connect.scopes : [];
+  return scopes.includes(ADMIN_SCOPE);
+}
+
 function hasEventScope(client: GatewayWsClient, event: string): boolean {
   const required = EVENT_SCOPE_GUARDS[event];
   if (!required) {
@@ -47,11 +52,41 @@ function hasEventScope(client: GatewayWsClient, event: string): boolean {
   if (role !== "operator") {
     return false;
   }
-  const scopes = Array.isArray(client.connect.scopes) ? client.connect.scopes : [];
-  if (scopes.includes(ADMIN_SCOPE)) {
+  if (hasAdminScope(client)) {
     return true;
   }
+  const scopes = Array.isArray(client.connect.scopes) ? client.connect.scopes : [];
   return required.some((scope) => scopes.includes(scope));
+}
+
+/**
+ * Check whether a client should receive a session-scoped chat event.
+ *
+ * Scoping rules (evaluated in order):
+ *  1. Clients with operator.admin scope → always receive all chat events.
+ *  2. Clients that have never sent chat.send (chatSessionKeys is
+ *     undefined or empty) → receive all events (backward compatibility
+ *     for Control UI and legacy clients).
+ *  3. Clients with a non-empty chatSessionKeys set → only receive events
+ *     whose sessionKey is in that set.
+ */
+function shouldReceiveChatEvent(client: GatewayWsClient, sessionKey: string | undefined): boolean {
+  // Admin-scoped clients (e.g., Control UI operators) always see everything.
+  if (hasAdminScope(client)) {
+    return true;
+  }
+  const tracked = client.chatSessionKeys;
+  // Clients that haven't declared interest in any session yet get all
+  // events — this preserves backward compatibility for existing clients
+  // that rely on client-side sessionKey filtering.
+  if (!tracked || tracked.size === 0) {
+    return true;
+  }
+  // If the event has no sessionKey we can't scope it — deliver to all.
+  if (!sessionKey) {
+    return true;
+  }
+  return tracked.has(sessionKey);
 }
 
 export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient> }) {
@@ -90,11 +125,22 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
       }
       logWs("out", "event", logMeta);
     }
+    // Extract sessionKey from chat event payloads for session-scoped delivery.
+    const chatSessionKey =
+      event === "chat" && payload && typeof payload === "object" && "sessionKey" in payload
+        ? (payload as { sessionKey?: string }).sessionKey
+        : undefined;
+
     for (const c of params.clients) {
       if (targetConnIds && !targetConnIds.has(c.connId)) {
         continue;
       }
       if (!hasEventScope(c, event)) {
+        continue;
+      }
+      // Session-scoped delivery for chat events: skip clients that have
+      // declared session interest and are not subscribed to this session.
+      if (event === "chat" && !shouldReceiveChatEvent(c, chatSessionKey)) {
         continue;
       }
       const slow = c.socket.bufferedAmount > MAX_BUFFERED_BYTES;

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -39,6 +39,10 @@ export type GatewayBroadcastToConnIdsFn = (
 ) => void;
 
 function hasAdminScope(client: GatewayWsClient): boolean {
+  const role = client.connect.role ?? "operator";
+  if (role !== "operator") {
+    return false;
+  }
   const scopes = Array.isArray(client.connect.scopes) ? client.connect.scopes : [];
   return scopes.includes(ADMIN_SCOPE);
 }

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -1,5 +1,7 @@
+import { loadConfig } from "../config/config.js";
 import { MAX_BUFFERED_BYTES } from "./server-constants.js";
 import type { GatewayWsClient } from "./server/ws-types.js";
+import { resolveSessionStoreKey } from "./session-utils.js";
 import { logWs, shouldLogWs, summarizeAgentEventForWsLog } from "./ws-log.js";
 
 const ADMIN_SCOPE = "operator.admin";
@@ -74,7 +76,11 @@ function hasEventScope(client: GatewayWsClient, event: string): boolean {
  *  3. Clients with a non-empty chatSessionKeys set → only receive events
  *     whose sessionKey is in that set.
  */
-function shouldReceiveChatEvent(client: GatewayWsClient, sessionKey: string | undefined): boolean {
+function shouldReceiveChatEvent(
+  client: GatewayWsClient,
+  sessionKey: string | undefined,
+  canonicalKey: string | undefined,
+): boolean {
   // Admin-scoped clients (e.g., Control UI operators) always see everything.
   if (hasAdminScope(client)) {
     return true;
@@ -90,7 +96,16 @@ function shouldReceiveChatEvent(client: GatewayWsClient, sessionKey: string | un
   if (!sessionKey) {
     return true;
   }
-  return tracked.has(sessionKey);
+  // Try raw key first (fast path), then fall back to canonical form.
+  // Event producers may emit raw aliases (e.g. "main") while tracked keys
+  // are canonical (e.g. "agent:main:main"), so we check both.
+  if (tracked.has(sessionKey)) {
+    return true;
+  }
+  if (canonicalKey && canonicalKey !== sessionKey) {
+    return tracked.has(canonicalKey);
+  }
+  return false;
 }
 
 export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient> }) {
@@ -130,10 +145,26 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
       logWs("out", "event", logMeta);
     }
     // Extract sessionKey from chat event payloads for session-scoped delivery.
-    const chatSessionKey =
-      event === "chat" && payload && typeof payload === "object" && "sessionKey" in payload
-        ? (payload as { sessionKey?: string }).sessionKey
-        : undefined;
+    // Resolve the canonical form once so we don't call resolveSessionStoreKey
+    // per-client inside the loop.
+    let chatSessionKey: string | undefined;
+    let chatCanonicalKey: string | undefined;
+    if (event === "chat" && payload && typeof payload === "object" && "sessionKey" in payload) {
+      chatSessionKey = (payload as { sessionKey?: string }).sessionKey;
+      if (chatSessionKey) {
+        try {
+          const resolved = resolveSessionStoreKey({
+            cfg: loadConfig(),
+            sessionKey: chatSessionKey,
+          });
+          if (resolved !== chatSessionKey) {
+            chatCanonicalKey = resolved;
+          }
+        } catch {
+          /* config not available — skip canonicalization */
+        }
+      }
+    }
 
     for (const c of params.clients) {
       if (targetConnIds && !targetConnIds.has(c.connId)) {
@@ -144,7 +175,7 @@ export function createGatewayBroadcaster(params: { clients: Set<GatewayWsClient>
       }
       // Session-scoped delivery for chat events: skip clients that have
       // declared session interest and are not subscribed to this session.
-      if (event === "chat" && !shouldReceiveChatEvent(c, chatSessionKey)) {
+      if (event === "chat" && !shouldReceiveChatEvent(c, chatSessionKey, chatCanonicalKey)) {
         continue;
       }
       const slow = c.socket.bufferedAmount > MAX_BUFFERED_BYTES;

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -540,16 +540,15 @@ export const chatHandlers: GatewayRequestHandlers = {
       limit?: number;
     };
 
-    // Track session association for session-scoped chat event delivery.
-    if (client && sessionKey) {
-      const wsClient = client as unknown as { chatSessionKeys?: Set<string> };
-      if (!wsClient.chatSessionKeys) {
-        wsClient.chatSessionKeys = new Set();
-      }
-      wsClient.chatSessionKeys.add(sessionKey);
-    }
+    const { cfg, storePath, entry, canonicalKey } = loadSessionEntry(sessionKey);
 
-    const { cfg, storePath, entry } = loadSessionEntry(sessionKey);
+    // Track canonical session key for session-scoped chat event delivery.
+    if (client && canonicalKey) {
+      if (!client.chatSessionKeys) {
+        client.chatSessionKeys = new Set();
+      }
+      client.chatSessionKeys.add(canonicalKey);
+    }
     const sessionId = entry?.sessionId;
     const rawMessages =
       sessionId && storePath ? readSessionMessages(sessionId, storePath, entry?.sessionFile) : [];
@@ -693,17 +692,6 @@ export const chatHandlers: GatewayRequestHandlers = {
       timeoutMs?: number;
       idempotencyKey: string;
     };
-    // Track session association for session-scoped chat event delivery.
-    // After the first chat.send, this connection will only receive chat
-    // events for sessions it has interacted with (unless it holds admin scope).
-    if (client && p.sessionKey) {
-      const wsClient = client as unknown as { chatSessionKeys?: Set<string> };
-      if (!wsClient.chatSessionKeys) {
-        wsClient.chatSessionKeys = new Set();
-      }
-      wsClient.chatSessionKeys.add(p.sessionKey);
-    }
-
     const sanitizedMessageResult = sanitizeChatSendMessageInput(p.message);
     if (!sanitizedMessageResult.ok) {
       respond(
@@ -742,6 +730,15 @@ export const chatHandlers: GatewayRequestHandlers = {
     }
     const rawSessionKey = p.sessionKey;
     const { cfg, entry, canonicalKey: sessionKey } = loadSessionEntry(rawSessionKey);
+
+    // Track canonical session key for session-scoped chat event delivery.
+    if (client && sessionKey) {
+      if (!client.chatSessionKeys) {
+        client.chatSessionKeys = new Set();
+      }
+      client.chatSessionKeys.add(sessionKey);
+    }
+
     const timeoutMs = resolveAgentTimeoutMs({
       cfg,
       overrideMs: p.timeoutMs,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -485,6 +485,8 @@ function broadcastChatFinal(params: {
   context: Pick<GatewayRequestContext, "broadcast" | "nodeSendToSession" | "agentRunSeq">;
   runId: string;
   sessionKey: string;
+  /** Raw key for node fanout — node subscriptions use exact key matching. */
+  rawSessionKey?: string;
   message?: Record<string, unknown>;
 }) {
   const seq = nextChatSeq({ agentRunSeq: params.context.agentRunSeq }, params.runId);
@@ -499,7 +501,9 @@ function broadcastChatFinal(params: {
     message: stripInlineDirectiveTagsFromMessageForDisplay(strippedEnvelopeMessage),
   };
   params.context.broadcast("chat", payload);
-  params.context.nodeSendToSession(params.sessionKey, "chat", payload);
+  // Use raw key for node routing — nodes subscribe with exact key text,
+  // not the canonical form.
+  params.context.nodeSendToSession(params.rawSessionKey ?? params.sessionKey, "chat", payload);
   params.context.agentRunSeq.delete(params.runId);
 }
 
@@ -507,6 +511,8 @@ function broadcastChatError(params: {
   context: Pick<GatewayRequestContext, "broadcast" | "nodeSendToSession" | "agentRunSeq">;
   runId: string;
   sessionKey: string;
+  /** Raw key for node fanout — node subscriptions use exact key matching. */
+  rawSessionKey?: string;
   errorMessage?: string;
 }) {
   const seq = nextChatSeq({ agentRunSeq: params.context.agentRunSeq }, params.runId);
@@ -518,7 +524,7 @@ function broadcastChatError(params: {
     errorMessage: params.errorMessage,
   };
   params.context.broadcast("chat", payload);
-  params.context.nodeSendToSession(params.sessionKey, "chat", payload);
+  params.context.nodeSendToSession(params.rawSessionKey ?? params.sessionKey, "chat", payload);
   params.context.agentRunSeq.delete(params.runId);
 }
 
@@ -962,6 +968,7 @@ export const chatHandlers: GatewayRequestHandlers = {
               context,
               runId: clientRunId,
               sessionKey,
+              rawSessionKey,
               message,
             });
           }
@@ -987,6 +994,7 @@ export const chatHandlers: GatewayRequestHandlers = {
             context,
             runId: clientRunId,
             sessionKey,
+            rawSessionKey,
             errorMessage: String(err),
           });
         })

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -523,7 +523,7 @@ function broadcastChatError(params: {
 }
 
 export const chatHandlers: GatewayRequestHandlers = {
-  "chat.history": async ({ params, respond, context }) => {
+  "chat.history": async ({ params, respond, context, client }) => {
     if (!validateChatHistoryParams(params)) {
       respond(
         false,
@@ -539,6 +539,16 @@ export const chatHandlers: GatewayRequestHandlers = {
       sessionKey: string;
       limit?: number;
     };
+
+    // Track session association for session-scoped chat event delivery.
+    if (client && sessionKey) {
+      const wsClient = client as unknown as { chatSessionKeys?: Set<string> };
+      if (!wsClient.chatSessionKeys) {
+        wsClient.chatSessionKeys = new Set();
+      }
+      wsClient.chatSessionKeys.add(sessionKey);
+    }
+
     const { cfg, storePath, entry } = loadSessionEntry(sessionKey);
     const sessionId = entry?.sessionId;
     const rawMessages =
@@ -683,6 +693,17 @@ export const chatHandlers: GatewayRequestHandlers = {
       timeoutMs?: number;
       idempotencyKey: string;
     };
+    // Track session association for session-scoped chat event delivery.
+    // After the first chat.send, this connection will only receive chat
+    // events for sessions it has interacted with (unless it holds admin scope).
+    if (client && p.sessionKey) {
+      const wsClient = client as unknown as { chatSessionKeys?: Set<string> };
+      if (!wsClient.chatSessionKeys) {
+        wsClient.chatSessionKeys = new Set();
+      }
+      wsClient.chatSessionKeys.add(p.sessionKey);
+    }
+
     const sanitizedMessageResult = sanitizeChatSendMessageInput(p.message);
     if (!sanitizedMessageResult.ok) {
       respond(

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -612,13 +612,18 @@ export const chatHandlers: GatewayRequestHandlers = {
       runId?: string;
     };
 
+    // Resolve canonical key so abort operations use the same key form
+    // stored by chat.send in chatAbortControllers.
+    const { canonicalKey } = loadSessionEntry(rawSessionKey);
+    const sessionKey = canonicalKey ?? rawSessionKey;
+
     const ops = createChatAbortOps(context);
 
     if (!runId) {
       const res = abortChatRunsForSessionKeyWithPartials({
         context,
         ops,
-        sessionKey: rawSessionKey,
+        sessionKey,
         abortOrigin: "rpc",
         stopReason: "rpc",
       });
@@ -631,7 +636,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       respond(true, { ok: true, aborted: false, runIds: [] });
       return;
     }
-    if (active.sessionKey !== rawSessionKey) {
+    if (active.sessionKey !== sessionKey) {
       respond(
         false,
         undefined,
@@ -643,13 +648,13 @@ export const chatHandlers: GatewayRequestHandlers = {
     const partialText = context.chatRunBuffers.get(runId);
     const res = abortChatRunById(ops, {
       runId,
-      sessionKey: rawSessionKey,
+      sessionKey,
       stopReason: "rpc",
     });
     if (res.aborted && partialText && partialText.trim()) {
       persistAbortedPartials({
         context,
-        sessionKey: rawSessionKey,
+        sessionKey,
         snapshots: [
           {
             runId,
@@ -766,7 +771,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       const res = abortChatRunsForSessionKeyWithPartials({
         context,
         ops: createChatAbortOps(context),
-        sessionKey: rawSessionKey,
+        sessionKey,
         abortOrigin: "stop-command",
         stopReason: "stop",
       });
@@ -796,7 +801,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       context.chatAbortControllers.set(clientRunId, {
         controller: abortController,
         sessionId: entry?.sessionId ?? clientRunId,
-        sessionKey: rawSessionKey,
+        sessionKey,
         startedAtMs: now,
         expiresAtMs: resolveChatRunExpiresAtMs({ now, timeoutMs }),
       });
@@ -906,7 +911,7 @@ export const chatHandlers: GatewayRequestHandlers = {
               // late-joining clients (e.g. page refresh mid-response) receive
               // in-progress tool events without leaking cross-session data.
               for (const [activeRunId, active] of context.chatAbortControllers) {
-                if (activeRunId !== runId && active.sessionKey === p.sessionKey) {
+                if (activeRunId !== runId && active.sessionKey === sessionKey) {
                   context.registerToolEventRecipient(activeRunId, connId);
                 }
               }
@@ -956,7 +961,7 @@ export const chatHandlers: GatewayRequestHandlers = {
             broadcastChatFinal({
               context,
               runId: clientRunId,
-              sessionKey: rawSessionKey,
+              sessionKey,
               message,
             });
           }
@@ -981,7 +986,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           broadcastChatError({
             context,
             runId: clientRunId,
-            sessionKey: rawSessionKey,
+            sessionKey,
             errorMessage: String(err),
           });
         })
@@ -1027,7 +1032,8 @@ export const chatHandlers: GatewayRequestHandlers = {
 
     // Load session to find transcript file
     const rawSessionKey = p.sessionKey;
-    const { cfg, storePath, entry } = loadSessionEntry(rawSessionKey);
+    const { cfg, storePath, entry, canonicalKey } = loadSessionEntry(rawSessionKey);
+    const sessionKey = canonicalKey ?? rawSessionKey;
     const sessionId = entry?.sessionId;
     if (!sessionId || !storePath) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "session not found"));
@@ -1040,7 +1046,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       sessionId,
       storePath,
       sessionFile: entry?.sessionFile,
-      agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
+      agentId: resolveSessionAgentId({ sessionKey, config: cfg }),
       createIfMissing: false,
     });
     if (!appended.ok || !appended.messageId || !appended.message) {
@@ -1055,10 +1061,11 @@ export const chatHandlers: GatewayRequestHandlers = {
       return;
     }
 
-    // Broadcast to webchat for immediate UI update
+    // Broadcast to webchat for immediate UI update — use canonical key
+    // so shouldReceiveChatEvent matches against chatSessionKeys correctly.
     const chatPayload = {
       runId: `inject-${appended.messageId}`,
-      sessionKey: rawSessionKey,
+      sessionKey,
       seq: 0,
       state: "final" as const,
       message: stripInlineDirectiveTagsFromMessageForDisplay(
@@ -1066,7 +1073,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       ),
     };
     context.broadcast("chat", chatPayload);
-    context.nodeSendToSession(rawSessionKey, "chat", chatPayload);
+    context.nodeSendToSession(sessionKey, "chat", chatPayload);
 
     respond(true, { ok: true, messageId: appended.messageId });
   },

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1073,7 +1073,10 @@ export const chatHandlers: GatewayRequestHandlers = {
       ),
     };
     context.broadcast("chat", chatPayload);
-    context.nodeSendToSession(sessionKey, "chat", chatPayload);
+    // Use the raw key for node fanout — node subscriptions are stored by
+    // the exact key text the node used when subscribing, not the canonical
+    // form.  sendToSession does an exact map lookup.
+    context.nodeSendToSession(rawSessionKey, "chat", chatPayload);
 
     respond(true, { ok: true, messageId: appended.messageId });
   },

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -18,6 +18,11 @@ export type GatewayClient = {
   connect: ConnectParams;
   connId?: string;
   clientIp?: string;
+  /**
+   * Session keys this connection has interacted with via chat.send or
+   * chat.history.  Used by the broadcaster to scope chat event delivery.
+   */
+  chatSessionKeys?: Set<string>;
   canvasHostUrl?: string;
   canvasCapability?: string;
   canvasCapabilityExpiresAtMs?: number;

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -11,12 +11,13 @@ export type GatewayWsClient = {
   canvasCapability?: string;
   canvasCapabilityExpiresAtMs?: number;
   /**
-   * Session keys this connection has interacted with via chat.send.
-   * Used to scope chat event delivery — connections only receive chat
-   * events for sessions they have participated in (unless they hold
-   * operator.admin scope, which always receives all events).
-   * Undefined/empty means the client has not sent any chat messages yet
-   * and will receive all chat events for backward compatibility.
+   * Session keys this connection has interacted with via chat.send or
+   * chat.history.  Used to scope chat event delivery — connections only
+   * receive chat events for sessions they have participated in (unless
+   * they hold operator.admin scope, which always receives all events).
+   * Undefined/empty means the client has not declared interest in any
+   * session yet and will receive all chat events for backward
+   * compatibility.
    */
   chatSessionKeys?: Set<string>;
 };

--- a/src/gateway/server/ws-types.ts
+++ b/src/gateway/server/ws-types.ts
@@ -10,4 +10,13 @@ export type GatewayWsClient = {
   canvasHostUrl?: string;
   canvasCapability?: string;
   canvasCapabilityExpiresAtMs?: number;
+  /**
+   * Session keys this connection has interacted with via chat.send.
+   * Used to scope chat event delivery — connections only receive chat
+   * events for sessions they have participated in (unless they hold
+   * operator.admin scope, which always receives all events).
+   * Undefined/empty means the client has not sent any chat messages yet
+   * and will receive all chat events for backward compatibility.
+   */
+  chatSessionKeys?: Set<string>;
 };


### PR DESCRIPTION
## Problem

The gateway broadcasts all `chat` events (delta, final, error) to **every** connected WebSocket client via `broadcast("chat", payload)`. While the payload includes `sessionKey`, there is no server-side filtering — all clients receive events from all sessions.

This causes:
- **Cross-session information leak**: A webchat client for Session A sees streaming events from Session B (e.g., a Telegram conversation happening concurrently).
- **Bandwidth waste**: Every client receives serialized JSON for all active sessions.
- **Broken standalone clients**: Third-party webchat integrations must implement client-side sessionKey filtering as a workaround.

## Root Cause

In `server-broadcast.ts`, `broadcastInternal()` iterates all connected clients and sends to every client passing `hasEventScope()`. There is no session affinity for chat events.

In `server-chat.ts`, both `emitChatDelta` and `emitChatFinal` call `broadcast("chat", payload)` which fans out unconditionally.

## Fix

1. **Track session association** — Add `chatSessionKeys: Set<string>` to `GatewayWsClient`. Populated when a client calls `chat.send` or `chat.history`.

2. **Session-scoped delivery** — In the broadcast loop, for `chat` events, skip clients that have declared session interest but are not subscribed to the event's session.

3. **Backward compatible** — Three scoping rules (evaluated in order):
   - `operator.admin` scoped clients → always receive all chat events (Control UI operators)
   - Clients with no session tracking (never called `chat.send`/`chat.history`) → receive all events (legacy/backward compat)
   - Clients with tracked sessions → only receive events for those sessions

## Changes

| File | Change |
|------|--------|
| `server/ws-types.ts` | Add optional `chatSessionKeys` field to `GatewayWsClient` |
| `server-broadcast.ts` | Add `shouldReceiveChatEvent()` check + extract `sessionKey` from chat payloads |
| `server-methods/chat.ts` | Track sessionKey in `chat.send` and `chat.history` handlers |
| `server-broadcast.session-scoping.test.ts` | 7 test cases covering all scoping rules |

## Testing

- All existing gateway chat tests pass (23 tests)
- 7 new tests: unscoped delivery, session scoping, admin bypass, backward compat, non-chat events unaffected, missing sessionKey handling, multi-session tracking
- TypeScript compilation clean (0 errors)

Closes #32579