### PR TITLE
fix(gateway): isolate channels.status probe/audit per-account failures

### DIFF
--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -150,6 +150,7 @@ export const channelsHandlers: GatewayRequestHandlers = {
               lastProbeAt = Date.now();
             } catch (err) {
               probeResult = { ok: false, error: formatForLog(err) };
+              lastProbeAt = Date.now();
             }
           }
         }

--- a/src/gateway/server-methods/channels.ts
+++ b/src/gateway/server-methods/channels.ts
@@ -141,12 +141,16 @@ export const channelsHandlers: GatewayRequestHandlers = {
             configured = await plugin.config.isConfigured(account, cfg);
           }
           if (configured) {
-            probeResult = await plugin.status.probeAccount({
-              account,
-              timeoutMs,
-              cfg,
-            });
-            lastProbeAt = Date.now();
+            try {
+              probeResult = await plugin.status.probeAccount({
+                account,
+                timeoutMs,
+                cfg,
+              });
+              lastProbeAt = Date.now();
+            } catch (err) {
+              probeResult = { ok: false, error: formatForLog(err) };
+            }
           }
         }
         let auditResult: unknown;
@@ -156,12 +160,16 @@ export const channelsHandlers: GatewayRequestHandlers = {
             configured = await plugin.config.isConfigured(account, cfg);
           }
           if (configured) {
-            auditResult = await plugin.status.auditAccount({
-              account,
-              timeoutMs,
-              cfg,
-              probe: probeResult,
-            });
+            try {
+              auditResult = await plugin.status.auditAccount({
+                account,
+                timeoutMs,
+                cfg,
+                probe: probeResult,
+              });
+            } catch (err) {
+              auditResult = { ok: false, error: formatForLog(err) };
+            }
           }
         }
         const runtimeSnapshot = resolveRuntimeSnapshot(channelId, accountId, defaultAccountId);

--- a/src/gateway/server.channels.test.ts
+++ b/src/gateway/server.channels.test.ts
@@ -183,7 +183,7 @@ describe("gateway server channels", () => {
         probeAccount: async () => {
           throw new Error("probe unreachable");
         },
-        buildAccountSnapshot: async ({ account, probe, audit }) => ({
+        buildAccountSnapshot: async ({ probe, audit }) => ({
           accountId: "default",
           enabled: true,
           configured: true,

--- a/src/gateway/server.channels.test.ts
+++ b/src/gateway/server.channels.test.ts
@@ -167,4 +167,54 @@ describe("gateway server channels", () => {
     expect(snap.config?.channels?.telegram?.botToken).toBeUndefined();
     expect(snap.config?.channels?.telegram?.groups?.["*"]?.requireMention).toBe(false);
   });
+
+  test("channels.status with probe isolates single-account probe failure", async () => {
+    const probeFailingPlugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({
+        id: "probe-fails",
+        label: "ProbeFails",
+        config: {
+          listAccountIds: () => ["default"],
+          isConfigured: async () => true,
+        },
+      }),
+      status: {
+        buildChannelSummary: async () => ({ configured: true }),
+        probeAccount: async () => {
+          throw new Error("probe unreachable");
+        },
+        buildAccountSnapshot: async ({ account, probe, audit }) => ({
+          accountId: "default",
+          enabled: true,
+          configured: true,
+          probe,
+          audit,
+        }),
+      },
+    };
+    const registryWithFailingProbe = createRegistry([
+      {
+        pluginId: "whatsapp",
+        source: "test",
+        plugin: createStubChannelPlugin({ id: "whatsapp", label: "WhatsApp" }),
+      },
+      { pluginId: "probe-fails", source: "test", plugin: probeFailingPlugin },
+    ]);
+    setRegistry(registryWithFailingProbe);
+    const res = await rpcReq<{
+      channelAccounts?: Record<
+        string,
+        Array<{ accountId?: string; probe?: { ok?: boolean; error?: string } }>
+      >;
+    }>(ws, "channels.status", { probe: true, timeoutMs: 2000 });
+    expect(res.ok).toBe(true);
+    const accounts = res.payload?.channelAccounts?.["probe-fails"];
+    expect(accounts).toBeDefined();
+    expect(Array.isArray(accounts) && accounts.length).toBe(1);
+    expect(accounts![0].probe).toEqual({
+      ok: false,
+      error: expect.stringContaining("probe unreachable"),
+    });
+    expect(res.payload?.channelAccounts?.whatsapp).toBeDefined();
+  });
 });

--- a/src/gateway/server.channels.test.ts
+++ b/src/gateway/server.channels.test.ts
@@ -204,7 +204,11 @@ describe("gateway server channels", () => {
     const res = await rpcReq<{
       channelAccounts?: Record<
         string,
-        Array<{ accountId?: string; probe?: { ok?: boolean; error?: string } }>
+        Array<{
+          accountId?: string;
+          probe?: { ok?: boolean; error?: string };
+          lastProbeAt?: number | null;
+        }>
       >;
     }>(ws, "channels.status", { probe: true, timeoutMs: 2000 });
     expect(res.ok).toBe(true);
@@ -215,6 +219,7 @@ describe("gateway server channels", () => {
       ok: false,
       error: expect.stringContaining("probe unreachable"),
     });
+    expect(typeof accounts![0].lastProbeAt).toBe("number");
     expect(res.payload?.channelAccounts?.whatsapp).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

- Isolates per-account probe/audit failures in `channels.status` RPC.
- When one plugin account’s `probeAccount` or `auditAccount` throws, that account gets `probe: { ok: false, error }` / `audit: { ok: false, error }` and the rest of the response is still returned.
- Avoids a single failing account from failing the whole `channels.status` call.

## Change Type

- [x] Bug fix / robustness
- [ ] Feature
- [ ] Refactor
- [ ] Docs

## Scope

- [x] Gateway RPC (`channels.status`)
- [x] Tests (`server.channels.test.ts`)
- [ ] CLI / commands

## User-visible Behavior

- Before: one account probe/audit throw could make `channels.status` (and thus `openclaw channels status --probe`) fail entirely.
- After: response remains `ok: true`; the failing account’s snapshot includes `probe: { ok: false, error: "..." }` (or audit equivalent); other channels/accounts unchanged.

## What Changed

1. **`src/gateway/server-methods/channels.ts`**
   - Wrapped `plugin.status.probeAccount` in try/catch; on throw set `probeResult = { ok: false, error: formatForLog(err) }`.
   - Wrapped `plugin.status.auditAccount` in try/catch; on throw set `auditResult = { ok: false, error: formatForLog(err) }`.
2. **`src/gateway/server.channels.test.ts`**
   - New test: `channels.status with probe isolates single-account probe failure` — plugin whose `probeAccount` throws; assert `res.ok === true`, failing account has `probe: { ok: false, error: expect.stringContaining("probe unreachable") }`, other channels still present.

## Verification

- `pnpm test -- src/gateway/server.channels.test.ts`
- `pnpm exec oxfmt --check src/gateway/server-methods/channels.ts src/gateway/server.channels.test.ts`

## Compatibility

- Backward compatible: **Yes**
- Config changes required: **No**
- Migration required: **No**

## Risk

- Low: only exception paths changed; success behavior unchanged. Existing consumers that already handle `probe.ok === false` / `audit.ok === false` are unchanged.
