### PR TITLE
Memory: broaden dated path matching for decay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Memory/temporal decay date detection: broaden memory path date parsing so dated files in nested folders or with basename suffixes (for example `memory/archive/morning-summary-YYYY-MM-DD.md`) receive recency decay as intended. (#32745) Thanks @ThatsR4d.
 - Telegram/multi-account default routing clarity: warn only for ambiguous (2+) account setups without an explicit default, add `openclaw doctor` warnings for missing/invalid multi-account defaults across channels, and document explicit-default guidance for channel routing and Telegram config. (#32544) thanks @Sid-Qin.
 - Agents/Skills runtime loading: propagate run config into embedded attempt and compaction skill-entry loading so explicitly enabled bundled companion skills are discovered consistently when skill snapshots do not already provide resolved entries. Thanks @gumadeiras.
 - Agents/Compaction continuity: expand staged-summary merge instructions to preserve active task status, batch progress, latest user request, and follow-up commitments so compaction handoffs retain in-flight work context. (#8903) thanks @joetomasone.

--- a/src/memory/temporal-decay.test.ts
+++ b/src/memory/temporal-decay.test.ts
@@ -153,6 +153,27 @@ describe("temporal decay", () => {
     expect(byPath.get("memory/2000-01-01.md")?.score ?? 1).toBeLessThan(0.001);
   });
 
+  it("parses dated memory filenames in nested folders and with basename suffixes", async () => {
+    const decayed = await applyTemporalDecayToHybridResults({
+      results: [
+        { path: "memory/2026-02-09-daily.md", score: 1, source: "memory" },
+        { path: "memory/archive/2026-01-01.md", score: 1, source: "memory" },
+        { path: "memory/archive/morning-summary-2026-01-26.md", score: 1, source: "memory" },
+      ],
+      temporalDecay: { enabled: true, halfLifeDays: 30 },
+      nowMs: NOW_MS,
+    });
+
+    const byPath = new Map(decayed.map((entry) => [entry.path, entry.score]));
+    const recent = byPath.get("memory/2026-02-09-daily.md") ?? 0;
+    const old = byPath.get("memory/archive/2026-01-01.md") ?? 0;
+    const middle = byPath.get("memory/archive/morning-summary-2026-01-26.md") ?? 0;
+
+    expect(recent).toBeGreaterThan(middle);
+    expect(middle).toBeGreaterThan(old);
+    expect(recent).toBeLessThan(1);
+  });
+
   it("uses file mtime fallback for non-memory sources", async () => {
     const dir = await makeTempDir();
     const sessionPath = path.join(dir, "sessions", "thread.jsonl");

--- a/src/memory/temporal-decay.ts
+++ b/src/memory/temporal-decay.ts
@@ -12,7 +12,7 @@ export const DEFAULT_TEMPORAL_DECAY_CONFIG: TemporalDecayConfig = {
 };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
-const DATED_MEMORY_PATH_RE = /(?:^|\/)memory\/(\d{4})-(\d{2})-(\d{2})\.md$/;
+const DATED_MEMORY_PATH_RE = /(?:^|\/)memory\/(?:[^/]+\/)*[^/]*(\d{4})-(\d{2})-(\d{2})[^/]*\.md$/;
 
 export function toDecayLambda(halfLifeDays: number): number {
   if (!Number.isFinite(halfLifeDays) || halfLifeDays <= 0) {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: temporal decay date extraction only matched `memory/YYYY-MM-DD.md`, missing common dated naming patterns.
- Why it matters: dated memory files in nested folders or with slug/suffix names were treated as evergreen and skipped recency decay.
- What changed: broadened memory date regex to recognize `YYYY-MM-DD` in memory basenames across nested `memory/**` paths.
- What changed: added regression test coverage for dated suffix and nested-path filename patterns.
- What did NOT change (scope boundary): evergreen rules and mtime fallback logic remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32745
- Related #

## User-visible / Behavior Changes

- Temporal decay now applies to more real-world dated memory files (nested folders and suffixed basenames).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): memory search temporal decay
- Relevant config (redacted): `memorySearch.query.hybrid.temporalDecay.enabled=true`

### Steps

1. Run temporal decay over memory paths that include date in nested/suffixed filenames.
2. Compare decayed scores across newer vs older dated files.
3. Ensure ordering follows recency.

### Expected

- Dated nested/suffixed filenames receive decayed scores according to age.

### Actual

- After fix, those filenames are parsed and decayed; recency ordering is preserved in tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `src/memory/temporal-decay.test.ts` with nested and suffixed dated paths.
- Edge cases checked: old/middle/recent dated filenames rank in expected decay order.
- What you did **not** verify: full production corpus behavior beyond unit coverage.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/memory/temporal-decay.ts`.
- Known bad symptoms reviewers should watch for: unexpected decay on previously non-decayed memory files with incidental date-like tokens.

## Risks and Mitigations

- Risk: broader pattern may match unintended date-like tokens in filenames.
  - Mitigation: strict `YYYY-MM-DD` parsing plus UTC date validation and focused regression tests.
