### PR TITLE
Slack: extract Block Kit text from inbound bot messages

### DIFF
--- a/src/slack/blocks-fallback.ts
+++ b/src/slack/blocks-fallback.ts
@@ -44,6 +44,40 @@ function readContextText(block: SlackBlockWithFields): string | undefined {
   return textParts.length > 0 ? textParts.join(" ") : undefined;
 }
 
+/** Extract text from all blocks (for inbound bot messages where we want full content). */
+export function extractAllSlackBlocksText(blocks: (Block | KnownBlock)[]): string {
+  const parts: string[] = [];
+  for (const raw of blocks) {
+    const block = raw as SlackBlockWithFields;
+    let text: string | undefined;
+    switch (block.type) {
+      case "header":
+        text = readHeaderText(block);
+        break;
+      case "section":
+        text = readSectionText(block);
+        break;
+      case "image":
+        text = readImageText(block) ?? "Shared an image";
+        break;
+      case "video":
+        text = readVideoText(block) ?? "Shared a video";
+        break;
+      case "file":
+        text = "Shared a file";
+        break;
+      case "context":
+        text = readContextText(block);
+        break;
+    }
+    if (text) {
+      parts.push(text);
+    }
+  }
+  return parts.join("\n");
+}
+
+/** Return the first meaningful text from blocks (for outbound fallback previews). */
 export function buildSlackBlocksFallbackText(blocks: (Block | KnownBlock)[]): string {
   for (const raw of blocks) {
     const block = raw as SlackBlockWithFields;

--- a/src/slack/monitor/message-handler/prepare-content.ts
+++ b/src/slack/monitor/message-handler/prepare-content.ts
@@ -1,4 +1,6 @@
+import type { Block, KnownBlock } from "@slack/web-api";
 import { logVerbose } from "../../../globals.js";
+import { extractAllSlackBlocksText } from "../../blocks-fallback.js";
 import type { SlackFile, SlackMessageEvent } from "../../types.js";
 import {
   MAX_SLACK_MEDIA_FILES,
@@ -85,11 +87,17 @@ export async function resolveSlackMessageContent(params: {
           .join("\n")
       : undefined;
 
+  const botBlocksText =
+    params.isBotMessage && !botAttachmentText && params.message.blocks?.length
+      ? extractAllSlackBlocksText(params.message.blocks as (Block | KnownBlock)[]) || undefined
+      : undefined;
+
   const rawBody =
     [
       (params.message.text ?? "").trim(),
       attachmentContent?.text,
       botAttachmentText,
+      botBlocksText,
       mediaPlaceholder,
       fileOnlyPlaceholder,
     ]

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -296,6 +296,39 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared!.ctxPayload.RawBody).toContain("Readiness probe failed");
   });
 
+  it("extracts Block Kit text for bot messages with no text or attachments", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: {
+        channels: {
+          slack: { enabled: true },
+        },
+      } as OpenClawConfig,
+      defaultRequireMention: false,
+    });
+    // oxlint-disable-next-line typescript/no-explicit-any
+    slackCtx.resolveUserName = async () => ({ name: "Zenduty" }) as any;
+
+    const account = createSlackAccount({ allowBots: true });
+    const message = createSlackMessage({
+      text: "",
+      bot_id: "B0ZENDUTY01",
+      subtype: "bot_message",
+      blocks: [
+        { type: "header", text: { type: "plain_text", text: "Incident #4521" } },
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: "Service *search-service-v2* is down in production" },
+        },
+      ],
+    });
+
+    const prepared = await prepareMessageWith(slackCtx, account, message);
+
+    expect(prepared).toBeTruthy();
+    expect(prepared!.ctxPayload.RawBody).toContain("Incident #4521");
+    expect(prepared!.ctxPayload.RawBody).toContain("search-service-v2");
+  });
+
   it("keeps channel metadata out of GroupSystemPrompt", async () => {
     const slackCtx = createInboundSlackCtx({
       cfg: {

--- a/src/slack/types.ts
+++ b/src/slack/types.ts
@@ -43,6 +43,7 @@ export type SlackMessageEvent = {
   channel_type?: "im" | "mpim" | "channel" | "group";
   files?: SlackFile[];
   attachments?: SlackAttachment[];
+  blocks?: unknown[];
 };
 
 export type SlackAppMentionEvent = {


### PR DESCRIPTION
## Problem

Bot messages from services like Zenduty, RCAi, PagerDuty, etc. use Block Kit blocks (headers, sections, context) instead of plain `text` or `attachments.text`. When these messages appear in thread history, they show up empty because `resolveSlackMessageContent()` only checks `message.text` and `attachment.text`/`fallback`.

This means agents can't read incident alerts, monitoring notifications, or other bot messages in threads — they see the sender name but no content.

## Fix

- Add `blocks` field to `SlackMessageEvent` type
- Add `extractAllSlackBlocksText()` that collects text from **all** blocks (unlike `buildSlackBlocksFallbackText` which returns only the first match)
- Use it as a final fallback in `resolveSlackMessageContent()` for bot messages where both `text` and `attachment.text` are empty
- Reuses the existing block-type readers from `blocks-fallback.ts`

## Changes

- `src/slack/types.ts` — add optional `blocks` field
- `src/slack/blocks-fallback.ts` — add `extractAllSlackBlocksText()`
- `src/slack/monitor/message-handler/prepare-content.ts` — use blocks fallback for bot messages
- `src/slack/monitor/message-handler/prepare.test.ts` — add test case

## Test plan

- Added test: bot message with only Block Kit blocks (header + section) → verifies both blocks are extracted
- All 22 existing prepare tests pass
- All 3 blocks-fallback tests pass
- TypeScript compiles clean (pre-existing discord test errors only)