### PR TITLE
fix(daemon): preserve empty quoted args in service parsing

### DIFF
--- a/src/daemon/arg-split.ts
+++ b/src/daemon/arg-split.ts
@@ -6,6 +6,7 @@ export function splitArgsPreservingQuotes(
 ): string[] {
   const args: string[] = [];
   let current = "";
+  let tokenStarted = false;
   let inQuotes = false;
   const escapeMode = options?.escapeMode ?? "none";
 
@@ -14,6 +15,7 @@ export function splitArgsPreservingQuotes(
     if (escapeMode === "backslash" && char === "\\") {
       if (i + 1 < value.length) {
         current += value[i + 1];
+        tokenStarted = true;
         i++;
       }
       continue;
@@ -25,23 +27,27 @@ export function splitArgsPreservingQuotes(
       value[i + 1] === '"'
     ) {
       current += '"';
+      tokenStarted = true;
       i++;
       continue;
     }
     if (char === '"') {
+      tokenStarted = true;
       inQuotes = !inQuotes;
       continue;
     }
     if (!inQuotes && /\s/.test(char)) {
-      if (current) {
+      if (tokenStarted) {
         args.push(current);
         current = "";
+        tokenStarted = false;
       }
       continue;
     }
     current += char;
+    tokenStarted = true;
   }
-  if (current) {
+  if (tokenStarted) {
     args.push(current);
   }
   return args;

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildSystemdUnit } from "./systemd-unit.js";
+import { buildSystemdUnit, parseSystemdExecStart } from "./systemd-unit.js";
 
 describe("buildSystemdUnit", () => {
   it("quotes arguments with whitespace", () => {
@@ -22,5 +22,23 @@ describe("buildSystemdUnit", () => {
         },
       }),
     ).toThrow(/CR or LF/);
+  });
+
+  it("round-trips explicit empty args in ExecStart", () => {
+    const unit = buildSystemdUnit({
+      description: "OpenClaw Gateway",
+      programArguments: ["/usr/bin/openclaw", "gateway", "--display-name", "", "--port", "18789"],
+      environment: {},
+    });
+    const execStart = unit.split("\n").find((line) => line.startsWith("ExecStart="));
+    expect(execStart).toBe('ExecStart=/usr/bin/openclaw gateway --display-name "" --port 18789');
+    expect(parseSystemdExecStart(execStart!.slice("ExecStart=".length))).toEqual([
+      "/usr/bin/openclaw",
+      "gateway",
+      "--display-name",
+      "",
+      "--port",
+      "18789",
+    ]);
   });
 });

--- a/src/daemon/systemd-unit.test.ts
+++ b/src/daemon/systemd-unit.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildSystemdUnit, parseSystemdExecStart } from "./systemd-unit.js";
+import {
+  buildSystemdUnit,
+  parseSystemdEnvAssignment,
+  parseSystemdExecStart,
+} from "./systemd-unit.js";
 
 describe("buildSystemdUnit", () => {
   it("quotes arguments with whitespace", () => {
@@ -40,5 +44,14 @@ describe("buildSystemdUnit", () => {
       "--port",
       "18789",
     ]);
+  });
+});
+
+describe("parseSystemdEnvAssignment", () => {
+  it("unescapes quoted environment values", () => {
+    expect(parseSystemdEnvAssignment('"OPENCLAW_LABEL=My \\"Quoted\\" Bot"')).toEqual({
+      key: "OPENCLAW_LABEL",
+      value: 'My "Quoted" Bot',
+    });
   });
 });

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -11,6 +11,9 @@ function assertNoSystemdLineBreaks(value: string, label: string): void {
 
 function systemdEscapeArg(value: string): string {
   assertNoSystemdLineBreaks(value, "Systemd unit values");
+  if (value === "") {
+    return '""';
+  }
   if (!/[\s"\\]/.test(value)) {
     return value;
   }

--- a/src/daemon/systemd-unit.ts
+++ b/src/daemon/systemd-unit.ts
@@ -99,7 +99,7 @@ export function parseSystemdEnvAssignment(raw: string): { key: string; value: st
         escapeNext = false;
         continue;
       }
-      if (ch === "\\\\") {
+      if (ch === "\\") {
         escapeNext = true;
         continue;
       }

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -184,6 +184,17 @@ describe("splitArgsPreservingQuotes", () => {
       }),
     ).toEqual(["openclaw", "--label", 'My "Quoted" Name']);
   });
+
+  it("preserves explicit empty quoted args", () => {
+    expect(splitArgsPreservingQuotes('node gateway.js --display-name "" --port 18789')).toEqual([
+      "node",
+      "gateway.js",
+      "--display-name",
+      "",
+      "--port",
+      "18789",
+    ]);
+  });
 });
 
 describe("parseSystemdExecStart", () => {


### PR DESCRIPTION
## Summary

- Fix daemon arg parsing to preserve explicit empty quoted args (`""`) instead of dropping them.
- Fix systemd unit rendering so empty args are emitted as `""` in `ExecStart`.
- Add regression tests for parser behavior and `ExecStart` round-trip with empty args.
- Scope is intentionally narrow: no lifecycle/service-control/auth/network changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #<optional-if-you-open-one>
- Related #15587
- Related #15642
- Related #995

## User-visible / Behavior Changes

- Daemon command introspection now preserves explicit empty args.
- systemd `ExecStart` output now keeps empty args as `""`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Windows 11 (local dev)
- Runtime/container: Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): daemon command parsing path
- Relevant config (redacted): N/A

### Steps

1. Parse command containing explicit empty arg: `node gateway.js --display-name "" --port 18789`.
2. Inspect parsed argv and rendered systemd `ExecStart`.
3. Compare before/after behavior.

### Expected

- Empty arg is preserved.

### Actual

- Empty arg was dropped before this fix.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Ran:
- `corepack pnpm exec vitest run src/daemon/systemd.test.ts src/daemon/systemd-unit.test.ts` (pass)

## Human Verification (required)

- Verified scenarios:
  - empty quoted arg preservation in parser
  - `ExecStart` round-trip preserves empty args
- Edge cases checked:
  - existing quoting/escaping tests stay green
- What you did **not** verify:
  - full cross-platform service-manager E2E reinstall flow

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - revert this commit
- Files/config to restore:
  - `src/daemon/arg-split.ts`
  - `src/daemon/systemd-unit.ts`
  - `src/daemon/systemd.test.ts`
  - `src/daemon/systemd-unit.test.ts`
- Known bad symptoms reviewers should watch for:
  - empty args missing from parsed command output

## Risks and Mitigations

- Risk:
  - shared arg-splitter token-boundary behavior changed
  - Mitigation:
    - focused regression tests added for empty-arg preservation
    - existing parser tests remain green