### PR TITLE
fix(hooks): fire message:sent from inline channel delivery paths

### DIFF
--- a/src/hooks/emit-message-sent.test.ts
+++ b/src/hooks/emit-message-sent.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { emitMessageSentHook } from "./emit-message-sent.js";
+
+const hookRunner = vi.hoisted(() => ({
+  hasHooks: vi.fn<(name: string) => boolean>(() => false),
+  runMessageSent: vi.fn(async () => {}),
+}));
+const internalHooks = vi.hoisted(() => ({
+  createInternalHookEvent: vi.fn(
+    (resource: string, action: string, sessionKey: string, data: Record<string, unknown>) => ({
+      resource,
+      action,
+      sessionKey,
+      data,
+    }),
+  ),
+  triggerInternalHook: vi.fn(async () => {}),
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => hookRunner,
+}));
+vi.mock("./internal-hooks.js", () => ({
+  createInternalHookEvent: (...args: Parameters<typeof internalHooks.createInternalHookEvent>) =>
+    internalHooks.createInternalHookEvent(...args),
+  triggerInternalHook: (...args: Parameters<typeof internalHooks.triggerInternalHook>) =>
+    internalHooks.triggerInternalHook(...args),
+}));
+
+describe("emitMessageSentHook", () => {
+  beforeEach(() => {
+    hookRunner.hasHooks.mockReset();
+    hookRunner.hasHooks.mockReturnValue(false);
+    hookRunner.runMessageSent.mockReset();
+    hookRunner.runMessageSent.mockResolvedValue(undefined);
+    internalHooks.createInternalHookEvent.mockClear();
+    internalHooks.triggerInternalHook.mockClear();
+    internalHooks.triggerInternalHook.mockResolvedValue(undefined);
+  });
+
+  it("fires plugin hook when message_sent hooks are registered", () => {
+    hookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+
+    emitMessageSentHook({
+      to: "+1555",
+      content: "hello",
+      success: true,
+      channelId: "signal",
+      accountId: "acc1",
+    });
+
+    expect(hookRunner.runMessageSent).toHaveBeenCalledWith(
+      { to: "+1555", content: "hello", success: true },
+      { channelId: "signal", accountId: "acc1", conversationId: "+1555" },
+    );
+  });
+
+  it("includes error in plugin hook on failure", () => {
+    hookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+
+    emitMessageSentHook({
+      to: "chat:123",
+      content: "hi",
+      success: false,
+      error: "timeout",
+      channelId: "telegram",
+    });
+
+    expect(hookRunner.runMessageSent).toHaveBeenCalledWith(
+      { to: "chat:123", content: "hi", success: false, error: "timeout" },
+      expect.objectContaining({ channelId: "telegram" }),
+    );
+  });
+
+  it("skips plugin hook when no hooks registered", () => {
+    emitMessageSentHook({
+      to: "+1555",
+      content: "hello",
+      success: true,
+      channelId: "signal",
+    });
+
+    expect(hookRunner.runMessageSent).not.toHaveBeenCalled();
+  });
+
+  it("fires internal hook when sessionKey is provided", () => {
+    emitMessageSentHook({
+      to: "+1555",
+      content: "hello",
+      success: true,
+      messageId: "msg-42",
+      channelId: "signal",
+      accountId: "acc1",
+      sessionKey: "session-abc",
+    });
+
+    expect(internalHooks.createInternalHookEvent).toHaveBeenCalledWith(
+      "message",
+      "sent",
+      "session-abc",
+      {
+        to: "+1555",
+        content: "hello",
+        success: true,
+        channelId: "signal",
+        accountId: "acc1",
+        conversationId: "+1555",
+        messageId: "msg-42",
+      },
+    );
+    expect(internalHooks.triggerInternalHook).toHaveBeenCalled();
+  });
+
+  it("skips internal hook when sessionKey is missing", () => {
+    emitMessageSentHook({
+      to: "+1555",
+      content: "hello",
+      success: true,
+      channelId: "signal",
+    });
+
+    expect(internalHooks.triggerInternalHook).not.toHaveBeenCalled();
+  });
+
+  it("fires both hooks when sessionKey is present and plugins registered", () => {
+    hookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+
+    emitMessageSentHook({
+      to: "user:U1",
+      content: "hey",
+      success: true,
+      messageId: "ts-1",
+      channelId: "slack",
+      accountId: "work",
+      sessionKey: "sess-1",
+    });
+
+    expect(hookRunner.runMessageSent).toHaveBeenCalled();
+    expect(internalHooks.triggerInternalHook).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/emit-message-sent.ts
+++ b/src/hooks/emit-message-sent.ts
@@ -1,0 +1,61 @@
+import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
+import { createInternalHookEvent, triggerInternalHook } from "./internal-hooks.js";
+
+/**
+ * Fire message:sent hooks (plugin + internal) for inline delivery paths.
+ *
+ * Mirrors the hook emission in src/infra/outbound/deliver.ts (emitMessageSent),
+ * extracted as a shared utility so channel-specific deliverReplies functions
+ * can fire hooks without routing through the centralized outbound path.
+ *
+ * Both hooks are fire-and-forget — errors are caught and swallowed.
+ */
+export function emitMessageSentHook(params: {
+  to: string;
+  content: string;
+  success: boolean;
+  error?: string;
+  messageId?: string;
+  channelId: string;
+  accountId?: string;
+  sessionKey?: string;
+}): void {
+  const { to, content, success, error, messageId, channelId, accountId, sessionKey } = params;
+
+  // Plugin hook
+  const hookRunner = getGlobalHookRunner();
+  if (hookRunner?.hasHooks("message_sent")) {
+    void hookRunner
+      .runMessageSent(
+        {
+          to,
+          content,
+          success,
+          ...(error ? { error } : {}),
+        },
+        {
+          channelId,
+          accountId,
+          conversationId: to,
+        },
+      )
+      .catch(() => {});
+  }
+
+  // Internal hook (requires sessionKey)
+  if (!sessionKey) {
+    return;
+  }
+  void triggerInternalHook(
+    createInternalHookEvent("message", "sent", sessionKey, {
+      to,
+      content,
+      success,
+      ...(error ? { error } : {}),
+      channelId,
+      accountId,
+      conversationId: to,
+      messageId,
+    }),
+  ).catch(() => {});
+}

--- a/src/imessage/monitor/deliver.test.ts
+++ b/src/imessage/monitor/deliver.test.ts
@@ -8,6 +8,7 @@ const chunkTextWithModeMock = vi.hoisted(() => vi.fn((text: string) => [text]));
 const resolveChunkModeMock = vi.hoisted(() => vi.fn(() => "length"));
 const convertMarkdownTablesMock = vi.hoisted(() => vi.fn((text: string) => text));
 const resolveMarkdownTableModeMock = vi.hoisted(() => vi.fn(() => "code"));
+const emitHookMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../send.js", () => ({
   sendMessageIMessage: (to: string, message: string, opts?: unknown) =>
@@ -29,6 +30,10 @@ vi.mock("../../config/markdown-tables.js", () => ({
 
 vi.mock("../../markdown/tables.js", () => ({
   convertMarkdownTables: (text: string) => convertMarkdownTablesMock(text),
+}));
+
+vi.mock("../../hooks/emit-message-sent.js", () => ({
+  emitMessageSentHook: (...args: unknown[]) => emitHookMock(...args),
 }));
 
 import { deliverReplies } from "./deliver.js";
@@ -148,5 +153,54 @@ describe("deliverReplies", () => {
       text: "second",
       messageId: "imsg-1",
     });
+  });
+
+  it("emits message:sent hook with messageId on success", async () => {
+    await deliverReplies({
+      replies: [{ text: "hi there" }],
+      target: "chat_id:40",
+      client,
+      accountId: "acct-4",
+      runtime,
+      maxBytes: 4096,
+      textLimit: 4000,
+      sessionKey: "sess-im",
+    });
+
+    expect(emitHookMock).toHaveBeenCalledWith({
+      to: "chat_id:40",
+      content: "hi there",
+      success: true,
+      messageId: "imsg-1",
+      channelId: "imessage",
+      accountId: "acct-4",
+      sessionKey: "sess-im",
+    });
+  });
+
+  it("emits message:sent failure hook when send throws", async () => {
+    sendMessageIMessageMock.mockRejectedValueOnce(new Error("delivery failed"));
+
+    await expect(
+      deliverReplies({
+        replies: [{ text: "oops" }],
+        target: "chat_id:50",
+        client,
+        accountId: "acct-5",
+        runtime,
+        maxBytes: 4096,
+        textLimit: 4000,
+        sessionKey: "sess-fail",
+      }),
+    ).rejects.toThrow("delivery failed");
+
+    expect(emitHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: "delivery failed",
+        channelId: "imessage",
+        sessionKey: "sess-fail",
+      }),
+    );
   });
 });

--- a/src/imessage/monitor/deliver.ts
+++ b/src/imessage/monitor/deliver.ts
@@ -2,6 +2,7 @@ import { chunkTextWithMode, resolveChunkMode } from "../../auto-reply/chunk.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import { loadConfig } from "../../config/config.js";
 import { resolveMarkdownTableMode } from "../../config/markdown-tables.js";
+import { emitMessageSentHook } from "../../hooks/emit-message-sent.js";
 import { convertMarkdownTables } from "../../markdown/tables.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import type { createIMessageRpcClient } from "../client.js";
@@ -17,9 +18,19 @@ export async function deliverReplies(params: {
   maxBytes: number;
   textLimit: number;
   sentMessageCache?: Pick<SentMessageCache, "remember">;
+  sessionKey?: string;
 }) {
-  const { replies, target, client, runtime, maxBytes, textLimit, accountId, sentMessageCache } =
-    params;
+  const {
+    replies,
+    target,
+    client,
+    runtime,
+    maxBytes,
+    textLimit,
+    accountId,
+    sentMessageCache,
+    sessionKey,
+  } = params;
   const scope = `${accountId ?? ""}:${target}`;
   const cfg = loadConfig();
   const tableMode = resolveMarkdownTableMode({
@@ -35,34 +46,60 @@ export async function deliverReplies(params: {
     if (!text && mediaList.length === 0) {
       continue;
     }
-    if (mediaList.length === 0) {
-      sentMessageCache?.remember(scope, { text });
-      for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
-        const sent = await sendMessageIMessage(target, chunk, {
-          maxBytes,
-          client,
-          accountId,
-          replyToId: payload.replyToId,
-        });
-        sentMessageCache?.remember(scope, { text: chunk, messageId: sent.messageId });
+    const content = text || "";
+    let lastMessageId: string | undefined;
+    try {
+      if (mediaList.length === 0) {
+        sentMessageCache?.remember(scope, { text });
+        for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
+          const sent = await sendMessageIMessage(target, chunk, {
+            maxBytes,
+            client,
+            accountId,
+            replyToId: payload.replyToId,
+          });
+          lastMessageId = sent.messageId;
+          sentMessageCache?.remember(scope, { text: chunk, messageId: sent.messageId });
+        }
+      } else {
+        let first = true;
+        for (const url of mediaList) {
+          const caption = first ? text : "";
+          first = false;
+          const sent = await sendMessageIMessage(target, caption, {
+            mediaUrl: url,
+            maxBytes,
+            client,
+            accountId,
+            replyToId: payload.replyToId,
+          });
+          lastMessageId = sent.messageId;
+          sentMessageCache?.remember(scope, {
+            text: caption || undefined,
+            messageId: sent.messageId,
+          });
+        }
       }
-    } else {
-      let first = true;
-      for (const url of mediaList) {
-        const caption = first ? text : "";
-        first = false;
-        const sent = await sendMessageIMessage(target, caption, {
-          mediaUrl: url,
-          maxBytes,
-          client,
-          accountId,
-          replyToId: payload.replyToId,
-        });
-        sentMessageCache?.remember(scope, {
-          text: caption || undefined,
-          messageId: sent.messageId,
-        });
-      }
+      emitMessageSentHook({
+        to: target,
+        content,
+        success: true,
+        messageId: lastMessageId,
+        channelId: "imessage",
+        accountId,
+        sessionKey,
+      });
+    } catch (error) {
+      emitMessageSentHook({
+        to: target,
+        content,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        channelId: "imessage",
+        accountId,
+        sessionKey,
+      });
+      throw error;
     }
     runtime.log?.(`imessage: delivered reply to ${target}`);
   }

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -389,6 +389,7 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
           maxBytes: mediaMaxBytes,
           textLimit,
           sentMessageCache,
+          sessionKey: decision.route.sessionKey,
         });
       },
       onError: (err, info) => {

--- a/src/signal/monitor.ts
+++ b/src/signal/monitor.ts
@@ -9,6 +9,7 @@ import {
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "../config/runtime-group-policy.js";
 import type { SignalReactionNotificationMode } from "../config/types.js";
+import { emitMessageSentHook } from "../hooks/emit-message-sent.js";
 import type { BackoffPolicy } from "../infra/backoff.js";
 import { waitForTransportReady } from "../infra/transport-ready.js";
 import { saveMediaBuffer } from "../media/store.js";
@@ -288,37 +289,74 @@ async function deliverReplies(params: {
   maxBytes: number;
   textLimit: number;
   chunkMode: "length" | "newline";
+  sessionKey?: string;
 }) {
-  const { replies, target, baseUrl, account, accountId, runtime, maxBytes, textLimit, chunkMode } =
-    params;
+  const {
+    replies,
+    target,
+    baseUrl,
+    account,
+    accountId,
+    runtime,
+    maxBytes,
+    textLimit,
+    chunkMode,
+    sessionKey,
+  } = params;
   for (const payload of replies) {
     const mediaList = payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []);
     const text = payload.text ?? "";
     if (!text && mediaList.length === 0) {
       continue;
     }
-    if (mediaList.length === 0) {
-      for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
-        await sendMessageSignal(target, chunk, {
-          baseUrl,
-          account,
-          maxBytes,
-          accountId,
-        });
+    const content = text || "";
+    let lastMessageId: string | undefined;
+    try {
+      if (mediaList.length === 0) {
+        for (const chunk of chunkTextWithMode(text, textLimit, chunkMode)) {
+          const sent = await sendMessageSignal(target, chunk, {
+            baseUrl,
+            account,
+            maxBytes,
+            accountId,
+          });
+          lastMessageId = sent.messageId;
+        }
+      } else {
+        let first = true;
+        for (const url of mediaList) {
+          const caption = first ? text : "";
+          first = false;
+          const sent = await sendMessageSignal(target, caption, {
+            baseUrl,
+            account,
+            mediaUrl: url,
+            maxBytes,
+            accountId,
+          });
+          lastMessageId = sent.messageId;
+        }
       }
-    } else {
-      let first = true;
-      for (const url of mediaList) {
-        const caption = first ? text : "";
-        first = false;
-        await sendMessageSignal(target, caption, {
-          baseUrl,
-          account,
-          mediaUrl: url,
-          maxBytes,
-          accountId,
-        });
-      }
+      emitMessageSentHook({
+        to: target,
+        content,
+        success: true,
+        messageId: lastMessageId,
+        channelId: "signal",
+        accountId,
+        sessionKey,
+      });
+    } catch (error) {
+      emitMessageSentHook({
+        to: target,
+        content,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        channelId: "signal",
+        accountId,
+        sessionKey,
+      });
+      throw error;
     }
     runtime.log?.(`delivered reply to ${target}`);
   }

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -259,6 +259,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
           runtime: deps.runtime,
           maxBytes: deps.mediaMaxBytes,
           textLimit: deps.textLimit,
+          sessionKey: route.sessionKey,
         });
       },
       onError: (err, info) => {

--- a/src/signal/monitor/event-handler.types.ts
+++ b/src/signal/monitor/event-handler.types.ts
@@ -105,6 +105,7 @@ export type SignalEventHandlerDeps = {
     runtime: RuntimeEnv;
     maxBytes: number;
     textLimit: number;
+    sessionKey?: string;
   }) => Promise<void>;
   resolveSignalReactionTargets: (reaction: SignalReactionMessage) => SignalReactionTarget[];
   isSignalReactionMessage: (

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -236,6 +236,7 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       replyThreadTs,
       replyToMode: prepared.replyToMode,
       ...(slackIdentity ? { identity: slackIdentity } : {}),
+      sessionKey: prepared.ctxPayload.SessionKey,
     });
     // Record the thread ts only after confirmed delivery success.
     if (replyThreadTs) {

--- a/src/slack/monitor/replies.test.ts
+++ b/src/slack/monitor/replies.test.ts
@@ -1,8 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const sendMock = vi.fn();
+const emitHookMock = vi.fn();
 vi.mock("../send.js", () => ({
   sendMessageSlack: (...args: unknown[]) => sendMock(...args),
+}));
+vi.mock("../../hooks/emit-message-sent.js", () => ({
+  emitMessageSentHook: (...args: unknown[]) => emitHookMock(...args),
 }));
 
 import { deliverReplies } from "./replies.js";
@@ -24,7 +28,7 @@ describe("deliverReplies identity passthrough", () => {
     sendMock.mockReset();
   });
   it("passes identity to sendMessageSlack for text replies", async () => {
-    sendMock.mockResolvedValue(undefined);
+    sendMock.mockResolvedValue({ messageId: "ts-1", channelId: "C123" });
     const identity = { username: "Bot", iconEmoji: ":robot:" };
     await deliverReplies(baseParams({ identity }));
 
@@ -33,7 +37,7 @@ describe("deliverReplies identity passthrough", () => {
   });
 
   it("passes identity to sendMessageSlack for media replies", async () => {
-    sendMock.mockResolvedValue(undefined);
+    sendMock.mockResolvedValue({ messageId: "ts-1", channelId: "C123" });
     const identity = { username: "Bot", iconUrl: "https://example.com/icon.png" };
     await deliverReplies(
       baseParams({
@@ -47,10 +51,59 @@ describe("deliverReplies identity passthrough", () => {
   });
 
   it("omits identity key when not provided", async () => {
-    sendMock.mockResolvedValue(undefined);
+    sendMock.mockResolvedValue({ messageId: "ts-1", channelId: "C123" });
     await deliverReplies(baseParams());
 
     expect(sendMock).toHaveBeenCalledOnce();
     expect(sendMock.mock.calls[0][2]).not.toHaveProperty("identity");
+  });
+});
+
+describe("deliverReplies message:sent hook", () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+    sendMock.mockResolvedValue({ messageId: "ts-1", channelId: "C123" });
+    emitHookMock.mockReset();
+  });
+
+  it("emits success hook with messageId after delivery", async () => {
+    await deliverReplies(baseParams({ sessionKey: "sess-1", accountId: "acct" }));
+
+    expect(emitHookMock).toHaveBeenCalledWith({
+      to: "C123",
+      content: "hello",
+      success: true,
+      messageId: "ts-1",
+      channelId: "slack",
+      accountId: "acct",
+      sessionKey: "sess-1",
+    });
+  });
+
+  it("emits failure hook when send throws", async () => {
+    sendMock.mockRejectedValue(new Error("network error"));
+
+    await expect(deliverReplies(baseParams({ sessionKey: "sess-1" }))).rejects.toThrow(
+      "network error",
+    );
+
+    expect(emitHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        error: "network error",
+        channelId: "slack",
+      }),
+    );
+  });
+
+  it("emits hook without sessionKey when not provided", async () => {
+    await deliverReplies(baseParams());
+
+    expect(emitHookMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        sessionKey: undefined,
+      }),
+    );
   });
 });

--- a/src/slack/monitor/replies.ts
+++ b/src/slack/monitor/replies.ts
@@ -4,6 +4,7 @@ import { createReplyReferencePlanner } from "../../auto-reply/reply/reply-refere
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
+import { emitMessageSentHook } from "../../hooks/emit-message-sent.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { markdownToSlackMrkdwnChunks } from "../format.js";
 import { sendMessageSlack, type SlackSendIdentity } from "../send.js";
@@ -18,6 +19,7 @@ export async function deliverReplies(params: {
   replyThreadTs?: string;
   replyToMode: "off" | "first" | "all";
   identity?: SlackSendIdentity;
+  sessionKey?: string;
 }) {
   for (const payload of params.replies) {
     // Keep reply tags opt-in: when replyToMode is off, explicit reply tags
@@ -30,30 +32,56 @@ export async function deliverReplies(params: {
       continue;
     }
 
-    if (mediaList.length === 0) {
-      const trimmed = text.trim();
-      if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
-        continue;
-      }
-      await sendMessageSlack(params.target, trimmed, {
-        token: params.token,
-        threadTs,
-        accountId: params.accountId,
-        ...(params.identity ? { identity: params.identity } : {}),
-      });
-    } else {
-      let first = true;
-      for (const mediaUrl of mediaList) {
-        const caption = first ? text : "";
-        first = false;
-        await sendMessageSlack(params.target, caption, {
+    const content = text || "";
+    let lastMessageId: string | undefined;
+    try {
+      if (mediaList.length === 0) {
+        const trimmed = text.trim();
+        if (!trimmed || isSilentReplyText(trimmed, SILENT_REPLY_TOKEN)) {
+          continue;
+        }
+        const sent = await sendMessageSlack(params.target, trimmed, {
           token: params.token,
-          mediaUrl,
           threadTs,
           accountId: params.accountId,
           ...(params.identity ? { identity: params.identity } : {}),
         });
+        lastMessageId = sent.messageId;
+      } else {
+        let first = true;
+        for (const mediaUrl of mediaList) {
+          const caption = first ? text : "";
+          first = false;
+          const sent = await sendMessageSlack(params.target, caption, {
+            token: params.token,
+            mediaUrl,
+            threadTs,
+            accountId: params.accountId,
+            ...(params.identity ? { identity: params.identity } : {}),
+          });
+          lastMessageId = sent.messageId;
+        }
       }
+      emitMessageSentHook({
+        to: params.target,
+        content,
+        success: true,
+        messageId: lastMessageId,
+        channelId: "slack",
+        accountId: params.accountId,
+        sessionKey: params.sessionKey,
+      });
+    } catch (error) {
+      emitMessageSentHook({
+        to: params.target,
+        content,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        channelId: "slack",
+        accountId: params.accountId,
+        sessionKey: params.sessionKey,
+      });
+      throw error;
     }
     params.runtime.log?.(`delivered reply to ${params.target}`);
   }

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -438,6 +438,7 @@ export const dispatchTelegramMessage = async ({
     chunkMode,
     linkPreview: telegramCfg.linkPreview,
     replyQuoteText,
+    sessionKey: ctxPayload.SessionKey,
   };
   const applyTextToPayload = (payload: ReplyPayload, text: string): ReplyPayload => {
     if (payload.text === text) {

--- a/src/telegram/bot/delivery.replies.ts
+++ b/src/telegram/bot/delivery.replies.ts
@@ -4,6 +4,7 @@ import type { ReplyPayload } from "../../auto-reply/types.js";
 import type { ReplyToMode } from "../../config/config.js";
 import type { MarkdownTableMode } from "../../config/types.base.js";
 import { danger, logVerbose } from "../../globals.js";
+import { emitMessageSentHook } from "../../hooks/emit-message-sent.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { buildOutboundMediaLoadOptions } from "../../media/load-options.js";
 import { isGifMedia, kindFromMime } from "../../media/mime.js";
@@ -444,6 +445,7 @@ export async function deliverReplies(params: {
   linkPreview?: boolean;
   /** Optional quote text for Telegram reply_parameters. */
   replyQuoteText?: string;
+  sessionKey?: string;
 }): Promise<{ delivered: boolean }> {
   const progress: DeliveryProgress = {
     hasReplied: false,
@@ -452,7 +454,6 @@ export async function deliverReplies(params: {
   };
   const hookRunner = getGlobalHookRunner();
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
-  const hasMessageSentHooks = hookRunner?.hasHooks("message_sent") ?? false;
   const chunkText = buildChunkTextResolver({
     textLimit: params.textLimit,
     chunkMode: params.chunkMode ?? "length",
@@ -547,37 +548,25 @@ export async function deliverReplies(params: {
         });
       }
 
-      if (hasMessageSentHooks) {
-        const deliveredThisReply = progress.deliveredCount > deliveredCountBeforeReply;
-        void hookRunner?.runMessageSent(
-          {
-            to: params.chatId,
-            content: contentForSentHook,
-            success: deliveredThisReply,
-          },
-          {
-            channelId: "telegram",
-            accountId: params.accountId,
-            conversationId: params.chatId,
-          },
-        );
-      }
+      const deliveredThisReply = progress.deliveredCount > deliveredCountBeforeReply;
+      emitMessageSentHook({
+        to: params.chatId,
+        content: contentForSentHook,
+        success: deliveredThisReply,
+        channelId: "telegram",
+        accountId: params.accountId,
+        sessionKey: params.sessionKey,
+      });
     } catch (error) {
-      if (hasMessageSentHooks) {
-        void hookRunner?.runMessageSent(
-          {
-            to: params.chatId,
-            content: contentForSentHook,
-            success: false,
-            error: error instanceof Error ? error.message : String(error),
-          },
-          {
-            channelId: "telegram",
-            accountId: params.accountId,
-            conversationId: params.chatId,
-          },
-        );
-      }
+      emitMessageSentHook({
+        to: params.chatId,
+        content: contentForSentHook,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        channelId: "telegram",
+        accountId: params.accountId,
+        sessionKey: params.sessionKey,
+      });
       throw error;
     }
   }

--- a/src/telegram/bot/delivery.test.ts
+++ b/src/telegram/bot/delivery.test.ts
@@ -7,7 +7,7 @@ const loadWebMedia = vi.fn();
 const messageHookRunner = vi.hoisted(() => ({
   hasHooks: vi.fn<(name: string) => boolean>(() => false),
   runMessageSending: vi.fn(),
-  runMessageSent: vi.fn(),
+  runMessageSent: vi.fn(async () => {}),
 }));
 const baseDeliveryParams = {
   chatId: "123",
@@ -112,6 +112,7 @@ describe("deliverReplies", () => {
     messageHookRunner.hasHooks.mockReturnValue(false);
     messageHookRunner.runMessageSending.mockReset();
     messageHookRunner.runMessageSent.mockReset();
+    messageHookRunner.runMessageSent.mockResolvedValue(undefined);
   });
 
   it("skips audioAsVoice-only payloads without logging an error", async () => {


### PR DESCRIPTION
## Summary

- **Problem:** The `message:sent` hook (both plugin and internal) only fires from the centralized outbound delivery path (`src/infra/outbound/deliver.ts`). Conversational replies — the primary message flow — route through channel-specific inline `deliverReplies()` functions in Telegram, Signal, Slack, and iMessage that bypass this path entirely, so the hook never fires.
- **Why it matters:** Any integration relying on `message:sent` for conversation logging, analytics, or downstream processing silently misses all conversational replies. This was identified as a gap in #24968.
- **What changed:** A shared `emitMessageSentHook()` utility is added and wired into all four inline delivery paths. `sessionKey` is threaded from each channel's routing context to enable internal hook emission. `accountId` is included for multi-account attribution. All send paths (text and media) emit both success and failure hooks. Slack and Signal delivery paths now capture `messageId` from their send results (previously discarded).
- **What did NOT change (scope boundary):** The centralized outbound delivery path is untouched. Hook semantics, payload shape, and fire-and-forget behavior are identical to the existing implementation. No new dependencies.

Supersedes #31052 and #28076 (same fix, clean commit history, all reviewer feedback addressed — including messageId capture for Slack/Signal).

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24968
- Supersedes #31052
- Supersedes #28076

## User-visible / Behavior Changes

- `message:sent` plugin hooks now fire for conversational replies delivered via Telegram, Signal, Slack, and iMessage inline delivery paths (previously only fired for outbound messages routed through the centralized delivery path).
- Internal hooks (`message` / `sent` events) now fire for the same paths when a `sessionKey` is available.
- Slack and Signal delivery paths now capture `messageId` from send results, making it available in hook payloads.
- No config changes required. No new config options.