### PR TITLE
fix(mistral): enable tool-use result pairing repair for Mistral models

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { resolveTranscriptPolicy } from "./transcript-policy.js";
+
+describe("resolveTranscriptPolicy", () => {
+  describe("Mistral models", () => {
+    it("enables repairToolUseResultPairing for mistral provider", () => {
+      const policy = resolveTranscriptPolicy({
+        modelApi: "openai-completions",
+        provider: "mistral",
+        modelId: "devstral-2512",
+      });
+      expect(policy.repairToolUseResultPairing).toBe(true);
+    });
+
+    it("enables repairToolUseResultPairing for mistralai model hints", () => {
+      const policy = resolveTranscriptPolicy({
+        modelApi: "openai-completions",
+        provider: "openrouter",
+        modelId: "mistralai/devstral-small-2505",
+      });
+      expect(policy.repairToolUseResultPairing).toBe(true);
+    });
+
+    it("enables repairToolUseResultPairing for codestral model", () => {
+      const policy = resolveTranscriptPolicy({
+        modelApi: "openai-completions",
+        provider: "openrouter",
+        modelId: "codestral-latest",
+      });
+      expect(policy.repairToolUseResultPairing).toBe(true);
+    });
+
+    it("sanitizes tool call ids for mistral", () => {
+      const policy = resolveTranscriptPolicy({
+        provider: "mistral",
+        modelId: "devstral-2512",
+      });
+      expect(policy.sanitizeToolCallIds).toBe(true);
+      expect(policy.toolCallIdMode).toBe("strict9");
+    });
+  });
+
+  describe("Anthropic models", () => {
+    it("enables repairToolUseResultPairing for anthropic", () => {
+      const policy = resolveTranscriptPolicy({
+        modelApi: "anthropic-messages",
+        provider: "anthropic",
+        modelId: "claude-sonnet-4-20250514",
+      });
+      expect(policy.repairToolUseResultPairing).toBe(true);
+    });
+  });
+
+  describe("Google models", () => {
+    it("enables repairToolUseResultPairing for google", () => {
+      const policy = resolveTranscriptPolicy({
+        modelApi: "google-genai",
+        provider: "google",
+        modelId: "gemini-2.5-pro",
+      });
+      expect(policy.repairToolUseResultPairing).toBe(true);
+    });
+  });
+
+  describe("OpenAI models", () => {
+    it("disables repairToolUseResultPairing for openai", () => {
+      const policy = resolveTranscriptPolicy({
+        modelApi: "openai-completions",
+        provider: "openai",
+        modelId: "gpt-4o",
+      });
+      expect(policy.repairToolUseResultPairing).toBe(false);
+    });
+  });
+});

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -91,7 +91,7 @@ export function resolveTranscriptPolicy(params: {
     : sanitizeToolCallIds
       ? "strict"
       : undefined;
-  const repairToolUseResultPairing = isGoogle || isAnthropic;
+  const repairToolUseResultPairing = isGoogle || isAnthropic || isMistral;
   const sanitizeThoughtSignatures = isOpenRouterGemini
     ? { allowBase64Only: true, includeCamelCase: true }
     : undefined;


### PR DESCRIPTION
## Problem

Mistral models (devstral, codestral, mixtral, pixtral, ministral) reject transcripts where a `user` message follows a `tool` result message. The error from Mistral's tokenizer is:

```
InvalidMessageStructureException: Unexpected role 'user' after role 'tool'
```

This happens because `repairToolUseResultPairing` — which moves tool result messages directly after their matching assistant tool-call turn — was enabled for Anthropic and Google models but **not for Mistral**.

## Fix

Add `isMistral` to the `repairToolUseResultPairing` condition in `transcript-policy.ts`, so displaced tool results are repaired before submission to Mistral endpoints.

## Changes

- **`src/agents/transcript-policy.ts`** — include Mistral in `repairToolUseResultPairing` 
- **`src/agents/transcript-policy.test.ts`** — new test file covering Mistral, Anthropic, Google, and OpenAI transcript policy resolution

## Testing

- Unit tests verify `repairToolUseResultPairing` is `true` for Mistral provider and model-hint variations (devstral, codestral, mistralai prefix)
- Unit tests verify OpenAI remains `false` (no repair needed)

Fixes #33177