### PR TITLE
fix(hooks): clean up previous gmail watcher on restart to prevent state leak

### DIFF
--- a/src/hooks/gmail-watcher.ts
+++ b/src/hooks/gmail-watcher.ts
@@ -125,6 +125,9 @@ export type GmailWatcherStartResult = {
  * Called automatically by the gateway if hooks.gmail is configured.
  */
 export async function startGmailWatcher(cfg: OpenClawConfig): Promise<GmailWatcherStartResult> {
+  // Clean up any previous watcher before starting a new one (safe on restart)
+  await stopGmailWatcher();
+
   // Check if gmail hooks are configured
   if (!cfg.hooks?.enabled) {
     return { started: false, reason: "hooks not enabled" };
@@ -209,24 +212,22 @@ export async function stopGmailWatcher(): Promise<void> {
 
   if (watcherProcess) {
     log.info("stopping gmail watcher");
-    watcherProcess.kill("SIGTERM");
+    const proc = watcherProcess;
+    watcherProcess = null;
+    proc.kill("SIGTERM");
 
     // Wait a bit for graceful shutdown
     await new Promise<void>((resolve) => {
       const timeout = setTimeout(() => {
-        if (watcherProcess) {
-          watcherProcess.kill("SIGKILL");
-        }
+        proc.kill("SIGKILL");
         resolve();
       }, 3000);
 
-      watcherProcess?.on("exit", () => {
+      proc.on("exit", () => {
         clearTimeout(timeout);
         resolve();
       });
     });
-
-    watcherProcess = null;
   }
 
   currentConfig = null;


### PR DESCRIPTION
## Summary
- `startGmailWatcher()` now calls `stopGmailWatcher()` first to clean up any previous watcher process and interval, preventing dual-process / stale state issues on gateway restart.
- `stopGmailWatcher()` captures the process reference into a local variable before nulling the module-level `watcherProcess`, avoiding a race where the exit callback references a stale variable.

## Test plan
- [ ] Verify gateway restart (SIGUSR1) properly cleans up old gmail watcher before starting new one
- [ ] Verify `stopGmailWatcher()` when process already crashed (null) returns immediately
- [ ] Run `pnpm test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)