### PR TITLE
fix(matrix): wire message tool asVoice/audioAsVoice into send path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - LINE/context and routing synthesis: fix group/room peer routing and command-authorization context propagation, and keep processing later events in mixed-success webhook batches. (from #21955, #24475, #27035, #28286) Thanks @lailoo, @mcaxtr, @jervyclaw, @Glucksberg, and @Takhoffman.
 - LINE/status/config/webhook synthesis: fix status false positives from snapshot/config state and accept LINE webhook HEAD probes for compatibility. (from #10487, #25726, #27537, #27908, #31387) Thanks @BlueBirdBack, @stakeswky, @loiie45e, @puritysb, and @mcaxtr.
 - LINE cleanup/test follow-ups: fold cleanup/test learnings into the synthesis review path while keeping runtime changes focused on regression fixes. (from #17630, #17289) Thanks @Clawborn and @davidahmann.
+- Matrix/message tool voice flag wiring: forward `asVoice`/`audioAsVoice` through Matrix `send` action handling so compatible audio attachments are sent as voice messages (`m.audio` with voice metadata) instead of generic file attachments. Fixes #32489.
 
 ## 2026.3.2
 

--- a/extensions/matrix/src/actions.test.ts
+++ b/extensions/matrix/src/actions.test.ts
@@ -1,0 +1,71 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { matrixMessageActions } from "./actions.js";
+import { handleMatrixAction } from "./tool-actions.js";
+
+vi.mock("./tool-actions.js", () => ({
+  handleMatrixAction: vi.fn().mockResolvedValue({
+    content: [{ type: "text", text: '{"ok":true}' }],
+  }),
+}));
+
+describe("matrixMessageActions send voice flags", () => {
+  const handleAction = matrixMessageActions.handleAction!;
+
+  const cfg = (): OpenClawConfig =>
+    ({
+      channels: {
+        matrix: {
+          enabled: true,
+        },
+      },
+    }) as OpenClawConfig;
+
+  const callSend = async (params: Record<string, unknown>) =>
+    await handleAction({
+      channel: "matrix",
+      action: "send",
+      cfg: cfg(),
+      params,
+      accountId: null,
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("maps asVoice to audioAsVoice when forwarding sendMessage action", async () => {
+    await callSend({
+      to: "room:!abc:example.org",
+      message: "",
+      media: "https://example.org/voice.ogg",
+      asVoice: true,
+    });
+
+    expect(handleMatrixAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sendMessage",
+        audioAsVoice: true,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("prefers explicit audioAsVoice over asVoice alias", async () => {
+    await callSend({
+      to: "room:!abc:example.org",
+      message: "",
+      media: "https://example.org/voice.ogg",
+      asVoice: false,
+      audioAsVoice: true,
+    });
+
+    expect(handleMatrixAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "sendMessage",
+        audioAsVoice: true,
+      }),
+      expect.any(Object),
+    );
+  });
+});

--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -69,6 +69,12 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
       const mediaUrl = readStringParam(params, "media", { trim: false });
       const replyTo = readStringParam(params, "replyTo");
       const threadId = readStringParam(params, "threadId");
+      const audioAsVoice =
+        typeof params.audioAsVoice === "boolean"
+          ? params.audioAsVoice
+          : typeof params.asVoice === "boolean"
+            ? params.asVoice
+            : undefined;
       return await handleMatrixAction(
         {
           action: "sendMessage",
@@ -77,6 +83,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyTo ?? undefined,
           threadId: threadId ?? undefined,
+          audioAsVoice,
         },
         cfg as CoreConfig,
       );

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -19,12 +19,14 @@ export async function sendMatrixMessage(
     mediaUrl?: string;
     replyToId?: string;
     threadId?: string;
+    audioAsVoice?: boolean;
   } = {},
 ) {
   return await sendMessageMatrix(to, content, {
     mediaUrl: opts.mediaUrl,
     replyToId: opts.replyToId,
     threadId: opts.threadId,
+    audioAsVoice: opts.audioAsVoice,
     client: opts.client,
     timeoutMs: opts.timeoutMs,
   });

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -82,10 +82,13 @@ export async function handleMatrixAction(
         const replyToId =
           readStringParam(params, "replyToId") ?? readStringParam(params, "replyTo");
         const threadId = readStringParam(params, "threadId");
+        const audioAsVoice =
+          typeof params.audioAsVoice === "boolean" ? params.audioAsVoice : undefined;
         const result = await sendMatrixMessage(to, content, {
           mediaUrl: mediaUrl ?? undefined,
           replyToId: replyToId ?? undefined,
           threadId: threadId ?? undefined,
+          audioAsVoice,
         });
         return jsonResult({ ok: true, result });
       }

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -211,6 +211,19 @@ describe("message tool schema scoping", () => {
       }
     },
   );
+
+  it("exposes audioAsVoice as an alias field in send schema", () => {
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "telegram", source: "test", plugin: telegramPlugin }]),
+    );
+    const tool = createMessageTool({
+      config: {} as never,
+      currentChannelProvider: "telegram",
+    });
+    const properties = getToolProperties(tool);
+    expect(properties.asVoice).toBeDefined();
+    expect(properties.audioAsVoice).toBeDefined();
+  });
 });
 
 describe("message tool description", () => {

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -194,6 +194,12 @@ function buildSendSchema(options: {
     replyTo: Type.Optional(Type.String()),
     threadId: Type.Optional(Type.String()),
     asVoice: Type.Optional(Type.Boolean()),
+    audioAsVoice: Type.Optional(
+      Type.Boolean({
+        description:
+          "Alias of asVoice. Send compatible audio as a voice-note/bubble when supported by the channel.",
+      }),
+    ),
     silent: Type.Optional(Type.Boolean()),
     quoteText: Type.Optional(
       Type.String({ description: "Quote text for Telegram reply_parameters" }),


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Matrix channel `send` action ignored voice flags from the message tool, so audio media always went through regular file flow.
- Why it matters: `asVoice`/`audioAsVoice` calls produced `m.file` attachments instead of Matrix voice-message payloads (`m.audio` + voice metadata).
- What changed: wired `asVoice`/`audioAsVoice` through Matrix action handlers all the way into `sendMessageMatrix(...)` and exposed `audioAsVoice` alias in the message tool schema for discoverability.
- What did NOT change (scope boundary): no changes to Matrix media compatibility detection or voice metadata generation logic itself.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32489
- Related #32252

## User-visible / Behavior Changes

For Matrix `message` tool sends, `asVoice: true` (and alias `audioAsVoice: true`) now reaches Matrix send internals, enabling voice-message delivery when media is voice-compatible.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Matrix extension
- Relevant config (redacted): Matrix enabled/configured

### Steps

1. Send Matrix media via `message` tool with `action=send`, media URL, and `asVoice=true`.
2. Verify Matrix action layer forwards voice flag to `sendMessageMatrix(...)`.
3. Repeat with `audioAsVoice=true` alias.

### Expected

- Voice flag is forwarded in send action chain so Matrix voice path can activate.

### Actual

- Behavior now matches expected; regression tests assert forwarding for both alias paths.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm exec vitest run extensions/matrix/src/actions.test.ts src/agents/tools/message-tool.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `asVoice` maps to Matrix `audioAsVoice`
  - explicit `audioAsVoice` is respected
  - message tool schema exposes both `asVoice` and `audioAsVoice`
- Edge cases checked: alias precedence (`audioAsVoice` overrides `asVoice` when both provided).
- What you did **not** verify: live Matrix homeserver end-to-end send with real room/client.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `extensions/matrix/src/actions.ts`, `extensions/matrix/src/tool-actions.ts`, `extensions/matrix/src/matrix/actions/messages.ts`, `src/agents/tools/message-tool.ts`.
- Known bad symptoms reviewers should watch for: Matrix send actions silently dropping `audioAsVoice` again.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: other channels might interpret `audioAsVoice` alias unexpectedly if they begin reading unknown params.
  - Mitigation: alias is schema-exposed for message tool, but forwarding in this PR is implemented only in Matrix action handlers.
