### PR TITLE
fix(discord): preserve HTTP status in probe result when JSON parsing fails

### DIFF
--- a/src/discord/probe.probe-discord.test.ts
+++ b/src/discord/probe.probe-discord.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest";
+import { probeDiscord } from "./probe.js";
+
+const VALID_TOKEN = "test-token.timestamp.hmac";
+
+function mockFetch(status: number, body: unknown, opts?: { jsonThrows?: boolean }): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: opts?.jsonThrows
+      ? vi.fn().mockRejectedValue(new SyntaxError("Unexpected token"))
+      : vi.fn().mockResolvedValue(body),
+  } as unknown as Response);
+}
+
+function networkErrorFetch(): typeof fetch {
+  return vi.fn().mockRejectedValue(new TypeError("fetch failed"));
+}
+
+describe("probeDiscord", () => {
+  it("returns ok with bot info on successful 200 response", async () => {
+    const fetcher = mockFetch(200, { id: "123456", username: "test-bot" });
+    const result = await probeDiscord(VALID_TOKEN, 5000, { fetcher });
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.bot).toEqual({ id: "123456", username: "test-bot" });
+    expect(result.error).toBeNull();
+  });
+
+  it("returns error with status on HTTP 401", async () => {
+    const fetcher = mockFetch(401, { message: "Unauthorized" });
+    const result = await probeDiscord(VALID_TOKEN, 5000, { fetcher });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(401);
+    expect(result.error).toContain("401");
+  });
+
+  it("returns error with status on HTTP 403", async () => {
+    const fetcher = mockFetch(403, { message: "Forbidden" });
+    const result = await probeDiscord(VALID_TOKEN, 5000, { fetcher });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(403);
+    expect(result.error).toContain("403");
+  });
+
+  it("preserves HTTP status when res.json() throws after a 200 response", async () => {
+    const fetcher = mockFetch(200, null, { jsonThrows: true });
+    const result = await probeDiscord(VALID_TOKEN, 5000, { fetcher });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(200);
+    expect(result.error).toContain("Unexpected token");
+  });
+
+  it("reports network errors with null status", async () => {
+    const fetcher = networkErrorFetch();
+    const result = await probeDiscord(VALID_TOKEN, 5000, { fetcher });
+
+    expect(result.ok).toBe(false);
+    expect(result.status).toBeNull();
+    expect(result.error).toContain("fetch failed");
+  });
+
+  it("returns missing token error for empty input", async () => {
+    const result = await probeDiscord("", 5000);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("missing token");
+  });
+
+  it("includes elapsedMs in all results", async () => {
+    const fetcher = mockFetch(200, { id: "1", username: "bot" });
+    const result = await probeDiscord(VALID_TOKEN, 5000, { fetcher });
+
+    expect(typeof result.elapsedMs).toBe("number");
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("handles missing id and username in response", async () => {
+    const fetcher = mockFetch(200, {});
+    const result = await probeDiscord(VALID_TOKEN, 5000, { fetcher });
+
+    expect(result.ok).toBe(true);
+    expect(result.bot).toEqual({ id: null, username: null });
+  });
+});

--- a/src/discord/probe.ts
+++ b/src/discord/probe.ts
@@ -147,8 +147,8 @@ export async function probeDiscord(
       timeoutMs,
       getResolvedFetch(fetcher),
     );
+    result.status = res.status;
     if (!res.ok) {
-      result.status = res.status;
       result.error = `getMe failed (${res.status})`;
       return { ...result, elapsedMs: Date.now() - started };
     }
@@ -166,7 +166,6 @@ export async function probeDiscord(
   } catch (err) {
     return {
       ...result,
-      status: err instanceof Response ? err.status : result.status,
       error: err instanceof Error ? err.message : String(err),
       elapsedMs: Date.now() - started,
     };


### PR DESCRIPTION
## Summary

- Problem: `probeDiscord()` only captured `res.status` on the `!res.ok` branch. When the HTTP response was 200 but `res.json()` threw (e.g., malformed body from a CDN or proxy), the catch block returned `status: null` — hiding the actual HTTP status from `openclaw status --deep` output.
- Why it matters: Users running `openclaw status --deep` see `status: null` instead of the real HTTP status code (e.g. 200), making it harder to diagnose Discord connectivity issues where the connection succeeds but the response body is corrupted.
- What changed: Moved `result.status = res.status` before the ok/not-ok branch so the HTTP status is always captured. Removed dead `err instanceof Response` check (`fetch()` throws `Error` objects, never `Response` objects, so the branch was unreachable). Added 8 unit tests covering all probe result paths.
- What did NOT change (scope boundary): No changes to `fetchDiscordApplicationId`, `fetchDiscordApplicationSummary`, or any other probe helper functions. Only the `probeDiscord` function and its error handling path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Discord probe status reporting

## User-visible / Behavior Changes

- `openclaw status --deep` now shows the actual HTTP status code (e.g. `200`) in the Discord probe result when the response body fails to parse as JSON. Previously it showed `null`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel: Discord
- Relevant config: Any Discord bot token configuration

### Steps

1. Configure Discord bot with a valid token
2. Simulate a scenario where Discord API returns HTTP 200 but with a malformed response body (e.g., CDN proxy returning HTML instead of JSON)
3. Run `openclaw status --deep`

### Expected

- Probe result shows `status: 200` with an error message about JSON parsing failure

### Actual (before fix)

- Probe result shows `status: null` — HTTP status is lost

## Evidence

- [x] Failing test/log before + passing after

New test `preserves HTTP status when res.json() throws after a 200 response` verifies the fix:
- Before: `result.status` is `null` when JSON parsing fails after a 200 response
- After: `result.status` is `200`, correctly reflecting the HTTP status

8 test cases cover: successful probe, HTTP 401/403 errors, JSON parse failure after 200, network errors, missing token, missing fields in response.

## Human Verification (required)

- Verified scenarios: All 8 new unit tests pass; all 12 existing probe tests (intents + parse-token) continue to pass
- Edge cases checked: Empty token, network error (null status), malformed JSON after success (status preserved), missing bot fields in response
- What you did **not** verify: Live Discord API testing (no bot token available in dev environment)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single line move in `probe.ts`
- Files/config to restore: `src/discord/probe.ts`
- Known bad symptoms reviewers should watch for: If `result.status` becomes non-null when it shouldn't be (e.g., for pure network errors where no HTTP response was received — but the fix preserves `null` for this case since `result.status` is only set after a successful fetch)

## Risks and Mitigations

- Risk: The status field now contains `200` for JSON parse failures, which could confuse monitoring that assumes `status: null` means "no HTTP response received"
  - Mitigation: The `ok: false` flag still correctly indicates failure. The status field now accurately reflects what actually happened at the HTTP layer, which is strictly more informative.

[AI-assisted]

Made with [Cursor](https://cursor.com)