### PR TITLE
fix: capitalize GitHub correctly in CONTRIBUTING.md maintainer list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,9 +57,9 @@ Welcome to the lobster tank! 🦞
   - GitHub: [@joshavant](https://github.com/joshavant) · X: [@joshavant](https://x.com/joshavant)
 
 - **Jonathan Taylor** - ACP subsystem, Gateway features/bugs, Gog/Mog/Sog CLI's, SEDMAT
-  - Github [@visionik](https://github.com/visionik) · X: [@visionik](https://x.com/visionik)
+  - GitHub [@visionik](https://github.com/visionik) · X: [@visionik](https://x.com/visionik)
 - **Josh Lehman** - Compaction, Tlon/Urbit subsystem
-  - Github [@jalehman](https://github.com/jalehman) · X: [@jlehman\_](https://x.com/jlehman_)
+  - GitHub [@jalehman](https://github.com/jalehman) · X: [@jlehman\_](https://x.com/jlehman_)
 
 ## How to Contribute
 


### PR DESCRIPTION
## Summary

Fix inconsistent capitalization of `Github` → `GitHub` in the maintainer list section of `CONTRIBUTING.md`.

## Changes

- Line 60: `Github [@visionik]` → `GitHub [@visionik]` (Jonathan Taylor)
- Line 62: `Github [@jalehman]` → `GitHub [@jalehman]` (Josh Lehman)

## Why

All other maintainer entries correctly use `GitHub` (capital H), matching the [official GitHub branding guidelines](https://github.com/logos). These two entries were the only ones using the lowercase `h` variant.

## Testing

- [x] Verified the change is purely cosmetic/textual
- [x] No functional code affected