### PR TITLE
fix(status): make gateway vs CLI version skew explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - Agents/Skills runtime loading: propagate run config into embedded attempt and compaction skill-entry loading so explicitly enabled bundled companion skills are discovered consistently when skill snapshots do not already provide resolved entries. Thanks @gumadeiras.
+- Status/Gateway version clarity: when `openclaw status` sees a running gateway app version different from the local CLI version, annotate the Gateway line as `app <gateway> (cli <local>)` to make version skew explicit. (#32647) Thanks @eguchi-lab.
 - Agents/Compaction continuity: expand staged-summary merge instructions to preserve active task status, batch progress, latest user request, and follow-up commitments so compaction handoffs retain in-flight work context. (#8903) thanks @joetomasone.
 - Gateway/status self version reporting: make Gateway self version in `openclaw status` prefer runtime `VERSION` (while preserving explicit `OPENCLAW_VERSION` override), preventing stale post-upgrade app version output. (#32655) thanks @liuxiaopai-ai.
 - Memory/QMD index isolation: set `QMD_CONFIG_DIR` alongside `XDG_CONFIG_HOME` so QMD config state stays per-agent despite upstream XDG handling bugs, preventing cross-agent collection indexing and excess disk/CPU usage. (#27028) thanks @HenryLoenwind.

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -18,6 +18,7 @@ import type { RuntimeEnv } from "../runtime.js";
 import { runSecurityAudit } from "../security/audit.js";
 import { renderTable } from "../terminal/table.js";
 import { theme } from "../terminal/theme.js";
+import { VERSION } from "../version.js";
 import { formatHealthChannelLines, type HealthSummary } from "./health.js";
 import { resolveControlUiLinks } from "./onboard-helpers.js";
 import { statusAllCommand } from "./status-all.js";
@@ -252,12 +253,18 @@ export async function statusCommand(
       gatewayReachable && !remoteUrlMissing
         ? ` · auth ${formatGatewayAuthUsed(resolveGatewayProbeAuth(cfg))}`
         : "";
+    const gatewayVersion = gatewaySelf?.version?.trim();
+    const appVersionLabel = gatewayVersion
+      ? gatewayVersion === VERSION
+        ? `app ${gatewayVersion}`
+        : `app ${gatewayVersion} (cli ${VERSION})`
+      : null;
     const self =
       gatewaySelf?.host || gatewaySelf?.version || gatewaySelf?.platform
         ? [
             gatewaySelf?.host ? gatewaySelf.host : null,
             gatewaySelf?.ip ? `(${gatewaySelf.ip})` : null,
-            gatewaySelf?.version ? `app ${gatewaySelf.version}` : null,
+            appVersionLabel,
             gatewaySelf?.platform ? gatewaySelf.platform : null,
           ]
             .filter(Boolean)

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -1,6 +1,7 @@
 import type { Mock } from "vitest";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
+import { VERSION } from "../version.js";
 
 let envSnapshot: ReturnType<typeof captureEnv>;
 
@@ -479,6 +480,21 @@ describe("statusCommand", () => {
       const logs = await runStatusAndGetLogs();
       expect(logs.some((l: string) => l.includes("auth token"))).toBe(true);
     });
+  });
+
+  it("annotates gateway app version when it differs from CLI version", async () => {
+    mockProbeGatewayResult({
+      ok: true,
+      connectLatencyMs: 30,
+      error: null,
+      health: {},
+      status: {},
+      presence: [{ mode: "gateway", reason: "self", host: "pi-host", version: "2026.2.21" }],
+    });
+
+    const joined = await runStatusAndGetJoinedLogs();
+    expect(joined).toContain("app 2026.2.");
+    expect(joined).toContain(`(cli ${VERSION})`);
   });
 
   it("surfaces channel runtime errors from the gateway", async () => {

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -489,12 +489,15 @@ describe("statusCommand", () => {
       error: null,
       health: {},
       status: {},
-      presence: [{ mode: "gateway", reason: "self", host: "pi-host", version: "2026.2.21" }],
+      presence: [
+        { mode: "gateway", reason: "self", host: "pi-host", version: "0.0.0-gateway-test" },
+      ],
     });
 
     const joined = await runStatusAndGetJoinedLogs();
-    expect(joined).toContain("app 2026.2.");
-    expect(joined).toContain(`(cli ${VERSION})`);
+    expect(joined).toContain("app 0.0.0-");
+    expect(joined).toContain("gateway-test (cli");
+    expect(joined).toContain(`cli ${VERSION}`);
   });
 
   it("surfaces channel runtime errors from the gateway", async () => {


### PR DESCRIPTION
## Summary

- Problem: `openclaw status` shows `app <version>` from the running gateway, but when it differs from local CLI version the output is easy to misread as stale/incorrect.
- Why it matters: operators can't quickly tell whether this is true runtime skew vs. status rendering bug.
- What changed: when gateway app version differs from local CLI `VERSION`, the Gateway row now prints `app <gateway> (cli <local>)`.
- What did NOT change (scope boundary): no gateway restart logic, no update logic, and no pairing/auth behavior changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32647
- Related #32620

## User-visible / Behavior Changes

- `openclaw status` now explicitly annotates gateway/CLI version skew in the Gateway overview line.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: mocked in unit tests
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): local gateway mode

### Steps

1. Mock gateway presence with self `version=2026.2.21`.
2. Run formatted status output.
3. Verify Gateway row includes `app 2026.2.21 (cli <local>)` annotation.

### Expected

- Version skew is explicit in one line.

### Actual

- ✅ Annotation appears and existing status output tests still pass.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: `pnpm test src/commands/status.test.ts`.
- Edge cases checked: formatting with wrapped table rows still preserves skew annotation.
- What you did **not** verify: live Pi host status output against a real stale gateway process in this run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `b99d345bb`.
- Files/config to restore: `src/commands/status.command.ts`, `src/commands/status.test.ts`.
- Known bad symptoms reviewers should watch for: malformed Gateway row text when version is absent.

## Risks and Mitigations

- Risk: extra status text may increase row wrapping on narrow terminals.
  - Mitigation: table renderer already wraps long values; test covers wrapped case.
