### PR TITLE
fix(channels): reschedule flush after send failure to avoid losing pending text

### DIFF
--- a/src/channels/draft-stream-loop.ts
+++ b/src/channels/draft-stream-loop.ts
@@ -42,6 +42,7 @@ export function createDraftStreamLoop(params: {
       const sent = await current;
       if (sent === false) {
         pendingText = text;
+        schedule(); // re-schedule so pending content is retried
         return;
       }
       lastSentAt = Date.now();

--- a/src/channels/draft-stream-loop.ts
+++ b/src/channels/draft-stream-loop.ts
@@ -42,6 +42,7 @@ export function createDraftStreamLoop(params: {
       const sent = await current;
       if (sent === false) {
         pendingText = text;
+        lastSentAt = Date.now(); // reset throttle window so schedule() respects the delay
         schedule(); // re-schedule so pending content is retried
         return;
       }


### PR DESCRIPTION
## Summary
- In `createDraftStreamLoop`, when `sendOrEditStreamMessage` returns `false` (rate-limited / send failure), the pending text was written back but no timer was rescheduled. Since `flush()` clears the timer on entry, if no subsequent `update()` call arrived, the pending content was permanently lost.
- Now calls `schedule()` before returning on send failure, ensuring a retry attempt.

## Test plan
- [ ] Verify streaming messages are not lost when send is rate-limited at the end of a stream
- [ ] Run `pnpm test` to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)