### PR TITLE
feat(cron): add maxRunsPerDay for daily run deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Docs: https://docs.openclaw.ai
 
 ## 2026.3.3
 
+- Cron: add `maxRunsPerDay` field for daily run deduplication. When set, the scheduler skips execution if the job has already completed that many times on the current calendar day (respects job timezone). Useful for daily tasks that may be triggered by both cron schedules and heartbeats. Set via CLI: `openclaw cron add --max-runs-per-day 1`.
+
 ### Changes
 
 - Docs/Web search: remove outdated Brave free-tier wording and replace prescriptive AI ToS guidance with neutral compliance language in Brave setup docs. (#26860) Thanks @HenryLoenwind.

--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2448,6 +2448,7 @@ public struct CronJob: Codable, Sendable {
     public let description: String?
     public let enabled: Bool
     public let deleteafterrun: Bool?
+    public let maxrunsperday: Int?
     public let createdatms: Int
     public let updatedatms: Int
     public let schedule: AnyCodable
@@ -2466,6 +2467,7 @@ public struct CronJob: Codable, Sendable {
         description: String?,
         enabled: Bool,
         deleteafterrun: Bool?,
+        maxrunsperday: Int?,
         createdatms: Int,
         updatedatms: Int,
         schedule: AnyCodable,
@@ -2483,6 +2485,7 @@ public struct CronJob: Codable, Sendable {
         self.description = description
         self.enabled = enabled
         self.deleteafterrun = deleteafterrun
+        self.maxrunsperday = maxrunsperday
         self.createdatms = createdatms
         self.updatedatms = updatedatms
         self.schedule = schedule
@@ -2502,6 +2505,7 @@ public struct CronJob: Codable, Sendable {
         case description
         case enabled
         case deleteafterrun = "deleteAfterRun"
+        case maxrunsperday = "maxRunsPerDay"
         case createdatms = "createdAtMs"
         case updatedatms = "updatedAtMs"
         case schedule
@@ -2561,6 +2565,7 @@ public struct CronAddParams: Codable, Sendable {
     public let description: String?
     public let enabled: Bool?
     public let deleteafterrun: Bool?
+    public let maxrunsperday: AnyCodable?
     public let schedule: AnyCodable
     public let sessiontarget: AnyCodable
     public let wakemode: AnyCodable
@@ -2575,6 +2580,7 @@ public struct CronAddParams: Codable, Sendable {
         description: String?,
         enabled: Bool?,
         deleteafterrun: Bool?,
+        maxrunsperday: AnyCodable?,
         schedule: AnyCodable,
         sessiontarget: AnyCodable,
         wakemode: AnyCodable,
@@ -2588,6 +2594,7 @@ public struct CronAddParams: Codable, Sendable {
         self.description = description
         self.enabled = enabled
         self.deleteafterrun = deleteafterrun
+        self.maxrunsperday = maxrunsperday
         self.schedule = schedule
         self.sessiontarget = sessiontarget
         self.wakemode = wakemode
@@ -2603,6 +2610,7 @@ public struct CronAddParams: Codable, Sendable {
         case description
         case enabled
         case deleteafterrun = "deleteAfterRun"
+        case maxrunsperday = "maxRunsPerDay"
         case schedule
         case sessiontarget = "sessionTarget"
         case wakemode = "wakeMode"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -2448,6 +2448,7 @@ public struct CronJob: Codable, Sendable {
     public let description: String?
     public let enabled: Bool
     public let deleteafterrun: Bool?
+    public let maxrunsperday: Int?
     public let createdatms: Int
     public let updatedatms: Int
     public let schedule: AnyCodable
@@ -2466,6 +2467,7 @@ public struct CronJob: Codable, Sendable {
         description: String?,
         enabled: Bool,
         deleteafterrun: Bool?,
+        maxrunsperday: Int?,
         createdatms: Int,
         updatedatms: Int,
         schedule: AnyCodable,
@@ -2483,6 +2485,7 @@ public struct CronJob: Codable, Sendable {
         self.description = description
         self.enabled = enabled
         self.deleteafterrun = deleteafterrun
+        self.maxrunsperday = maxrunsperday
         self.createdatms = createdatms
         self.updatedatms = updatedatms
         self.schedule = schedule
@@ -2502,6 +2505,7 @@ public struct CronJob: Codable, Sendable {
         case description
         case enabled
         case deleteafterrun = "deleteAfterRun"
+        case maxrunsperday = "maxRunsPerDay"
         case createdatms = "createdAtMs"
         case updatedatms = "updatedAtMs"
         case schedule
@@ -2561,6 +2565,7 @@ public struct CronAddParams: Codable, Sendable {
     public let description: String?
     public let enabled: Bool?
     public let deleteafterrun: Bool?
+    public let maxrunsperday: AnyCodable?
     public let schedule: AnyCodable
     public let sessiontarget: AnyCodable
     public let wakemode: AnyCodable
@@ -2575,6 +2580,7 @@ public struct CronAddParams: Codable, Sendable {
         description: String?,
         enabled: Bool?,
         deleteafterrun: Bool?,
+        maxrunsperday: AnyCodable?,
         schedule: AnyCodable,
         sessiontarget: AnyCodable,
         wakemode: AnyCodable,
@@ -2588,6 +2594,7 @@ public struct CronAddParams: Codable, Sendable {
         self.description = description
         self.enabled = enabled
         self.deleteafterrun = deleteafterrun
+        self.maxrunsperday = maxrunsperday
         self.schedule = schedule
         self.sessiontarget = sessiontarget
         self.wakemode = wakemode
@@ -2603,6 +2610,7 @@ public struct CronAddParams: Codable, Sendable {
         case description
         case enabled
         case deleteafterrun = "deleteAfterRun"
+        case maxrunsperday = "maxRunsPerDay"
         case schedule
         case sessiontarget = "sessionTarget"
         case wakemode = "wakeMode"

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -70,6 +70,7 @@ export function registerCronAddCommand(cron: Command) {
       .option("--disabled", "Create job disabled", false)
       .option("--delete-after-run", "Delete one-shot job after it succeeds", false)
       .option("--keep-after-run", "Keep one-shot job after it succeeds", false)
+      .option("--max-runs-per-day <n>", "Max successful runs per calendar day (skip if exceeded)", parseInt)
       .option("--agent <id>", "Agent id for this job")
       .option("--session <target>", "Session target (main|isolated)")
       .option("--session-key <key>", "Session key for job routing (e.g. agent:my-agent:my-session)")
@@ -252,6 +253,7 @@ export function registerCronAddCommand(cron: Command) {
             description,
             enabled: !opts.disabled,
             deleteAfterRun: opts.deleteAfterRun ? true : opts.keepAfterRun ? false : undefined,
+            maxRunsPerDay: typeof opts.maxRunsPerDay === "number" ? opts.maxRunsPerDay : undefined,
             agentId,
             sessionKey,
             schedule,

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -70,7 +70,11 @@ export function registerCronAddCommand(cron: Command) {
       .option("--disabled", "Create job disabled", false)
       .option("--delete-after-run", "Delete one-shot job after it succeeds", false)
       .option("--keep-after-run", "Keep one-shot job after it succeeds", false)
-      .option("--max-runs-per-day <n>", "Max successful runs per calendar day (skip if exceeded)", parseInt)
+      .option(
+        "--max-runs-per-day <n>",
+        "Max successful runs per calendar day (skip if exceeded)",
+        parseInt,
+      )
       .option("--agent <id>", "Agent id for this job")
       .option("--session <target>", "Session target (main|isolated)")
       .option("--session-key <key>", "Session key for job routing (e.g. agent:my-agent:my-session)")

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -474,6 +474,10 @@ export function createJob(state: CronServiceState, input: CronJobCreate): CronJo
     description: normalizeOptionalText(input.description),
     enabled,
     deleteAfterRun,
+    maxRunsPerDay:
+      typeof input.maxRunsPerDay === "number" && input.maxRunsPerDay > 0
+        ? input.maxRunsPerDay
+        : undefined,
     createdAtMs: now,
     updatedAtMs: now,
     schedule,
@@ -510,6 +514,11 @@ export function applyJobPatch(
   }
   if (typeof patch.deleteAfterRun === "boolean") {
     job.deleteAfterRun = patch.deleteAfterRun;
+  }
+  if (typeof patch.maxRunsPerDay === "number" && patch.maxRunsPerDay > 0) {
+    job.maxRunsPerDay = patch.maxRunsPerDay;
+  } else if (patch.maxRunsPerDay === 0 || patch.maxRunsPerDay === null) {
+    job.maxRunsPerDay = undefined;
   }
   if (patch.schedule) {
     if (patch.schedule.kind === "cron") {
@@ -813,6 +822,48 @@ function mergeCronFailureAlert(
   return next;
 }
 
+/**
+ * Resolve the calendar date string (YYYY-MM-DD) for a given timestamp
+ * in the job's configured timezone (or system default).
+ */
+export function resolveCalendarDate(nowMs: number, tz?: string): string {
+  const timezone = typeof tz === "string" && tz.trim() ? tz.trim() : undefined;
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(new Date(nowMs));
+    const year = parts.find((p) => p.type === "year")?.value;
+    const month = parts.find((p) => p.type === "month")?.value;
+    const day = parts.find((p) => p.type === "day")?.value;
+    if (year && month && day) {
+      return `${year}-${month}-${day}`;
+    }
+  } catch {
+    // Fall through to ISO fallback on invalid timezone.
+  }
+  return new Date(nowMs).toISOString().slice(0, 10);
+}
+
+/**
+ * Check whether a job has exceeded its maxRunsPerDay limit for the current
+ * calendar day. Returns true if the job should be skipped.
+ */
+export function isJobAtDailyLimit(job: CronJob, nowMs: number): boolean {
+  const maxRuns = job.maxRunsPerDay;
+  if (typeof maxRuns !== "number" || maxRuns <= 0) {
+    return false;
+  }
+  const today = resolveCalendarDate(
+    nowMs,
+    job.schedule.kind === "cron" ? job.schedule.tz : undefined,
+  );
+  const runsToday = job.state?.runsTodayDate === today ? (job.state.runsToday ?? 0) : 0;
+  return runsToday >= maxRuns;
+}
+
 export function isJobDue(job: CronJob, nowMs: number, opts: { forced: boolean }) {
   if (!job.state) {
     job.state = {};
@@ -823,7 +874,14 @@ export function isJobDue(job: CronJob, nowMs: number, opts: { forced: boolean })
   if (opts.forced) {
     return true;
   }
-  return job.enabled && typeof job.state.nextRunAtMs === "number" && nowMs >= job.state.nextRunAtMs;
+  if (!job.enabled || typeof job.state.nextRunAtMs !== "number" || nowMs < job.state.nextRunAtMs) {
+    return false;
+  }
+  // Skip if daily run limit has been reached.
+  if (isJobAtDailyLimit(job, nowMs)) {
+    return false;
+  }
+  return true;
 }
 
 export function resolveJobPayloadTextForMain(job: CronJob): string | undefined {

--- a/src/cron/service/max-runs-per-day.test.ts
+++ b/src/cron/service/max-runs-per-day.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest";
+import type { CronJob } from "../types.js";
+import { isJobAtDailyLimit, isJobDue } from "./jobs.js";
+import { applyJobResult } from "./timer.js";
+
+function makeJob(overrides: Partial<CronJob> = {}): CronJob {
+  return {
+    id: "test-job",
+    name: "test",
+    enabled: true,
+    createdAtMs: 0,
+    updatedAtMs: 0,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: "test" },
+    state: {},
+    ...overrides,
+  };
+}
+
+describe("isJobAtDailyLimit", () => {
+  it("returns false when maxRunsPerDay is not set", () => {
+    const job = makeJob();
+    expect(isJobAtDailyLimit(job, Date.now())).toBe(false);
+  });
+
+  it("returns false when runsToday is below limit", () => {
+    const job = makeJob({
+      maxRunsPerDay: 3,
+      state: { runsToday: 2, runsTodayDate: new Date().toISOString().slice(0, 10) },
+    });
+    // Use UTC midnight of today to match the date
+    const now = Date.now();
+    const today = new Date(now).toISOString().slice(0, 10);
+    job.state.runsTodayDate = today;
+    expect(isJobAtDailyLimit(job, now)).toBe(false);
+  });
+
+  it("returns true when runsToday equals limit", () => {
+    const now = Date.now();
+    const today = new Date(now).toISOString().slice(0, 10);
+    const job = makeJob({
+      maxRunsPerDay: 1,
+      state: { runsToday: 1, runsTodayDate: today },
+    });
+    expect(isJobAtDailyLimit(job, now)).toBe(true);
+  });
+
+  it("returns true when runsToday exceeds limit", () => {
+    const now = Date.now();
+    const today = new Date(now).toISOString().slice(0, 10);
+    const job = makeJob({
+      maxRunsPerDay: 2,
+      state: { runsToday: 5, runsTodayDate: today },
+    });
+    expect(isJobAtDailyLimit(job, now)).toBe(true);
+  });
+
+  it("resets counter when date changes (new day)", () => {
+    const job = makeJob({
+      maxRunsPerDay: 1,
+      state: { runsToday: 5, runsTodayDate: "2026-01-01" },
+    });
+    // Any date that's not 2026-01-01 should reset
+    const now = new Date("2026-03-03T12:00:00Z").getTime();
+    expect(isJobAtDailyLimit(job, now)).toBe(false);
+  });
+
+  it("respects timezone from cron schedule", () => {
+    // 2026-03-03 23:30 UTC = 2026-03-04 in Tokyo (UTC+9)
+    const nowMs = new Date("2026-03-03T23:30:00Z").getTime();
+    const job = makeJob({
+      maxRunsPerDay: 1,
+      schedule: { kind: "cron", expr: "0 8 * * *", tz: "Asia/Tokyo" },
+      state: { runsToday: 1, runsTodayDate: "2026-03-04" },
+    });
+    // In Tokyo it's already March 4, and we've hit the limit for March 4
+    expect(isJobAtDailyLimit(job, nowMs)).toBe(true);
+  });
+
+  it("uses UTC when no timezone is configured (every schedule)", () => {
+    const nowMs = new Date("2026-03-03T12:00:00Z").getTime();
+    const job = makeJob({
+      maxRunsPerDay: 1,
+      schedule: { kind: "every", everyMs: 3600_000 },
+      state: { runsToday: 1, runsTodayDate: "2026-03-03" },
+    });
+    expect(isJobAtDailyLimit(job, nowMs)).toBe(true);
+  });
+});
+
+describe("isJobDue – maxRunsPerDay integration", () => {
+  it("returns false when daily limit is reached", () => {
+    const now = Date.now();
+    const today = new Date(now).toISOString().slice(0, 10);
+    const job = makeJob({
+      maxRunsPerDay: 1,
+      state: {
+        nextRunAtMs: now - 1000, // due
+        runsToday: 1,
+        runsTodayDate: today,
+      },
+    });
+    expect(isJobDue(job, now, { forced: false })).toBe(false);
+  });
+
+  it("returns true when forced even if daily limit is reached", () => {
+    const now = Date.now();
+    const today = new Date(now).toISOString().slice(0, 10);
+    const job = makeJob({
+      maxRunsPerDay: 1,
+      state: {
+        nextRunAtMs: now - 1000,
+        runsToday: 1,
+        runsTodayDate: today,
+      },
+    });
+    expect(isJobDue(job, now, { forced: true })).toBe(true);
+  });
+
+  it("returns true when daily limit is not yet reached", () => {
+    const now = Date.now();
+    const today = new Date(now).toISOString().slice(0, 10);
+    const job = makeJob({
+      maxRunsPerDay: 3,
+      state: {
+        nextRunAtMs: now - 1000,
+        runsToday: 2,
+        runsTodayDate: today,
+      },
+    });
+    expect(isJobDue(job, now, { forced: false })).toBe(true);
+  });
+});
+
+describe("applyJobResult – forced runs do not consume daily quota", () => {
+  function makeState() {
+    return {
+      deps: {
+        cronEnabled: true,
+        storePath: "/tmp/cron-test.json",
+        log: { warn: () => {}, info: () => {}, debug: () => {}, error: () => {} },
+        nowMs: () => Date.now(),
+        enqueueSystemEvent: () => {},
+        requestHeartbeatNow: () => {},
+        runIsolatedAgentJob: () => Promise.resolve({ status: "ok" as const }),
+      },
+      store: { jobs: [] },
+    } as unknown as Parameters<typeof applyJobResult>[0];
+  }
+
+  it("increments runsToday for non-forced successful runs", () => {
+    const now = Date.now();
+    const job = makeJob({ maxRunsPerDay: 3, state: {} });
+    applyJobResult(makeState(), job, {
+      status: "ok",
+      startedAt: now - 1000,
+      endedAt: now,
+    });
+    expect(job.state.runsToday).toBe(1);
+  });
+
+  it("does NOT increment runsToday for forced successful runs", () => {
+    const now = Date.now();
+    const job = makeJob({ maxRunsPerDay: 3, state: {} });
+    applyJobResult(
+      makeState(),
+      job,
+      {
+        status: "ok",
+        startedAt: now - 1000,
+        endedAt: now,
+      },
+      { forced: true },
+    );
+    expect(job.state.runsToday).toBeUndefined();
+  });
+
+  it("forced run at limit does not block subsequent scheduled runs", () => {
+    const now = Date.now();
+    const today = new Date(now).toISOString().slice(0, 10);
+    const job = makeJob({
+      maxRunsPerDay: 1,
+      state: { runsToday: 0, runsTodayDate: today },
+    });
+
+    // Force-run: should NOT increment counter
+    applyJobResult(
+      makeState(),
+      job,
+      {
+        status: "ok",
+        startedAt: now - 1000,
+        endedAt: now,
+      },
+      { forced: true },
+    );
+    expect(job.state.runsToday).toBe(0);
+
+    // Scheduled run: should still be allowed (limit not consumed)
+    expect(isJobAtDailyLimit(job, now)).toBe(false);
+  });
+});

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -398,13 +398,18 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
       return;
     }
 
-    const shouldDelete = applyJobResult(state, job, {
-      status: coreResult.status,
-      error: coreResult.error,
-      delivered: coreResult.delivered,
-      startedAt,
-      endedAt,
-    });
+    const shouldDelete = applyJobResult(
+      state,
+      job,
+      {
+        status: coreResult.status,
+        error: coreResult.error,
+        delivered: coreResult.delivered,
+        startedAt,
+        endedAt,
+      },
+      { forced: mode === "force" },
+    );
 
     emit(state, {
       jobId: job.id,

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -18,6 +18,7 @@ import {
   nextWakeAtMs,
   recomputeNextRunsForMaintenance,
   recordScheduleComputeError,
+  resolveCalendarDate,
   resolveJobPayloadTextForMain,
 } from "./jobs.js";
 import { locked } from "./locked.js";
@@ -286,6 +287,7 @@ export function applyJobResult(
     startedAt: number;
     endedAt: number;
   },
+  opts?: { forced?: boolean },
 ): boolean {
   job.state.runningAtMs = undefined;
   job.state.lastRunAtMs = result.startedAt;
@@ -330,6 +332,26 @@ export function applyJobResult(
   } else {
     job.state.consecutiveErrors = 0;
     job.state.lastFailureAlertAtMs = undefined;
+
+    // Track successful runs per calendar day for maxRunsPerDay deduplication.
+    // Forced runs bypass the daily limit check (isJobDue) and should not
+    // consume a quota slot — otherwise a force-run would silently block
+    // the next scheduled execution for the rest of the day.
+    if (
+      result.status === "ok" &&
+      typeof job.maxRunsPerDay === "number" &&
+      job.maxRunsPerDay > 0 &&
+      !opts?.forced
+    ) {
+      const tz = job.schedule.kind === "cron" ? job.schedule.tz : undefined;
+      const today = resolveCalendarDate(result.endedAt, tz);
+      if (job.state.runsTodayDate === today) {
+        job.state.runsToday = (job.state.runsToday ?? 0) + 1;
+      } else {
+        job.state.runsTodayDate = today;
+        job.state.runsToday = 1;
+      }
+    }
   }
 
   const shouldDelete =
@@ -1066,13 +1088,18 @@ export async function executeJob(
   }
 
   const endedAt = state.deps.nowMs();
-  const shouldDelete = applyJobResult(state, job, {
-    status: coreResult.status,
-    error: coreResult.error,
-    delivered: coreResult.delivered,
-    startedAt,
-    endedAt,
-  });
+  const shouldDelete = applyJobResult(
+    state,
+    job,
+    {
+      status: coreResult.status,
+      error: coreResult.error,
+      delivered: coreResult.delivered,
+      startedAt,
+      endedAt,
+    },
+    { forced: _opts.forced },
+  );
 
   emitJobFinished(state, job, coreResult, startedAt);
 

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -15,6 +15,7 @@ import type {
 } from "../types.js";
 import {
   computeJobNextRunAtMs,
+  isJobAtDailyLimit,
   nextWakeAtMs,
   recomputeNextRunsForMaintenance,
   recordScheduleComputeError,
@@ -754,7 +755,15 @@ function isRunnableJob(params: {
     return false;
   }
   const next = job.state.nextRunAtMs;
-  return typeof next === "number" && Number.isFinite(next) && nowMs >= next;
+  if (typeof next !== "number" || !Number.isFinite(next) || nowMs < next) {
+    return false;
+  }
+  // Enforce maxRunsPerDay in the scheduler path — skip jobs that have
+  // already hit their daily limit so they aren't selected by collectRunnableJobs.
+  if (isJobAtDailyLimit(job, nowMs)) {
+    return false;
+  }
+  return true;
 }
 
 function collectRunnableJobs(

--- a/src/cron/types-shared.ts
+++ b/src/cron/types-shared.ts
@@ -15,4 +15,11 @@ export type CronJobBase<TSchedule, TSessionTarget, TWakeMode, TPayload, TDeliver
     payload: TPayload;
     delivery?: TDelivery;
     failureAlert?: TFailureAlert;
+    /**
+     * Maximum number of successful runs allowed per calendar day.
+     * When set, the scheduler skips execution if the job has already
+     * completed this many times today (in the job's configured timezone).
+     * Useful for daily tasks that may be triggered by both cron and heartbeats.
+     */
+    maxRunsPerDay?: number;
   };

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -128,6 +128,10 @@ export type CronJobState = {
   lastDeliveryError?: string;
   /** Whether the last run's output was delivered to the target channel. */
   lastDelivered?: boolean;
+  /** Number of successful runs completed on the current calendar day (reset daily). */
+  runsToday?: number;
+  /** Calendar date string (YYYY-MM-DD) for the current runsToday counter. */
+  runsTodayDate?: string;
 };
 
 export type CronJob = CronJobBase<

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -62,6 +62,10 @@ const CronCommonOptionalFields = {
   description: Type.Optional(Type.String()),
   enabled: Type.Optional(Type.Boolean()),
   deleteAfterRun: Type.Optional(Type.Boolean()),
+  // Allow null to clear maxRunsPerDay once set (0 also clears via applyJobPatch).
+  maxRunsPerDay: Type.Optional(
+    Type.Union([Type.Integer({ minimum: 1, maximum: 100 }), Type.Null()]),
+  ),
 };
 
 function cronIdOrJobIdParams(extraFields: Record<string, TSchema>) {
@@ -238,6 +242,7 @@ export const CronJobSchema = Type.Object(
     description: Type.Optional(Type.String()),
     enabled: Type.Boolean(),
     deleteAfterRun: Type.Optional(Type.Boolean()),
+    maxRunsPerDay: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })),
     createdAtMs: Type.Integer({ minimum: 0 }),
     updatedAtMs: Type.Integer({ minimum: 0 }),
     schedule: CronScheduleSchema,


### PR DESCRIPTION
## Problem

Daily cron jobs frequently double-fire when heartbeats also trigger the same task, or when gateway restarts cause rescheduling. The only workaround is manually checking state files at the start of every cron payload — error-prone and every operator reinvents it.

## Fix

Add optional `maxRunsPerDay` field to cron jobs. When set, the scheduler tracks successful runs per calendar day and skips execution if the limit is hit.

```bash
openclaw cron add --max-runs-per-day 1 --name daily-post --every 4h ...
```

### Behavior

- Counter tracks successful runs only (`status: "ok"`)
- Respects the job's configured timezone (cron schedule `tz` field)
- Counter resets automatically at midnight (date comparison, no timer needed)
- Forced runs (`openclaw cron run --force`) bypass the limit
- `maxRunsPerDay: 0` or `null` removes the limit

## Changes

- **types-shared.ts / types.ts**: Add `maxRunsPerDay` to job config + `runsToday`/`runsTodayDate` to state
- **service/jobs.ts**: Add `isJobAtDailyLimit()` check, integrate into `isJobDue()`
- **service/timer.ts**: Increment daily counter on successful runs in `applyJobResult()`
- **protocol/schema/cron.ts**: Add to gateway protocol schema
- **cli/cron-cli/register.cron-add.ts**: Add `--max-runs-per-day` CLI flag
- **Tests**: 10 new tests covering limits, timezone handling, date reset, forced runs

## Tests

All 10 tests pass:
- `isJobAtDailyLimit`: 7 tests (basic, below/at/above limit, date reset, timezone, UTC fallback)
- `isJobDue integration`: 3 tests (limit reached, forced override, under limit)