### PR TITLE
fix(mac): avoid Swift exclusivity violation in VoiceWakeOverlayController.present()

### DIFF
--- a/apps/macos/Sources/OpenClaw/OverlayPanelFactory.swift
+++ b/apps/macos/Sources/OpenClaw/OverlayPanelFactory.swift
@@ -81,6 +81,30 @@ enum OverlayPanelFactory {
         }
     }
 
+    /// Variant that avoids passing `isVisible` as `inout` to prevent Swift exclusivity
+    /// violations when callers hold overlapping access to the same stored property
+    /// (e.g. concurrent timer + dismiss on the same `@Observable` model).
+    @MainActor
+    static func present(
+        window: NSWindow?,
+        isCurrentlyVisible: Bool,
+        setVisible: (Bool) -> Void,
+        target: NSRect,
+        startOffsetY: CGFloat = -6,
+        onFirstPresent: (() -> Void)? = nil,
+        onAlreadyVisible: (NSWindow) -> Void)
+    {
+        guard let window else { return }
+        if !isCurrentlyVisible {
+            setVisible(true)
+            onFirstPresent?()
+            let start = target.offsetBy(dx: 0, dy: startOffsetY)
+            self.animatePresent(window: window, from: start, to: target)
+        } else {
+            onAlreadyVisible(window)
+        }
+    }
+
     @MainActor
     static func animateDismiss(
         window: NSWindow,

--- a/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift
@@ -15,13 +15,14 @@ extension VoiceWakeOverlayController {
         let target = self.targetFrame()
         OverlayPanelFactory.present(
             window: self.window,
-            isVisible: &self.model.isVisible,
+            isCurrentlyVisible: self.model.isVisible,
+            setVisible: { self.model.isVisible = $0 },
             target: target,
             onFirstPresent: {
                 self.logger.log(
                     level: .info,
                     "overlay present windowShown textLen=\(self.model.text.count, privacy: .public)")
-                // Keep the status item in “listening” mode until we explicitly dismiss the overlay.
+                // Keep the status item in "listening" mode until we explicitly dismiss the overlay.
                 AppStateStore.shared.triggerVoiceEars(ttl: nil)
             },
             onAlreadyVisible: { window in


### PR DESCRIPTION
## Problem

macOS app crashes with SIGABRT when Voice Wake trigger word fires. The crash is a Swift runtime exclusivity violation in `VoiceWakeOverlayController.present()`.

`OverlayPanelFactory.present()` takes `isVisible` as `inout Bool`, which holds an exclusive access to `self.model.isVisible` for the duration of the call. When `scheduleTriggerOnlyPauseCheck`'s timer fires and calls `beginCapture` → `startSession` → `present()` while a concurrent `dismiss()` animation completion handler also accesses `model.isVisible`, Swift's runtime exclusivity enforcement detects the overlapping access and aborts.

## Fix

Add a new `OverlayPanelFactory.present()` overload that takes `isCurrentlyVisible: Bool` (read) and `setVisible: (Bool) -> Void` (write) instead of `inout Bool`. This eliminates the overlapping exclusive access since the read and write are discrete operations.

Updated `VoiceWakeOverlayController.present()` to use the safe variant.

## Crash stack

```
swift_beginAccess + 84
closure #1 in VoiceWakeOverlayController.present() + 364
VoiceWakeOverlayController.present() + 1232
VoiceWakeOverlayController.startSession(...) + 2512
VoiceWakeRuntime.beginCapture(...) + 716
VoiceWakeRuntime.triggerOnlyPauseCheck(...) + 1
```

Fixes #33219