### PR TITLE
docs(telegram): clarify defaultAccount behavior for multi-account

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -72,6 +72,11 @@ openclaw pairing approve telegram <CODE>
 Token resolution order is account-aware. In practice, config values win over env fallback, and `TELEGRAM_BOT_TOKEN` only applies to the default account.
 </Note>
 
+<Warning>
+For multi-account Telegram setups, set `channels.telegram.defaultAccount` explicitly.
+If omitted, OpenClaw falls back to `default` when present, otherwise the first account id (alphabetical order), which can cause unexpected inbound/outbound routing.
+</Warning>
+
 ## Telegram side settings
 
 <AccordionGroup>
@@ -739,6 +744,7 @@ Primary reference:
 - `channels.telegram.groupPolicy`: `open | allowlist | disabled` (default: allowlist).
 - `channels.telegram.groupAllowFrom`: group sender allowlist (numeric Telegram user IDs). `openclaw doctor --fix` can resolve legacy `@username` entries to IDs. Non-numeric entries are ignored at auth time. Group auth does not use DM pairing-store fallback (`2026.2.25+`).
 - Multi-account precedence:
+  - `channels.telegram.defaultAccount` should be set explicitly in multi-account setups to avoid fallback-to-first-account behavior.
   - `channels.telegram.accounts.default.allowFrom` and `channels.telegram.accounts.default.groupAllowFrom` apply only to the `default` account.
   - Named accounts inherit `channels.telegram.allowFrom` and `channels.telegram.groupAllowFrom` when account-level values are unset.
   - Named accounts do not inherit `channels.telegram.accounts.default.allowFrom` / `groupAllowFrom`.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -205,6 +205,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 
 - Bot token: `channels.telegram.botToken` or `channels.telegram.tokenFile`, with `TELEGRAM_BOT_TOKEN` as fallback for the default account.
 - Optional `channels.telegram.defaultAccount` overrides default account selection when it matches a configured account id.
+- Multi-account recommendation: set `channels.telegram.defaultAccount` explicitly; otherwise OpenClaw picks `default` when present, or the first configured account id alphabetically.
 - `configWrites: false` blocks Telegram-initiated config writes (supergroup ID migrations, `/config set|unset`).
 - Telegram stream previews use `sendMessage` + `editMessageText` (works in direct and group chats).
 - Retry policy: see [Retry policy](/concepts/retry).


### PR DESCRIPTION
## Summary

- Problem: Telegram multi-account setups can behave unexpectedly when `channels.telegram.defaultAccount` is not set.
- Why it matters: operators may assume a specific account is default while runtime falls back to `default` or first account id.
- What changed: added explicit warnings and config-reference guidance in Telegram docs to set `defaultAccount` in multi-account setups.
- What did NOT change (scope boundary): no runtime routing logic changes in this PR.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32137
- Related #30673

## User-visible / Behavior Changes

- Telegram docs now explicitly call out default-account selection behavior and recommend setting `channels.telegram.defaultAccount` for multi-account installs.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: N/A (docs-only)
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): Telegram docs
- Relevant config (redacted): `channels.telegram.accounts.*`, `channels.telegram.defaultAccount`

### Steps

1. Review Telegram channel docs and configuration reference sections.
2. Verify default-account fallback behavior is documented.
3. Verify recommendation for explicit `defaultAccount` is present in both docs pages.

### Expected

- Operators can understand and avoid default-account ambiguity in multi-account configs.

### Actual

- ✅ Added warning and reference note in both targeted docs.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: rendered markdown content in updated docs sections; ran `pnpm format`.
- Edge cases checked: wording covers both `default` account present and alphabetical fallback behavior.
- What you did **not** verify: Mintlify preview render in hosted docs pipeline for this PR run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `6131377cb`.
- Files/config to restore: `docs/channels/telegram.md`, `docs/gateway/configuration-reference.md`.
- Known bad symptoms reviewers should watch for: none (docs-only change).

## Risks and Mitigations

- Risk: wording could overstate fallback behavior if implementation changes later.
  - Mitigation: language matches current `resolveDefaultTelegramAccountId` logic in source.
