### PR TITLE
feat(webchat): add confirmation dialog for 'New session' button

### DIFF
--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -224,4 +224,76 @@ describe("chat view", () => {
     expect(onNewSession).toHaveBeenCalledTimes(1);
     expect(container.textContent).not.toContain("Stop");
   });
+
+  it("skips confirmation when starting new session with no messages", () => {
+    const container = document.createElement("div");
+    const onNewSession = vi.fn();
+    const confirmSpy = vi.spyOn(window, "confirm");
+    render(
+      renderChat(
+        createProps({
+          canAbort: false,
+          messages: [],
+          onNewSession,
+        }),
+      ),
+      container,
+    );
+
+    const newSessionButton = Array.from(container.querySelectorAll("button")).find(
+      (btn) => btn.textContent?.trim() === "New session",
+    );
+    newSessionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(onNewSession).toHaveBeenCalledTimes(1);
+    confirmSpy.mockRestore();
+  });
+
+  it("shows confirmation before starting new session when messages exist", () => {
+    const container = document.createElement("div");
+    const onNewSession = vi.fn();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(
+      renderChat(
+        createProps({
+          canAbort: false,
+          messages: [{ kind: "message", key: "1", message: { role: "user", content: "hi" } }],
+          onNewSession,
+        }),
+      ),
+      container,
+    );
+
+    const newSessionButton = Array.from(container.querySelectorAll("button")).find(
+      (btn) => btn.textContent?.trim() === "New session",
+    );
+    newSessionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(onNewSession).toHaveBeenCalledTimes(1);
+    confirmSpy.mockRestore();
+  });
+
+  it("does not start new session when user cancels the confirmation", () => {
+    const container = document.createElement("div");
+    const onNewSession = vi.fn();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    render(
+      renderChat(
+        createProps({
+          canAbort: false,
+          messages: [{ kind: "message", key: "1", message: { role: "user", content: "hi" } }],
+          onNewSession,
+        }),
+      ),
+      container,
+    );
+
+    const newSessionButton = Array.from(container.querySelectorAll("button")).find(
+      (btn) => btn.textContent?.trim() === "New session",
+    );
+    newSessionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(onNewSession).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
 });

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -461,7 +461,17 @@ export function renderChat(props: ChatProps) {
             <button
               class="btn"
               ?disabled=${!props.connected || (!canAbort && props.sending)}
-              @click=${canAbort ? props.onAbort : props.onNewSession}
+              @click=${canAbort
+                ? props.onAbort
+                : () => {
+                    if (
+                      props.messages.length > 0 &&
+                      !window.confirm("Start new session? Current context will be lost.")
+                    ) {
+                      return;
+                    }
+                    props.onNewSession();
+                  }}
             >
               ${canAbort ? "Stop" : "New session"}
             </button>


### PR DESCRIPTION
## Summary

Add a confirmation dialog when clicking the **"New session"** button in the webchat UI to prevent accidental session resets.

Closes #34047

## Problem

As described in #34047, it's easy to accidentally trigger the "New session" button via keyboard navigation (Tab + Enter while typing in the chat input). This instantly resets the session with no way to recover the current context.

## Solution

Added a `window.confirm()` prompt before starting a new session, consistent with the existing confirmation pattern used elsewhere in the codebase (e.g., device pairing rejection, token revocation, session deletion in `controllers/devices.ts` and `controllers/sessions.ts`).

### Behavior:
- **No messages in chat**: Clicking "New session" proceeds immediately (no confirmation needed — there's no context to lose)
- **Messages exist**: Shows a confirmation dialog: *"Start new session? Current context will be lost."*
  - **Confirm**: Proceeds with new session
  - **Cancel**: Does nothing, preserving the current session

### Why `window.confirm()` over a custom modal?

The codebase already uses `window.confirm()` for similar destructive actions (see `controllers/devices.ts`, `controllers/sessions.ts`). This keeps the change minimal, consistent, and accessible. A custom modal could be a follow-up enhancement.

## Changes

| File | Change |
|------|--------|
| `ui/src/ui/views/chat.ts` | Wrap `onNewSession` click handler with confirmation when messages exist |
| `ui/src/ui/views/chat.test.ts` | Add 3 test cases for confirmation behavior |

## Tests Added

1. **Skips confirmation with empty session** — `onNewSession` called directly, `window.confirm` not invoked
2. **Shows confirmation when messages exist** — `window.confirm` called, proceeds on accept
3. **Blocks new session on cancel** — `window.confirm` called, `onNewSession` NOT called on decline

## Testing

- Existing test "shows a new session button when aborting is unavailable" continues to pass (uses empty messages by default)
- New tests cover the confirmation dialog behavior comprehensively