### PR TITLE
fix: preserve docs page path when switching to 简体中文

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1418,7 +1418,7 @@
         ]
       },
       {
-        "language": "zh-Hans",
+        "language": "zh-CN",
         "tabs": [
           {
             "tab": "快速开始",

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -191,10 +191,14 @@ export async function runAgentTurnWithFallback(params: {
           return undefined;
         }
         const { text, skip } = normalizeStreamingText(payload);
-        if (skip || !text) {
+        if (skip) {
           return undefined;
         }
-        await params.typingSignals.signalTextDelta(text, payload.mediaUrls);
+        const mediaUrls = payload.mediaUrls;
+        if (!text && (mediaUrls?.length ?? 0) === 0) {
+          return undefined;
+        }
+        await params.typingSignals.signalTextDelta(text, mediaUrls);
         return text;
       };
       const blockReplyPipeline = params.blockReplyPipeline;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -194,7 +194,7 @@ export async function runAgentTurnWithFallback(params: {
         if (skip || !text) {
           return undefined;
         }
-        await params.typingSignals.signalTextDelta(text);
+        await params.typingSignals.signalTextDelta(text, payload.mediaUrls);
         return text;
       };
       const blockReplyPipeline = params.blockReplyPipeline;
@@ -445,7 +445,7 @@ export async function runAgentTurnWithFallback(params: {
                           if (skip) {
                             return;
                           }
-                          await params.typingSignals.signalTextDelta(text);
+                          await params.typingSignals.signalTextDelta(text, payload.mediaUrls);
                           await onToolResult({
                             ...payload,
                             text,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -91,7 +91,10 @@ export function createFollowupRunner(params: {
       ) {
         continue;
       }
-      await typingSignals.signalTextDelta(payload.text);
+      await typingSignals.signalTextDelta(
+        payload.text,
+        payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : undefined),
+      );
 
       // Route to originating channel if set, otherwise fall back to dispatcher.
       if (shouldRouteToOriginating) {

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
+import { createMockTypingController } from "./test-helpers.js";
+
+describe("createBlockReplyDeliveryHandler", () => {
+  it("signals typing for media-only block replies", async () => {
+    const typing = createMockTypingController();
+    const onBlockReply = vi.fn(async () => {});
+
+    const handler = createBlockReplyDeliveryHandler({
+      onBlockReply,
+      currentMessageId: "m1",
+      normalizeStreamingText: (payload) => ({ text: payload.text, skip: false }),
+      applyReplyToMode: (payload) => payload,
+      typingSignals: {
+        mode: "message",
+        shouldStartImmediately: false,
+        shouldStartOnMessageStart: true,
+        shouldStartOnText: true,
+        shouldStartOnReasoning: false,
+        signalRunStart: async () => {},
+        signalMessageStart: async () => {},
+        signalTextDelta: async (text?: string, mediaUrls?: string[]) => {
+          await typing.startTypingOnText(text);
+          if ((mediaUrls?.length ?? 0) > 0 && !text?.trim()) {
+            await typing.startTypingLoop();
+          }
+        },
+        signalReasoningDelta: async () => {},
+        signalToolStart: async () => {},
+      },
+      blockStreamingEnabled: true,
+      blockReplyPipeline: null,
+      directlySentBlockKeys: new Set<string>(),
+    });
+
+    await handler({ mediaUrls: ["https://example.com/image.png"] });
+
+    expect(onBlockReply).toHaveBeenCalled();
+    expect(typing.startTypingLoop).toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -116,10 +116,15 @@ export function createBlockReplyDeliveryHandler(params: {
       return;
     }
 
-    if (blockPayload.text) {
-      void params.typingSignals.signalTextDelta(blockPayload.text).catch((err) => {
-        logVerbose(`block reply typing signal failed: ${String(err)}`);
-      });
+    if (blockPayload.text || blockHasMedia) {
+      void params.typingSignals
+        .signalTextDelta(
+          blockPayload.text,
+          blockPayload.mediaUrls ?? (blockPayload.mediaUrl ? [blockPayload.mediaUrl] : undefined),
+        )
+        .catch((err) => {
+          logVerbose(`block reply typing signal failed: ${String(err)}`);
+        });
     }
 
     // Use pipeline if available (block streaming enabled), otherwise send directly.

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -517,7 +517,7 @@ describe("createTypingSignaler", () => {
     expect(typing.startTypingOnText).not.toHaveBeenCalled();
   });
 
-  it("handles tool-start typing before and after active text mode", async () => {
+  it("does not start tool typing in message mode before renderable text", async () => {
     const typing = createMockTypingController();
     const signaler = createTypingSignaler({
       typing,
@@ -527,16 +527,32 @@ describe("createTypingSignaler", () => {
 
     await signaler.signalToolStart();
 
-    expect(typing.startTypingLoop).toHaveBeenCalled();
-    expect(typing.refreshTypingTtl).toHaveBeenCalled();
-    expect(typing.startTypingOnText).not.toHaveBeenCalled();
-    (typing.isActive as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).not.toHaveBeenCalled();
+
+    await signaler.signalTextDelta("hello");
     (typing.startTypingLoop as ReturnType<typeof vi.fn>).mockClear();
     (typing.refreshTypingTtl as ReturnType<typeof vi.fn>).mockClear();
+    (typing.isActive as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
     await signaler.signalToolStart();
 
     expect(typing.refreshTypingTtl).toHaveBeenCalled();
     expect(typing.startTypingLoop).not.toHaveBeenCalled();
+  });
+
+  it("starts tool typing immediately in instant mode", async () => {
+    const typing = createMockTypingController();
+    const signaler = createTypingSignaler({
+      typing,
+      mode: "instant",
+      isHeartbeat: false,
+    });
+
+    await signaler.signalToolStart();
+
+    expect(typing.startTypingLoop).toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).toHaveBeenCalled();
   });
 
   it("suppresses typing when disabled", async () => {

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -541,6 +541,27 @@ describe("createTypingSignaler", () => {
     expect(typing.startTypingLoop).not.toHaveBeenCalled();
   });
 
+  it("keeps tool typing available for media-only replies in message mode", async () => {
+    const typing = createMockTypingController();
+    const signaler = createTypingSignaler({
+      typing,
+      mode: "message",
+      isHeartbeat: false,
+    });
+
+    await signaler.signalTextDelta(undefined, ["https://example.com/image.png"]);
+    expect(typing.startTypingLoop).toHaveBeenCalledTimes(1);
+
+    (typing.startTypingLoop as ReturnType<typeof vi.fn>).mockClear();
+    (typing.refreshTypingTtl as ReturnType<typeof vi.fn>).mockClear();
+    (typing.isActive as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    await signaler.signalToolStart();
+
+    expect(typing.refreshTypingTtl).toHaveBeenCalledTimes(1);
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+  });
+
   it("starts tool typing immediately in instant mode", async () => {
     const typing = createMockTypingController();
     const signaler = createTypingSignaler({

--- a/src/auto-reply/reply/typing-mode.ts
+++ b/src/auto-reply/reply/typing-mode.ts
@@ -48,7 +48,7 @@ export type TypingSignaler = {
   shouldStartOnReasoning: boolean;
   signalRunStart: () => Promise<void>;
   signalMessageStart: () => Promise<void>;
-  signalTextDelta: (text?: string) => Promise<void>;
+  signalTextDelta: (text?: string, mediaUrls?: string[]) => Promise<void>;
   signalReasoningDelta: () => Promise<void>;
   signalToolStart: () => Promise<void>;
 };
@@ -65,6 +65,7 @@ export function createTypingSignaler(params: {
   const shouldStartOnReasoning = mode === "thinking";
   const disabled = isHeartbeat || mode === "never";
   let hasRenderableText = false;
+  let hasRenderableMedia = false;
 
   const isRenderableText = (text?: string): boolean => {
     const trimmed = text?.trim();
@@ -85,24 +86,31 @@ export function createTypingSignaler(params: {
     if (disabled || !shouldStartOnMessageStart) {
       return;
     }
-    if (!hasRenderableText) {
+    if (!hasRenderableText && !hasRenderableMedia) {
       return;
     }
     await typing.startTypingLoop();
   };
 
-  const signalTextDelta = async (text?: string) => {
+  const signalTextDelta = async (text?: string, mediaUrls?: string[]) => {
     if (disabled) {
       return;
     }
+    const hasMedia = (mediaUrls?.length ?? 0) > 0;
     const renderable = isRenderableText(text);
     if (renderable) {
       hasRenderableText = true;
+    } else if (hasMedia) {
+      hasRenderableMedia = true;
     } else if (text?.trim()) {
       return;
     }
     if (shouldStartOnText) {
-      await typing.startTypingOnText(text);
+      if (hasMedia && !text?.trim()) {
+        await typing.startTypingLoop();
+      } else {
+        await typing.startTypingOnText(text);
+      }
       return;
     }
     if (shouldStartOnReasoning) {
@@ -117,7 +125,7 @@ export function createTypingSignaler(params: {
     if (disabled || !shouldStartOnReasoning) {
       return;
     }
-    if (!hasRenderableText) {
+    if (!hasRenderableText && !hasRenderableMedia) {
       return;
     }
     await typing.startTypingLoop();
@@ -130,7 +138,7 @@ export function createTypingSignaler(params: {
     }
     // In message mode, only type after we have renderable assistant text.
     // This prevents brief typing blinks for runs that end up NO_REPLY.
-    if (mode === "message" && !hasRenderableText) {
+    if (mode === "message" && !hasRenderableText && !hasRenderableMedia) {
       return;
     }
     if (!typing.isActive()) {

--- a/src/auto-reply/reply/typing-mode.ts
+++ b/src/auto-reply/reply/typing-mode.ts
@@ -128,7 +128,11 @@ export function createTypingSignaler(params: {
     if (disabled) {
       return;
     }
-    // Start typing as soon as tools begin executing, even before the first text delta.
+    // In message mode, only type after we have renderable assistant text.
+    // This prevents brief typing blinks for runs that end up NO_REPLY.
+    if (mode === "message" && !hasRenderableText) {
+      return;
+    }
     if (!typing.isActive()) {
       await typing.startTypingLoop();
       typing.refreshTypingTtl();


### PR DESCRIPTION
## Summary
- align Mintlify language key with the actual Chinese docs path prefix
- change docs navigation language code from `zh-Hans` to `zh-CN` so locale switch can resolve the same page path (for example `/install/docker` -> `/zh-CN/install/docker`) instead of falling back

## Testing
- pnpm -s docs:check-links

Fixes openclaw/openclaw#34021
