### PR TITLE
fix(memory): broaden temporal decay regex to match dates in subdirs and suffixes

### DIFF
--- a/src/memory/temporal-decay.test.ts
+++ b/src/memory/temporal-decay.test.ts
@@ -108,6 +108,71 @@ describe("temporal decay", () => {
     expect(merged[0]?.score ?? 0).toBeGreaterThan(merged[1]?.score ?? 0);
   });
 
+  it("extracts date from memory path with topic suffix", async () => {
+    const decayed = await applyTemporalDecayToHybridResults({
+      results: [{ path: "memory/2026-02-10-niki-blog.md", score: 1, source: "memory" }],
+      temporalDecay: { enabled: true, halfLifeDays: 30 },
+      nowMs: NOW_MS,
+    });
+
+    // Date matches today (NOW_MS), so no decay
+    expect(decayed[0]?.score).toBeCloseTo(1);
+  });
+
+  it("extracts date from memory subdirectory path", async () => {
+    const decayed = await applyTemporalDecayToHybridResults({
+      results: [{ path: "memory/archive/2025-01-11.md", score: 1, source: "memory" }],
+      temporalDecay: { enabled: true, halfLifeDays: 30 },
+      nowMs: NOW_MS,
+    });
+
+    // ~395 days old, heavy decay
+    expect(decayed[0]?.score ?? 1).toBeLessThan(0.01);
+  });
+
+  it("extracts date from memory subdirectory path with suffix", async () => {
+    const decayed = await applyTemporalDecayToHybridResults({
+      results: [{ path: "memory/reference/2026-02-10-detail.md", score: 1, source: "memory" }],
+      temporalDecay: { enabled: true, halfLifeDays: 30 },
+      nowMs: NOW_MS,
+    });
+
+    // Date matches today (NOW_MS), so no decay
+    expect(decayed[0]?.score).toBeCloseTo(1);
+  });
+
+  it("extracts date when not at start of basename", async () => {
+    const decayed = await applyTemporalDecayToHybridResults({
+      results: [
+        { path: "memory/archive/morning-summary-2026-02-10.md", score: 1, source: "memory" },
+      ],
+      temporalDecay: { enabled: true, halfLifeDays: 30 },
+      nowMs: NOW_MS,
+    });
+
+    // Date matches today (NOW_MS), so no decay
+    expect(decayed[0]?.score).toBeCloseTo(1);
+  });
+
+  it("treats dated files in subdirectories as temporal, not evergreen", async () => {
+    const dir = await makeTempDir();
+
+    // Create a dated file in a memory subdirectory
+    const datedSubPath = path.join(dir, "memory", "archive", "2010-01-01.md");
+    await fs.mkdir(path.dirname(datedSubPath), { recursive: true });
+    await fs.writeFile(datedSubPath, "old dated");
+
+    const decayed = await applyTemporalDecayToHybridResults({
+      results: [{ path: "memory/archive/2010-01-01.md", score: 1, source: "memory" }],
+      workspaceDir: dir,
+      temporalDecay: { enabled: true, halfLifeDays: 30 },
+      nowMs: NOW_MS,
+    });
+
+    // Very old date means heavy decay — file must NOT be treated as evergreen
+    expect(decayed[0]?.score ?? 1).toBeLessThan(0.001);
+  });
+
   it("handles future dates, zero age, and very old memories", async () => {
     const merged = await mergeHybridResults({
       vectorWeight: 1,

--- a/src/memory/temporal-decay.ts
+++ b/src/memory/temporal-decay.ts
@@ -12,7 +12,7 @@ export const DEFAULT_TEMPORAL_DECAY_CONFIG: TemporalDecayConfig = {
 };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const DATED_MEMORY_PATH_RE = /(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})\.md$/;
+const DATED_MEMORY_PATH_RE = /(?:^|\/)memory\/(?:.+\/)?[^/]*?(\d{4})-(\d{2})-(\d{2})[^/]*\.md$/;
 
 export function toDecayLambda(halfLifeDays: number): number {
   if (!Number.isFinite(halfLifeDays) || halfLifeDays <= 0) {


### PR DESCRIPTION
## Summary

- **Problem:** `DATED_MEMORY_PATH_RE` only matched `memory/YYYY-MM-DD.md` exactly, failing on topic suffixes (`memory/2026-02-28-niki-blog.md`), subdirectories (`memory/archive/2026-02-27.md`), combined patterns (`memory/reference/2026-02-23-detail.md`), and mid-basename dates (`memory/archive/morning-summary-2026-01-26.md`).
- **Why it matters:** 97% of memory files got zero temporal decay, making the feature effectively useless.
- **What changed:** Broadened the regex to match `YYYY-MM-DD` anywhere in the basename under any `memory/` subdirectory. Added 5 new test cases covering all four failing patterns.
- **What did NOT change (scope boundary):** `parseMemoryDateFromPath()` logic, `isEvergreenMemoryPath()` logic, decay math, and all other temporal decay behavior remain untouched. Only the regex pattern changed.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Memory / storage

## Linked Issue/PR

- Closes #32745

## User-visible / Behavior Changes

Memory files with dates in subdirectories or with topic suffixes now correctly receive temporal decay instead of being silently skipped. Files like `memory/archive/2026-02-27.md` or `memory/2026-02-28-niki-blog.md` will decay over time as intended.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Steps

1. Create memory files with varied naming patterns (subdirectory, topic suffix, mid-basename date)
2. Enable temporal decay (`temporalDecay.enabled: true`)
3. Search memory — observe that dated files now decay correctly

### Expected

- All memory files with `YYYY-MM-DD` in their path receive temporal decay

### Actual (before fix)

- Only `memory/YYYY-MM-DD.md` exact pattern received decay; all others treated as evergreen

## Evidence

- [x] Failing test/log before + passing after
- 5 new test cases added covering: topic suffix, subdirectory, subdirectory+suffix, mid-basename date, and evergreen vs temporal classification
- All 11 tests pass: `pnpm vitest run src/memory/temporal-decay`

## Human Verification (required)

- Verified scenarios: all four failing patterns from the issue, plus backward compatibility with existing `memory/YYYY-MM-DD.md` pattern
- Edge cases checked: future dates, very old dates, evergreen files without dates, nested subdirectories
- What you did **not** verify: production data volume impact

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the single regex line in `src/memory/temporal-decay.ts`
- Known bad symptoms reviewers should watch for: unexpected decay on files that should be evergreen (files without dates in their basename)

## Risks and Mitigations

- Risk: Files with coincidental date-like patterns (e.g. `memory/report-2024-12-25-metrics.md`) now match as dated
  - Mitigation: This is the intended behavior — any file with a `YYYY-MM-DD` date should be temporal, not evergreen