### PR TITLE
feat(slack): add threadImplicitMention config to disable implicit thread triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -420,6 +420,7 @@ Docs: https://docs.openclaw.ai
 ### Changes
 
 - Docs/Contributing: require before/after screenshots for UI or visual PRs in the pre-PR checklist. (#32206) Thanks @hydro13.
+- Slack/Thread implicit mention: add `channels.slack.thread.implicitMention` (global) and `channels.slack.channels.<id>.threadImplicitMention` (per-channel) config options to disable implicit thread participation triggers; agents only respond to explicit `@mentions` in threads when set to `false` (default `true` preserves existing behavior).
 
 ### Fixes
 

--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -193,6 +193,7 @@ For actions/directory reads, user token can be preferred when configured. For wr
     Per-channel controls (`channels.slack.channels.<id|name>`):
 
     - `requireMention`
+    - `threadImplicitMention` — set to `false` to disable implicit thread participation triggers for this channel (overrides global `thread.implicitMention`)
     - `users` (allowlist)
     - `allowBots`
     - `skills`
@@ -239,6 +240,7 @@ and still route command execution against the target conversation session (`Comm
 - Thread replies can create thread session suffixes (`:thread:<threadTs>`) when applicable.
 - `channels.slack.thread.historyScope` default is `thread`; `thread.inheritParent` default is `false`.
 - `channels.slack.thread.initialHistoryLimit` controls how many existing thread messages are fetched when a new thread session starts (default `20`; set `0` to disable).
+- `channels.slack.thread.implicitMention` (default `true`) controls whether bot thread participation implicitly bypasses `requireMention`; set to `false` to require an explicit `@mention` even in threads the bot has posted in. Override per-channel with `channels.slack.channels.<id>.threadImplicitMention`.
 
 Reply threading controls:
 
@@ -527,7 +529,7 @@ Primary reference:
   - DM access: `dm.enabled`, `dmPolicy`, `allowFrom` (legacy: `dm.policy`, `dm.allowFrom`), `dm.groupEnabled`, `dm.groupChannels`
   - compatibility toggle: `dangerouslyAllowNameMatching` (break-glass; keep off unless needed)
   - channel access: `groupPolicy`, `channels.*`, `channels.*.users`, `channels.*.requireMention`
-  - threading/history: `replyToMode`, `replyToModeByChatType`, `thread.*`, `historyLimit`, `dmHistoryLimit`, `dms.*.historyLimit`
+  - threading/history: `replyToMode`, `replyToModeByChatType`, `thread.*` (incl. `thread.implicitMention`), `historyLimit`, `dmHistoryLimit`, `dms.*.historyLimit`
   - delivery: `textChunkLimit`, `chunkMode`, `mediaMaxMb`, `streaming`, `nativeStreaming`
   - ops/features: `configWrites`, `commands.native`, `slashCommand.*`, `actions.*`, `userToken`, `userTokenReadOnly`
 

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -31,6 +31,12 @@ export type SlackChannelConfig = {
   allow?: boolean;
   /** Require mentioning the bot to trigger replies. */
   requireMention?: boolean;
+  /**
+   * Per-channel override for thread implicit mention behaviour.
+   * When false, the bot will not auto-trigger in threads it has participated in for this channel.
+   * Overrides channels.slack.thread.implicitMention for this specific channel.
+   */
+  threadImplicitMention?: boolean;
   /** Optional tool policy overrides for this channel. */
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;
@@ -77,6 +83,11 @@ export type SlackThreadConfig = {
   inheritParent?: boolean;
   /** Maximum number of thread messages to fetch as context when starting a new thread session (default: 20). Set to 0 to disable thread history fetching. */
   initialHistoryLimit?: number;
+  /**
+   * If false, the bot will NOT auto-trigger in threads it has previously participated in.
+   * Requires an explicit @mention even inside threads. Default: true.
+   */
+  implicitMention?: boolean;
 };
 
 export type SlackAccountConfig = {

--- a/src/slack/monitor/channel-config.ts
+++ b/src/slack/monitor/channel-config.ts
@@ -11,6 +11,7 @@ import { allowListMatches, normalizeAllowListLower, normalizeSlackSlug } from ".
 export type SlackChannelConfigResolved = {
   allowed: boolean;
   requireMention: boolean;
+  threadImplicitMention?: boolean;
   allowBots?: boolean;
   users?: Array<string | number>;
   skills?: string[];
@@ -23,6 +24,7 @@ export type SlackChannelConfigEntry = {
   enabled?: boolean;
   allow?: boolean;
   requireMention?: boolean;
+  threadImplicitMention?: boolean;
   allowBots?: boolean;
   users?: Array<string | number>;
   skills?: string[];
@@ -133,6 +135,10 @@ export function resolveSlackChannelConfig(params: {
   const requireMention =
     firstDefined(resolved.requireMention, fallback?.requireMention, requireMentionDefault) ??
     requireMentionDefault;
+  const threadImplicitMention = firstDefined(
+    resolved.threadImplicitMention,
+    fallback?.threadImplicitMention,
+  );
   const allowBots = firstDefined(resolved.allowBots, fallback?.allowBots);
   const users = firstDefined(resolved.users, fallback?.users);
   const skills = firstDefined(resolved.skills, fallback?.skills);
@@ -140,6 +146,7 @@ export function resolveSlackChannelConfig(params: {
   const result: SlackChannelConfigResolved = {
     allowed,
     requireMention,
+    threadImplicitMention,
     allowBots,
     users,
     skills,

--- a/src/slack/monitor/context.test.ts
+++ b/src/slack/monitor/context.test.ts
@@ -34,6 +34,7 @@ function createTestContext() {
     replyToMode: "off",
     threadHistoryScope: "thread",
     threadInheritParent: false,
+    threadImplicitMention: true,
     slashCommand: {
       enabled: true,
       name: "openclaw",

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -49,6 +49,7 @@ export type SlackMonitorContext = {
   replyToMode: "off" | "first" | "all";
   threadHistoryScope: "thread" | "channel";
   threadInheritParent: boolean;
+  threadImplicitMention: boolean;
   slashCommand: Required<import("../../config/config.js").SlackSlashCommandConfig>;
   textLimit: number;
   ackReactionScope: string;
@@ -112,6 +113,7 @@ export function createSlackMonitorContext(params: {
   replyToMode: SlackMonitorContext["replyToMode"];
   threadHistoryScope: SlackMonitorContext["threadHistoryScope"];
   threadInheritParent: SlackMonitorContext["threadInheritParent"];
+  threadImplicitMention: SlackMonitorContext["threadImplicitMention"];
   slashCommand: SlackMonitorContext["slashCommand"];
   textLimit: number;
   ackReactionScope: string;
@@ -389,6 +391,7 @@ export function createSlackMonitorContext(params: {
     replyToMode: params.replyToMode,
     threadHistoryScope: params.threadHistoryScope,
     threadInheritParent: params.threadInheritParent,
+    threadImplicitMention: params.threadImplicitMention,
     slashCommand: params.slashCommand,
     textLimit: params.textLimit,
     ackReactionScope: params.ackReactionScope,

--- a/src/slack/monitor/message-handler/prepare.test-helpers.ts
+++ b/src/slack/monitor/message-handler/prepare.test-helpers.ts
@@ -4,6 +4,9 @@ import type { RuntimeEnv } from "../../../runtime.js";
 import type { ResolvedSlackAccount } from "../../accounts.js";
 import { createSlackMonitorContext } from "../context.js";
 
+/** Default value used across test context factories — mirrors the runtime default of `true`. */
+export const DEFAULT_THREAD_IMPLICIT_MENTION = true;
+
 export function createInboundSlackTestContext(params: {
   cfg: OpenClawConfig;
   appClient?: App["client"];
@@ -38,6 +41,7 @@ export function createInboundSlackTestContext(params: {
     replyToMode: params.replyToMode ?? "off",
     threadHistoryScope: "thread",
     threadInheritParent: false,
+    threadImplicitMention: DEFAULT_THREAD_IMPLICIT_MENTION,
     slashCommand: {
       enabled: false,
       name: "openclaw",

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -13,6 +13,7 @@ import type { SlackMessageEvent } from "../../types.js";
 import type { SlackMonitorContext } from "../context.js";
 import { createSlackMonitorContext } from "../context.js";
 import { prepareSlackMessage } from "./prepare.js";
+import { DEFAULT_THREAD_IMPLICIT_MENTION } from "./prepare.test-helpers.js";
 
 describe("slack prepareSlackMessage inbound contract", () => {
   let fixtureRoot = "";
@@ -72,6 +73,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
       replyToMode: params.replyToMode ?? "off",
       threadHistoryScope: "thread",
       threadInheritParent: false,
+      threadImplicitMention: DEFAULT_THREAD_IMPLICIT_MENTION,
       slashCommand: {
         enabled: false,
         name: "openclaw",
@@ -629,6 +631,72 @@ describe("slack prepareSlackMessage inbound contract", () => {
     // MessageThreadId should be set for the reply
     expect(prepared!.ctxPayload.MessageThreadId).toBe("500.000");
   });
+
+  it("drops thread reply when threadImplicitMention is false globally (no explicit mention)", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
+      defaultRequireMention: true,
+    });
+    slackCtx.threadImplicitMention = false;
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
+    slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    const message = createSlackMessage({
+      channel: "C123",
+      channel_type: "channel",
+      thread_ts: "100.000",
+      parent_user_id: "B1",
+    });
+
+    const prepared = await prepareMessageWith(slackCtx, createSlackAccount(), message);
+
+    expect(prepared).toBeNull();
+  });
+
+  it("allows thread reply when threadImplicitMention is false but bot is explicitly @mentioned", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
+      defaultRequireMention: true,
+    });
+    slackCtx.threadImplicitMention = false;
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
+    slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    const message = createSlackMessage({
+      channel: "C123",
+      channel_type: "channel",
+      text: "<@B1> what do you think?",
+      thread_ts: "100.000",
+      parent_user_id: "B1",
+    });
+
+    const prepared = await prepareMessageWith(slackCtx, createSlackAccount(), message);
+
+    expect(prepared).toBeTruthy();
+  });
+
+  it("drops thread reply when per-channel threadImplicitMention is false", async () => {
+    const slackCtx = createInboundSlackCtx({
+      cfg: { channels: { slack: { enabled: true } } } as OpenClawConfig,
+      defaultRequireMention: true,
+      channelsConfig: {
+        C123: { requireMention: true, threadImplicitMention: false } as never,
+      },
+    });
+    slackCtx.resolveUserName = async () => ({ name: "Alice" });
+    slackCtx.resolveChannelName = async () => ({ name: "general", type: "channel" });
+
+    const message = createSlackMessage({
+      channel: "C123",
+      channel_type: "channel",
+      thread_ts: "100.000",
+      parent_user_id: "B1",
+    });
+
+    const prepared = await prepareMessageWith(slackCtx, createSlackAccount(), message);
+
+    expect(prepared).toBeNull();
+  });
 });
 
 describe("prepareSlackMessage sender prefix", () => {
@@ -673,6 +741,7 @@ describe("prepareSlackMessage sender prefix", () => {
       replyToMode: "off",
       threadHistoryScope: "channel",
       threadInheritParent: false,
+      threadImplicitMention: DEFAULT_THREAD_IMPLICIT_MENTION,
       slashCommand: params.slashCommand,
       textLimit: 2000,
       ackReactionScope: "off",

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -380,7 +380,10 @@ export async function prepareSlackMessage(params: {
           canResolveExplicit: Boolean(ctx.botUserId),
         },
       }));
+  const effectiveThreadImplicitMention =
+    channelConfig?.threadImplicitMention ?? ctx.threadImplicitMention;
   const implicitMention = Boolean(
+    effectiveThreadImplicitMention &&
     !isDirectMessage &&
     ctx.botUserId &&
     message.thread_ts &&

--- a/src/slack/monitor/monitor.test.ts
+++ b/src/slack/monitor/monitor.test.ts
@@ -119,6 +119,7 @@ const baseParams = () => ({
   mediaMaxBytes: 1,
   threadHistoryScope: "thread" as const,
   threadInheritParent: false,
+  threadImplicitMention: true,
   removeAckAfterReply: false,
 });
 

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -149,6 +149,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const replyToMode = slackCfg.replyToMode ?? "off";
   const threadHistoryScope = slackCfg.thread?.historyScope ?? "thread";
   const threadInheritParent = slackCfg.thread?.inheritParent ?? false;
+  const threadImplicitMention = slackCfg.thread?.implicitMention ?? true;
   const slashCommand = resolveSlackSlashCommandConfig(opts.slashCommand ?? slackCfg.slashCommand);
   const textLimit = resolveTextChunkLimit(cfg, "slack", account.accountId);
   const ackReactionScope = cfg.messages?.ackReactionScope ?? "group-mentions";
@@ -248,6 +249,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     replyToMode,
     threadHistoryScope,
     threadInheritParent,
+    threadImplicitMention,
     slashCommand,
     textLimit,
     ackReactionScope,


### PR DESCRIPTION
## Summary
- **Problem:** In Slack channels with `requireMention: true`, agents auto-trigger in any thread they've previously posted in — even without an explicit `@mention`
- **Why it matters:** Multi-agent deployments share channels; every thread message fires every participating agent, burning tokens and creating noise
- **What changed:** Added `channels.slack.thread.implicitMention` (global) and `channels.slack.channels.<id>.threadImplicitMention` (per-channel) config flags; when `false`, implicit thread participation no longer bypasses `requireMention`
- **What did NOT change:** Default is `true` — existing behavior fully preserved unless opted in

## Change Type
- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope
- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR
- Closes #33945

## User-visible / Behavior Changes
- New config option `channels.slack.thread.implicitMention` (default `true`)
- New per-channel override `channels.slack.channels.<id>.threadImplicitMention`
- When set to `false`: agents in that scope require explicit `@mention` even inside threads they've posted in

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
- OS: Linux
- Runtime/container: Node / standard
- Integration/channel: Slack Socket Mode
- Relevant config:
```json
{ "channels": { "slack": { "thread": { "implicitMention": false } } } }
```

### Steps
1. Set `requireMention: true` and `thread.implicitMention: false` on a Slack channel
2. Have the bot post in a thread
3. Send a follow-up message in that thread without `@mentioning` the bot

### Expected
- Bot does not respond

### Actual (before fix)
- Bot responds due to implicit thread participation trigger

## Evidence
- [x] 3 new unit tests covering: global `false` drops message, explicit `@mention` still passes, per-channel override drops message

## Human Verification
- Verified scenarios: global flag, per-channel override, explicit mention passthrough
- Edge cases checked: default `true` preserves existing behavior; per-channel overrides global correctly
- What I did **not** verify: Socket Mode live integration test with real Slack workspace

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? Yes (new optional fields)
- Migration needed? No

## Failure Recovery
- How to revert: set `thread.implicitMention: true` (or remove the field — same as default)
- Files to restore: `provider.ts`, `prepare.ts` (2-line change each)
- Bad symptoms to watch: agents silently stop responding in threads → check `threadImplicitMention` config isn't accidentally set to `false`

## Risks and Mitigations
- Risk: User sets `false` globally and wonders why agents stopped responding in threads
  - Mitigation: Default is `true`, docs updated, CHANGELOG entry added — opt-in only