### PR TITLE
fix(telegram): add setStatus integration for health monitoring

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -495,6 +495,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         webhookPath: account.config.webhookPath,
         webhookHost: account.config.webhookHost,
         webhookPort: account.config.webhookPort,
+        setStatus: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
       });
     },
     logoutAccount: async ({ accountId, cfg }) => {

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -48,6 +48,7 @@ export type TelegramBotOptions = {
   replyToMode?: ReplyToMode;
   proxyFetch?: typeof fetch;
   config?: OpenClawConfig;
+  setStatus?: (next: Record<string, unknown>) => void;
   updateOffset?: {
     lastUpdateId?: number | null;
     onUpdateId?: (updateId: number) => void | Promise<void>;
@@ -163,6 +164,21 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       }
     }
   });
+
+  // Track inbound events for health monitoring (feature parity with Discord/Slack).
+  // Placed before sequentialize so timestamps update even for queued updates.
+  if (opts.setStatus) {
+    const setStatus = opts.setStatus;
+    bot.use(async (ctx, next) => {
+      try {
+        const at = Date.now();
+        setStatus({ lastEventAt: at, lastInboundAt: at });
+      } catch {
+        // Status tracking must never interrupt message processing.
+      }
+      return next();
+    });
+  }
 
   bot.use(sequentialize(getTelegramSequentialKey));
 

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -30,6 +30,7 @@ export type MonitorTelegramOpts = {
   webhookHost?: string;
   proxyFetch?: typeof fetch;
   webhookUrl?: string;
+  setStatus?: (next: Record<string, unknown>) => void;
 };
 
 export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
@@ -172,6 +173,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         fetch: proxyFetch,
         abortSignal: opts.abortSignal,
         publicUrl: opts.webhookUrl,
+        setStatus: opts.setStatus,
       });
       await waitForAbortSignal(opts.abortSignal);
       return;
@@ -220,6 +222,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
           proxyFetch,
           config: cfg,
           accountId: account.accountId,
+          setStatus: opts.setStatus,
           updateOffset: {
             lastUpdateId,
             onUpdateId: persistUpdateId,

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -87,6 +87,7 @@ export async function startTelegramWebhook(opts: {
   abortSignal?: AbortSignal;
   healthPath?: string;
   publicUrl?: string;
+  setStatus?: (next: Record<string, unknown>) => void;
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
@@ -107,6 +108,7 @@ export async function startTelegramWebhook(opts: {
     proxyFetch: opts.fetch,
     config: opts.config,
     accountId: opts.accountId,
+    setStatus: opts.setStatus,
   });
   await initializeTelegramWebhookBot({
     bot,


### PR DESCRIPTION
## Summary

- Thread `setStatus` callback from extension layer through monitor → bot/webhook so `lastEventAt` and `lastInboundAt` update on every inbound Telegram event
- Achieves feature parity with Discord and Slack health monitoring
- Error-isolated via try/catch to never interrupt message processing

## Changes

- `src/telegram/monitor.ts`: add `setStatus` to `MonitorTelegramOpts`, forward to polling and webhook paths
- `src/telegram/bot.ts`: add `setStatus` to `TelegramBotOptions`, add grammY middleware for inbound event tracking
- `src/telegram/webhook.ts`: add `setStatus` to webhook opts, forward to `createTelegramBot`
- `extensions/telegram/src/channel.ts`: pass `setStatus` with `accountId` wrapping to `monitorTelegramProvider`

## Test plan

- [ ] `pnpm tsgo` passes (verified locally — no new type errors)
- [ ] `pnpm test` passes (no regressions)
- [ ] Manual: start Telegram channel, send message, verify `lastEventAt`/`lastInboundAt` update in `openclaw channels status --deep`

Closes #32850