### PR TITLE
errors: avoid jinja false-positive context-overflow classification

### DIFF
--- a/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts
@@ -5,6 +5,7 @@ import {
   formatBillingErrorMessage,
   formatAssistantErrorText,
   formatRawAssistantErrorForUi,
+  isLikelyContextOverflowError,
 } from "./pi-embedded-helpers.js";
 import { makeAssistantMessageFixture } from "./test-helpers/assistant-message-fixtures.js";
 
@@ -35,6 +36,18 @@ describe("formatAssistantErrorText", () => {
     );
     expect(formatAssistantErrorText(msg)).toContain("Context overflow");
   });
+
+  it("does not misclassify jinja template errors when payload contains noisy context fields", () => {
+    const raw =
+      '400 {"type":"error","error":{"type":"invalid_request_error","message":"Error rendering prompt with jinja template: \\\"No user query found in messages.\\\""},"details":{"hint":"context window 262144"}}';
+    const msg = makeAssistantError(raw);
+    expect(isLikelyContextOverflowError(raw)).toBe(false);
+    expect(formatAssistantErrorText(msg)).toContain(
+      "LLM request rejected: Error rendering prompt with jinja template",
+    );
+    expect(formatAssistantErrorText(msg)).not.toContain("Context overflow");
+  });
+
   it("returns a reasoning-required message for mandatory reasoning endpoint errors", () => {
     const msg = makeAssistantError(
       "400 Reasoning is mandatory for this endpoint and cannot be disabled.",

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -306,6 +306,16 @@ describe("isContextOverflowError", () => {
     }
   });
 
+  it("matches overflow signals carried only in error.code or HTTP-prefixed payloads", () => {
+    const samples = [
+      '{"type":"error","error":{"type":"invalid_request_error","code":"request_too_large","message":"Invalid request"}}',
+      '413 {"type":"error","error":{"type":"invalid_request_error","message":"Request Entity Too Large"}}',
+    ];
+    for (const sample of samples) {
+      expect(isContextOverflowError(sample)).toBe(true);
+    }
+  });
+
   it("matches Kimi 'model token limit' context overflow errors", () => {
     const samples = [
       "Invalid request: Your request exceeded model token limit: 262144 (requested: 291351)",

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -71,18 +71,48 @@ function hasRateLimitTpmHint(raw: string): boolean {
   return /\btpm\b/i.test(lower) || lower.includes("tokens per minute");
 }
 
+function resolveContextOverflowCandidate(errorMessage: string): {
+  text: string;
+  type?: string;
+} {
+  const parsed = parseApiErrorInfo(errorMessage);
+  const candidate = parsed?.message?.trim();
+  return {
+    text: candidate && candidate.length > 0 ? candidate : errorMessage,
+    type: parsed?.type,
+  };
+}
+
+function isExplicitContextOverflowType(type?: string): boolean {
+  if (!type) {
+    return false;
+  }
+  const lower = type.toLowerCase();
+  return (
+    lower.includes("request_too_large") ||
+    lower.includes("context_length_exceeded") ||
+    lower.includes("context_window_exceeded") ||
+    lower.includes("context_overflow")
+  );
+}
+
 export function isContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) {
     return false;
   }
-  const lower = errorMessage.toLowerCase();
+  const candidate = resolveContextOverflowCandidate(errorMessage);
+  if (isExplicitContextOverflowType(candidate.type)) {
+    return true;
+  }
+
+  const lower = candidate.text.toLowerCase();
 
   // Groq uses 413 for TPM (tokens per minute) limits, which is a rate limit, not context overflow.
-  if (hasRateLimitTpmHint(errorMessage)) {
+  if (hasRateLimitTpmHint(candidate.text)) {
     return false;
   }
 
-  if (isReasoningConstraintErrorMessage(errorMessage)) {
+  if (isReasoningConstraintErrorMessage(candidate.text)) {
     return false;
   }
 
@@ -110,11 +140,11 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     // when the context window is exceeded. pi-ai surfaces it as "Unhandled stop reason: model_context_window_exceeded".
     lower.includes("context_window_exceeded") ||
     // Chinese proxy error messages for context overflow
-    errorMessage.includes("上下文过长") ||
-    errorMessage.includes("上下文超出") ||
-    errorMessage.includes("上下文长度超") ||
-    errorMessage.includes("超出最大上下文") ||
-    errorMessage.includes("请压缩上下文")
+    candidate.text.includes("上下文过长") ||
+    candidate.text.includes("上下文超出") ||
+    candidate.text.includes("上下文长度超") ||
+    candidate.text.includes("超出最大上下文") ||
+    candidate.text.includes("请压缩上下文")
   );
 }
 
@@ -128,13 +158,14 @@ export function isLikelyContextOverflowError(errorMessage?: string): boolean {
   if (!errorMessage) {
     return false;
   }
+  const candidate = resolveContextOverflowCandidate(errorMessage);
 
   // Groq uses 413 for TPM (tokens per minute) limits, which is a rate limit, not context overflow.
-  if (hasRateLimitTpmHint(errorMessage)) {
+  if (hasRateLimitTpmHint(candidate.text)) {
     return false;
   }
 
-  if (isReasoningConstraintErrorMessage(errorMessage)) {
+  if (isReasoningConstraintErrorMessage(candidate.text)) {
     return false;
   }
 
@@ -145,22 +176,22 @@ export function isLikelyContextOverflowError(errorMessage?: string): boolean {
     return false;
   }
 
-  if (CONTEXT_WINDOW_TOO_SMALL_RE.test(errorMessage)) {
+  if (CONTEXT_WINDOW_TOO_SMALL_RE.test(candidate.text)) {
     return false;
   }
   // Rate limit errors can match the broad CONTEXT_OVERFLOW_HINT_RE pattern
   // (e.g., "request reached organization TPD rate limit" matches request.*limit).
   // Exclude them before checking context overflow heuristics.
-  if (isRateLimitErrorMessage(errorMessage)) {
+  if (isRateLimitErrorMessage(candidate.text)) {
     return false;
   }
   if (isContextOverflowError(errorMessage)) {
     return true;
   }
-  if (RATE_LIMIT_HINT_RE.test(errorMessage)) {
+  if (RATE_LIMIT_HINT_RE.test(candidate.text)) {
     return false;
   }
-  return CONTEXT_OVERFLOW_HINT_RE.test(errorMessage);
+  return CONTEXT_OVERFLOW_HINT_RE.test(candidate.text);
 }
 
 export function isCompactionFailureError(errorMessage?: string): boolean {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -74,12 +74,20 @@ function hasRateLimitTpmHint(raw: string): boolean {
 function resolveContextOverflowCandidate(errorMessage: string): {
   text: string;
   type?: string;
+  code?: string;
 } {
   const parsed = parseApiErrorInfo(errorMessage);
-  const candidate = parsed?.message?.trim();
+  const candidateParts = [
+    parsed?.httpCode?.trim(),
+    parsed?.type?.trim(),
+    parsed?.code?.trim(),
+    parsed?.message?.trim(),
+  ].filter((value): value is string => Boolean(value && value.length > 0));
+  const candidate = candidateParts.join(" ").trim();
   return {
     text: candidate && candidate.length > 0 ? candidate : errorMessage,
     type: parsed?.type,
+    code: parsed?.code,
   };
 }
 
@@ -101,7 +109,10 @@ export function isContextOverflowError(errorMessage?: string): boolean {
     return false;
   }
   const candidate = resolveContextOverflowCandidate(errorMessage);
-  if (isExplicitContextOverflowType(candidate.type)) {
+  if (
+    isExplicitContextOverflowType(candidate.type) ||
+    isExplicitContextOverflowType(candidate.code)
+  ) {
     return true;
   }
 
@@ -612,6 +623,7 @@ export function isRawApiErrorPayload(raw?: string): boolean {
 export type ApiErrorInfo = {
   httpCode?: string;
   type?: string;
+  code?: string;
   message?: string;
   requestId?: string;
 };
@@ -650,14 +662,18 @@ export function parseApiErrorInfo(raw?: string): ApiErrorInfo | null {
   const topMessage = typeof payload.message === "string" ? payload.message : undefined;
 
   let errType: string | undefined;
+  let errCode: string | undefined;
   let errMessage: string | undefined;
   if (payload.error && typeof payload.error === "object" && !Array.isArray(payload.error)) {
     const err = payload.error as Record<string, unknown>;
     if (typeof err.type === "string") {
       errType = err.type;
     }
-    if (typeof err.code === "string" && !errType) {
-      errType = err.code;
+    if (typeof err.code === "string") {
+      errCode = err.code;
+      if (!errType) {
+        errType = err.code;
+      }
     }
     if (typeof err.message === "string") {
       errMessage = err.message;
@@ -667,6 +683,7 @@ export function parseApiErrorInfo(raw?: string): ApiErrorInfo | null {
   return {
     httpCode,
     type: errType ?? topType,
+    code: errCode,
     message: errMessage ?? topMessage,
     requestId,
   };


### PR DESCRIPTION
## Summary
- fix false-positive context-overflow classification for provider errors that include noisy payload fields
- prioritize parsed API `error.message` when determining overflow heuristics
- keep explicit overflow-type handling intact (`request_too_large`, `context_length_exceeded`, etc.)

## Why
Issue #32936 reports LM Studio Qwen Jinja template errors ("No user query found in messages") being misclassified as context overflow, which then triggers misleading auto-compaction loops.

## Changes
- `src/agents/pi-embedded-helpers/errors.ts`
  - add `resolveContextOverflowCandidate(...)` to classify overflow using parsed payload message first
  - add explicit overflow type guard (`isExplicitContextOverflowType`)
  - update `isContextOverflowError(...)` and `isLikelyContextOverflowError(...)` to evaluate candidate message instead of raw noisy payload
- `src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts`
  - add regression test for Jinja error payload with injected `context window` noise

## Validation
- `corepack pnpm exec vitest run src/agents/pi-embedded-helpers.formatassistanterrortext.test.ts src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts --reporter=dot`
- Result: 33 tests passed
