### PR TITLE
feat(compaction): add preserveSections config for post-compaction context [AI-assisted]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Docs: https://docs.openclaw.ai
 
 ## 2026.3.3
 
+- Compaction: add `agents.defaults.compaction.preserveSections` config to specify which AGENTS.md sections are preserved in post-compaction context. Defaults to `["Session Startup", "Red Lines"]` for backward compatibility. Agents with custom section names (e.g. "Safety", "Critical Rules") no longer lose those rules after compaction.
+
 ### Changes
 
 - Docs/Web search: remove outdated Brave free-tier wording and replace prescriptive AI ToS guidance with neutral compliance language in Brave setup docs. (#26860) Thanks @HenryLoenwind.

--- a/src/agents/pi-embedded-runner/extensions.ts
+++ b/src/agents/pi-embedded-runner/extensions.ts
@@ -83,6 +83,7 @@ export function buildEmbeddedExtensionFactories(params: {
       contextWindowTokens: contextWindowInfo.tokens,
       identifierPolicy: compactionCfg?.identifierPolicy,
       identifierInstructions: compactionCfg?.identifierInstructions,
+      preserveSections: compactionCfg?.preserveSections,
       model: params.model,
     });
     factories.push(compactionSafeguardExtension);

--- a/src/agents/pi-extensions/compaction-safeguard-runtime.ts
+++ b/src/agents/pi-extensions/compaction-safeguard-runtime.ts
@@ -14,6 +14,7 @@ export type CompactionSafeguardRuntimeValue = {
    */
   model?: Model<Api>;
   recentTurnsPreserve?: number;
+  preserveSections?: string[];
 };
 
 const registry = createSessionManagerRuntimeRegistry<CompactionSafeguardRuntimeValue>();

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -386,12 +386,14 @@ function appendSummarySection(summary: string, section: string): string {
   return `${summary}${section}`;
 }
 
+const DEFAULT_PRESERVE_SECTIONS = ["Session Startup", "Red Lines"];
+
 /**
  * Read and format critical workspace context for compaction summary.
- * Extracts "Session Startup" and "Red Lines" from AGENTS.md.
+ * Extracts configured sections (or defaults: "Session Startup" and "Red Lines") from AGENTS.md.
  * Limited to 2000 chars to avoid bloating the summary.
  */
-async function readWorkspaceContextForSummary(): Promise<string> {
+async function readWorkspaceContextForSummary(preserveSections?: string[]): Promise<string> {
   const MAX_SUMMARY_CONTEXT_CHARS = 2000;
   const workspaceDir = process.cwd();
   const agentsPath = path.join(workspaceDir, "AGENTS.md");
@@ -413,7 +415,11 @@ async function readWorkspaceContextForSummary(): Promise<string> {
         fs.closeSync(opened.fd);
       }
     })();
-    const sections = extractSections(content, ["Session Startup", "Red Lines"]);
+    const sectionNames =
+      Array.isArray(preserveSections) && preserveSections.length > 0
+        ? preserveSections
+        : DEFAULT_PRESERVE_SECTIONS;
+    const sections = extractSections(content, sectionNames);
 
     if (sections.length === 0) {
       return "";
@@ -619,8 +625,8 @@ export default function compactionSafeguardExtension(api: ExtensionAPI): void {
       summary = appendSummarySection(summary, toolFailureSection);
       summary = appendSummarySection(summary, fileOpsSummary);
 
-      // Append workspace critical context (Session Startup + Red Lines from AGENTS.md)
-      const workspaceContext = await readWorkspaceContextForSummary();
+      // Append workspace critical context (configured sections from AGENTS.md)
+      const workspaceContext = await readWorkspaceContextForSummary(runtime?.preserveSections);
       if (workspaceContext) {
         summary = appendSummarySection(summary, workspaceContext);
       }

--- a/src/agents/pi-extensions/compaction-safeguard.ts
+++ b/src/agents/pi-extensions/compaction-safeguard.ts
@@ -2,7 +2,10 @@ import fs from "node:fs";
 import path from "node:path";
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
 import type { ExtensionAPI, FileOperations } from "@mariozechner/pi-coding-agent";
-import { extractSections } from "../../auto-reply/reply/post-compaction-context.js";
+import {
+  DEFAULT_PRESERVE_SECTIONS,
+  extractSections,
+} from "../../auto-reply/reply/post-compaction-context.js";
 import { openBoundaryFile } from "../../infra/boundary-file-read.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import {
@@ -385,8 +388,6 @@ function appendSummarySection(summary: string, section: string): string {
   }
   return `${summary}${section}`;
 }
-
-const DEFAULT_PRESERVE_SECTIONS = ["Session Startup", "Red Lines"];
 
 /**
  * Read and format critical workspace context for compaction summary.

--- a/src/auto-reply/reply/post-compaction-context.test.ts
+++ b/src/auto-reply/reply/post-compaction-context.test.ts
@@ -215,6 +215,74 @@ Never modify memory/YYYY-MM-DD.md destructively.
     expect(result).toContain("America/New_York");
   });
 
+  it("uses configured preserveSections instead of defaults", async () => {
+    const content = `# My Agent
+
+## Safety
+
+Never delete production data.
+
+## Things You Must NEVER Get Wrong
+
+Always double-check before sending emails.
+
+## Session Startup
+
+Default section that should be ignored when custom sections are configured.
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const cfg = {
+      agents: {
+        defaults: {
+          compaction: {
+            preserveSections: ["Safety", "Things You Must NEVER Get Wrong"],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const result = await readPostCompactionContext(tmpDir, cfg);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Never delete production data");
+    expect(result).toContain("Always double-check before sending emails");
+    expect(result).not.toContain("Default section that should be ignored");
+  });
+
+  it("falls back to defaults when preserveSections is empty", async () => {
+    const content = `## Session Startup
+
+Read startup files.
+
+## Safety
+
+Custom section.
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const cfg = {
+      agents: {
+        defaults: {
+          compaction: {
+            preserveSections: [],
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const result = await readPostCompactionContext(tmpDir, cfg);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Read startup files");
+    expect(result).not.toContain("Custom section");
+  });
+
+  it("falls back to defaults when preserveSections is not configured", async () => {
+    const content = `## Session Startup
+
+Default preserved.
+`;
+    fs.writeFileSync(path.join(tmpDir, "AGENTS.md"), content);
+    const result = await readPostCompactionContext(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result).toContain("Default preserved");
+  });
+
   it("appends current time line even when no YYYY-MM-DD placeholder is present", async () => {
     const content = `## Session Startup
 

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -6,6 +6,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { openBoundaryFile } from "../../infra/boundary-file-read.js";
 
 const MAX_CONTEXT_CHARS = 3000;
+const DEFAULT_PRESERVE_SECTIONS = ["Session Startup", "Red Lines"];
 
 function formatDateStamp(nowMs: number, timezone: string): string {
   const parts = new Intl.DateTimeFormat("en-US", {
@@ -53,9 +54,14 @@ export async function readPostCompactionContext(
       }
     })();
 
-    // Extract "## Session Startup" and "## Red Lines" sections
-    // Each section ends at the next "## " heading or end of file
-    const sections = extractSections(content, ["Session Startup", "Red Lines"]);
+    // Extract configured sections from AGENTS.md for post-compaction context.
+    // Defaults to ["Session Startup", "Red Lines"] when not configured.
+    const configuredSections = cfg?.agents?.defaults?.compaction?.preserveSections;
+    const sectionNames =
+      Array.isArray(configuredSections) && configuredSections.length > 0
+        ? configuredSections
+        : DEFAULT_PRESERVE_SECTIONS;
+    const sections = extractSections(content, sectionNames);
 
     if (sections.length === 0) {
       return null;

--- a/src/auto-reply/reply/post-compaction-context.ts
+++ b/src/auto-reply/reply/post-compaction-context.ts
@@ -6,7 +6,9 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { openBoundaryFile } from "../../infra/boundary-file-read.js";
 
 const MAX_CONTEXT_CHARS = 3000;
-const DEFAULT_PRESERVE_SECTIONS = ["Session Startup", "Red Lines"];
+
+/** Default AGENTS.md sections preserved across compaction when not configured. */
+export const DEFAULT_PRESERVE_SECTIONS = ["Session Startup", "Red Lines"];
 
 function formatDateStamp(nowMs: number, timezone: string): string {
   const parts = new Intl.DateTimeFormat("en-US", {
@@ -80,10 +82,18 @@ export async function readPostCompactionContext(
         ? combined.slice(0, MAX_CONTEXT_CHARS) + "\n...[truncated]..."
         : combined;
 
+    // Build a dynamic instruction referencing the actual preserved sections,
+    // so agents aren't told to "Execute your Session Startup sequence" when
+    // that section doesn't exist in their config.
+    const hasSessionStartup = sectionNames.some((s) => s.toLowerCase() === "session startup");
+    const startupInstruction = hasSessionStartup
+      ? "Execute your Session Startup sequence now — read the required files before responding to the user."
+      : "Execute your startup sequence now — re-read your workspace files before responding to the user.";
+
     return (
       "[Post-compaction context refresh]\n\n" +
       "Session was just compacted. The conversation summary above is a hint, NOT a substitute for your startup sequence. " +
-      "Execute your Session Startup sequence now — read the required files before responding to the user.\n\n" +
+      `${startupInstruction}\n\n` +
       `Critical rules from AGENTS.md:\n\n${safeContent}\n\n${timeLine}`
     );
   } catch {

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -420,6 +420,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.compaction.maxHistoryShare": "Compaction Max History Share",
   "agents.defaults.compaction.identifierPolicy": "Compaction Identifier Policy",
   "agents.defaults.compaction.identifierInstructions": "Compaction Identifier Instructions",
+  "agents.defaults.compaction.preserveSections": "Compaction Preserve Sections",
   "agents.defaults.compaction.memoryFlush": "Compaction Memory Flush",
   "agents.defaults.compaction.memoryFlush.enabled": "Compaction Memory Flush Enabled",
   "agents.defaults.compaction.memoryFlush.softThresholdTokens":

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -297,6 +297,11 @@ export type AgentCompactionConfig = {
   identifierPolicy?: AgentCompactionIdentifierPolicy;
   /** Custom identifier-preservation instructions used when identifierPolicy is "custom". */
   identifierInstructions?: string;
+  /**
+   * AGENTS.md section names to preserve in post-compaction context.
+   * Defaults to ["Session Startup", "Red Lines"] when not configured.
+   */
+  preserveSections?: string[];
   /** Pre-compaction memory flush (agentic turn). Default: enabled. */
   memoryFlush?: AgentCompactionMemoryFlushConfig;
 };

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -92,6 +92,10 @@ export const AgentDefaultsSchema = z
           .union([z.literal("strict"), z.literal("off"), z.literal("custom")])
           .optional(),
         identifierInstructions: z.string().optional(),
+        preserveSections: z
+          .array(z.string().min(1).max(200))
+          .max(20)
+          .optional(),
         memoryFlush: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
## Problem

Post-compaction context injection hardcodes `["Session Startup", "Red Lines"]` as the only AGENTS.md sections preserved after compaction. Agents with custom section names (e.g. "Safety", "Critical Rules", "Things You Must NEVER Get Wrong") lose those rules mid-session.

This is the single most common cause of "my agent forgot its rules" after compaction.

Related: #25392, stale PR #25889, stale PR #20267.

## Fix

Add `agents.defaults.compaction.preserveSections` — an optional string array that specifies which AGENTS.md sections to preserve in post-compaction context refresh and compaction summaries.

```json
{
  "agents": {
    "defaults": {
      "compaction": {
        "preserveSections": ["Safety", "Critical Rules", "Things You Must NEVER Get Wrong"]
      }
    }
  }
}
```

Falls back to `["Session Startup", "Red Lines"]` when not configured (backward compatible).

## Changes

- **Config schema**: Add `preserveSections` to `AgentCompactionConfig` (zod + types + labels)
- **post-compaction-context.ts**: Read configured sections, fall back to defaults
- **compaction-safeguard.ts**: Thread `preserveSections` through runtime into summary generation
- **Tests**: 3 new tests covering custom sections, empty array fallback, and unconfigured fallback

## Tests

All 17 tests pass (3 new):
- `uses configured preserveSections instead of defaults`
- `falls back to defaults when preserveSections is empty`
- `falls back to defaults when preserveSections is not configured`