### PR TITLE
fix(subagents): prefer target session for native /subagents list

### DIFF
--- a/src/auto-reply/reply/commands-subagents.ts
+++ b/src/auto-reply/reply/commands-subagents.ts
@@ -48,7 +48,7 @@ export const handleSubagentsCommand: CommandHandler = async (params, allowTextCo
   }
 
   const requesterKey = resolveRequesterSessionKey(params, {
-    preferCommandTarget: action === "spawn",
+    preferCommandTarget: true,
   });
   if (!requesterKey) {
     return stopWithText("⚠️ Missing session key.");

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -1050,13 +1050,13 @@ describe("handleCommands subagents", () => {
     expect(result.reply?.text).not.toContain("after a short hard cutoff.");
   });
 
-  it("lists subagents for the current command session over the target session", async () => {
+  it("lists subagents for the command target session when provided", async () => {
     addSubagentRunForTests({
       runId: "run-1",
       childSessionKey: "agent:main:subagent:abc",
-      requesterSessionKey: "agent:main:slack:slash:u1",
-      requesterDisplayKey: "agent:main:slack:slash:u1",
-      task: "do thing",
+      requesterSessionKey: "agent:main:main",
+      requesterDisplayKey: "main",
+      task: "target session task",
       cleanup: "keep",
       createdAt: 1000,
       startedAt: 1000,
@@ -1066,7 +1066,7 @@ describe("handleCommands subagents", () => {
       childSessionKey: "agent:main:subagent:def",
       requesterSessionKey: "agent:main:slack:slash:u1",
       requesterDisplayKey: "agent:main:slack:slash:u1",
-      task: "another thing",
+      task: "command session task",
       cleanup: "keep",
       createdAt: 2000,
       startedAt: 2000,
@@ -1083,7 +1083,8 @@ describe("handleCommands subagents", () => {
     const result = await handleCommands(params);
     expect(result.shouldContinue).toBe(false);
     expect(result.reply?.text).toContain("active subagents:");
-    expect(result.reply?.text).toContain("do thing");
+    expect(result.reply?.text).toContain("target session task");
+    expect(result.reply?.text).not.toContain("command session task");
     expect(result.reply?.text).not.toContain("\n\n2.");
   });
 


### PR DESCRIPTION
## Summary
- make `/subagents` requester resolution prefer `CommandTargetSessionKey` whenever present
- align `/subagents list` behavior with existing `/subagents spawn` behavior for native slash routing
- update regression coverage to verify list uses the routed target session instead of the slash command session

Fixes #33508.

## Why
Native slash commands can have:
- command/session transport key in `sessionKey`
- routed conversation key in `CommandTargetSessionKey`

Before this change, list preferred the transport session while spawn preferred the target session, causing inconsistent behavior and empty/misleading list results.

## Validation
- `pnpm exec vitest run src/auto-reply/reply/commands.test.ts src/auto-reply/reply/commands-subagents-spawn.test.ts`
