### PR TITLE
heartbeat: add jitter to stagger first trigger across agents

### DIFF
--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -86,6 +86,7 @@ and logged; a message that is only `HEARTBEAT_OK` is dropped.
     defaults: {
       heartbeat: {
         every: "30m", // default: 30m (0m disables)
+        jitter: "10m", // optional: stagger first trigger per agent on startup
         model: "anthropic/claude-opus-4-6",
         includeReasoning: false, // default: false (deliver separate Reasoning: message when available)
         target: "last", // default: none | options: last | none | <channel id> (core or plugin, e.g. "bluebubbles")
@@ -206,6 +207,7 @@ Use `accountId` to target a specific account on multi-account channels like Tele
 ### Field notes
 
 - `every`: heartbeat interval (duration string; default unit = minutes).
+- `jitter`: random offset in `[0, jitter)` added to the first trigger per agent on startup. Staggers heartbeats across agents to avoid simultaneous firing after gateway restart (e.g. 7 agents with `every: "120m"` all firing at once). Duration string (default unit: minutes). Example: `jitter: "10m"` for up to 10 minutes delay.
 - `model`: optional model override for heartbeat runs (`provider/model`).
 - `includeReasoning`: when enabled, also deliver the separate `Reasoning:` message when available (same shape as `/reasoning on`).
 - `session`: optional session key for heartbeat runs.

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -221,6 +221,12 @@ export type AgentDefaultsConfig = {
   heartbeat?: {
     /** Heartbeat interval (duration string, default unit: minutes; default: 30m). */
     every?: string;
+    /**
+     * Random offset in [0, jitter) added to the first trigger per agent on startup.
+     * Staggers heartbeats across agents to avoid simultaneous firing after gateway restart.
+     * Duration string (default unit: minutes). Example: "10m" for up to 10 minutes delay.
+     */
+    jitter?: string;
     /** Optional active-hours window (local time); heartbeats run only inside this window. */
     activeHours?: {
       /** Start time (24h, HH:MM). Inclusive. */

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -15,6 +15,8 @@ import { sensitive } from "./zod-schema.sensitive.js";
 export const HeartbeatSchema = z
   .object({
     every: z.string().optional(),
+    /** Random offset [0, jitter) for first trigger on startup; duration string. */
+    jitter: z.string().optional(),
     activeHours: z
       .object({
         start: z.string().optional(),
@@ -48,6 +50,25 @@ export const HeartbeatSchema = z
         path: ["every"],
         message: "invalid duration (use ms, s, m, h)",
       });
+    }
+
+    if (val.jitter) {
+      try {
+        const jitterMs = parseDurationMs(val.jitter, { defaultUnit: "m" });
+        if (jitterMs < 0) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["jitter"],
+            message: "jitter must be non-negative",
+          });
+        }
+      } catch {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["jitter"],
+          message: "invalid duration (use ms, s, m, h)",
+        });
+      }
     }
 
     const active = val.activeHours;

--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -203,6 +203,44 @@ describe("startHeartbeatRunner", () => {
     runner.stop();
   });
 
+  it("staggers first trigger when jitter is configured (avoids simultaneous firing)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    // main gets 0 -> first due 30m; ops gets 0.9 -> first due 30m + 9m = 39m
+    const randomSpy = vi
+      .spyOn(Math, "random")
+      .mockImplementationOnce(() => 0)
+      .mockImplementationOnce(() => 0.9);
+
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: {
+          defaults: { heartbeat: { every: "30m", jitter: "10m" } },
+          list: [
+            { id: "main", heartbeat: { every: "30m" } },
+            { id: "ops", heartbeat: { every: "30m", jitter: "10m" } },
+          ],
+        },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+    });
+
+    // At 30m + 1s, only main fires (ops due at 39m)
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+    expect(runSpy.mock.calls[0]?.[0]).toMatchObject({ agentId: "main" });
+
+    // At 39m + 1s, ops fires
+    await vi.advanceTimersByTimeAsync(9 * 60_000);
+    expect(runSpy).toHaveBeenCalledTimes(2);
+    expect(runSpy.mock.calls[1]?.[0]).toMatchObject({ agentId: "ops" });
+
+    runner.stop();
+    randomSpy.mockRestore();
+  });
+
   it("does not fan out to unrelated agents for session-scoped exec wakes", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(0));

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -237,6 +237,24 @@ export function resolveHeartbeatIntervalMs(
   return ms;
 }
 
+/** Resolve jitter in ms; returns 0 if not configured or invalid. */
+function resolveHeartbeatJitterMs(cfg: OpenClawConfig, heartbeat?: HeartbeatConfig): number {
+  const raw = heartbeat?.jitter ?? cfg.agents?.defaults?.heartbeat?.jitter;
+  if (!raw) {
+    return 0;
+  }
+  const trimmed = String(raw).trim();
+  if (!trimmed) {
+    return 0;
+  }
+  try {
+    const ms = parseDurationMs(trimmed, { defaultUnit: "m" });
+    return Math.max(0, ms);
+  } catch {
+    return 0;
+  }
+}
+
 export function resolveHeartbeatPrompt(cfg: OpenClawConfig, heartbeat?: HeartbeatConfig) {
   return resolveHeartbeatPromptText(heartbeat?.prompt ?? cfg.agents?.defaults?.heartbeat?.prompt);
 }
@@ -1000,14 +1018,23 @@ export function startHeartbeatRunner(opts: {
   };
   let initialized = false;
 
-  const resolveNextDue = (now: number, intervalMs: number, prevState?: HeartbeatAgentState) => {
+  const resolveNextDue = (
+    now: number,
+    intervalMs: number,
+    prevState: HeartbeatAgentState | undefined,
+    jitterMs: number,
+  ) => {
     if (typeof prevState?.lastRunMs === "number") {
       return prevState.lastRunMs + intervalMs;
     }
     if (prevState && prevState.intervalMs === intervalMs && prevState.nextDueMs > now) {
       return prevState.nextDueMs;
     }
-    return now + intervalMs;
+    const base = now + intervalMs;
+    if (jitterMs <= 0) {
+      return base;
+    }
+    return base + Math.floor(Math.random() * jitterMs);
   };
 
   const advanceAgentSchedule = (agent: HeartbeatAgentState, now: number) => {
@@ -1060,7 +1087,8 @@ export function startHeartbeatRunner(opts: {
       }
       intervals.push(intervalMs);
       const prevState = prevAgents.get(agent.agentId);
-      const nextDueMs = resolveNextDue(now, intervalMs, prevState);
+      const jitterMs = resolveHeartbeatJitterMs(cfg, agent.heartbeat);
+      const nextDueMs = resolveNextDue(now, intervalMs, prevState, jitterMs);
       nextAgents.set(agent.agentId, {
         agentId: agent.agentId,
         heartbeat: agent.heartbeat,


### PR DESCRIPTION
## Summary

- **Problem:** When running multiple agents with the same `heartbeat.every` interval, all agents fire simultaneously after gateway restart. This causes request queue buildup on the main lane (e.g. 7 agents with `every: "120m"` led to lane wait times up to 859 seconds).
- **Why it matters:** Simultaneous heartbeat turns compete for the serialized main lane, causing `typing TTL reached` errors and degraded UX.
- **What changed:** Added optional `jitter` field to heartbeat config. Gateway adds a random offset in `[0, jitter)` to the first trigger per agent on startup, naturally staggering heartbeats.
- **What did NOT change:** Existing config remains valid; jitter is opt-in. Subsequent triggers after the first run use the normal `every` interval.

## Change Type (select all)

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33803
- Related #

## User-visible / Behavior Changes

- New optional config: `agents.defaults.heartbeat.jitter` and `agents.list[].heartbeat.jitter` (duration string, e.g. `"10m"`).
- When set, the first heartbeat trigger per agent on startup is delayed by a random amount in `[0, jitter)` to stagger agents.
- No change when jitter is omitted.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: `heartbeat: { every: "30m", jitter: "10m" }`

### Steps

1. Configure multiple agents with same `every` and `jitter`, e.g. `every: "30m"`, `jitter: "10m"`.
2. Start gateway.
3. Observe first triggers staggered across `[30m, 30m+jitter)` instead of all at 30m.

### Expected

- First triggers spread over the jitter window; no simultaneous firing.

### Actual

- As expected.

## Evidence

- [x] Failing test/log before + passing after
- New test: `staggers first trigger when jitter is configured (avoids simultaneous firing)` in `heartbeat-runner.scheduler.test.ts`

## Human Verification (required)

- Verified scenarios: Unit tests pass; jitter parsed and applied only on first trigger.
- Edge cases checked: No jitter (backward compat); invalid jitter (returns 0); per-agent override.
- What you did **not** verify: Live multi-agent gateway under load.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No** (new optional field)
- Migration needed? **No**

## Failure Recovery (if this breaks)

- How to disable/revert: Omit `jitter` field to restore original behavior.
- Files/config to restore: N/A
- Known bad symptoms: None expected.

## Risks and Mitigations

- None.