### PR TITLE
fix(heartbeat): avoid followup chaining when replies routed via messaging tool

### DIFF
--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -592,6 +592,75 @@ describe("runReplyAgent auto-compaction token update", () => {
   });
 });
 
+describe("runReplyAgent heartbeat routing", () => {
+  it("returns a silent marker when heartbeat output was delivered via messaging tool", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "briefing" }],
+      messagingToolSentTexts: ["briefing"],
+      messagingToolSentTargets: [{ tool: "imessage", provider: "imessage", to: "+82..." }],
+      meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+    });
+
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "heartbeat",
+      OriginatingChannel: "imessage",
+      OriginatingTo: "+82...",
+      MessageSid: "msg",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        sessionId: "session",
+        sessionKey: "main",
+        messageProvider: "heartbeat",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        provider: "anthropic",
+        model: "claude",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    const result = await runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: "main",
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      opts: { isHeartbeat: true },
+      typing,
+      sessionCtx,
+      defaultModel: "anthropic/claude-opus-4-5",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+
+    expect(result).toEqual({ text: "NO_REPLY" });
+  });
+});
+
 describe("runReplyAgent block streaming", () => {
   it("coalesces duplicate text_end block replies", async () => {
     const onBlockReply = vi.fn();

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -28,6 +28,7 @@ import {
 } from "../fallback-state.js";
 import type { OriginatingChannelType, TemplateContext } from "../templating.js";
 import { resolveResponseUsageMode, type VerboseLevel } from "../thinking.js";
+import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { runAgentTurnWithFallback } from "./agent-runner-execution.js";
 import {
@@ -500,6 +501,17 @@ export async function runReplyAgent(params: {
     didLogHeartbeatStrip = payloadResult.didLogHeartbeatStrip;
 
     if (replyPayloads.length === 0) {
+      // Heartbeat runs can be configured to deliver via a messaging tool
+      // (for example when heartbeat.target routes to iMessage/WhatsApp).
+      // In that case buildReplyPayloads may suppress duplicate payloads because
+      // the text/media was already delivered externally, leaving the main session
+      // with "no response" and triggering followup chaining.
+      const deliveredViaMessagingTool =
+        (runResult.messagingToolSentTexts?.length ?? 0) > 0 ||
+        (runResult.messagingToolSentMediaUrls?.length ?? 0) > 0;
+      if (isHeartbeat && deliveredViaMessagingTool) {
+        return finalizeWithFollowup({ text: SILENT_REPLY_TOKEN }, queueKey, runFollowupTurn);
+      }
       return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
     }
 


### PR DESCRIPTION
Fixes #33677.

When a heartbeat is configured to deliver via a messaging tool (heartbeat.target → messageChannel routing), final reply payloads can be suppressed as duplicates because the message was already sent externally. That leaves the main session with an empty reply and can trigger followup chaining.

This change returns a silent marker (NO_REPLY) for heartbeat runs when output was delivered via a messaging tool, preventing unbounded followup runs while keeping user-visible behavior unchanged.

Tests:
- Added coverage to ensure heartbeat runs return NO_REPLY when messaging-tool delivery suppresses the final reply payload.