### PR TITLE
fix(agents): rotate auth profile on /new using store-level lastUsed

### DIFF
--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -6,7 +6,7 @@ import type { SessionEntry } from "../../config/sessions.js";
 import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
 import { resolveSessionAuthProfileOverride } from "./session-override.js";
 
-async function writeAuthStore(agentDir: string) {
+async function writeAuthStore(agentDir: string, extra?: Record<string, unknown>) {
   const authPath = path.join(agentDir, "auth-profiles.json");
   const payload = {
     version: 1,
@@ -16,6 +16,26 @@ async function writeAuthStore(agentDir: string) {
     order: {
       zai: ["zai:work"],
     },
+    ...extra,
+  };
+  await fs.writeFile(authPath, JSON.stringify(payload), "utf-8");
+}
+
+async function writeMultiProfileStore(
+  agentDir: string,
+  opts?: { usageStats?: Record<string, { lastUsed?: number }> },
+) {
+  const authPath = path.join(agentDir, "auth-profiles.json");
+  const payload = {
+    version: 1,
+    profiles: {
+      "anthropic:default": { type: "api_key", provider: "anthropic", key: "sk-1" },
+      "anthropic:secondary": { type: "api_key", provider: "anthropic", key: "sk-2" },
+    },
+    order: {
+      anthropic: ["anthropic:default", "anthropic:secondary"],
+    },
+    ...(opts?.usageStats ? { usageStats: opts.usageStats } : {}),
   };
   await fs.writeFile(authPath, JSON.stringify(payload), "utf-8");
 }
@@ -48,6 +68,65 @@ describe("resolveSessionAuthProfileOverride", () => {
 
       expect(resolved).toBe("zai:work");
       expect(sessionEntry.authProfileOverride).toBe("zai:work");
+    });
+  });
+
+  it("rotates to next profile on /new using store-level lastUsed (#32444)", async () => {
+    await withStateDirEnv("openclaw-auth-rr-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeMultiProfileStore(agentDir, {
+        usageStats: {
+          "anthropic:default": { lastUsed: 1000 },
+          "anthropic:secondary": { lastUsed: 500 },
+        },
+      });
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s-new",
+        updatedAt: Date.now(),
+      };
+      const sessionStore = { "agent:main:dm": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "anthropic",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:dm",
+        storePath: undefined,
+        isNewSession: true,
+      });
+
+      expect(resolved).toBe("anthropic:secondary");
+    });
+  });
+
+  it("picks first available when no usageStats exist (#32444)", async () => {
+    await withStateDirEnv("openclaw-auth-rr-nousage-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+      await writeMultiProfileStore(agentDir);
+
+      const sessionEntry: SessionEntry = {
+        sessionId: "s-new2",
+        updatedAt: Date.now(),
+      };
+      const sessionStore = { "agent:main:dm": sessionEntry };
+
+      const resolved = await resolveSessionAuthProfileOverride({
+        cfg: {} as OpenClawConfig,
+        provider: "anthropic",
+        agentDir,
+        sessionEntry,
+        sessionStore,
+        sessionKey: "agent:main:dm",
+        storePath: undefined,
+        isNewSession: true,
+      });
+
+      expect(resolved).toBe("anthropic:default");
     });
   });
 });

--- a/src/agents/auth-profiles/session-override.ts
+++ b/src/agents/auth-profiles/session-override.ts
@@ -5,7 +5,24 @@ import {
   isProfileInCooldown,
   resolveAuthProfileOrder,
 } from "../auth-profiles.js";
+import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { normalizeProviderId } from "../model-selection.js";
+
+function findMostRecentlyUsedInOrder(store: AuthProfileStore, order: string[]): string | undefined {
+  if (order.length === 0 || !store.usageStats) {
+    return undefined;
+  }
+  let bestId: string | undefined;
+  let bestTs = -1;
+  for (const profileId of order) {
+    const ts = store.usageStats[profileId]?.lastUsed ?? 0;
+    if (ts > bestTs) {
+      bestTs = ts;
+      bestId = profileId;
+    }
+  }
+  return bestTs > 0 ? bestId : undefined;
+}
 
 function isProfileForProvider(params: {
   provider: string;
@@ -120,7 +137,12 @@ export async function resolveSessionAuthProfileOverride(params: {
 
   let next = current;
   if (isNewSession) {
-    next = current ? pickNextAvailable(current) : pickFirstAvailable();
+    if (current) {
+      next = pickNextAvailable(current);
+    } else {
+      const lastUsedId = findMostRecentlyUsedInOrder(store, order);
+      next = lastUsedId ? pickNextAvailable(lastUsedId) : pickFirstAvailable();
+    }
   } else if (current && compactionCount > storedCompaction) {
     next = pickNextAvailable(current);
   } else if (!current || isProfileInCooldown(store, current)) {


### PR DESCRIPTION
## Summary

- Problem: `/new` or `/reset` always picks the same auth profile (`order[0]`) because the new session has no `authProfileOverride`, so `pickFirstAvailable()` is unconditionally called, defeating round-robin rotation.
- Why it matters: Users with multiple auth profiles (e.g. two Anthropic keys for usage distribution) never see the second profile used. All sessions hit the same key, defeating the purpose of multi-profile configuration.
- What changed: When `current` is undefined for a new session, `findMostRecentlyUsedInOrder()` now consults `store.usageStats.lastUsed` to identify which profile was used most recently and passes it to `pickNextAvailable()`, enabling genuine round-robin rotation.
- What did NOT change (scope boundary): Existing session resume behavior, user-specified overrides, cooldown logic, and compaction-triggered rotation remain untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32444

## User-visible / Behavior Changes

`/new` and `/reset` now rotate between configured auth profiles instead of always picking the same one.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Configure two auth profiles for the same provider (e.g. `anthropic:default` + `anthropic:secondary`)
2. Run `/new` multiple times
3. Observe that sessions alternate between profiles

### Expected

- Profiles rotate: session 1 uses default, session 2 uses secondary, session 3 uses default, etc.

### Actual

- Before: Always picks `anthropic:default` (the one with the oldest `lastUsed`)
- After: Rotates to the profile after the most-recently-used one

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

2 new unit tests added:
- `rotates to next profile on /new using store-level lastUsed` — verifies rotation when `usageStats` shows which was used last
- `picks first available when no usageStats exist` — verifies fallback for fresh installs with no usage history

## Human Verification (required)

- Verified scenarios: New session with 2 profiles and known lastUsed timestamps; new session with no usage stats; existing session resume (not affected)
- Edge cases checked: Empty `usageStats`, all profiles in cooldown, single profile (returns itself)
- What you did **not** verify: Live multi-session rotation against real API endpoints

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the helper function and the if/else change in `session-override.ts` to restore the old `pickFirstAvailable()` behavior
- Files/config to restore: `src/agents/auth-profiles/session-override.ts`

## Risks and Mitigations

- Risk: If `usageStats` is stale or never written (e.g., very old install), the fallback to `pickFirstAvailable()` preserves the current behavior — no regression
  - Mitigation: The `bestTs > 0` guard ensures we only rotate when there's real usage data