### PR TITLE
fix(telegram): guard malformed replies and include hook accountId

### DIFF
--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -385,6 +385,7 @@ export const dispatchTelegramMessage = async ({
   };
   const deliveryBaseOptions = {
     chatId: String(chatId),
+    accountId: route.accountId,
     token: opts.token,
     runtime,
     bot,

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -445,12 +445,14 @@ export const registerTelegramNativeCommands = ({
   };
   const buildCommandDeliveryBaseOptions = (params: {
     chatId: string | number;
+    accountId: string;
     mediaLocalRoots?: readonly string[];
     threadSpec: ReturnType<typeof resolveTelegramThreadSpec>;
     tableMode: ReturnType<typeof resolveMarkdownTableMode>;
     chunkMode: ReturnType<typeof resolveChunkMode>;
   }) => ({
     chatId: String(params.chatId),
+    accountId: params.accountId,
     token: opts.token,
     runtime,
     bot,
@@ -513,6 +515,7 @@ export const registerTelegramNativeCommands = ({
             });
           const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
             chatId,
+            accountId: route.accountId,
             mediaLocalRoots,
             threadSpec,
             tableMode,
@@ -726,7 +729,7 @@ export const registerTelegramNativeCommands = ({
             return;
           }
           const { senderId, commandAuthorized, isGroup, isForum, resolvedThreadId } = auth;
-          const { threadSpec, mediaLocalRoots, tableMode, chunkMode } =
+          const { threadSpec, route, mediaLocalRoots, tableMode, chunkMode } =
             resolveCommandRuntimeContext({
               msg,
               isGroup,
@@ -735,6 +738,7 @@ export const registerTelegramNativeCommands = ({
             });
           const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
             chatId,
+            accountId: route.accountId,
             mediaLocalRoots,
             threadSpec,
             tableMode,

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -428,6 +428,7 @@ async function deliverMediaReply(params: {
 export async function deliverReplies(params: {
   replies: ReplyPayload[];
   chatId: string;
+  accountId?: string;
   token: string;
   runtime: RuntimeEnv;
   bot: Bot;
@@ -459,9 +460,9 @@ export async function deliverReplies(params: {
   });
   for (const originalReply of params.replies) {
     let reply = originalReply;
-    const mediaList = reply.mediaUrls?.length
+    const mediaList = reply?.mediaUrls?.length
       ? reply.mediaUrls
-      : reply.mediaUrl
+      : reply?.mediaUrl
         ? [reply.mediaUrl]
         : [];
     const hasMedia = mediaList.length > 0;
@@ -488,6 +489,7 @@ export async function deliverReplies(params: {
         },
         {
           channelId: "telegram",
+          accountId: params.accountId,
           conversationId: params.chatId,
         },
       );
@@ -555,6 +557,7 @@ export async function deliverReplies(params: {
           },
           {
             channelId: "telegram",
+            accountId: params.accountId,
             conversationId: params.chatId,
           },
         );
@@ -570,6 +573,7 @@ export async function deliverReplies(params: {
           },
           {
             channelId: "telegram",
+            accountId: params.accountId,
             conversationId: params.chatId,
           },
         );

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -126,6 +126,22 @@ describe("deliverReplies", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
+  it("skips malformed replies and continues with valid entries", async () => {
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 1, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      replies: [undefined, { text: "hello" }] as unknown as DeliverRepliesParams["replies"],
+      runtime,
+      bot,
+    });
+
+    expect(runtime.error).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage.mock.calls[0]?.[1]).toBe("hello");
+  });
+
   it("reports message_sent success=false when hooks blank out a text-only reply", async () => {
     messageHookRunner.hasHooks.mockImplementation(
       (name: string) => name === "message_sending" || name === "message_sent",
@@ -146,6 +162,40 @@ describe("deliverReplies", () => {
     expect(messageHookRunner.runMessageSent).toHaveBeenCalledWith(
       expect.objectContaining({ success: false, content: "" }),
       expect.objectContaining({ channelId: "telegram", conversationId: "123" }),
+    );
+  });
+
+  it("passes accountId into message hooks", async () => {
+    messageHookRunner.hasHooks.mockImplementation(
+      (name: string) => name === "message_sending" || name === "message_sent",
+    );
+
+    const runtime = createRuntime(false);
+    const sendMessage = vi.fn().mockResolvedValue({ message_id: 9, chat: { id: "123" } });
+    const bot = createBot({ sendMessage });
+
+    await deliverWith({
+      accountId: "work",
+      replies: [{ text: "hello" }],
+      runtime,
+      bot,
+    });
+
+    expect(messageHookRunner.runMessageSending).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        channelId: "telegram",
+        accountId: "work",
+        conversationId: "123",
+      }),
+    );
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true }),
+      expect.objectContaining({
+        channelId: "telegram",
+        accountId: "work",
+        conversationId: "123",
+      }),
     );
   });
 


### PR DESCRIPTION
## Summary
- guard malformed reply entries before reading `mediaUrls` so bad payloads skip instead of crashing the whole batch
- pass `accountId` into Telegram `message_sending` and `message_sent` hook context
- thread accountId through Telegram delivery call sites
- add regression tests for malformed reply skip/continue and hook accountId context

## Validation
- pnpm test src/telegram/bot/delivery.test.ts
- pnpm check
