### PR TITLE
fix(agents): auto-fallback to CLI backend for codex-responses models

### DIFF
--- a/src/agents/cli-backends.ts
+++ b/src/agents/cli-backends.ts
@@ -159,6 +159,19 @@ export function resolveCliBackendIds(cfg?: OpenClawConfig): Set<string> {
   return ids;
 }
 
+/**
+ * Returns true when the user has explicitly configured a CLI backend entry
+ * for the given provider (e.g. "codex-cli") in their config file, as opposed
+ * to relying on the built-in defaults.  This is used to guard auto-fallback
+ * logic: we should not silently spawn a CLI binary that the user never asked
+ * for.
+ */
+export function hasExplicitCliBackend(provider: string, cfg?: OpenClawConfig): boolean {
+  const normalized = normalizeBackendKey(provider);
+  const configured = cfg?.agents?.defaults?.cliBackends ?? {};
+  return Object.keys(configured).some((key) => normalizeBackendKey(key) === normalized);
+}
+
 export function resolveCliBackendConfig(
   provider: string,
   cfg?: OpenClawConfig,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -401,148 +401,146 @@ export async function runAgentTurnWithFallback(params: {
             authProfile,
           });
           const result = await runEmbeddedPiAgent({
-              ...embeddedContext,
-              trigger: params.isHeartbeat ? "heartbeat" : "user",
-              groupId: resolveGroupSessionKey(params.sessionCtx)?.id,
-              groupChannel:
-                params.sessionCtx.GroupChannel?.trim() ?? params.sessionCtx.GroupSubject?.trim(),
-              groupSpace: params.sessionCtx.GroupSpace?.trim() ?? undefined,
-              ...senderContext,
-              ...runBaseParams,
-              prompt: params.commandBody,
-              extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
-              toolResultFormat: (() => {
-                const channel = resolveMessageChannel(
-                  params.sessionCtx.Surface,
-                  params.sessionCtx.Provider,
-                );
-                if (!channel) {
-                  return "markdown";
-                }
-                return isMarkdownCapableMessageChannel(channel) ? "markdown" : "plain";
-              })(),
-              suppressToolErrorWarnings: params.opts?.suppressToolErrorWarnings,
-              bootstrapContextMode: params.opts?.bootstrapContextMode,
-              bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
-              images: params.opts?.images,
-              abortSignal: params.opts?.abortSignal,
-              blockReplyBreak: params.resolvedBlockStreamingBreak,
-              blockReplyChunking: params.blockReplyChunking,
-              onPartialReply: async (payload) => {
-                const textForTyping = await handlePartialForTyping(payload);
-                if (!params.opts?.onPartialReply || textForTyping === undefined) {
-                  return;
-                }
-                await params.opts.onPartialReply({
-                  text: textForTyping,
-                  mediaUrls: payload.mediaUrls,
-                });
-              },
-              onAssistantMessageStart: async () => {
-                await params.typingSignals.signalMessageStart();
-                await params.opts?.onAssistantMessageStart?.();
-              },
-              onReasoningStream:
-                params.typingSignals.shouldStartOnReasoning || params.opts?.onReasoningStream
-                  ? async (payload) => {
-                      await params.typingSignals.signalReasoningDelta();
-                      await params.opts?.onReasoningStream?.({
-                        text: payload.text,
-                        mediaUrls: payload.mediaUrls,
-                      });
-                    }
-                  : undefined,
-              onReasoningEnd: params.opts?.onReasoningEnd,
-              onAgentEvent: async (evt) => {
-                // Signal run start only after the embedded agent emits real activity.
-                const hasLifecyclePhase =
-                  evt.stream === "lifecycle" && typeof evt.data.phase === "string";
-                if (evt.stream !== "lifecycle" || hasLifecyclePhase) {
-                  notifyAgentRunStart();
-                }
-                // Trigger typing when tools start executing.
-                // Must await to ensure typing indicator starts before tool summaries are emitted.
-                if (evt.stream === "tool") {
-                  const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
-                  const name = typeof evt.data.name === "string" ? evt.data.name : undefined;
-                  if (phase === "start" || phase === "update") {
-                    await params.typingSignals.signalToolStart();
-                    await params.opts?.onToolStart?.({ name, phase });
+            ...embeddedContext,
+            trigger: params.isHeartbeat ? "heartbeat" : "user",
+            groupId: resolveGroupSessionKey(params.sessionCtx)?.id,
+            groupChannel:
+              params.sessionCtx.GroupChannel?.trim() ?? params.sessionCtx.GroupSubject?.trim(),
+            groupSpace: params.sessionCtx.GroupSpace?.trim() ?? undefined,
+            ...senderContext,
+            ...runBaseParams,
+            prompt: params.commandBody,
+            extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+            toolResultFormat: (() => {
+              const channel = resolveMessageChannel(
+                params.sessionCtx.Surface,
+                params.sessionCtx.Provider,
+              );
+              if (!channel) {
+                return "markdown";
+              }
+              return isMarkdownCapableMessageChannel(channel) ? "markdown" : "plain";
+            })(),
+            suppressToolErrorWarnings: params.opts?.suppressToolErrorWarnings,
+            bootstrapContextMode: params.opts?.bootstrapContextMode,
+            bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
+            images: params.opts?.images,
+            abortSignal: params.opts?.abortSignal,
+            blockReplyBreak: params.resolvedBlockStreamingBreak,
+            blockReplyChunking: params.blockReplyChunking,
+            onPartialReply: async (payload) => {
+              const textForTyping = await handlePartialForTyping(payload);
+              if (!params.opts?.onPartialReply || textForTyping === undefined) {
+                return;
+              }
+              await params.opts.onPartialReply({
+                text: textForTyping,
+                mediaUrls: payload.mediaUrls,
+              });
+            },
+            onAssistantMessageStart: async () => {
+              await params.typingSignals.signalMessageStart();
+              await params.opts?.onAssistantMessageStart?.();
+            },
+            onReasoningStream:
+              params.typingSignals.shouldStartOnReasoning || params.opts?.onReasoningStream
+                ? async (payload) => {
+                    await params.typingSignals.signalReasoningDelta();
+                    await params.opts?.onReasoningStream?.({
+                      text: payload.text,
+                      mediaUrls: payload.mediaUrls,
+                    });
                   }
-                }
-                // Track auto-compaction completion
-                if (evt.stream === "compaction") {
-                  const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
-                  if (phase === "end") {
-                    autoCompactionCompleted = true;
-                  }
-                }
-              },
-              // Always pass onBlockReply so flushBlockReplyBuffer works before tool execution,
-              // even when regular block streaming is disabled. The handler sends directly
-              // via opts.onBlockReply when the pipeline isn't available.
-              onBlockReply: params.opts?.onBlockReply
-                ? createBlockReplyDeliveryHandler({
-                    onBlockReply: params.opts.onBlockReply,
-                    currentMessageId:
-                      params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid,
-                    normalizeStreamingText,
-                    applyReplyToMode: params.applyReplyToMode,
-                    typingSignals: params.typingSignals,
-                    blockStreamingEnabled: params.blockStreamingEnabled,
-                    blockReplyPipeline,
-                    directlySentBlockKeys,
-                  })
                 : undefined,
-              onBlockReplyFlush:
-                params.blockStreamingEnabled && blockReplyPipeline
-                  ? async () => {
-                      await blockReplyPipeline.flush({ force: true });
-                    }
-                  : undefined,
-              shouldEmitToolResult: params.shouldEmitToolResult,
-              shouldEmitToolOutput: params.shouldEmitToolOutput,
-              bootstrapPromptWarningSignaturesSeen,
-              bootstrapPromptWarningSignature:
-                bootstrapPromptWarningSignaturesSeen[
-                  bootstrapPromptWarningSignaturesSeen.length - 1
-                ],
-              onToolResult: onToolResult
-                ? (() => {
-                    // Serialize tool result delivery to preserve message ordering.
-                    // Without this, concurrent tool callbacks race through typing signals
-                    // and message sends, causing out-of-order delivery to the user.
-                    // See: https://github.com/openclaw/openclaw/issues/11044
-                    let toolResultChain: Promise<void> = Promise.resolve();
-                    return (payload: ReplyPayload) => {
-                      toolResultChain = toolResultChain
-                        .then(async () => {
-                          const { text, skip } = normalizeStreamingText(payload);
-                          if (skip) {
-                            return;
-                          }
-                          await params.typingSignals.signalTextDelta(text);
-                          await onToolResult({
-                            text,
-                            mediaUrls: payload.mediaUrls,
-                          });
-                        })
-                        .catch((err) => {
-                          // Keep chain healthy after an error so later tool results still deliver.
-                          logVerbose(`tool result delivery failed: ${String(err)}`);
+            onReasoningEnd: params.opts?.onReasoningEnd,
+            onAgentEvent: async (evt) => {
+              // Signal run start only after the embedded agent emits real activity.
+              const hasLifecyclePhase =
+                evt.stream === "lifecycle" && typeof evt.data.phase === "string";
+              if (evt.stream !== "lifecycle" || hasLifecyclePhase) {
+                notifyAgentRunStart();
+              }
+              // Trigger typing when tools start executing.
+              // Must await to ensure typing indicator starts before tool summaries are emitted.
+              if (evt.stream === "tool") {
+                const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
+                const name = typeof evt.data.name === "string" ? evt.data.name : undefined;
+                if (phase === "start" || phase === "update") {
+                  await params.typingSignals.signalToolStart();
+                  await params.opts?.onToolStart?.({ name, phase });
+                }
+              }
+              // Track auto-compaction completion
+              if (evt.stream === "compaction") {
+                const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
+                if (phase === "end") {
+                  autoCompactionCompleted = true;
+                }
+              }
+            },
+            // Always pass onBlockReply so flushBlockReplyBuffer works before tool execution,
+            // even when regular block streaming is disabled. The handler sends directly
+            // via opts.onBlockReply when the pipeline isn't available.
+            onBlockReply: params.opts?.onBlockReply
+              ? createBlockReplyDeliveryHandler({
+                  onBlockReply: params.opts.onBlockReply,
+                  currentMessageId:
+                    params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid,
+                  normalizeStreamingText,
+                  applyReplyToMode: params.applyReplyToMode,
+                  typingSignals: params.typingSignals,
+                  blockStreamingEnabled: params.blockStreamingEnabled,
+                  blockReplyPipeline,
+                  directlySentBlockKeys,
+                })
+              : undefined,
+            onBlockReplyFlush:
+              params.blockStreamingEnabled && blockReplyPipeline
+                ? async () => {
+                    await blockReplyPipeline.flush({ force: true });
+                  }
+                : undefined,
+            shouldEmitToolResult: params.shouldEmitToolResult,
+            shouldEmitToolOutput: params.shouldEmitToolOutput,
+            bootstrapPromptWarningSignaturesSeen,
+            bootstrapPromptWarningSignature:
+              bootstrapPromptWarningSignaturesSeen[bootstrapPromptWarningSignaturesSeen.length - 1],
+            onToolResult: onToolResult
+              ? (() => {
+                  // Serialize tool result delivery to preserve message ordering.
+                  // Without this, concurrent tool callbacks race through typing signals
+                  // and message sends, causing out-of-order delivery to the user.
+                  // See: https://github.com/openclaw/openclaw/issues/11044
+                  let toolResultChain: Promise<void> = Promise.resolve();
+                  return (payload: ReplyPayload) => {
+                    toolResultChain = toolResultChain
+                      .then(async () => {
+                        const { text, skip } = normalizeStreamingText(payload);
+                        if (skip) {
+                          return;
+                        }
+                        await params.typingSignals.signalTextDelta(text);
+                        await onToolResult({
+                          text,
+                          mediaUrls: payload.mediaUrls,
                         });
-                      const task = toolResultChain.finally(() => {
-                        params.pendingToolTasks.delete(task);
+                      })
+                      .catch((err) => {
+                        // Keep chain healthy after an error so later tool results still deliver.
+                        logVerbose(`tool result delivery failed: ${String(err)}`);
                       });
-                      params.pendingToolTasks.add(task);
-                    };
-                  })()
-                : undefined,
-            });
-            bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-              result.meta?.systemPromptReport,
-            );
-            return result;
+                    const task = toolResultChain.finally(() => {
+                      params.pendingToolTasks.delete(task);
+                    });
+                    params.pendingToolTasks.add(task);
+                  };
+                })()
+              : undefined,
+          });
+          bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
+            result.meta?.systemPromptReport,
+          );
+          return result;
         },
       });
       runResult = fallbackResult.result;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -256,7 +256,6 @@ export async function runAgentTurnWithFallback(params: {
               },
             });
             const cliSessionId = getCliSessionId(params.getActiveSessionEntry(), cliProvider);
-            let lifecycleTerminalEmitted = false;
             try {
               const result = await runCliAgent({
                 sessionId: params.followupRun.run.sessionId,
@@ -306,33 +305,34 @@ export async function runAgentTurnWithFallback(params: {
                   endedAt: Date.now(),
                 },
               });
-              lifecycleTerminalEmitted = true;
-
               return result;
             } catch (err) {
-              // The user has a codex-cli backend in their config, but this
-              // particular model was auto-routed to it (isCodexAutoFallback)
-              // rather than the user explicitly requesting CLI execution.
-              // When the CLI binary is missing or crashes, fall through to
-              // the embedded runner which provides text-only output (no tool
-              // calls for codex models).
+              // The codex-cli backend was auto-selected based on model API
+              // detection (the user configured a codex-cli backend, but didn't
+              // explicitly request CLI execution for this model). When the CLI
+              // binary is missing or crashes, fall through to the embedded
+              // runner which provides text-only output (no tool calls for
+              // codex models).
               if (isCodexAutoFallback) {
-                defaultRuntime.log(
-                  `Codex CLI unavailable, falling back to embedded runner (tool calls will not be available): ${String(err)}`,
-                );
-                // Close the CLI lifecycle so downstream consumers don't stall
-                // on the open "start" event. The embedded runner emits its own.
+                // Do NOT emit lifecycle:error here — the embedded runner will
+                // emit its own lifecycle:start/end pair. Emitting error here
+                // would leave downstream consumers seeing a permanently-errored
+                // run even though the embedded runner succeeds.
+                // Instead, close the CLI lifecycle cleanly with "end" so the
+                // event stream is consistent, and warn about degradation.
                 emitAgentEvent({
                   runId,
                   stream: "lifecycle",
                   data: {
-                    phase: "error",
+                    phase: "end",
                     startedAt,
                     endedAt: Date.now(),
-                    error: `CLI fallback: ${String(err)}`,
                   },
                 });
-                lifecycleTerminalEmitted = true;
+                defaultRuntime.warn(
+                  `Codex CLI failed, falling back to embedded runner WITHOUT tool support. ` +
+                    `User will receive text-only output. Error: ${String(err)}`,
+                );
               } else {
                 emitAgentEvent({
                   runId,
@@ -344,23 +344,7 @@ export async function runAgentTurnWithFallback(params: {
                     error: String(err),
                   },
                 });
-                lifecycleTerminalEmitted = true;
                 throw err;
-              }
-            } finally {
-              // Defensive backstop: never let a CLI run complete without a terminal
-              // lifecycle event, otherwise downstream consumers can hang.
-              if (!lifecycleTerminalEmitted) {
-                emitAgentEvent({
-                  runId,
-                  stream: "lifecycle",
-                  data: {
-                    phase: "error",
-                    startedAt,
-                    endedAt: Date.now(),
-                    error: "CLI run completed without lifecycle terminal event",
-                  },
-                });
               }
             }
           }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
+import { resolveCliBackendConfig } from "../../agents/cli-backends.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
@@ -13,6 +14,7 @@ import {
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
+import { resolveModel } from "../../agents/pi-embedded-runner/model.js";
 import {
   resolveGroupSessionKey,
   resolveSessionTranscriptPath,
@@ -129,9 +131,32 @@ export async function runAgentTurnWithFallback(params: {
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.getActiveSessionEntry()?.systemPromptReport,
   );
+  const codexCliBackend = resolveCliBackendConfig("codex-cli", params.followupRun.run.config);
+  const modelApiByRef = new Map<string, string | undefined>();
 
   while (true) {
     try {
+      const resolveModelApi = (provider: string, model: string): string | undefined => {
+        const key = `${provider}\0${model}`;
+        if (modelApiByRef.has(key)) {
+          return modelApiByRef.get(key);
+        }
+        let resolvedApi: string | undefined;
+        try {
+          const resolved = resolveModel(
+            provider,
+            model,
+            params.followupRun.run.agentDir,
+            params.followupRun.run.config,
+          );
+          resolvedApi = resolved.model?.api;
+        } catch {
+          resolvedApi = undefined;
+        }
+        modelApiByRef.set(key, resolvedApi);
+        return resolvedApi;
+      };
+
       const normalizeStreamingText = (payload: ReplyPayload): { text?: string; skip: boolean } => {
         let text = payload.text;
         if (!params.isHeartbeat && text?.includes("HEARTBEAT_OK")) {
@@ -195,7 +220,23 @@ export async function runAgentTurnWithFallback(params: {
             thinkLevel: params.followupRun.run.thinkLevel,
           });
 
-          if (isCliProvider(provider, params.followupRun.run.config)) {
+          // Detect codex-responses models and auto-fallback to CLI backend
+          // when available. Codex embedded runner silently ignores tool calls.
+          // See: https://github.com/openclaw/openclaw/issues/33587
+          let cliProvider = isCliProvider(provider, params.followupRun.run.config)
+            ? provider
+            : undefined;
+          if (!cliProvider && codexCliBackend) {
+            const modelApi = resolveModelApi(provider, model);
+            if (modelApi === "openai-codex-responses") {
+              defaultRuntime.error(
+                "Codex model detected, routing through CLI backend for tool support",
+              );
+              cliProvider = codexCliBackend.id;
+            }
+          }
+
+          if (cliProvider) {
             const startedAt = Date.now();
             notifyAgentRunStart();
             emitAgentEvent({
@@ -206,7 +247,7 @@ export async function runAgentTurnWithFallback(params: {
                 startedAt,
               },
             });
-            const cliSessionId = getCliSessionId(params.getActiveSessionEntry(), provider);
+            const cliSessionId = getCliSessionId(params.getActiveSessionEntry(), cliProvider);
             return (async () => {
               let lifecycleTerminalEmitted = false;
               try {
@@ -218,7 +259,7 @@ export async function runAgentTurnWithFallback(params: {
                   workspaceDir: params.followupRun.run.workspaceDir,
                   config: params.followupRun.run.config,
                   prompt: params.commandBody,
-                  provider,
+                  provider: cliProvider,
                   model,
                   thinkLevel: params.followupRun.run.thinkLevel,
                   timeoutMs: params.followupRun.run.timeoutMs,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -13,8 +13,8 @@ import {
   isTransientHttpError,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
-import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import { resolveModel } from "../../agents/pi-embedded-runner/model.js";
+import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
 import {
   resolveGroupSessionKey,
   resolveSessionTranscriptPath,
@@ -211,7 +211,7 @@ export async function runAgentTurnWithFallback(params: {
       const onToolResult = params.opts?.onToolResult;
       const fallbackResult = await runWithModelFallback({
         ...resolveModelFallbackOptions(params.followupRun.run),
-        run: (provider, model) => {
+        run: async (provider, model) => {
           // Notify that model selection is complete (including after fallback).
           // This allows responsePrefix template interpolation with the actual model.
           params.opts?.onModelSelected?.({
@@ -226,13 +226,15 @@ export async function runAgentTurnWithFallback(params: {
           let cliProvider = isCliProvider(provider, params.followupRun.run.config)
             ? provider
             : undefined;
+          let isCodexAutoFallback = false;
           if (!cliProvider && codexCliBackend) {
             const modelApi = resolveModelApi(provider, model);
             if (modelApi === "openai-codex-responses") {
-              defaultRuntime.error(
+              defaultRuntime.log(
                 "Codex model detected, routing through CLI backend for tool support",
               );
               cliProvider = codexCliBackend.id;
+              isCodexAutoFallback = true;
             }
           }
 
@@ -248,61 +250,61 @@ export async function runAgentTurnWithFallback(params: {
               },
             });
             const cliSessionId = getCliSessionId(params.getActiveSessionEntry(), cliProvider);
-            return (async () => {
-              let lifecycleTerminalEmitted = false;
-              try {
-                const result = await runCliAgent({
-                  sessionId: params.followupRun.run.sessionId,
-                  sessionKey: params.sessionKey,
-                  agentId: params.followupRun.run.agentId,
-                  sessionFile: params.followupRun.run.sessionFile,
-                  workspaceDir: params.followupRun.run.workspaceDir,
-                  config: params.followupRun.run.config,
-                  prompt: params.commandBody,
-                  provider: cliProvider,
-                  model,
-                  thinkLevel: params.followupRun.run.thinkLevel,
-                  timeoutMs: params.followupRun.run.timeoutMs,
-                  runId,
-                  extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
-                  ownerNumbers: params.followupRun.run.ownerNumbers,
-                  cliSessionId,
-                  bootstrapPromptWarningSignaturesSeen,
-                  bootstrapPromptWarningSignature:
-                    bootstrapPromptWarningSignaturesSeen[
-                      bootstrapPromptWarningSignaturesSeen.length - 1
-                    ],
-                  images: params.opts?.images,
-                });
-                bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-                  result.meta?.systemPromptReport,
-                );
+            let lifecycleTerminalEmitted = false;
+            try {
+              const result = await runCliAgent({
+                sessionId: params.followupRun.run.sessionId,
+                sessionKey: params.sessionKey,
+                agentId: params.followupRun.run.agentId,
+                sessionFile: params.followupRun.run.sessionFile,
+                workspaceDir: params.followupRun.run.workspaceDir,
+                config: params.followupRun.run.config,
+                prompt: params.commandBody,
+                provider: cliProvider,
+                model,
+                thinkLevel: params.followupRun.run.thinkLevel,
+                timeoutMs: params.followupRun.run.timeoutMs,
+                runId,
+                extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+                ownerNumbers: params.followupRun.run.ownerNumbers,
+                cliSessionId,
+                bootstrapPromptWarningSignaturesSeen,
+                bootstrapPromptWarningSignature:
+                  bootstrapPromptWarningSignaturesSeen[
+                    bootstrapPromptWarningSignaturesSeen.length - 1
+                  ],
+                images: params.opts?.images,
+              });
+              bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
+                result.meta?.systemPromptReport,
+              );
 
-                // CLI backends don't emit streaming assistant events, so we need to
-                // emit one with the final text so server-chat can populate its buffer
-                // and send the response to TUI/WebSocket clients.
-                const cliText = result.payloads?.[0]?.text?.trim();
-                if (cliText) {
-                  emitAgentEvent({
-                    runId,
-                    stream: "assistant",
-                    data: { text: cliText },
-                  });
-                }
-
+              // CLI backends don't emit streaming assistant events, so we need to
+              // emit one with the final text so server-chat can populate its buffer
+              // and send the response to TUI/WebSocket clients.
+              const cliText = result.payloads?.[0]?.text?.trim();
+              if (cliText) {
                 emitAgentEvent({
                   runId,
-                  stream: "lifecycle",
-                  data: {
-                    phase: "end",
-                    startedAt,
-                    endedAt: Date.now(),
-                  },
+                  stream: "assistant",
+                  data: { text: cliText },
                 });
-                lifecycleTerminalEmitted = true;
+              }
 
-                return result;
-              } catch (err) {
+              emitAgentEvent({
+                runId,
+                stream: "lifecycle",
+                data: {
+                  phase: "end",
+                  startedAt,
+                  endedAt: Date.now(),
+                },
+              });
+              lifecycleTerminalEmitted = true;
+
+              return result;
+            } catch (err) {
+              if (!lifecycleTerminalEmitted) {
                 emitAgentEvent({
                   runId,
                   stream: "lifecycle",
@@ -314,24 +316,33 @@ export async function runAgentTurnWithFallback(params: {
                   },
                 });
                 lifecycleTerminalEmitted = true;
-                throw err;
-              } finally {
-                // Defensive backstop: never let a CLI run complete without a terminal
-                // lifecycle event, otherwise downstream consumers can hang.
-                if (!lifecycleTerminalEmitted) {
-                  emitAgentEvent({
-                    runId,
-                    stream: "lifecycle",
-                    data: {
-                      phase: "error",
-                      startedAt,
-                      endedAt: Date.now(),
-                      error: "CLI run completed without lifecycle terminal event",
-                    },
-                  });
-                }
               }
-            })();
+              // When the codex CLI backend was auto-selected (not explicitly configured
+              // by the user) and the CLI binary is unavailable or fails to launch,
+              // fall through to the embedded runner instead of surfacing an error.
+              if (isCodexAutoFallback) {
+                defaultRuntime.log(
+                  `Codex CLI backend unavailable, falling back to embedded runner: ${String(err)}`,
+                );
+              } else {
+                throw err;
+              }
+            } finally {
+              // Defensive backstop: never let a CLI run complete without a terminal
+              // lifecycle event, otherwise downstream consumers can hang.
+              if (!lifecycleTerminalEmitted) {
+                emitAgentEvent({
+                  runId,
+                  stream: "lifecycle",
+                  data: {
+                    phase: "error",
+                    startedAt,
+                    endedAt: Date.now(),
+                    error: "CLI run completed without lifecycle terminal event",
+                  },
+                });
+              }
+            }
           }
           const { authProfile, embeddedContext, senderContext } = buildEmbeddedRunContexts({
             run: params.followupRun.run,

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -282,7 +282,13 @@ export async function runAgentTurnWithFallback(params: {
                   result.meta?.systemPromptReport,
                 );
 
-                // CLI succeeded — emit lifecycle events retroactively
+                // CLI succeeded — emit lifecycle events retroactively.
+                // NOTE: notifyAgentRunStart and lifecycle:start are emitted after the
+                // CLI has already completed. This is an intentional trade-off of the
+                // speculative approach: we avoid orphaned lifecycle events on failure
+                // at the cost of downstream consumers (timers, UI spinners) having no
+                // window where the run is observable as "in progress". The startedAt
+                // timestamp is accurate; only the event delivery is retroactive.
                 notifyAgentRunStart();
                 emitAgentEvent({
                   runId,
@@ -394,8 +400,7 @@ export async function runAgentTurnWithFallback(params: {
             runId,
             authProfile,
           });
-          return (async () => {
-            const result = await runEmbeddedPiAgent({
+          const result = await runEmbeddedPiAgent({
               ...embeddedContext,
               trigger: params.isHeartbeat ? "heartbeat" : "user",
               groupId: resolveGroupSessionKey(params.sessionCtx)?.id,
@@ -538,7 +543,6 @@ export async function runAgentTurnWithFallback(params: {
               result.meta?.systemPromptReport,
             );
             return result;
-          })();
         },
       });
       runResult = fallbackResult.result;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -310,14 +310,17 @@ export async function runAgentTurnWithFallback(params: {
 
               return result;
             } catch (err) {
-              // When the codex CLI backend was auto-selected (not explicitly configured
-              // by the user) and the CLI binary is unavailable or fails to launch,
-              // fall through to the embedded runner instead of surfacing an error.
+              // The user explicitly configured a codex-cli backend, but the model
+              // was auto-routed to it based on API detection (isCodexAutoFallback).
+              // When the CLI binary is unavailable or fails to launch, fall through
+              // to the embedded runner. Warn at error level since the embedded runner
+              // does not support tool calls for codex models — the user will get
+              // text-only output, which is a visible degradation.
               // Emit a terminal lifecycle error for the CLI run so downstream
               // consumers don't stall on the open "start" event from line 250.
               if (isCodexAutoFallback) {
-                defaultRuntime.log(
-                  `Codex CLI backend unavailable, falling back to embedded runner: ${String(err)}`,
+                defaultRuntime.error(
+                  `Codex CLI backend failed, falling back to embedded runner (tool calls will be unavailable): ${String(err)}`,
                 );
                 // Close the CLI lifecycle so downstream consumers don't stall on an
                 // open "start" event. The embedded runner will emit its own lifecycle.

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -246,94 +246,127 @@ export async function runAgentTurnWithFallback(params: {
 
           if (cliProvider) {
             const startedAt = Date.now();
-            notifyAgentRunStart();
-            emitAgentEvent({
-              runId,
-              stream: "lifecycle",
-              data: {
-                phase: "start",
-                startedAt,
-              },
-            });
             const cliSessionId = getCliSessionId(params.getActiveSessionEntry(), cliProvider);
-            try {
-              const result = await runCliAgent({
-                sessionId: params.followupRun.run.sessionId,
-                sessionKey: params.sessionKey,
-                agentId: params.followupRun.run.agentId,
-                sessionFile: params.followupRun.run.sessionFile,
-                workspaceDir: params.followupRun.run.workspaceDir,
-                config: params.followupRun.run.config,
-                prompt: params.commandBody,
-                provider: cliProvider,
-                model,
-                thinkLevel: params.followupRun.run.thinkLevel,
-                timeoutMs: params.followupRun.run.timeoutMs,
-                runId,
-                extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
-                ownerNumbers: params.followupRun.run.ownerNumbers,
-                cliSessionId,
-                bootstrapPromptWarningSignaturesSeen,
-                bootstrapPromptWarningSignature:
-                  bootstrapPromptWarningSignaturesSeen[
-                    bootstrapPromptWarningSignaturesSeen.length - 1
-                  ],
-                images: params.opts?.images,
-              });
-              bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-                result.meta?.systemPromptReport,
-              );
 
-              // CLI backends don't emit streaming assistant events, so we need to
-              // emit one with the final text so server-chat can populate its buffer
-              // and send the response to TUI/WebSocket clients.
-              const cliText = result.payloads?.[0]?.text?.trim();
-              if (cliText) {
-                emitAgentEvent({
+            if (isCodexAutoFallback) {
+              // Auto-fallback: speculatively try the CLI backend without
+              // emitting lifecycle events. If the CLI succeeds we emit a
+              // single start/end pair after the fact. If it fails we log
+              // the degradation and fall through to the embedded runner,
+              // which manages its own lifecycle — no orphaned events.
+              try {
+                const result = await runCliAgent({
+                  sessionId: params.followupRun.run.sessionId,
+                  sessionKey: params.sessionKey,
+                  agentId: params.followupRun.run.agentId,
+                  sessionFile: params.followupRun.run.sessionFile,
+                  workspaceDir: params.followupRun.run.workspaceDir,
+                  config: params.followupRun.run.config,
+                  prompt: params.commandBody,
+                  provider: cliProvider,
+                  model,
+                  thinkLevel: params.followupRun.run.thinkLevel,
+                  timeoutMs: params.followupRun.run.timeoutMs,
                   runId,
-                  stream: "assistant",
-                  data: { text: cliText },
+                  extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+                  ownerNumbers: params.followupRun.run.ownerNumbers,
+                  cliSessionId,
+                  bootstrapPromptWarningSignaturesSeen,
+                  bootstrapPromptWarningSignature:
+                    bootstrapPromptWarningSignaturesSeen[
+                      bootstrapPromptWarningSignaturesSeen.length - 1
+                    ],
+                  images: params.opts?.images,
                 });
-              }
+                bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
+                  result.meta?.systemPromptReport,
+                );
 
-              emitAgentEvent({
-                runId,
-                stream: "lifecycle",
-                data: {
-                  phase: "end",
-                  startedAt,
-                  endedAt: Date.now(),
-                },
-              });
-              return result;
-            } catch (err) {
-              // The codex-cli backend was auto-selected based on model API
-              // detection (the user configured a codex-cli backend, but didn't
-              // explicitly request CLI execution for this model). When the CLI
-              // binary is missing or crashes, fall through to the embedded
-              // runner which provides text-only output (no tool calls for
-              // codex models).
-              if (isCodexAutoFallback) {
-                // Do NOT emit lifecycle:error here — the embedded runner will
-                // emit its own lifecycle:start/end pair. Emitting error here
-                // would leave downstream consumers seeing a permanently-errored
-                // run even though the embedded runner succeeds.
-                // Instead, close the CLI lifecycle cleanly with "end" so the
-                // event stream is consistent, and warn about degradation.
+                // CLI succeeded — emit lifecycle events retroactively
+                notifyAgentRunStart();
                 emitAgentEvent({
                   runId,
                   stream: "lifecycle",
-                  data: {
-                    phase: "end",
-                    startedAt,
-                    endedAt: Date.now(),
-                  },
+                  data: { phase: "start", startedAt },
                 });
+
+                const cliText = result.payloads?.[0]?.text?.trim();
+                if (cliText) {
+                  emitAgentEvent({
+                    runId,
+                    stream: "assistant",
+                    data: { text: cliText },
+                  });
+                }
+
+                emitAgentEvent({
+                  runId,
+                  stream: "lifecycle",
+                  data: { phase: "end", startedAt, endedAt: Date.now() },
+                });
+                return result;
+              } catch (err) {
+                // CLI failed — log degradation and fall through to embedded
+                // runner. No lifecycle events emitted for the CLI attempt,
+                // so the event stream stays clean for the embedded runner.
                 defaultRuntime.error(
                   `Codex CLI failed, falling back to embedded runner WITHOUT tool support. ` +
                     `User will receive text-only output. Error: ${String(err)}`,
                 );
-              } else {
+              }
+            } else {
+              // Explicit CLI backend: lifecycle events are committed upfront
+              // because failure is terminal (no fallback).
+              notifyAgentRunStart();
+              emitAgentEvent({
+                runId,
+                stream: "lifecycle",
+                data: { phase: "start", startedAt },
+              });
+              try {
+                const result = await runCliAgent({
+                  sessionId: params.followupRun.run.sessionId,
+                  sessionKey: params.sessionKey,
+                  agentId: params.followupRun.run.agentId,
+                  sessionFile: params.followupRun.run.sessionFile,
+                  workspaceDir: params.followupRun.run.workspaceDir,
+                  config: params.followupRun.run.config,
+                  prompt: params.commandBody,
+                  provider: cliProvider,
+                  model,
+                  thinkLevel: params.followupRun.run.thinkLevel,
+                  timeoutMs: params.followupRun.run.timeoutMs,
+                  runId,
+                  extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+                  ownerNumbers: params.followupRun.run.ownerNumbers,
+                  cliSessionId,
+                  bootstrapPromptWarningSignaturesSeen,
+                  bootstrapPromptWarningSignature:
+                    bootstrapPromptWarningSignaturesSeen[
+                      bootstrapPromptWarningSignaturesSeen.length - 1
+                    ],
+                  images: params.opts?.images,
+                });
+                bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
+                  result.meta?.systemPromptReport,
+                );
+
+                const cliText = result.payloads?.[0]?.text?.trim();
+                if (cliText) {
+                  emitAgentEvent({
+                    runId,
+                    stream: "assistant",
+                    data: { text: cliText },
+                  });
+                }
+
+                emitAgentEvent({
+                  runId,
+                  stream: "lifecycle",
+                  data: { phase: "end", startedAt, endedAt: Date.now() },
+                });
+                return result;
+              } catch (err) {
                 emitAgentEvent({
                   runId,
                   stream: "lifecycle",

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -329,7 +329,7 @@ export async function runAgentTurnWithFallback(params: {
                     endedAt: Date.now(),
                   },
                 });
-                defaultRuntime.warn(
+                defaultRuntime.error(
                   `Codex CLI failed, falling back to embedded runner WITHOUT tool support. ` +
                     `User will receive text-only output. Error: ${String(err)}`,
                 );

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -310,20 +310,18 @@ export async function runAgentTurnWithFallback(params: {
 
               return result;
             } catch (err) {
-              // The user explicitly configured a codex-cli backend, but the model
-              // was auto-routed to it based on API detection (isCodexAutoFallback).
-              // When the CLI binary is unavailable or fails to launch, fall through
-              // to the embedded runner. Warn at error level since the embedded runner
-              // does not support tool calls for codex models — the user will get
-              // text-only output, which is a visible degradation.
-              // Emit a terminal lifecycle error for the CLI run so downstream
-              // consumers don't stall on the open "start" event from line 250.
+              // The user has a codex-cli backend in their config, but this
+              // particular model was auto-routed to it (isCodexAutoFallback)
+              // rather than the user explicitly requesting CLI execution.
+              // When the CLI binary is missing or crashes, fall through to
+              // the embedded runner which provides text-only output (no tool
+              // calls for codex models).
               if (isCodexAutoFallback) {
-                defaultRuntime.error(
-                  `Codex CLI backend failed, falling back to embedded runner (tool calls will be unavailable): ${String(err)}`,
+                defaultRuntime.log(
+                  `Codex CLI unavailable, falling back to embedded runner (tool calls will not be available): ${String(err)}`,
                 );
-                // Close the CLI lifecycle so downstream consumers don't stall on an
-                // open "start" event. The embedded runner will emit its own lifecycle.
+                // Close the CLI lifecycle so downstream consumers don't stall
+                // on the open "start" event. The embedded runner emits its own.
                 emitAgentEvent({
                   runId,
                   stream: "lifecycle",
@@ -336,19 +334,17 @@ export async function runAgentTurnWithFallback(params: {
                 });
                 lifecycleTerminalEmitted = true;
               } else {
-                if (!lifecycleTerminalEmitted) {
-                  emitAgentEvent({
-                    runId,
-                    stream: "lifecycle",
-                    data: {
-                      phase: "error",
-                      startedAt,
-                      endedAt: Date.now(),
-                      error: String(err),
-                    },
-                  });
-                  lifecycleTerminalEmitted = true;
-                }
+                emitAgentEvent({
+                  runId,
+                  stream: "lifecycle",
+                  data: {
+                    phase: "error",
+                    startedAt,
+                    endedAt: Date.now(),
+                    error: String(err),
+                  },
+                });
+                lifecycleTerminalEmitted = true;
                 throw err;
               }
             } finally {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -1,7 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
-import { resolveCliBackendConfig } from "../../agents/cli-backends.js";
+import { hasExplicitCliBackend, resolveCliBackendConfig } from "../../agents/cli-backends.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
@@ -131,32 +131,38 @@ export async function runAgentTurnWithFallback(params: {
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.getActiveSessionEntry()?.systemPromptReport,
   );
-  const codexCliBackend = resolveCliBackendConfig("codex-cli", params.followupRun.run.config);
+  // Only resolve codex CLI backend for auto-fallback when the user has
+  // explicitly configured it.  resolveCliBackendConfig() always returns
+  // non-null for "codex-cli" because it merges with a built-in default,
+  // so without this guard we'd attempt to spawn the `codex` binary on
+  // every system — even when it isn't installed.
+  const codexCliBackend = hasExplicitCliBackend("codex-cli", params.followupRun.run.config)
+    ? resolveCliBackendConfig("codex-cli", params.followupRun.run.config)
+    : null;
   const modelApiByRef = new Map<string, string | undefined>();
+  const resolveModelApi = (provider: string, model: string): string | undefined => {
+    const key = `${provider}\0${model}`;
+    if (modelApiByRef.has(key)) {
+      return modelApiByRef.get(key);
+    }
+    let resolvedApi: string | undefined;
+    try {
+      const resolved = resolveModel(
+        provider,
+        model,
+        params.followupRun.run.agentDir,
+        params.followupRun.run.config,
+      );
+      resolvedApi = resolved.model?.api;
+    } catch {
+      resolvedApi = undefined;
+    }
+    modelApiByRef.set(key, resolvedApi);
+    return resolvedApi;
+  };
 
   while (true) {
     try {
-      const resolveModelApi = (provider: string, model: string): string | undefined => {
-        const key = `${provider}\0${model}`;
-        if (modelApiByRef.has(key)) {
-          return modelApiByRef.get(key);
-        }
-        let resolvedApi: string | undefined;
-        try {
-          const resolved = resolveModel(
-            provider,
-            model,
-            params.followupRun.run.agentDir,
-            params.followupRun.run.config,
-          );
-          resolvedApi = resolved.model?.api;
-        } catch {
-          resolvedApi = undefined;
-        }
-        modelApiByRef.set(key, resolvedApi);
-        return resolvedApi;
-      };
-
       const normalizeStreamingText = (payload: ReplyPayload): { text?: string; skip: boolean } => {
         let text = payload.text;
         if (!params.isHeartbeat && text?.includes("HEARTBEAT_OK")) {
@@ -304,27 +310,32 @@ export async function runAgentTurnWithFallback(params: {
 
               return result;
             } catch (err) {
-              if (!lifecycleTerminalEmitted) {
-                emitAgentEvent({
-                  runId,
-                  stream: "lifecycle",
-                  data: {
-                    phase: "error",
-                    startedAt,
-                    endedAt: Date.now(),
-                    error: String(err),
-                  },
-                });
-                lifecycleTerminalEmitted = true;
-              }
               // When the codex CLI backend was auto-selected (not explicitly configured
               // by the user) and the CLI binary is unavailable or fails to launch,
               // fall through to the embedded runner instead of surfacing an error.
+              // Don't emit a lifecycle error here — the embedded runner will emit its
+              // own complete lifecycle (start -> end), and emitting error + start would
+              // create an invalid sequence.
               if (isCodexAutoFallback) {
                 defaultRuntime.log(
                   `Codex CLI backend unavailable, falling back to embedded runner: ${String(err)}`,
                 );
+                // Mark as emitted so the finally-block backstop doesn't fire either.
+                lifecycleTerminalEmitted = true;
               } else {
+                if (!lifecycleTerminalEmitted) {
+                  emitAgentEvent({
+                    runId,
+                    stream: "lifecycle",
+                    data: {
+                      phase: "error",
+                      startedAt,
+                      endedAt: Date.now(),
+                      error: String(err),
+                    },
+                  });
+                  lifecycleTerminalEmitted = true;
+                }
                 throw err;
               }
             } finally {

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -313,14 +313,24 @@ export async function runAgentTurnWithFallback(params: {
               // When the codex CLI backend was auto-selected (not explicitly configured
               // by the user) and the CLI binary is unavailable or fails to launch,
               // fall through to the embedded runner instead of surfacing an error.
-              // Don't emit a lifecycle error here — the embedded runner will emit its
-              // own complete lifecycle (start -> end), and emitting error + start would
-              // create an invalid sequence.
+              // Emit a terminal lifecycle error for the CLI run so downstream
+              // consumers don't stall on the open "start" event from line 250.
               if (isCodexAutoFallback) {
                 defaultRuntime.log(
                   `Codex CLI backend unavailable, falling back to embedded runner: ${String(err)}`,
                 );
-                // Mark as emitted so the finally-block backstop doesn't fire either.
+                // Close the CLI lifecycle so downstream consumers don't stall on an
+                // open "start" event. The embedded runner will emit its own lifecycle.
+                emitAgentEvent({
+                  runId,
+                  stream: "lifecycle",
+                  data: {
+                    phase: "error",
+                    startedAt,
+                    endedAt: Date.now(),
+                    error: `CLI fallback: ${String(err)}`,
+                  },
+                });
                 lifecycleTerminalEmitted = true;
               } else {
                 if (!lifecycleTerminalEmitted) {


### PR DESCRIPTION
## Problem

When using `openai-codex-responses` API as an embedded subagent model, tool calls are silently ignored. The model receives tool definitions but never emits `tool_use` blocks, making fleet agents configured with Codex models unable to perform any autonomous work.

## Solution

Detect `openai-codex-responses` model API at the runner selection point (`agent-runner-execution.ts`) and automatically route through the `codex-cli` backend when available.

### Changes

- **`src/auto-reply/reply/agent-runner-execution.ts`**: Added codex model API detection with CLI backend fallback. When `resolveModelApi()` returns `"openai-codex-responses"` and a `codex-cli` backend is configured, execution routes through `runCliAgent()` instead of the embedded runner.
- Model API resolution is cached per `provider+model` pair to avoid repeated lookups.
- Warning logged: `"Codex model detected, routing through CLI backend for tool support"`

### Behavior

| Before | After |
|--------|-------|
| Codex model silently ignores tools | Auto-fallback to CLI backend |
| Fleet agents with Codex produce text-only output | Fleet agents can execute `exec`, `read`, `write`, etc. via CLI |
| No warning or indication of failure | Clear warning log emitted |

## Backward Compatibility

- No breaking changes: only affects models with `openai-codex-responses` API
- If no `codex-cli` backend is configured, behavior is unchanged (embedded runner)
- Existing CLI provider routing (`isCliProvider`) is preserved

Closes #33587
Ref: #33584 (ACP Fleet Agent Integration RFC, Phase 2)
Ref: PR #28736 (ACP fleet agent ID resolution)