### PR TITLE
fix(agents): resolve #32889 #32891 #32892

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -557,4 +557,18 @@ describe("createOpenClawCodingTools", () => {
     });
     expect(details?.truncation).not.toHaveProperty("content");
   });
+
+  it("returns EISDIR for directory reads without crashing image mime sniffing", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-read-dir-"));
+    await fs.mkdir(path.join(tmpDir, "docs"), { recursive: true });
+    try {
+      const readTool = createSandboxedReadTool({
+        root: tmpDir,
+        bridge: createHostSandboxFsBridge(tmpDir),
+      });
+      await expect(readTool.execute("read-dir-1", { path: "docs" })).rejects.toThrow(/EISDIR/);
+    } finally {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -521,8 +521,15 @@ function createSandboxReadOperations(params: SandboxToolParams) {
       if (!stat) {
         throw createFsAccessError("ENOENT", absolutePath);
       }
+      if (stat.type === "directory") {
+        throw createFsAccessError("EISDIR", absolutePath);
+      }
     },
     detectImageMimeType: async (absolutePath: string) => {
+      const stat = await params.bridge.stat({ filePath: absolutePath, cwd: params.root });
+      if (!stat || stat.type !== "file") {
+        return undefined;
+      }
       const buffer = await params.bridge.readFile({ filePath: absolutePath, cwd: params.root });
       const mime = await detectMime({ buffer, filePath: absolutePath });
       return mime && mime.startsWith("image/") ? mime : undefined;

--- a/src/agents/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagent-announce.format.e2e.test.ts
@@ -4,6 +4,7 @@ import {
   __testing as sessionBindingServiceTesting,
   registerSessionBindingAdapter,
 } from "../infra/outbound/session-binding-service.js";
+import { resetAnnounceQueuesForTests } from "./subagent-announce-queue.js";
 
 type AgentCallRequest = { method?: string; params?: Record<string, unknown> };
 type RequesterResolution = {
@@ -203,6 +204,7 @@ describe("subagent announce formatting", () => {
     chatHistoryMock.mockReset().mockResolvedValue({ messages: [] });
     sessionStore = {};
     sessionBindingServiceTesting.resetSessionBindingAdaptersForTests();
+    resetAnnounceQueuesForTests();
     configOverride = {
       session: {
         mainKey: "main",
@@ -620,6 +622,64 @@ describe("subagent announce formatting", () => {
     expect(msg).toContain(
       "If they are part of the same workflow, wait for the remaining results before sending a user update.",
     );
+  });
+
+  it("coalesces rapid completion announcements into a single parent turn when requester is idle", async () => {
+    vi.stubEnv("OPENCLAW_TEST_FAST", "0");
+    try {
+      sessionStore = {
+        "agent:main:subagent:child-a": {
+          sessionId: "child-session-a",
+        },
+        "agent:main:subagent:child-b": {
+          sessionId: "child-session-b",
+        },
+        "agent:main:main": {
+          sessionId: "requester-session-main",
+          queueMode: "collect",
+          queueDebounceMs: 10,
+        },
+      };
+      subagentRegistryMock.countActiveDescendantRuns.mockImplementation((sessionKey: string) =>
+        sessionKey === "agent:main:main" ? 2 : 0,
+      );
+
+      await Promise.all([
+        runSubagentAnnounceFlow({
+          childSessionKey: "agent:main:subagent:child-a",
+          childRunId: "run-child-a",
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
+          ...defaultOutcomeAnnounce,
+          expectsCompletionMessage: true,
+          roundOneReply: "result from child A",
+        }),
+        runSubagentAnnounceFlow({
+          childSessionKey: "agent:main:subagent:child-b",
+          childRunId: "run-child-b",
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          requesterOrigin: { channel: "discord", to: "channel:12345", accountId: "acct-1" },
+          ...defaultOutcomeAnnounce,
+          expectsCompletionMessage: true,
+          roundOneReply: "result from child B",
+        }),
+      ]);
+
+      await new Promise((resolve) => setTimeout(resolve, 2200));
+
+      expect(sendSpy).not.toHaveBeenCalled();
+      expect(agentSpy).toHaveBeenCalledTimes(1);
+      const call = agentSpy.mock.calls[0]?.[0] as { params?: Record<string, unknown> };
+      const message = typeof call?.params?.message === "string" ? call.params.message : "";
+      expect(message).toContain("Queued #1");
+      expect(message).toContain("Queued #2");
+      expect(message).toContain("result from child A");
+      expect(message).toContain("result from child B");
+    } finally {
+      vi.stubEnv("OPENCLAW_TEST_FAST", "1");
+    }
   });
 
   it("keeps session-mode completion delivery on the bound destination when sibling runs are active", async () => {

--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -664,6 +664,7 @@ async function maybeQueueSubagentAnnounce(params: {
   summaryLine?: string;
   requesterOrigin?: DeliveryContext;
   internalEvents?: AgentInternalEvent[];
+  allowIdleCoalescing?: boolean;
   signal?: AbortSignal;
 }): Promise<"steered" | "queued" | "none"> {
   if (params.signal?.aborted) {
@@ -696,8 +697,14 @@ async function maybeQueueSubagentAnnounce(params: {
     queueSettings.mode === "collect" ||
     queueSettings.mode === "steer-backlog" ||
     queueSettings.mode === "interrupt";
-  if (isActive && (shouldFollowup || queueSettings.mode === "steer")) {
+  const shouldQueueForIdleCoalescing =
+    params.allowIdleCoalescing === true && !isActive && shouldFollowup;
+  if (
+    (isActive && (shouldFollowup || queueSettings.mode === "steer")) ||
+    shouldQueueForIdleCoalescing
+  ) {
     const origin = resolveAnnounceOrigin(entry, params.requesterOrigin);
+    const coalescedDebounceMs = Math.max(2000, queueSettings.debounceMs ?? 0);
     enqueueAnnounce({
       key: buildAnnounceQueueKey(canonicalKey, origin),
       item: {
@@ -709,7 +716,13 @@ async function maybeQueueSubagentAnnounce(params: {
         sessionKey: canonicalKey,
         origin,
       },
-      settings: queueSettings,
+      settings: shouldQueueForIdleCoalescing
+        ? {
+            ...queueSettings,
+            mode: "collect",
+            debounceMs: coalescedDebounceMs,
+          }
+        : queueSettings,
       send: sendAnnounce,
     });
     return "queued";
@@ -839,6 +852,10 @@ async function sendSubagentAnnounceDirectly(params: {
           path: "direct",
         };
       }
+      return {
+        delivered: false,
+        path: "none",
+      };
     }
 
     const directOrigin = normalizeDeliveryContext(params.directOrigin);
@@ -915,6 +932,7 @@ async function deliverSubagentAnnouncement(params: {
   bestEffortDeliver?: boolean;
   completionRouteMode?: "bound" | "fallback" | "hook";
   spawnMode?: SpawnSubagentMode;
+  allowIdleCoalescing?: boolean;
   directIdempotencyKey: string;
   currentRunId?: string;
   signal?: AbortSignal;
@@ -931,6 +949,7 @@ async function deliverSubagentAnnouncement(params: {
         summaryLine: params.summaryLine,
         requesterOrigin: params.requesterOrigin,
         internalEvents: params.internalEvents,
+        allowIdleCoalescing: params.allowIdleCoalescing,
         signal: params.signal,
       }),
     direct: async () =>
@@ -1408,6 +1427,7 @@ export async function runSubagentAnnounceFlow(params: {
       bestEffortDeliver: params.bestEffortDeliver,
       completionRouteMode: completionResolution.routeMode,
       spawnMode: params.spawnMode,
+      allowIdleCoalescing: expectsCompletionMessage && remainingActiveSubagentRuns > 0,
       directIdempotencyKey,
       currentRunId: params.childRunId,
       signal: params.signal,

--- a/src/commands/models.auth.provider-resolution.test.ts
+++ b/src/commands/models.auth.provider-resolution.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ProviderPlugin } from "../plugins/types.js";
-import { resolveRequestedLoginProviderOrThrow } from "./models/auth.js";
+import { resolveLoginProviders, resolveRequestedLoginProviderOrThrow } from "./models/auth.js";
 
 function makeProvider(params: { id: string; label?: string; aliases?: string[] }): ProviderPlugin {
   return {
@@ -40,5 +40,20 @@ describe("resolveRequestedLoginProviderOrThrow", () => {
     ).toThrowError(
       'Unknown provider "google-antigravity". Loaded providers: google-gemini-cli, qwen-portal. Verify plugins via `openclaw plugins list --json`.',
     );
+  });
+});
+
+describe("resolveLoginProviders", () => {
+  it("includes openai-codex built-in provider when no plugins are installed", () => {
+    const providers = resolveLoginProviders([]);
+    expect(providers.some((provider) => provider.id === "openai-codex")).toBe(true);
+  });
+
+  it("prefers loaded plugins over built-in providers for the same id", () => {
+    const providers = resolveLoginProviders([
+      makeProvider({ id: "openai-codex", label: "custom" }),
+    ]);
+    const codex = providers.find((provider) => provider.id === "openai-codex");
+    expect(codex?.label).toBe("custom");
   });
 });

--- a/src/commands/models/auth.ts
+++ b/src/commands/models/auth.ts
@@ -21,6 +21,8 @@ import { isRemoteEnvironment } from "../oauth-env.js";
 import { createVpsAwareOAuthHandlers } from "../oauth-flow.js";
 import { applyAuthProfileConfig } from "../onboard-auth.js";
 import { openUrl } from "../onboard-helpers.js";
+import { OPENAI_CODEX_DEFAULT_MODEL } from "../openai-codex-model-default.js";
+import { loginOpenAICodexOAuth } from "../openai-codex-oauth.js";
 import {
   applyDefaultModel,
   mergeConfigPatch,
@@ -240,6 +242,67 @@ type LoginOptions = {
   setDefault?: boolean;
 };
 
+function resolveBuiltInLoginProviders(): ProviderPlugin[] {
+  return [
+    {
+      id: "openai-codex",
+      label: "openai-codex",
+      aliases: ["codex-cli"],
+      docsPath: "https://docs.openclaw.ai/start/auth",
+      auth: [
+        {
+          id: "oauth",
+          label: "OAuth",
+          kind: "oauth",
+          hint: "Sign in with your OpenAI account",
+          run: async (ctx) => {
+            const creds = await loginOpenAICodexOAuth({
+              prompter: ctx.prompter,
+              runtime: ctx.runtime,
+              isRemote: ctx.isRemote,
+              openUrl: async (url) => {
+                await ctx.openUrl(url);
+              },
+              localBrowserMessage: "Complete sign-in in browser…",
+            });
+            if (!creds) {
+              throw new Error("OpenAI Codex OAuth canceled.");
+            }
+            const email =
+              typeof creds.email === "string" && creds.email.trim()
+                ? creds.email.trim()
+                : "default";
+            return {
+              profiles: [
+                {
+                  profileId: `openai-codex:${email}`,
+                  credential: {
+                    type: "oauth" as const,
+                    provider: "openai-codex",
+                    ...creds,
+                  },
+                },
+              ],
+              defaultModel: OPENAI_CODEX_DEFAULT_MODEL,
+            };
+          },
+        },
+      ],
+    },
+  ];
+}
+
+export function resolveLoginProviders(pluginProviders: ProviderPlugin[]): ProviderPlugin[] {
+  const byId = new Map<string, ProviderPlugin>();
+  for (const provider of resolveBuiltInLoginProviders()) {
+    byId.set(normalizeProviderId(provider.id), provider);
+  }
+  for (const provider of pluginProviders) {
+    byId.set(normalizeProviderId(provider.id), provider);
+  }
+  return [...byId.values()];
+}
+
 export function resolveRequestedLoginProviderOrThrow(
   providers: ProviderPlugin[],
   rawProvider?: string,
@@ -283,7 +346,7 @@ export async function modelsAuthLoginCommand(opts: LoginOptions, runtime: Runtim
   const workspaceDir =
     resolveAgentWorkspaceDir(config, defaultAgentId) ?? resolveDefaultAgentWorkspaceDir();
 
-  const providers = resolvePluginProviders({ config, workspaceDir });
+  const providers = resolveLoginProviders(resolvePluginProviders({ config, workspaceDir }));
   if (providers.length === 0) {
     throw new Error(
       `No provider plugins found. Install one via \`${formatCliCommand("openclaw plugins install")}\`.`,


### PR DESCRIPTION
Fixes #32889 #32891 #32892.

- read: return EISDIR when path is a directory and skip image mime sniffing for non-files
- subagents: coalesce rapid completion announcements into one parent turn when sibling runs are still pending
- models auth: register openai-codex as a built-in login provider when plugins are absent

Tests:
- pnpm -s vitest src/commands/models.auth.provider-resolution.test.ts src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
- pnpm -s vitest --config vitest.e2e.config.ts src/agents/subagent-announce.format.e2e.test.ts
