### PR TITLE
fix(feishu): skip debounce for group @Bot command messages

### DIFF
--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -480,7 +480,10 @@ function registerEventHandlers(
       if (!text) {
         return false;
       }
-      return !core.channel.text.hasControlCommand(text, cfg);
+      // Strip <at> mention tags before command detection so group messages like
+      // "@Bot /help" are not incorrectly buffered by the debouncer.
+      const stripped = text.replace(/<at user_id="[^"]*">[^<]*<\/at>/g, "").trim();
+      return !core.channel.text.hasControlCommand(stripped, cfg);
     },
     onFlush: async (entries) => {
       const last = entries.at(-1);

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -703,4 +703,52 @@ describe("Feishu inbound debounce regressions", () => {
 
     expect(handleFeishuMessageMock).toHaveBeenCalledTimes(1);
   });
+
+  it("does not debounce group @Bot /help command message", async () => {
+    vi.spyOn(dedup, "tryRecordMessage").mockReturnValue(true);
+    vi.spyOn(dedup, "tryRecordMessagePersistent").mockResolvedValue(true);
+    vi.spyOn(dedup, "hasRecordedMessage").mockReturnValue(false);
+    vi.spyOn(dedup, "hasRecordedMessagePersistent").mockResolvedValue(false);
+    const onMessage = await setupDebounceMonitor();
+
+    await onMessage(
+      createTextEvent({
+        messageId: "om_cmd",
+        text: "@_user_1 /help",
+        mentions: [{ key: "@_user_1", id: { open_id: "ou_bot" }, name: "Bot" }],
+      }),
+    );
+    // Drain the fire-and-forget microtask chain (enqueue → onFlush → dispatchFeishuMessage
+    // → chat queue → handleFeishuMessage).  Multiple turns are needed because each async
+    // hop re-schedules as a microtask.
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+
+    // Command should be dispatched immediately without waiting for the debounce window.
+    expect(handleFeishuMessageMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("still debounces group @Bot conversational message", async () => {
+    vi.spyOn(dedup, "tryRecordMessage").mockReturnValue(true);
+    vi.spyOn(dedup, "tryRecordMessagePersistent").mockResolvedValue(true);
+    vi.spyOn(dedup, "hasRecordedMessage").mockReturnValue(false);
+    vi.spyOn(dedup, "hasRecordedMessagePersistent").mockResolvedValue(false);
+    const onMessage = await setupDebounceMonitor();
+
+    await onMessage(
+      createTextEvent({
+        messageId: "om_chat",
+        text: "@_user_1 hello",
+        mentions: [{ key: "@_user_1", id: { open_id: "ou_bot" }, name: "Bot" }],
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Conversational message should be buffered; not dispatched yet.
+    expect(handleFeishuMessageMock).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(25);
+
+    // After debounce window, dispatch should have occurred.
+    expect(handleFeishuMessageMock).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
fix(feishu): skip debounce for group @Bot command messages

## Summary

- **Problem:** In Feishu group chats, `@Bot /help` (and similar slash commands) were incorrectly buffered by the inbound debouncer. `parseFeishuMessageEvent` normalizes group mentions into `<at user_id="ou_bot">Bot</at> /help` — a string that doesn't start with `/`, so `hasControlCommand` returned `false` and `shouldDebounce` returned `true`, causing commands to be delayed or merged with subsequent messages.
- **Why it matters:** With `messages.inbound.debounceMs > 0`, users sending `@Bot /help` in a group got delayed or corrupted command execution.
- **What changed:** `shouldDebounce` now strips `<at>` mention tags before calling `hasControlCommand`, matching the same pattern Feishu's channel dock already registers as `stripPatterns`.
- **What did NOT change:** `resolveDebounceText` / `onFlush` are untouched; non-bot `<at>` tags for other users in merged burst text are still preserved.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related #31548

## User-visible / Behavior Changes

Group `@Bot /command` messages are now dispatched immediately instead of being held in the debounce buffer. Conversational group messages (e.g. `@Bot hello`) are still debounced as before.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Channel: Feishu group chat
- Config: `messages.inbound.byChannel.feishu` > 0

### Steps

1. Add bot to a Feishu group
2. Send `@Bot /help`
3. Observe whether the command fires immediately or waits for the debounce window

### Expected

- Command dispatched immediately

### Actual (before fix)

- Command buffered until debounce window expires; may be merged with subsequent messages

## Evidence

- [x] Failing test/log before + passing after

New regression tests in `monitor.reaction.test.ts`:
- `does not debounce group @Bot /help command message` — verifies immediate dispatch
- `still debounces group @Bot conversational message` — verifies normal messages still buffered

## Human Verification (required)

- Verified scenarios: unit tests cover command vs. conversational path
- Edge cases checked: `@Alice @Bot /help` (multiple mentions) — all `<at>` tags stripped → `/help` detected correctly
- What you did **not** verify: live Feishu group with real debounce window

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert: `git revert c07068bc42`
- Files to restore: `extensions/feishu/src/monitor.account.ts`
- Bad symptoms: group slash commands fire multiple times (if debounce was suppressing duplicates)

## Risks and Mitigations

- Risk: `@Alice /help` (mentioning another user, not the bot) — previously debounced, now dispatched immediately
  - Mitigation: With `requireMention=true` (default), bot still ignores messages where `mentionedBot=false`; no functional regression
