### PR TITLE
fix: improve Slack manifest copy instructions

### DIFF
--- a/src/channels/plugins/onboarding/slack.ts
+++ b/src/channels/plugins/onboarding/slack.ts
@@ -109,7 +109,7 @@ async function noteSlackTokenHelp(prompter: WizardPrompter, botName: string): Pr
       "Tip: set SLACK_BOT_TOKEN + SLACK_APP_TOKEN in your env.",
       `Docs: ${formatDocsLink("/slack", "slack")}`,
       "",
-      "Manifest (JSON):",
+      "Manifest (JSON - copy without formatting):",
       manifest,
     ].join("\n"),
     "Slack socket mode tokens",


### PR DESCRIPTION
Fixes #32493 - adds note to copy JSON manifest without CLI formatting