### PR TITLE
fix(discord): inherit parent guild allowlist when account groupPolicy overrides without users

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -126,6 +126,37 @@ describe("doctor config flow", () => {
     ).toBe(true);
   });
 
+  it("warns when discord account allowlist mode overrides parent guilds with empty guilds", async () => {
+    const doctorWarnings = await collectDoctorWarnings({
+      channels: {
+        discord: {
+          groupPolicy: "allowlist",
+          guilds: {
+            "123": {
+              channels: {
+                "456": { allow: true },
+              },
+            },
+          },
+          accounts: {
+            default: {
+              groupPolicy: "allowlist",
+              guilds: {},
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      doctorWarnings.some(
+        (line) =>
+          line.includes('channels.discord.accounts.default.groupPolicy is "allowlist"') &&
+          line.includes("guilds is empty"),
+      ),
+    ).toBe(true);
+  });
+
   it("drops unknown keys on repair", async () => {
     const result = await runDoctorConfigWithInput({
       repair: true,

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -151,7 +151,7 @@ describe("doctor config flow", () => {
     expect(
       doctorWarnings.some(
         (line) =>
-          line.includes('channels.discord.accounts.default.guilds is empty') &&
+          line.includes("channels.discord.accounts.default.guilds is empty") &&
           line.includes('effective groupPolicy is "allowlist"') &&
           line.includes("guilds is empty"),
       ),
@@ -182,7 +182,7 @@ describe("doctor config flow", () => {
     expect(
       doctorWarnings.some(
         (line) =>
-          line.includes('channels.discord.accounts.default.guilds is empty') &&
+          line.includes("channels.discord.accounts.default.guilds is empty") &&
           line.includes('effective groupPolicy is "allowlist"') &&
           line.includes("guilds is empty"),
       ),

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -151,7 +151,39 @@ describe("doctor config flow", () => {
     expect(
       doctorWarnings.some(
         (line) =>
-          line.includes('channels.discord.accounts.default.groupPolicy is "allowlist"') &&
+          line.includes('channels.discord.accounts.default.guilds is empty') &&
+          line.includes('effective groupPolicy is "allowlist"') &&
+          line.includes("guilds is empty"),
+      ),
+    ).toBe(true);
+  });
+
+  it("warns when discord account empty guild override inherits allowlist policy from parent", async () => {
+    const doctorWarnings = await collectDoctorWarnings({
+      channels: {
+        discord: {
+          groupPolicy: "allowlist",
+          guilds: {
+            "123": {
+              channels: {
+                "456": { allow: true },
+              },
+            },
+          },
+          accounts: {
+            default: {
+              guilds: {},
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      doctorWarnings.some(
+        (line) =>
+          line.includes('channels.discord.accounts.default.guilds is empty') &&
+          line.includes('effective groupPolicy is "allowlist"') &&
           line.includes("guilds is empty"),
       ),
     ).toBe(true);

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1318,6 +1318,12 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
   }
 
   const warnings: string[] = [];
+  const hasConfigEntries = (value: unknown): boolean => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return false;
+    }
+    return Object.keys(value as Record<string, unknown>).length > 0;
+  };
 
   const usesSenderBasedGroupAllowlist = (channelName?: string): boolean => {
     if (!channelName) {
@@ -1382,6 +1388,19 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
       (account.groupPolicy as string | undefined) ??
       (parent?.groupPolicy as string | undefined) ??
       undefined;
+
+    if (
+      channelName === "discord" &&
+      parent &&
+      groupPolicy === "allowlist" &&
+      Object.hasOwn(account, "guilds") &&
+      !hasConfigEntries(account.guilds) &&
+      hasConfigEntries(parent.guilds)
+    ) {
+      warnings.push(
+        `- ${prefix}.groupPolicy is "allowlist" but guilds is empty — this account override replaces channels.discord.guilds and can block all guild messages. Remove ${prefix}.guilds to inherit channels.discord.guilds, or configure guild entries under ${prefix}.guilds.`,
+      );
+    }
 
     if (groupPolicy === "allowlist" && usesSenderBasedGroupAllowlist(channelName)) {
       const rawGroupAllowFrom =

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1384,10 +1384,8 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
       );
     }
 
-    const groupPolicy =
-      (account.groupPolicy as string | undefined) ??
-      (parent?.groupPolicy as string | undefined) ??
-      undefined;
+    const accountGroupPolicy = account.groupPolicy as string | undefined;
+    const groupPolicy = accountGroupPolicy ?? (parent?.groupPolicy as string | undefined) ?? undefined;
 
     if (
       channelName === "discord" &&
@@ -1398,7 +1396,7 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
       hasConfigEntries(parent.guilds)
     ) {
       warnings.push(
-        `- ${prefix}.groupPolicy is "allowlist" but guilds is empty — this account override replaces channels.discord.guilds and can block all guild messages. Remove ${prefix}.guilds to inherit channels.discord.guilds, or configure guild entries under ${prefix}.guilds.`,
+        `- ${prefix}.guilds is empty while effective groupPolicy is "allowlist" — this account override replaces channels.discord.guilds and can block all guild messages. Remove ${prefix}.guilds to inherit channels.discord.guilds, or configure guild entries under ${prefix}.guilds.`,
       );
     }
 

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1385,7 +1385,8 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
     }
 
     const accountGroupPolicy = account.groupPolicy as string | undefined;
-    const groupPolicy = accountGroupPolicy ?? (parent?.groupPolicy as string | undefined) ?? undefined;
+    const groupPolicy =
+      accountGroupPolicy ?? (parent?.groupPolicy as string | undefined) ?? undefined;
 
     if (
       channelName === "discord" &&

--- a/src/discord/accounts.test.ts
+++ b/src/discord/accounts.test.ts
@@ -55,4 +55,63 @@ describe("resolveDiscordAccount allowFrom precedence", () => {
 
     expect(resolved.config.allowFrom).toBeUndefined();
   });
+
+  it("inherits top-level guilds when account allowlist mode overrides with empty guilds", () => {
+    const resolved = resolveDiscordAccount({
+      cfg: {
+        channels: {
+          discord: {
+            groupPolicy: "allowlist",
+            guilds: {
+              "123": {
+                channels: {
+                  "456": { allow: true },
+                },
+              },
+            },
+            accounts: {
+              default: {
+                token: "token-default",
+                groupPolicy: "allowlist",
+                guilds: {},
+              },
+            },
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(Object.keys(resolved.config.guilds ?? {})).toEqual(["123"]);
+    expect(resolved.config.guilds?.["123"]?.channels?.["456"]?.allow).toBe(true);
+  });
+
+  it("keeps explicit empty guild override when account groupPolicy is not allowlist", () => {
+    const resolved = resolveDiscordAccount({
+      cfg: {
+        channels: {
+          discord: {
+            groupPolicy: "allowlist",
+            guilds: {
+              "123": {
+                channels: {
+                  "456": { allow: true },
+                },
+              },
+            },
+            accounts: {
+              default: {
+                token: "token-default",
+                groupPolicy: "open",
+                guilds: {},
+              },
+            },
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(resolved.config.guilds).toEqual({});
+  });
 });

--- a/src/discord/accounts.test.ts
+++ b/src/discord/accounts.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
-import { resolveDiscordAccount } from "./accounts.js";
+import { beforeEach, describe, expect, it } from "vitest";
+import { resetDiscordAccountWarningStateForTests, resolveDiscordAccount } from "./accounts.js";
 
 describe("resolveDiscordAccount allowFrom precedence", () => {
+  beforeEach(() => {
+    resetDiscordAccountWarningStateForTests();
+  });
+
   it("prefers accounts.default.allowFrom over top-level for default account", () => {
     const resolved = resolveDiscordAccount({
       cfg: {
@@ -82,6 +86,36 @@ describe("resolveDiscordAccount allowFrom precedence", () => {
       accountId: "default",
     });
 
+    expect(Object.keys(resolved.config.guilds ?? {})).toEqual(["123"]);
+    expect(resolved.config.guilds?.["123"]?.channels?.["456"]?.allow).toBe(true);
+  });
+
+  it("inherits top-level guilds when allowlist policy is inherited and account guilds are empty", () => {
+    const resolved = resolveDiscordAccount({
+      cfg: {
+        channels: {
+          discord: {
+            groupPolicy: "allowlist",
+            guilds: {
+              "123": {
+                channels: {
+                  "456": { allow: true },
+                },
+              },
+            },
+            accounts: {
+              default: {
+                token: "token-default",
+                guilds: {},
+              },
+            },
+          },
+        },
+      },
+      accountId: "default",
+    });
+
+    expect(resolved.config.groupPolicy).toBe("allowlist");
     expect(Object.keys(resolved.config.guilds ?? {})).toEqual(["123"]);
     expect(resolved.config.guilds?.["123"]?.channels?.["456"]?.allow).toBe(true);
   });

--- a/src/discord/accounts.ts
+++ b/src/discord/accounts.ts
@@ -2,6 +2,7 @@ import { createAccountActionGate } from "../channels/plugins/account-action-gate
 import { createAccountListHelpers } from "../channels/plugins/account-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
 import type { DiscordAccountConfig, DiscordActionConfig } from "../config/types.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveAccountEntry } from "../routing/account-lookup.js";
 import { normalizeAccountId } from "../routing/session-key.js";
 import { resolveDiscordToken } from "./token.js";
@@ -18,6 +19,20 @@ export type ResolvedDiscordAccount = {
 const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("discord");
 export const listDiscordAccountIds = listAccountIds;
 export const resolveDefaultDiscordAccountId = resolveDefaultAccountId;
+const log = createSubsystemLogger("discord/accounts");
+const warnedEmptyGuildOverrides = new Set<string>();
+
+function asObjectRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+function hasObjectKeys(value: unknown): boolean {
+  const record = asObjectRecord(value);
+  return Boolean(record && Object.keys(record).length > 0);
+}
 
 function resolveAccountConfig(
   cfg: OpenClawConfig,
@@ -31,7 +46,29 @@ function mergeDiscordAccountConfig(cfg: OpenClawConfig, accountId: string): Disc
     accounts?: unknown;
   };
   const account = resolveAccountConfig(cfg, accountId) ?? {};
-  return { ...base, ...account };
+  const merged = { ...base, ...account };
+  const accountExplicitlyOverridesGuilds = Object.hasOwn(account, "guilds");
+  const accountGuildsEmpty = !hasObjectKeys(account.guilds);
+  const parentGuildsConfigured = hasObjectKeys(base.guilds);
+
+  // Preserve parent guild allowlist when an account sets allowlist mode but leaves
+  // guilds empty (for example `guilds: {}`), which otherwise overrides to deny-all.
+  if (
+    merged.groupPolicy === "allowlist" &&
+    accountExplicitlyOverridesGuilds &&
+    accountGuildsEmpty &&
+    parentGuildsConfigured
+  ) {
+    if (!warnedEmptyGuildOverrides.has(accountId)) {
+      warnedEmptyGuildOverrides.add(accountId);
+      log.warn?.(
+        `channels.discord.accounts.${accountId}.groupPolicy is "allowlist" but guilds is empty; inheriting channels.discord.guilds for this account. Configure channels.discord.accounts.${accountId}.guilds explicitly or remove the empty override.`,
+      );
+    }
+    merged.guilds = base.guilds;
+  }
+
+  return merged;
 }
 
 export function createDiscordActionGate(params: {

--- a/src/discord/accounts.ts
+++ b/src/discord/accounts.ts
@@ -22,6 +22,10 @@ export const resolveDefaultDiscordAccountId = resolveDefaultAccountId;
 const log = createSubsystemLogger("discord/accounts");
 const warnedEmptyGuildOverrides = new Set<string>();
 
+export function resetDiscordAccountWarningStateForTests(): void {
+  warnedEmptyGuildOverrides.clear();
+}
+
 function asObjectRecord(value: unknown): Record<string, unknown> | undefined {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return undefined;
@@ -62,7 +66,7 @@ function mergeDiscordAccountConfig(cfg: OpenClawConfig, accountId: string): Disc
     if (!warnedEmptyGuildOverrides.has(accountId)) {
       warnedEmptyGuildOverrides.add(accountId);
       log.warn?.(
-        `channels.discord.accounts.${accountId}.groupPolicy is "allowlist" but guilds is empty; inheriting channels.discord.guilds for this account. Configure channels.discord.accounts.${accountId}.guilds explicitly or remove the empty override.`,
+        `channels.discord.accounts.${accountId}.guilds is empty while effective groupPolicy is "allowlist"; inheriting channels.discord.guilds for this account. Configure channels.discord.accounts.${accountId}.guilds explicitly or remove the empty override.`,
       );
     }
     merged.guilds = base.guilds;


### PR DESCRIPTION
Fixes #33569

## Problem
When `channels.discord.accounts.<id>.groupPolicy` is set to `"allowlist"` without any account-level `guilds` or `users`, it silently overrides the parent-level guild allowlist and drops ALL Discord group messages with zero logs or warnings.

## Fix
In `resolveEffectiveDiscordAccountConfig()`, detect when an account-level config sets `groupPolicy: "allowlist"` but has an empty/absent `guilds` map while the parent config has a non-empty `guilds` map. In that case, inherit the parent guilds and emit a runtime warning guiding the user to configure explicitly.

## Changes
- `src/discord/accounts.ts`: Added `resolveEffectiveDiscordAccountConfig` logic to inherit parent guilds with a one-time log warning when account-level guilds are empty but parent guilds are configured
- Adds `warnedEmptyGuildOverrides` set to avoid log spam on repeated messages

## Testing
Reproducer: set `accounts.default.groupPolicy: "allowlist"` with no `guilds` key in the account block while the top-level channel has a populated `guilds` map. Before this fix all messages are dropped silently; after, they are processed and a warning is logged.