### PR TITLE
fix: harden heartbeat polling and delivery reliability

### DIFF
--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -56,7 +56,11 @@ export {
   normalizeTextForComparison,
 } from "./pi-embedded-helpers/messaging-dedupe.js";
 
-export { pickFallbackThinkingLevel } from "./pi-embedded-helpers/thinking.js";
+export {
+  pickFallbackThinkingLevel,
+  pickFallbackThinkingLevelWithCache,
+  resetFallbackThinkingCacheForTests,
+} from "./pi-embedded-helpers/thinking.js";
 
 export {
   mergeConsecutiveUserTurns,

--- a/src/agents/pi-embedded-helpers/thinking.test.ts
+++ b/src/agents/pi-embedded-helpers/thinking.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from "vitest";
-import { pickFallbackThinkingLevel } from "./thinking.js";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  pickFallbackThinkingLevel,
+  pickFallbackThinkingLevelWithCache,
+  resetFallbackThinkingCacheForTests,
+} from "./thinking.js";
+
+beforeEach(() => {
+  resetFallbackThinkingCacheForTests();
+});
 
 describe("pickFallbackThinkingLevel", () => {
   it("returns undefined for empty message", () => {
@@ -56,5 +64,67 @@ describe("pickFallbackThinkingLevel", () => {
       attempted: new Set(),
     });
     expect(result).toBeUndefined();
+  });
+});
+
+describe("pickFallbackThinkingLevelWithCache", () => {
+  it("stores and reuses parsed fallback per provider/model", () => {
+    const first = pickFallbackThinkingLevelWithCache({
+      message: 'Supported values are: "high", "medium"',
+      attempted: new Set(),
+      provider: "openai-codex",
+      model: "gpt-5.2",
+      nowMs: 1,
+    });
+    expect(first).toEqual({ level: "high", source: "parsed" });
+
+    const second = pickFallbackThinkingLevelWithCache({
+      message: "think value low is not supported",
+      attempted: new Set(),
+      provider: "openai-codex",
+      model: "gpt-5.2",
+      nowMs: 2,
+    });
+    expect(second).toEqual({ level: "high", source: "cache" });
+  });
+
+  it("does not reuse cached fallback when already attempted", () => {
+    pickFallbackThinkingLevelWithCache({
+      message: 'Supported values are: "high", "medium"',
+      attempted: new Set(),
+      provider: "openai-codex",
+      model: "gpt-5.2",
+      nowMs: 1,
+    });
+
+    const result = pickFallbackThinkingLevelWithCache({
+      message: "think value low is not supported",
+      attempted: new Set(["high"]),
+      provider: "openai-codex",
+      model: "gpt-5.2",
+      nowMs: 2,
+    });
+
+    expect(result).toEqual({ level: "off", source: "parsed" });
+  });
+
+  it("isolates cache by provider/model", () => {
+    pickFallbackThinkingLevelWithCache({
+      message: 'Supported values are: "high", "medium"',
+      attempted: new Set(),
+      provider: "openai-codex",
+      model: "gpt-5.2",
+      nowMs: 1,
+    });
+
+    const otherModel = pickFallbackThinkingLevelWithCache({
+      message: "think value low is not supported",
+      attempted: new Set(),
+      provider: "openai-codex",
+      model: "gpt-5.3",
+      nowMs: 2,
+    });
+
+    expect(otherModel).toEqual({ level: "off", source: "parsed" });
   });
 });

--- a/src/agents/pi-embedded-helpers/thinking.ts
+++ b/src/agents/pi-embedded-helpers/thinking.ts
@@ -1,5 +1,15 @@
 import { normalizeThinkLevel, type ThinkLevel } from "../../auto-reply/thinking.js";
 
+const FALLBACK_THINKING_CACHE_TTL_MS = 6 * 60 * 60_000;
+const FALLBACK_THINKING_CACHE_MAX = 256;
+
+type CachedFallbackThinking = {
+  level: ThinkLevel;
+  updatedAt: number;
+};
+
+const fallbackThinkingCache = new Map<string, CachedFallbackThinking>();
+
 function extractSupportedValues(raw: string): string[] {
   const match =
     raw.match(/supported values are:\s*([^\n.]+)/i) ?? raw.match(/supported values:\s*([^\n.]+)/i);
@@ -20,6 +30,13 @@ function extractSupportedValues(raw: string): string[] {
 }
 
 export function pickFallbackThinkingLevel(params: {
+  message?: string;
+  attempted: Set<ThinkLevel>;
+}): ThinkLevel | undefined {
+  return pickFallbackThinkingLevelFromMessage(params);
+}
+
+function pickFallbackThinkingLevelFromMessage(params: {
   message?: string;
   attempted: Set<ThinkLevel>;
 }): ThinkLevel | undefined {
@@ -50,4 +67,80 @@ export function pickFallbackThinkingLevel(params: {
     return normalized;
   }
   return undefined;
+}
+
+function buildFallbackThinkingCacheKey(params: {
+  provider?: string;
+  model?: string;
+}): string | null {
+  const provider = params.provider?.trim().toLowerCase();
+  const model = params.model?.trim().toLowerCase();
+  if (!provider || !model) {
+    return null;
+  }
+  return `${provider}/${model}`;
+}
+
+function isUnsupportedThinkingMessage(raw: string): boolean {
+  return /supported values|not supported/i.test(raw);
+}
+
+function pruneFallbackThinkingCache(now: number) {
+  const cutoff = now - FALLBACK_THINKING_CACHE_TTL_MS;
+  for (const [key, entry] of fallbackThinkingCache) {
+    if (entry.updatedAt < cutoff) {
+      fallbackThinkingCache.delete(key);
+    }
+  }
+  while (fallbackThinkingCache.size > FALLBACK_THINKING_CACHE_MAX) {
+    const oldestKey = fallbackThinkingCache.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    fallbackThinkingCache.delete(oldestKey);
+  }
+}
+
+export function pickFallbackThinkingLevelWithCache(params: {
+  message?: string;
+  attempted: Set<ThinkLevel>;
+  provider?: string;
+  model?: string;
+  nowMs?: number;
+}): { level?: ThinkLevel; source?: "cache" | "parsed" } {
+  const raw = params.message?.trim();
+  if (!raw || !isUnsupportedThinkingMessage(raw)) {
+    return {};
+  }
+  const now = params.nowMs ?? Date.now();
+  const cacheKey = buildFallbackThinkingCacheKey(params);
+  if (cacheKey) {
+    pruneFallbackThinkingCache(now);
+    const cached = fallbackThinkingCache.get(cacheKey);
+    if (cached && now - cached.updatedAt < FALLBACK_THINKING_CACHE_TTL_MS) {
+      if (!params.attempted.has(cached.level)) {
+        fallbackThinkingCache.delete(cacheKey);
+        fallbackThinkingCache.set(cacheKey, { ...cached, updatedAt: now });
+        return { level: cached.level, source: "cache" };
+      }
+    }
+  }
+
+  const parsed = pickFallbackThinkingLevelFromMessage({
+    message: raw,
+    attempted: params.attempted,
+  });
+  if (!parsed) {
+    return {};
+  }
+  if (cacheKey) {
+    fallbackThinkingCache.delete(cacheKey);
+    fallbackThinkingCache.set(cacheKey, { level: parsed, updatedAt: now });
+    pruneFallbackThinkingCache(now);
+  }
+  return { level: parsed, source: "parsed" };
+}
+
+export function resetFallbackThinkingCacheForTests() {
+  fallbackThinkingCache.clear();
 }

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -45,7 +45,7 @@ import {
   parseImageDimensionError,
   isRateLimitAssistantError,
   isTimeoutErrorMessage,
-  pickFallbackThinkingLevel,
+  pickFallbackThinkingLevelWithCache,
   type FailoverReason,
 } from "../pi-embedded-helpers.js";
 import { derivePromptTokens, normalizeUsage, type UsageLike } from "../usage.js";
@@ -1062,15 +1062,23 @@ export async function runEmbeddedPiAgent(
             ) {
               continue;
             }
-            const fallbackThinking = pickFallbackThinkingLevel({
+            const fallbackThinking = pickFallbackThinkingLevelWithCache({
               message: errorText,
               attempted: attemptedThinking,
+              provider,
+              model: modelId,
             });
-            if (fallbackThinking) {
-              log.warn(
-                `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
-              );
-              thinkLevel = fallbackThinking;
+            if (fallbackThinking.level) {
+              if (fallbackThinking.source === "parsed") {
+                log.warn(
+                  `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking.level}`,
+                );
+              } else {
+                log.debug(
+                  `unsupported thinking level for ${provider}/${modelId}; reusing cached fallback ${fallbackThinking.level}`,
+                );
+              }
+              thinkLevel = fallbackThinking.level;
               continue;
             }
             // FIX: Throw FailoverError for prompt errors when fallbacks configured
@@ -1087,15 +1095,23 @@ export async function runEmbeddedPiAgent(
             throw promptError;
           }
 
-          const fallbackThinking = pickFallbackThinkingLevel({
+          const fallbackThinking = pickFallbackThinkingLevelWithCache({
             message: lastAssistant?.errorMessage,
             attempted: attemptedThinking,
+            provider,
+            model: modelId,
           });
-          if (fallbackThinking && !aborted) {
-            log.warn(
-              `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking}`,
-            );
-            thinkLevel = fallbackThinking;
+          if (fallbackThinking.level && !aborted) {
+            if (fallbackThinking.source === "parsed") {
+              log.warn(
+                `unsupported thinking level for ${provider}/${modelId}; retrying with ${fallbackThinking.level}`,
+              );
+            } else {
+              log.debug(
+                `unsupported thinking level for ${provider}/${modelId}; reusing cached fallback ${fallbackThinking.level}`,
+              );
+            }
+            thinkLevel = fallbackThinking.level;
             continue;
           }
 

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -262,4 +262,15 @@ Current time: 2026-03-03 12:00 (Asia/Taipei)`;
       undefined,
     );
   });
+
+  it("accepts short legacy heartbeat poll command text", () => {
+    expect(isHeartbeatPollText("heartbeat poll")).toBe(true);
+    expect(isHeartbeatPollText("heartbeat wake")).toBe(true);
+  });
+
+  it("does not classify incidental heartbeat poll mentions in normal sentences", () => {
+    const text = "I want to configure the heartbeat poll interval for this room";
+    expect(isHeartbeatPollText(text)).toBe(false);
+    expect(normalizeHeartbeatPollForDedupe(text)).toBe(undefined);
+  });
 });

--- a/src/auto-reply/heartbeat.test.ts
+++ b/src/auto-reply/heartbeat.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   DEFAULT_HEARTBEAT_ACK_MAX_CHARS,
   isHeartbeatContentEffectivelyEmpty,
+  isHeartbeatPollText,
+  normalizeHeartbeatPollForDedupe,
   stripHeartbeatToken,
 } from "./heartbeat.js";
 import { HEARTBEAT_TOKEN } from "./tokens.js";
@@ -235,5 +237,29 @@ Check the server logs
 ### Subsection
 `;
     expect(isHeartbeatContentEffectivelyEmpty(content)).toBe(true);
+  });
+});
+
+describe("heartbeat poll helpers", () => {
+  it("detects direct heartbeat prompt text", () => {
+    const raw =
+      "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.";
+    expect(isHeartbeatPollText(raw)).toBe(true);
+  });
+
+  it("detects heartbeat prompt with trailing current time line", () => {
+    const raw = `Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.
+Current time: 2026-03-03 12:00 (Asia/Taipei)`;
+    expect(isHeartbeatPollText(raw)).toBe(true);
+    expect(normalizeHeartbeatPollForDedupe(raw)).toBe(
+      "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.",
+    );
+  });
+
+  it("does not classify normal user text as heartbeat poll", () => {
+    expect(isHeartbeatPollText("please check heartbeat status in this channel")).toBe(false);
+    expect(normalizeHeartbeatPollForDedupe("please check heartbeat status in this channel")).toBe(
+      undefined,
+    );
   });
 });

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -7,7 +7,9 @@ export const HEARTBEAT_PROMPT =
   "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.";
 export const DEFAULT_HEARTBEAT_EVERY = "30m";
 export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
-const HEARTBEAT_POLL_NOISE_RE = /\bheartbeat\s+(poll|wake)\b/i;
+// Legacy fallback for short "heartbeat poll"/"heartbeat wake" commands only.
+// Keep this strict so normal user sentences are not silently deduplicated.
+const HEARTBEAT_POLL_NOISE_RE = /^heartbeat\s+(poll|wake)\s*$/i;
 const CURRENT_TIME_LINE_RE = /^current time:/i;
 
 /**

--- a/src/auto-reply/heartbeat.ts
+++ b/src/auto-reply/heartbeat.ts
@@ -7,6 +7,8 @@ export const HEARTBEAT_PROMPT =
   "Read HEARTBEAT.md if it exists (workspace context). Follow it strictly. Do not infer or repeat old tasks from prior chats. If nothing needs attention, reply HEARTBEAT_OK.";
 export const DEFAULT_HEARTBEAT_EVERY = "30m";
 export const DEFAULT_HEARTBEAT_ACK_MAX_CHARS = 300;
+const HEARTBEAT_POLL_NOISE_RE = /\bheartbeat\s+(poll|wake)\b/i;
+const CURRENT_TIME_LINE_RE = /^current time:/i;
 
 /**
  * Check if HEARTBEAT.md content is "effectively empty" - meaning it has no actionable tasks.
@@ -55,6 +57,65 @@ export function isHeartbeatContentEffectivelyEmpty(content: string | undefined |
 export function resolveHeartbeatPrompt(raw?: string): string {
   const trimmed = typeof raw === "string" ? raw.trim() : "";
   return trimmed || HEARTBEAT_PROMPT;
+}
+
+function normalizeHeartbeatText(raw?: string): string {
+  if (typeof raw !== "string") {
+    return "";
+  }
+  return raw
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/\s+/g, " ").trim())
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+function stripTrailingCurrentTimeLine(raw: string): string {
+  if (!raw) {
+    return "";
+  }
+  const lines = raw.split("\n");
+  while (lines.length > 0) {
+    const last = lines.at(-1)?.trim() ?? "";
+    if (!CURRENT_TIME_LINE_RE.test(last)) {
+      break;
+    }
+    lines.pop();
+  }
+  return lines.join("\n").trim();
+}
+
+export function isHeartbeatPollText(raw?: string, opts?: { prompt?: string }): boolean {
+  const normalized = normalizeHeartbeatText(raw);
+  if (!normalized) {
+    return false;
+  }
+  const normalizedPrompt = normalizeHeartbeatText(resolveHeartbeatPrompt(opts?.prompt));
+  if (normalized === normalizedPrompt) {
+    return true;
+  }
+  if (stripTrailingCurrentTimeLine(normalized) === normalizedPrompt) {
+    return true;
+  }
+  return HEARTBEAT_POLL_NOISE_RE.test(normalized);
+}
+
+export function normalizeHeartbeatPollForDedupe(
+  raw?: string,
+  opts?: { prompt?: string },
+): string | undefined {
+  if (!isHeartbeatPollText(raw, opts)) {
+    return undefined;
+  }
+  const normalized = normalizeHeartbeatText(raw);
+  const stripped = stripTrailingCurrentTimeLine(normalized);
+  const normalizedPrompt = normalizeHeartbeatText(resolveHeartbeatPrompt(opts?.prompt));
+  if (stripped === normalizedPrompt) {
+    return normalizedPrompt;
+  }
+  return stripped || normalized;
 }
 
 export type StripHeartbeatMode = "heartbeat" | "message";

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1557,6 +1557,48 @@ describe("dispatchReplyFromConfig", () => {
     expect(replyResolver).toHaveBeenCalledTimes(2);
   });
 
+  it("does not dedupe heartbeat polls across different senders in the same session", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const replyResolver = vi.fn(async () => ({ text: "hi" }) as ReplyPayload);
+
+    const firstCtx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:group:12345",
+      SessionKey: "agent:main:main",
+      From: "telegram:user:111",
+      MessageSid: "msg-1",
+      CommandBody: `${HEARTBEAT_PROMPT}\nCurrent time: 2026-03-03 12:00 (Asia/Taipei)`,
+    });
+    const secondCtx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:group:12345",
+      SessionKey: "agent:main:main",
+      From: "telegram:user:222",
+      MessageSid: "msg-2",
+      CommandBody: `${HEARTBEAT_PROMPT}\nCurrent time: 2026-03-03 12:01 (Asia/Taipei)`,
+    });
+
+    await dispatchReplyFromConfig({
+      ctx: firstCtx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+    await dispatchReplyFromConfig({
+      ctx: secondCtx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(2);
+  });
+
   it("emits message_received hook with originating channel metadata", async () => {
     setNoAbort();
     hookMocks.runner.hasHooks.mockReturnValue(true);

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -3,6 +3,7 @@ import { AcpRuntimeError } from "../../acp/runtime/errors.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionBindingRecord } from "../../infra/outbound/session-binding-service.js";
 import { createInternalHookEventPayload } from "../../test-utils/internal-hook-event-payload.js";
+import { HEARTBEAT_PROMPT } from "../heartbeat.js";
 import type { MsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import type { ReplyDispatcher } from "./reply-dispatcher.js";
@@ -1418,6 +1419,86 @@ describe("dispatchReplyFromConfig", () => {
     });
 
     expect(replyResolver).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates heartbeat poll content even when MessageSid changes", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const replyResolver = vi.fn(async () => ({ text: "hi" }) as ReplyPayload);
+
+    const firstCtx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:12345",
+      SessionKey: "agent:main:main",
+      MessageSid: "msg-1",
+      CommandBody: `${HEARTBEAT_PROMPT}\nCurrent time: 2026-03-03 12:00 (Asia/Taipei)`,
+    });
+    const secondCtx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:12345",
+      SessionKey: "agent:main:main",
+      MessageSid: "msg-2",
+      CommandBody: `${HEARTBEAT_PROMPT}\nCurrent time: 2026-03-03 12:01 (Asia/Taipei)`,
+    });
+
+    await dispatchReplyFromConfig({
+      ctx: firstCtx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+    await dispatchReplyFromConfig({
+      ctx: secondCtx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dedupe non-heartbeat content when MessageSid differs", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const replyResolver = vi.fn(async () => ({ text: "hi" }) as ReplyPayload);
+
+    const firstCtx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:12345",
+      SessionKey: "agent:main:main",
+      MessageSid: "msg-1",
+      CommandBody: "daily summary please",
+    });
+    const secondCtx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:12345",
+      SessionKey: "agent:main:main",
+      MessageSid: "msg-2",
+      CommandBody: "daily summary please",
+    });
+
+    await dispatchReplyFromConfig({
+      ctx: firstCtx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+    await dispatchReplyFromConfig({
+      ctx: secondCtx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(2);
   });
 
   it("emits message_received hook with originating channel metadata", async () => {

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -1461,6 +1461,62 @@ describe("dispatchReplyFromConfig", () => {
     expect(replyResolver).toHaveBeenCalledTimes(1);
   });
 
+  it("deduplicates heartbeat polls using the resolved per-agent heartbeat prompt", async () => {
+    setNoAbort();
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          heartbeat: {
+            prompt: "default heartbeat prompt",
+          },
+        },
+        list: [
+          {
+            id: "ops",
+            heartbeat: {
+              prompt: "ops heartbeat prompt",
+            },
+          },
+        ],
+      },
+    };
+    const replyResolver = vi.fn(async () => ({ text: "hi" }) as ReplyPayload);
+
+    const firstCtx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:12345",
+      SessionKey: "agent:ops:main",
+      MessageSid: "msg-1",
+      CommandBody: "ops heartbeat prompt\nCurrent time: 2026-03-03 12:00 (Asia/Taipei)",
+    });
+    const secondCtx = buildTestCtx({
+      Provider: "telegram",
+      Surface: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:12345",
+      SessionKey: "agent:ops:main",
+      MessageSid: "msg-2",
+      CommandBody: "ops heartbeat prompt\nCurrent time: 2026-03-03 12:01 (Asia/Taipei)",
+    });
+
+    await dispatchReplyFromConfig({
+      ctx: firstCtx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+    await dispatchReplyFromConfig({
+      ctx: secondCtx,
+      cfg,
+      dispatcher: createDispatcher(),
+      replyResolver,
+    });
+
+    expect(replyResolver).toHaveBeenCalledTimes(1);
+  });
+
   it("does not dedupe non-heartbeat content when MessageSid differs", async () => {
     setNoAbort();
     const cfg = emptyConfig;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -159,7 +159,7 @@ export async function dispatchReplyFromConfig(params: {
     });
   };
 
-  if (shouldSkipDuplicateInbound(ctx)) {
+  if (shouldSkipDuplicateInbound(ctx, { config: cfg })) {
     recordProcessed("skipped", { reason: "duplicate" });
     return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
   }

--- a/src/auto-reply/reply/inbound-dedupe.ts
+++ b/src/auto-reply/reply/inbound-dedupe.ts
@@ -24,6 +24,9 @@ const normalizeProvider = (value?: string | null) => value?.trim().toLowerCase()
 const resolveInboundPeerId = (ctx: MsgContext) =>
   ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? ctx.SessionKey;
 
+const resolveInboundSenderId = (ctx: MsgContext) =>
+  ctx.SenderId ?? ctx.SenderE164 ?? ctx.SenderUsername ?? ctx.From ?? "";
+
 function resolveInboundTextBody(ctx: MsgContext): string {
   const candidates = [ctx.BodyForCommands, ctx.CommandBody, ctx.RawBody, ctx.Body];
   for (const candidate of candidates) {
@@ -103,6 +106,7 @@ export function shouldSkipDuplicateInbound(
   }
   const sessionKey = ctx.SessionKey?.trim() ?? "";
   const accountId = ctx.AccountId?.trim() ?? "";
+  const senderId = resolveInboundSenderId(ctx).trim();
   const threadId =
     ctx.MessageThreadId !== undefined && ctx.MessageThreadId !== null
       ? String(ctx.MessageThreadId)
@@ -115,7 +119,7 @@ export function shouldSkipDuplicateInbound(
     return false;
   }
 
-  const heartbeatKey = [provider, accountId, sessionKey, peerId, threadId, dedupeBody]
+  const heartbeatKey = [provider, accountId, sessionKey, peerId, senderId, threadId, dedupeBody]
     .filter(Boolean)
     .join("|");
   const heartbeatCache = opts?.heartbeatCache ?? heartbeatPollDedupeCache;

--- a/src/auto-reply/reply/inbound-dedupe.ts
+++ b/src/auto-reply/reply/inbound-dedupe.ts
@@ -1,19 +1,42 @@
+import type { OpenClawConfig } from "../../config/config.js";
 import { logVerbose, shouldLogVerbose } from "../../globals.js";
 import { createDedupeCache, type DedupeCache } from "../../infra/dedupe.js";
+import { normalizeHeartbeatPollForDedupe } from "../heartbeat.js";
 import type { MsgContext } from "../templating.js";
 
 const DEFAULT_INBOUND_DEDUPE_TTL_MS = 20 * 60_000;
 const DEFAULT_INBOUND_DEDUPE_MAX = 5000;
+const DEFAULT_HEARTBEAT_POLL_DEDUPE_TTL_MS = 60 * 60_000;
+const DEFAULT_HEARTBEAT_POLL_DEDUPE_MAX = 2000;
 
 const inboundDedupeCache = createDedupeCache({
   ttlMs: DEFAULT_INBOUND_DEDUPE_TTL_MS,
   maxSize: DEFAULT_INBOUND_DEDUPE_MAX,
+});
+const heartbeatPollDedupeCache = createDedupeCache({
+  ttlMs: DEFAULT_HEARTBEAT_POLL_DEDUPE_TTL_MS,
+  maxSize: DEFAULT_HEARTBEAT_POLL_DEDUPE_MAX,
 });
 
 const normalizeProvider = (value?: string | null) => value?.trim().toLowerCase() || "";
 
 const resolveInboundPeerId = (ctx: MsgContext) =>
   ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? ctx.SessionKey;
+
+function resolveInboundTextBody(ctx: MsgContext): string {
+  const candidates = [ctx.BodyForCommands, ctx.CommandBody, ctx.RawBody, ctx.Body];
+  for (const candidate of candidates) {
+    if (typeof candidate !== "string") {
+      continue;
+    }
+    const trimmed = candidate.trim();
+    if (!trimmed) {
+      continue;
+    }
+    return trimmed;
+  }
+  return "";
+}
 
 export function buildInboundDedupeKey(ctx: MsgContext): string | null {
   const provider = normalizeProvider(ctx.OriginatingChannel ?? ctx.Provider ?? ctx.Surface);
@@ -36,20 +59,56 @@ export function buildInboundDedupeKey(ctx: MsgContext): string | null {
 
 export function shouldSkipDuplicateInbound(
   ctx: MsgContext,
-  opts?: { cache?: DedupeCache; now?: number },
+  opts?: {
+    cache?: DedupeCache;
+    heartbeatCache?: DedupeCache;
+    config?: OpenClawConfig;
+    now?: number;
+  },
 ): boolean {
-  const key = buildInboundDedupeKey(ctx);
-  if (!key) {
+  const sidKey = buildInboundDedupeKey(ctx);
+  const cache = opts?.cache ?? inboundDedupeCache;
+  if (sidKey) {
+    const skipped = cache.check(sidKey, opts?.now);
+    if (skipped && shouldLogVerbose()) {
+      logVerbose(`inbound dedupe: skipped ${sidKey}`);
+    }
+    if (skipped) {
+      return true;
+    }
+  }
+
+  const provider = normalizeProvider(ctx.OriginatingChannel ?? ctx.Provider ?? ctx.Surface);
+  const peerId = resolveInboundPeerId(ctx);
+  if (!provider || !peerId) {
     return false;
   }
-  const cache = opts?.cache ?? inboundDedupeCache;
-  const skipped = cache.check(key, opts?.now);
-  if (skipped && shouldLogVerbose()) {
-    logVerbose(`inbound dedupe: skipped ${key}`);
+  const sessionKey = ctx.SessionKey?.trim() ?? "";
+  const accountId = ctx.AccountId?.trim() ?? "";
+  const threadId =
+    ctx.MessageThreadId !== undefined && ctx.MessageThreadId !== null
+      ? String(ctx.MessageThreadId)
+      : "";
+  const body = resolveInboundTextBody(ctx);
+  const dedupeBody = normalizeHeartbeatPollForDedupe(body, {
+    prompt: opts?.config?.agents?.defaults?.heartbeat?.prompt,
+  });
+  if (!dedupeBody) {
+    return false;
   }
-  return skipped;
+
+  const heartbeatKey = [provider, accountId, sessionKey, peerId, threadId, dedupeBody]
+    .filter(Boolean)
+    .join("|");
+  const heartbeatCache = opts?.heartbeatCache ?? heartbeatPollDedupeCache;
+  const skippedHeartbeat = heartbeatCache.check(heartbeatKey, opts?.now);
+  if (skippedHeartbeat && shouldLogVerbose()) {
+    logVerbose(`inbound dedupe: skipped heartbeat poll ${heartbeatKey}`);
+  }
+  return skippedHeartbeat;
 }
 
 export function resetInboundDedupe(): void {
   inboundDedupeCache.clear();
+  heartbeatPollDedupeCache.clear();
 }

--- a/src/auto-reply/reply/inbound-dedupe.ts
+++ b/src/auto-reply/reply/inbound-dedupe.ts
@@ -1,3 +1,4 @@
+import { resolveAgentConfig, resolveSessionAgentId } from "../../agents/agent-scope.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { logVerbose, shouldLogVerbose } from "../../globals.js";
 import { createDedupeCache, type DedupeCache } from "../../infra/dedupe.js";
@@ -36,6 +37,23 @@ function resolveInboundTextBody(ctx: MsgContext): string {
     return trimmed;
   }
   return "";
+}
+
+function resolveInboundHeartbeatPrompt(
+  ctx: MsgContext,
+  config?: OpenClawConfig,
+): string | undefined {
+  const defaultPrompt = config?.agents?.defaults?.heartbeat?.prompt;
+  if (!config) {
+    return defaultPrompt;
+  }
+  const sessionKey = ctx.SessionKey?.trim();
+  if (!sessionKey) {
+    return defaultPrompt;
+  }
+  const agentId = resolveSessionAgentId({ sessionKey, config });
+  const agentPrompt = resolveAgentConfig(config, agentId)?.heartbeat?.prompt;
+  return agentPrompt ?? defaultPrompt;
 }
 
 export function buildInboundDedupeKey(ctx: MsgContext): string | null {
@@ -91,7 +109,7 @@ export function shouldSkipDuplicateInbound(
       : "";
   const body = resolveInboundTextBody(ctx);
   const dedupeBody = normalizeHeartbeatPollForDedupe(body, {
-    prompt: opts?.config?.agents?.defaults?.heartbeat?.prompt,
+    prompt: resolveInboundHeartbeatPrompt(ctx, opts?.config),
   });
   if (!dedupeBody) {
     return false;

--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -208,4 +208,40 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
       }),
     );
   });
+
+  it("returns failed when readiness probe throws", async () => {
+    await withHeartbeatFixture(async ({ tmpDir, storePath, seedSession }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: {
+              every: "5m",
+              target: "whatsapp",
+            },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+      await seedSession(sessionKey, { lastChannel: "whatsapp", lastTo: "+1555" });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          getQueueSize: () => 0,
+          nowMs: () => 0,
+          webAuthExists: async () => {
+            throw new Error("readiness-boom");
+          },
+        },
+      });
+
+      expect(result.status).toBe("failed");
+      if (result.status === "failed") {
+        expect(result.reason).toContain("readiness-boom");
+      }
+    });
+  });
 });

--- a/src/infra/heartbeat-runner.model-override.test.ts
+++ b/src/infra/heartbeat-runner.model-override.test.ts
@@ -9,7 +9,7 @@ import { resolveAgentMainSessionKey, resolveMainSessionKey } from "../config/ses
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
-import { runHeartbeatOnce } from "./heartbeat-runner.js";
+import { resetHeartbeatDeliveryCircuitForTests, runHeartbeatOnce } from "./heartbeat-runner.js";
 import { seedSessionStore, withTempHeartbeatSandbox } from "./heartbeat-runner.test-utils.js";
 
 // Avoid pulling optional runtime deps during isolated runs.
@@ -45,6 +45,7 @@ async function withHeartbeatFixture(
 }
 
 beforeEach(() => {
+  resetHeartbeatDeliveryCircuitForTests();
   const runtime = createPluginRuntime();
   setTelegramRuntime(runtime);
   setWhatsAppRuntime(runtime);
@@ -94,6 +95,8 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
         deps: {
           getQueueSize: () => 0,
           nowMs: () => 0,
+          webAuthExists: async () => true,
+          hasActiveWebListener: () => true,
         },
       });
 
@@ -171,6 +174,8 @@ describe("runHeartbeatOnce – heartbeat model override", () => {
         deps: {
           getQueueSize: () => 0,
           nowMs: () => 0,
+          webAuthExists: async () => true,
+          hasActiveWebListener: () => true,
         },
       });
 

--- a/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
+++ b/src/infra/heartbeat-runner.respects-ackmaxchars-heartbeat-acks.test.ts
@@ -247,7 +247,7 @@ describe("runHeartbeatOnce ack handling", () => {
     });
   });
 
-  it("skips heartbeat LLM calls when visibility disables all output", async () => {
+  it("skips readiness and LLM calls when visibility disables all output", async () => {
     await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
       const cfg = createWhatsAppHeartbeatConfig({
         tmpDir,
@@ -262,14 +262,26 @@ describe("runHeartbeatOnce ack handling", () => {
       });
 
       const sendWhatsApp = createMessageSendSpy();
+      const webAuthExists = vi.fn(async () => {
+        throw new Error("should-not-run-readiness");
+      });
+      const hasActiveWebListener = vi.fn(() => {
+        throw new Error("should-not-run-listener-check");
+      });
 
       const result = await runHeartbeatOnce({
         cfg,
-        deps: makeWhatsAppDeps({ sendWhatsApp }),
+        deps: makeWhatsAppDeps({
+          sendWhatsApp,
+          webAuthExists,
+          hasActiveWebListener,
+        }),
       });
 
       expect(replySpy).not.toHaveBeenCalled();
       expect(sendWhatsApp).not.toHaveBeenCalled();
+      expect(webAuthExists).not.toHaveBeenCalled();
+      expect(hasActiveWebListener).not.toHaveBeenCalled();
       expect(result).toEqual({ status: "skipped", reason: "alerts-disabled" });
     });
   });

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -775,6 +775,85 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it("isolates delivery circuits per agent when targets are shared", async () => {
+    const tmpDir = await createCaseDir("hb-delivery-circuit-agent-scope");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: { workspace: tmpDir },
+          list: [
+            { id: "main", default: true, heartbeat: { every: "5m", target: "whatsapp" } },
+            { id: "ops", heartbeat: { every: "5m", target: "whatsapp" } },
+          ],
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const mainSessionKey = resolveAgentMainSessionKey({ cfg, agentId: "main" });
+      const opsSessionKey = resolveAgentMainSessionKey({ cfg, agentId: "ops" });
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [mainSessionKey]: {
+            sessionId: "sid-main",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+          },
+          [opsSessionKey]: {
+            sessionId: "sid-ops",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+          },
+        }),
+      );
+
+      replySpy.mockResolvedValue([{ text: "Final alert" }]);
+      const failingSend = vi
+        .fn<NonNullable<HeartbeatDeps["sendWhatsApp"]>>()
+        .mockRejectedValue(new Error("Network request for 'sendMessage' failed!"));
+      for (let i = 0; i < 3; i += 1) {
+        const result = await runHeartbeatOnce({
+          cfg,
+          agentId: "main",
+          deps: createHeartbeatDeps(failingSend, 1_000 + i),
+        });
+        expect(result.status).toBe("failed");
+      }
+
+      const blockedMain = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        deps: createHeartbeatDeps(
+          vi.fn<NonNullable<HeartbeatDeps["sendWhatsApp"]>>().mockResolvedValue({
+            messageId: "main-ok",
+            toJid: "jid",
+          }),
+          5_000,
+        ),
+      });
+      expect(blockedMain).toEqual({ status: "skipped", reason: "delivery-circuit-open" });
+
+      const opsSend = vi
+        .fn<NonNullable<HeartbeatDeps["sendWhatsApp"]>>()
+        .mockResolvedValue({ messageId: "ops-ok", toJid: "jid" });
+      const opsResult = await runHeartbeatOnce({
+        cfg,
+        agentId: "ops",
+        deps: createHeartbeatDeps(opsSend, 5_000),
+      });
+
+      expect(opsResult.status).toBe("ran");
+      expect(opsSend).toHaveBeenCalledTimes(1);
+    } finally {
+      replySpy.mockRestore();
+    }
+  });
+
   it("uses the last non-empty payload for delivery", async () => {
     const tmpDir = await createCaseDir("hb-last-payload");
     const storePath = path.join(tmpDir, "sessions.json");

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -645,6 +645,78 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it("does not immediately re-open the circuit on the first failure after cooldown expiry", async () => {
+    const tmpDir = await createCaseDir("hb-delivery-circuit-half-open");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "whatsapp" },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+          },
+        }),
+      );
+
+      replySpy.mockResolvedValue([{ text: "Final alert" }]);
+      const failingSend = vi
+        .fn<NonNullable<HeartbeatDeps["sendWhatsApp"]>>()
+        .mockRejectedValue(new Error("Network request for 'sendMessage' failed!"));
+
+      for (let i = 0; i < 3; i += 1) {
+        await runHeartbeatOnce({
+          cfg,
+          deps: createHeartbeatDeps(failingSend, 10_000 + i),
+        });
+      }
+
+      const stillBlocked = await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(failingSend, 20_000),
+      });
+      expect(stillBlocked).toEqual({ status: "skipped", reason: "delivery-circuit-open" });
+
+      const firstAfterCooldown = await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(failingSend, 16 * 60_000),
+      });
+      expect(firstAfterCooldown.status).toBe("failed");
+
+      await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(failingSend, 16 * 60_000 + 1_000),
+      });
+      await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(failingSend, 16 * 60_000 + 2_000),
+      });
+
+      const blockedAgain = await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(failingSend, 16 * 60_000 + 3_000),
+      });
+      expect(blockedAgain).toEqual({ status: "skipped", reason: "delivery-circuit-open" });
+    } finally {
+      replySpy.mockRestore();
+    }
+  });
+
   it("uses the last non-empty payload for delivery", async () => {
     const tmpDir = await createCaseDir("hb-last-payload");
     const storePath = path.join(tmpDir, "sessions.json");

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -577,6 +577,64 @@ describe("runHeartbeatOnce", () => {
     }
   });
 
+  it("skips immediately on open delivery circuit even when readiness probe throws", async () => {
+    const tmpDir = await createCaseDir("hb-delivery-circuit-readiness-throw");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "whatsapp" },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+          },
+        }),
+      );
+
+      replySpy.mockResolvedValue([{ text: "Final alert" }]);
+      const failingSend = vi
+        .fn<NonNullable<HeartbeatDeps["sendWhatsApp"]>>()
+        .mockRejectedValue(new Error("Network request for 'sendMessage' failed!"));
+
+      for (let i = 0; i < 3; i += 1) {
+        await runHeartbeatOnce({
+          cfg,
+          deps: createHeartbeatDeps(failingSend, 1_000 + i),
+        });
+      }
+
+      const blocked = await runHeartbeatOnce({
+        cfg,
+        deps: {
+          ...createHeartbeatDeps(failingSend, 5_000),
+          webAuthExists: async () => {
+            throw new Error("readiness-boom");
+          },
+        },
+      });
+
+      expect(blocked).toEqual({ status: "skipped", reason: "delivery-circuit-open" });
+      expect(replySpy).toHaveBeenCalledTimes(3);
+    } finally {
+      replySpy.mockRestore();
+    }
+  });
+
   it("allows delivery again after cooldown and resets circuit on success", async () => {
     const tmpDir = await createCaseDir("hb-delivery-circuit-recover");
     const storePath = path.join(tmpDir, "sessions.json");

--- a/src/infra/heartbeat-runner.returns-default-unset.test.ts
+++ b/src/infra/heartbeat-runner.returns-default-unset.test.ts
@@ -19,6 +19,7 @@ import { typedCases } from "../test-utils/typed-cases.js";
 import {
   type HeartbeatDeps,
   isHeartbeatEnabledForAgent,
+  resetHeartbeatDeliveryCircuitForTests,
   resolveHeartbeatIntervalMs,
   resolveHeartbeatPrompt,
   runHeartbeatOnce,
@@ -105,6 +106,7 @@ beforeAll(async () => {
 
 beforeEach(() => {
   resetSystemEventsForTest();
+  resetHeartbeatDeliveryCircuitForTests();
   if (testRegistry) {
     setActivePluginRegistry(testRegistry);
   }
@@ -514,6 +516,132 @@ describe("runHeartbeatOnce", () => {
     expect(res.status).toBe("skipped");
     if (res.status === "skipped") {
       expect(res.reason).toBe("quiet-hours");
+    }
+  });
+
+  it("opens delivery circuit after repeated send failures and skips new runs while open", async () => {
+    const tmpDir = await createCaseDir("hb-delivery-circuit-open");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "whatsapp" },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+          },
+        }),
+      );
+
+      replySpy.mockResolvedValue([{ text: "Final alert" }]);
+      const failingSend = vi
+        .fn<NonNullable<HeartbeatDeps["sendWhatsApp"]>>()
+        .mockRejectedValue(new Error("Network request for 'sendMessage' failed!"));
+
+      for (let i = 0; i < 3; i += 1) {
+        const result = await runHeartbeatOnce({
+          cfg,
+          deps: createHeartbeatDeps(failingSend, 1_000 + i),
+        });
+        expect(result.status).toBe("failed");
+      }
+
+      const guardedSend = vi
+        .fn<NonNullable<HeartbeatDeps["sendWhatsApp"]>>()
+        .mockResolvedValue({ messageId: "guarded", toJid: "jid" });
+      const blocked = await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(guardedSend, 5_000),
+      });
+
+      expect(blocked).toEqual({ status: "skipped", reason: "delivery-circuit-open" });
+      expect(guardedSend).not.toHaveBeenCalled();
+      expect(replySpy).toHaveBeenCalledTimes(3);
+    } finally {
+      replySpy.mockRestore();
+    }
+  });
+
+  it("allows delivery again after cooldown and resets circuit on success", async () => {
+    const tmpDir = await createCaseDir("hb-delivery-circuit-recover");
+    const storePath = path.join(tmpDir, "sessions.json");
+    const replySpy = vi.spyOn(replyModule, "getReplyFromConfig");
+    try {
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "5m", target: "whatsapp" },
+          },
+        },
+        channels: { whatsapp: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = resolveMainSessionKey(cfg);
+
+      await fs.writeFile(
+        storePath,
+        JSON.stringify({
+          [sessionKey]: {
+            sessionId: "sid",
+            updatedAt: Date.now(),
+            lastChannel: "whatsapp",
+            lastTo: "120363401234567890@g.us",
+          },
+        }),
+      );
+
+      replySpy.mockResolvedValue([{ text: "Final alert" }]);
+      const failingSend = vi
+        .fn<NonNullable<HeartbeatDeps["sendWhatsApp"]>>()
+        .mockRejectedValue(new Error("Network request for 'sendMessage' failed!"));
+      for (let i = 0; i < 3; i += 1) {
+        await runHeartbeatOnce({
+          cfg,
+          deps: createHeartbeatDeps(failingSend, 10_000 + i),
+        });
+      }
+
+      const stillBlocked = await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(failingSend, 20_000),
+      });
+      expect(stillBlocked).toEqual({ status: "skipped", reason: "delivery-circuit-open" });
+
+      const successSend = vi
+        .fn<NonNullable<HeartbeatDeps["sendWhatsApp"]>>()
+        .mockResolvedValue({ messageId: "ok", toJid: "jid" });
+      const recovered = await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(successSend, 16 * 60_000),
+      });
+      expect(recovered.status).toBe("ran");
+      expect(successSend).toHaveBeenCalledTimes(1);
+
+      replySpy.mockResolvedValueOnce([{ text: "Another alert" }]);
+      const secondSuccess = await runHeartbeatOnce({
+        cfg,
+        deps: createHeartbeatDeps(successSend, 16 * 60_000 + 1_000),
+      });
+      expect(secondSuccess.status).toBe("ran");
+      expect(successSend).toHaveBeenCalledTimes(2);
+    } finally {
+      replySpy.mockRestore();
     }
   });
 

--- a/src/infra/heartbeat-runner.test-harness.ts
+++ b/src/infra/heartbeat-runner.test-harness.ts
@@ -9,6 +9,7 @@ import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
 import { setActivePluginRegistry } from "../plugins/runtime.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
 import { createTestRegistry } from "../test-utils/channel-plugins.js";
+import { resetHeartbeatDeliveryCircuitForTests } from "./heartbeat-runner.js";
 
 const slackChannelPlugin = slackPlugin as unknown as ChannelPlugin;
 const telegramChannelPlugin = telegramPlugin as unknown as ChannelPlugin;
@@ -16,6 +17,7 @@ const whatsappChannelPlugin = whatsappPlugin as unknown as ChannelPlugin;
 
 export function installHeartbeatRunnerTestRuntime(params?: { includeSlack?: boolean }): void {
   beforeEach(() => {
+    resetHeartbeatDeliveryCircuitForTests();
     const runtime = createPluginRuntime();
     setTelegramRuntime(runtime);
     setWhatsAppRuntime(runtime);

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -166,13 +166,17 @@ function getHeartbeatDeliveryCircuitState(key: string, nowMs: number) {
 
 function recordHeartbeatDeliveryFailure(key: string, nowMs: number): HeartbeatDeliveryCircuitState {
   const prev = heartbeatDeliveryCircuit.get(key);
-  const next: HeartbeatDeliveryCircuitState = prev
-    ? { ...prev }
-    : {
-        consecutiveFailures: 0,
-        cooldownMs: HEARTBEAT_DELIVERY_BASE_COOLDOWN_MS,
-        openCount: 0,
-      };
+  const circuitNaturallyExpired = prev?.openUntil != null && nowMs >= prev.openUntil;
+  const next: HeartbeatDeliveryCircuitState =
+    prev && !circuitNaturallyExpired
+      ? { ...prev }
+      : {
+          // After cooldown expiry, start a fresh failure window so a single
+          // transient failure does not immediately re-open the circuit.
+          consecutiveFailures: 0,
+          cooldownMs: prev?.cooldownMs ?? HEARTBEAT_DELIVERY_BASE_COOLDOWN_MS,
+          openCount: prev?.openCount ?? 0,
+        };
   next.consecutiveFailures += 1;
   if (next.consecutiveFailures >= HEARTBEAT_DELIVERY_FAILURE_THRESHOLD) {
     if (next.openCount > 0) {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -113,6 +113,87 @@ export type HeartbeatRunner = {
   updateConfig: (cfg: OpenClawConfig) => void;
 };
 
+type HeartbeatDeliveryCircuitState = {
+  consecutiveFailures: number;
+  cooldownMs: number;
+  openUntil?: number;
+  openCount: number;
+};
+
+const HEARTBEAT_DELIVERY_FAILURE_THRESHOLD = 3;
+const HEARTBEAT_DELIVERY_BASE_COOLDOWN_MS = 15 * 60_000;
+const HEARTBEAT_DELIVERY_MAX_COOLDOWN_MS = 60 * 60_000;
+const HEARTBEAT_DELIVERY_CIRCUIT_MAX_KEYS = 2000;
+const heartbeatDeliveryCircuit = new Map<string, HeartbeatDeliveryCircuitState>();
+
+function resolveHeartbeatDeliveryCircuitKey(
+  delivery: ReturnType<typeof resolveHeartbeatDeliveryTarget>,
+): string | undefined {
+  if (delivery.channel === "none" || !delivery.to) {
+    return undefined;
+  }
+  return [
+    delivery.channel,
+    delivery.accountId ?? "",
+    delivery.to,
+    delivery.threadId != null ? String(delivery.threadId) : "",
+  ]
+    .filter(Boolean)
+    .join("|");
+}
+
+function pruneHeartbeatDeliveryCircuit() {
+  while (heartbeatDeliveryCircuit.size > HEARTBEAT_DELIVERY_CIRCUIT_MAX_KEYS) {
+    const oldestKey = heartbeatDeliveryCircuit.keys().next().value;
+    if (!oldestKey) {
+      break;
+    }
+    heartbeatDeliveryCircuit.delete(oldestKey);
+  }
+}
+
+function getHeartbeatDeliveryCircuitState(key: string, nowMs: number) {
+  const state = heartbeatDeliveryCircuit.get(key);
+  if (!state?.openUntil) {
+    return { isOpen: false, retryAfterMs: 0 };
+  }
+  const retryAfterMs = state.openUntil - nowMs;
+  if (retryAfterMs <= 0) {
+    return { isOpen: false, retryAfterMs: 0 };
+  }
+  return { isOpen: true, retryAfterMs };
+}
+
+function recordHeartbeatDeliveryFailure(key: string, nowMs: number): HeartbeatDeliveryCircuitState {
+  const prev = heartbeatDeliveryCircuit.get(key);
+  const next: HeartbeatDeliveryCircuitState = prev
+    ? { ...prev }
+    : {
+        consecutiveFailures: 0,
+        cooldownMs: HEARTBEAT_DELIVERY_BASE_COOLDOWN_MS,
+        openCount: 0,
+      };
+  next.consecutiveFailures += 1;
+  if (next.consecutiveFailures >= HEARTBEAT_DELIVERY_FAILURE_THRESHOLD) {
+    if (next.openCount > 0) {
+      next.cooldownMs = Math.min(next.cooldownMs * 2, HEARTBEAT_DELIVERY_MAX_COOLDOWN_MS);
+    }
+    next.openCount += 1;
+    next.openUntil = nowMs + next.cooldownMs;
+  }
+  heartbeatDeliveryCircuit.set(key, next);
+  pruneHeartbeatDeliveryCircuit();
+  return next;
+}
+
+function recordHeartbeatDeliverySuccess(key: string) {
+  heartbeatDeliveryCircuit.delete(key);
+}
+
+export function resetHeartbeatDeliveryCircuitForTests() {
+  heartbeatDeliveryCircuit.clear();
+}
+
 function hasExplicitHeartbeatAgents(cfg: OpenClawConfig) {
   const list = cfg.agents?.list ?? [];
   return list.some((entry) => Boolean(entry?.heartbeat));
@@ -659,6 +740,71 @@ export async function runHeartbeatOnce(opts: {
           accountId: delivery.accountId,
         })
       : { showOk: false, showAlerts: true, useIndicator: true };
+  const deliveryAccountId = delivery.accountId;
+  const heartbeatPlugin = delivery.channel !== "none" ? getChannelPlugin(delivery.channel) : null;
+  if (delivery.channel !== "none" && heartbeatPlugin?.heartbeat?.checkReady) {
+    const readiness = await heartbeatPlugin.heartbeat.checkReady({
+      cfg,
+      accountId: deliveryAccountId,
+      deps: opts.deps,
+    });
+    if (!readiness.ok) {
+      emitHeartbeatEvent({
+        status: "skipped",
+        reason: readiness.reason,
+        durationMs: Date.now() - startedAt,
+        channel: delivery.channel,
+        accountId: delivery.accountId,
+      });
+      log.info("heartbeat: channel not ready", {
+        channel: delivery.channel,
+        reason: readiness.reason,
+      });
+      return { status: "skipped", reason: readiness.reason };
+    }
+  }
+  const deliveryCircuitKey = resolveHeartbeatDeliveryCircuitKey(delivery);
+  if (deliveryCircuitKey) {
+    const circuitState = getHeartbeatDeliveryCircuitState(deliveryCircuitKey, startedAt);
+    if (circuitState.isOpen) {
+      emitHeartbeatEvent({
+        status: "skipped",
+        reason: "delivery-circuit-open",
+        durationMs: Date.now() - startedAt,
+        channel: delivery.channel !== "none" ? delivery.channel : undefined,
+        accountId: delivery.accountId,
+        indicatorType: visibility.useIndicator ? resolveIndicatorType("failed") : undefined,
+      });
+      return { status: "skipped", reason: "delivery-circuit-open" };
+    }
+  }
+
+  const markDeliverySuccess = () => {
+    if (!deliveryCircuitKey) {
+      return;
+    }
+    recordHeartbeatDeliverySuccess(deliveryCircuitKey);
+  };
+  const markDeliveryFailure = (err: unknown) => {
+    if (!deliveryCircuitKey) {
+      return;
+    }
+    const next = recordHeartbeatDeliveryFailure(
+      deliveryCircuitKey,
+      opts.deps?.nowMs?.() ?? Date.now(),
+    );
+    if (!next.openUntil) {
+      return;
+    }
+    log.warn("heartbeat: delivery circuit opened", {
+      channel: delivery.channel,
+      to: delivery.to,
+      accountId: delivery.accountId,
+      cooldownMs: next.cooldownMs,
+      consecutiveFailures: next.consecutiveFailures,
+      error: formatErrorMessage(err),
+    });
+  };
   const { sender } = resolveHeartbeatSenderContext({ cfg, entry, delivery });
   const responsePrefix = resolveEffectiveMessagesConfig(cfg, agentId, {
     channel: delivery.channel !== "none" ? delivery.channel : undefined,
@@ -709,27 +855,32 @@ export async function runHeartbeatOnce(opts: {
     if (!canAttemptHeartbeatOk || delivery.channel === "none" || !delivery.to) {
       return false;
     }
-    const heartbeatPlugin = getChannelPlugin(delivery.channel);
     if (heartbeatPlugin?.heartbeat?.checkReady) {
       const readiness = await heartbeatPlugin.heartbeat.checkReady({
         cfg,
-        accountId: delivery.accountId,
+        accountId: deliveryAccountId,
         deps: opts.deps,
       });
       if (!readiness.ok) {
         return false;
       }
     }
-    await deliverOutboundPayloads({
-      cfg,
-      channel: delivery.channel,
-      to: delivery.to,
-      accountId: delivery.accountId,
-      threadId: delivery.threadId,
-      payloads: [{ text: heartbeatOkText }],
-      session: outboundSession,
-      deps: opts.deps,
-    });
+    try {
+      await deliverOutboundPayloads({
+        cfg,
+        channel: delivery.channel,
+        to: delivery.to,
+        accountId: deliveryAccountId,
+        threadId: delivery.threadId,
+        payloads: [{ text: heartbeatOkText }],
+        session: outboundSession,
+        deps: opts.deps,
+      });
+      markDeliverySuccess();
+    } catch (err) {
+      markDeliveryFailure(err);
+      throw err;
+    }
     return true;
   };
 
@@ -896,52 +1047,32 @@ export async function runHeartbeatOnce(opts: {
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
 
-    const deliveryAccountId = delivery.accountId;
-    const heartbeatPlugin = getChannelPlugin(delivery.channel);
-    if (heartbeatPlugin?.heartbeat?.checkReady) {
-      const readiness = await heartbeatPlugin.heartbeat.checkReady({
+    try {
+      await deliverOutboundPayloads({
         cfg,
+        channel: delivery.channel,
+        to: delivery.to,
         accountId: deliveryAccountId,
+        session: outboundSession,
+        threadId: delivery.threadId,
+        payloads: [
+          ...reasoningPayloads,
+          ...(shouldSkipMain
+            ? []
+            : [
+                {
+                  text: normalized.text,
+                  mediaUrls,
+                },
+              ]),
+        ],
         deps: opts.deps,
       });
-      if (!readiness.ok) {
-        emitHeartbeatEvent({
-          status: "skipped",
-          reason: readiness.reason,
-          preview: previewText?.slice(0, 200),
-          durationMs: Date.now() - startedAt,
-          hasMedia: mediaUrls.length > 0,
-          channel: delivery.channel,
-          accountId: delivery.accountId,
-        });
-        log.info("heartbeat: channel not ready", {
-          channel: delivery.channel,
-          reason: readiness.reason,
-        });
-        return { status: "skipped", reason: readiness.reason };
-      }
+      markDeliverySuccess();
+    } catch (err) {
+      markDeliveryFailure(err);
+      throw err;
     }
-
-    await deliverOutboundPayloads({
-      cfg,
-      channel: delivery.channel,
-      to: delivery.to,
-      accountId: deliveryAccountId,
-      session: outboundSession,
-      threadId: delivery.threadId,
-      payloads: [
-        ...reasoningPayloads,
-        ...(shouldSkipMain
-          ? []
-          : [
-              {
-                text: normalized.text,
-                mediaUrls,
-              },
-            ]),
-      ],
-      deps: opts.deps,
-    });
 
     // Record last delivered heartbeat payload for dedupe.
     if (!shouldSkipMain && normalized.text.trim()) {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -127,12 +127,14 @@ const HEARTBEAT_DELIVERY_CIRCUIT_MAX_KEYS = 2000;
 const heartbeatDeliveryCircuit = new Map<string, HeartbeatDeliveryCircuitState>();
 
 function resolveHeartbeatDeliveryCircuitKey(
+  agentId: string,
   delivery: ReturnType<typeof resolveHeartbeatDeliveryTarget>,
 ): string | undefined {
   if (delivery.channel === "none" || !delivery.to) {
     return undefined;
   }
   return [
+    agentId,
     delivery.channel,
     delivery.accountId ?? "",
     delivery.to,
@@ -744,7 +746,7 @@ export async function runHeartbeatOnce(opts: {
           accountId: delivery.accountId,
         })
       : { showOk: false, showAlerts: true, useIndicator: true };
-  const deliveryCircuitKey = resolveHeartbeatDeliveryCircuitKey(delivery);
+  const deliveryCircuitKey = resolveHeartbeatDeliveryCircuitKey(agentId, delivery);
   if (deliveryCircuitKey) {
     const circuitState = getHeartbeatDeliveryCircuitState(deliveryCircuitKey, startedAt);
     if (circuitState.isOpen) {

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -759,6 +759,16 @@ export async function runHeartbeatOnce(opts: {
       return { status: "skipped", reason: "delivery-circuit-open" };
     }
   }
+  if (!visibility.showAlerts && !visibility.showOk && !visibility.useIndicator) {
+    emitHeartbeatEvent({
+      status: "skipped",
+      reason: "alerts-disabled",
+      durationMs: Date.now() - startedAt,
+      channel: delivery.channel !== "none" ? delivery.channel : undefined,
+      accountId: delivery.accountId,
+    });
+    return { status: "skipped", reason: "alerts-disabled" };
+  }
   const deliveryAccountId = delivery.accountId;
   const heartbeatPlugin = delivery.channel !== "none" ? getChannelPlugin(delivery.channel) : null;
   if (delivery.channel !== "none" && heartbeatPlugin?.heartbeat?.checkReady) {
@@ -850,16 +860,6 @@ export async function runHeartbeatOnce(opts: {
     Provider: hasExecCompletion ? "exec-event" : hasCronEvents ? "cron-event" : "heartbeat",
     SessionKey: sessionKey,
   };
-  if (!visibility.showAlerts && !visibility.showOk && !visibility.useIndicator) {
-    emitHeartbeatEvent({
-      status: "skipped",
-      reason: "alerts-disabled",
-      durationMs: Date.now() - startedAt,
-      channel: delivery.channel !== "none" ? delivery.channel : undefined,
-      accountId: delivery.accountId,
-    });
-    return { status: "skipped", reason: "alerts-disabled" };
-  }
 
   const heartbeatOkText = responsePrefix ? `${responsePrefix} ${HEARTBEAT_TOKEN}` : HEARTBEAT_TOKEN;
   const outboundSession = buildOutboundSessionContext({

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -747,11 +747,26 @@ export async function runHeartbeatOnce(opts: {
   const deliveryAccountId = delivery.accountId;
   const heartbeatPlugin = delivery.channel !== "none" ? getChannelPlugin(delivery.channel) : null;
   if (delivery.channel !== "none" && heartbeatPlugin?.heartbeat?.checkReady) {
-    const readiness = await heartbeatPlugin.heartbeat.checkReady({
-      cfg,
-      accountId: deliveryAccountId,
-      deps: opts.deps,
-    });
+    let readiness: { ok: boolean; reason: string };
+    try {
+      readiness = await heartbeatPlugin.heartbeat.checkReady({
+        cfg,
+        accountId: deliveryAccountId,
+        deps: opts.deps,
+      });
+    } catch (err) {
+      const reason = formatErrorMessage(err);
+      emitHeartbeatEvent({
+        status: "failed",
+        reason,
+        durationMs: Date.now() - startedAt,
+        channel: delivery.channel,
+        accountId: delivery.accountId,
+        indicatorType: visibility.useIndicator ? resolveIndicatorType("failed") : undefined,
+      });
+      log.error(`heartbeat failed: ${reason}`, { error: reason });
+      return { status: "failed", reason };
+    }
     if (!readiness.ok) {
       emitHeartbeatEvent({
         status: "skipped",

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -744,6 +744,21 @@ export async function runHeartbeatOnce(opts: {
           accountId: delivery.accountId,
         })
       : { showOk: false, showAlerts: true, useIndicator: true };
+  const deliveryCircuitKey = resolveHeartbeatDeliveryCircuitKey(delivery);
+  if (deliveryCircuitKey) {
+    const circuitState = getHeartbeatDeliveryCircuitState(deliveryCircuitKey, startedAt);
+    if (circuitState.isOpen) {
+      emitHeartbeatEvent({
+        status: "skipped",
+        reason: "delivery-circuit-open",
+        durationMs: Date.now() - startedAt,
+        channel: delivery.channel !== "none" ? delivery.channel : undefined,
+        accountId: delivery.accountId,
+        indicatorType: visibility.useIndicator ? resolveIndicatorType("failed") : undefined,
+      });
+      return { status: "skipped", reason: "delivery-circuit-open" };
+    }
+  }
   const deliveryAccountId = delivery.accountId;
   const heartbeatPlugin = delivery.channel !== "none" ? getChannelPlugin(delivery.channel) : null;
   if (delivery.channel !== "none" && heartbeatPlugin?.heartbeat?.checkReady) {
@@ -780,21 +795,6 @@ export async function runHeartbeatOnce(opts: {
         reason: readiness.reason,
       });
       return { status: "skipped", reason: readiness.reason };
-    }
-  }
-  const deliveryCircuitKey = resolveHeartbeatDeliveryCircuitKey(delivery);
-  if (deliveryCircuitKey) {
-    const circuitState = getHeartbeatDeliveryCircuitState(deliveryCircuitKey, startedAt);
-    if (circuitState.isOpen) {
-      emitHeartbeatEvent({
-        status: "skipped",
-        reason: "delivery-circuit-open",
-        durationMs: Date.now() - startedAt,
-        channel: delivery.channel !== "none" ? delivery.channel : undefined,
-        accountId: delivery.accountId,
-        indicatorType: visibility.useIndicator ? resolveIndicatorType("failed") : undefined,
-      });
-      return { status: "skipped", reason: "delivery-circuit-open" };
     }
   }
 


### PR DESCRIPTION
## Summary
- add heartbeat poll text detection + normalization, and dedupe repeated heartbeat poll inbound events even when provider message IDs differ
- add heartbeat delivery circuit breaker and pre-run readiness short-circuit to reduce repeated failed sends
- add cached fallback thinking-level parser path (warn once on parse, debug on cache hits) to reduce noisy logs during repeated fallbacks
- extend heartbeat runner tests for circuit behavior and update heartbeat model-override tests for the new readiness gate

## Testing
- pnpm check
- pnpm test

Closes #3181
