### PR TITLE
Telegram: wire setStatus liveness updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Telegram/health liveness tracking: thread `setStatus` through Telegram extension startup into polling/webhook bot creation and update `lastEventAt` + `lastInboundAt` on inbound updates so channel health can detect half-dead delivery paths. (#32850) Thanks @garnetlyx.
 - Telegram/multi-account default routing clarity: warn only for ambiguous (2+) account setups without an explicit default, add `openclaw doctor` warnings for missing/invalid multi-account defaults across channels, and document explicit-default guidance for channel routing and Telegram config. (#32544) thanks @Sid-Qin.
 - Agents/Skills runtime loading: propagate run config into embedded attempt and compaction skill-entry loading so explicitly enabled bundled companion skills are discovered consistently when skill snapshots do not already provide resolved entries. Thanks @gumadeiras.
 - Agents/Compaction continuity: expand staged-summary merge instructions to preserve active task status, batch progress, latest user request, and follow-up commitments so compaction handoffs retain in-flight work context. (#8903) thanks @joetomasone.

--- a/extensions/telegram/src/channel.test.ts
+++ b/extensions/telegram/src/channel.test.ts
@@ -137,18 +137,19 @@ describe("telegramPlugin duplicate token guard", () => {
       webhookPort: 9876,
     };
 
-    await telegramPlugin.gateway!.startAccount!(
-      createStartAccountCtx({
-        cfg,
-        accountId: "ops",
-        runtime: createRuntimeEnv(),
-      }),
-    );
+    const ctx = createStartAccountCtx({
+      cfg,
+      accountId: "ops",
+      runtime: createRuntimeEnv(),
+    });
+
+    await telegramPlugin.gateway!.startAccount!(ctx);
 
     expect(monitorTelegramProvider).toHaveBeenCalledWith(
       expect.objectContaining({
         useWebhook: true,
         webhookPort: 9876,
+        setStatus: ctx.setStatus,
       }),
     );
   });

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -488,6 +488,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         accountId: account.accountId,
         config: ctx.cfg,
         runtime: ctx.runtime,
+        setStatus: ctx.setStatus,
         abortSignal: ctx.abortSignal,
         useWebhook: Boolean(account.config.webhookUrl),
         webhookUrl: account.config.webhookUrl,

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -116,6 +116,45 @@ describe("createTelegramBot", () => {
     expect(middlewareUseSpy).toHaveBeenCalledWith(sequentializeSpy.mock.results[0]?.value);
     expect(sequentializeKey).toBe(getTelegramSequentialKey);
   });
+  it("updates channel liveness status on inbound updates when setStatus is provided", async () => {
+    const setStatus = vi.fn();
+    createTelegramBot({ token: "tok", setStatus });
+
+    const middlewares = middlewareUseSpy.mock.calls
+      .map((call) => call[0])
+      .filter(
+        (
+          middleware,
+        ): middleware is (
+          ctx: Record<string, unknown>,
+          next: () => Promise<void>,
+        ) => Promise<void> => typeof middleware === "function",
+      );
+
+    const ctx = {
+      update: {
+        update_id: 7,
+        message: {
+          chat: { id: 1234, type: "private" },
+          text: "hello",
+        },
+      },
+    };
+
+    for (const middleware of middlewares) {
+      await middleware(ctx, async () => {});
+      if (setStatus.mock.calls.length > 0) {
+        break;
+      }
+    }
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lastEventAt: expect.any(Number),
+        lastInboundAt: expect.any(Number),
+      }),
+    );
+  });
   it("routes callback_query payloads as messages and answers callbacks", async () => {
     createTelegramBot({ token: "tok" });
     const callbackHandler = onSpy.mock.calls.find((call) => call[0] === "callback_query")?.[1] as (

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -52,6 +52,7 @@ export type TelegramBotOptions = {
     lastUpdateId?: number | null;
     onUpdateId?: (updateId: number) => void | Promise<void>;
   };
+  setStatus?: (next: Record<string, unknown>) => void | Promise<void>;
   testTimings?: {
     mediaGroupFlushMs?: number;
     textFragmentGapMs?: number;
@@ -132,6 +133,22 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     void opts.updateOffset.onUpdateId(safe);
   };
 
+  const setStatusSafely = (next: Record<string, unknown>) => {
+    if (!opts.setStatus) {
+      return;
+    }
+    try {
+      const maybePending = opts.setStatus(next);
+      if (maybePending && typeof (maybePending as PromiseLike<unknown>).then === "function") {
+        void (maybePending as PromiseLike<unknown>).catch((err) => {
+          logVerbose(`telegram: setStatus failed: ${String(err)}`);
+        });
+      }
+    } catch (err) {
+      logVerbose(`telegram: setStatus failed: ${String(err)}`);
+    }
+  };
+
   const shouldSkipUpdate = (ctx: TelegramUpdateKeyContext) => {
     const updateId = resolveTelegramUpdateId(ctx);
     const skipCutoff = highestPersistedUpdateId ?? initialUpdateId;
@@ -162,6 +179,15 @@ export function createTelegramBot(opts: TelegramBotOptions) {
         maybePersistSafeWatermark();
       }
     }
+  });
+
+  bot.use(async (_ctx, next) => {
+    const now = Date.now();
+    setStatusSafely({
+      lastEventAt: now,
+      lastInboundAt: now,
+    });
+    await next();
   });
 
   bot.use(sequentialize(getTelegramSequentialKey));

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -58,6 +58,9 @@ const { registerUnhandledRejectionHandlerMock, emitUnhandledRejection, resetUnha
 const { createTelegramBotErrors } = vi.hoisted(() => ({
   createTelegramBotErrors: [] as unknown[],
 }));
+const { createTelegramBotCalls } = vi.hoisted(() => ({
+  createTelegramBotCalls: [] as Array<Record<string, unknown>>,
+}));
 
 const { createdBotStops } = vi.hoisted(() => ({
   createdBotStops: [] as Array<ReturnType<typeof vi.fn<() => void>>>,
@@ -135,7 +138,8 @@ vi.mock("../config/config.js", async (importOriginal) => {
 });
 
 vi.mock("./bot.js", () => ({
-  createTelegramBot: () => {
+  createTelegramBot: (opts?: Record<string, unknown>) => {
+    createTelegramBotCalls.push(opts ?? {});
     const nextError = createTelegramBotErrors.shift();
     if (nextError) {
       throw nextError;
@@ -210,6 +214,7 @@ describe("monitorTelegramProvider (grammY)", () => {
     registerUnhandledRejectionHandlerMock.mockClear();
     resetUnhandledRejection();
     createTelegramBotErrors.length = 0;
+    createTelegramBotCalls.length = 0;
     createdBotStops.length = 0;
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
@@ -236,6 +241,14 @@ describe("monitorTelegramProvider (grammY)", () => {
     expect(api.sendMessage).toHaveBeenCalledWith(123, "echo:hi", {
       parse_mode: "HTML",
     });
+  });
+
+  it("forwards setStatus callback to polling bot creation", async () => {
+    const setStatus = vi.fn();
+
+    await monitorWithAutoAbort({ setStatus });
+
+    expect(createTelegramBotCalls.at(-1)?.setStatus).toBe(setStatus);
   });
 
   it("uses agent maxConcurrent for runner concurrency", async () => {
@@ -447,6 +460,23 @@ describe("monitorTelegramProvider (grammY)", () => {
       }),
     );
     expect(runSpy).not.toHaveBeenCalled();
+  });
+
+  it("forwards setStatus callback in webhook mode", async () => {
+    const setStatus = vi.fn();
+    await monitorTelegramProvider({
+      token: "tok",
+      useWebhook: true,
+      webhookUrl: "https://example.test/telegram",
+      webhookSecret: "secret",
+      setStatus,
+    });
+
+    expect(startTelegramWebhookSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        setStatus,
+      }),
+    );
   });
 
   it("webhook mode waits for abort signal before returning", async () => {

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -30,6 +30,7 @@ export type MonitorTelegramOpts = {
   webhookHost?: string;
   proxyFetch?: typeof fetch;
   webhookUrl?: string;
+  setStatus?: (next: Record<string, unknown>) => void | Promise<void>;
 };
 
 export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
@@ -172,6 +173,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         fetch: proxyFetch,
         abortSignal: opts.abortSignal,
         publicUrl: opts.webhookUrl,
+        setStatus: opts.setStatus,
       });
       await waitForAbortSignal(opts.abortSignal);
       return;
@@ -220,6 +222,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
           proxyFetch,
           config: cfg,
           accountId: account.accountId,
+          setStatus: opts.setStatus,
           updateOffset: {
             lastUpdateId,
             onUpdateId: persistUpdateId,

--- a/src/telegram/webhook.test.ts
+++ b/src/telegram/webhook.test.ts
@@ -310,6 +310,7 @@ describe("startTelegramWebhook", () => {
     createTelegramBotSpy.mockClear();
     webhookCallbackSpy.mockClear();
     const runtimeLog = vi.fn();
+    const setStatus = vi.fn();
     const cfg = { bindings: [] };
     await withStartedWebhook(
       {
@@ -317,12 +318,14 @@ describe("startTelegramWebhook", () => {
         accountId: "opie",
         config: cfg,
         runtime: { log: runtimeLog, error: vi.fn(), exit: vi.fn() },
+        setStatus,
       },
       async ({ port }) => {
         expect(createTelegramBotSpy).toHaveBeenCalledWith(
           expect.objectContaining({
             accountId: "opie",
             config: expect.objectContaining({ bindings: [] }),
+            setStatus,
           }),
         );
         const health = await fetch(`http://127.0.0.1:${port}/healthz`);

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -87,6 +87,7 @@ export async function startTelegramWebhook(opts: {
   abortSignal?: AbortSignal;
   healthPath?: string;
   publicUrl?: string;
+  setStatus?: (next: Record<string, unknown>) => void | Promise<void>;
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
@@ -107,6 +108,7 @@ export async function startTelegramWebhook(opts: {
     proxyFetch: opts.fetch,
     config: opts.config,
     accountId: opts.accountId,
+    setStatus: opts.setStatus,
   });
   await initializeTelegramWebhookBot({
     bot,


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Telegram channel runtime never updated account liveness timestamps (`lastEventAt` / `lastInboundAt`), so health snapshots could not distinguish idle from half-dead delivery.
- Why it matters: polling/webhook can appear "running" while no inbound updates are actually being consumed.
- What changed: threaded `setStatus` callback from Telegram channel gateway startup into `monitorTelegramProvider`, `createTelegramBot`, and webhook startup path.
- What changed: added Telegram bot middleware that updates `lastEventAt` + `lastInboundAt` on inbound updates (error-isolated).
- What did NOT change (scope boundary): no changes to Telegram message routing, mention policy, reply formatting, or webhook auth behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32850
- Related #

## User-visible / Behavior Changes

- Telegram account runtime snapshots now refresh liveness timestamps from real inbound updates, improving health/readiness observability.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): default Telegram account + webhook/polling test fixtures

### Steps

1. Start Telegram account monitor with `setStatus` callback.
2. Feed inbound update through bot middleware/monitor path.
3. Inspect callback payload and monitor startup options.

### Expected

- `setStatus` is wired end-to-end and receives `lastEventAt` + `lastInboundAt` timestamps.

### Actual

- After fix, callback is forwarded in polling + webhook paths and receives liveness timestamps on inbound updates.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted tests for telegram bot middleware, monitor forwarding, webhook forwarding, and extension gateway forwarding.
- Edge cases checked: status callback errors are isolated; webhook and polling both carry callback.
- What you did **not** verify: live Telegram network runtime behavior against real bot token.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit/PR.
- Files/config to restore: `src/telegram/{bot,monitor,webhook}.ts`, `extensions/telegram/src/channel.ts`.
- Known bad symptoms reviewers should watch for: noisy status updates if callback implementation is unexpectedly expensive.

## Risks and Mitigations

- Risk: status callback failures could affect update flow.
  - Mitigation: callback invocation is wrapped with error isolation and does not block message handling.
