### PR TITLE
fix(telegram): drain buffered messages on graceful shutdown to prevent loss on systemd restart

### DIFF
--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -37,6 +37,9 @@ type DebounceBuffer<T> = {
   items: T[];
   timeout: ReturnType<typeof setTimeout> | null;
   debounceMs: number;
+  // Set to true by whichever path (timer or drain) flushes this buffer first,
+  // so a timer callback that already fired cannot produce a duplicate dispatch.
+  flushed?: boolean;
 };
 
 export type InboundDebounceCreateParams<T> = {
@@ -61,6 +64,13 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
   };
 
   const flushBuffer = async (key: string, buffer: DebounceBuffer<T>) => {
+    // Guard against duplicate processing: drain() and a timer callback that has
+    // already fired can both call flushBuffer for the same buffer; only the first
+    // path actually invokes onFlush.
+    if (buffer.flushed) {
+      return;
+    }
+    buffer.flushed = true;
     buffers.delete(key);
     if (buffer.timeout) {
       clearTimeout(buffer.timeout);

--- a/src/auto-reply/inbound-debounce.ts
+++ b/src/auto-reply/inbound-debounce.ts
@@ -120,5 +120,11 @@ export function createInboundDebouncer<T>(params: InboundDebounceCreateParams<T>
     scheduleFlush(key, buffer);
   };
 
-  return { enqueue, flushKey };
+  // Flush all pending debounce buffers immediately (used on graceful shutdown).
+  const drain = async () => {
+    const keys = [...buffers.keys()];
+    await Promise.all(keys.map((key) => flushKey(key)));
+  };
+
+  return { enqueue, flushKey, drain };
 }

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -143,6 +143,9 @@ export const registerTelegramHandlers = ({
     key: string;
     messages: Array<{ msg: Message; ctx: TelegramContext; receivedAtMs: number }>;
     timer: ReturnType<typeof setTimeout>;
+    // Set to true by whichever path (timer or drain) processes this entry first,
+    // so the other path becomes a no-op and cannot produce duplicate dispatches.
+    flushed?: boolean;
   };
   const textFragmentBuffer = new Map<string, TextFragmentEntry>();
   let textFragmentProcessing: Promise<void> = Promise.resolve();
@@ -340,6 +343,12 @@ export const registerTelegramHandlers = ({
 
   const processMediaGroup = async (entry: MediaGroupEntry) => {
     try {
+      // Guard against duplicate processing: drain() and a timer callback that
+      // already fired can both enqueue this entry; only the first wins.
+      if (entry.flushed) {
+        return;
+      }
+      entry.flushed = true;
       entry.messages.sort((a, b) => a.msg.message_id - b.msg.message_id);
 
       const captionMsg = entry.messages.find((m) => m.msg.caption || m.msg.text);
@@ -378,6 +387,12 @@ export const registerTelegramHandlers = ({
 
   const flushTextFragments = async (entry: TextFragmentEntry) => {
     try {
+      // Guard against duplicate processing: drain() and a timer callback that
+      // already fired can both enqueue this entry; only the first wins.
+      if (entry.flushed) {
+        return;
+      }
+      entry.flushed = true;
       entry.messages.sort((a, b) => a.msg.message_id - b.msg.message_id);
 
       const first = entry.messages[0];
@@ -1493,7 +1508,10 @@ export const registerTelegramHandlers = ({
   // confirmed to Telegram via getUpdates are never re-delivered, so without this
   // drain they would be silently lost on systemd restarts.
   const drain = async () => {
-    // Flush pending text-fragment reassembly timers
+    // Flush pending text-fragment reassembly timers.
+    // clearTimeout is a best-effort cancel; if a callback has already fired and
+    // is queued in the event loop, the flushed flag in flushTextFragments ensures
+    // it becomes a no-op so the same entry is never processed twice.
     const textEntries = [...textFragmentBuffer.values()];
     textFragmentBuffer.clear();
     for (const entry of textEntries) {
@@ -1502,11 +1520,14 @@ export const registerTelegramHandlers = ({
         .then(async () => {
           await flushTextFragments(entry);
         })
-        .catch(() => undefined);
+        .catch((err) => {
+          runtime.error?.(danger(`[telegram] drain: text-fragment flush error: ${String(err)}`));
+        });
     }
     await textFragmentProcessing;
 
-    // Flush pending media-group assembly timers
+    // Flush pending media-group assembly timers.
+    // Same flushed-flag guard applies to processMediaGroup.
     const mediaEntries = [...mediaGroupBuffer.values()];
     mediaGroupBuffer.clear();
     for (const entry of mediaEntries) {
@@ -1515,7 +1536,9 @@ export const registerTelegramHandlers = ({
         .then(async () => {
           await processMediaGroup(entry);
         })
-        .catch(() => undefined);
+        .catch((err) => {
+          runtime.error?.(danger(`[telegram] drain: media-group flush error: ${String(err)}`));
+        });
     }
     await mediaGroupProcessing;
 

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -119,7 +119,7 @@ export const registerTelegramHandlers = ({
   shouldSkipUpdate,
   processMessage,
   logger,
-}: RegisterTelegramHandlerParams) => {
+}: RegisterTelegramHandlerParams): { drain: () => Promise<void> } => {
   const DEFAULT_TEXT_FRAGMENT_MAX_GAP_MS = 1500;
   const TELEGRAM_TEXT_FRAGMENT_START_THRESHOLD_CHARS = 4000;
   const TELEGRAM_TEXT_FRAGMENT_MAX_GAP_MS =
@@ -1487,6 +1487,42 @@ export const registerTelegramHandlers = ({
     });
   });
 
+  // Flush all pending timer-based buffers. Called on graceful shutdown so that
+  // messages buffered for media-group assembly, text-fragment reassembly, or
+  // inbound debouncing are dispatched before the process exits.  Messages already
+  // confirmed to Telegram via getUpdates are never re-delivered, so without this
+  // drain they would be silently lost on systemd restarts.
+  const drain = async () => {
+    // Flush pending text-fragment reassembly timers
+    const textEntries = [...textFragmentBuffer.values()];
+    textFragmentBuffer.clear();
+    for (const entry of textEntries) {
+      clearTimeout(entry.timer);
+      textFragmentProcessing = textFragmentProcessing
+        .then(async () => {
+          await flushTextFragments(entry);
+        })
+        .catch(() => undefined);
+    }
+    await textFragmentProcessing;
+
+    // Flush pending media-group assembly timers
+    const mediaEntries = [...mediaGroupBuffer.values()];
+    mediaGroupBuffer.clear();
+    for (const entry of mediaEntries) {
+      clearTimeout(entry.timer);
+      mediaGroupProcessing = mediaGroupProcessing
+        .then(async () => {
+          await processMediaGroup(entry);
+        })
+        .catch(() => undefined);
+    }
+    await mediaGroupProcessing;
+
+    // Flush pending inbound-debounce buffers
+    await inboundDebouncer.drain();
+  };
+
   // Handle channel posts — enables bot-to-bot communication via Telegram channels.
   // Telegram bots cannot see other bot messages in groups, but CAN in channels.
   // This handler normalizes channel_post updates into the standard message pipeline.
@@ -1539,4 +1575,6 @@ export const registerTelegramHandlers = ({
       errorMessage: "channel_post handler failed",
     });
   });
+
+  return { drain };
 };

--- a/src/telegram/bot-updates.ts
+++ b/src/telegram/bot-updates.ts
@@ -12,6 +12,9 @@ export type MediaGroupEntry = {
     ctx: TelegramContext;
   }>;
   timer: ReturnType<typeof setTimeout>;
+  // Set to true by whichever path (timer or drain) processes this entry first,
+  // so the other path becomes a no-op and cannot produce duplicate dispatches.
+  flushed?: boolean;
 };
 
 export type TelegramUpdateKeyContext = {

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -2259,4 +2259,110 @@ describe("createTelegramBot", () => {
 
     expect(replySpy).toHaveBeenCalledTimes(1);
   });
+
+  it("drain() flushes pending media group buffers before timer fires", async () => {
+    onSpy.mockReset();
+    replySpy.mockReset();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"] },
+      },
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+          status: 200,
+          headers: { "content-type": "image/png" },
+        }),
+    );
+    try {
+      const { drain } = createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+      // Send two messages belonging to the same media group
+      await handler({
+        update: { update_id: 901 },
+        message: {
+          chat: { id: 123, type: "private" },
+          from: { id: 456, username: "testuser" },
+          message_id: 801,
+          date: 1736380800,
+          media_group_id: "drain-test-group",
+          caption: "drain test",
+          photo: [{ file_id: "drain-p1" }],
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ file_path: "photos/drain-p1.jpg" }),
+      });
+      await handler({
+        update: { update_id: 902 },
+        message: {
+          chat: { id: 123, type: "private" },
+          from: { id: 456, username: "testuser" },
+          message_id: 802,
+          date: 1736380800,
+          media_group_id: "drain-test-group",
+          photo: [{ file_id: "drain-p2" }],
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ file_path: "photos/drain-p2.jpg" }),
+      });
+
+      // The timer hasn't fired yet; nothing processed
+      expect(replySpy).not.toHaveBeenCalled();
+
+      // Calling drain() must flush the buffered media group immediately
+      await drain();
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const payload = replySpy.mock.calls[0]?.[0] as { MediaPaths?: string[] };
+      expect(payload.MediaPaths).toHaveLength(2);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("drain() flushes pending text fragment buffers before timer fires", async () => {
+    onSpy.mockReset();
+    replySpy.mockReset();
+
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: { dmPolicy: "open", allowFrom: ["*"] },
+      },
+    });
+
+    useFrozenTime("2026-02-20T00:00:00.000Z");
+    try {
+      const { drain } = createTelegramBot({ token: "tok", testTimings: TELEGRAM_TEST_TIMINGS });
+      const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+      const part1 = "X".repeat(4100);
+
+      await handler({
+        update: { update_id: 911 },
+        message: {
+          chat: { id: 123, type: "private" },
+          from: { id: 456, username: "testuser" },
+          message_id: 811,
+          date: 1736380800,
+          text: part1,
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({}),
+      });
+
+      // Fragment buffered; nothing dispatched yet
+      expect(replySpy).not.toHaveBeenCalled();
+
+      // drain() must flush the fragment immediately without waiting for the timer
+      await drain();
+
+      expect(replySpy).toHaveBeenCalledTimes(1);
+    } finally {
+      useRealTime();
+    }
+  });
 });

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -106,6 +106,8 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   const pendingUpdateIds = new Set<number>();
   let highestCompletedUpdateId: number | null = initialUpdateId;
   let highestPersistedUpdateId: number | null = initialUpdateId;
+  // Track the last pending watermark write so drain() can await it on shutdown.
+  let pendingWatermarkWrite: Promise<void> | undefined;
   const maybePersistSafeWatermark = () => {
     if (typeof opts.updateOffset?.onUpdateId !== "function") {
       return;
@@ -129,7 +131,12 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       return;
     }
     highestPersistedUpdateId = safe;
-    void opts.updateOffset.onUpdateId(safe);
+    // Track the write promise so drain() can await it, preventing offset loss on
+    // abrupt shutdown (e.g. systemd SIGTERM before the async write completes).
+    pendingWatermarkWrite = Promise.resolve(opts.updateOffset.onUpdateId(safe)).then(
+      () => undefined,
+      () => undefined,
+    );
   };
 
   const shouldSkipUpdate = (ctx: TelegramUpdateKeyContext) => {
@@ -362,7 +369,7 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     opts,
   });
 
-  registerTelegramHandlers({
+  const { drain: handlersDrain } = registerTelegramHandlers({
     cfg,
     accountId: account.accountId,
     bot,
@@ -379,7 +386,18 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     logger,
   });
 
-  return bot;
+  // Drain all pending timer-based buffers and await any in-flight watermark write.
+  // Called by the polling/webhook lifecycle on graceful shutdown so that buffered
+  // messages (media groups, text fragments, debounce windows) are dispatched before
+  // the process exits, and the update-offset file reflects the latest processed ID.
+  const drain = async () => {
+    await handlersDrain();
+    if (pendingWatermarkWrite) {
+      await pendingWatermarkWrite;
+    }
+  };
+
+  return { bot, drain };
 }
 
 export function createTelegramWebhookCallback(bot: Bot, path = "/telegram-webhook") {

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -63,6 +63,10 @@ const { createdBotStops } = vi.hoisted(() => ({
   createdBotStops: [] as Array<ReturnType<typeof vi.fn<() => void>>>,
 }));
 
+const { createdBotDrains } = vi.hoisted(() => ({
+  createdBotDrains: [] as Array<ReturnType<typeof vi.fn<() => Promise<void>>>>,
+}));
+
 const { computeBackoff, sleepWithAbort } = vi.hoisted(() => ({
   computeBackoff: vi.fn(() => 0),
   sleepWithAbort: vi.fn(async () => undefined),
@@ -154,7 +158,9 @@ vi.mock("./bot.js", () => ({
       }
       await api.sendMessage(chatId, `echo:${text}`, { parse_mode: "HTML" });
     };
-    return {
+    const drain = vi.fn(async () => undefined);
+    createdBotDrains.push(drain);
+    const bot = {
       on: vi.fn(),
       api,
       me: { username: "mybot" },
@@ -162,6 +168,7 @@ vi.mock("./bot.js", () => ({
       stop,
       start: vi.fn(),
     };
+    return { bot, drain };
   },
   createTelegramWebhookCallback: vi.fn(),
 }));
@@ -211,6 +218,7 @@ describe("monitorTelegramProvider (grammY)", () => {
     resetUnhandledRejection();
     createTelegramBotErrors.length = 0;
     createdBotStops.length = 0;
+    createdBotDrains.length = 0;
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
@@ -373,6 +381,30 @@ describe("monitorTelegramProvider (grammY)", () => {
 
     expect(createdBotStops.length).toBe(1);
     expect(createdBotStops[0]).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls drain before stopping bot on graceful shutdown", async () => {
+    const abort = new AbortController();
+    const callOrder: string[] = [];
+
+    mockRunOnceAndAbort(abort);
+
+    await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
+
+    // Patch the drain and stop mocks captured during createTelegramBot to record order
+    const drain = createdBotDrains[0];
+    const stop = createdBotStops[0];
+    expect(drain).toBeDefined();
+    expect(stop).toBeDefined();
+    expect(drain).toHaveBeenCalledTimes(1);
+    expect(stop).toHaveBeenCalledTimes(1);
+
+    // Verify drain was awaited before stop by checking invocation order on the mocks.
+    // Both are called exactly once; drain's mock call index must precede stop's.
+    const drainCallIdx = drain.mock.invocationCallOrder[0];
+    const stopCallIdx = stop.mock.invocationCallOrder[0];
+    expect(drainCallIdx).toBeLessThan(stopCallIdx);
+    void callOrder; // silence unused variable
   });
 
   it("surfaces non-recoverable errors", async () => {

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -385,13 +385,11 @@ describe("monitorTelegramProvider (grammY)", () => {
 
   it("calls drain before stopping bot on graceful shutdown", async () => {
     const abort = new AbortController();
-    const callOrder: string[] = [];
 
     mockRunOnceAndAbort(abort);
 
     await monitorTelegramProvider({ token: "tok", abortSignal: abort.signal });
 
-    // Patch the drain and stop mocks captured during createTelegramBot to record order
     const drain = createdBotDrains[0];
     const stop = createdBotStops[0];
     expect(drain).toBeDefined();
@@ -404,7 +402,6 @@ describe("monitorTelegramProvider (grammY)", () => {
     const drainCallIdx = drain.mock.invocationCallOrder[0];
     const stopCallIdx = stop.mock.invocationCallOrder[0];
     expect(drainCallIdx).toBeLessThan(stopCallIdx);
-    void callOrder; // silence unused variable
   });
 
   it("surfaces non-recoverable errors", async () => {

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -61,7 +61,7 @@ const TELEGRAM_POLL_RESTART_POLICY = {
   jitter: 0.25,
 };
 
-type TelegramBot = ReturnType<typeof createTelegramBot>;
+type TelegramBotResult = ReturnType<typeof createTelegramBot>;
 
 const isGetUpdatesConflict = (err: unknown) => {
   if (!err || typeof err !== "object") {
@@ -212,7 +212,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       );
     };
 
-    const createPollingBot = async (): Promise<TelegramBot | undefined> => {
+    const createPollingBot = async (): Promise<TelegramBotResult | undefined> => {
       try {
         return createTelegramBot({
           token,
@@ -237,7 +237,9 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       }
     };
 
-    const ensureWebhookCleanup = async (bot: TelegramBot): Promise<"ready" | "retry" | "exit"> => {
+    const ensureWebhookCleanup = async (
+      bot: TelegramBotResult["bot"],
+    ): Promise<"ready" | "retry" | "exit"> => {
       if (webhookCleared) {
         return "ready";
       }
@@ -258,7 +260,8 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       }
     };
 
-    const runPollingCycle = async (bot: TelegramBot): Promise<"continue" | "exit"> => {
+    const runPollingCycle = async (botResult: TelegramBotResult): Promise<"continue" | "exit"> => {
+      const { bot, drain } = botResult;
       const runner = run(bot, runnerOptions);
       activeRunner = runner;
       let stopPromise: Promise<void> | undefined;
@@ -316,17 +319,24 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       } finally {
         opts.abortSignal?.removeEventListener("abort", stopOnAbort);
         await stopRunner();
+        // Flush timer-buffered messages (media groups, text fragments, debounce
+        // windows) and persist the update-offset watermark before stopping the bot.
+        // Without this drain, updates already confirmed to Telegram via getUpdates
+        // are silently lost when the process exits (e.g. on systemd restart).
+        await drain().catch((err) => {
+          log(`[telegram] drain error on shutdown: ${formatErrorMessage(err)}`);
+        });
         await stopBot();
       }
     };
 
     while (!opts.abortSignal?.aborted) {
-      const bot = await createPollingBot();
-      if (!bot) {
+      const botResult = await createPollingBot();
+      if (!botResult) {
         continue;
       }
 
-      const cleanupState = await ensureWebhookCleanup(bot);
+      const cleanupState = await ensureWebhookCleanup(botResult.bot);
       if (cleanupState === "retry") {
         continue;
       }
@@ -334,7 +344,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         return;
       }
 
-      const state = await runPollingCycle(bot);
+      const state = await runPollingCycle(botResult);
       if (state === "exit") {
         return;
       }

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -13,9 +13,12 @@ const stopSpy = vi.hoisted(() => vi.fn());
 const webhookCallbackSpy = vi.hoisted(() => vi.fn(() => handlerSpy));
 const createTelegramBotSpy = vi.hoisted(() =>
   vi.fn(() => ({
-    init: initSpy,
-    api: { setWebhook: setWebhookSpy, deleteWebhook: deleteWebhookSpy },
-    stop: stopSpy,
+    bot: {
+      init: initSpy,
+      api: { setWebhook: setWebhookSpy, deleteWebhook: deleteWebhookSpy },
+      stop: stopSpy,
+    },
+    drain: vi.fn(async () => undefined),
   })),
 );
 

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -62,7 +62,7 @@ function resolveWebhookPublicUrl(params: {
 }
 
 async function initializeTelegramWebhookBot(params: {
-  bot: ReturnType<typeof createTelegramBot>;
+  bot: ReturnType<typeof createTelegramBot>["bot"];
   runtime: RuntimeEnv;
   abortSignal?: AbortSignal;
 }) {
@@ -101,7 +101,7 @@ export async function startTelegramWebhook(opts: {
   }
   const runtime = opts.runtime ?? defaultRuntime;
   const diagnosticsEnabled = isDiagnosticsEnabled(opts.config);
-  const bot = createTelegramBot({
+  const { bot } = createTelegramBot({
     token: opts.token,
     runtime,
     proxyFetch: opts.fetch,


### PR DESCRIPTION
## Summary

- **Problem:** When OpenClaw runs as a `systemd --user` service on a VPS, graceful restarts (SIGTERM) cause intermittent message loss: inbound messages silently disappear and bot replies are never delivered.
- **Why it matters:** Three timer-based buffers in the Telegram pipeline hold confirmed updates in memory — media-group assembly (500 ms), text-fragment reassembly (1500 ms), and inbound debounce windows. Because grammY's `getUpdates` already told Telegram these updates were received before the timers fire, Telegram will **not** redeliver them after restart. They vanish silently, breaking the user's automation.
- **What changed:**
  1. `createInboundDebouncer` gains a `drain()` method that immediately flushes all pending debounce buffers.
  2. `registerTelegramHandlers` now returns `{ drain }`. Calling it cancels all pending timers and sequentially processes every buffered media group, text fragment, and debounce window.
  3. `createTelegramBot` now returns `{ bot, drain }`. The drain also awaits any in-flight update-offset disk write, so the watermark file is correct before the process exits.
  4. `monitorTelegramProvider` / `runPollingCycle` calls `await drain()` in its `finally` block — after stopping the runner, before stopping the bot — on every graceful shutdown.
  5. `startTelegramWebhook` is updated to destructure `{ bot }` from the new return shape.
- **What did NOT change (scope boundary):** Polling logic, retry backoff, deduplication, offset-store format, grammY runner configuration, and all outbound delivery paths are unchanged. Webhook mode gains no new offset tracking (separate concern).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32841
- Related #

## User-visible / Behavior Changes

On graceful shutdown (systemd restart, `openclaw gateway stop`, SIGTERM), messages that were buffered for media-group assembly, text-fragment reassembly, or debounce coalescing are now dispatched before the process exits, instead of being silently dropped. For most users under normal operation (no simultaneous restart during an active message burst) the observable behavior is identical.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux VPS (tested; any Linux systemd deployment)
- Runtime/container: Node 22+ / Bun, npm global install, `systemd --user` service
- Model/provider: Any
- Integration/channel: Telegram (polling mode)
- Relevant config (redacted): `channels.telegram.botToken = <token>`

### Steps

1. Deploy OpenClaw on a VPS, run as a `systemd --user` service.
2. Send a multi-photo media group or a long pasted message (>4096 chars) to the bot.
3. Immediately issue `systemctl --user restart openclaw-gateway` (within the 500 ms / 1500 ms buffer window).
4. After restart, observe whether the bot processed and replied to the message.

### Expected (after fix)

- Bot processes and replies to the message even when the service was restarted during the buffer window.
- `update-offset-*.json` reflects the latest processed update ID after restart.

### Actual (before fix)

- Message silently dropped; bot never replies.
- No error log — the update was already confirmed to Telegram so no retry occurs.

## Evidence

- [x] New test: `monitor.test.ts` — "calls drain before stopping bot on graceful shutdown" verifies drain is awaited before bot.stop, checked via `mock.invocationCallOrder`.
- [x] New test: `bot.create-telegram-bot.test.ts` — "drain() flushes pending media group buffers before timer fires" sends two media-group frames, asserts `replySpy` not called, then calls `drain()` and asserts it was called exactly once with both photos.
- [x] New test: `bot.create-telegram-bot.test.ts` — "drain() flushes pending text fragment buffers before timer fires" sends a >4096-char message, asserts no dispatch, then calls `drain()` and asserts dispatch happened.
- [x] All 15 `monitor.test.ts` tests pass; all 48 `bot.create-telegram-bot.test.ts` tests pass; all `bot.test.ts` tests pass.
- [x] `pnpm tsgo` — no new type errors in modified files.

## Human Verification (required)

- **Verified scenarios:** Media group drain, text fragment drain, debounce drain, drain-before-stop ordering, watermark flush on drain.
- **Edge cases checked:** Empty buffers (drain is a no-op); multiple groups in flight (each queued through the existing serialised processing chain); drain errors are caught and logged, not swallowed.
- **What you did NOT verify:** Long-running VPS soak test with real Telegram traffic; webhook mode drain (webhooks are synchronous per-request so the timer-loss window is much smaller).

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: `git revert d5e79e016`
- Files/config to restore: `src/auto-reply/inbound-debounce.ts`, `src/telegram/bot-handlers.ts`, `src/telegram/bot.ts`, `src/telegram/monitor.ts`, `src/telegram/webhook.ts`
- Known bad symptoms reviewers should watch for: If drain itself throws and is not caught, the `finally` block swallows it with a warning log; `stopBot` still runs. No regression path that would cause duplicate delivery.

## Risks and Mitigations

- **Drain adds latency to shutdown.** The drain awaits in-flight media downloads and AI dispatch. For a clean shutdown (no messages in flight) this is near-zero. Worst case: one media-group or debounce window completes (≤1500 ms) plus the AI response. systemd's default `TimeoutStopSec` (90 s) provides ample headroom.
- **Drain errors.** Wrapped in `.catch` with a warning log; shutdown continues regardless.
- **Return type change.** `createTelegramBot` now returns `{ bot, drain }` instead of bare `Bot`. All callers updated; no external consumers of this private API.
