### PR TITLE
fix(gateway): include on-disk ACP session stores with agents.list

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -10,6 +10,7 @@ import {
   deriveSessionTitle,
   listAgentsForGateway,
   listSessionsFromStore,
+  loadCombinedSessionStoreForGateway,
   parseGroupKey,
   pruneLegacyStoreKeys,
   resolveGatewaySessionStoreTarget,
@@ -309,6 +310,44 @@ describe("gateway session utils", () => {
     expect(result.agents[0]?.identity?.avatarUrl).toBe(
       `data:image/png;base64,${Buffer.from("avatar").toString("base64")}`,
     );
+  });
+
+  test("loadCombinedSessionStoreForGateway includes on-disk ACP agent stores even when agents.list is configured", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-state-"));
+    const prevState = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    try {
+      // Simulate dynamically-created ACP agent dirs on disk.
+      fs.mkdirSync(path.join(stateDir, "agents", "main", "sessions"), { recursive: true });
+      fs.mkdirSync(path.join(stateDir, "agents", "codex", "sessions"), { recursive: true });
+
+      fs.writeFileSync(
+        path.join(stateDir, "agents", "main", "sessions", "sessions.json"),
+        JSON.stringify({ "agent:main:main": { sessionId: "s-main", updatedAt: 1 } }),
+        "utf8",
+      );
+      fs.writeFileSync(
+        path.join(stateDir, "agents", "codex", "sessions", "sessions.json"),
+        JSON.stringify({ "agent:codex:main": { sessionId: "s-codex", updatedAt: 2 } }),
+        "utf8",
+      );
+
+      const cfg = {
+        session: { mainKey: "main" },
+        agents: { list: [{ id: "main", default: true }] },
+      } as OpenClawConfig;
+
+      const combined = loadCombinedSessionStoreForGateway(cfg);
+      expect(Object.keys(combined.store)).toEqual(
+        expect.arrayContaining(["agent:main:main", "agent:codex:main"]),
+      );
+    } finally {
+      if (prevState === undefined) {
+        delete process.env.OPENCLAW_STATE_DIR;
+      } else {
+        process.env.OPENCLAW_STATE_DIR = prevState;
+      }
+    }
   });
 });
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -310,35 +310,30 @@ function listExistingAgentIdsFromDisk(): string[] {
 }
 
 function listConfiguredAgentIds(cfg: OpenClawConfig): string[] {
-  const agents = cfg.agents?.list ?? [];
-  if (agents.length > 0) {
-    const ids = new Set<string>();
-    for (const entry of agents) {
-      if (entry?.id) {
-        ids.add(normalizeAgentId(entry.id));
-      }
-    }
-    const defaultId = normalizeAgentId(resolveDefaultAgentId(cfg));
-    ids.add(defaultId);
-    const sorted = Array.from(ids).filter(Boolean);
-    sorted.sort((a, b) => a.localeCompare(b));
-    return sorted.includes(defaultId)
-      ? [defaultId, ...sorted.filter((id) => id !== defaultId)]
-      : sorted;
-  }
-
+  // IMPORTANT: Always include agent stores that exist on disk.
+  // This covers dynamically-created agent dirs (for example ACP runtimes like agents/codex/*)
+  // even when users configure a restrictive agents.list.
   const ids = new Set<string>();
   const defaultId = normalizeAgentId(resolveDefaultAgentId(cfg));
   ids.add(defaultId);
+
+  // Include configured agents.
+  for (const entry of cfg.agents?.list ?? []) {
+    if (entry?.id) {
+      ids.add(normalizeAgentId(entry.id));
+    }
+  }
+
+  // Include on-disk agents (covers ACP-created dirs).
   for (const id of listExistingAgentIdsFromDisk()) {
     ids.add(id);
   }
+
   const sorted = Array.from(ids).filter(Boolean);
   sorted.sort((a, b) => a.localeCompare(b));
-  if (sorted.includes(defaultId)) {
-    return [defaultId, ...sorted.filter((id) => id !== defaultId)];
-  }
-  return sorted;
+  return sorted.includes(defaultId)
+    ? [defaultId, ...sorted.filter((id) => id !== defaultId)]
+    : sorted;
 }
 
 export function listAgentsForGateway(cfg: OpenClawConfig): {


### PR DESCRIPTION
Problem

When configuredAgentIds is set, the gateway and related tools can miss ACP sessions stored under dynamically created agent directories (for example, .openclaw/agents/<agent-id>/acp/).

This happens because only explicitly configured agent IDs are considered when building the combined session store, ignoring agents discovered on disk.

Fix

Always merge:

Agent IDs defined in configuration

Agent IDs discovered on disk

when building the gateway’s combined session store.

Add a regression test that:

Simulates an on-disk ACP session store

Uses a limited configured agent list

Asserts that the ACP session store is still included



Fixes: openclaw/openclaw#32804