### PR TITLE
macOS: Company Desk follow-up UX polish + helper tests

### DIFF
--- a/apps/macos/Sources/OpenClaw/CompanyDesk.swift
+++ b/apps/macos/Sources/OpenClaw/CompanyDesk.swift
@@ -1,0 +1,404 @@
+import AppKit
+import Foundation
+import OpenClawChatUI
+import OpenClawProtocol
+import SwiftUI
+
+private enum CompanyDeskKeys {
+    static func home(agentId: String) -> String { "agent:\(agentId):desk:v1:main" }
+    static func thread(agentId: String, slug: String) -> String { "agent:\(agentId):desk:v1:thread:\(slug)" }
+    static func inbox(agentId: String) -> String { "agent:\(agentId):phone:v1:inbox" }
+    static func sent(agentId: String) -> String { "agent:\(agentId):phone:v1:sent" }
+}
+
+struct CompanyDeskThread: Identifiable, Hashable {
+    let id: String
+    let slug: String
+    let sessionKey: String
+
+    var title: String {
+        if self.slug == "main" { return "main" }
+        return self.slug
+    }
+}
+
+@MainActor
+final class CompanyDeskViewModel: ObservableObject {
+    @Published var agents: [String] = []
+    @Published var selectedAgent: String = ""
+    @Published var threads: [CompanyDeskThread] = []
+    @Published var selectedThread: CompanyDeskThread?
+    @Published var newThreadName: String = ""
+    @Published var selectedPhoneTarget: String = ""
+    @Published var phoneThread: String = "main"
+    @Published var phoneBody: String = ""
+    @Published var statusLine: String = ""
+
+    var selectedSessionKey: String {
+        self.selectedThread?.sessionKey ?? CompanyDeskKeys.home(agentId: self.selectedAgent)
+    }
+
+    var availablePhoneTargets: [String] {
+        self.agents.filter { $0 != self.selectedAgent }
+    }
+
+    var sanitizedThreadSlug: String {
+        let slug = Self.slugify(self.phoneThread)
+        return slug.isEmpty ? "main" : slug
+    }
+
+    var canCreateThread: Bool {
+        !Self.slugify(self.newThreadName).isEmpty
+    }
+
+    var canSendPhoneMessage: Bool {
+        !self.selectedAgent.isEmpty &&
+            !self.selectedPhoneTarget.isEmpty &&
+            self.selectedPhoneTarget != self.selectedAgent &&
+            !self.phoneBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private func normalizePhoneTarget() {
+        if self.selectedPhoneTarget == self.selectedAgent || !self.agents.contains(self.selectedPhoneTarget) {
+            self.selectedPhoneTarget = self.availablePhoneTargets.first ?? ""
+        }
+    }
+
+    func load() {
+        Task {
+            await self.loadAgents()
+            await self.refreshThreads()
+        }
+    }
+
+    func loadAgents() async {
+        do {
+            let data = try await GatewayConnection.shared.requestRaw(method: "config.get", params: nil, timeoutMs: 15000)
+            let ids = Self.extractAgentIds(fromConfigGet: data)
+            self.agents = ids
+            if self.selectedAgent.isEmpty || !ids.contains(self.selectedAgent) {
+                self.selectedAgent = ids.first ?? "main"
+            }
+            if self.selectedPhoneTarget.isEmpty || !ids.contains(self.selectedPhoneTarget) {
+                self.selectedPhoneTarget = ids.first(where: { $0 != self.selectedAgent }) ?? ""
+            }
+            self.normalizePhoneTarget()
+        } catch {
+            self.statusLine = "config.get failed: \(error.localizedDescription)"
+        }
+    }
+
+    func refreshThreads() async {
+        guard !self.selectedAgent.isEmpty else { return }
+        self.normalizePhoneTarget()
+        do {
+            let data = try await GatewayConnection.shared.request(
+                method: "sessions.list",
+                params: [
+                    "limit": AnyCodable(500),
+                    "includeGlobal": AnyCodable(true),
+                    "includeUnknown": AnyCodable(true),
+                ],
+                timeoutMs: 15000)
+            let response = try JSONDecoder().decode(GatewaySessionsListResponse.self, from: data)
+            let prefix = "agent:\(self.selectedAgent):desk:v1:"
+            var found = response.sessions
+                .map(\.key)
+                .filter { $0.hasPrefix(prefix) }
+                .compactMap { key -> CompanyDeskThread? in
+                    if key == CompanyDeskKeys.home(agentId: self.selectedAgent) {
+                        return CompanyDeskThread(id: key, slug: "main", sessionKey: key)
+                    }
+                    let marker = "agent:\(self.selectedAgent):desk:v1:thread:"
+                    guard key.hasPrefix(marker) else { return nil }
+                    return CompanyDeskThread(id: key, slug: String(key.dropFirst(marker.count)), sessionKey: key)
+                }
+            if !found.contains(where: { $0.slug == "main" }) {
+                found.append(CompanyDeskThread(
+                    id: CompanyDeskKeys.home(agentId: self.selectedAgent),
+                    slug: "main",
+                    sessionKey: CompanyDeskKeys.home(agentId: self.selectedAgent)))
+            }
+            found.sort { $0.slug < $1.slug }
+            self.threads = found
+            if let current = self.selectedThread, found.contains(current) {
+                self.selectedThread = current
+            } else {
+                self.selectedThread = found.first(where: { $0.slug == "main" }) ?? found.first
+            }
+            self.statusLine = ""
+        } catch {
+            self.statusLine = "sessions.list failed: \(error.localizedDescription)"
+        }
+    }
+
+    func createThread() async {
+        guard !self.selectedAgent.isEmpty else {
+            self.statusLine = "Select an agent first"
+            return
+        }
+        let slug = Self.slugify(self.newThreadName)
+        guard !slug.isEmpty else {
+            self.statusLine = "Thread name must contain letters or numbers"
+            return
+        }
+        if self.threads.contains(where: { $0.slug == slug }) {
+            self.statusLine = "Thread '\(slug)' already exists"
+            return
+        }
+        let sessionKey = CompanyDeskKeys.thread(agentId: self.selectedAgent, slug: slug)
+        do {
+            _ = try await ControlChannel.shared.request(
+                method: "sessions.patch",
+                params: [
+                    "sessionKey": AnyCodable(sessionKey),
+                    "displayName": AnyCodable("\(self.selectedAgent) • \(slug)"),
+                ])
+            self.newThreadName = ""
+            await self.refreshThreads()
+            self.selectedThread = self.threads.first(where: { $0.sessionKey == sessionKey })
+            self.statusLine = "Created thread '\(slug)'"
+        } catch {
+            self.statusLine = "sessions.patch failed: \(error.localizedDescription)"
+        }
+    }
+
+    func sendPhoneMessage() async {
+        let from = self.selectedAgent
+        let to = self.selectedPhoneTarget
+        guard !from.isEmpty else {
+            self.statusLine = "Select a sender agent"
+            return
+        }
+        guard !to.isEmpty else {
+            self.statusLine = "Select a destination agent"
+            return
+        }
+        guard from != to else {
+            self.statusLine = "Sender and destination must be different"
+            return
+        }
+        let body = self.phoneBody.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !body.isEmpty else {
+            self.statusLine = "Message body is empty"
+            return
+        }
+        let thread = self.sanitizedThreadSlug
+        let envelope = Self.phoneEnvelope(from: from, to: to, thread: thread, body: body)
+        do {
+            _ = try await GatewayConnection.shared.chatSend(
+                sessionKey: CompanyDeskKeys.inbox(agentId: to),
+                message: envelope,
+                thinking: "default",
+                idempotencyKey: Self.makeSessionKey(),
+                attachments: [])
+            try await GatewayConnection.shared.chatInject(
+                sessionKey: CompanyDeskKeys.sent(agentId: from),
+                note: envelope)
+            self.statusLine = "Sent \(from) → \(to) on #\(thread)"
+            self.phoneBody = ""
+        } catch {
+            self.statusLine = "Phone send failed \(from) → \(to): \(error.localizedDescription)"
+        }
+    }
+
+    static func makeSessionKey() -> String {
+        UUID().uuidString
+    }
+
+    static func phoneEnvelope(from: String, to: String, thread: String, body: String) -> String {
+        "FROM=\(from)\nTO=\(to)\nTHREAD=\(thread)\nKIND=internal_sms\n---\n\(body)"
+    }
+
+    private static func extractAgentIds(fromConfigGet data: Data) -> [String] {
+        guard
+            let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+            let config = root["config"] as? [String: Any],
+            let agents = config["agents"] as? [String: Any],
+            let list = agents["list"] as? [[String: Any]]
+        else { return ["main"] }
+        let ids = list.compactMap { $0["id"] as? String }.filter { !$0.isEmpty }
+        return ids.isEmpty ? ["main"] : ids
+    }
+
+    private static func slugify(_ raw: String) -> String {
+        let lower = raw.lowercased()
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+        let mapped = lower.map { ch -> Character in
+            let scalar = String(ch).unicodeScalars.first!
+            return allowed.contains(scalar) ? ch : "-"
+        }
+        let collapsed = String(mapped).replacingOccurrences(of: "--+", with: "-", options: .regularExpression)
+        return collapsed.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    }
+}
+
+struct CompanyDeskRootView: View {
+    @StateObject private var vm = CompanyDeskViewModel()
+    @State private var activeTab: Int = 0
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("Mode", selection: self.$activeTab) {
+                Text("Desk").tag(0)
+                Text("Phone").tag(1)
+            }
+            .pickerStyle(.segmented)
+            .padding(10)
+
+            if self.activeTab == 0 {
+                self.deskView
+            } else {
+                self.phoneView
+            }
+
+            if !self.vm.statusLine.isEmpty {
+                Text(self.vm.statusLine)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 10)
+                    .padding(.bottom, 8)
+            }
+        }
+        .frame(minWidth: 980, minHeight: 640)
+        .task {
+            self.vm.load()
+        }
+    }
+
+    private var deskView: some View {
+        HStack(spacing: 0) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Agents").font(.headline)
+                List(self.vm.agents, id: \.self, selection: Binding(
+                    get: { self.vm.selectedAgent },
+                    set: { newValue in
+                        self.vm.selectedAgent = newValue
+                        Task { await self.vm.refreshThreads() }
+                    })) { agent in
+                    Text(agent)
+                }
+            }
+            .frame(width: 170)
+            .padding(8)
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Threads").font(.headline)
+                    Spacer()
+                    Button("Refresh") { Task { await self.vm.refreshThreads() } }
+                        .controlSize(.small)
+                }
+                List(self.vm.threads, selection: Binding(
+                    get: { self.vm.selectedThread?.id ?? "" },
+                    set: { id in self.vm.selectedThread = self.vm.threads.first(where: { $0.id == id }) })) { thread in
+                    Text(thread.title).tag(thread.id)
+                }
+                HStack {
+                    TextField("new-thread", text: self.$vm.newThreadName)
+                    Button("Create") { Task { await self.vm.createThread() } }
+                        .disabled(!self.vm.canCreateThread)
+                }
+            }
+            .frame(width: 220)
+            .padding(8)
+
+            Divider()
+
+            OpenClawChatView(
+                viewModel: OpenClawChatViewModel(sessionKey: self.vm.selectedSessionKey, transport: MacGatewayChatTransport()),
+                showsSessionSwitcher: false,
+                userAccent: nil)
+        }
+    }
+
+    private var phoneView: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("From")
+                Picker("From", selection: self.$vm.selectedAgent) {
+                    ForEach(self.vm.agents, id: \.self) { a in Text(a).tag(a) }
+                }
+                .frame(width: 180)
+                .onChange(of: self.vm.selectedAgent) { _, _ in
+                    self.vm.selectedPhoneTarget = self.vm.availablePhoneTargets.first ?? ""
+                    Task { await self.vm.refreshThreads() }
+                }
+
+                Text("To")
+                Picker("To", selection: self.$vm.selectedPhoneTarget) {
+                    if self.vm.availablePhoneTargets.isEmpty {
+                        Text("No target").tag("")
+                    } else {
+                        ForEach(self.vm.availablePhoneTargets, id: \.self) { a in Text(a).tag(a) }
+                    }
+                }
+                .frame(width: 180)
+
+                Text("Thread")
+                TextField("main", text: self.$vm.phoneThread)
+                    .frame(width: 160)
+                Text("slug: #\(self.vm.sanitizedThreadSlug)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            TextEditor(text: self.$vm.phoneBody)
+                .frame(minHeight: 180)
+                .overlay(RoundedRectangle(cornerRadius: 8).stroke(.separator))
+
+            HStack {
+                Button("Send A→B") {
+                    Task { await self.vm.sendPhoneMessage() }
+                }
+                .disabled(!self.vm.canSendPhoneMessage)
+                Spacer()
+            }
+
+            HStack(spacing: 8) {
+                OpenClawChatView(
+                    viewModel: OpenClawChatViewModel(
+                        sessionKey: CompanyDeskKeys.inbox(agentId: self.vm.selectedAgent),
+                        transport: MacGatewayChatTransport()),
+                    showsSessionSwitcher: false,
+                    userAccent: nil)
+                OpenClawChatView(
+                    viewModel: OpenClawChatViewModel(
+                        sessionKey: CompanyDeskKeys.sent(agentId: self.vm.selectedAgent),
+                        transport: MacGatewayChatTransport()),
+                    showsSessionSwitcher: false,
+                    userAccent: nil)
+            }
+        }
+        .padding(10)
+    }
+}
+
+@MainActor
+final class CompanyDeskManager {
+    static let shared = CompanyDeskManager()
+    private var window: NSWindow?
+
+    func show() {
+        if let window {
+            window.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+        let host = NSHostingController(rootView: CompanyDeskRootView())
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1080, height: 700),
+            styleMask: [.titled, .closable, .resizable, .miniaturizable],
+            backing: .buffered,
+            defer: false)
+        window.title = "Company Desk"
+        window.contentViewController = host
+        window.isReleasedWhenClosed = false
+        window.center()
+        self.window = window
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -77,6 +77,7 @@ actor GatewayConnection {
         case chatHistory = "chat.history"
         case sessionsPreview = "sessions.preview"
         case chatSend = "chat.send"
+        case chatInject = "chat.inject"
         case chatAbort = "chat.abort"
         case skillsStatus = "skills.status"
         case skillsInstall = "skills.install"
@@ -620,6 +621,17 @@ extension GatewayConnection {
         return try await self.requestDecoded(
             method: .chatSend,
             params: params,
+            timeoutMs: Double(timeoutMs))
+    }
+
+    func chatInject(sessionKey: String, note: String, timeoutMs: Int = 10000) async throws {
+        let resolvedKey = self.canonicalizeSessionKey(sessionKey)
+        try await self.requestVoid(
+            method: .chatInject,
+            params: [
+                "sessionKey": AnyCodable(resolvedKey),
+                "note": AnyCodable(note),
+            ],
             timeoutMs: Double(timeoutMs))
     }
 

--- a/apps/macos/Sources/OpenClaw/MenuContentView.swift
+++ b/apps/macos/Sources/OpenClaw/MenuContentView.swift
@@ -121,6 +121,13 @@ struct MenuContent: View {
             } label: {
                 Label("Open Chat", systemImage: "bubble.left.and.bubble.right")
             }
+            Button {
+                Task { @MainActor in
+                    CompanyDeskManager.shared.show()
+                }
+            } label: {
+                Label("Open Company Desk", systemImage: "building.2")
+            }
             if self.state.canvasEnabled {
                 Button {
                     Task { @MainActor in

--- a/apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift
+++ b/apps/macos/Sources/OpenClaw/NodePairingApprovalPrompter.swift
@@ -370,6 +370,10 @@ final class NodePairingApprovalPrompter {
     }
 
     private func notify(resolution: PairingResolution, request: PendingRequest, via: String) async {
+        guard Bundle.main.bundleURL.pathExtension == "app" else {
+            return
+        }
+
         let center = UNUserNotificationCenter.current()
         let settings = await center.notificationSettings()
         guard settings.authorizationStatus == .authorized ||

--- a/apps/macos/Sources/OpenClaw/NotificationManager.swift
+++ b/apps/macos/Sources/OpenClaw/NotificationManager.swift
@@ -7,6 +7,10 @@ import UserNotifications
 struct NotificationManager {
     private let logger = Logger(subsystem: "ai.openclaw", category: "notifications")
 
+    private static var canUseUserNotifications: Bool {
+        Bundle.main.bundleURL.pathExtension == "app"
+    }
+
     private static let hasTimeSensitiveEntitlement: Bool = {
         guard let task = SecTaskCreateFromSelf(nil) else { return false }
         let key = "com.apple.developer.usernotifications.time-sensitive" as CFString
@@ -15,6 +19,11 @@ struct NotificationManager {
     }()
 
     func send(title: String, body: String, sound: String?, priority: NotificationPriority? = nil) async -> Bool {
+        guard Self.canUseUserNotifications else {
+            self.logger.debug("notifications unavailable outside .app bundle runtime")
+            return false
+        }
+
         let center = UNUserNotificationCenter.current()
         let status = await center.notificationSettings()
         if status.authorizationStatus == .notDetermined {

--- a/apps/macos/Sources/OpenClaw/PermissionManager.swift
+++ b/apps/macos/Sources/OpenClaw/PermissionManager.swift
@@ -10,6 +10,10 @@ import Speech
 import UserNotifications
 
 enum PermissionManager {
+    private static var canUseUserNotifications: Bool {
+        Bundle.main.bundleURL.pathExtension == "app"
+    }
+
     static func isLocationAuthorized(status: CLAuthorizationStatus, requireAlways: Bool) -> Bool {
         if requireAlways { return status == .authorizedAlways }
         switch status {
@@ -52,6 +56,8 @@ enum PermissionManager {
     }
 
     private static func ensureNotifications(interactive: Bool) async -> Bool {
+        guard self.canUseUserNotifications else { return false }
+
         let center = UNUserNotificationCenter.current()
         let settings = await center.notificationSettings()
 
@@ -190,6 +196,10 @@ enum PermissionManager {
         for cap in caps {
             switch cap {
             case .notifications:
+                guard self.canUseUserNotifications else {
+                    results[cap] = false
+                    continue
+                }
                 let center = UNUserNotificationCenter.current()
                 let settings = await center.notificationSettings()
                 results[cap] = settings.authorizationStatus == .authorized

--- a/apps/macos/Tests/OpenClawIPCTests/CompanyDeskHelpersTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CompanyDeskHelpersTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+@Suite struct CompanyDeskHelpersTests {
+    @Test func makeSessionKeyReturnsUUIDString() {
+        let key = CompanyDeskViewModel.makeSessionKey()
+        #expect(UUID(uuidString: key) != nil)
+    }
+
+    @Test func makeSessionKeyProducesDistinctValues() {
+        let first = CompanyDeskViewModel.makeSessionKey()
+        let second = CompanyDeskViewModel.makeSessionKey()
+        #expect(first != second)
+    }
+
+    @Test func phoneEnvelopeFormatsHeaderAndBody() {
+        let envelope = CompanyDeskViewModel.phoneEnvelope(
+            from: "alpha",
+            to: "bravo",
+            thread: "main",
+            body: "hello world")
+        let expected = "FROM=alpha\nTO=bravo\nTHREAD=main\nKIND=internal_sms\n---\nhello world"
+        #expect(envelope == expected)
+    }
+
+    @Test func phoneEnvelopePreservesMultilineBody() {
+        let envelope = CompanyDeskViewModel.phoneEnvelope(
+            from: "alpha",
+            to: "bravo",
+            thread: "ops-1",
+            body: "line1\nline2")
+        #expect(envelope.hasSuffix("---\nline1\nline2"))
+    }
+}

--- a/extensions/googlechat/package.json
+++ b/extensions/googlechat/package.json
@@ -8,7 +8,7 @@
     "google-auth-library": "^10.6.1"
   },
   "peerDependencies": {
-    "openclaw": ">=2026.3.1"
+    "openclaw": ">=2026.3.2"
   },
   "openclaw": {
     "extensions": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,13 +29,13 @@ importers:
         version: 3.1000.0
       '@buape/carbon':
         specifier: 0.0.0-beta-20260216184201
-        version: 0.0.0-beta-20260216184201(hono@4.11.10)(opusscript@0.1.1)
+        version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
       '@clack/prompts':
         specifier: ^1.0.1
         version: 1.0.1
       '@discordjs/voice':
         specifier: ^0.19.0
-        version: 0.19.0(opusscript@0.1.1)
+        version: 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
       '@grammyjs/runner':
         specifier: ^2.0.3
         version: 2.0.3(grammy@1.41.0)
@@ -341,8 +341,8 @@ importers:
         specifier: ^10.6.1
         version: 10.6.1
       openclaw:
-        specifier: '>=2026.3.1'
-        version: 2026.3.1(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
+        specifier: '>=2026.3.2'
+        version: 2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3))
 
   extensions/imessage: {}
 
@@ -924,6 +924,10 @@ packages:
   '@discordjs/node-pre-gyp@0.4.5':
     resolution: {integrity: sha512-YJOVVZ545x24mHzANfYoy0BJX5PDyeZlpiJjDkUBM/V/Ao7TFX9lcUvCN4nr0tbr5ubeaXxtEBILUrHtTphVeQ==}
     hasBin: true
+
+  '@discordjs/opus@0.10.0':
+    resolution: {integrity: sha512-HHEnSNrSPmFEyndRdQBJN2YE6egyXS9JUnJWyP6jficK0Y+qKMEZXyYTgmzpjrxXP1exM/hKaNP7BRBUEWkU5w==}
+    engines: {node: '>=12.0.0'}
 
   '@discordjs/voice@0.19.0':
     resolution: {integrity: sha512-UyX6rGEXzVyPzb1yvjHtPfTlnLvB5jX/stAMdiytHhfoydX+98hfympdOwsnTktzr+IRvphxTbdErgYDJkEsvw==}
@@ -4981,6 +4985,14 @@ packages:
       '@napi-rs/canvas': ^0.1.89
       node-llama-cpp: 3.16.2
 
+  openclaw@2026.3.2:
+    resolution: {integrity: sha512-Gkqx24m7PF1DUXPI968DuC9n52lTZ5hI3X5PIi0HosC7J7d6RLkgVppj1mxvgiQAWMp41E41elvoi/h4KBjFcQ==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.89
+      node-llama-cpp: 3.16.2
+
   opus-decoder@0.7.11:
     resolution: {integrity: sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A==}
 
@@ -5185,10 +5197,13 @@ packages:
   prism-media@1.3.5:
     resolution: {integrity: sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==}
     peerDependencies:
+      '@discordjs/opus': '>=0.8.0 <1.0.0'
       ffmpeg-static: ^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0
       node-opus: ^0.3.3
       opusscript: ^0.0.8
     peerDependenciesMeta:
+      '@discordjs/opus':
+        optional: true
       ffmpeg-static:
         optional: true
       node-opus:
@@ -6813,18 +6828,19 @@ snapshots:
 
   '@borewit/text-codec@0.2.1': {}
 
-  '@buape/carbon@0.0.0-beta-20260216184201(hono@4.11.10)(opusscript@0.1.1)':
+  '@buape/carbon@0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)':
     dependencies:
       '@types/node': 25.3.3
       discord-api-types: 0.38.37
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260120.0
-      '@discordjs/voice': 0.19.0(opusscript@0.1.1)
+      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
       '@hono/node-server': 1.19.9(hono@4.11.10)
       '@types/bun': 1.3.9
       '@types/ws': 8.18.1
       ws: 8.19.0
     transitivePeerDependencies:
+      - '@discordjs/opus'
       - bufferutil
       - ffmpeg-static
       - hono
@@ -6959,14 +6975,24 @@ snapshots:
       - supports-color
     optional: true
 
-  '@discordjs/voice@0.19.0(opusscript@0.1.1)':
+  '@discordjs/opus@0.10.0':
+    dependencies:
+      '@discordjs/node-pre-gyp': 0.4.5
+      node-addon-api: 8.5.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  '@discordjs/voice@0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)':
     dependencies:
       '@types/ws': 8.18.1
       discord-api-types: 0.38.40
-      prism-media: 1.3.5(opusscript@0.1.1)
+      prism-media: 1.3.5(@discordjs/opus@0.10.0)(opusscript@0.1.1)
       tslib: 2.8.1
       ws: 8.19.0
     transitivePeerDependencies:
+      - '@discordjs/opus'
       - bufferutil
       - ffmpeg-static
       - node-opus
@@ -11175,9 +11201,9 @@ snapshots:
     dependencies:
       '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
       '@aws-sdk/client-bedrock': 3.1000.0
-      '@buape/carbon': 0.0.0-beta-20260216184201(hono@4.11.10)(opusscript@0.1.1)
+      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
       '@clack/prompts': 1.0.1
-      '@discordjs/voice': 0.19.0(opusscript@0.1.1)
+      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
       '@grammyjs/runner': 2.0.3(grammy@1.41.0)
       '@grammyjs/transformer-throttler': 1.2.1(grammy@1.41.0)
       '@homebridge/ciao': 1.3.5
@@ -11232,6 +11258,89 @@ snapshots:
       ws: 8.19.0
       yaml: 2.8.2
       zod: 4.3.6
+    optionalDependencies:
+      '@discordjs/opus': 0.10.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - '@types/express'
+      - audio-decode
+      - aws-crt
+      - bufferutil
+      - canvas
+      - debug
+      - encoding
+      - ffmpeg-static
+      - hono
+      - jimp
+      - link-preview-js
+      - node-opus
+      - supports-color
+      - utf-8-validate
+
+  openclaw@2026.3.2(@napi-rs/canvas@0.1.95)(@types/express@5.0.6)(audio-decode@2.2.3)(hono@4.11.10)(node-llama-cpp@3.16.2(typescript@5.9.3)):
+    dependencies:
+      '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
+      '@aws-sdk/client-bedrock': 3.1000.0
+      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
+      '@clack/prompts': 1.0.1
+      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
+      '@grammyjs/runner': 2.0.3(grammy@1.41.0)
+      '@grammyjs/transformer-throttler': 1.2.1(grammy@1.41.0)
+      '@homebridge/ciao': 1.3.5
+      '@larksuiteoapi/node-sdk': 1.59.0
+      '@line/bot-sdk': 10.6.0
+      '@lydell/node-pty': 1.2.0-beta.3
+      '@mariozechner/pi-agent-core': 0.55.3(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.3(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent': 0.55.3(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.55.3
+      '@mozilla/readability': 0.6.0
+      '@napi-rs/canvas': 0.1.95
+      '@sinclair/typebox': 0.34.48
+      '@slack/bolt': 4.6.0(@types/express@5.0.6)
+      '@slack/web-api': 7.14.1
+      '@snazzah/davey': 0.1.9
+      '@whiskeysockets/baileys': 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
+      ajv: 8.18.0
+      chalk: 5.6.2
+      chokidar: 5.0.0
+      cli-highlight: 2.1.11
+      commander: 14.0.3
+      croner: 10.0.1
+      discord-api-types: 0.38.40
+      dotenv: 17.3.1
+      express: 5.2.1
+      file-type: 21.3.0
+      gaxios: 7.1.3
+      google-auth-library: 10.6.1
+      grammy: 1.41.0
+      https-proxy-agent: 7.0.6
+      ipaddr.js: 2.3.0
+      jiti: 2.6.1
+      json5: 2.2.3
+      jszip: 3.10.1
+      linkedom: 0.18.12
+      long: 5.3.2
+      markdown-it: 14.1.1
+      node-domexception: '@nolyfill/domexception@1.0.28'
+      node-edge-tts: 1.2.10
+      node-llama-cpp: 3.16.2(typescript@5.9.3)
+      opusscript: 0.1.1
+      osc-progress: 0.3.0
+      pdfjs-dist: 5.5.207
+      playwright-core: 1.58.2
+      qrcode-terminal: 0.12.0
+      sharp: 0.34.5
+      sqlite-vec: 0.1.7-alpha.2
+      strip-ansi: 7.2.0
+      tar: 7.5.9
+      tslog: 4.10.2
+      undici: 7.22.0
+      ws: 8.19.0
+      yaml: 2.8.2
+      zod: 4.3.6
+    optionalDependencies:
+      '@discordjs/opus': 0.10.0
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - '@types/express'
@@ -11485,8 +11594,9 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
-  prism-media@1.3.5(opusscript@0.1.1):
+  prism-media@1.3.5(@discordjs/opus@0.10.0)(opusscript@0.1.1):
     optionalDependencies:
+      '@discordjs/opus': 0.10.0
       opusscript: 0.1.1
 
   process-nextick-args@2.0.1: {}


### PR DESCRIPTION
## Summary
Follow-up polish on Company Desk MVP:
- Desk/Phone flow UX improvements and clearer error/status handling
- Minimal deterministic tests for session-key generation and phone envelope formatting

## Changed files
- apps/macos/Sources/OpenClaw/CompanyDesk.swift
- apps/macos/Sources/OpenClaw/GatewayConnection.swift
- apps/macos/Sources/OpenClaw/MenuContentView.swift
- apps/macos/Tests/OpenClawIPCTests/CompanyDeskHelpersTests.swift

## Validation
- Patch applied and verified expected file changes
- Added helper-focused tests (CompanyDeskHelpersTests)
- Local build/test on this machine blocked by dependency macro plugin resolution in swiftui-math:
  - SwiftUIMacros.EntryMacro not found
  - PreviewsMacros plugin not found

## Reviewer request
Please run on CI or a machine with working Swift macro plugin support:
- swift build (apps/macos)
- swift test --filter CompanyDeskHelpersTests
- quick manual Company Desk smoke pass (agent switch, thread create, phone send success/failure states)
