### PR TITLE
fix(memoryFlush): prevent transcript-size forced flush loops with fresh totals

### DIFF
--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -332,6 +332,7 @@ export async function runMemoryFlushIfNeeded(params: {
   const shouldCheckTranscriptSizeForForcedFlush = Boolean(
     canAttemptFlush &&
     entry &&
+    !hasFreshPersistedPromptTokens &&
     Number.isFinite(forceFlushTranscriptBytes) &&
     forceFlushTranscriptBytes > 0,
   );
@@ -347,7 +348,7 @@ export async function runMemoryFlushIfNeeded(params: {
       })
     : undefined;
   const transcriptByteSize = sessionLogSnapshot?.byteSize;
-  const shouldForceFlushByTranscriptSize =
+  const hasOversizedTranscript =
     typeof transcriptByteSize === "number" && transcriptByteSize >= forceFlushTranscriptBytes;
 
   const transcriptUsageSnapshot = sessionLogSnapshot?.usage;
@@ -398,6 +399,7 @@ export async function runMemoryFlushIfNeeded(params: {
   const hasFreshPromptTokensSnapshot =
     promptTokensSnapshot > 0 &&
     (hasFreshPersistedPromptTokens || hasReliableTranscriptPromptTokens);
+  const shouldForceFlushByTranscriptSize = hasOversizedTranscript && !hasFreshPromptTokensSnapshot;
 
   const projectedTokenCount = hasFreshPromptTokensSnapshot
     ? resolveEffectivePromptTokens(
@@ -423,7 +425,8 @@ export async function runMemoryFlushIfNeeded(params: {
       `persistedPromptTokens=${persistedPromptTokens ?? "undefined"} persistedFresh=${entry?.totalTokensFresh === true} ` +
       `promptTokensEst=${promptTokenEstimate ?? "undefined"} transcriptPromptTokens=${transcriptPromptTokens ?? "undefined"} transcriptOutputTokens=${transcriptOutputTokens ?? "undefined"} ` +
       `projectedTokenCount=${projectedTokenCount ?? "undefined"} transcriptBytes=${transcriptByteSize ?? "undefined"} ` +
-      `forceFlushTranscriptBytes=${forceFlushTranscriptBytes} forceFlushByTranscriptSize=${shouldForceFlushByTranscriptSize}`,
+      `forceFlushTranscriptBytes=${forceFlushTranscriptBytes} hasOversizedTranscript=${hasOversizedTranscript} ` +
+      `forceFlushByTranscriptSize=${shouldForceFlushByTranscriptSize}`,
   );
 
   const shouldFlushMemory =

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1748,6 +1748,65 @@ describe("runReplyAgent memory flush", () => {
     });
   });
 
+  it("skips transcript-size forced flush when prompt tokens are already fresh and below threshold", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "main";
+      const sessionFile = "oversized-fresh-session.jsonl";
+      const transcriptPath = path.join(path.dirname(storePath), sessionFile);
+      await fs.mkdir(path.dirname(transcriptPath), { recursive: true });
+      await fs.writeFile(transcriptPath, "x".repeat(3_000), "utf-8");
+
+      const sessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        sessionFile,
+        totalTokens: 10_000,
+        totalTokensFresh: true,
+        compactionCount: 1,
+      };
+
+      await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+      const calls: Array<{ prompt?: string }> = [];
+      state.runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
+        calls.push({ prompt: params.prompt });
+        return {
+          payloads: [{ text: "ok" }],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
+      });
+
+      const baseRun = createBaseRun({
+        storePath,
+        sessionEntry,
+        config: {
+          agents: {
+            defaults: {
+              compaction: {
+                memoryFlush: {
+                  forceFlushTranscriptBytes: 256,
+                },
+              },
+            },
+          },
+        },
+        runOverrides: { sessionFile },
+      });
+
+      await runReplyAgentWithBase({
+        baseRun,
+        storePath,
+        sessionKey,
+        sessionEntry,
+        commandBody: "hello",
+      });
+
+      expect(calls.map((call) => call.prompt)).toEqual(["hello"]);
+      const stored = JSON.parse(await fs.readFile(storePath, "utf-8"));
+      expect(stored[sessionKey].memoryFlushAt).toBeUndefined();
+    });
+  });
+
   it("skips memory flush when disabled in config", async () => {
     await withTempStore(async (storePath) => {
       const sessionKey = "main";


### PR DESCRIPTION
## Summary
- avoid forcing `memoryFlush` from transcript byte size when prompt token totals are already fresh
- only allow transcript-size forcing as a fallback when token freshness is unavailable
- add e2e regression coverage to ensure oversized transcript logs do not trigger flush loops when session tokens are fresh and below threshold

Fixes #32106

## Validation
- `pnpm test src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts src/auto-reply/reply/reply-state.test.ts`
- `pnpm vitest run --config vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`
