### PR TITLE
CLI: add built-in tool hint for plugin install manifest mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Plugins/install UX: when bare specs like `exec` fail with `package.json missing openclaw.extensions`, print an explicit hint that command/file/browser capabilities are built-in tools (enable `tools.profile: coding`) instead of leaving only npm plugin-manifest errors. Fixes #32833. Thanks @liuxiaopai-ai.
 - Telegram/multi-account default routing clarity: warn only for ambiguous (2+) account setups without an explicit default, add `openclaw doctor` warnings for missing/invalid multi-account defaults across channels, and document explicit-default guidance for channel routing and Telegram config. (#32544) thanks @Sid-Qin.
 - Agents/Skills runtime loading: propagate run config into embedded attempt and compaction skill-entry loading so explicitly enabled bundled companion skills are discovered consistently when skill snapshots do not already provide resolved entries. Thanks @gumadeiras.
 - Agents/Compaction continuity: expand staged-summary merge instructions to preserve active task status, batch progress, latest user request, and follow-up commitments so compaction handoffs retain in-flight work context. (#8903) thanks @joetomasone.

--- a/src/cli/plugin-install-plan.test.ts
+++ b/src/cli/plugin-install-plan.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { PLUGIN_INSTALL_ERROR_CODE } from "../plugins/install.js";
 import {
+  resolveBuiltinToolInstallHintForNpmFailure,
   resolveBundledInstallPlanBeforeNpm,
   resolveBundledInstallPlanForNpmFailure,
 } from "./plugin-install-plan.js";
@@ -63,5 +64,29 @@ describe("plugin install plan helpers", () => {
 
     expect(findBundledSource).not.toHaveBeenCalled();
     expect(result).toBeNull();
+  });
+
+  it("returns built-in tool hint for missing-openclaw-extensions on bare tool-like spec", () => {
+    const hint = resolveBuiltinToolInstallHintForNpmFailure({
+      rawSpec: "exec",
+      code: PLUGIN_INSTALL_ERROR_CODE.MISSING_OPENCLAW_EXTENSIONS,
+    });
+
+    expect(hint).toContain("built-in tool category");
+    expect(hint).toContain("tools.profile coding");
+  });
+
+  it("does not return built-in tool hint for scoped specs or other error codes", () => {
+    const scoped = resolveBuiltinToolInstallHintForNpmFailure({
+      rawSpec: "@openclaw/exec",
+      code: PLUGIN_INSTALL_ERROR_CODE.MISSING_OPENCLAW_EXTENSIONS,
+    });
+    const otherError = resolveBuiltinToolInstallHintForNpmFailure({
+      rawSpec: "exec",
+      code: PLUGIN_INSTALL_ERROR_CODE.NPM_PACKAGE_NOT_FOUND,
+    });
+
+    expect(scoped).toBeNull();
+    expect(otherError).toBeNull();
   });
 });

--- a/src/cli/plugin-install-plan.ts
+++ b/src/cli/plugin-install-plan.ts
@@ -12,6 +12,19 @@ function isBareNpmPackageName(spec: string): boolean {
   return /^[a-z0-9][a-z0-9-._~]*$/.test(trimmed);
 }
 
+const BUILTIN_TOOL_LIKE_PLUGIN_NAMES = new Set([
+  "exec",
+  "shell",
+  "bash",
+  "terminal",
+  "browser",
+  "web",
+  "playwright",
+  "file",
+  "files",
+  "fs",
+]);
+
 export function resolveBundledInstallPlanBeforeNpm(params: {
   rawSpec: string;
   findBundledSource: BundledLookup;
@@ -51,4 +64,21 @@ export function resolveBundledInstallPlanForNpmFailure(params: {
     bundledSource,
     warning: `npm package unavailable for ${params.rawSpec}; using bundled plugin at ${shortenHomePath(bundledSource.localPath)}.`,
   };
+}
+
+export function resolveBuiltinToolInstallHintForNpmFailure(params: {
+  rawSpec: string;
+  code?: string;
+}): string | null {
+  if (params.code !== PLUGIN_INSTALL_ERROR_CODE.MISSING_OPENCLAW_EXTENSIONS) {
+    return null;
+  }
+  if (!isBareNpmPackageName(params.rawSpec)) {
+    return null;
+  }
+  const normalized = params.rawSpec.trim().toLowerCase();
+  if (!BUILTIN_TOOL_LIKE_PLUGIN_NAMES.has(normalized)) {
+    return null;
+  }
+  return `Hint: "${params.rawSpec}" looks like a built-in tool category, not an OpenClaw plugin. For command/file/browser tools, enable a coding tool profile instead (for example: openclaw config set tools.profile coding), then restart the gateway.`;
 }

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -25,6 +25,7 @@ import { resolveUserPath, shortenHomeInString, shortenHomePath } from "../utils.
 import { looksLikeLocalInstallSpec } from "./install-spec.js";
 import { resolvePinnedNpmInstallRecordForCli } from "./npm-resolution.js";
 import {
+  resolveBuiltinToolInstallHintForNpmFailure,
   resolveBundledInstallPlanBeforeNpm,
   resolveBundledInstallPlanForNpmFailure,
 } from "./plugin-install-plan.js";
@@ -325,6 +326,13 @@ async function runPluginInstallCommand(params: {
       findBundledSource: (lookup) => findBundledPluginSource({ lookup }),
     });
     if (!bundledFallbackPlan) {
+      const builtInToolHint = resolveBuiltinToolInstallHintForNpmFailure({
+        rawSpec: raw,
+        code: result.code,
+      });
+      if (builtInToolHint) {
+        defaultRuntime.log(theme.warn(builtInToolHint));
+      }
       defaultRuntime.error(result.error);
       process.exit(1);
     }


### PR DESCRIPTION
## Summary

- Problem: users running `openclaw plugins install exec` can hit `package.json missing openclaw.extensions` and are left with low-signal npm manifest errors.
- Why it matters: users interpret this as "exec capability broken" after upgrade, even when command/file/browser tools are built-in and controlled by tool profile.
- What changed: on install failures with `missing_openclaw_extensions` for bare tool-like specs (`exec`, `browser`, `file`, etc.), CLI now prints a clear hint to enable `tools.profile: coding` instead of only surfacing plugin manifest errors.
- What did NOT change (scope boundary): plugin install validation rules are unchanged; we still reject non-OpenClaw plugin package manifests.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32833
- Related #32828

## User-visible / Behavior Changes

- Plugin-install failures for tool-like bare package names now include a targeted remediation hint (`openclaw config set tools.profile coding`).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + Vitest
- Model/provider: N/A
- Integration/channel (if any): CLI plugin install
- Relevant config (redacted): N/A

### Steps

1. Trigger install-plan helper with bare tool-like spec and `missing_openclaw_extensions` code.
2. Verify helper returns built-in-tool hint.
3. Trigger helper with scoped spec / other error code.
4. Verify no hint is produced.

### Expected

- Users get actionable guidance for common `plugins install exec` confusion.

### Actual

- New tests pass and show hint behavior only in targeted failure mode.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- Verified scenarios:
  - `pnpm test src/cli/plugin-install-plan.test.ts`
  - `pnpm lint -- src/cli/plugin-install-plan.ts src/cli/plugin-install-plan.test.ts src/cli/plugins-cli.ts`
- Edge cases checked:
  - no hint for scoped package specs
  - no hint for non-missing-extensions errors
- What you did **not** verify:
  - full interactive CLI run with real npm failure path

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/cli/plugin-install-plan.ts`
  - `src/cli/plugins-cli.ts`
- Known bad symptoms reviewers should watch for:
  - hint text showing in unrelated install failures.

## Risks and Mitigations

- Risk: tool-like name matching could over-hint for unrelated npm packages with same bare name.
  - Mitigation: hint only appears on `missing_openclaw_extensions` failures (already indicating a non-OpenClaw package manifest).
