### PR TITLE
fix(feishu): correct normalizeSecretInputString reference

### DIFF
--- a/extensions/feishu/src/secret-input.test.ts
+++ b/extensions/feishu/src/secret-input.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockedFeishuSdk = vi.hoisted(() => ({
+  buildSecretInputSchema: vi.fn(() => ({ type: "mock-schema" })),
   hasConfiguredSecretInput: vi.fn((value: unknown) => {
     if (typeof value === "string") {
       return value.trim().length > 0;

--- a/extensions/feishu/src/secret-input.test.ts
+++ b/extensions/feishu/src/secret-input.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockedFeishuSdk = vi.hoisted(() => ({
+  hasConfiguredSecretInput: vi.fn((value: unknown) => {
+    if (typeof value === "string") {
+      return value.trim().length > 0;
+    }
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return false;
+    }
+    const ref = value as { source?: unknown; provider?: unknown; id?: unknown };
+    const validSource = ref.source === "env" || ref.source === "file" || ref.source === "exec";
+    return (
+      validSource &&
+      typeof ref.provider === "string" &&
+      ref.provider.trim().length > 0 &&
+      typeof ref.id === "string" &&
+      ref.id.trim().length > 0
+    );
+  }),
+  normalizeResolvedSecretInputString: undefined as
+    | ((params: { value: unknown; refValue?: unknown; path: string }) => string | undefined)
+    | undefined,
+  normalizeSecretInputString: undefined as ((value: unknown) => string | undefined) | undefined,
+}));
+
+vi.mock("openclaw/plugin-sdk/feishu", () => mockedFeishuSdk);
+
+describe("feishu secret input compatibility", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockedFeishuSdk.hasConfiguredSecretInput.mockClear();
+    mockedFeishuSdk.normalizeResolvedSecretInputString = undefined;
+    mockedFeishuSdk.normalizeSecretInputString = undefined;
+  });
+
+  it("falls back to local string normalization when host helper is missing", async () => {
+    const { normalizeSecretInputString } = await import("./secret-input.js");
+
+    expect(normalizeSecretInputString("  secret  ")).toBe("secret");
+    expect(normalizeSecretInputString("   ")).toBeUndefined();
+  });
+
+  it("preserves unresolved SecretRef errors when resolved helper is missing", async () => {
+    const { normalizeResolvedSecretInputString } = await import("./secret-input.js");
+
+    expect(() =>
+      normalizeResolvedSecretInputString({
+        value: { source: "env", provider: "default", id: "FEISHU_APP_SECRET" },
+        path: "channels.feishu.appSecret",
+      }),
+    ).toThrow(/unresolved SecretRef/i);
+  });
+
+  it("delegates to host helpers when the runtime exports them", async () => {
+    const hostNormalizeSecretInputString = vi.fn(() => "from-host");
+    const hostNormalizeResolvedSecretInputString = vi.fn(() => "resolved-from-host");
+    mockedFeishuSdk.normalizeSecretInputString = hostNormalizeSecretInputString;
+    mockedFeishuSdk.normalizeResolvedSecretInputString = hostNormalizeResolvedSecretInputString;
+
+    const { normalizeResolvedSecretInputString, normalizeSecretInputString } = await import(
+      "./secret-input.js"
+    );
+
+    expect(normalizeSecretInputString("  secret  ")).toBe("from-host");
+    expect(hostNormalizeSecretInputString).toHaveBeenCalledWith("  secret  ");
+
+    expect(
+      normalizeResolvedSecretInputString({
+        value: "  secret  ",
+        path: "channels.feishu.appSecret",
+      }),
+    ).toBe("resolved-from-host");
+    expect(hostNormalizeResolvedSecretInputString).toHaveBeenCalledWith({
+      value: "  secret  ",
+      path: "channels.feishu.appSecret",
+    });
+  });
+});

--- a/extensions/feishu/src/secret-input.test.ts
+++ b/extensions/feishu/src/secret-input.test.ts
@@ -58,9 +58,8 @@ describe("feishu secret input compatibility", () => {
     mockedFeishuSdk.normalizeSecretInputString = hostNormalizeSecretInputString;
     mockedFeishuSdk.normalizeResolvedSecretInputString = hostNormalizeResolvedSecretInputString;
 
-    const { normalizeResolvedSecretInputString, normalizeSecretInputString } = await import(
-      "./secret-input.js"
-    );
+    const { normalizeResolvedSecretInputString, normalizeSecretInputString } =
+      await import("./secret-input.js");
 
     expect(normalizeSecretInputString("  secret  ")).toBe("from-host");
     expect(hostNormalizeSecretInputString).toHaveBeenCalledWith("  secret  ");

--- a/extensions/feishu/src/secret-input.ts
+++ b/extensions/feishu/src/secret-input.ts
@@ -1,8 +1,8 @@
 import * as feishuSdk from "openclaw/plugin-sdk/feishu";
 
 const { buildSecretInputSchema, hasConfiguredSecretInput } = feishuSdk;
-const _normalizeResolvedSecretInputString = feishuSdk.normalizeResolvedSecretInputString;
-const _normalizeSecretInputString = feishuSdk.normalizeSecretInputString;
+const hostNormalizeResolvedInputString = feishuSdk.normalizeResolvedSecretInputString;
+const hostNormalizeInputString = feishuSdk.normalizeSecretInputString;
 
 /**
  * Local fallback for normalizeSecretInputString when the host openclaw version
@@ -17,8 +17,8 @@ function normalizeSecretInputStringFallback(value: unknown): string | undefined 
 }
 
 export const normalizeSecretInputString: typeof normalizeSecretInputStringFallback =
-  typeof _normalizeSecretInputString === "function"
-    ? _normalizeSecretInputString
+  typeof hostNormalizeInputString === "function"
+    ? hostNormalizeInputString
     : normalizeSecretInputStringFallback;
 
 /**
@@ -45,8 +45,8 @@ function normalizeResolvedSecretInputStringFallback(params: {
 }
 
 export const normalizeResolvedSecretInputString: typeof normalizeResolvedSecretInputStringFallback =
-  typeof _normalizeResolvedSecretInputString === "function"
-    ? _normalizeResolvedSecretInputString
+  typeof hostNormalizeResolvedInputString === "function"
+    ? hostNormalizeResolvedInputString
     : normalizeResolvedSecretInputStringFallback;
 
 export {

--- a/extensions/feishu/src/secret-input.ts
+++ b/extensions/feishu/src/secret-input.ts
@@ -49,9 +49,4 @@ export const normalizeResolvedSecretInputString: typeof normalizeResolvedSecretI
     ? hostNormalizeResolvedInputString
     : normalizeResolvedSecretInputStringFallback;
 
-export {
-  buildSecretInputSchema,
-  hasConfiguredSecretInput,
-  normalizeResolvedSecretInputString,
-  normalizeSecretInputString,
-};
+export { buildSecretInputSchema, hasConfiguredSecretInput };

--- a/extensions/feishu/src/secret-input.ts
+++ b/extensions/feishu/src/secret-input.ts
@@ -1,9 +1,53 @@
-import {
-  buildSecretInputSchema,
-  hasConfiguredSecretInput,
-  normalizeResolvedSecretInputString,
-  normalizeSecretInputString,
-} from "openclaw/plugin-sdk/feishu";
+import * as feishuSdk from "openclaw/plugin-sdk/feishu";
+
+const { buildSecretInputSchema, hasConfiguredSecretInput } = feishuSdk;
+const _normalizeResolvedSecretInputString = feishuSdk.normalizeResolvedSecretInputString;
+const _normalizeSecretInputString = feishuSdk.normalizeSecretInputString;
+
+/**
+ * Local fallback for normalizeSecretInputString when the host openclaw version
+ * predates the export (added in 2026.3.2).
+ */
+function normalizeSecretInputStringFallback(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export const normalizeSecretInputString: typeof normalizeSecretInputStringFallback =
+  typeof _normalizeSecretInputString === "function"
+    ? _normalizeSecretInputString
+    : normalizeSecretInputStringFallback;
+
+/**
+ * Fallback for normalizeResolvedSecretInputString that preserves
+ * unresolved SecretRef validation: if the value looks like a SecretRef
+ * object (has a `source` key), throw so the user sees the real problem
+ * instead of silently treating the account as unconfigured.
+ */
+function normalizeResolvedSecretInputStringFallback(params: {
+  value: unknown;
+  refValue?: unknown;
+  path: string;
+}): string | undefined {
+  const normalized = normalizeSecretInputString(params.value);
+  if (normalized) {
+    return normalized;
+  }
+  if (params.value != null && typeof params.value === "object" && "source" in params.value) {
+    throw new Error(
+      `${params.path}: unresolved SecretRef. Resolve this against an active gateway runtime snapshot before reading it.`,
+    );
+  }
+  return undefined;
+}
+
+export const normalizeResolvedSecretInputString: typeof normalizeResolvedSecretInputStringFallback =
+  typeof _normalizeResolvedSecretInputString === "function"
+    ? _normalizeResolvedSecretInputString
+    : normalizeResolvedSecretInputStringFallback;
 
 export {
   buildSecretInputSchema,


### PR DESCRIPTION
## Summary

- **Problem:** Feishu channel plugin crashes with `normalizeSecretInputString is not a function` on WSL2 when the host openclaw version (2026.3.1) predates the export added in 2026.3.2.
- **Cause:** `normalizeSecretInputString` and `normalizeResolvedSecretInputString` were added to `openclaw/plugin-sdk` after the feishu plugin started importing themirthat version.
- **Fix:** Add runtime fallback in `extensions/feishu/src/secret-input.ts` — if the host SDK lacks these functions, local equivalents are used instead.

Closes #32808