### PR TITLE
fix(agents): guard read tool against EISDIR when path is a directory

### DIFF
--- a/src/agents/pi-tools.read.eisdir-guard.test.ts
+++ b/src/agents/pi-tools.read.eisdir-guard.test.ts
@@ -1,0 +1,81 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { createOpenClawReadTool } from "./pi-tools.read.js";
+import type { AnyAgentTool } from "./pi-tools.types.js";
+
+vi.mock("./sandbox-paths.js", () => ({
+  assertSandboxPath: vi.fn(async () => ({ resolved: "/tmp", relative: "" })),
+}));
+
+describe("createOpenClawReadTool directory guard (#32889)", () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "oc-read-dir-"));
+    await fs.writeFile(path.join(tmpDir, "a.txt"), "content-a");
+    await fs.writeFile(path.join(tmpDir, "b.txt"), "content-b");
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeBaseTool(): AnyAgentTool {
+    return {
+      name: "Read",
+      description: "read",
+      inputSchema: { type: "object", properties: { path: { type: "string" } } },
+      execute: vi.fn(async () => {
+        throw new Error("EISDIR: illegal operation on a directory, read");
+      }),
+    } as unknown as AnyAgentTool;
+  }
+
+  it("returns directory listing instead of EISDIR error", async () => {
+    const base = makeBaseTool();
+    const tool = createOpenClawReadTool(base);
+
+    const result = await tool.execute("tc1", { path: tmpDir });
+    const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? "";
+
+    expect(text).toContain("is a directory");
+    expect(text).toContain("a.txt");
+    expect(text).toContain("b.txt");
+    expect((base as { execute: ReturnType<typeof vi.fn> }).execute).not.toHaveBeenCalled();
+  });
+
+  it("returns empty directory message for empty dirs", async () => {
+    const emptyDir = path.join(tmpDir, "empty-sub");
+    await fs.mkdir(emptyDir, { recursive: true });
+
+    const base = makeBaseTool();
+    const tool = createOpenClawReadTool(base);
+
+    const result = await tool.execute("tc1", { path: emptyDir });
+    const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? "";
+
+    expect(text).toContain("is a directory");
+    expect(text).toContain("(empty directory)");
+  });
+
+  it("delegates to base tool for regular files", async () => {
+    const filePath = path.join(tmpDir, "a.txt");
+    const baseTool = {
+      name: "Read",
+      description: "read",
+      inputSchema: { type: "object", properties: { path: { type: "string" } } },
+      execute: vi.fn(async () => ({
+        content: [{ type: "text", text: "file content" }],
+      })),
+    } as unknown as AnyAgentTool;
+
+    const tool = createOpenClawReadTool(baseTool);
+    const result = await tool.execute("tc1", { path: filePath });
+    const text = (result.content as Array<{ type: string; text: string }>)[0]?.text ?? "";
+
+    expect(text).toBe("file content");
+    expect((baseTool as { execute: ReturnType<typeof vi.fn> }).execute).toHaveBeenCalled();
+  });
+});

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -493,6 +493,26 @@ export function createOpenClawReadTool(
         normalized ??
         (params && typeof params === "object" ? (params as Record<string, unknown>) : undefined);
       assertRequiredParams(record, CLAUDE_PARAM_GROUPS.read, base.name);
+      const readPath = typeof record?.path === "string" ? String(record.path).trim() : "";
+      if (readPath) {
+        try {
+          const stat = await fs.stat(readPath);
+          if (stat.isDirectory()) {
+            const entries = await fs.readdir(readPath);
+            const listing = entries.length ? entries.join("\n") : "(empty directory)";
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `The path "${readPath}" is a directory, not a file. Use the LS tool to list directories.\n\nDirectory contents (${entries.length} entries):\n${listing}`,
+                },
+              ],
+            } as AgentToolResult<unknown>;
+          }
+        } catch {
+          // Let the base tool handle missing files and other errors
+        }
+      }
       const result = await executeReadWithAdaptivePaging({
         base,
         toolCallId,


### PR DESCRIPTION
## Summary

- Problem: When the AI agent calls the read tool with a directory path (e.g., `/opt/homebrew/lib/node_modules/openclaw/docs`), the upstream `detectImageMimeType` function attempts `fileHandle.read()` on the directory, resulting in `EISDIR: illegal operation on a directory, read`. This blocks documentation generation workflows.
- Why it matters: Users asking the agent to generate documentation about itself hit an unrecoverable error, as the agent cannot proceed past the failed read.
- What changed: Added a `fs.stat()` directory check in `createOpenClawReadTool.execute` before delegating to the base tool. When the path is a directory, the tool returns a helpful listing of directory contents along with guidance to use the LS tool instead.
- What did NOT change (scope boundary): The upstream pi-coding-agent read tool is not modified. File reads, image detection, and adaptive paging are untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32889

## User-visible / Behavior Changes

When the AI agent attempts to read a directory path, instead of crashing with `EISDIR`, it now receives a helpful directory listing and guidance to use the LS tool. The agent can then proceed to read individual files.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No — the directory listing only shows entry names within the already-permitted path

## Repro + Verification

### Environment

- OS: macOS / Linux
- Runtime: Node.js 22+

### Steps

1. Start openclaw
2. Ask: "generate an openclaw introduction document"
3. Agent attempts to read the installation docs directory

### Expected

- Agent receives directory listing and reads individual files

### Actual

- Before: `EISDIR: illegal operation on a directory, read '/opt/homebrew/lib/node_modules/openclaw/docs'`
- After: Tool returns directory contents with guidance to use LS tool

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

3 new vitest unit tests:
- `returns directory listing instead of EISDIR error`
- `returns empty directory message for empty dirs`
- `delegates to base tool for regular files`

## Human Verification (required)

- Verified scenarios: directory path returns listing, empty directory returns empty message, regular file delegates to base tool
- Edge cases checked: non-existent paths (falls through to base tool), empty path string (skips guard)
- What you did **not** verify: symlinked directories, sandboxed execution environments

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; the directory guard is removed and the original EISDIR behavior is restored
- Files/config to restore: `src/agents/pi-tools.read.ts`

## Risks and Mitigations

- Risk: `fs.stat()` adds one extra syscall per read tool invocation
  - Mitigation: The stat call is negligible compared to the file read itself, and it only runs when a path is provided