### PR TITLE
fix(daemon): filter missing user service PATH dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Daemon/service PATH generation: include user-level bin entries only when the target directory exists, preventing `doctor --fix` from re-introducing stale/non-existent paths like `~/.npm-global/bin` and `~/.nvm/current/bin` into managed service environments. (#32448) thanks @cliffchen.
 - Telegram/multi-account default routing clarity: warn only for ambiguous (2+) account setups without an explicit default, add `openclaw doctor` warnings for missing/invalid multi-account defaults across channels, and document explicit-default guidance for channel routing and Telegram config. (#32544) thanks @Sid-Qin.
 - Agents/Skills runtime loading: propagate run config into embedded attempt and compaction skill-entry loading so explicitly enabled bundled companion skills are discovered consistently when skill snapshots do not already provide resolved entries. Thanks @gumadeiras.
 - Agents/Compaction continuity: expand staged-summary merge instructions to preserve active task status, batch progress, latest user request, and follow-up commitments so compaction handoffs retain in-flight work context. (#8903) thanks @joetomasone.

--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -11,8 +11,11 @@ import {
 } from "./service-env.js";
 
 describe("getMinimalServicePathParts - Linux user directories", () => {
+  const assumeDirsExist = { dirExists: () => true };
+
   it("includes user bin directories when HOME is set on Linux", () => {
     const result = getMinimalServicePathParts({
+      ...assumeDirsExist,
       platform: "linux",
       home: "/home/testuser",
     });
@@ -46,6 +49,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
 
   it("places user directories before system directories on Linux", () => {
     const result = getMinimalServicePathParts({
+      ...assumeDirsExist,
       platform: "linux",
       home: "/home/testuser",
     });
@@ -60,6 +64,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
 
   it("places extraDirs before user directories on Linux", () => {
     const result = getMinimalServicePathParts({
+      ...assumeDirsExist,
       platform: "linux",
       home: "/home/testuser",
       extraDirs: ["/custom/bin"],
@@ -75,6 +80,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
 
   it("includes env-configured bin roots when HOME is set on Linux", () => {
     const result = getMinimalServicePathPartsFromEnv({
+      ...assumeDirsExist,
       platform: "linux",
       env: {
         HOME: "/home/testuser",
@@ -99,6 +105,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
 
   it("includes version manager directories on macOS when HOME is set", () => {
     const result = getMinimalServicePathParts({
+      ...assumeDirsExist,
       platform: "darwin",
       home: "/Users/testuser",
     });
@@ -125,6 +132,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
 
   it("includes env-configured version manager dirs on macOS", () => {
     const result = getMinimalServicePathPartsFromEnv({
+      ...assumeDirsExist,
       platform: "darwin",
       env: {
         HOME: "/Users/testuser",
@@ -144,6 +152,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
 
   it("places version manager dirs before system dirs on macOS", () => {
     const result = getMinimalServicePathParts({
+      ...assumeDirsExist,
       platform: "darwin",
       home: "/Users/testuser",
     });
@@ -168,9 +177,25 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     // Windows returns empty array (uses existing PATH)
     expect(result).toEqual([]);
   });
+
+  it("filters out user directories that do not exist", () => {
+    const result = getMinimalServicePathParts({
+      platform: "linux",
+      home: "/home/testuser",
+      dirExists: (dir) =>
+        dir === "/home/testuser/.local/bin" || dir === "/home/testuser/.volta/bin",
+    });
+
+    expect(result).toContain("/home/testuser/.local/bin");
+    expect(result).toContain("/home/testuser/.volta/bin");
+    expect(result).not.toContain("/home/testuser/.npm-global/bin");
+    expect(result).not.toContain("/home/testuser/.nvm/current/bin");
+    expect(result).toContain("/usr/bin");
+  });
 });
 
 describe("buildMinimalServicePath", () => {
+  const assumeDirsExist = { dirExists: () => true };
   const splitPath = (value: string, platform: NodeJS.Platform) =>
     value.split(platform === "win32" ? path.win32.delimiter : path.posix.delimiter);
 
@@ -195,6 +220,7 @@ describe("buildMinimalServicePath", () => {
 
   it("includes Linux user directories when HOME is set in env", () => {
     const result = buildMinimalServicePath({
+      ...assumeDirsExist,
       platform: "linux",
       env: { HOME: "/home/alice" },
     });
@@ -227,6 +253,7 @@ describe("buildMinimalServicePath", () => {
 
   it("ensures user directories come before system directories on Linux", () => {
     const result = buildMinimalServicePath({
+      ...assumeDirsExist,
       platform: "linux",
       env: { HOME: "/home/bob" },
     });

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { VERSION } from "../version.js";
@@ -19,6 +20,7 @@ export type MinimalServicePathOptions = {
   extraDirs?: string[];
   home?: string;
   env?: Record<string, string | undefined>;
+  dirExists?: (dir: string) => boolean;
 };
 
 type BuildServicePathOptions = MinimalServicePathOptions & {
@@ -198,6 +200,7 @@ export function getMinimalServicePathParts(options: MinimalServicePathOptions = 
       : platform === "darwin"
         ? resolveDarwinUserBinDirs(options.home, options.env)
         : [];
+  const dirExists = options.dirExists ?? fs.existsSync;
 
   const add = (dir: string) => {
     if (!dir) {
@@ -207,13 +210,26 @@ export function getMinimalServicePathParts(options: MinimalServicePathOptions = 
       parts.push(dir);
     }
   };
+  const addUserDir = (dir: string) => {
+    if (!dir) {
+      return;
+    }
+    try {
+      if (!dirExists(dir)) {
+        return;
+      }
+    } catch {
+      return;
+    }
+    add(dir);
+  };
 
   for (const dir of extraDirs) {
     add(dir);
   }
   // User dirs first so user-installed binaries take precedence
   for (const dir of userDirs) {
-    add(dir);
+    addUserDir(dir);
   }
   for (const dir of systemDirs) {
     add(dir);


### PR DESCRIPTION
## Summary
- fix daemon service PATH assembly to include user-level bin directories only when they exist on disk
- keep behavior deterministic in tests by allowing an injected directory-existence checker
- add regression coverage for filtering stale/non-existent user bin paths and update changelog entry for #32448

## Testing
- pnpm test src/daemon/service-env.test.ts
- pnpm format

## Linked
- Fixes #32448
