### PR TITLE
Daemon: ignore mac app launch agent in gateway scan

### DIFF
--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -170,4 +170,119 @@ describe("findExtraGatewayServices (darwin)", () => {
       },
     ]);
   });
+
+  it("filters by parsed plist label instead of ignored filename", async () => {
+    readdirMock.mockImplementation(async (dir: string) => {
+      if (dir === "/Users/test/Library/LaunchAgents") {
+        return ["ai.openclaw.mac.plist"];
+      }
+      return [];
+    });
+    readFileMock.mockImplementation(async (filePath: string) => {
+      if (!filePath.endsWith("ai.openclaw.mac.plist")) {
+        return null;
+      }
+      return [
+        "<plist>",
+        "  <dict>",
+        "    <key>Label</key>",
+        "    <string>ai.openclaw.helper</string>",
+        "    <key>ProgramArguments</key>",
+        "    <array>",
+        "      <string>openclaw helper</string>",
+        "    </array>",
+        "  </dict>",
+        "</plist>",
+      ].join("\n");
+    });
+
+    const result = await findExtraGatewayServices({
+      HOME: "/Users/test",
+    });
+
+    expect(result).toEqual([
+      {
+        platform: "darwin",
+        label: "ai.openclaw.helper",
+        detail: "plist: /Users/test/Library/LaunchAgents/ai.openclaw.mac.plist",
+        scope: "user",
+        marker: "openclaw",
+        legacy: false,
+      },
+    ]);
+  });
+
+  it("reports default-profile gateway services as extra when a custom profile is active", async () => {
+    readdirMock.mockImplementation(async (dir: string) => {
+      if (dir === "/Users/test/Library/LaunchAgents") {
+        return ["ai.openclaw.gateway.plist"];
+      }
+      return [];
+    });
+    readFileMock.mockImplementation(async (filePath: string) => {
+      if (!filePath.endsWith("ai.openclaw.gateway.plist")) {
+        return null;
+      }
+      return [
+        "<plist>",
+        "  <dict>",
+        "    <key>Label</key>",
+        "    <string>ai.openclaw.gateway</string>",
+        "    <key>ProgramArguments</key>",
+        "    <array>",
+        "      <string>openclaw gateway run</string>",
+        "    </array>",
+        "  </dict>",
+        "</plist>",
+      ].join("\n");
+    });
+
+    const result = await findExtraGatewayServices({
+      HOME: "/Users/test",
+      OPENCLAW_PROFILE: "mac",
+    });
+
+    expect(result).toEqual([
+      {
+        platform: "darwin",
+        label: "ai.openclaw.gateway",
+        detail: "plist: /Users/test/Library/LaunchAgents/ai.openclaw.gateway.plist",
+        scope: "user",
+        marker: "openclaw",
+        legacy: false,
+      },
+    ]);
+  });
+
+  it("ignores the node host launch agent", async () => {
+    readdirMock.mockImplementation(async (dir: string) => {
+      if (dir === "/Users/test/Library/LaunchAgents") {
+        return ["ai.openclaw.node.plist"];
+      }
+      return [];
+    });
+    readFileMock.mockImplementation(async (filePath: string) => {
+      if (!filePath.endsWith("ai.openclaw.node.plist")) {
+        return null;
+      }
+      return [
+        "<plist>",
+        "  <dict>",
+        "    <key>Label</key>",
+        "    <string>ai.openclaw.node</string>",
+        "    <key>ProgramArguments</key>",
+        "    <array>",
+        "      <string>openclaw node run</string>",
+        "    </array>",
+        "  </dict>",
+        "</plist>",
+      ].join("\n");
+    });
+
+    const result = await findExtraGatewayServices({
+      HOME: "/Users/test",
+    });
+
+    expect(result).toEqual([]);
+  });
 });

--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -1,12 +1,23 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { findExtraGatewayServices } from "./inspect.js";
 
-const { execSchtasksMock } = vi.hoisted(() => ({
+const { execSchtasksMock, readdirMock, readFileMock } = vi.hoisted(() => ({
   execSchtasksMock: vi.fn(),
+  readdirMock: vi.fn(),
+  readFileMock: vi.fn(),
 }));
 
 vi.mock("./schtasks-exec.js", () => ({
   execSchtasks: (...args: unknown[]) => execSchtasksMock(...args),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: {
+    readdir: (...args: unknown[]) => readdirMock(...args),
+    readFile: (...args: unknown[]) => readFileMock(...args),
+  },
+  readdir: (...args: unknown[]) => readdirMock(...args),
+  readFile: (...args: unknown[]) => readFileMock(...args),
 }));
 
 describe("findExtraGatewayServices (win32)", () => {
@@ -81,6 +92,81 @@ describe("findExtraGatewayServices (win32)", () => {
         scope: "system",
         marker: "moltbot",
         legacy: true,
+      },
+    ]);
+  });
+});
+
+describe("findExtraGatewayServices (darwin)", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: "darwin",
+    });
+    readdirMock.mockReset();
+    readFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: originalPlatform,
+    });
+  });
+
+  it("ignores the mac app launch agent while reporting other openclaw services", async () => {
+    readdirMock.mockImplementation(async (dir: string) => {
+      if (dir === "/Users/test/Library/LaunchAgents") {
+        return ["ai.openclaw.mac.plist", "ai.openclaw.helper.plist"];
+      }
+      return [];
+    });
+    readFileMock.mockImplementation(async (filePath: string) => {
+      if (filePath.endsWith("ai.openclaw.mac.plist")) {
+        return [
+          "<plist>",
+          "  <dict>",
+          "    <key>Label</key>",
+          "    <string>ai.openclaw.mac</string>",
+          "    <key>ProgramArguments</key>",
+          "    <array>",
+          "      <string>OpenClaw.app</string>",
+          "    </array>",
+          "  </dict>",
+          "</plist>",
+        ].join("\n");
+      }
+      if (filePath.endsWith("ai.openclaw.helper.plist")) {
+        return [
+          "<plist>",
+          "  <dict>",
+          "    <key>Label</key>",
+          "    <string>ai.openclaw.helper</string>",
+          "    <key>ProgramArguments</key>",
+          "    <array>",
+          "      <string>openclaw helper</string>",
+          "    </array>",
+          "  </dict>",
+          "</plist>",
+        ].join("\n");
+      }
+      return null;
+    });
+
+    const result = await findExtraGatewayServices({
+      HOME: "/Users/test",
+    });
+
+    expect(result).toEqual([
+      {
+        platform: "darwin",
+        label: "ai.openclaw.helper",
+        detail: "plist: /Users/test/Library/LaunchAgents/ai.openclaw.helper.plist",
+        scope: "user",
+        marker: "openclaw",
+        legacy: false,
       },
     ]);
   });

--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -270,6 +270,13 @@ describe("findExtraGatewayServices (darwin)", () => {
         "  <dict>",
         "    <key>Label</key>",
         "    <string>ai.openclaw.node</string>",
+        "    <key>EnvironmentVariables</key>",
+        "    <dict>",
+        "      <key>OPENCLAW_SERVICE_MARKER</key>",
+        "      <string>openclaw</string>",
+        "      <key>OPENCLAW_SERVICE_KIND</key>",
+        "      <string>node</string>",
+        "    </dict>",
         "    <key>ProgramArguments</key>",
         "    <array>",
         "      <string>openclaw node run</string>",
@@ -284,5 +291,101 @@ describe("findExtraGatewayServices (darwin)", () => {
     });
 
     expect(result).toEqual([]);
+  });
+
+  it("reports stale gateway plists that reuse the node label", async () => {
+    readdirMock.mockImplementation(async (dir: string) => {
+      if (dir === "/Users/test/Library/LaunchAgents") {
+        return ["ai.openclaw.node.plist"];
+      }
+      return [];
+    });
+    readFileMock.mockImplementation(async (filePath: string) => {
+      if (!filePath.endsWith("ai.openclaw.node.plist")) {
+        return null;
+      }
+      return [
+        "<plist>",
+        "  <dict>",
+        "    <key>Label</key>",
+        "    <string>ai.openclaw.node</string>",
+        "    <key>EnvironmentVariables</key>",
+        "    <dict>",
+        "      <key>OPENCLAW_SERVICE_MARKER</key>",
+        "      <string>openclaw</string>",
+        "      <key>OPENCLAW_SERVICE_KIND</key>",
+        "      <string>gateway</string>",
+        "    </dict>",
+        "    <key>ProgramArguments</key>",
+        "    <array>",
+        "      <string>openclaw gateway run</string>",
+        "    </array>",
+        "  </dict>",
+        "</plist>",
+      ].join("\n");
+    });
+
+    const result = await findExtraGatewayServices({
+      HOME: "/Users/test",
+    });
+
+    expect(result).toEqual([
+      {
+        platform: "darwin",
+        label: "ai.openclaw.node",
+        detail: "plist: /Users/test/Library/LaunchAgents/ai.openclaw.node.plist",
+        scope: "user",
+        marker: "openclaw",
+        legacy: false,
+      },
+    ]);
+  });
+
+  it("reports stale gateway plists that reuse the mac app label", async () => {
+    readdirMock.mockImplementation(async (dir: string) => {
+      if (dir === "/Users/test/Library/LaunchAgents") {
+        return ["ai.openclaw.mac.plist"];
+      }
+      return [];
+    });
+    readFileMock.mockImplementation(async (filePath: string) => {
+      if (!filePath.endsWith("ai.openclaw.mac.plist")) {
+        return null;
+      }
+      return [
+        "<plist>",
+        "  <dict>",
+        "    <key>Label</key>",
+        "    <string>ai.openclaw.mac</string>",
+        "    <key>EnvironmentVariables</key>",
+        "    <dict>",
+        "      <key>OPENCLAW_SERVICE_MARKER</key>",
+        "      <string>openclaw</string>",
+        "      <key>OPENCLAW_SERVICE_KIND</key>",
+        "      <string>gateway</string>",
+        "    </dict>",
+        "    <key>ProgramArguments</key>",
+        "    <array>",
+        "      <string>openclaw gateway run</string>",
+        "    </array>",
+        "  </dict>",
+        "</plist>",
+      ].join("\n");
+    });
+
+    const result = await findExtraGatewayServices({
+      HOME: "/Users/test",
+    });
+
+    expect(result).toEqual([
+      {
+        platform: "darwin",
+        label: "ai.openclaw.mac",
+        detail: "plist: /Users/test/Library/LaunchAgents/ai.openclaw.mac.plist",
+        scope: "user",
+        marker: "openclaw",
+        legacy: false,
+      },
+    ]);
   });
 });

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -88,24 +88,6 @@ function hasGatewayServiceMarker(content: string): boolean {
   );
 }
 
-function isOpenClawGatewayLaunchdService(
-  label: string,
-  contents: string,
-  profile?: string,
-): boolean {
-  if (label !== resolveGatewayLaunchAgentLabel(profile)) {
-    return false;
-  }
-  if (hasGatewayServiceMarker(contents)) {
-    return true;
-  }
-  const lowerContents = contents.toLowerCase();
-  if (!lowerContents.includes("gateway")) {
-    return false;
-  }
-  return true;
-}
-
 function isOpenClawGatewaySystemdService(name: string, contents: string): boolean {
   if (hasGatewayServiceMarker(contents)) {
     return true;
@@ -263,9 +245,6 @@ async function scanLaunchdDir(params: {
       continue;
     }
     if (isGatewayLaunchdLabel(label, params.profile)) {
-      continue;
-    }
-    if (marker === "openclaw" && isOpenClawGatewayLaunchdService(label, contents, params.profile)) {
       continue;
     }
     if (marker === "openclaw" && isIgnoredNonGatewayLaunchdService(label, contents)) {

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -87,7 +87,14 @@ function hasGatewayServiceMarker(content: string): boolean {
   );
 }
 
-function isOpenClawGatewayLaunchdService(label: string, contents: string): boolean {
+function isOpenClawGatewayLaunchdService(
+  label: string,
+  contents: string,
+  profile?: string,
+): boolean {
+  if (label !== resolveGatewayLaunchAgentLabel(profile)) {
+    return false;
+  }
   if (hasGatewayServiceMarker(contents)) {
     return true;
   }
@@ -95,7 +102,7 @@ function isOpenClawGatewayLaunchdService(label: string, contents: string): boole
   if (!lowerContents.includes("gateway")) {
     return false;
   }
-  return label.startsWith("ai.openclaw.");
+  return true;
 }
 
 function isOpenClawGatewaySystemdService(name: string, contents: string): boolean {
@@ -125,9 +132,10 @@ function tryExtractPlistLabel(contents: string): string | null {
   return match[1]?.trim() || null;
 }
 
-function isIgnoredLaunchdLabel(label: string): boolean {
+function isIgnoredLaunchdLabel(label: string, profile?: string): boolean {
   return (
-    label === resolveGatewayLaunchAgentLabel() || IGNORED_NON_GATEWAY_LAUNCHD_LABELS.has(label)
+    label === resolveGatewayLaunchAgentLabel(profile) ||
+    IGNORED_NON_GATEWAY_LAUNCHD_LABELS.has(label)
   );
 }
 
@@ -191,12 +199,13 @@ async function collectServiceFiles(params: {
 async function scanLaunchdDir(params: {
   dir: string;
   scope: "user" | "system";
+  profile?: string;
 }): Promise<ExtraGatewayService[]> {
   const results: ExtraGatewayService[] = [];
   const candidates = await collectServiceFiles({
     dir: params.dir,
     extension: ".plist",
-    isIgnoredName: isIgnoredLaunchdLabel,
+    isIgnoredName: () => false,
   });
 
   for (const { name: labelFromName, fullPath, contents } of candidates) {
@@ -217,10 +226,10 @@ async function scanLaunchdDir(params: {
       });
       continue;
     }
-    if (isIgnoredLaunchdLabel(label)) {
+    if (isIgnoredLaunchdLabel(label, params.profile)) {
       continue;
     }
-    if (marker === "openclaw" && isOpenClawGatewayLaunchdService(label, contents)) {
+    if (marker === "openclaw" && isOpenClawGatewayLaunchdService(label, contents, params.profile)) {
       continue;
     }
     results.push({
@@ -338,6 +347,7 @@ export async function findExtraGatewayServices(
       for (const svc of await scanLaunchdDir({
         dir: userDir,
         scope: "user",
+        profile: env.OPENCLAW_PROFILE,
       })) {
         push(svc);
       }
@@ -345,12 +355,14 @@ export async function findExtraGatewayServices(
         for (const svc of await scanLaunchdDir({
           dir: path.join(path.sep, "Library", "LaunchAgents"),
           scope: "system",
+          profile: env.OPENCLAW_PROFILE,
         })) {
           push(svc);
         }
         for (const svc of await scanLaunchdDir({
           dir: path.join(path.sep, "Library", "LaunchDaemons"),
           scope: "system",
+          profile: env.OPENCLAW_PROFILE,
         })) {
           push(svc);
         }

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -4,6 +4,7 @@ import {
   GATEWAY_SERVICE_KIND,
   GATEWAY_SERVICE_MARKER,
   NODE_LAUNCH_AGENT_LABEL,
+  NODE_SERVICE_KIND,
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
@@ -24,7 +25,7 @@ export type FindExtraGatewayServicesOptions = {
 };
 
 const EXTRA_MARKERS = ["openclaw", "clawdbot", "moltbot"] as const;
-const IGNORED_NON_GATEWAY_LAUNCHD_LABELS = new Set(["ai.openclaw.mac", NODE_LAUNCH_AGENT_LABEL]);
+const MAC_APP_LAUNCH_AGENT_LABEL = "ai.openclaw.mac";
 
 export function renderGatewayServiceCleanupHints(
   env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
@@ -132,11 +133,46 @@ function tryExtractPlistLabel(contents: string): string | null {
   return match[1]?.trim() || null;
 }
 
-function isIgnoredLaunchdLabel(label: string, profile?: string): boolean {
-  return (
-    label === resolveGatewayLaunchAgentLabel(profile) ||
-    IGNORED_NON_GATEWAY_LAUNCHD_LABELS.has(label)
+function tryExtractLaunchdEnvironmentValue(contents: string, key: string): string | null {
+  const envMatch = contents.match(/<key>EnvironmentVariables<\/key>\s*<dict>([\s\S]*?)<\/dict>/i);
+  if (!envMatch) {
+    return null;
+  }
+  const entryPattern = new RegExp(
+    `<key>${key.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&")}<\\/key>\\s*<string>([\\s\\S]*?)<\\/string>`,
+    "i",
   );
+  const entry = envMatch[1].match(entryPattern);
+  return entry?.[1]?.trim() || null;
+}
+
+function isGatewayLaunchdLabel(label: string, profile?: string): boolean {
+  return label === resolveGatewayLaunchAgentLabel(profile);
+}
+
+function isOpenClawAppLaunchAgent(label: string, contents: string): boolean {
+  if (label !== MAC_APP_LAUNCH_AGENT_LABEL) {
+    return false;
+  }
+  if (
+    tryExtractLaunchdEnvironmentValue(contents, "OPENCLAW_SERVICE_KIND") === GATEWAY_SERVICE_KIND
+  ) {
+    return false;
+  }
+  return /<key>ProgramArguments<\/key>\s*<array>[\s\S]*?(?:OpenClaw\.app|\/Contents\/MacOS\/OpenClaw)<\/string>/i.test(
+    contents,
+  );
+}
+
+function isOpenClawNodeLaunchAgent(label: string, contents: string): boolean {
+  return (
+    label === NODE_LAUNCH_AGENT_LABEL &&
+    tryExtractLaunchdEnvironmentValue(contents, "OPENCLAW_SERVICE_KIND") === NODE_SERVICE_KIND
+  );
+}
+
+function isIgnoredNonGatewayLaunchdService(label: string, contents: string): boolean {
+  return isOpenClawAppLaunchAgent(label, contents) || isOpenClawNodeLaunchAgent(label, contents);
 }
 
 function isIgnoredSystemdName(name: string): boolean {
@@ -226,10 +262,13 @@ async function scanLaunchdDir(params: {
       });
       continue;
     }
-    if (isIgnoredLaunchdLabel(label, params.profile)) {
+    if (isGatewayLaunchdLabel(label, params.profile)) {
       continue;
     }
     if (marker === "openclaw" && isOpenClawGatewayLaunchdService(label, contents, params.profile)) {
+      continue;
+    }
+    if (marker === "openclaw" && isIgnoredNonGatewayLaunchdService(label, contents)) {
       continue;
     }
     results.push({

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import {
   GATEWAY_SERVICE_KIND,
   GATEWAY_SERVICE_MARKER,
+  NODE_LAUNCH_AGENT_LABEL,
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
@@ -23,6 +24,7 @@ export type FindExtraGatewayServicesOptions = {
 };
 
 const EXTRA_MARKERS = ["openclaw", "clawdbot", "moltbot"] as const;
+const IGNORED_NON_GATEWAY_LAUNCHD_LABELS = new Set(["ai.openclaw.mac", NODE_LAUNCH_AGENT_LABEL]);
 
 export function renderGatewayServiceCleanupHints(
   env: Record<string, string | undefined> = process.env as Record<string, string | undefined>,
@@ -124,7 +126,9 @@ function tryExtractPlistLabel(contents: string): string | null {
 }
 
 function isIgnoredLaunchdLabel(label: string): boolean {
-  return label === resolveGatewayLaunchAgentLabel();
+  return (
+    label === resolveGatewayLaunchAgentLabel() || IGNORED_NON_GATEWAY_LAUNCHD_LABELS.has(label)
+  );
 }
 
 function isIgnoredSystemdName(name: string): boolean {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `openclaw gateway status` can report `ai.openclaw.mac` as an extra gateway-like launchd service on macOS.
- Why it matters: the warning is a false positive for users who enable the macOS app LaunchAgent, so cleanup guidance becomes noisy and misleading.
- What changed: the darwin service scan now treats the mac app LaunchAgent label as a known non-gateway OpenClaw service and ignores it, and a regression test covers the user LaunchAgents scan.
- What did NOT change (scope boundary): gateway LaunchAgent detection, systemd/task scanning, and cleanup hint generation are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #23846
- Related #33342

## User-visible / Behavior Changes

- `openclaw gateway status` no longer warns about the mac app LaunchAgent (`ai.openclaw.mac`) as an extra gateway-like service.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): mac app installed with Launch at login enabled

### Steps

1. Install the macOS app and enable Launch at login so `~/Library/LaunchAgents/ai.openclaw.mac.plist` exists.
2. Run `openclaw gateway status`.
3. Inspect the `Other gateway-like services detected` section.

### Expected

- The status output ignores `ai.openclaw.mac` because it is the mac app LaunchAgent, not an extra gateway service.

### Actual

- The status output can list `ai.openclaw.mac` as an extra launchd service and suggest removing it.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: confirmed the darwin scan reports neighboring OpenClaw LaunchAgents but skips `ai.openclaw.mac`; existing win32 scan tests still pass.
- Edge cases checked: labels extracted from plist contents are still filtered after parsing, so the ignore applies even when the filename and plist label are both present.
- What you did **not** verify: a live macOS app install on this machine.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR to restore the previous darwin LaunchAgent scan behavior.
- Files/config to restore: `src/daemon/inspect.ts`, `src/daemon/inspect.test.ts`
- Known bad symptoms reviewers should watch for: legitimate non-gateway `ai.openclaw.*` launch agents being suppressed unexpectedly.

## Risks and Mitigations

- Risk: the ignore list could hide another non-gateway launchd label if it reuses the exact mac app label.
  - Mitigation: the allowlist is limited to the two known app-owned labels and covered by a regression test that still reports other OpenClaw launch agents.
