### PR TITLE
feat(slack): show tool-level progress in assistant thread status

### DIFF
--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -27,6 +27,40 @@ import { normalizeSlackAllowOwnerEntry } from "../allow-list.js";
 import { createSlackReplyDeliveryPlan, deliverReplies, resolveSlackThreadTs } from "../replies.js";
 import type { PreparedSlackMessage } from "./types.js";
 
+// ---------------------------------------------------------------------------
+// Tool → human-readable status labels for assistant.threads.setStatus
+// ---------------------------------------------------------------------------
+const TOOL_STATUS_LABELS: Record<string, string> = {
+  exec: "Running command…",
+  Read: "Reading files…",
+  Edit: "Editing files…",
+  Write: "Writing files…",
+  web_search: "Searching the web…",
+  web_fetch: "Fetching page…",
+  memory_search: "Checking memory…",
+  memory_get: "Reading memory…",
+  browser: "Using browser…",
+  message: "Sending message…",
+  tts: "Converting to speech…",
+  image: "Analyzing image…",
+  sessions_spawn: "Spawning sub-agent…",
+  sessions_send: "Messaging sub-agent…",
+  sessions_list: "Checking sessions…",
+  sessions_history: "Reading session history…",
+  session_status: "Checking status…",
+  cron: "Managing schedule…",
+  canvas: "Updating canvas…",
+  nodes: "Checking nodes…",
+  gateway: "Managing gateway…",
+  whatsapp_login: "WhatsApp login…",
+  agents_list: "Listing agents…",
+  process: "Managing process…",
+};
+
+function toolStatusLabel(toolName: string): string {
+  return TOOL_STATUS_LABELS[toolName] ?? `Using ${toolName}…`;
+}
+
 function hasMedia(payload: ReplyPayload): boolean {
   return Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
 }
@@ -437,6 +471,15 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
             },
       onAssistantMessageStart: onDraftBoundary,
       onReasoningEnd: onDraftBoundary,
+      onToolStart: async ({ name }: { name?: string }) => {
+        if (!name) return;
+        const label = toolStatusLabel(name);
+        await ctx.setSlackThreadStatus({
+          channelId: message.channel,
+          threadTs: statusThreadTs,
+          status: label,
+        });
+      },
     },
   });
   await draftStream.flush();

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -472,9 +472,8 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       onAssistantMessageStart: onDraftBoundary,
       onReasoningEnd: onDraftBoundary,
       onToolStart: async ({ name }: { name?: string }) => {
-        if (!name) return;
+        if (!name || !didSetStatus) return;
         const label = toolStatusLabel(name);
-        didSetStatus = true;
         await ctx.setSlackThreadStatus({
           channelId: message.channel,
           threadTs: statusThreadTs,

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -474,6 +474,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       onToolStart: async ({ name }: { name?: string }) => {
         if (!name) return;
         const label = toolStatusLabel(name);
+        didSetStatus = true;
         await ctx.setSlackThreadStatus({
           channelId: message.channel,
           threadTs: statusThreadTs,


### PR DESCRIPTION
## Summary

Updates Slack's `assistant.threads.setStatus` with human-readable labels as each tool executes, replacing the static `"is typing..."` message.

Instead of seeing a generic "Gathering information..." the entire time, users now see real-time progress:
- 📂 *Reading files…*
- 🔍 *Searching the web…*
- 💻 *Running command…*
- 🧠 *Checking memory…*
- etc.

## How it works

The agent execution layer (`agent-runner-execution.ts`) already emits `onToolStart` events with the tool name. The Slack context already has `setSlackThreadStatus`. This PR simply wires them together:

1. **Adds a tool-to-label mapping** (`TOOL_STATUS_LABELS`) with human-readable labels for all built-in tools, plus a fallback for unknown tools (`Using {toolName}…`)
2. **Adds an `onToolStart` callback** in the Slack dispatch's `replyOptions` that calls `ctx.setSlackThreadStatus()` with the appropriate label

## Changes

- **`src/slack/monitor/message-handler/dispatch.ts`** — 43 lines added (label map + callback wiring)

No new dependencies. No config changes needed (works immediately). No breaking changes.

## Why this matters

When the agent is doing multi-step work (transcribing audio, running heartbeat checks, triaging emails), users currently see a static indicator and can't tell if the agent is stuck or actively working. Tool-level status makes the experience feel responsive and transparent.

Closes #33413