### PR TITLE
WhatsApp: separate outbound allowSendTo from inbound allowFrom

### DIFF
--- a/extensions/whatsapp/src/accounts.ts
+++ b/extensions/whatsapp/src/accounts.ts
@@ -23,6 +23,7 @@ export type ResolvedWhatsAppAccount = {
   isLegacyAuthDir: boolean;
   selfChatMode?: boolean;
   allowFrom?: string[];
+  allowSendTo?: string[];
   groupAllowFrom?: string[];
   groupPolicy?: GroupPolicy;
   dmPolicy?: DmPolicy;
@@ -142,6 +143,7 @@ export function resolveWhatsAppAccount(params: {
     selfChatMode: accountCfg?.selfChatMode ?? rootCfg?.selfChatMode,
     dmPolicy: accountCfg?.dmPolicy ?? rootCfg?.dmPolicy,
     allowFrom: accountCfg?.allowFrom ?? rootCfg?.allowFrom,
+    allowSendTo: accountCfg?.allowSendTo ?? rootCfg?.allowSendTo,
     groupAllowFrom: accountCfg?.groupAllowFrom ?? rootCfg?.groupAllowFrom,
     groupPolicy: accountCfg?.groupPolicy ?? rootCfg?.groupPolicy,
     textChunkLimit: accountCfg?.textChunkLimit ?? rootCfg?.textChunkLimit,

--- a/extensions/whatsapp/src/action-runtime-target-auth.ts
+++ b/extensions/whatsapp/src/action-runtime-target-auth.ts
@@ -18,11 +18,12 @@ export function resolveAuthorizedWhatsAppOutboundTarget(params: {
   const resolution = resolveWhatsAppOutboundTarget({
     to: params.chatJid,
     allowFrom: account.allowFrom ?? [],
+    allowSendTo: account.allowSendTo,
     mode: "implicit",
   });
   if (!resolution.ok) {
     throw new ToolAuthorizationError(
-      `WhatsApp ${params.actionLabel} blocked: chatJid "${params.chatJid}" is not in the configured allowFrom list for account "${account.accountId}".`,
+      `WhatsApp ${params.actionLabel} blocked: chatJid "${params.chatJid}" is not in the configured allowSendTo/allowFrom list for account "${account.accountId}".`,
     );
   }
   return { to: resolution.to, accountId: account.accountId };

--- a/extensions/whatsapp/src/channel.ts
+++ b/extensions/whatsapp/src/channel.ts
@@ -160,8 +160,8 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
       sendPollWhatsApp: async (...args) =>
         await getWhatsAppRuntime().channel.whatsapp.sendPollWhatsApp(...args),
       shouldLogVerbose: () => getWhatsAppRuntime().logging.shouldLogVerbose(),
-      resolveTarget: ({ to, allowFrom, mode }) =>
-        resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
+      resolveTarget: ({ to, allowFrom, allowSendTo, mode }) =>
+        resolveWhatsAppOutboundTarget({ to, allowFrom, allowSendTo, mode }),
     }),
     normalizePayload: ({ payload }) => ({
       ...payload,
@@ -259,6 +259,7 @@ export const whatsappPlugin: ChannelPlugin<ResolvedWhatsAppAccount> = {
         lastError: runtime?.lastError ?? null,
         dmPolicy: account.dmPolicy,
         allowFrom: account.allowFrom,
+        allowSendTo: account.allowSendTo,
       };
     },
     resolveAccountState: ({ configured }) => (configured ? "linked" : "not linked"),

--- a/extensions/whatsapp/src/outbound-adapter.ts
+++ b/extensions/whatsapp/src/outbound-adapter.ts
@@ -21,8 +21,8 @@ export const whatsappOutbound: ChannelOutboundAdapter = {
   chunkerMode: "text",
   textChunkLimit: 4000,
   pollMaxOptions: 12,
-  resolveTarget: ({ to, allowFrom, mode }) =>
-    resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
+  resolveTarget: ({ to, allowFrom, allowSendTo, mode }) =>
+    resolveWhatsAppOutboundTarget({ to, allowFrom, allowSendTo, mode }),
   sendPayload: async (ctx) => {
     const text = trimLeadingWhitespace(ctx.payload.text);
     const hasMedia = resolveSendableOutboundReplyParts(ctx.payload).hasMedia;

--- a/extensions/whatsapp/src/resolve-target.test.ts
+++ b/extensions/whatsapp/src/resolve-target.test.ts
@@ -20,10 +20,12 @@ vi.mock("openclaw/plugin-sdk/whatsapp", async () => {
     resolveWhatsAppOutboundTarget: ({
       to,
       allowFrom,
+      allowSendTo,
       mode,
     }: {
       to?: string;
       allowFrom: string[];
+      allowSendTo?: string[];
       mode: "explicit" | "implicit";
     }) => {
       const raw = typeof to === "string" ? to.trim() : "";
@@ -36,8 +38,10 @@ vi.mock("openclaw/plugin-sdk/whatsapp", async () => {
       }
 
       if (mode === "implicit" && !normalized.endsWith("@g.us")) {
-        const allowAll = allowFrom.includes("*");
-        const allowExact = allowFrom.some((entry) => {
+        // Use allowSendTo if defined, otherwise fall back to allowFrom
+        const effectiveList = allowSendTo ?? allowFrom;
+        const allowAll = effectiveList.includes("*");
+        const allowExact = effectiveList.some((entry) => {
           if (!entry) {
             return false;
           }

--- a/extensions/whatsapp/src/shared.ts
+++ b/extensions/whatsapp/src/shared.ts
@@ -41,6 +41,7 @@ const whatsappConfigAdapter = createScopedChannelConfigAdapter<ResolvedWhatsAppA
   clearBaseFields: [],
   allowTopLevel: false,
   resolveAllowFrom: (account) => account.allowFrom,
+  resolveAllowSendTo: (account) => account.allowSendTo,
   formatAllowFrom: (allowFrom) => formatWhatsAppConfigAllowFromEntries(allowFrom),
   resolveDefaultTo: (account) => account.defaultTo,
 });

--- a/src/channels/plugins/setup-helpers.test.ts
+++ b/src/channels/plugins/setup-helpers.test.ts
@@ -5,6 +5,7 @@ import {
   applySetupAccountConfigPatch,
   createEnvPatchedAccountSetupAdapter,
   createPatchedAccountSetupAdapter,
+  moveSingleAccountChannelSectionToDefaultAccount,
   prepareScopedSetupConfig,
 } from "./setup-helpers.js";
 
@@ -236,5 +237,54 @@ describe("prepareScopedSetupConfig", () => {
       enabled: true,
       name: "Libera",
     });
+  });
+});
+
+describe("moveSingleAccountChannelSectionToDefaultAccount", () => {
+  it("moves whatsapp allowSendTo from root to accounts.default", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          allowFrom: ["+111"],
+          allowSendTo: ["+222"],
+          dmPolicy: "allowlist",
+        },
+      },
+    } as OpenClawConfig;
+
+    const updated = moveSingleAccountChannelSectionToDefaultAccount({
+      cfg,
+      channelKey: "whatsapp",
+    });
+
+    const channel = (updated.channels as Record<string, unknown>).whatsapp as Record<
+      string,
+      unknown
+    >;
+    expect(channel.allowSendTo).toBeUndefined();
+
+    const accounts = channel.accounts as Record<string, Record<string, unknown>>;
+    expect(accounts[DEFAULT_ACCOUNT_ID]?.allowSendTo).toEqual(["+222"]);
+    expect(accounts[DEFAULT_ACCOUNT_ID]?.allowFrom).toEqual(["+111"]);
+  });
+
+  it("does not rewrite when accounts already exist", () => {
+    const cfg = {
+      channels: {
+        whatsapp: {
+          allowSendTo: ["+222"],
+          accounts: {
+            default: { dmPolicy: "allowlist" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const updated = moveSingleAccountChannelSectionToDefaultAccount({
+      cfg,
+      channelKey: "whatsapp",
+    });
+
+    expect(updated).toEqual(cfg);
   });
 });

--- a/src/channels/plugins/setup-helpers.ts
+++ b/src/channels/plugins/setup-helpers.ts
@@ -329,6 +329,7 @@ const COMMON_SINGLE_ACCOUNT_KEYS_TO_MOVE = new Set([
   "code",
   "dmPolicy",
   "allowFrom",
+  "allowSendTo",
   "groupPolicy",
   "groupAllowFrom",
   "defaultTo",

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -101,6 +101,10 @@ export type ChannelConfigAdapter<ResolvedAccount> = {
     cfg: OpenClawConfig;
     accountId?: string | null;
   }) => Array<string | number> | undefined;
+  resolveAllowSendTo?: (params: {
+    cfg: OpenClawConfig;
+    accountId?: string | null;
+  }) => Array<string | number> | undefined;
   formatAllowFrom?: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;
@@ -160,6 +164,7 @@ export type ChannelOutboundAdapter = {
     cfg?: OpenClawConfig;
     to?: string;
     allowFrom?: string[];
+    allowSendTo?: string[];
     accountId?: string | null;
     mode?: ChannelOutboundTargetMode;
   }) => { ok: true; to: string } | { ok: false; error: Error };

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -168,6 +168,7 @@ export type ChannelAccountSnapshot = {
   mode?: string;
   dmPolicy?: string;
   allowFrom?: string[];
+  allowSendTo?: string[];
   tokenSource?: string;
   botTokenSource?: string;
   appTokenSource?: string;

--- a/src/channels/plugins/whatsapp-shared.ts
+++ b/src/channels/plugins/whatsapp-shared.ts
@@ -40,8 +40,8 @@ export function createWhatsAppOutboundBase({
   sendMessageWhatsApp,
   sendPollWhatsApp,
   shouldLogVerbose,
-  resolveTarget = ({ to, allowFrom, mode }) =>
-    resolveWhatsAppOutboundTarget({ to, allowFrom, mode }),
+  resolveTarget = ({ to, allowFrom, allowSendTo, mode }) =>
+    resolveWhatsAppOutboundTarget({ to, allowFrom, allowSendTo, mode }),
   normalizeText = (text) => text ?? "",
   skipEmptyText = false,
 }: CreateWhatsAppOutboundBaseParams): Pick<

--- a/src/commands/channels.config-only-status-output.test.ts
+++ b/src/commands/channels.config-only-status-output.test.ts
@@ -155,6 +155,47 @@ function makeUnavailableHttpSlackPlugin(): ChannelPlugin {
   });
 }
 
+function makeWhatsAppConfigOnlyStatusPlugin(): ChannelPlugin {
+  return {
+    id: "whatsapp",
+    meta: {
+      id: "whatsapp",
+      label: "WhatsApp",
+      selectionLabel: "WhatsApp",
+      docsPath: "/channels/whatsapp",
+      blurb: "test",
+    },
+    capabilities: { chatTypes: ["direct", "group"] },
+    config: {
+      listAccountIds: () => ["default"],
+      defaultAccountId: () => "default",
+      resolveAccount: () => ({
+        name: "Primary",
+        enabled: true,
+        configured: true,
+        dmPolicy: "allowlist",
+        allowFrom: ["+111"],
+        allowSendTo: [],
+      }),
+      isConfigured: () => true,
+      isEnabled: () => true,
+    },
+    status: {
+      buildAccountSnapshot: async ({ account }) => ({
+        accountId: "default",
+        enabled: true,
+        configured: true,
+        dmPolicy: (account as { dmPolicy?: string }).dmPolicy,
+        allowFrom: (account as { allowFrom?: string[] }).allowFrom,
+        allowSendTo: (account as { allowSendTo?: string[] }).allowSendTo,
+      }),
+    },
+    actions: {
+      describeMessageTool: () => ({ actions: ["send"] }),
+    },
+  };
+}
+
 function expectResolvedTokenStatusSummary(
   summary: string,
   options?: { includeUnavailableTokenLine?: boolean },
@@ -215,5 +256,15 @@ describe("config-only channels status output", () => {
     expect(joined).toContain("mode:http");
     expect(joined).toContain("bot:config");
     expect(joined).toContain("signing:config (unavailable)");
+  });
+
+  it("renders explicit empty allowSendTo in config-only status output", async () => {
+    registerSingleTestPlugin("whatsapp", makeWhatsAppConfigOnlyStatusPlugin());
+
+    const joined = await formatLocalStatusSummary({ channels: {} });
+    expect(joined).toContain("WhatsApp");
+    expect(joined).toContain("dm:allowlist");
+    expect(joined).toContain("allow:+111");
+    expect(joined).toContain("sendTo:none");
   });
 });

--- a/src/commands/channels/status.ts
+++ b/src/commands/channels/status.ts
@@ -144,6 +144,13 @@ export function formatGatewayChannelsStatusLines(payload: Record<string, unknown
       if (Array.isArray(account.allowFrom) && account.allowFrom.length > 0) {
         bits.push(`allow:${account.allowFrom.slice(0, 2).join(",")}`);
       }
+      if (Array.isArray(account.allowSendTo)) {
+        bits.push(
+          account.allowSendTo.length > 0
+            ? `sendTo:${account.allowSendTo.slice(0, 2).join(",")}`
+            : "sendTo:none",
+        );
+      }
       appendTokenSourceBits(bits, account);
       const application = account.application as
         | { intents?: { messageContent?: string } }

--- a/src/commands/channels/status.ts
+++ b/src/commands/channels/status.ts
@@ -79,6 +79,22 @@ function appendBaseUrlBit(bits: string[], account: Record<string, unknown>) {
   }
 }
 
+function appendDirectMessageRoutingBits(bits: string[], account: Record<string, unknown>) {
+  if (typeof account.dmPolicy === "string" && account.dmPolicy.length > 0) {
+    bits.push(`dm:${account.dmPolicy}`);
+  }
+  if (Array.isArray(account.allowFrom) && account.allowFrom.length > 0) {
+    bits.push(`allow:${account.allowFrom.slice(0, 2).join(",")}`);
+  }
+  if (Array.isArray(account.allowSendTo)) {
+    bits.push(
+      account.allowSendTo.length > 0
+        ? `sendTo:${account.allowSendTo.slice(0, 2).join(",")}`
+        : "sendTo:none",
+    );
+  }
+}
+
 function buildChannelAccountLine(
   provider: ChatChannel,
   account: Record<string, unknown>,
@@ -138,19 +154,7 @@ export function formatGatewayChannelsStatusLines(payload: Record<string, unknown
       if (botUsername) {
         bits.push(`bot:${botUsername}`);
       }
-      if (typeof account.dmPolicy === "string" && account.dmPolicy.length > 0) {
-        bits.push(`dm:${account.dmPolicy}`);
-      }
-      if (Array.isArray(account.allowFrom) && account.allowFrom.length > 0) {
-        bits.push(`allow:${account.allowFrom.slice(0, 2).join(",")}`);
-      }
-      if (Array.isArray(account.allowSendTo)) {
-        bits.push(
-          account.allowSendTo.length > 0
-            ? `sendTo:${account.allowSendTo.slice(0, 2).join(",")}`
-            : "sendTo:none",
-        );
-      }
+      appendDirectMessageRoutingBits(bits, account);
       appendTokenSourceBits(bits, account);
       const application = account.application as
         | { intents?: { messageContent?: string } }
@@ -238,6 +242,7 @@ export async function formatConfigChannelsStatusLines(
       const bits: string[] = [];
       appendEnabledConfiguredLinkedBits(bits, account);
       appendModeBit(bits, account);
+      appendDirectMessageRoutingBits(bits, account);
       appendTokenSourceBits(bits, account);
       appendBaseUrlBit(bits, account);
       return buildChannelAccountLine(provider, account, bits);

--- a/src/config/types.whatsapp.ts
+++ b/src/config/types.whatsapp.ts
@@ -47,6 +47,8 @@ type WhatsAppSharedConfig = {
   selfChatMode?: boolean;
   /** Optional allowlist for WhatsApp direct chats (E.164). */
   allowFrom?: string[];
+  /** Optional allowlist for outbound WhatsApp sends (E.164). When set, overrides allowFrom for outbound target resolution. Use ["*"] for unrestricted outbound. */
+  allowSendTo?: string[];
   /** Default delivery target for CLI `--deliver` when no explicit `--reply-to` is provided (E.164 or group JID). */
   defaultTo?: string;
   /** Optional allowlist for WhatsApp group senders (E.164). */

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -45,6 +45,7 @@ const WhatsAppSharedSchema = z.object({
   dmPolicy: DmPolicySchema.optional().default("pairing"),
   selfChatMode: z.boolean().optional(),
   allowFrom: z.array(z.string()).optional(),
+  allowSendTo: z.array(z.string()).optional(),
   defaultTo: z.string().optional(),
   groupAllowFrom: z.array(z.string()).optional(),
   groupPolicy: GroupPolicySchema.optional().default("allowlist"),

--- a/src/cron/isolated-agent/delivery-target.ts
+++ b/src/cron/isolated-agent/delivery-target.ts
@@ -16,7 +16,7 @@ import {
 import { readChannelAllowFromStoreSync } from "../../pairing/pairing-store.js";
 import { buildChannelAccountBindings } from "../../routing/bindings.js";
 import { normalizeAccountId, normalizeAgentId } from "../../routing/session-key.js";
-import { normalizeWhatsAppTarget } from "../../whatsapp/normalize.js";
+import { isWhatsAppGroupJid, normalizeWhatsAppTarget } from "../../whatsapp/normalize.js";
 
 export type DeliveryTargetResolution =
   | {
@@ -150,10 +150,11 @@ export async function resolveDeliveryTarget(
   }
 
   let allowFromOverride: string[] | undefined;
+  let allowSendToOverride: string[] | undefined;
   if (channel === "whatsapp") {
     const resolvedAccountId = normalizeAccountId(accountId);
-    const configuredAllowFromRaw =
-      resolveWhatsAppAccount({ cfg, accountId: resolvedAccountId }).allowFrom ?? [];
+    const whatsappAccount = resolveWhatsAppAccount({ cfg, accountId: resolvedAccountId });
+    const configuredAllowFromRaw = whatsappAccount.allowFrom ?? [];
     const configuredAllowFrom = configuredAllowFromRaw
       .map((entry) => String(entry).trim())
       .filter((entry) => entry && entry !== "*")
@@ -163,11 +164,33 @@ export async function resolveDeliveryTarget(
       .map((entry) => normalizeWhatsAppTarget(entry))
       .filter((entry): entry is string => Boolean(entry));
     allowFromOverride = [...new Set([...configuredAllowFrom, ...storeAllowFrom])];
+    allowSendToOverride = whatsappAccount.allowSendTo;
 
-    if (toCandidate && mode === "implicit" && allowFromOverride.length > 0) {
+    // When allowSendTo is explicitly defined, use it for implicit-mode target
+    // validation. Otherwise fall back to allowFromOverride (already normalized
+    // and wildcard-stripped above).
+    const hasExplicitSendTo = allowSendToOverride !== undefined && allowSendToOverride !== null;
+    const normalizedAllowSendTo = allowSendToOverride
+      ?.map((entry) => String(entry).trim())
+      .filter((entry) => entry && entry !== "*")
+      .map((entry) => normalizeWhatsAppTarget(entry))
+      .filter((entry): entry is string => Boolean(entry));
+    const hasSendToWildcard =
+      hasExplicitSendTo &&
+      (allowSendToOverride ?? []).some((entry) => String(entry).trim() === "*");
+    const effectiveSendList = hasExplicitSendTo ? (normalizedAllowSendTo ?? []) : allowFromOverride;
+
+    if (toCandidate && mode === "implicit" && effectiveSendList.length > 0 && !hasSendToWildcard) {
       const normalizedCurrentTarget = normalizeWhatsAppTarget(toCandidate);
-      if (!normalizedCurrentTarget || !allowFromOverride.includes(normalizedCurrentTarget)) {
-        toCandidate = allowFromOverride[0];
+      // Group JIDs bypass allowSendTo (governed by groupPolicy instead).
+      if (
+        normalizedCurrentTarget &&
+        !isWhatsAppGroupJid(normalizedCurrentTarget) &&
+        !effectiveSendList.includes(normalizedCurrentTarget)
+      ) {
+        toCandidate = effectiveSendList[0];
+      } else if (!normalizedCurrentTarget) {
+        toCandidate = effectiveSendList[0];
       }
     }
   }
@@ -179,6 +202,7 @@ export async function resolveDeliveryTarget(
     accountId,
     mode,
     allowFrom: allowFromOverride,
+    allowSendTo: allowSendToOverride,
   });
   if (!docked.ok) {
     return {

--- a/src/gateway/protocol/schema/channels.ts
+++ b/src/gateway/protocol/schema/channels.ts
@@ -118,6 +118,7 @@ export const ChannelAccountSnapshotSchema = Type.Object(
     mode: Type.Optional(Type.String()),
     dmPolicy: Type.Optional(Type.String()),
     allowFrom: Type.Optional(Type.Array(Type.String())),
+    allowSendTo: Type.Optional(Type.Array(Type.String())),
     tokenSource: Type.Optional(Type.String()),
     botTokenSource: Type.Optional(Type.String()),
     appTokenSource: Type.Optional(Type.String()),

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -185,6 +185,7 @@ export function resolveOutboundTarget(params: {
   channel: GatewayMessageChannel;
   to?: string;
   allowFrom?: string[];
+  allowSendTo?: string[];
   cfg?: OpenClawConfig;
   accountId?: string | null;
   mode?: ChannelOutboundTargetMode;
@@ -219,6 +220,16 @@ export function resolveOutboundTarget(params: {
       : undefined);
   const allowFrom = allowFromRaw ? mapAllowFromEntries(allowFromRaw) : undefined;
 
+  const allowSendToRaw =
+    params.allowSendTo ??
+    (params.cfg && plugin.config.resolveAllowSendTo
+      ? plugin.config.resolveAllowSendTo({
+          cfg: params.cfg,
+          accountId: params.accountId ?? undefined,
+        })
+      : undefined);
+  const allowSendTo = allowSendToRaw?.map((entry) => String(entry));
+
   // Fall back to per-channel defaultTo when no explicit target is provided.
   const effectiveTo =
     params.to?.trim() ||
@@ -235,6 +246,7 @@ export function resolveOutboundTarget(params: {
       cfg: params.cfg,
       to: effectiveTo,
       allowFrom,
+      allowSendTo,
       accountId: params.accountId ?? undefined,
       mode: params.mode ?? "explicit",
     });

--- a/src/plugin-sdk/channel-config-helpers.ts
+++ b/src/plugin-sdk/channel-config-helpers.ts
@@ -47,13 +47,17 @@ export function createScopedAccountConfigAccessors<
 >(params: {
   resolveAccount: (params: { cfg: Config; accountId?: string | null }) => ResolvedAccount;
   resolveAllowFrom: (account: ResolvedAccount) => Array<string | number> | null | undefined;
+  resolveAllowSendTo?: (account: ResolvedAccount) => Array<string | number> | null | undefined;
   formatAllowFrom: (allowFrom: Array<string | number>) => string[];
   resolveDefaultTo?: (account: ResolvedAccount) => string | number | null | undefined;
 }): Pick<
   ChannelConfigAdapter<ResolvedAccount>,
-  "resolveAllowFrom" | "formatAllowFrom" | "resolveDefaultTo"
+  "resolveAllowFrom" | "resolveAllowSendTo" | "formatAllowFrom" | "resolveDefaultTo"
 > {
-  const base = {
+  const base: Pick<
+    ChannelConfigAdapter<ResolvedAccount>,
+    "resolveAllowFrom" | "resolveAllowSendTo" | "formatAllowFrom"
+  > = {
     resolveAllowFrom: ({ cfg, accountId }: { cfg: OpenClawConfig; accountId?: string | null }) =>
       mapAllowFromEntries(
         params.resolveAllowFrom(params.resolveAccount({ cfg: cfg as Config, accountId })),
@@ -61,6 +65,16 @@ export function createScopedAccountConfigAccessors<
     formatAllowFrom: ({ allowFrom }: { allowFrom: Array<string | number> }) =>
       params.formatAllowFrom(allowFrom),
   };
+
+  if (params.resolveAllowSendTo) {
+    const resolveAllowSendToFn = params.resolveAllowSendTo;
+    base.resolveAllowSendTo = ({ cfg, accountId }) => {
+      const entries = resolveAllowSendToFn(
+        params.resolveAccount({ cfg: cfg as Config, accountId }),
+      );
+      return entries ? mapAllowFromEntries(entries) : undefined;
+    };
+  }
 
   if (!params.resolveDefaultTo) {
     return base;
@@ -136,6 +150,7 @@ export function createScopedChannelConfigAdapter<
   clearBaseFields: string[];
   allowTopLevel?: boolean;
   resolveAllowFrom: (account: AccessorAccount) => Array<string | number> | null | undefined;
+  resolveAllowSendTo?: (account: AccessorAccount) => Array<string | number> | null | undefined;
   formatAllowFrom: (allowFrom: Array<string | number>) => string[];
   resolveDefaultTo?: (account: AccessorAccount) => string | number | null | undefined;
 }): Pick<
@@ -147,6 +162,7 @@ export function createScopedChannelConfigAdapter<
   | "setAccountEnabled"
   | "deleteAccount"
   | "resolveAllowFrom"
+  | "resolveAllowSendTo"
   | "formatAllowFrom"
   | "resolveDefaultTo"
 > {
@@ -168,6 +184,7 @@ export function createScopedChannelConfigAdapter<
     ...createScopedAccountConfigAccessors<AccessorAccount, Config>({
       resolveAccount: resolveAccessorAccount,
       resolveAllowFrom: params.resolveAllowFrom,
+      resolveAllowSendTo: params.resolveAllowSendTo,
       formatAllowFrom: params.formatAllowFrom,
       resolveDefaultTo: params.resolveDefaultTo,
     }),
@@ -292,6 +309,7 @@ export function createTopLevelChannelConfigAdapter<
   deleteMode?: "remove-section" | "clear-fields";
   clearBaseFields?: string[];
   resolveAllowFrom: (account: AccessorAccount) => Array<string | number> | null | undefined;
+  resolveAllowSendTo?: (account: AccessorAccount) => Array<string | number> | null | undefined;
   formatAllowFrom: (allowFrom: Array<string | number>) => string[];
   resolveDefaultTo?: (account: AccessorAccount) => string | number | null | undefined;
 }): Pick<
@@ -303,6 +321,7 @@ export function createTopLevelChannelConfigAdapter<
   | "setAccountEnabled"
   | "deleteAccount"
   | "resolveAllowFrom"
+  | "resolveAllowSendTo"
   | "formatAllowFrom"
   | "resolveDefaultTo"
 > {
@@ -324,6 +343,7 @@ export function createTopLevelChannelConfigAdapter<
     ...createScopedAccountConfigAccessors<AccessorAccount, Config>({
       resolveAccount: resolveAccessorAccount,
       resolveAllowFrom: params.resolveAllowFrom,
+      resolveAllowSendTo: params.resolveAllowSendTo,
       formatAllowFrom: params.formatAllowFrom,
       resolveDefaultTo: params.resolveDefaultTo,
     }),
@@ -414,6 +434,7 @@ export function createHybridChannelConfigAdapter<
   clearBaseFields: string[];
   preserveSectionOnDefaultDelete?: boolean;
   resolveAllowFrom: (account: AccessorAccount) => Array<string | number> | null | undefined;
+  resolveAllowSendTo?: (account: AccessorAccount) => Array<string | number> | null | undefined;
   formatAllowFrom: (allowFrom: Array<string | number>) => string[];
   resolveDefaultTo?: (account: AccessorAccount) => string | number | null | undefined;
 }): Pick<
@@ -425,6 +446,7 @@ export function createHybridChannelConfigAdapter<
   | "setAccountEnabled"
   | "deleteAccount"
   | "resolveAllowFrom"
+  | "resolveAllowSendTo"
   | "formatAllowFrom"
   | "resolveDefaultTo"
 > {
@@ -446,6 +468,7 @@ export function createHybridChannelConfigAdapter<
     ...createScopedAccountConfigAccessors<AccessorAccount, Config>({
       resolveAccount: resolveAccessorAccount,
       resolveAllowFrom: params.resolveAllowFrom,
+      resolveAllowSendTo: params.resolveAllowSendTo,
       formatAllowFrom: params.formatAllowFrom,
       resolveDefaultTo: params.resolveDefaultTo,
     }),

--- a/src/plugin-sdk/channel-config-helpers.ts
+++ b/src/plugin-sdk/channel-config-helpers.ts
@@ -512,6 +512,19 @@ export function resolveWhatsAppConfigAllowFrom(params: {
     : [];
 }
 
+export function resolveWhatsAppConfigAllowSendTo(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): string[] | undefined {
+  const account = getChannelPlugin("whatsapp")?.config.resolveAccount(params.cfg, params.accountId);
+  return account &&
+    typeof account === "object" &&
+    "allowSendTo" in account &&
+    Array.isArray(account.allowSendTo)
+    ? account.allowSendTo.map(String)
+    : undefined;
+}
+
 /** Format WhatsApp allowlist entries with the same normalization used by the channel plugin. */
 export function formatWhatsAppConfigAllowFromEntries(allowFrom: Array<string | number>): string[] {
   return normalizeWhatsAppAllowFromEntries(allowFrom);

--- a/src/plugin-sdk/whatsapp.ts
+++ b/src/plugin-sdk/whatsapp.ts
@@ -30,6 +30,7 @@ export { formatDocsLink } from "../terminal/links.js";
 export {
   formatWhatsAppConfigAllowFromEntries,
   resolveWhatsAppConfigAllowFrom,
+  resolveWhatsAppConfigAllowSendTo,
   resolveWhatsAppConfigDefaultTo,
 } from "./channel-config-helpers.js";
 export { normalizeWhatsAppAllowFromEntries } from "../channels/plugins/normalize/whatsapp.js";

--- a/src/whatsapp/resolve-outbound-target.test.ts
+++ b/src/whatsapp/resolve-outbound-target.test.ts
@@ -38,6 +38,7 @@ function expectAllowedForTarget(params: {
   allowFrom: ResolveParams["allowFrom"];
   mode: ResolveParams["mode"];
   to?: string;
+  allowSendTo?: ResolveParams["allowSendTo"];
 }) {
   const to = params.to ?? PRIMARY_TARGET;
   expectResolutionOk(
@@ -45,6 +46,7 @@ function expectAllowedForTarget(params: {
       to,
       allowFrom: params.allowFrom,
       mode: params.mode,
+      allowSendTo: params.allowSendTo,
     },
     to,
   );
@@ -54,11 +56,13 @@ function expectDeniedForTarget(params: {
   allowFrom: ResolveParams["allowFrom"];
   mode: ResolveParams["mode"];
   to?: string;
+  allowSendTo?: ResolveParams["allowSendTo"];
 }) {
   expectResolutionError({
     to: params.to ?? PRIMARY_TARGET,
     allowFrom: params.allowFrom,
     mode: params.mode,
+    allowSendTo: params.allowSendTo,
   });
 }
 
@@ -200,6 +204,64 @@ describe("resolveWhatsAppOutboundTarget", () => {
     it("allows message in custom mode string when target is in allowList", () => {
       mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
       expectAllowedForTarget({ allowFrom: [PRIMARY_TARGET], mode: "broadcast" });
+    });
+  });
+
+  describe("allowSendTo override", () => {
+    it("allows message when target is in allowSendTo even if not in allowFrom", () => {
+      // Mock order: allowSendTo[0] normalize, then 'to' normalize (allowFrom is skipped)
+      mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
+      expectAllowedForTarget({
+        allowFrom: [SECONDARY_TARGET],
+        mode: "implicit",
+        allowSendTo: [PRIMARY_TARGET],
+      });
+    });
+
+    it("denies message when target is not in allowSendTo even if in allowFrom", () => {
+      // Mock order: allowSendTo[0] normalize, then 'to' normalize (allowFrom is skipped)
+      mockNormalizedDirectMessage(SECONDARY_TARGET, PRIMARY_TARGET);
+      expectDeniedForTarget({
+        allowFrom: [PRIMARY_TARGET],
+        mode: "implicit",
+        allowSendTo: [SECONDARY_TARGET],
+      });
+    });
+
+    it("allows any target when allowSendTo contains wildcard", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET);
+      expectAllowedForTarget({
+        allowFrom: [SECONDARY_TARGET],
+        mode: "implicit",
+        allowSendTo: ["*"],
+      });
+    });
+
+    it("falls back to allowFrom when allowSendTo is undefined", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
+      expectAllowedForTarget({
+        allowFrom: [PRIMARY_TARGET],
+        mode: "implicit",
+        allowSendTo: undefined,
+      });
+    });
+
+    it("falls back to allowFrom when allowSendTo is undefined and target not in list", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
+      expectDeniedForTarget({
+        allowFrom: [SECONDARY_TARGET],
+        mode: "implicit",
+        allowSendTo: undefined,
+      });
+    });
+
+    it("blocks all outbound when allowSendTo is empty array", () => {
+      mockNormalizedDirectMessage(PRIMARY_TARGET);
+      expectDeniedForTarget({
+        allowFrom: ["*"],
+        mode: "implicit",
+        allowSendTo: [],
+      });
     });
   });
 

--- a/src/whatsapp/resolve-outbound-target.ts
+++ b/src/whatsapp/resolve-outbound-target.ts
@@ -8,14 +8,19 @@ export type WhatsAppOutboundTargetResolution =
 export function resolveWhatsAppOutboundTarget(params: {
   to: string | null | undefined;
   allowFrom: Array<string | number> | null | undefined;
+  allowSendTo?: Array<string | number> | null | undefined;
   mode: string | null | undefined;
 }): WhatsAppOutboundTargetResolution {
   const trimmed = params.to?.trim() ?? "";
-  const allowListRaw = (params.allowFrom ?? [])
+
+  // When allowSendTo is explicitly defined, use it for outbound checks.
+  // Otherwise fall back to allowFrom (legacy behavior).
+  const hasExplicitSendTo = params.allowSendTo !== undefined && params.allowSendTo !== null;
+  const outboundListRaw = (hasExplicitSendTo ? params.allowSendTo! : (params.allowFrom ?? []))
     .map((entry) => String(entry).trim())
     .filter(Boolean);
-  const hasWildcard = allowListRaw.includes("*");
-  const allowList = allowListRaw
+  const hasWildcard = outboundListRaw.includes("*");
+  const outboundList = outboundListRaw
     .filter((entry) => entry !== "*")
     .map((entry) => normalizeWhatsAppTarget(entry))
     .filter((entry): entry is string => Boolean(entry));
@@ -28,15 +33,19 @@ export function resolveWhatsAppOutboundTarget(params: {
         error: missingTargetError("WhatsApp", "<E.164|group JID>"),
       };
     }
+    // Group JIDs bypass allowFrom/allowSendTo intentionally: group sends are
+    // governed by the separate groupPolicy/groupAllowFrom axis, not by the
+    // per-DM allowlist.  This matches legacy allowFrom behavior and keeps
+    // allowSendTo semantically consistent as a DM-only outbound gate.
     if (isWhatsAppGroupJid(normalizedTo)) {
       return { ok: true, to: normalizedTo };
     }
-    // Enforce allowFrom for all direct-message send modes (including explicit).
-    // Group destinations are handled by group policy and are allowed above.
-    if (hasWildcard || allowList.length === 0) {
+    // When allowSendTo is explicitly set, empty means "block all".
+    // Legacy allowFrom behavior: empty means "allow all" (no restrictions).
+    if (hasWildcard || (!hasExplicitSendTo && outboundList.length === 0)) {
       return { ok: true, to: normalizedTo };
     }
-    if (allowList.includes(normalizedTo)) {
+    if (outboundList.includes(normalizedTo)) {
       return { ok: true, to: normalizedTo };
     }
     return {


### PR DESCRIPTION
## Summary

- Adds `allowSendTo?: string[]` config field for WhatsApp accounts, enabling independent outbound target gating separate from the inbound `allowFrom` list
- When `allowSendTo` is defined, it controls which numbers the agent can send messages to; `allowFrom` continues to control who can message the agent
- `allowSendTo: ["*"]` allows unrestricted outbound while keeping inbound restricted
- Falls back to `allowFrom` behavior when `allowSendTo` is not set (fully backward compatible)

## Design decisions

- **Group JIDs bypass `allowSendTo` intentionally**: group sends are governed by `groupPolicy`/`groupAllowFrom`, not by the per-DM allowlist. This matches existing `allowFrom` behavior.
- **`allowSendTo: []` means "block all outbound"** (unlike `allowFrom: []` which means "allow all"). Enforced via `hasExplicitSendTo` flag.
- **Cron implicit-mode target substitution** uses `allowSendTo` when defined, with proper normalization and wildcard detection.

## Test plan

- [x] `pnpm tsgo` passes
- [x] `pnpm check` passes
- [x] `pnpm test` passes (6490 tests, 0 failures)
- [x] New unit tests for `allowSendTo` override in `resolve-outbound-target.test.ts`
- [x] Manual test: outbound with `allowSendTo: ["*"]` works, inbound still gated

Fixes #30087, #25039

🤖 Generated with [Claude Code](https://claude.com/claude-code)