### PR TITLE
fix(discord): exclude '*' wildcard from unresolvedChannels count

### DIFF
--- a/src/discord/audit.test.ts
+++ b/src/discord/audit.test.ts
@@ -36,6 +36,31 @@ describe("discord audit", () => {
     expect(collected.channelIds).toEqual(["111"]);
     expect(collected.unresolvedChannels).toBe(1);
 
+    const cfgWildcard = {
+      channels: {
+        discord: {
+          enabled: true,
+          token: "t",
+          groupPolicy: "allowlist",
+          guilds: {
+            "123": {
+              channels: {
+                "*": { allow: true },
+                "111": { allow: true },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as import("../config/config.js").OpenClawConfig;
+
+    const wildcardResult = collectDiscordAuditChannelIds({
+      cfg: cfgWildcard,
+      accountId: "default",
+    });
+    expect(wildcardResult.channelIds).toEqual(["111"]);
+    expect(wildcardResult.unresolvedChannels).toBe(0);
+
     (fetchChannelPermissionsDiscord as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       channelId: "111",
       permissions: ["ViewChannel"],
@@ -52,5 +77,30 @@ describe("discord audit", () => {
     expect(audit.ok).toBe(false);
     expect(audit.channels[0]?.channelId).toBe("111");
     expect(audit.channels[0]?.missing).toContain("SendMessages");
+  });
+
+  it("does not count '*' wildcard as unresolved (#32517)", async () => {
+    const { collectDiscordAuditChannelIds } = await import("./audit.js");
+
+    const cfg = {
+      channels: {
+        discord: {
+          enabled: true,
+          token: "t",
+          groupPolicy: "allowlist",
+          guilds: {
+            "999": {
+              channels: {
+                "*": { allow: true },
+              },
+            },
+          },
+        },
+      },
+    } as unknown as import("../config/config.js").OpenClawConfig;
+
+    const result = collectDiscordAuditChannelIds({ cfg, accountId: "default" });
+    expect(result.channelIds).toEqual([]);
+    expect(result.unresolvedChannels).toBe(0);
   });
 });

--- a/src/discord/audit.ts
+++ b/src/discord/audit.ts
@@ -75,7 +75,8 @@ export function collectDiscordAuditChannelIds(params: {
   });
   const keys = listConfiguredGuildChannelKeys(account.config.guilds);
   const channelIds = keys.filter((key) => /^\d+$/.test(key));
-  const unresolvedChannels = keys.length - channelIds.length;
+  const wildcardCount = keys.filter((key) => key === "*").length;
+  const unresolvedChannels = Math.max(0, keys.length - channelIds.length - wildcardCount);
   return { channelIds, unresolvedChannels };
 }
 


### PR DESCRIPTION
## Summary

- Problem: `collectDiscordAuditChannelIds` counts the `*` wildcard key as an unresolved channel, causing `doctor` and `channels status --probe` to emit a false positive warning: "Some configured guild channels are not numeric IDs (unresolvedChannels=1)".
- Why it matters: Users who correctly configure `"*": { "allow": true }` to allow all channels in a guild see a spurious warning that implies their config is broken.
- What changed: The wildcard key `*` is now excluded from the unresolved count in `collectDiscordAuditChannelIds`. A `wildcardCount` is subtracted from the non-numeric keys total.
- What did NOT change (scope boundary): The allowlist logic in `provider.allowlist.ts` already handles `*` correctly. Only the audit/diagnostic path is fixed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32517

## User-visible / Behavior Changes

`openclaw doctor` and `channels status --probe` no longer report `unresolvedChannels=1` when the only non-numeric channel key is the `*` wildcard.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Configure `channels.discord.guilds.<id>.channels` with `"*": { "allow": true }`
2. Run `openclaw doctor` or `channels status --probe`
3. Observe no false positive unresolvedChannels warning

### Expected

- No warning about unresolved channels when only `*` wildcard is used

### Actual

- Before: Warning: "Some configured guild channels are not numeric IDs (unresolvedChannels=1)"
- After: No warning; `unresolvedChannels` is `0`

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

2 tests pass:
- Existing test confirms non-numeric named keys (e.g. `general`) still count as unresolved
- New test confirms `*` wildcard-only config yields `unresolvedChannels: 0`

## Human Verification (required)

- Verified scenarios: Wildcard-only guild, mixed wildcard + numeric, mixed wildcard + named + numeric
- Edge cases checked: Empty guilds, disabled channels with wildcard
- What you did **not** verify: Live `openclaw doctor` output against a real Discord server

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the 3-line change in `src/discord/audit.ts`
- Files/config to restore: `src/discord/audit.ts`

## Risks and Mitigations

- Risk: None — this is a purely diagnostic change that removes a false positive
  - Mitigation: N/A