### PR TITLE
fix(media): cap inbound extracted file blocks (#14231)

### DIFF
--- a/src/media-understanding/apply.test.ts
+++ b/src/media-understanding/apply.test.ts
@@ -1122,6 +1122,46 @@ describe("applyMediaUnderstanding", () => {
     expect(ctx.Body).toContain("中文内容");
   });
 
+  it("caps extracted file blocks even when OpenResponses file maxChars is raised", async () => {
+    const tailMarker = "TAIL_MARKER_SHOULD_NOT_APPEAR";
+    const content = `${"A".repeat(210_000)}\n${tailMarker}`;
+    const filePath = await createTempMediaFile({
+      fileName: "huge.txt",
+      content,
+    });
+
+    const cfg: OpenClawConfig = {
+      ...createMediaDisabledConfig(),
+      gateway: {
+        http: {
+          endpoints: {
+            responses: {
+              files: {
+                // Simulate operators raising the OpenResponses input-file cap for API usage.
+                // Inbound attachment extraction must stay bounded to avoid bricking sessions (#14231).
+                maxChars: 500_000,
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const ctx: MsgContext = {
+      Body: "<media:file>",
+      MediaPath: filePath,
+      MediaType: "text/plain",
+    };
+
+    const result = await applyMediaUnderstanding({ ctx, cfg });
+    expect(result.appliedFile).toBe(true);
+    expect(ctx.Body).toContain("<file");
+    expect(ctx.Body).not.toContain(tailMarker);
+
+    const match = ctx.Body?.match(/<file[^>]*>\n([\s\S]*?)\n<\/file>/);
+    expect(match?.[1]?.length).toBe(200_000);
+  });
+
   it("skips binary application/vnd office attachments even when bytes look printable", async () => {
     // ZIP-based Office docs can have printable-leading bytes.
     const pseudoZip = Buffer.from("PK\u0003\u0004[Content_Types].xml xl/workbook.xml", "utf8");

--- a/src/media-understanding/apply.ts
+++ b/src/media-understanding/apply.ts
@@ -4,6 +4,7 @@ import type { MsgContext } from "../auto-reply/templating.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import {
+  DEFAULT_INPUT_FILE_MAX_CHARS,
   extractFileContentFromSource,
   normalizeMimeType,
   resolveInputFileLimits,
@@ -102,8 +103,14 @@ function sanitizeMimeType(value?: string): string | undefined {
 function resolveFileLimits(cfg: OpenClawConfig) {
   const files = cfg.gateway?.http?.endpoints?.responses?.files;
   const allowedMimesConfigured = Boolean(files?.allowedMimes?.length);
+  const base = resolveInputFileLimits(files);
   return {
-    ...resolveInputFileLimits(files),
+    ...base,
+    // Inbound attachment extraction shares the OpenResponses input-file config for
+    // MIME allowlists/timeouts, but should stay fail-safe even when operators raise
+    // OpenResponses `maxChars` for API use. Without a conservative cap, a single
+    // extracted attachment can exceed model context and brick a session (#14231).
+    maxChars: Math.min(base.maxChars, DEFAULT_INPUT_FILE_MAX_CHARS),
     allowedMimesConfigured,
   };
 }


### PR DESCRIPTION
## Summary

- Problem: Large inbound attachments can inline enormous extracted `<file>` blocks when `gateway.http.endpoints.responses.files.maxChars` is raised, potentially exceeding model context and repeatedly failing with “prompt too long”.
- Why it matters: This can effectively brick affected threads/sessions (compaction can’t recover if the next prompt still includes oversized extracted text).
- What changed: Inbound attachment extraction now clamps the extracted `<file>` block text to `DEFAULT_INPUT_FILE_MAX_CHARS` (200k) regardless of a higher OpenResponses `files.maxChars` setting.
- What did NOT change (scope boundary): No changes to OpenResponses limits for API/file endpoints; only inbound extracted attachment text is capped.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #14231

## User-visible / Behavior Changes

- Inbound extracted attachment text is capped at 200k characters to prevent repeated context-overflow failures.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Set `gateway.http.endpoints.responses.files.maxChars` to a value > 200k

### Steps

1. Run `pnpm check`.
2. Run `pnpm test src/media-understanding/apply.test.ts -t "caps extracted file blocks"`.

### Expected

- Checks pass; extracted `<file>` blocks are capped at 200k even when the config max is higher.

### Actual

- Before this change, inbound extraction could inline more than 200k characters, making prompts exceed context and repeatedly fail.

## Evidence

- [x] Failing scenario covered by regression test; `pnpm check` and targeted test passing locally.

## Human Verification (required)

- Verified scenarios: `pnpm check`; targeted unit test above
- Edge cases checked: Raised OpenResponses maxChars does not increase inbound extracted block size
- What you did **not** verify: Full end-to-end run with an actual provider/model context limit

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- Revert this commit.

## Risks and Mitigations

None.
