### PR TITLE
fix(delivery-queue): move 4xx permanent errors to failed/ with diagnostics

### DIFF
--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -124,7 +124,7 @@ export async function ackDelivery(id: string, stateDir?: string): Promise<void> 
   }
 }
 
-/** Update a queue entry after a failed delivery attempt. */
+/** Update a queue entry after a failed delivery attempt. Moves to failed/ on permanent errors. */
 export async function failDelivery(id: string, error: string, stateDir?: string): Promise<void> {
   const filePath = path.join(resolveQueueDir(stateDir), `${id}.json`);
   const raw = await fs.promises.readFile(filePath, "utf-8");
@@ -138,6 +138,9 @@ export async function failDelivery(id: string, error: string, stateDir?: string)
     mode: 0o600,
   });
   await fs.promises.rename(tmp, filePath);
+  if (isPermanentDeliveryError(error)) {
+    await moveToFailed(id, stateDir);
+  }
 }
 
 /** Load all pending delivery entries from the queue directory. */
@@ -349,20 +352,15 @@ export async function recoverPendingDeliveries(opts: {
       opts.log.info(`Recovered delivery ${entry.id} to ${entry.channel}:${entry.to}`);
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
-      if (isPermanentDeliveryError(errMsg)) {
-        opts.log.warn(`Delivery ${entry.id} hit permanent error — moving to failed/: ${errMsg}`);
-        try {
-          await moveToFailed(entry.id, opts.stateDir);
-        } catch (moveErr) {
-          opts.log.error(`Failed to move entry ${entry.id} to failed/: ${String(moveErr)}`);
-        }
-        failed += 1;
-        continue;
-      }
       try {
         await failDelivery(entry.id, errMsg, opts.stateDir);
       } catch {
         // Best-effort update.
+      }
+      if (isPermanentDeliveryError(errMsg)) {
+        opts.log.warn(`Delivery ${entry.id} hit permanent error — moving to failed/: ${errMsg}`);
+        failed += 1;
+        continue;
       }
       failed += 1;
       opts.log.warn(`Retry failed for delivery ${entry.id}: ${errMsg}`);
@@ -387,6 +385,12 @@ const PERMANENT_ERROR_PATTERNS: readonly RegExp[] = [
   /recipient is not a valid/i,
   /outbound not configured for channel/i,
   /ambiguous discord recipient/i,
+  // HTTP 4xx client errors (excluding 429 rate limit and 408 timeout)
+  /^4(?!29|08)\d{2}[\s:]/,
+  /message (?:is )?too long/i,
+  /caption (?:is )?too long/i,
+  /payload too large/i,
+  /request entity too large/i,
 ];
 
 export function isPermanentDeliveryError(error: string): boolean {

--- a/src/infra/outbound/delivery-queue.ts
+++ b/src/infra/outbound/delivery-queue.ts
@@ -352,13 +352,19 @@ export async function recoverPendingDeliveries(opts: {
       opts.log.info(`Recovered delivery ${entry.id} to ${entry.channel}:${entry.to}`);
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
+      let failErr: unknown = null;
       try {
         await failDelivery(entry.id, errMsg, opts.stateDir);
-      } catch {
-        // Best-effort update.
+      } catch (e) {
+        failErr = e;
       }
       if (isPermanentDeliveryError(errMsg)) {
-        opts.log.warn(`Delivery ${entry.id} hit permanent error — moving to failed/: ${errMsg}`);
+        if (failErr) {
+          const failErrMsg = failErr instanceof Error ? failErr.message : JSON.stringify(failErr);
+          opts.log.error(`Failed to move entry ${entry.id} to failed/: ${failErrMsg}`);
+        } else {
+          opts.log.warn(`Delivery ${entry.id} hit permanent error — moved to failed/: ${errMsg}`);
+        }
         failed += 1;
         continue;
       }

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -135,6 +135,23 @@ describe("delivery-queue", () => {
       expect(entry.lastAttemptAt).toBeGreaterThan(0);
       expect(entry.lastError).toBe("connection refused");
     });
+
+    it("moves to failed/ with diagnostic fields on permanent error", async () => {
+      const id = await enqueueDelivery(
+        { channel: "telegram", to: "123", payloads: [{ text: "test" }] },
+        tmpDir,
+      );
+
+      await failDelivery(id, "400: Bad Request: message text too long", tmpDir);
+
+      const queueDir = path.join(tmpDir, "delivery-queue");
+      const failedDir = path.join(queueDir, "failed");
+      expect(fs.existsSync(path.join(queueDir, `${id}.json`))).toBe(false);
+      expect(fs.existsSync(path.join(failedDir, `${id}.json`))).toBe(true);
+      const entry = JSON.parse(fs.readFileSync(path.join(failedDir, `${id}.json`), "utf-8"));
+      expect(entry.lastError).toBe("400: Bad Request: message text too long");
+      expect(entry.lastAttemptAt).toBeGreaterThan(0);
+    });
   });
 
   describe("moveToFailed", () => {
@@ -166,6 +183,14 @@ describe("delivery-queue", () => {
       "Forbidden: bot was kicked from the group chat",
       "chat_id is empty",
       "Outbound not configured for channel: msteams",
+      "400: Bad Request: message text too long",
+      "400: Bad Request: MESSAGE_TOO_LONG",
+      "403: Forbidden",
+      "404: Not Found",
+      "413: Request Entity Too Large",
+      "caption is too long",
+      "message too long",
+      "payload too large",
     ])("returns true for permanent error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(true);
     });
@@ -176,6 +201,8 @@ describe("delivery-queue", () => {
       "socket hang up",
       "rate limited",
       "500 Internal Server Error",
+      "429: Too Many Requests",
+      "408: Request Timeout",
     ])("returns false for transient error: %s", (msg) => {
       expect(isPermanentDeliveryError(msg)).toBe(false);
     });


### PR DESCRIPTION
## Summary

- Detect HTTP 4xx client errors (except 429 rate limit / 408 timeout) as permanent delivery failures so they stop retrying on every gateway restart
- Persist `lastError` and `lastAttemptAt` on the queue entry *before* moving to `failed/`, so operators can diagnose why a message was retired
- `failDelivery()` now handles the permanent→`failed/` move internally, fixing both the recovery path and the hot delivery path in `deliver.ts`

Closes #33403

## Test plan

- [x] New unit test: `failDelivery` with permanent error moves entry to `failed/` with diagnostic fields populated
- [x] New `isPermanentDeliveryError` test cases for `400`, `403`, `404`, `413`, content-specific patterns (`message too long`, `caption too long`, `payload too large`)
- [x] Negative test cases for `429` (rate limit) and `408` (timeout) — confirmed transient
- [x] Existing recovery integration test ("moves entries to failed/ immediately on permanent delivery errors") still passes
- [x] `deliver.test.ts` (35 tests) all pass
- [x] Full `pnpm build` and `pnpm check` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)