### PR TITLE
feat(web): add sender name prefix to BodyForAgent in DMs

### DIFF
--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -302,9 +302,13 @@ export async function processMessage(params: {
     params.msg.chatType !== "group"
       ? (() => {
           const rawName = params.msg.fromMe
-            ? (params.msg.senderName || params.msg.selfE164 || "Me")
-            : (params.msg.senderName || params.msg.from || "Unknown");
-          const safeName = rawName.replace(/[\[\]\r\n]/g, "").replace(/\s+/g, " ").trim() || "Unknown";
+            ? params.msg.senderName || params.msg.selfE164 || "Me"
+            : params.msg.senderName || params.msg.from || "Unknown";
+          const safeName =
+            rawName
+              .replace(/[[\]\r\n]/g, "")
+              .replace(/\s+/g, " ")
+              .trim() || "Unknown";
           return `[${safeName}]: `;
         })()
       : "";

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -293,9 +293,15 @@ export async function processMessage(params: {
         )
       : undefined;
 
+  // In DMs, prefix BodyForAgent with the sender name so the LLM can distinguish
+  // who said what.  Groups already have sender attribution via formatInboundEnvelope.
+  const dmSenderPrefix =
+    params.msg.chatType !== "group"
+      ? `[${params.msg.senderName || params.msg.from || "Unknown"}]: `
+      : "";
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
-    BodyForAgent: params.msg.body,
+    BodyForAgent: `${dmSenderPrefix}${params.msg.body}`,
     InboundHistory: inboundHistory,
     RawBody: params.msg.body,
     CommandBody: params.msg.body,

--- a/src/web/auto-reply/monitor/process-message.ts
+++ b/src/web/auto-reply/monitor/process-message.ts
@@ -295,9 +295,18 @@ export async function processMessage(params: {
 
   // In DMs, prefix BodyForAgent with the sender name so the LLM can distinguish
   // who said what.  Groups already have sender attribution via formatInboundEnvelope.
+  // For outbound (fromMe) messages, msg.from is the *contact's* address, not the
+  // owner's — use selfE164 instead.  Sanitize the name to prevent bracket/newline
+  // injection from user-controlled pushName values.
   const dmSenderPrefix =
     params.msg.chatType !== "group"
-      ? `[${params.msg.senderName || params.msg.from || "Unknown"}]: `
+      ? (() => {
+          const rawName = params.msg.fromMe
+            ? (params.msg.senderName || params.msg.selfE164 || "Me")
+            : (params.msg.senderName || params.msg.from || "Unknown");
+          const safeName = rawName.replace(/[\[\]\r\n]/g, "").replace(/\s+/g, " ").trim() || "Unknown";
+          return `[${safeName}]: `;
+        })()
       : "";
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,


### PR DESCRIPTION
## Summary

- Add `[SenderName]: ` prefix to `BodyForAgent` for WhatsApp DM messages
- Lets the LLM distinguish who said what in DM conversations
- Group messages unaffected (already have sender attribution)

## Motivation

In DM conversations, `BodyForAgent` (what the LLM receives) contains raw message text with no sender identification. When the agent sees both sides of a conversation (requires #33479), messages appear as an undifferentiated stream:

```
Hey, are you free tonight?
Yes, I'll be there at 8
Great, see you then!
```

With this change, the LLM sees:
```
[Alice]: Hey, are you free tonight?
[Bob]: Yes, I'll be there at 8
[Alice]: Great, see you then!
```

### Note on `Body` vs `BodyForAgent`

`formatInboundEnvelope` already handles `fromMe` in `Body` (added in a recent commit), but since `BodyForAgent` is what the LLM actually receives, the sender prefix needs to be applied there as well. This PR addresses the `BodyForAgent` side.

## Changes

`src/web/auto-reply/monitor/process-message.ts`: Add `dmSenderPrefix` using `msg.senderName` (from WhatsApp `pushName`) with fallback to `msg.from` (phone number) or `"Unknown"`.

## Test plan

- [ ] Send a message as the owner in a DM → LLM should see `[OwnerName]: message`
- [ ] Receive a message from a contact in DM → LLM should see `[ContactName]: message`
- [ ] Group messages → no prefix added (unchanged behavior)
- [ ] Contact without pushName → falls back to phone number

## Related

- Depends on #33479 (outbound DM passthrough) for full bidirectional context
- Closes #32954

🤖 Generated with [Claude Code](https://claude.com/claude-code)