### PR TITLE
web_fetch: detect interactive verification gates (WeChat/CAPTCHA)

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -552,6 +552,21 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("`style` can be `primary`, `success`, or `danger`");
   });
 
+  it("uses feishu-specific inline button guidance when inline buttons are unavailable", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["message"],
+      runtimeInfo: {
+        channel: "feishu",
+        capabilities: [],
+      },
+    });
+
+    expect(prompt).toContain("Inline buttons not enabled for feishu");
+    expect(prompt).toContain("supports rich interactive cards");
+    expect(prompt).not.toContain("feishu.capabilities.inlineButtons");
+  });
+
   it("includes runtime provider capabilities when present", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -145,7 +145,9 @@ function buildMessagingSection(params: {
           params.inlineButtonsEnabled
             ? "- Inline buttons supported. Use `action=send` with `buttons=[[{text,callback_data,style?}]]`; `style` can be `primary`, `success`, or `danger`."
             : params.runtimeChannel
-              ? `- Inline buttons not enabled for ${params.runtimeChannel}. If you need them, ask to set ${params.runtimeChannel}.capabilities.inlineButtons ("dm"|"group"|"all"|"allowlist").`
+              ? params.runtimeChannel === "feishu"
+                ? "- Inline buttons not enabled for feishu. Feishu currently supports rich interactive cards instead of message-tool inline buttons."
+                : `- Inline buttons not enabled for ${params.runtimeChannel}. If you need them, ask to set ${params.runtimeChannel}.capabilities.inlineButtons ("dm"|"group"|"all"|"allowlist").`
               : "",
           ...(params.messageToolHints ?? []),
         ]

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -238,6 +238,43 @@ function redactUrlForDebugLog(rawUrl: string): string {
   }
 }
 
+function detectVerificationGate(params: {
+  html: string;
+  finalUrl: string;
+}): { provider: "wechat" | "generic"; reason: string } | null {
+  const lowerHtml = params.html.toLowerCase();
+  const lowerUrl = params.finalUrl.toLowerCase();
+
+  const looksLikeWeChatVerify =
+    lowerUrl.includes("mp.weixin.qq.com") &&
+    (lowerHtml.includes("secitptpage/verify") ||
+      (params.html.includes("环境异常") && params.html.includes("去验证")));
+
+  if (looksLikeWeChatVerify) {
+    return {
+      provider: "wechat",
+      reason:
+        "WeChat returned an interactive verification page (环境异常 / 去验证), so the article body is unavailable to headless fetch.",
+    };
+  }
+
+  const looksLikeGenericVerify =
+    lowerHtml.includes("verify you are human") ||
+    lowerHtml.includes("captcha") ||
+    lowerHtml.includes("cf-chl") ||
+    lowerHtml.includes("attention required");
+
+  if (looksLikeGenericVerify) {
+    return {
+      provider: "generic",
+      reason:
+        "The target page requires interactive verification (CAPTCHA/human check), so content extraction is blocked.",
+    };
+  }
+
+  return null;
+}
+
 const WEB_FETCH_WRAPPER_WITH_WARNING_OVERHEAD = wrapWebContent("", "web_fetch").length;
 const WEB_FETCH_WRAPPER_NO_WARNING_OVERHEAD = wrapExternalContent("", {
   source: "web_fetch",
@@ -595,6 +632,47 @@ async function runWebFetch(params: WebFetchRuntimeParams): Promise<Record<string
     const responseTruncatedWarning = bodyResult.truncated
       ? `Response body truncated after ${params.maxResponseBytes} bytes.`
       : undefined;
+
+    const verificationGate =
+      contentType.includes("text/html") && body
+        ? detectVerificationGate({ html: body, finalUrl })
+        : null;
+
+    if (verificationGate) {
+      const rawMessage =
+        verificationGate.provider === "wechat"
+          ? `${verificationGate.reason}\nOpen the article in a real browser/WeChat app and share the text (or screenshots) for analysis.`
+          : `${verificationGate.reason}\nOpen the page in a real browser and complete verification before retrying.`;
+      const wrapped = wrapWebFetchContent(
+        params.extractMode === "text" ? markdownToText(rawMessage) : rawMessage,
+        params.maxChars,
+      );
+      const warningParts = [responseTruncatedWarning, verificationGate.reason].filter(Boolean);
+      const payload = {
+        url: params.url,
+        finalUrl,
+        status: res.status,
+        contentType: normalizeContentType(contentType) ?? "text/html",
+        title: undefined,
+        extractMode: params.extractMode,
+        extractor: "blocked-verification",
+        externalContent: {
+          untrusted: true,
+          source: "web_fetch",
+          wrapped: true,
+        },
+        truncated: wrapped.truncated,
+        length: wrapped.wrappedLength,
+        rawLength: wrapped.rawLength,
+        wrappedLength: wrapped.wrappedLength,
+        fetchedAt: new Date().toISOString(),
+        tookMs: Date.now() - start,
+        text: wrapped.text,
+        warning: warningParts.length ? wrapWebFetchField(warningParts.join(" ")) : undefined,
+      };
+      writeCache(FETCH_CACHE, cacheKey, payload, params.cacheTtlMs);
+      return payload;
+    }
 
     let title: string | undefined;
     let extractor = "raw";

--- a/src/agents/tools/web-fetch.ts
+++ b/src/agents/tools/web-fetch.ts
@@ -258,11 +258,23 @@ function detectVerificationGate(params: {
     };
   }
 
-  const looksLikeGenericVerify =
+  const titleMatch = params.html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+  const lowerTitle = (titleMatch?.[1] ?? "").toLowerCase();
+
+  const hasChallengeScript =
+    lowerHtml.includes("cf-chl") ||
+    lowerHtml.includes("g-recaptcha") ||
+    lowerHtml.includes("hcaptcha") ||
+    lowerHtml.includes("turnstile");
+
+  const hasHumanCheckCopy =
     lowerHtml.includes("verify you are human") ||
     lowerHtml.includes("captcha") ||
-    lowerHtml.includes("cf-chl") ||
-    lowerHtml.includes("attention required");
+    lowerHtml.includes("security check") ||
+    lowerHtml.includes("access denied") ||
+    lowerTitle.includes("attention required");
+
+  const looksLikeGenericVerify = hasChallengeScript && hasHumanCheckCopy;
 
   if (looksLikeGenericVerify) {
     return {

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -290,6 +290,29 @@ describe("web_fetch extraction fallbacks", () => {
   // NOTE: Test for wrapping url/finalUrl/warning fields requires DNS mocking.
   // The sanitization of these fields is verified by external-content.test.ts tests.
 
+  it("returns a verification-blocked payload for WeChat verification pages", async () => {
+    installMockFetch((input: RequestInfo | URL) =>
+      Promise.resolve(
+        htmlResponse(
+          "<!doctype html><html><body><h2>环境异常</h2><a id='js_verify'>去验证</a><script>var PAGE_MID='mmbizwap:secitptpage/verify.html';</script></body></html>",
+          requestUrl(input),
+        ),
+      ) as Promise<Response>,
+    );
+
+    const tool = createFetchTool({ firecrawl: { enabled: false } });
+    const result = await tool?.execute?.("call", { url: "https://mp.weixin.qq.com/s/abc" });
+    const details = result?.details as {
+      extractor?: string;
+      warning?: string;
+      text?: string;
+    };
+
+    expect(details.extractor).toBe("blocked-verification");
+    expect(details.warning).toContain("interactive verification page");
+    expect(details.text).toContain("Open the article in a real browser/WeChat app");
+  });
+
   it("falls back to firecrawl when readability returns no content", async () => {
     installMockFetch((input: RequestInfo | URL) => {
       const url = requestUrl(input);

--- a/src/agents/tools/web-tools.fetch.test.ts
+++ b/src/agents/tools/web-tools.fetch.test.ts
@@ -313,6 +313,47 @@ describe("web_fetch extraction fallbacks", () => {
     expect(details.text).toContain("Open the article in a real browser/WeChat app");
   });
 
+  it("returns a verification-blocked payload for generic challenge pages", async () => {
+    installMockFetch((input: RequestInfo | URL) =>
+      Promise.resolve(
+        htmlResponse(
+          "<!doctype html><html><head><title>Attention Required! | Cloudflare</title></head><body><div>Security check</div><script src='/cdn-cgi/challenge-platform/h/b/orchestrate/jsch/v1?ray=123'></script><div class='cf-chl-widget'></div></body></html>",
+          requestUrl(input),
+        ),
+      ) as Promise<Response>,
+    );
+
+    const tool = createFetchTool({ firecrawl: { enabled: false } });
+    const result = await tool?.execute?.("call", { url: "https://example.com/protected" });
+    const details = result?.details as {
+      extractor?: string;
+      warning?: string;
+      text?: string;
+    };
+
+    expect(details.extractor).toBe("blocked-verification");
+    expect(details.warning).toContain("interactive verification");
+    expect(details.text).toContain("complete verification before retrying");
+  });
+
+  it("does not classify normal pages mentioning captcha as blocked verification", async () => {
+    installMockFetch((input: RequestInfo | URL) =>
+      Promise.resolve(
+        htmlResponse(
+          "<!doctype html><html><head><title>How to add captcha in forms</title></head><body><article>This guide explains captcha UX patterns for signup forms.</article></body></html>",
+          requestUrl(input),
+        ),
+      ) as Promise<Response>,
+    );
+
+    const tool = createFetchTool({ firecrawl: { enabled: false } });
+    const result = await tool?.execute?.("call", { url: "https://example.com/blog" });
+    const details = result?.details as { extractor?: string; text?: string };
+
+    expect(details.extractor).not.toBe("blocked-verification");
+    expect(details.text).toContain("captcha UX patterns");
+  });
+
   it("falls back to firecrawl when readability returns no content", async () => {
     installMockFetch((input: RequestInfo | URL) => {
       const url = requestUrl(input);


### PR DESCRIPTION
## Summary

This PR addresses high-impact UX issues in two areas:

1. `web_fetch` handling of interactive verification gates (especially WeChat verify pages)
2. Feishu-specific messaging guidance in the system prompt

## What changed

### 1) `web_fetch`: verification-gate detection and actionable response

- Added verification-gate detection for:
  - WeChat verify pages (`mp.weixin.qq.com` + verify markers like `环境异常 / 去验证`)
  - Generic CAPTCHA/human-check pages
- Instead of returning a vague extraction failure, `web_fetch` now returns a structured payload with:
  - `extractor: "blocked-verification"`
  - actionable fallback guidance in `text`
  - explicit blocking reason in `warning`
- Existing untrusted-content wrapping/safety behavior remains intact.

### 2) Feishu prompt hint: remove misleading inline-button config hint

- When runtime channel is `feishu` and inline buttons are unavailable, the system prompt now gives Feishu-specific guidance:
  - explains that Feishu uses rich interactive cards (instead of message-tool inline buttons)
  - avoids suggesting `feishu.capabilities.inlineButtons` (which is misleading)

## Why

- WeChat verification pages are common in real usage and previously produced confusing errors.
- Feishu users were receiving a generic inline-button instruction that does not match Feishu behavior.

## Tests

Added/updated tests and ran targeted suites:

```bash
node ./node_modules/vitest/vitest.mjs run src/agents/tools/web-tools.fetch.test.ts src/agents/system-prompt.test.ts
```

Result: **58 passed**

- New test: `returns a verification-blocked payload for WeChat verification pages`
- New test: `uses feishu-specific inline button guidance when inline buttons are unavailable`
