### PR TITLE
fix: guard status --deep health probe against unreachable gateway (#17106)

### DIFF
--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -37,6 +37,11 @@ import {
   resolveUpdateAvailability,
 } from "./status.update.js";
 
+/** Type guard: distinguishes a caught error from a valid HealthSummary. */
+function isHealthError(v: HealthSummary | { error: string }): v is { error: string } {
+  return typeof (v as { error?: unknown }).error === "string";
+}
+
 function resolvePairingRecoveryContext(params: {
   error?: string | null;
   closeReason?: string | null;
@@ -141,22 +146,24 @@ export async function statusCommand(
         async () => await loadProviderUsageSummary({ timeoutMs: opts.timeoutMs }),
       )
     : undefined;
-  const health: HealthSummary | undefined = opts.deep
-    ? await withProgress(
-        {
-          label: "Checking gateway health…",
-          indeterminate: true,
-          enabled: opts.json !== true,
-        },
-        async () =>
-          await callGateway<HealthSummary>({
-            method: "health",
-            params: { probe: true },
-            timeoutMs: opts.timeoutMs,
-            config: scan.cfg,
-          }),
-      )
-    : undefined;
+  // Guard: skip health probe when gateway is unreachable (matches lastHeartbeat pattern below)
+  const health: HealthSummary | { error: string } | undefined =
+    opts.deep && gatewayReachable
+      ? await withProgress(
+          {
+            label: "Checking gateway health…",
+            indeterminate: true,
+            enabled: opts.json !== true,
+          },
+          async () =>
+            await callGateway<HealthSummary>({
+              method: "health",
+              params: { probe: true },
+              timeoutMs: opts.timeoutMs,
+              config: scan.cfg,
+            }).catch((err) => ({ error: String(err) })),
+        )
+      : undefined;
   const lastHeartbeat =
     opts.deep && gatewayReachable
       ? await callGateway<HeartbeatEventPayload | null>({
@@ -322,7 +329,21 @@ export async function statusCommand(
   const eventsValue =
     summary.queuedSystemEvents.length > 0 ? `${summary.queuedSystemEvents.length} queued` : "none";
 
-  const probesValue = health ? ok("enabled") : muted("skipped (use --deep)");
+  const probesValue = (() => {
+    if (!opts.deep) {
+      return muted("skipped (use --deep)");
+    }
+    if (!gatewayReachable) {
+      return warn("skipped (gateway unreachable)");
+    }
+    if (!health) {
+      return muted("skipped");
+    }
+    if (isHealthError(health)) {
+      return warn("failed");
+    }
+    return ok("enabled");
+  })();
 
   const heartbeatValue = (() => {
     const parts = summary.heartbeat.agents
@@ -606,42 +627,51 @@ export async function statusCommand(
     runtime.log("");
     runtime.log(theme.heading("Health"));
     const rows: Array<Record<string, string>> = [];
-    rows.push({
-      Item: "Gateway",
-      Status: ok("reachable"),
-      Detail: `${health.durationMs}ms`,
-    });
 
-    for (const line of formatHealthChannelLines(health, { accountMode: "all" })) {
-      const colon = line.indexOf(":");
-      if (colon === -1) {
-        continue;
-      }
-      const item = line.slice(0, colon).trim();
-      const detail = line.slice(colon + 1).trim();
-      const normalized = detail.toLowerCase();
-      const status = (() => {
-        if (normalized.startsWith("ok")) {
-          return ok("OK");
+    if (isHealthError(health)) {
+      rows.push({
+        Item: "Gateway",
+        Status: warn("ERROR"),
+        Detail: health.error,
+      });
+    } else {
+      rows.push({
+        Item: "Gateway",
+        Status: ok("reachable"),
+        Detail: `${health.durationMs}ms`,
+      });
+
+      for (const line of formatHealthChannelLines(health, { accountMode: "all" })) {
+        const colon = line.indexOf(":");
+        if (colon === -1) {
+          continue;
         }
-        if (normalized.startsWith("failed")) {
+        const item = line.slice(0, colon).trim();
+        const detail = line.slice(colon + 1).trim();
+        const normalized = detail.toLowerCase();
+        const status = (() => {
+          if (normalized.startsWith("ok")) {
+            return ok("OK");
+          }
+          if (normalized.startsWith("failed")) {
+            return warn("WARN");
+          }
+          if (normalized.startsWith("not configured")) {
+            return muted("OFF");
+          }
+          if (normalized.startsWith("configured")) {
+            return ok("OK");
+          }
+          if (normalized.startsWith("linked")) {
+            return ok("LINKED");
+          }
+          if (normalized.startsWith("not linked")) {
+            return warn("UNLINKED");
+          }
           return warn("WARN");
-        }
-        if (normalized.startsWith("not configured")) {
-          return muted("OFF");
-        }
-        if (normalized.startsWith("configured")) {
-          return ok("OK");
-        }
-        if (normalized.startsWith("linked")) {
-          return ok("LINKED");
-        }
-        if (normalized.startsWith("not linked")) {
-          return warn("UNLINKED");
-        }
-        return warn("WARN");
-      })();
-      rows.push({ Item: item, Status: status, Detail: detail });
+        })();
+        rows.push({ Item: item, Status: status, Detail: detail });
+      }
     }
 
     runtime.log(

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -347,6 +347,7 @@ vi.mock("../config/config.js", async (importOriginal) => {
   return {
     ...actual,
     loadConfig: mocks.loadConfig,
+    readBestEffortConfig: mocks.loadConfig,
   };
 });
 vi.mock("../daemon/service.js", () => ({
@@ -488,25 +489,43 @@ describe("statusCommand", () => {
   });
 
   it("warns instead of crashing when gateway auth SecretRef is unresolved for probe auth", async () => {
-    mocks.loadConfig.mockReturnValue({
-      session: {},
-      gateway: {
-        auth: {
-          mode: "token",
-          token: { source: "env", provider: "default", id: "MISSING_GATEWAY_TOKEN" },
+    // Clear gateway token env vars so the SecretRef resolution path is exercised
+    const savedToken = process.env.OPENCLAW_GATEWAY_TOKEN;
+    const savedLegacy = process.env.CLAWDBOT_GATEWAY_TOKEN;
+    delete process.env.OPENCLAW_GATEWAY_TOKEN;
+    delete process.env.CLAWDBOT_GATEWAY_TOKEN;
+    try {
+      mocks.loadConfig.mockReturnValue({
+        session: {},
+        gateway: {
+          auth: {
+            mode: "token",
+            token: { source: "env", provider: "default", id: "MISSING_GATEWAY_TOKEN" },
+          },
         },
-      },
-      secrets: {
-        providers: {
-          default: { source: "env" },
+        secrets: {
+          providers: {
+            default: { source: "env" },
+          },
         },
-      },
-    });
+      });
 
-    await statusCommand({ json: true }, runtime as never);
-    const payload = JSON.parse(String(runtimeLogMock.mock.calls.at(-1)?.[0]));
-    expect(payload.gateway.error).toContain("gateway.auth.token");
-    expect(payload.gateway.error).toContain("SecretRef");
+      await statusCommand({ json: true }, runtime as never);
+      const payload = JSON.parse(String(runtimeLogMock.mock.calls.at(-1)?.[0]));
+      expect(payload.gateway.error).toContain("gateway.auth.token");
+      expect(payload.gateway.error).toContain("SecretRef");
+    } finally {
+      if (savedToken !== undefined) {
+        process.env.OPENCLAW_GATEWAY_TOKEN = savedToken;
+      } else {
+        delete process.env.OPENCLAW_GATEWAY_TOKEN;
+      }
+      if (savedLegacy !== undefined) {
+        process.env.CLAWDBOT_GATEWAY_TOKEN = savedLegacy;
+      } else {
+        delete process.env.CLAWDBOT_GATEWAY_TOKEN;
+      }
+    }
   });
 
   it("surfaces channel runtime errors from the gateway", async () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -596,6 +596,45 @@ describe("statusCommand", () => {
     expect(joined).toContain("devices approve req-close-456");
   });
 
+  it("skips deep health probe when gateway is unreachable (guard)", async () => {
+    // Default probeGateway mock returns ok: false → gatewayReachable is false.
+    // The health probe callGateway should NOT be called at all.
+    mocks.callGateway.mockClear();
+
+    await expect(statusCommand({ deep: true }, runtime as never)).resolves.not.toThrow();
+
+    // Verify callGateway was never called with method "health"
+    const healthCalls = mocks.callGateway.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { method?: string })?.method === "health",
+    );
+    expect(healthCalls).toHaveLength(0);
+  });
+
+  it("captures health probe error instead of crashing when gateway is reachable (catch)", async () => {
+    // Gateway is reachable but the health probe itself fails
+    mockProbeGatewayResult({
+      ok: true,
+      connectLatencyMs: 10,
+      error: null,
+      health: {},
+      status: {},
+      presence: [],
+    });
+    // First callGateway (channels.status from scanStatus) succeeds,
+    // second callGateway (health probe) rejects
+    mocks.callGateway
+      .mockResolvedValueOnce({}) // channels.status
+      .mockRejectedValueOnce(new Error("gateway closed (1008): unauthorized"));
+
+    // Should not throw — error should be captured gracefully
+    await expect(statusCommand({ deep: true }, runtime as never)).resolves.not.toThrow();
+
+    // Health section should show the error
+    const logs = getRuntimeLogs();
+    expect(logs.some((l) => l.includes("Health"))).toBe(true);
+    expect(logs.some((l) => l.includes("gateway closed (1008): unauthorized"))).toBe(true);
+  });
+
   it("includes sessions across agents in JSON output", async () => {
     const originalAgents = mocks.listAgentsForGateway.getMockImplementation();
     const originalResolveStorePath = mocks.resolveStorePath.getMockImplementation();


### PR DESCRIPTION
Root cause: `status --deep` health probe checked only `opts.deep` with no `gatewayReachable` guard and no `.catch()`, causing unhandled WebSocket errors when the gateway is unreachable.

Fix: Add `gatewayReachable` guard (matching the adjacent `lastHeartbeat` pattern) and wrap the probe in `.catch((err) => ({ error: String(err) }))` so failures display in the Health section instead of crashing.

Test: Two independent tests verify (1) guard prevents health probe when gateway is unreachable, (2) errors are captured and displayed when probe fails.

Fixes #17106