### PR TITLE
fix(telegram): forward audioAsVoice flag in outbound adapter for voice bubbles

### DIFF
--- a/src/channels/plugins/outbound/telegram.test.ts
+++ b/src/channels/plugins/outbound/telegram.test.ts
@@ -139,4 +139,65 @@ describe("telegramOutbound", () => {
     expect(secondCallOpts?.buttons).toBeUndefined();
     expect(result).toEqual({ channel: "telegram", messageId: "tg-2", chatId: "123" });
   });
+
+  it("forwards audioAsVoice as asVoice to send for voice bubble delivery", async () => {
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "tg-voice-1", chatId: "123" });
+    const sendPayload = telegramOutbound.sendPayload;
+    expect(sendPayload).toBeDefined();
+
+    const payload: ReplyPayload = {
+      text: "voice caption",
+      mediaUrl: "https://example.com/voice.opus",
+      audioAsVoice: true,
+    };
+
+    await sendPayload!({
+      cfg: {},
+      to: "123",
+      text: "",
+      payload,
+      accountId: "default",
+      deps: { sendTelegram },
+    });
+
+    expect(sendTelegram).toHaveBeenCalledTimes(1);
+    expect(sendTelegram).toHaveBeenCalledWith(
+      "123",
+      "voice caption",
+      expect.objectContaining({
+        asVoice: true,
+        mediaUrl: "https://example.com/voice.opus",
+      }),
+    );
+  });
+
+  it("does not set asVoice when audioAsVoice is absent", async () => {
+    const sendTelegram = vi.fn().mockResolvedValue({ messageId: "tg-audio-1", chatId: "123" });
+    const sendPayload = telegramOutbound.sendPayload;
+    expect(sendPayload).toBeDefined();
+
+    const payload: ReplyPayload = {
+      text: "audio caption",
+      mediaUrl: "https://example.com/audio.mp3",
+    };
+
+    await sendPayload!({
+      cfg: {},
+      to: "123",
+      text: "",
+      payload,
+      accountId: "default",
+      deps: { sendTelegram },
+    });
+
+    expect(sendTelegram).toHaveBeenCalledTimes(1);
+    expect(sendTelegram).toHaveBeenCalledWith(
+      "123",
+      "audio caption",
+      expect.objectContaining({
+        asVoice: false,
+        mediaUrl: "https://example.com/audio.mp3",
+      }),
+    );
+  });
 });

--- a/src/channels/plugins/outbound/telegram.ts
+++ b/src/channels/plugins/outbound/telegram.ts
@@ -98,6 +98,7 @@ export const telegramOutbound: ChannelOutboundAdapter = {
       ...contextOpts,
       quoteText,
       mediaLocalRoots,
+      asVoice: payload.audioAsVoice === true,
     };
 
     if (mediaUrls.length === 0) {


### PR DESCRIPTION
## Summary

- Problem: When TTS generates audio for Telegram, voice messages display as audio file cards (rectangular player) instead of native voice bubbles (round waveform).
- Why it matters: The TTS pipeline correctly sets `audioAsVoice: true` on the reply payload, but the Telegram outbound adapter drops this flag, so `sendMessageTelegram` never receives `asVoice` and defaults to `sendAudio` instead of `sendVoice`.
- What changed: Added `asVoice: payload.audioAsVoice === true` to `payloadOpts` in the Telegram outbound adapter's `sendPayload` method, completing the data flow: `payload.audioAsVoice` -> `payloadOpts.asVoice` -> `sendMessageTelegram(opts.asVoice)` -> `resolveTelegramVoiceSend({ wantsVoice: true })` -> Telegram `sendVoice` API.
- What did NOT change (scope boundary): No changes to TTS pipeline, voice compatibility detection, or `sendMessageTelegram` internals. Only the adapter boundary is fixed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #11654

## User-visible / Behavior Changes

- TTS-generated audio sent to Telegram via the outbound adapter now displays as native voice bubbles (round waveform) instead of audio file cards, when the audio format is voice-compatible (OGG/Opus, MP3, M4A).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No` — same Telegram API, just `sendVoice` instead of `sendAudio`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + Vitest
- Integration/channel: Telegram

### Steps

1. Enable TTS with a provider (e.g. ElevenLabs)
2. Send a voice message to the bot on Telegram
3. Observe the response: should display as voice bubble, not audio card

### Expected

- Voice messages appear as round waveform voice bubbles in Telegram.

### Actual

- All 6 tests pass, including 2 new tests verifying `asVoice` passthrough when `audioAsVoice=true` and absence when not set.

## Evidence

- [x] Failing test/log before + passing after

## Human Verification (required)

- Verified scenarios: `pnpm test src/channels/plugins/outbound/telegram.test.ts` — 6/6 pass
- Edge cases checked: `audioAsVoice=true` passes `asVoice: true`; absent/false `audioAsVoice` passes `asVoice: false`
- What you did **not** verify: live Telegram delivery with real TTS audio

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this PR commit.
- Files/config to restore: `src/channels/plugins/outbound/telegram.ts`
- Known bad symptoms reviewers should watch for: Audio files that should display as file cards appearing as voice bubbles.

## Risks and Mitigations

- Risk: Non-voice-compatible audio files could be sent with `asVoice: true` if the upstream payload incorrectly sets `audioAsVoice`.
  - Mitigation: `resolveTelegramVoiceSend` already checks voice compatibility (OGG/Opus, MP3, M4A) and falls back to `sendAudio` for incompatible formats, with a log warning.

Made with [Cursor](https://cursor.com)