### PR TITLE
fix(auto-reply): trim static thread metadata in inbound context (#33042)

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -331,4 +331,64 @@ describe("buildInboundUserContextPrefix", () => {
     const conversationInfo = parseConversationInfoPayload(text);
     expect(conversationInfo["sender"]).toBe("user@example.com");
   });
+
+  it("drops static thread metadata in threaded conversations and keeps per-message delta", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      ConversationLabel: "slack-team",
+      GroupSubject: "#all-slack",
+      ThreadLabel: "Slack thread #all-slack: subject",
+      MessageThreadId: "1772490038.636569",
+      MessageSid: "1772543223.976569",
+      ReplyToId: "1772490038.636569",
+      SenderId: "U123",
+      SenderName: "Alice",
+      WasMentioned: true,
+      Timestamp: Date.UTC(2026, 2, 3, 13, 7),
+    } as TemplateContext);
+
+    const conversationInfo = parseConversationInfoPayload(text);
+
+    // Static thread-level descriptors should be omitted to avoid repetition.
+    expect(conversationInfo["conversation_label"]).toBeUndefined();
+    expect(conversationInfo["group_subject"]).toBeUndefined();
+    expect(conversationInfo["thread_label"]).toBeUndefined();
+    expect(conversationInfo["topic_id"]).toBeUndefined();
+
+    // Per-message identifiers and dynamic flags should still be present.
+    expect(conversationInfo["message_id"]).toBe("1772543223.976569");
+    expect(conversationInfo["reply_to_id"]).toBe("1772490038.636569");
+    expect(conversationInfo["sender_id"]).toBe("U123");
+    expect(conversationInfo["sender"]).toBe("Alice");
+    expect(conversationInfo["was_mentioned"]).toBe(true);
+    expect(conversationInfo["timestamp"]).toEqual(expect.any(String));
+  });
+
+  it("keeps is_forum flag for threaded conversations even when static metadata is trimmed", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "group",
+      ConversationLabel: "telegram-forum",
+      GroupSubject: "#forum",
+      ThreadLabel: "Telegram topic: subject",
+      // ThreadLabel-only path (no MessageThreadId) still counts as threaded.
+      MessageSid: "777777.123",
+      SenderId: "user-1",
+      IsForum: true,
+      WasMentioned: true,
+    } as TemplateContext);
+
+    const conversationInfo = parseConversationInfoPayload(text);
+
+    // Static thread descriptors are still omitted.
+    expect(conversationInfo["conversation_label"]).toBeUndefined();
+    expect(conversationInfo["group_subject"]).toBeUndefined();
+    expect(conversationInfo["thread_label"]).toBeUndefined();
+    expect(conversationInfo["topic_id"]).toBeUndefined();
+
+    // Forum flag should be preserved for Telegram forum topics.
+    expect(conversationInfo["is_forum"]).toBe(true);
+    expect(conversationInfo["message_id"]).toBe("777777.123");
+    expect(conversationInfo["sender_id"]).toBe("user-1");
+    expect(conversationInfo["was_mentioned"]).toBe(true);
+  });
 });

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -86,6 +86,8 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
   const directChannelValue = resolveInboundChannel(ctx);
+  const isThreadConversation =
+    ctx.MessageThreadId != null || Boolean(safeTrim(ctx.ThreadLabel));
   const includeDirectConversationInfo = Boolean(
     directChannelValue && directChannelValue !== "webchat",
   );
@@ -124,12 +126,35 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
         ? ctx.InboundHistory.length
         : undefined,
   };
-  if (Object.values(conversationInfo).some((v) => v !== undefined)) {
+
+  // For threaded conversations (Slack/Discord/Telegram topics, etc.), avoid repeating large
+  // static metadata blocks on every turn. Most of the high-cardinality fields
+  // (conversation_label, group_subject, thread_label, topic_id, etc.) stay constant across
+  // all messages in the thread. Keep only the per-message identifiers and dynamic flags
+  // in the untrusted metadata block to reduce token bloat.
+  const effectiveConversationInfo = isThreadConversation
+    ? {
+        message_id: conversationInfo.message_id,
+        reply_to_id: conversationInfo.reply_to_id,
+        sender_id: conversationInfo.sender_id,
+        sender: conversationInfo.sender,
+        timestamp: conversationInfo.timestamp,
+        is_forum: conversationInfo.is_forum,
+        is_group_chat: conversationInfo.is_group_chat,
+        was_mentioned: conversationInfo.was_mentioned,
+        has_reply_context: conversationInfo.has_reply_context,
+        has_forwarded_context: conversationInfo.has_forwarded_context,
+        has_thread_starter: conversationInfo.has_thread_starter,
+        history_count: conversationInfo.history_count,
+      }
+    : conversationInfo;
+
+  if (Object.values(effectiveConversationInfo).some((v) => v !== undefined)) {
     blocks.push(
       [
         "Conversation info (untrusted metadata):",
         "```json",
-        JSON.stringify(conversationInfo, null, 2),
+        JSON.stringify(effectiveConversationInfo, null, 2),
         "```",
       ].join("\n"),
     );


### PR DESCRIPTION
﻿Fixes #33042.

## Summary
- Reduce token bloat from repeated Slack thread metadata blocks.
- Treat threaded conversations (Slack threads / Discord threads / Telegram topics, etc.) specially in the generic inbound meta builder.
- For threads, keep only per-message identifiers and dynamic flags in the "Conversation info (untrusted metadata)" block, while omitting static thread-level descriptors.

## Details
- Detect threaded conversations when `MessageThreadId` is set or a `ThreadLabel` is present.
- In threaded mode, the conversation info JSON now only includes:
  - `message_id`, `reply_to_id`, `sender_id`, `sender`, `timestamp`
  - `is_group_chat`, `was_mentioned`
  - `has_reply_context`, `has_forwarded_context`, `has_thread_starter`, `history_count`
- Omit static fields like `conversation_label`, `group_subject`, `thread_label`, and `topic_id` that are constant across all messages in the thread.

## Testing
- Added unit test to ensure threaded conversations drop static metadata while keeping per-message delta fields.
