### PR TITLE
Gateway: preserve sessionFile when touching session store

### DIFF
--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -32,6 +32,7 @@ vi.mock("../infra/heartbeat-wake.js", () => ({
 }));
 vi.mock("../commands/agent.js", () => ({
   agentCommand: vi.fn(),
+  agentCommandFromIngress: vi.fn(() => Promise.resolve()),
 }));
 vi.mock("../config/config.js", () => ({
   loadConfig: vi.fn(() => ({ session: { mainKey: "agent:main:main" } })),
@@ -329,6 +330,33 @@ describe("voice transcript events", () => {
         sourceTool: "gateway.voice.transcript",
       },
     });
+  });
+
+  it("preserves sessionFile when touching session store (fixes transcriptPath persistence)", async () => {
+    const ctx = buildCtx();
+    const sessionKey = "agent:main:main";
+    const existingSessionFile = "/data/sessions/agent/main/sess-123.jsonl";
+    const store: Record<string, { sessionId: string; updatedAt: number; sessionFile?: string }> = {
+      [sessionKey]: {
+        sessionId: "sess-123",
+        updatedAt: 1,
+        sessionFile: existingSessionFile,
+      },
+    };
+    updateSessionStoreMock.mockImplementation(async (_storePath, update) => {
+      update(store);
+    });
+
+    await handleNodeEvent(ctx, "node-v3", {
+      event: "voice.transcript",
+      payloadJSON: JSON.stringify({
+        text: "preserve sessionFile",
+        sessionKey,
+      }),
+    });
+    await Promise.resolve();
+
+    expect(store[sessionKey]?.sessionFile).toBe(existingSessionFile);
   });
 
   it("does not block agent dispatch when session-store touch fails", async () => {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -4,6 +4,7 @@ import { createOutboundSendDeps } from "../cli/outbound-send-deps.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
 import { loadConfig } from "../config/config.js";
 import { updateSessionStore } from "../config/sessions.js";
+import type { SessionEntry } from "../config/sessions.js";
 import { requestHeartbeatNow } from "../infra/heartbeat-wake.js";
 import { deliverOutboundPayloads } from "../infra/outbound/deliver.js";
 import { buildOutboundSessionContext } from "../infra/outbound/session-context.js";
@@ -156,21 +157,28 @@ async function touchSessionStore(params: {
       key: params.sessionKey,
       store,
     });
+    // Preserve existing entry (e.g. sessionFile) before pruning; touch must not drop transcript path.
+    const existing: SessionEntry | undefined =
+      (store[target.canonicalKey] as SessionEntry | undefined) ??
+      [...target.storeKeys]
+        .map((k) => store[k] as SessionEntry | undefined)
+        .find((e): e is SessionEntry => Boolean(e?.sessionId));
     pruneLegacyStoreKeys({
       store,
       canonicalKey: target.canonicalKey,
       candidates: target.storeKeys,
     });
     store[params.canonicalKey] = {
+      ...existing,
       sessionId: params.sessionId,
       updatedAt: params.now,
-      thinkingLevel: params.entry?.thinkingLevel,
-      verboseLevel: params.entry?.verboseLevel,
-      reasoningLevel: params.entry?.reasoningLevel,
-      systemSent: params.entry?.systemSent,
-      sendPolicy: params.entry?.sendPolicy,
-      lastChannel: params.entry?.lastChannel,
-      lastTo: params.entry?.lastTo,
+      thinkingLevel: params.entry?.thinkingLevel ?? existing?.thinkingLevel,
+      verboseLevel: params.entry?.verboseLevel ?? existing?.verboseLevel,
+      reasoningLevel: params.entry?.reasoningLevel ?? existing?.reasoningLevel,
+      systemSent: params.entry?.systemSent ?? existing?.systemSent,
+      sendPolicy: params.entry?.sendPolicy ?? existing?.sendPolicy,
+      lastChannel: params.entry?.lastChannel ?? existing?.lastChannel,
+      lastTo: params.entry?.lastTo ?? existing?.lastTo,
     };
   });
 }


### PR DESCRIPTION
Fixes #32633

**Root cause:** In `server-node-events.ts`, `touchSessionStore` (used on voice transcript and other node events) was replacing the session entry with a new object that only contained a few fields (`sessionId`, `updatedAt`, `thinkingLevel`, etc.), so `sessionFile` (transcript path) was dropped. After gateway restart, sessions.json had no transcript path and recovery led to 400s (e.g. unexpected tool_use_id).

**Fix:** Before pruning legacy keys, we read the existing entry from the store (canonical or legacy key), then merge it with the touch payload so `sessionFile` and other existing fields are preserved when writing back.

**Test:** Added a voice transcript test that asserts `sessionFile` is preserved when the store already has an entry with `sessionFile`; fixed the agent mock to include `agentCommandFromIngress` so voice transcript tests can run.
