### PR TITLE
fix: correct abort-signal import in nextcloud-talk extension

### DIFF
--- a/extensions/nextcloud-talk/src/channel.ts
+++ b/extensions/nextcloud-talk/src/channel.ts
@@ -8,11 +8,11 @@ import {
   resolveAllowlistProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
   setAccountEnabledInConfigSection,
+  waitUntilAbort,
   type ChannelPlugin,
   type OpenClawConfig,
   type ChannelSetupInput,
 } from "openclaw/plugin-sdk/nextcloud-talk";
-import { waitForAbortSignal } from "../../../src/infra/abort-signal.js";
 import {
   listNextcloudTalkAccountIds,
   resolveDefaultNextcloudTalkAccountId,
@@ -336,7 +336,7 @@ export const nextcloudTalkPlugin: ChannelPlugin<ResolvedNextcloudTalkAccount> = 
       });
 
       // Keep webhook channels pending for the account lifecycle.
-      await waitForAbortSignal(ctx.abortSignal);
+      await waitUntilAbort(ctx.abortSignal);
       stop();
     },
     logoutAccount: async ({ accountId, cfg }) => {

--- a/src/plugin-sdk/nextcloud-talk.ts
+++ b/src/plugin-sdk/nextcloud-talk.ts
@@ -90,3 +90,4 @@ export {
   resolveOutboundMediaUrls,
 } from "./reply-payload.js";
 export { createLoggerBackedRuntime } from "./runtime.js";
+export { waitUntilAbort } from "./channel-lifecycle.js";


### PR DESCRIPTION
Fixes #32662 - correct import path for waitForAbortSignal