### PR TITLE
fix(cron): guard armTimer against watchdog clearance during tick execution (#18121)

### DIFF
--- a/src/cron/service.rapid-create-delete-race.test.ts
+++ b/src/cron/service.rapid-create-delete-race.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createCronStoreHarness,
+  createNoopLogger,
+  createRunningCronServiceState,
+  createStartedCronServiceWithFinishedBarrier,
+  installCronTestHooks,
+} from "./service.test-harness.js";
+import { armTimer } from "./service/timer.js";
+import type { CronJob } from "./types.js";
+
+const noopLogger = createNoopLogger();
+const { makeStorePath } = createCronStoreHarness({ prefix: "openclaw-cron-race-" });
+installCronTestHooks({
+  logger: noopLogger,
+  baseTimeIso: "2026-02-16T12:00:00.000Z",
+});
+
+function createRecurringJob(params: { id: string; nowMs: number; nextRunAtMs: number }): CronJob {
+  return {
+    id: params.id,
+    name: params.id,
+    enabled: true,
+    deleteAfterRun: false,
+    createdAtMs: params.nowMs,
+    updatedAtMs: params.nowMs,
+    schedule: { kind: "every", everyMs: 60_000 },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: "beat" },
+    delivery: { mode: "none" },
+    state: { nextRunAtMs: params.nextRunAtMs },
+  };
+}
+
+describe("CronService - rapid create/delete race (#18121)", () => {
+  it("armTimer is a no-op when state.running is true, preserving the watchdog", async () => {
+    const store = await makeStorePath();
+    const now = Date.parse("2026-02-16T12:00:00.000Z");
+
+    const state = createRunningCronServiceState({
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      jobs: [createRecurringJob({ id: "job-1", nowMs: now, nextRunAtMs: now + 60_000 })],
+    });
+
+    // state.running is already true via createRunningCronServiceState.
+    // Set a sentinel timer to simulate the watchdog armed by armRunningRecheckTimer.
+    const sentinelTimer = setTimeout(() => {}, 999_999);
+    state.timer = sentinelTimer;
+
+    // Call armTimer — it should skip entirely because state.running is true.
+    armTimer(state);
+
+    // The timer must NOT have been replaced.
+    expect(state.timer).toBe(sentinelTimer);
+
+    // Verify the debug log was emitted.
+    expect(noopLogger.debug).toHaveBeenCalledWith({}, "cron: armTimer skipped - tick in progress");
+
+    clearTimeout(sentinelTimer);
+    await store.cleanup();
+  });
+
+  it("armTimer does not clear the watchdog even when all jobs are temporarily deleted", async () => {
+    const store = await makeStorePath();
+    const now = Date.parse("2026-02-16T12:00:00.000Z");
+
+    const state = createRunningCronServiceState({
+      storePath: store.storePath,
+      log: noopLogger,
+      nowMs: () => now,
+      jobs: [], // empty — simulates all jobs deleted mid-tick
+    });
+
+    const watchdog = setTimeout(() => {}, 999_999);
+    state.timer = watchdog;
+
+    armTimer(state);
+
+    // Watchdog must survive even though there are zero jobs.
+    expect(state.timer).toBe(watchdog);
+
+    clearTimeout(watchdog);
+    await store.cleanup();
+  });
+
+  it("scheduler recovers and fires jobs after bulk delete-then-create cycle", async () => {
+    const store = await makeStorePath();
+    const { cron, enqueueSystemEvent, finished } = createStartedCronServiceWithFinishedBarrier({
+      storePath: store.storePath,
+      logger: noopLogger,
+    });
+
+    await cron.start();
+
+    // Create 6 jobs (simulating ensure-crons with 6 agents).
+    const jobIds: string[] = [];
+    for (let i = 0; i < 6; i++) {
+      const job = await cron.add({
+        name: `agent-${i}`,
+        enabled: true,
+        schedule: { kind: "every", everyMs: 10_000 },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: `heartbeat-${i}` },
+      });
+      jobIds.push(job.id);
+    }
+
+    // Fire all jobs once.
+    const firstJob = (await cron.list())[0];
+    const firstDueAt = firstJob.state.nextRunAtMs!;
+    vi.setSystemTime(new Date(firstDueAt + 5));
+    await vi.runOnlyPendingTimersAsync();
+    await finished.waitForOk(firstJob.id);
+
+    expect(enqueueSystemEvent.mock.calls.length).toBeGreaterThanOrEqual(1);
+
+    // Rapid bulk delete of all jobs.
+    for (const id of jobIds) {
+      await cron.remove(id);
+    }
+
+    // Zero jobs momentarily.
+    const midStatus = await cron.status();
+    expect(midStatus.jobs).toBe(0);
+
+    // Re-create all jobs.
+    for (let i = 0; i < 6; i++) {
+      await cron.add({
+        name: `agent-v2-${i}`,
+        enabled: true,
+        schedule: { kind: "every", everyMs: 10_000 },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "systemEvent", text: `heartbeat-v2-${i}` },
+      });
+    }
+
+    // Advance time past the next scheduled run and fire.
+    enqueueSystemEvent.mockClear();
+    const newJob = (await cron.list())[0];
+    const nextDueAt = newJob.state.nextRunAtMs!;
+    vi.setSystemTime(new Date(nextDueAt + 5));
+    await vi.runOnlyPendingTimersAsync();
+    await finished.waitForOk(newJob.id);
+
+    // The re-created jobs must fire — scheduler must not be frozen.
+    expect(enqueueSystemEvent.mock.calls.length).toBeGreaterThanOrEqual(1);
+
+    const finalStatus = await cron.status();
+    expect(finalStatus.enabled).toBe(true);
+    expect(finalStatus.nextWakeAtMs).not.toBeNull();
+
+    cron.stop();
+    await store.cleanup();
+  });
+});

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -465,6 +465,17 @@ function applyOutcomeToStoredJob(state: CronServiceState, result: TimedCronRunOu
 }
 
 export function armTimer(state: CronServiceState) {
+  // If a timer tick is currently executing, don't interfere with its timer.
+  // The running tick will call armTimer() in its finally block after setting
+  // state.running = false, ensuring proper timer re-arm without race conditions.
+  // Without this guard, rapid add()/remove() calls can clear the watchdog timer
+  // set by armRunningRecheckTimer(), leaving the scheduler without a safety net
+  // if execution hangs.
+  // See: https://github.com/openclaw/openclaw/issues/18121
+  if (state.running) {
+    state.deps.log.debug({}, "cron: armTimer skipped - tick in progress");
+    return;
+  }
   if (state.timer) {
     clearTimeout(state.timer);
   }


### PR DESCRIPTION
## Summary

Fresh minimal PR addressing the timer race condition in #18121, as requested in the [review of PR #18191](https://github.com/openclaw/openclaw/pull/18191).

- **Problem**: `armTimer()` unconditionally clears `state.timer` when called by `add()`/`remove()`/`update()` during tick execution. This kills the watchdog timer set by `armRunningRecheckTimer()` (8bf3c37c6c), leaving the scheduler without a safety net if execution hangs.
- **Fix**: Early return in `armTimer()` when `state.running` is true. The running tick's `finally` block already calls `armTimer()` after `state.running = false`, so timer updates are deferred — not lost.
- **Scope**: Only `src/cron/service/timer.ts` (+11 lines) and one new test file. No CHANGELOG, no unrelated files.

### Why the existing watchdog alone is not sufficient

The watchdog from `8bf3c37c6c` arms a 60 s re-check timer right after `state.running = true`. But during rapid create/delete cycles, each `add()`/`remove()` call invokes `armTimer()` which does:

```
clearTimeout(state.timer)   ← kills the watchdog
state.timer = null
```

If all jobs are momentarily deleted (common in `ensure-crons`), `nextWakeAtMs` returns null and `state.timer` stays null. The watchdog is gone. If execution then hangs, the scheduler freezes permanently.

The `state.running` guard and the watchdog are **complementary**:
- Watchdog: keeps the scheduler alive when execution hangs
- Guard: prevents external callers from killing the watchdog

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Fixes #18121
- Supersedes #18191

## Test plan

- [x] Unit test: `armTimer()` is a no-op when `state.running` is true — sentinel timer preserved
- [x] Unit test: watchdog survives even when all jobs are temporarily deleted mid-tick
- [x] Integration test: 6-agent ensure-crons cycle (create → fire → bulk delete → bulk recreate → verify scheduler fires new jobs)
- [x] Full cron test suite: 52 files, 381 tests — all pass, zero regressions

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- How to revert: Remove the `if (state.running)` guard from `armTimer()`
- Worst case if guard misfires: timer re-arm is delayed until the running tick's `finally` block completes (seconds, not permanent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)