### PR TITLE
fix(models): allow timeout-cooldown same-provider fallbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Models/fallback cooldown handling: allow same-provider fallback candidates to run when provider profiles are in transient timeout cooldown (in addition to rate-limit cooldown), so overload-style failures can still advance to sibling fallback models. (#32865)
 - Telegram/multi-account default routing clarity: warn only for ambiguous (2+) account setups without an explicit default, add `openclaw doctor` warnings for missing/invalid multi-account defaults across channels, and document explicit-default guidance for channel routing and Telegram config. (#32544) thanks @Sid-Qin.
 - Agents/Skills runtime loading: propagate run config into embedded attempt and compaction skill-entry loading so explicitly enabled bundled companion skills are discovered consistently when skill snapshots do not already provide resolved entries. Thanks @gumadeiras.
 - Agents/Compaction continuity: expand staged-summary merge instructions to preserve active task status, batch progress, latest user request, and follow-up commitments so compaction handoffs retain in-flight work context. (#8903) thanks @joetomasone.

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -996,7 +996,7 @@ describe("runWithModelFallback", () => {
   describe("fallback behavior with provider cooldowns", () => {
     async function makeAuthStoreWithCooldown(
       provider: string,
-      reason: "rate_limit" | "auth" | "billing",
+      reason: "rate_limit" | "timeout" | "auth" | "billing",
     ): Promise<{ store: AuthProfileStore; dir: string }> {
       const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
       const now = Date.now();
@@ -1007,12 +1007,12 @@ describe("runWithModelFallback", () => {
         },
         usageStats: {
           [`${provider}:default`]:
-            reason === "rate_limit"
+            reason === "rate_limit" || reason === "timeout"
               ? {
                   // Real rate-limit cooldowns are tracked through cooldownUntil
                   // and failureCounts, not disabledReason.
                   cooldownUntil: now + 300000,
-                  failureCounts: { rate_limit: 1 },
+                  failureCounts: { [reason]: 1 },
                 }
               : {
                   // Auth/billing issues use disabledUntil
@@ -1050,6 +1050,34 @@ describe("runWithModelFallback", () => {
 
       expect(result.result).toBe("sonnet success");
       expect(run).toHaveBeenCalledTimes(1); // Primary skipped, fallback attempted
+      expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5");
+    });
+
+    it("attempts same-provider fallbacks during timeout cooldown", async () => {
+      const { dir } = await makeAuthStoreWithCooldown("anthropic", "timeout");
+      const cfg = makeCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+              fallbacks: ["anthropic/claude-sonnet-4-5", "groq/llama-3.3-70b-versatile"],
+            },
+          },
+        },
+      });
+
+      const run = vi.fn().mockResolvedValueOnce("sonnet success");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "anthropic",
+        model: "claude-opus-4-6",
+        run,
+        agentDir: dir,
+      });
+
+      expect(result.result).toBe("sonnet success");
+      expect(run).toHaveBeenCalledTimes(1);
       expect(run).toHaveBeenNthCalledWith(1, "anthropic", "claude-sonnet-4-5");
     });
 

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -412,11 +412,13 @@ function resolveCooldownDecision(params: {
   }
 
   // For primary: try when requested model or when probe allows.
-  // For same-provider fallbacks: only relax cooldown on rate_limit, which
-  // is commonly model-scoped and can recover on a sibling model.
+  // For same-provider fallbacks: relax cooldown on rate_limit/timeout, which
+  // are typically transient and can recover on a sibling model.
+  const shouldRelaxSameProviderCooldown =
+    inferredReason === "rate_limit" || inferredReason === "timeout";
   const shouldAttemptDespiteCooldown =
     (params.isPrimary && (!params.requestedModel || shouldProbe)) ||
-    (!params.isPrimary && inferredReason === "rate_limit");
+    (!params.isPrimary && shouldRelaxSameProviderCooldown);
   if (!shouldAttemptDespiteCooldown) {
     return {
       type: "skip",


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: when provider profiles are in timeout cooldown state, same-provider fallback models are skipped.
- Why it matters: overload/503-style failures can leave users stuck on one model path instead of advancing to sibling fallback models.
- What changed: model-fallback cooldown decision now treats `timeout` like `rate_limit` for same-provider fallback attempts.
- What changed: added regression coverage for timeout-cooldown fallback behavior.
- What did NOT change (scope boundary): no change to auth/billing cooldown semantics; those still skip same-provider fallbacks.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32865
- Related #10266

## User-visible / Behavior Changes

- Fallback chains can now continue to same-provider sibling models when profile cooldown reason is timeout.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A (unit regression)
- Integration/channel (if any): model fallback path
- Relevant config (redacted): `agents.defaults.model.primary/fallbacks`

### Steps

1. Put primary provider auth profile into timeout cooldown state.
2. Configure same-provider fallback + cross-provider fallback.
3. Run model fallback selection.

### Expected

- Same-provider fallback candidate should still be attempted for timeout cooldown reasons.

### Actual

- After fix: timeout cooldown behaves like rate_limit cooldown for same-provider fallback attempts.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test src/agents/model-fallback.test.ts`
  - New test: `attempts same-provider fallbacks during timeout cooldown`.
- Edge cases checked:
  - Existing auth/billing cooldown tests still pass and keep stricter behavior.
  - Rate-limit cooldown behavior remains unchanged.
- What you did **not** verify:
  - Live upstream provider retry traces in a production environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this PR commit.
- Files/config to restore:
  - `src/agents/model-fallback.ts`
  - `src/agents/model-fallback.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected extra same-provider fallback attempts during provider outages.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: timeout outages can trigger extra same-provider retries before cross-provider fallback.
  - Mitigation: behavior remains bounded by existing candidate order and retry limits, and only applies when same-provider fallback candidates are explicitly configured.
