### PR TITLE
fix(tui): serialize loadHistory calls to prevent race conditions

### DIFF
--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -281,7 +281,30 @@ export function createSessionActions(context: SessionActionContext) {
     applySessionInfo({ entry, force: true });
   };
 
-  const loadHistory = async () => {
+  // Serialize loadHistory calls: if one is already in-flight, the next call
+  // queues itself and runs once the current one completes. This prevents
+  // concurrent clearAll() + rebuild cycles from racing and dropping messages.
+  let historyLoadInFlight = false;
+  let historyLoadQueued = false;
+
+  const loadHistory = async (): Promise<void> => {
+    if (historyLoadInFlight) {
+      historyLoadQueued = true;
+      return;
+    }
+    historyLoadInFlight = true;
+    try {
+      await loadHistoryOnce();
+    } finally {
+      historyLoadInFlight = false;
+      if (historyLoadQueued) {
+        historyLoadQueued = false;
+        void loadHistory();
+      }
+    }
+  };
+
+  const loadHistoryOnce = async () => {
     try {
       const history = await client.loadHistory({
         sessionKey: state.currentSessionKey,
@@ -354,7 +377,7 @@ export function createSessionActions(context: SessionActionContext) {
     }
     await refreshSessionInfo();
     tui.requestRender();
-  };
+  }; // end loadHistoryOnce
 
   const setSession = async (rawKey: string) => {
     const nextKey = resolveSessionKey(rawKey);


### PR DESCRIPTION
## Problem

When multiple runs finalize in quick succession (e.g. a heartbeat completing while a user reply is streaming), `maybeRefreshHistoryForRun` fires multiple concurrent `void loadHistory()` calls.

Each call independently executes `chatLog.clearAll()` + full rebuild. Whichever network request completes **last** wins — messages visible only in the losing rebuild appear to disappear from the TUI. Users see only the "last" message.

## Root Cause

`loadHistory` in `tui-session-actions.ts` has no concurrency guard:

```
Run A finalizes → void loadHistory() → [fetching...]
Run B finalizes → void loadHistory() → [fetching...]
                             ↓                  ↓
                       clearAll() + N msgs  clearAll() + M msgs  ← last wins
```

## Fix

Introduce an in-flight flag + queue flag so at most one `loadHistory` executes at a time. A call that arrives while one is in-flight sets a queue flag; when the in-flight load completes, it re-runs once to catch any state that changed in the interim.

This ensures the final rebuild always reflects the most up-to-date server state without requiring debounce delays.

## Reproduction

1. Configure heartbeats firing every ~10 minutes
2. Send a message and receive a reply in the TUI around the same time a heartbeat run finalizes
3. Observe earlier messages disappearing — only the last rebuild survives

## Testing

No behavior change when calls are sequential (the common case). Existing TUI tests pass.