### PR TITLE
fix(providers): forward toolChoice to openai-codex-responses payload

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -970,6 +970,42 @@ describe("applyExtraParamsToAgent", () => {
     expect(payloads[0]?.tool_choice).toBe("auto");
   });
 
+  it("runtime toolChoice overrides configured toolChoice for Codex payload", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { tool_choice: "auto" };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai-codex/gpt-5.3-codex": {
+              params: { toolChoice: "required" },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "openai-codex", "gpt-5.3-codex");
+
+    const model = {
+      api: "openai-codex-responses",
+      provider: "openai-codex",
+      id: "gpt-5.3-codex",
+    } as Model<"openai-codex-responses">;
+    void agent.streamFn?.(model, { messages: [] }, {
+      toolChoice: "none",
+    } as unknown as SimpleStreamOptions);
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.tool_choice).toBe("none");
+  });
+
   it("disables prompt caching for non-Anthropic Bedrock models", () => {
     const { calls, agent } = createOptionsCaptureAgent();
 

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -849,6 +849,127 @@ describe("applyExtraParamsToAgent", () => {
     expect(calls[0]?.transport).toBe("auto");
   });
 
+  it("forwards configured toolChoice to Codex payload via onPayload", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { tool_choice: "auto" };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai-codex/gpt-5.3-codex": {
+              params: {
+                toolChoice: "required",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "openai-codex", "gpt-5.3-codex");
+
+    const model = {
+      api: "openai-codex-responses",
+      provider: "openai-codex",
+      id: "gpt-5.3-codex",
+    } as Model<"openai-codex-responses">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.tool_choice).toBe("required");
+  });
+
+  it("forwards runtime toolChoice option to Codex payload", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { tool_choice: "auto" };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "openai-codex", "gpt-5.3-codex");
+
+    const model = {
+      api: "openai-codex-responses",
+      provider: "openai-codex",
+      id: "gpt-5.3-codex",
+    } as Model<"openai-codex-responses">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, { toolChoice: "none" } as unknown as SimpleStreamOptions);
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.tool_choice).toBe("none");
+  });
+
+  it("forwards function-specific toolChoice to Codex payload", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { tool_choice: "auto" };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    const toolChoice = { type: "function", function: { name: "my_tool" } };
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "openai-codex/gpt-5.3-codex": {
+              params: { toolChoice },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(agent, cfg, "openai-codex", "gpt-5.3-codex");
+
+    const model = {
+      api: "openai-codex-responses",
+      provider: "openai-codex",
+      id: "gpt-5.3-codex",
+    } as Model<"openai-codex-responses">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.tool_choice).toEqual(toolChoice);
+  });
+
+  it("preserves default tool_choice=auto for Codex when no toolChoice configured", () => {
+    const payloads: Record<string, unknown>[] = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      const payload: Record<string, unknown> = { tool_choice: "auto" };
+      options?.onPayload?.(payload);
+      payloads.push(payload);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+
+    applyExtraParamsToAgent(agent, undefined, "openai-codex", "gpt-5.3-codex");
+
+    const model = {
+      api: "openai-codex-responses",
+      provider: "openai-codex",
+      id: "gpt-5.3-codex",
+    } as Model<"openai-codex-responses">;
+    const context: Context = { messages: [] };
+    void agent.streamFn?.(model, context, {});
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.tool_choice).toBe("auto");
+  });
+
   it("disables prompt caching for non-Anthropic Bedrock models", () => {
     const { calls, agent } = createOptionsCaptureAgent();
 

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -47,6 +47,7 @@ type CacheRetention = "none" | "short" | "long";
 type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
   cacheRetention?: CacheRetention;
   openaiWsWarmup?: boolean;
+  toolChoice?: unknown;
 };
 
 /**
@@ -127,6 +128,9 @@ function createStreamFnWithExtraParams(
   }
   if (typeof extraParams.openaiWsWarmup === "boolean") {
     streamParams.openaiWsWarmup = extraParams.openaiWsWarmup;
+  }
+  if (extraParams.toolChoice !== undefined) {
+    streamParams.toolChoice = extraParams.toolChoice;
   }
   const cacheRetention = resolveCacheRetention(extraParams, provider);
   if (cacheRetention) {
@@ -307,6 +311,33 @@ function createOpenAIResponsesContextManagementWrapper(
               },
             ];
           }
+        }
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}
+
+/**
+ * Work around upstream pi-ai hardcoding `tool_choice: "auto"` in the
+ * openai-codex-responses provider. `buildBaseOptions()` drops `toolChoice`
+ * from stream options, and `buildRequestBody()` hardcodes it to `"auto"`.
+ * This wrapper intercepts the request payload via `onPayload` and overrides
+ * `tool_choice` with the caller-supplied value.
+ */
+function createCodexToolChoiceWrapper(baseStreamFn: StreamFn | undefined): StreamFn {
+  const underlying = baseStreamFn ?? streamSimple;
+  return (model, context, options) => {
+    const toolChoice = (options as CacheRetentionStreamOptions | undefined)?.toolChoice;
+    if (toolChoice === undefined) {
+      return underlying(model, context, options);
+    }
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          (payload as Record<string, unknown>).tool_choice = toolChoice;
         }
         originalOnPayload?.(payload);
       },
@@ -876,6 +907,9 @@ export function applyExtraParamsToAgent(
   if (provider === "openai-codex") {
     // Default Codex to WebSocket-first when nothing else specifies transport.
     agent.streamFn = createCodexDefaultTransportWrapper(agent.streamFn);
+    // Forward toolChoice via onPayload since pi-ai's buildBaseOptions drops it
+    // and buildRequestBody hardcodes tool_choice: "auto".
+    agent.streamFn = createCodexToolChoiceWrapper(agent.streamFn);
   } else if (provider === "openai") {
     // Default OpenAI Responses to WebSocket-first with transparent SSE fallback.
     agent.streamFn = createOpenAIDefaultTransportWrapper(agent.streamFn);


### PR DESCRIPTION
## Summary

- Fix `toolChoice` being silently dropped for `openai-codex-responses` provider (used by `gpt-5.3-codex` and other Codex models)
- Add `onPayload` wrapper that intercepts the request body and overrides the hardcoded `tool_choice: "auto"` with the caller-supplied value
- Pass `toolChoice` through `createStreamFnWithExtraParams` so it's available from model config `params`

## Root Cause

Upstream `@mariozechner/pi-ai` has two issues:
1. `buildBaseOptions()` in `simple-options.js` explicitly lists which options to pass through, and `toolChoice` is not included
2. `buildRequestBody()` in `openai-codex-responses.js` hardcodes `tool_choice: "auto"` instead of reading from options

Other providers (`openai-completions`, `anthropic`, `amazon-bedrock`) correctly forward `toolChoice`.

## Approach

Rather than patching the upstream dependency, this fix uses the existing `onPayload` wrapper pattern (already used for `store`, `tool_stream`, `thinking`, etc.) to intercept the request payload and override `tool_choice` when `toolChoice` is provided via:
- Model config params (`agents.defaults.models["openai-codex/model"].params.toolChoice`)
- Runtime stream options

## Test plan

- [x] Added test: configured `toolChoice` forwarded to Codex payload via `onPayload`
- [x] Added test: runtime `toolChoice` option forwarded to Codex payload
- [x] Added test: function-specific `toolChoice` (object form) forwarded correctly
- [x] Added test: default `tool_choice: "auto"` preserved when no `toolChoice` configured
- [x] All 51 existing + new tests pass

Fixes #33421