### PR TITLE
fix(feishu): suppress typing indicator on group non-mentions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu/group typing indicators: suppress typing reactions for non-mention group dispatches while preserving existing behavior for DMs and explicit bot mentions, reducing noisy reaction flashes on observe-only messages. (#32853) Thanks @miaciswang.
 - Telegram/multi-account default routing clarity: warn only for ambiguous (2+) account setups without an explicit default, add `openclaw doctor` warnings for missing/invalid multi-account defaults across channels, and document explicit-default guidance for channel routing and Telegram config. (#32544) thanks @Sid-Qin.
 - Agents/Skills runtime loading: propagate run config into embedded attempt and compaction skill-entry loading so explicitly enabled bundled companion skills are discovered consistently when skill snapshots do not already provide resolved entries. Thanks @gumadeiras.
 - Agents/Compaction continuity: expand staged-summary merge instructions to preserve active task status, batch progress, latest user request, and follow-up commitments so compaction handoffs retain in-flight work context. (#8903) thanks @joetomasone.

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1396,6 +1396,7 @@ export async function handleFeishuMessage(params: {
             mentionTargets: ctx.mentionTargets,
             accountId: account.accountId,
             messageCreateTimeMs,
+            allowTypingIndicator: !isGroup || ctx.mentionedBot,
           });
 
           log(
@@ -1494,6 +1495,7 @@ export async function handleFeishuMessage(params: {
         mentionTargets: ctx.mentionTargets,
         accountId: account.accountId,
         messageCreateTimeMs,
+        allowTypingIndicator: !isGroup || ctx.mentionedBot,
       });
 
       log(`feishu[${account.accountId}]: dispatching to agent (session=${route.sessionKey})`);

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -116,6 +116,22 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(addTypingIndicatorMock).not.toHaveBeenCalled();
   });
 
+  it("skips typing indicator when allowTypingIndicator is false", async () => {
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: {} as never,
+      chatId: "oc_chat",
+      replyToMessageId: "om_parent",
+      allowTypingIndicator: false,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.onReplyStart?.();
+
+    expect(addTypingIndicatorMock).not.toHaveBeenCalled();
+  });
+
   it("skips typing indicator for stale replayed messages", async () => {
     createFeishuReplyDispatcher({
       cfg: {} as never,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -53,6 +53,8 @@ export type CreateFeishuReplyDispatcherParams = {
   /** Epoch ms when the inbound message was created. Used to suppress typing
    *  indicators on old/replayed messages after context compaction (#30418). */
   messageCreateTimeMs?: number;
+  /** Override to skip typing indicator for this dispatch (for example group non-mentions). */
+  allowTypingIndicator?: boolean;
 };
 
 export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherParams) {
@@ -80,6 +82,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     start: async () => {
       // Check if typing indicator is enabled (default: true)
       if (!(account.config.typingIndicator ?? true)) {
+        return;
+      }
+      if (params.allowTypingIndicator === false) {
         return;
       }
       if (!replyToMessageId) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Feishu group traffic can flash typing reactions even when a message does not mention the bot and no reply is intended.
- Why it matters: In observe-only group flows (`requireMention: false`), this creates noisy/confusing UI signals for unrelated messages.
- What changed: Added `allowTypingIndicator` gating in Feishu reply dispatcher and set it from bot dispatch context.
- What changed: Group dispatch now enables typing indicators only when the bot is explicitly mentioned; DMs and mentioned group messages keep existing behavior.
- What did NOT change (scope boundary): No changes to reply routing, mention resolution, NO_REPLY behavior, or typing reaction implementation itself.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32853
- Related #28660

## User-visible / Behavior Changes

- Feishu typing reactions are now suppressed for group messages that do not mention the bot.
- Mentioned group messages and DMs keep typing indicator behavior.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Feishu
- Relevant config (redacted): group dispatch with `requireMention: false`

### Steps

1. Configure Feishu group routing so bot can observe non-mention messages.
2. Send a group message without mentioning the bot.
3. Trigger dispatch flow.

### Expected

- No typing reaction should be added for non-mention group messages.

### Actual

- After fix: typing reaction is skipped unless group message mentions the bot.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test extensions/feishu/src/reply-dispatcher.test.ts`
  - Added regression test for `allowTypingIndicator: false`.
- Edge cases checked:
  - Existing fresh-message typing path still adds indicator when not gated.
  - DMs and mentioned flows remain unchanged by default.
- What you did **not** verify:
  - Live Feishu tenant UI/manual validation in this run.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `extensions/feishu/src/bot.ts`
  - `extensions/feishu/src/reply-dispatcher.ts`
- Known bad symptoms reviewers should watch for:
  - Typing indicators unexpectedly missing in mentioned group messages.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Incorrect mention gating could suppress intended typing indicators in groups.
  - Mitigation: Gating is fed by existing `ctx.mentionedBot` signal already used in dispatch decisions, and covered by targeted reply-dispatcher tests.
