### PR TITLE
export-session: Fix empty contents in exported html

### DIFF
--- a/src/auto-reply/reply/export-html/template.html
+++ b/src/auto-reply/reply/export-html/template.html
@@ -60,29 +60,17 @@
 
     <!-- Vendored libraries -->
     <script>
-      {
-        {
-          MARKED_JS;
-        }
-      }
+      {{MARKED_JS}}
     </script>
 
     <!-- highlight.js -->
     <script>
-      {
-        {
-          HIGHLIGHT_JS;
-        }
-      }
+      {{HIGHLIGHT_JS}}
     </script>
 
     <!-- Main application code -->
     <script>
-      {
-        {
-          JS;
-        }
-      }
+      {{JS}}
     </script>
   </body>
 </html>


### PR DESCRIPTION
replace("{{MARKED_JS}}", markedJs) in generateHtml takes no effect because the incorrect format in template.html.


