### PR TITLE
fix: merge "sandbox" openclaw.json config in the same way as "models" for webhook invocations

### DIFF
--- a/src/cron/isolated-agent/run.sandbox-config-merge.test.ts
+++ b/src/cron/isolated-agent/run.sandbox-config-merge.test.ts
@@ -1,0 +1,167 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearFastTestEnv,
+  loadRunCronIsolatedAgentTurn,
+  makeCronSession,
+  makeCronSessionEntry,
+  resolveAgentConfigMock,
+  resolveAllowedModelRefMock,
+  resolveConfiguredModelRefMock,
+  resolveCronSessionMock,
+  resetRunCronIsolatedAgentTurnHarness,
+  restoreFastTestEnv,
+  runWithModelFallbackMock,
+  updateSessionStoreMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+// ---------- helpers ----------
+
+function makeJob(overrides?: Record<string, unknown>) {
+  return {
+    id: "sandbox-test-job",
+    name: "Sandbox Test",
+    schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+    sessionTarget: "isolated",
+    agentId: "test-agent",
+    payload: {
+      kind: "agentTurn",
+      message: "test sandbox merge",
+    },
+    ...overrides,
+  } as never;
+}
+
+function makeParams(overrides?: Record<string, unknown>) {
+  return {
+    cfg: {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all" as const, workspaceAccess: "rw" as const },
+        },
+      },
+    },
+    deps: {} as never,
+    job: makeJob(),
+    message: "test sandbox merge",
+    sessionKey: "cron:sandbox-test",
+    ...overrides,
+  };
+}
+
+/**
+ * Extract the config passed to runWithModelFallback so we can inspect
+ * the merged agents.defaults.sandbox values.
+ */
+function getCfgPassedToModelFallback(): Record<string, unknown> | undefined {
+  const call = runWithModelFallbackMock.mock.calls[0];
+  return call?.[0]?.cfg;
+}
+
+// ---------- tests ----------
+
+describe("runCronIsolatedAgentTurn — sandbox config merge", () => {
+  let previousFastTestEnv: string | undefined;
+
+  beforeEach(() => {
+    previousFastTestEnv = clearFastTestEnv();
+    resetRunCronIsolatedAgentTurnHarness();
+
+    resolveConfiguredModelRefMock.mockReturnValue({
+      provider: "openai",
+      model: "gpt-4",
+    });
+    resolveAllowedModelRefMock.mockReturnValue({
+      ref: { provider: "openai", model: "gpt-4" },
+    });
+    updateSessionStoreMock.mockResolvedValue(undefined);
+    resolveCronSessionMock.mockReturnValue(
+      makeCronSession({ sessionEntry: makeCronSessionEntry() }),
+    );
+  });
+
+  afterEach(() => {
+    restoreFastTestEnv(previousFastTestEnv);
+  });
+
+  it("preserves agents.defaults.sandbox.mode when agent config has no sandbox", async () => {
+    // Agent exists in config but has no sandbox settings
+    resolveAgentConfigMock.mockReturnValue({
+      name: "test-agent",
+      workspace: "/tmp/test",
+    });
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    const cfg = getCfgPassedToModelFallback() as {
+      agents?: { defaults?: { sandbox?: { mode?: string; workspaceAccess?: string } } };
+    };
+    expect(cfg?.agents?.defaults?.sandbox?.mode).toBe("all");
+    expect(cfg?.agents?.defaults?.sandbox?.workspaceAccess).toBe("rw");
+  });
+
+  it("preserves agents.defaults.sandbox.mode when agent config has sandbox: undefined", async () => {
+    // Agent config explicitly returns sandbox: undefined (the resolveAgentConfig pattern)
+    resolveAgentConfigMock.mockReturnValue({
+      name: "test-agent",
+      sandbox: undefined,
+    });
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    const cfg = getCfgPassedToModelFallback() as {
+      agents?: { defaults?: { sandbox?: { mode?: string } } };
+    };
+    expect(cfg?.agents?.defaults?.sandbox?.mode).toBe("all");
+  });
+
+  it("deep-merges agent-specific sandbox overrides without clobbering defaults", async () => {
+    // Agent has partial sandbox config — only workspaceAccess, no mode
+    resolveAgentConfigMock.mockReturnValue({
+      name: "test-agent",
+      sandbox: { workspaceAccess: "none" },
+    });
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    const cfg = getCfgPassedToModelFallback() as {
+      agents?: { defaults?: { sandbox?: { mode?: string; workspaceAccess?: string } } };
+    };
+    // mode from defaults must survive the merge
+    expect(cfg?.agents?.defaults?.sandbox?.mode).toBe("all");
+    // workspaceAccess should be overridden by agent-specific value
+    expect(cfg?.agents?.defaults?.sandbox?.workspaceAccess).toBe("none");
+  });
+
+  it("allows agent-specific sandbox to override mode", async () => {
+    // Agent explicitly sets sandbox.mode = "off"
+    resolveAgentConfigMock.mockReturnValue({
+      name: "test-agent",
+      sandbox: { mode: "off" },
+    });
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    const cfg = getCfgPassedToModelFallback() as {
+      agents?: { defaults?: { sandbox?: { mode?: string; workspaceAccess?: string } } };
+    };
+    // Agent override takes precedence
+    expect(cfg?.agents?.defaults?.sandbox?.mode).toBe("off");
+    // Default workspaceAccess should still be present
+    expect(cfg?.agents?.defaults?.sandbox?.workspaceAccess).toBe("rw");
+  });
+
+  it("preserves sandbox defaults when no agent config exists at all", async () => {
+    // No agent-specific config
+    resolveAgentConfigMock.mockReturnValue(undefined);
+
+    await runCronIsolatedAgentTurn(makeParams({ job: makeJob({ agentId: undefined }) }));
+
+    const cfg = getCfgPassedToModelFallback() as {
+      agents?: { defaults?: { sandbox?: { mode?: string; workspaceAccess?: string } } };
+    };
+    expect(cfg?.agents?.defaults?.sandbox?.mode).toBe("all");
+    expect(cfg?.agents?.defaults?.sandbox?.workspaceAccess).toBe("rw");
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -119,16 +119,33 @@ export async function runCronIsolatedAgentTurn(params: {
   const agentConfigOverride = normalizedRequested
     ? resolveAgentConfig(params.cfg, normalizedRequested)
     : undefined;
-  const { model: overrideModel, ...agentOverrideRest } = agentConfigOverride ?? {};
+  const {
+    model: overrideModel,
+    sandbox: overrideSandbox,
+    ...agentOverrideRest
+  } = agentConfigOverride ?? {};
   // Use the requested agentId even when there is no explicit agent config entry.
   // This ensures auth-profiles, workspace, and agentDir all resolve to the
   // correct per-agent paths (e.g. ~/.openclaw/agents/<agentId>/agent/).
   const agentId = normalizedRequested ?? defaultAgentId;
+  // Filter out undefined values so Object.assign doesn't clobber defaults with undefined.
+  const filteredOverride: Partial<AgentDefaultsConfig> = {};
+  for (const [k, v] of Object.entries(agentOverrideRest)) {
+    if (v !== undefined) {
+      (filteredOverride as Record<string, unknown>)[k] = v;
+    }
+  }
   const agentCfg: AgentDefaultsConfig = Object.assign(
     {},
     params.cfg.agents?.defaults,
-    agentOverrideRest as Partial<AgentDefaultsConfig>,
+    filteredOverride,
   );
+  // Deep-merge sandbox config so agent-specific overrides don't clobber global
+  // defaults (e.g. agents.defaults.sandbox.mode = "all" must survive when the
+  // agent entry only specifies sandbox.workspaceAccess).
+  if (overrideSandbox && typeof overrideSandbox === "object") {
+    agentCfg.sandbox = { ...agentCfg.sandbox, ...overrideSandbox };
+  }
   // Merge agent model override with defaults instead of replacing, so that
   // `fallbacks` from `agents.defaults.model` are preserved when the agent
   // (or its per-cron model pin) only specifies `primary`.


### PR DESCRIPTION
## Summary

- **Problem:** Webhook-invoked agents (POST /hooks/agent) ignore `agents.defaults.sandbox.mode` from `openclaw.json`, causing exec commands to run outside the Docker sandbox
- **Why it matters:** Agents that should be sandboxed run unsandboxed, bypassing a security boundary the user explicitly configured
- **What changed:** `runCronIsolatedAgentTurn` in `src/cron/isolated-agent/run.ts` now filters out `undefined` values before `Object.assign` and deep-merges the `sandbox` object (same pattern already used for `model`)
- **What did NOT change (scope boundary):** Normal (non-webhook) agent invocation path is unaffected; sandbox resolution logic in `src/agents/sandbox/` is untouched

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33349
- Related #33349

## User-visible / Behavior Changes

Webhook/cron-invoked agents now correctly respect `agents.defaults.sandbox.mode` (e.g. `"all"`). Previously these sessions always ran unsandboxed regardless of config.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `Yes`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: Exec commands in webhook agent sessions are now routed through the Docker sandbox when configured. This *restores* the intended security boundary — before this fix, those commands ran on the host. Risk is low; the change makes behavior match the existing config contract.

## Repro + Verification

### Environment

- OS: Windows 11 Enterprise
- Runtime/container: Docker Desktop
- Model/provider: Any
- Integration/channel (if any): Webhook (POST /hooks/agent)
- Relevant config (redacted): `agents.defaults.sandbox.mode = "all"` in `openclaw.json`

### Steps

1. Set `agents.defaults.sandbox.mode` to `"all"` in `openclaw.json`
2. Invoke an agent via POST /hooks/agent
3. Observe whether exec commands run inside Docker sandbox

### Expected

- Exec commands run inside the Docker sandbox container

### Actual

- Before fix: exec commands run on the host (unsandboxed)
- After fix: exec commands run inside Docker sandbox as configured

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

5 new unit tests in `run.sandbox-config-merge.test.ts` verify the config merging. These tests would fail on the previous code (sandbox defaults clobbered by `Object.assign`).

## Human Verification (required)

- Verified scenarios: Webhook-invoked agent with `sandbox.mode = "all"` — confirmed exec runs inside Docker container on local machine
- Edge cases checked: Agent with no sandbox config, agent with partial sandbox config, agent with explicit `sandbox.mode = "off"` override
- What you did **not** verify: `sandbox.mode = "non-all"` behaviour

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit on `src/cron/isolated-agent/run.ts`
- Files/config to restore: `src/cron/isolated-agent/run.ts` (original `Object.assign` without filtering)
- Known bad symptoms reviewers should watch for: Webhook agents failing to start if sandbox/Docker is misconfigured (would surface as container creation errors, not silent failures)

## Risks and Mitigations

- Risk: Existing webhook agents that were (unknowingly) relying on unsandboxed exec may break if Docker is not available or misconfigured
  - Mitigation: This restores documented behaviour — users who set `sandbox.mode = "all"` expect sandboxing. If Docker is unavailable, the existing sandbox error handling applies.

🤖 AI-assisted (Claude Code). I understand what the code does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
