### PR TITLE
fix(models): preserve explicit moonshot baseUrl for implicit provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/Moonshot CN onboarding: preserve explicit `models.providers.moonshot.baseUrl` when injecting implicit Moonshot provider config, so `.cn` endpoint selections are not overwritten by the default `.ai` base URL. (#32607)
+
 ## 2026.3.2
 
 ### Changes

--- a/src/agents/models-config.providers.moonshot.test.ts
+++ b/src/agents/models-config.providers.moonshot.test.ts
@@ -1,0 +1,32 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveImplicitProviders } from "./models-config.providers.js";
+
+describe("moonshot implicit provider", () => {
+  const createAgentDir = () => mkdtempSync(join(tmpdir(), "openclaw-test-"));
+
+  it("preserves explicit moonshot baseUrl on implicit provider injection", async () => {
+    const agentDir = createAgentDir();
+    process.env.MOONSHOT_API_KEY = "test-key";
+
+    try {
+      const providers = await resolveImplicitProviders({
+        agentDir,
+        explicitProviders: {
+          moonshot: {
+            baseUrl: "https://api.moonshot.cn/v1",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      });
+
+      expect(providers?.moonshot?.baseUrl).toBe("https://api.moonshot.cn/v1");
+      expect(providers?.moonshot?.apiKey).toBe("MOONSHOT_API_KEY");
+    } finally {
+      delete process.env.MOONSHOT_API_KEY;
+    }
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -635,9 +635,9 @@ function buildMinimaxPortalProvider(): ProviderConfig {
   };
 }
 
-function buildMoonshotProvider(): ProviderConfig {
+function buildMoonshotProvider(baseUrl?: string): ProviderConfig {
   return {
-    baseUrl: MOONSHOT_BASE_URL,
+    baseUrl: baseUrl?.trim() || MOONSHOT_BASE_URL,
     api: "openai-completions",
     models: [
       {
@@ -948,7 +948,10 @@ export async function resolveImplicitProviders(params: {
     resolveEnvApiKeyVarName("moonshot") ??
     resolveApiKeyFromProfiles({ provider: "moonshot", store: authStore });
   if (moonshotKey) {
-    providers.moonshot = { ...buildMoonshotProvider(), apiKey: moonshotKey };
+    providers.moonshot = {
+      ...buildMoonshotProvider(params.explicitProviders?.moonshot?.baseUrl),
+      apiKey: moonshotKey,
+    };
   }
 
   const kimiCodingKey =


### PR DESCRIPTION
## Summary
- preserve explicit `models.providers.moonshot.baseUrl` when building implicit Moonshot provider entries
- keep default behavior unchanged when no explicit baseUrl is configured
- add a regression test covering the `.cn` endpoint case
- add a changelog fix note

## Testing
- pnpm vitest src/agents/models-config.providers.moonshot.test.ts
- pnpm vitest src/agents/models-config.providers.ollama.test.ts src/agents/models-config.providers.kimi-coding.test.ts
- pnpm exec oxfmt --check src/agents/models-config.providers.ts src/agents/models-config.providers.moonshot.test.ts CHANGELOG.md

Closes #32607
