### PR TITLE
fix: strip reasoning_effort from payloads sent to unsupported providers

### DIFF
--- a/src/agents/pi-embedded-runner/extra-params.strip-reasoning-effort.test.ts
+++ b/src/agents/pi-embedded-runner/extra-params.strip-reasoning-effort.test.ts
@@ -1,0 +1,131 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { Context, Model, SimpleStreamOptions } from "@mariozechner/pi-ai";
+import { describe, expect, it, vi } from "vitest";
+import { applyExtraParamsToAgent } from "./extra-params.js";
+
+vi.mock("@mariozechner/pi-ai", () => ({
+  streamSimple: vi.fn(() => ({
+    push: vi.fn(),
+    result: vi.fn(),
+  })),
+}));
+
+type ReasoningEffortCase = {
+  applyProvider: string;
+  applyModelId: string;
+  model: Model<"openai-completions">;
+  cfg?: Parameters<typeof applyExtraParamsToAgent>[1];
+  options?: SimpleStreamOptions;
+};
+
+function runReasoningEffortCase(params: ReasoningEffortCase) {
+  const payload: Record<string, unknown> = {
+    model: params.model.id,
+    messages: [],
+    reasoning_effort: "medium",
+  };
+  const baseStreamFn: StreamFn = (_model, _context, options) => {
+    options?.onPayload?.(payload);
+    return {} as ReturnType<StreamFn>;
+  };
+  const agent = { streamFn: baseStreamFn };
+
+  applyExtraParamsToAgent(agent, params.cfg, params.applyProvider, params.applyModelId);
+
+  const context: Context = { messages: [] };
+  void agent.streamFn?.(params.model, context, params.options ?? {});
+
+  return payload;
+}
+
+describe("extra-params: strip reasoning_effort for unsupported providers", () => {
+  it("strips reasoning_effort for custom providers", () => {
+    const payload = runReasoningEffortCase({
+      applyProvider: "custom-provider",
+      applyModelId: "some-model",
+      model: {
+        api: "openai-completions",
+        provider: "custom-provider",
+        id: "some-model",
+        reasoning: true,
+      } as Model<"openai-completions">,
+    });
+
+    expect(payload).not.toHaveProperty("reasoning_effort");
+  });
+
+  it("strips reasoning_effort for moonshot provider", () => {
+    const payload = runReasoningEffortCase({
+      applyProvider: "moonshot",
+      applyModelId: "k2-0411",
+      model: {
+        api: "openai-completions",
+        provider: "moonshot",
+        id: "k2-0411",
+        reasoning: true,
+      } as Model<"openai-completions">,
+    });
+
+    expect(payload).not.toHaveProperty("reasoning_effort");
+  });
+
+  it("preserves reasoning_effort for openai provider", () => {
+    const payload = runReasoningEffortCase({
+      applyProvider: "openai",
+      applyModelId: "o3",
+      model: {
+        api: "openai-completions",
+        provider: "openai",
+        id: "o3",
+        reasoning: true,
+      } as Model<"openai-completions">,
+    });
+
+    expect(payload.reasoning_effort).toBe("medium");
+  });
+
+  it("preserves reasoning_effort for openai-codex provider", () => {
+    const payload = runReasoningEffortCase({
+      applyProvider: "openai-codex",
+      applyModelId: "gpt-5.3-codex",
+      model: {
+        api: "openai-completions",
+        provider: "openai-codex",
+        id: "gpt-5.3-codex",
+        reasoning: true,
+      } as Model<"openai-completions">,
+    });
+
+    expect(payload.reasoning_effort).toBe("medium");
+  });
+
+  it("preserves reasoning_effort for azure-openai-responses provider", () => {
+    const payload = runReasoningEffortCase({
+      applyProvider: "azure-openai-responses",
+      applyModelId: "o3",
+      model: {
+        api: "openai-completions",
+        provider: "azure-openai-responses",
+        id: "o3",
+        reasoning: true,
+      } as Model<"openai-completions">,
+    });
+
+    expect(payload.reasoning_effort).toBe("medium");
+  });
+
+  it("strips reasoning_effort for siliconflow provider", () => {
+    const payload = runReasoningEffortCase({
+      applyProvider: "siliconflow",
+      applyModelId: "Pro/deepseek-ai/DeepSeek-R1",
+      model: {
+        api: "openai-completions",
+        provider: "siliconflow",
+        id: "Pro/deepseek-ai/DeepSeek-R1",
+        reasoning: true,
+      } as Model<"openai-completions">,
+    });
+
+    expect(payload).not.toHaveProperty("reasoning_effort");
+  });
+});

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -15,6 +15,11 @@ const ANTHROPIC_1M_MODEL_PREFIXES = ["claude-opus-4", "claude-sonnet-4"] as cons
 // Codex responses (chatgpt.com/backend-api/codex/responses) require `store=false`.
 const OPENAI_RESPONSES_APIS = new Set(["openai-responses"]);
 const OPENAI_RESPONSES_PROVIDERS = new Set(["openai", "azure-openai-responses"]);
+const NATIVE_REASONING_EFFORT_PROVIDERS = new Set([
+  "openai",
+  "openai-codex",
+  "azure-openai-responses",
+]);
 
 /**
  * Resolve provider-specific extra params from model config.
@@ -964,4 +969,26 @@ export function applyExtraParamsToAgent(
   // Force `store=true` for direct OpenAI Responses models and auto-enable
   // server-side compaction for compatible OpenAI Responses payloads.
   agent.streamFn = createOpenAIResponsesContextManagementWrapper(agent.streamFn, merged);
+
+  // Strip reasoning_effort for providers that don't natively support it.
+  // pi-ai may inject reasoning_effort based on model.reasoning flag, but custom
+  // providers and some built-in providers use different thinking formats.
+  // Only direct OpenAI-compatible providers accept this parameter.
+  // See: openclaw/openclaw#33272
+  if (!NATIVE_REASONING_EFFORT_PROVIDERS.has(provider)) {
+    log.debug(`stripping reasoning_effort for unsupported provider ${provider}/${modelId}`);
+    const underlyingForReasoningStrip = agent.streamFn ?? streamSimple;
+    agent.streamFn = (model, context, options) => {
+      const originalOnPayload = options?.onPayload;
+      return underlyingForReasoningStrip(model, context, {
+        ...options,
+        onPayload: (payload) => {
+          if (payload && typeof payload === "object") {
+            delete (payload as Record<string, unknown>).reasoning_effort;
+          }
+          originalOnPayload?.(payload);
+        },
+      });
+    };
+  }
 }


### PR DESCRIPTION
## Summary

- **Problem:** pi-ai injects `reasoning_effort` into the API payload when `model.reasoning` is true. Custom providers and some built-in providers (moonshot, siliconflow, etc.) do not support this OpenAI-specific parameter — it breaks tool calling silently.
- **Why it matters:** Users with custom provider endpoints (e.g., Kimi K2.5 via `api: "openai-completions"`) experience silent tool call failures with no error message.
- **What changed:** Added a cleanup wrapper at the end of `applyExtraParamsToAgent()` that strips `reasoning_effort` for any provider not in the known set of native supporters.
- **What did NOT change:** OpenAI, OpenAI Codex, and Azure OpenAI Responses providers are unaffected — they support `reasoning_effort` natively.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Providers / Model handling

## Linked Issue/PR

- Closes #33272

## User-visible / Behavior Changes

Custom providers no longer receive `reasoning_effort` in the API payload, which was causing silent tool calling failures. No change for OpenAI-compatible providers that support it natively.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (arm64)
- Runtime: Node v25.6.0
- Model/provider: custom provider with `api: "openai-completions"` and `model.reasoning: true`

### Steps

1. Configure a custom provider with a reasoning-capable model
2. Enable thinking in config
3. Use tool calling — previously fails silently

### Expected

- Tool calls work correctly with custom providers

### Actual

- (Before this PR) `reasoning_effort` injected into payload, custom endpoint rejects or ignores it, tool calls fail silently

## Evidence

- [x] Failing test/log before + passing after

6 new tests added, all passing:
- `strips reasoning_effort for custom providers`
- `strips reasoning_effort for moonshot provider`
- `preserves reasoning_effort for openai provider`
- `preserves reasoning_effort for openai-codex provider`
- `preserves reasoning_effort for azure-openai-responses provider`
- `strips reasoning_effort for siliconflow provider`

Full check suite: `pnpm check` passes.

## Human Verification (required)

- Verified: `pnpm check` passes, all 6 tests pass
- Edge cases: known providers preserved, unknown providers stripped, OpenRouter already handled by its own wrapper
- Not verified: live testing against actual custom provider endpoints

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this single commit
- The wrapper is a no-op for known providers — zero impact on existing behavior

## Risks and Mitigations

- Risk: A custom provider might actually support `reasoning_effort`
  - Mitigation: Unlikely — only OpenAI-format providers use this param. If needed, the provider can be added to `NATIVE_REASONING_EFFORT_PROVIDERS`

## AI Disclosure

- [x] AI-assisted (Codex CLI)
- [x] Fully tested