### PR TITLE
fix(CLI): validate channels status timeout input

### DIFF
--- a/src/commands/channels/status.timeout.test.ts
+++ b/src/commands/channels/status.timeout.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { channelsStatusCommand } from "./status.js";
+
+const callGatewayMock = vi.fn();
+const withProgressMock = vi.fn(
+  async (_opts: unknown, action: () => Promise<unknown>) => await action(),
+);
+
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: (options: { method: string; params: unknown; timeoutMs: number }) =>
+    callGatewayMock(options),
+}));
+
+vi.mock("../../cli/progress.js", () => ({
+  withProgress: (opts: unknown, action: () => Promise<unknown>) => withProgressMock(opts, action),
+}));
+
+function createRuntime() {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const runtime = {
+    log: (...args: unknown[]) => {
+      logs.push(args.map(String).join(" "));
+    },
+    error: (...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    },
+    exit: (code: number) => {
+      throw new Error(`exit:${code}`);
+    },
+  };
+  return { runtime, logs, errors };
+}
+
+describe("channelsStatusCommand timeout validation", () => {
+  beforeEach(() => {
+    callGatewayMock.mockReset();
+    withProgressMock.mockClear();
+  });
+
+  it("exits with clear error for non-numeric timeout", async () => {
+    const { runtime, errors } = createRuntime();
+    await expect(channelsStatusCommand({ timeout: "nope" }, runtime)).rejects.toThrow("exit:1");
+    expect(errors).toContain("--timeout must be a positive integer (milliseconds)");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("exits with clear error for zero timeout", async () => {
+    const { runtime, errors } = createRuntime();
+    await expect(channelsStatusCommand({ timeout: "0" }, runtime)).rejects.toThrow("exit:1");
+    expect(errors).toContain("--timeout must be a positive integer (milliseconds)");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("exits with clear error for negative timeout", async () => {
+    const { runtime, errors } = createRuntime();
+    await expect(channelsStatusCommand({ timeout: "-1" }, runtime)).rejects.toThrow("exit:1");
+    expect(errors).toContain("--timeout must be a positive integer (milliseconds)");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("exits with clear error for decimal timeout", async () => {
+    const { runtime, errors } = createRuntime();
+    await expect(channelsStatusCommand({ timeout: "1.5" }, runtime)).rejects.toThrow("exit:1");
+    expect(errors).toContain("--timeout must be a positive integer (milliseconds)");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("exits with clear error for empty or whitespace-only timeout", async () => {
+    const { runtime, errors } = createRuntime();
+    await expect(channelsStatusCommand({ timeout: "" }, runtime)).rejects.toThrow("exit:1");
+    expect(errors).toContain("--timeout must be a positive integer (milliseconds)");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+    const { runtime: r2, errors: e2 } = createRuntime();
+    await expect(channelsStatusCommand({ timeout: "  " }, r2)).rejects.toThrow("exit:1");
+    expect(e2).toContain("--timeout must be a positive integer (milliseconds)");
+  });
+
+  it("passes validated timeout to gateway call", async () => {
+    const { runtime } = createRuntime();
+    callGatewayMock.mockResolvedValueOnce({});
+    await channelsStatusCommand({ timeout: "2500", json: true }, runtime);
+    expect(callGatewayMock).toHaveBeenCalledWith({
+      method: "channels.status",
+      params: { probe: false, timeoutMs: 2500 },
+      timeoutMs: 2500,
+    });
+  });
+});

--- a/src/commands/channels/status.ts
+++ b/src/commands/channels/status.ts
@@ -18,6 +18,31 @@ export type ChannelsStatusOptions = {
   timeout?: string;
 };
 
+function resolvePositiveTimeoutMs(value: unknown): number | null {
+  // Only undefined/null mean "not provided"; empty or whitespace-only string is invalid.
+  if (value === undefined || value === null) {
+    return 10_000;
+  }
+  if (typeof value === "number") {
+    if (!Number.isInteger(value) || value <= 0) {
+      return null;
+    }
+    return value;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return null;
+    }
+    const parsed = Number(trimmed);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      return null;
+    }
+    return parsed;
+  }
+  return null;
+}
+
 function appendEnabledConfiguredLinkedBits(bits: string[], account: Record<string, unknown>) {
   if (typeof account.enabled === "boolean") {
     bits.push(account.enabled ? "enabled" : "disabled");
@@ -241,7 +266,12 @@ export async function channelsStatusCommand(
   opts: ChannelsStatusOptions,
   runtime: RuntimeEnv = defaultRuntime,
 ) {
-  const timeoutMs = Number(opts.timeout ?? 10_000);
+  const timeoutMs = resolvePositiveTimeoutMs(opts.timeout);
+  if (timeoutMs === null) {
+    runtime.error("--timeout must be a positive integer (milliseconds)");
+    runtime.exit(1);
+    return;
+  }
   const statusLabel = opts.probe ? "Checking channel status (probe)…" : "Checking channel status…";
   const shouldLogStatus = opts.json !== true && !process.stderr.isTTY;
   if (shouldLogStatus) {


### PR DESCRIPTION
## Summary

This PR fixes inconsistent timeout handling in `openclaw channels status`.

`--timeout` is now validated as a **positive integer (milliseconds)** before any gateway call.  
Invalid inputs (for example `nope`, `0`, negative, decimal, or empty) now fail fast with a clear error instead of producing ambiguous runtime behavior.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs

## Scope

- [x] CLI command behavior (`channels status`)
- [x] Command-level validation tests
- [ ] Gateway protocol/contracts

## User-visible Behavior

- Before: invalid `--timeout` values could flow into execution and fail unclearly.
- After: command exits with:
  - `--timeout must be a positive integer (milliseconds)`
  - exit code `1`

## What Changed

1. `src/commands/channels/status.ts`
   - Added strict timeout parser (`resolvePositiveTimeoutMs`).
   - Added early validation failure path with explicit error + exit.
2. `src/commands/channels/status.timeout.test.ts` (new)
   - invalid string timeout -> fails with exit
   - zero timeout -> fails with exit
   - valid timeout -> correctly passed to `callGateway`

## Verification

- `pnpm exec oxfmt --check src/commands/channels/status.ts src/commands/channels/status.timeout.test.ts`
- `pnpm test -- src/commands/channels/status.timeout.test.ts`

## Compatibility

- Backward compatible: **Yes** (valid inputs unchanged)
- Config changes required: **No**
- Migration required: **No**

## Risk

Low risk.  
Changes are limited to input validation and targeted tests; no behavior change for valid timeout values.