### PR TITLE
fix(macos): use user login shell in restart-mac.sh for nvm/fnm compat

### DIFF
--- a/scripts/restart-mac.sh
+++ b/scripts/restart-mac.sh
@@ -28,6 +28,21 @@ fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 # Ensure local node binaries (rolldown, pnpm) are discoverable for the steps below.
 export PATH="${ROOT_DIR}/node_modules/.bin:${PATH}"
 
+# Use the user's login shell (typically zsh on macOS) for subshells so that
+# version managers like nvm/fnm load correctly.
+# zsh -lc only sources ~/.zprofile, not ~/.zshrc where nvm/fnm usually live,
+# so we use -ilc for zsh to force interactive mode and load ~/.zshrc.
+USER_SHELL="${SHELL:-/bin/bash}"
+
+run_in_user_shell() {
+  local cmd="$1"
+  if [[ "$(basename "$USER_SHELL")" == "zsh" ]]; then
+    "$USER_SHELL" -ilc "$cmd"
+  else
+    "$USER_SHELL" -lc "$cmd"
+  fi
+}
+
 run_step() {
   local label="$1"; shift
   log "==> ${label}"
@@ -154,11 +169,11 @@ kill_all_openclaw
 stop_launch_agent
 
 # Bundle Gateway-hosted Canvas A2UI assets.
-run_step "bundle canvas a2ui" bash -lc "cd '${ROOT_DIR}' && pnpm canvas:a2ui:bundle"
+run_step "bundle canvas a2ui" run_in_user_shell "cd '${ROOT_DIR}' && pnpm canvas:a2ui:bundle"
 
 # 2) Rebuild into the same path the packager consumes (.build).
-run_step "clean build cache" bash -lc "cd '${ROOT_DIR}/apps/macos' && rm -rf .build .build-swift .swiftpm 2>/dev/null || true"
-run_step "swift build" bash -lc "cd '${ROOT_DIR}/apps/macos' && swift build -q --product OpenClaw"
+run_step "clean build cache" run_in_user_shell "cd '${ROOT_DIR}/apps/macos' && rm -rf .build .build-swift .swiftpm 2>/dev/null || true"
+run_step "swift build" run_in_user_shell "cd '${ROOT_DIR}/apps/macos' && swift build -q --product OpenClaw"
 
 if [ "$AUTO_DETECT_SIGNING" -eq 1 ]; then
   if check_signing_keys; then
@@ -184,7 +199,7 @@ elif [ "$SIGN" -eq 1 ]; then
 fi
 
 # 3) Package app (no embedded gateway).
-run_step "package app" bash -lc "cd '${ROOT_DIR}' && SKIP_TSC=${SKIP_TSC:-1} '${ROOT_DIR}/scripts/package-mac-app.sh'"
+run_step "package app" run_in_user_shell "cd '${ROOT_DIR}' && SKIP_TSC=${SKIP_TSC:-1} '${ROOT_DIR}/scripts/package-mac-app.sh'"
 
 choose_app_bundle() {
   if [[ -n "${APP_BUNDLE}" && -d "${APP_BUNDLE}" ]]; then
@@ -217,8 +232,8 @@ fi
 # When unsigned, ensure the gateway LaunchAgent targets the repo CLI (before the app launches).
 # This reduces noisy "could not connect" errors during app startup.
 if [ "$NO_SIGN" -eq 1 ] && [ "$ATTACH_ONLY" -ne 1 ]; then
-  run_step "install gateway launch agent (unsigned)" bash -lc "cd '${ROOT_DIR}' && node openclaw.mjs daemon install --force --runtime node"
-  run_step "restart gateway daemon (unsigned)" bash -lc "cd '${ROOT_DIR}' && node openclaw.mjs daemon restart"
+  run_step "install gateway launch agent (unsigned)" run_in_user_shell "cd '${ROOT_DIR}' && node openclaw.mjs daemon install --force --runtime node"
+  run_step "restart gateway daemon (unsigned)" run_in_user_shell "cd '${ROOT_DIR}' && node openclaw.mjs daemon restart"
   if [[ "${GATEWAY_WAIT_SECONDS}" -gt 0 ]]; then
     run_step "wait for gateway (unsigned)" sleep "${GATEWAY_WAIT_SECONDS}"
   fi
@@ -236,7 +251,7 @@ if [ "$NO_SIGN" -eq 1 ] && [ "$ATTACH_ONLY" -ne 1 ]; then
       }
     '
   )"
-  run_step "verify gateway port ${GATEWAY_PORT} (unsigned)" bash -lc "lsof -iTCP:${GATEWAY_PORT} -sTCP:LISTEN | head -n 5 || true"
+  run_step "verify gateway port ${GATEWAY_PORT} (unsigned)" run_in_user_shell "lsof -iTCP:${GATEWAY_PORT} -sTCP:LISTEN | head -n 5 || true"
 fi
 
 ATTACH_ONLY_ARGS=()
@@ -265,5 +280,5 @@ else
 fi
 
 if [ "$NO_SIGN" -eq 1 ] && [ "$ATTACH_ONLY" -ne 1 ]; then
-  run_step "show gateway launch agent args (unsigned)" bash -lc "/usr/bin/plutil -p '${HOME}/Library/LaunchAgents/ai.openclaw.gateway.plist' | head -n 40 || true"
+  run_step "show gateway launch agent args (unsigned)" run_in_user_shell "/usr/bin/plutil -p '${HOME}/Library/LaunchAgents/ai.openclaw.gateway.plist' | head -n 40 || true"
 fi


### PR DESCRIPTION
## Summary
- Add `run_in_user_shell` helper that uses `$SHELL` (user's login shell, defaults to `/bin/bash`)
- For zsh: uses `-ilc` (interactive login) to source `~/.zshrc` where nvm/fnm init typically lives — `zsh -lc` alone only sources `~/.zprofile`
- For bash/others: uses `-lc` as before
- On macOS (default shell zsh since Catalina), the previous hardcoded `bash -lc` didn't load nvm/fnm, causing native bindings (e.g. rolldown) to fail with the wrong Node version

Addresses bot review feedback:
- **Greptile**: `zsh -lc` skips `~/.zshrc` → fixed with `-ilc` for zsh via helper function
- **Codex**: non-POSIX shells (fish) → command strings use POSIX syntax, and `$SHELL` defaults to `/bin/bash` if unset

## Test plan
- [x] Verified `restart-mac.sh` completes full rebuild cycle (bundle, swift build, package, sign, launch) on macOS with nvm in zsh
- [x] Verified `zsh -ilc` loads nvm and produces no extra output noise
- [ ] Confirm no regression on systems using bash as default shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)