### PR TITLE
Onboarding: print Slack manifest without note framing

### DIFF
--- a/src/channels/plugins/onboarding/slack.test.ts
+++ b/src/channels/plugins/onboarding/slack.test.ts
@@ -8,15 +8,28 @@ describe("buildSlackManifest", () => {
     expect(parsed.display_information?.name).toBe("OpenClaw");
     expect(manifest).not.toContain("│");
   });
+
+  it("falls back to OpenClaw when botName is blank", () => {
+    const manifest = buildSlackManifest("   ");
+    const parsed = JSON.parse(manifest) as { display_information?: { name?: string } };
+    expect(parsed.display_information?.name).toBe("OpenClaw");
+  });
 });
 
 describe("writeSlackManifestRaw", () => {
   it("writes raw manifest content with trailing newline", () => {
-    const write = vi.fn<Pick<NodeJS.WriteStream, "write">["write"]>(() => true);
+    const stream = {
+      write: (
+        _buffer: string | Uint8Array,
+        _encodingOrCallback?: BufferEncoding | ((err?: Error | null) => void),
+        _callback?: (err?: Error | null) => void,
+      ) => true,
+    } satisfies Pick<NodeJS.WriteStream, "write">;
+    const writeSpy = vi.spyOn(stream, "write");
     const manifest = '{\n  "hello": "world"\n}';
 
-    writeSlackManifestRaw(manifest, { write });
+    writeSlackManifestRaw(manifest, stream);
 
-    expect(write).toHaveBeenCalledWith(`${manifest}\n`);
+    expect(writeSpy).toHaveBeenCalledWith(`${manifest}\n`);
   });
 });

--- a/src/channels/plugins/onboarding/slack.test.ts
+++ b/src/channels/plugins/onboarding/slack.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildSlackManifest, writeSlackManifestRaw } from "./slack.js";
+
+describe("buildSlackManifest", () => {
+  it("builds valid manifest JSON without framing characters", () => {
+    const manifest = buildSlackManifest("OpenClaw");
+    const parsed = JSON.parse(manifest) as { display_information?: { name?: string } };
+    expect(parsed.display_information?.name).toBe("OpenClaw");
+    expect(manifest).not.toContain("│");
+  });
+});
+
+describe("writeSlackManifestRaw", () => {
+  it("writes raw manifest content with trailing newline", () => {
+    const write = vi.fn<Pick<NodeJS.WriteStream, "write">["write"]>(() => true);
+    const manifest = '{\n  "hello": "world"\n}';
+
+    writeSlackManifestRaw(manifest, { write });
+
+    expect(write).toHaveBeenCalledWith(`${manifest}\n`);
+  });
+});

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -116,7 +116,8 @@ async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Pr
       "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
       `Docs: ${formatDocsLink("/slack", "slack")}`,
       "",
-      "Manifest (JSON) is printed below without framing for copy/paste.",
+      "Manifest (JSON):",
+      manifest,
     ].join("\n"),
     "Slack socket mode tokens",
   );

--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -28,7 +28,7 @@ import {
 
 const channel = "slack" as const;
 
-function buildSlackManifest(botName: string) {
+export function buildSlackManifest(botName: string): string {
   const safeName = botName.trim() || "OpenClaw";
   const manifest = {
     display_information: {
@@ -97,6 +97,13 @@ function buildSlackManifest(botName: string) {
   return JSON.stringify(manifest, null, 2);
 }
 
+export function writeSlackManifestRaw(
+  manifest: string,
+  writer: Pick<NodeJS.WriteStream, "write"> = process.stdout,
+): void {
+  writer.write(`${manifest}\n`);
+}
+
 async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Promise<void> {
   const manifest = buildSlackManifest(botName);
   await prompter.note(
@@ -109,11 +116,11 @@ async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Pr
       "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
       `Docs: ${formatDocsLink("/slack", "slack")}`,
       "",
-      "Manifest (JSON):",
-      manifest,
+      "Manifest (JSON) is printed below without framing for copy/paste.",
     ].join("\n"),
     "Slack socket mode tokens",
   );
+  writeSlackManifestRaw(manifest);
 }
 
 function setSlackChannelAllowlist(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Slack onboarding printed the app manifest inside `prompter.note()`, which renders framed output that is awkward to copy as valid JSON.
- Why it matters: users copying from terminal could capture framing characters and end up with invalid manifest JSON.
- What changed: Slack onboarding guidance remains in a note, but the manifest body is now printed raw (unframed) to stdout for copy/paste.
- What changed: added tests for manifest generation and raw manifest writer behavior.
- What did NOT change (scope boundary): no token handling or Slack runtime behavior was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32493
- Related #32731

## User-visible / Behavior Changes

During Slack channel onboarding, the JSON manifest is now printed as plain JSON (no note framing) for direct copy/paste.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Slack onboarding (CLI)
- Relevant config (redacted): N/A

### Steps

1. Run `openclaw channels add` and choose Slack onboarding.
2. Reach the Slack manifest guidance step.
3. Copy the printed manifest.

### Expected

- Manifest content is copy-safe plain JSON.

### Actual

- Manifest is now printed raw to stdout, separate from note-framed guidance text.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

`pnpm test src/channels/plugins/onboarding/*.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Slack onboarding still shows setup guidance note.
  - Manifest content is emitted via raw writer path.
- Edge cases checked:
  - Manifest writer appends newline and preserves JSON content exactly.
- What you did **not** verify:
  - Full end-to-end Slack workspace install flow against live Slack API.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this PR commit
- Files/config to restore:
  - `src/channels/plugins/onboarding/slack.ts`
  - `src/channels/plugins/onboarding/slack.test.ts`
- Known bad symptoms reviewers should watch for:
  - manifest no longer visible during onboarding
  - manifest output contains extra framing characters

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: raw manifest output appears less visually grouped than note boxes.
  - Mitigation: guidance note explicitly announces raw JSON output location.
