### PR TITLE
feat(feishu): add first topic message trigger

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -325,6 +325,11 @@ After approval, you can chat normally.
 - `true` = require @mention (default)
 - `false` = respond without mentions
 
+**3. First message in topic trigger** (`firstMessageInTopicTrigger`):
+
+- `false` = keep normal mention rule (default)
+- `true` = when a group message has no `root_id` and no `parent_id`, treat it as the first message of a topic and allow a reply even if the bot was not mentioned
+
 ---
 
 ## Group configuration examples
@@ -350,6 +355,25 @@ After approval, you can chat normally.
     feishu: {
       groups: {
         oc_xxx: { requireMention: false },
+      },
+    },
+  },
+}
+```
+
+### Customer-service topic groups: only auto-reply to the first message in each topic
+
+When `requireMention: true`, enabling `firstMessageInTopicTrigger` lets OpenClaw auto-reply to the first message of each topic (where `root_id` and `parent_id` are both empty), while still ignoring most non-mention follow-up messages.
+
+```json5
+{
+  channels: {
+    feishu: {
+      groups: {
+        oc_support_group: {
+          requireMention: true,
+          firstMessageInTopicTrigger: true,
+        },
       },
     },
   },
@@ -595,29 +619,31 @@ Full configuration: [Gateway configuration](/gateway/configuration)
 
 Key options:
 
-| Setting                                           | Description                             | Default          |
-| ------------------------------------------------- | --------------------------------------- | ---------------- |
-| `channels.feishu.enabled`                         | Enable/disable channel                  | `true`           |
-| `channels.feishu.domain`                          | API domain (`feishu` or `lark`)         | `feishu`         |
-| `channels.feishu.connectionMode`                  | Event transport mode                    | `websocket`      |
-| `channels.feishu.defaultAccount`                  | Default account ID for outbound routing | `default`        |
-| `channels.feishu.verificationToken`               | Required for webhook mode               | -                |
-| `channels.feishu.webhookPath`                     | Webhook route path                      | `/feishu/events` |
-| `channels.feishu.webhookHost`                     | Webhook bind host                       | `127.0.0.1`      |
-| `channels.feishu.webhookPort`                     | Webhook bind port                       | `3000`           |
-| `channels.feishu.accounts.<id>.appId`             | App ID                                  | -                |
-| `channels.feishu.accounts.<id>.appSecret`         | App Secret                              | -                |
-| `channels.feishu.accounts.<id>.domain`            | Per-account API domain override         | `feishu`         |
-| `channels.feishu.dmPolicy`                        | DM policy                               | `pairing`        |
-| `channels.feishu.allowFrom`                       | DM allowlist (open_id list)             | -                |
-| `channels.feishu.groupPolicy`                     | Group policy                            | `open`           |
-| `channels.feishu.groupAllowFrom`                  | Group allowlist                         | -                |
-| `channels.feishu.groups.<chat_id>.requireMention` | Require @mention                        | `true`           |
-| `channels.feishu.groups.<chat_id>.enabled`        | Enable group                            | `true`           |
-| `channels.feishu.textChunkLimit`                  | Message chunk size                      | `2000`           |
-| `channels.feishu.mediaMaxMb`                      | Media size limit                        | `30`             |
-| `channels.feishu.streaming`                       | Enable streaming card output            | `true`           |
-| `channels.feishu.blockStreaming`                  | Enable block streaming                  | `true`           |
+| Setting                                                       | Description                             | Default          |
+| ------------------------------------------------------------- | --------------------------------------- | ---------------- |
+| `channels.feishu.enabled`                                     | Enable/disable channel                  | `true`           |
+| `channels.feishu.domain`                                      | API domain (`feishu` or `lark`)         | `feishu`         |
+| `channels.feishu.connectionMode`                              | Event transport mode                    | `websocket`      |
+| `channels.feishu.defaultAccount`                              | Default account ID for outbound routing | `default`        |
+| `channels.feishu.verificationToken`                           | Required for webhook mode               | -                |
+| `channels.feishu.webhookPath`                                 | Webhook route path                      | `/feishu/events` |
+| `channels.feishu.webhookHost`                                 | Webhook bind host                       | `127.0.0.1`      |
+| `channels.feishu.webhookPort`                                 | Webhook bind port                       | `3000`           |
+| `channels.feishu.accounts.<id>.appId`                         | App ID                                  | -                |
+| `channels.feishu.accounts.<id>.appSecret`                     | App Secret                              | -                |
+| `channels.feishu.accounts.<id>.domain`                        | Per-account API domain override         | `feishu`         |
+| `channels.feishu.dmPolicy`                                    | DM policy                               | `pairing`        |
+| `channels.feishu.allowFrom`                                   | DM allowlist (open_id list)             | -                |
+| `channels.feishu.groupPolicy`                                 | Group policy                            | `open`           |
+| `channels.feishu.groupAllowFrom`                              | Group allowlist                         | -                |
+| `channels.feishu.firstMessageInTopicTrigger`                  | Global first-topic-message trigger      | `false`          |
+| `channels.feishu.groups.<chat_id>.requireMention`             | Require @mention                        | `true`           |
+| `channels.feishu.groups.<chat_id>.firstMessageInTopicTrigger` | Per-group first-topic-message trigger   | inherits global  |
+| `channels.feishu.groups.<chat_id>.enabled`                    | Enable group                            | `true`           |
+| `channels.feishu.textChunkLimit`                              | Message chunk size                      | `2000`           |
+| `channels.feishu.mediaMaxMb`                                  | Media size limit                        | `30`             |
+| `channels.feishu.streaming`                                   | Enable streaming card output            | `true`           |
+| `channels.feishu.blockStreaming`                              | Enable block streaming                  | `true`           |
 
 ---
 

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -365,6 +365,8 @@ After approval, you can chat normally.
 
 When `requireMention: true`, enabling `firstMessageInTopicTrigger` lets OpenClaw auto-reply to the first message of each topic (where `root_id` and `parent_id` are both empty), while still ignoring most non-mention follow-up messages.
 
+> Note: This is intended for topic/thread-style groups. In regular non-topic groups, most messages may not carry `root_id`/`parent_id`, so enabling this flag can effectively relax mention-gating more broadly than expected.
+
 ```json5
 {
   channels: {

--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -371,6 +371,8 @@ openclaw pairing approve feishu <配对码>
 
 当 `requireMention: true` 时，开启 `firstMessageInTopicTrigger` 后，OpenClaw 会在每个 topic 的首条消息（`root_id` 与 `parent_id` 都为空）自动触发回复；其余大多数未 @ 的后续消息仍会被忽略，避免打扰。
 
+> 注意：该开关主要用于 topic/thread 话题群。在普通非话题群中，多数消息可能都不带 `root_id`/`parent_id`，开启后可能会比预期更广泛地放宽 @ 提及门槛。
+
 ```json5
 {
   channels: {

--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -329,6 +329,11 @@ openclaw pairing approve feishu <配对码>
 - `true` = 需要 @机器人才响应（默认）
 - `false` = 无需 @也响应
 
+**3. 话题首条消息触发**（`firstMessageInTopicTrigger`）：
+
+- `false` = 维持正常 @ 规则（默认）
+- `true` = 当群消息同时没有 `root_id` 和 `parent_id` 时，视为该 topic 的首条消息，即使未 @ 机器人也允许触发回复
+
 ---
 
 ## 群组配置示例
@@ -356,6 +361,25 @@ openclaw pairing approve feishu <配对码>
     feishu: {
       groups: {
         oc_xxx: { requireMention: false },
+      },
+    },
+  },
+}
+```
+
+### 客服话题群：仅自动回复每个 topic 的首条消息
+
+当 `requireMention: true` 时，开启 `firstMessageInTopicTrigger` 后，OpenClaw 会在每个 topic 的首条消息（`root_id` 与 `parent_id` 都为空）自动触发回复；其余大多数未 @ 的后续消息仍会被忽略，避免打扰。
+
+```json5
+{
+  channels: {
+    feishu: {
+      groups: {
+        oc_support_group: {
+          requireMention: true,
+          firstMessageInTopicTrigger: true,
+        },
       },
     },
   },
@@ -642,29 +666,31 @@ openclaw pairing list feishu
 
 主要选项：
 
-| 配置项                                            | 说明                              | 默认值           |
-| ------------------------------------------------- | --------------------------------- | ---------------- |
-| `channels.feishu.enabled`                         | 启用/禁用渠道                     | `true`           |
-| `channels.feishu.domain`                          | API 域名（`feishu` 或 `lark`）    | `feishu`         |
-| `channels.feishu.connectionMode`                  | 事件传输模式（websocket/webhook） | `websocket`      |
-| `channels.feishu.defaultAccount`                  | 出站路由默认账号 ID               | `default`        |
-| `channels.feishu.verificationToken`               | Webhook 模式必填                  | -                |
-| `channels.feishu.webhookPath`                     | Webhook 路由路径                  | `/feishu/events` |
-| `channels.feishu.webhookHost`                     | Webhook 监听地址                  | `127.0.0.1`      |
-| `channels.feishu.webhookPort`                     | Webhook 监听端口                  | `3000`           |
-| `channels.feishu.accounts.<id>.appId`             | 应用 App ID                       | -                |
-| `channels.feishu.accounts.<id>.appSecret`         | 应用 App Secret                   | -                |
-| `channels.feishu.accounts.<id>.domain`            | 单账号 API 域名覆盖               | `feishu`         |
-| `channels.feishu.dmPolicy`                        | 私聊策略                          | `pairing`        |
-| `channels.feishu.allowFrom`                       | 私聊白名单（open_id 列表）        | -                |
-| `channels.feishu.groupPolicy`                     | 群组策略                          | `open`           |
-| `channels.feishu.groupAllowFrom`                  | 群组白名单                        | -                |
-| `channels.feishu.groups.<chat_id>.requireMention` | 是否需要 @提及                    | `true`           |
-| `channels.feishu.groups.<chat_id>.enabled`        | 是否启用该群组                    | `true`           |
-| `channels.feishu.textChunkLimit`                  | 消息分块大小                      | `2000`           |
-| `channels.feishu.mediaMaxMb`                      | 媒体大小限制                      | `30`             |
-| `channels.feishu.streaming`                       | 启用流式卡片输出                  | `true`           |
-| `channels.feishu.blockStreaming`                  | 启用块级流式                      | `true`           |
+| 配置项                                                        | 说明                              | 默认值           |
+| ------------------------------------------------------------- | --------------------------------- | ---------------- |
+| `channels.feishu.enabled`                                     | 启用/禁用渠道                     | `true`           |
+| `channels.feishu.domain`                                      | API 域名（`feishu` 或 `lark`）    | `feishu`         |
+| `channels.feishu.connectionMode`                              | 事件传输模式（websocket/webhook） | `websocket`      |
+| `channels.feishu.defaultAccount`                              | 出站路由默认账号 ID               | `default`        |
+| `channels.feishu.verificationToken`                           | Webhook 模式必填                  | -                |
+| `channels.feishu.webhookPath`                                 | Webhook 路由路径                  | `/feishu/events` |
+| `channels.feishu.webhookHost`                                 | Webhook 监听地址                  | `127.0.0.1`      |
+| `channels.feishu.webhookPort`                                 | Webhook 监听端口                  | `3000`           |
+| `channels.feishu.accounts.<id>.appId`                         | 应用 App ID                       | -                |
+| `channels.feishu.accounts.<id>.appSecret`                     | 应用 App Secret                   | -                |
+| `channels.feishu.accounts.<id>.domain`                        | 单账号 API 域名覆盖               | `feishu`         |
+| `channels.feishu.dmPolicy`                                    | 私聊策略                          | `pairing`        |
+| `channels.feishu.allowFrom`                                   | 私聊白名单（open_id 列表）        | -                |
+| `channels.feishu.groupPolicy`                                 | 群组策略                          | `open`           |
+| `channels.feishu.groupAllowFrom`                              | 群组白名单                        | -                |
+| `channels.feishu.firstMessageInTopicTrigger`                  | 全局话题首条消息触发              | `false`          |
+| `channels.feishu.groups.<chat_id>.requireMention`             | 是否需要 @提及                    | `true`           |
+| `channels.feishu.groups.<chat_id>.firstMessageInTopicTrigger` | 群级话题首条消息触发              | 继承全局         |
+| `channels.feishu.groups.<chat_id>.enabled`                    | 是否启用该群组                    | `true`           |
+| `channels.feishu.textChunkLimit`                              | 消息分块大小                      | `2000`           |
+| `channels.feishu.mediaMaxMb`                                  | 媒体大小限制                      | `30`             |
+| `channels.feishu.streaming`                                   | 启用流式卡片输出                  | `true`           |
+| `channels.feishu.blockStreaming`                              | 启用块级流式                      | `true`           |
 
 ---
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1823,6 +1823,41 @@ describe("broadcast dispatch", () => {
     expect(mockCreateFeishuReplyDispatcher).not.toHaveBeenCalled();
   });
 
+  it("allows first topic message without mention when firstMessageInTopicTrigger=true", async () => {
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-topic-group": {
+              requireMention: true,
+              firstMessageInTopicTrigger: true,
+            },
+          },
+        },
+      },
+    } as unknown as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-sender" } },
+      message: {
+        message_id: "msg-topic-first-no-mention",
+        chat_id: "oc-topic-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "first topic message" }),
+      },
+    };
+
+    await handleFeishuMessage({
+      cfg,
+      event,
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledTimes(1);
+  });
+
   it("preserves single-agent dispatch when no broadcast config", async () => {
     const cfg: ClawdbotConfig = {
       channels: {

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1858,6 +1858,85 @@ describe("broadcast dispatch", () => {
     expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledTimes(1);
   });
 
+  it("rejects non-first topic messages without mention when firstMessageInTopicTrigger=true", async () => {
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-topic-group": {
+              requireMention: true,
+              firstMessageInTopicTrigger: true,
+            },
+          },
+        },
+      },
+    } as unknown as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-sender" } },
+      message: {
+        message_id: "msg-topic-follow-up-no-mention",
+        chat_id: "oc-topic-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "follow-up in thread" }),
+        root_id: "msg-root-123",
+        parent_id: "msg-root-123",
+      },
+    };
+
+    await handleFeishuMessage({
+      cfg,
+      event,
+      runtime: createRuntimeEnv(),
+    });
+
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+    expect(mockCreateFeishuReplyDispatcher).not.toHaveBeenCalled();
+  });
+
+  it("keeps one active broadcast dispatcher for first topic trigger messages", async () => {
+    const cfg: ClawdbotConfig = {
+      broadcast: { "oc-broadcast-group": ["susan", "main"] },
+      agents: { list: [{ id: "main" }, { id: "susan" }] },
+      channels: {
+        feishu: {
+          groups: {
+            "oc-broadcast-group": {
+              requireMention: true,
+              firstMessageInTopicTrigger: true,
+            },
+          },
+        },
+      },
+    } as unknown as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-sender" } },
+      message: {
+        message_id: "msg-broadcast-topic-first-no-mention",
+        chat_id: "oc-broadcast-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "first topic message" }),
+      },
+    };
+
+    await handleFeishuMessage({
+      cfg,
+      event,
+      runtime: createRuntimeEnv(),
+    });
+
+    // Both agents still receive context/inference in broadcast mode.
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(2);
+    // One active agent must own real Feishu reply dispatch.
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledTimes(1);
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "main" }),
+    );
+  });
+
   it("preserves single-agent dispatch when no broadcast config", async () => {
     const cfg: ClawdbotConfig = {
       channels: {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -989,6 +989,7 @@ export async function handleFeishuMessage(params: {
     : null;
 
   let requireMention = false; // DMs never require mention; groups may override below
+  let allowWithoutMention = false;
   if (isGroup) {
     if (groupConfig?.enabled === false) {
       log(`feishu[${account.accountId}]: group ${ctx.chatId} is disabled`);
@@ -1052,7 +1053,7 @@ export async function handleFeishuMessage(params: {
     const firstMessageInTopicTrigger =
       groupConfig?.firstMessageInTopicTrigger ?? feishuCfg?.firstMessageInTopicTrigger ?? false;
     const isFirstMessageInTopic = !ctx.rootId && !ctx.parentId;
-    const allowWithoutMention = firstMessageInTopicTrigger && isFirstMessageInTopic;
+    allowWithoutMention = firstMessageInTopicTrigger && isFirstMessageInTopic;
 
     if (requireMention && !ctx.mentionedBot && !allowWithoutMention) {
       log(`feishu[${account.accountId}]: message in group ${ctx.chatId} did not mention bot`);
@@ -1368,7 +1369,9 @@ export async function handleFeishuMessage(params: {
         ((cfg as Record<string, unknown>).broadcast as Record<string, unknown> | undefined)
           ?.strategy || "parallel";
       const activeAgentId =
-        ctx.mentionedBot || !requireMention ? normalizeAgentId(route.agentId) : null;
+        ctx.mentionedBot || !requireMention || allowWithoutMention
+          ? normalizeAgentId(route.agentId)
+          : null;
       const agentIds = (cfg.agents?.list ?? []).map((a: { id: string }) => normalizeAgentId(a.id));
       const hasKnownAgents = agentIds.length > 0;
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1049,7 +1049,12 @@ export async function handleFeishuMessage(params: {
       groupConfig,
     }));
 
-    if (requireMention && !ctx.mentionedBot) {
+    const firstMessageInTopicTrigger =
+      groupConfig?.firstMessageInTopicTrigger ?? feishuCfg?.firstMessageInTopicTrigger ?? false;
+    const isFirstMessageInTopic = !ctx.rootId && !ctx.parentId;
+    const allowWithoutMention = firstMessageInTopicTrigger && isFirstMessageInTopic;
+
+    if (requireMention && !ctx.mentionedBot && !allowWithoutMention) {
       log(`feishu[${account.accountId}]: message in group ${ctx.chatId} did not mention bot`);
       // Record to pending history for non-broadcast groups only. For broadcast groups,
       // the mentioned handler's broadcast dispatch writes the turn directly into all
@@ -1069,6 +1074,11 @@ export async function handleFeishuMessage(params: {
         });
       }
       return;
+    }
+    if (requireMention && !ctx.mentionedBot && allowWithoutMention) {
+      log(
+        `feishu[${account.accountId}]: first topic message trigger enabled for group ${ctx.chatId}`,
+      );
     }
   } else {
   }

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -121,6 +121,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
           items: { oneOf: [{ type: "string" }, { type: "number" }] },
         },
         requireMention: { type: "boolean" },
+        firstMessageInTopicTrigger: { type: "boolean" },
         groupSessionScope: {
           type: "string",
           enum: ["group", "group_sender", "group_topic", "group_topic_sender"],
@@ -149,6 +150,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
               webhookHost: { type: "string" },
               webhookPath: { type: "string" },
               webhookPort: { type: "integer", minimum: 1 },
+              firstMessageInTopicTrigger: { type: "boolean" },
             },
           },
         },

--- a/extensions/feishu/src/config-schema.test.ts
+++ b/extensions/feishu/src/config-schema.test.ts
@@ -137,6 +137,34 @@ describe("FeishuConfigSchema replyInThread", () => {
   });
 });
 
+describe("FeishuConfigSchema firstMessageInTopicTrigger", () => {
+  it("accepts firstMessageInTopicTrigger at top level", () => {
+    const result = FeishuConfigSchema.parse({ firstMessageInTopicTrigger: true });
+    expect(result.firstMessageInTopicTrigger).toBe(true);
+  });
+
+  it("accepts firstMessageInTopicTrigger in group config", () => {
+    const result = FeishuGroupSchema.parse({ firstMessageInTopicTrigger: true });
+    expect(result.firstMessageInTopicTrigger).toBe(true);
+  });
+
+  it("accepts firstMessageInTopicTrigger in account config", () => {
+    const result = FeishuConfigSchema.parse({
+      accounts: {
+        main: { firstMessageInTopicTrigger: true },
+      },
+    });
+    expect(result.accounts?.main?.firstMessageInTopicTrigger).toBe(true);
+  });
+
+  it("rejects invalid firstMessageInTopicTrigger value", () => {
+    const result = FeishuConfigSchema.safeParse({
+      firstMessageInTopicTrigger: "enabled",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
 describe("FeishuConfigSchema optimization flags", () => {
   it("defaults top-level typingIndicator and resolveSenderNames to true", () => {
     const result = FeishuConfigSchema.parse({});

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -131,6 +131,7 @@ const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
 export const FeishuGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
+    firstMessageInTopicTrigger: z.boolean().optional(),
     tools: ToolPolicySchema,
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
@@ -154,6 +155,7 @@ const FeishuSharedConfigShape = {
   groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   groupSenderAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
   requireMention: z.boolean().optional(),
+  firstMessageInTopicTrigger: z.boolean().optional(),
   groups: z.record(z.string(), FeishuGroupSchema.optional()).optional(),
   historyLimit: z.number().int().min(0).optional(),
   dmHistoryLimit: z.number().int().min(0).optional(),


### PR DESCRIPTION
## Summary
- add `firstMessageInTopicTrigger` to Feishu config schema + channel metadata, with support at global/account/group scope
- when `requireMention=true`, allow one auto-reply only for the first message in a topic (`root_id` and `parent_id` are both empty)
- keep existing mention-gating behavior for follow-up topic messages and non-first-topic traffic
- add schema/bot tests and docs updates (EN + zh-CN)

## Why
At MiniMax, OpenClaw is being used to replace part of cloud customer-service operations.

In Feishu topic groups, requiring `@bot` for every first customer message is operationally expensive, but removing mention gating entirely can cause over-replies from multiple participants.

This change introduces a narrow trigger to detect a new topic reliably and respond once, so we can keep normal mention gating for follow-up traffic while still handling new customer conversations automatically.

## User-visible behavior
- default behavior is unchanged (`firstMessageInTopicTrigger` defaults to `false`)
- if enabled and `requireMention=true`, first topic messages can trigger reply without `@`
- non-first topic messages still require `@` when mention gating is enabled

## Compatibility / migration
- backward compatible: **Yes**
- config migration required: **No**
- optional rollout: enable `firstMessageInTopicTrigger` per target group first, then expand if needed

## Risk and mitigation
- Risk: false-positive first-topic detection could allow an unintended no-mention reply
  - Mitigation: trigger is strictly scoped to messages where both `root_id` and `parent_id` are empty
- Risk: behavior change in busy support groups
  - Mitigation: flag is opt-in and can be enabled per group rather than globally

## Rollback
- immediate rollback path: set `firstMessageInTopicTrigger: false` (global/account/group)
- hard rollback path: revert this PR commit

## Test plan
- [x] `pnpm test extensions/feishu/src/config-schema.test.ts extensions/feishu/src/bot.test.ts`