### PR TITLE
feat(context-pruning): add file block awareness to softTrim

### DIFF
--- a/src/agents/pi-extensions/context-pruning.test.ts
+++ b/src/agents/pi-extensions/context-pruning.test.ts
@@ -7,6 +7,7 @@ import {
   default as contextPruningExtension,
   DEFAULT_CONTEXT_PRUNING_SETTINGS,
   pruneContextMessages,
+  softTrimFileBlocksInText,
 } from "./context-pruning.js";
 import { getContextPruningRuntime, setContextPruningRuntime } from "./context-pruning/runtime.js";
 
@@ -422,5 +423,170 @@ describe("context-pruning", () => {
     expect(text).toContain("abcdef");
     expect(text).toContain("efghij");
     expect(text).toContain("[Tool result trimmed:");
+  });
+
+  // --- File block awareness tests ---
+
+  function makeUserWithFile(name: string, mime: string, body: string): AgentMessage {
+    return {
+      role: "user",
+      content: `Here is the file:\n<file name="${name}" mime="${mime}">\n${body}\n</file>`,
+      timestamp: Date.now(),
+    };
+  }
+
+  it("softTrimFileBlocksInText trims oversized file blocks", () => {
+    const body = "x".repeat(5000);
+    const text = `prefix\n<file name="report.pdf" mime="application/pdf">${body}</file>\nsuffix`;
+    const settings = makeAggressiveSettings({
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+    const result = softTrimFileBlocksInText(text, settings);
+    expect(result.trimmedChars).toBeGreaterThan(0);
+    expect(result.text).toContain("prefix");
+    expect(result.text).toContain("suffix");
+    expect(result.text).toContain("[File block trimmed: kept first 30 and last 30 of 5000 chars]");
+    expect(result.text).toContain(`<file name="report.pdf" mime="application/pdf">`);
+    expect(result.text).toContain("</file>");
+  });
+
+  it("softTrimFileBlocksInText does not trim small file blocks", () => {
+    const body = "short content";
+    const text = `<file name="small.txt" mime="text/plain">${body}</file>`;
+    const settings = makeAggressiveSettings({
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+    const result = softTrimFileBlocksInText(text, settings);
+    expect(result.trimmedChars).toBe(0);
+    expect(result.text).toBe(text);
+  });
+
+  it("softTrimFileBlocksInText handles multiple file blocks (only trims oversized)", () => {
+    const smallBody = "ok";
+    const bigBody = "y".repeat(3000);
+    const text = `<file name="a.txt" mime="text/plain">${smallBody}</file>\nmiddle\n<file name="b.pdf" mime="application/pdf">${bigBody}</file>`;
+    const settings = makeAggressiveSettings({
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 20, tailChars: 20 },
+    });
+    const result = softTrimFileBlocksInText(text, settings);
+    expect(result.trimmedChars).toBeGreaterThan(0);
+    // Small block untouched
+    expect(result.text).toContain(`<file name="a.txt" mime="text/plain">${smallBody}</file>`);
+    // Big block trimmed
+    expect(result.text).toContain("[File block trimmed:");
+    expect(result.text).toContain("middle");
+  });
+
+  it("trims file blocks in user messages with string content", () => {
+    const bigBody = "z".repeat(10_000);
+    const messages: AgentMessage[] = [
+      makeUserWithFile("report.pdf", "application/pdf", bigBody),
+      makeAssistant("a1"),
+    ];
+
+    const next = pruneWithAggressiveDefaults(messages, {
+      hardClearRatio: 10.0,
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+
+    const userMsg = next[0];
+    expect(userMsg?.role).toBe("user");
+    const content = (userMsg as { content: string }).content;
+    expect(content).toContain("[File block trimmed:");
+    expect(content.length).toBeLessThan(bigBody.length);
+  });
+
+  it("trims file blocks in user messages with array content", () => {
+    const bigBody = "w".repeat(10_000);
+    const messages: AgentMessage[] = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: `Here is the file:\n<file name="doc.pdf" mime="application/pdf">${bigBody}</file>`,
+          },
+        ],
+        timestamp: Date.now(),
+      } as unknown as AgentMessage,
+      makeAssistant("a1"),
+    ];
+
+    const next = pruneWithAggressiveDefaults(messages, {
+      hardClearRatio: 10.0,
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+
+    const userMsg = next[0];
+    expect(userMsg?.role).toBe("user");
+    const content = (userMsg as { content: Array<{ type: string; text: string }> }).content;
+    expect(content[0]?.text).toContain("[File block trimmed:");
+  });
+
+  it("runs both file block and tool result trimming when both are present", () => {
+    const bigFileBody = "f".repeat(10_000);
+    const bigToolText = "t".repeat(20_000);
+    const messages: AgentMessage[] = [
+      makeUserWithFile("big.pdf", "application/pdf", bigFileBody),
+      makeAssistant("a1"),
+      makeToolResult({ toolCallId: "t1", toolName: "exec", text: bigToolText }),
+      makeAssistant("a2"),
+    ];
+
+    const next = pruneWithAggressiveDefaults(messages, {
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+
+    // File block trimmed
+    const userContent = (next[0] as { content: string }).content;
+    expect(userContent).toContain("[File block trimmed:");
+    // Tool result also trimmed or cleared
+    const toolMsg = findToolResult(next, "t1");
+    expect(toolText(toolMsg).length).toBeLessThan(bigToolText.length);
+  });
+
+  it("does not trim file blocks when fileBlocks.enabled is false", () => {
+    const bigBody = "n".repeat(10_000);
+    const messages: AgentMessage[] = [
+      makeUserWithFile("report.pdf", "application/pdf", bigBody),
+      makeAssistant("a1"),
+    ];
+
+    const next = pruneWithAggressiveDefaults(messages, {
+      hardClearRatio: 10.0,
+      fileBlocks: { enabled: false, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+
+    const userMsg = next[0];
+    const content = (userMsg as { content: string }).content;
+    expect(content).toContain(bigBody);
+    expect(content).not.toContain("[File block trimmed:");
+  });
+
+  it("keepLastAssistants protects recent user message file blocks", () => {
+    const bigBody = "p".repeat(10_000);
+    const messages: AgentMessage[] = [
+      makeUserWithFile("old.pdf", "application/pdf", bigBody),
+      makeAssistant("a1"),
+      makeAssistant("a2"),
+      makeUserWithFile("new.pdf", "application/pdf", bigBody),
+      makeAssistant("a3"),
+    ];
+
+    // keepLastAssistants=2 => cutoff is at a2 (index 2), protecting messages from index 2 onward.
+    // The user message at index 3 (new.pdf) is after cutoff, so it's protected.
+    const next = pruneWithAggressiveDefaults(messages, {
+      keepLastAssistants: 2,
+      hardClearRatio: 10.0,
+      fileBlocks: { enabled: true, maxChars: 100, headChars: 30, tailChars: 30 },
+    });
+
+    // Old file block (before cutoff) should be trimmed
+    const oldContent = (next[0] as { content: string }).content;
+    expect(oldContent).toContain("[File block trimmed:");
+
+    // New file block (after cutoff) should be preserved
+    const newContent = (next[3] as { content: string }).content;
+    expect(newContent).toContain(bigBody);
   });
 });

--- a/src/agents/pi-extensions/context-pruning.ts
+++ b/src/agents/pi-extensions/context-pruning.ts
@@ -7,7 +7,7 @@
 
 export { default } from "./context-pruning/extension.js";
 
-export { pruneContextMessages } from "./context-pruning/pruner.js";
+export { pruneContextMessages, softTrimFileBlocksInText } from "./context-pruning/pruner.js";
 export type {
   ContextPruningConfig,
   ContextPruningToolMatch,

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -217,6 +217,71 @@ ${tail}`;
   return { ...msg, content: [asText(trimmed + note)] };
 }
 
+const FILE_BLOCK_RE = /<file\s+name="([^"]*)"(?:\s+mime="([^"]*)")?\s*>([\s\S]*?)<\/file>/g;
+
+export function softTrimFileBlocksInText(
+  text: string,
+  settings: EffectiveContextPruningSettings,
+): { text: string; trimmedChars: number } {
+  const { maxChars, headChars, tailChars } = settings.fileBlocks;
+  let trimmedChars = 0;
+  const result = text.replace(
+    FILE_BLOCK_RE,
+    (match, name: string, mime: string | undefined, body: string) => {
+      if (body.length <= maxChars) {
+        return match;
+      }
+      const h = Math.max(0, headChars);
+      const t = Math.max(0, tailChars);
+      if (h + t >= body.length) {
+        return match;
+      }
+      const head = body.slice(0, h);
+      const tail = body.slice(body.length - t);
+      trimmedChars += body.length - h - t;
+      const mimeAttr = mime ? ` mime="${mime}"` : "";
+      return `<file name="${name}"${mimeAttr}>${head}\n...\n[File block trimmed: kept first ${h} and last ${t} of ${body.length} chars]\n...${tail}</file>`;
+    },
+  );
+  return { text: result, trimmedChars };
+}
+
+function softTrimFileBlocksInUserMessage(
+  msg: AgentMessage,
+  settings: EffectiveContextPruningSettings,
+): AgentMessage | null {
+  if (msg.role !== "user") {
+    return null;
+  }
+  const content = msg.content;
+  if (typeof content === "string") {
+    const { text, trimmedChars } = softTrimFileBlocksInText(content, settings);
+    if (trimmedChars === 0) {
+      return null;
+    }
+    return { ...msg, content: text };
+  }
+  if (Array.isArray(content)) {
+    let changed = false;
+    const newContent = content.map((block) => {
+      if (block.type !== "text") {
+        return block;
+      }
+      const { text, trimmedChars } = softTrimFileBlocksInText(block.text, settings);
+      if (trimmedChars === 0) {
+        return block;
+      }
+      changed = true;
+      return { ...block, text };
+    });
+    if (!changed) {
+      return null;
+    }
+    return { ...msg, content: newContent };
+  }
+  return null;
+}
+
 export function pruneContextMessages(params: {
   messages: AgentMessage[];
   settings: EffectiveContextPruningSettings;
@@ -260,11 +325,38 @@ export function pruneContextMessages(params: {
     return messages;
   }
 
-  const prunableToolIndexes: number[] = [];
   let next: AgentMessage[] | null = null;
 
+  // --- File block trimming pass (before tool result trimming) ---
+  if (settings.fileBlocks.enabled) {
+    for (let i = pruneStartIndex; i < cutoffIndex; i++) {
+      const msg = (next ?? messages)[i];
+      if (!msg || msg.role !== "user") {
+        continue;
+      }
+      const updated = softTrimFileBlocksInUserMessage(msg, settings);
+      if (!updated) {
+        continue;
+      }
+      const beforeChars = estimateMessageChars(msg);
+      const afterChars = estimateMessageChars(updated);
+      totalChars += afterChars - beforeChars;
+      if (!next) {
+        next = messages.slice();
+      }
+      next[i] = updated;
+    }
+    ratio = totalChars / charWindow;
+    if (ratio < settings.softTrimRatio) {
+      return next ?? messages;
+    }
+  }
+
+  // --- Tool result soft trim pass ---
+  const prunableToolIndexes: number[] = [];
+
   for (let i = pruneStartIndex; i < cutoffIndex; i++) {
-    const msg = messages[i];
+    const msg = (next ?? messages)[i];
     if (!msg || msg.role !== "toolResult") {
       continue;
     }

--- a/src/agents/pi-extensions/context-pruning/settings.ts
+++ b/src/agents/pi-extensions/context-pruning/settings.ts
@@ -20,6 +20,12 @@ export type ContextPruningConfig = {
     headChars?: number;
     tailChars?: number;
   };
+  fileBlocks?: {
+    enabled?: boolean;
+    maxChars?: number;
+    headChars?: number;
+    tailChars?: number;
+  };
   hardClear?: {
     enabled?: boolean;
     placeholder?: string;
@@ -35,6 +41,12 @@ export type EffectiveContextPruningSettings = {
   minPrunableToolChars: number;
   tools: ContextPruningToolMatch;
   softTrim: {
+    maxChars: number;
+    headChars: number;
+    tailChars: number;
+  };
+  fileBlocks: {
+    enabled: boolean;
     maxChars: number;
     headChars: number;
     tailChars: number;
@@ -57,6 +69,12 @@ export const DEFAULT_CONTEXT_PRUNING_SETTINGS: EffectiveContextPruningSettings =
     maxChars: 4_000,
     headChars: 1_500,
     tailChars: 1_500,
+  },
+  fileBlocks: {
+    enabled: true,
+    maxChars: 2_000,
+    headChars: 800,
+    tailChars: 800,
   },
   hardClear: {
     enabled: true,
@@ -108,6 +126,20 @@ export function computeEffectiveSettings(raw: unknown): EffectiveContextPruningS
     }
     if (typeof cfg.softTrim.tailChars === "number" && Number.isFinite(cfg.softTrim.tailChars)) {
       s.softTrim.tailChars = Math.max(0, Math.floor(cfg.softTrim.tailChars));
+    }
+  }
+  if (cfg.fileBlocks) {
+    if (typeof cfg.fileBlocks.enabled === "boolean") {
+      s.fileBlocks.enabled = cfg.fileBlocks.enabled;
+    }
+    if (typeof cfg.fileBlocks.maxChars === "number" && Number.isFinite(cfg.fileBlocks.maxChars)) {
+      s.fileBlocks.maxChars = Math.max(0, Math.floor(cfg.fileBlocks.maxChars));
+    }
+    if (typeof cfg.fileBlocks.headChars === "number" && Number.isFinite(cfg.fileBlocks.headChars)) {
+      s.fileBlocks.headChars = Math.max(0, Math.floor(cfg.fileBlocks.headChars));
+    }
+    if (typeof cfg.fileBlocks.tailChars === "number" && Number.isFinite(cfg.fileBlocks.tailChars)) {
+      s.fileBlocks.tailChars = Math.max(0, Math.floor(cfg.fileBlocks.tailChars));
     }
   }
   if (cfg.hardClear) {

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -38,6 +38,12 @@ export type AgentContextPruningConfig = {
     headChars?: number;
     tailChars?: number;
   };
+  fileBlocks?: {
+    enabled?: boolean;
+    maxChars?: number;
+    headChars?: number;
+    tailChars?: number;
+  };
   hardClear?: {
     enabled?: boolean;
     placeholder?: string;

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -71,6 +71,15 @@ export const AgentDefaultsSchema = z
           })
           .strict()
           .optional(),
+        fileBlocks: z
+          .object({
+            enabled: z.boolean().optional(),
+            maxChars: z.number().int().nonnegative().optional(),
+            headChars: z.number().int().nonnegative().optional(),
+            tailChars: z.number().int().nonnegative().optional(),
+          })
+          .strict()
+          .optional(),
         hardClear: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><!-- obsidian --><p>File blocks (<code>&#x3C;file></code> tags) injected into user messages by the media pipeline can be 200K+ chars but were never pruned by <code>contextPruning</code>, causing system prompt rules to be pushed out of the model's effective attention window. Add a new <code>fileBlocks</code> config section that trims oversized file blocks in user messages to head+tail summaries, running before the existing tool result trimming pass.</p>
<h2 data-heading="Summary">Summary</h2>
<ul>
<li><strong>Problem</strong>: <code>&#x3C;file></code> blocks in user messages (from PDF/Excel/Word attachments) are never pruned by <code>contextPruning.softTrim</code>, which only handles <code>toolResult</code> messages</li>
<li><strong>Why it matters</strong>: A single 200K-char PDF file block pushes SOUL.md output hygiene rules out of the model's effective attention window, causing English thinking leakage in non-English channels</li>
<li><strong>What changed</strong>: New <code>contextPruning.fileBlocks</code> config section + file block trimming pass in <code>pruneContextMessages()</code> that runs before the existing tool result trimming pass; trims oversized <code>&#x3C;file></code> blocks to head+tail summaries</li>
<li><strong>What did NOT change (scope boundary)</strong>: Existing <code>toolResult</code> soft trim / hard clear logic is untouched; no changes to the media pipeline or file block generation</li>
</ul>
<h2 data-heading="Change Type">Change Type</h2>
<ul>
<li>Feature</li>
</ul>
<h2 data-heading="Scope">Scope</h2>
<ul>
<li>Gateway / orchestration</li>
</ul>
<h2 data-heading="Linked Issue/PR">Linked Issue/PR</h2>
<ul>
<li>Related: Discord <a class="tag" href="#project">#project</a> channel English thinking leakage root cause</li>
</ul>
<h2 data-heading="User-visible / Behavior Changes">User-visible / Behavior Changes</h2>
<ul>
<li>New config: <code>contextPruning.fileBlocks.{enabled, maxChars, headChars, tailChars}</code> (defaults: <code>true, 2000, 800, 800</code>)</li>
<li>Oversized <code>&#x3C;file></code> blocks in older user messages are now automatically trimmed to head+tail when context pressure exceeds <code>softTrimRatio</code></li>
<li>Trimmed blocks include an annotation: <code>[File block trimmed: kept first N and last M of X chars]</code></li>
</ul>
<h2 data-heading="Security Impact">Security Impact</h2>
<ul>
<li>New permissions/capabilities? <code>No</code></li>
<li>Secrets/tokens handling changed? <code>No</code></li>
<li>New/changed network calls? <code>No</code></li>
<li>Command/tool execution surface changed? <code>No</code></li>
<li>Data access scope changed? <code>No</code></li>
</ul>
<h2 data-heading="Repro + Verification">Repro + Verification</h2>
<h3 data-heading="Environment">Environment</h3>
<ul>
<li>OS: macOS 15.5</li>
<li>Runtime: Node 22 + Bun 1.3.9</li>
<li>Relevant config: <code>contextPruning.mode: "cache-ttl"</code></li>
</ul>
<h3 data-heading="Steps">Steps</h3>
<ol>
<li>Send a 200K+ char PDF attachment in a Discord channel</li>
<li>Continue conversation for several turns until context pressure builds</li>
<li>Observe that SOUL.md rules remain effective (no English thinking leakage)</li>
</ol>
<h3 data-heading="Expected">Expected</h3>
<ul>
<li>File blocks in older messages are trimmed; system prompt rules stay within attention window</li>
</ul>
<h3 data-heading="Actual">Actual</h3>
<ul>
<li>Before: file blocks never trimmed -> system prompt pushed out -> English thinking leaked</li>
<li>After: file blocks trimmed to 2000 chars (800 head + 800 tail + annotation)</li>
</ul>
<h2 data-heading="Evidence">Evidence</h2>
<ul>
<li>All 19 tests pass (10 existing + 8 new file block tests + 1 settings test)</li>
<li><code>pnpm tsgo</code> zero errors, <code>pnpm check</code> clean, Codex CLI review no issues</li>
</ul>
<h2 data-heading="Human Verification">Human Verification</h2>
<ul>
<li>Verified scenarios: unit trim, string/array content, multi-block, integration with tool result trimming, enabled=false bypass, keepLastAssistants protection</li>
<li>Edge cases checked: small blocks untouched, multiple blocks in one message (only oversized trimmed), file blocks without mime attribute</li>
<li>What you did <strong>not</strong> verify: production load with real 200K PDF; only synthetic test data</li>
</ul>
<h2 data-heading="Compatibility / Migration">Compatibility / Migration</h2>
<ul>
<li>Backward compatible? <code>Yes</code></li>
<li>Config/env changes? <code>Yes</code> - new optional <code>contextPruning.fileBlocks</code> section (defaults are sensible, no action required)</li>
<li>Migration needed? <code>No</code></li>
</ul>
<h2 data-heading="Failure Recovery (if this breaks)">Failure Recovery (if this breaks)</h2>
<ul>
<li>How to disable/revert: set <code>contextPruning.fileBlocks.enabled: false</code> in agent defaults config</li>
<li>Files/config to restore: no migration, just toggle the flag</li>
<li>Known bad symptoms: if the regex matches unintended content inside user messages, file content could be incorrectly trimmed; disable via config flag</li>
</ul>
<h2 data-heading="Risks and Mitigations">Risks and Mitigations</h2>
<ul>
<li>Risk: Regex <code>&#x3C;file ...>...&#x3C;/file></code> could match user-typed text that happens to look like a file block
<ul>
<li>Mitigation: The <code>&#x3C;file></code> tag format is generated by the media pipeline with XML-escaped attributes; user-typed content is extremely unlikely to match. Additionally, trimming only applies to blocks exceeding <code>maxChars</code> (2000 default), so short false matches are ignored</li>
</ul>
</li>
</ul>
<h2 data-heading="Changed Files">Changed Files</h2>

File | Change
-- | --
context-pruning/settings.ts | fileBlocks type, defaults (2000/800/800), config parsing
types.agent-defaults.ts | AgentContextPruningConfig add fileBlocks field
zod-schema.agent-defaults.ts | fileBlocks Zod validation
context-pruning/pruner.ts | softTrimFileBlocksInText() + softTrimFileBlocksInUserMessage() + integration into pruneContextMessages()
context-pruning.ts | barrel re-export softTrimFileBlocksInText
context-pruning.test.ts | 8 new test cases

<!--EndFragment-->
</body>
</html>File blocks (`<file>` tags) injected into user messages by the media pipeline can be 200K+ chars but were never pruned by `contextPruning`, causing system prompt rules to be pushed out of the model's effective attention window. Add a new `fileBlocks` config section that trims oversized file blocks in user messages to head+tail summaries, running before the existing tool result trimming pass.

## Summary

- **Problem**: `<file>` blocks in user messages (from PDF/Excel/Word attachments) are never pruned by `contextPruning.softTrim`, which only handles `toolResult` messages
- **Why it matters**: A single 200K-char PDF file block pushes SOUL.md output hygiene rules out of the model's effective attention window, causing English thinking leakage in non-English channels
- **What changed**: New `contextPruning.fileBlocks` config section + file block trimming pass in `pruneContextMessages()` that runs before the existing tool result trimming pass; trims oversized `<file>` blocks to head+tail summaries
- **What did NOT change (scope boundary)**: Existing `toolResult` soft trim / hard clear logic is untouched; no changes to the media pipeline or file block generation

## Change Type

- Feature

## Scope

- Gateway / orchestration

## Linked Issue/PR

- Related: Discord [#project](https://github.com/openclaw/openclaw/pull/32750#project) channel English thinking leakage root cause

## User-visible / Behavior Changes

- New config: `contextPruning.fileBlocks.{enabled, maxChars, headChars, tailChars}` (defaults: `true, 2000, 800, 800`)
- Oversized `<file>` blocks in older user messages are now automatically trimmed to head+tail when context pressure exceeds `softTrimRatio`
- Trimmed blocks include an annotation: `[File block trimmed: kept first N and last M of X chars]`

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS 15.5
- Runtime: Node 22 + Bun 1.3.9
- Relevant config: `contextPruning.mode: "cache-ttl"`

### Steps

1. Send a 200K+ char PDF attachment in a Discord channel
2. Continue conversation for several turns until context pressure builds
3. Observe that SOUL.md rules remain effective (no English thinking leakage)

### Expected

- File blocks in older messages are trimmed; system prompt rules stay within attention window

### Actual

- Before: file blocks never trimmed -> system prompt pushed out -> English thinking leaked
- After: file blocks trimmed to 2000 chars (800 head + 800 tail + annotation)

## Evidence

- All 19 tests pass (10 existing + 8 new file block tests + 1 settings test)
- `pnpm tsgo` zero errors, `pnpm check` clean, Codex CLI review no issues

## Human Verification

- Verified scenarios: unit trim, string/array content, multi-block, integration with tool result trimming, enabled=false bypass, keepLastAssistants protection
- Edge cases checked: small blocks untouched, multiple blocks in one message (only oversized trimmed), file blocks without mime attribute
- What you did **not** verify: production load with real 200K PDF; only synthetic test data

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `Yes` - new optional `contextPruning.fileBlocks` section (defaults are sensible, no action required)
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: set `contextPruning.fileBlocks.enabled: false` in agent defaults config
- Files/config to restore: no migration, just toggle the flag
- Known bad symptoms: if the regex matches unintended content inside user messages, file content could be incorrectly trimmed; disable via config flag

## Risks and Mitigations

- Risk: Regex `<file ...>...</file>` could match user-typed text that happens to look like a file block
  - Mitigation: The `<file>` tag format is generated by the media pipeline with XML-escaped attributes; user-typed content is extremely unlikely to match. Additionally, trimming only applies to blocks exceeding `maxChars` (2000 default), so short false matches are ignored

## Changed Files

| File | Change |
|------|--------|
| `context-pruning/settings.ts` | `fileBlocks` type, defaults (2000/800/800), config parsing |
| `types.agent-defaults.ts` | `AgentContextPruningConfig` add `fileBlocks` field |
| `zod-schema.agent-defaults.ts` | `fileBlocks` Zod validation |
| `context-pruning/pruner.ts` | `softTrimFileBlocksInText()` + `softTrimFileBlocksInUserMessage()` + integration into `pruneContextMessages()` |
| `context-pruning.ts` | barrel re-export `softTrimFileBlocksInText` |
| `context-pruning.test.ts` | 8 new test cases |