### PR TITLE
fix(telegram): keep RTL direction in DM draft previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/DM draft RTL preview: prepend a right-to-left mark for plain-text `sendMessageDraft` previews when content contains RTL scripts and has no existing bidi markers, so Hebrew/Arabic partial-stream previews render in the expected direction while keeping HTML-rendered drafts unchanged. (#32852) Thanks @taibaran.
 - Telegram/multi-account default routing clarity: warn only for ambiguous (2+) account setups without an explicit default, add `openclaw doctor` warnings for missing/invalid multi-account defaults across channels, and document explicit-default guidance for channel routing and Telegram config. (#32544) thanks @Sid-Qin.
 - Agents/Skills runtime loading: propagate run config into embedded attempt and compaction skill-entry loading so explicitly enabled bundled companion skills are discovered consistently when skill snapshots do not already provide resolved entries. Thanks @gumadeiras.
 - Agents/Compaction continuity: expand staged-summary merge instructions to preserve active task status, batch progress, latest user request, and follow-up commitments so compaction handoffs retain in-flight work context. (#8903) thanks @joetomasone.

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -133,6 +133,36 @@ describe("createTelegramDraftStream", () => {
     expect(api.deleteMessage).not.toHaveBeenCalled();
   });
 
+  it("prepends RLM for RTL draft previews without parse_mode", async () => {
+    const api = createMockDraftApi();
+    const stream = createThreadedDraftStream(api, { id: 42, scope: "dm" });
+
+    stream.update("שלום");
+    await vi.waitFor(() =>
+      expect(api.sendMessageDraft).toHaveBeenCalledWith(123, expect.any(Number), "\u200Fשלום", {
+        message_thread_id: 42,
+      }),
+    );
+  });
+
+  it("keeps rendered HTML draft previews unchanged", async () => {
+    const api = createMockDraftApi();
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      thread: { id: 42, scope: "dm" },
+      renderText: (text) => ({ text: `<i>${text}</i>`, parseMode: "HTML" }),
+    });
+
+    stream.update("שלום");
+    await vi.waitFor(() =>
+      expect(api.sendMessageDraft).toHaveBeenCalledWith(123, expect.any(Number), "<i>שלום</i>", {
+        message_thread_id: 42,
+        parse_mode: "HTML",
+      }),
+    );
+  });
+
   it("supports forcing message transport in dm threads", async () => {
     const api = createMockDraftApi();
     const stream = createDraftStream(api, {

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -145,6 +145,18 @@ describe("createTelegramDraftStream", () => {
     );
   });
 
+  it("does not prepend RLM when the first strong letter is LTR", async () => {
+    const api = createMockDraftApi();
+    const stream = createThreadedDraftStream(api, { id: 42, scope: "dm" });
+
+    stream.update("Summary: שלום");
+    await vi.waitFor(() =>
+      expect(api.sendMessageDraft).toHaveBeenCalledWith(123, expect.any(Number), "Summary: שלום", {
+        message_thread_id: 42,
+      }),
+    );
+  });
+
   it("keeps rendered HTML draft previews unchanged", async () => {
     const api = createMockDraftApi();
     const stream = createTelegramDraftStream({
@@ -224,6 +236,28 @@ describe("createTelegramDraftStream", () => {
     await stream.flush();
 
     expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "Hello again");
+  });
+
+  it("uses unhinted text when draft transport falls back to message transport", async () => {
+    const api = createMockDraftApi();
+    api.sendMessageDraft.mockRejectedValueOnce(
+      new Error(
+        "Call to 'sendMessageDraft' failed! (400: Bad Request: method sendMessageDraft can be used only in private chats)",
+      ),
+    );
+    const stream = createDraftStream(api, {
+      thread: { id: 42, scope: "dm" },
+      previewTransport: "draft",
+    });
+
+    stream.update("שלום");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledWith(123, "שלום", { message_thread_id: 42 });
+
+    stream.update("שלום");
+    await stream.flush();
+    expect(api.editMessageText).not.toHaveBeenCalled();
   });
 
   it("retries DM message preview send without thread when thread is not found", async () => {

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -414,6 +414,43 @@ describe("createTelegramDraftStream", () => {
     expect(api.editMessageText).not.toHaveBeenCalledWith(123, 17, "Message B partial");
   });
 
+  it("does not skip first post-forceNewMessage update after superseded draft fallback", async () => {
+    let resolveFirstSend: ((value: { message_id: number }) => void) | undefined;
+    const firstSend = new Promise<{ message_id: number }>((resolve) => {
+      resolveFirstSend = resolve;
+    });
+    const api = createMockDraftApi();
+    api.sendMessageDraft.mockRejectedValueOnce(
+      new Error(
+        "Call to 'sendMessageDraft' failed! (400: Bad Request: method sendMessageDraft can be used only in private chats)",
+      ),
+    );
+    api.sendMessage.mockReturnValueOnce(firstSend).mockResolvedValueOnce({ message_id: 42 });
+    const onSupersededPreview = vi.fn();
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      thread: { id: 42, scope: "dm" },
+      previewTransport: "draft",
+      onSupersededPreview,
+    });
+
+    stream.update("שלום");
+    await vi.waitFor(() => expect(api.sendMessage).toHaveBeenCalledTimes(1));
+
+    stream.forceNewMessage();
+    resolveFirstSend?.({ message_id: 17 });
+    await vi.waitFor(() => expect(onSupersededPreview).toHaveBeenCalledTimes(1));
+
+    stream.update("שלום");
+    await stream.flush();
+
+    expect(api.sendMessage).toHaveBeenCalledTimes(2);
+    expect(api.sendMessage).toHaveBeenNthCalledWith(2, 123, "שלום", {
+      message_thread_id: 42,
+    });
+  });
+
   it("supports rendered previews with parse_mode", async () => {
     const api = createMockDraftApi();
     const stream = createTelegramDraftStream({

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -9,6 +9,9 @@ const THREAD_NOT_FOUND_RE = /400:\s*Bad Request:\s*message thread not found/i;
 const DRAFT_METHOD_UNAVAILABLE_RE =
   /(unknown method|method .*not (found|available|supported)|unsupported)/i;
 const DRAFT_CHAT_UNSUPPORTED_RE = /(can't be used|can be used only)/i;
+const RTL_SCRIPT_RE = /[\u0590-\u08ff\ufb1d-\ufdff\ufe70-\ufefc]/;
+const BIDI_CONTROL_RE = /[\u200e\u200f\u202a-\u202e\u2066-\u2069]/;
+const RTL_DIRECTION_MARK = "\u200F";
 
 type TelegramSendMessageDraft = (
   chatId: number,
@@ -51,6 +54,16 @@ function shouldFallbackFromDraftTransport(err: unknown): boolean {
     return false;
   }
   return DRAFT_METHOD_UNAVAILABLE_RE.test(text) || DRAFT_CHAT_UNSUPPORTED_RE.test(text);
+}
+
+function applyDraftDirectionalityHint(text: string, parseMode?: "HTML"): string {
+  if (parseMode === "HTML") {
+    return text;
+  }
+  if (!RTL_SCRIPT_RE.test(text) || BIDI_CONTROL_RE.test(text)) {
+    return text;
+  }
+  return `${RTL_DIRECTION_MARK}${text}`;
 }
 
 export type TelegramDraftStream = {
@@ -233,16 +246,20 @@ export function createTelegramDraftStream(params: {
     if (!renderedText) {
       return false;
     }
-    if (renderedText.length > maxChars) {
+    const transportText =
+      previewTransport === "draft"
+        ? applyDraftDirectionalityHint(renderedText, renderedParseMode)
+        : renderedText;
+    if (transportText.length > maxChars) {
       // Telegram text messages/edits cap at 4096 chars.
       // Stop streaming once we exceed the cap to avoid repeated API failures.
       streamState.stopped = true;
       params.warn?.(
-        `telegram stream preview stopped (text length ${renderedText.length} > ${maxChars})`,
+        `telegram stream preview stopped (text length ${transportText.length} > ${maxChars})`,
       );
       return false;
     }
-    if (renderedText === lastSentText && renderedParseMode === lastSentParseMode) {
+    if (transportText === lastSentText && renderedParseMode === lastSentParseMode) {
       return true;
     }
     const sendGeneration = generation;
@@ -254,14 +271,14 @@ export function createTelegramDraftStream(params: {
       }
     }
 
-    lastSentText = renderedText;
+    lastSentText = transportText;
     lastSentParseMode = renderedParseMode;
     try {
       let sent = false;
       if (previewTransport === "draft") {
         try {
           sent = await sendDraftTransportPreview({
-            renderedText,
+            renderedText: transportText,
             renderedParseMode,
             sendGeneration,
           });
@@ -275,14 +292,14 @@ export function createTelegramDraftStream(params: {
             "telegram stream preview: sendMessageDraft rejected by API; falling back to sendMessage/editMessageText",
           );
           sent = await sendMessageTransportPreview({
-            renderedText,
+            renderedText: transportText,
             renderedParseMode,
             sendGeneration,
           });
         }
       } else {
         sent = await sendMessageTransportPreview({
-          renderedText,
+          renderedText: transportText,
           renderedParseMode,
           sendGeneration,
         });

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -11,6 +11,7 @@ const DRAFT_METHOD_UNAVAILABLE_RE =
 const DRAFT_CHAT_UNSUPPORTED_RE = /(can't be used|can be used only)/i;
 const RTL_SCRIPT_RE = /[\u0590-\u08ff\ufb1d-\ufdff\ufe70-\ufefc]/;
 const BIDI_CONTROL_RE = /[\u200e\u200f\u202a-\u202e\u2066-\u2069]/;
+const UNICODE_LETTER_RE = /\p{Letter}/u;
 const RTL_DIRECTION_MARK = "\u200F";
 
 type TelegramSendMessageDraft = (
@@ -60,10 +61,19 @@ function applyDraftDirectionalityHint(text: string, parseMode?: "HTML"): string 
   if (parseMode === "HTML") {
     return text;
   }
-  if (!RTL_SCRIPT_RE.test(text) || BIDI_CONTROL_RE.test(text)) {
+  if (BIDI_CONTROL_RE.test(text)) {
     return text;
   }
-  return `${RTL_DIRECTION_MARK}${text}`;
+  for (const char of text) {
+    if (RTL_SCRIPT_RE.test(char)) {
+      return `${RTL_DIRECTION_MARK}${text}`;
+    }
+    // Only add a RTL direction hint when the first strong letter is RTL.
+    if (UNICODE_LETTER_RE.test(char)) {
+      return text;
+    }
+  }
+  return text;
 }
 
 export type TelegramDraftStream = {
@@ -291,11 +301,15 @@ export function createTelegramDraftStream(params: {
           params.warn?.(
             "telegram stream preview: sendMessageDraft rejected by API; falling back to sendMessage/editMessageText",
           );
+          const fallbackText = renderedText;
           sent = await sendMessageTransportPreview({
-            renderedText: transportText,
+            renderedText: fallbackText,
             renderedParseMode,
             sendGeneration,
           });
+          if (sent) {
+            lastSentText = fallbackText;
+          }
         }
       } else {
         sent = await sendMessageTransportPreview({

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -307,7 +307,7 @@ export function createTelegramDraftStream(params: {
             renderedParseMode,
             sendGeneration,
           });
-          if (sent) {
+          if (sent && sendGeneration === generation) {
             lastSentText = fallbackText;
           }
         }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram DM streaming previews sent through `sendMessageDraft` can render Hebrew/Arabic text left-to-right.
- Why it matters: Partial streaming is user-visible; wrong text direction makes draft previews hard to read until final settle.
- What changed: In draft transport, plain-text previews now prepend an RLM marker (`\u200F`) when RTL scripts are detected and no bidi marker is already present.
- What changed: Added regression tests for RTL draft previews and for HTML-rendered drafts (no marker injection).
- What did NOT change (scope boundary): No changes to non-draft preview transport, final message rendering, or Telegram markdown/html rendering pipeline.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32852
- Related #31824

## User-visible / Behavior Changes

- In Telegram DM partial streaming with native `sendMessageDraft` preview transport, RTL-language draft previews now render with correct directionality.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Telegram DM draft streaming
- Relevant config (redacted): `channels.telegram.streaming: partial`

### Steps

1. Configure Telegram with partial streaming and DM draft preview transport.
2. Send an RTL prompt (for example, Hebrew) so preview updates use `sendMessageDraft`.
3. Observe draft update payload text and directionality behavior.

### Expected

- Draft previews should render in RTL direction for RTL-language content.

### Actual

- Before fix: plain-text draft previews can render LTR until final message settles.
- After fix: draft payload includes RLM for plain RTL text, so preview direction is correct.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/telegram/draft-stream.test.ts`
  - New tests validate RTL draft marker insertion and HTML-rendered draft passthrough.
- Edge cases checked:
  - Existing parse_mode=`HTML` draft previews remain unchanged.
  - Non-RTL content behavior remains unchanged.
- What you did **not** verify:
  - Live Telegram device/manual UI validation in this run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/telegram/draft-stream.ts`
  - `src/telegram/draft-stream.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected control character prefixes in non-RTL draft previews.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: False-positive RTL detection could prepend RLM where not needed.
  - Mitigation: Marker insertion is restricted to draft transport plain text and skipped when bidi markers already exist or when parse mode is HTML.
