### PR TITLE
fix: suppress Slack typing blink for NO_REPLY runs in message mode

### DIFF
--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -517,7 +517,7 @@ describe("createTypingSignaler", () => {
     expect(typing.startTypingOnText).not.toHaveBeenCalled();
   });
 
-  it("handles tool-start typing before and after active text mode", async () => {
+  it("does not start tool typing in message mode before renderable text", async () => {
     const typing = createMockTypingController();
     const signaler = createTypingSignaler({
       typing,
@@ -527,16 +527,32 @@ describe("createTypingSignaler", () => {
 
     await signaler.signalToolStart();
 
-    expect(typing.startTypingLoop).toHaveBeenCalled();
-    expect(typing.refreshTypingTtl).toHaveBeenCalled();
-    expect(typing.startTypingOnText).not.toHaveBeenCalled();
-    (typing.isActive as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).not.toHaveBeenCalled();
+
+    await signaler.signalTextDelta("hello");
     (typing.startTypingLoop as ReturnType<typeof vi.fn>).mockClear();
     (typing.refreshTypingTtl as ReturnType<typeof vi.fn>).mockClear();
+    (typing.isActive as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
     await signaler.signalToolStart();
 
     expect(typing.refreshTypingTtl).toHaveBeenCalled();
     expect(typing.startTypingLoop).not.toHaveBeenCalled();
+  });
+
+  it("starts tool typing immediately in instant mode", async () => {
+    const typing = createMockTypingController();
+    const signaler = createTypingSignaler({
+      typing,
+      mode: "instant",
+      isHeartbeat: false,
+    });
+
+    await signaler.signalToolStart();
+
+    expect(typing.startTypingLoop).toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).toHaveBeenCalled();
   });
 
   it("suppresses typing when disabled", async () => {

--- a/src/auto-reply/reply/typing-mode.ts
+++ b/src/auto-reply/reply/typing-mode.ts
@@ -128,7 +128,11 @@ export function createTypingSignaler(params: {
     if (disabled) {
       return;
     }
-    // Start typing as soon as tools begin executing, even before the first text delta.
+    // In message mode, only type after we have renderable assistant text.
+    // This prevents brief typing blinks for runs that end up NO_REPLY.
+    if (mode === "message" && !hasRenderableText) {
+      return;
+    }
     if (!typing.isActive()) {
       await typing.startTypingLoop();
       typing.refreshTypingTtl();


### PR DESCRIPTION
## Summary
- prevent `signalToolStart` from starting typing in `typingMode: "message"` before any renderable assistant text exists
- keep existing behavior for other modes (`instant`/`thinking`) and for message mode once real text has begun
- this removes the brief typing/status bubble on runs that end with `NO_REPLY`

## Testing
- pnpm vitest src/auto-reply/reply/reply-utils.test.ts

Fixes openclaw/openclaw#33951