### PR TITLE
fix(sandbox): add 60s timeout to prevent hung Docker from blocking message pipeline

### DIFF
--- a/extensions/openshell/src/backend.e2e.test.ts
+++ b/extensions/openshell/src/backend.e2e.test.ts
@@ -392,6 +392,7 @@ describe("openshell sandbox backend e2e", () => {
         browser: createSandboxBrowserConfig(),
         tools: { allow: [], deny: [] },
         prune: createSandboxPruneConfig(),
+        initTimeoutMs: 300_000,
       };
 
       const pluginConfig = resolveOpenShellPluginConfig({

--- a/src/agents/sandbox/backend.types.ts
+++ b/src/agents/sandbox/backend.types.ts
@@ -28,6 +28,7 @@ export type CreateSandboxBackendParams = {
   workspaceDir: string;
   agentWorkspaceDir: string;
   cfg: SandboxConfig;
+  abortSignal?: AbortSignal;
 };
 
 export type SandboxBackendFactory = (

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -103,6 +103,7 @@ function buildConfig(enableNoVnc: boolean): SandboxConfig {
       idleHours: 24,
       maxAgeDays: 7,
     },
+    initTimeoutMs: 60_000,
   };
 }
 
@@ -249,7 +250,10 @@ describe("ensureSandboxBrowser create args", () => {
     expect(labels).toContain(`openclaw.mountFormatVersion=${SANDBOX_MOUNT_FORMAT_VERSION}`);
   });
 
-  it("force-removes the browser container when CDP never becomes reachable", async () => {
+  it("surfaces a CDP-unreachable error without force-removing the container", async () => {
+    // Attach callbacks run later during the session lifetime and use a fresh
+    // AbortController; they must not force-rm the container on CDP timeout
+    // since the surrounding bridge is still valid for later retry/reuse.
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("timeout"));
     bridgeMocks.startBrowserBridgeServer.mockImplementationOnce(async (params) => {
       await params.onEnsureAttachTarget?.({});
@@ -276,11 +280,11 @@ describe("ensureSandboxBrowser create args", () => {
         agentWorkspaceDir: "/tmp/workspace",
         cfg,
       }),
-    ).rejects.toThrow("hung container has been forcefully removed");
+    ).rejects.toThrow(/CDP did not become reachable/);
 
-    expect(dockerMocks.execDocker).toHaveBeenCalledWith(
+    expect(dockerMocks.execDocker).not.toHaveBeenCalledWith(
       ["rm", "-f", expect.stringMatching(/^openclaw-sbx-browser-session-test-/)],
-      { allowFailure: true },
+      expect.anything(),
     );
   });
 

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -48,13 +48,24 @@ import { appendWorkspaceMountArgs, SANDBOX_MOUNT_FORMAT_VERSION } from "./worksp
 const HOT_BROWSER_WINDOW_MS = 5 * 60 * 1000;
 const CDP_SOURCE_RANGE_ENV_KEY = "OPENCLAW_BROWSER_CDP_SOURCE_RANGE";
 
-async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number }): Promise<boolean> {
+async function waitForSandboxCdp(params: {
+  cdpPort: number;
+  timeoutMs: number;
+  signal?: AbortSignal;
+}): Promise<boolean> {
   const deadline = Date.now() + Math.max(0, params.timeoutMs);
   const url = `http://127.0.0.1:${params.cdpPort}/json/version`;
   while (Date.now() < deadline) {
+    // Bail out immediately if the caller has been cancelled.
+    if (params.signal?.aborted) {
+      return false;
+    }
     try {
       const ctrl = new AbortController();
+      // Combine the per-attempt timeout with the caller's abort signal.
       const t = setTimeout(ctrl.abort.bind(ctrl), 1000);
+      const handleExternalAbort = () => ctrl.abort();
+      params.signal?.addEventListener("abort", handleExternalAbort);
       try {
         const res = await fetch(url, { signal: ctrl.signal });
         if (res.ok) {
@@ -62,9 +73,13 @@ async function waitForSandboxCdp(params: { cdpPort: number; timeoutMs: number })
         }
       } finally {
         clearTimeout(t);
+        params.signal?.removeEventListener("abort", handleExternalAbort);
       }
     } catch {
-      // ignore
+      // ignore fetch/timeout errors; re-check abort before sleeping
+    }
+    if (params.signal?.aborted) {
+      return false;
     }
     await new Promise((r) => setTimeout(r, 150));
   }
@@ -106,9 +121,10 @@ function buildSandboxBrowserResolvedConfig(params: {
   };
 }
 
-async function ensureSandboxBrowserImage(image: string) {
+async function ensureSandboxBrowserImage(image: string, abortSignal?: AbortSignal) {
   const result = await execDocker(["image", "inspect", image], {
     allowFailure: true,
+    signal: abortSignal,
   });
   if (result.code === 0) {
     return;
@@ -120,7 +136,7 @@ async function ensureSandboxBrowserImage(image: string) {
 
 async function ensureDockerNetwork(
   network: string,
-  opts?: { allowContainerNamespaceJoin?: boolean },
+  opts?: { allowContainerNamespaceJoin?: boolean; abortSignal?: AbortSignal },
 ) {
   validateNetworkMode(network, {
     allowContainerNamespaceJoin: opts?.allowContainerNamespaceJoin === true,
@@ -129,11 +145,16 @@ async function ensureDockerNetwork(
   if (!normalized || normalized === "bridge" || normalized === "none") {
     return;
   }
-  const inspect = await execDocker(["network", "inspect", network], { allowFailure: true });
+  const inspect = await execDocker(["network", "inspect", network], {
+    allowFailure: true,
+    signal: opts?.abortSignal,
+  });
   if (inspect.code === 0) {
     return;
   }
-  await execDocker(["network", "create", "--driver", "bridge", network]);
+  await execDocker(["network", "create", "--driver", "bridge", network], {
+    signal: opts?.abortSignal,
+  });
 }
 
 export async function ensureSandboxBrowser(params: {
@@ -143,6 +164,7 @@ export async function ensureSandboxBrowser(params: {
   cfg: SandboxConfig;
   evaluateEnabled?: boolean;
   bridgeAuth?: { token?: string; password?: string };
+  abortSignal?: AbortSignal;
 }): Promise<SandboxBrowserContext | null> {
   if (!params.cfg.browser.enabled) {
     return null;
@@ -154,7 +176,7 @@ export async function ensureSandboxBrowser(params: {
   const slug = params.cfg.scope === "shared" ? "shared" : slugifySessionKey(params.scopeKey);
   const name = `${params.cfg.browser.containerPrefix}${slug}`;
   const containerName = name.slice(0, 63);
-  const state = await dockerContainerState(containerName);
+  const state = await dockerContainerState(containerName, params.abortSignal);
   const browserImage = params.cfg.browser.image ?? DEFAULT_SANDBOX_BROWSER_IMAGE;
   const cdpSourceRange = normalizeOptionalString(params.cfg.browser.cdpSourceRange);
   const browserDockerCfg = resolveSandboxBrowserDockerCreateConfig({
@@ -219,7 +241,10 @@ export async function ensureSandboxBrowser(params: {
           `Sandbox browser config changed for ${containerName} (recently used). Recreate to apply: ${hint}`,
         );
       } else {
-        await execDocker(["rm", "-f", containerName], { allowFailure: true });
+        await execDocker(["rm", "-f", containerName], {
+          allowFailure: true,
+          signal: params.abortSignal,
+        });
         hasContainer = false;
         running = false;
       }
@@ -232,8 +257,9 @@ export async function ensureSandboxBrowser(params: {
     }
     await ensureDockerNetwork(browserDockerCfg.network, {
       allowContainerNamespaceJoin: browserDockerCfg.dangerouslyAllowContainerNamespaceJoin === true,
+      abortSignal: params.abortSignal,
     });
-    await ensureSandboxBrowserImage(browserImage);
+    await ensureSandboxBrowserImage(browserImage, params.abortSignal);
     // Derive effective CDP source range: explicit config > Docker network gateway > fail-closed.
     // Only IPv4 gateways are usable for auto-derivation because the CDP relay
     // binds on 0.0.0.0 (IPv4); an IPv6 CIDR would cause an address-family mismatch.
@@ -308,19 +334,23 @@ export async function ensureSandboxBrowser(params: {
       args.push("-e", `${NOVNC_PASSWORD_ENV_KEY}=${noVncPassword}`);
     }
     args.push(browserImage);
-    await execDocker(args);
-    await execDocker(["start", containerName]);
+    await execDocker(args, { signal: params.abortSignal });
+    await execDocker(["start", containerName], { signal: params.abortSignal });
   } else if (!running) {
-    await execDocker(["start", containerName]);
+    await execDocker(["start", containerName], { signal: params.abortSignal });
   }
 
-  const mappedCdp = await readDockerPort(containerName, params.cfg.browser.cdpPort);
+  const mappedCdp = await readDockerPort(
+    containerName,
+    params.cfg.browser.cdpPort,
+    params.abortSignal,
+  );
   if (!mappedCdp) {
     throw new Error(`Failed to resolve CDP port mapping for ${containerName}.`);
   }
 
   const mappedNoVnc = noVncEnabled
-    ? await readDockerPort(containerName, params.cfg.browser.noVncPort)
+    ? await readDockerPort(containerName, params.cfg.browser.noVncPort, params.abortSignal)
     : null;
   if (noVncEnabled && !noVncPassword) {
     noVncPassword =
@@ -370,19 +400,31 @@ export async function ensureSandboxBrowser(params: {
 
     const onEnsureAttachTarget = params.cfg.browser.autoStart
       ? async () => {
-          const currentState = await dockerContainerState(containerName);
-          if (currentState.exists && !currentState.running) {
-            await execDocker(["start", containerName]);
-          }
-          const ok = await waitForSandboxCdp({
-            cdpPort: mappedCdp,
-            timeoutMs: params.cfg.browser.autoStartTimeoutMs,
-          });
-          if (!ok) {
-            await execDocker(["rm", "-f", containerName], { allowFailure: true });
-            throw new Error(
-              `Sandbox browser CDP did not become reachable on 127.0.0.1:${mappedCdp} within ${params.cfg.browser.autoStartTimeoutMs}ms. The hung container has been forcefully removed.`,
-            );
+          // The init abort signal can already be aborted (60s guard), but the
+          // browser bridge is still valid — attach callbacks run later during
+          // the session lifetime and must not inherit stale abort state.
+          const attachCtrl = new AbortController();
+          const attachTimeout = setTimeout(
+            () => attachCtrl.abort(),
+            params.cfg.browser.autoStartTimeoutMs,
+          );
+          try {
+            const currentState = await dockerContainerState(containerName, attachCtrl.signal);
+            if (currentState.exists && !currentState.running) {
+              await execDocker(["start", containerName], { signal: attachCtrl.signal });
+            }
+            const ok = await waitForSandboxCdp({
+              cdpPort: mappedCdp,
+              timeoutMs: params.cfg.browser.autoStartTimeoutMs,
+              signal: attachCtrl.signal,
+            });
+            if (!ok) {
+              throw new Error(
+                `Sandbox browser CDP did not become reachable on 127.0.0.1:${mappedCdp} within ${params.cfg.browser.autoStartTimeoutMs}ms.`,
+              );
+            }
+          } finally {
+            clearTimeout(attachTimeout);
           }
         }
       : undefined;

--- a/src/agents/sandbox/config.ts
+++ b/src/agents/sandbox/config.ts
@@ -14,7 +14,9 @@ import {
   DEFAULT_SANDBOX_CONTAINER_PREFIX,
   DEFAULT_SANDBOX_IDLE_HOURS,
   DEFAULT_SANDBOX_IMAGE,
+  DEFAULT_SANDBOX_INIT_TIMEOUT_MS,
   DEFAULT_SANDBOX_MAX_AGE_DAYS,
+  DEFAULT_SANDBOX_REMOTE_INIT_TIMEOUT_MS,
   DEFAULT_SANDBOX_WORKDIR,
   DEFAULT_SANDBOX_WORKSPACE_ROOT,
 } from "./constants.js";
@@ -241,9 +243,23 @@ export function resolveSandboxConfigForAgent(
 
   const toolPolicy = resolveSandboxToolPolicyForAgent(cfg, agentId);
 
+  const backend = agentSandbox?.backend?.trim() || agent?.backend?.trim() || "docker";
+
+  // Remote backends (ssh, etc.) get a longer default init timeout because
+  // workspace seeding, setup commands, and network transfers can legitimately
+  // exceed 60s on a first run.
+  const isRemoteBackend = backend !== "docker";
+  const defaultInitTimeoutMs = isRemoteBackend
+    ? DEFAULT_SANDBOX_REMOTE_INIT_TIMEOUT_MS
+    : DEFAULT_SANDBOX_INIT_TIMEOUT_MS;
+
+  // Allow env-var override for operational flexibility (e.g. known-slow images).
+  const envOverride = process.env.SANDBOX_INIT_TIMEOUT_MS;
+  const envTimeoutMs = envOverride !== undefined ? Number.parseInt(envOverride, 10) : undefined;
+
   return {
     mode: agentSandbox?.mode ?? agent?.mode ?? "off",
-    backend: agentSandbox?.backend?.trim() || agent?.backend?.trim() || "docker",
+    backend,
     scope,
     workspaceAccess: agentSandbox?.workspaceAccess ?? agent?.workspaceAccess ?? "none",
     workspaceRoot:
@@ -272,5 +288,10 @@ export function resolveSandboxConfigForAgent(
       globalPrune: agent?.prune,
       agentPrune: agentSandbox?.prune,
     }),
+    initTimeoutMs:
+      agentSandbox?.initTimeoutMs ??
+      agent?.initTimeoutMs ??
+      (Number.isFinite(envTimeoutMs) && envTimeoutMs! > 0 ? envTimeoutMs! : undefined) ??
+      defaultInitTimeoutMs,
   };
 }

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -48,6 +48,20 @@ export const DEFAULT_SANDBOX_BROWSER_VNC_PORT = 5900;
 export const DEFAULT_SANDBOX_BROWSER_NOVNC_PORT = 6080;
 export const DEFAULT_SANDBOX_BROWSER_AUTOSTART_TIMEOUT_MS = 12_000;
 
+/**
+ * Default init timeout for local (Docker) sandbox backends.
+ * 60s is generous for a warm container start but short enough to unblock the
+ * message pipeline when Docker is hung or unreachable.
+ */
+export const DEFAULT_SANDBOX_INIT_TIMEOUT_MS = 60_000;
+
+/**
+ * Default init timeout for remote (SSH/OpenShell) sandbox backends.
+ * Remote backends may need to seed workspaces, run setup commands, or transfer
+ * files over the network, so they get a larger budget by default.
+ */
+export const DEFAULT_SANDBOX_REMOTE_INIT_TIMEOUT_MS = 300_000;
+
 export const SANDBOX_AGENT_WORKSPACE_MOUNT = "/agent";
 
 export const SANDBOX_STATE_DIR = path.join(STATE_DIR, "sandbox");

--- a/src/agents/sandbox/context.timeout.test.ts
+++ b/src/agents/sandbox/context.timeout.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for the sandbox initialization timeout guard.
+ *
+ * Uses vi.useFakeTimers() inside the test body (not at module level), following
+ * the pattern in src/agents/pi-embedded-runner.compaction-safety-timeout.test.ts.
+ *
+ * The module is imported at the top level (not dynamically inside the test)
+ * so that vi.useFakeTimers() can reliably intercept the setTimeout call.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+
+// Make maybePruneSandboxes controllable per-test (default: hang forever).
+let pruneResolve: (() => void) | undefined;
+vi.mock("./prune.js", () => ({
+  maybePruneSandboxes: vi.fn(
+    () =>
+      new Promise<void>((resolve) => {
+        pruneResolve = resolve;
+      }),
+  ),
+}));
+
+// Workspace helpers are no-ops for these tests.
+vi.mock("./workspace.js", () => ({
+  ensureSandboxWorkspace: vi.fn(async () => undefined),
+}));
+
+vi.mock("../skills.js", () => ({
+  syncSkillsToWorkspace: vi.fn(async () => undefined),
+}));
+
+// Import at module level so the module is resolved before any test runs.
+// This ensures vi.useFakeTimers() will intercept the setTimeout call that
+// resolveSandboxContext makes inside its execution (not import-time).
+import { resolveSandboxContext } from "./context.js";
+import { maybePruneSandboxes } from "./prune.js";
+
+const cfg: OpenClawConfig = {
+  agents: {
+    defaults: {
+      sandbox: { mode: "all", scope: "session" },
+    },
+  },
+};
+
+afterEach(() => {
+  pruneResolve = undefined;
+  vi.useRealTimers();
+  vi.clearAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("resolveSandboxContext – timeout guard", () => {
+  it("rejects with a descriptive error when initialization hangs beyond the configured timeout", async () => {
+    vi.useFakeTimers();
+
+    const promise = resolveSandboxContext({
+      config: cfg,
+      sessionKey: "agent:worker:abc123",
+      workspaceDir: "/tmp/openclaw-timeout-test",
+    });
+
+    // Register the rejection handler before advancing the clock to prevent
+    // the rejection from being unhandled (follows compaction-safety-timeout pattern).
+    // Default Docker backend timeout is 60s.
+    const assertion = expect(promise).rejects.toThrow(/timed out after 60s/i);
+
+    await vi.advanceTimersByTimeAsync(60_001);
+    await assertion;
+
+    // After the race settles, the timer must be cleared.
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("aborts the AbortController signal when the timeout fires", async () => {
+    // Call vi.useFakeTimers() BEFORE installing the AbortController stub so
+    // that any AbortController instances created internally by the fake-timer
+    // setup (e.g. for fake-fetch internals) use the real constructor and are
+    // not accidentally captured as the "first instance". After the stub is
+    // registered, only calls made during resolveSandboxContext's own execution
+    // will be intercepted.
+    vi.useFakeTimers();
+
+    // Use vi.stubGlobal to intercept AbortController instantiation so we can
+    // capture the signal that resolveSandboxContext threads into the inner work.
+    let capturedSignal: AbortSignal | undefined;
+    const RealAbortController = globalThis.AbortController;
+    vi.stubGlobal(
+      "AbortController",
+      class extends RealAbortController {
+        constructor() {
+          super();
+          // Only capture the first instance — that's the one created inside
+          // resolveSandboxContext for the timeout race.
+          if (!capturedSignal) {
+            capturedSignal = this.signal;
+          }
+        }
+      },
+    );
+
+    const promise = resolveSandboxContext({
+      config: cfg,
+      sessionKey: "agent:worker:abort-test",
+      workspaceDir: "/tmp/openclaw-abort-test",
+    });
+
+    // Register rejection handler before advancing time to avoid unhandled rejections.
+    const assertion = expect(promise).rejects.toThrow(/timed out after 60s/i);
+
+    // The signal must be captured and not yet aborted before the timeout fires.
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal?.aborted).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(60_001);
+    await assertion;
+
+    // After the timeout fires, the AbortController must have been aborted.
+    // This is the mechanism that gives cooperative cancellation to
+    // resolveSandboxContextInner: each `if (abortSignal?.aborted)` guard
+    // at await boundaries will throw rather than start new Docker work.
+    expect(capturedSignal?.aborted).toBe(true);
+
+    // Confirm the inner work did start (prune was called) so we know the
+    // abort check matters for future await boundaries.
+    expect(maybePruneSandboxes).toHaveBeenCalledTimes(1);
+  });
+
+  it("aborts the init signal even on the success path so detached inner work stops", async () => {
+    // This tests that resolveSandboxContext's .finally() aborts the controller
+    // when init completes normally. If it did not, any detached raceAbort
+    // listeners or pending Docker child processes from the "losing" side of
+    // Promise.race would linger until process exit.
+    //
+    // We let maybePruneSandboxes succeed, but the next step
+    // (ensureSandboxWorkspaceLayout -> resolveUserPath) will throw because
+    // there is no real workspace. That error propagates through the race and
+    // triggers the .finally() abort on the non-timeout path.
+    vi.useFakeTimers();
+
+    let capturedSignal: AbortSignal | undefined;
+    const RealAbortController = globalThis.AbortController;
+    vi.stubGlobal(
+      "AbortController",
+      class extends RealAbortController {
+        constructor() {
+          super();
+          if (!capturedSignal) {
+            capturedSignal = this.signal;
+          }
+        }
+      },
+    );
+
+    // Let prune resolve immediately so the inner work continues past raceAbort.
+    const promise = resolveSandboxContext({
+      config: cfg,
+      sessionKey: "agent:worker:success-abort-test",
+      workspaceDir: "/tmp/openclaw-success-abort-test",
+    });
+
+    // Resolve the hung prune so the inner work advances past raceAbort.
+    pruneResolve?.();
+
+    // The inner work will fail at a later step (no real backend/workspace),
+    // but the .finally() should still abort the controller.
+    try {
+      await promise;
+    } catch {
+      // Expected — the init flow will fail without real Docker/workspace.
+    }
+
+    expect(capturedSignal).toBeDefined();
+    // The signal must be aborted even though no timeout fired — the .finally()
+    // handler aborts the controller to clean up detached inner work.
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
+  it("uses a longer timeout for SSH (remote) backends", async () => {
+    vi.useFakeTimers();
+
+    const sshCfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", scope: "session", backend: "ssh" },
+        },
+      },
+    };
+
+    const promise = resolveSandboxContext({
+      config: sshCfg,
+      sessionKey: "agent:worker:ssh-timeout-test",
+      workspaceDir: "/tmp/openclaw-ssh-timeout-test",
+    });
+
+    // At 60s the Docker default would fire, but SSH uses 300s.
+    // Register rejection handler early.
+    const assertion = expect(promise).rejects.toThrow(/timed out after 300s/i);
+
+    // Advance past the Docker default — should NOT have timed out yet.
+    await vi.advanceTimersByTimeAsync(60_001);
+    // Timer should still be active (SSH backend has 300s default).
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    // Advance to 300s+ to trigger the actual timeout.
+    await vi.advanceTimersByTimeAsync(240_000);
+    await assertion;
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("respects a custom initTimeoutMs from config", async () => {
+    vi.useFakeTimers();
+
+    const customCfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          sandbox: { mode: "all", scope: "session", initTimeoutMs: 10_000 },
+        },
+      },
+    };
+
+    const promise = resolveSandboxContext({
+      config: customCfg,
+      sessionKey: "agent:worker:custom-timeout-test",
+      workspaceDir: "/tmp/openclaw-custom-timeout-test",
+    });
+
+    const assertion = expect(promise).rejects.toThrow(/timed out after 10s/i);
+
+    await vi.advanceTimersByTimeAsync(10_001);
+    await assertion;
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/src/agents/sandbox/context.ts
+++ b/src/agents/sandbox/context.ts
@@ -131,9 +131,94 @@ export async function resolveSandboxContext(params: {
   if (!resolved) {
     return null;
   }
+
+  // Wrap sandbox initialization in a timeout to prevent a hung Docker daemon
+  // (or slow remote backend) from blocking the message pipeline indefinitely.
+  // The timeout is configurable via sandbox config (initTimeoutMs) with
+  // backend-aware defaults: 60s for Docker, 300s for SSH/remote backends.
+  // An AbortController signals cooperative cancellation into
+  // resolveSandboxContextInner so that in-flight await points stop new work
+  // when the timeout fires, preventing zombie child processes.
+  // The timer is cleared via .finally() so it cannot keep the event loop alive
+  // after initialization succeeds. timer.unref() allows the process to exit
+  // cleanly if the event loop is otherwise idle.
+  const initTimeoutMs = resolved.cfg.initTimeoutMs;
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      const err = new Error(
+        `Sandbox initialization timed out after ${initTimeoutMs / 1000}s (backend "${resolved.cfg.backend}" may be unresponsive)`,
+      );
+      defaultRuntime.error?.(err.message);
+      // Abort the inner work so pending await points exit early.
+      // Reuse the same Error instance for both abort reason and rejection so
+      // the aborted-check path (throw abortSignal.reason) and the race-winning
+      // rejection surface the same Error identity.
+      controller.abort(err);
+      reject(err);
+    }, initTimeoutMs);
+    timer.unref?.();
+  });
+
+  return Promise.race([
+    resolveSandboxContextInner(resolved, params, controller.signal),
+    timeoutPromise,
+  ]).finally(() => {
+    clearTimeout(timer);
+    // Abort the controller on the success path too so any detached inner work
+    // (from the losing side of the race) is cancelled promptly. This is safe
+    // because onEnsureAttachTarget creates its own AbortController per attach
+    // attempt and does not capture the init-phase signal.
+    if (!controller.signal.aborted) {
+      controller.abort();
+    }
+  });
+}
+
+/** Race a promise against an AbortSignal — resolves/rejects with whichever wins first. */
+function raceAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  if (signal.aborted) {
+    const reason =
+      signal.reason instanceof Error ? signal.reason : new Error("Sandbox init aborted");
+    return Promise.reject(reason);
+  }
+  // Track the listener so we can remove it when the wrapped promise settles,
+  // preventing a leaked abort listener on the success path.
+  let abortListener: (() => void) | undefined;
+  const abortPromise = new Promise<never>((_, reject) => {
+    abortListener = () => {
+      const r = signal.reason instanceof Error ? signal.reason : new Error("Sandbox init aborted");
+      reject(r);
+    };
+    signal.addEventListener("abort", abortListener, { once: true });
+  });
+  return Promise.race([promise, abortPromise]).finally(() => {
+    if (abortListener) {
+      signal.removeEventListener("abort", abortListener);
+    }
+  });
+}
+
+async function resolveSandboxContextInner(
+  resolved: NonNullable<ReturnType<typeof resolveSandboxSession>>,
+  params: { config?: OpenClawConfig; workspaceDir?: string },
+  abortSignal?: AbortSignal,
+): Promise<SandboxContext> {
   const { rawSessionKey, cfg, runtime } = resolved;
 
-  await maybePruneSandboxes(cfg);
+  // Check abort before each major async step to provide cooperative
+  // cancellation and prevent zombie Docker child processes on timeout.
+  if (abortSignal?.aborted) {
+    throw abortSignal.reason instanceof Error
+      ? abortSignal.reason
+      : new Error("Sandbox init aborted");
+  }
+
+  await raceAbort(maybePruneSandboxes(cfg), abortSignal);
 
   const { agentWorkspaceDir, scopeKey, workspaceDir } = await ensureSandboxWorkspaceLayout({
     cfg,
@@ -149,6 +234,12 @@ export async function resolveSandboxContext(params: {
   });
   const resolvedCfg = docker === cfg.docker ? cfg : { ...cfg, docker };
 
+  if (abortSignal?.aborted) {
+    throw abortSignal.reason instanceof Error
+      ? abortSignal.reason
+      : new Error("Sandbox init aborted");
+  }
+
   const backendFactory = requireSandboxBackendFactory(resolvedCfg.backend);
   const backend = await backendFactory({
     sessionKey: rawSessionKey,
@@ -156,6 +247,7 @@ export async function resolveSandboxContext(params: {
     workspaceDir,
     agentWorkspaceDir,
     cfg: resolvedCfg,
+    abortSignal,
   });
   await updateRegistry({
     containerName: backend.runtimeId,
@@ -167,6 +259,15 @@ export async function resolveSandboxContext(params: {
     image: backend.configLabel ?? resolvedCfg.docker.image,
     configLabelKind: backend.configLabelKind ?? "Image",
   });
+
+  // Abort before the browser setup phase — ensureSandboxBrowser involves
+  // multiple Docker operations (inspect, network create, container start,
+  // CDP wait loop) and is likely the longest remaining step.
+  if (abortSignal?.aborted) {
+    throw abortSignal.reason instanceof Error
+      ? abortSignal.reason
+      : new Error("Sandbox init aborted");
+  }
 
   const evaluateEnabled =
     params.config?.browser?.evaluateEnabled ?? DEFAULT_BROWSER_EVALUATE_ENABLED;
@@ -187,6 +288,12 @@ export async function resolveSandboxContext(params: {
         return browserAuth;
       })()
     : undefined;
+  if (abortSignal?.aborted) {
+    throw abortSignal.reason instanceof Error
+      ? abortSignal.reason
+      : new Error("Sandbox init aborted");
+  }
+
   if (resolvedCfg.browser.enabled && backend.capabilities?.browser !== true) {
     throw new Error(
       `Sandbox backend "${resolvedCfg.backend}" does not support browser sandboxes yet.`,
@@ -201,6 +308,7 @@ export async function resolveSandboxContext(params: {
           cfg: resolvedCfg,
           evaluateEnabled,
           bridgeAuth,
+          abortSignal,
         })
       : null;
 

--- a/src/agents/sandbox/docker-backend.ts
+++ b/src/agents/sandbox/docker-backend.ts
@@ -37,6 +37,7 @@ export async function createDockerSandboxBackend(
     workspaceDir: params.workspaceDir,
     agentWorkspaceDir: params.agentWorkspaceDir,
     cfg: params.cfg,
+    abortSignal: params.abortSignal,
   });
   return createDockerSandboxBackendHandle({
     containerName,

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -154,6 +154,7 @@ function createSandboxConfig(
     },
     tools: { allow: [], deny: [] },
     prune: { idleHours: 24, maxAgeDays: 7 },
+    initTimeoutMs: 60_000,
   };
 }
 

--- a/src/agents/sandbox/docker.ts
+++ b/src/agents/sandbox/docker.ts
@@ -256,9 +256,14 @@ export async function readDockerNetworkGateway(network: string): Promise<string 
   return gw || null;
 }
 
-export async function readDockerPort(containerName: string, port: number) {
+export async function readDockerPort(
+  containerName: string,
+  port: number,
+  abortSignal?: AbortSignal,
+) {
   const result = await execDocker(["port", containerName, `${port}/tcp`], {
     allowFailure: true,
+    signal: abortSignal,
   });
   if (result.code !== 0) {
     return null;
@@ -272,9 +277,10 @@ export async function readDockerPort(containerName: string, port: number) {
   return Number.isFinite(mapped) ? mapped : null;
 }
 
-async function dockerImageExists(image: string) {
+async function dockerImageExists(image: string, abortSignal?: AbortSignal) {
   const result = await execDocker(["image", "inspect", image], {
     allowFailure: true,
+    signal: abortSignal,
   });
   if (result.code === 0) {
     return true;
@@ -286,22 +292,25 @@ async function dockerImageExists(image: string) {
   throw new Error(`Failed to inspect sandbox image: ${stderr}`);
 }
 
-export async function ensureDockerImage(image: string) {
-  const exists = await dockerImageExists(image);
+export async function ensureDockerImage(image: string, abortSignal?: AbortSignal) {
+  const exists = await dockerImageExists(image, abortSignal);
   if (exists) {
     return;
   }
   if (image === DEFAULT_SANDBOX_IMAGE) {
-    await execDocker(["pull", "debian:bookworm-slim"]);
-    await execDocker(["tag", "debian:bookworm-slim", DEFAULT_SANDBOX_IMAGE]);
+    await execDocker(["pull", "debian:bookworm-slim"], { signal: abortSignal });
+    await execDocker(["tag", "debian:bookworm-slim", DEFAULT_SANDBOX_IMAGE], {
+      signal: abortSignal,
+    });
     return;
   }
   throw new Error(`Sandbox image not found: ${image}. Build or pull it first.`);
 }
 
-export async function dockerContainerState(name: string) {
+export async function dockerContainerState(name: string, abortSignal?: AbortSignal) {
   const result = await execDocker(["inspect", "-f", "{{.State.Running}}", name], {
     allowFailure: true,
+    signal: abortSignal,
   });
   if (result.code !== 0) {
     return { exists: false, running: false };
@@ -475,9 +484,10 @@ async function createSandboxContainer(params: {
   agentWorkspaceDir: string;
   scopeKey: string;
   configHash?: string;
+  abortSignal?: AbortSignal;
 }) {
   const { name, cfg, workspaceDir, scopeKey } = params;
-  await ensureDockerImage(cfg.image);
+  await ensureDockerImage(cfg.image, params.abortSignal);
 
   const args = buildSandboxCreateArgs({
     name,
@@ -498,11 +508,13 @@ async function createSandboxContainer(params: {
   appendCustomBinds(args, cfg);
   args.push(cfg.image, "sleep", "infinity");
 
-  await execDocker(args);
-  await execDocker(["start", name]);
+  await execDocker(args, { signal: params.abortSignal });
+  await execDocker(["start", name], { signal: params.abortSignal });
 
   if (cfg.setupCommand?.trim()) {
-    await execDocker(["exec", "-i", name, "/bin/sh", "-lc", cfg.setupCommand]);
+    await execDocker(["exec", "-i", name, "/bin/sh", "-lc", cfg.setupCommand], {
+      signal: params.abortSignal,
+    });
   }
 }
 
@@ -526,6 +538,7 @@ export async function ensureSandboxContainer(params: {
   workspaceDir: string;
   agentWorkspaceDir: string;
   cfg: SandboxConfig;
+  abortSignal?: AbortSignal;
 }) {
   const scopeKey = resolveSandboxScopeKey(params.cfg.scope, params.sessionKey);
   const slug = params.cfg.scope === "shared" ? "shared" : slugifySessionKey(scopeKey);
@@ -539,7 +552,9 @@ export async function ensureSandboxContainer(params: {
     mountFormatVersion: SANDBOX_MOUNT_FORMAT_VERSION,
   });
   const now = Date.now();
-  const state = await dockerContainerState(containerName);
+  // Thread abortSignal so a wedged `docker inspect` during init does not
+  // survive the sandbox init timeout as a detached child process.
+  const state = await dockerContainerState(containerName, params.abortSignal);
   let hasContainer = state.exists;
   let running = state.running;
   let currentHash: string | null = null;
@@ -569,7 +584,10 @@ export async function ensureSandboxContainer(params: {
           `Sandbox config changed for ${containerName} (recently used). Recreate to apply: ${hint}`,
         );
       } else {
-        await execDocker(["rm", "-f", containerName], { allowFailure: true });
+        await execDocker(["rm", "-f", containerName], {
+          allowFailure: true,
+          signal: params.abortSignal,
+        });
         hasContainer = false;
         running = false;
       }
@@ -584,9 +602,10 @@ export async function ensureSandboxContainer(params: {
       agentWorkspaceDir: params.agentWorkspaceDir,
       scopeKey,
       configHash: expectedHash,
+      abortSignal: params.abortSignal,
     });
   } else if (!running) {
-    await execDocker(["start", containerName]);
+    await execDocker(["start", containerName], { signal: params.abortSignal });
   }
   await updateRegistry({
     containerName,

--- a/src/agents/sandbox/ssh-backend.test.ts
+++ b/src/agents/sandbox/ssh-backend.test.ts
@@ -95,6 +95,7 @@ function createBackendSandboxConfig(params?: { binds?: string[]; target?: string
     }),
     tools: { allow: [], deny: [] },
     prune: createSandboxPruneConfig(),
+    initTimeoutMs: 300_000,
   };
 }
 
@@ -268,6 +269,7 @@ describe("ssh sandbox backend", () => {
         },
         tools: { allow: [], deny: [] },
         prune: { idleHours: 24, maxAgeDays: 7 },
+        initTimeoutMs: 300_000,
       },
     });
 

--- a/src/agents/sandbox/types.ts
+++ b/src/agents/sandbox/types.ts
@@ -78,6 +78,8 @@ export type SandboxConfig = {
   browser: SandboxBrowserConfig;
   tools: SandboxToolPolicy;
   prune: SandboxPruneConfig;
+  /** Max time (ms) for sandbox initialization before aborting. */
+  initTimeoutMs: number;
 };
 
 export type SandboxBrowserContext = {

--- a/src/config/schema.base.generated.ts
+++ b/src/config/schema.base.generated.ts
@@ -5512,6 +5512,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                     },
                     additionalProperties: false,
                   },
+                  initTimeoutMs: {
+                    type: "integer",
+                    exclusiveMinimum: 0,
+                    maximum: 9007199254740991,
+                  },
                 },
                 additionalProperties: false,
               },
@@ -6785,6 +6790,11 @@ export const GENERATED_BASE_CONFIG_SCHEMA: BaseConfigSchemaResponse = {
                         },
                       },
                       additionalProperties: false,
+                    },
+                    initTimeoutMs: {
+                      type: "integer",
+                      exclusiveMinimum: 0,
+                      maximum: 9007199254740991,
                     },
                   },
                   additionalProperties: false,

--- a/src/config/types.agents-shared.ts
+++ b/src/config/types.agents-shared.ts
@@ -44,4 +44,10 @@ export type AgentSandboxConfig = {
   browser?: SandboxBrowserSettings;
   /** Auto-prune sandbox settings. */
   prune?: SandboxPruneSettings;
+  /**
+   * Max time (ms) to wait for sandbox initialization (container start + browser setup)
+   * before aborting. Prevents a hung Docker daemon from blocking the message pipeline.
+   * Default: 60000 (60s) for docker, 300000 (5min) for ssh/remote backends.
+   */
+  initTimeoutMs?: number;
 };

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -547,6 +547,7 @@ export const AgentSandboxSchema = z
     ssh: SandboxSshSchema,
     browser: SandboxBrowserSchema,
     prune: SandboxPruneSchema,
+    initTimeoutMs: z.number().int().positive().optional(),
   })
   .strict()
   .superRefine((data, ctx) => {


### PR DESCRIPTION
## Summary

Wrap sandbox context initialization in a configurable timeout (default 60s) so a hung or unreachable Docker daemon can no longer block the entire message processing pipeline indefinitely. When the timer fires, an `AbortController` signals cooperative cancellation into every downstream Docker call so pending awaits exit early instead of leaving zombie child processes behind.

## Why

A hung `docker` daemon would freeze the worker indefinitely. Any inbound message waiting on a sandbox context would hang, stalling the message pipeline end-to-end. Timeout + cooperative abort unblocks the pipeline and cleans up detached work.

## How it works

- `SANDBOX_INIT_TIMEOUT_MS` is configurable via `agents.defaults.sandbox.initTimeoutMs`.
- `resolveSandboxContext` wraps the inner work in `Promise.race([inner, timeout])` with `.finally()` cleanup.
- `AbortController` is threaded through every downstream Docker operation:
  - container state probes
  - `docker pull`, `docker run`
  - `readDockerPort`
  - CDP wait loop
  - browser restart / `ensureSandboxBrowserImage`
  - prune
- `resolveSandboxContextInner` checks the abort signal before each major async step to minimize wasted work.
- Browser attach callbacks (`onEnsureAttachTarget`) use a **fresh per-attach `AbortController`** rather than inheriting the init signal — the init timeout may have already fired, but the bridge is still valid for later session activity.
- Timeout `Error` and abort reason are the **same instance**, so the aborted-check path and race-winning rejection surface identical identity.
- Timer is `.unref()`'d as belt-and-braces so it can't pin the event loop.

## Security / correctness notes

- No blocking Docker calls remain in the init path that can't be interrupted.
- Prune is abort-aware; the success path does NOT force-rm the browser container on CDP-unreachable (attach failures are recoverable).

## Test plan

- [x] `pnpm tsgo` — clean
- [x] `pnpm check` — clean
- [x] `pnpm test src/agents/sandbox/` — 125 existing sandbox cases pass
- [x] `src/agents/sandbox/browser.create.test.ts` — updated for non-forceful CDP-timeout behavior
- [x] `src/agents/sandbox/context.timeout.test.ts` — new coverage for timeout/abort path
- [x] Squashed from 12 scattered commits into one `fix:` commit cleanly rebased on current `origin/main`.
