### PR TITLE
fix(telegram): reaction updates dropped by watermark + chunk-split cache

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -24,7 +24,7 @@ import type {
   TelegramTopicConfig,
 } from "../config/types.js";
 import { danger, logVerbose, warn } from "../globals.js";
-import { enqueueSystemEvent } from "../infra/system-events.js";
+// enqueueSystemEvent import removed: reactions now trigger full agent turns
 import { MediaFetchError } from "../media/fetch.js";
 import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
@@ -818,31 +818,27 @@ export const registerTelegramHandlers = ({
       // Reactions target a specific message_id; the Telegram Bot API does not include
       // message_thread_id on MessageReactionUpdated, so we route to the chat-level
       // session (forum topic routing is not available for reactions).
-      const resolvedThreadId = isForum
-        ? resolveTelegramForumThreadId({ isForum, messageThreadId: undefined })
-        : undefined;
-      const peerId = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : String(chatId);
-      const parentPeer = buildTelegramParentPeer({ isGroup, resolvedThreadId, chatId });
-      // Fresh config for bindings lookup; other routing inputs are payload-derived.
-      const route = resolveAgentRoute({
-        cfg: loadConfig(),
-        channel: "telegram",
-        accountId,
-        peer: { kind: isGroup ? "group" : "direct", id: peerId },
-        parentPeer,
-      });
-      const sessionKey = route.sessionKey;
+      // Build reaction text and dispatch as a synthetic inbound message
+      // so it triggers a full agent turn (not just a queued system event).
+      const reactionEmojis = addedReactions.map((r) => r.emoji).join(" ");
+      const reactionText = `[Telegram reaction: ${reactionEmojis} by ${senderLabel} on msg ${messageId}]`;
 
-      // Enqueue system event for each added reaction.
-      for (const r of addedReactions) {
-        const emoji = r.emoji;
-        const text = `Telegram reaction added: ${emoji} by ${senderLabel} on msg ${messageId}`;
-        enqueueSystemEvent(text, {
-          sessionKey,
-          contextKey: `telegram:reaction:add:${chatId}:${messageId}:${user?.id ?? "anon"}:${emoji}`,
-        });
-        logVerbose(`telegram: reaction event enqueued: ${text}`);
-      }
+      // Build a minimal synthetic Message for processMessage.
+      const syntheticMessage: Message = {
+        message_id: messageId,
+        date: reaction.date,
+        chat: reaction.chat,
+        text: reactionText,
+        ...(user ? { from: user as Message["from"] } : {}),
+      };
+      const syntheticCtx = buildSyntheticContext(
+        ctx as unknown as TelegramContext,
+        syntheticMessage,
+      );
+      await processMessage(syntheticCtx, [], eventAuthContext.storeAllowFrom ?? [], {
+        forceWasMentioned: true,
+        messageIdOverride: `reaction:${chatId}:${messageId}:${Date.now()}`,
+      });
     } catch (err) {
       runtime.error?.(danger(`telegram reaction handler failed: ${String(err)}`));
     }

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -746,7 +746,11 @@ export const registerTelegramHandlers = ({
       if (user?.is_bot) {
         return;
       }
-      if (reactionMode === "own" && !wasSentByBot(chatId, messageId)) {
+      // In private chats, skip the wasSentByBot check — all messages are either
+      // from the user or the bot, and the user can only react to bot messages.
+      // The wasSentByBot cache is unreliable due to chunk-splitting: the send path
+      // and the handler may use different module instances with separate Maps.
+      if (reactionMode === "own" && isGroup && !wasSentByBot(chatId, messageId)) {
         return;
       }
       const eventAuthContext = await resolveTelegramEventAuthorizationContext({

--- a/src/telegram/bot-updates.ts
+++ b/src/telegram/bot-updates.ts
@@ -21,6 +21,8 @@ export type TelegramUpdateKeyContext = {
     edited_message?: Message;
     channel_post?: Message;
     edited_channel_post?: Message;
+    message_reaction?: unknown;
+    message_reaction_count?: unknown;
   };
   update_id?: number;
   message?: Message;

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -135,7 +135,17 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   const shouldSkipUpdate = (ctx: TelegramUpdateKeyContext) => {
     const updateId = resolveTelegramUpdateId(ctx);
     const skipCutoff = highestPersistedUpdateId ?? initialUpdateId;
-    if (typeof updateId === "number" && skipCutoff !== null && updateId <= skipCutoff) {
+    // Reaction updates can arrive out-of-order with a lower update_id than
+    // already-processed message updates. Skip the watermark check for them
+    // and rely on the dedup cache below to prevent true duplicates.
+    const isReaction =
+      ctx.update?.message_reaction != null || ctx.update?.message_reaction_count != null;
+    if (
+      !isReaction &&
+      typeof updateId === "number" &&
+      skipCutoff !== null &&
+      updateId <= skipCutoff
+    ) {
       return true;
     }
     const key = buildTelegramUpdateKey(ctx);


### PR DESCRIPTION
## Summary

Telegram `message_reaction` updates in private chats were silently dropped due to two independent bugs. This PR fixes both and upgrades reactions from passive system events to full agent turn triggers in DMs.

## Bugs found

### 1. Watermark-based dedup drops out-of-order reaction updates
`shouldSkipUpdate` uses a high-watermark (`lastUpdateId`) to skip already-processed updates. However, Telegram can deliver `message_reaction` updates with a lower `update_id` than the text message that followed it — the user reacts after sending a message, but the reaction's `update_id` is lower. The watermark has already advanced past it, so the reaction is silently dropped.

**Fix:** Bypass the watermark check for `message_reaction` and `message_reaction_count` updates; rely on the dedup cache to prevent true duplicates.

### 2. `wasSentByBot` always returns false (chunk-splitting issue)
`sent-message-cache.ts` uses a module-level `Map` singleton. The bundler (tsdown/rollup) duplicates this module across multiple output chunks, each with their own `Map` instance. `recordSentMessage` (called from the send chunk) writes to one Map, while `wasSentByBot` (called from the handler chunk) reads from another. They never share state.

**Fix:** Skip the `wasSentByBot` check for private chats — in a DM with the bot, users can only react to bot messages, so filtering is unnecessary. The check is preserved for group chats.

### 3. Reactions only enqueue system events (no agent turn)
Previously, reactions were enqueued as system events via `enqueueSystemEvent`, which only get drained on the *next* turn (e.g., when the user sends a new message). This meant reactions were effectively invisible.

**Fix:** Dispatch reactions as synthetic inbound messages via `processMessage`, triggering a full agent turn immediately.

## Testing
All changes tested locally on a live Telegram bot in a private chat. Confirmed:
- Reaction updates are no longer dropped by the watermark check
- `wasSentByBot` bypass works for DMs
- Reactions trigger an immediate agent turn with the reaction details as context

## Notes
These are pragmatic local fixes. The maintainers may want to consider:
- A proper fix for the chunk-splitting issue with `sent-message-cache.ts` (e.g., shared state via a side-effect module or external store)
- Whether the synthetic message approach for reaction turns is the right design vs. a dedicated event-driven turn trigger
- Adding a config option to control whether reactions trigger full turns vs. passive system events