### PR TITLE
fix(feishu): prefer message.reply for streaming cards in topic threads

### DIFF
--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -162,20 +162,12 @@ export class FeishuStreamingSession {
     const cardId = createData.data.card_id;
     const cardContent = JSON.stringify({ type: "card", data: { card_id: cardId } });
 
-    // Topic-group replies require root_id routing. Prefer create+root_id when available.
+    // Prefer message.reply when we have a reply target — reply_in_thread
+    // reliably routes streaming cards into Feishu topics, whereas
+    // message.create with root_id may silently ignore root_id for card
+    // references (card_id format).
     let sendRes;
-    if (options?.rootId) {
-      const createData = {
-        receive_id: receiveId,
-        msg_type: "interactive",
-        content: cardContent,
-        root_id: options.rootId,
-      };
-      sendRes = await this.client.im.message.create({
-        params: { receive_id_type: receiveIdType },
-        data: createData,
-      });
-    } else if (options?.replyToMessageId) {
+    if (options?.replyToMessageId) {
       sendRes = await this.client.im.message.reply({
         path: { message_id: options.replyToMessageId },
         data: {
@@ -183,6 +175,15 @@ export class FeishuStreamingSession {
           content: cardContent,
           ...(options.replyInThread ? { reply_in_thread: true } : {}),
         },
+      });
+    } else if (options?.rootId) {
+      // root_id is undeclared in the SDK types but accepted at runtime
+      sendRes = await this.client.im.message.create({
+        params: { receive_id_type: receiveIdType },
+        data: Object.assign(
+          { receive_id: receiveId, msg_type: "interactive", content: cardContent },
+          { root_id: options.rootId },
+        ),
       });
     } else {
       sendRes = await this.client.im.message.create({


### PR DESCRIPTION
## Summary

- Fix streaming card messages being sent to the main group chat instead of the topic thread when `replyInThread` is enabled
- The root cause is commit 4221b5f8 which added a `rootId` path to `streaming-card.ts` with higher priority than the existing `message.reply` path. The `message.create` + `root_id` approach does not reliably route streaming card references (`{ type: "card", data: { card_id: ... } }`) into Feishu topic threads
- Fix: swap the priority so `message.reply` + `reply_in_thread: true` is preferred when `replyToMessageId` is available (the path that was working before). `message.create` + `root_id` is kept as a fallback when there is no reply target

## Test plan

- [x] `pnpm tsgo` passes
- [x] `pnpm test -- extensions/feishu/src/reply-dispatcher.test.ts` — 13 tests pass
- [x] `pnpm check` passes
- [x] Manual testing: streaming card replies now correctly appear inside Feishu topic threads instead of the main group

Fixes regression introduced by 4221b5f8.
