### PR TITLE
fix(workspace): ensure memory/ dir exists

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -90,7 +90,7 @@ describe("ensureAgentWorkspace", () => {
     await expectBootstrapSeeded(tempDir);
   });
 
-  it("always ensures a memory/ directory exists", async () => {
+  it("ensures memory/ directory exists when ensureBootstrapFiles is true", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
 
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -90,6 +90,14 @@ describe("ensureAgentWorkspace", () => {
     await expectBootstrapSeeded(tempDir);
   });
 
+  it("always ensures a memory/ directory exists", async () => {
+    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+
+    await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });
+
+    await expect(fs.access(path.join(tempDir, "memory"))).resolves.toBeUndefined();
+  });
+
   it("does not recreate BOOTSTRAP.md after completion, even when a core file is recreated", async () => {
     const tempDir = await makeTempWorkspace("openclaw-workspace-");
     await ensureAgentWorkspace({ dir: tempDir, ensureBootstrapFiles: true });

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -444,6 +444,11 @@ export async function ensureAgentWorkspace(params?: {
   if (stateDirty) {
     await writeWorkspaceOnboardingState(statePath, state);
   }
+
+  // Ensure the daily memory directory exists. Some installs/upgrades can leave workspaces
+  // without it, which breaks journaling and memory workflows.
+  await fs.mkdir(path.join(dir, "memory"), { recursive: true });
+
   await ensureGitRepo(dir, isBrandNewWorkspace);
 
   return {


### PR DESCRIPTION
Fixes missing workspace memory/ directory, which breaks memory/journaling flows on some installs/upgrades.

- Ensure ensureAgentWorkspace(..., ensureBootstrapFiles: true) always creates memory/.
- Add unit test to lock behavior.

Fixes #33773