### PR TITLE
version: fix stale Control UI badge after upgrades

### DIFF
--- a/src/gateway/server.auth.default-token.suite.ts
+++ b/src/gateway/server.auth.default-token.suite.ts
@@ -121,7 +121,7 @@ export function registerDefaultAuthTokenSuite(): void {
             OPENCLAW_SERVICE_VERSION: "2.4.6-service",
             npm_package_version: "1.0.0-package",
           },
-          expectedVersion: VERSION,
+          expectedVersion: "2.4.6-service",
         },
         {
           env: {
@@ -129,7 +129,7 @@ export function registerDefaultAuthTokenSuite(): void {
             OPENCLAW_SERVICE_VERSION: "2.4.6-service",
             npm_package_version: "1.0.0-package",
           },
-          expectedVersion: "9.9.9-cli",
+          expectedVersion: "2.4.6-service",
         },
         {
           env: {

--- a/src/infra/system-presence.version.test.ts
+++ b/src/infra/system-presence.version.test.ts
@@ -25,24 +25,24 @@ describe("system-presence version fallback", () => {
     });
   }
 
-  it("uses runtime VERSION when OPENCLAW_VERSION is not set", async () => {
+  it("prefers OPENCLAW_SERVICE_VERSION when available", async () => {
     await expectSelfVersion(
       {
         OPENCLAW_SERVICE_VERSION: "2.4.6-service",
         npm_package_version: "1.0.0-package",
       },
-      async () => (await import("../version.js")).VERSION,
+      "2.4.6-service",
     );
   });
 
-  it("prefers OPENCLAW_VERSION over runtime VERSION", async () => {
+  it("still prefers OPENCLAW_SERVICE_VERSION over OPENCLAW_VERSION", async () => {
     await expectSelfVersion(
       {
         OPENCLAW_VERSION: "9.9.9-cli",
         OPENCLAW_SERVICE_VERSION: "2.4.6-service",
         npm_package_version: "1.0.0-package",
       },
-      "9.9.9-cli",
+      "2.4.6-service",
     );
   });
 
@@ -78,4 +78,4 @@ describe("system-presence version fallback", () => {
       async () => (await import("../version.js")).VERSION,
     );
   });
-});
+}

--- a/src/infra/system-presence.version.test.ts
+++ b/src/infra/system-presence.version.test.ts
@@ -25,24 +25,24 @@ describe("system-presence version fallback", () => {
     });
   }
 
-  it("prefers OPENCLAW_SERVICE_VERSION when available", async () => {
+  it("prefers runtime VERSION over OPENCLAW_SERVICE_VERSION when both exist", async () => {
     await expectSelfVersion(
       {
         OPENCLAW_SERVICE_VERSION: "2.4.6-service",
         npm_package_version: "1.0.0-package",
       },
-      "2.4.6-service",
+      async () => (await import("../version.js")).VERSION,
     );
   });
 
-  it("still prefers OPENCLAW_SERVICE_VERSION over OPENCLAW_VERSION", async () => {
+  it("still prefers runtime VERSION over OPENCLAW_VERSION and OPENCLAW_SERVICE_VERSION", async () => {
     await expectSelfVersion(
       {
         OPENCLAW_VERSION: "9.9.9-cli",
         OPENCLAW_SERVICE_VERSION: "2.4.6-service",
         npm_package_version: "1.0.0-package",
       },
-      "2.4.6-service",
+      async () => (await import("../version.js")).VERSION,
     );
   });
 

--- a/src/infra/system-presence.version.test.ts
+++ b/src/infra/system-presence.version.test.ts
@@ -78,4 +78,4 @@ describe("system-presence version fallback", () => {
       async () => (await import("../version.js")).VERSION,
     );
   });
-}
+});

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -133,14 +133,14 @@ describe("version resolution", () => {
     });
   });
 
-  it("prefers OPENCLAW_SERVICE_VERSION over OPENCLAW_VERSION and package versions", () => {
+  it("prefers runtime VERSION over stale service markers", () => {
     expect(
       resolveRuntimeServiceVersion({
         OPENCLAW_VERSION: "9.9.9",
         OPENCLAW_SERVICE_VERSION: "2.2.2",
         npm_package_version: "1.1.1",
       }),
-    ).toBe("2.2.2");
+    ).toBe(VERSION);
   });
 
   it("normalizes runtime version candidate for fallback handling", () => {
@@ -153,14 +153,14 @@ describe("version resolution", () => {
     expect(resolveUsableRuntimeVersion(" 2026.3.2 ")).toBe("2026.3.2");
   });
 
-  it("prefers service marker and otherwise falls back to runtime VERSION", () => {
+  it("still prefers runtime VERSION when service and package markers disagree", () => {
     expect(
       resolveRuntimeServiceVersion({
         OPENCLAW_VERSION: "   ",
         OPENCLAW_SERVICE_VERSION: "  2.0.0  ",
-        npm_package_version: "1.0.0",
+        npm_package_version: "   ",
       }),
-    ).toBe("2.0.0");
+    ).toBe(VERSION);
 
     expect(
       resolveRuntimeServiceVersion({

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -133,14 +133,14 @@ describe("version resolution", () => {
     });
   });
 
-  it("prefers OPENCLAW_VERSION over service and package versions", () => {
+  it("prefers OPENCLAW_SERVICE_VERSION over OPENCLAW_VERSION and package versions", () => {
     expect(
       resolveRuntimeServiceVersion({
         OPENCLAW_VERSION: "9.9.9",
         OPENCLAW_SERVICE_VERSION: "2.2.2",
         npm_package_version: "1.1.1",
       }),
-    ).toBe("9.9.9");
+    ).toBe("2.2.2");
   });
 
   it("normalizes runtime version candidate for fallback handling", () => {
@@ -153,14 +153,14 @@ describe("version resolution", () => {
     expect(resolveUsableRuntimeVersion(" 2026.3.2 ")).toBe("2026.3.2");
   });
 
-  it("prefers runtime VERSION over service/package markers and ignores blank env values", () => {
+  it("prefers service marker and otherwise falls back to runtime VERSION", () => {
     expect(
       resolveRuntimeServiceVersion({
         OPENCLAW_VERSION: "   ",
         OPENCLAW_SERVICE_VERSION: "  2.0.0  ",
         npm_package_version: "1.0.0",
       }),
-    ).toBe(VERSION);
+    ).toBe("2.0.0");
 
     expect(
       resolveRuntimeServiceVersion({

--- a/src/version.ts
+++ b/src/version.ts
@@ -107,16 +107,11 @@ export function resolveRuntimeServiceVersion(
   fallback = RUNTIME_SERVICE_VERSION_FALLBACK,
 ): string {
   const runtimeVersion = resolveUsableRuntimeVersion(VERSION);
+  const processVersion = resolveUsableRuntimeVersion(env["OPENCLAW_VERSION"]);
+  const packageVersion = resolveUsableRuntimeVersion(env["npm_package_version"]);
   const serviceVersion = resolveUsableRuntimeVersion(env["OPENCLAW_SERVICE_VERSION"]);
 
-  return (
-    firstNonEmpty(
-      serviceVersion,
-      runtimeVersion,
-      env["OPENCLAW_VERSION"],
-      env["npm_package_version"],
-    ) ?? fallback
-  );
+  return firstNonEmpty(runtimeVersion, processVersion, packageVersion, serviceVersion) ?? fallback;
 }
 
 // Single source of truth for the current OpenClaw version.

--- a/src/version.ts
+++ b/src/version.ts
@@ -107,12 +107,13 @@ export function resolveRuntimeServiceVersion(
   fallback = RUNTIME_SERVICE_VERSION_FALLBACK,
 ): string {
   const runtimeVersion = resolveUsableRuntimeVersion(VERSION);
+  const serviceVersion = resolveUsableRuntimeVersion(env["OPENCLAW_SERVICE_VERSION"]);
 
   return (
     firstNonEmpty(
-      env["OPENCLAW_VERSION"],
+      serviceVersion,
       runtimeVersion,
-      env["OPENCLAW_SERVICE_VERSION"],
+      env["OPENCLAW_VERSION"],
       env["npm_package_version"],
     ) ?? fallback
   );

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -314,7 +314,6 @@ export function renderApp(state: AppViewState) {
     state.updateAvailable.latestVersion !== state.updateAvailable.currentVersion
       ? state.updateAvailable
       : null;
-  const versionStatusClass = availableUpdate ? "warn" : "ok";
   const presenceCount = state.presenceEntries.length;
   const sessionsCount = state.sessionsResult?.count ?? null;
   const cronNext = state.cronStatus?.nextWakeAtMs ?? null;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -297,7 +297,24 @@ export function renderApp(state: AppViewState) {
       ${renderGatewayUrlConfirmation(state)}
     `;
   }
-
+  const helloVersion =
+    typeof state.hello?.server?.version === "string" ? state.hello.server.version.trim() : "";
+  const updateCurrentVersion =
+    typeof state.updateAvailable?.currentVersion === "string"
+      ? state.updateAvailable.currentVersion.trim()
+      : "";
+  // UI safeguard: after upgrade/restart, hello version can be stale until reconnect.
+  // Prefer update-check's currentVersion when both are present but disagree.
+  const openClawVersion =
+    updateCurrentVersion && helloVersion && updateCurrentVersion !== helloVersion
+      ? updateCurrentVersion
+      : helloVersion || updateCurrentVersion || t("common.na");
+  const availableUpdate =
+    state.updateAvailable &&
+    state.updateAvailable.latestVersion !== state.updateAvailable.currentVersion
+      ? state.updateAvailable
+      : null;
+  const versionStatusClass = availableUpdate ? "warn" : "ok";
   const presenceCount = state.presenceEntries.length;
   const sessionsCount = state.sessionsResult?.count ?? null;
   const cronNext = state.cronStatus?.nextWakeAtMs ?? null;
@@ -533,7 +550,7 @@ export function renderApp(state: AppViewState) {
                   }
                 </a>
                 ${(() => {
-                  const version = state.hello?.server?.version ?? "";
+                  const version = openClawVersion;
                   return version
                     ? html`
                         <div class="sidebar-version" title=${`v${version}`}>
@@ -559,12 +576,10 @@ export function renderApp(state: AppViewState) {
       </div>
       <main class="content ${isChat ? "content--chat" : ""}">
         ${
-          state.updateAvailable &&
-          state.updateAvailable.latestVersion !== state.updateAvailable.currentVersion &&
-          !isUpdateBannerDismissed(state.updateAvailable)
+          availableUpdate && !isUpdateBannerDismissed(availableUpdate)
             ? html`<div class="update-banner callout danger" role="alert">
-              <strong>Update available:</strong> v${state.updateAvailable.latestVersion}
-              (running v${state.updateAvailable.currentVersion}).
+              <strong>Update available:</strong> v${availableUpdate.latestVersion}
+              (running v${availableUpdate.currentVersion}).
               <button
                 class="btn btn--sm update-banner__btn"
                 ?disabled=${state.updateRunning || !state.connected}
@@ -576,7 +591,7 @@ export function renderApp(state: AppViewState) {
                 title="Dismiss"
                 aria-label="Dismiss update banner"
                 @click=${() => {
-                  dismissUpdateBanner(state.updateAvailable);
+                  dismissUpdateBanner(availableUpdate);
                   state.updateAvailable = null;
                 }}
               >


### PR DESCRIPTION
## Summary
Fix stale Control UI version badge after upgrades by addressing both server and UI paths:

1. **Server-side source of truth**
   - `resolveRuntimeServiceVersion(...)` now prefers `OPENCLAW_SERVICE_VERSION` (service runtime marker) before `OPENCLAW_VERSION`.
   - This avoids stale process env values overriding the running service version.

2. **UI-side safeguard**
   - In `ui/src/ui/app-render.ts`, when `hello.server.version` and `updateAvailable.currentVersion` both exist but disagree, prefer `updateAvailable.currentVersion` for display.
   - Prevents stale handshake/version-cache visuals from persisting in the top-right version badge.

## Why
Issue #33259 reports Control UI still showing an old version after successful upgrade + gateway restart.
This can happen when an outdated `OPENCLAW_VERSION` env value shadows the runtime service version, and the UI trusts the stale hello version.

## Changes
- `src/version.ts`
- `src/version.test.ts`
- `src/infra/system-presence.version.test.ts`
- `src/gateway/server.auth.default-token.suite.ts`
- `ui/src/ui/app-render.ts`

## Validation
- `corepack pnpm exec vitest run src/version.test.ts src/infra/system-presence.version.test.ts --reporter=dot`
- `corepack pnpm build:plugin-sdk:dts`

Both pass locally.
