### PR TITLE
Slack: avoid socket-mode restart loops on transient disconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Slack/socket reconnect stability: add a disconnect grace window before forcing provider restarts so transient Socket Mode reconnects do not trigger restart loops on healthy sessions. Fixes #32739. Thanks @liuxiaopai-ai.
 - Telegram/multi-account default routing clarity: warn only for ambiguous (2+) account setups without an explicit default, add `openclaw doctor` warnings for missing/invalid multi-account defaults across channels, and document explicit-default guidance for channel routing and Telegram config. (#32544) thanks @Sid-Qin.
 - Agents/Skills runtime loading: propagate run config into embedded attempt and compaction skill-entry loading so explicitly enabled bundled companion skills are discovered consistently when skill snapshots do not already provide resolved entries. Thanks @gumadeiras.
 - Agents/Compaction continuity: expand staged-summary merge instructions to preserve active task status, batch progress, latest user request, and follow-up commitments so compaction handoffs retain in-flight work context. (#8903) thanks @joetomasone.

--- a/src/slack/monitor/provider.reconnect.test.ts
+++ b/src/slack/monitor/provider.reconnect.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { __testing } from "./provider.js";
+import { SLACK_SOCKET_DISCONNECT_GRACE_MS } from "./reconnect-policy.js";
 
 class FakeEmitter {
   private listeners = new Map<string, Set<(...args: unknown[]) => void>>();
@@ -22,14 +23,41 @@ class FakeEmitter {
 }
 
 describe("slack socket reconnect helpers", () => {
-  it("resolves disconnect waiter on socket disconnect event", async () => {
+  it("resolves disconnect waiter after disconnect grace period", async () => {
+    vi.useFakeTimers();
     const client = new FakeEmitter();
     const app = { receiver: { client } };
 
     const waiter = __testing.waitForSlackSocketDisconnect(app as never);
     client.emit("disconnected");
 
+    await vi.advanceTimersByTimeAsync(SLACK_SOCKET_DISCONNECT_GRACE_MS - 1);
+    let settled = false;
+    void waiter.then(() => {
+      settled = true;
+    });
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
     await expect(waiter).resolves.toEqual({ event: "disconnect" });
+    vi.useRealTimers();
+  });
+
+  it("ignores transient disconnect when socket reconnects within grace period", async () => {
+    vi.useFakeTimers();
+    const client = new FakeEmitter();
+    const app = { receiver: { client } };
+    const err = new Error("later failure");
+
+    const waiter = __testing.waitForSlackSocketDisconnect(app as never);
+    client.emit("disconnected");
+    await vi.advanceTimersByTimeAsync(Math.floor(SLACK_SOCKET_DISCONNECT_GRACE_MS / 2));
+    client.emit("connected");
+    await vi.advanceTimersByTimeAsync(SLACK_SOCKET_DISCONNECT_GRACE_MS);
+
+    client.emit("error", err);
+    await expect(waiter).resolves.toEqual({ event: "error", error: err });
+    vi.useRealTimers();
   });
 
   it("resolves disconnect waiter on socket error event", async () => {

--- a/src/slack/monitor/reconnect-policy.ts
+++ b/src/slack/monitor/reconnect-policy.ts
@@ -9,6 +9,8 @@ export const SLACK_SOCKET_RECONNECT_POLICY = {
   maxAttempts: 12,
 } as const;
 
+export const SLACK_SOCKET_DISCONNECT_GRACE_MS = 15_000;
+
 export type SlackSocketDisconnectEvent = "disconnect" | "unable_to_socket_mode_start" | "error";
 
 type EmitterLike = {
@@ -58,14 +60,34 @@ export function waitForSlackSocketDisconnect(
       return;
     }
 
-    const disconnectListener = () => resolveOnce({ event: "disconnect" });
+    let disconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    const clearDisconnectTimer = () => {
+      if (!disconnectTimer) {
+        return;
+      }
+      clearTimeout(disconnectTimer);
+      disconnectTimer = null;
+    };
+    const disconnectListener = () => {
+      // Slack socket mode can emit transient "disconnected" while auto-reconnecting.
+      // Give it a grace window before forcing a full provider restart.
+      clearDisconnectTimer();
+      disconnectTimer = setTimeout(() => {
+        resolveOnce({ event: "disconnect" });
+      }, SLACK_SOCKET_DISCONNECT_GRACE_MS);
+    };
+    const connectedListener = () => {
+      clearDisconnectTimer();
+    };
     const startFailListener = (error?: unknown) =>
       resolveOnce({ event: "unable_to_socket_mode_start", error });
     const errorListener = (error: unknown) => resolveOnce({ event: "error", error });
     const abortListener = () => resolveOnce({ event: "disconnect" });
 
     const cleanup = () => {
+      clearDisconnectTimer();
       emitter.off("disconnected", disconnectListener);
+      emitter.off("connected", connectedListener);
       emitter.off("unable_to_socket_mode_start", startFailListener);
       emitter.off("error", errorListener);
       abortSignal?.removeEventListener("abort", abortListener);
@@ -77,6 +99,7 @@ export function waitForSlackSocketDisconnect(
     };
 
     emitter.on("disconnected", disconnectListener);
+    emitter.on("connected", connectedListener);
     emitter.on("unable_to_socket_mode_start", startFailListener);
     emitter.on("error", errorListener);
     abortSignal?.addEventListener("abort", abortListener, { once: true });


### PR DESCRIPTION
## Summary

- Problem: Slack Socket Mode can emit transient `disconnected` events during internal auto-reconnect, but provider logic treated each disconnect as a hard failure and force-restarted the provider.
- Why it matters: users can hit recurring reconnect loops (every few seconds) even when Slack can recover the socket itself.
- What changed: `waitForSlackSocketDisconnect` now applies a disconnect grace window (`SLACK_SOCKET_DISCONNECT_GRACE_MS=15000`) before surfacing a disconnect; reconnect (`connected`) within the window cancels the pending disconnect.
- What did NOT change (scope boundary): auth error handling, backoff strategy, and reconnect-attempt limits are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32739
- Related #32377

## User-visible / Behavior Changes

- Slack Socket Mode no longer restarts immediately on transient socket disconnects that self-recover within 15 seconds.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): Slack Socket Mode
- Relevant config (redacted): `channels.slack.mode=socket`

### Steps

1. Start disconnect waiter and emit `disconnected`.
2. Verify waiter does not resolve before grace timeout.
3. Emit `connected` within grace and verify disconnect resolution is cancelled.
4. Emit `error` afterwards and verify waiter resolves with the error payload.

### Expected

- Transient disconnects are ignored when socket reconnects within grace.

### Actual

- Tests pass with delayed disconnect + reconnect-cancel behavior.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/slack/monitor/provider.reconnect.test.ts`
  - `pnpm lint -- src/slack/monitor/reconnect-policy.ts src/slack/monitor/provider.reconnect.test.ts`
- Edge cases checked:
  - disconnect resolves after grace timeout
  - reconnect cancels pending disconnect resolution
  - non-disconnect socket error still resolves immediately
- What you did **not** verify:
  - live Slack workspace end-to-end run

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/slack/monitor/reconnect-policy.ts`
  - `src/slack/monitor/provider.reconnect.test.ts`
- Known bad symptoms reviewers should watch for:
  - disconnects no longer trigger restart after prolonged socket loss.

## Risks and Mitigations

- Risk: grace window could delay recovery on truly dead sockets by up to 15s.
  - Mitigation: only applies to plain `disconnected`; explicit socket errors and auth failures still fail fast.
