### PR TITLE
fix(tui): stream chat runs for non-main sessions

### DIFF
--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -461,15 +461,23 @@ export const agentHandlers: GatewayRequestHandlers = {
         });
         sessionEntry = persisted;
       }
-      if (canonicalSessionKey === mainSessionKey || canonicalSessionKey === "global") {
-        context.addChatRun(idem, {
-          sessionKey: canonicalSessionKey,
-          clientRunId: idem,
-        });
-        if (requestedBestEffortDeliver === undefined) {
-          bestEffortDeliver = true;
-        }
+      // Ensure chat UI clients refresh when this run completes.
+      // This maps agent bus events (keyed by sessionId) to chat events (keyed by clientRunId).
+      // Previously this was limited to main/global sessions, which could break real-time TUI updates
+      // for non-main sessions (e.g. sub-agent sessions).
+      context.addChatRun(idem, {
+        sessionKey: canonicalSessionKey,
+        clientRunId: idem,
+      });
+
+      // Preserve previous delivery default: treat main/global as best-effort deliver unless explicitly set.
+      if (
+        (canonicalSessionKey === mainSessionKey || canonicalSessionKey === "global") &&
+        requestedBestEffortDeliver === undefined
+      ) {
+        bestEffortDeliver = true;
       }
+
       registerAgentRunContext(idem, { sessionKey: canonicalSessionKey });
     }
 

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -461,15 +461,6 @@ export const agentHandlers: GatewayRequestHandlers = {
         });
         sessionEntry = persisted;
       }
-      // Ensure chat UI clients refresh when this run completes.
-      // This maps agent bus events (keyed by sessionId) to chat events (keyed by clientRunId).
-      // Previously this was limited to main/global sessions, which could break real-time TUI updates
-      // for non-main sessions (e.g. sub-agent sessions).
-      context.addChatRun(idem, {
-        sessionKey: canonicalSessionKey,
-        clientRunId: idem,
-      });
-
       // Preserve previous delivery default: treat main/global as best-effort deliver unless explicitly set.
       if (
         (canonicalSessionKey === mainSessionKey || canonicalSessionKey === "global") &&
@@ -607,6 +598,17 @@ export const agentHandlers: GatewayRequestHandlers = {
       payload: accepted,
     });
     respond(true, accepted, undefined, { runId });
+
+    // Ensure chat UI clients receive real-time updates for this run.
+    // Map agent bus events (keyed by sessionId/runId) to chat events (keyed by clientRunId).
+    // Register only after all validations and once we are about to start the agent run,
+    // to avoid orphaned chat-run entries on early exits.
+    if (resolvedSessionKey) {
+      context.addChatRun(runId, {
+        sessionKey: resolvedSessionKey,
+        clientRunId: runId,
+      });
+    }
 
     const resolvedThreadId = explicitThreadId ?? deliveryPlan.resolvedThreadId;
 


### PR DESCRIPTION
Fixes a regression where TUI users viewing/sending to non-main sessions (e.g. sub-agent sessions) could miss real-time chat updates and only see results after a restart/history reload.

Change: always register chat runs via addChatRun for all session keys; preserve best-effort delivery default for main/global only.

Fixes #33768