### PR TITLE
feat(scripts): add gateway CLI tools and live monitor dashboard

### DIFF
--- a/scripts/oc
+++ b/scripts/oc
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# OpenClaw Gateway CLI — host-side shortcut
+# Usage:
+#   oc                          # interactive mode
+#   oc --once                   # auth check
+#   oc sessions.list            # list sessions
+#   oc chat.send "hello"        # send message
+#   oc channels.status          # channel status
+#   oc chat.history 10          # last 10 messages
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+export OPENCLAW_IDENTITY_FILE="${PROJECT_DIR}/config/identity/cli-device.json"
+export OPENCLAW_CONFIG="${PROJECT_DIR}/config/openclaw.json"
+export OPENCLAW_GATEWAY_URL="${OPENCLAW_GATEWAY_URL:-ws://127.0.0.1:18789}"
+
+exec node "${SCRIPT_DIR}/ws-gateway-client.mjs" "$@"

--- a/scripts/oc-monitor
+++ b/scripts/oc-monitor
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# OpenClaw Gateway Monitor — live terminal dashboard
+# Usage: oc-monitor [--compact]
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+export OPENCLAW_IDENTITY_FILE="${PROJECT_DIR}/config/identity/cli-device.json"
+export OPENCLAW_CONFIG="${PROJECT_DIR}/config/openclaw.json"
+export OPENCLAW_GATEWAY_URL="${OPENCLAW_GATEWAY_URL:-ws://127.0.0.1:18789}"
+
+exec node "${SCRIPT_DIR}/oc-monitor.mjs" "$@"

--- a/scripts/oc-monitor.mjs
+++ b/scripts/oc-monitor.mjs
@@ -184,7 +184,12 @@ function connect() {
   let authenticated = false;
 
   ws.on("message", (data) => {
-    const msg = JSON.parse(data);
+    let msg;
+    try {
+      msg = JSON.parse(data);
+    } catch {
+      return;
+    }
 
     if (msg.event === "connect.challenge") {
       const nonce = msg.payload.nonce;

--- a/scripts/oc-monitor.mjs
+++ b/scripts/oc-monitor.mjs
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+/**
+ * OpenClaw Gateway Monitor
+ *
+ * Live terminal dashboard showing channels, sessions, events.
+ * Stays connected and refreshes on state changes.
+ *
+ * Usage:
+ *   oc-monitor              # full dashboard
+ *   oc-monitor --compact     # compact one-line status
+ *   oc-monitor --events      # event stream only
+ */
+import WebSocket from "ws";
+
+const GATEWAY_URL = process.env.OPENCLAW_GATEWAY_URL || "ws://127.0.0.1:18789";
+const IDENTITY_FILE = process.env.OPENCLAW_IDENTITY_FILE || "";
+const IDENTITY_DIR = process.env.OPENCLAW_IDENTITY_DIR || "/home/node/.openclaw/identity";
+const CONFIG_PATH = process.env.OPENCLAW_CONFIG || "/home/node/.openclaw/openclaw.json";
+
+const args = new Set(process.argv.slice(2));
+const compact = args.has("--compact");
+const eventsOnly = args.has("--events");
+
+const devicePath = IDENTITY_FILE || path.join(IDENTITY_DIR, "device.json");
+const deviceConfig = JSON.parse(fs.readFileSync(devicePath, "utf-8"));
+const openclawConfig = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+
+const { deviceId, privateKeyPem, publicKeyPem } = deviceConfig;
+const gatewayToken = openclawConfig.gateway?.auth?.token;
+if (!gatewayToken) {
+  console.error("[FATAL] gateway.auth.token not set");
+  process.exit(1);
+}
+
+const spkiDer = crypto.createPublicKey(publicKeyPem).export({ type: "spki", format: "der" });
+const rawKey = spkiDer.subarray(spkiDer.length - 32);
+const pubKeyB64Url = rawKey
+  .toString("base64")
+  .replace(/\+/g, "-")
+  .replace(/\//g, "_")
+  .replace(/=/g, "");
+
+// --- State ---
+let channels = {};
+let sessions = [];
+let nodes = [];
+let connId = "";
+let _connectedAt = null;
+let eventCount = 0;
+let lastEvent = "";
+let chatActive = false;
+let currentRunId = "";
+
+const pending = new Map();
+function rpc(ws, method, params = {}) {
+  return new Promise((resolve, reject) => {
+    const id = crypto.randomUUID();
+    pending.set(id, { resolve, reject, method });
+    ws.send(JSON.stringify({ type: "req", id, method, params }));
+    setTimeout(() => {
+      if (pending.has(id)) {
+        pending.delete(id);
+        reject(new Error("timeout"));
+      }
+    }, 15000);
+  });
+}
+
+// --- Display ---
+
+const CLEAR = "\x1b[2J\x1b[H";
+const BOLD = "\x1b[1m";
+const DIM = "\x1b[2m";
+const RESET = "\x1b[0m";
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[33m";
+const CYAN = "\x1b[36m";
+const MAGENTA = "\x1b[35m";
+
+function statusIcon(running) {
+  return running ? `${GREEN}●${RESET}` : `${RED}○${RESET}`;
+}
+function timeAgo(ms) {
+  if (!ms) {
+    return "never";
+  }
+  const sec = Math.floor((Date.now() - ms) / 1000);
+  if (sec < 60) {
+    return `${sec}s ago`;
+  }
+  if (sec < 3600) {
+    return `${Math.floor(sec / 60)}m ago`;
+  }
+  return `${Math.floor(sec / 3600)}h ago`;
+}
+
+function renderDashboard() {
+  if (eventsOnly) {
+    return;
+  }
+
+  const lines = [];
+  const now = new Date().toLocaleTimeString();
+
+  if (compact) {
+    const chSummary = Object.entries(channels)
+      .map(([id, ch]) => `${id}:${ch.running ? "UP" : "DOWN"}`)
+      .join(" ");
+    const sessCount = sessions.length;
+    const nodeCount = nodes.length;
+    process.stdout.write(
+      `\r${DIM}${now}${RESET} conn:${GREEN}${connId.substring(0, 8)}${RESET} ch:[${chSummary}] sess:${sessCount} nodes:${nodeCount} events:${eventCount} ${chatActive ? `${YELLOW}[chat]${RESET}` : ""} last:${lastEvent}    `,
+    );
+    return;
+  }
+
+  lines.push(CLEAR);
+  lines.push(`${BOLD}╔══════════════════════════════════════════════════════════════╗${RESET}`);
+  lines.push(`${BOLD}║              OPENCLAW GATEWAY MONITOR                       ║${RESET}`);
+  lines.push(`${BOLD}╠══════════════════════════════════════════════════════════════╣${RESET}`);
+  lines.push(
+    `${BOLD}║${RESET} ${DIM}Time:${RESET} ${now}  ${DIM}Conn:${RESET} ${GREEN}${connId.substring(0, 12)}${RESET}  ${DIM}Events:${RESET} ${eventCount}  ${chatActive ? `${YELLOW}[CHAT ACTIVE]${RESET}` : `${DIM}idle${RESET}`}`,
+  );
+  lines.push(`${BOLD}╠══════════════════════════════════════════════════════════════╣${RESET}`);
+
+  // Channels
+  lines.push(`${BOLD}║ CHANNELS${RESET}`);
+  if (Object.keys(channels).length === 0) {
+    lines.push(`${BOLD}║${RESET}   ${DIM}(none)${RESET}`);
+  }
+  for (const [id, ch] of Object.entries(channels)) {
+    const icon = statusIcon(ch.running);
+    const mode = ch.mode ? ` (${ch.mode})` : "";
+    const err = ch.lastError ? ` ${RED}${ch.lastError}${RESET}` : "";
+    const inbound = ch.lastInboundAt ? ` in:${timeAgo(ch.lastInboundAt)}` : "";
+    lines.push(
+      `${BOLD}║${RESET}   ${icon} ${CYAN}${id}${RESET}${mode}${err}${DIM}${inbound}${RESET}`,
+    );
+  }
+  lines.push(`${BOLD}╠══════════════════════════════════════════════════════════════╣${RESET}`);
+
+  // Sessions
+  lines.push(`${BOLD}║ SESSIONS${RESET} ${DIM}(${sessions.length})${RESET}`);
+  for (const s of sessions.slice(0, 8)) {
+    const name = s.displayName || s.key;
+    const model = s.model ? ` ${DIM}${s.model}${RESET}` : "";
+    const tokens = s.totalTokens ? ` ${DIM}${(s.totalTokens / 1000).toFixed(1)}k tok${RESET}` : "";
+    const updated = s.updatedAt ? ` ${DIM}${timeAgo(s.updatedAt)}${RESET}` : "";
+    lines.push(`${BOLD}║${RESET}   ${MAGENTA}${name}${RESET}${model}${tokens}${updated}`);
+  }
+  if (sessions.length > 8) {
+    lines.push(`${BOLD}║${RESET}   ${DIM}... +${sessions.length - 8} more${RESET}`);
+  }
+  lines.push(`${BOLD}╠══════════════════════════════════════════════════════════════╣${RESET}`);
+
+  // Nodes
+  lines.push(`${BOLD}║ NODES${RESET} ${DIM}(${nodes.length})${RESET}`);
+  for (const n of nodes) {
+    const name = n.displayName || n.nodeId?.substring(0, 12);
+    const caps = n.caps?.join(", ") || "";
+    lines.push(
+      `${BOLD}║${RESET}   ${GREEN}${name}${RESET} ${DIM}[${caps}]${RESET} ${DIM}${n.platform || ""}${RESET}`,
+    );
+  }
+  lines.push(`${BOLD}╠══════════════════════════════════════════════════════════════╣${RESET}`);
+
+  // Recent events
+  lines.push(`${BOLD}║ LAST EVENT${RESET}`);
+  lines.push(`${BOLD}║${RESET}   ${lastEvent || `${DIM}(waiting)${RESET}`}`);
+  lines.push(`${BOLD}╚══════════════════════════════════════════════════════════════╝${RESET}`);
+  lines.push(`${DIM}Press Ctrl+C to exit${RESET}`);
+
+  process.stdout.write(lines.join("\n") + "\n");
+}
+
+// --- Connection ---
+
+function connect() {
+  const ws = new WebSocket(GATEWAY_URL);
+  let authenticated = false;
+
+  ws.on("message", (data) => {
+    const msg = JSON.parse(data);
+
+    if (msg.event === "connect.challenge") {
+      const nonce = msg.payload.nonce;
+      const signedAtMs = Date.now();
+      const role = "operator";
+      const scopes = ["operator.admin"];
+      const platform = process.platform;
+      const payload = [
+        "v3",
+        deviceId,
+        "cli",
+        "cli",
+        role,
+        scopes.join(","),
+        String(signedAtMs),
+        gatewayToken,
+        nonce,
+        platform.toLowerCase(),
+        "",
+      ].join("|");
+      const signature = crypto
+        .sign(null, Buffer.from(payload), { key: privateKeyPem, format: "pem" })
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=/g, "");
+      ws.send(
+        JSON.stringify({
+          type: "req",
+          id: crypto.randomUUID(),
+          method: "connect",
+          params: {
+            minProtocol: 3,
+            maxProtocol: 3,
+            client: { id: "cli", version: "dev", platform, mode: "cli" },
+            role,
+            scopes,
+            auth: { token: gatewayToken },
+            device: {
+              id: deviceId,
+              publicKey: pubKeyB64Url,
+              signature,
+              signedAt: signedAtMs,
+              nonce,
+            },
+          },
+        }),
+      );
+      return;
+    }
+
+    if (msg.type === "res") {
+      if (!authenticated && msg.ok) {
+        authenticated = true;
+        connId = msg.payload?.server?.connId || "";
+        _connectedAt = Date.now();
+        void refresh(ws);
+        return;
+      }
+      if (!authenticated && !msg.ok) {
+        console.error("[FAIL]", msg.error?.code, msg.error?.message);
+        ws.close();
+        process.exit(1);
+      }
+      const p = pending.get(msg.id);
+      if (p) {
+        pending.delete(msg.id);
+        if (msg.ok) {
+          p.resolve(msg.payload ?? msg);
+        } else {
+          p.reject(new Error(p.method + " failed"));
+        }
+      }
+      return;
+    }
+
+    if (msg.type === "event") {
+      eventCount++;
+      handleEvent(msg, ws);
+    }
+  });
+
+  ws.on("error", (e) => {
+    if (!compact) {
+      console.error("[ERR]", e.message);
+    }
+  });
+  ws.on("close", () => {
+    if (!compact) {
+      console.error("[RECONNECT] in 3s...");
+    }
+    setTimeout(connect, 3000);
+  });
+}
+
+async function refresh(ws) {
+  try {
+    const [chResult, sessResult, nodeResult] = await Promise.all([
+      rpc(ws, "channels.status"),
+      rpc(ws, "sessions.list"),
+      rpc(ws, "node.list").catch(() => ({ nodes: [] })),
+    ]);
+
+    // Flatten channel accounts for display
+    channels = {};
+    if (chResult.channelAccounts) {
+      for (const [chId, accounts] of Object.entries(chResult.channelAccounts)) {
+        for (const acct of Array.isArray(accounts) ? accounts : Object.values(accounts)) {
+          channels[chId + (acct.accountId !== "default" ? `:${acct.accountId}` : "")] = acct;
+        }
+      }
+    } else if (chResult.channels) {
+      channels = chResult.channels;
+    }
+
+    sessions = sessResult.sessions || [];
+    nodes = nodeResult.nodes || [];
+
+    renderDashboard();
+  } catch (e) {
+    if (!compact) {
+      console.error("[ERR] refresh:", e.message);
+    }
+  }
+}
+
+function handleEvent(msg, ws) {
+  const evt = msg.event;
+  const p = msg.payload || {};
+
+  // Agent events
+  if (evt === "agent") {
+    if (p.stream === "lifecycle" && p.data?.phase === "start") {
+      chatActive = true;
+      currentRunId = p.runId || "";
+      lastEvent = `${YELLOW}chat started${RESET} ${DIM}${currentRunId?.substring(0, 8)}${RESET}`;
+      if (eventsOnly) {
+        console.log(
+          `[${new Date().toLocaleTimeString()}] ${evt} lifecycle:start runId=${currentRunId?.substring(0, 8)}`,
+        );
+      }
+      renderDashboard();
+    } else if (p.stream === "assistant") {
+      const text = p.data?.delta || p.data?.text || "";
+      lastEvent = `${CYAN}assistant:${RESET} ${text.substring(0, 60)}`;
+      if (eventsOnly) {
+        process.stdout.write(text);
+      }
+      renderDashboard();
+    } else if (p.stream === "lifecycle" && p.data?.phase === "end") {
+      chatActive = false;
+      lastEvent = `${GREEN}chat completed${RESET}`;
+      if (eventsOnly) {
+        console.log(`\n[${new Date().toLocaleTimeString()}] ${evt} lifecycle:end`);
+      }
+      renderDashboard();
+    }
+    return;
+  }
+
+  // Chat events
+  if (evt === "chat") {
+    return;
+  } // handled via agent events
+
+  // Health — do a full refresh instead of partial update
+  if (evt === "health") {
+    void refresh(ws);
+    return;
+  }
+
+  // Device pairing
+  if (evt === "device.pair.requested") {
+    lastEvent = `${YELLOW}pairing request${RESET} ${p.deviceId?.substring(0, 12)} (${p.platform})`;
+    if (eventsOnly) {
+      console.log(
+        `[${new Date().toLocaleTimeString()}] ${evt} device=${p.deviceId?.substring(0, 12)} platform=${p.platform}`,
+      );
+    }
+    renderDashboard();
+    return;
+  }
+
+  // Tick — periodic refresh
+  if (evt === "tick") {
+    void refresh(ws);
+    return;
+  }
+
+  // Generic
+  lastEvent = `${DIM}${evt}${RESET}`;
+  if (eventsOnly) {
+    console.log(`[${new Date().toLocaleTimeString()}] ${evt}`);
+  }
+  renderDashboard();
+}
+
+// --- Startup ---
+
+process.on("SIGINT", () => {
+  if (!compact) {
+    process.stdout.write(CLEAR);
+    console.log("Monitor stopped.");
+  } else {
+    console.log("");
+  }
+  process.exit(0);
+});
+
+connect();

--- a/scripts/ws-gateway-client.mjs
+++ b/scripts/ws-gateway-client.mjs
@@ -97,9 +97,15 @@ function parseCommand(parts) {
         },
       };
     case "chat.history":
-      return { method, params: { limit: parseInt(parts[1]) || 20 } };
+      return {
+        method,
+        params: {
+          sessionKey: parts[2] ? parts[1] : "agent:main:main",
+          limit: parseInt(parts[2] || parts[1]) || 20,
+        },
+      };
     case "chat.abort":
-      return { method, params: {} };
+      return { method, params: { sessionKey: parts[1] || "agent:main:main" } };
     case "chat.inject":
       return {
         method,
@@ -114,7 +120,7 @@ function parseCommand(parts) {
     case "sessions.list":
       return { method, params: {} };
     case "sessions.preview":
-      return { method, params: { sessionId: parts[1] || "main" } };
+      return { method, params: { keys: [parts[1] || "agent:main:main"] } };
     case "sessions.delete":
       return { method, params: { key: parts[1] } };
     case "sessions.reset":
@@ -143,17 +149,17 @@ function parseCommand(parts) {
         params: { name: parts[1], workspace: parts[1], ...JSON.parse(parts[2] || "{}") },
       };
     case "agents.update":
-      return { method, params: { id: parts[1], ...JSON.parse(parts[2] || "{}") } };
+      return { method, params: { agentId: parts[1], ...JSON.parse(parts[2] || "{}") } };
     case "agents.delete":
-      return { method, params: { id: parts[1] } };
+      return { method, params: { agentId: parts[1] } };
 
     // --- Config ---
     case "config.get":
       return { method, params: {} };
     case "config.set":
-      return { method, params: { path: parts[1], value: JSON.parse(parts[2] || "null") } };
+      return { method, params: { raw: parts.slice(1).join(" ") } };
     case "config.patch":
-      return { method, params: { path: parts[1], value: JSON.parse(parts[2] || "null") } };
+      return { method, params: { raw: parts.slice(1).join(" ") } };
     case "config.apply":
       return { method, params: JSON.parse(parts[1] || "{}") };
     case "config.schema":
@@ -503,18 +509,16 @@ async function afterAuth(ws) {
       }
       if (parts[0] === "help") {
         console.error(
-          "Chat:     chat.send <msg>, chat.send <sessionKey> <msg>, chat.history [n], chat.abort, chat.inject <key> <role> <text>",
+          "Chat:     chat.send <msg>, chat.send <key> <msg>, chat.history [key] [n], chat.abort [key], chat.inject <key> <role> <text>",
         );
         console.error(
-          "Sessions: sessions.list, sessions.preview [id], sessions.delete <key>, sessions.reset <key>, sessions.compact <key>, sessions.usage",
+          "Sessions: sessions.list, sessions.preview [key], sessions.delete <key>, sessions.reset <key>, sessions.compact <key>, sessions.usage",
         );
         console.error("Channels: channels.status, channels.logout <ch>");
         console.error(
           "Agents:   agents.list, agents.create <id> [json], agents.update <id> [json], agents.delete <id>",
         );
-        console.error(
-          "Config:   config.get, config.set <path> <json>, config.patch <path> <json>, config.schema",
-        );
+        console.error("Config:   config.get, config.set <raw>, config.patch <raw>, config.schema");
         console.error(
           "Cron:     cron.list, cron.add <json>, cron.remove <id>, cron.run <id>, cron.runs <id> [n]",
         );

--- a/scripts/ws-gateway-client.mjs
+++ b/scripts/ws-gateway-client.mjs
@@ -1,0 +1,543 @@
+#!/usr/bin/env node
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+import readline from "readline";
+/**
+ * OpenClaw Gateway Client
+ *
+ * Authenticated WebSocket client for interacting with the OpenClaw gateway.
+ * Supports RPC commands via CLI args or interactive stdin.
+ *
+ * Usage:
+ *   node ws-gateway-client.mjs                          # interactive mode
+ *   node ws-gateway-client.mjs --once                   # auth check only
+ *   node ws-gateway-client.mjs chat.send "hello"        # send message
+ *   node ws-gateway-client.mjs sessions.list            # list sessions
+ *   node ws-gateway-client.mjs chat.history              # get chat history
+ *   node ws-gateway-client.mjs channels.status           # channel status
+ *   node ws-gateway-client.mjs config.get gateway        # get config
+ *   echo '{"method":"chat.send","params":{"text":"hi"}}' | node ws-gateway-client.mjs --stdin
+ *
+ * Environment:
+ *   OPENCLAW_GATEWAY_URL   ws://127.0.0.1:18789
+ *   OPENCLAW_IDENTITY_FILE device.json path (overrides IDENTITY_DIR)
+ *   OPENCLAW_IDENTITY_DIR  /home/node/.openclaw/identity
+ *   OPENCLAW_CONFIG        /home/node/.openclaw/openclaw.json
+ */
+import WebSocket from "ws";
+
+const GATEWAY_URL = process.env.OPENCLAW_GATEWAY_URL || "ws://127.0.0.1:18789";
+const IDENTITY_FILE = process.env.OPENCLAW_IDENTITY_FILE || "";
+const IDENTITY_DIR = process.env.OPENCLAW_IDENTITY_DIR || "/home/node/.openclaw/identity";
+const CONFIG_PATH = process.env.OPENCLAW_CONFIG || "/home/node/.openclaw/openclaw.json";
+
+const args = process.argv.slice(2);
+const flagOnce = args.includes("--once");
+const flagStdin = args.includes("--stdin");
+const flagQuiet = args.includes("-q") || args.includes("--quiet");
+const positional = args.filter((a) => !a.startsWith("-"));
+
+// --- Auth setup ---
+
+const devicePath = IDENTITY_FILE || path.join(IDENTITY_DIR, "device.json");
+const deviceConfig = JSON.parse(fs.readFileSync(devicePath, "utf-8"));
+const openclawConfig = JSON.parse(fs.readFileSync(CONFIG_PATH, "utf-8"));
+
+const { deviceId, privateKeyPem, publicKeyPem } = deviceConfig;
+const gatewayToken = openclawConfig.gateway?.auth?.token;
+if (!gatewayToken) {
+  console.error("[FATAL] gateway.auth.token not set");
+  process.exit(1);
+}
+
+const spkiDer = crypto.createPublicKey(publicKeyPem).export({ type: "spki", format: "der" });
+const rawKey = spkiDer.subarray(spkiDer.length - 32);
+const pubKeyB64Url = rawKey
+  .toString("base64")
+  .replace(/\+/g, "-")
+  .replace(/\//g, "_")
+  .replace(/=/g, "");
+
+// --- RPC helpers ---
+
+const pending = new Map();
+
+function rpc(ws, method, params = {}) {
+  return new Promise((resolve, reject) => {
+    const id = crypto.randomUUID();
+    pending.set(id, { resolve, reject, method });
+    ws.send(JSON.stringify({ type: "req", id, method, params }));
+    setTimeout(() => {
+      if (pending.has(id)) {
+        pending.delete(id);
+        reject(new Error("timeout"));
+      }
+    }, 30000);
+  });
+}
+
+// --- Shorthand command parser ---
+
+function parseCommand(parts) {
+  const method = parts[0];
+  if (!method) {
+    return null;
+  }
+
+  switch (method) {
+    // --- Chat ---
+    case "chat.send":
+      return {
+        method,
+        params: {
+          sessionKey: parts[2] ? parts[1] : "agent:main:main",
+          message: parts[2] || parts.slice(1).join(" ") || "ping",
+          idempotencyKey: crypto.randomUUID(),
+        },
+      };
+    case "chat.history":
+      return { method, params: { limit: parseInt(parts[1]) || 20 } };
+    case "chat.abort":
+      return { method, params: {} };
+    case "chat.inject":
+      return {
+        method,
+        params: {
+          sessionKey: parts[1] || "agent:main:main",
+          role: parts[2] || "user",
+          text: parts.slice(3).join(" ") || "",
+        },
+      };
+
+    // --- Sessions ---
+    case "sessions.list":
+      return { method, params: {} };
+    case "sessions.preview":
+      return { method, params: { sessionId: parts[1] || "main" } };
+    case "sessions.delete":
+      return { method, params: { key: parts[1] } };
+    case "sessions.reset":
+      return { method, params: { key: parts[1] } };
+    case "sessions.compact":
+      return { method, params: { key: parts[1] } };
+    case "sessions.patch":
+      return { method, params: { sessionKey: parts[1], ...JSON.parse(parts[2] || "{}") } };
+    case "sessions.resolve":
+      return { method, params: { sessionKey: parts[1] } };
+    case "sessions.usage":
+      return { method, params: {} };
+
+    // --- Channels ---
+    case "channels.status":
+      return { method, params: {} };
+    case "channels.logout":
+      return { method, params: { channel: parts[1] } };
+
+    // --- Agents ---
+    case "agents.list":
+      return { method, params: {} };
+    case "agents.create":
+      return {
+        method,
+        params: { name: parts[1], workspace: parts[1], ...JSON.parse(parts[2] || "{}") },
+      };
+    case "agents.update":
+      return { method, params: { id: parts[1], ...JSON.parse(parts[2] || "{}") } };
+    case "agents.delete":
+      return { method, params: { id: parts[1] } };
+
+    // --- Config ---
+    case "config.get":
+      return { method, params: {} };
+    case "config.set":
+      return { method, params: { path: parts[1], value: JSON.parse(parts[2] || "null") } };
+    case "config.patch":
+      return { method, params: { path: parts[1], value: JSON.parse(parts[2] || "null") } };
+    case "config.apply":
+      return { method, params: JSON.parse(parts[1] || "{}") };
+    case "config.schema":
+      return { method, params: {} };
+
+    // --- Skills ---
+    case "skills.status":
+      return { method, params: {} };
+    case "skills.install":
+      return { method, params: { url: parts[1] } };
+    case "skills.update":
+      return { method, params: { id: parts[1] } };
+
+    // --- Cron ---
+    case "cron.list":
+      return { method, params: {} };
+    case "cron.add":
+      return { method, params: JSON.parse(parts.slice(1).join(" ") || "{}") };
+    case "cron.update":
+      return { method, params: JSON.parse(parts.slice(1).join(" ") || "{}") };
+    case "cron.remove":
+      return { method, params: { id: parts[1] } };
+    case "cron.run":
+      return { method, params: { id: parts[1] } };
+    case "cron.runs":
+      return { method, params: { id: parts[1], limit: parseInt(parts[2]) || 10 } };
+
+    // --- Tools ---
+    case "tools.catalog":
+      return { method, params: {} };
+
+    // --- Devices ---
+    case "device.pair.list":
+      return { method, params: {} };
+    case "device.pair.approve":
+      return {
+        method,
+        params: {
+          requestId: parts[1],
+          role: "operator",
+          scopes: [
+            "operator.admin",
+            "operator.read",
+            "operator.write",
+            "operator.approvals",
+            "operator.pairing",
+          ],
+        },
+      };
+    case "device.pair.reject":
+      return { method, params: { requestId: parts[1] } };
+    case "device.pair.remove":
+      return { method, params: { deviceId: parts[1] } };
+    case "device.token.rotate":
+      return { method, params: { deviceId: parts[1] } };
+    case "device.token.revoke":
+      return { method, params: { deviceId: parts[1], role: parts[2] || "operator" } };
+
+    // --- Nodes ---
+    case "node.list":
+      return { method, params: {} };
+    case "node.invoke":
+      return {
+        method,
+        params: {
+          nodeId: parts[1],
+          command: parts[2],
+          params: JSON.parse(parts[3] || "{}"),
+          idempotencyKey: crypto.randomUUID(),
+        },
+      };
+    case "node.describe":
+      return { method, params: { nodeId: parts[1] } };
+    case "node.rename":
+      return { method, params: { nodeId: parts[1], name: parts[2] } };
+
+    // --- Exec Approvals ---
+    case "exec.approvals.get":
+      return { method, params: {} };
+    case "exec.approval.resolve":
+      return { method, params: { requestId: parts[1], approved: parts[2] !== "deny" } };
+
+    // --- Logs ---
+    case "logs.tail":
+      return { method, params: { lines: parseInt(parts[1]) || 50 } };
+
+    // --- System ---
+    case "gateway.reload":
+      return { method, params: {} };
+    case "update.run":
+      return { method, params: {} };
+
+    // --- TTS ---
+    case "tts.status":
+      return { method, params: {} };
+    case "tts.providers":
+      return { method, params: {} };
+
+    // --- Wizard ---
+    case "wizard.status":
+      return { method, params: {} };
+    case "wizard.start":
+      return { method, params: { channel: parts[1] } };
+
+    default:
+      // Generic: treat remaining args as JSON params
+      try {
+        const params = parts[1] ? JSON.parse(parts.slice(1).join(" ")) : {};
+        return { method, params };
+      } catch {
+        return { method, params: {} };
+      }
+  }
+}
+
+// --- Streaming support ---
+
+const STREAMING_METHODS = new Set(["chat.send", "chat.inject"]);
+let _waitingForCompletion = false;
+let completionResolve = null;
+
+// --- Connection ---
+
+function connect() {
+  const ws = new WebSocket(GATEWAY_URL);
+  let authenticated = false;
+
+  ws.on("message", (data) => {
+    const msg = JSON.parse(data);
+
+    // --- Auth handshake ---
+    if (msg.event === "connect.challenge") {
+      const nonce = msg.payload.nonce;
+      const signedAtMs = Date.now();
+      const role = "operator";
+      const scopes = ["operator.admin"];
+      const platform = process.platform;
+
+      const payload = [
+        "v3",
+        deviceId,
+        "cli",
+        "cli",
+        role,
+        scopes.join(","),
+        String(signedAtMs),
+        gatewayToken,
+        nonce,
+        platform.toLowerCase(),
+        "",
+      ].join("|");
+
+      const signature = crypto
+        .sign(null, Buffer.from(payload), { key: privateKeyPem, format: "pem" })
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=/g, "");
+
+      ws.send(
+        JSON.stringify({
+          type: "req",
+          id: crypto.randomUUID(),
+          method: "connect",
+          params: {
+            minProtocol: 3,
+            maxProtocol: 3,
+            client: { id: "cli", version: "dev", platform, mode: "cli" },
+            role,
+            scopes,
+            auth: { token: gatewayToken },
+            device: {
+              id: deviceId,
+              publicKey: pubKeyB64Url,
+              signature,
+              signedAt: signedAtMs,
+              nonce,
+            },
+          },
+        }),
+      );
+      return;
+    }
+
+    // --- RPC response ---
+    if (msg.type === "res") {
+      if (!authenticated && msg.ok) {
+        authenticated = true;
+        if (!flagQuiet) {
+          console.error("[OK] connected " + (msg.payload?.server?.connId || ""));
+        }
+        if (flagOnce) {
+          ws.close();
+          process.exit(0);
+        }
+        void afterAuth(ws);
+        return;
+      }
+      if (!authenticated && !msg.ok) {
+        console.error("[FAIL]", msg.error?.code, msg.error?.message);
+        ws.close();
+        process.exit(1);
+      }
+      // Resolve pending RPC
+      const p = pending.get(msg.id);
+      if (p) {
+        pending.delete(msg.id);
+        if (msg.ok) {
+          p.resolve(msg.payload ?? msg);
+        } else {
+          p.reject(new Error(`${p.method}: ${msg.error?.message || "error"}`));
+        }
+      }
+      return;
+    }
+
+    // --- Events ---
+    if (msg.type === "event") {
+      if (msg.event === "tick" || msg.event === "health") {
+        return;
+      }
+
+      // Agent stream: assistant text chunks
+      if (msg.event === "agent" && msg.payload?.stream === "assistant") {
+        process.stdout.write(msg.payload.data?.delta || msg.payload.data?.text || "");
+        return;
+      }
+      // Agent lifecycle
+      if (msg.event === "agent" && msg.payload?.stream === "lifecycle") {
+        if (msg.payload?.data?.phase === "end") {
+          process.stdout.write("\n");
+          if (completionResolve) {
+            completionResolve();
+            completionResolve = null;
+          }
+        }
+        return;
+      }
+      // Chat state events (suppress delta since agent stream handles text)
+      if (msg.event === "chat") {
+        if (msg.payload?.state === "final" && completionResolve) {
+          completionResolve();
+          completionResolve = null;
+        }
+        return;
+      }
+      // Legacy events
+      if (msg.event === "chat.completion.chunk") {
+        process.stdout.write(msg.payload?.text || msg.payload?.delta || "");
+        return;
+      }
+      if (
+        msg.event === "chat.completion" ||
+        msg.event === "response.completed" ||
+        msg.event === "response.failed"
+      ) {
+        if (completionResolve) {
+          completionResolve();
+          completionResolve = null;
+        }
+        return;
+      }
+      if (!flagQuiet) {
+        console.error("[event]", msg.event);
+      }
+    }
+  });
+
+  ws.on("error", (e) => console.error("[ERR]", e.message));
+  ws.on("close", (_code) => {
+    if (!flagOnce && authenticated) {
+      console.error("[RECONNECT] in 3s...");
+      setTimeout(connect, 3000);
+    } else if (!authenticated) {
+      process.exit(1);
+    }
+  });
+}
+
+// --- Post-auth actions ---
+
+async function afterAuth(ws) {
+  // One-shot command from CLI args
+  if (positional.length > 0) {
+    const cmd = parseCommand(positional);
+    if (cmd) {
+      const isStreaming = STREAMING_METHODS.has(cmd.method);
+      try {
+        if (isStreaming) {
+          const completionPromise = new Promise((resolve) => {
+            completionResolve = resolve;
+            setTimeout(resolve, 60000); // 60s timeout for streaming
+          });
+          const result = await rpc(ws, cmd.method, cmd.params);
+          if (!flagQuiet) {
+            console.error("[started] runId=" + (result.runId || ""));
+          }
+          await completionPromise;
+        } else {
+          const result = await rpc(ws, cmd.method, cmd.params);
+          console.log(JSON.stringify(result, null, 2));
+        }
+      } catch (e) {
+        console.error("[ERROR]", e.message);
+      }
+      ws.close();
+      process.exit(0);
+    }
+  }
+
+  // Piped stdin (JSON lines)
+  if (flagStdin) {
+    const rl = readline.createInterface({ input: process.stdin });
+    for await (const line of rl) {
+      try {
+        const { method, params } = JSON.parse(line);
+        const result = await rpc(ws, method, params);
+        console.log(JSON.stringify(result));
+      } catch (e) {
+        console.error("[ERROR]", e.message);
+      }
+    }
+    ws.close();
+    process.exit(0);
+  }
+
+  // Interactive mode
+  if (process.stdin.isTTY) {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stderr,
+      prompt: "openclaw> ",
+    });
+    rl.prompt();
+    rl.on("line", async (line) => {
+      const parts = line.trim().split(/\s+/);
+      if (!parts[0] || parts[0] === "exit" || parts[0] === "quit") {
+        ws.close();
+        process.exit(0);
+      }
+      if (parts[0] === "help") {
+        console.error(
+          "Chat:     chat.send <msg>, chat.send <sessionKey> <msg>, chat.history [n], chat.abort, chat.inject <key> <role> <text>",
+        );
+        console.error(
+          "Sessions: sessions.list, sessions.preview [id], sessions.delete <key>, sessions.reset <key>, sessions.compact <key>, sessions.usage",
+        );
+        console.error("Channels: channels.status, channels.logout <ch>");
+        console.error(
+          "Agents:   agents.list, agents.create <id> [json], agents.update <id> [json], agents.delete <id>",
+        );
+        console.error(
+          "Config:   config.get [path], config.set <path> <json>, config.patch <path> <json>, config.schema",
+        );
+        console.error(
+          "Cron:     cron.list, cron.add <json>, cron.remove <id>, cron.run <id>, cron.runs <id> [n]",
+        );
+        console.error(
+          "Devices:  device.pair.list, device.pair.approve <reqId>, device.pair.reject <reqId>, device.pair.remove <devId>",
+        );
+        console.error(
+          "Nodes:    node.list, node.describe <id>, node.invoke <id> <method> [json], node.rename <id> <name>",
+        );
+        console.error("Skills:   skills.status, skills.install <url>, skills.update <id>");
+        console.error("Tools:    tools.catalog");
+        console.error("Logs:     logs.tail [n]");
+        console.error("System:   gateway.reload, update.run, tts.status, wizard.status");
+        console.error("Generic:  <any.method> [json_params]");
+        console.error("          exit / quit");
+        rl.prompt();
+        return;
+      }
+      const cmd = parseCommand(parts);
+      if (cmd) {
+        try {
+          const result = await rpc(ws, cmd.method, cmd.params);
+          console.log(JSON.stringify(result, null, 2));
+        } catch (e) {
+          console.error("[ERROR]", e.message);
+        }
+      }
+      rl.prompt();
+    });
+  }
+}
+
+connect();

--- a/scripts/ws-gateway-client.mjs
+++ b/scripts/ws-gateway-client.mjs
@@ -16,7 +16,7 @@ import readline from "readline";
  *   node ws-gateway-client.mjs sessions.list            # list sessions
  *   node ws-gateway-client.mjs chat.history              # get chat history
  *   node ws-gateway-client.mjs channels.status           # channel status
- *   node ws-gateway-client.mjs config.get gateway        # get config
+ *   node ws-gateway-client.mjs config.get               # get full config
  *   echo '{"method":"chat.send","params":{"text":"hi"}}' | node ws-gateway-client.mjs --stdin
  *
  * Environment:
@@ -92,7 +92,7 @@ function parseCommand(parts) {
         method,
         params: {
           sessionKey: parts[2] ? parts[1] : "agent:main:main",
-          message: parts[2] || parts.slice(1).join(" ") || "ping",
+          message: parts[2] ? parts.slice(2).join(" ") : parts.slice(1).join(" ") || "ping",
           idempotencyKey: crypto.randomUUID(),
         },
       };
@@ -272,7 +272,6 @@ function parseCommand(parts) {
 // --- Streaming support ---
 
 const STREAMING_METHODS = new Set(["chat.send", "chat.inject"]);
-let _waitingForCompletion = false;
 let completionResolve = null;
 
 // --- Connection ---
@@ -282,7 +281,15 @@ function connect() {
   let authenticated = false;
 
   ws.on("message", (data) => {
-    const msg = JSON.parse(data);
+    let msg;
+    try {
+      msg = JSON.parse(data);
+    } catch {
+      if (!flagQuiet) {
+        console.error("[WARN] malformed JSON frame");
+      }
+      return;
+    }
 
     // --- Auth handshake ---
     if (msg.event === "connect.challenge") {
@@ -506,7 +513,7 @@ async function afterAuth(ws) {
           "Agents:   agents.list, agents.create <id> [json], agents.update <id> [json], agents.delete <id>",
         );
         console.error(
-          "Config:   config.get [path], config.set <path> <json>, config.patch <path> <json>, config.schema",
+          "Config:   config.get, config.set <path> <json>, config.patch <path> <json>, config.schema",
         );
         console.error(
           "Cron:     cron.list, cron.add <json>, cron.remove <id>, cron.run <id>, cron.runs <id> [n]",


### PR DESCRIPTION
## Summary

- Add `ws-gateway-client.mjs`: Authenticated WebSocket client supporting 40+ RPC methods with interactive, one-shot, and piped stdin modes, including streaming for chat
- Add `oc-monitor.mjs`: Live terminal monitoring dashboard showing real-time channel status, sessions, events, and nodes with auto-refresh
- Add `oc` / `oc-monitor` shell wrappers for convenient host-side usage with configurable identity and gateway URL via environment variables

## Details

The gateway client supports all major RPC methods: chat (send/history/abort/inject), sessions, channels, agents, config, cron, nodes, devices, exec approvals, skills, tools, and more. It handles the v3 WebSocket authentication handshake with Ed25519 device signatures.

The monitor dashboard offers three display modes: full dashboard (default), compact one-line status, and event stream only.

## Test plan

- [ ] Verify `oc --once` authenticates and exits cleanly
- [ ] Verify `oc sessions.list` returns session data
- [ ] Verify `oc chat.send "test"` sends a message with streaming output
- [ ] Verify `oc-monitor` shows live dashboard with channel status
- [ ] Verify piped stdin mode: `echo '{"method":"sessions.list","params":{}}' | oc --stdin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)