### PR TITLE
fix(googlechat): handle Add-on non-MESSAGE events (ADDED_TO_SPACE, REMOVED_FROM_SPACE)

### DIFF
--- a/extensions/googlechat/src/monitor-webhook.ts
+++ b/extensions/googlechat/src/monitor-webhook.ts
@@ -24,7 +24,7 @@ function extractBearerToken(header: unknown): string {
 
 type ParsedGoogleChatInboundPayload =
   | { ok: true; event: GoogleChatEvent; addOnBearerToken: string }
-  | { ok: false };
+  | { ok: false; unknownAddonEvent?: boolean; addOnBearerToken?: string }
 
 function parseGoogleChatInboundPayload(
   raw: unknown,
@@ -50,17 +50,44 @@ function parseGoogleChatInboundPayload(
     authorizationEventObject?: { systemIdToken?: string };
   };
 
-  if (rawObj.commonEventObject?.hostApp === "CHAT" && rawObj.chat?.messagePayload) {
-    const chat = rawObj.chat;
-    const messagePayload = chat.messagePayload;
-    eventPayload = {
-      type: "MESSAGE",
-      space: messagePayload?.space,
-      message: messagePayload?.message,
-      user: chat.user,
-      eventTime: chat.eventTime,
-    };
+  if (rawObj.commonEventObject?.hostApp === "CHAT") {
+    const chat = rawObj.chat as (typeof rawObj.chat & {
+      addedToSpacePayload?: { space?: GoogleChatSpace };
+      removedFromSpacePayload?: { space?: GoogleChatSpace };
+    }) | undefined;
     addOnBearerToken = String(rawObj.authorizationEventObject?.systemIdToken ?? "").trim();
+
+    if (chat?.messagePayload) {
+      // MESSAGE event
+      const messagePayload = chat.messagePayload;
+      eventPayload = {
+        type: "MESSAGE",
+        space: messagePayload?.space,
+        message: messagePayload?.message,
+        user: chat.user,
+        eventTime: chat.eventTime,
+      };
+    } else if (chat?.addedToSpacePayload) {
+      // ADDED_TO_SPACE event
+      eventPayload = {
+        type: "ADDED_TO_SPACE",
+        space: chat.addedToSpacePayload.space,
+        user: chat.user,
+        eventTime: chat.eventTime,
+      };
+    } else if (chat?.removedFromSpacePayload) {
+      // REMOVED_FROM_SPACE event
+      eventPayload = {
+        type: "REMOVED_FROM_SPACE",
+        space: chat.removedFromSpacePayload.space,
+        user: chat.user,
+        eventTime: chat.eventTime,
+      };
+    } else {
+      // Unknown Add-on event type: return flag so caller can respond 200
+      // after verifying the token (avoid auth bypass)
+      return { ok: false, unknownAddonEvent: true, addOnBearerToken };
+    }
   }
 
   const event = eventPayload as GoogleChatEvent;
@@ -163,10 +190,9 @@ export function createGoogleChatWebhookRequestHandler(params: {
         }
 
         const parsed = parseGoogleChatInboundPayload(body.value, res);
-        if (!parsed.ok) {
+        if (!parsed.ok && !parsed.unknownAddonEvent) {
           return true;
         }
-        parsedEvent = parsed.event;
 
         if (!parsed.addOnBearerToken) {
           res.statusCode = 401;
@@ -179,7 +205,7 @@ export function createGoogleChatWebhookRequestHandler(params: {
           res,
           isMatch: async (target) => {
             const verification = await verifyGoogleChatRequest({
-              bearer: parsed.addOnBearerToken,
+              bearer: parsed.addOnBearerToken!,
               audienceType: target.audienceType,
               audience: target.audience,
             });
@@ -189,6 +215,16 @@ export function createGoogleChatWebhookRequestHandler(params: {
         if (!selectedTarget) {
           return true;
         }
+
+        // Unknown Add-on event type: respond 200 after auth passes
+        if (parsed.unknownAddonEvent) {
+          res.statusCode = 200;
+          res.setHeader("Content-Type", "application/json");
+          res.end("{}");
+          return true;
+        }
+
+        parsedEvent = (parsed as { ok: true; event: GoogleChatEvent }).event;
       }
 
       if (!selectedTarget || !parsedEvent) {


### PR DESCRIPTION
## Problem

When a Chat app is configured as a **Google Workspace Add-on**, Google Chat sends events in the Add-on format (`commonEventObject.hostApp === "CHAT"`).

Previously, only MESSAGE events (`chat.messagePayload`) were transformed. Other event types like `ADDED_TO_SPACE` and `REMOVED_FROM_SPACE` were not handled, causing:
- `400 'invalid payload'` responses from OpenClaw
- Google Chat entering a backoff/suspended state and **completely stopping event delivery** to the endpoint

## Fix (monitor-webhook.ts)

- Handle `ADDED_TO_SPACE` events via `chat.addedToSpacePayload`
- Handle `REMOVED_FROM_SPACE` events via `chat.removedFromSpacePayload`
- Move `addOnBearerToken` extraction before event-type branching (applies to all Add-on events)
- For unknown Add-on event types: return `unknownAddonEvent` flag instead of responding `200` immediately — caller verifies token first, then responds `200` after successful auth (prevents authentication bypass)

## Security

The unknown-event `200` response is only sent **after** bearer token verification, consistent with how all other event types are handled.

## How to Reproduce

1. Configure a Chat app as a Google Workspace Add-on (HTTP endpoint)
2. Add the bot to a Google Chat space
3. Google sends `ADDED_TO_SPACE` in Add-on format → OpenClaw returns `400`
4. Google Chat stops sending any further events to the endpoint

## Reference

- Google Workspace Add-ons Chat events: https://developers.google.com/workspace/add-ons/chat/build#actions