### PR TITLE
fix: resolve Return Msg: <400> InternalError.Algo.DataInspectionFailed

### DIFF
--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -37,6 +37,7 @@ export {
   isRateLimitErrorMessage,
   isTransientHttpError,
   isTimeoutErrorMessage,
+  isContentFilterErrorMessage,
   parseImageDimensionError,
   parseImageSizeError,
 } from "./pi-embedded-helpers/errors.js";

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -542,6 +542,13 @@ export function formatAssistantErrorText(
     return formatBillingErrorMessage(opts?.provider, opts?.model ?? msg.model);
   }
 
+  if (isContentFilterErrorMessage(raw)) {
+    return (
+      "Request was rejected by the model provider's content filters. " +
+      "Try rephrasing your message, starting a fresh session with /new, or switching to a different model."
+    );
+  }
+
   if (isLikelyHttpErrorText(raw) || isRawApiErrorPayload(raw)) {
     return formatRawAssistantErrorForUi(raw);
   }
@@ -719,6 +726,27 @@ export function isRateLimitErrorMessage(raw: string): boolean {
 
 export function isTimeoutErrorMessage(raw: string): boolean {
   return matchesErrorPatterns(raw, ERROR_PATTERNS.timeout);
+}
+
+/**
+ * Detect provider-side content inspection / safety filter errors that reject
+ * otherwise normal-looking input text. This currently targets known shapes
+ * from Alibaba Bailian/Qwen-style endpoints.
+ */
+export function isContentFilterErrorMessage(raw: string): boolean {
+  if (!raw) {
+    return false;
+  }
+  const lower = raw.toLowerCase();
+  // Bailian/Qwen error type
+  if (lower.includes("datainspectionfailed")) {
+    return true;
+  }
+  // Bailian/Qwen error message text
+  if (lower.includes("input text data may contain inappropriate content")) {
+    return true;
+  }
+  return false;
 }
 
 /**

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -9,6 +9,7 @@ import {
   isContextOverflowError,
   isLikelyContextOverflowError,
   isTransientHttpError,
+  isContentFilterErrorMessage,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
@@ -479,6 +480,7 @@ export async function runAgentTurnWithFallback(params: {
       const isSessionCorruption = /function call turn comes immediately after/i.test(message);
       const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(message);
       const isTransientHttp = isTransientHttpError(message);
+      const isContentFilterError = isContentFilterErrorMessage(message);
 
       if (
         isCompactionFailure &&
@@ -574,7 +576,9 @@ export async function runAgentTurnWithFallback(params: {
         ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
         : isRoleOrderingError
           ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-          : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+          : isContentFilterError
+            ? "⚠️ Request was rejected by the model provider's content filters. Try rephrasing your message, starting a fresh session with /new, or switching to a different model."
+            : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
       return {
         kind: "final",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: When using Bailian/Qwen models, if the provider returns InternalError.Algo.DataInspectionFailed: Input text data may contain inappropriate content., users see the raw 400 error text and don’t know how to recover.
- Why it matters: Content-safety false positives combined with sending full conversation history mean future requests also get rejected; users think OpenClaw or all channels are broken and have no clear guidance.
- What changed: Added a classifier for Bailian-style content inspection errors (isContentFilterErrorMessage) and updated formatAssistantErrorText and the auto-reply execution path to return a consistent, actionable message (suggesting rephrasing, /new, or switching models).
- What did NOT change (scope boundary): Did not change model call semantics, session storage, or any channel protocols; did not add auto-reset or any bypass of the provider’s content filter; only improved error detection and user-facing copy.

## Change Type (select all)

- [x] Bug fix


## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] UI / DX

## Linked Issue/PR

- Closes # https://github.com/openclaw/openclaw/issues/32622#issue-4014871195

## User-visible / Behavior Changes

When the model returns a Bailian-style content inspection error (containing DataInspectionFailed or Input text data may contain inappropriate content), users no longer see the raw <400> InternalError.Algo... payload but instead a standardized message:
“Request was rejected by the model provider's content filters. Try rephrasing your message, starting a fresh session with /new, or switching to a different model.”

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22+
- Model/provider: Bailian / Qwen (e.g., bailian/qwen3.5-plus)
- Integration/channel (if any):  Feishu (or Telegram/WhatsApp, same auto-reply path)
- Relevant config (redacted): Agent configured to use the above model

### Steps

1. Configure a Bailian-backed model and connect Feishu (or another channel).
2. Trigger a Bailian content inspection rejection in a conversation (or simulate a 400 with DataInspectionFailed).
3. Observe the bot’s error response in the channel.


## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Local review of changes, confirmed they only affect error classification and messaging; lints pass.
- Edge cases checked: Matching is scoped to lowercase “datainspectionfailed” and “input text data may contain inappropriate content” to reduce accidental matches on normal conversation text.
- What you did **not** verify: Did not run an end-to-end test against a real Bailian environment or Feishu channel (depends on user/CI environment).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No


## Risks and Mitigations

- Risk: A non-Bailian provider returns an error string that includes “datainspectionfailed” or “input text data may contain inappropriate content”, causing misclassification as a content filter rejection.
  - Mitigation: These substrings are relatively specific API error texts; if we see false positives in the wild, we can narrow the matcher to more precise patterns (e.g., including InternalError.Algo or explicit HTTP 400 context).
