### PR TITLE
fix(gateway): broadcast chat events for external channel messages to web UI

### DIFF
--- a/src/auto-reply/reply/channel-chat-broadcast.ts
+++ b/src/auto-reply/reply/channel-chat-broadcast.ts
@@ -1,0 +1,42 @@
+/**
+ * Global Channel Chat Broadcast
+ *
+ * Singleton that holds the gateway's broadcast + nodeSendToSession
+ * functions so that the auto-reply dispatch path can notify web UI
+ * clients and paired node subscribers when external channel messages
+ * (Telegram, WhatsApp, AnyGen, etc.) are processed.
+ *
+ * Normal chat events fan out through both websocket broadcast and
+ * nodeSendToSession (see createAgentEventHandler in server-chat.ts).
+ * This singleton mirrors that fan-out for synthetic channel events.
+ *
+ * Pattern follows src/plugins/hook-runner-global.ts.
+ */
+
+export type ChannelChatNotifyFn = (event: string, payload: unknown, sessionKey?: string) => void;
+
+let globalNotify: ChannelChatNotifyFn | null = null;
+
+/**
+ * Register the gateway broadcast + node fan-out function.
+ * Called once during gateway startup after the broadcaster and
+ * node subscription manager are created.
+ */
+export function setGlobalChannelChatBroadcast(notify: ChannelChatNotifyFn): void {
+  globalNotify = notify;
+}
+
+/**
+ * Get the registered notify function.
+ * Returns null if the gateway hasn't started yet.
+ */
+export function getGlobalChannelChatBroadcast(): ChannelChatNotifyFn | null {
+  return globalNotify;
+}
+
+/**
+ * Reset the global broadcast (for testing).
+ */
+export function resetGlobalChannelChatBroadcast(): void {
+  globalNotify = null;
+}

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -24,6 +24,7 @@ import { getReplyFromConfig } from "../reply.js";
 import type { FinalizedMsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { formatAbortReplyText, tryFastAbortFromMessage } from "./abort.js";
+import { getGlobalChannelChatBroadcast } from "./channel-chat-broadcast.js";
 import { shouldBypassAcpDispatchForCommand, tryDispatchAcpReply } from "./dispatch-acp.js";
 import { shouldSkipDuplicateInbound } from "./inbound-dedupe.js";
 import type { ReplyDispatcher, ReplyDispatchKind } from "./reply-dispatcher.js";
@@ -157,6 +158,27 @@ export async function dispatchReplyFromConfig(params: {
       state: "idle",
       reason,
     });
+  };
+
+  // Notify web UI that session history changed (external channel messages only).
+  // Web UI messages (provider === "webchat") already broadcast via createAgentEventHandler.
+  // Guard on ctx.Provider (not ctx.Surface) so relayed external turns where
+  // Surface is "webchat" but Provider is a real channel still trigger the broadcast.
+  const notifyWebUi = () => {
+    const channelChatBroadcast = getGlobalChannelChatBroadcast();
+    const provider = normalizeMessageChannel(ctx.Provider);
+    if (channelChatBroadcast && sessionKey && provider !== INTERNAL_MESSAGE_CHANNEL) {
+      channelChatBroadcast(
+        "chat",
+        {
+          runId: `channel-${messageId ?? `ts-${Date.now()}`}`,
+          sessionKey,
+          seq: 0,
+          state: "final",
+        },
+        sessionKey,
+      );
+    }
   };
 
   if (shouldSkipDuplicateInbound(ctx)) {
@@ -296,6 +318,7 @@ export async function dispatchReplyFromConfig(params: {
       counts.final += routedFinalCount;
       recordProcessed("completed", { reason: "fast_abort" });
       markIdle("message_completed");
+      notifyWebUi();
       return { queuedFinal, counts };
     }
 
@@ -342,6 +365,7 @@ export async function dispatchReplyFromConfig(params: {
       markIdle,
     });
     if (acpDispatch) {
+      notifyWebUi();
       return acpDispatch;
     }
 
@@ -542,6 +566,7 @@ export async function dispatchReplyFromConfig(params: {
     counts.final += routedFinalCount;
     recordProcessed("completed");
     markIdle("message_completed");
+    notifyWebUi();
     return { queuedFinal, counts };
   } catch (err) {
     recordProcessed("error", { error: String(err) });

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -3,6 +3,7 @@ import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
+import { setGlobalChannelChatBroadcast } from "../auto-reply/reply/channel-chat-broadcast.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
@@ -569,6 +570,16 @@ export async function startGatewayServer(
   };
   const nodeSendToSession = (sessionKey: string, event: string, payload: unknown) =>
     nodeSubscriptions.sendToSession(sessionKey, event, payload, nodeSendEvent);
+
+  // Register channel chat broadcast + node fan-out so dispatchReplyFromConfig
+  // can notify both web UI clients and paired node subscribers.
+  setGlobalChannelChatBroadcast((event, payload, sk) => {
+    broadcast(event, payload);
+    if (sk) {
+      nodeSendToSession(sk, event, payload);
+    }
+  });
+
   const nodeSendToAllSubscribed = (event: string, payload: unknown) =>
     nodeSubscriptions.sendToAllSubscribed(event, payload, nodeSendEvent);
   const nodeSubscribe = nodeSubscriptions.subscribe;


### PR DESCRIPTION
## Summary

- External channel messages (Telegram, WhatsApp, AnyGen, etc.) processed through `dispatchReplyFromConfig` did not emit "chat" events to web UI clients, requiring a manual page refresh to see new messages
- Added a global channel chat broadcast singleton (`channel-chat-broadcast.ts`) following the `hook-runner-global.ts` pattern
- After external channel message dispatch completes, broadcasts a `state: "final"` chat event that triggers the web UI's existing `shouldReloadHistoryForFinalEvent` → `loadChatHistory` flow
- Web UI-initiated messages (`channel === "webchat"`) are unaffected as they already broadcast via `createAgentEventHandler`

## Test plan

- [x] Run `pnpm test src/auto-reply/reply/dispatch-from-config.test.ts` — all 37 tests pass
- [x] Start gateway with an external channel configured (e.g., Telegram)
- [x] Open web UI and navigate to the session used by that channel
- [x] Send a message from the external channel
- [x] Verify the message and AI reply appear in the web UI automatically (without page refresh)
- [x] Verify web UI-initiated chat still works normally (no duplicate reloads)
