### PR TITLE
fix(agents): expand tilde in tool file paths

### DIFF
--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -160,10 +160,14 @@ export function resolveWorkdir(workdir: string, warnings: string[]) {
   const current = safeCwd();
   const fallback = current ?? homedir();
   try {
-    const expanded = path.resolve(expandHomePrefix(workdir, { home: homedir() }));
-    const stats = statSync(expanded);
+    const expanded = expandHomePrefix(workdir, { home: homedir() });
+    const resolved = path.resolve(expanded);
+    const stats = statSync(resolved);
     if (stats.isDirectory()) {
-      return expanded;
+      // Only return the absolute path when tilde was actually expanded;
+      // otherwise preserve the original value so relative workdirs (e.g. ".")
+      // stay relative for node-host exec, which forwards cwd to remote nodes.
+      return expanded !== workdir ? resolved : workdir;
     }
   } catch {
     // ignore — path.resolve can throw ENOENT if cwd is gone and workdir is relative

--- a/src/agents/bash-tools.shared.ts
+++ b/src/agents/bash-tools.shared.ts
@@ -2,6 +2,7 @@ import { existsSync, statSync } from "node:fs";
 import fs from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
+import { expandHomePrefix } from "../infra/home-dir.js";
 import { sliceUtf16Safe } from "../utils.js";
 import { assertSandboxPath } from "./sandbox-paths.js";
 
@@ -159,12 +160,13 @@ export function resolveWorkdir(workdir: string, warnings: string[]) {
   const current = safeCwd();
   const fallback = current ?? homedir();
   try {
-    const stats = statSync(workdir);
+    const expanded = path.resolve(expandHomePrefix(workdir, { home: homedir() }));
+    const stats = statSync(expanded);
     if (stats.isDirectory()) {
-      return workdir;
+      return expanded;
     }
   } catch {
-    // ignore, fallback below
+    // ignore — path.resolve can throw ENOENT if cwd is gone and workdir is relative
   }
   warnings.push(`Warning: workdir "${workdir}" is unavailable; using "${fallback}".`);
   return fallback;

--- a/src/agents/pi-tools.read.tilde-expansion.test.ts
+++ b/src/agents/pi-tools.read.tilde-expansion.test.ts
@@ -1,0 +1,217 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveWorkdir } from "./bash-tools.shared.js";
+
+type WriteOps = {
+  mkdir: (dir: string) => Promise<void>;
+  writeFile: (absolutePath: string, content: string) => Promise<void>;
+};
+type EditOps = {
+  readFile: (absolutePath: string) => Promise<Buffer>;
+  writeFile: (absolutePath: string, content: string) => Promise<void>;
+  access: (absolutePath: string) => Promise<void>;
+};
+
+const captured = vi.hoisted(() => ({
+  writeOps: undefined as WriteOps | undefined,
+  editOps: undefined as EditOps | undefined,
+}));
+
+vi.mock("@mariozechner/pi-coding-agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mariozechner/pi-coding-agent")>();
+  return {
+    ...actual,
+    createWriteTool: (_cwd: string, options?: { operations?: WriteOps }) => {
+      captured.writeOps = options?.operations;
+      return {
+        name: "write",
+        description: "test write tool",
+        parameters: { type: "object", properties: {} },
+        execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+      };
+    },
+    createEditTool: (_cwd: string, options?: { operations?: EditOps }) => {
+      captured.editOps = options?.operations;
+      return {
+        name: "edit",
+        description: "test edit tool",
+        parameters: { type: "object", properties: {} },
+        execute: async () => ({ content: [{ type: "text" as const, text: "ok" }] }),
+      };
+    },
+  };
+});
+
+const { createHostWorkspaceWriteTool, createHostWorkspaceEditTool } =
+  await import("./pi-tools.read.js");
+
+describe("tilde expansion in tool path resolution", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-tilde-test-"));
+  });
+
+  afterEach(async () => {
+    captured.writeOps = undefined;
+    captured.editOps = undefined;
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  describe("host-wide write (workspaceOnly=false)", () => {
+    it("expands ~ in writeFile path", async () => {
+      const home = os.homedir();
+      const fileName = `.openclaw-tilde-test-${Date.now()}.tmp`;
+      const testFile = path.join(home, fileName);
+
+      createHostWorkspaceWriteTool(tmpDir, { workspaceOnly: false });
+      expect(captured.writeOps).toBeDefined();
+
+      try {
+        await captured.writeOps!.writeFile(`~/${fileName}`, "hello");
+        const content = await fs.readFile(testFile, "utf-8");
+        expect(content).toBe("hello");
+      } finally {
+        await fs.rm(testFile, { force: true }).catch(() => {});
+      }
+    });
+
+    it("expands ~ in mkdir path", async () => {
+      const dirName = `.openclaw-tilde-mkdir-test-${Date.now()}`;
+      const home = os.homedir();
+      const expected = path.join(home, dirName);
+
+      createHostWorkspaceWriteTool(tmpDir, { workspaceOnly: false });
+      expect(captured.writeOps).toBeDefined();
+
+      try {
+        await captured.writeOps!.mkdir(`~/${dirName}`);
+        const stat = await fs.stat(expected);
+        expect(stat.isDirectory()).toBe(true);
+      } finally {
+        await fs.rm(expected, { recursive: true, force: true }).catch(() => {});
+      }
+    });
+  });
+
+  describe("host-wide edit (workspaceOnly=false)", () => {
+    it("expands ~ in readFile path", async () => {
+      const fileName = `.openclaw-tilde-read-test-${Date.now()}.tmp`;
+      const home = os.homedir();
+      const filePath = path.join(home, fileName);
+
+      await fs.writeFile(filePath, "tilde-test-content", "utf-8");
+
+      createHostWorkspaceEditTool(tmpDir, { workspaceOnly: false });
+      expect(captured.editOps).toBeDefined();
+
+      try {
+        const content = await captured.editOps!.readFile(`~/${fileName}`);
+        expect(content.toString()).toBe("tilde-test-content");
+      } finally {
+        await fs.rm(filePath, { force: true }).catch(() => {});
+      }
+    });
+
+    it("expands ~ in access check", async () => {
+      const fileName = `.openclaw-tilde-access-test-${Date.now()}.tmp`;
+      const home = os.homedir();
+      const filePath = path.join(home, fileName);
+
+      await fs.writeFile(filePath, "exists", "utf-8");
+
+      createHostWorkspaceEditTool(tmpDir, { workspaceOnly: false });
+      expect(captured.editOps).toBeDefined();
+
+      try {
+        // Should not throw — file exists at expanded ~ path.
+        await captured.editOps!.access(`~/${fileName}`);
+      } finally {
+        await fs.rm(filePath, { force: true }).catch(() => {});
+      }
+    });
+  });
+
+  describe("workspace-mode (workspaceOnly=true)", () => {
+    it("rejects ~ paths that resolve outside workspace root", async () => {
+      createHostWorkspaceWriteTool(tmpDir, { workspaceOnly: true });
+      expect(captured.writeOps).toBeDefined();
+
+      // ~ expands to home dir which is outside tmpDir workspace
+      await expect(captured.writeOps!.writeFile("~/outside.txt", "data")).rejects.toThrow(
+        /escapes workspace root/i,
+      );
+    });
+
+    it("accepts ~ paths when workspace root is under home", async () => {
+      const home = os.homedir();
+      const workspaceInHome = path.join(home, `.openclaw-tilde-ws-${Date.now()}`);
+      await fs.mkdir(workspaceInHome, { recursive: true });
+
+      createHostWorkspaceEditTool(workspaceInHome, { workspaceOnly: true });
+      expect(captured.editOps).toBeDefined();
+
+      const testFile = path.join(workspaceInHome, "test.txt");
+      await fs.writeFile(testFile, "in-workspace", "utf-8");
+
+      try {
+        // ~/.<workspace-name>/test.txt should resolve inside the workspace
+        const wsBasename = path.basename(workspaceInHome);
+        const content = await captured.editOps!.readFile(`~/${wsBasename}/test.txt`);
+        expect(content.toString()).toBe("in-workspace");
+      } finally {
+        await fs.rm(workspaceInHome, { recursive: true, force: true }).catch(() => {});
+      }
+    });
+  });
+
+  describe("paths without tilde are unaffected", () => {
+    it("resolves absolute paths normally", async () => {
+      const testFile = path.join(tmpDir, "absolute.txt");
+      await fs.writeFile(testFile, "absolute-content", "utf-8");
+
+      createHostWorkspaceEditTool(tmpDir, { workspaceOnly: false });
+      expect(captured.editOps).toBeDefined();
+
+      const content = await captured.editOps!.readFile(testFile);
+      expect(content.toString()).toBe("absolute-content");
+    });
+  });
+
+  describe("exec/bash workdir tilde expansion", () => {
+    it("resolves ~ workdir to home directory", () => {
+      const warnings: string[] = [];
+      const result = resolveWorkdir("~", warnings);
+      expect(result).toBe(os.homedir());
+      expect(warnings).toHaveLength(0);
+    });
+
+    it("resolves ~/subdir workdir to home subdirectory", async () => {
+      const dirName = `.openclaw-tilde-workdir-test-${Date.now()}`;
+      const expected = path.join(os.homedir(), dirName);
+      await fs.mkdir(expected, { recursive: true });
+
+      try {
+        const warnings: string[] = [];
+        const result = resolveWorkdir(`~/${dirName}`, warnings);
+        expect(result).toBe(expected);
+        expect(warnings).toHaveLength(0);
+      } finally {
+        await fs.rm(expected, { recursive: true, force: true }).catch(() => {});
+      }
+    });
+
+    it("falls back when ~ subdir does not exist", () => {
+      const warnings: string[] = [];
+      const result = resolveWorkdir("~/nonexistent-dir-that-should-not-exist-12345", warnings);
+      // Should fall back to cwd or homedir, with a warning
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toMatch(/unavailable/);
+      expect(result).not.toContain("~");
+    });
+  });
+});

--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
@@ -9,6 +10,7 @@ import {
   readFileWithinRoot,
   writeFileWithinRoot,
 } from "../infra/fs-safe.js";
+import { expandHomePrefix } from "../infra/home-dir.js";
 import { detectMime } from "../media/mime.js";
 import { sniffMimeFromBase64 } from "../media/sniff-mime-from-base64.js";
 import type { ImageSanitizationLimits } from "./image-sanitization.js";
@@ -557,7 +559,7 @@ function createSandboxEditOperations(params: SandboxToolParams) {
 }
 
 async function writeHostFile(absolutePath: string, content: string) {
-  const resolved = path.resolve(absolutePath);
+  const resolved = path.resolve(expandHomePrefix(absolutePath, { home: os.homedir() }));
   await fs.mkdir(path.dirname(resolved), { recursive: true });
   await fs.writeFile(resolved, content, "utf-8");
 }
@@ -569,7 +571,7 @@ function createHostWriteOperations(root: string, options?: { workspaceOnly?: boo
     // When workspaceOnly is false, allow writes anywhere on the host
     return {
       mkdir: async (dir: string) => {
-        const resolved = path.resolve(dir);
+        const resolved = path.resolve(expandHomePrefix(dir, { home: os.homedir() }));
         await fs.mkdir(resolved, { recursive: true });
       },
       writeFile: writeHostFile,
@@ -603,12 +605,12 @@ function createHostEditOperations(root: string, options?: { workspaceOnly?: bool
     // When workspaceOnly is false, allow edits anywhere on the host
     return {
       readFile: async (absolutePath: string) => {
-        const resolved = path.resolve(absolutePath);
+        const resolved = path.resolve(expandHomePrefix(absolutePath, { home: os.homedir() }));
         return await fs.readFile(resolved);
       },
       writeFile: writeHostFile,
       access: async (absolutePath: string) => {
-        const resolved = path.resolve(absolutePath);
+        const resolved = path.resolve(expandHomePrefix(absolutePath, { home: os.homedir() }));
         await fs.access(resolved);
       },
     } as const;

--- a/src/agents/sandbox/fs-paths.test.ts
+++ b/src/agents/sandbox/fs-paths.test.ts
@@ -1,3 +1,4 @@
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -43,6 +44,20 @@ describe("parseSandboxBindMount", () => {
     expect(parseSandboxBindMount("//server/share:/workspace:ro")).toEqual({
       hostRoot: path.resolve("//server/share"),
       containerRoot: "/workspace",
+      writable: false,
+    });
+  });
+
+  it("expands ~ in host path of bind spec", () => {
+    const home = os.homedir();
+    expect(parseSandboxBindMount("~/mydata:/data:rw")).toEqual({
+      hostRoot: path.resolve(path.join(home, "mydata")),
+      containerRoot: "/data",
+      writable: true,
+    });
+    expect(parseSandboxBindMount("~:/home-mount:ro")).toEqual({
+      hostRoot: path.resolve(home),
+      containerRoot: "/home-mount",
       writable: false,
     });
   });

--- a/src/agents/sandbox/fs-paths.ts
+++ b/src/agents/sandbox/fs-paths.ts
@@ -1,4 +1,6 @@
+import os from "node:os";
 import path from "node:path";
+import { expandHomePrefix } from "../../infra/home-dir.js";
 import { resolveSandboxInputPath, resolveSandboxPath } from "../sandbox-paths.js";
 import { splitSandboxBindSpec } from "./bind-spec.js";
 import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
@@ -51,7 +53,7 @@ export function parseSandboxBindMount(spec: string): ParsedBindMount | null {
     : [];
   const writable = !optionParts.includes("ro");
   return {
-    hostRoot: path.resolve(hostToken),
+    hostRoot: path.resolve(expandHomePrefix(hostToken, { home: os.homedir() })),
     containerRoot: normalizeContainerPath(containerToken),
     writable,
   };

--- a/src/infra/fs-safe.test.ts
+++ b/src/infra/fs-safe.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -476,7 +477,7 @@ describe("tilde expansion in file tools", () => {
   it("expandHomePrefix respects process.env.HOME changes", async () => {
     const { expandHomePrefix } = await import("./home-dir.js");
     const originalHome = process.env.HOME;
-    const fakeHome = path.resolve(path.sep, "tmp", "fake-home-test");
+    const fakeHome = path.resolve(os.tmpdir(), "fake-home-test");
     process.env.HOME = fakeHome;
     try {
       const result = expandHomePrefix("~/file.txt");


### PR DESCRIPTION
## Summary

- `path.resolve("~/file.txt")` treats `~` as a literal directory name, resolving to `<cwd>/~/file.txt` instead of `/home/user/file.txt`
- Add `expandHomePrefix(..., { home: os.homedir() })` before `path.resolve()` at all affected tool path resolution points, ensuring `~` always expands to the real OS home (not `OPENCLAW_HOME`)
- Fix a pre-existing Windows CI failure in `fs-safe.test.ts` where a hardcoded Unix path `/tmp/fake-home-test` broke on Windows

This is a rebase of #30866 which was closed as a duplicate of #30431, but the two PRs have significantly different scope (see comparison below).

## Why this is not a duplicate of #30431

| Aspect | #30431 | This PR |
|--------|--------|---------|
| Files changed | 2 | 6 |
| Path resolution points fixed | 1 (`normalizeToolParams` only) | 5 distinct call sites |
| `writeHostFile` (host write) | Not fixed | Fixed |
| `readFile` / `access` (host edit) | Not fixed | Fixed (already on main via earlier merge) |
| `resolveWorkdir()` (bash/exec cwd) | Not fixed | Fixed |
| `parseSandboxBindMount()` (Docker bind mounts) | Not fixed | Fixed |
| Workspace boundary (`toRelativeWorkspacePath`) | Not fixed | Covered (main now handles via `expandPath`) |
| Test cases | 1 | 11 |
| Windows CI fix | No | Yes (`os.tmpdir()` instead of hardcoded `/tmp`) |
| Closes issue | #30335 | #30669 |

#30431 only adds tilde expansion in `normalizeToolParams`, which handles the `path` parameter normalization for read/write/edit tool inputs. However, several other code paths resolve file paths independently of `normalizeToolParams`:

1. **`writeHostFile()`** — the shared host write helper uses `path.resolve()` directly without tilde expansion
2. **`resolveWorkdir()`** in `bash-tools.shared.ts` — the working directory for exec/bash tools bypasses `normalizeToolParams` entirely
3. **`parseSandboxBindMount()`** in `sandbox/fs-paths.ts` — Docker bind mount host paths like `~/mydata:/data:rw` are parsed separately

These three paths would remain broken with only #30431 merged.

## Path resolution points covered

| Tool path | Status |
|---|---|
| `writeHostFile()` shared write helper | Fixed |
| Host write `mkdir` non-workspace | Fixed |
| Host edit `readFile` / `access` non-workspace | Fixed |
| `toRelativeWorkspacePath()` workspace boundary | Covered by main's `expandPath()` |
| `resolveWorkdir()` non-sandbox exec/bash workdir | Fixed |
| `parseSandboxBindMount()` Docker bind mount host path | Fixed |
| Host read tool | Already handled by upstream `expandPath()` |
| Sandbox read/write/edit | Already handled by upstream `expandPath()` |

## Test plan

- [x] Host-wide write with `~` path creates file in home directory
- [x] Host-wide write `mkdir` with `~` creates directory in home
- [x] Host-wide edit `readFile` with `~` reads from home
- [x] Host-wide edit `access` with `~` checks home path
- [x] Workspace-mode rejects `~` paths outside workspace root
- [x] Workspace-mode accepts `~` paths inside workspace root
- [x] Absolute paths without tilde are unaffected
- [x] `resolveWorkdir("~")` returns home directory
- [x] `resolveWorkdir("~/subdir")` returns home subdirectory
- [x] `resolveWorkdir` falls back with warning for nonexistent `~` subdir
- [x] `parseSandboxBindMount("~/mydata:/data:rw")` expands host path
- [x] `expandHomePrefix` test uses platform-correct paths (Windows CI fix)

Closes #30669
Related: #30782, #30788, #30744, #30770, #30756, #30753, #30752, #30747