### PR TITLE
fix(cli): clarify wildcard entries in approvals output

### DIFF
--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -177,7 +177,7 @@ function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: s
       const lastUsedAt = typeof entry.lastUsedAt === "number" ? entry.lastUsedAt : null;
       allowlistRows.push({
         Target: targetLabel,
-        Agent: agentId,
+        Agent: agentId === "*" ? "* (all agents)" : agentId,
         Pattern: pattern,
         LastUsed: lastUsedAt ? formatTimeAgo(Math.max(0, now - lastUsedAt)) : muted("unknown"),
       });
@@ -192,7 +192,7 @@ function renderApprovalsSnapshot(snapshot: ExecApprovalsSnapshot, targetLabel: s
     { Field: "Version", Value: String(file.version ?? 1) },
     { Field: "Socket", Value: file.socket?.path ?? "default" },
     { Field: "Defaults", Value: defaultsParts.length > 0 ? defaultsParts.join(", ") : "none" },
-    { Field: "Agents", Value: String(Object.keys(agents).length) },
+    { Field: "Agents", Value: String(Object.keys(agents).filter((k) => k !== "*").length) },
     { Field: "Allowlist", Value: String(allowlistRows.length) },
   ];
 


### PR DESCRIPTION
## Summary

- Problem: `openclaw approvals get` counts `agents["*"]` as a regular agent and shows `*` as the agent name in the allowlist table, with no indication that those entries actually apply to all agents.
- Why it matters: Users running `--agent "*"` see a confusing third "agent" named `*` and reasonably assume their wildcard entries aren't working — when they are. Issue #33268 was filed because of this.
- What changed: The "Agents" count now excludes `*` (wildcard), and wildcard entries in the allowlist table are labeled `* (all agents)` instead of just `*`.
- What did NOT change: Runtime behavior is untouched. The wildcard allowlist has always been merged correctly in `resolveExecApprovalsFromFile` — this is a display-only fix.

## Change Type (select all)

- [x] Bug fix
- [x] UI / DX

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Closes #33268

## User-visible / Behavior Changes

`openclaw approvals get` output changes:
- "Agents" count no longer includes the `*` wildcard key.
- Wildcard allowlist entries show `* (all agents)` under the Agent column instead of `*`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. `openclaw approvals allowlist add --agent "*" "/usr/bin/uname"`
2. `openclaw approvals get`

### Expected (after fix)

Agents count reflects only concrete agents. Wildcard entry shows `* (all agents)` in the Agent column.

### Actual (before fix)

Agents count included `*` as a third agent. Entry showed `*` in the Agent column with no explanation.

## Evidence

- [x] Code inspection confirming `resolveExecApprovalsFromFile` already merges `agents["*"].allowlist` at runtime (lines 434-436 in `src/infra/exec-approvals.ts`).

## Human Verification (required)

- Verified the runtime wildcard merge logic is untouched.
- Verified `filter((k) => k !== "*")` only affects the display count, not the underlying data.
- What I did not verify: full CLI run against a live gateway.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Two-line revert in `src/cli/exec-approvals-cli.ts`.

## Risks and Mitigations

- None. Display-only change with no effect on stored data or runtime evaluation.