### PR TITLE
docs(slack): add copy-paste native slash command manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Docs/Slack slash commands: add a copy-paste native slash command manifest snippet (`features.slash_commands`) so operators can register full native command coverage without manual per-command entry. (#32499) Thanks @theDanielJLewis.
 - Docs/Web search: remove outdated Brave free-tier wording and replace prescriptive AI ToS guidance with neutral compliance language in Brave setup docs. (#26860) Thanks @HenryLoenwind.
 - Tools/Diffs guidance loading: move diffs usage guidance from unconditional prompt-hook injection to the plugin companion skill path, reducing unrelated-turn prompt noise while keeping diffs tool behavior unchanged. (#32630) thanks @sircrumpet.
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -259,6 +259,8 @@ and still route command execution against the target conversation session (`Comm
       { "command": "/agents", "description": "OpenClaw /agents", "should_escape": false },
       { "command": "/kill", "description": "OpenClaw /kill", "should_escape": false },
       { "command": "/steer", "description": "OpenClaw /steer", "should_escape": false },
+      { "command": "/config", "description": "OpenClaw /config", "should_escape": false },
+      { "command": "/debug", "description": "OpenClaw /debug", "should_escape": false },
       { "command": "/usage", "description": "OpenClaw /usage", "should_escape": false },
       { "command": "/stop", "description": "OpenClaw /stop", "should_escape": false },
       { "command": "/restart", "description": "OpenClaw /restart", "should_escape": false },

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -231,6 +231,69 @@ Slash sessions use isolated keys:
 
 and still route command execution against the target conversation session (`CommandTargetSessionKey`).
 
+<AccordionGroup>
+  <Accordion title="Native slash command manifest snippet (copy/paste)">
+
+```json
+{
+  "features": {
+    "slash_commands": [
+      { "command": "/help", "description": "OpenClaw /help", "should_escape": false },
+      { "command": "/commands", "description": "OpenClaw /commands", "should_escape": false },
+      { "command": "/skill", "description": "OpenClaw /skill", "should_escape": false },
+      { "command": "/agentstatus", "description": "OpenClaw /agentstatus", "should_escape": false },
+      { "command": "/approve", "description": "OpenClaw /approve", "should_escape": false },
+      { "command": "/context", "description": "OpenClaw /context", "should_escape": false },
+      {
+        "command": "/export-session",
+        "description": "OpenClaw /export-session",
+        "should_escape": false
+      },
+      { "command": "/tts", "description": "OpenClaw /tts", "should_escape": false },
+      { "command": "/whoami", "description": "OpenClaw /whoami", "should_escape": false },
+      { "command": "/session", "description": "OpenClaw /session", "should_escape": false },
+      { "command": "/subagents", "description": "OpenClaw /subagents", "should_escape": false },
+      { "command": "/acp", "description": "OpenClaw /acp", "should_escape": false },
+      { "command": "/focus", "description": "OpenClaw /focus", "should_escape": false },
+      { "command": "/unfocus", "description": "OpenClaw /unfocus", "should_escape": false },
+      { "command": "/agents", "description": "OpenClaw /agents", "should_escape": false },
+      { "command": "/kill", "description": "OpenClaw /kill", "should_escape": false },
+      { "command": "/steer", "description": "OpenClaw /steer", "should_escape": false },
+      { "command": "/usage", "description": "OpenClaw /usage", "should_escape": false },
+      { "command": "/stop", "description": "OpenClaw /stop", "should_escape": false },
+      { "command": "/restart", "description": "OpenClaw /restart", "should_escape": false },
+      { "command": "/activation", "description": "OpenClaw /activation", "should_escape": false },
+      { "command": "/send", "description": "OpenClaw /send", "should_escape": false },
+      { "command": "/reset", "description": "OpenClaw /reset", "should_escape": false },
+      { "command": "/new", "description": "OpenClaw /new", "should_escape": false },
+      { "command": "/compact", "description": "OpenClaw /compact", "should_escape": false },
+      { "command": "/think", "description": "OpenClaw /think", "should_escape": false },
+      { "command": "/verbose", "description": "OpenClaw /verbose", "should_escape": false },
+      { "command": "/reasoning", "description": "OpenClaw /reasoning", "should_escape": false },
+      { "command": "/elevated", "description": "OpenClaw /elevated", "should_escape": false },
+      { "command": "/exec", "description": "OpenClaw /exec", "should_escape": false },
+      { "command": "/model", "description": "OpenClaw /model", "should_escape": false },
+      { "command": "/models", "description": "OpenClaw /models", "should_escape": false },
+      { "command": "/queue", "description": "OpenClaw /queue", "should_escape": false },
+      {
+        "command": "/dock_telegram",
+        "description": "OpenClaw /dock_telegram",
+        "should_escape": false
+      },
+      {
+        "command": "/dock_discord",
+        "description": "OpenClaw /dock_discord",
+        "should_escape": false
+      },
+      { "command": "/dock_slack", "description": "OpenClaw /dock_slack", "should_escape": false }
+    ]
+  }
+}
+```
+
+  </Accordion>
+</AccordionGroup>
+
 ## Threading, sessions, and reply tags
 
 - DMs route as `direct`; channels as `channel`; MPIMs as `group`.

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -293,6 +293,13 @@ and still route command execution against the target conversation session (`Comm
 }
 ```
 
+Notes:
+
+- This snippet is a baseline for core built-in native commands.
+- If `commands.nativeSkills` (or `channels.slack.commands.nativeSkills`) is enabled, also register generated skill slash commands.
+- Native-capable dock/plugin commands can add additional slash commands; keep your Slack app manifest aligned with your active native command set.
+- Naming/limits for generated skill commands are documented in [Slash Commands](/tools/slash-commands#command-list).
+
   </Accordion>
 </AccordionGroup>
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -293,12 +293,12 @@ and still route command execution against the target conversation session (`Comm
 }
 ```
 
-Notes:
-
-- This snippet is a baseline for core built-in native commands.
-- If `commands.nativeSkills` (or `channels.slack.commands.nativeSkills`) is enabled, also register generated skill slash commands.
-- Native-capable dock/plugin commands can add additional slash commands; keep your Slack app manifest aligned with your active native command set.
-- Naming/limits for generated skill commands are documented in [Slash Commands](/tools/slash-commands#command-list).
+Notes: This snippet is a baseline for core built-in native commands. If
+`commands.nativeSkills` (or `channels.slack.commands.nativeSkills`) is enabled,
+also register generated skill slash commands. Native-capable dock/plugin
+commands can add additional slash commands, so keep your Slack app manifest
+aligned with your active native command set. Naming and limits for generated
+skill commands are documented in [Slash Commands](/tools/slash-commands#command-list).
 
   </Accordion>
 </AccordionGroup>

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -295,12 +295,6 @@ and still route command execution against the target conversation session (`Comm
         "description": "Send guidance to a running subagent.",
         "should_escape": false
       },
-      { "command": "/config", "description": "Show or set config values.", "should_escape": false },
-      {
-        "command": "/debug",
-        "description": "Set runtime debug overrides.",
-        "should_escape": false
-      },
       {
         "command": "/usage",
         "description": "Show usage footer or cost summary.",
@@ -362,6 +356,24 @@ and still route command execution against the target conversation session (`Comm
 ```
 
 Notes: This snippet is a baseline for core built-in native commands. If
+`commands.config` or `commands.debug` is enabled, also register these optional
+entries:
+
+```json
+{
+  "features": {
+    "slash_commands": [
+      { "command": "/config", "description": "Show or set config values.", "should_escape": false },
+      { "command": "/debug", "description": "Set runtime debug overrides.", "should_escape": false }
+    ]
+  }
+}
+```
+
+If these command flags are disabled (default), do not register `/config` or
+`/debug` in your Slack manifest.
+
+If
 `commands.nativeSkills` (or `channels.slack.commands.nativeSkills`) is enabled,
 also register generated skill slash commands. Native-capable dock/plugin
 commands can add additional slash commands, so keep your Slack app manifest

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -238,56 +238,124 @@ and still route command execution against the target conversation session (`Comm
 {
   "features": {
     "slash_commands": [
-      { "command": "/help", "description": "OpenClaw /help", "should_escape": false },
-      { "command": "/commands", "description": "OpenClaw /commands", "should_escape": false },
-      { "command": "/skill", "description": "OpenClaw /skill", "should_escape": false },
-      { "command": "/agentstatus", "description": "OpenClaw /agentstatus", "should_escape": false },
-      { "command": "/approve", "description": "OpenClaw /approve", "should_escape": false },
-      { "command": "/context", "description": "OpenClaw /context", "should_escape": false },
+      { "command": "/help", "description": "Show available commands.", "should_escape": false },
+      { "command": "/commands", "description": "List all slash commands.", "should_escape": false },
+      { "command": "/skill", "description": "Run a skill by name.", "should_escape": false },
+      { "command": "/agentstatus", "description": "Show current status.", "should_escape": false },
       {
-        "command": "/export-session",
-        "description": "OpenClaw /export-session",
+        "command": "/approve",
+        "description": "Approve or deny exec requests.",
         "should_escape": false
       },
-      { "command": "/tts", "description": "OpenClaw /tts", "should_escape": false },
-      { "command": "/whoami", "description": "OpenClaw /whoami", "should_escape": false },
-      { "command": "/session", "description": "OpenClaw /session", "should_escape": false },
-      { "command": "/subagents", "description": "OpenClaw /subagents", "should_escape": false },
-      { "command": "/acp", "description": "OpenClaw /acp", "should_escape": false },
-      { "command": "/focus", "description": "OpenClaw /focus", "should_escape": false },
-      { "command": "/unfocus", "description": "OpenClaw /unfocus", "should_escape": false },
-      { "command": "/agents", "description": "OpenClaw /agents", "should_escape": false },
-      { "command": "/kill", "description": "OpenClaw /kill", "should_escape": false },
-      { "command": "/steer", "description": "OpenClaw /steer", "should_escape": false },
-      { "command": "/config", "description": "OpenClaw /config", "should_escape": false },
-      { "command": "/debug", "description": "OpenClaw /debug", "should_escape": false },
-      { "command": "/usage", "description": "OpenClaw /usage", "should_escape": false },
-      { "command": "/stop", "description": "OpenClaw /stop", "should_escape": false },
-      { "command": "/restart", "description": "OpenClaw /restart", "should_escape": false },
-      { "command": "/activation", "description": "OpenClaw /activation", "should_escape": false },
-      { "command": "/send", "description": "OpenClaw /send", "should_escape": false },
-      { "command": "/reset", "description": "OpenClaw /reset", "should_escape": false },
-      { "command": "/new", "description": "OpenClaw /new", "should_escape": false },
-      { "command": "/compact", "description": "OpenClaw /compact", "should_escape": false },
-      { "command": "/think", "description": "OpenClaw /think", "should_escape": false },
-      { "command": "/verbose", "description": "OpenClaw /verbose", "should_escape": false },
-      { "command": "/reasoning", "description": "OpenClaw /reasoning", "should_escape": false },
-      { "command": "/elevated", "description": "OpenClaw /elevated", "should_escape": false },
-      { "command": "/exec", "description": "OpenClaw /exec", "should_escape": false },
-      { "command": "/model", "description": "OpenClaw /model", "should_escape": false },
-      { "command": "/models", "description": "OpenClaw /models", "should_escape": false },
-      { "command": "/queue", "description": "OpenClaw /queue", "should_escape": false },
+      {
+        "command": "/context",
+        "description": "Explain how context is built and used.",
+        "should_escape": false
+      },
+      {
+        "command": "/export-session",
+        "description": "Export this session to HTML.",
+        "should_escape": false
+      },
+      { "command": "/tts", "description": "Control text-to-speech (TTS).", "should_escape": false },
+      { "command": "/whoami", "description": "Show your sender id.", "should_escape": false },
+      {
+        "command": "/session",
+        "description": "Manage session settings (idle/max-age).",
+        "should_escape": false
+      },
+      {
+        "command": "/subagents",
+        "description": "List, spawn, or control subagent runs.",
+        "should_escape": false
+      },
+      {
+        "command": "/acp",
+        "description": "Manage ACP sessions and runtime options.",
+        "should_escape": false
+      },
+      {
+        "command": "/focus",
+        "description": "Bind this thread to a session target.",
+        "should_escape": false
+      },
+      {
+        "command": "/unfocus",
+        "description": "Remove the current thread binding.",
+        "should_escape": false
+      },
+      { "command": "/agents", "description": "List thread-bound agents.", "should_escape": false },
+      {
+        "command": "/kill",
+        "description": "Kill a running subagent (or all).",
+        "should_escape": false
+      },
+      {
+        "command": "/steer",
+        "description": "Send guidance to a running subagent.",
+        "should_escape": false
+      },
+      { "command": "/config", "description": "Show or set config values.", "should_escape": false },
+      {
+        "command": "/debug",
+        "description": "Set runtime debug overrides.",
+        "should_escape": false
+      },
+      {
+        "command": "/usage",
+        "description": "Show usage footer or cost summary.",
+        "should_escape": false
+      },
+      { "command": "/stop", "description": "Stop the current run.", "should_escape": false },
+      { "command": "/restart", "description": "Restart OpenClaw.", "should_escape": false },
+      {
+        "command": "/activation",
+        "description": "Set group activation mode.",
+        "should_escape": false
+      },
+      { "command": "/send", "description": "Set send policy.", "should_escape": false },
+      { "command": "/reset", "description": "Reset the current session.", "should_escape": false },
+      { "command": "/new", "description": "Start a new session.", "should_escape": false },
+      {
+        "command": "/compact",
+        "description": "Compact the session context.",
+        "should_escape": false
+      },
+      { "command": "/think", "description": "Set thinking level.", "should_escape": false },
+      { "command": "/verbose", "description": "Toggle verbose mode.", "should_escape": false },
+      {
+        "command": "/reasoning",
+        "description": "Toggle reasoning visibility.",
+        "should_escape": false
+      },
+      { "command": "/elevated", "description": "Toggle elevated mode.", "should_escape": false },
+      {
+        "command": "/exec",
+        "description": "Set exec defaults for this session.",
+        "should_escape": false
+      },
+      { "command": "/model", "description": "Show or set the model.", "should_escape": false },
+      {
+        "command": "/models",
+        "description": "List providers or provider models.",
+        "should_escape": false
+      },
+      { "command": "/queue", "description": "Adjust queue settings.", "should_escape": false },
       {
         "command": "/dock_telegram",
-        "description": "OpenClaw /dock_telegram",
+        "description": "Open Telegram dock commands.",
         "should_escape": false
       },
       {
         "command": "/dock_discord",
-        "description": "OpenClaw /dock_discord",
+        "description": "Open Discord dock commands.",
         "should_escape": false
       },
-      { "command": "/dock_slack", "description": "OpenClaw /dock_slack", "should_escape": false }
+      {
+        "command": "/dock_slack",
+        "description": "Open Slack dock commands.",
+        "should_escape": false
+      }
     ]
   }
 }


### PR DESCRIPTION
## Summary

- Problem: Slack docs told users to register native slash commands manually but did not provide a ready-to-paste full command manifest array.
- Why it matters: setup is tedious and error-prone; missing commands silently reduce native command coverage.
- What changed: added a copy-paste `features.slash_commands` snippet covering current Slack native command names.
- What did NOT change (scope boundary): no runtime slash registration logic or manifest generation code changes in this PR.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32499
- Related #32088

## User-visible / Behavior Changes

- Slack channel docs now include a full copy-paste slash command manifest snippet for native commands.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: N/A (docs-only)
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): Slack docs
- Relevant config (redacted): `channels.slack.commands.native`

### Steps

1. Open Slack channel docs commands section.
2. Confirm copy-paste `features.slash_commands` JSON snippet is present.
3. Confirm snippet includes current native slash command names.

### Expected

- Operators can paste a ready list instead of manually adding each slash command.

### Actual

- ✅ Full manifest snippet added.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios: reviewed markdown rendering structure and command list coverage; ran `pnpm format`.
- Edge cases checked: includes `/agentstatus` alias expectation and dock commands shown in native list.
- What you did **not** verify: hosted docs deployment preview in this run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `4e3fb9b41`.
- Files/config to restore: `docs/channels/slack.md`.
- Known bad symptoms reviewers should watch for: stale doc command list if native command set changes later.

## Risks and Mitigations

- Risk: docs list may drift from runtime command set in future releases.
  - Mitigation: list was generated from current command registry output and scoped as a docs convenience snippet.
