### PR TITLE
fix(whatsapp): block outbound DMs to third-party contacts in selfChatMode

### DIFF
--- a/src/web/inbound/access-control.test.ts
+++ b/src/web/inbound/access-control.test.ts
@@ -158,3 +158,83 @@ describe("WhatsApp dmPolicy precedence", () => {
     expect(sendMessageMock).not.toHaveBeenCalled();
   });
 });
+
+describe("WhatsApp selfChatMode outbound DM filtering (#32632)", () => {
+  it("blocks outbound DMs to third-party contacts in selfChatMode", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          dmPolicy: "allowlist",
+          selfChatMode: true,
+          allowFrom: ["+15550009999"],
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15550009999",
+      selfE164: "+15550009999",
+      senderE164: "+15550009999",
+      group: false,
+      pushName: "Owner",
+      isFromMe: true,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15557778888@s.whatsapp.net",
+    });
+
+    expect(result.allowed).toBe(false);
+  });
+
+  it("allows outbound DMs to self (note-to-self) in selfChatMode", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          dmPolicy: "allowlist",
+          selfChatMode: true,
+          allowFrom: ["+15550009999"],
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15550009999",
+      selfE164: "+15550009999",
+      senderE164: "+15550009999",
+      group: false,
+      pushName: "Owner",
+      isFromMe: true,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15550009999@s.whatsapp.net",
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+
+  it("handles JID with device suffix correctly (#32632)", async () => {
+    setAccessControlTestConfig({
+      channels: {
+        whatsapp: {
+          dmPolicy: "allowlist",
+          selfChatMode: true,
+          allowFrom: ["+15550009999"],
+        },
+      },
+    });
+
+    const result = await checkInboundAccessControl({
+      accountId: "default",
+      from: "+15550009999",
+      selfE164: "+15550009999",
+      senderE164: "+15550009999",
+      group: false,
+      pushName: "Owner",
+      isFromMe: true,
+      sock: { sendMessage: sendMessageMock },
+      remoteJid: "15550009999:1@s.whatsapp.net",
+    });
+
+    expect(result.allowed).toBe(true);
+  });
+});

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -148,8 +148,11 @@ export async function checkInboundAccessControl(params: {
 
   // DM access control (secure defaults): "pairing" (default) / "allowlist" / "open" / "disabled".
   if (!params.group) {
-    if (params.isFromMe && !isSamePhone) {
-      logVerbose("Skipping outbound DM (fromMe); no pairing reply needed.");
+    const remoteDigits = params.remoteJid.replace(/@.*$/, "").replace(/:\d+$/, "");
+    const isRemoteJidSelf =
+      params.selfE164 != null && normalizeE164(remoteDigits) === normalizeE164(params.selfE164);
+    if (params.isFromMe && !isRemoteJidSelf) {
+      logVerbose("Skipping outbound DM (fromMe to other contact); no pairing reply needed.");
       return {
         allowed: false,
         shouldMarkRead: false,


### PR DESCRIPTION
## Summary

- Problem: When `selfChatMode: true` is enabled, the agent processes and responds to outbound DMs sent to third-party contacts (friends), not just note-to-self chats. The outbound DM guard compared `params.from` against `selfE164` (`isSamePhone`), which is always `true` for outbound messages since the sender is the user's own number.
- Why it matters: The agent responds in conversations with friends, leaking AI-generated messages to third-party contacts who never expected to interact with the agent.
- What changed: The outbound DM guard in `checkInboundAccessControl` now compares `remoteJid` (recipient) against `selfE164` instead of `params.from` (sender). Outbound messages to other contacts are correctly skipped, while note-to-self messages continue to trigger the agent.
- What did NOT change (scope boundary): Group message handling, inbound DM processing, pairing logic, and the `isSelfChatMode` heuristic are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32632

## User-visible / Behavior Changes

- In selfChatMode, the agent no longer responds in DM threads with friends. Only note-to-self (sender == recipient == user's number) triggers the agent.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Configure WhatsApp with `selfChatMode: true` and `allowFrom` containing the user's own number
2. Send a DM to a third-party contact (friend)
3. Observe whether the agent responds in that thread

### Expected

- Agent does NOT respond in DM threads with friends

### Actual

- Before: Agent processes and responds in all outbound DM threads where sender matches selfE164
- After: Agent only processes note-to-self DMs where remoteJid also matches selfE164

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Three new vitest tests added:
- `blocks outbound DMs to third-party contacts in selfChatMode`
- `allows outbound DMs to self (note-to-self) in selfChatMode`
- `handles JID with device suffix correctly`

## Human Verification (required)

- Verified scenarios: Outbound DM to friend blocked, note-to-self allowed, JID with device suffix handled
- Edge cases checked: JID device suffix (e.g. `15550009999:1@s.whatsapp.net`), group messages (not affected by this path)
- What you did **not** verify: WhatsApp Business API behavior (personal account only)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; the old `isSamePhone` check is restored
- Files/config to restore: `src/web/inbound/access-control.ts`

## Risks and Mitigations

- Risk: Some self-chat JID formats may not be recognized as self (e.g., LID-based JIDs)
  - Mitigation: The fix uses the same `normalizeE164` utility already used throughout the module; LID-based JIDs would need a separate fix regardless