### PR TITLE
Infra: catch rebase --abort failure to prevent stuck repo state

### DIFF
--- a/src/infra/update-runner.ts
+++ b/src/infra/update-runner.ts
@@ -761,7 +761,7 @@ export async function runGatewayUpdate(opts: UpdateRunnerOptions = {}): Promise<
         const abortResult = await runCommand(["git", "-C", gitRoot, "rebase", "--abort"], {
           cwd: gitRoot,
           timeoutMs,
-        });
+        }).catch(() => ({ stdout: "", stderr: "rebase --abort failed", code: -1 }));
         steps.push({
           name: "git rebase --abort",
           command: "git rebase --abort",


### PR DESCRIPTION
## Summary

- When `git rebase` fails during a git-mode update, the recovery `git rebase --abort` command could itself throw (e.g. timeout or process hang), causing the exception to propagate and skip the structured error return
- This leaves the repository stuck in an incomplete rebase state, requiring manual `git rebase --abort` to recover
- Added `.catch()` to the abort `runCommand` call so it always returns a result instead of throwing

## Test plan

- [ ] Verify `pnpm tsgo` passes (no type errors in changed files)
- [ ] Simulate a rebase failure scenario where `--abort` also fails — confirm the function returns a structured `rebase-failed` error instead of throwing


🤖 Generated with [Claude Code](https://claude.com/claude-code)