### PR TITLE
fix(feishu): download media from quoted/replied messages

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -729,7 +729,6 @@ export async function handleFeishuMessage(params: {
       log,
       accountId: account.accountId,
     });
-    const mediaPayload = buildAgentMediaPayload(mediaList);
 
     // Fetch quoted/replied message content if parentId exists
     let quotedMessageInfo: Awaited<ReturnType<typeof getMessageFeishu>> = null;
@@ -756,6 +755,27 @@ export async function handleFeishuMessage(params: {
           log(
             `feishu[${account.accountId}]: fetched quoted message: ${quotedContent?.slice(0, 100)}`,
           );
+
+          // Download media from quoted message if it is a media type
+          const quotedMediaTypes = ["image", "file", "audio", "media", "sticker", "post"];
+          if (quotedMediaTypes.includes(quotedMessageInfo.contentType)) {
+            try {
+              const quotedMedia = await resolveFeishuMediaList({
+                cfg,
+                messageId: quotedMessageInfo.messageId,
+                messageType: quotedMessageInfo.contentType,
+                content: quotedMessageInfo.rawContent ?? "",
+                maxBytes: mediaMaxBytes,
+                log,
+                accountId: account.accountId,
+              });
+              mediaList.push(...quotedMedia);
+            } catch (quotedMediaErr) {
+              log(
+                `feishu[${account.accountId}]: failed to download quoted media: ${String(quotedMediaErr)}`,
+              );
+            }
+          }
         } else if (quotedMessageInfo) {
           log(
             `feishu[${account.accountId}]: skipped quoted message from sender ${quotedMessageInfo.senderId ?? "unknown"} (mode=${contextVisibilityMode})`,
@@ -765,6 +785,8 @@ export async function handleFeishuMessage(params: {
         log(`feishu[${account.accountId}]: failed to fetch quoted message: ${String(err)}`);
       }
     }
+
+    const mediaPayload = buildAgentMediaPayload(mediaList);
 
     const isTopicSessionForThread =
       isGroup &&

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -276,6 +276,7 @@ function parseFeishuMessageItem(
     senderType: item.sender?.sender_type,
     content: parseFeishuMessageContent(rawContent, msgType),
     contentType: msgType,
+    rawContent,
     createTime: item.create_time ? parseInt(item.create_time, 10) : undefined,
     threadId: item.thread_id || undefined,
   };

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -71,6 +71,8 @@ export type FeishuMessageInfo = {
   senderType?: string;
   content: string;
   contentType: string;
+  /** Raw JSON content string from the Feishu API, used for media key extraction. */
+  rawContent?: string;
   createTime?: number;
   /** Feishu thread ID (omt_xxx) — present when the message belongs to a topic thread. */
   threadId?: string;


### PR DESCRIPTION
## Summary

- **Problem:** When a user replies to an image message in a Feishu group and @mentions the bot, the bot cannot see the image. `getMessageFeishu` only extracts text content from the quoted message, ignoring attached media.
- **Why it matters:** Users commonly reply to images with "What is this?" or "Describe this picture" — the bot sees the question but not the image, making the interaction useless.
- **What changed:** After fetching quoted message metadata, the code now checks if it is a media type and downloads the media using the existing `resolveFeishuMediaList` function. Also added `rawContent` field to `FeishuMessageInfo` to preserve the original JSON needed for media key extraction.
- **What did NOT change:** Direct message media handling, the `resolveFeishuMediaList` implementation, or the Feishu API call patterns. No new dependencies.

## Change Type

- [x] Bug fix

## Scope

- [x] Integrations

## Linked Issue

- Closes #33798

## User-visible / Behavior Changes

- When replying to an image/video/file/audio/post message with @bot, the bot now receives the media from the quoted message alongside the text.
- No change in behavior for text-only quoted messages.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? Yes — when a quoted message contains media, an additional download API call is made to fetch it.
  - **Risk:** Low. Uses the same `resolveFeishuMediaList` and `downloadMessageResourceFeishu` functions already used for direct messages. Media download failures are caught and logged without blocking message processing.
- Command/tool execution surface changed? No
- Data access scope changed? No (the bot already has permission to read messages in the conversation)

## Repro + Verification

### Environment

- OS: macOS Darwin 25.0.0 (arm64)
- Runtime: Node.js v24.13.0
- OpenClaw: 2026.2.26

### Steps

1. Send an image in a Feishu group chat where bot is present
2. Reply to that image with "@bot What is in this picture?"
3. Observe the bot now receives the image attachment

### Expected

- Bot receives both the reply text and the quoted image

### Actual (before fix)

- Bot only receives text: `[Replying to: "{\"image_key\":\"img_xxx\"}"] What is in this picture?`

## Evidence

- [x] All 55 existing feishu tests pass (48 bot + 4 send + 3 reply-fallback)

```
✓ extensions/feishu/src/bot.test.ts (48 tests) 68ms
✓ extensions/feishu/src/send.test.ts (4 tests) 2ms
✓ extensions/feishu/src/send.reply-fallback.test.ts (3 tests) 2ms
```

## Human Verification

- Verified: All existing tests pass without modification
- Edge cases checked: Non-media quoted messages (no change), media download failure (caught and logged), post messages with embedded images
- Not verified: Live Feishu API calls (no test bot available in this environment)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- Revert: Remove the quoted media download block in `bot.ts` and `rawContent` from `FeishuMessageInfo`
- Media download failure is non-blocking — the message is still processed with text-only content

## Risks and Mitigations

- Risk: Additional API call latency for media-type quoted messages
  - Mitigation: Only triggered for media types, uses existing download infrastructure, errors are non-blocking

[AI-assisted development by OpenClaw agent 虾干 🦐]