### PR TITLE
Web search tool Brave adds support for custom BaseUrl

### DIFF
--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1133,6 +1133,7 @@ async function runWebSearch(params: {
   geminiModel?: string;
   kimiBaseUrl?: string;
   kimiModel?: string;
+  braveBaseUrl?: string;
 }): Promise<Record<string, unknown>> {
   const cacheKey = normalizeCacheKey(
     params.provider === "brave"
@@ -1265,7 +1266,7 @@ async function runWebSearch(params: {
     throw new Error("Unsupported web search provider.");
   }
 
-  const url = new URL(BRAVE_SEARCH_ENDPOINT);
+  const url = new URL(params.braveBaseUrl || BRAVE_SEARCH_ENDPOINT);
   url.searchParams.set("q", params.query);
   url.searchParams.set("count", String(params.count));
   if (params.country) {
@@ -1450,6 +1451,7 @@ export function createWebSearchTool(options?: {
         geminiModel: resolveGeminiModel(geminiConfig),
         kimiBaseUrl: resolveKimiBaseUrl(kimiConfig),
         kimiModel: resolveKimiModel(kimiConfig),
+        braveBaseUrl: search?.baseUrl?.trim() || undefined,
       });
       return jsonResult(result);
     },

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -450,6 +450,8 @@ export type ToolsConfig = {
       timeoutSeconds?: number;
       /** Cache TTL in minutes for search results. */
       cacheTtlMinutes?: number;
+      /** Base URL for Brave Search API (defaults to "https://api.search.brave.com/res/v1/web/search"). */
+      baseUrl?: string;
       /** Perplexity-specific configuration (used when provider="perplexity"). */
       perplexity?: {
         /** API key for Perplexity or OpenRouter (defaults to PERPLEXITY_API_KEY or OPENROUTER_API_KEY env var). */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -275,6 +275,7 @@ export const ToolsWebSearchSchema = z
     maxResults: z.number().int().positive().optional(),
     timeoutSeconds: z.number().int().positive().optional(),
     cacheTtlMinutes: z.number().nonnegative().optional(),
+    baseUrl: z.string().optional(),
     perplexity: z
       .object({
         apiKey: SecretInputSchema.optional().register(sensitive),


### PR DESCRIPTION
 feat(web-search): add baseUrl support for Brave Search API                                                                                                                                                  
  Allow users to configure a custom base URL for the Brave Web Search                                                                                                                                           API endpoint, useful for proxy scenarios. Falls back to the default
  endpoint when not specified.

  PR title:

  feat(web-search): add baseUrl support for Brave Search API

  PR body:

  ## Summary
  - Add configurable `baseUrl` for the Brave Web Search API endpoint, useful for proxy scenarios
  - When `baseUrl` is not specified, falls back to the default `https://api.search.brave.com/res/v1/web/search`
  - Changes across 3 files: type definition, zod schema validation, and web-search tool logic

  ## Test plan
  - [ ] Run `npx vitest run src/agents/tools/web-search.test.ts` to verify existing tests pass
  - [ ] Verify that omitting `baseUrl` uses the default Brave endpoint
  - [ ] Verify that setting a custom `baseUrl` in config routes requests to the custom endpoint

  PR creation link: https://github.com/xingkeyan-creator/openclaw_local/pull/new/feat/brave-search-base-url