### PR TITLE
fix: output Slack manifest as clean JSON without box formatting

### DIFF
--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -108,10 +108,12 @@ async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Pr
       "5) App Home → enable the Messages tab for DMs",
       "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
       `Docs: ${formatDocsLink("/slack", "slack")}`,
+      "",
+      "Manifest JSON is printed below for easy copying.",
     ].join("\n"),
     "Slack socket mode tokens",
   );
-  console.log("\nManifest JSON (copy this):\n");
+  console.log("\nManifest JSON (copy this):");
   console.log(manifest);
 }
 

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -108,12 +108,11 @@ async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Pr
       "5) App Home → enable the Messages tab for DMs",
       "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
       `Docs: ${formatDocsLink("/slack", "slack")}`,
-      "",
-      "Manifest (JSON):",
-      manifest,
     ].join("\n"),
     "Slack socket mode tokens",
   );
+  console.log("\nManifest JSON (copy this):\n");
+  console.log(manifest);
 }
 
 function setSlackChannelAllowlist(


### PR DESCRIPTION
Fixes #32493

The Slack JSON manifest was being rendered inside `prompter.note()`, which wraps text in a box with `│` pipe characters — making it impossible to copy cleanly.

**Changes:**
- Moved the manifest output outside the boxed note
- Instructions stay in the note, manifest prints via `console.log()` so users can copy it directly

Minimal change, one file only.

`pnpm check` passes (format + lint verified). AI-assisted (Codex), reviewed and verified manually.