### PR TITLE
Feishu: fallback secret helpers when plugin-sdk exports are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/plugin-sdk compatibility: add local SecretInput helper fallbacks in the Feishu extension so channel setup still works when older `openclaw/plugin-sdk` builds omit newer secret helper exports. Fixes #32808. Thanks @liuxiaopai-ai.
 - Telegram/multi-account default routing clarity: warn only for ambiguous (2+) account setups without an explicit default, add `openclaw doctor` warnings for missing/invalid multi-account defaults across channels, and document explicit-default guidance for channel routing and Telegram config. (#32544) thanks @Sid-Qin.
 - Agents/Skills runtime loading: propagate run config into embedded attempt and compaction skill-entry loading so explicitly enabled bundled companion skills are discovered consistently when skill snapshots do not already provide resolved entries. Thanks @gumadeiras.
 - Agents/Compaction continuity: expand staged-summary merge instructions to preserve active task status, batch progress, latest user request, and follow-up commitments so compaction handoffs retain in-flight work context. (#8903) thanks @joetomasone.

--- a/extensions/feishu/src/secret-input.test.ts
+++ b/extensions/feishu/src/secret-input.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("feishu secret-input compatibility helpers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unmock("openclaw/plugin-sdk");
+  });
+
+  it("uses plugin-sdk secret helpers when available", async () => {
+    const normalizeSecretInputString = vi.fn((value: unknown) =>
+      typeof value === "string" ? value.trim() || undefined : undefined,
+    );
+    const normalizeResolvedSecretInputString = vi.fn((params: { value: unknown; path: string }) =>
+      typeof params.value === "string" ? params.value.trim() || undefined : undefined,
+    );
+    const hasConfiguredSecretInput = vi.fn((value: unknown) => value === "configured");
+
+    vi.doMock("openclaw/plugin-sdk", () => ({
+      normalizeSecretInputString,
+      normalizeResolvedSecretInputString,
+      hasConfiguredSecretInput,
+    }));
+
+    const mod = await import("./secret-input.js");
+
+    expect(mod.normalizeSecretInputString("  value  ")).toBe("value");
+    expect(mod.hasConfiguredSecretInput("configured")).toBe(true);
+    expect(
+      mod.normalizeResolvedSecretInputString({
+        value: "  token  ",
+        path: "channels.feishu.accounts.default.appSecret",
+      }),
+    ).toBe("token");
+
+    expect(normalizeSecretInputString).toHaveBeenCalledTimes(1);
+    expect(hasConfiguredSecretInput).toHaveBeenCalledTimes(1);
+    expect(normalizeResolvedSecretInputString).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to local normalization when plugin-sdk secret helpers are missing", async () => {
+    vi.doMock("openclaw/plugin-sdk", () => ({
+      normalizeSecretInputString: undefined,
+      normalizeResolvedSecretInputString: undefined,
+      hasConfiguredSecretInput: undefined,
+    }));
+    const mod = await import("./secret-input.js");
+
+    expect(mod.normalizeSecretInputString("  app-secret  ")).toBe("app-secret");
+    expect(mod.normalizeSecretInputString("   ")).toBeUndefined();
+
+    expect(mod.hasConfiguredSecretInput("  token  ")).toBe(true);
+    expect(
+      mod.hasConfiguredSecretInput({
+        source: "env",
+        provider: "default",
+        id: "FEISHU_APP_SECRET",
+      }),
+    ).toBe(true);
+
+    expect(() =>
+      mod.normalizeResolvedSecretInputString({
+        value: {
+          source: "env",
+          provider: "default",
+          id: "FEISHU_APP_SECRET",
+        },
+        path: "channels.feishu.accounts.default.appSecret",
+      }),
+    ).toThrow(/unresolved SecretRef/);
+  });
+});

--- a/extensions/feishu/src/secret-input.ts
+++ b/extensions/feishu/src/secret-input.ts
@@ -1,11 +1,84 @@
-import {
-  hasConfiguredSecretInput,
-  normalizeResolvedSecretInputString,
-  normalizeSecretInputString,
-} from "openclaw/plugin-sdk";
+import * as pluginSdk from "openclaw/plugin-sdk";
 import { z } from "zod";
 
-export { hasConfiguredSecretInput, normalizeResolvedSecretInputString, normalizeSecretInputString };
+type SecretRefLike = {
+  source: "env" | "file" | "exec";
+  provider: string;
+  id: string;
+};
+
+function fallbackNormalizeSecretInputString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function coerceSecretRefLike(value: unknown): SecretRefLike | null {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+  const candidate = value as Record<string, unknown>;
+  const source = candidate.source;
+  const provider = candidate.provider;
+  const id = candidate.id;
+  if (
+    (source === "env" || source === "file" || source === "exec") &&
+    typeof provider === "string" &&
+    provider.trim().length > 0 &&
+    typeof id === "string" &&
+    id.trim().length > 0
+  ) {
+    return {
+      source,
+      provider,
+      id,
+    };
+  }
+  return null;
+}
+
+function fallbackHasConfiguredSecretInput(value: unknown): boolean {
+  if (fallbackNormalizeSecretInputString(value)) {
+    return true;
+  }
+  return coerceSecretRefLike(value) !== null;
+}
+
+function fallbackNormalizeResolvedSecretInputString(params: {
+  value: unknown;
+  path: string;
+}): string | undefined {
+  const normalized = fallbackNormalizeSecretInputString(params.value);
+  if (normalized) {
+    return normalized;
+  }
+  const ref = coerceSecretRefLike(params.value);
+  if (!ref) {
+    return undefined;
+  }
+  throw new Error(
+    `${params.path}: unresolved SecretRef "${ref.source}:${ref.provider}:${ref.id}". Resolve this command against an active gateway runtime snapshot before reading it.`,
+  );
+}
+
+const sdk = pluginSdk as Partial<typeof pluginSdk>;
+
+export const normalizeSecretInputString =
+  typeof sdk.normalizeSecretInputString === "function"
+    ? sdk.normalizeSecretInputString
+    : fallbackNormalizeSecretInputString;
+
+export const hasConfiguredSecretInput =
+  typeof sdk.hasConfiguredSecretInput === "function"
+    ? sdk.hasConfiguredSecretInput
+    : fallbackHasConfiguredSecretInput;
+
+export const normalizeResolvedSecretInputString =
+  typeof sdk.normalizeResolvedSecretInputString === "function"
+    ? sdk.normalizeResolvedSecretInputString
+    : fallbackNormalizeResolvedSecretInputString;
 
 export function buildSecretInputSchema() {
   return z.union([


### PR DESCRIPTION
## Summary

- Problem: Feishu plugin startup/channel setup can crash on older OpenClaw cores where `openclaw/plugin-sdk` does not export the newer secret helper functions.
- Why it matters: channel onboarding fails with `normalizeSecretInputString is not a function` / `normalizeResolvedSecretInputString is not a function`, especially in mixed-version installs.
- What changed: `extensions/feishu/src/secret-input.ts` now keeps using plugin-sdk helpers when available, but falls back to local compatible implementations when those exports are missing.
- What did NOT change (scope boundary): no auth flow, token semantics, or Feishu API behavior changed; this only adds compatibility fallback for missing helper exports.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32808
- Related #32833

## User-visible / Behavior Changes

- Feishu plugin setup no longer crashes in older-core/newer-plugin mixed installs when plugin-sdk secret helper exports are missing.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): Feishu extension
- Relevant config (redacted): `channels.feishu.accounts.*`

### Steps

1. Mock plugin-sdk with secret helpers present and verify Feishu helper module forwards calls.
2. Mock plugin-sdk with missing secret helpers and verify local fallbacks normalize plaintext/SecretRef inputs.
3. Verify unresolved SecretRef fallback error message remains explicit.

### Expected

- Extension remains loadable and functional in both modern and older-core plugin-sdk export shapes.

### Actual

- New compatibility test file passes for both paths.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test extensions/feishu/src/secret-input.test.ts`
  - `pnpm lint -- extensions/feishu/src/secret-input.ts extensions/feishu/src/secret-input.test.ts`
- Edge cases checked:
  - missing helper exports fallback path
  - unresolved SecretRef error path
- What you did **not** verify:
  - live WSL2 + Feishu onboarding end-to-end

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `extensions/feishu/src/secret-input.ts`
  - `extensions/feishu/src/secret-input.test.ts`
- Known bad symptoms reviewers should watch for:
  - unexpected SecretRef normalization behavior in Feishu account resolution.

## Risks and Mitigations

- Risk: local fallback may drift from core helper semantics over time.
  - Mitigation: fallback intentionally mirrors core behavior for plaintext + unresolved SecretRef handling and is used only when sdk exports are missing.
