### PR TITLE
fix: update Discord invite link for consistency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Welcome to the lobster tank! 🦞
 
 - **GitHub:** https://github.com/openclaw/openclaw
 - **Vision:** [`VISION.md`](VISION.md)
-- **Discord:** https://discord.gg/qkhbAGHRBT
+- **Discord:** https://discord.gg/clawd
 - **X/Twitter:** [@steipete](https://x.com/steipete) / [@openclaw](https://x.com/openclaw)
 
 ## Maintainers


### PR DESCRIPTION
## Summary
- Updated Discord invite link in CONTRIBUTING.md from `discord.gg/qkhbAGHRBT` to `discord.gg/clawd`
- Now matches the official Discord link used in README.md

## Test plan
- Verified both files now use the same Discord invite link
- Link resolves to the official OpenClaw Discord server

🤖 AI-assisted PR - Created with OpenClaw assistant