### PR TITLE
feat(commands): add /crons for cron listing and bulk management

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -75,6 +75,7 @@ Text + native (when enabled):
 - `/status` (show current status; includes provider usage/quota for the current model provider when available)
 - `/allowlist` (list/add/remove allowlist entries)
 - `/approve <id> allow-once|allow-always|deny` (resolve exec approval prompts)
+- `/crons [all|delete|delete-inactive]` (alias: `/cron`) (list active jobs, list all including inactive, or bulk-delete jobs)
 - `/context [list|detail|json]` (explain “context”; `detail` shows per-file + per-tool + per-skill + system prompt size)
 - `/export-session [path]` (alias: `/export`) (export current session to HTML with full system prompt)
 - `/whoami` (show your sender id; alias: `/id`)

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -189,6 +189,21 @@ function buildChatCommands(): ChatCommandDefinition[] {
       category: "management",
     }),
     defineChatCommand({
+      key: "crons",
+      nativeName: "crons",
+      description: "List and bulk-manage cron jobs.",
+      textAlias: "/crons",
+      category: "management",
+      args: [
+        {
+          name: "action",
+          description: "all | delete | delete-inactive",
+          type: "string",
+          choices: ["all", "delete", "delete-inactive"],
+        },
+      ],
+    }),
+    defineChatCommand({
       key: "context",
       nativeName: "context",
       description: "Explain how context is built and used.",
@@ -738,6 +753,7 @@ function buildChatCommands(): ChatCommandDefinition[] {
   ];
 
   registerAlias(commands, "whoami", "/id");
+  registerAlias(commands, "crons", "/cron");
   registerAlias(commands, "think", "/thinking", "/t");
   registerAlias(commands, "verbose", "/v");
   registerAlias(commands, "reasoning", "/reason");

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -271,6 +271,10 @@ describe("commands registry", () => {
   it("normalizes dock command aliases", () => {
     expect(normalizeCommandBody("/dock_telegram")).toBe("/dock-telegram");
   });
+
+  it("normalizes /cron alias to /crons", () => {
+    expect(normalizeCommandBody("/cron all")).toBe("/crons all");
+  });
 });
 
 describe("commands registry args", () => {

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -10,6 +10,7 @@ import { handleApproveCommand } from "./commands-approve.js";
 import { handleBashCommand } from "./commands-bash.js";
 import { handleCompactCommand } from "./commands-compact.js";
 import { handleConfigCommand, handleDebugCommand } from "./commands-config.js";
+import { handleCronsCommand } from "./commands-crons.js";
 import {
   handleCommandsListCommand,
   handleContextCommand,
@@ -147,6 +148,7 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
       handleStatusCommand,
       handleAllowlistCommand,
       handleApproveCommand,
+      handleCronsCommand,
       handleContextCommand,
       handleExportSessionCommand,
       handleWhoamiCommand,

--- a/src/auto-reply/reply/commands-crons.test.ts
+++ b/src/auto-reply/reply/commands-crons.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import type { CronJob } from "../../cron/types.js";
+import type { MsgContext } from "../templating.js";
+import { buildCommandContext, handleCommands } from "./commands.js";
+import { buildCommandTestParams } from "./commands.test-harness.js";
+
+const callGatewayMock = vi.hoisted(() => vi.fn());
+vi.mock("../../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+function makeCronJob(overrides: Partial<CronJob> = {}): CronJob {
+  return {
+    id: overrides.id ?? "job-1",
+    name: overrides.name ?? "Daily Check",
+    enabled: overrides.enabled ?? true,
+    createdAtMs: overrides.createdAtMs ?? 1,
+    updatedAtMs: overrides.updatedAtMs ?? 1,
+    schedule: overrides.schedule ?? { kind: "every", everyMs: 3_600_000 },
+    sessionTarget: overrides.sessionTarget ?? "main",
+    wakeMode: overrides.wakeMode ?? "now",
+    payload: overrides.payload ?? { kind: "systemEvent", text: "Check inbox" },
+    state: overrides.state ?? { nextRunAtMs: Date.parse("2026-03-03T13:30:00.000Z") },
+  };
+}
+
+function buildParams(commandBody: string, ctxOverrides?: Partial<MsgContext>) {
+  const cfg = {
+    commands: { text: true },
+    channels: { whatsapp: { allowFrom: ["*"] } },
+  } as OpenClawConfig;
+  return buildCommandTestParams(commandBody, cfg, ctxOverrides);
+}
+
+describe("/crons command", () => {
+  beforeEach(() => {
+    callGatewayMock.mockReset();
+  });
+
+  it("lists active cron jobs", async () => {
+    const fast = makeCronJob({ id: "fast", name: "Morning Prep" });
+    const slow = makeCronJob({ id: "slow", name: "Nightly Wrap" });
+    callGatewayMock.mockResolvedValueOnce({
+      jobs: [fast, slow],
+      hasMore: false,
+      nextOffset: null,
+    });
+
+    const result = await handleCommands(buildParams("/crons"));
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Active cron jobs (2):");
+    expect(result.reply?.text).toContain("1. Morning Prep");
+    expect(result.reply?.text).toContain("Summary:");
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "cron.list",
+        params: expect.objectContaining({
+          enabled: "enabled",
+          sortBy: "nextRunAtMs",
+          sortDir: "asc",
+          limit: 200,
+          offset: 0,
+        }),
+      }),
+    );
+  });
+
+  it("lists all cron jobs (including inactive)", async () => {
+    const active = makeCronJob({ id: "a", name: "Active", enabled: true });
+    const inactive = makeCronJob({ id: "b", name: "Inactive", enabled: false, state: {} });
+    callGatewayMock.mockResolvedValueOnce({
+      jobs: [active, inactive],
+      hasMore: false,
+      nextOffset: null,
+    });
+
+    const result = await handleCommands(buildParams("/crons all"));
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Cron jobs (including inactive) (2):");
+    expect(result.reply?.text).toContain("Inactive (inactive)");
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "cron.list",
+        params: expect.objectContaining({ enabled: "all" }),
+      }),
+    );
+  });
+
+  it("paginates cron list responses so /crons is uncapped", async () => {
+    callGatewayMock
+      .mockResolvedValueOnce({
+        jobs: [makeCronJob({ id: "one", name: "First" })],
+        hasMore: true,
+        nextOffset: 1,
+      })
+      .mockResolvedValueOnce({
+        jobs: [makeCronJob({ id: "two", name: "Second" })],
+        hasMore: false,
+        nextOffset: null,
+      });
+
+    const result = await handleCommands(buildParams("/crons"));
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("1. First");
+    expect(result.reply?.text).toContain("2. Second");
+    expect(callGatewayMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: "cron.list",
+        params: expect.objectContaining({ offset: 0 }),
+      }),
+    );
+    expect(callGatewayMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: "cron.list",
+        params: expect.objectContaining({ offset: 1 }),
+      }),
+    );
+  });
+
+  it("deletes all cron jobs", async () => {
+    const jobs = [makeCronJob({ id: "a" }), makeCronJob({ id: "b" })];
+    callGatewayMock
+      .mockResolvedValueOnce({ jobs, hasMore: false, nextOffset: null })
+      .mockResolvedValueOnce({ removed: true })
+      .mockResolvedValueOnce({ removed: true });
+
+    const result = await handleCommands(buildParams("/crons delete"));
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toBe("✅ Deleted 2 cron jobs.");
+    expect(callGatewayMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: "cron.list",
+        params: expect.objectContaining({ enabled: "all" }),
+      }),
+    );
+    expect(callGatewayMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ method: "cron.remove", params: { id: "a" } }),
+    );
+    expect(callGatewayMock).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ method: "cron.remove", params: { id: "b" } }),
+    );
+  });
+
+  it("deletes inactive cron jobs only", async () => {
+    const inactive = [
+      makeCronJob({ id: "x", enabled: false }),
+      makeCronJob({ id: "y", enabled: false }),
+    ];
+    callGatewayMock
+      .mockResolvedValueOnce({ jobs: inactive, hasMore: false, nextOffset: null })
+      .mockResolvedValueOnce({ removed: true })
+      .mockResolvedValueOnce({ removed: true });
+
+    const result = await handleCommands(buildParams("/crons delete-inactive"));
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toBe("✅ Deleted 2 inactive cron jobs.");
+    expect(callGatewayMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: "cron.list",
+        params: expect.objectContaining({ enabled: "disabled" }),
+      }),
+    );
+  });
+
+  it("returns usage for unsupported args", async () => {
+    const result = await handleCommands(buildParams("/crons nope"));
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toBe("Usage: /crons [all|delete|delete-inactive]");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores unauthorized senders", async () => {
+    const params = buildParams("/crons");
+    params.command.isAuthorizedSender = false;
+
+    const result = await handleCommands(params);
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply).toBeUndefined();
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("requires operator.admin for gateway clients", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildCommandTestParams("/crons", cfg, {
+      Provider: "webchat",
+      Surface: "webchat",
+      GatewayClientScopes: ["operator.read"],
+    });
+    params.command = buildCommandContext({
+      ctx: params.ctx,
+      cfg,
+      isGroup: false,
+      triggerBodyNormalized: "/crons",
+      commandAuthorized: true,
+    });
+    params.command.isAuthorizedSender = true;
+
+    const result = await handleCommands(params);
+
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("requires operator.admin");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/reply/commands-crons.ts
+++ b/src/auto-reply/reply/commands-crons.ts
@@ -1,0 +1,311 @@
+import type { CronJob } from "../../cron/types.js";
+import { callGateway } from "../../gateway/call.js";
+import { logVerbose } from "../../globals.js";
+import { formatDurationHuman } from "../../infra/format-time/format-duration.ts";
+import { isInternalMessageChannel } from "../../utils/message-channel.js";
+import { rejectUnauthorizedCommand } from "./command-gates.js";
+import type { CommandHandler, CommandHandlerResult } from "./commands-types.js";
+
+const COMMAND = "/crons";
+const USAGE_TEXT = "Usage: /crons [all|delete|delete-inactive]";
+const EMPTY_STATE_TEXT = "No cron jobs scheduled or active.";
+const CRON_LIST_LIMIT = 200;
+
+type CronsAction = "list" | "all" | "delete" | "delete-inactive";
+
+type ParsedCronsCommand = { ok: true; action: CronsAction } | { ok: false; error: string } | null;
+
+type CronListPage = {
+  jobs?: CronJob[];
+  hasMore?: boolean;
+  nextOffset?: number | null;
+};
+
+function parseCronsCommand(normalized: string): ParsedCronsCommand {
+  const trimmed = normalized.trim();
+  if (trimmed === COMMAND) {
+    return { ok: true, action: "list" };
+  }
+  if (!trimmed.startsWith(`${COMMAND} `)) {
+    return null;
+  }
+
+  const tokens = trimmed.slice(COMMAND.length).trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) {
+    return { ok: true, action: "list" };
+  }
+
+  const [action] = tokens;
+  if (tokens.length > 1) {
+    return { ok: false, error: USAGE_TEXT };
+  }
+
+  if (action === "list") {
+    return { ok: true, action: "list" };
+  }
+  if (action === "all") {
+    return { ok: true, action: "all" };
+  }
+  if (action === "delete") {
+    return { ok: true, action: "delete" };
+  }
+  if (action === "delete-inactive") {
+    return { ok: true, action: "delete-inactive" };
+  }
+
+  return { ok: false, error: USAGE_TEXT };
+}
+
+function truncateSummary(text: string, maxLength = 80): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return "(no details)";
+  }
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxLength - 1)).trimEnd()}…`;
+}
+
+function summarizeSchedule(job: CronJob): string {
+  const schedule = job.schedule;
+  if (schedule.kind === "at") {
+    return "one-time";
+  }
+  if (schedule.kind === "every") {
+    return `every ${formatDurationHuman(schedule.everyMs)}`;
+  }
+  const tzSuffix = schedule.tz ? ` (${schedule.tz})` : "";
+  return `cron ${schedule.expr}${tzSuffix}`;
+}
+
+function summarizePayload(job: CronJob): string {
+  if (job.description?.trim()) {
+    return truncateSummary(job.description);
+  }
+
+  if (job.payload.kind === "systemEvent") {
+    return `reminder: ${truncateSummary(job.payload.text)}`;
+  }
+
+  return `task: ${truncateSummary(job.payload.message)}`;
+}
+
+function formatLocalTimestamp(timestampMs: number | undefined): string {
+  if (typeof timestampMs !== "number" || !Number.isFinite(timestampMs)) {
+    return "Not scheduled";
+  }
+
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+    timeZoneName: "short",
+  }).format(new Date(timestampMs));
+}
+
+function formatCronListReply(params: { jobs: CronJob[]; includeDisabled: boolean }): string {
+  const { jobs, includeDisabled } = params;
+  if (jobs.length === 0) {
+    return EMPTY_STATE_TEXT;
+  }
+
+  const heading = includeDisabled
+    ? `Cron jobs (including inactive) (${jobs.length}):`
+    : `Active cron jobs (${jobs.length}):`;
+
+  const lines = jobs.map((job, index) => {
+    const name = job.enabled ? job.name : `${job.name} (inactive)`;
+    const nextRunLabel = job.enabled ? formatLocalTimestamp(job.state.nextRunAtMs) : "Inactive";
+    const summary = `${summarizeSchedule(job)} • ${summarizePayload(job)}`;
+
+    return `${index + 1}. ${name}\n   Next: ${nextRunLabel}\n   Summary: ${summary}`;
+  });
+
+  return `${heading}\n\n${lines.join("\n\n")}`;
+}
+
+async function listCronJobs(params: {
+  enabled: "enabled" | "all" | "disabled";
+}): Promise<CronJob[]> {
+  const allJobs: CronJob[] = [];
+  let offset = 0;
+
+  for (let page = 0; page < 10_000; page += 1) {
+    const response = await callGateway<CronListPage>({
+      method: "cron.list",
+      params: {
+        enabled: params.enabled,
+        sortBy: "nextRunAtMs",
+        sortDir: "asc",
+        offset,
+        limit: CRON_LIST_LIMIT,
+      },
+    });
+
+    const jobs = Array.isArray(response?.jobs) ? response.jobs : [];
+    allJobs.push(...jobs);
+
+    if (response?.hasMore !== true) {
+      break;
+    }
+
+    const nextOffset =
+      typeof response.nextOffset === "number" && Number.isFinite(response.nextOffset)
+        ? response.nextOffset
+        : null;
+    if (nextOffset === null || nextOffset <= offset || jobs.length === 0) {
+      break;
+    }
+    offset = nextOffset;
+  }
+
+  return allJobs;
+}
+
+async function removeCronJobs(jobs: CronJob[]): Promise<{
+  removedCount: number;
+  failed: Array<{ id: string; error: string }>;
+}> {
+  let removedCount = 0;
+  const failed: Array<{ id: string; error: string }> = [];
+
+  for (const job of jobs) {
+    try {
+      const result = await callGateway<{ removed?: boolean }>({
+        method: "cron.remove",
+        params: { id: job.id },
+      });
+      if (result?.removed) {
+        removedCount += 1;
+      } else {
+        failed.push({ id: job.id, error: "not removed" });
+      }
+    } catch (err) {
+      failed.push({ id: job.id, error: err instanceof Error ? err.message : String(err) });
+    }
+  }
+
+  return { removedCount, failed };
+}
+
+function formatDeletionReply(params: {
+  removedCount: number;
+  failed: Array<{ id: string; error: string }>;
+  label: "cron jobs" | "inactive cron jobs";
+}): string {
+  const { removedCount, failed, label } = params;
+  if (failed.length === 0) {
+    return `✅ Deleted ${removedCount} ${label}.`;
+  }
+
+  const failureSummary = failed
+    .slice(0, 3)
+    .map((entry) => `${entry.id} (${entry.error})`)
+    .join(", ");
+  const overflow = failed.length > 3 ? ` (+${failed.length - 3} more)` : "";
+
+  return `⚠️ Deleted ${removedCount} ${label}, failed ${failed.length}: ${failureSummary}${overflow}`;
+}
+
+function rejectNonAdminGatewayClient(
+  params: Parameters<CommandHandler>[0],
+): CommandHandlerResult | null {
+  if (!isInternalMessageChannel(params.command.channel)) {
+    return null;
+  }
+  const scopes = params.ctx.GatewayClientScopes ?? [];
+  if (scopes.includes("operator.admin")) {
+    return null;
+  }
+  logVerbose("Ignoring /crons from gateway client missing operator.admin.");
+  return {
+    shouldContinue: false,
+    reply: {
+      text: "❌ /crons requires operator.admin for gateway clients.",
+    },
+  };
+}
+
+export const handleCronsCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+
+  const parsed = parseCronsCommand(params.command.commandBodyNormalized);
+  if (!parsed) {
+    return null;
+  }
+
+  const unauthorized = rejectUnauthorizedCommand(params, COMMAND);
+  if (unauthorized) {
+    return unauthorized;
+  }
+
+  const adminRequired = rejectNonAdminGatewayClient(params);
+  if (adminRequired) {
+    return adminRequired;
+  }
+
+  if (!parsed.ok) {
+    return {
+      shouldContinue: false,
+      reply: { text: parsed.error },
+    };
+  }
+
+  try {
+    if (parsed.action === "list" || parsed.action === "all") {
+      const includeDisabled = parsed.action === "all";
+      const jobs = await listCronJobs({ enabled: includeDisabled ? "all" : "enabled" });
+      return {
+        shouldContinue: false,
+        reply: {
+          text: formatCronListReply({ jobs, includeDisabled }),
+        },
+      };
+    }
+
+    if (parsed.action === "delete") {
+      const jobs = await listCronJobs({ enabled: "all" });
+      if (jobs.length === 0) {
+        return {
+          shouldContinue: false,
+          reply: { text: EMPTY_STATE_TEXT },
+        };
+      }
+      const { removedCount, failed } = await removeCronJobs(jobs);
+      return {
+        shouldContinue: false,
+        reply: {
+          text: formatDeletionReply({ removedCount, failed, label: "cron jobs" }),
+        },
+      };
+    }
+
+    const inactiveJobs = await listCronJobs({ enabled: "disabled" });
+    if (inactiveJobs.length === 0) {
+      return {
+        shouldContinue: false,
+        reply: { text: "No inactive cron jobs to delete." },
+      };
+    }
+    const { removedCount, failed } = await removeCronJobs(inactiveJobs);
+    return {
+      shouldContinue: false,
+      reply: {
+        text: formatDeletionReply({ removedCount, failed, label: "inactive cron jobs" }),
+      },
+    };
+  } catch (err) {
+    return {
+      shouldContinue: false,
+      reply: {
+        text: `❌ Failed to process /crons: ${err instanceof Error ? err.message : String(err)}`,
+      },
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- add a new chat command `/crons` (alias `/cron`) to manage cron jobs from chat
- support:
  - `/crons` -> list enabled cron jobs
  - `/crons all` -> list enabled + inactive cron jobs
  - `/crons delete` -> delete all cron jobs
  - `/crons delete-inactive` -> delete only inactive cron jobs
- list output now includes:
  - cron name
  - next runtime in local time
  - phrase-style summary
- use empty-state text exactly: `No cron jobs scheduled or active.`
- enforce command authorization and require `operator.admin` for internal gateway clients

## Docs
- documented `/crons [all|delete|delete-inactive]` in slash commands docs

## Tests
- added `src/auto-reply/reply/commands-crons.test.ts`
- updated command registry tests for `/cron` alias normalization
- slash-command docs coverage test passes with new command docs

## Verification
- `pnpm build`
- `pnpm check`
- `env -u OPENCLAW_LAUNCHD_LABEL -u OPENCLAW_SYSTEMD_UNIT -u OPENCLAW_SERVICE_MARKER pnpm test`

## AI-assisted disclosure
- [x] AI-assisted PR
- [x] Fully tested locally
- [x] I understand what the code does
