### PR TITLE
feat(telegram): topic-scoped bootstrap for forum topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Docs/security hardening guidance: document Docker `DOCKER-USER` + UFW policy and add cross-linking from Docker install docs for VPS/public-host setups. (#27613) thanks @dorukardahan.
 - Docs/tool-loop detection config keys: align `docs/tools/loop-detection.md` examples and field names with the current `tools.loopDetection` schema to prevent copy-paste validation failures from outdated keys. (#33182) Thanks @Mylszd.
 - Discord/inbound debouncer: skip bot-own MESSAGE_CREATE events before they reach the debounce queue to avoid self-triggered slowdowns in busy servers. Thanks @thewilloftheshadow.
 - Discord/Agent-scoped media roots: pass `mediaLocalRoots` through Discord monitor reply delivery (message + component interaction paths) so local media attachments honor per-agent workspace roots instead of falling back to default global roots. Thanks @thewilloftheshadow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,6 +391,10 @@ Docs: https://docs.openclaw.ai
 
 ## Unreleased
 
+### Changes
+
+- Docs/Contributing: require before/after screenshots for UI or visual PRs in the pre-PR checklist. (#32206) Thanks @hydro13.
+
 ### Fixes
 
 - Feishu/Multi-account + reply reliability: add `channels.feishu.defaultAccount` outbound routing support with schema validation, prevent inbound preview text from leaking into prompt system events, keep quoted-message extraction text-first (post/interactive/file placeholders instead of raw JSON), route Feishu video sends as `msg_type: "file"`, and avoid websocket event blocking by using non-blocking event handling in monitor dispatch. Landed from contributor PRs #31209, #29610, #30432, #30331, and #29501. Thanks @stakeswky, @hclsys, @bmendonca3, @patrick-yingxi-pan, and @zwffff.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,7 @@ Welcome to the lobster tank! 🦞
 - Ensure CI checks pass
 - Keep PRs focused (one thing per PR; do not mix unrelated concerns)
 - Describe what & why
+- **Include screenshots** — one showing the problem/before, one showing the fix/after (for UI or visual changes)
 
 ## Control UI Decorators
 

--- a/docs/gateway/security/index.md
+++ b/docs/gateway/security/index.md
@@ -630,7 +630,56 @@ Rules of thumb:
 - If you must bind to LAN, firewall the port to a tight allowlist of source IPs; do not port-forward it broadly.
 - Never expose the Gateway unauthenticated on `0.0.0.0`.
 
-### 0.4.1) mDNS/Bonjour discovery (information disclosure)
+### 0.4.1) Docker port publishing + UFW (`DOCKER-USER`)
+
+If you run OpenClaw with Docker on a VPS, remember that published container ports
+(`-p HOST:CONTAINER` or Compose `ports:`) are routed through Docker's forwarding
+chains, not only host `INPUT` rules.
+
+To keep Docker traffic aligned with your firewall policy, enforce rules in
+`DOCKER-USER` (this chain is evaluated before Docker's own accept rules).
+On many modern distros, `iptables`/`ip6tables` use the `iptables-nft` frontend
+and still apply these rules to the nftables backend.
+
+Minimal allowlist example (IPv4):
+
+```bash
+# /etc/ufw/after.rules (append as its own *filter section)
+*filter
+:DOCKER-USER - [0:0]
+-A DOCKER-USER -m conntrack --ctstate ESTABLISHED,RELATED -j RETURN
+-A DOCKER-USER -s 127.0.0.0/8 -j RETURN
+-A DOCKER-USER -s 10.0.0.0/8 -j RETURN
+-A DOCKER-USER -s 172.16.0.0/12 -j RETURN
+-A DOCKER-USER -s 192.168.0.0/16 -j RETURN
+-A DOCKER-USER -s 100.64.0.0/10 -j RETURN
+-A DOCKER-USER -p tcp --dport 80 -j RETURN
+-A DOCKER-USER -p tcp --dport 443 -j RETURN
+-A DOCKER-USER -m conntrack --ctstate NEW -j DROP
+-A DOCKER-USER -j RETURN
+COMMIT
+```
+
+IPv6 has separate tables. Add a matching policy in `/etc/ufw/after6.rules` if
+Docker IPv6 is enabled.
+
+Avoid hardcoding interface names like `eth0` in docs snippets. Interface names
+vary across VPS images (`ens3`, `enp*`, etc.) and mismatches can accidentally
+skip your deny rule.
+
+Quick validation after reload:
+
+```bash
+ufw reload
+iptables -S DOCKER-USER
+ip6tables -S DOCKER-USER
+nmap -sT -p 1-65535 <public-ip> --open
+```
+
+Expected external ports should be only what you intentionally expose (for most
+setups: SSH + your reverse proxy ports).
+
+### 0.4.2) mDNS/Bonjour discovery (information disclosure)
 
 The Gateway broadcasts its presence via mDNS (`_openclaw-gw._tcp` on port 5353) for local device discovery. In full mode, this includes TXT records that may expose operational details:
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -28,6 +28,9 @@ Sandboxing details: [Sandboxing](/gateway/sandboxing)
 - Docker Desktop (or Docker Engine) + Docker Compose v2
 - At least 2 GB RAM for image build (`pnpm install` may be OOM-killed on 1 GB hosts with exit 137)
 - Enough disk for images + logs
+- If running on a VPS/public host, review
+  [Security hardening for network exposure](/gateway/security#04-network-exposure-bind--port--firewall),
+  especially Docker `DOCKER-USER` firewall policy.
 
 ## Containerized Gateway (Docker Compose)
 

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -101,7 +101,7 @@ describe("resolveBootstrapFilesForRun", () => {
       const files = await resolveBootstrapFilesForRun({
         workspaceDir,
         agentId: "main",
-        ...( { topicId: 7 } as { topicId: number } ),
+        topicId: 7,
       });
 
       const agents = files.find((file) => file.name === "AGENTS.md");

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -6,6 +7,7 @@ import {
   registerInternalHook,
   type AgentBootstrapHookContext,
 } from "../hooks/internal-hooks.js";
+import { resolveAgentTopicsDir } from "../config/sessions/paths.js";
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import { resolveBootstrapContextForRun, resolveBootstrapFilesForRun } from "./bootstrap-files.js";
 import type { WorkspaceBootstrapFile } from "./workspace.js";
@@ -80,6 +82,35 @@ describe("resolveBootstrapFilesForRun", () => {
     ).toBe(true);
     expect(warnings).toHaveLength(3);
     expect(warnings[0]).toContain('missing or invalid "path" field');
+  });
+
+  it("merges topic-scoped bootstrap files with workspace bootstrap, with topic overrides", async () => {
+    const workspaceDir = await makeTempWorkspace("openclaw-bootstrap-");
+    await fs.writeFile(path.join(workspaceDir, "AGENTS.md"), "global-agents", "utf8");
+
+    const prevStateDir = process.env.OPENCLAW_STATE_DIR;
+    const stateRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-topic-bootstrap-"));
+    process.env.OPENCLAW_STATE_DIR = stateRoot;
+
+    try {
+      const topicsRoot = resolveAgentTopicsDir("main");
+      const topicDir = path.join(topicsRoot, "7");
+      await fs.mkdir(topicDir, { recursive: true });
+      await fs.writeFile(path.join(topicDir, "AGENTS.md"), "topic-agents", "utf8");
+
+      const files = await resolveBootstrapFilesForRun({
+        workspaceDir,
+        agentId: "main",
+        ...( { topicId: 7 } as { topicId: number } ),
+      });
+
+      const agents = files.find((file) => file.name === "AGENTS.md");
+      expect(agents?.content).toBe("topic-agents");
+      expect(agents?.path).toBe(path.join(topicDir, "AGENTS.md"));
+    } finally {
+      process.env.OPENCLAW_STATE_DIR = prevStateDir;
+      await fs.rm(stateRoot, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -74,7 +74,7 @@ async function loadTopicBootstrapFiles(params: {
 
   const dirName =
     typeof topicId === "string" ? topicId.trim() : Number.isFinite(topicId) ? String(topicId) : "";
-  if (!dirName) {
+  if (!dirName || dirName.includes("/") || dirName.includes("\\") || dirName.includes("..")) {
     return [];
   }
 

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -1,4 +1,6 @@
+import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
+import { resolveAgentTopicsDir } from "../config/sessions/paths.js";
 import { getOrLoadBootstrapFiles } from "./bootstrap-cache.js";
 import { applyBootstrapHookOverrides } from "./bootstrap-hooks.js";
 import type { EmbeddedContextFile } from "./pi-embedded-helpers.js";
@@ -61,6 +63,26 @@ function applyContextModeFilter(params: {
   return [];
 }
 
+async function loadTopicBootstrapFiles(params: {
+  agentId?: string;
+  topicId?: string | number;
+}): Promise<WorkspaceBootstrapFile[]> {
+  const topicId = params.topicId;
+  if (topicId === undefined || topicId === null) {
+    return [];
+  }
+
+  const dirName =
+    typeof topicId === "string" ? topicId.trim() : Number.isFinite(topicId) ? String(topicId) : "";
+  if (!dirName) {
+    return [];
+  }
+
+  const topicsRootDir = resolveAgentTopicsDir(params.agentId);
+  const topicDir = path.join(topicsRootDir, dirName);
+  return await loadWorkspaceBootstrapFiles(topicDir);
+}
+
 export async function resolveBootstrapFilesForRun(params: {
   workspaceDir: string;
   config?: OpenClawConfig;
@@ -78,8 +100,28 @@ export async function resolveBootstrapFilesForRun(params: {
         sessionKey: params.sessionKey,
       })
     : await loadWorkspaceBootstrapFiles(params.workspaceDir);
+  const topicFiles = await loadTopicBootstrapFiles({
+    agentId: params.agentId,
+    // Allow future callers to pass topicId without changing the exported
+    // params type in a breaking way.
+    topicId: (params as { topicId?: string | number }).topicId,
+  });
+
+  const mergedFiles = (() => {
+    if (!topicFiles.length) {
+      return rawFiles;
+    }
+    const overrides = topicFiles.filter((file) => !file.missing);
+    if (!overrides.length) {
+      return rawFiles;
+    }
+    const overriddenNames = new Set(overrides.map((file) => file.name));
+    const baseFiles = rawFiles.filter((file) => !overriddenNames.has(file.name));
+    return [...baseFiles, ...overrides];
+  })();
+
   const bootstrapFiles = applyContextModeFilter({
-    files: filterBootstrapFilesForSession(rawFiles, sessionKey),
+    files: filterBootstrapFilesForSession(mergedFiles, sessionKey),
     contextMode: params.contextMode,
     runKind: params.runKind,
   });
@@ -91,6 +133,7 @@ export async function resolveBootstrapFilesForRun(params: {
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
     agentId: params.agentId,
+    topicId: (params as { topicId?: string | number }).topicId,
   });
   return sanitizeBootstrapFiles(updated, params.warn);
 }
@@ -108,7 +151,11 @@ export async function resolveBootstrapContextForRun(params: {
   bootstrapFiles: WorkspaceBootstrapFile[];
   contextFiles: EmbeddedContextFile[];
 }> {
-  const bootstrapFiles = await resolveBootstrapFilesForRun(params);
+  const bootstrapFiles = await resolveBootstrapFilesForRun(
+    params as Parameters<typeof resolveBootstrapFilesForRun>[0] & {
+      topicId?: string | number;
+    },
+  );
   const contextFiles = buildBootstrapContextFiles(bootstrapFiles, {
     maxChars: resolveBootstrapMaxChars(params.config),
     totalMaxChars: resolveBootstrapTotalMaxChars(params.config),

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -92,6 +92,7 @@ export async function resolveBootstrapFilesForRun(params: {
   warn?: (message: string) => void;
   contextMode?: BootstrapContextMode;
   runKind?: BootstrapContextRunKind;
+  topicId?: string | number;
 }): Promise<WorkspaceBootstrapFile[]> {
   const sessionKey = params.sessionKey ?? params.sessionId;
   const rawFiles = params.sessionKey
@@ -102,9 +103,7 @@ export async function resolveBootstrapFilesForRun(params: {
     : await loadWorkspaceBootstrapFiles(params.workspaceDir);
   const topicFiles = await loadTopicBootstrapFiles({
     agentId: params.agentId,
-    // Allow future callers to pass topicId without changing the exported
-    // params type in a breaking way.
-    topicId: (params as { topicId?: string | number }).topicId,
+    topicId: params.topicId,
   });
 
   const mergedFiles = (() => {
@@ -133,7 +132,7 @@ export async function resolveBootstrapFilesForRun(params: {
     sessionKey: params.sessionKey,
     sessionId: params.sessionId,
     agentId: params.agentId,
-    topicId: (params as { topicId?: string | number }).topicId,
+    topicId: params.topicId,
   });
   return sanitizeBootstrapFiles(updated, params.warn);
 }
@@ -147,15 +146,12 @@ export async function resolveBootstrapContextForRun(params: {
   warn?: (message: string) => void;
   contextMode?: BootstrapContextMode;
   runKind?: BootstrapContextRunKind;
+  topicId?: string | number;
 }): Promise<{
   bootstrapFiles: WorkspaceBootstrapFile[];
   contextFiles: EmbeddedContextFile[];
 }> {
-  const bootstrapFiles = await resolveBootstrapFilesForRun(
-    params as Parameters<typeof resolveBootstrapFilesForRun>[0] & {
-      topicId?: string | number;
-    },
-  );
+  const bootstrapFiles = await resolveBootstrapFilesForRun(params);
   const contextFiles = buildBootstrapContextFiles(bootstrapFiles, {
     maxChars: resolveBootstrapMaxChars(params.config),
     totalMaxChars: resolveBootstrapTotalMaxChars(params.config),

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -593,12 +593,19 @@ export async function runEmbeddedAttempt(
     });
 
     const sessionLabel = params.sessionKey ?? params.sessionId;
+    const topicId =
+      params.messageProvider === "telegram" && params.messageThreadId != null
+        ? params.messageThreadId
+        : undefined;
     const { bootstrapFiles: hookAdjustedBootstrapFiles, contextFiles } =
       await resolveBootstrapContextForRun({
         workspaceDir: effectiveWorkspace,
         config: params.config,
         sessionKey: params.sessionKey,
         sessionId: params.sessionId,
+        agentId: params.agentId,
+        // Thread-scoped bootstrap (e.g., Telegram forum topics and DM threads)
+        topicId,
         warn: makeBootstrapWarn({ sessionLabel, warn: (message) => log.warn(message) }),
         contextMode: params.bootstrapContextMode,
         runKind: params.bootstrapContextRunKind,

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -30,7 +30,7 @@ export async function resolveCommandsSystemPromptBundle(
   const workspaceDir = params.workspaceDir;
   const topicId =
     params.command.channel === "telegram"
-      ? params.sessionEntry?.lastThreadId ?? undefined
+      ? params.sessionEntry?.lastThreadId
       : undefined;
   const { bootstrapFiles, contextFiles: injectedFiles } = await resolveBootstrapContextForRun({
     workspaceDir,

--- a/src/auto-reply/reply/commands-system-prompt.ts
+++ b/src/auto-reply/reply/commands-system-prompt.ts
@@ -28,11 +28,17 @@ export async function resolveCommandsSystemPromptBundle(
   params: HandleCommandsParams,
 ): Promise<CommandsSystemPromptBundle> {
   const workspaceDir = params.workspaceDir;
+  const topicId =
+    params.command.channel === "telegram"
+      ? params.sessionEntry?.lastThreadId ?? undefined
+      : undefined;
   const { bootstrapFiles, contextFiles: injectedFiles } = await resolveBootstrapContextForRun({
     workspaceDir,
     config: params.cfg,
     sessionKey: params.sessionKey,
     sessionId: params.sessionEntry?.sessionId,
+    agentId: params.agentId,
+    topicId,
   });
   const skillsSnapshot = (() => {
     try {

--- a/src/config/sessions/paths.ts
+++ b/src/config/sessions/paths.ts
@@ -15,6 +15,16 @@ function resolveAgentSessionsDir(
   return path.join(root, "agents", id, "sessions");
 }
 
+export function resolveAgentTopicsDir(
+  agentId?: string,
+  env: NodeJS.ProcessEnv = process.env,
+  homedir: () => string = () => resolveRequiredHomeDir(env, os.homedir),
+): string {
+  const root = resolveStateDir(env, homedir);
+  const id = normalizeAgentId(agentId ?? DEFAULT_AGENT_ID);
+  return path.join(root, "agents", id, "topics");
+}
+
 export function resolveSessionTranscriptsDir(
   env: NodeJS.ProcessEnv = process.env,
   homedir: () => string = () => resolveRequiredHomeDir(env, os.homedir),

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -19,6 +19,8 @@ export type AgentBootstrapHookContext = {
   sessionKey?: string;
   sessionId?: string;
   agentId?: string;
+  /** Optional topic identifier (e.g., Telegram messageThreadId) for topic-scoped bootstrap */
+  topicId?: string | number;
 };
 
 export type AgentBootstrapHookEvent = InternalHookEvent & {


### PR DESCRIPTION
## Summary

Implements topic-specific bootstrap overrides for Telegram forum topics and DM threads, so each topic can have its own AGENTS/SOUL/USER/MEMORY context instead of sharing a single global bootstrap.

Fixes openclaw/openclaw#33398.

## Implementation details

- Add a per-agent topics directory under the state dir:
  - `~/.openclaw/agents/<agentId>/topics/<topicId>/AGENTS.md|SOUL.md|USER.md|MEMORY.md`
- Extend `resolveBootstrapFilesForRun` / `resolveBootstrapContextForRun` to:
  - Load the existing workspace bootstrap files.
  - Load topic-scoped bootstrap files when `topicId` is present.
  - Merge them so topic files override workspace files of the same name, while still allowing topic-only files.
- Thread `topicId` into bootstrap resolution:
  - Embedded Telegram runs (forum topics + DM threads) via `messageThreadId`.
  - Commands path for Telegram using `sessionEntry.lastThreadId`.
- Expose `topicId` on `AgentBootstrapHookContext` so bootstrap hooks can react to topic context if needed.

## Testing

- Added a unit test in `src/agents/bootstrap-files.test.ts` to verify that:
  - A topic `AGENTS.md` under `agents/main/topics/7/` overrides the workspace `AGENTS.md` for that session.
- Ran the bootstrap tests locally:
  - `pnpm test src/agents/bootstrap-files.test.ts`