### PR TITLE
feat(config): add "config restore" command for gateway recovery

### DIFF
--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -393,9 +393,8 @@ export async function runConfigRestore(opts: {
     }
 
     // Validate backup is parseable before overwriting anything
-    let backupContent: string;
     try {
-      backupContent = fs.readFileSync(restorePath, "utf8");
+      const backupContent = fs.readFileSync(restorePath, "utf8");
       JSON5.parse(backupContent);
     } catch (e) {
       runtime.error(danger(`Backup file is not valid JSON5 and cannot be restored: ${restorePath}`));
@@ -416,8 +415,12 @@ export async function runConfigRestore(opts: {
 
     // Restore
     fs.copyFileSync(restorePath, configPath);
-    runtime.log(success(`Config restored from ${shortenHomePath(restorePath)}`));
-    runtime.log(info("Run \`openclaw gateway restart\` to apply."));
+    if (opts.json) {
+      runtime.log(JSON.stringify({ ok: true, restored: restorePath }));
+    } else {
+      runtime.log(success(`Config restored from ${shortenHomePath(restorePath)}`));
+      runtime.log(info("Run \`openclaw gateway restart\` to apply."));
+    }
   } catch (err) {
     runtime.error(danger(`Restore failed: ${String(err)}`));
     runtime.exit(1);
@@ -507,3 +510,4 @@ export function registerConfigCli(program: Command) {
       });
     });
 }
+

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -1,9 +1,11 @@
+import fs from "node:fs";
 import type { Command } from "commander";
 import JSON5 from "json5";
 import { readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
+import { CONFIG_BACKUP_COUNT } from "../config/backup-rotation.js";
 import { isBlockedObjectKey } from "../config/prototype-keys.js";
 import { redactConfigObject } from "../config/redact-snapshot.js";
-import { danger, info } from "../globals.js";
+import { danger, info, success } from "../globals.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
@@ -324,6 +326,104 @@ export async function runConfigUnset(opts: { path: string; runtime?: RuntimeEnv 
   }
 }
 
+
+export async function runConfigRestore(opts: {
+  backup?: string;
+  list?: boolean;
+  json?: boolean;
+  runtime?: RuntimeEnv;
+} = {}) {
+  const runtime = opts.runtime ?? defaultRuntime;
+  try {
+    const snapshot = await readConfigFileSnapshot();
+    const configPath = snapshot.path;
+    const backupBase = `${configPath}.bak`;
+
+    // Collect available backups from the rotation ring
+    const backups: Array<{ label: string; path: string }> = [];
+    if (fs.existsSync(backupBase)) {
+      backups.push({ label: ".bak (latest)", path: backupBase });
+    }
+    for (let i = 1; i < CONFIG_BACKUP_COUNT; i++) {
+      const bPath = `${backupBase}.${i}`;
+      if (fs.existsSync(bPath)) {
+        backups.push({ label: `.bak.${i}`, path: bPath });
+      }
+    }
+
+    if (opts.list) {
+      if (opts.json) {
+        runtime.log(
+          JSON.stringify({
+            backups: backups.map((b) => ({ label: b.label, path: b.path })),
+          }),
+        );
+      } else if (backups.length === 0) {
+        runtime.log(info("No config backups found."));
+      } else {
+        runtime.log(info("Available config backups:"));
+        for (const b of backups) {
+          runtime.log(`  ${b.label}  ${shortenHomePath(b.path)}`);
+        }
+      }
+      return;
+    }
+
+    // Resolve which backup to restore
+    let restorePath: string;
+    if (opts.backup) {
+      restorePath = opts.backup;
+      if (!fs.existsSync(restorePath)) {
+        runtime.error(danger(`Backup not found: ${restorePath}`));
+        runtime.exit(1);
+        return;
+      }
+    } else {
+      if (backups.length === 0) {
+        runtime.error(
+          danger(
+            "No config backups found. Nothing to restore.\n" +
+              "If you have a manual backup, pass it with: openclaw config restore --backup <path>",
+          ),
+        );
+        runtime.exit(1);
+        return;
+      }
+      restorePath = backups[0].path;
+    }
+
+    // Validate backup is parseable before overwriting anything
+    let backupContent: string;
+    try {
+      backupContent = fs.readFileSync(restorePath, "utf8");
+      JSON5.parse(backupContent);
+    } catch (e) {
+      runtime.error(danger(`Backup file is not valid JSON5 and cannot be restored: ${restorePath}`));
+      runtime.exit(1);
+      return;
+    }
+
+    // Preserve the current (possibly broken) config as a safety copy
+    if (snapshot.exists) {
+      const safetyPath = `${configPath}.bak.broken`;
+      try {
+        fs.copyFileSync(configPath, safetyPath);
+        runtime.log(info(`Current config saved to ${shortenHomePath(safetyPath)}`));
+      } catch {
+        // best-effort
+      }
+    }
+
+    // Restore
+    fs.copyFileSync(restorePath, configPath);
+    runtime.log(success(`Config restored from ${shortenHomePath(restorePath)}`));
+    runtime.log(info("Run \`openclaw gateway restart\` to apply."));
+  } catch (err) {
+    runtime.error(danger(`Restore failed: ${String(err)}`));
+    runtime.exit(1);
+  }
+}
+
 export function registerConfigCli(program: Command) {
   const cmd = program
     .command("config")
@@ -389,5 +489,21 @@ export function registerConfigCli(program: Command) {
     .argument("<path>", "Config path (dot or bracket notation)")
     .action(async (path: string) => {
       await runConfigUnset({ path });
+    });
+
+  cmd
+    .command("restore")
+    .description(
+      "Restore config from an automatic backup. Useful when a bad config prevents the gateway from starting.",
+    )
+    .option("--list", "List available backups without restoring", false)
+    .option("--backup <path>", "Path to a specific backup file to restore")
+    .option("--json", "Output as JSON", false)
+    .action(async (opts) => {
+      await runConfigRestore({
+        backup: opts.backup as string | undefined,
+        list: Boolean(opts.list),
+        json: Boolean(opts.json),
+      });
     });
 }

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -403,11 +403,15 @@ export async function runConfigRestore(opts: {
     }
 
     // Preserve the current (possibly broken) config as a safety copy
+    let safetyCopy: string | null = null;
     if (snapshot.exists) {
       const safetyPath = `${configPath}.bak.broken`;
       try {
         fs.copyFileSync(configPath, safetyPath);
-        runtime.log(info(`Current config saved to ${shortenHomePath(safetyPath)}`));
+        safetyCopy = safetyPath;
+        if (!opts.json) {
+          runtime.log(info(`Current config saved to ${shortenHomePath(safetyPath)}`));
+        }
       } catch {
         // best-effort
       }
@@ -416,7 +420,7 @@ export async function runConfigRestore(opts: {
     // Restore
     fs.copyFileSync(restorePath, configPath);
     if (opts.json) {
-      runtime.log(JSON.stringify({ ok: true, restored: restorePath }));
+      runtime.log(JSON.stringify({ ok: true, restored: restorePath, safety_copy: safetyCopy }));
     } else {
       runtime.log(success(`Config restored from ${shortenHomePath(restorePath)}`));
       runtime.log(info("Run \`openclaw gateway restart\` to apply."));

--- a/src/cli/config-cli.ts
+++ b/src/cli/config-cli.ts
@@ -394,8 +394,7 @@ export async function runConfigRestore(opts: {
 
     // Validate backup is parseable before overwriting anything
     try {
-      const backupContent = fs.readFileSync(restorePath, "utf8");
-      JSON5.parse(backupContent);
+      JSON5.parse(fs.readFileSync(restorePath, "utf8"));
     } catch (e) {
       runtime.error(danger(`Backup file is not valid JSON5 and cannot be restored: ${restorePath}`));
       runtime.exit(1);


### PR DESCRIPTION
## Problem

When an invalid config causes the gateway to fail to start, the agent becomes completely unreachable. There is no CLI path to recover without manually editing the config file — which is error-prone and requires knowing the file location.

This was raised publicly by @chrysb with significant community interest.

## What Already Existed

OpenClaw already auto-creates a `.bak` rotation ring (`openclaw.json.bak`, `.bak.1`…`.bak.4`) on every config write via `maintainConfigBackups`. These backups exist — they just had no CLI surface to list or restore from.

## What This Adds

```bash
# List available backups
openclaw config restore --list

# Restore the latest backup (works without gateway running)
openclaw config restore

# Restore a specific backup
openclaw config restore --backup ~/.openclaw/openclaw.json.bak.2

# Machine-readable output
openclaw config restore --list --json
```

## Behavior

- **Validates** the backup is parseable JSON5 before touching anything
- **Preserves** the current (broken) config as `.bak.broken` before overwriting — so recovery is always reversible
- **Reminds** the user to restart the gateway after a successful restore
- **Works offline** — no gateway required, pure filesystem operation
- `--json` flag for scripting and tooling integration

## Changes

- `src/cli/config-cli.ts`: adds `runConfigRestore()` function + `.command("restore")` registration
- Imports `CONFIG_BACKUP_COUNT` from the existing `backup-rotation.ts` (no duplication)
- Adds `import fs from "node:fs"` and `success` from globals
- Zero breaking changes — additive only

## Context

We run a 4-agent OpenClaw setup and have hit the "gateway down due to bad config" scenario multiple times. The backup files were always there — we just had to find and restore them manually. This closes that gap.