### PR TITLE
fix(slack): print onboarding manifest as raw JSON for copy/paste

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 - LINE/context and routing synthesis: fix group/room peer routing and command-authorization context propagation, and keep processing later events in mixed-success webhook batches. (from #21955, #24475, #27035, #28286) Thanks @lailoo, @mcaxtr, @jervyclaw, @Glucksberg, and @Takhoffman.
 - LINE/status/config/webhook synthesis: fix status false positives from snapshot/config state and accept LINE webhook HEAD probes for compatibility. (from #10487, #25726, #27537, #27908, #31387) Thanks @BlueBirdBack, @stakeswky, @loiie45e, @puritysb, and @mcaxtr.
 - LINE cleanup/test follow-ups: fold cleanup/test learnings into the synthesis review path while keeping runtime changes focused on regression fixes. (from #17630, #17289) Thanks @Clawborn and @davidahmann.
+- Slack/onboarding manifest copyability: print Slack app manifest JSON as raw output (instead of inside note framing) so users can copy/paste valid JSON without removing box characters. Fixes #32493.
 
 ## 2026.3.2
 

--- a/src/channels/plugins/onboarding/slack.test.ts
+++ b/src/channels/plugins/onboarding/slack.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WizardPrompter } from "../../../wizard/prompts.js";
+import { buildSlackManifest, noteSlackTokenHelp } from "./slack.js";
+
+describe("noteSlackTokenHelp", () => {
+  const writes: string[] = [];
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    writes.length = 0;
+    writeSpy = vi.spyOn(process.stdout, "write").mockImplementation(((chunk: unknown) => {
+      if (typeof chunk === "string") {
+        writes.push(chunk);
+      } else if (chunk instanceof Uint8Array) {
+        writes.push(Buffer.from(chunk).toString("utf8"));
+      } else {
+        writes.push(String(chunk));
+      }
+      return true;
+    }) as never);
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+  });
+
+  it("prints the Slack manifest as raw JSON instead of embedding it in note framing", async () => {
+    const note = vi.fn(async () => {});
+    const prompter = { note } as unknown as WizardPrompter;
+    const manifest = buildSlackManifest("OpenClaw");
+
+    await noteSlackTokenHelp(prompter, "OpenClaw");
+
+    expect(note).toHaveBeenCalledTimes(1);
+    const noteMessage = String(note.mock.calls[0]?.[0] ?? "");
+    expect(noteMessage).toContain("Manifest (JSON) is printed raw below for copy/paste.");
+    expect(noteMessage).not.toContain('"display_information"');
+    expect(writes.join("")).toContain(manifest);
+  });
+});

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -28,7 +28,7 @@ import {
 
 const channel = "slack" as const;
 
-function buildSlackManifest(botName: string) {
+export function buildSlackManifest(botName: string) {
   const safeName = botName.trim() || "OpenClaw";
   const manifest = {
     display_information: {
@@ -97,7 +97,7 @@ function buildSlackManifest(botName: string) {
   return JSON.stringify(manifest, null, 2);
 }
 
-async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Promise<void> {
+export async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Promise<void> {
   const manifest = buildSlackManifest(botName);
   await prompter.note(
     [
@@ -109,11 +109,11 @@ async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Pr
       "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
       `Docs: ${formatDocsLink("/slack", "slack")}`,
       "",
-      "Manifest (JSON):",
-      manifest,
+      "Manifest (JSON) is printed raw below for copy/paste.",
     ].join("\n"),
     "Slack socket mode tokens",
   );
+  process.stdout.write(`\n${manifest}\n`);
 }
 
 function setSlackChannelAllowlist(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Slack onboarding printed app manifest JSON inside `prompter.note(...)`, which is rendered with framed note characters in TTY output.
- Why it matters: users copying from CLI got invalid JSON with framing artifacts, breaking Slack “From manifest” setup.
- What changed: keep setup guidance in `note`, but print manifest JSON as raw stdout output for copy/paste.
- What did NOT change (scope boundary): manifest content/scopes are unchanged; only output presentation changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32493
- Related #32033

## User-visible / Behavior Changes

During Slack onboarding, the manifest JSON now prints as plain raw JSON (no boxed note framing), so it can be copied directly into Slack app manifest setup.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Slack onboarding flow
- Relevant config (redacted): N/A

### Steps

1. Run Slack onboarding with no existing Slack tokens configured.
2. Observe setup guidance + manifest output.
3. Copy printed JSON into Slack “From manifest”.

### Expected

- Manifest appears as valid raw JSON without framing characters.

### Actual

- Behavior now matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm exec vitest run src/channels/plugins/onboarding/slack.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - guidance note no longer embeds full JSON body
  - raw stdout output contains valid manifest JSON from `buildSlackManifest`
- Edge cases checked: custom bot name still flows through manifest builder.
- What you did **not** verify: live Slack app creation flow in a real workspace.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/channels/plugins/onboarding/slack.ts`.
- Known bad symptoms reviewers should watch for: manifest missing from onboarding output.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: direct stdout manifest output may be less visually separated than boxed notes.
  - Mitigation: guidance note explicitly indicates manifest follows below as raw copy/paste JSON.
