### PR TITLE
docs: fix grammar in models.md merge precedence description

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -212,6 +212,6 @@ is merged by default unless `models.mode` is set to `replace`.
 
 Merge mode precedence for matching provider IDs:
 
-- Non-empty `apiKey`/`baseUrl` already present in the agent `models.json` win.
-- Empty or missing agent `apiKey`/`baseUrl` fall back to config `models.providers`.
+- Non-empty `apiKey`/`baseUrl` already present in the agent `models.json` will win.
+- Empty or missing agent `apiKey`/`baseUrl` will fall back to config `models.providers`.
 - Other provider fields are refreshed from config and normalized catalog data.


### PR DESCRIPTION
## Summary

Fix missing auxiliary verb in the merge mode precedence section of `docs/concepts/models.md`.

## Changes

- Line 215: `...models.json win.` → `...models.json **will** win.`
- Line 216: `...apiKey/baseUrl fall back to...` → `...apiKey/baseUrl **will** fall back to...`

## Why

The current phrasing reads awkwardly in English. The sentences describe conditional/future behavior (what happens during merge), so the auxiliary verb `will` is needed to form proper future tense. Compare with line 217 which correctly uses present tense with a different construction ("are refreshed").

**Before:**
> - Non-empty apiKey/baseUrl already present in the agent models.json win.
> - Empty or missing agent apiKey/baseUrl fall back to config models.providers.

**After:**
> - Non-empty apiKey/baseUrl already present in the agent models.json **will** win.
> - Empty or missing agent apiKey/baseUrl **will** fall back to config models.providers.

## Testing

- [x] Verified the change is purely textual (documentation only)
- [x] No functional code affected