### PR TITLE
CLI: use actual install root for post-update plugin sync

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1032,7 +1032,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
   }
 
   await updatePluginsAfterCoreUpdate({
-    root,
+    root: result.root ?? root,
     channel,
     configSnapshot: postUpdateConfigSnapshot,
     opts,

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -1038,7 +1038,7 @@ export async function updateCommand(opts: UpdateCommandOptions): Promise<void> {
     opts,
   });
 
-  await tryWriteCompletionCache(root, Boolean(opts.json));
+  await tryWriteCompletionCache(result.root ?? root, Boolean(opts.json));
   await tryInstallShellCompletion({
     jsonMode: Boolean(opts.json),
     skipPrompt: Boolean(opts.yes),


### PR DESCRIPTION
## Summary

- When switching install modes (`--channel dev` triggering `switchToGit`, or git-to-package via `switchToPackage`), the post-update plugin sync was always using the original `root` variable instead of the actual install root from the update result
- For `switchToGit`: plugins would look for bundled sources in the old npm package dir instead of the new git checkout
- For `switchToPackage`: plugins would reference the old git dir instead of the new npm global location
- Fixed by using `result.root ?? root` so the plugin sync always targets the correct install directory

## Test plan

- [ ] Verify `pnpm tsgo` passes (no type errors in changed files)
- [ ] Test `openclaw update --channel dev` from a package install — confirm plugins are synced from the git checkout dir, not the old npm dir
- [ ] Test `openclaw update --channel stable` from a git install — confirm plugins point to the npm global dir


🤖 Generated with [Claude Code](https://claude.com/claude-code)