### PR TITLE
fix(feishu): parse quoted interactive card body content

### DIFF
--- a/extensions/feishu/src/send.test.ts
+++ b/extensions/feishu/src/send.test.ts
@@ -69,6 +69,43 @@ describe("getMessageFeishu", () => {
     );
   });
 
+  it("extracts text content from interactive card body elements", async () => {
+    mockClientGet.mockResolvedValueOnce({
+      code: 0,
+      data: {
+        items: [
+          {
+            message_id: "om_card_body",
+            chat_id: "oc_card_body",
+            msg_type: "interactive",
+            body: {
+              content: JSON.stringify({
+                schema: "2.0",
+                body: {
+                  elements: [{ tag: "markdown", content: "card body markdown" }],
+                },
+              }),
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await getMessageFeishu({
+      cfg: {} as ClawdbotConfig,
+      messageId: "om_card_body",
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageId: "om_card_body",
+        chatId: "oc_card_body",
+        contentType: "interactive",
+        content: "card body markdown",
+      }),
+    );
+  });
+
   it("extracts text content from post messages", async () => {
     mockClientGet.mockResolvedValueOnce({
       code: 0,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -35,13 +35,18 @@ function parseInteractiveCardContent(parsed: unknown): string {
     return "[Interactive Card]";
   }
 
-  const candidate = parsed as { elements?: unknown };
-  if (!Array.isArray(candidate.elements)) {
+  const candidate = parsed as { elements?: unknown; body?: { elements?: unknown } };
+  const elements = Array.isArray(candidate.elements)
+    ? candidate.elements
+    : Array.isArray(candidate.body?.elements)
+      ? candidate.body.elements
+      : null;
+  if (!elements) {
     return "[Interactive Card]";
   }
 
   const texts: string[] = [];
-  for (const element of candidate.elements) {
+  for (const element of elements) {
     if (!element || typeof element !== "object") {
       continue;
     }

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -39,7 +39,7 @@ function parseInteractiveCardContent(parsed: unknown): string {
   const elements = Array.isArray(candidate.elements)
     ? candidate.elements
     : Array.isArray(candidate.body?.elements)
-      ? candidate.body.elements
+      ? candidate.body?.elements
       : null;
   if (!elements) {
     return "[Interactive Card]";


### PR DESCRIPTION
## Summary
Fix Feishu quoted-message extraction for interactive cards that use schema 2.0 (`body.elements`) so quoted card mentions no longer degrade to `[Interactive Card]`.

## Root cause
`parseInteractiveCardContent` only read top-level `elements`, but Feishu markdown cards are sent in schema 2.0 shape with content under `body.elements`.

## Changes
- Extend interactive card parsing to read either:
  - top-level `elements` (existing shape)
  - `body.elements` (schema 2.0 card shape)
- Add regression test covering interactive card payload with `body.elements`.

## Validation
- `pnpm exec vitest run extensions/feishu/src/send.test.ts`

Fixes #32712
