### PR TITLE
fix(telegram): add setStatus integration for health monitoring

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -495,6 +495,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         webhookPath: account.config.webhookPath,
         webhookHost: account.config.webhookHost,
         webhookPort: account.config.webhookPort,
+        setStatus: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
       });
     },
     logoutAccount: async ({ accountId, cfg }) => {

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -2259,4 +2259,44 @@ describe("createTelegramBot", () => {
 
     expect(replySpy).toHaveBeenCalledTimes(1);
   });
+
+  it("registers setStatus middleware that reports lastEventAt on each update", async () => {
+    const setStatus = vi.fn();
+    createTelegramBot({ token: "tok", setStatus });
+
+    type Middleware = (
+      ctx: Record<string, unknown>,
+      next: () => Promise<void>,
+    ) => Promise<void> | void;
+
+    const middlewares = middlewareUseSpy.mock.calls
+      .map((call) => call[0])
+      .filter((fn): fn is Middleware => typeof fn === "function");
+
+    const nextSpy = vi.fn(async () => {});
+    // Run all middleware in sequence; the setStatus middleware will fire.
+    for (const mw of middlewares) {
+      await mw({ update: { update_id: 999 } }, nextSpy);
+    }
+
+    expect(setStatus).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lastEventAt: expect.any(Number),
+        lastInboundAt: expect.any(Number),
+      }),
+    );
+  });
+
+  it("does not register setStatus middleware when setStatus is not provided", () => {
+    const beforeCount = middlewareUseSpy.mock.calls.length;
+    createTelegramBot({ token: "tok" });
+    const afterCount = middlewareUseSpy.mock.calls.length;
+
+    middlewareUseSpy.mockClear();
+    createTelegramBot({ token: "tok", setStatus: vi.fn() });
+    const withStatusCount = middlewareUseSpy.mock.calls.length;
+
+    // When setStatus is provided, one additional middleware is registered.
+    expect(withStatusCount).toBe(afterCount - beforeCount + 1);
+  });
 });

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -56,6 +56,7 @@ export type TelegramBotOptions = {
     mediaGroupFlushMs?: number;
     textFragmentGapMs?: number;
   };
+  setStatus?: (patch: Record<string, unknown>) => void;
 };
 
 export { getTelegramSequentialKey };
@@ -163,6 +164,21 @@ export function createTelegramBot(opts: TelegramBotOptions) {
       }
     }
   });
+
+  // Track inbound events for health monitoring so the gateway doesn't
+  // restart a healthy provider after the stale-event threshold.
+  if (opts.setStatus) {
+    const statusSink = opts.setStatus;
+    bot.use(async (ctx, next) => {
+      try {
+        const now = Date.now();
+        statusSink({ lastEventAt: now, lastInboundAt: now });
+      } catch {
+        // Status tracking must never break message processing.
+      }
+      await next();
+    });
+  }
 
   bot.use(sequentialize(getTelegramSequentialKey));
 

--- a/src/telegram/monitor.test.ts
+++ b/src/telegram/monitor.test.ts
@@ -59,8 +59,9 @@ const { createTelegramBotErrors } = vi.hoisted(() => ({
   createTelegramBotErrors: [] as unknown[],
 }));
 
-const { createdBotStops } = vi.hoisted(() => ({
+const { createdBotStops, createTelegramBotCalls } = vi.hoisted(() => ({
   createdBotStops: [] as Array<ReturnType<typeof vi.fn<() => void>>>,
+  createTelegramBotCalls: [] as Array<Record<string, unknown>>,
 }));
 
 const { computeBackoff, sleepWithAbort } = vi.hoisted(() => ({
@@ -135,7 +136,10 @@ vi.mock("../config/config.js", async (importOriginal) => {
 });
 
 vi.mock("./bot.js", () => ({
-  createTelegramBot: () => {
+  createTelegramBot: (opts?: Record<string, unknown>) => {
+    if (opts) {
+      createTelegramBotCalls.push(opts);
+    }
     const nextError = createTelegramBotErrors.shift();
     if (nextError) {
       throw nextError;
@@ -211,6 +215,7 @@ describe("monitorTelegramProvider (grammY)", () => {
     resetUnhandledRejection();
     createTelegramBotErrors.length = 0;
     createdBotStops.length = 0;
+    createTelegramBotCalls.length = 0;
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   });
 
@@ -466,6 +471,27 @@ describe("monitorTelegramProvider (grammY)", () => {
     abort.abort();
     await monitor;
     expect(settled).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes setStatus through to createTelegramBot in polling mode", async () => {
+    const setStatus = vi.fn();
+    await monitorWithAutoAbort({ setStatus });
+
+    expect(createTelegramBotCalls.length).toBe(1);
+    expect(createTelegramBotCalls[0].setStatus).toBe(setStatus);
+  });
+
+  it("passes setStatus through to webhook mode", async () => {
+    const setStatus = vi.fn();
+    await monitorTelegramProvider({
+      token: "tok",
+      useWebhook: true,
+      webhookUrl: "https://example.test/telegram",
+      webhookSecret: "secret",
+      setStatus,
+    });
+
+    expect(startTelegramWebhookSpy).toHaveBeenCalledWith(expect.objectContaining({ setStatus }));
   });
 
   it("falls back to configured webhookSecret when not passed explicitly", async () => {

--- a/src/telegram/monitor.ts
+++ b/src/telegram/monitor.ts
@@ -30,6 +30,7 @@ export type MonitorTelegramOpts = {
   webhookHost?: string;
   proxyFetch?: typeof fetch;
   webhookUrl?: string;
+  setStatus?: (patch: Record<string, unknown>) => void;
 };
 
 export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
@@ -172,6 +173,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         fetch: proxyFetch,
         abortSignal: opts.abortSignal,
         publicUrl: opts.webhookUrl,
+        setStatus: opts.setStatus,
       });
       await waitForAbortSignal(opts.abortSignal);
       return;
@@ -224,6 +226,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
             lastUpdateId,
             onUpdateId: persistUpdateId,
           },
+          setStatus: opts.setStatus,
         });
       } catch (err) {
         const shouldRetry = await waitBeforeRetryOnRecoverableSetupError(

--- a/src/telegram/webhook.ts
+++ b/src/telegram/webhook.ts
@@ -87,6 +87,7 @@ export async function startTelegramWebhook(opts: {
   abortSignal?: AbortSignal;
   healthPath?: string;
   publicUrl?: string;
+  setStatus?: (patch: Record<string, unknown>) => void;
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
@@ -107,6 +108,7 @@ export async function startTelegramWebhook(opts: {
     proxyFetch: opts.fetch,
     config: opts.config,
     accountId: opts.accountId,
+    setStatus: opts.setStatus,
   });
   await initializeTelegramWebhookBot({
     bot,


### PR DESCRIPTION
## Summary

Thread `setStatus` callback from the Telegram channel extension through `monitorTelegramProvider` and into `createTelegramBot`/`startTelegramWebhook`, matching the established Discord and Slack pattern.

## Problem

The Telegram provider never calls `setStatus({ lastEventAt: ... })`. The channel health monitor uses `lastEventAt` to detect stale connections — without it, `lastEventAt` stays `null`, falls back to epoch `0`, and the health monitor unconditionally restarts the Telegram provider every 30 minutes (`DEFAULT_STALE_EVENT_THRESHOLD_MS`).

This causes:
- Unnecessary provider restarts every 30 minutes (visible in logs as `health-monitor: restarting (reason: stale-socket)`)
- **Silent message loss** when a restart happens during in-flight reply delivery

## Fix

- Add `setStatus` to `MonitorTelegramOpts` and `TelegramBotOptions`
- Register grammY middleware in `bot.ts` that reports `lastEventAt`/`lastInboundAt` on every inbound update (with try/catch isolation so status tracking never breaks message processing)
- Pass `setStatus` from channel extension → monitor → bot/webhook
- Add tests for middleware registration and passthrough

## Evidence

Gateway logs showing the 30-minute restart cycle:
```
[health-monitor] [telegram:main] health-monitor: restarting (reason: stale-socket)  # every 30 min
```

Discord (working correctly) passes setStatus at `extensions/discord/src/channel.ts:458`:
```ts
setStatus: (patch) => ctx.setStatus({ accountId: account.accountId, ...patch }),
```

Telegram was missing the equivalent line.

## Testing

- 64/64 telegram tests passing
- Type-checking clean (`tsgo`)
- New tests verify setStatus middleware registration and passthrough in both polling and webhook modes

Closes #32850
