### PR TITLE
fix(models): honor explicit provider apiKey/baseUrl over stale cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/merge-mode provider sync: when `openclaw.json` explicitly sets provider `apiKey` or `baseUrl`, regenerate `agents/*/agent/models.json` with those explicit values instead of pinning stale cached secrets/endpoints from prior runs; agent-local values are still preserved when explicit config fields are empty. Fixes #28996 and #32607.
+
 ## 2026.3.2
 
 ### Changes

--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -82,12 +82,13 @@ async function runCustomProviderMergeTest(seedProvider: {
 function createMoonshotConfig(overrides: {
   contextWindow: number;
   maxTokens: number;
+  baseUrl?: string;
 }): OpenClawConfig {
   return {
     models: {
       providers: {
         moonshot: {
-          baseUrl: "https://api.moonshot.ai/v1",
+          baseUrl: overrides.baseUrl ?? "https://api.moonshot.ai/v1",
           api: "openai-completions",
           models: [
             {
@@ -215,6 +216,40 @@ describe("models-config", () => {
         api: "openai-responses",
         models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
       });
+      expect(parsed.providers.custom?.apiKey).toBe("CONFIG_KEY");
+      expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
+    });
+  });
+
+  it("preserves existing apiKey/baseUrl when config values are empty", async () => {
+    await withTempHome(async () => {
+      await writeAgentModelsJson({
+        providers: {
+          custom: {
+            baseUrl: "https://agent.example/v1",
+            apiKey: "AGENT_KEY",
+            api: "openai-responses",
+            models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
+          },
+        },
+      });
+
+      await ensureOpenClawModelsJson({
+        models: {
+          mode: "merge",
+          providers: {
+            custom: {
+              ...createMergeConfigProvider(),
+              baseUrl: "",
+              apiKey: "",
+            },
+          },
+        },
+      });
+
+      const parsed = await readGeneratedModelsJson<{
+        providers: Record<string, { apiKey?: string; baseUrl?: string }>;
+      }>();
       expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
       expect(parsed.providers.custom?.baseUrl).toBe("https://agent.example/v1");
     });
@@ -230,6 +265,46 @@ describe("models-config", () => {
       });
       expect(parsed.providers.custom?.apiKey).toBe("CONFIG_KEY");
       expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
+    });
+  });
+
+  it("overrides stale moonshot baseUrl in models.json when config explicitly sets CN endpoint", async () => {
+    await withTempHome(async () => {
+      await withEnvVar("MOONSHOT_API_KEY", "sk-moonshot-test", async () => {
+        await writeAgentModelsJson({
+          providers: {
+            moonshot: {
+              baseUrl: "https://api.moonshot.ai/v1",
+              apiKey: "MOONSHOT_API_KEY",
+              api: "openai-completions",
+              models: [
+                {
+                  id: "kimi-k2.5",
+                  name: "Kimi K2.5",
+                  input: ["text"],
+                  reasoning: false,
+                  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                  contextWindow: 256000,
+                  maxTokens: 8192,
+                },
+              ],
+            },
+          },
+        });
+
+        const cfg = createMoonshotConfig({
+          contextWindow: 1024,
+          maxTokens: 256,
+          baseUrl: "https://api.moonshot.cn/v1",
+        });
+
+        await ensureOpenClawModelsJson(cfg);
+
+        const parsed = await readGeneratedModelsJson<{
+          providers: Record<string, { baseUrl?: string }>;
+        }>();
+        expect(parsed.providers.moonshot?.baseUrl).toBe("https://api.moonshot.cn/v1");
+      });
     });
   });
 

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -141,8 +141,9 @@ async function resolveProvidersForModelsJson(params: {
 function mergeWithExistingProviderSecrets(params: {
   nextProviders: Record<string, ProviderConfig>;
   existingProviders: Record<string, NonNullable<ModelsConfig["providers"]>[string]>;
+  explicitProviders?: NonNullable<ModelsConfig["providers"]> | null;
 }): Record<string, ProviderConfig> {
-  const { nextProviders, existingProviders } = params;
+  const { nextProviders, existingProviders, explicitProviders } = params;
   const mergedProviders: Record<string, ProviderConfig> = {};
   for (const [key, entry] of Object.entries(existingProviders)) {
     mergedProviders[key] = entry;
@@ -154,15 +155,23 @@ function mergeWithExistingProviderSecrets(params: {
           baseUrl?: string;
         })
       | undefined;
+    const explicit = explicitProviders?.[key] as
+      | (NonNullable<ModelsConfig["providers"]>[string] & {
+          apiKey?: string;
+          baseUrl?: string;
+        })
+      | undefined;
+    const explicitApiKey = typeof explicit?.apiKey === "string" ? explicit.apiKey.trim() : "";
+    const explicitBaseUrl = typeof explicit?.baseUrl === "string" ? explicit.baseUrl.trim() : "";
     if (!existing) {
       mergedProviders[key] = newEntry;
       continue;
     }
     const preserved: Record<string, unknown> = {};
-    if (typeof existing.apiKey === "string" && existing.apiKey) {
+    if (typeof existing.apiKey === "string" && existing.apiKey && !explicitApiKey) {
       preserved.apiKey = existing.apiKey;
     }
-    if (typeof existing.baseUrl === "string" && existing.baseUrl) {
+    if (typeof existing.baseUrl === "string" && existing.baseUrl && !explicitBaseUrl) {
       preserved.baseUrl = existing.baseUrl;
     }
     mergedProviders[key] = { ...newEntry, ...preserved };
@@ -174,6 +183,7 @@ async function resolveProvidersForMode(params: {
   mode: NonNullable<ModelsConfig["mode"]>;
   targetPath: string;
   providers: Record<string, ProviderConfig>;
+  explicitProviders?: NonNullable<ModelsConfig["providers"]> | null;
 }): Promise<Record<string, ProviderConfig>> {
   if (params.mode !== "merge") {
     return params.providers;
@@ -189,6 +199,7 @@ async function resolveProvidersForMode(params: {
   return mergeWithExistingProviderSecrets({
     nextProviders: params.providers,
     existingProviders,
+    explicitProviders: params.explicitProviders,
   });
 }
 
@@ -225,6 +236,7 @@ export async function ensureOpenClawModelsJson(
     mode,
     targetPath,
     providers,
+    explicitProviders: cfg.models?.providers,
   });
 
   const normalizedProviders = normalizeProviders({


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: in `models.mode = "merge"`, existing `agents/*/agent/models.json` always preserved cached `apiKey`/`baseUrl`, even after explicit updates in `openclaw.json`.
- Why it matters: provider endpoint/key updates in config (for example Moonshot CN endpoint switch) were silently ignored, causing persistent stale routing and auth failures.
- What changed: merge now preserves cached `apiKey`/`baseUrl` only when the explicit provider config does **not** set those fields; explicit non-empty config values now take precedence.
- What did NOT change (scope boundary): model catalog merging behavior, implicit provider discovery, and empty-field fallback behavior remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32607
- Closes #28996
- Related #30395
- Related #30667

## User-visible / Behavior Changes

When users explicitly update `models.providers.*.apiKey` or `baseUrl` in `openclaw.json`, regenerated agent `models.json` now reflects those updated values instead of pinning stale cached values.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: Moonshot/custom provider merge-mode paths
- Integration/channel (if any): N/A
- Relevant config (redacted): `models.mode = "merge"`

### Steps

1. Seed agent `models.json` with stale provider `apiKey`/`baseUrl`.
2. Configure explicit provider `apiKey`/`baseUrl` in `openclaw.json`.
3. Run models generation and inspect resulting agent `models.json`.

### Expected

- Explicit config values override stale cached values.

### Actual

- Now matches expected; stale cached values only persist when explicit config field is empty.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm exec vitest run src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - explicit config `apiKey/baseUrl` overrides non-empty stale agent cache values
  - empty explicit config fields still preserve existing agent values
  - Moonshot stale `.ai` cache is replaced by explicit `.cn` config endpoint
- Edge cases checked: existing empty agent values still backfill from config values.
- What you did **not** verify: live provider API traffic against real Moonshot credentials.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/models-config.ts`, related tests.
- Known bad symptoms reviewers should watch for: explicit provider `apiKey/baseUrl` unexpectedly reverting to stale agent-local values after regeneration.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: users who intentionally relied on stale agent-local overrides for explicit provider fields may now see config values take precedence.
  - Mitigation: preserve behavior remains for empty explicit fields; tests cover both precedence modes.
