### PR TITLE
fix(whatsapp): prevent selfChatMode from triggering on outbound DMs to third parties

### DIFF
--- a/src/web/inbound/access-control.test.ts
+++ b/src/web/inbound/access-control.test.ts
@@ -239,3 +239,32 @@ describe("selfChatMode: outbound DMs to third parties (#32632)", () => {
     expect(result.allowed).toBe(true);
   });
 });
+
+describe("selfChatMode: LID-format JID handling (#32632)", () => {
+  it("should block outbound DM when remoteJid is an unresolvable LID JID", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          enabled: true,
+          dmPolicy: "allowlist",
+          selfChatMode: true,
+          allowFrom: ["+15550009999"],
+        },
+      },
+    });
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15550009999",
+      selfE164: "+15550009999",
+      senderE164: "+15550009999",
+      group: false,
+      pushName: "Me",
+      isFromMe: true,
+      sock: { sendMessage: sendMessageMock },
+      // LID-format JID that cannot be resolved to E164
+      remoteJid: "123456789:0@lid",
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.isSelfChat).toBe(false);
+  });
+});

--- a/src/web/inbound/access-control.test.ts
+++ b/src/web/inbound/access-control.test.ts
@@ -158,3 +158,84 @@ describe("WhatsApp dmPolicy precedence", () => {
     expect(sendMessageMock).not.toHaveBeenCalled();
   });
 });
+
+describe("selfChatMode: outbound DMs to third parties (#32632)", () => {
+  it("should block outbound DMs to a third party even when selfChatMode is true", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          enabled: true,
+          dmPolicy: "allowlist",
+          selfChatMode: true,
+          allowFrom: ["+15550009999"],
+        },
+      },
+    });
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15550009999",
+      selfE164: "+15550009999",
+      senderE164: "+15550009999",
+      group: false,
+      pushName: "Me",
+      isFromMe: true,
+      sock: { sendMessage: sendMessageMock },
+      // Remote JID is a DIFFERENT number (third party)
+      remoteJid: "15551112222@s.whatsapp.net",
+    });
+    expect(result.allowed).toBe(false);
+    expect(result.isSelfChat).toBe(false);
+  });
+
+  it("should allow true self-chat (sender == recipient == self)", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          enabled: true,
+          dmPolicy: "allowlist",
+          selfChatMode: true,
+          allowFrom: ["+15550009999"],
+        },
+      },
+    });
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15550009999",
+      selfE164: "+15550009999",
+      senderE164: "+15550009999",
+      group: false,
+      pushName: "Me",
+      isFromMe: true,
+      sock: { sendMessage: sendMessageMock },
+      // Remote JID is the SAME number (true self-chat)
+      remoteJid: "15550009999@s.whatsapp.net",
+    });
+    expect(result.allowed).toBe(true);
+    expect(result.isSelfChat).toBe(true);
+  });
+
+  it("should allow inbound DMs from allowlisted third parties", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          enabled: true,
+          dmPolicy: "allowlist",
+          selfChatMode: true,
+          allowFrom: ["+15550009999", "+15551112222"],
+        },
+      },
+    });
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15551112222",
+      selfE164: "+15550009999",
+      senderE164: "+15551112222",
+      group: false,
+      pushName: "Dylan",
+      isFromMe: false,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15551112222@s.whatsapp.net",
+    });
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -11,7 +11,7 @@ import {
   readStoreAllowFromForDmPolicy,
   resolveDmGroupAccessWithLists,
 } from "../../security/dm-policy-shared.js";
-import { isSelfChatMode, normalizeE164 } from "../../utils.js";
+import { isSelfChatMode, jidToE164, normalizeE164 } from "../../utils.js";
 import { resolveWhatsAppAccount } from "../accounts.js";
 
 export type InboundAccessControlResult = {
@@ -73,6 +73,11 @@ export async function checkInboundAccessControl(params: {
   const groupAllowFrom =
     account.groupAllowFrom ?? (configuredAllowFrom.length > 0 ? configuredAllowFrom : undefined);
   const isSamePhone = params.from === params.selfE164;
+  // True self-chat: both sender AND recipient are the user's own number.
+  // Without this, outbound DMs to third parties are misidentified as self-chat
+  // when selfChatMode is enabled (see #32632).
+  const remoteE164 = jidToE164(params.remoteJid);
+  const isTrueSelfChat = isSamePhone && (!remoteE164 || remoteE164 === params.selfE164);
   const isSelfChat = account.selfChatMode ?? isSelfChatMode(params.selfE164, configuredAllowFrom);
   const pairingGraceMs =
     typeof params.pairingGraceMs === "number" && params.pairingGraceMs > 0
@@ -120,7 +125,7 @@ export async function checkInboundAccessControl(params: {
           .map((entry) => normalizeE164(String(entry)))
           .filter((entry): entry is string => Boolean(entry)),
       );
-      if (!params.group && isSamePhone) {
+      if (!params.group && isTrueSelfChat) {
         return true;
       }
       return params.group
@@ -148,12 +153,12 @@ export async function checkInboundAccessControl(params: {
 
   // DM access control (secure defaults): "pairing" (default) / "allowlist" / "open" / "disabled".
   if (!params.group) {
-    if (params.isFromMe && !isSamePhone) {
-      logVerbose("Skipping outbound DM (fromMe); no pairing reply needed.");
+    if (params.isFromMe && !isTrueSelfChat) {
+      logVerbose("Skipping outbound DM (fromMe to third party); not a self-chat.");
       return {
         allowed: false,
         shouldMarkRead: false,
-        isSelfChat,
+        isSelfChat: false,
         resolvedAccountId: account.accountId,
       };
     }

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -76,8 +76,11 @@ export async function checkInboundAccessControl(params: {
   // True self-chat: both sender AND recipient are the user's own number.
   // Without this, outbound DMs to third parties are misidentified as self-chat
   // when selfChatMode is enabled (see #32632).
+  // NOTE: If remoteJid cannot be resolved (e.g. LID-format JID without cached
+  // mapping), we default to false (not self-chat) as a safe fallback to avoid
+  // re-introducing the outbound DM bypass.
   const remoteE164 = jidToE164(params.remoteJid);
-  const isTrueSelfChat = isSamePhone && (!remoteE164 || remoteE164 === params.selfE164);
+  const isTrueSelfChat = isSamePhone && remoteE164 !== null && remoteE164 === params.selfE164;
   const isSelfChat = account.selfChatMode ?? isSelfChatMode(params.selfE164, configuredAllowFrom);
   const pairingGraceMs =
     typeof params.pairingGraceMs === "number" && params.pairingGraceMs > 0


### PR DESCRIPTION
## Summary

Fixes #32632 — When `selfChatMode: true`, the agent incorrectly processes and responds to messages sent in any DM thread, not just the user's self-chat (note-to-self).

## Root Cause

The access control checks `isSamePhone` (sender's number == user's own number) to auto-allow messages in self-chat mode. However, in WhatsApp, all outbound messages have the user as sender regardless of recipient. This means outbound DMs to friends pass through as if they were self-chat.

## Fix

Introduces `isTrueSelfChat` which verifies that **both** the sender AND recipient (`remoteJid`) resolve to the user's own E164 number. Only when sender == recipient == self is it treated as a true self-chat.

### Changes
- Import `jidToE164` to resolve `remoteJid` to E164 format
- Add `isTrueSelfChat` check (`isSamePhone && remoteE164 === selfE164`)
- Update `isSenderAllowed` callback to use `isTrueSelfChat` instead of `isSamePhone`
- Update outbound DM skip logic to block non-self-chat outbound messages and set `isSelfChat: false`
- Add 3 tests: outbound DM to third party (blocked), true self-chat (allowed), inbound from allowlisted third party (allowed)

## Testing

All 9 tests pass including 3 new tests:
```
✓ src/web/inbound/access-control.test.ts (9 tests) 7ms
```