### PR TITLE
fix(media): allow sandbox workspaces for local attachments

### DIFF
--- a/src/media/local-roots.test.ts
+++ b/src/media/local-roots.test.ts
@@ -89,7 +89,7 @@ describe("local media roots", () => {
       name: "keeps temp, media cache, and workspace roots by default",
       stateDir: path.join("/tmp", "openclaw-media-roots-state"),
       getRoots: () => getDefaultMediaLocalRoots(),
-      expectedContained: ["media", "workspace", "sandboxes"],
+      expectedContained: ["media", "workspace", "workspaces", "sandboxes"],
       expectedExcluded: ["agents"],
       minLength: 3,
     },

--- a/src/media/local-roots.ts
+++ b/src/media/local-roots.ts
@@ -32,6 +32,7 @@ export function buildMediaLocalRoots(
       preferredTmpDir,
       path.join(resolvedStateDir, "media"),
       path.join(resolvedStateDir, "workspace"),
+      path.join(resolvedStateDir, "workspaces"),
       path.join(resolvedStateDir, "sandboxes"),
       // Upgraded installs can still resolve the active state dir to the legacy
       // ~/.clawdbot tree while new media writes already go under ~/.openclaw/media.


### PR DESCRIPTION
## Summary

This patch adds `path.join(stateDir, "workspaces")` to the default local media roots.

This fixes Slack file sends in sandbox mode when agents create files under `/workspace/...`, which are resolved on the host to `~/.openclaw/workspaces/...`.

Without this root, Slack local media validation rejects sandbox workspace files as being outside allowed directories.

## Why this change

- OpenClaw documents `message send + media` as the standard file-send path
- Telegram already works with `/workspace/...` in sandbox mode
- Slack upload also works once `~/.openclaw/workspaces` is included in local media roots
- The failure is caused by missing allowlist coverage for sandbox-hosted workspaces, not by the Slack upload flow itself

## Changes

- add `path.join(resolvedStateDir, "workspaces")` to default local media roots
- add a focused test covering that default root

## Validation

```bash
pnpm exec vitest run src/media/local-roots.test.ts
```

## Notes

Refs #33251

This keeps the existing `message send + media` contract unchanged and only expands default local media roots so sandbox-hosted workspace files are treated consistently across channels.
