### PR TITLE
fix(gateway): reset lastSeq on WebSocket reconnect to prevent false event gap errors

### DIFF
--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -424,3 +424,38 @@ describe("GatewayClient connect auth payload", () => {
     client.stop();
   });
 });
+
+describe("GatewayClient event seq gap reset on reconnect (#32628)", () => {
+  beforeEach(() => {
+    wsInstances.length = 0;
+  });
+
+  it("resets lastSeq on reconnect so stale seq does not trigger false gap", () => {
+    const onGap = vi.fn();
+    const client = new GatewayClient({
+      url: "ws://127.0.0.1:18789",
+      token: "t",
+      onGap,
+    });
+
+    client.start();
+    const ws1 = getLatestWs();
+    ws1.emitOpen();
+
+    ws1.emitMessage(JSON.stringify({ type: "event", event: "tick", seq: 100 }));
+    ws1.emitMessage(JSON.stringify({ type: "event", event: "tick", seq: 101 }));
+    expect(onGap).not.toHaveBeenCalled();
+
+    ws1.emitClose(1006, "");
+
+    client.start();
+    const ws2 = getLatestWs();
+    ws2.emitOpen();
+
+    ws2.emitMessage(JSON.stringify({ type: "event", event: "tick", seq: 1 }));
+    ws2.emitMessage(JSON.stringify({ type: "event", event: "tick", seq: 2 }));
+
+    expect(onGap).not.toHaveBeenCalled();
+    client.stop();
+  });
+});

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -409,6 +409,7 @@ export class GatewayClient {
   private queueConnect() {
     this.connectNonce = null;
     this.connectSent = false;
+    this.lastSeq = null;
     const rawConnectDelayMs = this.opts.connectDelayMs;
     const connectChallengeTimeoutMs =
       typeof rawConnectDelayMs === "number" && Number.isFinite(rawConnectDelayMs)

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -350,6 +350,7 @@ export class GatewayBrowserClient {
   private queueConnect() {
     this.connectNonce = null;
     this.connectSent = false;
+    this.lastSeq = null;
     if (this.connectTimer !== null) {
       window.clearTimeout(this.connectTimer);
     }


### PR DESCRIPTION
## Summary

- Problem: Browser and Node gateway WS clients retained stale lastSeq across reconnections, causing false event gap detected errors.
- Why it matters: Users see misleading error messages in Control UI after every reconnect/gateway restart.
- What changed: Added this.lastSeq = null in queueConnect() for both browser (ui/src/ui/gateway.ts) and Node (src/gateway/client.ts) clients, matching iOS client behavior.
- What did NOT change: Server-side seq counter, event delivery, gap detection algorithm.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] UI / DX

## Linked Issue/PR

- Closes #32628

## User-visible / Behavior Changes

Control UI no longer shows false event gap detected errors after WebSocket reconnections or gateway restarts.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS / Linux / WSL2
- Runtime: Node.js 22+

### Steps

1. Open Control UI in browser
2. Restart the gateway (or cause a WebSocket reconnection)
3. Observe the status bar for error messages

### Expected

- No false gap errors after reconnect

### Actual

- Before: event gap detected (expected seq X, got Y) appears after every reconnect
- After: No gap error; sequence tracking starts fresh

## Evidence

- [x] Failing test/log before + passing after

New vitest test: resets lastSeq on reconnect so stale seq does not trigger false gap

## Human Verification (required)

- Verified scenarios: Reconnect with lower seq (gateway restart), reconnect with higher seq (network blip)
- Edge cases checked: First event after reconnect with seq=1 vs old lastSeq=100+; iOS client already implements same reset
- What you did not verify: Browser WebSocket reconnection in real network conditions (unit test only)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit
- Files/config to restore: ui/src/ui/gateway.ts, src/gateway/client.ts

## Risks and Mitigations

- Risk: Legitimate gap no longer reported on first event post-reconnect
  - Mitigation: Real gaps still detected for subsequent missing events within same connection