### PR TITLE
fix: skills.entries.<key>.enabled

### DIFF
--- a/src/agents/skills/config.test.ts
+++ b/src/agents/skills/config.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { SkillEntry } from "./types.js";
+
+vi.mock("../../shared/config-eval.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../shared/config-eval.js")>();
+  return {
+    ...actual,
+    evaluateRuntimeEligibility: vi.fn(),
+  };
+});
+
+import * as configEvalModule from "../../shared/config-eval.js";
+import { shouldIncludeSkill } from "./config.js";
+
+const evaluateRuntimeEligibilityMock = vi.mocked(configEvalModule.evaluateRuntimeEligibility);
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+function createSkillEntry(metadata?: SkillEntry["metadata"]): SkillEntry {
+  return {
+    skill: { name: "test-skill" } as unknown as SkillEntry["skill"],
+    frontmatter: {},
+    metadata,
+  };
+}
+
+function createConfigForSkill(
+  skillKey: string,
+  skillConfig: NonNullable<OpenClawConfig["skills"]>["entries"][string],
+): OpenClawConfig {
+  return {
+    skills: {
+      entries: {
+        [skillKey]: skillConfig,
+      },
+    },
+  };
+}
+
+describe("skills/config shouldIncludeSkill", () => {
+  it("returns false when enabled is explicitly false without evaluating runtime eligibility", () => {
+    const entry = createSkillEntry();
+    const config = createConfigForSkill("test-skill", { enabled: false });
+
+    const result = shouldIncludeSkill({ entry, config });
+
+    expect(result).toBe(false);
+    expect(evaluateRuntimeEligibilityMock).not.toHaveBeenCalled();
+  });
+
+  it("returns true when enabled is explicitly true without evaluating runtime eligibility", () => {
+    const entry = createSkillEntry({
+      requires: {
+        bins: ["missing-cli"],
+      },
+    });
+    const config = createConfigForSkill("test-skill", { enabled: true });
+
+    const result = shouldIncludeSkill({ entry, config });
+
+    expect(result).toBe(true);
+    expect(evaluateRuntimeEligibilityMock).not.toHaveBeenCalled();
+  });
+
+  it("falls through to runtime eligibility when enabled is not set", () => {
+    evaluateRuntimeEligibilityMock.mockReturnValue(true);
+
+    const entry = createSkillEntry();
+    const config = createConfigForSkill("test-skill", {});
+
+    const result = shouldIncludeSkill({ entry, config });
+
+    expect(result).toBe(true);
+    expect(evaluateRuntimeEligibilityMock).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/src/agents/skills/config.ts
+++ b/src/agents/skills/config.ts
@@ -83,6 +83,9 @@ export function shouldIncludeSkill(params: {
   if (!isBundledSkillAllowed(entry, allowBundled)) {
     return false;
   }
+  if (skillConfig?.enabled === true) {
+    return true;
+  }
   return evaluateRuntimeEligibility({
     os: entry.metadata?.os,
     remotePlatforms: eligibility?.remote?.platforms,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Setting skills.entries.<key>.enabled: true in openclaw.json did not force-enable a skill when its requires.bins condition was not satisfied on the gateway host, while enabled: false did force-disable regardless of requirements.
- Why it matters: Deployments where the required binaries are available only inside the sandbox (e.g., via sidecar/proxy) but not on the gateway host’s PATH could not opt into those skills, even though the runtime environment was actually capable of running them.
- What changed: shouldIncludeSkill in src/agents/skills/config.ts now treats enabled === true as a symmetric “force enable” override: after passing the bundled-skill allowlist, it returns true without calling evaluateRuntimeEligibility, mirroring the existing enabled === false force-disable behavior; unit tests were added to cover both override cases.
- What did NOT change (scope boundary): Default behavior when enabled is undefined is unchanged (still uses evaluateRuntimeEligibility and requires.*); allowlists (skills.allowBundled) and runtime eligibility logic (including host vs remote binary checks) are untouched for skills that do not explicitly opt into enabled: true.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution

## Linked Issue/PR

- Closes # https://github.com/openclaw/openclaw/issues/32752#issue-4015316592

## User-visible / Behavior Changes

For skills with skills.entries.<key>.enabled: true in openclaw.json, the enabled flag now force-enables the skill as long as it is not blocked by the bundled-skill allowlist, even if requires.bins would fail on the gateway host.
For all other skills (where enabled is not explicitly set), runtime eligibility and requires.* checks continue to behave exactly as before.
Existing configs that do not set skills.entries.<key>.enabled: true are unaffected.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: OpenClaw gateway with sandboxed skills execution (Pi agent)
- Model/provider:  Any (not directly relevant)
- Integration/channel (if any): Any (not directly relevant)
- Relevant config (redacted): skills.entries.<bundled-skill-key>.enabled: true, bundled skill with requires: { bins: ["some-cli"] }

### Steps

1. Use a bundled skill whose SKILL.md frontmatter declares requires: { bins: ["some-cli"] }.
2. Ensure some-cli is available inside the sandbox container but not on the gateway host’s PATH.
3. In openclaw.json, set skills.entries.<skill-key>.enabled: true for that skill and restart the gateway.
4. Observe whether the skill appears in the loaded skills snapshot / is available to the agent.

### Expected

-The skill is force-enabled and available to the agent because the user explicitly opted in via enabled: true, even though the host-level hasBinary check would fail.

### Actual

-Before this change, the skill remained unavailable: shouldIncludeSkill only short-circuited on enabled === false but always evaluated evaluateRuntimeEligibility otherwise, and hasBinary() only checked the gateway host’s PATH, causing the skill to be filtered out.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after


## Human Verification (required)

- Verified scenarios: Reasoned through shouldIncludeSkill control flow for:
enabled: false (force-disable early return).
enabled: true (new force-enable early return after allowlist check, before runtime eligibility).
enabled unset (default path through evaluateRuntimeEligibility with existing requires.* semantics).
Ensured that bundled-skill allowlist (skills.allowBundled) is still respected even when enabled: true is set.
- Edge cases checked: Skill with no explicit skills.entries.<key> config: behavior unchanged.
Non-bundled skills: unaffected by allowlist logic; enabled overrides still work as expected.
Config objects with extra keys in SkillConfig (e.g., apiKey, env) continue to be used by hasEnv logic the same way as before.
- What you did **not** verify: Did not run a live gateway with a real sandbox to observe end-to-end skill invocation, due to environment limitations.

## Compatibility / Migration

- Backward compatible? Yes — default behavior (enabled unset) is unchanged.
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Users may now force-enable a skill (enabled: true) even when some runtime requirements (requires.*) are not satisfied, leading to runtime errors inside the sandbox instead of earlier, host-side filtering.
  - Mitigation: This behavior only applies when the user explicitly opts in with enabled: true; default behavior remains unchanged, and all skills without that override continue to be protected by the existing runtime eligibility checks.
