### PR TITLE
feat(secrets): HWVault hardware-backed delegation integration (single PR)

### DIFF
--- a/docs/cli/secrets.md
+++ b/docs/cli/secrets.md
@@ -129,6 +129,7 @@ Exec provider safety note:
 - Homebrew installs often expose symlinked binaries under `/opt/homebrew/bin/*`.
 - Set `allowSymlinkCommand: true` only when needed for trusted package-manager paths, and pair it with `trustedDirs` (for example `["/opt/homebrew"]`).
 - On Windows, if ACL verification is unavailable for a provider path, OpenClaw fails closed. For trusted paths only, set `allowInsecurePath: true` on that provider to bypass path security checks.
+- `secrets configure` includes an optional **HWVault resolver preset** for exec providers. It can prefill a hardware trust-root mode (TPM, YubiKey, or TPM/YubiKey) and include identity pass-through env keys for delegation workflows.
 
 ## Apply a saved plan
 

--- a/docs/gateway/hwvault-integration.md
+++ b/docs/gateway/hwvault-integration.md
@@ -1,0 +1,205 @@
+---
+summary: "Integrate OpenClaw SecretRefs with hwvault (TPM/passkey/fingerprint-backed)"
+read_when:
+  - You want OpenClaw secrets sourced from hwvault
+  - You want hardware-backed unlock + policy gate before agent secret access
+title: "HWVault Integration"
+---
+
+# HWVault integration
+
+This guide shows how to wire `hwvault` into OpenClaw using SecretRef **exec providers**.
+
+The model is:
+
+- OpenClaw stores **refs**, not plaintext credentials.
+- OpenClaw calls a local resolver binary using the exec provider protocol.
+- The resolver fetches values from `hwvault` (which can be TPM/passkey/fingerprint gated).
+
+## Why this pattern
+
+- Keeps long-lived secrets out of `openclaw.json`.
+- Lets you enforce hardware-backed unlock outside request hot paths.
+- Works with existing OpenClaw `secrets audit/configure/apply/reload` flows.
+
+## 1) Install and initialize hwvault
+
+Example (adjust to your environment):
+
+```bash
+hwvault init
+hwvault unlock
+```
+
+Store secret material under stable names (example):
+
+```bash
+hwvault store openai-api-key ignored-user "sk-..."
+hwvault store anthropic-api-key ignored-user "sk-ant-..."
+```
+
+## 2) Add an OpenClaw exec provider
+
+Add a provider that calls a local resolver script/binary:
+
+```json5
+{
+  secrets: {
+    providers: {
+      hwvault: {
+        source: "exec",
+        command: "/usr/local/bin/openclaw-hwvault-resolver",
+        passEnv: ["PATH", "HOME"],
+        timeoutMs: 5000,
+        jsonOnly: true,
+      },
+    },
+    defaults: {
+      exec: "hwvault",
+    },
+  },
+}
+```
+
+Then use SecretRefs in credential fields:
+
+```json5
+{
+  models: {
+    providers: {
+      openai: {
+        apiKey: { source: "exec", provider: "hwvault", id: "openai-api-key" },
+      },
+      anthropic: {
+        apiKey: { source: "exec", provider: "hwvault", id: "anthropic-api-key" },
+      },
+    },
+  },
+}
+```
+
+## 3) Resolver contract (stdin/stdout)
+
+OpenClaw sends:
+
+```json
+{ "protocolVersion": 1, "provider": "hwvault", "ids": ["openai-api-key"] }
+```
+
+Resolver returns:
+
+```json
+{ "protocolVersion": 1, "values": { "openai-api-key": "sk-..." } }
+```
+
+You may also return per-id errors:
+
+```json
+{
+  "protocolVersion": 1,
+  "values": {},
+  "errors": {
+    "openai-api-key": { "message": "not found" }
+  }
+}
+```
+
+## 4) Minimal resolver example
+
+This example maps each OpenClaw `id` to `hwvault get <id>` and returns the password field.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+req="$(cat)"
+ids_json="$(jq -c '.ids // []' <<<"$req")"
+
+values='{}'
+errors='{}'
+
+while IFS= read -r id; do
+  if out="$(hwvault get "$id" 2>/dev/null)"; then
+    # expected format from hwvault get: Name/User/Pass/... lines
+    pass="$(awk -F': ' '/^Pass:/ {print $2; exit}' <<<"$out")"
+    if [[ -n "$pass" ]]; then
+      values="$(jq --arg id "$id" --arg v "$pass" '. + {($id): $v}' <<<"$values")"
+    else
+      errors="$(jq --arg id "$id" '. + {($id): {"message":"secret payload missing Pass field"}}' <<<"$errors")"
+    fi
+  else
+    errors="$(jq --arg id "$id" '. + {($id): {"message":"hwvault get failed"}}' <<<"$errors")"
+  fi
+done < <(jq -r '.[]' <<<"$ids_json")
+
+jq -n --argjson values "$values" --argjson errors "$errors" '{
+  protocolVersion: 1,
+  values: $values,
+  errors: (if ($errors|length) > 0 then $errors else empty end)
+}'
+```
+
+Hardening recommendations:
+
+- Keep resolver executable root-owned and non-writable by other users.
+- Restrict accepted `id` values (allowlist/prefix checks).
+- Add policy checks before returning secrets (agent/session mapping).
+- Emit audit logs without writing secret values.
+
+## 5) Delegation: short-lived tokens for agents
+
+For high-trust setups, avoid returning long-lived static secrets directly to agent-callers.
+Issue short-lived, one-time delegation tokens and redeem them only where needed.
+
+Example flow:
+
+1. `delegate-issue <id> [ttlSeconds]` on resolver side
+2. pass token to the agent task runtime
+3. `delegate-redeem <token>` right before use
+4. token is consumed and cannot be replayed
+
+Notes:
+
+- Keep TTL short (for example 60–300s).
+- Scope tokens per secret id and requester identity when possible.
+- Deny by default on policy mismatch.
+
+## 6) Auditability requirements
+
+A production-grade integration should keep a tamper-evident audit trail for secret resolution decisions:
+
+- event fields: timestamp, requester, secret id, decision, reason
+- hash-chain or signed-event integrity metadata
+- strict redaction (never log secret payloads)
+
+## 7) Apply + verify
+
+```bash
+openclaw secrets audit --check
+openclaw secrets reload
+openclaw secrets audit --check
+```
+
+If using migration helpers:
+
+```bash
+openclaw secrets configure
+openclaw secrets apply --from /tmp/openclaw-secrets-plan.json
+openclaw secrets reload
+```
+
+## Release gate checklist (recommended)
+
+Before shipping to production, require all of the following:
+
+- merge-clean integration path to current OpenClaw main
+- hardware trust-root verification (TPM/YubiKey) in real-host tests
+- short-lived delegation token enforcement (TTL + one-time redemption)
+- policy enforcement (deny-by-default)
+- tamper-evident audit trail and redaction checks
+
+## Notes
+
+- OpenClaw currently treats hwvault as an external resolver via `source: "exec"`.
+- This gives immediate compatibility without adding a new built-in secret source type.
+- For stronger delegation, have the resolver issue short-lived tokens or enforce per-agent policy before resolving each id.

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -19,6 +19,9 @@ Use this page for day-1 startup and day-2 operations of the Gateway service.
   <Card title="Secrets management" icon="key-round" href="/gateway/secrets">
     SecretRef contract, runtime snapshot behavior, and migrate/reload operations.
   </Card>
+  <Card title="HWVault integration" icon="key-square" href="/gateway/hwvault-integration">
+    Use hardware-backed `hwvault` with OpenClaw SecretRef exec providers.
+  </Card>
   <Card title="Secrets plan contract" icon="shield-check" href="/gateway/secrets-plan-contract">
     Exact `secrets apply` target/path rules and ref-only auth-profile behavior.
   </Card>

--- a/docs/gateway/secrets.md
+++ b/docs/gateway/secrets.md
@@ -279,7 +279,13 @@ Optional per-id errors:
 }
 ```
 
-## Supported credential surface
+### `hwvault`
+
+Use `hwvault` through an exec resolver adapter (protocol stdin/stdout). See:
+
+- [HWVault Integration](/gateway/hwvault-integration)
+
+## In-scope fields (v1)
 
 Canonical supported and unsupported credentials are listed in:
 

--- a/src/secrets/configure.hwvault.test.ts
+++ b/src/secrets/configure.hwvault.test.ts
@@ -37,6 +37,15 @@ describe("applyHwvaultPresetToExecProvider", () => {
       policyPath: "/tmp/policy.json",
     });
 
-    expect(result.passEnv).toHaveLength(4);
+    expect(result.passEnv).toEqual([
+      "OPENCLAW_AGENT_ID",
+      "OPENCLAW_SESSION_KEY",
+      "OPENCLAW_DELEGATION_AUDIENCE",
+      "HWVAULT_BIN",
+    ]);
+    expect(result.env).toMatchObject({
+      HWVAULT_POLICY_PATH: "/tmp/policy.json",
+      HWVAULT_TRUST_ROOTS: "tpm",
+    });
   });
 });

--- a/src/secrets/configure.hwvault.test.ts
+++ b/src/secrets/configure.hwvault.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { applyHwvaultPresetToExecProvider } from "./configure.js";
+
+describe("applyHwvaultPresetToExecProvider", () => {
+  it("adds required pass-through env names and policy env values", () => {
+    const result = applyHwvaultPresetToExecProvider({
+      passEnv: ["PATH", "HWVAULT_BIN"],
+      env: { EXISTING: "1" },
+      trustRoots: "tpm,yubikey",
+      policyPath: " ~/.config/hwvault/openclaw-policy.json ",
+    });
+
+    expect(result.passEnv).toEqual([
+      "PATH",
+      "HWVAULT_BIN",
+      "OPENCLAW_AGENT_ID",
+      "OPENCLAW_SESSION_KEY",
+      "OPENCLAW_DELEGATION_AUDIENCE",
+    ]);
+    expect(result.env).toMatchObject({
+      EXISTING: "1",
+      HWVAULT_POLICY_PATH: "~/.config/hwvault/openclaw-policy.json",
+      HWVAULT_TRUST_ROOTS: "tpm,yubikey",
+    });
+  });
+
+  it("does not duplicate required env keys", () => {
+    const result = applyHwvaultPresetToExecProvider({
+      passEnv: [
+        "OPENCLAW_AGENT_ID",
+        "OPENCLAW_SESSION_KEY",
+        "OPENCLAW_DELEGATION_AUDIENCE",
+        "HWVAULT_BIN",
+      ],
+      env: {},
+      trustRoots: "tpm",
+      policyPath: "/tmp/policy.json",
+    });
+
+    expect(result.passEnv).toHaveLength(4);
+  });
+});

--- a/src/secrets/configure.hwvault.test.ts
+++ b/src/secrets/configure.hwvault.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from "vitest";
-import { applyHwvaultPresetToExecProvider } from "./configure.js";
+import {
+  applyHwvaultPresetToExecProvider,
+  getHwvaultDefaultCommandForPlatform,
+} from "./configure.js";
+
+describe("getHwvaultDefaultCommandForPlatform", () => {
+  it("returns empty default for Windows", () => {
+    expect(getHwvaultDefaultCommandForPlatform("win32")).toBe("");
+  });
+
+  it("returns resolver path for non-Windows", () => {
+    expect(getHwvaultDefaultCommandForPlatform("linux")).toBe(
+      "/usr/local/bin/openclaw-hwvault-resolver",
+    );
+  });
+});
 
 describe("applyHwvaultPresetToExecProvider", () => {
   it("adds required pass-through env names and policy env values", () => {

--- a/src/secrets/configure.ts
+++ b/src/secrets/configure.ts
@@ -50,6 +50,34 @@ function parseCsv(value: string): string[] {
     .filter((entry) => entry.length > 0);
 }
 
+const HWVAULT_REQUIRED_PASS_ENV = [
+  "OPENCLAW_AGENT_ID",
+  "OPENCLAW_SESSION_KEY",
+  "OPENCLAW_DELEGATION_AUDIENCE",
+  "HWVAULT_BIN",
+] as const;
+
+export function applyHwvaultPresetToExecProvider(options: {
+  passEnv: string[];
+  env: Record<string, string>;
+  trustRoots: string;
+  policyPath: string;
+}): { passEnv: string[]; env: Record<string, string> } {
+  const passEnv = [...options.passEnv];
+  const env = { ...options.env };
+
+  env.HWVAULT_POLICY_PATH = options.policyPath.trim();
+  env.HWVAULT_TRUST_ROOTS = options.trustRoots;
+
+  for (const key of HWVAULT_REQUIRED_PASS_ENV) {
+    if (!passEnv.includes(key)) {
+      passEnv.push(key);
+    }
+  }
+
+  return { passEnv, env };
+}
+
 function parseOptionalPositiveInt(value: string, max: number): number | undefined {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -490,10 +518,19 @@ async function parseArgsInput(rawValue: string): Promise<string[] | undefined> {
 async function promptExecProvider(
   base?: Extract<SecretProviderConfig, { source: "exec" }>,
 ): Promise<Extract<SecretProviderConfig, { source: "exec" }>> {
+  const useHwvaultPreset = assertNoCancel(
+    await confirm({
+      message: "Use HWVault resolver preset?",
+      initialValue: false,
+    }),
+    "Secrets configure cancelled.",
+  );
+
+  const hwvaultDefaultCommand = "/usr/local/bin/openclaw-hwvault-resolver";
   const command = assertNoCancel(
     await text({
       message: "Command path (absolute)",
-      initialValue: base?.command ?? "",
+      initialValue: base?.command ?? (useHwvaultPreset ? hwvaultDefaultCommand : ""),
       validate: (value) => {
         const trimmed = String(value ?? "").trim();
         if (!trimmed) {
@@ -600,6 +637,40 @@ async function promptExecProvider(
   const args = await parseArgsInput(String(argsRaw ?? ""));
   const trustedDirs = parseCsv(String(trustedDirsRaw ?? ""));
 
+  const nextEnv = isRecord(base?.env) ? { ...base.env } : ({} as Record<string, string>);
+
+  if (useHwvaultPreset) {
+    const trustRoots = assertNoCancel(
+      await select({
+        message: "HW trust-root mode",
+        options: [
+          { value: "tpm", label: "TPM only" },
+          { value: "yubikey", label: "YubiKey only" },
+          { value: "tpm,yubikey", label: "TPM or YubiKey (recommended)" },
+        ],
+        initialValue: "tpm,yubikey",
+      }),
+      "Secrets configure cancelled.",
+    );
+
+    const policyPath = assertNoCancel(
+      await text({
+        message: "HWVault policy file path",
+        initialValue: nextEnv.HWVAULT_POLICY_PATH ?? "~/.config/hwvault/openclaw-policy.json",
+      }),
+      "Secrets configure cancelled.",
+    );
+
+    const preset = applyHwvaultPresetToExecProvider({
+      passEnv,
+      env: nextEnv,
+      trustRoots: String(trustRoots),
+      policyPath: String(policyPath),
+    });
+    passEnv.splice(0, passEnv.length, ...preset.passEnv);
+    Object.assign(nextEnv, preset.env);
+  }
+
   return {
     source: "exec",
     command: String(command).trim(),
@@ -612,7 +683,7 @@ async function promptExecProvider(
     ...(trustedDirs.length > 0 ? { trustedDirs } : {}),
     ...(allowInsecurePath ? { allowInsecurePath: true } : {}),
     ...(allowSymlinkCommand ? { allowSymlinkCommand: true } : {}),
-    ...(isRecord(base?.env) ? { env: base.env } : {}),
+    ...(Object.keys(nextEnv).length > 0 ? { env: nextEnv } : {}),
   };
 }
 

--- a/src/secrets/configure.ts
+++ b/src/secrets/configure.ts
@@ -78,13 +78,17 @@ export function applyHwvaultPresetToExecProvider(options: {
   return { passEnv, env };
 }
 
-function getHwvaultDefaultCommand(): string {
+export function getHwvaultDefaultCommandForPlatform(platform: NodeJS.Platform): string {
   // Avoid forcing a Unix path on Windows. On Windows we intentionally leave
   // this blank so users provide an explicit absolute path.
-  if (process.platform === "win32") {
+  if (platform === "win32") {
     return "";
   }
   return "/usr/local/bin/openclaw-hwvault-resolver";
+}
+
+function getHwvaultDefaultCommand(): string {
+  return getHwvaultDefaultCommandForPlatform(process.platform);
 }
 
 function isLikelyHwvaultExecProvider(

--- a/src/secrets/configure.ts
+++ b/src/secrets/configure.ts
@@ -78,6 +78,40 @@ export function applyHwvaultPresetToExecProvider(options: {
   return { passEnv, env };
 }
 
+function getHwvaultDefaultCommand(): string {
+  // Avoid forcing a Unix path on Windows. On Windows we intentionally leave
+  // this blank so users provide an explicit absolute path.
+  if (process.platform === "win32") {
+    return "";
+  }
+  return "/usr/local/bin/openclaw-hwvault-resolver";
+}
+
+function isLikelyHwvaultExecProvider(
+  base?: Extract<SecretProviderConfig, { source: "exec" }>,
+): boolean {
+  if (!base) {
+    return true;
+  }
+  if (base.command.toLowerCase().includes("hwvault")) {
+    return true;
+  }
+  if (isRecord(base.env)) {
+    return Boolean(base.env.HWVAULT_POLICY_PATH || base.env.HWVAULT_TRUST_ROOTS);
+  }
+  return false;
+}
+
+function pickInitialHwvaultTrustRoots(
+  base?: Extract<SecretProviderConfig, { source: "exec" }>,
+): "tpm" | "yubikey" | "tpm,yubikey" {
+  const current = isRecord(base?.env) ? base.env.HWVAULT_TRUST_ROOTS : undefined;
+  if (current === "tpm" || current === "yubikey" || current === "tpm,yubikey") {
+    return current;
+  }
+  return "tpm,yubikey";
+}
+
 function parseOptionalPositiveInt(value: string, max: number): number | undefined {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -518,19 +552,21 @@ async function parseArgsInput(rawValue: string): Promise<string[] | undefined> {
 async function promptExecProvider(
   base?: Extract<SecretProviderConfig, { source: "exec" }>,
 ): Promise<Extract<SecretProviderConfig, { source: "exec" }>> {
-  const useHwvaultPreset = assertNoCancel(
-    await confirm({
-      message: "Use HWVault resolver preset?",
-      initialValue: false,
-    }),
-    "Secrets configure cancelled.",
-  );
+  const showHwvaultPresetPrompt = isLikelyHwvaultExecProvider(base);
+  const useHwvaultPreset = showHwvaultPresetPrompt
+    ? assertNoCancel(
+        await confirm({
+          message: "Use HWVault resolver preset?",
+          initialValue: !base,
+        }),
+        "Secrets configure cancelled.",
+      )
+    : false;
 
-  const hwvaultDefaultCommand = "/usr/local/bin/openclaw-hwvault-resolver";
   const command = assertNoCancel(
     await text({
       message: "Command path (absolute)",
-      initialValue: base?.command ?? (useHwvaultPreset ? hwvaultDefaultCommand : ""),
+      initialValue: base?.command ?? (useHwvaultPreset ? getHwvaultDefaultCommand() : ""),
       validate: (value) => {
         const trimmed = String(value ?? "").trim();
         if (!trimmed) {
@@ -648,7 +684,7 @@ async function promptExecProvider(
           { value: "yubikey", label: "YubiKey only" },
           { value: "tpm,yubikey", label: "TPM or YubiKey (recommended)" },
         ],
-        initialValue: "tpm,yubikey",
+        initialValue: pickInitialHwvaultTrustRoots(base),
       }),
       "Secrets configure cancelled.",
     );
@@ -657,6 +693,13 @@ async function promptExecProvider(
       await text({
         message: "HWVault policy file path",
         initialValue: nextEnv.HWVAULT_POLICY_PATH ?? "~/.config/hwvault/openclaw-policy.json",
+        validate: (value) => {
+          const trimmed = String(value ?? "").trim();
+          if (!trimmed) {
+            return "Required";
+          }
+          return undefined;
+        },
       }),
       "Secrets configure cancelled.",
     );


### PR DESCRIPTION
## Summary

Integrates HWVault setup into OpenClaw's existing SecretRef exec-provider flow for hardware-backed security + delegated agent access.

This single focused PR adds:

1. Gateway docs for HWVault integration via `secrets.providers.*.source = "exec"`
2. `secrets configure` HWVault preset with trust-root selection (TPM/YubiKey/both)
3. Pass-through env setup for delegation context (`OPENCLAW_AGENT_ID`, `OPENCLAW_SESSION_KEY`, `OPENCLAW_DELEGATION_AUDIENCE`, `HWVAULT_BIN`)
4. Release-gate guidance (delegation TTL, auditability expectations)
5. Unit test coverage for HWVault preset logic, including platform default behavior

## Why this fits OpenClaw

- Uses existing exec-provider architecture (no new secret source type required)
- Backwards-compatible and opt-in
- Keeps OpenClaw core generic while enabling hardware-backed external secret resolvers

## Non-goals

- No new built-in secret source type
- No runtime dependency on HWVault internals
- No change to existing provider resolution semantics

## Files changed

- `docs/gateway/hwvault-integration.md` (new)
- `docs/gateway/index.md`
- `docs/gateway/secrets.md`
- `docs/cli/secrets.md`
- `src/secrets/configure.ts`
- `src/secrets/configure.hwvault.test.ts` (new)

## Tests run

```bash
pnpm exec vitest run src/secrets/configure.hwvault.test.ts src/cli/secrets-cli.test.ts
pnpm exec oxfmt --check src/secrets/configure.ts src/secrets/configure.hwvault.test.ts docs/cli/secrets.md docs/gateway/index.md docs/gateway/secrets.md docs/gateway/hwvault-integration.md
```

All passed locally.

## Manual verification steps

```bash
# 1) run interactive setup
openclaw secrets configure

# 2) choose exec provider + HWVault preset
#    - select trust-root mode (TPM / YubiKey / both)
#    - provide policy path

# 3) confirm resulting provider has expected fields
openclaw config get secrets.providers --json

# 4) re-resolve runtime snapshot
openclaw secrets reload --json

# 5) run audit gate
openclaw secrets audit --check
```

Expected:
- provider has `env.HWVAULT_POLICY_PATH`, `env.HWVAULT_TRUST_ROOTS`
- provider `passEnv` includes delegation identity keys
- reload succeeds when resolver can resolve refs

## CI note on skipped checks

Some checks may show `SKIPPED` based on workflow scope/conditions (for example platform-specific lanes not applicable to this change set). Required checks for this PR remain enforced and must pass.
