### PR TITLE
fix: typing interval=0 support and embedding cache batch loading

### DIFF
--- a/src/auto-reply/reply/typing.ts
+++ b/src/auto-reply/reply/typing.ts
@@ -158,6 +158,11 @@ export function createTypingController(params: {
     if (!onReplyStart) {
       return;
     }
+    // When interval is 0, send typing once only (no repeated indicator). Avoids "typing forever" if cleanup is delayed.
+    if (typingIntervalMs <= 0) {
+      await ensureStart();
+      return;
+    }
     if (typingLoop.isRunning()) {
       return;
     }

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -146,7 +146,7 @@ export const AgentDefaultsSchema = z
     timeoutSeconds: z.number().int().positive().optional(),
     mediaMaxMb: z.number().positive().optional(),
     imageMaxDimensionPx: z.number().int().positive().optional(),
-    typingIntervalSeconds: z.number().int().positive().optional(),
+    typingIntervalSeconds: z.number().int().min(0).optional(),
     typingMode: TypingModeSchema.optional(),
     heartbeat: HeartbeatSchema,
     maxConcurrent: z.number().int().positive().optional(),

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -50,7 +50,7 @@ export const SessionSchema = z
       .optional(),
     resetByChannel: z.record(z.string(), SessionResetConfigSchema).optional(),
     store: z.string().optional(),
-    typingIntervalSeconds: z.number().int().positive().optional(),
+    typingIntervalSeconds: z.number().int().min(0).optional(),
     typingMode: TypingModeSchema.optional(),
     parentForkMaxTokens: z.number().int().nonnegative().optional(),
     mainKey: z.string().optional(),

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -265,21 +265,15 @@ export abstract class MemoryManagerSyncOps {
     if (!this.cache.enabled) {
       return;
     }
+    // Process in batches to avoid loading all embedding JSON into V8 heap at once.
+    // Each cached embedding can be ~50KB+ of JSON; loading thousands at once causes heap spikes.
+    const SEED_BATCH_SIZE = 50;
     try {
-      const rows = sourceDb
-        .prepare(
-          `SELECT provider, model, provider_key, hash, embedding, dims, updated_at FROM ${EMBEDDING_CACHE_TABLE}`,
-        )
-        .all() as Array<{
-        provider: string;
-        model: string;
-        provider_key: string;
-        hash: string;
-        embedding: string;
-        dims: number | null;
-        updated_at: number;
-      }>;
-      if (!rows.length) {
+      const countRow = sourceDb
+        .prepare(`SELECT COUNT(*) as c FROM ${EMBEDDING_CACHE_TABLE}`)
+        .get() as { c: number } | undefined;
+      const total = countRow?.c ?? 0;
+      if (total === 0) {
         return;
       }
       const insert = this.db.prepare(
@@ -290,19 +284,34 @@ export abstract class MemoryManagerSyncOps {
            dims=excluded.dims,
            updated_at=excluded.updated_at`,
       );
-      this.db.exec("BEGIN");
-      for (const row of rows) {
-        insert.run(
-          row.provider,
-          row.model,
-          row.provider_key,
-          row.hash,
-          row.embedding,
-          row.dims,
-          row.updated_at,
-        );
+      for (let offset = 0; offset < total; offset += SEED_BATCH_SIZE) {
+        const rows = sourceDb
+          .prepare(
+            `SELECT provider, model, provider_key, hash, embedding, dims, updated_at FROM ${EMBEDDING_CACHE_TABLE} LIMIT ? OFFSET ?`,
+          )
+          .all(SEED_BATCH_SIZE, offset) as Array<{
+          provider: string;
+          model: string;
+          provider_key: string;
+          hash: string;
+          embedding: string;
+          dims: number | null;
+          updated_at: number;
+        }>;
+        this.db.exec("BEGIN");
+        for (const row of rows) {
+          insert.run(
+            row.provider,
+            row.model,
+            row.provider_key,
+            row.hash,
+            row.embedding,
+            row.dims,
+            row.updated_at,
+          );
+        }
+        this.db.exec("COMMIT");
       }
-      this.db.exec("COMMIT");
     } catch (err) {
       try {
         this.db.exec("ROLLBACK");


### PR DESCRIPTION
## Summary

Two independent fixes discovered during production use:

### 1. Allow `typingIntervalSeconds=0` to disable repeated typing indicator

**Problem**: When `typingIntervalSeconds` is set to 0 (to disable the typing indicator completely), the Zod schema rejects it due to `.positive()` validation. Additionally, the typing controller skips sending the initial indicator when interval <= 0.

**Fix**:
- Change validation from `.positive()` to `.min(0)` in both agent-defaults and session schemas
- Fix controller to send typing once when interval=0 (then stop), avoiding "typing forever" if cleanup is delayed

### 2. Batch embedding cache seeding to prevent V8 heap spikes

**Problem**: Loading large embedding caches into memory for seeding can cause V8 heap spikes (each cached embedding is ~50KB+ JSON; thousands at once = OOM risk).

**Fix**: Process embedding cache in batches of 50 rows during seeding, with individual transaction commits per batch.

## Files Changed

- `src/auto-reply/reply/typing.ts` - Fix typing controller logic
- `src/config/zod-schema.agent-defaults.ts` - Allow 0 in validation
- `src/config/zod-schema.session.ts` - Allow 0 in validation
- `src/memory/manager-sync-ops.ts` - Batch embedding cache loading

## Testing

- [x] `typingIntervalSeconds=0` no longer rejected by config validation
- [x] Gateway starts and handles messages with new config
- [x] Embedding cache seeding completes without heap spikes on large caches
