### PR TITLE
feat(plugins): add usage-tracker extension

### DIFF
--- a/changelog/fragments/pr-usage-tracker.md
+++ b/changelog/fragments/pr-usage-tracker.md
@@ -1,0 +1,1 @@
+- **feat(plugins)**: Add `usage-tracker` extension — tracks tool calls and skill usage in real-time via `after_tool_call` hook, with historical backfill from session transcripts, query API, agent tool, and a Chart.js web dashboard. Zero external dependencies.

--- a/extensions/usage-tracker/README.md
+++ b/extensions/usage-tracker/README.md
@@ -1,0 +1,62 @@
+# Usage Tracker
+
+OpenClaw plugin that tracks tool calls and skill usage in real-time, with
+historical backfill from session transcripts.
+
+## Features
+
+- **Real-time tracking** via `after_tool_call` hook — every tool invocation is recorded
+- **Skill classification** — detects when the agent reads a SKILL.md (entry) or supporting files (sub)
+- **Skill session lifecycle** — measures the full chain from SKILL.md read to final response
+- **Historical backfill** — scans session transcript JSONL files to reconstruct past data
+- **Query engine** — aggregate by tool, skill, day, or agent with date range filters
+- **Agent tool** — `usage_tracker` tool for in-conversation queries
+- **Web dashboard** — Chart.js-powered dark-theme dashboard at `/plugins/usage-tracker/`
+- **Zero external dependencies** — uses only Node.js built-ins; Chart.js loaded via CDN
+
+## Usage
+
+### Enable the plugin
+
+Add to your `openclaw.json`:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "usage-tracker": {
+        "enabled": true
+      }
+    }
+  }
+}
+```
+
+### Agent tool
+
+The plugin registers a `usage_tracker` tool with these actions:
+
+| Action | Description |
+|--------|-------------|
+| `status` | Overview: total records, date range, top tools/skills |
+| `query` | Aggregated tool/skill usage with groupBy (tool, skill, day, agent) |
+| `skill_health` | Per-skill read metrics: entry/sub reads, errors, avg duration |
+| `skill_sessions` | Full skill lifecycle analysis: duration, tool chains, end patterns |
+
+### Web dashboard
+
+Visit `http://localhost:<port>/plugins/usage-tracker/` for the interactive dashboard.
+
+Click **Recalculate** to backfill historical data from session transcripts.
+
+### Gateway RPC
+
+- `usage-tracker.query` — same as the tool query action
+- `usage-tracker.backfill` — trigger historical backfill
+- `usage-tracker.status` — same as the tool status action
+
+## Data storage
+
+Per-day JSONL files at `<stateDir>/plugins/usage-tracker/data/YYYY-MM-DD.jsonl`.
+
+Skill session records at `<stateDir>/plugins/usage-tracker/data/skill-sessions.jsonl`.

--- a/extensions/usage-tracker/README.md
+++ b/extensions/usage-tracker/README.md
@@ -36,11 +36,11 @@ Add to your `openclaw.json`:
 
 The plugin registers a `usage_tracker` tool with these actions:
 
-| Action | Description |
-|--------|-------------|
-| `status` | Overview: total records, date range, top tools/skills |
-| `query` | Aggregated tool/skill usage with groupBy (tool, skill, day, agent) |
-| `skill_health` | Per-skill read metrics: entry/sub reads, errors, avg duration |
+| Action           | Description                                                        |
+| ---------------- | ------------------------------------------------------------------ |
+| `status`         | Overview: total records, date range, top tools/skills              |
+| `query`          | Aggregated tool/skill usage with groupBy (tool, skill, day, agent) |
+| `skill_health`   | Per-skill read metrics: entry/sub reads, errors, avg duration      |
 | `skill_sessions` | Full skill lifecycle analysis: duration, tool chains, end patterns |
 
 ### Web dashboard

--- a/extensions/usage-tracker/index.ts
+++ b/extensions/usage-tracker/index.ts
@@ -1,0 +1,102 @@
+/**
+ * Usage Tracker Plugin — entry point.
+ */
+
+import path from "node:path";
+import type { OpenClawPluginApi, GatewayRequestHandlerOptions } from "openclaw/plugin-sdk";
+import { runBackfill, backfillSkillSessions } from "./src/backfill.js";
+import { createAfterToolCallHandler } from "./src/hook.js";
+import { queryUsage, querySkillHealth, queryStatus, querySkillSessions, type QueryParams } from "./src/query.js";
+import { UsageStorage, SkillSessionStorage } from "./src/storage.js";
+import { createUsageTrackerTool } from "./src/tool.js";
+import { createDashboardHandler } from "./src/web/dashboard.js";
+
+const DEFAULT_AGENT_ID = "main";
+
+function resolveSessionsDir(stateDir: string, agentId: string): string {
+  return path.join(stateDir, "agents", agentId, "sessions");
+}
+
+export default function register(api: OpenClawPluginApi) {
+  const stateDir = api.runtime.state.resolveStateDir();
+  const agentId = DEFAULT_AGENT_ID;
+  const sessionsDir = resolveSessionsDir(stateDir, agentId);
+
+  const storage = new UsageStorage(stateDir);
+  const skillSessionStorage = new SkillSessionStorage(stateDir);
+  api.logger.info(`usage-tracker: data dir: ${stateDir}/plugins/usage-tracker/data/`);
+
+  // 1. Real-time tracking via after_tool_call hook
+  const hookHandler = createAfterToolCallHandler(storage, api.logger);
+  api.on("after_tool_call", hookHandler);
+
+  // 2. Agent tool for in-conversation queries
+  const tool = createUsageTrackerTool(storage, skillSessionStorage);
+  api.registerTool(tool, { name: "usage_tracker" });
+
+  // 3. Gateway RPC methods
+  api.registerGatewayMethod(
+    "usage-tracker.query",
+    async ({ params, respond }: GatewayRequestHandlerOptions) => {
+      try {
+        const p = params ?? {};
+        const queryParams: QueryParams = {
+          startDay: typeof p.startDay === "string" ? p.startDay : undefined,
+          endDay: typeof p.endDay === "string" ? p.endDay : undefined,
+          tool: typeof p.tool === "string" ? p.tool : undefined,
+          skill: typeof p.skill === "string" ? p.skill : undefined,
+          groupBy: typeof p.groupBy === "string" ? (p.groupBy as QueryParams["groupBy"]) : undefined,
+        };
+        const result = await queryUsage(storage, queryParams);
+        respond(true, result);
+      } catch (err) {
+        respond(false, undefined, { code: -1, message: String(err) });
+      }
+    },
+  );
+
+  api.registerGatewayMethod(
+    "usage-tracker.backfill",
+    async ({ respond }: GatewayRequestHandlerOptions) => {
+      try {
+        const [usageResult, sessionResult] = await Promise.all([
+          runBackfill({ sessionsDir, agentId, storage, logger: api.logger }),
+          backfillSkillSessions({ sessionsDir, agentId, skillSessionStorage, logger: api.logger }),
+        ]);
+        respond(true, {
+          ...usageResult,
+          skillSessionsFound: sessionResult.skillSessionsFound,
+        });
+      } catch (err) {
+        respond(false, undefined, { code: -1, message: String(err) });
+      }
+    },
+  );
+
+  api.registerGatewayMethod(
+    "usage-tracker.status",
+    async ({ respond }: GatewayRequestHandlerOptions) => {
+      try {
+        const result = await queryStatus(storage);
+        respond(true, result);
+      } catch (err) {
+        respond(false, undefined, { code: -1, message: String(err) });
+      }
+    },
+  );
+
+  // 4. Web dashboard — prefix match to handle /api sub-routes
+  const dashboardHandler = createDashboardHandler({
+    storage,
+    skillSessionStorage,
+    sessionsDir,
+    agentId,
+    logger: api.logger,
+  });
+  api.registerHttpRoute({
+    path: "/plugins/usage-tracker",
+    handler: dashboardHandler,
+    auth: "plugin",
+    match: "prefix",
+  });
+}

--- a/extensions/usage-tracker/index.ts
+++ b/extensions/usage-tracker/index.ts
@@ -6,7 +6,13 @@ import path from "node:path";
 import type { OpenClawPluginApi, GatewayRequestHandlerOptions } from "openclaw/plugin-sdk";
 import { runBackfill, backfillSkillSessions } from "./src/backfill.js";
 import { createAfterToolCallHandler } from "./src/hook.js";
-import { queryUsage, querySkillHealth, queryStatus, querySkillSessions, type QueryParams } from "./src/query.js";
+import {
+  queryUsage,
+  querySkillHealth,
+  queryStatus,
+  querySkillSessions,
+  type QueryParams,
+} from "./src/query.js";
 import { UsageStorage, SkillSessionStorage } from "./src/storage.js";
 import { createUsageTrackerTool } from "./src/tool.js";
 import { createDashboardHandler } from "./src/web/dashboard.js";
@@ -45,12 +51,13 @@ export default function register(api: OpenClawPluginApi) {
           endDay: typeof p.endDay === "string" ? p.endDay : undefined,
           tool: typeof p.tool === "string" ? p.tool : undefined,
           skill: typeof p.skill === "string" ? p.skill : undefined,
-          groupBy: typeof p.groupBy === "string" ? (p.groupBy as QueryParams["groupBy"]) : undefined,
+          groupBy:
+            typeof p.groupBy === "string" ? (p.groupBy as QueryParams["groupBy"]) : undefined,
         };
         const result = await queryUsage(storage, queryParams);
         respond(true, result);
       } catch (err) {
-        respond(false, undefined, { code: -1, message: String(err) });
+        respond(false, undefined, { code: "error", message: String(err) });
       }
     },
   );
@@ -68,7 +75,7 @@ export default function register(api: OpenClawPluginApi) {
           skillSessionsFound: sessionResult.skillSessionsFound,
         });
       } catch (err) {
-        respond(false, undefined, { code: -1, message: String(err) });
+        respond(false, undefined, { code: "error", message: String(err) });
       }
     },
   );
@@ -80,7 +87,7 @@ export default function register(api: OpenClawPluginApi) {
         const result = await queryStatus(storage);
         respond(true, result);
       } catch (err) {
-        respond(false, undefined, { code: -1, message: String(err) });
+        respond(false, undefined, { code: "error", message: String(err) });
       }
     },
   );

--- a/extensions/usage-tracker/openclaw.plugin.json
+++ b/extensions/usage-tracker/openclaw.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "usage-tracker",
+  "name": "Usage Tracker",
+  "description": "Tracks tool calls and skill usage in real-time with historical backfill, query API, and web dashboard.",
+  "entry": "./index.ts",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/usage-tracker/package.json
+++ b/extensions/usage-tracker/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/usage-tracker",
+  "version": "0.1.0",
+  "private": true,
+  "description": "OpenClaw plugin that tracks tool calls and skill usage with dashboard",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/usage-tracker/src/backfill.ts
+++ b/extensions/usage-tracker/src/backfill.ts
@@ -1,0 +1,430 @@
+/**
+ * Backfill engine: scan historical session transcripts and generate past JSONL data.
+ * Uses stream parsing (readline) for memory efficiency.
+ * Computes duration by matching toolCall → toolResult timestamp pairs.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+import type { PluginLogger } from "openclaw/plugin-sdk";
+import { classifyReadPath } from "./classifier.js";
+import type { UsageRecord, UsageStorage } from "./storage.js";
+
+type PendingToolCall = {
+  toolName: string;
+  toolCallId: string;
+  params?: Record<string, unknown>;
+  timestamp?: number; // ms epoch
+  entryTimestamp?: string; // ISO string
+};
+
+/**
+ * Parse a timestamp from a transcript entry.
+ * Returns millisecond epoch or undefined.
+ */
+function parseTimestamp(
+  entry: Record<string, unknown>,
+  message: Record<string, unknown>,
+): number | undefined {
+  // entry.timestamp is ISO string (e.g. "2026-03-03T17:41:32.008Z")
+  if (typeof entry.timestamp === "string") {
+    const parsed = new Date(entry.timestamp);
+    if (!Number.isNaN(parsed.valueOf())) {
+      return parsed.getTime();
+    }
+  }
+  // message.timestamp is ms epoch
+  if (typeof message.timestamp === "number" && message.timestamp > 1_000_000_000_000) {
+    return message.timestamp;
+  }
+  if (typeof message.timestamp === "number" && message.timestamp > 1_000_000_000) {
+    return message.timestamp * 1000;
+  }
+  return undefined;
+}
+
+/**
+ * Backfill a single session transcript file.
+ * Matches toolCall entries with their toolResult entries to compute duration.
+ */
+async function backfillSessionFile(
+  filePath: string,
+  sessionId: string,
+  agentId: string,
+): Promise<UsageRecord[]> {
+  const records: UsageRecord[] = [];
+  const pendingCalls = new Map<string, PendingToolCall>();
+
+  const fileStream = fs.createReadStream(filePath, { encoding: "utf-8" });
+  const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+
+  try {
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      let entry: Record<string, unknown>;
+      try {
+        entry = JSON.parse(trimmed) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+
+      if (entry.type !== "message") continue;
+      const message = entry.message as Record<string, unknown> | undefined;
+      if (!message || typeof message !== "object") continue;
+
+      const role = message.role as string;
+      const tsMs = parseTimestamp(entry, message);
+
+      // Handle assistant messages with tool calls
+      if (role === "assistant") {
+        const content = message.content;
+        if (!Array.isArray(content)) continue;
+
+        for (const block of content) {
+          if (!block || typeof block !== "object") continue;
+          const b = block as Record<string, unknown>;
+          const type = typeof b.type === "string" ? b.type.trim().toLowerCase() : "";
+
+          if (type === "tool_use" || type === "toolcall" || type === "tool_call") {
+            const name = typeof b.name === "string" ? b.name.trim() : undefined;
+            const id = typeof b.id === "string" ? b.id : undefined;
+            if (!name) continue;
+
+            // Transcript uses "arguments" for tool call params
+            const args = (b.arguments ?? b.input) as Record<string, unknown> | undefined;
+
+            if (id) {
+              pendingCalls.set(id, {
+                toolName: name,
+                toolCallId: id,
+                params: args ?? undefined,
+                timestamp: tsMs,
+                entryTimestamp: typeof entry.timestamp === "string" ? entry.timestamp : undefined,
+              });
+            } else {
+              // No id — emit immediately without duration
+              const tsSec = tsMs ? Math.floor(tsMs / 1000) : Math.floor(Date.now() / 1000);
+              const record: UsageRecord = {
+                ts: tsSec,
+                tool: name,
+                session: sessionId,
+                agent: agentId,
+              };
+              classifyAndAttach(record, name, args);
+              records.push(record);
+            }
+          }
+        }
+      }
+
+      // Handle tool results — match with pending calls to compute duration
+      if (role === "toolResult" || role === "tool") {
+        const toolCallId = (message.toolCallId ?? message.tool_call_id) as string | undefined;
+        if (!toolCallId) continue;
+
+        const pending = pendingCalls.get(toolCallId);
+        if (!pending) continue;
+        pendingCalls.delete(toolCallId);
+
+        const callTs = pending.timestamp;
+        const resultTs = tsMs;
+        const durationMs = callTs && resultTs ? Math.max(0, resultTs - callTs) : undefined;
+        const tsSec = callTs ? Math.floor(callTs / 1000) : Math.floor(Date.now() / 1000);
+
+        const isError = message.isError === true;
+        const record: UsageRecord = {
+          ts: tsSec,
+          tool: pending.toolName,
+          session: sessionId,
+          agent: agentId,
+          dur: durationMs,
+        };
+
+        if (isError) {
+          const content = message.content;
+          let errMsg = "";
+          if (typeof content === "string") {
+            errMsg = content;
+          } else if (Array.isArray(content)) {
+            for (const block of content) {
+              if (
+                typeof block === "object" &&
+                block &&
+                typeof (block as Record<string, unknown>).text === "string"
+              ) {
+                errMsg = (block as Record<string, unknown>).text as string;
+                break;
+              }
+            }
+          }
+          if (errMsg) {
+            record.err = errMsg.slice(0, 200);
+          }
+        }
+
+        classifyAndAttach(record, pending.toolName, pending.params);
+        records.push(record);
+      }
+    }
+  } finally {
+    rl.close();
+    fileStream.destroy();
+  }
+
+  // Flush any remaining pending calls (tool calls without matching results)
+  for (const pending of pendingCalls.values()) {
+    const tsSec = pending.timestamp
+      ? Math.floor(pending.timestamp / 1000)
+      : Math.floor(Date.now() / 1000);
+    const record: UsageRecord = {
+      ts: tsSec,
+      tool: pending.toolName,
+      session: sessionId,
+      agent: agentId,
+    };
+    classifyAndAttach(record, pending.toolName, pending.params);
+    records.push(record);
+  }
+
+  return records;
+}
+
+function classifyAndAttach(
+  record: UsageRecord,
+  toolName: string,
+  params?: Record<string, unknown>,
+): void {
+  if (toolName === "read" || toolName === "Read") {
+    const filePath =
+      typeof params?.file_path === "string"
+        ? params.file_path
+        : typeof params?.path === "string"
+          ? params.path
+          : undefined;
+
+    if (filePath) {
+      record.path = filePath;
+      const classification = classifyReadPath(filePath);
+      if (classification.isSkill) {
+        record.skill = classification.skill;
+        record.skillType = classification.skillType;
+      }
+    }
+  }
+}
+
+export type BackfillResult = {
+  sessionsScanned: number;
+  recordsGenerated: number;
+  errors: string[];
+};
+
+/**
+ * Run backfill across all session transcripts for a given agent.
+ * Clears existing data and regenerates from scratch.
+ */
+export async function runBackfill(params: {
+  sessionsDir: string;
+  agentId: string;
+  storage: UsageStorage;
+  logger: PluginLogger;
+  clear?: boolean;
+}): Promise<BackfillResult> {
+  const { sessionsDir, agentId, storage, logger } = params;
+  const result: BackfillResult = { sessionsScanned: 0, recordsGenerated: 0, errors: [] };
+
+  if (params.clear !== false) {
+    storage.clear();
+  }
+
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true });
+  } catch {
+    result.errors.push(`Cannot read sessions directory: ${sessionsDir}`);
+    return result;
+  }
+
+  const files = entries.filter((e) => e.isFile() && e.name.endsWith(".jsonl"));
+  logger.info(`usage-tracker: backfilling ${files.length} session files`);
+
+  for (const file of files) {
+    const fp = path.join(sessionsDir, file.name);
+    const sid = file.name.slice(0, -6); // strip .jsonl
+
+    try {
+      const records = await backfillSessionFile(fp, sid, agentId);
+      if (records.length > 0) {
+        storage.appendBatch(records);
+        result.recordsGenerated += records.length;
+      }
+      result.sessionsScanned += 1;
+    } catch (err) {
+      const msg = `Failed to backfill ${file.name}: ${String(err)}`;
+      logger.error(`usage-tracker: ${msg}`);
+      result.errors.push(msg);
+    }
+  }
+
+  logger.info(
+    `usage-tracker: backfill complete — ${result.sessionsScanned} sessions, ${result.recordsGenerated} records`,
+  );
+  return result;
+}
+
+// ── Skill Session extraction during backfill ──────────────────────────
+
+
+import { extractSkillSessions, type TranscriptEntry } from "./skill-session.js";
+import type { SkillSessionRecord, SkillSessionStorage } from "./storage.js";
+
+/**
+ * Extract transcript entries suitable for skill session analysis from a session file.
+ */
+async function extractTranscriptEntries(
+  filePath: string,
+): Promise<TranscriptEntry[]> {
+  const entries: TranscriptEntry[] = [];
+  const fileStream = fs.createReadStream(filePath, { encoding: "utf-8" });
+  const rl2 = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+
+  try {
+    for await (const line of rl2) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      let raw: Record<string, unknown>;
+      try {
+        raw = JSON.parse(trimmed) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+
+      if (raw.type !== "message") continue;
+      const message = raw.message as Record<string, unknown> | undefined;
+      if (!message) continue;
+
+      const role = message.role as string;
+      // Parse timestamp
+      let tsMs = 0;
+      if (typeof raw.timestamp === "string") {
+        const d = new Date(raw.timestamp as string);
+        if (!Number.isNaN(d.valueOf())) tsMs = d.getTime();
+      }
+      if (!tsMs && typeof message.timestamp === "number") {
+        tsMs = (message.timestamp as number) > 1e12
+          ? (message.timestamp as number)
+          : (message.timestamp as number) * 1000;
+      }
+
+      const toolCalls: Array<{ name: string; path?: string }> = [];
+      let hasTextResponse = false;
+      let skillEntry: string | undefined;
+      let skillSubRead: string | undefined;
+
+      const content = message.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (!block || typeof block !== "object") continue;
+          const b = block as Record<string, unknown>;
+          const btype = typeof b.type === "string" ? b.type.trim().toLowerCase() : "";
+
+          if (btype === "tool_use" || btype === "toolcall" || btype === "tool_call") {
+            const name = typeof b.name === "string" ? b.name.trim() : "";
+            if (!name) continue;
+            const args = (b.arguments ?? b.input) as Record<string, unknown> | undefined;
+            const p = typeof args?.file_path === "string" ? args.file_path
+              : typeof args?.path === "string" ? args.path : undefined;
+            toolCalls.push({ name, path: p });
+
+            // Classify for skill detection
+            if ((name === "read" || name === "Read") && p) {
+              const cls = classifyReadPath(p);
+              if (cls.isSkill) {
+                if (cls.skillType === "entry") {
+                  skillEntry = cls.skill;
+                } else {
+                  skillSubRead = cls.skill;
+                }
+              }
+            }
+          } else if (btype === "text" && typeof b.text === "string" && b.text.length > 30) {
+            hasTextResponse = true;
+          }
+        }
+      } else if (typeof content === "string" && content.length > 30) {
+        hasTextResponse = true;
+      }
+
+      // Text response = assistant with text but no tool calls
+      if (role !== "assistant") {
+        hasTextResponse = false;
+      }
+
+      entries.push({
+        tsMs,
+        role,
+        toolCalls,
+        hasTextResponse: hasTextResponse && toolCalls.length === 0,
+        skillEntry,
+        skillSubRead,
+      });
+    }
+  } finally {
+    rl2.close();
+    fileStream.destroy();
+  }
+
+  return entries;
+}
+
+/**
+ * Backfill skill sessions from all session transcripts.
+ */
+export async function backfillSkillSessions(params: {
+  sessionsDir: string;
+  agentId: string;
+  skillSessionStorage: SkillSessionStorage;
+  logger: PluginLogger;
+}): Promise<{ sessionsScanned: number; skillSessionsFound: number }> {
+  const { sessionsDir, agentId, skillSessionStorage, logger } = params;
+  skillSessionStorage.clear();
+
+  let entries: fs.Dirent[];
+  try {
+    entries = await fs.promises.readdir(sessionsDir, { withFileTypes: true });
+  } catch {
+    return { sessionsScanned: 0, skillSessionsFound: 0 };
+  }
+
+  const files = entries.filter((e) => e.isFile() && e.name.endsWith(".jsonl"));
+  let totalSkillSessions = 0;
+
+  for (const file of files) {
+    const fp = path.join(sessionsDir, file.name);
+    const sid = file.name.slice(0, -6);
+
+    try {
+      const transcriptEntries = await extractTranscriptEntries(fp);
+      const skillSessions = extractSkillSessions(transcriptEntries);
+
+      if (skillSessions.length > 0) {
+        const records: SkillSessionRecord[] = skillSessions.map((s) => ({
+          ...s,
+          session: sid,
+          agent: agentId,
+        }));
+        skillSessionStorage.appendBatch(records);
+        totalSkillSessions += skillSessions.length;
+      }
+    } catch (err) {
+      logger.error(`usage-tracker: skill session backfill error for ${file.name}: ${String(err)}`);
+    }
+  }
+
+  logger.info(`usage-tracker: skill session backfill — ${totalSkillSessions} sessions from ${files.length} files`);
+  return { sessionsScanned: files.length, skillSessionsFound: totalSkillSessions };
+}

--- a/extensions/usage-tracker/src/backfill.ts
+++ b/extensions/usage-tracker/src/backfill.ts
@@ -9,7 +9,13 @@ import path from "node:path";
 import readline from "node:readline";
 import type { PluginLogger } from "openclaw/plugin-sdk";
 import { classifyReadPath } from "./classifier.js";
-import type { UsageRecord, UsageStorage } from "./storage.js";
+import { extractSkillSessions, type TranscriptEntry } from "./skill-session.js";
+import type {
+  SkillSessionRecord,
+  SkillSessionStorage,
+  UsageRecord,
+  UsageStorage,
+} from "./storage.js";
 
 type PendingToolCall = {
   toolName: string;
@@ -277,16 +283,10 @@ export async function runBackfill(params: {
 
 // ── Skill Session extraction during backfill ──────────────────────────
 
-
-import { extractSkillSessions, type TranscriptEntry } from "./skill-session.js";
-import type { SkillSessionRecord, SkillSessionStorage } from "./storage.js";
-
 /**
  * Extract transcript entries suitable for skill session analysis from a session file.
  */
-async function extractTranscriptEntries(
-  filePath: string,
-): Promise<TranscriptEntry[]> {
+async function extractTranscriptEntries(filePath: string): Promise<TranscriptEntry[]> {
   const entries: TranscriptEntry[] = [];
   const fileStream = fs.createReadStream(filePath, { encoding: "utf-8" });
   const rl2 = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
@@ -315,9 +315,10 @@ async function extractTranscriptEntries(
         if (!Number.isNaN(d.valueOf())) tsMs = d.getTime();
       }
       if (!tsMs && typeof message.timestamp === "number") {
-        tsMs = (message.timestamp as number) > 1e12
-          ? (message.timestamp as number)
-          : (message.timestamp as number) * 1000;
+        tsMs =
+          (message.timestamp as number) > 1e12
+            ? (message.timestamp as number)
+            : (message.timestamp as number) * 1000;
       }
 
       const toolCalls: Array<{ name: string; path?: string }> = [];
@@ -336,8 +337,12 @@ async function extractTranscriptEntries(
             const name = typeof b.name === "string" ? b.name.trim() : "";
             if (!name) continue;
             const args = (b.arguments ?? b.input) as Record<string, unknown> | undefined;
-            const p = typeof args?.file_path === "string" ? args.file_path
-              : typeof args?.path === "string" ? args.path : undefined;
+            const p =
+              typeof args?.file_path === "string"
+                ? args.file_path
+                : typeof args?.path === "string"
+                  ? args.path
+                  : undefined;
             toolCalls.push({ name, path: p });
 
             // Classify for skill detection
@@ -425,6 +430,8 @@ export async function backfillSkillSessions(params: {
     }
   }
 
-  logger.info(`usage-tracker: skill session backfill — ${totalSkillSessions} sessions from ${files.length} files`);
+  logger.info(
+    `usage-tracker: skill session backfill — ${totalSkillSessions} sessions from ${files.length} files`,
+  );
   return { sessionsScanned: files.length, skillSessionsFound: totalSkillSessions };
 }

--- a/extensions/usage-tracker/src/classifier.ts
+++ b/extensions/usage-tracker/src/classifier.ts
@@ -1,0 +1,49 @@
+/**
+ * Classify file-read tool calls as skill-related or not.
+ * Detects SKILL.md entry reads vs sub-file reads within a skill directory.
+ */
+
+export type SkillClassification =
+  | { isSkill: false }
+  | { isSkill: true; skill: string; skillType: "entry" | "sub" };
+
+const SKILL_DIR_PATTERNS = [
+  // <workspace>/skills/<name>/
+  /\/skills\/([^/]+)\//,
+  // <workspace>/.agents/skills/<name>/
+  /\/.agents\/skills\/([^/]+)\//,
+  // ~/.openclaw/skills/<name>/
+  /\/\.openclaw\/skills\/([^/]+)\//,
+];
+
+const SKILL_ENTRY_FILE = "SKILL.md";
+
+/**
+ * Classify a file path from a read tool call.
+ *
+ * @param filePath - The path being read
+ * @returns classification with skill name and type if applicable
+ */
+export function classifyReadPath(filePath: string): SkillClassification {
+  if (!filePath) {
+    return { isSkill: false };
+  }
+
+  for (const pattern of SKILL_DIR_PATTERNS) {
+    const match = pattern.exec(filePath);
+    if (!match) {
+      continue;
+    }
+
+    const skill = match[1];
+    const isEntry = filePath.endsWith(`/${SKILL_ENTRY_FILE}`);
+
+    return {
+      isSkill: true,
+      skill,
+      skillType: isEntry ? "entry" : "sub",
+    };
+  }
+
+  return { isSkill: false };
+}

--- a/extensions/usage-tracker/src/hook.ts
+++ b/extensions/usage-tracker/src/hook.ts
@@ -1,0 +1,64 @@
+/**
+ * after_tool_call hook handler for real-time usage tracking.
+ * NEVER throws — all errors are caught and logged.
+ */
+
+import type { PluginLogger } from "openclaw/plugin-sdk";
+import { classifyReadPath } from "./classifier.js";
+import type { UsageRecord, UsageStorage } from "./storage.js";
+
+/**
+ * Create the after_tool_call hook handler.
+ * Uses inline types to avoid import issues with unexported plugin hook types.
+ */
+export function createAfterToolCallHandler(storage: UsageStorage, logger: PluginLogger) {
+  return (
+    event: {
+      toolName: string;
+      params: Record<string, unknown>;
+      result?: unknown;
+      error?: string;
+      durationMs?: number;
+    },
+    ctx: { agentId?: string; sessionKey?: string; toolName: string },
+  ): void => {
+    try {
+      const now = Math.floor(Date.now() / 1000);
+
+      const record: UsageRecord = {
+        ts: now,
+        tool: event.toolName,
+        session: ctx.sessionKey,
+        agent: ctx.agentId,
+        dur: event.durationMs,
+      };
+
+      if (event.error) {
+        record.err = event.error.slice(0, 200);
+      }
+
+      // Classify read tool calls for skill detection
+      if (event.toolName === "read" || event.toolName === "Read") {
+        const filePath =
+          typeof event.params?.file_path === "string"
+            ? event.params.file_path
+            : typeof event.params?.path === "string"
+              ? event.params.path
+              : undefined;
+
+        if (filePath) {
+          record.path = filePath;
+          const classification = classifyReadPath(filePath);
+          if (classification.isSkill) {
+            record.skill = classification.skill;
+            record.skillType = classification.skillType;
+          }
+        }
+      }
+
+      storage.append(record);
+    } catch (err) {
+      logger.error(`usage-tracker hook error: ${String(err)}`);
+    }
+  };
+}

--- a/extensions/usage-tracker/src/query.ts
+++ b/extensions/usage-tracker/src/query.ts
@@ -1,0 +1,260 @@
+/**
+ * Aggregation engine: query usage data by tool, skill, day, date range.
+ */
+
+import type { UsageRecord, UsageStorage } from "./storage.js";
+
+export type QueryParams = {
+  startDay?: string; // YYYY-MM-DD
+  endDay?: string; // YYYY-MM-DD
+  tool?: string;
+  skill?: string;
+  groupBy?: "tool" | "skill" | "day" | "agent";
+};
+
+export type AggregatedBucket = {
+  key: string;
+  count: number;
+  errors: number;
+  avgDurMs: number;
+  totalDurMs: number;
+  skills: string[];
+};
+
+export type QueryResult = {
+  totalRecords: number;
+  totalErrors: number;
+  buckets: AggregatedBucket[];
+  dateRange: { start: string; end: string };
+};
+
+export type SkillHealthEntry = {
+  skill: string;
+  totalCalls: number;
+  entryReads: number;
+  subReads: number;
+  errors: number;
+  avgDurMs: number;
+};
+
+export type StatusResult = {
+  totalRecords: number;
+  daysTracked: number;
+  dateRange: { start: string; end: string } | null;
+  topTools: Array<{ tool: string; count: number }>;
+  topSkills: Array<{ skill: string; count: number }>;
+};
+
+function todayKey(): string {
+  const d = new Date();
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function daysAgoKey(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function dayKeyFromTs(ts: number): string {
+  const d = new Date(ts * 1000);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Run an aggregation query against the usage storage.
+ */
+export async function queryUsage(storage: UsageStorage, params: QueryParams): Promise<QueryResult> {
+  const startDay = params.startDay ?? daysAgoKey(30);
+  const endDay = params.endDay ?? todayKey();
+  const groupBy = params.groupBy ?? "tool";
+
+  const records = await storage.readRange(startDay, endDay);
+
+  // Apply filters
+  const filtered = records.filter((r) => {
+    if (params.tool && r.tool !== params.tool) return false;
+    if (params.skill && r.skill !== params.skill) return false;
+    return true;
+  });
+
+  // Group into buckets
+  const bucketMap = new Map<string, { records: UsageRecord[] }>();
+  for (const r of filtered) {
+    let key: string;
+    switch (groupBy) {
+      case "tool":
+        key = r.tool;
+        break;
+      case "skill":
+        key = r.skill ?? "(none)";
+        break;
+      case "day":
+        key = dayKeyFromTs(r.ts);
+        break;
+      case "agent":
+        key = r.agent ?? "(unknown)";
+        break;
+      default:
+        key = r.tool;
+    }
+    const bucket = bucketMap.get(key) ?? { records: [] };
+    bucket.records.push(r);
+    bucketMap.set(key, bucket);
+  }
+
+  const buckets: AggregatedBucket[] = [];
+  for (const [key, bucket] of bucketMap) {
+    const errors = bucket.records.filter((r) => r.err).length;
+    const durations = bucket.records.filter((r) => r.dur != null).map((r) => r.dur!);
+    const totalDurMs = durations.reduce((sum, d) => sum + d, 0);
+    const avgDurMs = durations.length > 0 ? totalDurMs / durations.length : 0;
+    const skills = [...new Set(bucket.records.filter((r) => r.skill).map((r) => r.skill!))];
+
+    buckets.push({
+      key,
+      count: bucket.records.length,
+      errors,
+      avgDurMs: Math.round(avgDurMs),
+      totalDurMs,
+      skills,
+    });
+  }
+
+  // Sort by count descending
+  buckets.sort((a, b) => b.count - a.count);
+
+  return {
+    totalRecords: filtered.length,
+    totalErrors: filtered.filter((r) => r.err).length,
+    buckets,
+    dateRange: { start: startDay, end: endDay },
+  };
+}
+
+/**
+ * Get skill health metrics — aggregated per-skill breakdown.
+ */
+export async function querySkillHealth(
+  storage: UsageStorage,
+  params: { startDay?: string; endDay?: string },
+): Promise<SkillHealthEntry[]> {
+  const startDay = params.startDay ?? daysAgoKey(30);
+  const endDay = params.endDay ?? todayKey();
+
+  const records = await storage.readRange(startDay, endDay);
+  const skillRecords = records.filter((r) => r.skill);
+
+  const skillMap = new Map<string, UsageRecord[]>();
+  for (const r of skillRecords) {
+    const list = skillMap.get(r.skill!) ?? [];
+    list.push(r);
+    skillMap.set(r.skill!, list);
+  }
+
+  const entries: SkillHealthEntry[] = [];
+  for (const [skill, recs] of skillMap) {
+    const errors = recs.filter((r) => r.err).length;
+    const durations = recs.filter((r) => r.dur != null).map((r) => r.dur!);
+    const avgDurMs =
+      durations.length > 0 ? durations.reduce((a, b) => a + b, 0) / durations.length : 0;
+
+    entries.push({
+      skill,
+      totalCalls: recs.length,
+      entryReads: recs.filter((r) => r.skillType === "entry").length,
+      subReads: recs.filter((r) => r.skillType === "sub").length,
+      errors,
+      avgDurMs: Math.round(avgDurMs),
+    });
+  }
+
+  entries.sort((a, b) => b.totalCalls - a.totalCalls);
+  return entries;
+}
+
+/**
+ * Get high-level status overview.
+ */
+export async function queryStatus(storage: UsageStorage): Promise<StatusResult> {
+  const days = storage.listDays();
+  if (days.length === 0) {
+    return {
+      totalRecords: 0,
+      daysTracked: 0,
+      dateRange: null,
+      topTools: [],
+      topSkills: [],
+    };
+  }
+
+  const startDay = days[0];
+  const endDay = days[days.length - 1];
+  const records = await storage.readRange(startDay, endDay);
+
+  // Top tools
+  const toolCounts = new Map<string, number>();
+  for (const r of records) {
+    toolCounts.set(r.tool, (toolCounts.get(r.tool) ?? 0) + 1);
+  }
+  const topTools = [...toolCounts.entries()]
+    .map(([tool, count]) => ({ tool, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+
+  // Top skills
+  const skillCounts = new Map<string, number>();
+  for (const r of records) {
+    if (r.skill) {
+      skillCounts.set(r.skill, (skillCounts.get(r.skill) ?? 0) + 1);
+    }
+  }
+  const topSkills = [...skillCounts.entries()]
+    .map(([skill, count]) => ({ skill, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+
+  return {
+    totalRecords: records.length,
+    daysTracked: days.length,
+    dateRange: { start: startDay, end: endDay },
+    topTools,
+    topSkills,
+  };
+}
+
+// ── Skill Session queries ──────────────────────────────────────────────
+
+import { aggregateSkillSessions, type SkillSessionHealth } from "./skill-session.js";
+import type { SkillSessionStorage } from "./storage.js";
+
+export async function querySkillSessions(
+  skillSessionStorage: SkillSessionStorage,
+): Promise<SkillSessionHealth[]> {
+  const records = await skillSessionStorage.readAll();
+
+  // Convert storage records to SkillSession type
+  const sessions = records.map((r) => ({
+    skill: r.skill,
+    startTs: r.startTs,
+    endTs: r.endTs,
+    durationSec: r.durationSec,
+    toolCalls: r.toolCalls,
+    toolBreakdown: r.toolBreakdown,
+    subReads: r.subReads,
+    endReason: r.endReason as "text_response" | "user_msg" | "different_skill" | "eof",
+    sessionKey: r.session,
+    agent: r.agent,
+  }));
+
+  return aggregateSkillSessions(sessions);
+}

--- a/extensions/usage-tracker/src/query.ts
+++ b/extensions/usage-tracker/src/query.ts
@@ -2,7 +2,8 @@
  * Aggregation engine: query usage data by tool, skill, day, date range.
  */
 
-import type { UsageRecord, UsageStorage } from "./storage.js";
+import { aggregateSkillSessions, type SkillSessionHealth } from "./skill-session.js";
+import type { UsageRecord, UsageStorage, SkillSessionStorage } from "./storage.js";
 
 export type QueryParams = {
   startDay?: string; // YYYY-MM-DD
@@ -233,9 +234,6 @@ export async function queryStatus(storage: UsageStorage): Promise<StatusResult> 
 }
 
 // ── Skill Session queries ──────────────────────────────────────────────
-
-import { aggregateSkillSessions, type SkillSessionHealth } from "./skill-session.js";
-import type { SkillSessionStorage } from "./storage.js";
 
 export async function querySkillSessions(
   skillSessionStorage: SkillSessionStorage,

--- a/extensions/usage-tracker/src/skill-session.ts
+++ b/extensions/usage-tracker/src/skill-session.ts
@@ -1,0 +1,196 @@
+/**
+ * Skill Session tracking.
+ * 
+ * A "skill session" is the full lifecycle from reading a SKILL.md to the agent
+ * delivering a final text response. It captures:
+ * - Total wall-clock duration
+ * - All tool calls made while the skill was "active"
+ * - Sub-file reads within the skill directory
+ * - How the session ended (text response, user message, different skill, eof)
+ */
+
+import type { UsageRecord } from "./storage.js";
+
+export type SkillSession = {
+  skill: string;
+  startTs: number;     // seconds epoch
+  endTs: number;       // seconds epoch
+  durationSec: number; // wall-clock seconds
+  toolCalls: number;   // total tool calls during this session
+  toolBreakdown: Record<string, number>; // tool name → count
+  subReads: number;    // sub-file reads within the skill directory
+  endReason: "text_response" | "user_msg" | "different_skill" | "eof";
+  sessionKey?: string;
+  agent?: string;
+};
+
+/**
+ * Extract skill sessions from a chronologically-ordered list of transcript entries.
+ * Each entry represents one message (user/assistant/toolResult).
+ */
+export type TranscriptEntry = {
+  tsMs: number;        // millisecond epoch
+  role: string;        // user | assistant | toolResult | tool
+  toolCalls: Array<{ name: string; path?: string }>;
+  hasTextResponse: boolean; // assistant message with substantial text, no tool calls
+  skillEntry?: string;      // skill name if this entry reads a SKILL.md
+  skillSubRead?: string;    // skill name if this entry reads a skill sub-file
+};
+
+export function extractSkillSessions(entries: TranscriptEntry[]): SkillSession[] {
+  const sessions: SkillSession[] = [];
+  let i = 0;
+
+  while (i < entries.length) {
+    const e = entries[i];
+    
+    // Look for skill entry point (SKILL.md read)
+    if (!e.skillEntry) {
+      i++;
+      continue;
+    }
+
+    const skillName = e.skillEntry;
+    const startTs = e.tsMs;
+    const toolBreakdown: Record<string, number> = {};
+    let toolCalls = 0;
+    let subReads = 0;
+    let endTs = startTs;
+    let endReason: SkillSession["endReason"] = "eof";
+
+    // Count the initial entry's tool calls
+    for (const tc of e.toolCalls) {
+      toolBreakdown[tc.name] = (toolBreakdown[tc.name] ?? 0) + 1;
+      toolCalls++;
+    }
+
+    // Trace forward
+    let j = i + 1;
+    while (j < entries.length) {
+      const ej = entries[j];
+      const ejTs = ej.tsMs || endTs;
+
+      // User message → skill session ended
+      if (ej.role === "user") {
+        endReason = "user_msg";
+        break;
+      }
+
+      // Different skill entry → this skill session ended
+      if (ej.skillEntry && ej.skillEntry !== skillName) {
+        endReason = "different_skill";
+        break;
+      }
+
+      // Count tool calls
+      for (const tc of ej.toolCalls) {
+        toolBreakdown[tc.name] = (toolBreakdown[tc.name] ?? 0) + 1;
+        toolCalls++;
+      }
+
+      // Count sub-reads for this skill
+      if (ej.skillSubRead === skillName) {
+        subReads++;
+      }
+
+      endTs = ejTs;
+
+      // Assistant text response with no tool calls → likely the final answer
+      // But only if the NEXT entry is a user message or eof
+      if (ej.hasTextResponse && ej.toolCalls.length === 0 && ej.role === "assistant") {
+        const next = j + 1 < entries.length ? entries[j + 1] : null;
+        if (!next || next.role === "user") {
+          endReason = "text_response";
+          break;
+        }
+      }
+
+      j++;
+    }
+
+    const durationSec = startTs && endTs ? Math.max(0, (endTs - startTs) / 1000) : 0;
+
+    sessions.push({
+      skill: skillName,
+      startTs: Math.floor(startTs / 1000),
+      endTs: Math.floor(endTs / 1000),
+      durationSec: Math.round(durationSec * 10) / 10,
+      toolCalls,
+      toolBreakdown,
+      subReads,
+      endReason,
+    });
+
+    // Move past this skill session
+    i = j;
+  }
+
+  return sessions;
+}
+
+/**
+ * Aggregate skill sessions into per-skill health metrics.
+ */
+export type SkillSessionHealth = {
+  skill: string;
+  sessionCount: number;
+  avgDurationSec: number;
+  maxDurationSec: number;
+  minDurationSec: number;
+  avgToolCalls: number;
+  avgSubReads: number;
+  totalToolCalls: number;
+  topTools: Array<{ tool: string; count: number }>;
+  endReasons: Record<string, number>;
+};
+
+export function aggregateSkillSessions(sessions: SkillSession[]): SkillSessionHealth[] {
+  const bySkill = new Map<string, SkillSession[]>();
+  for (const s of sessions) {
+    const list = bySkill.get(s.skill) ?? [];
+    list.push(s);
+    bySkill.set(s.skill, list);
+  }
+
+  const result: SkillSessionHealth[] = [];
+  for (const [skill, ss] of bySkill) {
+    const n = ss.length;
+    const durations = ss.map((s) => s.durationSec);
+    const totalTools = ss.reduce((sum, s) => sum + s.toolCalls, 0);
+    const totalSubs = ss.reduce((sum, s) => sum + s.subReads, 0);
+
+    // Aggregate tool breakdown
+    const toolTotals = new Map<string, number>();
+    for (const s of ss) {
+      for (const [tool, count] of Object.entries(s.toolBreakdown)) {
+        toolTotals.set(tool, (toolTotals.get(tool) ?? 0) + count);
+      }
+    }
+    const topTools = [...toolTotals.entries()]
+      .map(([tool, count]) => ({ tool, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 5);
+
+    // End reasons
+    const endReasons: Record<string, number> = {};
+    for (const s of ss) {
+      endReasons[s.endReason] = (endReasons[s.endReason] ?? 0) + 1;
+    }
+
+    result.push({
+      skill,
+      sessionCount: n,
+      avgDurationSec: Math.round((durations.reduce((a, b) => a + b, 0) / n) * 10) / 10,
+      maxDurationSec: Math.max(...durations),
+      minDurationSec: Math.min(...durations),
+      avgToolCalls: Math.round((totalTools / n) * 10) / 10,
+      avgSubReads: Math.round((totalSubs / n) * 10) / 10,
+      totalToolCalls: totalTools,
+      topTools,
+      endReasons,
+    });
+  }
+
+  result.sort((a, b) => b.sessionCount - a.sessionCount);
+  return result;
+}

--- a/extensions/usage-tracker/src/skill-session.ts
+++ b/extensions/usage-tracker/src/skill-session.ts
@@ -1,6 +1,6 @@
 /**
  * Skill Session tracking.
- * 
+ *
  * A "skill session" is the full lifecycle from reading a SKILL.md to the agent
  * delivering a final text response. It captures:
  * - Total wall-clock duration
@@ -9,16 +9,14 @@
  * - How the session ended (text response, user message, different skill, eof)
  */
 
-import type { UsageRecord } from "./storage.js";
-
 export type SkillSession = {
   skill: string;
-  startTs: number;     // seconds epoch
-  endTs: number;       // seconds epoch
+  startTs: number; // seconds epoch
+  endTs: number; // seconds epoch
   durationSec: number; // wall-clock seconds
-  toolCalls: number;   // total tool calls during this session
+  toolCalls: number; // total tool calls during this session
   toolBreakdown: Record<string, number>; // tool name → count
-  subReads: number;    // sub-file reads within the skill directory
+  subReads: number; // sub-file reads within the skill directory
   endReason: "text_response" | "user_msg" | "different_skill" | "eof";
   sessionKey?: string;
   agent?: string;
@@ -29,12 +27,12 @@ export type SkillSession = {
  * Each entry represents one message (user/assistant/toolResult).
  */
 export type TranscriptEntry = {
-  tsMs: number;        // millisecond epoch
-  role: string;        // user | assistant | toolResult | tool
+  tsMs: number; // millisecond epoch
+  role: string; // user | assistant | toolResult | tool
   toolCalls: Array<{ name: string; path?: string }>;
   hasTextResponse: boolean; // assistant message with substantial text, no tool calls
-  skillEntry?: string;      // skill name if this entry reads a SKILL.md
-  skillSubRead?: string;    // skill name if this entry reads a skill sub-file
+  skillEntry?: string; // skill name if this entry reads a SKILL.md
+  skillSubRead?: string; // skill name if this entry reads a skill sub-file
 };
 
 export function extractSkillSessions(entries: TranscriptEntry[]): SkillSession[] {
@@ -43,7 +41,7 @@ export function extractSkillSessions(entries: TranscriptEntry[]): SkillSession[]
 
   while (i < entries.length) {
     const e = entries[i];
-    
+
     // Look for skill entry point (SKILL.md read)
     if (!e.skillEntry) {
       i++;

--- a/extensions/usage-tracker/src/storage.ts
+++ b/extensions/usage-tracker/src/storage.ts
@@ -1,0 +1,221 @@
+/**
+ * Per-day JSONL storage for usage tracking records.
+ * Files stored in <stateDir>/plugins/usage-tracker/data/YYYY-MM-DD.jsonl
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+
+export type UsageRecord = {
+  ts: number;
+  tool: string;
+  skill?: string;
+  skillType?: "entry" | "sub";
+  path?: string;
+  session?: string;
+  agent?: string;
+  dur?: number;
+  err?: string;
+};
+
+function formatDayKey(ts: number): string {
+  const d = new Date(ts * 1000);
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export class UsageStorage {
+  private readonly dataDir: string;
+
+  constructor(stateDir: string) {
+    this.dataDir = path.join(stateDir, "plugins", "usage-tracker", "data");
+  }
+
+  private ensureDir(): void {
+    if (!fs.existsSync(this.dataDir)) {
+      fs.mkdirSync(this.dataDir, { recursive: true });
+    }
+  }
+
+  private fileForDay(dayKey: string): string {
+    return path.join(this.dataDir, `${dayKey}.jsonl`);
+  }
+
+  /** Append a single record to the appropriate day file. */
+  append(record: UsageRecord): void {
+    this.ensureDir();
+    const dayKey = formatDayKey(record.ts);
+    const filePath = this.fileForDay(dayKey);
+    const line = JSON.stringify(record) + "\n";
+    fs.appendFileSync(filePath, line, "utf-8");
+  }
+
+  /** Append multiple records, grouped by day for efficiency. */
+  appendBatch(records: UsageRecord[]): void {
+    if (records.length === 0) return;
+    this.ensureDir();
+
+    const byDay = new Map<string, string[]>();
+    for (const record of records) {
+      const dayKey = formatDayKey(record.ts);
+      const lines = byDay.get(dayKey) ?? [];
+      lines.push(JSON.stringify(record));
+      byDay.set(dayKey, lines);
+    }
+
+    for (const [dayKey, lines] of byDay) {
+      const filePath = this.fileForDay(dayKey);
+      fs.appendFileSync(filePath, lines.join("\n") + "\n", "utf-8");
+    }
+  }
+
+  /** Read all records from a specific day file. */
+  async readDay(dayKey: string): Promise<UsageRecord[]> {
+    const filePath = this.fileForDay(dayKey);
+    if (!fs.existsSync(filePath)) return [];
+    return this.readFile(filePath);
+  }
+
+  /** Read all records from a date range (inclusive). */
+  async readRange(startDay: string, endDay: string): Promise<UsageRecord[]> {
+    const days = this.listDays();
+    const results: UsageRecord[] = [];
+
+    for (const day of days) {
+      if (day < startDay || day > endDay) continue;
+      const records = await this.readDay(day);
+      results.push(...records);
+    }
+
+    return results;
+  }
+
+  /** List all available day keys, sorted ascending. */
+  listDays(): string[] {
+    if (!fs.existsSync(this.dataDir)) return [];
+
+    return fs
+      .readdirSync(this.dataDir)
+      .filter((f) => f.endsWith(".jsonl") && /^\d{4}-\d{2}-\d{2}\.jsonl$/.test(f))
+      .map((f) => f.slice(0, -6))
+      .sort();
+  }
+
+  /** Delete a specific day file (used during backfill to replace). */
+  deleteDay(dayKey: string): void {
+    const filePath = this.fileForDay(dayKey);
+    if (fs.existsSync(filePath)) {
+      fs.unlinkSync(filePath);
+    }
+  }
+
+  /** Delete all data files. */
+  clear(): void {
+    if (!fs.existsSync(this.dataDir)) return;
+    for (const f of fs.readdirSync(this.dataDir)) {
+      if (f.endsWith(".jsonl")) {
+        fs.unlinkSync(path.join(this.dataDir, f));
+      }
+    }
+  }
+
+  private async readFile(filePath: string): Promise<UsageRecord[]> {
+    const records: UsageRecord[] = [];
+    const fileStream = fs.createReadStream(filePath, { encoding: "utf-8" });
+    const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+
+    try {
+      for await (const line of rl) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const parsed = JSON.parse(trimmed) as UsageRecord;
+          if (parsed && typeof parsed.ts === "number" && typeof parsed.tool === "string") {
+            records.push(parsed);
+          }
+        } catch {
+          // skip malformed lines
+        }
+      }
+    } finally {
+      rl.close();
+      fileStream.destroy();
+    }
+
+    return records;
+  }
+}
+
+// ── Skill Session storage ──────────────────────────────────────────────
+
+export type SkillSessionRecord = {
+  skill: string;
+  startTs: number;
+  endTs: number;
+  durationSec: number;
+  toolCalls: number;
+  toolBreakdown: Record<string, number>;
+  subReads: number;
+  endReason: string;
+  session?: string;
+  agent?: string;
+};
+
+const SESSIONS_FILENAME = "skill-sessions.jsonl";
+
+export class SkillSessionStorage {
+  private readonly filePath: string;
+  private readonly dataDir: string;
+
+  constructor(stateDir: string) {
+    this.dataDir = path.join(stateDir, "plugins", "usage-tracker", "data");
+    this.filePath = path.join(this.dataDir, SESSIONS_FILENAME);
+  }
+
+  private ensureDir(): void {
+    if (!fs.existsSync(this.dataDir)) {
+      fs.mkdirSync(this.dataDir, { recursive: true });
+    }
+  }
+
+  appendBatch(records: SkillSessionRecord[]): void {
+    if (records.length === 0) return;
+    this.ensureDir();
+    const lines = records.map((r) => JSON.stringify(r)).join("\n") + "\n";
+    fs.appendFileSync(this.filePath, lines, "utf-8");
+  }
+
+  clear(): void {
+    if (fs.existsSync(this.filePath)) {
+      fs.unlinkSync(this.filePath);
+    }
+  }
+
+  async readAll(): Promise<SkillSessionRecord[]> {
+    if (!fs.existsSync(this.filePath)) return [];
+    const records: SkillSessionRecord[] = [];
+    const fileStream = fs.createReadStream(this.filePath, { encoding: "utf-8" });
+    const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
+    try {
+      for await (const line of rl) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const parsed = JSON.parse(trimmed) as SkillSessionRecord;
+          if (parsed && typeof parsed.skill === "string") {
+            records.push(parsed);
+          }
+        } catch {
+          // skip
+        }
+      }
+    } finally {
+      rl.close();
+      fileStream.destroy();
+    }
+    return records;
+  }
+}

--- a/extensions/usage-tracker/src/tool.ts
+++ b/extensions/usage-tracker/src/tool.ts
@@ -1,0 +1,87 @@
+/**
+ * Agent tool definition for in-conversation usage queries.
+ */
+
+import type { UsageStorage, SkillSessionStorage } from "./storage.js";
+import { queryUsage, querySkillHealth, queryStatus, querySkillSessions, type QueryParams } from "./query.js";
+
+const UsageTrackerToolSchema = {
+  type: "object" as const,
+  properties: {
+    action: {
+      type: "string" as const,
+      enum: ["query", "skill_health", "skill_sessions", "status"],
+      description: "Action: 'query' for tool/skill aggregation, 'skill_health' for per-skill read metrics, 'skill_sessions' for full skill lifecycle metrics (duration, tool chain), 'status' for overview.",
+    },
+    startDay: {
+      type: "string" as const,
+      description: "Start date (YYYY-MM-DD). Defaults to 30 days ago.",
+    },
+    endDay: {
+      type: "string" as const,
+      description: "End date (YYYY-MM-DD). Defaults to today.",
+    },
+    tool: {
+      type: "string" as const,
+      description: "Filter by tool name.",
+    },
+    skill: {
+      type: "string" as const,
+      description: "Filter by skill name.",
+    },
+    groupBy: {
+      type: "string" as const,
+      enum: ["tool", "skill", "day", "agent"],
+      description: "Group results by dimension. Default: 'tool'.",
+    },
+  },
+  required: ["action"] as string[],
+};
+
+function jsonResult(payload: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(payload, null, 2) }],
+    details: payload,
+  };
+}
+
+export function createUsageTrackerTool(storage: UsageStorage, skillSessionStorage: SkillSessionStorage) {
+  return {
+    name: "usage_tracker",
+    label: "Usage Tracker",
+    description:
+      "Query tool call and skill usage statistics. Use 'status' for overview, 'query' for aggregation, 'skill_health' for per-skill read metrics, 'skill_sessions' for full skill lifecycle analysis (duration, tool chains, completion patterns).",
+    parameters: UsageTrackerToolSchema,
+    async execute(
+      _toolCallId: string,
+      params: Record<string, unknown>,
+    ) {
+      const action = params.action as string;
+
+      if (action === "status") {
+        return jsonResult(await queryStatus(storage));
+      }
+
+      if (action === "skill_health") {
+        return jsonResult(await querySkillHealth(storage, {
+          startDay: params.startDay as string | undefined,
+          endDay: params.endDay as string | undefined,
+        }));
+      }
+
+      if (action === "skill_sessions") {
+        return jsonResult(await querySkillSessions(skillSessionStorage));
+      }
+
+      // Default: query
+      const queryParams: QueryParams = {
+        startDay: params.startDay as string | undefined,
+        endDay: params.endDay as string | undefined,
+        tool: params.tool as string | undefined,
+        skill: params.skill as string | undefined,
+        groupBy: params.groupBy as QueryParams["groupBy"],
+      };
+      return jsonResult(await queryUsage(storage, queryParams));
+    },
+  };
+}

--- a/extensions/usage-tracker/src/tool.ts
+++ b/extensions/usage-tracker/src/tool.ts
@@ -2,8 +2,14 @@
  * Agent tool definition for in-conversation usage queries.
  */
 
+import {
+  queryUsage,
+  querySkillHealth,
+  queryStatus,
+  querySkillSessions,
+  type QueryParams,
+} from "./query.js";
 import type { UsageStorage, SkillSessionStorage } from "./storage.js";
-import { queryUsage, querySkillHealth, queryStatus, querySkillSessions, type QueryParams } from "./query.js";
 
 const UsageTrackerToolSchema = {
   type: "object" as const,
@@ -11,7 +17,8 @@ const UsageTrackerToolSchema = {
     action: {
       type: "string" as const,
       enum: ["query", "skill_health", "skill_sessions", "status"],
-      description: "Action: 'query' for tool/skill aggregation, 'skill_health' for per-skill read metrics, 'skill_sessions' for full skill lifecycle metrics (duration, tool chain), 'status' for overview.",
+      description:
+        "Action: 'query' for tool/skill aggregation, 'skill_health' for per-skill read metrics, 'skill_sessions' for full skill lifecycle metrics (duration, tool chain), 'status' for overview.",
     },
     startDay: {
       type: "string" as const,
@@ -45,17 +52,17 @@ function jsonResult(payload: unknown) {
   };
 }
 
-export function createUsageTrackerTool(storage: UsageStorage, skillSessionStorage: SkillSessionStorage) {
+export function createUsageTrackerTool(
+  storage: UsageStorage,
+  skillSessionStorage: SkillSessionStorage,
+) {
   return {
     name: "usage_tracker",
     label: "Usage Tracker",
     description:
       "Query tool call and skill usage statistics. Use 'status' for overview, 'query' for aggregation, 'skill_health' for per-skill read metrics, 'skill_sessions' for full skill lifecycle analysis (duration, tool chains, completion patterns).",
     parameters: UsageTrackerToolSchema,
-    async execute(
-      _toolCallId: string,
-      params: Record<string, unknown>,
-    ) {
+    async execute(_toolCallId: string, params: Record<string, unknown>) {
       const action = params.action as string;
 
       if (action === "status") {
@@ -63,10 +70,12 @@ export function createUsageTrackerTool(storage: UsageStorage, skillSessionStorag
       }
 
       if (action === "skill_health") {
-        return jsonResult(await querySkillHealth(storage, {
-          startDay: params.startDay as string | undefined,
-          endDay: params.endDay as string | undefined,
-        }));
+        return jsonResult(
+          await querySkillHealth(storage, {
+            startDay: params.startDay as string | undefined,
+            endDay: params.endDay as string | undefined,
+          }),
+        );
       }
 
       if (action === "skill_sessions") {

--- a/extensions/usage-tracker/src/web/dashboard.html
+++ b/extensions/usage-tracker/src/web/dashboard.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Usage Tracker — OpenClaw</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<style>
+  :root { --bg: #0d1117; --fg: #c9d1d9; --card: #161b22; --border: #30363d; --accent: #58a6ff; --green: #3fb950; --red: #f85149; --purple: #d2a8ff; --orange: #f0883e; }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, monospace; background: var(--bg); color: var(--fg); padding: 24px; }
+  h1 { font-size: 1.4rem; margin-bottom: 16px; }
+  .controls { display: flex; gap: 12px; align-items: center; margin-bottom: 20px; flex-wrap: wrap; }
+  .controls label { font-size: 0.85rem; color: #8b949e; }
+  .controls input[type="date"] { background: var(--card); border: 1px solid var(--border); color: var(--fg); padding: 4px 8px; border-radius: 4px; }
+  button { background: var(--accent); color: #000; border: none; padding: 6px 14px; border-radius: 4px; cursor: pointer; font-weight: 600; font-size: 0.85rem; }
+  button:hover { opacity: 0.9; }
+  button.secondary { background: var(--border); color: var(--fg); }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: 16px; margin-bottom: 24px; }
+  .card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
+  .card.full { grid-column: 1 / -1; }
+  .card h2 { font-size: 1rem; margin-bottom: 12px; color: var(--accent); }
+  .card h2 .badge { font-size: 0.7rem; background: var(--accent); color: #000; padding: 2px 6px; border-radius: 3px; margin-left: 8px; vertical-align: middle; }
+  .stat-row { display: flex; justify-content: space-between; padding: 4px 0; font-size: 0.85rem; border-bottom: 1px solid var(--border); }
+  .stat-row:last-child { border-bottom: none; }
+  .stat-value { font-weight: 600; }
+  .chart-container { position: relative; height: 260px; }
+  .status-msg { font-size: 0.85rem; color: #8b949e; padding: 8px 0; }
+  table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
+  th, td { text-align: left; padding: 6px 8px; border-bottom: 1px solid var(--border); }
+  th { color: var(--accent); font-weight: 600; }
+  .err { color: var(--red); }
+  .dur { color: var(--orange); }
+  .sub { color: var(--purple); }
+  .small { font-size: 0.75rem; color: #8b949e; }
+</style>
+</head>
+<body>
+<h1>Usage Tracker</h1>
+
+<div class="controls">
+  <label>From <input type="date" id="startDay" /></label>
+  <label>To <input type="date" id="endDay" /></label>
+  <button onclick="loadData()">Refresh</button>
+  <button class="secondary" onclick="recalculate()">Recalculate</button>
+  <span id="statusMsg" class="status-msg"></span>
+</div>
+
+<div class="grid">
+  <div class="card">
+    <h2>Overview</h2>
+    <div id="overview">Loading...</div>
+  </div>
+  <div class="card">
+    <h2>Tool Calls by Day</h2>
+    <div class="chart-container"><canvas id="dailyChart"></canvas></div>
+  </div>
+</div>
+
+<div class="grid">
+  <div class="card">
+    <h2>Top Tools</h2>
+    <div id="toolsTable"></div>
+  </div>
+  <div class="card">
+    <h2>Skill Reads</h2>
+    <div id="skillsTable"></div>
+  </div>
+</div>
+
+<div class="grid">
+  <div class="card full">
+    <h2>Skill Lifecycle <span class="badge">Sessions</span></h2>
+    <p class="small" style="margin-bottom:12px">Full lifecycle from SKILL.md read → final response. Shows real usage cost per skill.</p>
+    <div id="skillSessionsTable"></div>
+  </div>
+</div>
+
+<div class="grid">
+  <div class="card full">
+    <h2>Tools Distribution</h2>
+    <div class="chart-container"><canvas id="toolsPie"></canvas></div>
+  </div>
+</div>
+
+<script>
+const BASE = window.location.pathname.replace(/\/$/, '');
+let dailyChartInstance = null;
+let pieChartInstance = null;
+
+function defaultDates() {
+  const end = new Date();
+  const start = new Date();
+  start.setDate(start.getDate() - 30);
+  document.getElementById('startDay').value = fmt(start);
+  document.getElementById('endDay').value = fmt(end);
+}
+
+function fmt(d) { return d.toISOString().slice(0, 10); }
+
+function fmtDur(sec) {
+  if (sec < 60) return sec.toFixed(1) + 's';
+  if (sec < 3600) return (sec / 60).toFixed(1) + 'm';
+  return (sec / 3600).toFixed(1) + 'h';
+}
+
+async function apiFetch(action, extra) {
+  const startDay = document.getElementById('startDay').value;
+  const endDay = document.getElementById('endDay').value;
+  const params = new URLSearchParams({ action, startDay, endDay, ...extra });
+  const res = await fetch(BASE + '/api?' + params.toString());
+  return res.json();
+}
+
+async function loadData() {
+  document.getElementById('statusMsg').textContent = 'Loading...';
+  try {
+    const [status, byTool, byDay, skills, skillSessions] = await Promise.all([
+      apiFetch('status'),
+      apiFetch('query', { groupBy: 'tool' }),
+      apiFetch('query', { groupBy: 'day' }),
+      apiFetch('skill_health'),
+      apiFetch('skill_sessions'),
+    ]);
+    renderOverview(status);
+    renderDailyChart(byDay);
+    renderToolsTable(byTool);
+    renderToolsPie(byTool);
+    renderSkillsTable(skills);
+    renderSkillSessions(skillSessions);
+    document.getElementById('statusMsg').textContent = 'Updated ' + new Date().toLocaleTimeString();
+  } catch (err) {
+    document.getElementById('statusMsg').textContent = 'Error: ' + err.message;
+  }
+}
+
+function renderOverview(data) {
+  const el = document.getElementById('overview');
+  if (!data || data.totalRecords === 0) {
+    el.innerHTML = '<p class="status-msg">No data yet. Click Recalculate to backfill historical data.</p>';
+    return;
+  }
+  el.innerHTML = `
+    <div class="stat-row"><span>Total Records</span><span class="stat-value">${data.totalRecords.toLocaleString()}</span></div>
+    <div class="stat-row"><span>Days Tracked</span><span class="stat-value">${data.daysTracked}</span></div>
+    <div class="stat-row"><span>Date Range</span><span class="stat-value">${data.dateRange ? data.dateRange.start + ' → ' + data.dateRange.end : 'N/A'}</span></div>
+    <div class="stat-row"><span>Top Tool</span><span class="stat-value">${data.topTools?.[0]?.tool ?? 'N/A'} (${data.topTools?.[0]?.count ?? 0})</span></div>
+    <div class="stat-row"><span>Top Skill</span><span class="stat-value">${data.topSkills?.[0]?.skill ?? 'N/A'} (${data.topSkills?.[0]?.count ?? 0})</span></div>`;
+}
+
+function renderDailyChart(data) {
+  const ctx = document.getElementById('dailyChart');
+  if (dailyChartInstance) dailyChartInstance.destroy();
+  if (!data?.buckets?.length) return;
+  const sorted = data.buckets.sort((a, b) => a.key.localeCompare(b.key));
+  dailyChartInstance = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: sorted.map(b => b.key),
+      datasets: [{
+        label: 'Tool Calls', data: sorted.map(b => b.count),
+        backgroundColor: '#58a6ff88', borderColor: '#58a6ff', borderWidth: 1,
+      }, {
+        label: 'Errors', data: sorted.map(b => b.errors),
+        backgroundColor: '#f8514988', borderColor: '#f85149', borderWidth: 1,
+      }],
+    },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      scales: {
+        x: { ticks: { color: '#8b949e', maxRotation: 45 }, grid: { color: '#30363d' } },
+        y: { ticks: { color: '#8b949e' }, grid: { color: '#30363d' }, beginAtZero: true },
+      },
+      plugins: { legend: { labels: { color: '#c9d1d9' } } },
+    },
+  });
+}
+
+function renderToolsTable(data) {
+  const el = document.getElementById('toolsTable');
+  if (!data?.buckets?.length) { el.innerHTML = '<p class="status-msg">No data</p>'; return; }
+  const rows = data.buckets.slice(0, 15).map(b =>
+    `<tr><td>${b.key}</td><td>${b.count}</td><td class="err">${b.errors}</td><td class="dur">${b.avgDurMs}ms</td></tr>`
+  ).join('');
+  el.innerHTML = `<table><tr><th>Tool</th><th>Calls</th><th>Errors</th><th>Avg Dur</th></tr>${rows}</table>`;
+}
+
+function renderToolsPie(data) {
+  const ctx = document.getElementById('toolsPie');
+  if (pieChartInstance) pieChartInstance.destroy();
+  if (!data?.buckets?.length) return;
+  const top = data.buckets.slice(0, 10);
+  const colors = ['#58a6ff','#3fb950','#d2a8ff','#f0883e','#f85149','#79c0ff','#56d364','#e3b341','#bc8cff','#db6d28'];
+  pieChartInstance = new Chart(ctx, {
+    type: 'doughnut',
+    data: { labels: top.map(b => b.key), datasets: [{ data: top.map(b => b.count), backgroundColor: colors }] },
+    options: {
+      responsive: true, maintainAspectRatio: false,
+      plugins: { legend: { position: 'right', labels: { color: '#c9d1d9', boxWidth: 12 } } },
+    },
+  });
+}
+
+function renderSkillsTable(data) {
+  const el = document.getElementById('skillsTable');
+  if (!data?.length) { el.innerHTML = '<p class="status-msg">No skill data</p>'; return; }
+  const rows = data.slice(0, 15).map(s =>
+    `<tr><td>${s.skill}</td><td>${s.totalCalls}</td><td>${s.entryReads}</td><td class="sub">${s.subReads}</td><td class="err">${s.errors}</td><td class="dur">${s.avgDurMs}ms</td></tr>`
+  ).join('');
+  el.innerHTML = `<table><tr><th>Skill</th><th>Total</th><th>Entry</th><th>Sub</th><th>Errors</th><th>Avg Dur</th></tr>${rows}</table>`;
+}
+
+function renderSkillSessions(data) {
+  const el = document.getElementById('skillSessionsTable');
+  if (!data?.length) { el.innerHTML = '<p class="status-msg">No skill session data. Click Recalculate first.</p>'; return; }
+  const rows = data.map(s => {
+    const topTools = (s.topTools || []).slice(0, 3).map(t => `${t.tool}(${t.count})`).join(', ');
+    return `<tr>
+      <td>${s.skill}</td>
+      <td>${s.sessionCount}</td>
+      <td class="dur">${fmtDur(s.avgDurationSec)}</td>
+      <td class="dur">${fmtDur(s.maxDurationSec)}</td>
+      <td>${s.avgToolCalls}</td>
+      <td class="sub">${s.avgSubReads}</td>
+      <td class="small">${topTools}</td>
+    </tr>`;
+  }).join('');
+  el.innerHTML = `<table>
+    <tr><th>Skill</th><th>Sessions</th><th>Avg Dur</th><th>Max Dur</th><th>Avg Tools</th><th>Avg Sub</th><th>Top Tools</th></tr>
+    ${rows}
+  </table>`;
+}
+
+async function recalculate() {
+  document.getElementById('statusMsg').textContent = 'Recalculating...';
+  try {
+    const res = await fetch(BASE + '/api?action=backfill', { method: 'POST' });
+    const result = await res.json();
+    document.getElementById('statusMsg').textContent =
+      `Done: ${result.sessionsScanned} sessions, ${result.recordsGenerated} records, ${result.skillSessionsFound ?? 0} skill sessions`;
+    await loadData();
+  } catch (err) {
+    document.getElementById('statusMsg').textContent = 'Error: ' + err.message;
+  }
+}
+
+defaultDates();
+loadData();
+</script>
+</body>
+</html>

--- a/extensions/usage-tracker/src/web/dashboard.html
+++ b/extensions/usage-tracker/src/web/dashboard.html
@@ -1,221 +1,387 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-<meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Usage Tracker — OpenClaw</title>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
-<style>
-  :root { --bg: #0d1117; --fg: #c9d1d9; --card: #161b22; --border: #30363d; --accent: #58a6ff; --green: #3fb950; --red: #f85149; --purple: #d2a8ff; --orange: #f0883e; }
-  * { box-sizing: border-box; margin: 0; padding: 0; }
-  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, monospace; background: var(--bg); color: var(--fg); padding: 24px; }
-  h1 { font-size: 1.4rem; margin-bottom: 16px; }
-  .controls { display: flex; gap: 12px; align-items: center; margin-bottom: 20px; flex-wrap: wrap; }
-  .controls label { font-size: 0.85rem; color: #8b949e; }
-  .controls input[type="date"] { background: var(--card); border: 1px solid var(--border); color: var(--fg); padding: 4px 8px; border-radius: 4px; }
-  button { background: var(--accent); color: #000; border: none; padding: 6px 14px; border-radius: 4px; cursor: pointer; font-weight: 600; font-size: 0.85rem; }
-  button:hover { opacity: 0.9; }
-  button.secondary { background: var(--border); color: var(--fg); }
-  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(340px, 1fr)); gap: 16px; margin-bottom: 24px; }
-  .card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 16px; }
-  .card.full { grid-column: 1 / -1; }
-  .card h2 { font-size: 1rem; margin-bottom: 12px; color: var(--accent); }
-  .card h2 .badge { font-size: 0.7rem; background: var(--accent); color: #000; padding: 2px 6px; border-radius: 3px; margin-left: 8px; vertical-align: middle; }
-  .stat-row { display: flex; justify-content: space-between; padding: 4px 0; font-size: 0.85rem; border-bottom: 1px solid var(--border); }
-  .stat-row:last-child { border-bottom: none; }
-  .stat-value { font-weight: 600; }
-  .chart-container { position: relative; height: 260px; }
-  .status-msg { font-size: 0.85rem; color: #8b949e; padding: 8px 0; }
-  table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
-  th, td { text-align: left; padding: 6px 8px; border-bottom: 1px solid var(--border); }
-  th { color: var(--accent); font-weight: 600; }
-  .err { color: var(--red); }
-  .dur { color: var(--orange); }
-  .sub { color: var(--purple); }
-  .small { font-size: 0.75rem; color: #8b949e; }
-</style>
-</head>
-<body>
-<h1>Usage Tracker</h1>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Usage Tracker — OpenClaw</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+    <style>
+      :root {
+        --bg: #0d1117;
+        --fg: #c9d1d9;
+        --card: #161b22;
+        --border: #30363d;
+        --accent: #58a6ff;
+        --green: #3fb950;
+        --red: #f85149;
+        --purple: #d2a8ff;
+        --orange: #f0883e;
+      }
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, monospace;
+        background: var(--bg);
+        color: var(--fg);
+        padding: 24px;
+      }
+      h1 {
+        font-size: 1.4rem;
+        margin-bottom: 16px;
+      }
+      .controls {
+        display: flex;
+        gap: 12px;
+        align-items: center;
+        margin-bottom: 20px;
+        flex-wrap: wrap;
+      }
+      .controls label {
+        font-size: 0.85rem;
+        color: #8b949e;
+      }
+      .controls input[type="date"] {
+        background: var(--card);
+        border: 1px solid var(--border);
+        color: var(--fg);
+        padding: 4px 8px;
+        border-radius: 4px;
+      }
+      button {
+        background: var(--accent);
+        color: #000;
+        border: none;
+        padding: 6px 14px;
+        border-radius: 4px;
+        cursor: pointer;
+        font-weight: 600;
+        font-size: 0.85rem;
+      }
+      button:hover {
+        opacity: 0.9;
+      }
+      button.secondary {
+        background: var(--border);
+        color: var(--fg);
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+        gap: 16px;
+        margin-bottom: 24px;
+      }
+      .card {
+        background: var(--card);
+        border: 1px solid var(--border);
+        border-radius: 8px;
+        padding: 16px;
+      }
+      .card.full {
+        grid-column: 1 / -1;
+      }
+      .card h2 {
+        font-size: 1rem;
+        margin-bottom: 12px;
+        color: var(--accent);
+      }
+      .card h2 .badge {
+        font-size: 0.7rem;
+        background: var(--accent);
+        color: #000;
+        padding: 2px 6px;
+        border-radius: 3px;
+        margin-left: 8px;
+        vertical-align: middle;
+      }
+      .stat-row {
+        display: flex;
+        justify-content: space-between;
+        padding: 4px 0;
+        font-size: 0.85rem;
+        border-bottom: 1px solid var(--border);
+      }
+      .stat-row:last-child {
+        border-bottom: none;
+      }
+      .stat-value {
+        font-weight: 600;
+      }
+      .chart-container {
+        position: relative;
+        height: 260px;
+      }
+      .status-msg {
+        font-size: 0.85rem;
+        color: #8b949e;
+        padding: 8px 0;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 0.85rem;
+      }
+      th,
+      td {
+        text-align: left;
+        padding: 6px 8px;
+        border-bottom: 1px solid var(--border);
+      }
+      th {
+        color: var(--accent);
+        font-weight: 600;
+      }
+      .err {
+        color: var(--red);
+      }
+      .dur {
+        color: var(--orange);
+      }
+      .sub {
+        color: var(--purple);
+      }
+      .small {
+        font-size: 0.75rem;
+        color: #8b949e;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Usage Tracker</h1>
 
-<div class="controls">
-  <label>From <input type="date" id="startDay" /></label>
-  <label>To <input type="date" id="endDay" /></label>
-  <button onclick="loadData()">Refresh</button>
-  <button class="secondary" onclick="recalculate()">Recalculate</button>
-  <span id="statusMsg" class="status-msg"></span>
-</div>
+    <div class="controls">
+      <label>From <input type="date" id="startDay" /></label>
+      <label>To <input type="date" id="endDay" /></label>
+      <button onclick="loadData()">Refresh</button>
+      <button class="secondary" onclick="recalculate()">Recalculate</button>
+      <span id="statusMsg" class="status-msg"></span>
+    </div>
 
-<div class="grid">
-  <div class="card">
-    <h2>Overview</h2>
-    <div id="overview">Loading...</div>
-  </div>
-  <div class="card">
-    <h2>Tool Calls by Day</h2>
-    <div class="chart-container"><canvas id="dailyChart"></canvas></div>
-  </div>
-</div>
+    <div class="grid">
+      <div class="card">
+        <h2>Overview</h2>
+        <div id="overview">Loading...</div>
+      </div>
+      <div class="card">
+        <h2>Tool Calls by Day</h2>
+        <div class="chart-container"><canvas id="dailyChart"></canvas></div>
+      </div>
+    </div>
 
-<div class="grid">
-  <div class="card">
-    <h2>Top Tools</h2>
-    <div id="toolsTable"></div>
-  </div>
-  <div class="card">
-    <h2>Skill Reads</h2>
-    <div id="skillsTable"></div>
-  </div>
-</div>
+    <div class="grid">
+      <div class="card">
+        <h2>Top Tools</h2>
+        <div id="toolsTable"></div>
+      </div>
+      <div class="card">
+        <h2>Skill Reads</h2>
+        <div id="skillsTable"></div>
+      </div>
+    </div>
 
-<div class="grid">
-  <div class="card full">
-    <h2>Skill Lifecycle <span class="badge">Sessions</span></h2>
-    <p class="small" style="margin-bottom:12px">Full lifecycle from SKILL.md read → final response. Shows real usage cost per skill.</p>
-    <div id="skillSessionsTable"></div>
-  </div>
-</div>
+    <div class="grid">
+      <div class="card full">
+        <h2>Skill Lifecycle <span class="badge">Sessions</span></h2>
+        <p class="small" style="margin-bottom: 12px">
+          Full lifecycle from SKILL.md read → final response. Shows real usage cost per skill.
+        </p>
+        <div id="skillSessionsTable"></div>
+      </div>
+    </div>
 
-<div class="grid">
-  <div class="card full">
-    <h2>Tools Distribution</h2>
-    <div class="chart-container"><canvas id="toolsPie"></canvas></div>
-  </div>
-</div>
+    <div class="grid">
+      <div class="card full">
+        <h2>Tools Distribution</h2>
+        <div class="chart-container"><canvas id="toolsPie"></canvas></div>
+      </div>
+    </div>
 
-<script>
-const BASE = window.location.pathname.replace(/\/$/, '');
-let dailyChartInstance = null;
-let pieChartInstance = null;
+    <script>
+      const BASE = window.location.pathname.replace(/\/$/, "");
+      let dailyChartInstance = null;
+      let pieChartInstance = null;
 
-function defaultDates() {
-  const end = new Date();
-  const start = new Date();
-  start.setDate(start.getDate() - 30);
-  document.getElementById('startDay').value = fmt(start);
-  document.getElementById('endDay').value = fmt(end);
-}
+      function defaultDates() {
+        const end = new Date();
+        const start = new Date();
+        start.setDate(start.getDate() - 30);
+        document.getElementById("startDay").value = fmt(start);
+        document.getElementById("endDay").value = fmt(end);
+      }
 
-function fmt(d) { return d.toISOString().slice(0, 10); }
+      function fmt(d) {
+        return d.toISOString().slice(0, 10);
+      }
 
-function fmtDur(sec) {
-  if (sec < 60) return sec.toFixed(1) + 's';
-  if (sec < 3600) return (sec / 60).toFixed(1) + 'm';
-  return (sec / 3600).toFixed(1) + 'h';
-}
+      function fmtDur(sec) {
+        if (sec < 60) return sec.toFixed(1) + "s";
+        if (sec < 3600) return (sec / 60).toFixed(1) + "m";
+        return (sec / 3600).toFixed(1) + "h";
+      }
 
-async function apiFetch(action, extra) {
-  const startDay = document.getElementById('startDay').value;
-  const endDay = document.getElementById('endDay').value;
-  const params = new URLSearchParams({ action, startDay, endDay, ...extra });
-  const res = await fetch(BASE + '/api?' + params.toString());
-  return res.json();
-}
+      async function apiFetch(action, extra) {
+        const startDay = document.getElementById("startDay").value;
+        const endDay = document.getElementById("endDay").value;
+        const params = new URLSearchParams({ action, startDay, endDay, ...extra });
+        const res = await fetch(BASE + "/api?" + params.toString());
+        return res.json();
+      }
 
-async function loadData() {
-  document.getElementById('statusMsg').textContent = 'Loading...';
-  try {
-    const [status, byTool, byDay, skills, skillSessions] = await Promise.all([
-      apiFetch('status'),
-      apiFetch('query', { groupBy: 'tool' }),
-      apiFetch('query', { groupBy: 'day' }),
-      apiFetch('skill_health'),
-      apiFetch('skill_sessions'),
-    ]);
-    renderOverview(status);
-    renderDailyChart(byDay);
-    renderToolsTable(byTool);
-    renderToolsPie(byTool);
-    renderSkillsTable(skills);
-    renderSkillSessions(skillSessions);
-    document.getElementById('statusMsg').textContent = 'Updated ' + new Date().toLocaleTimeString();
-  } catch (err) {
-    document.getElementById('statusMsg').textContent = 'Error: ' + err.message;
-  }
-}
+      async function loadData() {
+        document.getElementById("statusMsg").textContent = "Loading...";
+        try {
+          const [status, byTool, byDay, skills, skillSessions] = await Promise.all([
+            apiFetch("status"),
+            apiFetch("query", { groupBy: "tool" }),
+            apiFetch("query", { groupBy: "day" }),
+            apiFetch("skill_health"),
+            apiFetch("skill_sessions"),
+          ]);
+          renderOverview(status);
+          renderDailyChart(byDay);
+          renderToolsTable(byTool);
+          renderToolsPie(byTool);
+          renderSkillsTable(skills);
+          renderSkillSessions(skillSessions);
+          document.getElementById("statusMsg").textContent =
+            "Updated " + new Date().toLocaleTimeString();
+        } catch (err) {
+          document.getElementById("statusMsg").textContent = "Error: " + err.message;
+        }
+      }
 
-function renderOverview(data) {
-  const el = document.getElementById('overview');
-  if (!data || data.totalRecords === 0) {
-    el.innerHTML = '<p class="status-msg">No data yet. Click Recalculate to backfill historical data.</p>';
-    return;
-  }
-  el.innerHTML = `
+      function renderOverview(data) {
+        const el = document.getElementById("overview");
+        if (!data || data.totalRecords === 0) {
+          el.innerHTML =
+            '<p class="status-msg">No data yet. Click Recalculate to backfill historical data.</p>';
+          return;
+        }
+        el.innerHTML = `
     <div class="stat-row"><span>Total Records</span><span class="stat-value">${data.totalRecords.toLocaleString()}</span></div>
     <div class="stat-row"><span>Days Tracked</span><span class="stat-value">${data.daysTracked}</span></div>
-    <div class="stat-row"><span>Date Range</span><span class="stat-value">${data.dateRange ? data.dateRange.start + ' → ' + data.dateRange.end : 'N/A'}</span></div>
-    <div class="stat-row"><span>Top Tool</span><span class="stat-value">${data.topTools?.[0]?.tool ?? 'N/A'} (${data.topTools?.[0]?.count ?? 0})</span></div>
-    <div class="stat-row"><span>Top Skill</span><span class="stat-value">${data.topSkills?.[0]?.skill ?? 'N/A'} (${data.topSkills?.[0]?.count ?? 0})</span></div>`;
-}
+    <div class="stat-row"><span>Date Range</span><span class="stat-value">${data.dateRange ? data.dateRange.start + " → " + data.dateRange.end : "N/A"}</span></div>
+    <div class="stat-row"><span>Top Tool</span><span class="stat-value">${data.topTools?.[0]?.tool ?? "N/A"} (${data.topTools?.[0]?.count ?? 0})</span></div>
+    <div class="stat-row"><span>Top Skill</span><span class="stat-value">${data.topSkills?.[0]?.skill ?? "N/A"} (${data.topSkills?.[0]?.count ?? 0})</span></div>`;
+      }
 
-function renderDailyChart(data) {
-  const ctx = document.getElementById('dailyChart');
-  if (dailyChartInstance) dailyChartInstance.destroy();
-  if (!data?.buckets?.length) return;
-  const sorted = data.buckets.sort((a, b) => a.key.localeCompare(b.key));
-  dailyChartInstance = new Chart(ctx, {
-    type: 'bar',
-    data: {
-      labels: sorted.map(b => b.key),
-      datasets: [{
-        label: 'Tool Calls', data: sorted.map(b => b.count),
-        backgroundColor: '#58a6ff88', borderColor: '#58a6ff', borderWidth: 1,
-      }, {
-        label: 'Errors', data: sorted.map(b => b.errors),
-        backgroundColor: '#f8514988', borderColor: '#f85149', borderWidth: 1,
-      }],
-    },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      scales: {
-        x: { ticks: { color: '#8b949e', maxRotation: 45 }, grid: { color: '#30363d' } },
-        y: { ticks: { color: '#8b949e' }, grid: { color: '#30363d' }, beginAtZero: true },
-      },
-      plugins: { legend: { labels: { color: '#c9d1d9' } } },
-    },
-  });
-}
+      function renderDailyChart(data) {
+        const ctx = document.getElementById("dailyChart");
+        if (dailyChartInstance) dailyChartInstance.destroy();
+        if (!data?.buckets?.length) return;
+        const sorted = data.buckets.sort((a, b) => a.key.localeCompare(b.key));
+        dailyChartInstance = new Chart(ctx, {
+          type: "bar",
+          data: {
+            labels: sorted.map((b) => b.key),
+            datasets: [
+              {
+                label: "Tool Calls",
+                data: sorted.map((b) => b.count),
+                backgroundColor: "#58a6ff88",
+                borderColor: "#58a6ff",
+                borderWidth: 1,
+              },
+              {
+                label: "Errors",
+                data: sorted.map((b) => b.errors),
+                backgroundColor: "#f8514988",
+                borderColor: "#f85149",
+                borderWidth: 1,
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              x: { ticks: { color: "#8b949e", maxRotation: 45 }, grid: { color: "#30363d" } },
+              y: { ticks: { color: "#8b949e" }, grid: { color: "#30363d" }, beginAtZero: true },
+            },
+            plugins: { legend: { labels: { color: "#c9d1d9" } } },
+          },
+        });
+      }
 
-function renderToolsTable(data) {
-  const el = document.getElementById('toolsTable');
-  if (!data?.buckets?.length) { el.innerHTML = '<p class="status-msg">No data</p>'; return; }
-  const rows = data.buckets.slice(0, 15).map(b =>
-    `<tr><td>${b.key}</td><td>${b.count}</td><td class="err">${b.errors}</td><td class="dur">${b.avgDurMs}ms</td></tr>`
-  ).join('');
-  el.innerHTML = `<table><tr><th>Tool</th><th>Calls</th><th>Errors</th><th>Avg Dur</th></tr>${rows}</table>`;
-}
+      function renderToolsTable(data) {
+        const el = document.getElementById("toolsTable");
+        if (!data?.buckets?.length) {
+          el.innerHTML = '<p class="status-msg">No data</p>';
+          return;
+        }
+        const rows = data.buckets
+          .slice(0, 15)
+          .map(
+            (b) =>
+              `<tr><td>${b.key}</td><td>${b.count}</td><td class="err">${b.errors}</td><td class="dur">${b.avgDurMs}ms</td></tr>`,
+          )
+          .join("");
+        el.innerHTML = `<table><tr><th>Tool</th><th>Calls</th><th>Errors</th><th>Avg Dur</th></tr>${rows}</table>`;
+      }
 
-function renderToolsPie(data) {
-  const ctx = document.getElementById('toolsPie');
-  if (pieChartInstance) pieChartInstance.destroy();
-  if (!data?.buckets?.length) return;
-  const top = data.buckets.slice(0, 10);
-  const colors = ['#58a6ff','#3fb950','#d2a8ff','#f0883e','#f85149','#79c0ff','#56d364','#e3b341','#bc8cff','#db6d28'];
-  pieChartInstance = new Chart(ctx, {
-    type: 'doughnut',
-    data: { labels: top.map(b => b.key), datasets: [{ data: top.map(b => b.count), backgroundColor: colors }] },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      plugins: { legend: { position: 'right', labels: { color: '#c9d1d9', boxWidth: 12 } } },
-    },
-  });
-}
+      function renderToolsPie(data) {
+        const ctx = document.getElementById("toolsPie");
+        if (pieChartInstance) pieChartInstance.destroy();
+        if (!data?.buckets?.length) return;
+        const top = data.buckets.slice(0, 10);
+        const colors = [
+          "#58a6ff",
+          "#3fb950",
+          "#d2a8ff",
+          "#f0883e",
+          "#f85149",
+          "#79c0ff",
+          "#56d364",
+          "#e3b341",
+          "#bc8cff",
+          "#db6d28",
+        ];
+        pieChartInstance = new Chart(ctx, {
+          type: "doughnut",
+          data: {
+            labels: top.map((b) => b.key),
+            datasets: [{ data: top.map((b) => b.count), backgroundColor: colors }],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: { legend: { position: "right", labels: { color: "#c9d1d9", boxWidth: 12 } } },
+          },
+        });
+      }
 
-function renderSkillsTable(data) {
-  const el = document.getElementById('skillsTable');
-  if (!data?.length) { el.innerHTML = '<p class="status-msg">No skill data</p>'; return; }
-  const rows = data.slice(0, 15).map(s =>
-    `<tr><td>${s.skill}</td><td>${s.totalCalls}</td><td>${s.entryReads}</td><td class="sub">${s.subReads}</td><td class="err">${s.errors}</td><td class="dur">${s.avgDurMs}ms</td></tr>`
-  ).join('');
-  el.innerHTML = `<table><tr><th>Skill</th><th>Total</th><th>Entry</th><th>Sub</th><th>Errors</th><th>Avg Dur</th></tr>${rows}</table>`;
-}
+      function renderSkillsTable(data) {
+        const el = document.getElementById("skillsTable");
+        if (!data?.length) {
+          el.innerHTML = '<p class="status-msg">No skill data</p>';
+          return;
+        }
+        const rows = data
+          .slice(0, 15)
+          .map(
+            (s) =>
+              `<tr><td>${s.skill}</td><td>${s.totalCalls}</td><td>${s.entryReads}</td><td class="sub">${s.subReads}</td><td class="err">${s.errors}</td><td class="dur">${s.avgDurMs}ms</td></tr>`,
+          )
+          .join("");
+        el.innerHTML = `<table><tr><th>Skill</th><th>Total</th><th>Entry</th><th>Sub</th><th>Errors</th><th>Avg Dur</th></tr>${rows}</table>`;
+      }
 
-function renderSkillSessions(data) {
-  const el = document.getElementById('skillSessionsTable');
-  if (!data?.length) { el.innerHTML = '<p class="status-msg">No skill session data. Click Recalculate first.</p>'; return; }
-  const rows = data.map(s => {
-    const topTools = (s.topTools || []).slice(0, 3).map(t => `${t.tool}(${t.count})`).join(', ');
-    return `<tr>
+      function renderSkillSessions(data) {
+        const el = document.getElementById("skillSessionsTable");
+        if (!data?.length) {
+          el.innerHTML =
+            '<p class="status-msg">No skill session data. Click Recalculate first.</p>';
+          return;
+        }
+        const rows = data
+          .map((s) => {
+            const topTools = (s.topTools || [])
+              .slice(0, 3)
+              .map((t) => `${t.tool}(${t.count})`)
+              .join(", ");
+            return `<tr>
       <td>${s.skill}</td>
       <td>${s.sessionCount}</td>
       <td class="dur">${fmtDur(s.avgDurationSec)}</td>
@@ -224,28 +390,29 @@ function renderSkillSessions(data) {
       <td class="sub">${s.avgSubReads}</td>
       <td class="small">${topTools}</td>
     </tr>`;
-  }).join('');
-  el.innerHTML = `<table>
+          })
+          .join("");
+        el.innerHTML = `<table>
     <tr><th>Skill</th><th>Sessions</th><th>Avg Dur</th><th>Max Dur</th><th>Avg Tools</th><th>Avg Sub</th><th>Top Tools</th></tr>
     ${rows}
   </table>`;
-}
+      }
 
-async function recalculate() {
-  document.getElementById('statusMsg').textContent = 'Recalculating...';
-  try {
-    const res = await fetch(BASE + '/api?action=backfill', { method: 'POST' });
-    const result = await res.json();
-    document.getElementById('statusMsg').textContent =
-      `Done: ${result.sessionsScanned} sessions, ${result.recordsGenerated} records, ${result.skillSessionsFound ?? 0} skill sessions`;
-    await loadData();
-  } catch (err) {
-    document.getElementById('statusMsg').textContent = 'Error: ' + err.message;
-  }
-}
+      async function recalculate() {
+        document.getElementById("statusMsg").textContent = "Recalculating...";
+        try {
+          const res = await fetch(BASE + "/api?action=backfill", { method: "POST" });
+          const result = await res.json();
+          document.getElementById("statusMsg").textContent =
+            `Done: ${result.sessionsScanned} sessions, ${result.recordsGenerated} records, ${result.skillSessionsFound ?? 0} skill sessions`;
+          await loadData();
+        } catch (err) {
+          document.getElementById("statusMsg").textContent = "Error: " + err.message;
+        }
+      }
 
-defaultDates();
-loadData();
-</script>
-</body>
+      defaultDates();
+      loadData();
+    </script>
+  </body>
 </html>

--- a/extensions/usage-tracker/src/web/dashboard.ts
+++ b/extensions/usage-tracker/src/web/dashboard.ts
@@ -1,0 +1,105 @@
+/**
+ * HTTP route handler for the web dashboard.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { PluginLogger } from "openclaw/plugin-sdk";
+import type { UsageStorage, SkillSessionStorage } from "../storage.js";
+import { queryUsage, querySkillHealth, queryStatus, querySkillSessions, type QueryParams } from "../query.js";
+import { runBackfill, backfillSkillSessions, type BackfillResult } from "../backfill.js";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const HTML_PATH = path.join(__dirname, "dashboard.html");
+
+let cachedHtml: string | null = null;
+function readHtml(): string {
+  if (!cachedHtml) {
+    cachedHtml = fs.readFileSync(HTML_PATH, "utf-8");
+  }
+  return cachedHtml;
+}
+
+function sendJson(res: ServerResponse, data: unknown, status = 200): void {
+  const body = JSON.stringify(data);
+  res.writeHead(status, {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+function sendHtml(res: ServerResponse, html: string): void {
+  res.writeHead(200, {
+    "Content-Type": "text/html; charset=utf-8",
+    "Content-Length": Buffer.byteLength(html),
+  });
+  res.end(html);
+}
+
+export function createDashboardHandler(params: {
+  storage: UsageStorage;
+  skillSessionStorage: SkillSessionStorage;
+  sessionsDir: string;
+  agentId: string;
+  logger: PluginLogger;
+}) {
+  const { storage, skillSessionStorage, sessionsDir, agentId, logger } = params;
+
+  return async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+    try {
+      const parsed = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+      const subPath = parsed.pathname.replace(/^\/plugins\/usage-tracker\/?/, "");
+
+      if (subPath === "api" || subPath === "api/") {
+        const action = parsed.searchParams.get("action") ?? "status";
+        const startDay = parsed.searchParams.get("startDay") ?? undefined;
+        const endDay = parsed.searchParams.get("endDay") ?? undefined;
+
+        if (action === "backfill" && req.method === "POST") {
+          const [usageResult, sessionResult] = await Promise.all([
+            runBackfill({ sessionsDir, agentId, storage, logger }),
+            backfillSkillSessions({ sessionsDir, agentId, skillSessionStorage, logger }),
+          ]);
+          sendJson(res, {
+            ...usageResult,
+            skillSessionsFound: sessionResult.skillSessionsFound,
+          });
+          return;
+        }
+
+        if (action === "status") {
+          sendJson(res, await queryStatus(storage));
+          return;
+        }
+
+        if (action === "skill_health") {
+          sendJson(res, await querySkillHealth(storage, { startDay, endDay }));
+          return;
+        }
+
+        if (action === "skill_sessions") {
+          sendJson(res, await querySkillSessions(skillSessionStorage));
+          return;
+        }
+
+        const queryParams: QueryParams = {
+          startDay,
+          endDay,
+          tool: parsed.searchParams.get("tool") ?? undefined,
+          skill: parsed.searchParams.get("skill") ?? undefined,
+          groupBy: (parsed.searchParams.get("groupBy") as QueryParams["groupBy"]) ?? undefined,
+        };
+        sendJson(res, await queryUsage(storage, queryParams));
+        return;
+      }
+
+      sendHtml(res, readHtml());
+    } catch (err) {
+      logger.error(`usage-tracker dashboard error: ${String(err)}`);
+      sendJson(res, { error: String(err) }, 500);
+    }
+  };
+}

--- a/extensions/usage-tracker/src/web/dashboard.ts
+++ b/extensions/usage-tracker/src/web/dashboard.ts
@@ -3,13 +3,19 @@
  */
 
 import fs from "node:fs";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import path from "node:path";
 import url from "node:url";
-import type { IncomingMessage, ServerResponse } from "node:http";
 import type { PluginLogger } from "openclaw/plugin-sdk";
-import type { UsageStorage, SkillSessionStorage } from "../storage.js";
-import { queryUsage, querySkillHealth, queryStatus, querySkillSessions, type QueryParams } from "../query.js";
 import { runBackfill, backfillSkillSessions, type BackfillResult } from "../backfill.js";
+import {
+  queryUsage,
+  querySkillHealth,
+  queryStatus,
+  querySkillSessions,
+  type QueryParams,
+} from "../query.js";
+import type { UsageStorage, SkillSessionStorage } from "../storage.js";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const HTML_PATH = path.join(__dirname, "dashboard.html");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -490,6 +490,8 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
 
+  extensions/usage-tracker: {}
+
   extensions/voice-call:
     dependencies:
       '@sinclair/typebox':


### PR DESCRIPTION
## Summary

Add a bundled `usage-tracker` plugin that tracks tool calls and skill usage in real-time, with historical backfill from session transcripts, a query API, an agent tool, and a web dashboard.

## Motivation

OpenClaw has no built-in way to understand how tools and skills are actually used. Users can't answer questions like:
- Which tools are called most often?
- Which skills take the longest to complete?
- What's the error rate for different tools?
- How has usage changed over time?

While external observability solutions exist (OpenTelemetry, third-party plugins), they require additional infrastructure. This plugin provides a lightweight, zero-dependency alternative that works out of the box.

## Features

### Real-time tracking
Uses the `after_tool_call` hook to record every tool invocation with timing, error state, and skill classification.

### Skill classification
When the agent reads a file, the classifier checks if the path falls within a known skill directory:
- **Entry read**: The SKILL.md itself (skill activation)
- **Sub read**: Supporting files within the skill directory

### Skill session lifecycle
Measures the full chain from SKILL.md read → final text response, tracking:
- Wall-clock duration
- Tool call count and breakdown
- Sub-file reads
- How the session ended (text response, user message, different skill)

### Historical backfill
Stream-parses session transcript JSONL files to reconstruct past data. Pairs `toolCall` → `toolResult` entries to compute accurate durations.

### Query engine
Aggregate data by tool, skill, day, or agent with date range filters. Includes skill health metrics (entry/sub reads, error rates, avg duration).

### Agent tool
Registers `usage_tracker` with four actions:
| Action | Description |
|--------|-------------|
| `status` | Overview: total records, date range, top tools/skills |
| `query` | Aggregated usage with flexible groupBy |
| `skill_health` | Per-skill read metrics |
| `skill_sessions` | Full lifecycle analysis |

### Web dashboard
Chart.js-powered dark-theme dashboard at `/plugins/usage-tracker/` with:
- Overview stats card
- Tool calls by day (bar chart)
- Top tools and skill reads tables
- Skill lifecycle table (avg/max duration, tool chains)
- Tools distribution (doughnut chart)
- Recalculate button for historical backfill

### Gateway RPC
- `usage-tracker.query`
- `usage-tracker.backfill`
- `usage-tracker.status`

## Technical notes

- **Zero external dependencies** — only Node.js built-ins; Chart.js via CDN
- **Per-day JSONL storage** — one file per day, easy to rotate/archive
- **Stream parsing** — uses readline for memory-efficient backfill
- **Hook handler safety** — wrapped in try/catch, never throws

## Testing

Deployed and tested on a live instance:
- 267 sessions scanned, 5318 tool call records generated
- 36 skill sessions detected across 17 skills
- Real-time tracking verified: reading a SKILL.md immediately increments counters
- Dashboard renders correctly with all charts and tables
- Recalculate button works end-to-end
- Bug found and fixed during testing (skill-sessions.jsonl appearing in day listing)