### PR TITLE
fix(agents): normalize Groq reasoning_effort to none or default

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -380,7 +380,10 @@ describe("applyExtraParamsToAgent", () => {
   it("keeps reasoning_effort none for Groq when already none", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {
-      const payload: Record<string, unknown> = { reasoning_effort: "none" };
+      const payload: Record<string, unknown> = {
+        reasoning_effort: "none",
+        reasoning: { effort: "none" },
+      };
       options?.onPayload?.(payload);
       payloads.push(payload);
       return {} as ReturnType<StreamFn>;
@@ -399,6 +402,7 @@ describe("applyExtraParamsToAgent", () => {
 
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.reasoning_effort).toBe("none");
+    expect((payloads[0]?.reasoning as Record<string, unknown>)?.effort).toBe("none");
   });
 
   it("normalizes thinking=off to null for SiliconFlow Pro models", () => {

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -349,6 +349,58 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]).not.toHaveProperty("reasoning_effort");
   });
 
+  it("normalizes reasoning_effort to none or default for Groq (#32638)", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = {
+        reasoning_effort: "low",
+        reasoning: { effort: "high" },
+      };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "groq", "qwen/qwen3-32b");
+
+    const model = {
+      api: "openai-completions",
+      provider: "groq",
+      id: "qwen/qwen3-32b",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.reasoning_effort).toBe("default");
+    expect((payloads[0]?.reasoning as Record<string, unknown>)?.effort).toBe("default");
+  });
+
+  it("keeps reasoning_effort none for Groq when already none", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { reasoning_effort: "none" };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "groq", "qwen/qwen3-32b");
+
+    const model = {
+      api: "openai-completions",
+      provider: "groq",
+      id: "qwen/qwen3-32b",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.reasoning_effort).toBe("none");
+  });
+
   it("normalizes thinking=off to null for SiliconFlow Pro models", () => {
     const payloads: Record<string, unknown>[] = [];
     const baseStreamFn: StreamFn = (_model, _context, options) => {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -721,6 +721,45 @@ function createOpenRouterWrapper(
   };
 }
 
+/** Groq API only accepts "none" or "default" for reasoning_effort. Map any other value to "default". */
+const GROQ_REASONING_EFFORT_VALID = new Set(["none", "default"]);
+
+function createGroqReasoningEffortWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const onPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          const payloadObj = payload as Record<string, unknown>;
+          const flat = payloadObj.reasoning_effort;
+          if (typeof flat === "string") {
+            payloadObj.reasoning_effort = GROQ_REASONING_EFFORT_VALID.has(flat) ? flat : "default";
+          }
+          const reasoning = payloadObj.reasoning;
+          if (
+            reasoning &&
+            typeof reasoning === "object" &&
+            !Array.isArray(reasoning) &&
+            "effort" in reasoning
+          ) {
+            const effort = (reasoning as Record<string, unknown>).effort;
+            if (typeof effort === "string") {
+              (reasoning as Record<string, unknown>).effort = GROQ_REASONING_EFFORT_VALID.has(
+                effort,
+              )
+                ? effort
+                : "default";
+            }
+          }
+        }
+        onPayload?.(payload);
+      },
+    });
+  };
+}
+
 /**
  * Models on OpenRouter that do not support the `reasoning.effort` parameter.
  * Injecting it causes "Invalid arguments passed to the model" errors.
@@ -907,6 +946,13 @@ export function applyExtraParamsToAgent(
       `normalizing thinking=off to thinking=null for SiliconFlow compatibility (${provider}/${modelId})`,
     );
     agent.streamFn = createSiliconFlowThinkingWrapper(agent.streamFn);
+  }
+
+  // Groq only accepts reasoning_effort "none" or "default". pi-ai may send
+  // low/medium/high; normalize to "default" to avoid 400. See openclaw/openclaw#32638.
+  if (provider === "groq") {
+    log.debug(`applying Groq reasoning_effort normalization for ${provider}/${modelId}`);
+    agent.streamFn = createGroqReasoningEffortWrapper(agent.streamFn);
   }
 
   if (provider === "moonshot") {


### PR DESCRIPTION
Fixes #32638

## Summary
Groq API only accepts `reasoning_effort` values `"none"` or `"default"`. OpenClaw/pi-ai was sending values like `"low"` or `"medium"` from the thinking level config, causing 400 errors when using Groq with reasoning-capable models (e.g. `qwen/qwen3-32b`).

## Changes
- Add `createGroqReasoningEffortWrapper` in `extra-params.ts` that normalizes both top-level `reasoning_effort` and nested `reasoning.effort` to only `"none"` or `"default"` (any other value is mapped to `"default"`).
- Apply this wrapper in `applyExtraParamsToAgent` when `provider === "groq"`.
- Add two tests: one that low/high are normalized to default, and one that "none" is preserved.
