### PR TITLE
fix: prevent TUI replies leaking to Telegram and restore full tool access after onboard

### DIFF
--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -18,7 +18,7 @@ import {
 } from "../../infra/outbound/payloads.js";
 import type { OutboundSessionContext } from "../../infra/outbound/session-context.js";
 import type { RuntimeEnv } from "../../runtime.js";
-import { isInternalMessageChannel } from "../../utils/message-channel.js";
+import { isDeliverableMessageChannel, isInternalMessageChannel } from "../../utils/message-channel.js";
 import type { AgentCommandOpts } from "./types.js";
 
 type RunResult = Awaited<
@@ -96,7 +96,14 @@ export async function deliverAgentCommandResult(params: {
   });
   let deliveryChannel = deliveryPlan.resolvedChannel;
   const explicitChannelHint = (opts.replyChannel ?? opts.channel)?.trim();
-  if (deliver && isInternalMessageChannel(deliveryChannel) && !explicitChannelHint) {
+  // Only auto-resolve the delivery channel when the turn originated from an
+  // external (deliverable) channel.  When the turn source is webchat / TUI
+  // (an internal channel that is NOT deliverable), we must NOT fall back to
+  // "the single configured channel" — doing so causes TUI replies to be
+  // forwarded to Telegram (or whichever channel is the sole configured one).
+  const turnSourceIsExternal =
+    turnSourceChannel != null && isDeliverableMessageChannel(turnSourceChannel);
+  if (deliver && isInternalMessageChannel(deliveryChannel) && !explicitChannelHint && turnSourceIsExternal) {
     try {
       const selection = await resolveMessageChannelSelection({ cfg });
       deliveryChannel = selection.channel;

--- a/src/commands/onboard-config.ts
+++ b/src/commands/onboard-config.ts
@@ -3,7 +3,7 @@ import type { DmScope } from "../config/types.base.js";
 import type { ToolProfileId } from "../config/types.tools.js";
 
 export const ONBOARDING_DEFAULT_DM_SCOPE: DmScope = "per-channel-peer";
-export const ONBOARDING_DEFAULT_TOOLS_PROFILE: ToolProfileId = "messaging";
+export const ONBOARDING_DEFAULT_TOOLS_PROFILE: ToolProfileId = "full";
 
 export function applyOnboardingLocalWorkspaceConfig(
   baseConfig: OpenClawConfig,


### PR DESCRIPTION
## Summary

Two regressions introduced in 2026.3.2 that were hard to diagnose:

Closes #32833

### Bug 1: TUI replies forwarded to Telegram (`delivery.ts`)

**Root cause:** When a turn originates from webchat/TUI (an internal, non-deliverable channel), `turnSourceChannel` is `undefined` because `isDeliverableMessageChannel("webchat")` returns false. The code then falls through to `resolveMessageChannelSelection()` with no channel hint, which returns the sole configured channel (e.g. Telegram) and overwrites the internal channel marker.

**Fix:** Only perform the auto-channel-resolve fallback when `turnSourceChannel` is an external deliverable channel. When the turn source is internal (TUI/webchat), keep the internal marker as-is.

Regression introduced by: b5350bf46 / 1d0a4d1be

### Bug 2: `onboard` silently sets `tools.profile = "messaging"` (`onboard-config.ts`)

**Root cause:** The new onboarding default `ONBOARDING_DEFAULT_TOOLS_PROFILE = "messaging"` is applied via `??` to any user who had no prior `tools.profile` config. This silently strips `exec`, `browser`, and all non-messaging tools after every `onboard` run — a silent breaking change that was very hard to diagnose.

**Fix:** Change the default back to `"full"` (no restriction), preserving pre-2026.3.2 behavior. Users who want a restricted profile can opt in explicitly via config.

Regression introduced by: 16df7ef4a

## Testing

- Verified by reproducing both issues on 2026.3.2 and confirming the fixes resolve them.
- Bug 2 fix confirmed by #32833 author — changing `tools.profile` to `"full"` resolved their issue.