### PR TITLE
feat(hooks): add auto-wake hook — assistant speaks first after restart

### DIFF
--- a/src/hooks/bundled/auto-wake/HOOK.md
+++ b/src/hooks/bundled/auto-wake/HOOK.md
@@ -1,0 +1,51 @@
+---
+name: auto-wake
+description: "Assistant speaks first after gateway restart"
+homepage: https://docs.openclaw.ai/automation/hooks#auto-wake
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "👋",
+        "events": ["gateway:startup", "agent:bootstrap"],
+        "requires": { "config": ["gateway.port", "gateway.auth.token"] },
+        "install": [{ "id": "bundled", "kind": "bundled", "label": "Bundled with OpenClaw" }],
+      },
+  }
+---
+
+# Auto-Wake Hook
+
+After gateway startup, sends a message to the main webchat session via the
+`/v1/chat/completions` HTTP endpoint with `x-openclaw-session-key: agent:main:main`.
+This triggers the full bootstrap chain and the assistant responds in the UI without
+the user having to type first.
+
+## Why Two Events?
+
+`gateway:startup` fires before hooks finish loading (~3-5 s gap). By also subscribing
+to `agent:bootstrap` (which fires when the boot session starts), the handler catches
+whichever event arrives first after it is ready.
+
+## Dedup
+
+A file stamp (`~/.openclaw/.auto-wake-stamp`) prevents double-fire within a 2-minute
+window, handling multiple bootstrap events and rapid restart sequences.
+
+## Configuration
+
+Enable in `openclaw.json`:
+
+```json
+{
+  "hooks": {
+    "internal": {
+      "entries": {
+        "auto-wake": { "enabled": true }
+      }
+    }
+  }
+}
+```
+
+Requires `gateway.auth.token` to be set (used as Bearer token on the POST).

--- a/src/hooks/bundled/auto-wake/handler.test.ts
+++ b/src/hooks/bundled/auto-wake/handler.test.ts
@@ -1,0 +1,154 @@
+import fs from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { InternalHookEvent } from "../../internal-hooks.js";
+
+const logInfo = vi.fn();
+const logDebug = vi.fn();
+const logWarn = vi.fn();
+
+vi.mock("../../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => ({
+    info: logInfo,
+    debug: logDebug,
+    warn: logWarn,
+  }),
+}));
+
+function makeEvent(overrides?: Partial<InternalHookEvent>): InternalHookEvent {
+  return {
+    type: "agent",
+    action: "bootstrap",
+    sessionKey: "test",
+    context: {
+      cfg: {
+        gateway: {
+          port: 18789,
+          auth: { token: "test-token" },
+        },
+      },
+    },
+    timestamp: new Date(),
+    messages: [],
+    ...overrides,
+  };
+}
+
+describe("auto-wake handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.spyOn(fs, "readFile").mockRejectedValue(new Error("ENOENT"));
+    vi.spyOn(fs, "writeFile").mockResolvedValue();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("ok", { status: 200 }));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("schedules wake on first event and fires after delay", async () => {
+    // Fresh module import so wakeScheduled resets
+    vi.resetModules();
+    const { default: handler } = await import("./handler.js");
+
+    await handler(makeEvent());
+
+    expect(logInfo).toHaveBeenCalledWith(expect.stringContaining("will speak in"));
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+
+    // Advance past WAKE_DELAY_MS
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "http://localhost:18789/v1/chat/completions",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          "x-openclaw-session-key": "agent:main:main",
+        }),
+      }),
+    );
+    expect(logInfo).toHaveBeenCalledWith(expect.stringContaining("wake complete"));
+  });
+
+  it("skips when no auth token in config", async () => {
+    vi.resetModules();
+    const { default: handler } = await import("./handler.js");
+
+    await handler(
+      makeEvent({
+        context: { cfg: { gateway: { port: 18789, auth: {} } } },
+      }),
+    );
+
+    expect(logDebug).toHaveBeenCalledWith(expect.stringContaining("no gateway auth token"));
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("skips when stamp is within dedup window", async () => {
+    vi.resetModules();
+    vi.spyOn(fs, "readFile").mockResolvedValue(String(Date.now()) as never);
+    const { default: handler } = await import("./handler.js");
+
+    await handler(makeEvent());
+
+    expect(logDebug).toHaveBeenCalledWith(expect.stringContaining("fired within last 2 min"));
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("only fires once (wakeScheduled guard)", async () => {
+    vi.resetModules();
+    const { default: handler } = await import("./handler.js");
+
+    await handler(makeEvent());
+    await handler(makeEvent());
+
+    // logInfo called once for "will speak in" — second call is a no-op
+    expect(logInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs warning on HTTP error", async () => {
+    vi.resetModules();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("unauthorized", { status: 401 }));
+    const { default: handler } = await import("./handler.js");
+
+    await handler(makeEvent());
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("HTTP 401"));
+  });
+
+  it("logs warning on fetch failure", async () => {
+    vi.resetModules();
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("connection refused"));
+    const { default: handler } = await import("./handler.js");
+
+    await handler(makeEvent());
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(logWarn).toHaveBeenCalledWith(expect.stringContaining("connection refused"));
+  });
+
+  it("reads port from config", async () => {
+    vi.resetModules();
+    const { default: handler } = await import("./handler.js");
+
+    await handler(
+      makeEvent({
+        context: {
+          cfg: {
+            gateway: { port: 9999, auth: { token: "test-token" } },
+          },
+        },
+      }),
+    );
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "http://localhost:9999/v1/chat/completions",
+      expect.anything(),
+    );
+  });
+});

--- a/src/hooks/bundled/auto-wake/handler.ts
+++ b/src/hooks/bundled/auto-wake/handler.ts
@@ -25,7 +25,6 @@ const autoWakeHook: HookHandler = async (event) => {
   if (wakeScheduled) {
     return;
   }
-  wakeScheduled = true;
 
   const cfg = event.context?.cfg as Record<string, unknown> | undefined;
   const gateway = cfg?.gateway as Record<string, unknown> | undefined;
@@ -38,7 +37,12 @@ const autoWakeHook: HookHandler = async (event) => {
     return;
   }
 
-  const stampPath = path.join(process.env.HOME || ".", ".openclaw", ".auto-wake-stamp");
+  // Set flag after token check so a retry via the fallback event is possible
+  wakeScheduled = true;
+
+  const stateDir = process.env.OPENCLAW_STATE_DIR
+    || path.join(process.env.HOME || ".", ".openclaw");
+  const stampPath = path.join(stateDir, ".auto-wake-stamp");
 
   try {
     const stamp = await fs.readFile(stampPath, "utf-8");
@@ -50,8 +54,6 @@ const autoWakeHook: HookHandler = async (event) => {
   } catch {
     // No stamp file yet — first fire
   }
-
-  await fs.writeFile(stampPath, String(Date.now()), "utf-8");
 
   log.info(`assistant will speak in ${WAKE_DELAY_MS / 1000}s`);
 
@@ -74,6 +76,11 @@ const autoWakeHook: HookHandler = async (event) => {
       } else {
         log.warn(`HTTP ${String(res.status)}: ${await res.text().catch(() => "")}`);
       }
+
+      // Write stamp after the request, not before — prevents dedup
+      // from blocking retries if the process dies during the delay
+      await fs.mkdir(stateDir, { recursive: true });
+      await fs.writeFile(stampPath, String(Date.now()), "utf-8");
     } catch (err) {
       log.warn(`failed: ${err instanceof Error ? err.message : String(err)}`);
     }

--- a/src/hooks/bundled/auto-wake/handler.ts
+++ b/src/hooks/bundled/auto-wake/handler.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { createSubsystemLogger } from "../../../logging/subsystem.js";
+import type { HookHandler } from "../../hooks.js";
+
+const log = createSubsystemLogger("auto-wake");
+
+const WAKE_DELAY_MS = 20_000;
+const DEDUP_WINDOW_MS = 120_000;
+const WAKE_MESSAGE =
+  "Gateway just restarted. Run your hydration checklist, then report status briefly.";
+
+let wakeScheduled = false;
+
+/**
+ * After gateway restart, sends a single message to the main webchat session
+ * so the assistant speaks first — no user input required.
+ *
+ * Subscribes to both `gateway:startup` and `agent:bootstrap` because the
+ * startup event often fires before hooks finish loading. The handler triggers
+ * on whichever event arrives first, with a file-stamp dedup to prevent
+ * double-fire within a 2-minute window.
+ */
+const autoWakeHook: HookHandler = async (event) => {
+  if (wakeScheduled) {
+    return;
+  }
+  wakeScheduled = true;
+
+  const cfg = event.context?.cfg as Record<string, unknown> | undefined;
+  const gateway = cfg?.gateway as Record<string, unknown> | undefined;
+  const auth = gateway?.auth as Record<string, unknown> | undefined;
+  const token = auth?.token as string | undefined;
+  const port = (gateway?.port as number) || 18789;
+
+  if (!token) {
+    log.debug("no gateway auth token in config, skipping");
+    return;
+  }
+
+  const stampPath = path.join(process.env.HOME || ".", ".openclaw", ".auto-wake-stamp");
+
+  try {
+    const stamp = await fs.readFile(stampPath, "utf-8");
+    const lastFire = parseInt(stamp, 10);
+    if (Date.now() - lastFire < DEDUP_WINDOW_MS) {
+      log.debug("skipping — fired within last 2 min");
+      return;
+    }
+  } catch {
+    // No stamp file yet — first fire
+  }
+
+  await fs.writeFile(stampPath, String(Date.now()), "utf-8");
+
+  log.info(`assistant will speak in ${WAKE_DELAY_MS / 1000}s`);
+
+  setTimeout(async () => {
+    try {
+      const res = await fetch(`http://localhost:${String(port)}/v1/chat/completions`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+          "x-openclaw-session-key": "agent:main:main",
+        },
+        body: JSON.stringify({
+          messages: [{ role: "user", content: WAKE_MESSAGE }],
+        }),
+      });
+
+      if (res.ok) {
+        log.info("assistant responded — wake complete");
+      } else {
+        log.warn(`HTTP ${String(res.status)}: ${await res.text().catch(() => "")}`);
+      }
+    } catch (err) {
+      log.warn(`failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }, WAKE_DELAY_MS);
+};
+
+export default autoWakeHook;


### PR DESCRIPTION
## Summary

After gateway restart the assistant sits idle until the user types something. This adds a bundled **auto-wake** hook that sends a single message to the main webchat session automatically, triggering the full bootstrap chain so the assistant responds without user input.

- Subscribes to `gateway:startup` + `agent:bootstrap` — startup fires before hooks finish loading (~3-5 s gap), so `agent:bootstrap` is the reliable fallback
- 20 s delay allows other hooks and webchat clients to connect first
- File-stamp dedup (`~/.openclaw/.auto-wake-stamp`) prevents double-fire within a 2-minute window
- Reads gateway port and auth token from config (no hardcoded values)
- Routes via `x-openclaw-session-key: agent:main:main` header on `/v1/chat/completions`

### Enable

```json
{
  "hooks": {
    "internal": {
      "entries": {
        "auto-wake": { "enabled": true }
      }
    }
  }
}
```

Requires `gateway.auth.token` to be configured.

## Test plan

- [x] Unit tests covering: happy path, dedup skip, missing token, HTTP errors, fetch failures, port config
- [ ] Manual: enable hook, restart gateway, verify assistant responds in webchat UI within ~50 s without typing
- [ ] Verify dedup: rapid double-restart within 2 min fires only once

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>