### PR TITLE
Config: accept agents.list[].mcp server definitions

### DIFF
--- a/src/agents/pi-embedded-runner/skills-runtime.integration.test.ts
+++ b/src/agents/pi-embedded-runner/skills-runtime.integration.test.ts
@@ -45,7 +45,11 @@ async function setupBundledDiffsPlugin() {
 }
 
 afterEach(async () => {
-  process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = originalBundledDir;
+  if (originalBundledDir === undefined) {
+    delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
+  } else {
+    process.env.OPENCLAW_BUNDLED_PLUGINS_DIR = originalBundledDir;
+  }
   clearPluginManifestRegistryCache();
   await Promise.all(
     tempDirs.splice(0, tempDirs.length).map((dir) => fs.rm(dir, { recursive: true, force: true })),

--- a/src/config/config-misc.test.ts
+++ b/src/config/config-misc.test.ts
@@ -31,6 +31,61 @@ describe("$schema key in config (#14998)", () => {
   });
 });
 
+describe("agents.list[].mcp", () => {
+  it("accepts per-agent MCP server definitions", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [
+          {
+            id: "main",
+            mcp: {
+              servers: [
+                {
+                  name: "minimax",
+                  command: "uvx",
+                  args: ["minimax-coding-plan-mcp", "-y"],
+                  env: {
+                    MINIMAX_API_KEY: "test-key",
+                    MINIMAX_API_HOST: "https://api.minimax.io",
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects invalid MCP server entries", () => {
+    const res = validateConfigObject({
+      agents: {
+        list: [
+          {
+            id: "main",
+            mcp: {
+              servers: [
+                {
+                  name: "minimax",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((issue) => issue.path === "agents.list.0.mcp.servers.0.command")).toBe(
+        true,
+      );
+    }
+  });
+});
+
 describe("ui.seamColor", () => {
   it("accepts hex colors", () => {
     const res = validateConfigObject({ ui: { seamColor: "#FF4500" } });

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -5,6 +5,17 @@ import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
 
+export type AgentMcpServerConfig = {
+  name: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+};
+
+export type AgentMcpConfig = {
+  servers?: AgentMcpServerConfig[];
+};
+
 export type AgentConfig = {
   id: string;
   default?: boolean;
@@ -21,14 +32,7 @@ export type AgentConfig = {
   heartbeat?: AgentDefaultsConfig["heartbeat"];
   identity?: IdentityConfig;
   groupChat?: GroupChatConfig;
-  mcp?: {
-    servers?: Array<{
-      name: string;
-      command: string;
-      args?: string[];
-      env?: Record<string, string>;
-    }>;
-  };
+  mcp?: AgentMcpConfig;
   subagents?: {
     /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
     allowAgents?: string[];

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -21,6 +21,14 @@ export type AgentConfig = {
   heartbeat?: AgentDefaultsConfig["heartbeat"];
   identity?: IdentityConfig;
   groupChat?: GroupChatConfig;
+  mcp?: {
+    servers?: Array<{
+      name: string;
+      command: string;
+      args?: string[];
+      env?: Record<string, string>;
+    }>;
+  };
   subagents?: {
     /** Allow spawning sub-agents under other agent ids. Use "*" to allow any. */
     allowAgents?: string[];

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -692,6 +692,7 @@ const AgentMcpSchema = z
   })
   .strict()
   .optional();
+
 export { AgentModelSchema };
 export const AgentEntrySchema = z
   .object({

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -676,6 +676,22 @@ export const MemorySearchSchema = z
   })
   .strict()
   .optional();
+
+const AgentMcpServerSchema = z
+  .object({
+    name: z.string(),
+    command: z.string(),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string(), z.string()).optional(),
+  })
+  .strict();
+
+const AgentMcpSchema = z
+  .object({
+    servers: z.array(AgentMcpServerSchema).optional(),
+  })
+  .strict()
+  .optional();
 export { AgentModelSchema };
 export const AgentEntrySchema = z
   .object({
@@ -691,6 +707,7 @@ export const AgentEntrySchema = z
     heartbeat: HeartbeatSchema,
     identity: IdentitySchema,
     groupChat: GroupChatSchema,
+    mcp: AgentMcpSchema,
     subagents: z
       .object({
         allowAgents: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw.json` rejects `agents.list[].mcp` with `Unrecognized key`.
- Why it matters: users cannot keep MCP server definitions in per-agent config blocks.
- What changed: added `agents.list[].mcp` schema (`servers[].name/command/args/env`) and matching TypeScript type.
- What changed: added regression tests for valid and invalid `agents.list[].mcp` payloads.
- What did NOT change (scope boundary): no MCP runtime wiring/execution behavior was added in this PR.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32583
- Related #4834

## User-visible / Behavior Changes

`openclaw.json` now accepts `agents.list[].mcp.servers` in config validation.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): config validation path
- Relevant config (redacted):
  - `agents.list[0].mcp.servers[0] = { name, command, args, env }`

### Steps

1. Add an `mcp` block under `agents.list[0]` in config.
2. Run config validation before this patch.
3. Apply this patch and rerun validation.

### Expected

- Config validates when `servers[].command` is present.

### Actual

- Validation now passes for valid server entries, and correctly errors when required fields are missing.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test src/config/config-misc.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - valid `agents.list[].mcp.servers[]` entry passes schema validation
  - invalid server entry (missing `command`) fails at expected path
- Edge cases checked:
  - optional `args` and `env` remain optional
- What you did **not** verify:
  - MCP runtime execution/transport behavior

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR commit
- Files/config to restore:
  - `src/config/zod-schema.agent-runtime.ts`
  - `src/config/types.agents.ts`
  - `src/config/config-misc.test.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected `agents.list[].mcp.*` validation acceptance/rejection

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: config accepts MCP shape but runtime behavior is unchanged.
  - Mitigation: explicitly documented scope boundary in this PR.
