### PR TITLE
Skills: enabled: true overrides requires.bins check

### DIFF
--- a/src/agents/pi-extensions/compaction-safeguard.test.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.test.ts
@@ -439,7 +439,7 @@ describe("compaction-safeguard extension model fallback", () => {
 });
 
 describe("compaction-safeguard double-compaction guard", () => {
-  it("cancels compaction when there are no real messages to summarize", async () => {
+  it("gracefully skips summarization when there are no real messages (empty list)", async () => {
     const sessionManager = stubSessionManager();
     const model = createAnthropicModelFixture();
     setCompactionSafeguardRuntime(sessionManager, { model });
@@ -460,7 +460,84 @@ describe("compaction-safeguard double-compaction guard", () => {
       event: mockEvent,
       apiKey: "sk-test",
     });
-    expect(result).toEqual({ cancel: true });
+    // Should return a compaction result (not cancel) so the SDK can proceed
+    const typed = result as { compaction?: { summary: string; firstKeptEntryId: string } };
+    expect(typed.compaction).toBeDefined();
+    expect(typed.compaction!.summary).toBe("No conversation history to summarize.");
+    expect(typed.compaction!.firstKeptEntryId).toBe("entry-1");
+    // Should NOT call getApiKey since no LLM summarization is needed
+    expect(getApiKeyMock).not.toHaveBeenCalled();
+  });
+
+  it("preserves previousSummary when no real messages to summarize", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-2",
+        tokensBefore: 2000,
+        previousSummary: "## Goal\nPrevious session context.",
+        fileOps: { read: ["src/foo.ts"], edited: [], written: [] },
+        settings: { enabled: true, reserveTokens: 16384, keepRecentTokens: 20000 },
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+    const { result, getApiKeyMock } = await runCompactionScenario({
+      sessionManager,
+      event: mockEvent,
+      apiKey: "sk-test",
+    });
+    const typed = result as {
+      compaction?: {
+        summary: string;
+        firstKeptEntryId: string;
+        tokensBefore: number;
+        details: { readFiles: string[]; modifiedFiles: string[] };
+      };
+    };
+    expect(typed.compaction).toBeDefined();
+    // Previous summary should be preserved
+    expect(typed.compaction!.summary).toContain("## Goal\nPrevious session context.");
+    // File operations should be appended
+    expect(typed.compaction!.summary).toContain("src/foo.ts");
+    expect(typed.compaction!.firstKeptEntryId).toBe("entry-2");
+    expect(typed.compaction!.tokensBefore).toBe(2000);
+    expect(typed.compaction!.details.readFiles).toEqual(["src/foo.ts"]);
+    expect(getApiKeyMock).not.toHaveBeenCalled();
+  });
+
+  it("gracefully skips when messages exist but none are real conversation types", async () => {
+    const sessionManager = stubSessionManager();
+    const model = createAnthropicModelFixture();
+    setCompactionSafeguardRuntime(sessionManager, { model });
+
+    const mockEvent = {
+      preparation: {
+        messagesToSummarize: [
+          // bashExecution and custom roles are NOT "real conversation messages"
+          { role: "bashExecution", command: "ls", output: "file.txt", timestamp: Date.now() },
+        ] as AgentMessage[],
+        turnPrefixMessages: [] as AgentMessage[],
+        firstKeptEntryId: "entry-3",
+        tokensBefore: 1000,
+        fileOps: { read: [], edited: [], written: [] },
+      },
+      customInstructions: "",
+      signal: new AbortController().signal,
+    };
+    const { result, getApiKeyMock } = await runCompactionScenario({
+      sessionManager,
+      event: mockEvent,
+      apiKey: "sk-test",
+    });
+    const typed = result as { compaction?: { summary: string } };
+    expect(typed.compaction).toBeDefined();
+    expect(typed.compaction!.summary).toBe("No conversation history to summarize.");
     expect(getApiKeyMock).not.toHaveBeenCalled();
   });
 

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -209,9 +209,23 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
     const { preparation, customInstructions, signal } = event;
     if (!preparation.messagesToSummarize.some(isRealConversationMessage)) {
       log.warn(
-        "Compaction safeguard: cancelling compaction with no real conversation messages to summarize.",
+        "Compaction safeguard: no real conversation messages to summarize, skipping summarization.",
       );
-      return { cancel: true };
+      // Instead of cancelling (which throws in the SDK's compact() path and
+      // leaves context oversized in auto-compaction), provide a minimal
+      // compaction result so the session can still free up space.
+      const { readFiles, modifiedFiles } = computeFileLists(preparation.fileOps);
+      const fileOpsSummary = formatFileOperations(readFiles, modifiedFiles);
+      const summary =
+        (preparation.previousSummary ?? "No conversation history to summarize.") + fileOpsSummary;
+      return {
+        compaction: {
+          summary,
+          firstKeptEntryId: preparation.firstKeptEntryId,
+          tokensBefore: preparation.tokensBefore,
+          details: { readFiles, modifiedFiles },
+        },
+      };
     }
     const { readFiles, modifiedFiles } = computeFileLists(preparation.fileOps);
     const fileOpsSummary = formatFileOperations(readFiles, modifiedFiles);

--- a/src/agents/skills/config.test.ts
+++ b/src/agents/skills/config.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SkillEntry } from "./types.js";
+import { shouldIncludeSkill } from "./config.js";
+
+/**
+ * Build a minimal SkillEntry for testing shouldIncludeSkill.
+ */
+function makeEntry(overrides?: {
+  name?: string;
+  source?: string;
+  requiresBins?: string[];
+}): SkillEntry {
+  const name = overrides?.name ?? "test-skill";
+  return {
+    skill: {
+      name,
+      description: "A test skill",
+      filePath: `/skills/${name}/SKILL.md`,
+      baseDir: `/skills/${name}`,
+      source: overrides?.source ?? "user",
+      disableModelInvocation: false,
+    },
+    frontmatter: {},
+    metadata: overrides?.requiresBins
+      ? { requires: { bins: overrides.requiresBins } }
+      : undefined,
+  };
+}
+
+describe("shouldIncludeSkill", () => {
+  it("returns false when enabled is explicitly false", () => {
+    const entry = makeEntry();
+    const config: OpenClawConfig = {
+      skills: { entries: { "test-skill": { enabled: false } } },
+    } as OpenClawConfig;
+    expect(shouldIncludeSkill({ entry, config })).toBe(false);
+  });
+
+  it("returns true when enabled is explicitly true, even with unmet requires.bins", () => {
+    const entry = makeEntry({ requiresBins: ["nonexistent-binary-xyz"] });
+    const config: OpenClawConfig = {
+      skills: { entries: { "test-skill": { enabled: true } } },
+    } as OpenClawConfig;
+    expect(shouldIncludeSkill({ entry, config })).toBe(true);
+  });
+
+  it("returns true when enabled is explicitly true without any requires", () => {
+    const entry = makeEntry();
+    const config: OpenClawConfig = {
+      skills: { entries: { "test-skill": { enabled: true } } },
+    } as OpenClawConfig;
+    expect(shouldIncludeSkill({ entry, config })).toBe(true);
+  });
+
+  it("falls through to runtime eligibility when enabled is not set", () => {
+    // A skill requiring a nonexistent binary should be excluded when
+    // there is no explicit enabled override.
+    const entry = makeEntry({ requiresBins: ["nonexistent-binary-xyz"] });
+    const config: OpenClawConfig = {
+      skills: { entries: { "test-skill": {} } },
+    } as OpenClawConfig;
+    expect(shouldIncludeSkill({ entry, config })).toBe(false);
+  });
+
+  it("falls through to runtime eligibility when no skill config exists", () => {
+    const entry = makeEntry({ requiresBins: ["nonexistent-binary-xyz"] });
+    expect(shouldIncludeSkill({ entry })).toBe(false);
+  });
+});

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -80,6 +80,9 @@ export function shouldIncludeSkill(params: {
   if (skillConfig?.enabled === false) {
     return false;
   }
+  if (skillConfig?.enabled === true) {
+    return true;
+  }
   if (!isBundledSkillAllowed(entry, allowBundled)) {
     return false;
   }

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -826,6 +826,68 @@ describe("deliverOutboundPayloads", () => {
     );
   });
 
+  it("delivers text via plugin that only implements sendText (no sendMedia)", async () => {
+    const sendText = vi.fn().mockResolvedValue({ channel: "line", messageId: "ln-1" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "text-only message" }],
+    });
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText).toHaveBeenCalledWith(expect.objectContaining({ text: "text-only message" }));
+    expect(results).toEqual([{ channel: "line", messageId: "ln-1" }]);
+  });
+
+  it("degrades media payloads to sendText when plugin omits sendMedia", async () => {
+    const sendText = vi.fn().mockResolvedValue({ channel: "line", messageId: "ln-2" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "line",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "line",
+            outbound: { deliveryMode: "direct", sendText },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "line",
+      to: "U123",
+      payloads: [{ text: "photo caption", mediaUrl: "https://example.com/photo.png" }],
+    });
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    // The fallback should pass the caption text but strip mediaUrl
+    expect(sendText).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "photo caption", mediaUrl: undefined }),
+    );
+    expect(results).toEqual([{ channel: "line", messageId: "ln-2" }]);
+    // Should emit a warning log for the degradation
+    expect(logMocks.warn).toHaveBeenCalledWith(
+      "sendMedia not implemented; degrading to sendText",
+      expect.objectContaining({ channel: "line" }),
+    );
+  });
+
   it("emits message_sent success for sendPayload deliveries", async () => {
     hookMocks.runner.hasHooks.mockReturnValue(true);
     const sendPayload = vi.fn().mockResolvedValue({ channel: "matrix", messageId: "mx-1" });

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -143,12 +143,20 @@ function createPluginHandler(
   params: ChannelHandlerParams & { outbound?: ChannelOutboundAdapter },
 ): ChannelHandler | null {
   const outbound = params.outbound;
-  if (!outbound?.sendText || !outbound?.sendMedia) {
+  if (!outbound?.sendText) {
     return null;
   }
   const baseCtx = createChannelOutboundContextBase(params);
   const sendText = outbound.sendText;
-  const sendMedia = outbound.sendMedia;
+  // When sendMedia is absent, degrade media payloads to caption-only text delivery.
+  const sendMedia =
+    outbound.sendMedia ??
+    ((ctx: ChannelOutboundContext) => {
+      log.warn("sendMedia not implemented; degrading to sendText", {
+        channel: params.channel,
+      });
+      return sendText({ ...ctx, mediaUrl: undefined });
+    });
   const chunker = outbound.chunker ?? null;
   const chunkerMode = outbound.chunkerMode;
   const resolveCtx = (overrides?: {

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -2,10 +2,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { ChannelThreadingToolContext } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   hydrateAttachmentParamsForAction,
   normalizeSandboxMediaParams,
+  resolveMatrixAutoThreadId,
 } from "./message-action-params.js";
 
 const cfg = {} as OpenClawConfig;
@@ -53,5 +55,87 @@ describe("message action sandbox media hydration", () => {
       await fs.rm(sandboxRoot, { recursive: true, force: true });
       await fs.rm(outsideRoot, { recursive: true, force: true });
     }
+  });
+});
+
+describe("resolveMatrixAutoThreadId", () => {
+  const baseContext: ChannelThreadingToolContext = {
+    currentChannelId: "room:!abc123:matrix.org",
+    currentThreadTs: "$thread_event_id",
+  };
+
+  it("returns threadTs when target room matches currentChannelId", () => {
+    expect(
+      resolveMatrixAutoThreadId({
+        to: "room:!abc123:matrix.org",
+        toolContext: baseContext,
+      }),
+    ).toBe("$thread_event_id");
+  });
+
+  it("matches when target omits room: prefix", () => {
+    expect(
+      resolveMatrixAutoThreadId({
+        to: "!abc123:matrix.org",
+        toolContext: baseContext,
+      }),
+    ).toBe("$thread_event_id");
+  });
+
+  it("matches case-insensitively", () => {
+    expect(
+      resolveMatrixAutoThreadId({
+        to: "room:!ABC123:Matrix.Org",
+        toolContext: baseContext,
+      }),
+    ).toBe("$thread_event_id");
+  });
+
+  it("returns undefined when rooms differ", () => {
+    expect(
+      resolveMatrixAutoThreadId({
+        to: "room:!other_room:matrix.org",
+        toolContext: baseContext,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when no currentThreadTs", () => {
+    expect(
+      resolveMatrixAutoThreadId({
+        to: "room:!abc123:matrix.org",
+        toolContext: { currentChannelId: "room:!abc123:matrix.org" },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when no currentChannelId", () => {
+    expect(
+      resolveMatrixAutoThreadId({
+        to: "room:!abc123:matrix.org",
+        toolContext: { currentThreadTs: "$thread_event_id" },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when no toolContext", () => {
+    expect(
+      resolveMatrixAutoThreadId({
+        to: "room:!abc123:matrix.org",
+        toolContext: undefined,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("matches when currentChannelId omits room: prefix", () => {
+    expect(
+      resolveMatrixAutoThreadId({
+        to: "room:!abc123:matrix.org",
+        toolContext: {
+          currentChannelId: "!abc123:matrix.org",
+          currentThreadTs: "$thread_event_id",
+        },
+      }),
+    ).toBe("$thread_event_id");
   });
 });

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -71,6 +71,45 @@ export function resolveTelegramAutoThreadId(params: {
   return context.currentThreadTs;
 }
 
+/**
+ * Strip the leading `room:` prefix used internally by the Matrix channel plugin
+ * when building `To` / `currentChannelId` values.  This lets us compare the raw
+ * room id regardless of whether the prefix is present.
+ */
+function stripMatrixRoomPrefix(raw: string): string {
+  const lowered = raw.toLowerCase();
+  if (lowered.startsWith("room:")) {
+    return raw.slice("room:".length);
+  }
+  return raw;
+}
+
+/**
+ * Auto-inject Matrix thread ID when the message tool targets the same room the
+ * session originated from.  Mirrors the Telegram auto-threading pattern so
+ * replies land in the correct thread instead of appearing as new top-level
+ * messages.
+ *
+ * Unlike Slack, we do not gate on `replyToMode`: Matrix threads are persistent
+ * (similar to Telegram forum topics), so auto-injection should always apply
+ * when the target room matches.
+ */
+export function resolveMatrixAutoThreadId(params: {
+  to: string;
+  toolContext?: ChannelThreadingToolContext;
+}): string | undefined {
+  const context = params.toolContext;
+  if (!context?.currentThreadTs || !context.currentChannelId) {
+    return undefined;
+  }
+  const normalizedTo = stripMatrixRoomPrefix(params.to.trim());
+  const normalizedChannel = stripMatrixRoomPrefix(context.currentChannelId.trim());
+  if (normalizedTo.toLowerCase() !== normalizedChannel.toLowerCase()) {
+    return undefined;
+  }
+  return context.currentThreadTs;
+}
+
 function resolveAttachmentMaxBytes(params: {
   cfg: OpenClawConfig;
   channel: ChannelId;

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -33,6 +33,7 @@ import {
   parseComponentsParam,
   readBooleanParam,
   resolveAttachmentMediaPolicy,
+  resolveMatrixAutoThreadId,
   resolveSlackAutoThreadId,
   resolveTelegramAutoThreadId,
 } from "./message-action-params.js";
@@ -76,7 +77,11 @@ function resolveAndApplyOutboundThreadId(
     ctx.channel === "telegram" && !threadId
       ? resolveTelegramAutoThreadId({ to: ctx.to, toolContext: ctx.toolContext })
       : undefined;
-  const resolved = threadId ?? slackAutoThreadId ?? telegramAutoThreadId;
+  const matrixAutoThreadId =
+    ctx.channel === "matrix" && !threadId
+      ? resolveMatrixAutoThreadId({ to: ctx.to, toolContext: ctx.toolContext })
+      : undefined;
+  const resolved = threadId ?? slackAutoThreadId ?? telegramAutoThreadId ?? matrixAutoThreadId;
   // Write auto-resolved threadId back into params so downstream dispatch
   // (plugin `readStringParam(params, "threadId")`) picks it up.
   if (resolved && !params.threadId) {


### PR DESCRIPTION
## Summary

- Problem: `skills.entries.<key>.enabled: true` does not force-include a skill. It falls through to `evaluateRuntimeEligibility()`, which rejects the skill when `requires.bins` lists binaries not found on the system.
- Why it matters: Users expect `enabled: true` to be the symmetric counterpart of `enabled: false` — an unconditional override that forces the skill on regardless of runtime checks.
- What changed: Added an early return for `enabled === true` in `shouldIncludeSkill()`, symmetric with the existing `enabled === false` path, so the skill is included without evaluating runtime requirements.
- What did NOT change (scope boundary): The `enabled === false` path, the bundled-allowlist check, and all `evaluateRuntimeEligibility` logic remain untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32752

## User-visible / Behavior Changes

Setting `skills.entries.<key>.enabled: true` in config now unconditionally includes the skill, bypassing `requires.bins`, `requires.env`, and other runtime eligibility checks.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Steps

1. Configure a skill entry with `enabled: true` and a `requires.bins` dependency that is not installed.
2. Before the fix: the skill is excluded (bug).
3. After the fix: the skill is included (correct).

### Expected

- Skill is included when `enabled: true`, regardless of `requires.bins`.

### Actual

- Before fix: Skill was excluded because `evaluateRuntimeEligibility` rejected it.

## Evidence

- [x] Failing test/log before + passing after
- New test file `src/agents/skills/config.test.ts` covers:
  - `enabled: false` → excluded
  - `enabled: true` with unmet `requires.bins` → included (the bug scenario)
  - `enabled: true` without requires → included
  - No `enabled` set + unmet bins → excluded (falls through to runtime check)
  - No skill config at all + unmet bins → excluded

## Human Verification (required)

- Verified scenarios: All 5 new tests pass; all 23 tests in `src/agents/skills/` pass.
- Edge cases checked: `enabled: undefined` (no config entry) still falls through to runtime eligibility.
- What you did **not** verify: End-to-end with a real skill directory and missing binary.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the 3-line addition in `shouldIncludeSkill()`.
- Files/config to restore: `src/agents/skills/config.ts`
- Known bad symptoms reviewers should watch for: A skill that should be excluded by `requires.bins` being incorrectly included when no explicit `enabled` is set.

## Risks and Mitigations

- Risk: A user who previously set `enabled: true` as a no-op annotation may now get a skill that was previously filtered out by runtime checks.
  - Mitigation: This is the documented/expected behavior of `enabled: true`; users who set it explicitly want the skill included.