### PR TITLE
fix(agents): default custom providers to openai-completions API format

### DIFF
--- a/src/agents/pi-embedded-runner/model.test.ts
+++ b/src/agents/pi-embedded-runner/model.test.ts
@@ -226,6 +226,60 @@ describe("resolveModel", () => {
     expect(result.model?.reasoning).toBe(true);
   });
 
+  it("defaults to openai-completions for custom providers without explicit api (#32871)", () => {
+    const cfg = {
+      models: {
+        providers: {
+          routellm: {
+            baseUrl: "https://routellm.example.com/v1",
+            models: [makeModel("gpt-5")],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("routellm", "gpt-5", "/tmp/agent", cfg);
+
+    expect(result.model?.api).toBe("openai-completions");
+    expect(result.model?.id).toBe("gpt-5");
+  });
+
+  it("respects explicit api: openai-completions from provider config (#32871)", () => {
+    const cfg = {
+      models: {
+        providers: {
+          routellm: {
+            baseUrl: "https://routellm.example.com/v1",
+            api: "openai-completions" as const,
+            models: [makeModel("gpt-5")],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("routellm", "gpt-5", "/tmp/agent", cfg);
+
+    expect(result.model?.api).toBe("openai-completions");
+  });
+
+  it("respects explicit api: openai-responses from provider config", () => {
+    const cfg = {
+      models: {
+        providers: {
+          myopenai: {
+            baseUrl: "https://api.openai.com/v1",
+            api: "openai-responses" as const,
+            models: [makeModel("gpt-5")],
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const result = resolveModel("myopenai", "gpt-5", "/tmp/agent", cfg);
+
+    expect(result.model?.api).toBe("openai-responses");
+  });
+
   it("builds an openai-codex fallback for gpt-5.3-codex", () => {
     mockOpenAICodexTemplateModel();
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -63,7 +63,10 @@ export function resolveModel(
       (entry) => normalizeProviderId(entry.provider) === normalizedProvider && entry.id === modelId,
     );
     if (inlineMatch) {
-      const normalized = normalizeModelCompat(inlineMatch as Model<Api>);
+      const withApi = inlineMatch.api
+        ? inlineMatch
+        : { ...inlineMatch, api: "openai-completions" as const };
+      const normalized = normalizeModelCompat(withApi as Model<Api>);
       return {
         model: normalized,
         authStorage,
@@ -97,10 +100,11 @@ export function resolveModel(
     const providerCfg = providers[provider];
     if (providerCfg || modelId.startsWith("mock-")) {
       const configuredModel = providerCfg?.models?.find((candidate) => candidate.id === modelId);
+      const resolvedApi = configuredModel?.api ?? providerCfg?.api ?? "openai-completions";
       const fallbackModel: Model<Api> = normalizeModelCompat({
         id: modelId,
         name: modelId,
-        api: providerCfg?.api ?? "openai-responses",
+        api: resolvedApi,
         provider,
         baseUrl: providerCfg?.baseUrl,
         reasoning: configuredModel?.reasoning ?? false,


### PR DESCRIPTION
## Summary

- Problem: Custom OpenAI-compatible providers (routellm, LiteLLM, vLLM, etc.) fail with `Invalid value: 'input_text'. Supported values are: 'output_text' and 'refusal'` because OpenClaw defaults to the Responses API format (`openai-responses`) which sends `input_text` content type. These providers only support the Chat Completions API format.
- Why it matters: Users configuring third-party LLM proxies get HTTP 400 errors on every message, even when `api: "openai-completions"` is correctly set in some code paths.
- What changed: Changed the default API format from `"openai-responses"` to `"openai-completions"` in two resolution paths: (1) inline model resolution when neither model nor provider specifies `api`, and (2) the provider-config fallback path. Also added `configuredModel?.api` precedence in the fallback path.
- What did NOT change (scope boundary): Native OpenAI and Azure providers still use Responses API when explicitly configured. Forward-compat models (codex, anthropic, gemini, zai) are unaffected.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #32871

## User-visible / Behavior Changes

Custom OpenAI-compatible providers (routellm, LiteLLM, vLLM, etc.) now default to Chat Completions API format instead of Responses API. Users who explicitly set `api: "openai-responses"` in their provider config are unaffected.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No — same endpoints, different request body format
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime: Node.js 22+

### Steps

1. Configure routellm provider with `api: "openai-completions"` and a model
2. Send a message to the agent using `routellm/gpt-5`

### Expected

- Chat Completions format request sent; model responds normally

### Actual

- Before: HTTP 400 `Invalid value: 'input_text'` — Responses API format sent
- After: Chat Completions format sent; model responds normally

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

3 new vitest unit tests:
- `defaults to openai-completions for custom providers without explicit api`
- `respects explicit api: openai-completions from provider config`
- `respects explicit api: openai-responses from provider config`

## Human Verification (required)

- Verified scenarios: custom provider without api field, custom provider with explicit openai-completions, custom provider with explicit openai-responses
- Edge cases checked: inline model with model-level api override, provider config fallback path, forward-compat models still use their specific APIs
- What you did **not** verify: Live routellm/LiteLLM endpoint (tested with mocks and unit tests only)

## Compatibility / Migration

- Backward compatible? Yes — users who explicitly set `api: "openai-responses"` are unaffected
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert this commit; providers will default to `openai-responses` again
- Files/config to restore: `src/agents/pi-embedded-runner/model.ts`

## Risks and Mitigations

- Risk: Custom providers that previously worked with the Responses API default may break
  - Mitigation: The Responses API is OpenAI-specific; third-party proxies overwhelmingly use Chat Completions. Any provider that needs Responses API should set `api: "openai-responses"` explicitly.