### PR TITLE
fix(heartbeat): trim whitespace from activeHours time strings

### DIFF
--- a/src/infra/heartbeat-active-hours.test.ts
+++ b/src/infra/heartbeat-active-hours.test.ts
@@ -76,6 +76,23 @@ describe("isWithinActiveHours", () => {
     expect(isWithinActiveHours(cfg, heartbeat, Date.UTC(2025, 0, 1, 23, 30, 0))).toBe(false);
   });
 
+  it("trims whitespace from active hours time strings", () => {
+    const cfg = cfgWithUserTimezone("UTC");
+    const heartbeat = heartbeatWindow(" 09:00 ", " 17:00 ", "UTC");
+
+    expect(isWithinActiveHours(cfg, heartbeat, Date.UTC(2025, 0, 1, 12, 0, 0))).toBe(true);
+    expect(isWithinActiveHours(cfg, heartbeat, Date.UTC(2025, 0, 1, 8, 0, 0))).toBe(false);
+    expect(isWithinActiveHours(cfg, heartbeat, Date.UTC(2025, 0, 1, 18, 0, 0))).toBe(false);
+  });
+
+  it("trims whitespace from 24:00 end boundary", () => {
+    const cfg = cfgWithUserTimezone("UTC");
+    const heartbeat = heartbeatWindow("  22:00  ", "  24:00  ", "UTC");
+
+    expect(isWithinActiveHours(cfg, heartbeat, Date.UTC(2025, 0, 1, 23, 0, 0))).toBe(true);
+    expect(isWithinActiveHours(cfg, heartbeat, Date.UTC(2025, 0, 1, 21, 0, 0))).toBe(false);
+  });
+
   it("falls back to user timezone when activeHours timezone is invalid", () => {
     const cfg = cfgWithUserTimezone("UTC");
     const heartbeat = heartbeatWindow("08:00", "10:00", "Mars/Olympus");

--- a/src/infra/heartbeat-active-hours.ts
+++ b/src/infra/heartbeat-active-hours.ts
@@ -24,10 +24,11 @@ function resolveActiveHoursTimezone(cfg: OpenClawConfig, raw?: string): string {
 }
 
 function parseActiveHoursTime(opts: { allow24: boolean }, raw?: string): number | null {
-  if (!raw || !ACTIVE_HOURS_TIME_PATTERN.test(raw)) {
+  const trimmed = raw?.trim();
+  if (!trimmed || !ACTIVE_HOURS_TIME_PATTERN.test(trimmed)) {
     return null;
   }
-  const [hourStr, minuteStr] = raw.split(":");
+  const [hourStr, minuteStr] = trimmed.split(":");
   const hour = Number(hourStr);
   const minute = Number(minuteStr);
   if (!Number.isFinite(hour) || !Number.isFinite(minute)) {


### PR DESCRIPTION
## Summary

- Problem: `parseActiveHoursTime` tested the raw config value directly against the HH:MM regex (`/^(?:([01]\d|2[0-3]):([0-5]\d)|24:00)$/`) without trimming. Leading/trailing whitespace (e.g. `" 09:00 "`) caused the anchored regex to fail, returning `null` for both `start` and `end`.
- Why it matters: When both `start` and `end` parse as `null`, `isWithinActiveHours` falls back to returning `true` (always active), silently ignoring the user's configured active-hours window. The heartbeat fires around the clock instead of only during the intended window.
- What changed: Added `.trim()` to the input before regex validation in `parseActiveHoursTime`. Added 2 test cases covering whitespace in normal ranges and the `24:00` end boundary.
- What did NOT change (scope boundary): No changes to timezone resolution, overnight range handling, or the regex pattern itself. Only the pre-processing of the raw time string.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Heartbeat active-hours configuration parsing

## User-visible / Behavior Changes

- Active-hours time values with leading/trailing whitespace (e.g. `" 09:00 "`) are now correctly parsed instead of silently falling back to "always active".

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel: N/A (heartbeat system)
- Relevant config:
  ```json
  {
    "agents": {
      "defaults": {
        "heartbeat": {
          "activeHours": {
            "start": " 09:00 ",
            "end": " 17:00 ",
            "timezone": "UTC"
          }
        }
      }
    }
  }
  ```

### Steps

1. Configure heartbeat with `activeHours.start: " 09:00 "` (note whitespace)
2. Observe heartbeat behavior outside the 09:00–17:00 window

### Expected

- Heartbeat only fires between 09:00 and 17:00 UTC

### Actual (before fix)

- Heartbeat fires at all hours — active-hours gate is silently bypassed

## Evidence

- [x] Failing test/log before + passing after

Two new tests verify whitespace handling:
- `trims whitespace from active hours time strings`: confirms `" 09:00 "` / `" 17:00 "` are correctly parsed and the window is respected
- `trims whitespace from 24:00 end boundary`: confirms `"  24:00  "` end boundary with whitespace is correctly handled

All 9 tests pass (7 existing + 2 new).

## Human Verification (required)

- Verified scenarios: All 9 unit tests pass; whitespace in both start and end is correctly trimmed; the 24:00 boundary case is handled
- Edge cases checked: Leading whitespace only, trailing whitespace only, both sides, whitespace around 24:00
- What you did **not** verify: Live heartbeat scheduling with a running gateway

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single-line change in `heartbeat-active-hours.ts`
- Files/config to restore: `src/infra/heartbeat-active-hours.ts`
- Known bad symptoms reviewers should watch for: None expected; the change only adds `.trim()` before existing validation

## Risks and Mitigations

None — the change is purely additive (trimming before validation) and does not alter the regex or any other parsing logic.

[AI-assisted]

Made with [Cursor](https://cursor.com)