### PR TITLE
runner: sanitize verbose assistant API errors before transcript replay

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   BILLING_ERROR_USER_MESSAGE,
   formatBillingErrorMessage,
+  formatAssistantErrorForTranscript,
   formatAssistantErrorText,
   formatRawAssistantErrorForUi,
 } from "./pi-embedded-helpers.js";
@@ -151,5 +152,21 @@ describe("formatRawAssistantErrorForUi", () => {
     expect(formatRawAssistantErrorForUi(htmlError)).toBe(
       "The AI service is temporarily unavailable (HTTP 521). Please try again in a moment.",
     );
+  });
+});
+
+describe("formatAssistantErrorForTranscript", () => {
+  it("reduces verbose API payloads to a short user-safe line", () => {
+    const text = formatAssistantErrorForTranscript(
+      '529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"},"request_id":"req_123"}',
+    );
+    expect(text).toBe("The AI service is temporarily overloaded. Please try again in a moment.");
+  });
+
+  it("caps very long unknown errors", () => {
+    const raw = `boom:${"x".repeat(500)}`;
+    const text = formatAssistantErrorForTranscript(raw);
+    expect(text.length).toBeLessThanOrEqual(221);
+    expect(text.endsWith("…")).toBe(true);
   });
 });

--- a/src/agents/pi-embedded-helpers.ts
+++ b/src/agents/pi-embedded-helpers.ts
@@ -15,6 +15,7 @@ export {
   classifyFailoverReason,
   classifyFailoverReasonFromHttpStatus,
   formatRawAssistantErrorForUi,
+  formatAssistantErrorForTranscript,
   formatAssistantErrorText,
   getApiErrorPayloadFingerprint,
   isAuthAssistantError,

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -42,6 +42,7 @@ export const BILLING_ERROR_USER_MESSAGE = formatBillingErrorMessage();
 const RATE_LIMIT_ERROR_USER_MESSAGE = "⚠️ API rate limit reached. Please try again later.";
 const OVERLOADED_ERROR_USER_MESSAGE =
   "The AI service is temporarily overloaded. Please try again in a moment.";
+const TRANSCRIPT_ERROR_MAX_CHARS = 220;
 
 function formatRateLimitOrOverloadedErrorCopy(raw: string): string | undefined {
   if (isRateLimitErrorMessage(raw)) {
@@ -669,6 +670,43 @@ export function formatRawAssistantErrorForUi(raw?: string): string {
   }
 
   return trimmed.length > 600 ? `${trimmed.slice(0, 600)}…` : trimmed;
+}
+
+export function formatAssistantErrorForTranscript(raw?: string): string {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) {
+    return "LLM request failed with an unknown error.";
+  }
+
+  if (isContextOverflowError(trimmed)) {
+    return "Context overflow: prompt too large for the model.";
+  }
+
+  if (isReasoningConstraintErrorMessage(trimmed)) {
+    return "Reasoning is required for this model endpoint.";
+  }
+
+  const transientCopy = formatRateLimitOrOverloadedErrorCopy(trimmed);
+  if (transientCopy) {
+    return transientCopy;
+  }
+
+  if (isTimeoutErrorMessage(trimmed)) {
+    return "LLM request timed out.";
+  }
+
+  if (isBillingErrorMessage(trimmed)) {
+    return BILLING_ERROR_USER_MESSAGE;
+  }
+
+  const uiText =
+    isLikelyHttpErrorText(trimmed) || isRawApiErrorPayload(trimmed)
+      ? formatRawAssistantErrorForUi(trimmed)
+      : trimmed;
+
+  return uiText.length > TRANSCRIPT_ERROR_MAX_CHARS
+    ? `${uiText.slice(0, TRANSCRIPT_ERROR_MAX_CHARS)}…`
+    : uiText;
 }
 
 export function formatAssistantErrorText(

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -12,8 +12,11 @@ import { resolveImageSanitizationLimits } from "../image-sanitization.js";
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
   downgradeOpenAIReasoningBlocks,
+  formatAssistantErrorForTranscript,
   isCompactionFailureError,
   isGoogleModelApi,
+  isRawApiErrorPayload,
+  parseApiErrorInfo,
   sanitizeGoogleTurnOrdering,
   sanitizeSessionMessagesImages,
 } from "../pi-embedded-helpers.js";
@@ -310,6 +313,137 @@ function ensureAssistantUsageSnapshots(messages: AgentMessage[]): AgentMessage[]
   return touched ? out : messages;
 }
 
+function normalizeAssistantErrorContent(params: {
+  content: unknown;
+  normalizedError: string;
+  rawError?: string;
+}): unknown {
+  const shouldReplaceAssistantErrorText = (text: string): boolean => {
+    const hasRawError =
+      typeof params.rawError === "string" &&
+      params.rawError.length > 0 &&
+      text.includes(params.rawError);
+    const lowerText = text.toLowerCase();
+    const looksLikeRawErrorPayload =
+      isRawApiErrorPayload(text) ||
+      parseApiErrorInfo(text) !== null ||
+      lowerText.includes("<!doctype html") ||
+      lowerText.includes("<html");
+    return hasRawError || looksLikeRawErrorPayload;
+  };
+
+  if (typeof params.content === "string") {
+    return shouldReplaceAssistantErrorText(params.content)
+      ? params.normalizedError
+      : params.content;
+  }
+  if (!Array.isArray(params.content)) {
+    return params.content;
+  }
+  let changed = false;
+  const next = params.content.map((block) => {
+    if (!block || typeof block !== "object") {
+      return block;
+    }
+    const typed = block as { type?: unknown; text?: unknown } & Record<string, unknown>;
+    if (typed.type !== "text" || typeof typed.text !== "string") {
+      return block;
+    }
+    const text = typed.text;
+    if (!shouldReplaceAssistantErrorText(text)) {
+      return block;
+    }
+    changed = true;
+    return {
+      ...typed,
+      text: params.normalizedError,
+    };
+  });
+  return changed ? next : params.content;
+}
+
+function stripRepeatedTranscriptSuffix(text: string): string {
+  return text.replace(/\s+\(repeated x\d+\)$/i, "");
+}
+
+function addRepeatedSuffixWithCap(params: {
+  base: string;
+  repeatedCount: number;
+  maxChars?: number;
+}): string {
+  const maxChars = params.maxChars ?? 220;
+  const suffix = ` (repeated x${params.repeatedCount})`;
+  if (params.base.length + suffix.length <= maxChars) {
+    return `${params.base}${suffix}`;
+  }
+  const keep = Math.max(0, maxChars - suffix.length - 1);
+  if (keep === 0) {
+    return suffix.trimStart().slice(0, maxChars);
+  }
+  return `${params.base.slice(0, keep)}…${suffix}`;
+}
+
+function sanitizeAssistantErrorsForTranscript(messages: AgentMessage[]): AgentMessage[] {
+  let touched = false;
+  let previousFingerprint: string | null = null;
+  let repeatedCount = 1;
+
+  const out = messages.map((message) => {
+    if (!message || typeof message !== "object" || message.role !== "assistant") {
+      previousFingerprint = null;
+      repeatedCount = 1;
+      return message;
+    }
+
+    const assistant = message as AgentMessage & {
+      errorMessage?: unknown;
+      stopReason?: unknown;
+      content?: unknown;
+    };
+    const rawError =
+      typeof assistant.errorMessage === "string" ? assistant.errorMessage.trim() : undefined;
+    if (assistant.stopReason !== "error" && !rawError) {
+      previousFingerprint = null;
+      repeatedCount = 1;
+      return message;
+    }
+
+    const normalized = formatAssistantErrorForTranscript(rawError);
+    const fingerprint = stripRepeatedTranscriptSuffix(normalized).toLowerCase();
+    let normalizedForMessage = normalized;
+    if (fingerprint === previousFingerprint) {
+      repeatedCount += 1;
+      normalizedForMessage = addRepeatedSuffixWithCap({
+        base: normalized,
+        repeatedCount,
+      });
+    } else {
+      previousFingerprint = fingerprint;
+      repeatedCount = 1;
+    }
+
+    const nextContent = normalizeAssistantErrorContent({
+      content: assistant.content,
+      normalizedError: normalizedForMessage,
+      rawError,
+    });
+
+    const next = {
+      ...(assistant as unknown as Record<string, unknown>),
+      errorMessage: normalizedForMessage,
+      content: nextContent,
+    } as AgentMessage;
+
+    if (assistant.errorMessage !== normalizedForMessage || nextContent !== assistant.content) {
+      touched = true;
+    }
+
+    return next;
+  });
+
+  return touched ? out : messages;
+}
+
 export function findUnsupportedSchemaKeywords(schema: unknown, path: string): string[] {
   if (!schema || typeof schema !== "object") {
     return [];
@@ -537,8 +671,9 @@ export async function sanitizeSessionHistory(params: {
       modelId: params.modelId,
     });
   const withInterSessionMarkers = annotateInterSessionUserMessages(params.messages);
+  const sanitizedAssistantErrors = sanitizeAssistantErrorsForTranscript(withInterSessionMarkers);
   const sanitizedImages = await sanitizeSessionMessagesImages(
-    withInterSessionMarkers,
+    sanitizedAssistantErrors,
     "session:history",
     {
       sanitizeMode: policy.sanitizeMode,

--- a/src/agents/pi-embedded-runner/sanitize-session-history.assistant-errors.test.ts
+++ b/src/agents/pi-embedded-runner/sanitize-session-history.assistant-errors.test.ts
@@ -1,0 +1,78 @@
+import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { SessionManager } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
+import { sanitizeSessionHistory } from "./google.js";
+
+describe("sanitizeSessionHistory assistant error sanitization", () => {
+  it("rewrites oversized raw API payload errors before replaying transcript", async () => {
+    const sm = SessionManager.inMemory();
+    const rawError =
+      '529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"},"request_id":"req_abc"}';
+
+    const messages: AgentMessage[] = [
+      makeAssistantMessageFixture({
+        stopReason: "error",
+        errorMessage: rawError,
+        content: [{ type: "text", text: rawError }],
+      }) as unknown as AgentMessage,
+    ];
+
+    const sanitized = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-codex-responses",
+      provider: "openai",
+      modelId: "gpt-5.3-codex",
+      sessionManager: sm,
+      sessionId: "test",
+    });
+
+    const assistant = sanitized[0] as AgentMessage & {
+      errorMessage?: string;
+      content?: Array<{ type?: string; text?: string }>;
+    };
+
+    expect(assistant.errorMessage).toBe(
+      "The AI service is temporarily overloaded. Please try again in a moment.",
+    );
+    expect(assistant.content?.[0]?.text).toBe(
+      "The AI service is temporarily overloaded. Please try again in a moment.",
+    );
+  });
+
+  it("marks repeated consecutive assistant errors with a compact counter", async () => {
+    const sm = SessionManager.inMemory();
+    const rawError =
+      '529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"},"request_id":"req_abc"}';
+
+    const messages: AgentMessage[] = [
+      makeAssistantMessageFixture({
+        stopReason: "error",
+        errorMessage: rawError,
+      }) as unknown as AgentMessage,
+      makeAssistantMessageFixture({
+        stopReason: "error",
+        errorMessage: rawError,
+      }) as unknown as AgentMessage,
+    ];
+
+    const sanitized = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-codex-responses",
+      provider: "openai",
+      modelId: "gpt-5.3-codex",
+      sessionManager: sm,
+      sessionId: "test",
+    });
+
+    const first = sanitized[0] as { errorMessage?: string };
+    const second = sanitized[1] as { errorMessage?: string };
+
+    expect(first.errorMessage).toBe(
+      "The AI service is temporarily overloaded. Please try again in a moment.",
+    );
+    expect(second.errorMessage).toBe(
+      "The AI service is temporarily overloaded. Please try again in a moment. (repeated x2)",
+    );
+  });
+});

--- a/src/agents/pi-embedded-runner/sanitize-session-history.assistant-errors.test.ts
+++ b/src/agents/pi-embedded-runner/sanitize-session-history.assistant-errors.test.ts
@@ -40,6 +40,69 @@ describe("sanitizeSessionHistory assistant error sanitization", () => {
     );
   });
 
+  it("does not overwrite long non-error assistant text blocks", async () => {
+    const sm = SessionManager.inMemory();
+    const rawError =
+      '529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"},"request_id":"req_abc"}';
+    const partialLegitText = `partial:${"a".repeat(320)}`;
+
+    const messages: AgentMessage[] = [
+      makeAssistantMessageFixture({
+        stopReason: "error",
+        errorMessage: rawError,
+        content: [{ type: "text", text: partialLegitText }],
+      }) as unknown as AgentMessage,
+    ];
+
+    const sanitized = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-codex-responses",
+      provider: "openai",
+      modelId: "gpt-5.3-codex",
+      sessionManager: sm,
+      sessionId: "test",
+    });
+
+    const assistant = sanitized[0] as AgentMessage & {
+      errorMessage?: string;
+      content?: Array<{ type?: string; text?: string }>;
+    };
+
+    expect(assistant.errorMessage).toBe(
+      "The AI service is temporarily overloaded. Please try again in a moment.",
+    );
+    expect(assistant.content?.[0]?.text).toBe(partialLegitText);
+  });
+
+  it("caps repeated suffix variants to keep transcript errors bounded", async () => {
+    const sm = SessionManager.inMemory();
+    const rawError = `boom:${"x".repeat(600)}`;
+
+    const messages: AgentMessage[] = [
+      makeAssistantMessageFixture({
+        stopReason: "error",
+        errorMessage: rawError,
+      }) as unknown as AgentMessage,
+      makeAssistantMessageFixture({
+        stopReason: "error",
+        errorMessage: rawError,
+      }) as unknown as AgentMessage,
+    ];
+
+    const sanitized = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-codex-responses",
+      provider: "openai",
+      modelId: "gpt-5.3-codex",
+      sessionManager: sm,
+      sessionId: "test",
+    });
+
+    const second = sanitized[1] as { errorMessage?: string };
+    expect((second.errorMessage ?? "").length).toBeLessThanOrEqual(220);
+    expect(second.errorMessage).toContain("(repeated x2)");
+  });
+
   it("marks repeated consecutive assistant errors with a compact counter", async () => {
     const sm = SessionManager.inMemory();
     const rawError =

--- a/src/agents/pi-embedded-runner/sanitize-session-history.assistant-errors.test.ts
+++ b/src/agents/pi-embedded-runner/sanitize-session-history.assistant-errors.test.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import { SessionManager } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
+import { formatAssistantErrorForTranscript } from "../pi-embedded-helpers.js";
 import { makeAssistantMessageFixture } from "../test-helpers/assistant-message-fixtures.js";
 import { sanitizeSessionHistory } from "./google.js";
 
@@ -74,6 +75,94 @@ describe("sanitizeSessionHistory assistant error sanitization", () => {
     expect(assistant.content?.[0]?.text).toBe(partialLegitText);
   });
 
+  it("rewrites string-shaped assistant content when it still contains a raw error payload", async () => {
+    const sm = SessionManager.inMemory();
+    const rawError =
+      '500 {"type":"error","error":{"type":"server_error","message":"Oops"},"request_id":"req_abc"}';
+    const malformedAssistant = makeAssistantMessageFixture({
+      stopReason: "error",
+      errorMessage: rawError,
+    }) as unknown as AgentMessage & { content?: unknown };
+    malformedAssistant.content = rawError;
+
+    const sanitized = await sanitizeSessionHistory({
+      messages: [malformedAssistant],
+      modelApi: "openai-codex-responses",
+      provider: "openai",
+      modelId: "gpt-5.3-codex",
+      sessionManager: sm,
+      sessionId: "test",
+    });
+
+    const assistant = sanitized[0] as AgentMessage & {
+      errorMessage?: string;
+      content?: string;
+    };
+
+    const normalized = formatAssistantErrorForTranscript(rawError);
+    expect(assistant.errorMessage).toBe(normalized);
+    expect(assistant.content).toBe(normalized);
+  });
+
+  it("does not overwrite string-shaped legitimate partial assistant content", async () => {
+    const sm = SessionManager.inMemory();
+    const rawError =
+      '500 {"type":"error","error":{"type":"server_error","message":"Oops"},"request_id":"req_abc"}';
+    const partialLegitText = `partial:${"b".repeat(320)}`;
+    const malformedAssistant = makeAssistantMessageFixture({
+      stopReason: "error",
+      errorMessage: rawError,
+    }) as unknown as AgentMessage & { content?: unknown };
+    malformedAssistant.content = partialLegitText;
+
+    const sanitized = await sanitizeSessionHistory({
+      messages: [malformedAssistant],
+      modelApi: "openai-codex-responses",
+      provider: "openai",
+      modelId: "gpt-5.3-codex",
+      sessionManager: sm,
+      sessionId: "test",
+    });
+
+    const assistant = sanitized[0] as AgentMessage & {
+      errorMessage?: string;
+      content?: string;
+    };
+
+    expect(assistant.errorMessage).toBe(formatAssistantErrorForTranscript(rawError));
+    expect(assistant.content).toBe(partialLegitText);
+  });
+
+  it("rewrites pretty-printed payload blocks even when the compact raw error string differs", async () => {
+    const sm = SessionManager.inMemory();
+    const rawError =
+      '500 {"type":"error","error":{"type":"server_error","message":"Oops"},"request_id":"req_abc"}';
+    const prettyPrinted = `500 {\n  "type": "error",\n  "error": {\n    "type": "server_error",\n    "message": "Oops"\n  },\n  "request_id": "req_abc"\n}`;
+
+    const messages: AgentMessage[] = [
+      makeAssistantMessageFixture({
+        stopReason: "error",
+        errorMessage: rawError,
+        content: [{ type: "text", text: prettyPrinted }],
+      }) as unknown as AgentMessage,
+    ];
+
+    const sanitized = await sanitizeSessionHistory({
+      messages,
+      modelApi: "openai-codex-responses",
+      provider: "openai",
+      modelId: "gpt-5.3-codex",
+      sessionManager: sm,
+      sessionId: "test",
+    });
+
+    const assistant = sanitized[0] as AgentMessage & {
+      content?: Array<{ type?: string; text?: string }>;
+    };
+
+    expect(assistant.content?.[0]?.text).toBe(formatAssistantErrorForTranscript(rawError));
+  });
+
   it("caps repeated suffix variants to keep transcript errors bounded", async () => {
     const sm = SessionManager.inMemory();
     const rawError = `boom:${"x".repeat(600)}`;
@@ -136,6 +225,50 @@ describe("sanitizeSessionHistory assistant error sanitization", () => {
     );
     expect(second.errorMessage).toBe(
       "The AI service is temporarily overloaded. Please try again in a moment. (repeated x2)",
+    );
+  });
+
+  it("continues counting repeated errors across later replay passes", async () => {
+    const sm = SessionManager.inMemory();
+    const rawError =
+      '529 {"type":"error","error":{"type":"overloaded_error","message":"Overloaded"},"request_id":"req_abc"}';
+
+    const firstPass = await sanitizeSessionHistory({
+      messages: [
+        makeAssistantMessageFixture({
+          stopReason: "error",
+          errorMessage: rawError,
+        }) as unknown as AgentMessage,
+        makeAssistantMessageFixture({
+          stopReason: "error",
+          errorMessage: rawError,
+        }) as unknown as AgentMessage,
+      ],
+      modelApi: "openai-codex-responses",
+      provider: "openai",
+      modelId: "gpt-5.3-codex",
+      sessionManager: sm,
+      sessionId: "test",
+    });
+
+    const secondPass = await sanitizeSessionHistory({
+      messages: [
+        ...firstPass,
+        makeAssistantMessageFixture({
+          stopReason: "error",
+          errorMessage: rawError,
+        }) as unknown as AgentMessage,
+      ],
+      modelApi: "openai-codex-responses",
+      provider: "openai",
+      modelId: "gpt-5.3-codex",
+      sessionManager: sm,
+      sessionId: "test",
+    });
+
+    const third = secondPass[2] as { errorMessage?: string };
+    expect(third.errorMessage).toBe(
+      "The AI service is temporarily overloaded. Please try again in a moment. (repeated x3)",
     );
   });
 });


### PR DESCRIPTION
## Summary
- sanitize assistant `errorMessage` before replaying session history so huge raw API payloads/HTML are not re-injected into context
- normalize repetitive consecutive assistant errors with a compact `(repeated xN)` suffix
- add transcript-focused formatter for safe, bounded error strings

## Why
Issue #32995 reports context bloat caused by raw error payloads being preserved in transcript history.

## Changes
- add `formatAssistantErrorForTranscript(...)` in `src/agents/pi-embedded-helpers/errors.ts`
- apply assistant-error sanitization in `sanitizeSessionHistory(...)` (`src/agents/pi-embedded-runner/google.ts`)
- export the new helper from `src/agents/pi-embedded-helpers.ts`
- add/extend tests:
  - `src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts`
  - `src/agents/pi-embedded-runner/sanitize-session-history.assistant-errors.test.ts`

## Validation
- `corepack pnpm exec vitest run src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/agents/pi-embedded-runner/sanitize-session-history.assistant-errors.test.ts src/agents/pi-embedded-runner/sanitize-session-history.tool-result-details.test.ts`

All targeted tests pass locally.
