### PR TITLE
fix(gateway): prevent zero Avg Tokens/Msg when messageCounts.total is 0

### DIFF
--- a/src/gateway/server-methods/usage.sessions-usage.test.ts
+++ b/src/gateway/server-methods/usage.sessions-usage.test.ts
@@ -219,6 +219,45 @@ describe("sessions.usage", () => {
     expect(vi.mocked(loadSessionLogs).mock.calls[0]?.[0]?.agentId).toBe("opus");
   });
 
+  it("aggregates messages.total as 1 when messageCounts is null but tokens exist (#32623)", async () => {
+    vi.mocked(loadSessionCostSummary).mockResolvedValueOnce({
+      input: 500,
+      output: 300,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 800,
+      totalCost: 0.01,
+      inputCost: 0,
+      outputCost: 0,
+      cacheReadCost: 0,
+      cacheWriteCost: 0,
+      missingCostEntries: 0,
+    });
+    vi.mocked(loadSessionCostSummary).mockResolvedValueOnce({
+      input: 200,
+      output: 100,
+      cacheRead: 0,
+      cacheWrite: 0,
+      totalTokens: 300,
+      totalCost: 0,
+      inputCost: 0,
+      outputCost: 0,
+      cacheReadCost: 0,
+      cacheWriteCost: 0,
+      missingCostEntries: 0,
+      messageCounts: { total: 0, user: 0, assistant: 0, toolCalls: 5, toolResults: 5, errors: 0 },
+    });
+
+    const respond = await runSessionsUsage(BASE_USAGE_RANGE);
+    expect(respond.mock.calls[0]?.[0]).toBe(true);
+    const result = respond.mock.calls[0]?.[1] as {
+      aggregates: { messages: { total: number } };
+      totals: { totalTokens: number };
+    };
+    expect(result.totals.totalTokens).toBe(1100);
+    expect(result.aggregates.messages.total).toBeGreaterThan(0);
+  });
+
   it("rejects traversal-style keys in timeseries/log lookups", async () => {
     const timeseriesRespond = await runSessionsUsageTimeseries({
       key: "agent:opus:../../etc/passwd",

--- a/src/gateway/server-methods/usage.ts
+++ b/src/gateway/server-methods/usage.ts
@@ -612,12 +612,22 @@ export const usageHandlers: GatewayRequestHandlers = {
 
       if (usage) {
         if (usage.messageCounts) {
-          aggregateMessages.total += usage.messageCounts.total;
+          const effectiveTotal =
+            usage.messageCounts.total > 0
+              ? usage.messageCounts.total
+              : usage.messageCounts.assistant + usage.messageCounts.user > 0
+                ? usage.messageCounts.assistant + usage.messageCounts.user
+                : usage.totalTokens > 0
+                  ? 1
+                  : 0;
+          aggregateMessages.total += effectiveTotal;
           aggregateMessages.user += usage.messageCounts.user;
           aggregateMessages.assistant += usage.messageCounts.assistant;
           aggregateMessages.toolCalls += usage.messageCounts.toolCalls;
           aggregateMessages.toolResults += usage.messageCounts.toolResults;
           aggregateMessages.errors += usage.messageCounts.errors;
+        } else if (usage.totalTokens > 0) {
+          aggregateMessages.total += 1;
         }
 
         if (usage.toolUsage) {


### PR DESCRIPTION
## Summary

- Problem: The Usage dashboard shows "Avg Tokens / Msg: 0" for agents with subagent sessions because `sessions.json` never persists `messageCounts` (only token counts). The `sessions.usage` server-side aggregation skips sessions with `messageCounts: undefined`, causing `aggregateMessages.total` to stay 0 while `totalTokens` accumulates — resulting in `totalTokens / 0` displayed as 0.
- Why it matters: Users cannot see meaningful per-message token averages for agents that primarily use subagent sessions, making it hard to assess token efficiency.
- What changed: The aggregation now handles three fallback cases: (1) when `messageCounts.total` is 0 but `user + assistant > 0`, uses that sum; (2) when `messageCounts` is null/undefined but tokens exist, counts 1 message per session; (3) when `messageCounts` exists with `total > 0`, uses it as before.
- What did NOT change (scope boundary): Individual session cost summaries, transcript scanning, per-session messageCounts computation, and the sessions.json persistence model are all unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32623

## User-visible / Behavior Changes

"Avg Tokens / Msg" in the Usage dashboard now shows a non-zero value for agents with subagent sessions that previously showed 0.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Configure an agent that spawns subagent sessions
2. Run several subagent sessions that consume tokens
3. Check the Usage dashboard "Avg Tokens / Msg" metric

### Expected

- Shows a meaningful non-zero average

### Actual

- Before: Shows "0" because messageCounts is null in the aggregation
- After: Shows a positive value (at minimum, counts 1 message per token-consuming session)

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

New test: "aggregates messages.total as 1 when messageCounts is null but tokens exist" — mocks one session with null messageCounts and another with total=0 but toolCalls>0, verifies aggregate messages.total > 0.

## Human Verification (required)

- Verified scenarios: Session with null messageCounts + tokens, session with messageCounts.total=0 + toolCalls>0 + tokens, session with normal messageCounts
- Edge cases checked: Session with no tokens and no messageCounts (correctly stays 0), session with messageCounts.total > 0 (unchanged behavior)
- What you did **not** verify: Live dashboard rendering with real subagent sessions

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert the aggregation fallback in `src/gateway/server-methods/usage.ts` to restore the original `if (usage.messageCounts)` check
- Files/config to restore: `src/gateway/server-methods/usage.ts`

## Risks and Mitigations

- Risk: Overcounting messages (1 per session) when messageCounts is truly unavailable, slightly deflating the average
  - Mitigation: This is a conservative lower bound; the alternative (0) is strictly worse. Future work can persist messageCounts to sessions.json for exact counts.