### PR TITLE
fix(systemd): ensure stdout is checked when stderr is polluted by execFileUtf8 fallback

### DIFF
--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -90,6 +90,19 @@ describe("isSystemdServiceEnabled", () => {
       "systemctl is-enabled unavailable: Failed to connect to bus",
     );
   });
+
+  it("returns false when systemctl reports not-found with empty stderr (execFileUtf8 fallback)", async () => {
+    const { isSystemdServiceEnabled } = await import("./systemd.js");
+    execFileMock.mockImplementationOnce((_cmd, _args, _opts, cb) => {
+      // Simulates the bug: exit code 4, stdout="not-found", stderr="" (empty)
+      // execFileUtf8 falls back to e.message for stderr when real stderr is empty
+      const err = new Error("Command failed: systemctl --user is-enabled openclaw-gateway.service") as Error & { code?: number };
+      err.code = 4;
+      cb(err, "not-found\n", "");
+    });
+    const result = await isSystemdServiceEnabled({ env: {} });
+    expect(result).toBe(false);
+  });
 });
 
 describe("systemd runtime parsing", () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -143,7 +143,9 @@ async function execSystemctl(
 }
 
 function readSystemctlDetail(result: { stdout: string; stderr: string }): string {
-  return (result.stderr || result.stdout || "").trim();
+  // Concatenate both fields to ensure stdout is never shadowed by synthetic stderr
+  // (e.g., when execFileUtf8 falls back to e.message for empty stderr)
+  return `${result.stderr} ${result.stdout}`.trim();
 }
 
 function isSystemctlMissing(detail: string): boolean {


### PR DESCRIPTION
When systemctl exits with a non-zero code but empty stderr, execFileUtf8 falls back to Node.js' error message for stderr. This caused readSystemctlDetail to miss the actual status in stdout (e.g., 'not-found').

The fix concatenates stderr and stdout instead of using || short-circuit, matching the pattern already used in isSystemdUserServiceAvailable().

Fixes #33020

**Testing:**
- Added test case for the specific bug scenario
- All 20 tests pass