### PR TITLE
feat(mattermost): block streaming edit-in-place (rebased)

### DIFF
--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -580,3 +580,48 @@ export async function uploadMattermostFile(
   }
   return info;
 }
+
+/**
+ * Update an existing Mattermost post (partial patch).
+ * Requires edit_post (own) or edit_others_posts permission.
+ */
+export async function patchMattermostPost(
+  client: MattermostClient,
+  params: { postId: string; message: string },
+): Promise<void> {
+  const res = await fetch(`${client.apiBaseUrl}/posts/${params.postId}/patch`, {
+    method: "PUT",
+    headers: {
+      Authorization: `Bearer ${client.token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ message: params.message }),
+  });
+  if (!res.ok) {
+    const detail = await readMattermostError(res);
+    throw new Error(
+      `Mattermost patch post ${res.status} ${res.statusText}: ${detail || "unknown error"}`,
+    );
+  }
+}
+
+/**
+ * Delete a Mattermost post (soft delete).
+ */
+export async function deleteMattermostPost(
+  client: MattermostClient,
+  postId: string,
+): Promise<void> {
+  const res = await fetch(`${client.apiBaseUrl}/posts/${postId}`, {
+    method: "DELETE",
+    headers: {
+      Authorization: `Bearer ${client.token}`,
+    },
+  });
+  if (!res.ok) {
+    const detail = await readMattermostError(res);
+    throw new Error(
+      `Mattermost delete post ${res.status} ${res.statusText}: ${detail || "unknown error"}`,
+    );
+  }
+}

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -589,20 +589,10 @@ export async function patchMattermostPost(
   client: MattermostClient,
   params: { postId: string; message: string },
 ): Promise<void> {
-  const res = await fetch(`${client.apiBaseUrl}/posts/${params.postId}/patch`, {
+  await client.request<void>(`/posts/${params.postId}/patch`, {
     method: "PUT",
-    headers: {
-      Authorization: `Bearer ${client.token}`,
-      "Content-Type": "application/json",
-    },
     body: JSON.stringify({ message: params.message }),
   });
-  if (!res.ok) {
-    const detail = await readMattermostError(res);
-    throw new Error(
-      `Mattermost patch post ${res.status} ${res.statusText}: ${detail || "unknown error"}`,
-    );
-  }
 }
 
 /**
@@ -612,16 +602,7 @@ export async function deleteMattermostPost(
   client: MattermostClient,
   postId: string,
 ): Promise<void> {
-  const res = await fetch(`${client.apiBaseUrl}/posts/${postId}`, {
+  await client.request<void>(`/posts/${postId}`, {
     method: "DELETE",
-    headers: {
-      Authorization: `Bearer ${client.token}`,
-    },
   });
-  if (!res.ok) {
-    const detail = await readMattermostError(res);
-    throw new Error(
-      `Mattermost delete post ${res.status} ${res.statusText}: ${detail || "unknown error"}`,
-    );
-  }
 }

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -587,11 +587,12 @@ export async function uploadMattermostFile(
  */
 export async function patchMattermostPost(
   client: MattermostClient,
-  params: { postId: string; message: string },
+  params: { postId: string; message: string; signal?: AbortSignal },
 ): Promise<void> {
   await client.request<void>(`/posts/${params.postId}/patch`, {
     method: "PUT",
     body: JSON.stringify({ message: params.message }),
+    signal: params.signal,
   });
 }
 

--- a/extensions/mattermost/src/mattermost/client.ts
+++ b/extensions/mattermost/src/mattermost/client.ts
@@ -487,6 +487,7 @@ export async function createMattermostPost(
     rootId?: string;
     fileIds?: string[];
     props?: Record<string, unknown>;
+    signal?: AbortSignal;
   },
 ): Promise<MattermostPost> {
   const payload: Record<string, unknown> = {
@@ -505,6 +506,7 @@ export async function createMattermostPost(
   return await client.request<MattermostPost>("/posts", {
     method: "POST",
     body: JSON.stringify(payload),
+    signal: params.signal,
   });
 }
 

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1583,12 +1583,21 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
 
           // Compute reply target divergence before flushing, so we don't
           // accidentally create a preview post in the wrong thread on flush.
+          // Compute the reply target for this payload. When payload.replyToId is set
+          // and resolves to a different thread than the one the streaming preview was
+          // created in (effectiveReplyToId), we must not patch the preview in-place.
+          // We compare the raw payload.replyToId against effectiveReplyToId directly
+          // instead of going through resolveMattermostReplyRootId(), because that
+          // helper always returns threadRootId when set, making the comparison always
+          // false when effectiveReplyToId is non-empty (ID=2965349638).
           const finalReplyToId = resolveMattermostReplyRootId({
             threadRootId: effectiveReplyToId,
             replyToId: payload.replyToId,
           });
           const replyTargetDiverged =
-            finalReplyToId !== effectiveReplyToId && payload.replyToId != null;
+            payload.replyToId != null &&
+            payload.replyToId.trim() !== "" &&
+            payload.replyToId.trim() !== effectiveReplyToId;
 
           if (isFinal && blockStreamingClient) {
             if (replyTargetDiverged) {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1544,6 +1544,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 runtime.log?.(`stream-patch edited ${streamMessageId}`);
               } catch (err) {
                 logVerboseMessage(`mattermost stream-patch edit failed: ${String(err)}`);
+                // Stop retrying on patch failure — the post may not be editable
+                // (missing edit_post permission, deleted, etc.). The preview stays
+                // frozen; final delivery will patch or replace it via deliver().
+                stopPatchInterval();
               }
             }
           } finally {
@@ -1571,10 +1575,22 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           const replyTargetDiverged =
             finalReplyToId !== effectiveReplyToId && payload.replyToId != null;
 
-          // Flush any pending partial-reply patch before final delivery —
-          // but only when the reply stays in the same thread as the preview post.
-          if (isFinal && blockStreamingClient && !replyTargetDiverged) {
-            await flushPendingPatch();
+          if (isFinal && blockStreamingClient) {
+            if (replyTargetDiverged) {
+              // Divergent target: don't flush (we don't want to create a preview in
+              // the wrong thread), but do stop the interval and wait for any in-flight
+              // tick/send to settle. This ensures streamMessageId is populated if the
+              // first sendMessageMattermost resolves during this window, so the orphan
+              // cleanup below can capture and delete it.
+              stopPatchInterval();
+              const deadline = Date.now() + 2000;
+              while (patchSending && Date.now() < deadline) {
+                await new Promise<void>((r) => setTimeout(r, 20));
+              }
+            } else {
+              // Same thread: flush pending patches normally.
+              await flushPendingPatch();
+            }
           }
 
           // Final + streaming active: patch the streamed message with authoritative

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1856,7 +1856,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             const orphanId = streamMessageId;
             streamMessageId = null;
             if (orphanId) {
-              await deleteMattermostPost(client, orphanId).catch(() => {
+              void deleteMattermostPost(client, orphanId).catch(() => {
                 // Best-effort — the run is already complete.
               });
             }

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1525,6 +1525,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           const sendPromise = sendMessageMattermost(to, text, {
             accountId: account.accountId,
             replyToId: effectiveReplyToId,
+            signal: flushAbortController.signal,
           });
           // Register in patchInflight so awaitInflightBounded can track it
           patchInflight = sendPromise;
@@ -1598,6 +1599,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 const result = await sendMessageMattermost(to, text, {
                   accountId: account.accountId,
                   replyToId: effectiveReplyToId,
+                  signal: ac.signal,
                 });
                 streamMessageId = result.messageId;
                 lastSentText = text;

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1470,14 +1470,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     const flushPendingPatch = async () => {
       stopPatchInterval();
       if (!blockStreamingClient) return;
-      // Wait for any in-flight interval tick to settle before flushing.
-      // Without this, an interval tick that set lastSentText synchronously but hasn't
-      // completed the async send yet would cause flushPendingPatch to exit early
-      // (text === lastSentText guard), leaving streamMessageId null and causing
-      // final delivery to fall through to a new post instead of patching in place.
-      const deadline = Date.now() + 2000;
-      while (patchSending && Date.now() < deadline) {
-        await new Promise<void>((r) => setTimeout(r, 20));
+      // Await the in-flight promise directly so we never miss a late-resolving
+      // POST/PATCH — the busy-wait on patchSending had a race where patchSending
+      // could clear before the network request settled (ID=2965256849).
+      if (patchInflight) {
+        await patchInflight.catch(() => {});
       }
       const rawText = pendingPatchText;
       if (!rawText) return;
@@ -1601,9 +1598,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               // first sendMessageMattermost resolves during this window, so the orphan
               // cleanup below can capture and delete it.
               stopPatchInterval();
-              const deadline = Date.now() + 2000;
-              while (patchSending && Date.now() < deadline) {
-                await new Promise<void>((r) => setTimeout(r, 20));
+              if (patchInflight) {
+                await patchInflight.catch(() => {});
               }
             } else {
               // Same thread: flush pending patches normally.

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1443,6 +1443,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     let lastSentText = "";
     let patchInterval: ReturnType<typeof setInterval> | null = null;
     let patchSending = false; // prevents concurrent network calls
+    // Tracks the currently in-flight sendMessageMattermost / patchMattermostPost
+    // promise so that onSettled can await it directly rather than busy-waiting.
+    let patchInflight: Promise<unknown> | null = null;
     // Latches true after the first send/edit failure to prevent the interval
     // from being re-armed by a later onPartialReply call (ID=2964357928).
     let previewSendFailed = false;
@@ -1525,7 +1528,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         // re-patching with the same truncated content every 200 ms and hit rate limits.
         if (text === lastSentText) return;
         patchSending = true;
-        void (async () => {
+        const runTick = async () => {
           try {
             if (!streamMessageId) {
               try {
@@ -1562,7 +1565,13 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           } finally {
             patchSending = false;
           }
-        })();
+        };
+        const inflightRun = runTick();
+        patchInflight = inflightRun;
+        inflightRun.finally(() => {
+          if (patchInflight === inflightRun) patchInflight = null;
+        });
+        void inflightRun;
       }, STREAM_PATCH_INTERVAL_MS);
     };
     // ── End P4 streaming state ────────────────────────────────────────────────
@@ -1754,10 +1763,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           lastSentText = "";
           const client = blockStreamingClient;
           void (async () => {
-            // Wait for any in-flight send/patch to settle so we get the final messageId.
-            const deadline = Date.now() + 3000;
-            while (patchSending && Date.now() < deadline) {
-              await new Promise((r) => setTimeout(r, 50));
+            // Await the in-flight promise directly so we never miss a late-resolving
+            // POST — a 3s timeout would race on slow Mattermost links (ID=2964616785).
+            if (patchInflight) {
+              await patchInflight.catch(() => {});
             }
             patchSending = false;
             const orphanId = streamMessageId;

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1738,16 +1738,31 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         // the reply pipeline produces no final payload (e.g. messaging-tool sends that
         // are suppressed, or empty/heartbeat responses). Without this, onPartialReply
         // can create a Mattermost post that is never deleted or patched with final text.
-        if (streamMessageId && blockStreamingClient) {
+        //
+        // We must also handle the race where the first preview POST is still in flight
+        // (patchSending=true, streamMessageId=null): stopPatchInterval() prevents new
+        // ticks, and the async cleanup waits for patchSending to clear so it can capture
+        // the messageId that the in-flight send will set.
+        if ((streamMessageId || patchSending) && blockStreamingClient) {
           stopPatchInterval();
-          const orphanId = streamMessageId;
-          streamMessageId = null;
           pendingPatchText = "";
           lastSentText = "";
-          patchSending = false;
-          void deleteMattermostPost(blockStreamingClient, orphanId).catch(() => {
-            // Best-effort — the run is already complete.
-          });
+          const client = blockStreamingClient;
+          void (async () => {
+            // Wait for any in-flight send/patch to settle so we get the final messageId.
+            const deadline = Date.now() + 3000;
+            while (patchSending && Date.now() < deadline) {
+              await new Promise((r) => setTimeout(r, 50));
+            }
+            patchSending = false;
+            const orphanId = streamMessageId;
+            streamMessageId = null;
+            if (orphanId) {
+              await deleteMattermostPost(client, orphanId).catch(() => {
+                // Best-effort — the run is already complete.
+              });
+            }
+          })();
         }
       },
       run: () =>

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -5,7 +5,10 @@ import {
   fetchMattermostChannel,
   fetchMattermostMe,
   fetchMattermostUser,
+  fetchMattermostUserTeams,
+  deleteMattermostPost,
   normalizeMattermostBaseUrl,
+  patchMattermostPost,
   sendMattermostTyping,
   updateMattermostPost,
   type MattermostChannel,
@@ -550,7 +553,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           replyOptions: {
             ...replyOptions,
             disableBlockStreaming:
-              typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
+              typeof account.blockStreaming === "boolean" ? !account.blockStreaming : false,
             onModelSelected,
           },
         });
@@ -763,7 +766,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           replyOptions: {
             ...replyOptions,
             disableBlockStreaming:
-              typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
+              typeof account.blockStreaming === "boolean" ? !account.blockStreaming : false,
             onModelSelected,
           },
         }),
@@ -1432,12 +1435,164 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         },
       },
     });
+    // ── P4: Edit-in-place streaming state ──────────────────────────────────────
+    // Uses onPartialReply (full cumulative text each tick) + 200ms throttled
+    // setInterval to progressively edit a single Mattermost post in-place.
+    let streamMessageId: string | null = null;
+    let pendingPatchText = "";
+    let lastSentText = "";
+    let patchInterval: ReturnType<typeof setInterval> | null = null;
+    let patchSending = false; // prevents concurrent network calls
+    const STREAM_PATCH_INTERVAL_MS = 200;
+
+    const streamingEnabled = account.blockStreaming !== false;
+    const blockStreamingClient =
+      streamingEnabled && baseUrl && botToken
+        ? createMattermostClient({ baseUrl, botToken })
+        : null;
+
+    const stopPatchInterval = () => {
+      if (patchInterval) {
+        clearInterval(patchInterval);
+        patchInterval = null;
+      }
+    };
+
+    const flushPendingPatch = async () => {
+      stopPatchInterval();
+      if (!blockStreamingClient) return;
+      const text = pendingPatchText;
+      if (!text || text === lastSentText) return;
+      lastSentText = text;
+      if (!streamMessageId) {
+        try {
+          const result = await sendMessageMattermost(to, text, {
+            accountId: account.accountId,
+            replyToId: effectiveReplyToId,
+          });
+          streamMessageId = result.messageId;
+          runtime.log?.(`stream-patch started ${streamMessageId}`);
+        } catch (err) {
+          logVerboseMessage(`mattermost stream-patch flush send failed: ${String(err)}`);
+        }
+      } else {
+        try {
+          await patchMattermostPost(blockStreamingClient, {
+            postId: streamMessageId,
+            message: text,
+          });
+          runtime.log?.(`stream-patch flushed ${streamMessageId}`);
+        } catch (err) {
+          logVerboseMessage(`mattermost stream-patch flush failed: ${String(err)}`);
+        }
+      }
+    };
+
+    const schedulePatch = (fullText: string) => {
+      if (!blockStreamingClient) return;
+      pendingPatchText = fullText;
+      if (patchInterval) return;
+      patchInterval = setInterval(() => {
+        const text = pendingPatchText;
+        if (!text || text === lastSentText || patchSending) return;
+        lastSentText = text;
+        patchSending = true;
+        void (async () => {
+          try {
+            if (!streamMessageId) {
+              try {
+                const result = await sendMessageMattermost(to, text, {
+                  accountId: account.accountId,
+                  replyToId: effectiveReplyToId,
+                });
+                streamMessageId = result.messageId;
+                runtime.log?.(`stream-patch started ${streamMessageId}`);
+              } catch (err) {
+                logVerboseMessage(`mattermost stream-patch send failed: ${String(err)}`);
+              }
+            } else {
+              try {
+                await patchMattermostPost(blockStreamingClient, {
+                  postId: streamMessageId,
+                  message: text,
+                });
+                runtime.log?.(`stream-patch edited ${streamMessageId}`);
+              } catch (err) {
+                logVerboseMessage(`mattermost stream-patch edit failed: ${String(err)}`);
+              }
+            }
+          } finally {
+            patchSending = false;
+          }
+        })();
+      }, STREAM_PATCH_INTERVAL_MS);
+    };
+    // ── End P4 streaming state ────────────────────────────────────────────────
+
     const { dispatcher, replyOptions, markDispatchIdle } =
       core.channel.reply.createReplyDispatcherWithTyping({
         ...replyPipeline,
         humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, route.agentId),
         typingCallbacks,
-        deliver: async (payload: ReplyPayload) => {
+        deliver: async (payload: ReplyPayload, info) => {
+          const isFinal = info.kind === "final";
+
+          // Flush any pending partial-reply patch before final delivery.
+          if (isFinal && blockStreamingClient) {
+            await flushPendingPatch();
+          }
+
+          // Final + streaming active: patch the streamed message with authoritative
+          // complete text, or fall back to a new message (with orphan cleanup).
+          if (isFinal && streamMessageId && payload.text) {
+            const text = core.channel.text.convertMarkdownTables(payload.text, tableMode);
+            try {
+              await patchMattermostPost(blockStreamingClient!, {
+                postId: streamMessageId,
+                message: text,
+              });
+              runtime.log?.(`stream-patch final edit ${streamMessageId}`);
+            } catch (err) {
+              logVerboseMessage(
+                `mattermost stream-patch final edit failed: ${String(err)}, sending new message`,
+              );
+              const orphanId = streamMessageId;
+              streamMessageId = null;
+              try {
+                await deleteMattermostPost(blockStreamingClient!, orphanId);
+              } catch {
+                // Ignore delete failure — delivering the complete message takes priority
+              }
+              await deliverMattermostReplyPayload({
+                core,
+                cfg,
+                payload,
+                to,
+                accountId: account.accountId,
+                agentId: route.agentId,
+                replyToId: resolveMattermostReplyRootId({
+                  threadRootId: effectiveReplyToId,
+                  replyToId: payload.replyToId,
+                }),
+                textLimit,
+                tableMode,
+                sendMessage: sendMessageMattermost,
+              });
+              return;
+            }
+            streamMessageId = null;
+            return;
+          }
+
+          if (isFinal) {
+            stopPatchInterval();
+            streamMessageId = null;
+            pendingPatchText = "";
+            lastSentText = "";
+            patchSending = false;
+          }
+
+          // Normal delivery — streaming not active or non-final partial.
           await deliverMattermostReplyPayload({
             core,
             cfg,
@@ -1472,8 +1627,22 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           dispatcher,
           replyOptions: {
             ...replyOptions,
-            disableBlockStreaming:
-              typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
+            // Use onPartialReply (full cumulative text) for edit-in-place streaming.
+            onPartialReply: blockStreamingClient
+              ? (payload: ReplyPayload) => {
+                  const rawText = payload.text ?? "";
+                  const fullText = core.channel.text.convertMarkdownTables(rawText, tableMode);
+                  if (fullText) {
+                    schedulePatch(fullText);
+                  }
+                }
+              : undefined,
+            // Disable core block streaming since we handle streaming via onPartialReply.
+            disableBlockStreaming: blockStreamingClient
+              ? true
+              : typeof account.blockStreaming === "boolean"
+                ? !account.blockStreaming
+                : false,
             onModelSelected,
           },
         }),

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1512,6 +1512,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       // Bound flush requests so a stalled Mattermost API cannot block
       // final delivery forever (ID=2978002394).
       const FLUSH_TIMEOUT_MS = 8_000;
+      const flushAbortController = new AbortController();
       const flushTimeout = new Promise<"timeout">((r) =>
         setTimeout(() => r("timeout"), FLUSH_TIMEOUT_MS),
       );
@@ -1521,9 +1522,17 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             accountId: account.accountId,
             replyToId: effectiveReplyToId,
           });
+          // Register in patchInflight so awaitInflightBounded can track it
+          patchInflight = sendPromise;
+          patchAbortController = flushAbortController;
+          sendPromise.finally(() => {
+            if (patchInflight === sendPromise) patchInflight = null;
+            if (patchAbortController === flushAbortController) patchAbortController = null;
+          });
           const raceResult = await Promise.race([sendPromise, flushTimeout]);
           if (raceResult === "timeout") {
             logVerboseMessage("mattermost stream-patch flush send timed out, skipping preview");
+            flushAbortController.abort();
             return;
           }
           const result = raceResult;
@@ -1538,10 +1547,19 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           const patchPromise = patchMattermostPost(blockStreamingClient, {
             postId: streamMessageId,
             message: text,
+            signal: flushAbortController.signal,
+          });
+          // Register in patchInflight so awaitInflightBounded can track it
+          patchInflight = patchPromise;
+          patchAbortController = flushAbortController;
+          patchPromise.finally(() => {
+            if (patchInflight === patchPromise) patchInflight = null;
+            if (patchAbortController === flushAbortController) patchAbortController = null;
           });
           const raceResult = await Promise.race([patchPromise, flushTimeout]);
           if (raceResult === "timeout") {
             logVerboseMessage("mattermost stream-patch flush patch timed out, skipping");
+            flushAbortController.abort();
             return;
           }
           lastSentText = text;

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1562,23 +1562,24 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         deliver: async (payload: ReplyPayload, info) => {
           const isFinal = info.kind === "final";
 
-          // Flush any pending partial-reply patch before final delivery.
-          if (isFinal && blockStreamingClient) {
+          // Compute reply target divergence before flushing, so we don't
+          // accidentally create a preview post in the wrong thread on flush.
+          const finalReplyToId = resolveMattermostReplyRootId({
+            threadRootId: effectiveReplyToId,
+            replyToId: payload.replyToId,
+          });
+          const replyTargetDiverged =
+            finalReplyToId !== effectiveReplyToId && payload.replyToId != null;
+
+          // Flush any pending partial-reply patch before final delivery —
+          // but only when the reply stays in the same thread as the preview post.
+          if (isFinal && blockStreamingClient && !replyTargetDiverged) {
             await flushPendingPatch();
           }
 
           // Final + streaming active: patch the streamed message with authoritative
           // complete text, or fall back to a new message (with orphan cleanup).
-          // If the final payload carries an explicit replyToId that differs from
-          // the one the streaming post was created under, skip the in-place patch
-          // and fall through to normal delivery so the reply lands in the right thread.
-          const finalReplyToId = resolveMattermostReplyRootId({
-            threadRootId: effectiveReplyToId,
-            replyToId: payload.replyToId,
-          });
-          const streamReplyToId = effectiveReplyToId;
-          const replyTargetDiverged =
-            finalReplyToId !== streamReplyToId && payload.replyToId != null;
+          // (When replyTargetDiverged the preview is cleaned up further below.)
           if (isFinal && streamMessageId && payload.text && !replyTargetDiverged) {
             const text = core.channel.text.convertMarkdownTables(payload.text, tableMode);
             try {
@@ -1630,22 +1631,39 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
 
           if (isFinal) {
             stopPatchInterval();
-            // If the reply target diverged and we have an orphaned stream post,
-            // attempt to delete it before normal delivery creates the correct post.
-            if (replyTargetDiverged && streamMessageId) {
-              const orphanId = streamMessageId;
-              streamMessageId = null;
-              try {
-                await deleteMattermostPost(blockStreamingClient!, orphanId);
-              } catch {
-                // Ignore — delivering to the correct thread takes priority.
-              }
-            } else {
-              streamMessageId = null;
-            }
+            // Capture and clear the stream ID so normal delivery below can proceed.
+            // If the reply target diverged we hold the orphan ID and delete it
+            // *after* the replacement message is successfully sent (see below).
+            const orphanedStreamId = replyTargetDiverged ? streamMessageId : null;
+            streamMessageId = null;
             pendingPatchText = "";
             lastSentText = "";
             patchSending = false;
+
+            if (!orphanedStreamId) {
+              // No divergence — fall through to normal delivery.
+            } else {
+              // Divergent target: deliver to the correct thread first, then clean
+              // up the orphan. If delivery fails the user keeps the partial preview.
+              await deliverMattermostReplyPayload({
+                core,
+                cfg,
+                payload,
+                to,
+                accountId: account.accountId,
+                agentId: route.agentId,
+                replyToId: finalReplyToId,
+                textLimit,
+                tableMode,
+                sendMessage: sendMessageMattermost,
+              });
+              try {
+                await deleteMattermostPost(blockStreamingClient!, orphanedStreamId);
+              } catch {
+                // Ignore — the complete message was already delivered.
+              }
+              return;
+            }
           }
 
           // Normal delivery — streaming not active or non-final partial.
@@ -1698,7 +1716,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               ? true
               : typeof account.blockStreaming === "boolean"
                 ? !account.blockStreaming
-                : false,
+                : undefined,
             onModelSelected,
           },
         }),

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1461,9 +1461,17 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     const flushPendingPatch = async () => {
       stopPatchInterval();
       if (!blockStreamingClient) return;
+      // Wait for any in-flight interval tick to settle before flushing.
+      // Without this, an interval tick that set lastSentText synchronously but hasn't
+      // completed the async send yet would cause flushPendingPatch to exit early
+      // (text === lastSentText guard), leaving streamMessageId null and causing
+      // final delivery to fall through to a new post instead of patching in place.
+      const deadline = Date.now() + 2000;
+      while (patchSending && Date.now() < deadline) {
+        await new Promise<void>((r) => setTimeout(r, 20));
+      }
       const text = pendingPatchText;
       if (!text || text === lastSentText) return;
-      lastSentText = text;
       if (!streamMessageId) {
         try {
           const result = await sendMessageMattermost(to, text, {
@@ -1471,6 +1479,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             replyToId: effectiveReplyToId,
           });
           streamMessageId = result.messageId;
+          lastSentText = text;
           runtime.log?.(`stream-patch started ${streamMessageId}`);
         } catch (err) {
           logVerboseMessage(`mattermost stream-patch flush send failed: ${String(err)}`);
@@ -1481,6 +1490,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             postId: streamMessageId,
             message: text,
           });
+          lastSentText = text;
           runtime.log?.(`stream-patch flushed ${streamMessageId}`);
         } catch (err) {
           logVerboseMessage(`mattermost stream-patch flush failed: ${String(err)}`);
@@ -1495,7 +1505,6 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       patchInterval = setInterval(() => {
         const text = pendingPatchText;
         if (!text || text === lastSentText || patchSending) return;
-        lastSentText = text;
         patchSending = true;
         void (async () => {
           try {
@@ -1506,6 +1515,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   replyToId: effectiveReplyToId,
                 });
                 streamMessageId = result.messageId;
+                lastSentText = text;
                 runtime.log?.(`stream-patch started ${streamMessageId}`);
               } catch (err) {
                 logVerboseMessage(`mattermost stream-patch send failed: ${String(err)}`);
@@ -1516,6 +1526,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   postId: streamMessageId,
                   message: text,
                 });
+                lastSentText = text;
                 runtime.log?.(`stream-patch edited ${streamMessageId}`);
               } catch (err) {
                 logVerboseMessage(`mattermost stream-patch edit failed: ${String(err)}`);
@@ -1580,7 +1591,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               });
               return;
             }
+            // Successful final patch: reset all streaming state.
             streamMessageId = null;
+            pendingPatchText = "";
+            lastSentText = "";
+            patchSending = false;
             return;
           }
 

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1660,6 +1660,26 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             pendingPatchText = "";
             lastSentText = "";
             patchSending = false;
+            // If the payload also has media attachments, deliver them now via the
+            // normal path. The patch only updates text; deliverMattermostReplyPayload
+            // is the only code that actually uploads/sends media (ID=2965023940).
+            if (payload.mediaUrls?.length || payload.mediaUrl) {
+              await deliverMattermostReplyPayload({
+                core,
+                cfg,
+                payload: { ...payload, text: undefined },
+                to,
+                accountId: account.accountId,
+                agentId: route.agentId,
+                replyToId: resolveMattermostReplyRootId({
+                  threadRootId: effectiveReplyToId,
+                  replyToId: payload.replyToId,
+                }),
+                textLimit,
+                tableMode,
+                sendMessage: sendMessageMattermost,
+              });
+            }
             return;
           }
 

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1779,11 +1779,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 tableMode,
                 sendMessage: sendMessageMattermost,
               });
-              try {
-                await deleteMattermostPost(blockStreamingClient!, orphanedStreamId);
-              } catch {
-                // Ignore — the complete message was already delivered.
-              }
+              // Fire-and-forget: delivery already succeeded; don't block withReplyDispatcher.
+              void deleteMattermostPost(blockStreamingClient!, orphanedStreamId).catch(() => {});
               return;
             }
 
@@ -1803,11 +1800,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 tableMode,
                 sendMessage: sendMessageMattermost,
               });
-              try {
-                await deleteMattermostPost(blockStreamingClient!, orphanedStreamId);
-              } catch {
-                // Ignore — media was already delivered.
-              }
+              // Fire-and-forget: media delivery already succeeded; don't block withReplyDispatcher.
+              void deleteMattermostPost(blockStreamingClient!, orphanedStreamId).catch(() => {});
               return;
             }
             // Otherwise fall through to normal delivery.

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1460,7 +1460,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     const streamingEnabled = account.blockStreaming === true;
     const blockStreamingClient =
       streamingEnabled && baseUrl && botToken
-        ? createMattermostClient({ baseUrl, botToken })
+        ? createMattermostClient({
+            baseUrl,
+            botToken,
+            allowPrivateNetwork: account.config?.allowPrivateNetwork === true,
+          })
         : null;
 
     const INFLIGHT_TIMEOUT_MS = 10_000;

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1615,70 +1615,59 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           // complete text, or fall back to a new message (with orphan cleanup).
           // (When replyTargetDiverged the preview is cleaned up further below.)
           if (isFinal && streamMessageId && payload.text && !replyTargetDiverged) {
-            const text = core.channel.text.convertMarkdownTables(payload.text, tableMode);
-            try {
-              await patchMattermostPost(blockStreamingClient!, {
-                postId: streamMessageId,
-                message: text,
-              });
-              runtime.log?.(`stream-patch final edit ${streamMessageId}`);
-            } catch (err) {
-              logVerboseMessage(
-                `mattermost stream-patch final edit failed: ${String(err)}, sending new message`,
-              );
-              const orphanId = streamMessageId;
-              streamMessageId = null;
-              // Deliver the fallback message first. Only delete the orphaned
-              // stream post after we know the replacement was successfully sent —
-              // if delivery also fails the user keeps the partial preview rather
-              // than losing all visible output.
-              await deliverMattermostReplyPayload({
-                core,
-                cfg,
-                payload,
-                to,
-                accountId: account.accountId,
-                agentId: route.agentId,
-                replyToId: resolveMattermostReplyRootId({
-                  threadRootId: effectiveReplyToId,
-                  replyToId: payload.replyToId,
-                }),
-                textLimit,
-                tableMode,
-                sendMessage: sendMessageMattermost,
-              });
-              // Fallback succeeded — now clean up the orphaned partial.
+            const hasMedia = payload.mediaUrls?.length || payload.mediaUrl;
+            // When the payload also has media, skip the in-place patch: patching
+            // the preview with only the text and then posting captionless media
+            // separately splits a single captioned-file reply into two posts.
+            // Fall through to deliverMattermostReplyPayload which sends
+            // text+media together in the correct Mattermost format (ID=2965096969).
+            if (!hasMedia) {
+              const text = core.channel.text.convertMarkdownTables(payload.text, tableMode);
               try {
-                await deleteMattermostPost(blockStreamingClient!, orphanId);
-              } catch {
-                // Ignore — the complete message was already delivered.
+                await patchMattermostPost(blockStreamingClient!, {
+                  postId: streamMessageId,
+                  message: text,
+                });
+                runtime.log?.(`stream-patch final edit ${streamMessageId}`);
+                // Successful text-only patch. Reset streaming state and return.
+                streamMessageId = null;
+                pendingPatchText = "";
+                lastSentText = "";
+                patchSending = false;
+                return;
+              } catch (err) {
+                logVerboseMessage(
+                  `mattermost stream-patch final edit failed: ${String(err)}, sending new message`,
+                );
+                // Fall through to deliverMattermostReplyPayload below.
               }
-              return;
             }
-            // Successful final patch: reset all streaming state.
+            // Media payload or patch failure: deliver the full payload via the
+            // normal path (handles text+media together, chunking, etc.).
+            // Delete the preview only after successful delivery.
+            const orphanId = streamMessageId;
             streamMessageId = null;
             pendingPatchText = "";
             lastSentText = "";
             patchSending = false;
-            // If the payload also has media attachments, deliver them now via the
-            // normal path. The patch only updates text; deliverMattermostReplyPayload
-            // is the only code that actually uploads/sends media (ID=2965023940).
-            if (payload.mediaUrls?.length || payload.mediaUrl) {
-              await deliverMattermostReplyPayload({
-                core,
-                cfg,
-                payload: { ...payload, text: undefined },
-                to,
-                accountId: account.accountId,
-                agentId: route.agentId,
-                replyToId: resolveMattermostReplyRootId({
-                  threadRootId: effectiveReplyToId,
-                  replyToId: payload.replyToId,
-                }),
-                textLimit,
-                tableMode,
-                sendMessage: sendMessageMattermost,
-              });
+            await deliverMattermostReplyPayload({
+              core,
+              cfg,
+              payload,
+              to,
+              accountId: account.accountId,
+              agentId: route.agentId,
+              replyToId: resolveMattermostReplyRootId({
+                threadRootId: effectiveReplyToId,
+                replyToId: payload.replyToId,
+              }),
+              textLimit,
+              tableMode,
+              sendMessage: sendMessageMattermost,
+            });
+            // Delivery succeeded — clean up the orphaned preview.
+            if (orphanId) {
+              void deleteMattermostPost(blockStreamingClient!, orphanId).catch(() => {});
             }
             return;
           }

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1632,17 +1632,13 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           if (isFinal) {
             stopPatchInterval();
             // Capture and clear the stream ID so normal delivery below can proceed.
-            // If the reply target diverged we hold the orphan ID and delete it
-            // *after* the replacement message is successfully sent (see below).
-            const orphanedStreamId = replyTargetDiverged ? streamMessageId : null;
+            const orphanedStreamId = streamMessageId;
             streamMessageId = null;
             pendingPatchText = "";
             lastSentText = "";
             patchSending = false;
 
-            if (!orphanedStreamId) {
-              // No divergence — fall through to normal delivery.
-            } else {
+            if (replyTargetDiverged && orphanedStreamId) {
               // Divergent target: deliver to the correct thread first, then clean
               // up the orphan. If delivery fails the user keeps the partial preview.
               await deliverMattermostReplyPayload({
@@ -1664,6 +1660,31 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               }
               return;
             }
+
+            if (orphanedStreamId && !payload.text) {
+              // Media-only final with a streamed text-preview: deliver media first,
+              // then delete the orphaned preview so users don't see stale partial
+              // text alongside the attachment. If delivery fails, the preview stays.
+              await deliverMattermostReplyPayload({
+                core,
+                cfg,
+                payload,
+                to,
+                accountId: account.accountId,
+                agentId: route.agentId,
+                replyToId: finalReplyToId,
+                textLimit,
+                tableMode,
+                sendMessage: sendMessageMattermost,
+              });
+              try {
+                await deleteMattermostPost(blockStreamingClient!, orphanedStreamId);
+              } catch {
+                // Ignore — media was already delivered.
+              }
+              return;
+            }
+            // Otherwise fall through to normal delivery.
           }
 
           // Normal delivery — streaming not active or non-final partial.

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -553,7 +553,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           replyOptions: {
             ...replyOptions,
             disableBlockStreaming:
-              typeof account.blockStreaming === "boolean" ? !account.blockStreaming : false,
+              typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
             onModelSelected,
           },
         });
@@ -766,7 +766,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           replyOptions: {
             ...replyOptions,
             disableBlockStreaming:
-              typeof account.blockStreaming === "boolean" ? !account.blockStreaming : false,
+              typeof account.blockStreaming === "boolean" ? !account.blockStreaming : undefined,
             onModelSelected,
           },
         }),

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1445,7 +1445,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     let patchSending = false; // prevents concurrent network calls
     const STREAM_PATCH_INTERVAL_MS = 200;
 
-    const streamingEnabled = account.blockStreaming !== false;
+    // Edit-in-place streaming is opt-in: only activate when blockStreaming is
+    // explicitly true. When the config key is absent (undefined) we leave the
+    // agent's blockStreamingDefault in place and do not inject onPartialReply.
+    const streamingEnabled = account.blockStreaming === true;
     const blockStreamingClient =
       streamingEnabled && baseUrl && botToken
         ? createMattermostClient({ baseUrl, botToken })
@@ -1470,8 +1473,11 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       while (patchSending && Date.now() < deadline) {
         await new Promise<void>((r) => setTimeout(r, 20));
       }
-      const text = pendingPatchText;
-      if (!text || text === lastSentText) return;
+      const rawText = pendingPatchText;
+      if (!rawText || rawText === lastSentText) return;
+      // Truncate to textLimit so intermediate patches never exceed the server limit.
+      // Final delivery applies full chunking; streaming posts only need the first chunk.
+      const text = rawText.length > textLimit ? rawText.slice(0, textLimit) : rawText;
       if (!streamMessageId) {
         try {
           const result = await sendMessageMattermost(to, text, {
@@ -1479,7 +1485,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             replyToId: effectiveReplyToId,
           });
           streamMessageId = result.messageId;
-          lastSentText = text;
+          lastSentText = rawText;
           runtime.log?.(`stream-patch started ${streamMessageId}`);
         } catch (err) {
           logVerboseMessage(`mattermost stream-patch flush send failed: ${String(err)}`);
@@ -1490,7 +1496,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             postId: streamMessageId,
             message: text,
           });
-          lastSentText = text;
+          lastSentText = rawText;
           runtime.log?.(`stream-patch flushed ${streamMessageId}`);
         } catch (err) {
           logVerboseMessage(`mattermost stream-patch flush failed: ${String(err)}`);
@@ -1503,8 +1509,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       pendingPatchText = fullText;
       if (patchInterval) return;
       patchInterval = setInterval(() => {
-        const text = pendingPatchText;
-        if (!text || text === lastSentText || patchSending) return;
+        const rawText = pendingPatchText;
+        if (!rawText || rawText === lastSentText || patchSending) return;
+        // Truncate to textLimit so intermediate patches never exceed the server limit.
+        const text = rawText.length > textLimit ? rawText.slice(0, textLimit) : rawText;
         patchSending = true;
         void (async () => {
           try {
@@ -1515,7 +1523,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   replyToId: effectiveReplyToId,
                 });
                 streamMessageId = result.messageId;
-                lastSentText = text;
+                lastSentText = rawText;
                 runtime.log?.(`stream-patch started ${streamMessageId}`);
               } catch (err) {
                 logVerboseMessage(`mattermost stream-patch send failed: ${String(err)}`);
@@ -1526,7 +1534,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   postId: streamMessageId,
                   message: text,
                 });
-                lastSentText = text;
+                lastSentText = rawText;
                 runtime.log?.(`stream-patch edited ${streamMessageId}`);
               } catch (err) {
                 logVerboseMessage(`mattermost stream-patch edit failed: ${String(err)}`);
@@ -1555,7 +1563,17 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
 
           // Final + streaming active: patch the streamed message with authoritative
           // complete text, or fall back to a new message (with orphan cleanup).
-          if (isFinal && streamMessageId && payload.text) {
+          // If the final payload carries an explicit replyToId that differs from
+          // the one the streaming post was created under, skip the in-place patch
+          // and fall through to normal delivery so the reply lands in the right thread.
+          const finalReplyToId = resolveMattermostReplyRootId({
+            threadRootId: effectiveReplyToId,
+            replyToId: payload.replyToId,
+          });
+          const streamReplyToId = effectiveReplyToId;
+          const replyTargetDiverged =
+            finalReplyToId !== streamReplyToId && payload.replyToId != null;
+          if (isFinal && streamMessageId && payload.text && !replyTargetDiverged) {
             const text = core.channel.text.convertMarkdownTables(payload.text, tableMode);
             try {
               await patchMattermostPost(blockStreamingClient!, {
@@ -1601,7 +1619,19 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
 
           if (isFinal) {
             stopPatchInterval();
-            streamMessageId = null;
+            // If the reply target diverged and we have an orphaned stream post,
+            // attempt to delete it before normal delivery creates the correct post.
+            if (replyTargetDiverged && streamMessageId) {
+              const orphanId = streamMessageId;
+              streamMessageId = null;
+              try {
+                await deleteMattermostPost(blockStreamingClient!, orphanId);
+              } catch {
+                // Ignore — delivering to the correct thread takes priority.
+              }
+            } else {
+              streamMessageId = null;
+            }
             pendingPatchText = "";
             lastSentText = "";
             patchSending = false;

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1583,21 +1583,26 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
 
           // Compute reply target divergence before flushing, so we don't
           // accidentally create a preview post in the wrong thread on flush.
-          // Compute the reply target for this payload. When payload.replyToId is set
-          // and resolves to a different thread than the one the streaming preview was
-          // created in (effectiveReplyToId), we must not patch the preview in-place.
-          // We compare the raw payload.replyToId against effectiveReplyToId directly
-          // instead of going through resolveMattermostReplyRootId(), because that
-          // helper always returns threadRootId when set, making the comparison always
-          // false when effectiveReplyToId is non-empty (ID=2965349638).
+          // Compute the reply target for this payload. When payload.replyToId resolves
+          // to a different Mattermost thread root than effectiveReplyToId, we must not
+          // patch the preview in-place (different thread).
+          //
+          // Both sides go through resolveMattermostReplyRootId so that child-post IDs
+          // (e.g. from [[reply_to_current]] inside a thread) are normalized to the same
+          // thread root as effectiveReplyToId before comparing. Raw payload.replyToId
+          // comparison was wrong: [[reply_to_current]] sets a child-post id that differs
+          // from the thread root but resolves to the same thread (ID=2965488514).
           const finalReplyToId = resolveMattermostReplyRootId({
             threadRootId: effectiveReplyToId,
             replyToId: payload.replyToId,
           });
+          const baseReplyToId = resolveMattermostReplyRootId({
+            threadRootId: effectiveReplyToId,
+          });
           const replyTargetDiverged =
             payload.replyToId != null &&
             payload.replyToId.trim() !== "" &&
-            payload.replyToId.trim() !== effectiveReplyToId;
+            finalReplyToId !== baseReplyToId;
 
           if (isFinal && blockStreamingClient) {
             if (replyTargetDiverged) {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1474,10 +1474,13 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         await new Promise<void>((r) => setTimeout(r, 20));
       }
       const rawText = pendingPatchText;
-      if (!rawText || rawText === lastSentText) return;
+      if (!rawText) return;
       // Truncate to textLimit so intermediate patches never exceed the server limit.
       // Final delivery applies full chunking; streaming posts only need the first chunk.
       const text = rawText.length > textLimit ? rawText.slice(0, textLimit) : rawText;
+      // Guard on the truncated text so long replies (past textLimit) do not keep
+      // re-patching with the same truncated content every 200 ms and hit rate limits.
+      if (text === lastSentText) return;
       if (!streamMessageId) {
         try {
           const result = await sendMessageMattermost(to, text, {
@@ -1485,7 +1488,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             replyToId: effectiveReplyToId,
           });
           streamMessageId = result.messageId;
-          lastSentText = rawText;
+          lastSentText = text;
           runtime.log?.(`stream-patch started ${streamMessageId}`);
         } catch (err) {
           logVerboseMessage(`mattermost stream-patch flush send failed: ${String(err)}`);
@@ -1496,7 +1499,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             postId: streamMessageId,
             message: text,
           });
-          lastSentText = rawText;
+          lastSentText = text;
           runtime.log?.(`stream-patch flushed ${streamMessageId}`);
         } catch (err) {
           logVerboseMessage(`mattermost stream-patch flush failed: ${String(err)}`);
@@ -1510,9 +1513,12 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       if (patchInterval) return;
       patchInterval = setInterval(() => {
         const rawText = pendingPatchText;
-        if (!rawText || rawText === lastSentText || patchSending) return;
+        if (!rawText || patchSending) return;
         // Truncate to textLimit so intermediate patches never exceed the server limit.
         const text = rawText.length > textLimit ? rawText.slice(0, textLimit) : rawText;
+        // Guard on the truncated text so long replies (past textLimit) do not keep
+        // re-patching with the same truncated content every 200 ms and hit rate limits.
+        if (text === lastSentText) return;
         patchSending = true;
         void (async () => {
           try {
@@ -1523,7 +1529,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   replyToId: effectiveReplyToId,
                 });
                 streamMessageId = result.messageId;
-                lastSentText = rawText;
+                lastSentText = text;
                 runtime.log?.(`stream-patch started ${streamMessageId}`);
               } catch (err) {
                 logVerboseMessage(`mattermost stream-patch send failed: ${String(err)}`);
@@ -1534,7 +1540,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                   postId: streamMessageId,
                   message: text,
                 });
-                lastSentText = rawText;
+                lastSentText = text;
                 runtime.log?.(`stream-patch edited ${streamMessageId}`);
               } catch (err) {
                 logVerboseMessage(`mattermost stream-patch edit failed: ${String(err)}`);
@@ -1587,11 +1593,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               );
               const orphanId = streamMessageId;
               streamMessageId = null;
-              try {
-                await deleteMattermostPost(blockStreamingClient!, orphanId);
-              } catch {
-                // Ignore delete failure — delivering the complete message takes priority
-              }
+              // Deliver the fallback message first. Only delete the orphaned
+              // stream post after we know the replacement was successfully sent —
+              // if delivery also fails the user keeps the partial preview rather
+              // than losing all visible output.
               await deliverMattermostReplyPayload({
                 core,
                 cfg,
@@ -1607,6 +1612,12 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 tableMode,
                 sendMessage: sendMessageMattermost,
               });
+              // Fallback succeeded — now clean up the orphaned partial.
+              try {
+                await deleteMattermostPost(blockStreamingClient!, orphanId);
+              } catch {
+                // Ignore — the complete message was already delivered.
+              }
               return;
             }
             // Successful final patch: reset all streaming state.

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1443,6 +1443,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     let lastSentText = "";
     let patchInterval: ReturnType<typeof setInterval> | null = null;
     let patchSending = false; // prevents concurrent network calls
+    // Latches true after the first send/edit failure to prevent the interval
+    // from being re-armed by a later onPartialReply call (ID=2964357928).
+    let previewSendFailed = false;
     const STREAM_PATCH_INTERVAL_MS = 200;
 
     // Edit-in-place streaming is opt-in: only activate when blockStreaming is
@@ -1509,6 +1512,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
 
     const schedulePatch = (fullText: string) => {
       if (!blockStreamingClient) return;
+      // Do not re-arm if a permanent send/edit failure has been latched.
+      if (previewSendFailed) return;
       pendingPatchText = fullText;
       if (patchInterval) return;
       patchInterval = setInterval(() => {
@@ -1533,9 +1538,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 runtime.log?.(`stream-patch started ${streamMessageId}`);
               } catch (err) {
                 logVerboseMessage(`mattermost stream-patch send failed: ${String(err)}`);
-                // Stop retrying on initial-send failure (e.g. missing post permission,
-                // DM-channel creation failure). Without this the interval keeps firing
-                // every 200 ms and flooding the API/logs for the rest of the response.
+                // Latch the failure so schedulePatch() does not re-arm the interval
+                // on subsequent onPartialReply calls (which would retry indefinitely).
+                previewSendFailed = true;
                 stopPatchInterval();
               }
             } else {
@@ -1548,9 +1553,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 runtime.log?.(`stream-patch edited ${streamMessageId}`);
               } catch (err) {
                 logVerboseMessage(`mattermost stream-patch edit failed: ${String(err)}`);
-                // Stop retrying on patch failure — the post may not be editable
-                // (missing edit_post permission, deleted, etc.). The preview stays
-                // frozen; final delivery will patch or replace it via deliver().
+                // Latch the failure so schedulePatch() does not re-arm the interval
+                // on subsequent onPartialReply calls.
+                previewSendFailed = true;
                 stopPatchInterval();
               }
             }
@@ -1743,7 +1748,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         // (patchSending=true, streamMessageId=null): stopPatchInterval() prevents new
         // ticks, and the async cleanup waits for patchSending to clear so it can capture
         // the messageId that the in-flight send will set.
-        if ((streamMessageId || patchSending) && blockStreamingClient) {
+        if ((streamMessageId || patchSending || patchInterval) && blockStreamingClient) {
           stopPatchInterval();
           pendingPatchText = "";
           lastSentText = "";

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1533,6 +1533,10 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 runtime.log?.(`stream-patch started ${streamMessageId}`);
               } catch (err) {
                 logVerboseMessage(`mattermost stream-patch send failed: ${String(err)}`);
+                // Stop retrying on initial-send failure (e.g. missing post permission,
+                // DM-channel creation failure). Without this the interval keeps firing
+                // every 200 ms and flooding the API/logs for the rest of the response.
+                stopPatchInterval();
               }
             } else {
               try {
@@ -1730,6 +1734,21 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       dispatcher,
       onSettled: () => {
         markDispatchIdle();
+        // Clean up any streaming preview that was never finalized — this happens when
+        // the reply pipeline produces no final payload (e.g. messaging-tool sends that
+        // are suppressed, or empty/heartbeat responses). Without this, onPartialReply
+        // can create a Mattermost post that is never deleted or patched with final text.
+        if (streamMessageId && blockStreamingClient) {
+          stopPatchInterval();
+          const orphanId = streamMessageId;
+          streamMessageId = null;
+          pendingPatchText = "";
+          lastSentText = "";
+          patchSending = false;
+          void deleteMattermostPost(blockStreamingClient, orphanId).catch(() => {
+            // Best-effort — the run is already complete.
+          });
+        }
       },
       run: () =>
         core.channel.reply.dispatchReplyFromConfig({

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1509,12 +1509,24 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       // Guard on the truncated text so long replies (past textLimit) do not keep
       // re-patching with the same truncated content every 200 ms and hit rate limits.
       if (text === lastSentText) return;
+      // Bound flush requests so a stalled Mattermost API cannot block
+      // final delivery forever (ID=2978002394).
+      const FLUSH_TIMEOUT_MS = 8_000;
+      const flushTimeout = new Promise<"timeout">((r) =>
+        setTimeout(() => r("timeout"), FLUSH_TIMEOUT_MS),
+      );
       if (!streamMessageId) {
         try {
-          const result = await sendMessageMattermost(to, text, {
+          const sendPromise = sendMessageMattermost(to, text, {
             accountId: account.accountId,
             replyToId: effectiveReplyToId,
           });
+          const raceResult = await Promise.race([sendPromise, flushTimeout]);
+          if (raceResult === "timeout") {
+            logVerboseMessage("mattermost stream-patch flush send timed out, skipping preview");
+            return;
+          }
+          const result = raceResult;
           streamMessageId = result.messageId;
           lastSentText = text;
           runtime.log?.(`stream-patch started ${streamMessageId}`);
@@ -1523,10 +1535,15 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         }
       } else {
         try {
-          await patchMattermostPost(blockStreamingClient, {
+          const patchPromise = patchMattermostPost(blockStreamingClient, {
             postId: streamMessageId,
             message: text,
           });
+          const raceResult = await Promise.race([patchPromise, flushTimeout]);
+          if (raceResult === "timeout") {
+            logVerboseMessage("mattermost stream-patch flush patch timed out, skipping");
+            return;
+          }
           lastSentText = text;
           runtime.log?.(`stream-patch flushed ${streamMessageId}`);
         } catch (err) {

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1679,23 +1679,28 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             // text+media together in the correct Mattermost format (ID=2965096969).
             if (!hasMedia) {
               const text = core.channel.text.convertMarkdownTables(payload.text, tableMode);
-              try {
-                await patchMattermostPost(blockStreamingClient!, {
-                  postId: streamMessageId,
-                  message: text,
-                });
-                runtime.log?.(`stream-patch final edit ${streamMessageId}`);
-                // Successful text-only patch. Reset streaming state and return.
-                streamMessageId = null;
-                pendingPatchText = "";
-                lastSentText = "";
-                patchSending = false;
-                return;
-              } catch (err) {
-                logVerboseMessage(
-                  `mattermost stream-patch final edit failed: ${String(err)}, sending new message`,
-                );
-                // Fall through to deliverMattermostReplyPayload below.
+              // If the final text exceeds textChunkLimit, skip the in-place patch
+              // and fall through to deliverMattermostReplyPayload which applies
+              // chunkMarkdownTextWithMode for proper multi-post delivery (ID=2978002398).
+              if (text.length <= textLimit) {
+                try {
+                  await patchMattermostPost(blockStreamingClient!, {
+                    postId: streamMessageId,
+                    message: text,
+                  });
+                  runtime.log?.(`stream-patch final edit ${streamMessageId}`);
+                  // Successful text-only patch. Reset streaming state and return.
+                  streamMessageId = null;
+                  pendingPatchText = "";
+                  lastSentText = "";
+                  patchSending = false;
+                  return;
+                } catch (err) {
+                  logVerboseMessage(
+                    `mattermost stream-patch final edit failed: ${String(err)}, sending new message`,
+                  );
+                  // Fall through to deliverMattermostReplyPayload below.
+                }
               }
             }
             // Media payload or patch failure: deliver the full payload via the

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1877,7 +1877,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               ? (payload: ReplyPayload) => {
                   const rawText = payload.text ?? "";
                   const fullText = core.channel.text.convertMarkdownTables(rawText, tableMode);
-                  if (fullText) {
+                  if (fullText.trim()) {
                     schedulePatch(fullText);
                   }
                 }

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1446,6 +1446,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     // Tracks the currently in-flight sendMessageMattermost / patchMattermostPost
     // promise so that onSettled can await it directly rather than busy-waiting.
     let patchInflight: Promise<unknown> | null = null;
+    // AbortController for the current in-flight preview request so timed-out
+    // requests can be cancelled before continuing (ID=2978002391).
+    let patchAbortController: AbortController | null = null;
     // Latches true after the first send/edit failure to prevent the interval
     // from being re-armed by a later onPartialReply call (ID=2964357928).
     let previewSendFailed = false;
@@ -1460,6 +1463,31 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         ? createMattermostClient({ baseUrl, botToken })
         : null;
 
+    const INFLIGHT_TIMEOUT_MS = 10_000;
+
+    /** Await patchInflight with a bounded timeout; abort the underlying
+     *  request if the timeout fires so late resolves cannot create orphan
+     *  posts or overwrite authoritative text (ID=2978002391). */
+    const awaitInflightBounded = async () => {
+      const inflight = patchInflight;
+      if (!inflight) return;
+      const ac = patchAbortController;
+      let settled = false;
+      const markSettled = inflight.then(
+        () => {
+          settled = true;
+        },
+        () => {
+          settled = true;
+        },
+      );
+      const timeout = new Promise<void>((resolve) => setTimeout(resolve, INFLIGHT_TIMEOUT_MS));
+      await Promise.race([markSettled, timeout]);
+      if (!settled) {
+        ac?.abort();
+      }
+    };
+
     const stopPatchInterval = () => {
       if (patchInterval) {
         clearInterval(patchInterval);
@@ -1470,12 +1498,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
     const flushPendingPatch = async () => {
       stopPatchInterval();
       if (!blockStreamingClient) return;
-      // Await the in-flight promise directly so we never miss a late-resolving
-      // POST/PATCH — the busy-wait on patchSending had a race where patchSending
-      // could clear before the network request settled (ID=2965256849).
-      if (patchInflight) {
-        await patchInflight.catch(() => {});
-      }
+      // Await the in-flight promise with a bounded timeout so we never miss a
+      // late-resolving POST/PATCH, and abort if it exceeds the limit (ID=2978002391).
+      await awaitInflightBounded();
       const rawText = pendingPatchText;
       if (!rawText) return;
       // Truncate to textLimit so intermediate patches never exceed the server limit.
@@ -1525,6 +1550,8 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
         // re-patching with the same truncated content every 200 ms and hit rate limits.
         if (text === lastSentText) return;
         patchSending = true;
+        const ac = new AbortController();
+        patchAbortController = ac;
         const runTick = async () => {
           try {
             if (!streamMessageId) {
@@ -1537,6 +1564,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 lastSentText = text;
                 runtime.log?.(`stream-patch started ${streamMessageId}`);
               } catch (err) {
+                if (ac.signal.aborted) return;
                 logVerboseMessage(`mattermost stream-patch send failed: ${String(err)}`);
                 // Latch the failure so schedulePatch() does not re-arm the interval
                 // on subsequent onPartialReply calls (which would retry indefinitely).
@@ -1548,10 +1576,12 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
                 await patchMattermostPost(blockStreamingClient, {
                   postId: streamMessageId,
                   message: text,
+                  signal: ac.signal,
                 });
                 lastSentText = text;
                 runtime.log?.(`stream-patch edited ${streamMessageId}`);
               } catch (err) {
+                if (ac.signal.aborted) return;
                 logVerboseMessage(`mattermost stream-patch edit failed: ${String(err)}`);
                 // Latch the failure so schedulePatch() does not re-arm the interval
                 // on subsequent onPartialReply calls.
@@ -1561,6 +1591,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
             }
           } finally {
             patchSending = false;
+            if (patchAbortController === ac) patchAbortController = null;
           }
         };
         const inflightRun = runTick();
@@ -1612,9 +1643,7 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
               // first sendMessageMattermost resolves during this window, so the orphan
               // cleanup below can capture and delete it.
               stopPatchInterval();
-              if (patchInflight) {
-                await patchInflight.catch(() => {});
-              }
+              await awaitInflightBounded();
             } else {
               // Same thread: flush pending patches normally.
               await flushPendingPatch();
@@ -1782,11 +1811,9 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
           lastSentText = "";
           const client = blockStreamingClient;
           void (async () => {
-            // Await the in-flight promise directly so we never miss a late-resolving
-            // POST — a 3s timeout would race on slow Mattermost links (ID=2964616785).
-            if (patchInflight) {
-              await patchInflight.catch(() => {});
-            }
+            // Await the in-flight promise with a bounded timeout and abort if it
+            // exceeds the limit (ID=2978002391, ID=2964616785).
+            await awaitInflightBounded();
             patchSending = false;
             const orphanId = streamMessageId;
             streamMessageId = null;

--- a/extensions/mattermost/src/mattermost/send.ts
+++ b/extensions/mattermost/src/mattermost/send.ts
@@ -37,6 +37,8 @@ export type MattermostSendOpts = {
   attachmentText?: string;
   /** Retry options for DM channel creation */
   dmRetryOptions?: CreateDmChannelRetryOptions;
+  /** Abort signal forwarded to the underlying HTTP request */
+  signal?: AbortSignal;
 };
 
 export type MattermostSendResult = {
@@ -458,6 +460,7 @@ export async function sendMessageMattermost(
     rootId: opts.replyToId,
     fileIds,
     props,
+    signal: opts.signal,
   });
 
   recordMattermostOutboundActivity(accountId);


### PR DESCRIPTION
Rebase/continuation of Luna2026-a11y’s work for:
- #25295 (edit/delete actions)
- #25635 (block streaming edit-in-place)

This PR cherry-picks and resolves conflicts against current upstream main.

Notes:
- Conflict resolution updated to match current ReplyDispatcher deliver signature: deliver(payload, info:{kind}).
- Mattermost extension unit tests pass locally via `pnpm test:extensions` (overall suite currently has unrelated failures in other extensions on latest main).

Refs:
- Issue: #25635
- Original PR(s): #25295, #25635
