### PR TITLE
Outbound: allow text-only plugin adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Outbound/plugin adapter compatibility: allow channel plugins that only implement `sendText` (without `sendMedia`) and fall back media sends to text delivery so text-only outbound adapters no longer fail as “Outbound not configured”. (#32711) Thanks @NOVA-Openclaw.
 - Telegram/multi-account default routing clarity: warn only for ambiguous (2+) account setups without an explicit default, add `openclaw doctor` warnings for missing/invalid multi-account defaults across channels, and document explicit-default guidance for channel routing and Telegram config. (#32544) thanks @Sid-Qin.
 - Agents/Skills runtime loading: propagate run config into embedded attempt and compaction skill-entry loading so explicitly enabled bundled companion skills are discovered consistently when skill snapshots do not already provide resolved entries. Thanks @gumadeiras.
 - Agents/Compaction continuity: expand staged-summary merge instructions to preserve active task status, batch progress, latest user request, and follow-up commitments so compaction handoffs retain in-flight work context. (#8903) thanks @joetomasone.

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -614,6 +614,50 @@ describe("deliverOutboundPayloads", () => {
     expect(chunker).toHaveBeenNthCalledWith(1, text, 4000);
   });
 
+  it("falls back to sendText when plugin outbound omits sendMedia", async () => {
+    const sendText = vi.fn().mockResolvedValue({
+      channel: "matrix" as const,
+      messageId: "mx-text-only",
+      roomId: "r1",
+    });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "matrix",
+          source: "test",
+          plugin: createOutboundTestPlugin({
+            id: "matrix",
+            outbound: {
+              deliveryMode: "direct",
+              sendText,
+            },
+          }),
+        },
+      ]),
+    );
+
+    const results = await deliverOutboundPayloads({
+      cfg: {},
+      channel: "matrix",
+      to: "!room",
+      payloads: [{ text: "caption", mediaUrl: "https://example.com/pic.png" }],
+    });
+
+    expect(sendText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "!room",
+        text: "caption",
+        mediaUrl: undefined,
+      }),
+    );
+    expect(results).toEqual([
+      expect.objectContaining({
+        channel: "matrix",
+        messageId: "mx-text-only",
+      }),
+    ]);
+  });
+
   it("uses iMessage media maxBytes from agent fallback", async () => {
     const sendIMessage = vi.fn().mockResolvedValue({ messageId: "i1" });
     setActivePluginRegistry(

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -143,12 +143,18 @@ function createPluginHandler(
   params: ChannelHandlerParams & { outbound?: ChannelOutboundAdapter },
 ): ChannelHandler | null {
   const outbound = params.outbound;
-  if (!outbound?.sendText || !outbound?.sendMedia) {
+  if (!outbound?.sendText) {
     return null;
   }
   const baseCtx = createChannelOutboundContextBase(params);
   const sendText = outbound.sendText;
-  const sendMedia = outbound.sendMedia;
+  const sendMedia =
+    outbound.sendMedia ??
+    (async (ctx: ChannelOutboundContext) =>
+      await sendText({
+        ...ctx,
+        mediaUrl: undefined,
+      }));
   const chunker = outbound.chunker ?? null;
   const chunkerMode = outbound.chunkerMode;
   const resolveCtx = (overrides?: {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: outbound plugin adapter bootstrap required both `sendText` and `sendMedia`, even though plugin adapter contract marks `sendMedia` as optional.
- Why it matters: text-only channel plugins failed as “Outbound not configured,” blocking even plain text delivery.
- What changed: require only `sendText` at handler creation.
- What changed: when `sendMedia` is absent, outbound now falls back to `sendText` (caption text only; media URL dropped).
- What did NOT change (scope boundary): no changes to channel registry/discovery or built-in channel media adapters.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32711
- Related #

## User-visible / Behavior Changes

- Text-only channel plugins that implement only `sendText` can now deliver outbound text successfully.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): plugin outbound adapter (matrix test stub)
- Relevant config (redacted): default outbound test fixtures

### Steps

1. Register a plugin outbound adapter with `sendText` only (no `sendMedia`).
2. Deliver a payload containing `mediaUrl` + caption text through outbound delivery.
3. Verify fallback uses `sendText` and no "Outbound not configured" error is thrown.

### Expected

- Delivery succeeds through `sendText` fallback when `sendMedia` is absent.

### Actual

- After fix, delivery succeeds and fallback payload drops media URL as intended.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: added and ran targeted regression in `src/infra/outbound/deliver.test.ts` for text-only outbound adapter fallback.
- Edge cases checked: handler still requires `sendText`; fallback path preserves caption text.
- What you did **not** verify: live third-party plugin behavior outside test harness.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit/PR.
- Files/config to restore: `src/infra/outbound/deliver.ts`.
- Known bad symptoms reviewers should watch for: text-only channels unexpectedly emitting empty captions for media-only payloads.

## Risks and Mitigations

- Risk: media-only payloads on text-only adapters may degrade to empty text payloads.
  - Mitigation: fallback intentionally drops media URL and keeps text contract; behavior is now deterministic and tested.
