### PR TITLE
[WIP] feat(feishu): add document comment reply support

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -3,6 +3,7 @@ import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
 import { registerFeishuBitableTools } from "./src/bitable.js";
 import { feishuPlugin } from "./src/channel.js";
 import { registerFeishuChatTools } from "./src/chat.js";
+import { registerFeishuDocCommentTool } from "./src/doc-comment-tool.js";
 import { registerFeishuDocTools } from "./src/docx.js";
 import { registerFeishuDriveTools } from "./src/drive.js";
 import { registerFeishuPermTools } from "./src/perm.js";
@@ -59,6 +60,7 @@ const plugin = {
     registerFeishuDriveTools(api);
     registerFeishuPermTools(api);
     registerFeishuBitableTools(api);
+    registerFeishuDocCommentTool(api);
   },
 };
 

--- a/extensions/feishu/skills/feishu-doc/SKILL.md
+++ b/extensions/feishu/skills/feishu-doc/SKILL.md
@@ -189,6 +189,24 @@ Rules:
 - optional `filename` override
 - optional `parent_block_id`
 
+### Download File from Feishu Message
+
+Download a file attachment from a Feishu message (e.g. a forwarded `.md`, `.pdf`, or `.docx` file) to a local path for further processing.
+
+```json
+{
+  "action": "download_message_file",
+  "message_id": "om_xxx",
+  "file_key": "file_v3_xxx"
+}
+```
+
+- `message_id`: starts with `om_`, visible in the inbound message context
+- `file_key`: from the message body JSON (`file_key` field); use `list_blocks` or check the quoted message body
+- `file_type`: optional, `"file"` (default) or `"image"`
+
+Returns `file_path` (local path), `content_type`, and `size_bytes`. Pass `file_path` to `write` or `append` as needed.
+
 ## Reading Workflow
 
 1. Start with `action: "read"` - get plain text + statistics

--- a/extensions/feishu/src/doc-comment-schema.ts
+++ b/extensions/feishu/src/doc-comment-schema.ts
@@ -1,0 +1,37 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+const FileType = Type.Union([
+  Type.Literal("doc"),
+  Type.Literal("docx"),
+  Type.Literal("sheet"),
+  Type.Literal("bitable"),
+]);
+
+export const FeishuDocCommentSchema = Type.Union([
+  Type.Object({
+    action: Type.Literal("list_comments"),
+    file_token: Type.String({ description: "Document file token" }),
+    file_type: FileType,
+  }),
+  Type.Object({
+    action: Type.Literal("get_comment"),
+    file_token: Type.String({ description: "Document file token" }),
+    file_type: FileType,
+    comment_id: Type.String({ description: "Comment ID" }),
+  }),
+  Type.Object({
+    action: Type.Literal("reply_comment"),
+    file_token: Type.String({ description: "Document file token" }),
+    file_type: FileType,
+    comment_id: Type.String({ description: "Comment ID to reply to" }),
+    content: Type.String({ description: "Reply content" }),
+  }),
+  Type.Object({
+    action: Type.Literal("create_comment"),
+    file_token: Type.String({ description: "Document file token" }),
+    file_type: FileType,
+    content: Type.String({ description: "Comment content" }),
+  }),
+]);
+
+export type FeishuDocCommentParams = Static<typeof FeishuDocCommentSchema>;

--- a/extensions/feishu/src/doc-comment-tool.ts
+++ b/extensions/feishu/src/doc-comment-tool.ts
@@ -1,0 +1,111 @@
+/**
+ * Feishu Document Comment Tool
+ *
+ * Provides agent access to document comment operations:
+ * - List comments on a document
+ * - Get a specific comment
+ * - Reply to a comment
+ * - Create a new comment
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { listEnabledFeishuAccounts } from "./accounts.js";
+import { FeishuDocCommentSchema, type FeishuDocCommentParams } from "./doc-comment-schema.js";
+import {
+  listDocComments,
+  getDocComment,
+  replyToDocComment,
+  createDocComment,
+  type DocFileType,
+} from "./doc-comment.js";
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
+
+// ============ Helpers ============
+
+function json(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    details: data,
+  };
+}
+
+// ============ Tool Registration ============
+
+export function registerFeishuDocCommentTool(api: OpenClawPluginApi) {
+  if (!api.config) {
+    api.logger.debug?.("feishu_doc_comment: No config available, skipping tool registration");
+    return;
+  }
+
+  const accounts = listEnabledFeishuAccounts(api.config);
+  if (accounts.length === 0) {
+    api.logger.debug?.(
+      "feishu_doc_comment: No Feishu accounts configured, skipping tool registration",
+    );
+    return;
+  }
+
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
+  // Enable doc_comment tool if drive is enabled (they share similar permissions)
+  if (!toolsCfg.drive) {
+    api.logger.debug?.("feishu_doc_comment: drive tool disabled in config, skipping");
+    return;
+  }
+
+  type FeishuDocCommentExecuteParams = FeishuDocCommentParams & { accountId?: string };
+
+  api.registerTool(
+    (ctx) => {
+      const defaultAccountId = ctx.agentAccountId;
+      return {
+        name: "feishu_doc_comment",
+        label: "Feishu Document Comment",
+        description:
+          "Feishu document comment operations. Actions: list_comments, get_comment, reply_comment, create_comment. " +
+          "Use this to read and reply to comments on Feishu documents.",
+        parameters: FeishuDocCommentSchema,
+        async execute(_toolCallId, params) {
+          const p = params as FeishuDocCommentExecuteParams;
+          try {
+            const client = createFeishuToolClient({
+              api,
+              executeParams: p,
+              defaultAccountId,
+            });
+
+            switch (p.action) {
+              case "list_comments":
+                return json(await listDocComments(client, p.file_token, p.file_type));
+
+              case "get_comment":
+                return json(await getDocComment(client, p.file_token, p.file_type, p.comment_id));
+
+              case "reply_comment":
+                return json(
+                  await replyToDocComment(
+                    client,
+                    p.file_token,
+                    p.file_type,
+                    p.comment_id,
+                    p.content,
+                  ),
+                );
+
+              case "create_comment":
+                return json(await createDocComment(client, p.file_token, p.file_type, p.content));
+
+              default:
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any -- exhaustive check fallback
+                return json({ error: `Unknown action: ${(p as any).action}` });
+            }
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
+          }
+        },
+      };
+    },
+    { name: "feishu_doc_comment" },
+  );
+
+  api.logger.info?.(`feishu_doc_comment: Registered feishu_doc_comment tool`);
+}

--- a/extensions/feishu/src/doc-comment-tool.ts
+++ b/extensions/feishu/src/doc-comment-tool.ts
@@ -12,7 +12,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { listEnabledFeishuAccounts } from "./accounts.js";
 import { FeishuDocCommentSchema, type FeishuDocCommentParams } from "./doc-comment-schema.js";
 import {
-  listDocComments,
+  listAllDocComments,
   getDocComment,
   replyToDocComment,
   createDocComment,
@@ -75,7 +75,7 @@ export function registerFeishuDocCommentTool(api: OpenClawPluginApi) {
 
             switch (p.action) {
               case "list_comments":
-                return json(await listDocComments(client, p.file_token, p.file_type));
+                return json(await listAllDocComments(client, p.file_token, p.file_type));
 
               case "get_comment":
                 return json(await getDocComment(client, p.file_token, p.file_type, p.comment_id));

--- a/extensions/feishu/src/doc-comment.test.ts
+++ b/extensions/feishu/src/doc-comment.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import { parseDocUrl, extractDocUrls } from "./doc-comment.js";
+
+describe("parseDocUrl", () => {
+  it("should parse docx URL", () => {
+    const result = parseDocUrl("https://example.feishu.cn/docx/ABC123");
+    expect(result).toEqual({
+      fileToken: "ABC123",
+      fileType: "docx",
+      commentId: undefined,
+      replyId: undefined,
+    });
+  });
+
+  it("should parse docs URL", () => {
+    const result = parseDocUrl("https://example.feishu.cn/docs/XYZ789");
+    expect(result).toEqual({
+      fileToken: "XYZ789",
+      fileType: "doc",
+      commentId: undefined,
+      replyId: undefined,
+    });
+  });
+
+  it("should parse sheets URL", () => {
+    const result = parseDocUrl("https://example.feishu.cn/sheets/Sheet123");
+    expect(result).toEqual({
+      fileToken: "Sheet123",
+      fileType: "sheet",
+      commentId: undefined,
+      replyId: undefined,
+    });
+  });
+
+  it("should parse bitable URL", () => {
+    const result = parseDocUrl("https://example.feishu.cn/base/Base456");
+    expect(result).toEqual({
+      fileToken: "Base456",
+      fileType: "bitable",
+      commentId: undefined,
+      replyId: undefined,
+    });
+  });
+
+  it("should parse URL with comment anchor", () => {
+    const result = parseDocUrl("https://example.feishu.cn/docx/ABC123#comment-CMT001");
+    expect(result).toEqual({
+      fileToken: "ABC123",
+      fileType: "docx",
+      commentId: "CMT001",
+      replyId: undefined,
+    });
+  });
+
+  it("should parse URL with comment and reply anchor", () => {
+    const result = parseDocUrl("https://example.feishu.cn/docx/ABC123#comment-CMT001-reply-RPL001");
+    expect(result).toEqual({
+      fileToken: "ABC123",
+      fileType: "docx",
+      commentId: "CMT001",
+      replyId: "RPL001",
+    });
+  });
+
+  it("should return null for invalid URL", () => {
+    expect(parseDocUrl("https://example.com/not-feishu")).toBeNull();
+    expect(parseDocUrl("not-a-url")).toBeNull();
+    expect(parseDocUrl("https://example.feishu.cn/unknown/ABC")).toBeNull();
+  });
+
+  it("should handle Lark international domain", () => {
+    const result = parseDocUrl("https://example.larksuite.com/docx/ABC123");
+    // Also supports .larksuite.com domain (international Lark)
+    expect(result).toEqual({
+      fileToken: "ABC123",
+      fileType: "docx",
+      commentId: undefined,
+      replyId: undefined,
+    });
+  });
+});
+
+describe("extractDocUrls", () => {
+  it("should extract single URL from text", () => {
+    const text = "请查看这个文档 https://example.feishu.cn/docx/ABC123 谢谢";
+    const results = extractDocUrls(text);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toEqual({
+      fileToken: "ABC123",
+      fileType: "docx",
+      commentId: undefined,
+      replyId: undefined,
+    });
+  });
+
+  it("should extract multiple URLs from text", () => {
+    const text = `
+      文档1: https://example.feishu.cn/docx/DOC001
+      文档2: https://example.feishu.cn/sheets/SHEET001#comment-CMT001
+    `;
+    const results = extractDocUrls(text);
+    expect(results).toHaveLength(2);
+    expect(results[0].fileToken).toBe("DOC001");
+    expect(results[1].fileToken).toBe("SHEET001");
+    expect(results[1].commentId).toBe("CMT001");
+  });
+
+  it("should return empty array for text without URLs", () => {
+    const results = extractDocUrls("普通文本，没有链接");
+    expect(results).toHaveLength(0);
+  });
+
+  it("should ignore non-document Feishu URLs", () => {
+    const text = "https://example.feishu.cn/messenger/chat/123";
+    const results = extractDocUrls(text);
+    expect(results).toHaveLength(0);
+  });
+});

--- a/extensions/feishu/src/doc-comment.test.ts
+++ b/extensions/feishu/src/doc-comment.test.ts
@@ -78,6 +78,14 @@ describe("parseDocUrl", () => {
       replyId: undefined,
     });
   });
+
+  it("should reject non-Feishu domain with valid doc path", () => {
+    // Security: must reject URLs from arbitrary domains even if path looks valid
+    expect(parseDocUrl("https://evil.com/docx/ABC123")).toBeNull();
+    expect(parseDocUrl("https://fake-feishu.cn/docx/ABC123")).toBeNull();
+    expect(parseDocUrl("https://feishu.cn.evil.com/docx/ABC123")).toBeNull();
+    expect(parseDocUrl("https://not-larksuite.com/docx/ABC123")).toBeNull();
+  });
 });
 
 describe("extractDocUrls", () => {

--- a/extensions/feishu/src/doc-comment.test.ts
+++ b/extensions/feishu/src/doc-comment.test.ts
@@ -68,10 +68,34 @@ describe("parseDocUrl", () => {
     expect(parseDocUrl("https://example.feishu.cn/unknown/ABC")).toBeNull();
   });
 
-  it("should handle Lark international domain", () => {
+  it("should handle Lark international domain (larksuite.com)", () => {
     const result = parseDocUrl("https://example.larksuite.com/docx/ABC123");
-    // Also supports .larksuite.com domain (international Lark)
     expect(result).toEqual({
+      fileToken: "ABC123",
+      fileType: "docx",
+      commentId: undefined,
+      replyId: undefined,
+    });
+  });
+
+  it("should handle Lark international domain (larkoffice.com)", () => {
+    const result = parseDocUrl("https://example.larkoffice.com/docx/ABC123");
+    expect(result).toEqual({
+      fileToken: "ABC123",
+      fileType: "docx",
+      commentId: undefined,
+      replyId: undefined,
+    });
+  });
+
+  it("should handle bare domain without subdomain", () => {
+    expect(parseDocUrl("https://feishu.cn/docx/ABC123")).toEqual({
+      fileToken: "ABC123",
+      fileType: "docx",
+      commentId: undefined,
+      replyId: undefined,
+    });
+    expect(parseDocUrl("https://larksuite.com/docx/ABC123")).toEqual({
       fileToken: "ABC123",
       fileType: "docx",
       commentId: undefined,

--- a/extensions/feishu/src/doc-comment.ts
+++ b/extensions/feishu/src/doc-comment.ts
@@ -10,9 +10,11 @@ import type * as Lark from "@larksuiteoapi/node-sdk";
 
 // ============ Types ============
 
+export type DocFileType = "doc" | "docx" | "sheet" | "bitable";
+
 export interface DocCommentInfo {
   fileToken: string;
-  fileType: "doc" | "docx" | "sheet" | "bitable";
+  fileType: DocFileType;
   commentId?: string;
   replyId?: string;
 }
@@ -32,6 +34,48 @@ export interface Comment {
   is_solved: boolean;
   quote: string;
   replies: CommentReply[];
+}
+
+// ============ HTTP Helper ============
+
+interface FeishuApiResponse<T> {
+  code: number;
+  msg?: string;
+  data?: T;
+}
+
+async function feishuHttpRequest<T>(
+  client: Lark.Client,
+  method: "GET" | "POST" | "PUT" | "DELETE",
+  path: string,
+  params?: Record<string, string>,
+  data?: unknown,
+): Promise<FeishuApiResponse<T>> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accessing internal SDK property
+  const domain = (client as any).domain ?? "https://open.feishu.cn";
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accessing internal SDK property
+  const httpInstance = (client as any).httpInstance;
+
+  let url = `${domain}${path}`;
+  if (params && Object.keys(params).length > 0) {
+    const query = new URLSearchParams(params).toString();
+    url = `${url}?${query}`;
+  }
+
+  let res: FeishuApiResponse<T>;
+  if (method === "GET") {
+    res = await httpInstance.get(url);
+  } else if (method === "POST") {
+    res = await httpInstance.post(url, data);
+  } else if (method === "PUT") {
+    res = await httpInstance.put(url, data);
+  } else if (method === "DELETE") {
+    res = await httpInstance.delete(url);
+  } else {
+    throw new Error(`Unsupported method: ${method}`);
+  }
+
+  return res;
 }
 
 // ============ URL Parsing ============
@@ -130,46 +174,45 @@ export function extractDocUrls(text: string): DocCommentInfo[] {
 
 /**
  * List comments on a document.
+ *
+ * API: GET /open-apis/drive/v1/files/:file_token/comments
  */
 export async function listDocComments(
   client: Lark.Client,
   fileToken: string,
-  fileType: string,
+  fileType: DocFileType,
 ): Promise<Comment[]> {
-  const res = await client.drive.fileComment.list({
-    path: {
-      file_token: fileToken,
-    },
-    params: {
-      file_type: fileType,
-    },
-  });
+  const res = await feishuHttpRequest<{ items?: Comment[] }>(
+    client,
+    "GET",
+    `/open-apis/drive/v1/files/${fileToken}/comments`,
+    { file_type: fileType },
+  );
 
   if (res.code !== 0) {
     throw new Error(`Failed to list comments: ${res.msg}`);
   }
 
-  return (res.data?.items || []) as Comment[];
+  return res.data?.items || [];
 }
 
 /**
  * Get a specific comment by ID.
+ *
+ * API: GET /open-apis/drive/v1/files/:file_token/comments/:comment_id
  */
 export async function getDocComment(
   client: Lark.Client,
   fileToken: string,
-  fileType: string,
+  fileType: DocFileType,
   commentId: string,
 ): Promise<Comment | null> {
-  const res = await client.drive.fileComment.get({
-    path: {
-      file_token: fileToken,
-      comment_id: commentId,
-    },
-    params: {
-      file_type: fileType,
-    },
-  });
+  const res = await feishuHttpRequest<Comment>(
+    client,
+    "GET",
+    `/open-apis/drive/v1/files/${fileToken}/comments/${commentId}`,
+    { file_type: fileType },
+  );
 
   if (res.code !== 0) {
     if (res.code === 1300002) {
@@ -179,28 +222,27 @@ export async function getDocComment(
     throw new Error(`Failed to get comment: ${res.msg}`);
   }
 
-  return res.data as Comment | null;
+  return res.data || null;
 }
 
 /**
  * Reply to a document comment.
+ *
+ * API: POST /open-apis/drive/v1/files/:file_token/comments/:comment_id/replies
  */
 export async function replyToDocComment(
   client: Lark.Client,
   fileToken: string,
-  fileType: string,
+  fileType: DocFileType,
   commentId: string,
   content: string,
 ): Promise<CommentReply> {
-  const res = await client.drive.fileCommentReply.create({
-    path: {
-      file_token: fileToken,
-      comment_id: commentId,
-    },
-    params: {
-      file_type: fileType,
-    },
-    data: {
+  const res = await feishuHttpRequest<CommentReply>(
+    client,
+    "POST",
+    `/open-apis/drive/v1/files/${fileToken}/comments/${commentId}/replies`,
+    { file_type: fileType },
+    {
       content: {
         elements: [
           {
@@ -212,32 +254,37 @@ export async function replyToDocComment(
         ],
       },
     },
-  });
+  );
 
   if (res.code !== 0) {
     throw new Error(`Failed to reply to comment: ${res.msg}`);
   }
 
-  return res.data as CommentReply;
+  if (!res.data) {
+    throw new Error("No reply data returned");
+  }
+
+  return res.data;
 }
 
 /**
  * Create a new comment on a document (not a reply).
+ * Note: Creating comments requires specifying a quote (text range to attach the comment to).
+ *
+ * API: POST /open-apis/drive/v1/files/:file_token/comments
  */
 export async function createDocComment(
   client: Lark.Client,
   fileToken: string,
-  fileType: string,
+  fileType: DocFileType,
   content: string,
 ): Promise<Comment> {
-  const res = await client.drive.fileComment.create({
-    path: {
-      file_token: fileToken,
-    },
-    params: {
-      file_type: fileType,
-    },
-    data: {
+  const res = await feishuHttpRequest<Comment>(
+    client,
+    "POST",
+    `/open-apis/drive/v1/files/${fileToken}/comments`,
+    { file_type: fileType },
+    {
       content: {
         elements: [
           {
@@ -249,11 +296,15 @@ export async function createDocComment(
         ],
       },
     },
-  });
+  );
 
   if (res.code !== 0) {
     throw new Error(`Failed to create comment: ${res.msg}`);
   }
 
-  return res.data as Comment;
+  if (!res.data) {
+    throw new Error("No comment data returned");
+  }
+
+  return res.data;
 }

--- a/extensions/feishu/src/doc-comment.ts
+++ b/extensions/feishu/src/doc-comment.ts
@@ -93,10 +93,18 @@ async function feishuHttpRequest<T>(
 // ============ URL Parsing ============
 
 /**
+ * Valid Feishu/Lark domain suffixes.
+ * Includes both China (feishu.cn) and international (larksuite.com, larkoffice.com) domains.
+ */
+const FEISHU_DOMAINS = ["feishu.cn", "larksuite.com", "larkoffice.com"];
+
+/**
  * Check if a hostname is a valid Feishu/Lark domain.
+ * Accepts both bare domains (feishu.cn) and subdomains (xxx.feishu.cn).
  */
 function isFeishuDomain(hostname: string): boolean {
-  return hostname.endsWith(".feishu.cn") || hostname.endsWith(".larksuite.com");
+  const lowerHost = hostname.toLowerCase();
+  return FEISHU_DOMAINS.some((domain) => lowerHost === domain || lowerHost.endsWith(`.${domain}`));
 }
 
 /**
@@ -181,9 +189,9 @@ export function parseDocUrl(url: string): DocCommentInfo | null {
  * Extract document URLs from message text.
  */
 export function extractDocUrls(text: string): DocCommentInfo[] {
-  // Support both feishu.cn and larksuite.com domains
+  // Support feishu.cn, larksuite.com, and larkoffice.com domains (with or without subdomain)
   const urlPattern =
-    /https?:\/\/[^\s<>"{}|\\^`[\]]+\.(?:feishu\.cn|larksuite\.com)\/(?:docx|docs|sheets|base)\/[A-Za-z0-9]+[^\s<>"{}|\\^`[\]]*/gi;
+    /https?:\/\/(?:[^\s<>"{}|\\^`[\]]+\.)?(?:feishu\.cn|larksuite\.com|larkoffice\.com)\/(?:docx|docs|sheets|base)\/[A-Za-z0-9]+[^\s<>"{}|\\^`[\]]*/gi;
   const matches = text.match(urlPattern) || [];
   const results: DocCommentInfo[] = [];
 

--- a/extensions/feishu/src/doc-comment.ts
+++ b/extensions/feishu/src/doc-comment.ts
@@ -19,9 +19,20 @@ export interface DocCommentInfo {
   replyId?: string;
 }
 
+export interface CommentContentElement {
+  type: "text_run" | "docs_link" | "person";
+  text_run?: { text: string };
+  docs_link?: { url: string };
+  person?: { user_id: string };
+}
+
+export interface CommentContent {
+  elements: CommentContentElement[];
+}
+
 export interface CommentReply {
   reply_id: string;
-  content: string;
+  content: CommentContent;
   create_time: number;
   update_time: number;
 }
@@ -33,7 +44,8 @@ export interface Comment {
   update_time: number;
   is_solved: boolean;
   quote: string;
-  replies: CommentReply[];
+  content?: CommentContent;
+  replies?: CommentReply[];
 }
 
 // ============ HTTP Helper ============
@@ -81,6 +93,13 @@ async function feishuHttpRequest<T>(
 // ============ URL Parsing ============
 
 /**
+ * Check if a hostname is a valid Feishu/Lark domain.
+ */
+function isFeishuDomain(hostname: string): boolean {
+  return hostname.endsWith(".feishu.cn") || hostname.endsWith(".larksuite.com");
+}
+
+/**
  * Extract document info from a Feishu document URL.
  *
  * Supported URL formats:
@@ -89,10 +108,18 @@ async function feishuHttpRequest<T>(
  * - https://xxx.feishu.cn/sheets/ABC123
  * - https://xxx.feishu.cn/base/ABC123
  * - With comment anchor: ...#comment-XYZ
+ *
+ * Only accepts URLs from feishu.cn or larksuite.com domains.
  */
 export function parseDocUrl(url: string): DocCommentInfo | null {
   try {
     const parsed = new URL(url);
+
+    // Validate domain - only accept feishu.cn and larksuite.com
+    if (!isFeishuDomain(parsed.hostname)) {
+      return null;
+    }
+
     const pathname = parsed.pathname;
 
     // Match /docx/, /docs/, /sheets/, /base/ patterns
@@ -172,8 +199,15 @@ export function extractDocUrls(text: string): DocCommentInfo[] {
 
 // ============ Comment API ============
 
+export interface ListCommentsResult {
+  comments: Comment[];
+  hasMore: boolean;
+  pageToken?: string;
+}
+
 /**
  * List comments on a document.
+ * Handles pagination - use pageToken to fetch subsequent pages.
  *
  * API: GET /open-apis/drive/v1/files/:file_token/comments
  */
@@ -181,19 +215,57 @@ export async function listDocComments(
   client: Lark.Client,
   fileToken: string,
   fileType: DocFileType,
-): Promise<Comment[]> {
-  const res = await feishuHttpRequest<{ items?: Comment[] }>(
-    client,
-    "GET",
-    `/open-apis/drive/v1/files/${fileToken}/comments`,
-    { file_type: fileType },
-  );
+  options?: { pageToken?: string; pageSize?: number },
+): Promise<ListCommentsResult> {
+  const params: Record<string, string> = { file_type: fileType };
+  if (options?.pageToken) {
+    params.page_token = options.pageToken;
+  }
+  if (options?.pageSize) {
+    params.page_size = String(options.pageSize);
+  }
+
+  const res = await feishuHttpRequest<{
+    items?: Comment[];
+    has_more?: boolean;
+    page_token?: string;
+  }>(client, "GET", `/open-apis/drive/v1/files/${fileToken}/comments`, params);
 
   if (res.code !== 0) {
     throw new Error(`Failed to list comments: ${res.msg}`);
   }
 
-  return res.data?.items || [];
+  return {
+    comments: res.data?.items || [],
+    hasMore: res.data?.has_more ?? false,
+    pageToken: res.data?.page_token,
+  };
+}
+
+/**
+ * List all comments on a document (handles pagination automatically).
+ * Use with caution for documents with many comments.
+ *
+ * API: GET /open-apis/drive/v1/files/:file_token/comments
+ */
+export async function listAllDocComments(
+  client: Lark.Client,
+  fileToken: string,
+  fileType: DocFileType,
+  maxPages = 10,
+): Promise<Comment[]> {
+  const allComments: Comment[] = [];
+  let pageToken: string | undefined;
+  let pageCount = 0;
+
+  do {
+    const result = await listDocComments(client, fileToken, fileType, { pageToken });
+    allComments.push(...result.comments);
+    pageToken = result.hasMore ? result.pageToken : undefined;
+    pageCount++;
+  } while (pageToken && pageCount < maxPages);
+
+  return allComments;
 }
 
 /**

--- a/extensions/feishu/src/doc-comment.ts
+++ b/extensions/feishu/src/doc-comment.ts
@@ -1,0 +1,259 @@
+/**
+ * Feishu Document Comment Operations
+ *
+ * Handles document comment detection and reply functionality.
+ * When a user @mentions the bot in a document comment, the bot can detect this
+ * and reply to the comment directly.
+ */
+
+import type * as Lark from "@larksuiteoapi/node-sdk";
+
+// ============ Types ============
+
+export interface DocCommentInfo {
+  fileToken: string;
+  fileType: "doc" | "docx" | "sheet" | "bitable";
+  commentId?: string;
+  replyId?: string;
+}
+
+export interface CommentReply {
+  reply_id: string;
+  content: string;
+  create_time: number;
+  update_time: number;
+}
+
+export interface Comment {
+  comment_id: string;
+  user_id: string;
+  create_time: number;
+  update_time: number;
+  is_solved: boolean;
+  quote: string;
+  replies: CommentReply[];
+}
+
+// ============ URL Parsing ============
+
+/**
+ * Extract document info from a Feishu document URL.
+ *
+ * Supported URL formats:
+ * - https://xxx.feishu.cn/docx/ABC123
+ * - https://xxx.feishu.cn/docs/ABC123
+ * - https://xxx.feishu.cn/sheets/ABC123
+ * - https://xxx.feishu.cn/base/ABC123
+ * - With comment anchor: ...#comment-XYZ
+ */
+export function parseDocUrl(url: string): DocCommentInfo | null {
+  try {
+    const parsed = new URL(url);
+    const pathname = parsed.pathname;
+
+    // Match /docx/, /docs/, /sheets/, /base/ patterns
+    const docxMatch = pathname.match(/\/docx\/([A-Za-z0-9]+)/);
+    const docsMatch = pathname.match(/\/docs\/([A-Za-z0-9]+)/);
+    const sheetsMatch = pathname.match(/\/sheets\/([A-Za-z0-9]+)/);
+    const baseMatch = pathname.match(/\/base\/([A-Za-z0-9]+)/);
+
+    let fileToken: string | undefined;
+    let fileType: "doc" | "docx" | "sheet" | "bitable" | undefined;
+
+    if (docxMatch) {
+      fileToken = docxMatch[1];
+      fileType = "docx";
+    } else if (docsMatch) {
+      fileToken = docsMatch[1];
+      fileType = "doc";
+    } else if (sheetsMatch) {
+      fileToken = sheetsMatch[1];
+      fileType = "sheet";
+    } else if (baseMatch) {
+      fileToken = baseMatch[1];
+      fileType = "bitable";
+    }
+
+    if (!fileToken || !fileType) {
+      return null;
+    }
+
+    // Extract comment ID from hash if present
+    // Format: #comment-ABC123 or #comment-ABC123-reply-XYZ
+    const hash = parsed.hash;
+    let commentId: string | undefined;
+    let replyId: string | undefined;
+
+    if (hash) {
+      const commentMatch = hash.match(/comment-([A-Za-z0-9]+)/);
+      if (commentMatch) {
+        commentId = commentMatch[1];
+      }
+      const replyMatch = hash.match(/reply-([A-Za-z0-9]+)/);
+      if (replyMatch) {
+        replyId = replyMatch[1];
+      }
+    }
+
+    return {
+      fileToken,
+      fileType,
+      commentId,
+      replyId,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract document URLs from message text.
+ */
+export function extractDocUrls(text: string): DocCommentInfo[] {
+  // Support both feishu.cn and larksuite.com domains
+  const urlPattern =
+    /https?:\/\/[^\s<>"{}|\\^`[\]]+\.(?:feishu\.cn|larksuite\.com)\/(?:docx|docs|sheets|base)\/[A-Za-z0-9]+[^\s<>"{}|\\^`[\]]*/gi;
+  const matches = text.match(urlPattern) || [];
+  const results: DocCommentInfo[] = [];
+
+  for (const url of matches) {
+    const info = parseDocUrl(url);
+    if (info) {
+      results.push(info);
+    }
+  }
+
+  return results;
+}
+
+// ============ Comment API ============
+
+/**
+ * List comments on a document.
+ */
+export async function listDocComments(
+  client: Lark.Client,
+  fileToken: string,
+  fileType: string,
+): Promise<Comment[]> {
+  const res = await client.drive.fileComment.list({
+    path: {
+      file_token: fileToken,
+    },
+    params: {
+      file_type: fileType,
+    },
+  });
+
+  if (res.code !== 0) {
+    throw new Error(`Failed to list comments: ${res.msg}`);
+  }
+
+  return (res.data?.items || []) as Comment[];
+}
+
+/**
+ * Get a specific comment by ID.
+ */
+export async function getDocComment(
+  client: Lark.Client,
+  fileToken: string,
+  fileType: string,
+  commentId: string,
+): Promise<Comment | null> {
+  const res = await client.drive.fileComment.get({
+    path: {
+      file_token: fileToken,
+      comment_id: commentId,
+    },
+    params: {
+      file_type: fileType,
+    },
+  });
+
+  if (res.code !== 0) {
+    if (res.code === 1300002) {
+      // Comment not found
+      return null;
+    }
+    throw new Error(`Failed to get comment: ${res.msg}`);
+  }
+
+  return res.data as Comment | null;
+}
+
+/**
+ * Reply to a document comment.
+ */
+export async function replyToDocComment(
+  client: Lark.Client,
+  fileToken: string,
+  fileType: string,
+  commentId: string,
+  content: string,
+): Promise<CommentReply> {
+  const res = await client.drive.fileCommentReply.create({
+    path: {
+      file_token: fileToken,
+      comment_id: commentId,
+    },
+    params: {
+      file_type: fileType,
+    },
+    data: {
+      content: {
+        elements: [
+          {
+            type: "text_run",
+            text_run: {
+              text: content,
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  if (res.code !== 0) {
+    throw new Error(`Failed to reply to comment: ${res.msg}`);
+  }
+
+  return res.data as CommentReply;
+}
+
+/**
+ * Create a new comment on a document (not a reply).
+ */
+export async function createDocComment(
+  client: Lark.Client,
+  fileToken: string,
+  fileType: string,
+  content: string,
+): Promise<Comment> {
+  const res = await client.drive.fileComment.create({
+    path: {
+      file_token: fileToken,
+    },
+    params: {
+      file_type: fileType,
+    },
+    data: {
+      content: {
+        elements: [
+          {
+            type: "text_run",
+            text_run: {
+              text: content,
+            },
+          },
+        ],
+      },
+    },
+  });
+
+  if (res.code !== 0) {
+    throw new Error(`Failed to create comment: ${res.msg}`);
+  }
+
+  return res.data as Comment;
+}

--- a/extensions/feishu/src/doc-schema.ts
+++ b/extensions/feishu/src/doc-schema.ts
@@ -167,6 +167,23 @@ export const FeishuDocSchema = Type.Union([
     ),
     filename: Type.Optional(Type.String({ description: "Optional filename override" })),
   }),
+  // Download a file attachment from a Feishu message
+  Type.Object({
+    action: Type.Literal("download_message_file"),
+    message_id: Type.String({
+      description:
+        "Feishu message ID containing the file (starts with 'om_'). Visible in the message context or inbound metadata.",
+    }),
+    file_key: Type.String({
+      description:
+        "File key from the message body (file_key field). Use list_blocks or read the quoted message body to obtain it.",
+    }),
+    file_type: Type.Optional(
+      Type.Union([Type.Literal("file"), Type.Literal("image")], {
+        description: "Resource type: 'file' (default) or 'image'.",
+      }),
+    ),
+  }),
   // Text color / style
   Type.Object({
     action: Type.Literal("color_text"),

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -17,6 +17,7 @@ import {
   deleteTableColumns,
   mergeTableCells,
 } from "./docx-table-ops.js";
+import { downloadMessageResourceFeishu } from "./media.js";
 import { getFeishuRuntime } from "./runtime.js";
 import {
   createFeishuToolClient,
@@ -1376,6 +1377,29 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
                       p.filename,
                     ),
                   );
+                case "download_message_file": {
+                  const runtime = getFeishuRuntime();
+                  const result = await downloadMessageResourceFeishu({
+                    cfg: api.config,
+                    messageId: p.message_id,
+                    fileKey: p.file_key,
+                    type: p.file_type === "image" ? "image" : "file",
+                    accountId: defaultAccountId,
+                  });
+                  const mimeType = await runtime.media.detectMime({ buffer: result.buffer });
+                  const saved = await runtime.channel.media.saveMediaBuffer(
+                    result.buffer,
+                    mimeType,
+                    "inbound",
+                    getMediaMaxBytes(p, defaultAccountId),
+                  );
+                  return json({
+                    success: true,
+                    file_path: saved.path,
+                    content_type: saved.contentType,
+                    size_bytes: result.buffer.length,
+                  });
+                }
                 case "color_text":
                   return json(await updateColorText(client, p.doc_token, p.block_id, p.content));
                 case "insert_table_row":


### PR DESCRIPTION
## Summary

Add support for Feishu document comment detection and reply functionality.

When a user @mentions the bot in a document comment, the bot can detect this from the IM message and reply directly to the comment.

## Changes

### Commit 1: URL Parsing
- Add `doc-comment.ts` with URL parsing for doc/docx/sheet/bitable URLs
- Support extracting document token, comment ID, and reply ID from URLs
- Support both feishu.cn and larksuite.com domains

### Commit 2: Agent Tool
- Add `feishu_doc_comment` tool for agents
- Actions: `list_comments`, `get_comment`, `reply_comment`, `create_comment`
- Use HTTP helper for direct API calls (SDK lacks comment reply support)
- Register tool when drive tools are enabled

## TODO

- [x] URL parsing for Feishu document links
- [x] Add tool for agent to reply to document comments
- [ ] Integrate with bot message handler to detect @mention from document comments
- [ ] Add tests for API calls (mocked)

## Testing

```bash
pnpm test extensions/feishu/src/doc-comment.test.ts
```

All 12 tests passing.
