### PR TITLE
fix(telegram): add MAX_CHATS bound to sent-message-cache

### DIFF
--- a/src/telegram/sent-message-cache.test.ts
+++ b/src/telegram/sent-message-cache.test.ts
@@ -49,4 +49,21 @@ describe("sent-message-cache", () => {
     expect(wasSentByBot(100, 1)).toBe(true);
     expect(wasSentByBot(100, 2)).toBe(true);
   });
+
+  it("implements true LRU: recently accessed chats survive eviction", () => {
+    // Fill to capacity
+    for (let i = 0; i < 5000; i++) {
+      recordSentMessage(i, 1);
+    }
+    
+    // Access chat 0 (moves it to end)
+    expect(wasSentByBot(0, 1)).toBe(true);
+    
+    // Add new chat - should evict chat 1 (oldest), not chat 0 (recently accessed)
+    recordSentMessage(5000, 1);
+    
+    expect(wasSentByBot(0, 1)).toBe(true);  // Recently accessed, should survive
+    expect(wasSentByBot(1, 1)).toBe(false); // Oldest unaccessed, should be evicted
+    expect(wasSentByBot(5000, 1)).toBe(true);
+  });
 });

--- a/src/telegram/sent-message-cache.test.ts
+++ b/src/telegram/sent-message-cache.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  recordSentMessage,
+  wasSentByBot,
+  clearSentMessageCache,
+} from "./sent-message-cache.js";
+
+describe("sent-message-cache", () => {
+  beforeEach(() => {
+    clearSentMessageCache();
+  });
+
+  it("records and checks sent messages", () => {
+    recordSentMessage(123, 456);
+    expect(wasSentByBot(123, 456)).toBe(true);
+    expect(wasSentByBot(123, 789)).toBe(false);
+  });
+
+  it("respects MAX_CHATS limit by evicting oldest", () => {
+    // Fill cache to capacity (5000 chats)
+    for (let i = 0; i < 5000; i++) {
+      recordSentMessage(i, 1);
+    }
+    
+    // First chat should still exist
+    expect(wasSentByBot(0, 1)).toBe(true);
+    
+    // Add one more chat - should evict chat 0
+    recordSentMessage(5000, 1);
+    
+    // Chat 0 should be evicted
+    expect(wasSentByBot(0, 1)).toBe(false);
+    // New chat should exist
+    expect(wasSentByBot(5000, 1)).toBe(true);
+  });
+
+  it("does not evict when updating existing chat", () => {
+    // Fill to capacity
+    for (let i = 0; i < 5000; i++) {
+      recordSentMessage(i, 1);
+    }
+    
+    // Update existing chat (should not trigger eviction)
+    recordSentMessage(100, 2);
+    
+    // Chat 0 should still exist
+    expect(wasSentByBot(0, 1)).toBe(true);
+    // Chat 100 should have both messages
+    expect(wasSentByBot(100, 1)).toBe(true);
+    expect(wasSentByBot(100, 2)).toBe(true);
+  });
+});

--- a/src/telegram/sent-message-cache.ts
+++ b/src/telegram/sent-message-cache.ts
@@ -27,7 +27,7 @@ function cleanupExpired(entry: CacheEntry): void {
 
 function evictOldestChat(): void {
   const oldest = sentMessages.keys().next().value;
-  if (oldest) {
+  if (oldest !== undefined) {
     sentMessages.delete(oldest);
   }
 }
@@ -66,7 +66,15 @@ export function wasSentByBot(chatId: number | string, messageId: number): boolea
   }
   // Clean up expired entries on read
   cleanupExpired(entry);
-  return entry.timestamps.has(messageId);
+  const result = entry.timestamps.has(messageId);
+  
+  // LRU: move to end by re-inserting
+  if (result) {
+    sentMessages.delete(key);
+    sentMessages.set(key, entry);
+  }
+  
+  return result;
 }
 
 /**

--- a/src/telegram/sent-message-cache.ts
+++ b/src/telegram/sent-message-cache.ts
@@ -4,6 +4,7 @@
  */
 
 const TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const MAX_CHATS = 5000;
 
 type CacheEntry = {
   timestamps: Map<number, number>;
@@ -24,11 +25,24 @@ function cleanupExpired(entry: CacheEntry): void {
   }
 }
 
+function evictOldestChat(): void {
+  const oldest = sentMessages.keys().next().value;
+  if (oldest) {
+    sentMessages.delete(oldest);
+  }
+}
+
 /**
  * Record a message ID as sent by the bot.
  */
 export function recordSentMessage(chatId: number | string, messageId: number): void {
   const key = getChatKey(chatId);
+  
+  // Evict oldest chat if at capacity
+  if (sentMessages.size >= MAX_CHATS && !sentMessages.has(key)) {
+    evictOldestChat();
+  }
+  
   let entry = sentMessages.get(key);
   if (!entry) {
     entry = { timestamps: new Map() };

--- a/src/telegram/sent-message-cache.ts
+++ b/src/telegram/sent-message-cache.ts
@@ -38,17 +38,26 @@ function evictOldestChat(): void {
 export function recordSentMessage(chatId: number | string, messageId: number): void {
   const key = getChatKey(chatId);
   
-  // Evict oldest chat if at capacity
-  if (sentMessages.size >= MAX_CHATS && !sentMessages.has(key)) {
+  const exists = sentMessages.has(key);
+  
+  // Evict oldest chat if at capacity and this is a new chat
+  if (sentMessages.size >= MAX_CHATS && !exists) {
     evictOldestChat();
   }
   
   let entry = sentMessages.get(key);
   if (!entry) {
     entry = { timestamps: new Map() };
-    sentMessages.set(key, entry);
   }
+  
   entry.timestamps.set(messageId, Date.now());
+  
+  // LRU: move to end by re-inserting (even for existing chats)
+  if (exists) {
+    sentMessages.delete(key);
+  }
+  sentMessages.set(key, entry);
+  
   // Periodic cleanup
   if (entry.timestamps.size > 100) {
     cleanupExpired(entry);


### PR DESCRIPTION
## Problem

telegram/sent-message-cache.ts lacks global size limit, causing unbounded memory growth in high-traffic scenarios.

Current: no limit on sentMessages Map → memory leak when bot serves 10k+ chats
Compare: slack/sent-thread-cache.ts has MAX_ENTRIES=5000 + evictOldest()

## Solution

Add MAX_CHATS=5000 with LRU eviction when at capacity.

## Testing

Unit tests added for eviction behavior.

## Impact

Low risk, prevents memory leak in production.