### PR TITLE
fix(daemon-cli): avoid lsof-missing restart false timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/Skills runtime loading: propagate run config into embedded attempt and compaction skill-entry loading so explicitly enabled bundled companion skills are discovered consistently when skill snapshots do not already provide resolved entries. Thanks @gumadeiras.
+- Daemon/restart health fallback: treat `port busy + no listener details` as healthy ownership even when runtime PID is known (for example when `lsof` is unavailable), avoiding false 60s restart timeouts on minimal Linux installs. (#32620) Thanks @riftzen-bit.
 - Agents/Compaction continuity: expand staged-summary merge instructions to preserve active task status, batch progress, latest user request, and follow-up commitments so compaction handoffs retain in-flight work context. (#8903) thanks @joetomasone.
 - Gateway/status self version reporting: make Gateway self version in `openclaw status` prefer runtime `VERSION` (while preserving explicit `OPENCLAW_VERSION` override), preventing stale post-upgrade app version output. (#32655) thanks @liuxiaopai-ai.
 - Memory/QMD index isolation: set `QMD_CONFIG_DIR` alongside `XDG_CONFIG_HOME` so QMD config state stays per-agent despite upstream XDG handling bugs, preventing cross-agent collection indexing and excess disk/CPU usage. (#27028) thanks @HenryLoenwind.

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -116,6 +116,26 @@ describe("inspectGatewayRestart", () => {
     expect(snapshot.staleGatewayPids).toEqual([]);
   });
 
+  it("does not treat busy-without-listeners as healthy when no diagnostic errors are present", async () => {
+    const service = {
+      readRuntime: vi.fn(async () => ({ status: "running", pid: 8100 })),
+    } as unknown as GatewayService;
+
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [],
+      hints: [],
+      errors: [],
+    });
+
+    const { inspectGatewayRestart } = await import("./restart-health.js");
+    const snapshot = await inspectGatewayRestart({ service, port: 18789 });
+
+    expect(snapshot.healthy).toBe(false);
+    expect(snapshot.staleGatewayPids).toEqual([]);
+  });
+
   it("treats unknown listeners as stale on Windows when enabled", async () => {
     const snapshot = await inspectUnknownListenerFallback({
       runtime: { status: "stopped" },

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -136,6 +136,26 @@ describe("inspectGatewayRestart", () => {
     expect(snapshot.staleGatewayPids).toEqual([]);
   });
 
+  it("treats busy-without-listeners as healthy when runtime pid is unavailable", async () => {
+    const service = {
+      readRuntime: vi.fn(async () => ({ status: "running" })),
+    } as unknown as GatewayService;
+
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [],
+      hints: [],
+      errors: [],
+    });
+
+    const { inspectGatewayRestart } = await import("./restart-health.js");
+    const snapshot = await inspectGatewayRestart({ service, port: 18789 });
+
+    expect(snapshot.healthy).toBe(true);
+    expect(snapshot.staleGatewayPids).toEqual([]);
+  });
+
   it("treats unknown listeners as stale on Windows when enabled", async () => {
     const snapshot = await inspectUnknownListenerFallback({
       runtime: { status: "stopped" },

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -96,6 +96,26 @@ describe("inspectGatewayRestart", () => {
     expect(snapshot.staleGatewayPids).toEqual([9000]);
   });
 
+  it("treats busy-without-listeners as healthy when runtime is running", async () => {
+    const service = {
+      readRuntime: vi.fn(async () => ({ status: "running", pid: 8100 })),
+    } as unknown as GatewayService;
+
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [],
+      hints: [],
+      errors: ["Error: spawn lsof ENOENT"],
+    });
+
+    const { inspectGatewayRestart } = await import("./restart-health.js");
+    const snapshot = await inspectGatewayRestart({ service, port: 18789 });
+
+    expect(snapshot.healthy).toBe(true);
+    expect(snapshot.staleGatewayPids).toEqual([]);
+  });
+
   it("treats unknown listeners as stale on Windows when enabled", async () => {
     const snapshot = await inspectUnknownListenerFallback({
       runtime: { status: "stopped" },

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -74,11 +74,14 @@ export async function inspectGatewayRestart(params: {
       : [];
   const running = runtime.status === "running";
   const runtimePid = runtime.pid;
+  const noListenerDetailsAvailable =
+    portUsage.status === "busy" && portUsage.listeners.length === 0;
   const ownsPort =
     runtimePid != null
-      ? portUsage.listeners.some((listener) => listenerOwnedByRuntimePid({ listener, runtimePid }))
-      : gatewayListeners.length > 0 ||
-        (portUsage.status === "busy" && portUsage.listeners.length === 0);
+      ? portUsage.listeners.some((listener) =>
+          listenerOwnedByRuntimePid({ listener, runtimePid }),
+        ) || noListenerDetailsAvailable
+      : gatewayListeners.length > 0 || noListenerDetailsAvailable;
   const healthy = running && ownsPort;
   const staleGatewayPids = Array.from(
     new Set([

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -74,17 +74,16 @@ export async function inspectGatewayRestart(params: {
       : [];
   const running = runtime.status === "running";
   const runtimePid = runtime.pid;
+  const busyWithoutListeners = portUsage.status === "busy" && portUsage.listeners.length === 0;
   const noListenerDetailsAvailable =
-    portUsage.status === "busy" &&
-    portUsage.listeners.length === 0 &&
-    portUsage.errors != null &&
-    portUsage.errors.length > 0;
+    busyWithoutListeners && portUsage.errors != null && portUsage.errors.length > 0;
+  const noListenerFallbackWithoutPid = busyWithoutListeners && runtimePid == null;
   const ownsPort =
     runtimePid != null
       ? portUsage.listeners.some((listener) =>
           listenerOwnedByRuntimePid({ listener, runtimePid }),
         ) || noListenerDetailsAvailable
-      : gatewayListeners.length > 0 || noListenerDetailsAvailable;
+      : gatewayListeners.length > 0 || noListenerFallbackWithoutPid;
   const healthy = running && ownsPort;
   const staleGatewayPids = Array.from(
     new Set([

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -75,7 +75,10 @@ export async function inspectGatewayRestart(params: {
   const running = runtime.status === "running";
   const runtimePid = runtime.pid;
   const noListenerDetailsAvailable =
-    portUsage.status === "busy" && portUsage.listeners.length === 0;
+    portUsage.status === "busy" &&
+    portUsage.listeners.length === 0 &&
+    portUsage.errors != null &&
+    portUsage.errors.length > 0;
   const ownsPort =
     runtimePid != null
       ? portUsage.listeners.some((listener) =>


### PR DESCRIPTION
## Summary

- Problem: `gateway restart` can time out for 60s on Linux systems without `lsof` because port listeners are empty and PID ownership check returns false.
- Why it matters: restart appears failed even when gateway is healthy and serving `/health`.
- What changed: when runtime is running, `inspectGatewayRestart` now treats `status=busy && listeners=[]` as a valid ownership fallback.
- What did NOT change (scope boundary): no process-kill policy changes and no listener classification logic changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32620
- Related #32613

## User-visible / Behavior Changes

- `openclaw gateway restart` no longer false-times out on lsof-less systems when runtime is running and port is already busy.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (without `lsof`)
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): gateway port 18789

### Steps

1. Mock restart health snapshot with `runtime.status=running`, `runtime.pid` present.
2. Return port usage as `status=busy` with empty listeners and `spawn lsof ENOENT` error.
3. Inspect health snapshot.

### Expected

- Snapshot should be healthy, not force timeout loop.

### Actual

- ✅ `snapshot.healthy` is now `true`.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test src/cli/daemon-cli/restart-health.test.ts`.
- Edge cases checked: non-owned listener PID remains unhealthy/stale; Windows unknown-listener fallback behavior unchanged.
- What you did **not** verify: full restart end-to-end on physical lsof-less host in this run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `21f17bf63`.
- Files/config to restore: `src/cli/daemon-cli/restart-health.ts`, `src/cli/daemon-cli/restart-health.test.ts`.
- Known bad symptoms reviewers should watch for: busy/empty-listener state incorrectly treated as healthy when runtime is not actually running.

## Risks and Mitigations

- Risk: fallback could over-trust busy ports in some ambiguous states.
  - Mitigation: fallback only applies when runtime reports `running`; stale/non-owned listener detection remains intact.
