### PR TITLE
fix(gateway): allow silent local re-pair on metadata-upgrade

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -136,7 +136,7 @@ function shouldAllowSilentLocalPairing(params: {
   return (
     params.isLocalClient &&
     (!params.hasBrowserOriginHeader || params.isControlUi || params.isWebchat) &&
-    (params.reason === "not-paired" || params.reason === "scope-upgrade")
+    (params.reason === "not-paired" || params.reason === "scope-upgrade" || params.reason === "metadata-upgrade")
   );
 }
 

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -136,7 +136,9 @@ function shouldAllowSilentLocalPairing(params: {
   return (
     params.isLocalClient &&
     (!params.hasBrowserOriginHeader || params.isControlUi || params.isWebchat) &&
-    (params.reason === "not-paired" || params.reason === "scope-upgrade" || params.reason === "metadata-upgrade")
+    (params.reason === "not-paired" ||
+      params.reason === "scope-upgrade" ||
+      params.reason === "metadata-upgrade")
   );
 }
 


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                            
                                                                                                                                                                                                                        
  - Problem: After a routine macOS minor update (e.g. 15.7.3 → 15.7.4), the gateway rejects the macOS app's loopback connection with a misleading "rejected auth" error                                                 
  - Why it matters: Every user who updates macOS gets locked out until they manually clear device pairing state                                                                                                         
  - What changed: `shouldAllowSilentLocalPairing()` now also auto-approves `metadata-upgrade` for local connections                                                                                                   
  - What did NOT change: Remote connections still require interactive approval for metadata-upgrade                                                                                                                     
                                                                                                                                                                                                                        
  ## Change Type (select all)                                                                                                                                                                                           
                                                                                                                                                                                                                        
  - [x] Bug fix                                                                                                                                                                                                         
  - [ ] Feature
  - [ ] Refactor
  - [ ] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [x] Gateway / orchestration
  - [ ] Skills / tool execution
  - [x] Auth / tokens
  - [ ] Memory / storage
  - [ ] Integrations
  - [ ] API / contracts
  - [ ] UI / DX
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - None

  ## User-visible / Behavior Changes

  Local loopback connections no longer require interactive re-pairing after OS minor version updates. Previously users saw "Gateway on port 18789 rejected auth" and had to manually clear
  `~/.openclaw/devices/paired.json`.

  ## Security Impact (required)

  - New permissions/capabilities? No
  - Secrets/tokens handling changed? No
  - New/changed network calls? No
  - Command/tool execution surface changed? No
  - Data access scope changed? No

  ## Repro + Verification

  ### Environment

  - OS: macOS 15.7.3 → 15.7.4
  - Runtime/container: Node 22+
  - Model/provider: N/A
  - Integration/channel: N/A
  - Relevant config: `gateway.bind: loopback`, `gateway.auth.mode: token`

  ### Steps

  1. Pair macOS app with gateway on macOS 15.7.3
  2. Update macOS to 15.7.4
  3. Reopen the app

  ### Expected

  - App connects to gateway normally

  ### Actual

  - App shows "Gateway on port 18789 rejected auth" error
  - Gateway logs show `code=1008 reason=pairing required` with `claimedPlatform=macOS 15.7.4 pinnedPlatform=macOS 15.7.3`

  ## Evidence

  - [x] Trace/log snippets (gateway.err.log showing repeated `metadata-upgrade` → `code=1008 reason=pairing required`)

  ## Human Verification (required)

  - Verified scenarios: Confirmed root cause via gateway logs matching OS update timestamp from `/var/db/softwareupdate/journal.plist`
  - Edge cases checked: Remote connections are not affected (only `isLocalClient` path changed)
  - What you did **not** verify: Automated test coverage

  ## Compatibility / Migration

  - Backward compatible? Yes
  - Config/env changes? No
  - Migration needed? No

  ## Failure Recovery (if this breaks)

  - How to disable/revert this change quickly: Revert the one-line change in `shouldAllowSilentLocalPairing()`
  - Files/config to restore: `src/gateway/server/ws-connection/message-handler.ts`
  - Known bad symptoms reviewers should watch for: None expected

  ## Risks and Mitigations

  - Risk: A compromised device token on a different machine with a different OS could silently re-pair on loopback
    - Mitigation: Only applies to `isLocalClient` (127.0.0.1) — attacker would need local access, at which point they already have full control