### PR TITLE
Auto-reply: preserve block/tool ordering on same-channel dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Auto-reply/block-stream ordering: await same-channel block queue drain before later tool updates/final replies so visible reply order stays consistent during streaming + tool execution flows. (#32868) Thanks @liuxiaopai-ai.
 - Telegram/multi-account default routing clarity: warn only for ambiguous (2+) account setups without an explicit default, add `openclaw doctor` warnings for missing/invalid multi-account defaults across channels, and document explicit-default guidance for channel routing and Telegram config. (#32544) thanks @Sid-Qin.
 - Agents/Skills runtime loading: propagate run config into embedded attempt and compaction skill-entry loading so explicitly enabled bundled companion skills are discovered consistently when skill snapshots do not already provide resolved entries. Thanks @gumadeiras.
 - Agents/Compaction continuity: expand staged-summary merge instructions to preserve active task status, batch progress, latest user request, and follow-up commitments so compaction handoffs retain in-flight work context. (#8903) thanks @joetomasone.

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -517,6 +517,52 @@ describe("dispatchReplyFromConfig", () => {
     expect(dispatcher.sendFinalReply).toHaveBeenCalledTimes(1);
   });
 
+  it("waits for block queue drain before emitting later tool updates on the same channel", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      ChatType: "direct",
+    });
+    let releaseWait: (() => void) | undefined;
+    const waitForIdleGate = new Promise<void>((resolve) => {
+      releaseWait = resolve;
+    });
+    (dispatcher.waitForIdle as ReturnType<typeof vi.fn>).mockImplementation(
+      async () => waitForIdleGate,
+    );
+
+    const run = dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver: async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+        await opts?.onBlockReply?.({ text: "partial block" });
+        await opts?.onToolResult?.({ text: "tool result" });
+        return { text: "done" } satisfies ReplyPayload;
+      },
+    });
+
+    await vi.waitFor(() => {
+      expect(dispatcher.sendBlockReply).toHaveBeenCalledTimes(1);
+      expect(dispatcher.waitForIdle).toHaveBeenCalledTimes(1);
+    });
+
+    expect(dispatcher.sendToolResult).not.toHaveBeenCalled();
+    expect(dispatcher.sendFinalReply).not.toHaveBeenCalled();
+
+    releaseWait?.();
+    await run;
+
+    expect(dispatcher.sendToolResult).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "tool result" }),
+    );
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "done" }),
+    );
+  });
+
   it("suppresses native tool summaries but still forwards tool media", async () => {
     setNoAbort();
     const cfg = emptyConfig;

--- a/src/auto-reply/reply/dispatch-from-config.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.test.ts
@@ -563,6 +563,43 @@ describe("dispatchReplyFromConfig", () => {
     );
   });
 
+  it("stops waiting for block queue drain when block reply abort signal is aborted", async () => {
+    setNoAbort();
+    const cfg = emptyConfig;
+    const dispatcher = createDispatcher();
+    const ctx = buildTestCtx({
+      Provider: "whatsapp",
+      ChatType: "direct",
+    });
+    (dispatcher.waitForIdle as ReturnType<typeof vi.fn>).mockImplementation(
+      async () => await new Promise<void>(() => {}),
+    );
+    const blockAbort = new AbortController();
+
+    const run = dispatchReplyFromConfig({
+      ctx,
+      cfg,
+      dispatcher,
+      replyResolver: async (_ctx: MsgContext, opts?: GetReplyOptions) => {
+        await opts?.onBlockReply?.({ text: "partial block" }, { abortSignal: blockAbort.signal });
+        await opts?.onToolResult?.({ text: "tool result" });
+        return { text: "done" } satisfies ReplyPayload;
+      },
+    });
+
+    await vi.waitFor(() => expect(dispatcher.waitForIdle).toHaveBeenCalledTimes(1));
+    blockAbort.abort();
+    await run;
+
+    expect(dispatcher.sendBlockReply).toHaveBeenCalledTimes(1);
+    expect(dispatcher.sendToolResult).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "tool result" }),
+    );
+    expect(dispatcher.sendFinalReply).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "done" }),
+    );
+  });
+
   it("suppresses native tool summaries but still forwards tool media", async () => {
     setNoAbort();
     const cfg = emptyConfig;

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -425,7 +425,10 @@ export async function dispatchReplyFromConfig(params: {
             if (shouldRouteToOriginating) {
               await sendPayloadAsync(ttsPayload, context?.abortSignal, false);
             } else {
-              dispatcher.sendBlockReply(ttsPayload);
+              const queued = dispatcher.sendBlockReply(ttsPayload);
+              if (queued) {
+                await dispatcher.waitForIdle();
+              }
             }
           };
           return run();

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -257,6 +257,41 @@ export async function dispatchReplyFromConfig(params: {
       logVerbose(`dispatch-from-config: route-reply failed: ${result.error ?? "unknown error"}`);
     }
   };
+  const waitForDispatcherIdle = async (abortSignal?: AbortSignal): Promise<void> => {
+    if (abortSignal?.aborted) {
+      return;
+    }
+    if (!abortSignal) {
+      await dispatcher.waitForIdle();
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const cleanup = () => {
+        abortSignal.removeEventListener("abort", onAbort);
+      };
+      const settle = (callback: () => void) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        callback();
+      };
+      const onAbort = () => {
+        settle(resolve);
+      };
+      abortSignal.addEventListener("abort", onAbort, { once: true });
+      void dispatcher
+        .waitForIdle()
+        .then(() => {
+          settle(resolve);
+        })
+        .catch((err) => {
+          settle(() => reject(err));
+        });
+    });
+  };
 
   markProcessing();
 
@@ -427,7 +462,7 @@ export async function dispatchReplyFromConfig(params: {
             } else {
               const queued = dispatcher.sendBlockReply(ttsPayload);
               if (queued) {
-                await dispatcher.waitForIdle();
+                await waitForDispatcherIdle(context?.abortSignal);
               }
             }
           };


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: same-channel block streaming queued payloads but did not wait for queue drain before resolver continued to emit tool/final updates.
- Why it matters: users can observe tool/final messages appearing before prior block chunks finish delivering, causing out-of-order UX.
- What changed: in `onBlockReply` same-channel path, wait for `dispatcher.waitForIdle()` after successful `sendBlockReply(...)` enqueue.
- What changed: added regression test that blocks `waitForIdle` and verifies later tool/final outputs are not emitted early.
- What did NOT change (scope boundary): no change to cross-channel routing path, payload shaping, ACP branch, or typing policy behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32868
- Related #

## User-visible / Behavior Changes

- Same-channel block-streaming replies now finish queue-drain before subsequent tool updates/final replies are emitted, preserving visible reply order.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): generic same-channel dispatch path
- Relevant config (redacted): default

### Steps

1. Emit a block reply through `onBlockReply` where `sendBlockReply(...)` returns true and `waitForIdle()` is pending.
2. Attempt to emit subsequent tool result/final reply in the same resolver flow.
3. Release `waitForIdle` gate.

### Expected

- Tool/final outputs are held until block queue drain completes.

### Actual

- After fix: ordering is preserved; no early tool/final emission while block queue is draining.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran targeted regression in `dispatch-from-config.test.ts`, including new blocked `waitForIdle` case.
- Edge cases checked: same-channel path only gates when queueing succeeds; test keeps tool/final blocked until gate release.
- What you did **not** verify: full end-to-end channel runtime behavior in live integrations.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit on this PR branch.
- Files/config to restore: `src/auto-reply/reply/dispatch-from-config.ts` and test.
- Known bad symptoms reviewers should watch for: potential stuck stream if downstream queue never drains.

## Risks and Mitigations

- Risk: waiting for queue drain could increase latency when queue is unhealthy.
  - Mitigation: only waits after successful enqueue and only for same-channel block path; covered by regression test.
