### PR TITLE
feat(cron): enforce payload.paths allow/deny for isolated agent writes

### DIFF
--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -312,6 +312,61 @@ describe("applyPatch", () => {
     });
   });
 
+  it("enforces writePathPolicy allow patterns", async () => {
+    await withTempDir(async (dir) => {
+      const deniedPatch = `*** Begin Patch
+*** Add File: blocked.txt
++blocked
+*** End Patch`;
+
+      await expect(
+        applyPatch(deniedPatch, {
+          cwd: dir,
+          workspaceOnly: false,
+          writePathPolicy: { allow: ["notes/**"] },
+        }),
+      ).rejects.toThrow(/not allowed by cron payload\.paths\.allow/i);
+
+      const allowedPatch = `*** Begin Patch
+*** Add File: notes/allowed.txt
++ok
+*** End Patch`;
+      await applyPatch(allowedPatch, {
+        cwd: dir,
+        workspaceOnly: false,
+        writePathPolicy: { allow: ["notes/**"] },
+      });
+
+      expect(await fs.readFile(path.join(dir, "notes", "allowed.txt"), "utf8")).toBe("ok\n");
+      await expect(fs.stat(path.join(dir, "blocked.txt"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    });
+  });
+
+  it("enforces writePathPolicy deny patterns before allow patterns", async () => {
+    await withTempDir(async (dir) => {
+      const deniedPatch = `*** Begin Patch
+*** Add File: notes/private.txt
++blocked
+*** End Patch`;
+      await expect(
+        applyPatch(deniedPatch, {
+          cwd: dir,
+          workspaceOnly: false,
+          writePathPolicy: {
+            allow: ["notes/**"],
+            deny: ["notes/private/**", "notes/private.txt"],
+          },
+        }),
+      ).rejects.toThrow(/payload\.paths\.deny pattern/i);
+
+      await expect(fs.stat(path.join(dir, "notes", "private.txt"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    });
+  });
+
   it("allows deleting a symlink itself even if it points outside cwd", async () => {
     await withTempDir(async (dir) => {
       const outsideDir = await fs.mkdtemp(path.join(path.dirname(dir), "openclaw-patch-outside-"));

--- a/src/agents/apply-patch.ts
+++ b/src/agents/apply-patch.ts
@@ -10,6 +10,7 @@ import { applyUpdateHunk } from "./apply-patch-update.js";
 import { toRelativeSandboxPath, resolvePathFromInput } from "./path-policy.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
+import { assertToolWritePathAllowed, type ToolWritePathPolicy } from "./tool-write-path-policy.js";
 
 const BEGIN_PATCH_MARKER = "*** Begin Patch";
 const END_PATCH_MARKER = "*** End Patch";
@@ -73,6 +74,8 @@ type ApplyPatchOptions = {
   sandbox?: SandboxApplyPatchConfig;
   /** Restrict patch paths to the workspace root (cwd). Default: true. Set false to opt out. */
   workspaceOnly?: boolean;
+  /** Additional per-run allow/deny policy for mutating paths. */
+  writePathPolicy?: ToolWritePathPolicy;
   signal?: AbortSignal;
 };
 
@@ -83,7 +86,12 @@ const applyPatchSchema = Type.Object({
 });
 
 export function createApplyPatchTool(
-  options: { cwd?: string; sandbox?: SandboxApplyPatchConfig; workspaceOnly?: boolean } = {},
+  options: {
+    cwd?: string;
+    sandbox?: SandboxApplyPatchConfig;
+    workspaceOnly?: boolean;
+    writePathPolicy?: ToolWritePathPolicy;
+  } = {},
 ): AgentTool<typeof applyPatchSchema, ApplyPatchToolDetails> {
   const cwd = options.cwd ?? process.cwd();
   const sandbox = options.sandbox;
@@ -111,6 +119,7 @@ export function createApplyPatchTool(
         cwd,
         sandbox,
         workspaceOnly,
+        writePathPolicy: options.writePathPolicy,
         signal,
       });
 
@@ -302,10 +311,17 @@ async function resolvePatchPath(
         allowFinalHardlinkForUnlink: aliasPolicy.allowFinalHardlinkForUnlink,
       });
     }
-    return {
+    const result = {
       resolved: resolved.hostPath,
       display: resolved.relativePath || resolved.hostPath,
     };
+    assertToolWritePathAllowed({
+      policy: options.writePathPolicy,
+      workspaceRoot: options.cwd,
+      candidatePath: result.resolved,
+      cwd: options.cwd,
+    });
+    return result;
   }
 
   const workspaceOnly = options.workspaceOnly !== false;
@@ -320,10 +336,17 @@ async function resolvePatchPath(
         })
       ).resolved
     : resolvePathFromInput(filePath, options.cwd);
-  return {
+  const result = {
     resolved,
     display: toDisplayPath(resolved, options.cwd),
   };
+  assertToolWritePathAllowed({
+    policy: options.writePathPolicy,
+    workspaceRoot: options.cwd,
+    candidatePath: result.resolved,
+    cwd: options.cwd,
+  });
+  return result;
 }
 
 function assertBoundaryRead(

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -736,6 +736,7 @@ export async function runEmbeddedPiAgent(
             sessionFile: params.sessionFile,
             workspaceDir: resolvedWorkspace,
             agentDir,
+            writePathPolicy: params.writePathPolicy,
             config: params.config,
             skillsSnapshot: params.skillsSnapshot,
             prompt,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -649,6 +649,7 @@ export async function runEmbeddedAttempt(
           runId: params.runId,
           agentDir,
           workspaceDir: effectiveWorkspace,
+          writePathPolicy: params.writePathPolicy,
           config: params.config,
           abortSignal: runAbortController.signal,
           modelProvider: params.model.provider,

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -8,6 +8,7 @@ import type { ExecElevatedDefaults, ExecToolDefaults } from "../../bash-tools.js
 import type { BlockReplyPayload } from "../../pi-embedded-payloads.js";
 import type { BlockReplyChunking, ToolResultFormat } from "../../pi-embedded-subscribe.js";
 import type { SkillSnapshot } from "../../skills.js";
+import type { ToolWritePathPolicy } from "../../tool-write-path-policy.js";
 
 // Simplified tool definition for client-provided tools (OpenResponses hosted tools)
 export type ClientToolDefinition = {
@@ -63,6 +64,8 @@ export type RunEmbeddedPiAgentParams = {
   sessionFile: string;
   workspaceDir: string;
   agentDir?: string;
+  /** Optional allow/deny path policy for write/edit/apply_patch tools. */
+  writePathPolicy?: ToolWritePathPolicy;
   config?: OpenClawConfig;
   skillsSnapshot?: SkillSnapshot;
   prompt: string;

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -25,6 +25,11 @@ import type { AnyAgentTool } from "./pi-tools.types.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 import type { SandboxFsBridge } from "./sandbox/fs-bridge.js";
 import { sanitizeToolResultImages } from "./tool-images.js";
+import {
+  assertToolWritePathAllowed,
+  normalizeToolWritePathPolicy,
+  type ToolWritePathPolicy,
+} from "./tool-write-path-policy.js";
 
 export {
   CLAUDE_PARAM_GROUPS,
@@ -352,6 +357,44 @@ async function normalizeReadImageResult(
 
 export function wrapToolWorkspaceRootGuard(tool: AnyAgentTool, root: string): AnyAgentTool {
   return wrapToolWorkspaceRootGuardWithOptions(tool, root);
+}
+
+export function wrapToolWritePathPolicyGuard(
+  tool: AnyAgentTool,
+  root: string,
+  policy: ToolWritePathPolicy | undefined,
+  options?: {
+    containerWorkdir?: string;
+  },
+): AnyAgentTool {
+  const normalizedPolicy = normalizeToolWritePathPolicy(policy);
+  if (!normalizedPolicy) {
+    return tool;
+  }
+  return {
+    ...tool,
+    execute: async (toolCallId, args, signal, onUpdate) => {
+      const normalized = normalizeToolParams(args);
+      const record =
+        normalized ??
+        (args && typeof args === "object" ? (args as Record<string, unknown>) : undefined);
+      const filePath = record?.path;
+      if (typeof filePath === "string" && filePath.trim()) {
+        const candidatePath = mapContainerPathToWorkspaceRoot({
+          filePath,
+          root,
+          containerWorkdir: options?.containerWorkdir,
+        });
+        assertToolWritePathAllowed({
+          policy: normalizedPolicy,
+          workspaceRoot: root,
+          candidatePath,
+          cwd: root,
+        });
+      }
+      return tool.execute(toolCallId, normalized ?? args, signal, onUpdate);
+    },
+  };
 }
 
 function mapContainerPathToWorkspaceRoot(params: {

--- a/src/agents/pi-tools.read.workspace-root-guard.test.ts
+++ b/src/agents/pi-tools.read.workspace-root-guard.test.ts
@@ -1,15 +1,19 @@
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { wrapToolWorkspaceRootGuardWithOptions } from "./pi-tools.read.js";
+import { wrapToolWorkspaceRootGuardWithOptions, wrapToolWritePathPolicyGuard } from "./pi-tools.read.js";
 import type { AnyAgentTool } from "./pi-tools.types.js";
 
 const mocks = vi.hoisted(() => ({
   assertSandboxPath: vi.fn(async () => ({ resolved: "/tmp/root", relative: "" })),
 }));
 
-vi.mock("./sandbox-paths.js", () => ({
-  assertSandboxPath: mocks.assertSandboxPath,
-}));
+vi.mock("./sandbox-paths.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./sandbox-paths.js")>();
+  return {
+    ...actual,
+    assertSandboxPath: mocks.assertSandboxPath,
+  };
+});
 
 function createToolHarness() {
   const execute = vi.fn(async () => ({
@@ -104,5 +108,50 @@ describe("wrapToolWorkspaceRootGuardWithOptions", () => {
       cwd: root,
       root,
     });
+  });
+});
+
+describe("wrapToolWritePathPolicyGuard", () => {
+  const root = "/tmp/root";
+
+  it("allows writes mapped under an allowed container workspace path", async () => {
+    const { execute, tool } = createToolHarness();
+    const wrapped = wrapToolWritePathPolicyGuard(
+      tool,
+      root,
+      { allow: ["docs/**"] },
+      { containerWorkdir: "/workspace" },
+    );
+
+    await wrapped.execute("tc-allow", { path: "/workspace/docs/readme.md", content: "ok" });
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects writes outside allow patterns after container-path remap", async () => {
+    const { execute, tool } = createToolHarness();
+    const wrapped = wrapToolWritePathPolicyGuard(
+      tool,
+      root,
+      { allow: ["docs/**"] },
+      { containerWorkdir: "/workspace" },
+    );
+
+    await expect(
+      wrapped.execute("tc-deny-allow", { path: "/workspace/secrets.txt", content: "no" }),
+    ).rejects.toThrow(/not allowed by cron payload\.paths\.allow/i);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("applies deny patterns before allow patterns", async () => {
+    const { execute, tool } = createToolHarness();
+    const wrapped = wrapToolWritePathPolicyGuard(tool, root, {
+      allow: ["docs/**"],
+      deny: ["docs/private/**"],
+    });
+
+    await expect(
+      wrapped.execute("tc-deny-first", { path: "docs/private/notes.md", content: "no" }),
+    ).rejects.toThrow(/payload\.paths\.deny pattern/i);
+    expect(execute).not.toHaveBeenCalled();
   });
 });

--- a/src/agents/pi-tools.ts
+++ b/src/agents/pi-tools.ts
@@ -36,6 +36,7 @@ import {
   createSandboxedWriteTool,
   normalizeToolParams,
   patchToolSchemaForClaudeCompatibility,
+  wrapToolWritePathPolicyGuard,
   wrapToolWorkspaceRootGuard,
   wrapToolWorkspaceRootGuardWithOptions,
   wrapToolParamNormalization,
@@ -45,6 +46,7 @@ import type { AnyAgentTool } from "./pi-tools.types.js";
 import type { SandboxContext } from "./sandbox.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { createToolFsPolicy, resolveToolFsConfig } from "./tool-fs-policy.js";
+import type { ToolWritePathPolicy } from "./tool-write-path-policy.js";
 import {
   applyToolPolicyPipeline,
   buildDefaultToolPolicyPipelineSteps,
@@ -194,6 +196,8 @@ export function createOpenClawCodingTools(options?: {
   runId?: string;
   agentDir?: string;
   workspaceDir?: string;
+  /** Optional per-run write/edit/apply_patch path policy. */
+  writePathPolicy?: ToolWritePathPolicy;
   config?: OpenClawConfig;
   abortSignal?: AbortSignal;
   /**
@@ -314,6 +318,7 @@ export function createOpenClawCodingTools(options?: {
   const allowWorkspaceWrites = sandbox?.workspaceAccess !== "ro";
   const workspaceRoot = resolveWorkspaceRoot(options?.workspaceDir);
   const workspaceOnly = fsPolicy.workspaceOnly;
+  const writePathPolicy = options?.writePathPolicy;
   const applyPatchConfig = execConfig.applyPatch;
   // Secure by default: apply_patch is workspace-contained unless explicitly disabled.
   // (tools.fs.workspaceOnly is a separate umbrella flag for read/write/edit/apply_patch.)
@@ -363,15 +368,19 @@ export function createOpenClawCodingTools(options?: {
       if (sandboxRoot) {
         return [];
       }
-      const wrapped = createHostWorkspaceWriteTool(workspaceRoot, { workspaceOnly });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      let wrapped = createHostWorkspaceWriteTool(workspaceRoot, { workspaceOnly });
+      wrapped = wrapToolWritePathPolicyGuard(wrapped, workspaceRoot, writePathPolicy);
+      wrapped = workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped;
+      return [wrapped];
     }
     if (tool.name === "edit") {
       if (sandboxRoot) {
         return [];
       }
-      const wrapped = createHostWorkspaceEditTool(workspaceRoot, { workspaceOnly });
-      return [workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped];
+      let wrapped = createHostWorkspaceEditTool(workspaceRoot, { workspaceOnly });
+      wrapped = wrapToolWritePathPolicyGuard(wrapped, workspaceRoot, writePathPolicy);
+      wrapped = workspaceOnly ? wrapToolWorkspaceRootGuard(wrapped, workspaceRoot) : wrapped;
+      return [wrapped];
     }
     return [tool];
   });
@@ -425,30 +434,45 @@ export function createOpenClawCodingTools(options?: {
               ? { root: sandboxRoot, bridge: sandboxFsBridge! }
               : undefined,
           workspaceOnly: applyPatchWorkspaceOnly,
+          writePathPolicy,
         });
   const tools: AnyAgentTool[] = [
     ...base,
     ...(sandboxRoot
       ? allowWorkspaceWrites
         ? [
-            workspaceOnly
-              ? wrapToolWorkspaceRootGuardWithOptions(
-                  createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
-                  sandboxRoot,
-                  {
-                    containerWorkdir: sandbox.containerWorkdir,
-                  },
-                )
-              : createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
-            workspaceOnly
-              ? wrapToolWorkspaceRootGuardWithOptions(
-                  createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
-                  sandboxRoot,
-                  {
-                    containerWorkdir: sandbox.containerWorkdir,
-                  },
-                )
-              : createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+            wrapToolWritePathPolicyGuard(
+              workspaceOnly
+                ? wrapToolWorkspaceRootGuardWithOptions(
+                    createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+                    sandboxRoot,
+                    {
+                      containerWorkdir: sandbox.containerWorkdir,
+                    },
+                  )
+                : createSandboxedEditTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+              sandboxRoot,
+              writePathPolicy,
+              {
+                containerWorkdir: sandbox.containerWorkdir,
+              },
+            ),
+            wrapToolWritePathPolicyGuard(
+              workspaceOnly
+                ? wrapToolWorkspaceRootGuardWithOptions(
+                    createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+                    sandboxRoot,
+                    {
+                      containerWorkdir: sandbox.containerWorkdir,
+                    },
+                  )
+                : createSandboxedWriteTool({ root: sandboxRoot, bridge: sandboxFsBridge! }),
+              sandboxRoot,
+              writePathPolicy,
+              {
+                containerWorkdir: sandbox.containerWorkdir,
+              },
+            ),
           ]
         : []
       : []),

--- a/src/agents/tool-write-path-policy.test.ts
+++ b/src/agents/tool-write-path-policy.test.ts
@@ -1,0 +1,130 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  assertToolWritePathAllowed,
+  normalizeToolWritePathPolicy,
+} from "./tool-write-path-policy.js";
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-tool-path-policy-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("normalizeToolWritePathPolicy", () => {
+  it("trims and dedupes allow/deny patterns", () => {
+    expect(
+      normalizeToolWritePathPolicy({
+        allow: [" notes/** ", "notes/**", ""],
+        deny: [" private/** ", "private/**", " "],
+      }),
+    ).toEqual({
+      allow: ["notes/**"],
+      deny: ["private/**"],
+    });
+  });
+});
+
+describe("assertToolWritePathAllowed", () => {
+  it("allows writes that match allow patterns", async () => {
+    await withTempDir(async (workspaceRoot) => {
+      await fs.mkdir(path.join(workspaceRoot, "notes"), { recursive: true });
+      const targetPath = path.join(workspaceRoot, "notes", "ok.txt");
+      expect(() =>
+        assertToolWritePathAllowed({
+          policy: { allow: ["notes/**"] },
+          workspaceRoot,
+          candidatePath: targetPath,
+          cwd: workspaceRoot,
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  it("rejects write paths that traverse symlinked directories outside allow patterns", async () => {
+    await withTempDir(async (workspaceRoot) => {
+      const notesDir = path.join(workspaceRoot, "notes");
+      const privateDir = path.join(workspaceRoot, "private");
+      await fs.mkdir(notesDir, { recursive: true });
+      await fs.mkdir(privateDir, { recursive: true });
+      await fs.symlink(
+        privateDir,
+        path.join(notesDir, "linkdir"),
+        process.platform === "win32" ? "junction" : undefined,
+      );
+
+      const candidatePath = path.join(notesDir, "linkdir", "new.txt");
+      expect(() =>
+        assertToolWritePathAllowed({
+          policy: { allow: ["notes/**"] },
+          workspaceRoot,
+          candidatePath,
+          cwd: workspaceRoot,
+        }),
+      ).toThrow(/not allowed by cron payload\.paths\.allow/i);
+    });
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "rejects existing symlink file targets outside allow patterns",
+    async () => {
+      await withTempDir(async (workspaceRoot) => {
+        const notesDir = path.join(workspaceRoot, "notes");
+        const privateDir = path.join(workspaceRoot, "private");
+        await fs.mkdir(notesDir, { recursive: true });
+        await fs.mkdir(privateDir, { recursive: true });
+        const privateFile = path.join(privateDir, "secret.txt");
+        await fs.writeFile(privateFile, "secret", "utf8");
+        const linkPath = path.join(notesDir, "secret-link.txt");
+        await fs.symlink(privateFile, linkPath);
+
+        expect(() =>
+          assertToolWritePathAllowed({
+            policy: { allow: ["notes/**"] },
+            workspaceRoot,
+            candidatePath: linkPath,
+            cwd: workspaceRoot,
+          }),
+        ).toThrow(/not allowed by cron payload\.paths\.allow/i);
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "rejects hardlinked files because target identity is ambiguous",
+    async () => {
+      await withTempDir(async (workspaceRoot) => {
+        const notesDir = path.join(workspaceRoot, "notes");
+        const privateDir = path.join(workspaceRoot, "private");
+        await fs.mkdir(notesDir, { recursive: true });
+        await fs.mkdir(privateDir, { recursive: true });
+
+        const privateFile = path.join(privateDir, "secret.txt");
+        const aliasPath = path.join(notesDir, "hardlink.txt");
+        await fs.writeFile(privateFile, "secret", "utf8");
+        try {
+          await fs.link(privateFile, aliasPath);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "EXDEV") {
+            return;
+          }
+          throw error;
+        }
+
+        expect(() =>
+          assertToolWritePathAllowed({
+            policy: { allow: ["notes/**"] },
+            workspaceRoot,
+            candidatePath: aliasPath,
+            cwd: workspaceRoot,
+          }),
+        ).toThrow(/hardlinked file/i);
+      });
+    },
+  );
+});

--- a/src/agents/tool-write-path-policy.test.ts
+++ b/src/agents/tool-write-path-policy.test.ts
@@ -71,6 +71,25 @@ describe("assertToolWritePathAllowed", () => {
   });
 
   it.runIf(process.platform !== "win32")(
+    "matches payload.paths patterns case-sensitively",
+    async () => {
+      await withTempDir(async (workspaceRoot) => {
+        await fs.mkdir(path.join(workspaceRoot, "notes"), { recursive: true });
+        const mixedCasePath = path.join(workspaceRoot, "Notes", "new.txt");
+
+        expect(() =>
+          assertToolWritePathAllowed({
+            policy: { allow: ["notes/**"] },
+            workspaceRoot,
+            candidatePath: mixedCasePath,
+            cwd: workspaceRoot,
+          }),
+        ).toThrow(/not allowed by cron payload\.paths\.allow/i);
+      });
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
     "rejects existing symlink file targets outside allow patterns",
     async () => {
       await withTempDir(async (workspaceRoot) => {

--- a/src/agents/tool-write-path-policy.ts
+++ b/src/agents/tool-write-path-policy.ts
@@ -1,0 +1,105 @@
+import path from "node:path";
+import { matchesExecAllowlistPattern } from "../infra/exec-allowlist-pattern.js";
+import { resolvePathFromInput } from "./path-policy.js";
+
+export type ToolWritePathPolicy = {
+  allow?: string[];
+  deny?: string[];
+};
+
+function normalizePatternList(value: string[] | undefined): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const unique = new Set<string>();
+  for (const entry of value) {
+    const trimmed = typeof entry === "string" ? entry.trim() : "";
+    if (trimmed) {
+      unique.add(trimmed);
+    }
+  }
+  return Array.from(unique);
+}
+
+export function normalizeToolWritePathPolicy(
+  policy: ToolWritePathPolicy | undefined,
+): ToolWritePathPolicy | undefined {
+  if (!policy) {
+    return undefined;
+  }
+  const allow = normalizePatternList(policy.allow);
+  const deny = normalizePatternList(policy.deny);
+  if (allow.length === 0 && deny.length === 0) {
+    return undefined;
+  }
+  return {
+    allow: allow.length > 0 ? allow : undefined,
+    deny: deny.length > 0 ? deny : undefined,
+  };
+}
+
+function resolvePattern(pattern: string, workspaceRoot: string): string {
+  if (pattern.startsWith("~")) {
+    return pattern;
+  }
+  if (path.isAbsolute(pattern)) {
+    return pattern;
+  }
+  return path.resolve(workspaceRoot, pattern);
+}
+
+function matchPattern(patterns: string[] | undefined, targetPath: string, workspaceRoot: string) {
+  if (!patterns || patterns.length === 0) {
+    return undefined;
+  }
+  for (const pattern of patterns) {
+    const resolvedPattern = resolvePattern(pattern, workspaceRoot);
+    if (matchesExecAllowlistPattern(resolvedPattern, targetPath)) {
+      return pattern;
+    }
+  }
+  return undefined;
+}
+
+function formatPathForError(targetPath: string, workspaceRoot: string): string {
+  const relative = path.relative(workspaceRoot, targetPath);
+  if (!relative || relative === ".") {
+    return ".";
+  }
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    return targetPath;
+  }
+  return relative;
+}
+
+export function assertToolWritePathAllowed(params: {
+  policy?: ToolWritePathPolicy;
+  workspaceRoot: string;
+  candidatePath: string;
+  cwd?: string;
+}): void {
+  const normalized = normalizeToolWritePathPolicy(params.policy);
+  if (!normalized) {
+    return;
+  }
+  const workspaceRoot = path.resolve(params.workspaceRoot);
+  const targetPath = resolvePathFromInput(params.candidatePath, params.cwd ?? workspaceRoot);
+  const displayPath = formatPathForError(targetPath, workspaceRoot);
+
+  const denyMatch = matchPattern(normalized.deny, targetPath, workspaceRoot);
+  if (denyMatch) {
+    throw new Error(
+      `write denied: path "${displayPath}" matches cron payload.paths.deny pattern "${denyMatch}"`,
+    );
+  }
+
+  const allow = normalized.allow;
+  if (allow && allow.length > 0) {
+    const allowMatch = matchPattern(allow, targetPath, workspaceRoot);
+    if (!allowMatch) {
+      throw new Error(
+        `write denied: path "${displayPath}" is not allowed by cron payload.paths.allow`,
+      );
+    }
+  }
+}

--- a/src/agents/tool-write-path-policy.ts
+++ b/src/agents/tool-write-path-policy.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import path from "node:path";
 import { matchesExecAllowlistPattern } from "../infra/exec-allowlist-pattern.js";
 import { resolvePathFromInput } from "./path-policy.js";
@@ -72,6 +73,67 @@ function formatPathForError(targetPath: string, workspaceRoot: string): string {
   return relative;
 }
 
+function isNotFoundPathError(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const code = (error as { code?: unknown }).code;
+  return code === "ENOENT" || code === "ENOTDIR";
+}
+
+function resolveCanonicalPathIfPossible(targetPath: string): string {
+  try {
+    return fs.realpathSync.native(targetPath);
+  } catch {
+    return targetPath;
+  }
+}
+
+function resolveCanonicalWriteTarget(targetPath: string): string {
+  let cursor = targetPath;
+  const missingSegments: string[] = [];
+
+  while (true) {
+    try {
+      const resolvedBase = fs.realpathSync.native(cursor);
+      if (missingSegments.length === 0) {
+        return resolvedBase;
+      }
+      return path.resolve(resolvedBase, ...missingSegments.reverse());
+    } catch (error) {
+      if (!isNotFoundPathError(error)) {
+        throw error;
+      }
+      const parent = path.dirname(cursor);
+      if (parent === cursor) {
+        return targetPath;
+      }
+      missingSegments.push(path.basename(cursor));
+      cursor = parent;
+    }
+  }
+}
+
+function assertNoHardlinkedTarget(targetPath: string, displayPath: string): void {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(targetPath);
+  } catch (error) {
+    if (isNotFoundPathError(error)) {
+      return;
+    }
+    throw error;
+  }
+  if (!stat.isFile()) {
+    return;
+  }
+  if (stat.nlink > 1) {
+    throw new Error(
+      `write denied: path "${displayPath}" is a hardlinked file and cannot be validated against cron payload.paths policy`,
+    );
+  }
+}
+
 export function assertToolWritePathAllowed(params: {
   policy?: ToolWritePathPolicy;
   workspaceRoot: string;
@@ -82,9 +144,11 @@ export function assertToolWritePathAllowed(params: {
   if (!normalized) {
     return;
   }
-  const workspaceRoot = path.resolve(params.workspaceRoot);
-  const targetPath = resolvePathFromInput(params.candidatePath, params.cwd ?? workspaceRoot);
+  const workspaceRoot = resolveCanonicalPathIfPossible(path.resolve(params.workspaceRoot));
+  const resolvedTargetPath = resolvePathFromInput(params.candidatePath, params.cwd ?? workspaceRoot);
+  const targetPath = resolveCanonicalWriteTarget(resolvedTargetPath);
   const displayPath = formatPathForError(targetPath, workspaceRoot);
+  assertNoHardlinkedTarget(targetPath, displayPath);
 
   const denyMatch = matchPattern(normalized.deny, targetPath, workspaceRoot);
   if (denyMatch) {

--- a/src/agents/tool-write-path-policy.ts
+++ b/src/agents/tool-write-path-policy.ts
@@ -55,7 +55,7 @@ function matchPattern(patterns: string[] | undefined, targetPath: string, worksp
   }
   for (const pattern of patterns) {
     const resolvedPattern = resolvePattern(pattern, workspaceRoot);
-    if (matchesExecAllowlistPattern(resolvedPattern, targetPath)) {
+    if (matchesExecAllowlistPattern(resolvedPattern, targetPath, { caseSensitive: true })) {
       return pattern;
     }
   }
@@ -145,7 +145,10 @@ export function assertToolWritePathAllowed(params: {
     return;
   }
   const workspaceRoot = resolveCanonicalPathIfPossible(path.resolve(params.workspaceRoot));
-  const resolvedTargetPath = resolvePathFromInput(params.candidatePath, params.cwd ?? workspaceRoot);
+  const resolvedTargetPath = resolvePathFromInput(
+    params.candidatePath,
+    params.cwd ?? workspaceRoot,
+  );
   const targetPath = resolveCanonicalWriteTarget(resolvedTargetPath);
   const displayPath = formatPathForError(targetPath, workspaceRoot);
   assertNoHardlinkedTarget(targetPath, displayPath);

--- a/src/cron/isolated-agent/run.paths-policy.test.ts
+++ b/src/cron/isolated-agent/run.paths-policy.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import {
+  makeIsolatedAgentTurnJob,
+  makeIsolatedAgentTurnParams,
+  setupRunCronIsolatedAgentTurnSuite,
+} from "./run.suite-helpers.js";
+import {
+  loadRunCronIsolatedAgentTurn,
+  runEmbeddedPiAgentMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+describe("runCronIsolatedAgentTurn - payload.paths policy", () => {
+  setupRunCronIsolatedAgentTurnSuite();
+
+  it("passes normalized payload.paths policy to embedded runs", async () => {
+    runWithModelFallbackMock.mockImplementationOnce(
+      async (params: { run: (provider: string, model: string) => Promise<unknown> }) => {
+        const result = await params.run("openai", "gpt-4");
+        return { result, provider: "openai", model: "gpt-4", attempts: [] };
+      },
+    );
+
+    const result = await runCronIsolatedAgentTurn(
+      makeIsolatedAgentTurnParams({
+        job: makeIsolatedAgentTurnJob({
+          payload: {
+            kind: "agentTurn",
+            message: "test",
+            paths: {
+              allow: [" reports/** ", "reports/**"],
+              deny: ["notes/conversations/**", " "],
+            },
+          },
+        }),
+      }),
+    );
+
+    expect(result.status).toBe("ok");
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledOnce();
+    expect(runEmbeddedPiAgentMock.mock.calls[0]?.[0]).toMatchObject({
+      writePathPolicy: {
+        allow: ["reports/**"],
+        deny: ["notes/conversations/**"],
+      },
+    });
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -24,6 +24,7 @@ import {
 } from "../../agents/model-selection.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
+import { normalizeToolWritePathPolicy } from "../../agents/tool-write-path-policy.js";
 import { deriveSessionTotalTokens, hasNonzeroUsage } from "../../agents/usage.js";
 import { ensureAgentWorkspace } from "../../agents/workspace.js";
 import {
@@ -330,6 +331,7 @@ export async function runCronIsolatedAgentTurn(params: {
   });
 
   const agentPayload = params.job.payload.kind === "agentTurn" ? params.job.payload : null;
+  const writePathPolicy = normalizeToolWritePathPolicy(agentPayload?.paths);
   const deliveryPlan = resolveCronDeliveryPlan(params.job);
   const deliveryRequested = deliveryPlan.requested;
 
@@ -496,6 +498,7 @@ export async function runCronIsolatedAgentTurn(params: {
           sessionFile,
           agentDir,
           workspaceDir,
+          writePathPolicy,
           config: cfgWithAgentDefaults,
           skillsSnapshot,
           prompt: commandBody,

--- a/src/cron/normalize.test.ts
+++ b/src/cron/normalize.test.ts
@@ -377,6 +377,42 @@ describe("normalizeCronJobCreate", () => {
     expect(payload.allowUnsafeExternalContent).toBe(true);
   });
 
+  it("normalizes payload.paths allow/deny lists", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "payload paths",
+      schedule: { kind: "every", everyMs: 60_000 },
+      payload: {
+        kind: "agentTurn",
+        message: "hello",
+        paths: {
+          allow: [" notes/** ", "", "notes/**"],
+          deny: ["notes/conversations/**", "  "],
+        },
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    const paths = payload.paths as Record<string, unknown>;
+    expect(paths.allow).toEqual(["notes/**"]);
+    expect(paths.deny).toEqual(["notes/conversations/**"]);
+  });
+
+  it("maps top-level legacy paths into payload.paths for agentTurn jobs", () => {
+    const normalized = normalizeCronJobCreate({
+      name: "legacy root paths",
+      schedule: { kind: "every", everyMs: 60_000 },
+      payload: { kind: "agentTurn", message: "hello" },
+      paths: {
+        allow: ["reports/**"],
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    const paths = payload.paths as Record<string, unknown>;
+    expect(paths.allow).toEqual(["reports/**"]);
+    expect((normalized as { paths?: unknown }).paths).toBeUndefined();
+  });
+
   it("preserves timeoutSeconds=0 for no-timeout agentTurn payloads", () => {
     const normalized = normalizeCronJobCreate({
       name: "legacy no-timeout",
@@ -441,6 +477,18 @@ describe("normalizeCronJobPatch", () => {
     expect(payload.kind).toBeUndefined();
     expect(payload.channel).toBe("telegram");
     expect(payload.to).toBe("+15550001111");
+  });
+
+  it("infers agentTurn kind for paths-only payload patches", () => {
+    const normalized = normalizeCronJobPatch({
+      payload: {
+        paths: { deny: ["notes/**"] },
+      },
+    }) as unknown as Record<string, unknown>;
+
+    const payload = normalized.payload as Record<string, unknown>;
+    expect(payload.kind).toBe("agentTurn");
+    expect(payload.paths).toEqual({ deny: ["notes/**"] });
   });
 
   it("preserves null sessionKey patches and trims string values", () => {

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -103,7 +103,8 @@ function coercePayload(payload: UnknownRecord) {
       typeof next.model === "string" ||
       typeof next.thinking === "string" ||
       typeof next.timeoutSeconds === "number" ||
-      typeof next.allowUnsafeExternalContent === "boolean";
+      typeof next.allowUnsafeExternalContent === "boolean" ||
+      isRecord(next.paths);
     if (hasMessage) {
       next.kind = "agentTurn";
     } else if (hasText) {
@@ -147,6 +148,14 @@ function coercePayload(payload: UnknownRecord) {
       }
     } else {
       delete next.thinking;
+    }
+  }
+  if ("paths" in next) {
+    const normalizedPaths = normalizeAgentTurnPathsValue(next.paths);
+    if (normalizedPaths) {
+      next.paths = normalizedPaths;
+    } else {
+      delete next.paths;
     }
   }
   if ("timeoutSeconds" in next) {
@@ -262,6 +271,12 @@ function copyTopLevelAgentTurnFields(next: UnknownRecord, payload: UnknownRecord
   ) {
     payload.allowUnsafeExternalContent = next.allowUnsafeExternalContent;
   }
+  if (!isRecord(payload.paths)) {
+    const normalizedPaths = normalizeAgentTurnPathsValue(next.paths);
+    if (normalizedPaths) {
+      payload.paths = normalizedPaths;
+    }
+  }
 }
 
 function copyTopLevelLegacyDeliveryFields(next: UnknownRecord, payload: UnknownRecord) {
@@ -300,11 +315,40 @@ function stripLegacyTopLevelFields(next: UnknownRecord) {
   delete next.allowUnsafeExternalContent;
   delete next.message;
   delete next.text;
+  delete next.paths;
   delete next.deliver;
   delete next.channel;
   delete next.to;
   delete next.bestEffortDeliver;
   delete next.provider;
+}
+
+function normalizeAgentTurnPathsValue(value: unknown): UnknownRecord | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const normalizeList = (list: unknown): string[] | undefined => {
+    if (!Array.isArray(list)) {
+      return undefined;
+    }
+    const cleaned = list
+      .filter((entry): entry is string => typeof entry === "string")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    if (cleaned.length === 0) {
+      return undefined;
+    }
+    return [...new Set(cleaned)];
+  };
+  const allow = normalizeList(value.allow);
+  const deny = normalizeList(value.deny);
+  if (!allow && !deny) {
+    return undefined;
+  }
+  return {
+    ...(allow ? { allow } : {}),
+    ...(deny ? { deny } : {}),
+  };
 }
 
 export function normalizeCronJobInput(

--- a/src/cron/normalize.ts
+++ b/src/cron/normalize.ts
@@ -5,6 +5,7 @@ import {
   hasLegacyDeliveryHints,
   stripLegacyDeliveryFields,
 } from "./legacy-delivery.js";
+import { normalizeCronAgentTurnPathPolicy } from "./path-policy.js";
 import { parseAbsoluteTimeMs } from "./parse.js";
 import { migrateLegacyCronPayload } from "./payload-migration.js";
 import { inferLegacyName } from "./service/normalize.js";
@@ -151,7 +152,7 @@ function coercePayload(payload: UnknownRecord) {
     }
   }
   if ("paths" in next) {
-    const normalizedPaths = normalizeAgentTurnPathsValue(next.paths);
+    const normalizedPaths = normalizeCronAgentTurnPathPolicy(next.paths);
     if (normalizedPaths) {
       next.paths = normalizedPaths;
     } else {
@@ -272,7 +273,7 @@ function copyTopLevelAgentTurnFields(next: UnknownRecord, payload: UnknownRecord
     payload.allowUnsafeExternalContent = next.allowUnsafeExternalContent;
   }
   if (!isRecord(payload.paths)) {
-    const normalizedPaths = normalizeAgentTurnPathsValue(next.paths);
+    const normalizedPaths = normalizeCronAgentTurnPathPolicy(next.paths);
     if (normalizedPaths) {
       payload.paths = normalizedPaths;
     }
@@ -321,34 +322,6 @@ function stripLegacyTopLevelFields(next: UnknownRecord) {
   delete next.to;
   delete next.bestEffortDeliver;
   delete next.provider;
-}
-
-function normalizeAgentTurnPathsValue(value: unknown): UnknownRecord | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const normalizeList = (list: unknown): string[] | undefined => {
-    if (!Array.isArray(list)) {
-      return undefined;
-    }
-    const cleaned = list
-      .filter((entry): entry is string => typeof entry === "string")
-      .map((entry) => entry.trim())
-      .filter(Boolean);
-    if (cleaned.length === 0) {
-      return undefined;
-    }
-    return [...new Set(cleaned)];
-  };
-  const allow = normalizeList(value.allow);
-  const deny = normalizeList(value.deny);
-  if (!allow && !deny) {
-    return undefined;
-  }
-  return {
-    ...(allow ? { allow } : {}),
-    ...(deny ? { deny } : {}),
-  };
 }
 
 export function normalizeCronJobInput(

--- a/src/cron/path-policy.ts
+++ b/src/cron/path-policy.ts
@@ -1,0 +1,33 @@
+import { isRecord } from "../utils.js";
+import type { CronAgentTurnPathPolicy } from "./types.js";
+
+export function normalizeCronAgentTurnPathPolicy(
+  value: unknown,
+): CronAgentTurnPathPolicy | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const normalizeList = (list: unknown): string[] | undefined => {
+    if (!Array.isArray(list)) {
+      return undefined;
+    }
+    const normalized = list
+      .filter((entry): entry is string => typeof entry === "string")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    if (normalized.length === 0) {
+      return undefined;
+    }
+    return [...new Set(normalized)];
+  };
+
+  const allow = normalizeList(value.allow);
+  const deny = normalizeList(value.deny);
+  if (!allow && !deny) {
+    return undefined;
+  }
+  return {
+    ...(allow ? { allow } : {}),
+    ...(deny ? { deny } : {}),
+  };
+}

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -169,6 +169,29 @@ describe("applyJobPatch", () => {
     }
   });
 
+  it("merges payload.paths updates for existing agentTurn jobs", () => {
+    const job = createIsolatedAgentTurnJob("job-path-policy", {
+      mode: "announce",
+    });
+    job.payload = {
+      kind: "agentTurn",
+      message: "do it",
+      paths: { allow: ["reports/**"] },
+    };
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        paths: { deny: ["notes/**"] },
+      },
+    });
+
+    expect(job.payload.kind).toBe("agentTurn");
+    if (job.payload.kind === "agentTurn") {
+      expect(job.payload.paths).toEqual({ deny: ["notes/**"] });
+    }
+  });
+
   it("applies payload.lightContext when replacing payload kind via patch", () => {
     const job = createIsolatedAgentTurnJob("job-light-context-switch", {
       mode: "announce",
@@ -188,6 +211,28 @@ describe("applyJobPatch", () => {
     expect(payload.kind).toBe("agentTurn");
     if (payload.kind === "agentTurn") {
       expect(payload.lightContext).toBe(true);
+    }
+  });
+
+  it("applies payload.paths when replacing payload kind via patch", () => {
+    const job = createIsolatedAgentTurnJob("job-path-policy-switch", {
+      mode: "announce",
+      channel: "telegram",
+    });
+    job.payload = { kind: "systemEvent", text: "ping" };
+
+    applyJobPatch(job, {
+      payload: {
+        kind: "agentTurn",
+        message: "do it",
+        paths: { allow: ["cron/**"], deny: ["notes/**"] },
+      },
+    });
+
+    const payload = job.payload as CronJob["payload"];
+    expect(payload.kind).toBe("agentTurn");
+    if (payload.kind === "agentTurn") {
+      expect(payload.paths).toEqual({ allow: ["cron/**"], deny: ["notes/**"] });
     }
   });
 

--- a/src/cron/service.jobs.test.ts
+++ b/src/cron/service.jobs.test.ts
@@ -169,7 +169,7 @@ describe("applyJobPatch", () => {
     }
   });
 
-  it("merges payload.paths updates for existing agentTurn jobs", () => {
+  it("replaces payload.paths on patch for existing agentTurn jobs", () => {
     const job = createIsolatedAgentTurnJob("job-path-policy", {
       mode: "announce",
     });

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -609,6 +609,9 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
   if (typeof patch.thinking === "string") {
     next.thinking = patch.thinking;
   }
+  if ("paths" in patch) {
+    next.paths = normalizeCronAgentTurnPaths(patch.paths);
+  }
   if (typeof patch.timeoutSeconds === "number") {
     next.timeoutSeconds = patch.timeoutSeconds;
   }
@@ -691,6 +694,7 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     message: patch.message,
     model: patch.model,
     thinking: patch.thinking,
+    paths: normalizeCronAgentTurnPaths(patch.paths),
     timeoutSeconds: patch.timeoutSeconds,
     lightContext: patch.lightContext,
     allowUnsafeExternalContent: patch.allowUnsafeExternalContent,
@@ -704,6 +708,38 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
 function normalizeOptionalTrimmedString(value: unknown): string | undefined {
   const trimmed = typeof value === "string" ? value.trim() : "";
   return trimmed ? trimmed : undefined;
+}
+
+function normalizeCronAgentTurnPaths(
+  value: unknown,
+): Extract<CronPayload, { kind: "agentTurn" }>["paths"] | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const normalizeList = (list: unknown): string[] | undefined => {
+    if (!Array.isArray(list)) {
+      return undefined;
+    }
+    const normalized = list
+      .filter((entry): entry is string => typeof entry === "string")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    if (normalized.length === 0) {
+      return undefined;
+    }
+    return [...new Set(normalized)];
+  };
+
+  const allow = normalizeList(record.allow);
+  const deny = normalizeList(record.deny);
+  if (!allow && !deny) {
+    return undefined;
+  }
+  return {
+    ...(allow ? { allow } : {}),
+    ...(deny ? { deny } : {}),
+  };
 }
 
 function mergeCronDelivery(

--- a/src/cron/service/jobs.ts
+++ b/src/cron/service/jobs.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import { normalizeCronAgentTurnPathPolicy } from "../path-policy.js";
 import { parseAbsoluteTimeMs } from "../parse.js";
 import { computeNextRunAtMs } from "../schedule.js";
 import {
@@ -610,7 +611,7 @@ function mergeCronPayload(existing: CronPayload, patch: CronPayloadPatch): CronP
     next.thinking = patch.thinking;
   }
   if ("paths" in patch) {
-    next.paths = normalizeCronAgentTurnPaths(patch.paths);
+    next.paths = normalizeCronAgentTurnPathPolicy(patch.paths);
   }
   if (typeof patch.timeoutSeconds === "number") {
     next.timeoutSeconds = patch.timeoutSeconds;
@@ -694,7 +695,7 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
     message: patch.message,
     model: patch.model,
     thinking: patch.thinking,
-    paths: normalizeCronAgentTurnPaths(patch.paths),
+    paths: normalizeCronAgentTurnPathPolicy(patch.paths),
     timeoutSeconds: patch.timeoutSeconds,
     lightContext: patch.lightContext,
     allowUnsafeExternalContent: patch.allowUnsafeExternalContent,
@@ -708,38 +709,6 @@ function buildPayloadFromPatch(patch: CronPayloadPatch): CronPayload {
 function normalizeOptionalTrimmedString(value: unknown): string | undefined {
   const trimmed = typeof value === "string" ? value.trim() : "";
   return trimmed ? trimmed : undefined;
-}
-
-function normalizeCronAgentTurnPaths(
-  value: unknown,
-): Extract<CronPayload, { kind: "agentTurn" }>["paths"] | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return undefined;
-  }
-  const record = value as Record<string, unknown>;
-  const normalizeList = (list: unknown): string[] | undefined => {
-    if (!Array.isArray(list)) {
-      return undefined;
-    }
-    const normalized = list
-      .filter((entry): entry is string => typeof entry === "string")
-      .map((entry) => entry.trim())
-      .filter(Boolean);
-    if (normalized.length === 0) {
-      return undefined;
-    }
-    return [...new Set(normalized)];
-  };
-
-  const allow = normalizeList(record.allow);
-  const deny = normalizeList(record.deny);
-  if (!allow && !deny) {
-    return undefined;
-  }
-  return {
-    ...(allow ? { allow } : {}),
-    ...(deny ? { deny } : {}),
-  };
 }
 
 function mergeCronDelivery(

--- a/src/cron/types.ts
+++ b/src/cron/types.ts
@@ -87,6 +87,11 @@ type CronAgentTurnPayloadFields = {
   model?: string;
   /** Optional per-job fallback models; overrides agent/global fallbacks when defined. */
   fallbacks?: string[];
+  /**
+   * Optional write/edit/apply_patch path policy for this isolated cron run.
+   * Relative patterns are resolved from the agent workspace root.
+   */
+  paths?: CronAgentTurnPathPolicy;
   thinking?: string;
   timeoutSeconds?: number;
   allowUnsafeExternalContent?: boolean;
@@ -105,6 +110,11 @@ type CronAgentTurnPayload = {
 type CronAgentTurnPayloadPatch = {
   kind: "agentTurn";
 } & Partial<CronAgentTurnPayloadFields>;
+
+export type CronAgentTurnPathPolicy = {
+  allow?: string[];
+  deny?: string[];
+};
 
 export type CronJobState = {
   nextRunAtMs?: number;

--- a/src/gateway/protocol/schema/cron.ts
+++ b/src/gateway/protocol/schema/cron.ts
@@ -1,6 +1,14 @@
 import { Type, type TSchema } from "@sinclair/typebox";
 import { NonEmptyString } from "./primitives.js";
 
+const CronAgentTurnPathsSchema = Type.Object(
+  {
+    allow: Type.Optional(Type.Array(NonEmptyString)),
+    deny: Type.Optional(Type.Array(NonEmptyString)),
+  },
+  { additionalProperties: false },
+);
+
 function cronAgentTurnPayloadSchema(params: { message: TSchema }) {
   return Type.Object(
     {
@@ -8,6 +16,7 @@ function cronAgentTurnPayloadSchema(params: { message: TSchema }) {
       message: params.message,
       model: Type.Optional(Type.String()),
       fallbacks: Type.Optional(Type.Array(Type.String())),
+      paths: Type.Optional(CronAgentTurnPathsSchema),
       thinking: Type.Optional(Type.String()),
       timeoutSeconds: Type.Optional(Type.Integer({ minimum: 0 })),
       allowUnsafeExternalContent: Type.Optional(Type.Boolean()),

--- a/src/infra/exec-allowlist-pattern.test.ts
+++ b/src/infra/exec-allowlist-pattern.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { matchesExecAllowlistPattern } from "./exec-allowlist-pattern.js";
+
+describe("matchesExecAllowlistPattern", () => {
+  it("matches case-insensitively by default", () => {
+    expect(matchesExecAllowlistPattern("/workspace/notes/**", "/workspace/Notes/todo.txt")).toBe(
+      true,
+    );
+  });
+
+  it("supports case-sensitive matching when requested", () => {
+    expect(
+      matchesExecAllowlistPattern("/workspace/notes/**", "/workspace/notes/todo.txt", {
+        caseSensitive: true,
+      }),
+    ).toBe(true);
+    expect(
+      matchesExecAllowlistPattern("/workspace/notes/**", "/workspace/Notes/todo.txt", {
+        caseSensitive: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/infra/exec-allowlist-pattern.ts
+++ b/src/infra/exec-allowlist-pattern.ts
@@ -4,12 +4,19 @@ import { expandHomePrefix } from "./home-dir.js";
 const GLOB_REGEX_CACHE_LIMIT = 512;
 const globRegexCache = new Map<string, RegExp>();
 
-function normalizeMatchTarget(value: string): string {
+type MatchTargetOptions = {
+  caseSensitive?: boolean;
+};
+
+function normalizeMatchTarget(value: string, options: MatchTargetOptions = {}): string {
+  const caseSensitive = options.caseSensitive === true;
   if (process.platform === "win32") {
     const stripped = value.replace(/^\\\\[?.]\\/, "");
-    return stripped.replace(/\\/g, "/").toLowerCase();
+    const normalized = stripped.replace(/\\/g, "/");
+    return caseSensitive ? normalized : normalized.toLowerCase();
   }
-  return value.replace(/\\\\/g, "/").toLowerCase();
+  const normalized = value.replace(/\\\\/g, "/");
+  return caseSensitive ? normalized : normalized.toLowerCase();
 }
 
 function tryRealpath(value: string): string | null {
@@ -24,8 +31,14 @@ function escapeRegExpLiteral(input: string): string {
   return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-function compileGlobRegex(pattern: string): RegExp {
-  const cached = globRegexCache.get(pattern);
+type CompileGlobRegexOptions = {
+  caseSensitive?: boolean;
+};
+
+function compileGlobRegex(pattern: string, options: CompileGlobRegexOptions = {}): RegExp {
+  const caseSensitive = options.caseSensitive === true;
+  const cacheKey = `${caseSensitive ? "cs" : "ci"}:${pattern}`;
+  const cached = globRegexCache.get(cacheKey);
   if (cached) {
     return cached;
   }
@@ -55,19 +68,28 @@ function compileGlobRegex(pattern: string): RegExp {
   }
   regex += "$";
 
-  const compiled = new RegExp(regex, "i");
+  const compiled = new RegExp(regex, caseSensitive ? "" : "i");
   if (globRegexCache.size >= GLOB_REGEX_CACHE_LIMIT) {
     globRegexCache.clear();
   }
-  globRegexCache.set(pattern, compiled);
+  globRegexCache.set(cacheKey, compiled);
   return compiled;
 }
 
-export function matchesExecAllowlistPattern(pattern: string, target: string): boolean {
+type MatchExecAllowlistPatternOptions = {
+  caseSensitive?: boolean;
+};
+
+export function matchesExecAllowlistPattern(
+  pattern: string,
+  target: string,
+  options: MatchExecAllowlistPatternOptions = {},
+): boolean {
   const trimmed = pattern.trim();
   if (!trimmed) {
     return false;
   }
+  const caseSensitive = options.caseSensitive === true;
 
   const expanded = trimmed.startsWith("~") ? expandHomePrefix(trimmed) : trimmed;
   const hasWildcard = /[*?]/.test(expanded);
@@ -77,7 +99,7 @@ export function matchesExecAllowlistPattern(pattern: string, target: string): bo
     normalizedPattern = tryRealpath(expanded) ?? expanded;
     normalizedTarget = tryRealpath(target) ?? target;
   }
-  normalizedPattern = normalizeMatchTarget(normalizedPattern);
-  normalizedTarget = normalizeMatchTarget(normalizedTarget);
-  return compileGlobRegex(normalizedPattern).test(normalizedTarget);
+  normalizedPattern = normalizeMatchTarget(normalizedPattern, { caseSensitive });
+  normalizedTarget = normalizeMatchTarget(normalizedTarget, { caseSensitive });
+  return compileGlobRegex(normalizedPattern, { caseSensitive }).test(normalizedTarget);
 }


### PR DESCRIPTION
## Summary
- add `payload.paths.allow|deny` support to cron `agentTurn` payload schema/types/normalization
- normalize/trim/dedupe path lists and support legacy top-level `paths -> payload.paths` migration
- propagate cron path policy into isolated embedded runs as `writePathPolicy`
- enforce policy on mutating coding tools (`write`, `edit`, `apply_patch`) for host + sandbox flows
- ensure deny rules take precedence over allow rules

## Why
`#33148` requests payload-level path policy controls for isolated cron agent turns so writes can be constrained to approved workspace areas.

Fixes #33148

## Tests
### Targeted path-policy tests
- `pnpm test src/cron/normalize.test.ts src/cron/service.jobs.test.ts src/cron/isolated-agent/run.paths-policy.test.ts`
- `pnpm test src/agents/apply-patch.test.ts src/agents/pi-tools.read.workspace-root-guard.test.ts`

### Broad regression runs
- `pnpm test src/cron`
  - Result: 52 files, 384 tests passed
- `pnpm test src/agents/apply-patch.test.ts src/agents/pi-tools.read.workspace-root-guard.test.ts src/agents/pi-tools.read.host-edit-recovery.test.ts src/agents/pi-tools.workspace-paths.test.ts src/agents/pi-tools.workspace-only-false.test.ts src/agents/pi-tools.sandbox-mounted-paths.workspace-only.test.ts`
  - Result: 6 files, 45 tests passed