### PR TITLE
fix(process): guard draining flag against generation change in pump finally

### DIFF
--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -108,6 +108,7 @@ function drainLane(lane: string) {
   state.draining = true;
 
   const pump = () => {
+    const pumpGeneration = state.generation;
     try {
       while (state.activeTaskIds.size < state.maxConcurrent && state.queue.length > 0) {
         const entry = state.queue.shift() as QueueEntry;
@@ -154,7 +155,10 @@ function drainLane(lane: string) {
         })();
       }
     } finally {
-      state.draining = false;
+      // Only clear draining if generation hasn't changed mid-pump (e.g. via resetAllLanes)
+      if (state.generation === pumpGeneration) {
+        state.draining = false;
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- In `command-queue.ts`, `pump()`'s `finally` block unconditionally set `state.draining = false`. If `resetAllLanes()` bumped the generation and started a new drain cycle mid-flight, a stale pump's `finally` could clear the draining flag for the new generation, allowing duplicate drain entries.
- Now `pump()` captures `pumpGeneration` at entry and only clears `draining` in `finally` if the generation hasn't changed, preventing stale completions from interfering with the new cycle.

## Test plan
- [ ] Verify in-process restart (SIGUSR1) correctly drains queued tasks without duplicate pump
- [ ] Run `pnpm test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)