### PR TITLE
fix(slack): prevent NO_REPLY token prefix leak and duplicate status messages

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -2,7 +2,6 @@ import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import {
   HEARTBEAT_TOKEN,
-  isSilentReplyPrefixText,
   isSilentReplyText,
   SILENT_REPLY_TOKEN,
   stripSilentToken,
@@ -58,16 +57,22 @@ export function normalizeReplyPayload(
       opts.onSkip?.("silent");
       return null;
     }
-  }
-  // After stripping, the remaining text may itself be a partial silent token
-  // prefix (e.g. "NO" left over from "NO NO_REPLY").  Suppress it so the
-  // prefix never leaks to end users.
-  if (text && isSilentReplyPrefixText(text.trim(), silentToken)) {
-    if (!hasMedia && !hasChannelData) {
-      opts.onSkip?.("silent");
-      return null;
+    // After stripping, the remaining text may itself be a bare prefix of the
+    // silent token (e.g. "NO" left over from "NO NO_REPLY").  We only check
+    // here — inside the stripping block — so that legitimate replies like "No"
+    // are never suppressed.
+    const afterStrip = text?.trim().toUpperCase() ?? "";
+    if (
+      afterStrip &&
+      /^[A-Z]+$/.test(afterStrip) &&
+      silentToken.toUpperCase().startsWith(afterStrip)
+    ) {
+      if (!hasMedia && !hasChannelData) {
+        opts.onSkip?.("silent");
+        return null;
+      }
+      text = "";
     }
-    text = "";
   }
   if (text && !trimmed) {
     // Keep empty text when media exists so media-only replies still send.

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -2,6 +2,7 @@ import { sanitizeUserFacingText } from "../../agents/pi-embedded-helpers.js";
 import { stripHeartbeatToken } from "../heartbeat.js";
 import {
   HEARTBEAT_TOKEN,
+  isSilentReplyPrefixText,
   isSilentReplyText,
   SILENT_REPLY_TOKEN,
   stripSilentToken,
@@ -57,6 +58,16 @@ export function normalizeReplyPayload(
       opts.onSkip?.("silent");
       return null;
     }
+  }
+  // After stripping, the remaining text may itself be a partial silent token
+  // prefix (e.g. "NO" left over from "NO NO_REPLY").  Suppress it so the
+  // prefix never leaks to end users.
+  if (text && isSilentReplyPrefixText(text.trim(), silentToken)) {
+    if (!hasMedia && !hasChannelData) {
+      opts.onSkip?.("silent");
+      return null;
+    }
+    text = "";
   }
   if (text && !trimmed) {
     // Keep empty text when media exists so media-only replies still send.

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -57,7 +57,10 @@ export function isSilentReplyPrefixText(
     return false;
   }
   const normalized = text.trimStart().toUpperCase();
-  if (!normalized || normalized.length < 2) {
+  if (!normalized) {
+    return false;
+  }
+  if (!normalized.includes("_")) {
     return false;
   }
   if (/[^A-Z_]/.test(normalized)) {

--- a/src/auto-reply/tokens.ts
+++ b/src/auto-reply/tokens.ts
@@ -57,10 +57,7 @@ export function isSilentReplyPrefixText(
     return false;
   }
   const normalized = text.trimStart().toUpperCase();
-  if (!normalized) {
-    return false;
-  }
-  if (!normalized.includes("_")) {
+  if (!normalized || normalized.length < 2) {
     return false;
   }
   if (/[^A-Z_]/.test(normalized)) {

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -32,7 +32,11 @@ export async function deliverReplies(params: {
 
     if (mediaList.length === 0) {
       const trimmed = text.trim();
-      if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN) || isSilentReplyPrefixText(trimmed, SILENT_REPLY_TOKEN)) {
+      if (
+        !trimmed ||
+        isSilentReplyText(trimmed, SILENT_REPLY_TOKEN) ||
+        isSilentReplyPrefixText(trimmed, SILENT_REPLY_TOKEN)
+      ) {
         continue;
       }
       await sendMessageSlack(params.target, trimmed, {

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -1,7 +1,7 @@
 import type { ChunkMode } from "../../auto-reply/chunk.js";
 import { chunkMarkdownTextWithMode } from "../../auto-reply/chunk.js";
 import { createReplyReferencePlanner } from "../../auto-reply/reply/reply-reference.js";
-import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
+import { isSilentReplyPrefixText, isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
 import type { RuntimeEnv } from "../../runtime.js";
@@ -32,7 +32,7 @@ export async function deliverReplies(params: {
 
     if (mediaList.length === 0) {
       const trimmed = text.trim();
-      if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
+      if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN) || isSilentReplyPrefixText(trimmed, SILENT_REPLY_TOKEN)) {
         continue;
       }
       await sendMessageSlack(params.target, trimmed, {

--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -254,7 +254,11 @@ export async function sendMessageSlack(
   opts: SlackSendOpts = {},
 ): Promise<SlackSendResult> {
   const trimmedMessage = message?.trim() ?? "";
-  if ((isSilentReplyText(trimmedMessage) || isSilentReplyPrefixText(trimmedMessage)) && !opts.mediaUrl && !opts.blocks) {
+  if (
+    (isSilentReplyText(trimmedMessage) || isSilentReplyPrefixText(trimmedMessage)) &&
+    !opts.mediaUrl &&
+    !opts.blocks
+  ) {
     logVerbose("slack send: suppressed NO_REPLY token (or prefix) before API call");
     return { messageId: "suppressed", channelId: "" };
   }

--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -4,7 +4,7 @@ import {
   resolveChunkMode,
   resolveTextChunkLimit,
 } from "../auto-reply/chunk.js";
-import { isSilentReplyText } from "../auto-reply/tokens.js";
+import { isSilentReplyPrefixText, isSilentReplyText } from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
@@ -254,8 +254,8 @@ export async function sendMessageSlack(
   opts: SlackSendOpts = {},
 ): Promise<SlackSendResult> {
   const trimmedMessage = message?.trim() ?? "";
-  if (isSilentReplyText(trimmedMessage) && !opts.mediaUrl && !opts.blocks) {
-    logVerbose("slack send: suppressed NO_REPLY token before API call");
+  if ((isSilentReplyText(trimmedMessage) || isSilentReplyPrefixText(trimmedMessage)) && !opts.mediaUrl && !opts.blocks) {
+    logVerbose("slack send: suppressed NO_REPLY token (or prefix) before API call");
     return { messageId: "suppressed", channelId: "" };
   }
   const blocks = opts.blocks == null ? undefined : validateSlackBlocksArray(opts.blocks);

--- a/src/slack/threading.test.ts
+++ b/src/slack/threading.test.ts
@@ -15,7 +15,8 @@ describe("resolveSlackThreadTargets", () => {
 
     expect(isThreadReply).toBe(false);
     expect(replyThreadTs).toBeUndefined();
-    expect(statusThreadTs).toBeUndefined();
+    // Status indicator still fires using the message ts as fallback
+    expect(statusThreadTs).toBe("123");
   }
 
   it("threads replies when message is already threaded", () => {
@@ -47,7 +48,7 @@ describe("resolveSlackThreadTargets", () => {
     expect(statusThreadTs).toBe("123");
   });
 
-  it("does not thread status indicator when reply threading is off", () => {
+  it("shows status indicator on message ts even when reply threading is off", () => {
     const { replyThreadTs, statusThreadTs } = resolveSlackThreadTargets({
       replyToMode: "off",
       message: {
@@ -58,7 +59,8 @@ describe("resolveSlackThreadTargets", () => {
     });
 
     expect(replyThreadTs).toBeUndefined();
-    expect(statusThreadTs).toBeUndefined();
+    // Status indicator uses message ts as fallback so it fires in main channels
+    expect(statusThreadTs).toBe("123");
   });
 
   it("does not treat auto-created top-level thread_ts as a real thread when mode is off", () => {

--- a/src/slack/threading.ts
+++ b/src/slack/threading.ts
@@ -53,6 +53,8 @@ export function resolveSlackThreadTargets(params: {
     : params.replyToMode === "all"
       ? messageTs
       : undefined;
-  const statusThreadTs = replyThreadTs;
+  // Status indicator should always fire — even for main-channel messages
+  // where we don't reply in a thread — so use the message ts as fallback.
+  const statusThreadTs = replyThreadTs ?? messageTs;
   return { replyThreadTs, statusThreadTs, isThreadReply };
 }


### PR DESCRIPTION
## Summary

When integrating [SignalPilot](https://www.signalpilot.ai/) (our data science tool) with OpenClaw via the Slack channel, we encountered two issues that caused confusing duplicate and junk messages in Slack conversations:

### Bug 1: `NO_REPLY` token prefix leaking as "NO"

The `stripSilentToken` function correctly removes a trailing `NO_REPLY` from mixed content (e.g. `"NO NO_REPLY"`), but leaves the prefix `"NO"` behind. This prefix then passes through all downstream guards because:

1. `isSilentReplyText` only matches the exact string `"NO_REPLY"`
2. `isSilentReplyPrefixText` required an underscore character, so bare `"NO"` escaped detection

This caused messages like this to appear in Slack:
```
OpenClaw  [8:08 AM]
Running that SPY analysis now. (edited)
[8:21 AM] NO           <-- leaked token prefix
[8:21 AM] Running that SPY analysis now.  <-- duplicate status message
```

**Fix:** 
- `tokens.ts`: Replace underscore requirement with a minimum length check so `"NO"` (2+ chars, all uppercase) is caught as a silent token prefix
- `normalize-reply.ts`: After stripping, check if the remainder is a silent token prefix and suppress it
- `replies.ts`: Add `isSilentReplyPrefixText` guard in `deliverReplies`
- `send.ts`: Add `isSilentReplyPrefixText` guard in `sendMessageSlack`

### Bug 2: Missing status indicator for non-threaded messages

`resolveSlackThreadTargets` tied the `statusThreadTs` directly to `replyThreadTs`, so when reply threading was off (main-channel messages), the status indicator ("typing…" / "thinking…") never fired — and when the bot did respond, the earlier status message would re-post as a duplicate.

**Fix:**
- `threading.ts`: Use `messageTs` as a fallback for `statusThreadTs` so the status indicator always fires, even for main-channel (non-threaded) messages

### Reproduction context

We discovered this while integrating SignalPilot on Slack. A user would `@OpenClaw` with a request, and the conversation would look like:

> **Daniel Schaffield** [8:08 AM]  
> @OpenClaw chart last 3 months of SPY data and write a small report here on the state of SPY  
> *5 replies*  
> **OpenClaw** [8:08 AM]  
> Running that SPY analysis now. *(edited)*  
> **OpenClaw** [8:21 AM]  
> SignalPilot is timing out on requests right now...  
> [8:21 AM] **NO**  
> [8:21 AM] Running that SPY analysis now.

The `"NO"` line is the leaked token prefix, and the repeated "Running that SPY analysis now." is the duplicate status message caused by the missing status thread target.

## Changes

| File | Change |
|------|--------|
| `src/auto-reply/tokens.ts` | Relax `isSilentReplyPrefixText` to catch `"NO"` (remove underscore requirement, add min-length check) |
| `src/auto-reply/reply/normalize-reply.ts` | Suppress remaining text if it's a silent token prefix after stripping |
| `src/slack/monitor/replies.ts` | Add `isSilentReplyPrefixText` guard in `deliverReplies` |
| `src/slack/send.ts` | Add `isSilentReplyPrefixText` guard in `sendMessageSlack` |
| `src/slack/threading.ts` | Use `messageTs` as fallback for `statusThreadTs` |
| `src/slack/threading.test.ts` | Update tests to reflect new status indicator behavior |

## Test plan

- [x] Updated `threading.test.ts` to verify status indicator fires on `messageTs` fallback
- [x] Verify in a live Slack workspace that `NO_REPLY` prefix tokens no longer leak
- [x] Verify status indicators appear for both threaded and non-threaded messages
- [x] Verify no duplicate status messages appear in main-channel conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)