### PR TITLE
fix: show configured fallback models in /status output

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -357,6 +357,68 @@ describe("buildStatusMessage", () => {
     expect(normalized).not.toContain("Fallback:");
   });
 
+  it("shows configured fallbacks when model config has fallbacks array", () => {
+    const text = buildStatusMessage({
+      config: {
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-sonnet-4",
+              fallbacks: ["openai/gpt-4.1", "google/gemini-2.0-flash"],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig,
+      agent: {
+        model: {
+          primary: "anthropic/claude-sonnet-4",
+          fallbacks: ["openai/gpt-4.1", "google/gemini-2.0-flash"],
+        },
+      },
+      sessionEntry: {
+        sessionId: "test-fallbacks",
+        updatedAt: 0,
+        contextTokens: 32_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Model: anthropic/claude-sonnet-4");
+    expect(normalized).toContain("Fallbacks: openai/gpt-4.1, google/gemini-2.0-flash");
+  });
+
+  it("does not show fallbacks when model config is a string", () => {
+    const text = buildStatusMessage({
+      config: {
+        agents: {
+          defaults: {
+            model: "anthropic/claude-sonnet-4",
+          },
+        },
+      } as unknown as OpenClawConfig,
+      agent: {
+        model: "anthropic/claude-sonnet-4",
+      },
+      sessionEntry: {
+        sessionId: "test-no-fallbacks",
+        updatedAt: 0,
+        contextTokens: 32_000,
+      },
+      sessionKey: "agent:main:main",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+      modelAuth: "api-key",
+    });
+
+    const normalized = normalizeTestText(text);
+    expect(normalized).toContain("Model: anthropic/claude-sonnet-4");
+    expect(normalized).not.toContain("Fallbacks:");
+  });
+
   it("keeps provider prefix from configured model", () => {
     const text = buildStatusMessage({
       agent: {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -13,6 +13,7 @@ import { derivePromptTokens, normalizeUsage, type UsageLike } from "../agents/us
 import { resolveChannelModelOverride } from "../channels/model-overrides.js";
 import { isCommandFlagEnabled } from "../config/commands.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveAgentModelFallbackValues } from "../config/model-input.js";
 import {
   resolveMainSessionKey,
   resolveSessionFilePath,
@@ -647,8 +648,14 @@ export function buildStatusMessage(args: StatusArgs): string {
     }
     return "channel override";
   })();
+
+  // Extract configured fallbacks from model config
+  const configuredFallbacks = resolveAgentModelFallbackValues(args.config?.agents?.defaults?.model);
+  const fallbacksNote =
+    configuredFallbacks.length > 0 ? ` · Fallbacks: ${configuredFallbacks.join(", ")}` : "";
+
   const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";
-  const modelLine = `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}`;
+  const modelLine = `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}${fallbacksNote}`;
   const showFallbackAuth = activeAuthLabelValue && activeAuthLabelValue !== selectedAuthLabelValue;
   const fallbackLine = fallbackState.active
     ? `↪️ Fallback: ${activeModelLabel}${


### PR DESCRIPTION
## Description

When fallback models are configured in `agents.defaults.model.fallbacks`, the `/status` command (and session status card) now displays them so users can verify their setup at a glance.

Fixes #33099

## Changes

- Import `resolveAgentModelFallbackValues` helper to extract fallbacks from model config
- Add fallback display to the Model line in `buildStatusMessage`
- Add tests to verify fallbacks are shown when configured and hidden when not

## Example

**Before:**
```
🧠 Model: anthropic/claude-opus-4-6
```

**After:**
```
🧠 Model: anthropic/claude-opus-4-6 · Fallbacks: google/gemini-2.5-flash
```

## Testing

- Added 2 new test cases to verify the fix
- All existing tests pass (28 tests in status.test.ts)
- TypeScript compilation succeeds with no errors

## Notes

The fallbacks are only shown when the model configuration uses the object format with a `fallbacks` array. When the model is configured as a simple string, no fallbacks are shown (as expected).