### PR TITLE
feat(cli): add tui.deliver config option for default --deliver behavior

### DIFF
--- a/src/cli/tui-cli.test.ts
+++ b/src/cli/tui-cli.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: vi.fn(() => ({ tui: { deliver: true } })),
+}));
+
+vi.mock("../runtime.js", () => ({
+  defaultRuntime: {
+    error: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+
+vi.mock("../tui/tui.js", () => ({
+  runTui: vi.fn(async () => {}),
+}));
+
+describe("tui-cli --deliver config", () => {
+  it("should load config and use tui.deliver as default", async () => {
+    const { loadConfig } = await import("../config/config.js");
+    const { runTui } = await import("../tui/tui.js");
+
+    // Create a mock program and command
+    const mockAction = vi.fn();
+    const mockCommand = {
+      command: vi.fn(() => mockCommand),
+      description: vi.fn(() => mockCommand),
+      option: vi.fn(() => mockCommand),
+      addHelpText: vi.fn(() => mockCommand),
+      action: (fn: () => Promise<void>) => {
+        mockAction(fn);
+      },
+    };
+    const mockProgram = {
+      command: vi.fn(() => mockCommand),
+    };
+
+    // Register the CLI
+    const { registerTuiCli } = await import("./tui-cli.js");
+    registerTuiCli(mockProgram as unknown as { command: () => unknown });
+
+    // Get the action function
+    const actionFn = mockAction.mock.calls[0][0];
+
+    // Call with no --deliver flag (should use config value)
+    await actionFn({ historyLimit: "200" });
+
+    // Verify config was loaded
+    expect(loadConfig).toHaveBeenCalled();
+
+    // Verify runTui was called with config value (true)
+    expect(runTui).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deliver: true,
+      }),
+    );
+  });
+});

--- a/src/cli/tui-cli.ts
+++ b/src/cli/tui-cli.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import { loadConfig } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
 import { formatDocsLink } from "../terminal/links.js";
 import { theme } from "../terminal/theme.js";
@@ -13,7 +14,8 @@ export function registerTuiCli(program: Command) {
     .option("--token <token>", "Gateway token (if required)")
     .option("--password <password>", "Gateway password (if required)")
     .option("--session <key>", 'Session key (default: "main", or "global" when scope is global)')
-    .option("--deliver", "Deliver assistant replies", false)
+    .option("--deliver", "Deliver assistant replies (default: config tui.deliver or false)")
+    .option("--no-deliver", "Disable delivering assistant replies")
     .option("--thinking <level>", "Thinking level override")
     .option("--message <text>", "Send an initial message after connecting")
     .option("--timeout-ms <ms>", "Agent timeout in ms (defaults to agents.defaults.timeoutSeconds)")
@@ -24,6 +26,11 @@ export function registerTuiCli(program: Command) {
     )
     .action(async (opts) => {
       try {
+        const config = loadConfig();
+        const configDeliver = config.tui?.deliver ?? false;
+        // CLI flag overrides config: --deliver sets true, --no-deliver sets false, no flag uses config
+        const deliver = opts.deliver !== undefined ? Boolean(opts.deliver) : configDeliver;
+
         const timeoutMs = parseTimeoutMs(opts.timeoutMs);
         if (opts.timeoutMs !== undefined && timeoutMs === undefined) {
           defaultRuntime.error(
@@ -36,7 +43,7 @@ export function registerTuiCli(program: Command) {
           token: opts.token as string | undefined,
           password: opts.password as string | undefined,
           session: opts.session as string | undefined,
-          deliver: Boolean(opts.deliver),
+          deliver,
           thinking: opts.thinking as string | undefined,
           message: opts.message as string | undefined,
           timeoutMs,

--- a/src/config/types.cli.ts
+++ b/src/config/types.cli.ts
@@ -11,3 +11,12 @@ export type CliConfig = {
     taglineMode?: CliBannerTaglineMode;
   };
 };
+
+export type TuiConfig = {
+  /**
+   * Deliver assistant replies to stdout by default.
+   * When false (default), replies are stored but not printed.
+   * Can be overridden with --deliver flag.
+   */
+  deliver?: boolean;
+};

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -5,7 +5,7 @@ import type { AuthConfig } from "./types.auth.js";
 import type { DiagnosticsConfig, LoggingConfig, SessionConfig, WebConfig } from "./types.base.js";
 import type { BrowserConfig } from "./types.browser.js";
 import type { ChannelsConfig } from "./types.channels.js";
-import type { CliConfig } from "./types.cli.js";
+import type { CliConfig, TuiConfig } from "./types.cli.js";
 import type { CronConfig } from "./types.cron.js";
 import type {
   CanvasHostConfig,
@@ -63,6 +63,7 @@ export type OpenClawConfig = {
   diagnostics?: DiagnosticsConfig;
   logging?: LoggingConfig;
   cli?: CliConfig;
+  tui?: TuiConfig;
   update?: {
     /** Update channel for git + npm installs ("stable", "beta", or "dev"). */
     channel?: "stable" | "beta" | "dev";


### PR DESCRIPTION
## Problem

The `openclaw tui` command has a `--deliver` flag that defaults to `false`. This means assistant replies are stored but not printed to stdout by default. Users find this confusing and have to pass `--deliver` every time or use shell aliases.

## Solution

Added `tui.deliver` config option so users can set their preferred default in the config file:

```json
{
  "tui": {
    "deliver": true
  }
}
```

The CLI flag still overrides the config:
- `--deliver` forces it on
- `--no-deliver` forces it off
- No flag uses the config value (or `false` if not set)

## Changes

- `src/config/types.cli.ts`: Added `TuiConfig` type with `deliver` option
- `src/config/types.openclaw.ts`: Added `tui` to `OpenClawConfig`
- `src/cli/tui-cli.ts`: Load config and use `tui.deliver` as default
- `src/cli/tui-cli.test.ts`: Test for config-based default

Fixes #33102