### PR TITLE
Agents: fix Save button disabled when agent not in config list

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -748,7 +748,8 @@ export function renderApp(state: AppViewState) {
                     index = list.length;
                     updateConfigFormValue(state, ["agents", "list", index, "id"], agentId);
                   }
-                  const entry = list[index] as { skills?: unknown };
+                  // list[index] may be undefined when the stub was just created above.
+                  const entry = list[index] as { skills?: unknown } | undefined;
                   const normalizedSkill = skillName.trim();
                   if (!normalizedSkill) {
                     return;
@@ -756,8 +757,8 @@ export function renderApp(state: AppViewState) {
                   const allSkills =
                     state.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
                     [];
-                  const existing = Array.isArray(entry.skills)
-                    ? entry.skills.map((name) => String(name).trim()).filter(Boolean)
+                  const existing = Array.isArray(entry?.skills)
+                    ? (entry.skills as unknown[]).map((name) => String(name).trim()).filter(Boolean)
                     : undefined;
                   const base = existing ?? allSkills;
                   const next = new Set(base);
@@ -861,9 +862,10 @@ export function renderApp(state: AppViewState) {
                     updateConfigFormValue(state, ["agents", "list", index, "id"], agentId);
                   }
                   const basePath = ["agents", "list", index, "model"];
-                  const entry = list[index] as { model?: unknown };
+                  // list[index] may be undefined when the stub was just created above.
+                  const entry = list[index] as { model?: unknown } | undefined;
                   const normalized = fallbacks.map((name) => name.trim()).filter(Boolean);
-                  const existing = entry.model;
+                  const existing = entry?.model;
                   const resolvePrimary = () => {
                     if (typeof existing === "string") {
                       return existing.trim() || null;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -666,11 +666,9 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
+                  const rawList = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+                  const list = Array.isArray(rawList) ? rawList : [];
+                  let index = list.findIndex(
                     (entry) =>
                       entry &&
                       typeof entry === "object" &&
@@ -678,7 +676,9 @@ export function renderApp(state: AppViewState) {
                       (entry as { id?: string }).id === agentId,
                   );
                   if (index < 0) {
-                    return;
+                    // Agent not yet in config list — create a stub entry so the path exists.
+                    index = list.length;
+                    updateConfigFormValue(state, ["agents", "list", index, "id"], agentId);
                   }
                   const basePath = ["agents", "list", index, "tools"];
                   if (profile) {
@@ -694,11 +694,9 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
+                  const rawList = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+                  const list = Array.isArray(rawList) ? rawList : [];
+                  let index = list.findIndex(
                     (entry) =>
                       entry &&
                       typeof entry === "object" &&
@@ -706,7 +704,9 @@ export function renderApp(state: AppViewState) {
                       (entry as { id?: string }).id === agentId,
                   );
                   if (index < 0) {
-                    return;
+                    // Agent not yet in config list — create a stub entry so the path exists.
+                    index = list.length;
+                    updateConfigFormValue(state, ["agents", "list", index, "id"], agentId);
                   }
                   const basePath = ["agents", "list", index, "tools"];
                   if (alsoAllow.length > 0) {
@@ -734,11 +734,9 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
+                  const rawList = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+                  const list = Array.isArray(rawList) ? rawList : [];
+                  let index = list.findIndex(
                     (entry) =>
                       entry &&
                       typeof entry === "object" &&
@@ -746,7 +744,9 @@ export function renderApp(state: AppViewState) {
                       (entry as { id?: string }).id === agentId,
                   );
                   if (index < 0) {
-                    return;
+                    // Agent not yet in config list — create a stub entry so the path exists.
+                    index = list.length;
+                    updateConfigFormValue(state, ["agents", "list", index, "id"], agentId);
                   }
                   const entry = list[index] as { skills?: unknown };
                   const normalizedSkill = skillName.trim();
@@ -772,10 +772,8 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
+                  const rawList = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+                  const list = Array.isArray(rawList) ? rawList : [];
                   const index = list.findIndex(
                     (entry) =>
                       entry &&
@@ -792,11 +790,9 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
+                  const rawList = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+                  const list = Array.isArray(rawList) ? rawList : [];
+                  let index = list.findIndex(
                     (entry) =>
                       entry &&
                       typeof entry === "object" &&
@@ -804,7 +800,9 @@ export function renderApp(state: AppViewState) {
                       (entry as { id?: string }).id === agentId,
                   );
                   if (index < 0) {
-                    return;
+                    // Agent not yet in config list — create a stub entry so the path exists.
+                    index = list.length;
+                    updateConfigFormValue(state, ["agents", "list", index, "id"], agentId);
                   }
                   updateConfigFormValue(state, ["agents", "list", index, "skills"], []);
                 },
@@ -812,11 +810,9 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
+                  const rawList = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+                  const list = Array.isArray(rawList) ? rawList : [];
+                  let index = list.findIndex(
                     (entry) =>
                       entry &&
                       typeof entry === "object" &&
@@ -824,7 +820,9 @@ export function renderApp(state: AppViewState) {
                       (entry as { id?: string }).id === agentId,
                   );
                   if (index < 0) {
-                    return;
+                    // Agent not yet in config list — create a stub entry so the path exists.
+                    index = list.length;
+                    updateConfigFormValue(state, ["agents", "list", index, "id"], agentId);
                   }
                   const basePath = ["agents", "list", index, "model"];
                   if (!modelId) {
@@ -848,11 +846,9 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
+                  const rawList = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+                  const list = Array.isArray(rawList) ? rawList : [];
+                  let index = list.findIndex(
                     (entry) =>
                       entry &&
                       typeof entry === "object" &&
@@ -860,7 +856,9 @@ export function renderApp(state: AppViewState) {
                       (entry as { id?: string }).id === agentId,
                   );
                   if (index < 0) {
-                    return;
+                    // Agent not yet in config list — create a stub entry so the path exists.
+                    index = list.length;
+                    updateConfigFormValue(state, ["agents", "list", index, "id"], agentId);
                   }
                   const basePath = ["agents", "list", index, "model"];
                   const entry = list[index] as { model?: unknown };


### PR DESCRIPTION
## Summary

- **Problem:** In the Agents dashboard (Tools / Skills / Overview panels), the **Save button stays permanently disabled** after enabling or disabling tools, because the underlying config mutation handlers silently bail out when the agent is not explicitly present in `agents.list` in the config.
- **Why it matters:** On a new install (or any setup where the default "main" agent is not written into `agents.list`), users can toggle tools/skills/model settings but can never save those changes — the Save button is unclickable.
- **Root cause:** Six handlers in `app-render.ts` (`onToolsProfileChange`, `onToolsOverridesChange`, `onAgentSkillToggle`, `onAgentSkillsDisableAll`, `onModelChange`, `onModelFallbacksChange`) shared the same guard pattern:
  1. `if (!Array.isArray(list)) { return; }` — bails when `agents.list` is absent
  2. `if (index < 0) { return; }` — bails when the agent isn't found in the list

  Neither path ever calls `updateConfigFormValue`, so `configFormDirty` stays `false` and the Save button (`?disabled=${!params.configDirty}`) is never enabled.
- **What changed:** When an agent is not found in the list, instead of returning early, the handlers now append a minimal `{ id: agentId }` stub entry at `["agents", "list", <next index>]` via `updateConfigFormValue`, then proceed with the actual path update. The existing `setPathValue` util already creates intermediate objects/arrays on demand, so no additional changes are needed.
- **What did NOT change (scope boundary):** Save / reload / config serialization logic is untouched. The stub entry written is valid config (an agent entry with an `id` field).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32812
- Related #

## User-visible / Behavior Changes

- The Save button in the Agents → Tools panel is now clickable after enabling or disabling any tool on a new install (or any config that does not explicitly list the agent in `agents.list`).
- Same fix applies to the Skills and Overview (model) panels — toggling skills or changing the model now correctly enables the Save button.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS 26.3 (reported), any OS with a browser-accessible gateway dashboard
- Runtime/container: Browser (Web UI)
- Model/provider: N/A
- Integration/channel (if any): Web control UI — Agents tab
- Relevant config (redacted): Fresh install with no explicit `agents.list` in `openclaw.config.json`

### Steps

1. Fresh install of OpenClaw (`openclaw 2026.3.2` or any version without an explicit agent entry in config)
2. Open Web UI → **Agents** tab → select **Main** → open **Tools** panel
3. Toggle any tool on or off
4. Observe the **Save** button

### Expected

- Save button becomes **enabled** (primary style) after any toggle
- Clicking Save persists the change and reloads config

### Actual (before fix)

- Save button remains **disabled** regardless of toggles
- Same for "Enable All" / "Disable All" buttons (they toggle the UI but Save never activates)

### Actual (after fix)

- Save button enables immediately after the first toggle
- Clicking Save successfully persists tool overrides to config

## Evidence

- [x] `pnpm check` passes
- [x] Existing tests pass (`ui/src/ui/controllers/agents.test.ts`, `ui/src/ui/views/agents-utils.test.ts`)
- [x] Code diff: six handler blocks updated from early-return to stub-entry creation

## Human Verification (required)

- **Verified scenarios:** Agent present in list (existing behaviour unchanged), agent absent from list (stub created, Save enabled), `agents.list` entirely missing (array created at `agents.list[0]`)
- **Edge cases checked:** Toggling a tool that is already allowed/denied with no net change still creates the stub; benign but expected
- **What you did NOT verify:** Full round-trip on a live gateway with a real config containing multiple agents

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: `git revert f88ef3a54`
- Files/config to restore: `ui/src/ui/app-render.ts`
- Known bad symptoms reviewers should watch for: Save button becomes active when no meaningful change was made (edge case: toggling an already-allowed tool with no custom overrides)

## Risks and Mitigations

- **Stub entry creation:** The written stub `{ id: agentId }` is valid gateway config. The gateway already handles agents that have only partial overrides; adding an explicit entry for the default agent is equivalent to what the Config tab's form mode would produce.
- **Idempotent path updates:** `updateConfigFormValue` always clones from the latest `state.configForm`, so the first stub write and subsequent override writes are each based on the freshest state.
