### PR TITLE
fix(feishu): typing indicator should target new message, not reply target

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1354,6 +1354,9 @@ export async function handleFeishuMessage(params: {
       (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
     const replyTargetMessageId =
       isTopicSession || configReplyInThread ? (ctx.rootId ?? ctx.messageId) : ctx.messageId;
+    // Typing indicator should be added to the new message, not the reply target.
+    // When replying, ctx.messageId is the new message, ctx.rootId is the reply target.
+    const typingTargetMessageId = ctx.messageId;
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
 
     if (broadcastAgents) {
@@ -1405,6 +1408,7 @@ export async function handleFeishuMessage(params: {
             runtime: runtime as RuntimeEnv,
             chatId: ctx.chatId,
             replyToMessageId: replyTargetMessageId,
+            typingTargetMessageId,
             skipReplyToInMessages: !isGroup,
             replyInThread,
             rootId: ctx.rootId,
@@ -1503,6 +1507,7 @@ export async function handleFeishuMessage(params: {
         runtime: runtime as RuntimeEnv,
         chatId: ctx.chatId,
         replyToMessageId: replyTargetMessageId,
+        typingTargetMessageId,
         skipReplyToInMessages: !isGroup,
         replyInThread,
         rootId: ctx.rootId,

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -42,7 +42,7 @@ export type CreateFeishuReplyDispatcherParams = {
   runtime: RuntimeEnv;
   chatId: string;
   replyToMessageId?: string;
-  /** When true, preserve typing indicator on reply target but send messages without reply metadata */
+  /** When true, send messages without reply metadata (no reply_in_thread quote). */
   skipReplyToInMessages?: boolean;
   replyInThread?: boolean;
   /** True when inbound message is already inside a thread/topic context */

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -53,6 +53,9 @@ export type CreateFeishuReplyDispatcherParams = {
   /** Epoch ms when the inbound message was created. Used to suppress typing
    *  indicators on old/replayed messages after context compaction (#30418). */
   messageCreateTimeMs?: number;
+  /** Message ID to add typing indicator reaction to. Defaults to replyToMessageId.
+   *  When replying to a message, this should be the new message ID, not the reply target. */
+  typingTargetMessageId?: string;
 };
 
 export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherParams) {
@@ -68,8 +71,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     rootId,
     mentionTargets,
     accountId,
+    typingTargetMessageId,
   } = params;
   const sendReplyToMessageId = skipReplyToInMessages ? undefined : replyToMessageId;
+  const effectiveTypingTargetId = typingTargetMessageId ?? replyToMessageId;
   const threadReplyMode = threadReply === true;
   const effectiveReplyInThread = threadReplyMode ? true : replyInThread;
   const account = resolveFeishuAccount({ cfg, accountId });
@@ -82,7 +87,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (!(account.config.typingIndicator ?? true)) {
         return;
       }
-      if (!replyToMessageId) {
+      if (!effectiveTypingTargetId) {
         return;
       }
       // Skip typing indicator for old messages — likely replays after context
@@ -102,7 +107,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       }
       typingState = await addTypingIndicator({
         cfg,
-        messageId: replyToMessageId,
+        messageId: effectiveTypingTargetId,
         accountId,
         runtime: params.runtime,
       });


### PR DESCRIPTION
## Summary

When replying to a message in Feishu, the typing indicator reaction was being added to the replied-to message instead of the new message.

## Root Cause

`replyToMessageId` was used for both:
1. Reply reference target (should be `ctx.rootId` - the original message)
2. Typing indicator target (should be `ctx.messageId` - the new message)

## Fix

Add new `typingTargetMessageId` parameter to `createFeishuReplyDispatcher` to separate these concerns:
- `replyToMessageId` → used for reply reference (ctx.rootId ?? ctx.messageId)
- `typingTargetMessageId` → used for typing indicator (ctx.messageId)

The typing indicator now correctly targets the new message while reply references still target the original message.

## Testing

1. Send a direct message to the bot → typing indicator should appear on your message ✅
2. Reply to a bot message → typing indicator should appear on your NEW message, not the replied-to message ✅

## Files Changed

- `extensions/feishu/src/reply-dispatcher.ts` - Add `typingTargetMessageId` parameter
- `extensions/feishu/src/bot.ts` - Pass `ctx.messageId` as typing target