### PR TITLE
feat(feishu): support text keyword triggers in group mention gating

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -141,6 +141,74 @@
             <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.2.14/OpenClaw-2026.2.14.zip" length="22914034" type="application/octet-stream" sparkle:edSignature="lR3nuq46/akMIN8RFDpMkTE0VOVoDVG53Xts589LryMGEtUvJxRQDtHBXfx7ZvToTq6CFKG+L5Kq/4rUspMoAQ=="/>
         </item>
         <item>
+            <title>2026.2.15</title>
+            <pubDate>Mon, 16 Feb 2026 05:04:34 +0100</pubDate>
+            <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
+            <sparkle:version>11213</sparkle:version>
+            <sparkle:shortVersionString>2026.2.15</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+            <description><![CDATA[<h2>OpenClaw 2026.2.15</h2>
+<h3>Changes</h3>
+<ul>
+<li>Discord: unlock rich interactive agent prompts with Components v2 (buttons, selects, modals, and attachment-backed file blocks) so for native interaction through Discord. Thanks @thewilloftheshadow.</li>
+<li>Discord: components v2 UI + embeds passthrough + exec approval UX refinements (CV2 containers, button layout, Discord-forwarding skip). Thanks @thewilloftheshadow.</li>
+<li>Plugins: expose <code>llm_input</code> and <code>llm_output</code> hook payloads so extensions can observe prompt/input context and model output usage details. (#16724) Thanks @SecondThread.</li>
+<li>Subagents: nested sub-agents (sub-sub-agents) with configurable depth. Set <code>agents.defaults.subagents.maxSpawnDepth: 2</code> to allow sub-agents to spawn their own children. Includes <code>maxChildrenPerAgent</code> limit (default 5), depth-aware tool policy, and proper announce chain routing. (#14447) Thanks @tyler6204.</li>
+<li>Slack/Discord/Telegram: add per-channel ack reaction overrides (account/channel-level) to support platform-specific emoji formats. (#17092) Thanks @zerone0x.</li>
+<li>Cron/Gateway: add finished-run webhook delivery toggle (<code>notify</code>) and dedicated webhook auth token support (<code>cron.webhookToken</code>) for outbound cron webhook posts. (#14535) Thanks @advaitpaliwal.</li>
+<li>Channels: deduplicate probe/token resolution base types across core + extensions while preserving per-channel error typing. (#16986) Thanks @iyoda and @thewilloftheshadow.</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li>Security: replace deprecated SHA-1 sandbox configuration hashing with SHA-256 for deterministic sandbox cache identity and recreation checks. Thanks @kexinoh.</li>
+<li>Security/Logging: redact Telegram bot tokens from error messages and uncaught stack traces to prevent accidental secret leakage into logs. Thanks @aether-ai-agent.</li>
+<li>Sandbox/Security: block dangerous sandbox Docker config (bind mounts, host networking, unconfined seccomp/apparmor) to prevent container escape via config injection. Thanks @aether-ai-agent.</li>
+<li>Sandbox: preserve array order in config hashing so order-sensitive Docker/browser settings trigger container recreation correctly. Thanks @kexinoh.</li>
+<li>Gateway/Security: redact sensitive session/path details from <code>status</code> responses for non-admin clients; full details remain available to <code>operator.admin</code>. (#8590) Thanks @fr33d3m0n.</li>
+<li>Gateway/Control UI: preserve requested operator scopes for Control UI bypass modes (<code>allowInsecureAuth</code> / <code>dangerouslyDisableDeviceAuth</code>) when device identity is unavailable, preventing false <code>missing scope</code> failures on authenticated LAN/HTTP operator sessions. (#17682) Thanks @leafbird.</li>
+<li>LINE/Security: fail closed on webhook startup when channel token or channel secret is missing, and treat LINE accounts as configured only when both are present. (#17587) Thanks @davidahmann.</li>
+<li>Skills/Security: restrict <code>download</code> installer <code>targetDir</code> to the per-skill tools directory to prevent arbitrary file writes. Thanks @Adam55A-code.</li>
+<li>Skills/Linux: harden go installer fallback on apt-based systems by handling root/no-sudo environments safely, doing best-effort apt index refresh, and returning actionable errors instead of failing with spawn errors. (#17687) Thanks @mcrolly.</li>
+<li>Web Fetch/Security: cap downloaded response body size before HTML parsing to prevent memory exhaustion from oversized or deeply nested pages. Thanks @xuemian168.</li>
+<li>Config/Gateway: make sensitive-key whitelist suffix matching case-insensitive while preserving <code>passwordFile</code> path exemptions, preventing accidental redaction of non-secret config values like <code>maxTokens</code> and IRC password-file paths. (#16042) Thanks @akramcodez.</li>
+<li>Dev tooling: harden git <code>pre-commit</code> hook against option injection from malicious filenames (for example <code>--force</code>), preventing accidental staging of ignored files. Thanks @mrthankyou.</li>
+<li>Gateway/Agent: reject malformed <code>agent:</code>-prefixed session keys (for example, <code>agent:main</code>) in <code>agent</code> and <code>agent.identity.get</code> instead of silently resolving them to the default agent, preventing accidental cross-session routing. (#15707) Thanks @rodrigouroz.</li>
+<li>Gateway/Chat: harden <code>chat.send</code> inbound message handling by rejecting null bytes, stripping unsafe control characters, and normalizing Unicode to NFC before dispatch. (#8593) Thanks @fr33d3m0n.</li>
+<li>Gateway/Send: return an actionable error when <code>send</code> targets internal-only <code>webchat</code>, guiding callers to use <code>chat.send</code> or a deliverable channel. (#15703) Thanks @rodrigouroz.</li>
+<li>Control UI: prevent stored XSS via assistant name/avatar by removing inline script injection, serving bootstrap config as JSON, and enforcing <code>script-src 'self'</code>. Thanks @Adam55A-code.</li>
+<li>Agents/Security: sanitize workspace paths before embedding into LLM prompts (strip Unicode control/format chars) to prevent instruction injection via malicious directory names. Thanks @aether-ai-agent.</li>
+<li>Agents/Sandbox: clarify system prompt path guidance so sandbox <code>bash/exec</code> uses container paths (for example <code>/workspace</code>) while file tools keep host-bridge mapping, avoiding first-attempt path misses from host-only absolute paths in sandbox command execution. (#17693) Thanks @app/juniordevbot.</li>
+<li>Agents/Context: apply configured model <code>contextWindow</code> overrides after provider discovery so <code>lookupContextTokens()</code> honors operator config values (including discovery-failure paths). (#17404) Thanks @michaelbship and @vignesh07.</li>
+<li>Agents/Context: derive <code>lookupContextTokens()</code> from auth-available model metadata and keep the smallest discovered context window for duplicate model ids, preventing cross-provider cache collisions from overestimating session context limits. (#17586) Thanks @githabideri and @vignesh07.</li>
+<li>Agents/OpenAI: force <code>store=true</code> for direct OpenAI Responses/Codex runs to preserve multi-turn server-side conversation state, while leaving proxy/non-OpenAI endpoints unchanged. (#16803) Thanks @mark9232 and @vignesh07.</li>
+<li>Memory/FTS: make <code>buildFtsQuery</code> Unicode-aware so non-ASCII queries (including CJK) produce keyword tokens instead of falling back to vector-only search. (#17672) Thanks @KinGP5471.</li>
+<li>Auto-reply/Compaction: resolve <code>memory/YYYY-MM-DD.md</code> placeholders with timezone-aware runtime dates and append a <code>Current time:</code> line to memory-flush turns, preventing wrong-year memory filenames without making the system prompt time-variant. (#17603, #17633) Thanks @nicholaspapadam-wq and @vignesh07.</li>
+<li>Agents: return an explicit timeout error reply when an embedded run times out before producing any payloads, preventing silent dropped turns during slow cache-refresh transitions. (#16659) Thanks @liaosvcaf and @vignesh07.</li>
+<li>Group chats: always inject group chat context (name, participants, reply guidance) into the system prompt on every turn, not just the first. Prevents the model from losing awareness of which group it's in and incorrectly using the message tool to send to the same group. (#14447) Thanks @tyler6204.</li>
+<li>Browser/Agents: when browser control service is unavailable, return explicit non-retry guidance (instead of "try again") so models do not loop on repeated browser tool calls until timeout. (#17673) Thanks @austenstone.</li>
+<li>Subagents: use child-run-based deterministic announce idempotency keys across direct and queued delivery paths (with legacy queued-item fallback) to prevent duplicate announce retries without collapsing distinct same-millisecond announces. (#17150) Thanks @widingmarcus-cyber.</li>
+<li>Subagents/Models: preserve <code>agents.defaults.model.fallbacks</code> when subagent sessions carry a model override, so subagent runs fail over to configured fallback models instead of retrying only the overridden primary model.</li>
+<li>Telegram: omit <code>message_thread_id</code> for DM sends/draft previews and keep forum-topic handling (<code>id=1</code> general omitted, non-general kept), preventing DM failures with <code>400 Bad Request: message thread not found</code>. (#10942) Thanks @garnetlyx.</li>
+<li>Telegram: replace inbound <code><media:audio></code> placeholder with successful preflight voice transcript in message body context, preventing placeholder-only prompt bodies for mention-gated voice messages. (#16789) Thanks @Limitless2023.</li>
+<li>Telegram: retry inbound media <code>getFile</code> calls (3 attempts with backoff) and gracefully fall back to placeholder-only processing when retries fail, preventing dropped voice/media messages on transient Telegram network errors. (#16154) Thanks @yinghaosang.</li>
+<li>Telegram: finalize streaming preview replies in place instead of sending a second final message, preventing duplicate Telegram assistant outputs at stream completion. (#17218) Thanks @obviyus.</li>
+<li>Discord: preserve channel session continuity when runtime payloads omit <code>message.channelId</code> by falling back to event/raw <code>channel_id</code> values for routing/session keys, so same-channel messages keep history across turns/restarts. Also align diagnostics so active Discord runs no longer appear as <code>sessionKey=unknown</code>. (#17622) Thanks @shakkernerd.</li>
+<li>Discord: dedupe native skill commands by skill name in multi-agent setups to prevent duplicated slash commands with <code>_2</code> suffixes. (#17365) Thanks @seewhyme.</li>
+<li>Discord: ensure role allowlist matching uses raw role IDs for message routing authorization. Thanks @xinhuagu.</li>
+<li>Web UI/Agents: hide <code>BOOTSTRAP.md</code> in the Agents Files list after onboarding is completed, avoiding confusing missing-file warnings for completed workspaces. (#17491) Thanks @gumadeiras.</li>
+<li>Auto-reply/WhatsApp/TUI/Web: when a final assistant message is <code>NO_REPLY</code> and a messaging tool send succeeded, mirror the delivered messaging-tool text into session-visible assistant output so TUI/Web no longer show <code>NO_REPLY</code> placeholders. (#7010) Thanks @Morrowind-Xie.</li>
+<li>Cron: infer <code>payload.kind="agentTurn"</code> for model-only <code>cron.update</code> payload patches, so partial agent-turn updates do not fail validation when <code>kind</code> is omitted. (#15664) Thanks @rodrigouroz.</li>
+<li>TUI: make searchable-select filtering and highlight rendering ANSI-aware so queries ignore hidden escape codes and no longer corrupt ANSI styling sequences during match highlighting. (#4519) Thanks @bee4come.</li>
+<li>TUI/Windows: coalesce rapid single-line submit bursts in Git Bash into one multiline message as a fallback when bracketed paste is unavailable, preventing pasted multiline text from being split into multiple sends. (#4986) Thanks @adamkane.</li>
+<li>TUI: suppress false <code>(no output)</code> placeholders for non-local empty final events during concurrent runs, preventing external-channel replies from showing empty assistant bubbles while a local run is still streaming. (#5782) Thanks @LagWizard and @vignesh07.</li>
+<li>TUI: preserve copy-sensitive long tokens (URLs/paths/file-like identifiers) during wrapping and overflow sanitization so wrapped output no longer inserts spaces that corrupt copy/paste values. (#17515, #17466, #17505) Thanks @abe238, @trevorpan, and @JasonCry.</li>
+<li>CLI/Build: make legacy daemon CLI compatibility shim generation tolerant of minimal tsdown daemon export sets, while preserving restart/register compatibility aliases and surfacing explicit errors for unavailable legacy daemon commands. Thanks @vignesh07.</li>
+</ul>
+<p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
+]]></description>
+            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.2.15/OpenClaw-2026.2.15.zip" length="22896513" type="application/octet-stream" sparkle:edSignature="MLGsd2NeHXFRH1Or0bFQnAjqfuuJDuhl1mvKFIqTQcRvwbeyvOyyLXrqSbmaOgJR3wBQBKLs6jYQ9dQ/3R8RCg=="/>
+        </item>
+        <item>
             <title>2026.2.13</title>
             <pubDate>Sat, 14 Feb 2026 04:30:23 +0100</pubDate>
             <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
@@ -240,102 +308,6 @@
 <p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
 ]]></description>
             <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.2.13/OpenClaw-2026.2.13.zip" length="22902077" type="application/octet-stream" sparkle:edSignature="RpkwlPtB2yN7UOYZWfthV5grhDUcbhcHMeicdRA864Vo/P0Hnq5aHKmSvcbWkjHut96TC57bX+AeUrL7txpLCg=="/>
-        </item>
-        <item>
-            <title>2026.2.12</title>
-            <pubDate>Fri, 13 Feb 2026 03:17:54 +0100</pubDate>
-            <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
-            <sparkle:version>9500</sparkle:version>
-            <sparkle:shortVersionString>2026.2.12</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
-            <description><![CDATA[<h2>OpenClaw 2026.2.12</h2>
-<h3>Changes</h3>
-<ul>
-<li>CLI: add <code>openclaw logs --local-time</code> to display log timestamps in local timezone. (#13818) Thanks @xialonglee.</li>
-<li>Telegram: render blockquotes as native <code><blockquote></code> tags instead of stripping them. (#14608)</li>
-<li>Config: avoid redacting <code>maxTokens</code>-like fields during config snapshot redaction, preventing round-trip validation failures in <code>/config</code>. (#14006) Thanks @constansino.</li>
-</ul>
-<h3>Breaking</h3>
-<ul>
-<li>Hooks: <code>POST /hooks/agent</code> now rejects payload <code>sessionKey</code> overrides by default. To keep fixed hook context, set <code>hooks.defaultSessionKey</code> (recommended with <code>hooks.allowedSessionKeyPrefixes: ["hook:"]</code>). If you need legacy behavior, explicitly set <code>hooks.allowRequestSessionKey: true</code>. Thanks @alpernae for reporting.</li>
-</ul>
-<h3>Fixes</h3>
-<ul>
-<li>Gateway/OpenResponses: harden URL-based <code>input_file</code>/<code>input_image</code> handling with explicit SSRF deny policy, hostname allowlists (<code>files.urlAllowlist</code> / <code>images.urlAllowlist</code>), per-request URL input caps (<code>maxUrlParts</code>), blocked-fetch audit logging, and regression coverage/docs updates.</li>
-<li>Security: fix unauthenticated Nostr profile API remote config tampering. (#13719) Thanks @coygeek.</li>
-<li>Security: remove bundled soul-evil hook. (#14757) Thanks @Imccccc.</li>
-<li>Security/Audit: add hook session-routing hardening checks (<code>hooks.defaultSessionKey</code>, <code>hooks.allowRequestSessionKey</code>, and prefix allowlists), and warn when HTTP API endpoints allow explicit session-key routing.</li>
-<li>Security/Sandbox: confine mirrored skill sync destinations to the sandbox <code>skills/</code> root and stop using frontmatter-controlled skill names as filesystem destination paths. Thanks @1seal.</li>
-<li>Security/Web tools: treat browser/web content as untrusted by default (wrapped outputs for browser snapshot/tabs/console and structured external-content metadata for web tools), and strip <code>toolResult.details</code> from model-facing transcript/compaction inputs to reduce prompt-injection replay risk.</li>
-<li>Security/Hooks: harden webhook and device token verification with shared constant-time secret comparison, and add per-client auth-failure throttling for hook endpoints (<code>429</code> + <code>Retry-After</code>). Thanks @akhmittra.</li>
-<li>Security/Browser: require auth for loopback browser control HTTP routes, auto-generate <code>gateway.auth.token</code> when browser control starts without auth, and add a security-audit check for unauthenticated browser control. Thanks @tcusolle.</li>
-<li>Sessions/Gateway: harden transcript path resolution and reject unsafe session IDs/file paths so session operations stay within agent sessions directories. Thanks @akhmittra.</li>
-<li>Gateway: raise WS payload/buffer limits so 5,000,000-byte image attachments work reliably. (#14486) Thanks @0xRaini.</li>
-<li>Logging/CLI: use local timezone timestamps for console prefixing, and include <code>±HH:MM</code> offsets when using <code>openclaw logs --local-time</code> to avoid ambiguity. (#14771) Thanks @0xRaini.</li>
-<li>Gateway: drain active turns before restart to prevent message loss. (#13931) Thanks @0xRaini.</li>
-<li>Gateway: auto-generate auth token during install to prevent launchd restart loops. (#13813) Thanks @cathrynlavery.</li>
-<li>Gateway: prevent <code>undefined</code>/missing token in auth config. (#13809) Thanks @asklee-klawd.</li>
-<li>Gateway: handle async <code>EPIPE</code> on stdout/stderr during shutdown. (#13414) Thanks @keshav55.</li>
-<li>Gateway/Control UI: resolve missing dashboard assets when <code>openclaw</code> is installed globally via symlink-based Node managers (nvm/fnm/n/Homebrew). (#14919) Thanks @aynorica.</li>
-<li>Cron: use requested <code>agentId</code> for isolated job auth resolution. (#13983) Thanks @0xRaini.</li>
-<li>Cron: prevent cron jobs from skipping execution when <code>nextRunAtMs</code> advances. (#14068) Thanks @WalterSumbon.</li>
-<li>Cron: pass <code>agentId</code> to <code>runHeartbeatOnce</code> for main-session jobs. (#14140) Thanks @ishikawa-pro.</li>
-<li>Cron: re-arm timers when <code>onTimer</code> fires while a job is still executing. (#14233) Thanks @tomron87.</li>
-<li>Cron: prevent duplicate fires when multiple jobs trigger simultaneously. (#14256) Thanks @xinhuagu.</li>
-<li>Cron: isolate scheduler errors so one bad job does not break all jobs. (#14385) Thanks @MarvinDontPanic.</li>
-<li>Cron: prevent one-shot <code>at</code> jobs from re-firing on restart after skipped/errored runs. (#13878) Thanks @lailoo.</li>
-<li>Heartbeat: prevent scheduler stalls on unexpected run errors and avoid immediate rerun loops after <code>requests-in-flight</code> skips. (#14901) Thanks @joeykrug.</li>
-<li>Cron: honor stored session model overrides for isolated-agent runs while preserving <code>hooks.gmail.model</code> precedence for Gmail hook sessions. (#14983) Thanks @shtse8.</li>
-<li>Logging/Browser: fall back to <code>os.tmpdir()/openclaw</code> for default log, browser trace, and browser download temp paths when <code>/tmp/openclaw</code> is unavailable.</li>
-<li>WhatsApp: convert Markdown bold/strikethrough to WhatsApp formatting. (#14285) Thanks @Raikan10.</li>
-<li>WhatsApp: allow media-only sends and normalize leading blank payloads. (#14408) Thanks @karimnaguib.</li>
-<li>WhatsApp: default MIME type for voice messages when Baileys omits it. (#14444) Thanks @mcaxtr.</li>
-<li>Telegram: handle no-text message in model picker editMessageText. (#14397) Thanks @0xRaini.</li>
-<li>Telegram: surface REACTION_INVALID as non-fatal warning. (#14340) Thanks @0xRaini.</li>
-<li>BlueBubbles: fix webhook auth bypass via loopback proxy trust. (#13787) Thanks @coygeek.</li>
-<li>Slack: change default replyToMode from "off" to "all". (#14364) Thanks @nm-de.</li>
-<li>Slack: detect control commands when channel messages start with bot mention prefixes (for example, <code>@Bot /new</code>). (#14142) Thanks @beefiker.</li>
-<li>Signal: enforce E.164 validation for the Signal bot account prompt so mistyped numbers are caught early. (#15063) Thanks @Duartemartins.</li>
-<li>Discord: process DM reactions instead of silently dropping them. (#10418) Thanks @mcaxtr.</li>
-<li>Discord: respect replyToMode in threads. (#11062) Thanks @cordx56.</li>
-<li>Heartbeat: filter noise-only system events so scheduled reminder notifications do not fire when cron runs carry only heartbeat markers. (#13317) Thanks @pvtclawn.</li>
-<li>Signal: render mention placeholders as <code>@uuid</code>/<code>@phone</code> so mention gating and Clawdbot targeting work. (#2013) Thanks @alexgleason.</li>
-<li>Discord: omit empty content fields for media-only messages while preserving caption whitespace. (#9507) Thanks @leszekszpunar.</li>
-<li>Onboarding/Providers: add Z.AI endpoint-specific auth choices (<code>zai-coding-global</code>, <code>zai-coding-cn</code>, <code>zai-global</code>, <code>zai-cn</code>) and expand default Z.AI model wiring. (#13456) Thanks @tomsun28.</li>
-<li>Onboarding/Providers: update MiniMax API default/recommended models from M2.1 to M2.5, add M2.5/M2.5-Lightning model entries, and include <code>minimax-m2.5</code> in modern model filtering. (#14865) Thanks @adao-max.</li>
-<li>Ollama: use configured <code>models.providers.ollama.baseUrl</code> for model discovery and normalize <code>/v1</code> endpoints to the native Ollama API root. (#14131) Thanks @shtse8.</li>
-<li>Voice Call: pass Twilio stream auth token via <code><Parameter></code> instead of query string. (#14029) Thanks @mcwigglesmcgee.</li>
-<li>Feishu: pass <code>Buffer</code> directly to the Feishu SDK upload APIs instead of <code>Readable.from(...)</code> to avoid form-data upload failures. (#10345) Thanks @youngerstyle.</li>
-<li>Feishu: trigger mention-gated group handling only when the bot itself is mentioned (not just any mention). (#11088) Thanks @openperf.</li>
-<li>Feishu: probe status uses the resolved account context for multi-account credential checks. (#11233) Thanks @onevcat.</li>
-<li>Feishu DocX: preserve top-level converted block order using <code>firstLevelBlockIds</code> when writing/appending documents. (#13994) Thanks @Cynosure159.</li>
-<li>Feishu plugin packaging: remove <code>workspace:*</code> <code>openclaw</code> dependency from <code>extensions/feishu</code> and sync lockfile for install compatibility. (#14423) Thanks @jackcooper2015.</li>
-<li>CLI/Wizard: exit with code 1 when <code>configure</code>, <code>agents add</code>, or interactive <code>onboard</code> wizards are canceled, so <code>set -e</code> automation stops correctly. (#14156) Thanks @0xRaini.</li>
-<li>Media: strip <code>MEDIA:</code> lines with local paths instead of leaking as visible text. (#14399) Thanks @0xRaini.</li>
-<li>Config/Cron: exclude <code>maxTokens</code> from config redaction and honor <code>deleteAfterRun</code> on skipped cron jobs. (#13342) Thanks @niceysam.</li>
-<li>Config: ignore <code>meta</code> field changes in config file watcher. (#13460) Thanks @brandonwise.</li>
-<li>Cron: use requested <code>agentId</code> for isolated job auth resolution. (#13983) Thanks @0xRaini.</li>
-<li>Cron: pass <code>agentId</code> to <code>runHeartbeatOnce</code> for main-session jobs. (#14140) Thanks @ishikawa-pro.</li>
-<li>Cron: prevent cron jobs from skipping execution when <code>nextRunAtMs</code> advances. (#14068) Thanks @WalterSumbon.</li>
-<li>Cron: re-arm timers when <code>onTimer</code> fires while a job is still executing. (#14233) Thanks @tomron87.</li>
-<li>Cron: prevent duplicate fires when multiple jobs trigger simultaneously. (#14256) Thanks @xinhuagu.</li>
-<li>Cron: isolate scheduler errors so one bad job does not break all jobs. (#14385) Thanks @MarvinDontPanic.</li>
-<li>Cron: prevent one-shot <code>at</code> jobs from re-firing on restart after skipped/errored runs. (#13878) Thanks @lailoo.</li>
-<li>Daemon: suppress <code>EPIPE</code> error when restarting LaunchAgent. (#14343) Thanks @0xRaini.</li>
-<li>Antigravity: add opus 4.6 forward-compat model and bypass thinking signature sanitization. (#14218) Thanks @jg-noncelogic.</li>
-<li>Agents: prevent file descriptor leaks in child process cleanup. (#13565) Thanks @KyleChen26.</li>
-<li>Agents: prevent double compaction caused by cache TTL bypassing guard. (#13514) Thanks @taw0002.</li>
-<li>Agents: use last API call's cache tokens for context display instead of accumulated sum. (#13805) Thanks @akari-musubi.</li>
-<li>Agents: keep followup-runner session <code>totalTokens</code> aligned with post-compaction context by using last-call usage and shared token-accounting logic. (#14979) Thanks @shtse8.</li>
-<li>Hooks/Plugins: wire 9 previously unwired plugin lifecycle hooks into core runtime paths (session, compaction, gateway, and outbound message hooks). (#14882) Thanks @shtse8.</li>
-<li>Hooks/Tools: dispatch <code>before_tool_call</code> and <code>after_tool_call</code> hooks from both tool execution paths with rebased conflict fixes. (#15012) Thanks @Patrick-Barletta, @Takhoffman.</li>
-<li>Discord: allow channel-edit to archive/lock threads and set auto-archive duration. (#5542) Thanks @stumct.</li>
-<li>Discord tests: use a partial @buape/carbon mock in slash command coverage. (#13262) Thanks @arosstale.</li>
-<li>Tests: update thread ID handling in Slack message collection tests. (#14108) Thanks @swizzmagik.</li>
-</ul>
-<p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
-]]></description>
-            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.2.12/OpenClaw-2026.2.12.zip" length="22877692" type="application/octet-stream" sparkle:edSignature="TGylTM4/7Lab+qp1nuPeOAmEVV1WkafXUPub8ws0z/0mYfbVygRuiev+u3zdPjQWhLnGYTgRgKVyW+kB2+Q2BQ=="/>
         </item>
     </channel>
 </rss>

--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -299,6 +299,64 @@ After approval, you can chat normally.
 }
 ```
 
+### Support `@bot`, `@all`, and plain-text mention triggers together
+
+Use this when you want all of these to trigger replies:
+
+- `@BotName`
+- Feishu builtin `@all`
+- plain-text nicknames (for example: "Jarvis")
+- plain-text "everyone"/"all"
+
+```json5
+{
+  channels: {
+    feishu: {
+      groupPolicy: "open",
+      requireMention: true,
+      triggerKeywords: {
+        enabled: true,
+        keywords: ["all", "everyone", "jarvis", "javis"],
+      },
+      groups: {
+        "*": {
+          requireMention: true,
+          triggerKeywords: {
+            enabled: true,
+            keywords: ["all", "everyone", "jarvis", "javis"],
+          },
+        },
+      },
+    },
+  },
+  agents: {
+    list: [
+      {
+        id: "main",
+        groupChat: {
+          mentionPatterns: [
+            "@?jarvis",
+            "@?javis",
+            "@_all",
+            "@all",
+            "@everyone",
+            "@(?:all|everyone)",
+            "all",
+            "everyone",
+            "jarvis",
+            "javis",
+          ],
+        },
+      },
+    ],
+  },
+}
+```
+
+> With `requireMention: true`, group messages trigger when either mention patterns or
+> trigger keywords match.
+> For non-@ text triggers, ensure Feishu permission `im:message.group_msg` is granted.
+
 ### Allow all groups, no @mention required
 
 ```json5
@@ -391,7 +449,9 @@ openclaw pairing list feishu
 1. Ensure the bot is added to the group
 2. Ensure you @mention the bot (default behavior)
 3. Check `groupPolicy` is not set to `"disabled"`
-4. Check logs: `openclaw logs --follow`
+4. If relying on plain-text triggers, verify `im:message.group_msg` permission is enabled
+5. Verify your `mentionPatterns` and `triggerKeywords` match real chat text
+6. Check logs: `openclaw logs --follow`
 
 ### Bot does not receive messages
 
@@ -527,23 +587,25 @@ Full configuration: [Gateway configuration](/gateway/configuration)
 
 Key options:
 
-| Setting                                           | Description                     | Default   |
-| ------------------------------------------------- | ------------------------------- | --------- |
-| `channels.feishu.enabled`                         | Enable/disable channel          | `true`    |
-| `channels.feishu.domain`                          | API domain (`feishu` or `lark`) | `feishu`  |
-| `channels.feishu.accounts.<id>.appId`             | App ID                          | -         |
-| `channels.feishu.accounts.<id>.appSecret`         | App Secret                      | -         |
-| `channels.feishu.accounts.<id>.domain`            | Per-account API domain override | `feishu`  |
-| `channels.feishu.dmPolicy`                        | DM policy                       | `pairing` |
-| `channels.feishu.allowFrom`                       | DM allowlist (open_id list)     | -         |
-| `channels.feishu.groupPolicy`                     | Group policy                    | `open`    |
-| `channels.feishu.groupAllowFrom`                  | Group allowlist                 | -         |
-| `channels.feishu.groups.<chat_id>.requireMention` | Require @mention                | `true`    |
-| `channels.feishu.groups.<chat_id>.enabled`        | Enable group                    | `true`    |
-| `channels.feishu.textChunkLimit`                  | Message chunk size              | `2000`    |
-| `channels.feishu.mediaMaxMb`                      | Media size limit                | `30`      |
-| `channels.feishu.streaming`                       | Enable streaming card output    | `true`    |
-| `channels.feishu.blockStreaming`                  | Enable block streaming          | `true`    |
+| Setting                                            | Description                     | Default   |
+| -------------------------------------------------- | ------------------------------- | --------- |
+| `channels.feishu.enabled`                          | Enable/disable channel          | `true`    |
+| `channels.feishu.domain`                           | API domain (`feishu` or `lark`) | `feishu`  |
+| `channels.feishu.accounts.<id>.appId`              | App ID                          | -         |
+| `channels.feishu.accounts.<id>.appSecret`          | App Secret                      | -         |
+| `channels.feishu.accounts.<id>.domain`             | Per-account API domain override | `feishu`  |
+| `channels.feishu.dmPolicy`                         | DM policy                       | `pairing` |
+| `channels.feishu.allowFrom`                        | DM allowlist (open_id list)     | -         |
+| `channels.feishu.groupPolicy`                      | Group policy                    | `open`    |
+| `channels.feishu.groupAllowFrom`                   | Group allowlist                 | -         |
+| `channels.feishu.groups.<chat_id>.requireMention`  | Require @mention                | `true`    |
+| `channels.feishu.triggerKeywords`                  | Group text trigger keywords     | -         |
+| `channels.feishu.groups.<chat_id>.triggerKeywords` | Per-group text trigger keywords | -         |
+| `channels.feishu.groups.<chat_id>.enabled`         | Enable group                    | `true`    |
+| `channels.feishu.textChunkLimit`                   | Message chunk size              | `2000`    |
+| `channels.feishu.mediaMaxMb`                       | Media size limit                | `30`      |
+| `channels.feishu.streaming`                        | Enable streaming card output    | `true`    |
+| `channels.feishu.blockStreaming`                   | Enable block streaming          | `true`    |
 
 ---
 

--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -305,6 +305,65 @@ openclaw pairing approve feishu <配对码>
 }
 ```
 
+### 同时支持 `@机器人`、`@所有人`、以及纯文字提及触发
+
+适用于以下目标：
+
+- `@机器人名称` 可触发
+- 飞书内置 `@所有人` 可触发
+- 纯文字提及昵称（如“贾维斯”“假维斯”“jarvis”）可触发
+- 纯文字“所有人”可触发
+
+```json5
+{
+  channels: {
+    feishu: {
+      groupPolicy: "open",
+      requireMention: true, // 仍然开启群聊触发门控
+      triggerKeywords: {
+        enabled: true,
+        keywords: ["所有人", "贾维斯", "假维斯", "jarvis", "javis"],
+      },
+      groups: {
+        "*": {
+          requireMention: true,
+          triggerKeywords: {
+            enabled: true,
+            keywords: ["所有人", "贾维斯", "假维斯", "jarvis", "javis"],
+          },
+        },
+      },
+    },
+  },
+  agents: {
+    list: [
+      {
+        id: "main",
+        groupChat: {
+          mentionPatterns: [
+            "@?贾维斯",
+            "@?假维斯",
+            "@?jarvis",
+            "@?javis",
+            "@_all",
+            "@所有人",
+            "@(?:所有人|全体成员|全员|all|everyone)",
+            "所有人",
+            "贾维斯",
+            "假维斯",
+            "jarvis",
+            "javis",
+          ],
+        },
+      },
+    ],
+  },
+}
+```
+
+> 说明：`requireMention=true` 时，消息会先做“提及匹配”或“关键词匹配”；任一命中即触发回复。
+> 对于“非 @ 文本触发”，请确保飞书开放平台已开通敏感权限 `im:message.group_msg`，否则群消息正文可能不会下发。
+
 ### 允许所有群组，无需 @提及
 
 需要为特定群组配置：
@@ -399,7 +458,9 @@ openclaw pairing list feishu
 1. 检查机器人是否已添加到群组
 2. 检查是否 @了机器人（默认需要 @提及）
 3. 检查 `groupPolicy` 是否为 `"disabled"`
-4. 查看日志：`openclaw logs --follow`
+4. 如果依赖“纯文字提及”触发，确认已开通 `im:message.group_msg`
+5. 检查 `mentionPatterns` 和 `triggerKeywords` 是否覆盖了实际文案
+6. 查看日志：`openclaw logs --follow`
 
 ### 机器人收不到消息
 
@@ -578,23 +639,25 @@ openclaw pairing list feishu
 
 主要选项：
 
-| 配置项                                            | 说明                           | 默认值    |
-| ------------------------------------------------- | ------------------------------ | --------- |
-| `channels.feishu.enabled`                         | 启用/禁用渠道                  | `true`    |
-| `channels.feishu.domain`                          | API 域名（`feishu` 或 `lark`） | `feishu`  |
-| `channels.feishu.accounts.<id>.appId`             | 应用 App ID                    | -         |
-| `channels.feishu.accounts.<id>.appSecret`         | 应用 App Secret                | -         |
-| `channels.feishu.accounts.<id>.domain`            | 单账号 API 域名覆盖            | `feishu`  |
-| `channels.feishu.dmPolicy`                        | 私聊策略                       | `pairing` |
-| `channels.feishu.allowFrom`                       | 私聊白名单（open_id 列表）     | -         |
-| `channels.feishu.groupPolicy`                     | 群组策略                       | `open`    |
-| `channels.feishu.groupAllowFrom`                  | 群组白名单                     | -         |
-| `channels.feishu.groups.<chat_id>.requireMention` | 是否需要 @提及                 | `true`    |
-| `channels.feishu.groups.<chat_id>.enabled`        | 是否启用该群组                 | `true`    |
-| `channels.feishu.textChunkLimit`                  | 消息分块大小                   | `2000`    |
-| `channels.feishu.mediaMaxMb`                      | 媒体大小限制                   | `30`      |
-| `channels.feishu.streaming`                       | 启用流式卡片输出               | `true`    |
-| `channels.feishu.blockStreaming`                  | 启用块级流式                   | `true`    |
+| 配置项                                             | 说明                           | 默认值    |
+| -------------------------------------------------- | ------------------------------ | --------- |
+| `channels.feishu.enabled`                          | 启用/禁用渠道                  | `true`    |
+| `channels.feishu.domain`                           | API 域名（`feishu` 或 `lark`） | `feishu`  |
+| `channels.feishu.accounts.<id>.appId`              | 应用 App ID                    | -         |
+| `channels.feishu.accounts.<id>.appSecret`          | 应用 App Secret                | -         |
+| `channels.feishu.accounts.<id>.domain`             | 单账号 API 域名覆盖            | `feishu`  |
+| `channels.feishu.dmPolicy`                         | 私聊策略                       | `pairing` |
+| `channels.feishu.allowFrom`                        | 私聊白名单（open_id 列表）     | -         |
+| `channels.feishu.groupPolicy`                      | 群组策略                       | `open`    |
+| `channels.feishu.groupAllowFrom`                   | 群组白名单                     | -         |
+| `channels.feishu.groups.<chat_id>.requireMention`  | 是否需要 @提及                 | `true`    |
+| `channels.feishu.triggerKeywords`                  | 群聊文字触发关键词             | -         |
+| `channels.feishu.groups.<chat_id>.triggerKeywords` | 群级覆盖的文字触发关键词       | -         |
+| `channels.feishu.groups.<chat_id>.enabled`         | 是否启用该群组                 | `true`    |
+| `channels.feishu.textChunkLimit`                   | 消息分块大小                   | `2000`    |
+| `channels.feishu.mediaMaxMb`                       | 媒体大小限制                   | `30`      |
+| `channels.feishu.streaming`                        | 启用流式卡片输出               | `true`    |
+| `channels.feishu.blockStreaming`                   | 启用块级流式                   | `true`    |
 
 ---
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -262,4 +262,158 @@ describe("handleFeishuMessage command authorization", () => {
       }),
     );
   });
+
+  it("accepts group messages when mentionPatterns match without @mention", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      messages: {
+        groupChat: {
+          // Text trigger without @.
+          mentionPatterns: ["李维斯"],
+        },
+      },
+      channels: {
+        feishu: {
+          groupPolicy: "open",
+          requireMention: true,
+          // Keep keywords off for this test - mentionPatterns should be enough.
+          triggerKeywords: { enabled: false, keywords: ["所有人", "李维斯"] },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-alice" } },
+      message: {
+        message_id: "msg-group-mentionpatterns-text",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "李维斯 在吗？" }),
+        mentions: [],
+      },
+    };
+
+    await handleFeishuMessage({
+      cfg,
+      event,
+      runtime: { log: vi.fn(), error: vi.fn() } as RuntimeEnv,
+      chatHistories: new Map(),
+    });
+
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts group messages when triggerKeywords match without @mention", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groupPolicy: "open",
+          requireMention: true,
+          triggerKeywords: { enabled: true, keywords: ["所有人", "李维斯"] },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-alice" } },
+      message: {
+        message_id: "msg-group-triggerkeywords-text",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "所有人 看一下" }),
+        mentions: [],
+      },
+    };
+
+    await handleFeishuMessage({
+      cfg,
+      event,
+      runtime: { log: vi.fn(), error: vi.fn() } as RuntimeEnv,
+      chatHistories: new Map(),
+    });
+
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts group messages when @all is used (Feishu builtin @_all)", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      messages: {
+        groupChat: {
+          // Match @all via the expanded "@所有人" form.
+          mentionPatterns: ["@(?:所有人|全体成员|全员|all|everyone)"],
+        },
+      },
+      channels: {
+        feishu: {
+          groupPolicy: "open",
+          requireMention: true,
+          triggerKeywords: { enabled: false, keywords: [] },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-alice" } },
+      message: {
+        message_id: "msg-group-atall",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "@_all 大家看一下" }),
+        mentions: [{ key: "@_all", name: "所有人", id: { user_id: "all" } }],
+      },
+    };
+
+    await handleFeishuMessage({
+      cfg,
+      event,
+      runtime: { log: vi.fn(), error: vi.fn() } as RuntimeEnv,
+      chatHistories: new Map(),
+    });
+
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips group messages that only @mention other users", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      messages: { groupChat: { mentionPatterns: ["李维斯"] } },
+      channels: {
+        feishu: {
+          groupPolicy: "open",
+          requireMention: true,
+          triggerKeywords: { enabled: true, keywords: ["所有人", "李维斯"] },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-alice" } },
+      message: {
+        message_id: "msg-group-at-other-user",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "@_user_1 你好" }),
+        mentions: [{ key: "@_user_1", name: "Alice", id: { open_id: "ou-someone" } }],
+      },
+    };
+
+    await handleFeishuMessage({
+      cfg,
+      event,
+      runtime: { log: vi.fn(), error: vi.fn() } as RuntimeEnv,
+      chatHistories: new Map(),
+    });
+
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
 });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -18,12 +18,14 @@ import { extractMentionTargets, extractMessageBody, isMentionForwardRequest } fr
 import {
   resolveFeishuGroupConfig,
   resolveFeishuReplyPolicy,
+  resolveFeishuTriggerKeywords,
   resolveFeishuAllowlistMatch,
   isFeishuGroupAllowed,
 } from "./policy.js";
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu, sendMessageFeishu } from "./send.js";
+import { matchesTriggerKeywords } from "./trigger-keywords.js";
 
 // --- Permission error extraction ---
 // Extract permission grant URL from Feishu API error response.
@@ -71,6 +73,59 @@ const senderNameCache = new Map<string, { name: string; expireAt: number }>();
 // Key: appId or "default", Value: timestamp of last notification
 const permissionErrorNotifiedAt = new Map<string, number>();
 const PERMISSION_ERROR_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+
+const BACKSPACE_CHAR = "\u0008";
+
+function normalizeMentionPattern(pattern: string): string {
+  if (!pattern.includes(BACKSPACE_CHAR)) {
+    return pattern;
+  }
+  return pattern.split(BACKSPACE_CHAR).join("\\b");
+}
+
+function normalizeMentionText(text: string): string {
+  return (text ?? "").replace(/[\u200b-\u200f\u202a-\u202e\u2060-\u206f]/g, "").toLowerCase();
+}
+
+function buildMentionRegexesFromConfig(cfg: ClawdbotConfig, agentId?: string): RegExp[] {
+  const cfgAny = cfg as any;
+  const agents = Array.isArray(cfgAny?.agents?.list) ? cfgAny.agents.list : [];
+  const agent = agentId ? agents.find((entry: any) => entry?.id === agentId) : agents[0];
+  const agentPatterns = Array.isArray(agent?.groupChat?.mentionPatterns)
+    ? agent.groupChat.mentionPatterns
+    : undefined;
+  const globalPatterns = Array.isArray(cfgAny?.messages?.groupChat?.mentionPatterns)
+    ? cfgAny.messages.groupChat.mentionPatterns
+    : undefined;
+  const patterns = (agentPatterns ?? globalPatterns ?? []) as string[];
+
+  return patterns
+    .map((pattern) => normalizeMentionPattern(String(pattern)))
+    .map((pattern) => {
+      try {
+        return new RegExp(pattern, "i");
+      } catch {
+        return null;
+      }
+    })
+    .filter((value): value is RegExp => Boolean(value));
+}
+
+function matchesMentionWithExplicitLocal(params: {
+  text: string;
+  mentionRegexes: RegExp[];
+  explicit: { hasAnyMention: boolean; isExplicitlyMentioned: boolean };
+}): boolean {
+  const cleaned = normalizeMentionText(params.text);
+  const explicit = params.explicit.isExplicitlyMentioned;
+  if (params.explicit.hasAnyMention) {
+    return explicit || params.mentionRegexes.some((re) => re.test(cleaned));
+  }
+  if (!cleaned) {
+    return explicit;
+  }
+  return explicit || params.mentionRegexes.some((re) => re.test(cleaned));
+}
 
 type SenderNameResult = {
   name?: string;
@@ -194,12 +249,35 @@ function checkBotMentioned(event: FeishuMessageEvent, botOpenId?: string): boole
 function stripBotMention(
   text: string,
   mentions?: FeishuMessageEvent["message"]["mentions"],
+  botOpenId?: string,
 ): string {
   if (!mentions || mentions.length === 0) return text;
   let result = text;
   for (const mention of mentions) {
+    if (!botOpenId || mention.id.open_id !== botOpenId) {
+      continue;
+    }
     result = result.replace(new RegExp(`@${mention.name}\\s*`, "g"), "").trim();
     result = result.replace(new RegExp(mention.key, "g"), "").trim();
+  }
+  return result;
+}
+
+function expandMentionPlaceholders(
+  text: string,
+  mentions?: FeishuMessageEvent["message"]["mentions"],
+): string {
+  if (!mentions || mentions.length === 0 || !text) {
+    return text;
+  }
+  let result = text;
+  for (const mention of mentions) {
+    const key = mention.key?.trim();
+    const name = mention.name?.trim();
+    if (!key || !name) {
+      continue;
+    }
+    result = result.split(key).join(`@${name}`);
   }
   return result;
 }
@@ -440,7 +518,10 @@ export function parseFeishuMessageEvent(
 ): FeishuMessageContext {
   const rawContent = parseMessageContent(event.message.content, event.message.message_type);
   const mentionedBot = checkBotMentioned(event, botOpenId);
-  const content = stripBotMention(rawContent, event.message.mentions);
+  const content = expandMentionPlaceholders(
+    stripBotMention(rawContent, event.message.mentions, botOpenId),
+    event.message.mentions,
+  );
 
   const ctx: FeishuMessageContext = {
     chatId: event.message.chat_id,
@@ -451,6 +532,7 @@ export function parseFeishuMessageEvent(
     mentionedBot,
     rootId: event.message.root_id || undefined,
     parentId: event.message.parent_id || undefined,
+    rawContent,
     content,
     contentType: event.message.message_type,
   };
@@ -495,6 +577,7 @@ export async function handleFeishuMessage(params: {
 
   let ctx = parseFeishuMessageEvent(event, botOpenId);
   const isGroup = ctx.chatType === "group";
+  const core = getFeishuRuntime();
 
   // Resolve sender display name (best-effort) so the agent can attribute messages correctly.
   const senderResult = await resolveFeishuSenderName({
@@ -537,6 +620,7 @@ export async function handleFeishuMessage(params: {
   const dmPolicy = feishuCfg?.dmPolicy ?? "pairing";
   const configAllowFrom = feishuCfg?.allowFrom ?? [];
   const useAccessGroups = cfg.commands?.useAccessGroups !== false;
+  let wasMentioned = ctx.mentionedBot;
 
   if (isGroup) {
     const groupPolicy = feishuCfg?.groupPolicy ?? "open";
@@ -576,10 +660,38 @@ export async function handleFeishuMessage(params: {
       globalConfig: feishuCfg,
       groupConfig,
     });
+    const triggerKeywords = resolveFeishuTriggerKeywords({
+      isDirectMessage: false,
+      globalConfig: feishuCfg,
+      groupConfig,
+    });
+    const routeForMention = core.channel.routing.resolveAgentRoute({
+      cfg,
+      channel: "feishu",
+      accountId: account.accountId,
+      peer: {
+        kind: "group",
+        id: ctx.chatId,
+      },
+    });
+    const mentionRegexes = buildMentionRegexesFromConfig(cfg, routeForMention.agentId);
+    const expandedForMention = expandMentionPlaceholders(ctx.rawContent, event.message.mentions);
+    const hasAnyMention = (event.message.mentions?.length ?? 0) > 0;
+    const mentionMatched = matchesMentionWithExplicitLocal({
+      text: expandedForMention,
+      mentionRegexes,
+      explicit: {
+        hasAnyMention,
+        isExplicitlyMentioned: ctx.mentionedBot,
+        canResolveExplicit: true,
+      },
+    });
+    const keywordMatched = matchesTriggerKeywords(expandedForMention, triggerKeywords);
+    wasMentioned = mentionMatched || keywordMatched;
 
-    if (requireMention && !ctx.mentionedBot) {
+    if (requireMention && !wasMentioned) {
       log(
-        `feishu[${account.accountId}]: message in group ${ctx.chatId} did not mention bot, recording to history`,
+        `feishu[${account.accountId}]: message in group ${ctx.chatId} did not match mention/keyword trigger, recording to history`,
       );
       if (chatHistories) {
         recordPendingHistoryEntryIfEnabled({
@@ -600,7 +712,6 @@ export async function handleFeishuMessage(params: {
   }
 
   try {
-    const core = getFeishuRuntime();
     const shouldComputeCommandAuthorized = core.channel.commands.shouldComputeCommandAuthorized(
       ctx.content,
       cfg,
@@ -907,7 +1018,7 @@ export async function handleFeishuMessage(params: {
       MessageSid: ctx.messageId,
       ReplyToBody: quotedContent ?? undefined,
       Timestamp: Date.now(),
-      WasMentioned: ctx.mentionedBot,
+      WasMentioned: isGroup ? wasMentioned : undefined,
       CommandAuthorized: commandAuthorized,
       OriginatingChannel: "feishu" as const,
       OriginatingTo: feishuTo,

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -98,6 +98,13 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
           items: { oneOf: [{ type: "string" }, { type: "number" }] },
         },
         requireMention: { type: "boolean" },
+        triggerKeywords: {
+          type: "object",
+          properties: {
+            enabled: { type: "boolean" },
+            keywords: { type: "array", items: { type: "string" } },
+          },
+        },
         topicSessionMode: { type: "string", enum: ["disabled", "enabled"] },
         historyLimit: { type: "integer", minimum: 0 },
         dmHistoryLimit: { type: "integer", minimum: 0 },
@@ -118,6 +125,13 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
               verificationToken: { type: "string" },
               domain: { type: "string", enum: ["feishu", "lark"] },
               connectionMode: { type: "string", enum: ["websocket", "webhook"] },
+              triggerKeywords: {
+                type: "object",
+                properties: {
+                  enabled: { type: "boolean" },
+                  keywords: { type: "array", items: { type: "string" } },
+                },
+              },
             },
           },
         },

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -100,9 +100,18 @@ const FeishuToolsConfigSchema = z
  */
 const TopicSessionModeSchema = z.enum(["disabled", "enabled"]).optional();
 
+const TriggerKeywordsSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    keywords: z.array(z.string()).optional(),
+  })
+  .strict()
+  .optional();
+
 export const FeishuGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
+    triggerKeywords: TriggerKeywordsSchema,
     tools: ToolPolicySchema,
     skills: z.array(z.string()).optional(),
     enabled: z.boolean().optional(),
@@ -136,6 +145,7 @@ export const FeishuAccountConfigSchema = z
     groupPolicy: GroupPolicySchema.optional(),
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     requireMention: z.boolean().optional(),
+    triggerKeywords: TriggerKeywordsSchema,
     groups: z.record(z.string(), FeishuGroupSchema.optional()).optional(),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
@@ -171,6 +181,7 @@ export const FeishuConfigSchema = z
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     requireMention: z.boolean().optional().default(true),
+    triggerKeywords: TriggerKeywordsSchema,
     groups: z.record(z.string(), FeishuGroupSchema.optional()).optional(),
     topicSessionMode: TopicSessionModeSchema,
     historyLimit: z.number().int().min(0).optional(),

--- a/extensions/feishu/src/policy.ts
+++ b/extensions/feishu/src/policy.ts
@@ -4,7 +4,7 @@ import type {
   GroupToolPolicyConfig,
 } from "openclaw/plugin-sdk";
 import { resolveAllowlistMatchSimple } from "openclaw/plugin-sdk";
-import type { FeishuConfig, FeishuGroupConfig } from "./types.js";
+import type { FeishuConfig, FeishuGroupConfig, TriggerKeywordsConfig } from "./types.js";
 
 export type FeishuAllowlistMatch = AllowlistMatch<"wildcard" | "id" | "name">;
 
@@ -81,4 +81,15 @@ export function resolveFeishuReplyPolicy(params: {
     params.groupConfig?.requireMention ?? params.globalConfig?.requireMention ?? true;
 
   return { requireMention };
+}
+
+export function resolveFeishuTriggerKeywords(params: {
+  isDirectMessage: boolean;
+  globalConfig?: FeishuConfig;
+  groupConfig?: FeishuGroupConfig;
+}): TriggerKeywordsConfig | undefined {
+  if (params.isDirectMessage) {
+    return undefined;
+  }
+  return params.groupConfig?.triggerKeywords ?? params.globalConfig?.triggerKeywords;
 }

--- a/extensions/feishu/src/trigger-keywords.test.ts
+++ b/extensions/feishu/src/trigger-keywords.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { matchesTriggerKeywords } from "./trigger-keywords.js";
+
+describe("matchesTriggerKeywords", () => {
+  it("returns false when disabled", () => {
+    expect(matchesTriggerKeywords("所有人 看一下", { enabled: false, keywords: ["所有人"] })).toBe(
+      false,
+    );
+  });
+
+  it("matches by substring (case-insensitive)", () => {
+    expect(matchesTriggerKeywords("Jarvis 在吗", { enabled: true, keywords: ["jarvis"] })).toBe(
+      true,
+    );
+  });
+
+  it("matches Chinese keywords", () => {
+    expect(matchesTriggerKeywords("所有人 看一下", { enabled: true, keywords: ["所有人"] })).toBe(
+      true,
+    );
+  });
+
+  it("ignores empty keywords", () => {
+    expect(matchesTriggerKeywords("hello", { enabled: true, keywords: ["", "   "] })).toBe(false);
+  });
+});

--- a/extensions/feishu/src/trigger-keywords.ts
+++ b/extensions/feishu/src/trigger-keywords.ts
@@ -1,0 +1,24 @@
+export type TriggerKeywordsConfig = {
+  enabled?: boolean;
+  keywords?: string[];
+};
+
+function normalizeText(text: string): string {
+  // Mirror mention normalizer behavior: remove invisible formatting chars + lowercase.
+  return (text ?? "").replace(/[\u200b-\u200f\u202a-\u202e\u2060-\u206f]/g, "").toLowerCase();
+}
+
+export function matchesTriggerKeywords(text: string, cfg?: TriggerKeywordsConfig | null): boolean {
+  if (!cfg || cfg.enabled !== true) {
+    return false;
+  }
+  const keywords = (cfg.keywords ?? []).map((k) => String(k).trim()).filter(Boolean);
+  if (keywords.length === 0) {
+    return false;
+  }
+  const cleaned = normalizeText(text);
+  if (!cleaned) {
+    return false;
+  }
+  return keywords.some((kw) => cleaned.includes(normalizeText(kw)));
+}

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -10,6 +10,10 @@ import type { MentionTarget } from "./mention.js";
 export type FeishuConfig = z.infer<typeof FeishuConfigSchema>;
 export type FeishuGroupConfig = z.infer<typeof FeishuGroupSchema>;
 export type FeishuAccountConfig = z.infer<typeof FeishuAccountConfigSchema>;
+export type TriggerKeywordsConfig = {
+  enabled?: boolean;
+  keywords?: string[];
+};
 
 export type FeishuDomain = "feishu" | "lark" | (string & {});
 export type FeishuConnectionMode = "websocket" | "webhook";
@@ -40,6 +44,8 @@ export type FeishuMessageContext = {
   mentionedBot: boolean;
   rootId?: string;
   parentId?: string;
+  /** Raw message text before stripping bot @mentions (used for mention/keyword gating). */
+  rawContent: string;
   content: string;
   contentType: string;
   /** Mention forward targets (excluding the bot itself) */


### PR DESCRIPTION
## Summary
- add `triggerKeywords` support to Feishu channel/group config schema and channel metadata
- allow Feishu group dispatch to pass mention-gating when either:
  - mention patterns match, or
  - trigger keywords match
- keep `@_all` and native mention behavior, and improve mention placeholder expansion
- document combined trigger setup for `@bot`, `@all`, and plain-text mentions (EN + zh-CN docs)
- add unit coverage for keyword matching and updated Feishu mention behavior

## Why
Feishu groups with `requireMention=true` were dropping plain-text nickname/all-hands triggers even when users configured patterns/keywords. This makes config behavior inconsistent with operator expectations.

## Validation
- `pnpm vitest run extensions/feishu/src/trigger-keywords.test.ts extensions/feishu/src/bot.checkBotMentioned.test.ts extensions/feishu/src/bot.stripBotMention.test.ts extensions/feishu/src/bot.test.ts`

All tests passed locally.