### PR TITLE
feat(discord): add self-profile action for safe bot-only nickname/avatar/status updates

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -894,6 +894,7 @@ Core examples:
 - reactions: `react`, `reactions`, `emojiList`
 - moderation: `timeout`, `kick`, `ban`
 - presence: `setPresence`
+- self profile (bot-only): `self-profile`
 
 Action gates live under `channels.discord.actions.*`.
 
@@ -905,6 +906,49 @@ Default gate behavior:
 | roles                                                                                                                                                                    | disabled |
 | moderation                                                                                                                                                               | disabled |
 | presence                                                                                                                                                                 | disabled |
+| selfProfile                                                                                                                                                              | disabled |
+
+### `self-profile` (strict bot self-only updates)
+
+`self-profile` lets the bot update only its own Discord profile/presence fields:
+
+- guild nickname (`nickname`, requires `guildId`)
+- account avatar (`avatar` or `media`/`path`/`filePath`/`buffer`)
+- status (`online`/`idle`/`dnd`/`invisible`)
+- activity/custom status text (`activity*` or `statusMessage`)
+
+Safety behavior:
+
+- action defaults to self (bot account)
+- if `userId`, `memberId`, or `target` is provided and does not match the bot user id, the action is rejected
+- channel/member edits for other users are not permitted through this action
+- when multiple Discord accounts are enabled, pass `accountId` explicitly for `self-profile`
+
+Operational notes:
+
+- nickname changes require a valid `guildId` and Discord permission constraints still apply (for example role hierarchy and `Manage Nicknames`).
+- avatar updates accept PNG/JPEG/GIF/WEBP only and enforce Discord's 10 MB limit.
+- by default, updates are fail-fast. Set `bestEffort: true` to continue remaining steps and return a partial result payload (`ok: false`, `partial: true`, `updates`, `errors`).
+
+Examples:
+
+```json
+{
+  "action": "self-profile",
+  "channel": "discord",
+  "guildId": "123456789012345678",
+  "nickname": "OpenClaw Bot"
+}
+```
+
+```json
+{
+  "action": "self-profile",
+  "channel": "discord",
+  "status": "idle",
+  "statusMessage": "Shipping fixes"
+}
+```
 
 ## Components v2 UI
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -236,6 +236,8 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
         voiceStatus: true,
         events: true,
         moderation: false,
+        presence: false,
+        selfProfile: false,
       },
       replyToMode: "off", // off | first | all
       dmPolicy: "pairing",
@@ -320,6 +322,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - OpenClaw additionally attempts voice receive recovery by leaving/rejoining a voice session after repeated decrypt failures.
 - `channels.discord.streaming` is the canonical stream mode key. Legacy `streamMode` and boolean `streaming` values are auto-migrated.
 - `channels.discord.autoPresence` maps runtime availability to bot presence (healthy => online, degraded => idle, exhausted => dnd) and allows optional status text overrides.
+- `channels.discord.actions.selfProfile` enables the Discord `self-profile` message action (strict bot self-only nickname/avatar/status/activity updates).
 - `channels.discord.dangerouslyAllowNameMatching` re-enables mutable name/tag matching (break-glass compatibility mode).
 
 **Reaction notification modes:** `off` (none), `own` (bot's messages, default), `all` (all messages), `allowlist` (from `guilds.<id>.users` on all messages).

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -422,6 +422,7 @@ Core actions:
 - `role-add` / `role-remove`
 - `channel-info` / `channel-list`
 - `voice-status`
+- `self-profile` (Discord bot self-only nickname/avatar/status/activity updates)
 - `event-list` / `event-create`
 - `timeout` / `kick` / `ban`
 

--- a/src/agents/tools/discord-actions-presence.test.ts
+++ b/src/agents/tools/discord-actions-presence.test.ts
@@ -7,11 +7,27 @@ import { handleDiscordPresenceAction } from "./discord-actions-presence.js";
 
 const mockUpdatePresence = vi.fn();
 
+const discordSendMocks = vi.hoisted(() => ({
+  fetchCurrentUserDiscord: vi.fn(async () => ({ id: "bot-1" })),
+  updateCurrentUserAvatarDiscord: vi.fn(async () => ({ id: "bot-1" })),
+  updateSelfNicknameDiscord: vi.fn(async () => ({ nick: "Bot" })),
+}));
+
+const { fetchCurrentUserDiscord, updateCurrentUserAvatarDiscord, updateSelfNicknameDiscord } =
+  discordSendMocks;
+
+vi.mock("../../discord/send.js", () => ({
+  ...discordSendMocks,
+}));
+
 function createMockGateway(connected = true): GatewayPlugin {
   return { isConnected: connected, updatePresence: mockUpdatePresence } as unknown as GatewayPlugin;
 }
 
 const presenceEnabled: ActionGate<DiscordActionConfig> = (key) => key === "presence";
+const selfProfileEnabled: ActionGate<DiscordActionConfig> = (key) => key === "selfProfile";
+const presenceAndSelfProfileEnabled: ActionGate<DiscordActionConfig> = (key) =>
+  key === "presence" || key === "selfProfile";
 const presenceDisabled: ActionGate<DiscordActionConfig> = () => false;
 
 describe("handleDiscordPresenceAction", () => {
@@ -22,8 +38,18 @@ describe("handleDiscordPresenceAction", () => {
     return await handleDiscordPresenceAction("setPresence", params, actionGate);
   }
 
+  async function updateSelfProfile(
+    params: Record<string, unknown>,
+    actionGate: ActionGate<DiscordActionConfig> = selfProfileEnabled,
+  ) {
+    return await handleDiscordPresenceAction("updateSelfProfile", params, actionGate);
+  }
+
   beforeEach(() => {
     mockUpdatePresence.mockClear();
+    fetchCurrentUserDiscord.mockClear();
+    updateCurrentUserAvatarDiscord.mockClear();
+    updateSelfNicknameDiscord.mockClear();
     clearGateways();
     registerGateway(undefined, createMockGateway());
   });
@@ -40,10 +66,10 @@ describe("handleDiscordPresenceAction", () => {
       status: "online",
       afk: false,
     });
-    const textBlock = result.content.find((block) => block.type === "text");
-    const payload = JSON.parse(
-      (textBlock as { type: "text"; text: string } | undefined)?.text ?? "{}",
-    );
+    const payload = result.details as {
+      ok: boolean;
+      activities: Array<{ type: number; name: string }>;
+    };
     expect(payload.ok).toBe(true);
     expect(payload.activities[0]).toEqual({ type: 0, name: "with fire" });
   });
@@ -76,7 +102,7 @@ describe("handleDiscordPresenceAction", () => {
     {
       name: "custom activity using state",
       params: { activityType: "custom", activityState: "Vibing" },
-      expectedActivities: [{ name: "", type: 4, state: "Vibing" }],
+      expectedActivities: [{ name: "Custom Status", type: 4, state: "Vibing" }],
     },
     {
       name: "activity with state",
@@ -152,9 +178,215 @@ describe("handleDiscordPresenceAction", () => {
     );
   });
 
-  it("rejects unknown presence actions", async () => {
-    await expect(handleDiscordPresenceAction("unknownAction", {}, presenceEnabled)).rejects.toThrow(
-      /Unknown presence action/,
+  it("updates self profile fields (nickname/avatar/presence)", async () => {
+    const result = await updateSelfProfile({
+      guildId: "guild-1",
+      nickname: "OpenClaw Bot",
+      userId: "user:bot-1",
+      buffer: "Zm9v",
+      contentType: "image/png",
+      status: "idle",
+      statusMessage: "Shipping features",
+    });
+
+    expect(fetchCurrentUserDiscord).toHaveBeenCalledWith();
+    expect(updateSelfNicknameDiscord).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      nickname: "OpenClaw Bot",
+    });
+    expect(updateCurrentUserAvatarDiscord).toHaveBeenCalledWith({
+      avatar: "data:image/png;base64,Zm9v",
+    });
+    expect(mockUpdatePresence).toHaveBeenCalledWith({
+      since: null,
+      activities: [{ name: "Custom Status", type: 4, state: "Shipping features" }],
+      status: "idle",
+      afk: false,
+    });
+
+    const payload = result.details as {
+      ok: boolean;
+      selfUserId: string;
+      updates: Record<string, unknown>;
+    };
+    expect(payload.ok).toBe(true);
+    expect(payload.selfUserId).toBe("bot-1");
+    expect(payload.updates).toEqual(
+      expect.objectContaining({
+        nickname: { guildId: "guild-1", nickname: "OpenClaw Bot" },
+        avatar: { updated: true },
+      }),
     );
+  });
+
+  it("rejects non-self user selectors", async () => {
+    await expect(
+      updateSelfProfile({ guildId: "guild-1", nickname: "Nope", userId: "user:bot-2" }),
+    ).rejects.toThrow(/restricted to the bot account/);
+    expect(updateSelfNicknameDiscord).not.toHaveBeenCalled();
+  });
+
+  it("rejects when no update fields are provided", async () => {
+    await expect(updateSelfProfile({ userId: "user:bot-1" })).rejects.toThrow(
+      /No self-profile fields provided/,
+    );
+  });
+
+  it("requires guildId when nickname is provided", async () => {
+    await expect(updateSelfProfile({ nickname: "Nick" })).rejects.toThrow(/guildId required/);
+  });
+
+  it("continues other steps in bestEffort mode when nickname is missing guildId", async () => {
+    const result = await updateSelfProfile({
+      nickname: "Nick",
+      buffer: "Zm9v",
+      contentType: "image/png",
+      bestEffort: true,
+    });
+
+    const payload = result.details as {
+      ok: boolean;
+      partial: boolean;
+      updates: Record<string, unknown>;
+      errors: Array<{ step: string; message: string }>;
+    };
+
+    expect(payload.ok).toBe(false);
+    expect(payload.partial).toBe(true);
+    expect(payload.updates).toEqual({ avatar: { updated: true } });
+    expect(payload.errors).toHaveLength(1);
+    expect(payload.errors[0]?.step).toBe("nickname");
+    expect(payload.errors[0]?.message).toMatch(/guildId required/i);
+    expect(updateCurrentUserAvatarDiscord).toHaveBeenCalledWith({
+      avatar: "data:image/png;base64,Zm9v",
+    });
+  });
+
+  it("rejects avatar buffers without a valid image content type", async () => {
+    await expect(updateSelfProfile({ buffer: "Zm9v", contentType: "text/plain" })).rejects.toThrow(
+      /avatar updates require PNG, JPEG, GIF, or WEBP/i,
+    );
+  });
+
+  it("rejects invalid avatar base64 buffers", async () => {
+    await expect(
+      updateSelfProfile({
+        buffer: "this is not base64@@",
+        contentType: "image/png",
+      }),
+    ).rejects.toThrow(/must be valid base64/i);
+  });
+
+  it("rejects avatar buffers that exceed Discord size limits", async () => {
+    const tooLargeBase64 = Buffer.alloc(10 * 1024 * 1024 + 1, 0).toString("base64");
+    await expect(
+      updateSelfProfile({
+        buffer: tooLargeBase64,
+        contentType: "image/png",
+      }),
+    ).rejects.toThrow(/exceeds the Discord limit of 10 MB/i);
+  });
+
+  it("updates nickname without needing an active gateway connection", async () => {
+    clearGateways();
+    await updateSelfProfile({ guildId: "guild-1", nickname: "Only Nick" });
+    expect(updateSelfNicknameDiscord).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      nickname: "Only Nick",
+    });
+    expect(mockUpdatePresence).not.toHaveBeenCalled();
+  });
+
+  it("fails before REST mutations when presence fields are requested and gateway is disconnected", async () => {
+    clearGateways();
+
+    await expect(
+      updateSelfProfile({
+        guildId: "guild-1",
+        nickname: "Nick + Presence",
+        status: "online",
+      }),
+    ).rejects.toThrow(/gateway not available|gateway is not connected/i);
+
+    expect(updateSelfNicknameDiscord).not.toHaveBeenCalled();
+    expect(updateCurrentUserAvatarDiscord).not.toHaveBeenCalled();
+    expect(mockUpdatePresence).not.toHaveBeenCalled();
+  });
+
+  it("returns partial result in bestEffort mode when one step fails", async () => {
+    updateCurrentUserAvatarDiscord.mockRejectedValueOnce(new Error("avatar upload failed"));
+
+    const result = await updateSelfProfile({
+      guildId: "guild-1",
+      nickname: "Still Apply Nick",
+      buffer: "Zm9v",
+      contentType: "image/png",
+      bestEffort: true,
+    });
+
+    const payload = result.details as {
+      ok: boolean;
+      partial: boolean;
+      updates: Record<string, unknown>;
+      errors: Array<{ step: string; message: string }>;
+    };
+
+    expect(payload.ok).toBe(false);
+    expect(payload.partial).toBe(true);
+    expect(payload.updates).toEqual({
+      nickname: { guildId: "guild-1", nickname: "Still Apply Nick" },
+    });
+    expect(payload.errors).toEqual([{ step: "avatar", message: "avatar upload failed" }]);
+  });
+
+  it("reports applied steps when a later step fails without bestEffort", async () => {
+    updateCurrentUserAvatarDiscord.mockRejectedValueOnce(new Error("avatar upload failed"));
+
+    await expect(
+      updateSelfProfile({
+        guildId: "guild-1",
+        nickname: "Still Apply Nick",
+        buffer: "Zm9v",
+        contentType: "image/png",
+      }),
+    ).rejects.toThrow(/Applied before failure: nickname/);
+  });
+
+  it("uses accountId for self-profile REST and gateway operations", async () => {
+    registerGateway("my-account", createMockGateway());
+    await updateSelfProfile(
+      {
+        accountId: "my-account",
+        guildId: "guild-1",
+        nickname: "Per Account",
+        status: "online",
+      },
+      presenceAndSelfProfileEnabled,
+    );
+    expect(fetchCurrentUserDiscord).toHaveBeenCalledWith({ accountId: "my-account" });
+    expect(updateSelfNicknameDiscord).toHaveBeenCalledWith(
+      {
+        guildId: "guild-1",
+        nickname: "Per Account",
+      },
+      { accountId: "my-account" },
+    );
+    expect(mockUpdatePresence).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "online",
+      }),
+    );
+  });
+
+  it("respects self-profile gating", async () => {
+    await expect(
+      updateSelfProfile({ guildId: "guild-1", nickname: "n" }, presenceEnabled),
+    ).rejects.toThrow(/self-profile updates are disabled/);
+  });
+
+  it("rejects unknown presence actions", async () => {
+    await expect(
+      handleDiscordPresenceAction("unknownAction", {}, presenceAndSelfProfileEnabled),
+    ).rejects.toThrow(/Unknown presence action/);
   });
 });

--- a/src/agents/tools/discord-actions-presence.ts
+++ b/src/agents/tools/discord-actions-presence.ts
@@ -2,6 +2,13 @@ import type { Activity, UpdatePresenceData } from "@buape/carbon/gateway";
 import type { AgentToolResult } from "@mariozechner/pi-agent-core";
 import type { DiscordActionConfig } from "../../config/config.js";
 import { getGateway } from "../../discord/monitor/gateway-registry.js";
+import {
+  fetchCurrentUserDiscord,
+  updateCurrentUserAvatarDiscord,
+  updateSelfNicknameDiscord,
+} from "../../discord/send.js";
+import { parseDiscordTarget } from "../../discord/targets.js";
+import { loadWebMediaRaw } from "../../web/media.js";
 import { type ActionGate, jsonResult, readStringParam } from "./common.js";
 
 const ACTIVITY_TYPE_MAP: Record<string, number> = {
@@ -13,51 +20,73 @@ const ACTIVITY_TYPE_MAP: Record<string, number> = {
   competing: 5,
 };
 
+const CUSTOM_STATUS_ACTIVITY_NAME = "Custom Status";
+
 const VALID_STATUSES = new Set(["online", "dnd", "idle", "invisible"]);
+const ALLOWED_AVATAR_MIME_TYPES = new Set([
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/gif",
+  "image/webp",
+]);
+const DISCORD_MAX_AVATAR_BYTES = 10 * 1024 * 1024;
 
-export async function handleDiscordPresenceAction(
-  action: string,
-  params: Record<string, unknown>,
-  isActionEnabled: ActionGate<DiscordActionConfig>,
-): Promise<AgentToolResult<unknown>> {
-  if (action !== "setPresence") {
-    throw new Error(`Unknown presence action: ${action}`);
-  }
-
-  if (!isActionEnabled("presence", false)) {
-    throw new Error("Discord presence changes are disabled.");
-  }
-
-  const accountId = readStringParam(params, "accountId");
-  const gateway = getGateway(accountId);
-  if (!gateway) {
-    throw new Error(
-      `Discord gateway not available${accountId ? ` for account "${accountId}"` : ""}. The bot may not be connected.`,
-    );
-  }
-  if (!gateway.isConnected) {
-    throw new Error(
-      `Discord gateway is not connected${accountId ? ` for account "${accountId}"` : ""}.`,
-    );
-  }
-
-  const statusRaw = readStringParam(params, "status") ?? "online";
-  if (!VALID_STATUSES.has(statusRaw)) {
+function buildPresencePayload(params: {
+  values: Record<string, unknown>;
+  defaultStatus: UpdatePresenceData["status"];
+  includeStatusMessageAlias: boolean;
+  allowEmpty: boolean;
+}): UpdatePresenceData | undefined {
+  const statusRaw = readStringParam(params.values, "status");
+  if (statusRaw && !VALID_STATUSES.has(statusRaw)) {
     throw new Error(
       `Invalid status "${statusRaw}". Must be one of: ${[...VALID_STATUSES].join(", ")}`,
     );
   }
-  const status = statusRaw as UpdatePresenceData["status"];
 
-  const activityTypeRaw = readStringParam(params, "activityType");
-  const activityName = readStringParam(params, "activityName");
+  let activityTypeRaw = readStringParam(params.values, "activityType");
+  const activityName = readStringParam(params.values, "activityName");
+  const activityUrl = readStringParam(params.values, "activityUrl");
+  let activityState = readStringParam(params.values, "activityState");
+  const statusMessage = params.includeStatusMessageAlias
+    ? readStringParam(params.values, "statusMessage", { allowEmpty: true })
+    : undefined;
+
+  if (statusMessage !== undefined) {
+    if (activityState === undefined) {
+      activityState = statusMessage;
+    }
+    if (!activityTypeRaw) {
+      activityTypeRaw = "custom";
+    }
+  }
+
+  const hasPresenceInputs =
+    statusRaw !== undefined ||
+    activityTypeRaw !== undefined ||
+    activityName !== undefined ||
+    activityUrl !== undefined ||
+    activityState !== undefined;
+
+  if (!hasPresenceInputs) {
+    if (!params.allowEmpty) {
+      return undefined;
+    }
+    return {
+      since: null,
+      activities: [],
+      status: params.defaultStatus,
+      afk: false,
+    };
+  }
 
   const activities: Activity[] = [];
 
-  if (activityTypeRaw || activityName) {
+  if (activityTypeRaw || activityName || activityUrl || activityState !== undefined) {
     if (!activityTypeRaw) {
       throw new Error(
-        "activityType is required when activityName is provided. " +
+        "activityType is required when activityName/activityState/activityUrl is provided. " +
           `Valid types: ${Object.keys(ACTIVITY_TYPE_MAP).join(", ")}`,
       );
     }
@@ -69,43 +98,341 @@ export async function handleDiscordPresenceAction(
     }
 
     const activity: Activity = {
-      name: activityName ?? "",
+      name: activityName ?? (typeNum === 4 ? CUSTOM_STATUS_ACTIVITY_NAME : ""),
       type: typeNum,
     };
 
-    // Streaming URL (Twitch/YouTube). May not render for bots but is the correct payload shape.
-    if (typeNum === 1) {
-      const url = readStringParam(params, "activityUrl");
-      if (url) {
-        activity.url = url;
-      }
+    if (typeNum === 1 && activityUrl) {
+      activity.url = activityUrl;
     }
 
-    const state = readStringParam(params, "activityState");
-    if (state) {
-      activity.state = state;
+    if (activityState !== undefined) {
+      activity.state = activityState;
     }
 
     activities.push(activity);
   }
 
-  const presenceData: UpdatePresenceData = {
+  return {
     since: null,
     activities,
-    status,
+    status: (statusRaw ?? params.defaultStatus) as UpdatePresenceData["status"],
     afk: false,
   };
+}
 
-  gateway.updatePresence(presenceData);
+function requireConnectedGateway(accountId?: string): {
+  updatePresence: (payload: UpdatePresenceData) => void;
+} {
+  const gateway = getGateway(accountId);
+  if (!gateway) {
+    throw new Error(
+      `Discord gateway not available${accountId ? ` for account "${accountId}"` : ""}. The bot may not be connected.`,
+    );
+  }
+  if (!gateway.isConnected) {
+    throw new Error(
+      `Discord gateway is not connected${accountId ? ` for account "${accountId}"` : ""}.`,
+    );
+  }
+  return gateway;
+}
 
-  return jsonResult({
-    ok: true,
-    status,
-    activities: activities.map((a) => ({
-      type: a.type,
-      name: a.name,
-      ...(a.url ? { url: a.url } : {}),
-      ...(a.state ? { state: a.state } : {}),
-    })),
+function normalizeUserLikeTarget(raw: string, label: string): string {
+  let parsed: ReturnType<typeof parseDiscordTarget> | undefined;
+  try {
+    parsed = parseDiscordTarget(raw, { defaultKind: "user" });
+  } catch {
+    parsed = undefined;
+  }
+  if (parsed) {
+    if (parsed.kind !== "user") {
+      throw new Error(
+        `Discord self-profile updates only accept user/member selectors. ${label} must resolve to a user id.`,
+      );
+    }
+    return parsed.id;
+  }
+  return raw.trim();
+}
+
+function enforceSelfOnlyScope(params: { values: Record<string, unknown>; selfId: string }): void {
+  const checks: Array<{ label: string; value?: string }> = [
+    { label: "userId", value: readStringParam(params.values, "userId") },
+    { label: "memberId", value: readStringParam(params.values, "memberId") },
+    { label: "target", value: readStringParam(params.values, "target") },
+  ];
+
+  for (const check of checks) {
+    if (!check.value) {
+      continue;
+    }
+    const normalized = normalizeUserLikeTarget(check.value, check.label);
+    if (normalized !== params.selfId) {
+      throw new Error(
+        `Discord self-profile updates are restricted to the bot account. ${check.label} "${check.value}" does not match bot user id "${params.selfId}".`,
+      );
+    }
+  }
+}
+
+function normalizeAvatarMime(raw?: string): string | undefined {
+  const contentType = raw?.trim().toLowerCase();
+  if (!contentType) {
+    return undefined;
+  }
+  if (contentType === "image/jpg") {
+    return "image/jpeg";
+  }
+  return contentType;
+}
+
+function validateAvatarMime(contentType?: string): string {
+  const normalized = normalizeAvatarMime(contentType);
+  if (!normalized || !ALLOWED_AVATAR_MIME_TYPES.has(normalized)) {
+    throw new Error(
+      "Discord avatar updates require PNG, JPEG, GIF, or WEBP image input (contentType/mimeType).",
+    );
+  }
+  return normalized;
+}
+
+function decodeBase64Strict(raw: string): Buffer {
+  const normalized = raw.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, "=");
+  if (!/^[A-Za-z0-9+/]+=*$/.test(padded)) {
+    throw new Error("Avatar buffer must be valid base64 data.");
+  }
+  const decoded = Buffer.from(padded, "base64");
+  if (decoded.length === 0 && padded.length > 0) {
+    throw new Error("Avatar buffer must be valid base64 data.");
+  }
+  const reEncoded = decoded.toString("base64").replace(/=+$/g, "");
+  const comparable = padded.replace(/=+$/g, "");
+  if (reEncoded !== comparable) {
+    throw new Error("Avatar buffer must be valid base64 data.");
+  }
+  return decoded;
+}
+
+async function resolveAvatarDataUri(params: {
+  values: Record<string, unknown>;
+  mediaLocalRoots?: readonly string[];
+}): Promise<string | undefined> {
+  const explicitAvatar = readStringParam(params.values, "avatar", { trim: false });
+  const mediaUrl =
+    explicitAvatar ??
+    readStringParam(params.values, "mediaUrl", { trim: false }) ??
+    readStringParam(params.values, "media", { trim: false }) ??
+    readStringParam(params.values, "path", { trim: false }) ??
+    readStringParam(params.values, "filePath", { trim: false });
+
+  const rawBuffer = readStringParam(params.values, "buffer", { trim: false });
+  const hintedContentType =
+    readStringParam(params.values, "contentType") ?? readStringParam(params.values, "mimeType");
+
+  if (!mediaUrl && !rawBuffer) {
+    return undefined;
+  }
+
+  if (rawBuffer) {
+    const dataUrlMatch = /^data:([^;]+);base64,(.*)$/i.exec(rawBuffer.trim());
+    const contentType = validateAvatarMime(hintedContentType ?? dataUrlMatch?.[1]);
+    const payload = (dataUrlMatch ? dataUrlMatch[2] : rawBuffer.trim()).replace(/\s+/g, "");
+    if (!payload) {
+      throw new Error("Avatar buffer is empty.");
+    }
+    const decodedBuffer = decodeBase64Strict(payload);
+    if (decodedBuffer.byteLength > DISCORD_MAX_AVATAR_BYTES) {
+      throw new Error(
+        `Avatar buffer exceeds the Discord limit of ${Math.floor(DISCORD_MAX_AVATAR_BYTES / (1024 * 1024))} MB.`,
+      );
+    }
+    return `data:${contentType};base64,${decodedBuffer.toString("base64")}`;
+  }
+
+  const media = await loadWebMediaRaw(mediaUrl as string, {
+    maxBytes: DISCORD_MAX_AVATAR_BYTES,
+    localRoots: params.mediaLocalRoots,
   });
+  const contentType = validateAvatarMime(hintedContentType ?? media.contentType);
+  return `data:${contentType};base64,${media.buffer.toString("base64")}`;
+}
+
+function stringifyError(err: unknown): string {
+  if (err instanceof Error && err.message.trim()) {
+    return err.message.trim();
+  }
+  return String(err);
+}
+
+function listAppliedSelfProfileSteps(updates: Record<string, unknown>): string[] {
+  return ["nickname", "avatar", "presence"].filter((key) => Object.hasOwn(updates, key));
+}
+
+export async function handleDiscordPresenceAction(
+  action: string,
+  params: Record<string, unknown>,
+  isActionEnabled: ActionGate<DiscordActionConfig>,
+  options?: {
+    mediaLocalRoots?: readonly string[];
+  },
+): Promise<AgentToolResult<unknown>> {
+  const accountId = readStringParam(params, "accountId");
+
+  if (action === "setPresence") {
+    if (!isActionEnabled("presence", false)) {
+      throw new Error("Discord presence changes are disabled.");
+    }
+
+    const gateway = requireConnectedGateway(accountId);
+    const presenceData = buildPresencePayload({
+      values: params,
+      defaultStatus: "online",
+      includeStatusMessageAlias: false,
+      allowEmpty: true,
+    });
+
+    if (!presenceData) {
+      throw new Error("Failed to build Discord presence payload.");
+    }
+
+    gateway.updatePresence(presenceData);
+
+    return jsonResult({
+      ok: true,
+      status: presenceData.status,
+      activities: presenceData.activities.map((a) => ({
+        type: a.type,
+        name: a.name,
+        ...(a.url ? { url: a.url } : {}),
+        ...(a.state !== undefined ? { state: a.state } : {}),
+      })),
+    });
+  }
+
+  if (action === "updateSelfProfile") {
+    if (!isActionEnabled("selfProfile", false)) {
+      throw new Error("Discord self-profile updates are disabled.");
+    }
+
+    const selfUser = accountId
+      ? await fetchCurrentUserDiscord({ accountId })
+      : await fetchCurrentUserDiscord();
+    enforceSelfOnlyScope({ values: params, selfId: selfUser.id });
+
+    const nickname = readStringParam(params, "nickname", { allowEmpty: true });
+    const avatarDataUri = await resolveAvatarDataUri({
+      values: params,
+      mediaLocalRoots: options?.mediaLocalRoots,
+    });
+    const presenceData = buildPresencePayload({
+      values: params,
+      defaultStatus: "online",
+      includeStatusMessageAlias: true,
+      allowEmpty: false,
+    });
+
+    if (nickname === undefined && !avatarDataUri && !presenceData) {
+      throw new Error(
+        "No self-profile fields provided. Set at least one of: nickname, avatar (avatar/media/path/filePath/buffer), status, statusMessage, or activity* fields.",
+      );
+    }
+
+    const gateway = presenceData ? requireConnectedGateway(accountId) : null;
+    const bestEffort = params.bestEffort === true;
+
+    const updates: Record<string, unknown> = {};
+    const errors: Array<{ step: "nickname" | "avatar" | "presence"; message: string }> = [];
+
+    const runSelfProfileStep = async (
+      step: "nickname" | "avatar" | "presence",
+      task: () => Promise<void>,
+    ): Promise<void> => {
+      try {
+        await task();
+      } catch (err) {
+        const message = stringifyError(err);
+        errors.push({ step, message });
+        if (!bestEffort) {
+          const appliedSteps = listAppliedSelfProfileSteps(updates);
+          const appliedMessage =
+            appliedSteps.length > 0 ? ` Applied before failure: ${appliedSteps.join(", ")}.` : "";
+          const normalizedMessage = message.replace(/[.\s]+$/g, "");
+          throw new Error(
+            `Discord self-profile update failed at ${step}: ${normalizedMessage}.${appliedMessage}`,
+            { cause: err },
+          );
+        }
+      }
+    };
+
+    if (nickname !== undefined) {
+      await runSelfProfileStep("nickname", async () => {
+        const guildId = readStringParam(params, "guildId", { required: true });
+        if (accountId) {
+          await updateSelfNicknameDiscord(
+            {
+              guildId,
+              nickname: nickname || null,
+            },
+            { accountId },
+          );
+        } else {
+          await updateSelfNicknameDiscord({
+            guildId,
+            nickname: nickname || null,
+          });
+        }
+        updates.nickname = {
+          guildId,
+          nickname: nickname || null,
+        };
+      });
+    }
+
+    if (avatarDataUri) {
+      await runSelfProfileStep("avatar", async () => {
+        if (accountId) {
+          await updateCurrentUserAvatarDiscord({ avatar: avatarDataUri }, { accountId });
+        } else {
+          await updateCurrentUserAvatarDiscord({ avatar: avatarDataUri });
+        }
+        updates.avatar = { updated: true };
+      });
+    }
+
+    if (presenceData && gateway) {
+      await runSelfProfileStep("presence", async () => {
+        gateway.updatePresence(presenceData);
+        updates.presence = {
+          status: presenceData.status,
+          activities: presenceData.activities.map((a) => ({
+            type: a.type,
+            name: a.name,
+            ...(a.url ? { url: a.url } : {}),
+            ...(a.state !== undefined ? { state: a.state } : {}),
+          })),
+        };
+      });
+    }
+
+    if (errors.length > 0) {
+      return jsonResult({
+        ok: false,
+        partial: true,
+        selfUserId: selfUser.id,
+        updates,
+        errors,
+      });
+    }
+
+    return jsonResult({
+      ok: true,
+      selfUserId: selfUser.id,
+      updates,
+    });
+  }
+
+  throw new Error(`Unknown presence action: ${action}`);
 }

--- a/src/agents/tools/discord-actions.ts
+++ b/src/agents/tools/discord-actions.ts
@@ -53,7 +53,7 @@ const guildActions = new Set([
 
 const moderationActions = new Set(["timeout", "kick", "ban"]);
 
-const presenceActions = new Set(["setPresence"]);
+const presenceActions = new Set(["setPresence", "updateSelfProfile"]);
 
 export async function handleDiscordAction(
   params: Record<string, unknown>,
@@ -76,7 +76,7 @@ export async function handleDiscordAction(
     return await handleDiscordModerationAction(action, params, isActionEnabled);
   }
   if (presenceActions.has(action)) {
-    return await handleDiscordPresenceAction(action, params, isActionEnabled);
+    return await handleDiscordPresenceAction(action, params, isActionEnabled, options);
   }
   throw new Error(`Unknown action: ${action}`);
 }

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -375,6 +375,34 @@ function buildPresenceSchema() {
   };
 }
 
+function buildDiscordSelfProfileSchema() {
+  return {
+    nickname: Type.Optional(
+      Type.String({
+        description: "Guild-specific bot nickname (self-only). Requires guildId.",
+      }),
+    ),
+    memberId: Type.Optional(
+      Type.String({
+        description:
+          "Optional self-check id. If provided, must match the bot account user id (self-only action).",
+      }),
+    ),
+    statusMessage: Type.Optional(
+      Type.String({
+        description:
+          "Custom status text for Discord self-profile action (maps to custom activity state).",
+      }),
+    ),
+    avatar: Type.Optional(
+      Type.String({
+        description:
+          "Avatar source URL or local path for Discord self-profile action (alias for media/path/filePath).",
+      }),
+    ),
+  };
+}
+
 function buildChannelManagementSchema() {
   return {
     name: Type.Optional(Type.String()),
@@ -412,6 +440,7 @@ function buildMessageToolSchemaProps(options: {
     ...buildGatewaySchema(),
     ...buildChannelManagementSchema(),
     ...buildPresenceSchema(),
+    ...buildDiscordSelfProfileSchema(),
   };
 }
 

--- a/src/channels/plugins/actions/actions.test.ts
+++ b/src/channels/plugins/actions/actions.test.ts
@@ -203,6 +203,21 @@ describe("discord message actions", () => {
     expect(actions).toContain("emoji-upload");
     expect(actions).toContain("sticker-upload");
     expect(actions).toContain("channel-create");
+    expect(actions).not.toContain("self-profile");
+  });
+
+  it("lists self-profile action only when gate is enabled", () => {
+    const disabledCfg = { channels: { discord: { token: "d0" } } } as OpenClawConfig;
+    const enabledCfg = {
+      channels: { discord: { token: "d0", actions: { selfProfile: true } } },
+    } as OpenClawConfig;
+
+    expect(discordMessageActions.listActions?.({ cfg: disabledCfg }) ?? []).not.toContain(
+      "self-profile",
+    );
+    expect(discordMessageActions.listActions?.({ cfg: enabledCfg }) ?? []).toContain(
+      "self-profile",
+    );
   });
 
   it("respects disabled channel actions", async () => {
@@ -397,6 +412,29 @@ describe("handleDiscordMessageAction", () => {
         autoArchiveDuration: 1440,
       },
     },
+    {
+      name: "forwards self-profile update payload",
+      input: {
+        action: "self-profile" as const,
+        params: {
+          guildId: "guild-1",
+          userId: "bot-1",
+          nickname: "Bot",
+          statusMessage: "Working",
+          buffer: "Zm9v",
+          contentType: "image/png",
+        },
+      },
+      expected: {
+        action: "updateSelfProfile",
+        guildId: "guild-1",
+        userId: "bot-1",
+        nickname: "Bot",
+        statusMessage: "Working",
+        buffer: "Zm9v",
+        contentType: "image/png",
+      },
+    },
   ] as const;
 
   for (const testCase of forwardingCases) {
@@ -411,6 +449,81 @@ describe("handleDiscordMessageAction", () => {
       expect(call?.[1]).toEqual(expect.any(Object));
     });
   }
+
+  it("requires accountId for self-profile when multiple Discord accounts are enabled", async () => {
+    await expect(
+      handleDiscordMessageAction({
+        action: "self-profile",
+        params: {
+          guildId: "guild-1",
+          nickname: "Bot",
+        },
+        cfg: {
+          channels: {
+            discord: {
+              accounts: {
+                alpha: { token: "a" },
+                beta: { token: "b" },
+              },
+            },
+          },
+        } as OpenClawConfig,
+      }),
+    ).rejects.toThrow(/accountId required/i);
+
+    expect(handleDiscordAction).not.toHaveBeenCalled();
+  });
+
+  it("requires accountId for self-profile when multiple accounts are enabled even if only one has token", async () => {
+    await expect(
+      handleDiscordMessageAction({
+        action: "self-profile",
+        params: {
+          guildId: "guild-1",
+          nickname: "Bot",
+        },
+        cfg: {
+          channels: {
+            discord: {
+              accounts: {
+                alpha: { token: "a" },
+                beta: {},
+              },
+            },
+          },
+        } as OpenClawConfig,
+      }),
+    ).rejects.toThrow(/accountId required/i);
+
+    expect(handleDiscordAction).not.toHaveBeenCalled();
+  });
+
+  it("defaults self-profile accountId to the sole enabled Discord account", async () => {
+    await handleDiscordMessageAction({
+      action: "self-profile",
+      params: {
+        guildId: "guild-1",
+        nickname: "Bot",
+      },
+      cfg: {
+        channels: {
+          discord: {
+            accounts: {
+              ops: { token: "tok" },
+            },
+          },
+        },
+      } as OpenClawConfig,
+    });
+
+    const call = handleDiscordAction.mock.calls.at(-1);
+    expect(call?.[0]).toEqual(
+      expect.objectContaining({
+        action: "updateSelfProfile",
+        accountId: "ops",
+      }),
+    );
+  });
 
   it("uses trusted requesterSenderId for moderation and ignores params senderUserId", async () => {
     await handleDiscordMessageAction({

--- a/src/channels/plugins/actions/discord.ts
+++ b/src/channels/plugins/actions/discord.ts
@@ -98,6 +98,9 @@ export const discordMessageActions: ChannelMessageActionAdapter = {
     if (isEnabled("presence", false)) {
       actions.add("set-presence");
     }
+    if (isEnabled("selfProfile", false)) {
+      actions.add("self-profile");
+    }
     return Array.from(actions);
   },
   extractToolSend: ({ args }) => {

--- a/src/channels/plugins/actions/discord/handle-action.ts
+++ b/src/channels/plugins/actions/discord/handle-action.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../../agents/tools/common.js";
 import { readDiscordParentIdParam } from "../../../../agents/tools/discord-actions-shared.js";
 import { handleDiscordAction } from "../../../../agents/tools/discord-actions.js";
+import { listEnabledDiscordAccounts } from "../../../../discord/accounts.js";
 import { resolveDiscordChannelId } from "../../../../discord/targets.js";
 import type { ChannelMessageActionContext } from "../../types.js";
 import { resolveReactionMessageId } from "../reaction-message-id.js";
@@ -274,6 +275,49 @@ export async function handleDiscordMessageAction(
         activityName: readStringParam(params, "activityName"),
         activityUrl: readStringParam(params, "activityUrl"),
         activityState: readStringParam(params, "activityState"),
+      },
+      cfg,
+      actionOptions,
+    );
+  }
+
+  if (action === "self-profile") {
+    const enabledAccounts = listEnabledDiscordAccounts(cfg);
+    let effectiveAccountId = accountId;
+    if (!effectiveAccountId) {
+      if (enabledAccounts.length > 1) {
+        throw new Error(
+          "accountId required for Discord self-profile updates when multiple Discord accounts are enabled.",
+        );
+      }
+      if (enabledAccounts.length === 1) {
+        effectiveAccountId = enabledAccounts[0]?.accountId;
+      }
+    }
+
+    return await handleDiscordAction(
+      {
+        action: "updateSelfProfile",
+        accountId: effectiveAccountId ?? undefined,
+        guildId: readStringParam(params, "guildId"),
+        userId: readStringParam(params, "userId"),
+        memberId: readStringParam(params, "memberId"),
+        target: readStringParam(params, "target"),
+        nickname: readStringParam(params, "nickname", { allowEmpty: true }),
+        avatar: readStringParam(params, "avatar", { trim: false }),
+        mediaUrl:
+          readStringParam(params, "media", { trim: false }) ??
+          readStringParam(params, "path", { trim: false }) ??
+          readStringParam(params, "filePath", { trim: false }),
+        buffer: readStringParam(params, "buffer", { trim: false }),
+        contentType: readStringParam(params, "contentType") ?? readStringParam(params, "mimeType"),
+        status: readStringParam(params, "status"),
+        statusMessage: readStringParam(params, "statusMessage", { allowEmpty: true }),
+        activityType: readStringParam(params, "activityType"),
+        activityName: readStringParam(params, "activityName"),
+        activityUrl: readStringParam(params, "activityUrl"),
+        activityState: readStringParam(params, "activityState", { allowEmpty: true }),
+        bestEffort: params.bestEffort === true,
       },
       cfg,
       actionOptions,

--- a/src/channels/plugins/message-action-names.ts
+++ b/src/channels/plugins/message-action-names.ts
@@ -50,6 +50,7 @@ export const CHANNEL_MESSAGE_ACTION_NAMES = [
   "kick",
   "ban",
   "set-presence",
+  "self-profile",
   "download-file",
 ] as const;
 

--- a/src/config/types.discord.ts
+++ b/src/config/types.discord.ts
@@ -97,6 +97,8 @@ export type DiscordActionConfig = {
   channels?: boolean;
   /** Enable bot presence/activity changes (default: false). */
   presence?: boolean;
+  /** Enable self-only bot profile updates (nickname/avatar/status/activity). Default: false. */
+  selfProfile?: boolean;
 };
 
 export type DiscordIntentsConfig = {

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -451,6 +451,7 @@ export const DiscordAccountSchema = z
         moderation: z.boolean().optional(),
         channels: z.boolean().optional(),
         presence: z.boolean().optional(),
+        selfProfile: z.boolean().optional(),
       })
       .strict()
       .optional(),

--- a/src/discord/send.profile.ts
+++ b/src/discord/send.profile.ts
@@ -1,0 +1,28 @@
+import { Routes, type APIGuildMember, type APIUser } from "discord-api-types/v10";
+import { resolveDiscordRest } from "./send.shared.js";
+import type { DiscordReactOpts } from "./send.types.js";
+
+export async function fetchCurrentUserDiscord(opts: DiscordReactOpts = {}): Promise<APIUser> {
+  const rest = resolveDiscordRest(opts);
+  return (await rest.get(Routes.user("@me"))) as APIUser;
+}
+
+export async function updateSelfNicknameDiscord(
+  payload: { guildId: string; nickname: string | null },
+  opts: DiscordReactOpts = {},
+): Promise<APIGuildMember> {
+  const rest = resolveDiscordRest(opts);
+  return (await rest.patch(Routes.guildMember(payload.guildId, "@me"), {
+    body: { nick: payload.nickname },
+  })) as APIGuildMember;
+}
+
+export async function updateCurrentUserAvatarDiscord(
+  payload: { avatar: string | null },
+  opts: DiscordReactOpts = {},
+): Promise<APIUser> {
+  const rest = resolveDiscordRest(opts);
+  return (await rest.patch(Routes.user("@me"), {
+    body: { avatar: payload.avatar },
+  })) as APIUser;
+}

--- a/src/discord/send.ts
+++ b/src/discord/send.ts
@@ -12,6 +12,11 @@ export {
   uploadStickerDiscord,
 } from "./send.emojis-stickers.js";
 export {
+  fetchCurrentUserDiscord,
+  updateCurrentUserAvatarDiscord,
+  updateSelfNicknameDiscord,
+} from "./send.profile.js";
+export {
   addRoleDiscord,
   banMemberDiscord,
   createScheduledEventDiscord,

--- a/src/infra/outbound/message-action-params.test.ts
+++ b/src/infra/outbound/message-action-params.test.ts
@@ -54,4 +54,28 @@ describe("message action sandbox media hydration", () => {
       await fs.rm(outsideRoot, { recursive: true, force: true });
     }
   });
+
+  it("normalizes avatar alias paths in sandbox mode", async () => {
+    const sandboxRoot = await fs.mkdtemp(path.join(os.tmpdir(), "msg-params-avatar-"));
+    try {
+      const avatarPath = path.join(sandboxRoot, "avatar.png");
+      await fs.writeFile(avatarPath, "png", "utf8");
+
+      const args: Record<string, unknown> = {
+        avatar: "/workspace/avatar.png",
+      };
+
+      await normalizeSandboxMediaParams({
+        args,
+        mediaPolicy: {
+          mode: "sandbox",
+          sandboxRoot,
+        },
+      });
+
+      expect(args.avatar).toBe(avatarPath);
+    } finally {
+      await fs.rm(sandboxRoot, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/infra/outbound/message-action-params.ts
+++ b/src/infra/outbound/message-action-params.ts
@@ -269,7 +269,12 @@ export async function normalizeSandboxMediaParams(params: {
 }): Promise<void> {
   const sandboxRoot =
     params.mediaPolicy.mode === "sandbox" ? params.mediaPolicy.sandboxRoot.trim() : undefined;
-  const mediaKeys: Array<"media" | "path" | "filePath"> = ["media", "path", "filePath"];
+  const mediaKeys: Array<"media" | "path" | "filePath" | "avatar"> = [
+    "media",
+    "path",
+    "filePath",
+    "avatar",
+  ];
   for (const key of mediaKeys) {
     const raw = readStringParam(params.args, key, { trim: false });
     if (!raw) {

--- a/src/infra/outbound/message-action-runner.test.ts
+++ b/src/infra/outbound/message-action-runner.test.ts
@@ -704,6 +704,53 @@ describe("runMessageAction sandboxed media validation", () => {
     });
   });
 
+  it("forwards sandboxRoot in mediaLocalRoots for plugin avatar actions", async () => {
+    await withSandbox(async (sandboxDir) => {
+      const avatarPath = path.join(sandboxDir, "avatar.png");
+      await fs.writeFile(avatarPath, "png", "utf8");
+
+      const messageActionsModule = await import("../../channels/plugins/message-actions.js");
+      const dispatchSpy = vi
+        .spyOn(messageActionsModule, "dispatchChannelMessageAction")
+        .mockResolvedValue(jsonResult({ ok: true }));
+
+      let call:
+        | {
+            params?: Record<string, unknown>;
+            mediaLocalRoots?: readonly string[];
+          }
+        | undefined;
+      try {
+        await runMessageAction({
+          cfg: {
+            channels: {
+              discord: {
+                token: "d-token",
+              },
+            },
+          } as OpenClawConfig,
+          action: "self-profile",
+          params: {
+            channel: "discord",
+            avatar: "/workspace/avatar.png",
+          },
+          sandboxRoot: sandboxDir,
+        });
+        call = dispatchSpy.mock.calls.at(-1)?.[0] as
+          | {
+              params?: Record<string, unknown>;
+              mediaLocalRoots?: readonly string[];
+            }
+          | undefined;
+      } finally {
+        dispatchSpy.mockRestore();
+      }
+
+      expect(call?.params).toEqual(expect.objectContaining({ avatar: avatarPath }));
+      expect(call?.mediaLocalRoots).toEqual(expect.arrayContaining([sandboxDir]));
+    });
+  });
+
   it("rewrites MEDIA directives under sandbox", async () => {
     await withSandbox(async (sandboxDir) => {
       await expectSandboxMediaRewrite({

--- a/src/infra/outbound/message-action-runner.ts
+++ b/src/infra/outbound/message-action-runner.ts
@@ -278,12 +278,25 @@ type ResolvedActionContext = {
   channel: ChannelId;
   accountId?: string | null;
   dryRun: boolean;
+  mediaLocalRoots?: readonly string[];
   gateway?: MessageActionRunnerGateway;
   input: RunMessageActionParams;
   agentId?: string;
   resolvedTarget?: ResolvedMessagingTarget;
   abortSignal?: AbortSignal;
 };
+
+function resolvePluginMediaLocalRoots(params: {
+  mediaPolicy: ReturnType<typeof resolveAttachmentMediaPolicy>;
+  mediaLocalRoots?: readonly string[];
+}): readonly string[] | undefined {
+  const roots = [...(params.mediaLocalRoots ?? [])];
+  if (params.mediaPolicy.mode === "sandbox") {
+    roots.push(params.mediaPolicy.sandboxRoot.trim());
+  }
+  const normalized = [...new Set(roots.map((root) => root.trim()).filter(Boolean))];
+  return normalized.length > 0 ? normalized : undefined;
+}
 function resolveGateway(input: RunMessageActionParams): MessageActionRunnerGateway | undefined {
   if (!input.gateway) {
     return undefined;
@@ -653,7 +666,8 @@ async function handlePollAction(ctx: ResolvedActionContext): Promise<MessageActi
 }
 
 async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageActionRunResult> {
-  const { cfg, params, channel, accountId, dryRun, gateway, input, abortSignal } = ctx;
+  const { cfg, params, channel, accountId, dryRun, mediaLocalRoots, gateway, input, abortSignal } =
+    ctx;
   throwIfAborted(abortSignal);
   const action = input.action as Exclude<ChannelMessageActionName, "send" | "poll" | "broadcast">;
   if (dryRun) {
@@ -672,6 +686,7 @@ async function handlePluginAction(ctx: ResolvedActionContext): Promise<MessageAc
     action,
     cfg,
     params,
+    mediaLocalRoots,
     accountId: accountId ?? undefined,
     requesterSenderId: input.requesterSenderId ?? undefined,
     gateway,
@@ -732,6 +747,10 @@ export async function runMessageAction(
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, resolvedAgentId);
   const mediaPolicy = resolveAttachmentMediaPolicy({
     sandboxRoot: input.sandboxRoot,
+    mediaLocalRoots,
+  });
+  const pluginMediaLocalRoots = resolvePluginMediaLocalRoots({
+    mediaPolicy,
     mediaLocalRoots,
   });
 
@@ -802,6 +821,7 @@ export async function runMessageAction(
     channel,
     accountId,
     dryRun,
+    mediaLocalRoots: pluginMediaLocalRoots,
     gateway,
     input,
     abortSignal: input.abortSignal,

--- a/src/infra/outbound/message-action-spec.ts
+++ b/src/infra/outbound/message-action-spec.ts
@@ -55,6 +55,7 @@ export const MESSAGE_ACTION_TARGET_MODE: Record<ChannelMessageActionName, Messag
     kick: "none",
     ban: "none",
     "set-presence": "none",
+    "self-profile": "none",
     "download-file": "none",
   };
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenClaw lacks a dedicated, safe Discord **self-profile update** capability (self-only nickname/avatar/status/activity).
- Why it matters: Operators still need safe in-band bot identity/profile control without manual Discord UI edits or direct token scripts.
- What changed:
  - Adds `self-profile` message action (Discord only) behind `channels.discord.actions.selfProfile` (default `false`).
  - Enforces strict self-only scope (`userId/memberId/target` must resolve to bot self id).
  - Adds avatar validation hardening (MIME allowlist + strict base64 + 10MB limit).
  - Adds gateway preflight for combined profile+presence updates.
  - Adds multi-account safety (`accountId` required when multiple Discord accounts are enabled).
  - Adds partial-failure ergonomics (`bestEffort: true` -> returns `{ ok:false, partial:true, updates, errors }`).
  - Improves custom status normalization (`Custom Status` default activity name).
- What did NOT change (scope boundary):
  - No arbitrary member/user profile editing.
  - No generic cross-provider profile API.

## Change Type (select all)

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #34004

## User-visible / Behavior Changes

- New Discord action: `self-profile` (only when `channels.discord.actions.selfProfile=true`).
- Supports bot self updates for:
  - guild nickname (`nickname` + `guildId`)
  - avatar (`avatar`/`media`/`path`/`filePath`/`buffer`)
  - presence fields (`status`, `statusMessage`, `activity*`)
- Multi-account safety:
  - if multiple Discord accounts are enabled and `accountId` is omitted, action is rejected.
- Validation/safety:
  - strict self-only target checks
  - strict base64 validation
  - avatar size cap (10MB)
- Failure behavior:
  - default fail-fast with applied-step hint in error
  - `bestEffort: true` returns partial result payload instead of immediate throw.

## Security Impact (required)

- New permissions/capabilities? (`Yes`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

  - Risk: bot profile mutation capability can be abused if too broad.
  - Mitigation:
    - action gate default-off (`selfProfile=false`)
    - strict self-only enforcement (`userId/memberId/target` mismatch rejected)
    - no endpoint path for non-self member edits
    - explicit `accountId` requirement for multi-account contexts.

## Repro + Verification

### Environment

- OS: Linux (containerized)
- Runtime/container: OpenClaw gateway
- Model/provider: openai-codex / gpt-5.3-codex
- Integration/channel (if any): Discord
- Relevant config (redacted):

```json5
{
  channels: {
    discord: {
      actions: {
        selfProfile: true,
      },
      // when multiple accounts are configured, pass accountId in self-profile actions
      accounts: {
        ops: { token: "***" },
        chat: { token: "***" },
      },
    },
  },
}
```

### Steps

1. Enable `channels.discord.actions.selfProfile=true`.
2. Call `message` with `action:"self-profile"` and update nickname/avatar/statusMessage.
3. Try non-self selector (`userId` not bot id) and verify rejection.
4. In multi-account config, omit `accountId` and verify rejection.
5. Send invalid base64 avatar buffer and verify validation rejection.
6. Use `bestEffort:true` and force one step failure to verify partial response payload.

### Expected

- Self-only updates succeed when valid.
- Non-self selectors are rejected.
- Multi-account ambiguity is rejected without `accountId`.
- Invalid base64 / oversize avatar is rejected before outbound mutation.
- `bestEffort:true` returns partial structured result.

### Actual

- Matches expected in targeted tests.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Commands run:

- `pnpm vitest run src/agents/tools/discord-actions-presence.test.ts src/channels/plugins/actions/actions.test.ts src/agents/tools/message-tool.test.ts src/infra/outbound/message-action-runner.test.ts src/infra/outbound/message-action-runner.threading.test.ts`
- `pnpm exec oxlint --type-aware src/agents/tools/discord-actions-presence.ts src/agents/tools/discord-actions-presence.test.ts src/channels/plugins/actions/discord/handle-action.ts src/channels/plugins/actions/actions.test.ts`
- `pnpm exec oxfmt --check src/agents/tools/discord-actions-presence.ts src/agents/tools/discord-actions-presence.test.ts src/channels/plugins/actions/discord/handle-action.ts src/channels/plugins/actions/actions.test.ts`

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - self-profile dispatch + gating
  - strict self-only checks
  - multi-account `accountId` enforcement
  - strict avatar base64/size validation
  - bestEffort partial payload behavior
- Edge cases checked:
  - gateway preflight with combined nickname+presence updates
  - fail-fast error includes applied-step hints
- What you did **not** verify:
  - live Discord production account mutation in this CI-like environment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Optional`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

  - Optional only: set `channels.discord.actions.selfProfile=true`.
  - In multi-account Discord setups, include `accountId` when using `self-profile`.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - set `channels.discord.actions.selfProfile=false`
- Files/config to restore:
  - revert the self-profile-only branch commits
- Known bad symptoms reviewers should watch for:
  - unexpected self-profile rejection due to missing `accountId` in multi-account config
  - malformed avatar buffer errors from invalid inputs.

## Risks and Mitigations

- Risk: over-strict account routing in multi-account deployments may block legacy automation.
  - Mitigation: explicit, actionable error message and docs update.
- Risk: partial mutation confusion in multi-step updates.
  - Mitigation: fail-fast default + bestEffort structured partial payload.

## AI assistance disclosure

- AI-assisted: Yes (OpenClaw/Codex)
- Human review: Completed
- Test level: Focused targeted tests + lint/format checks
