### PR TITLE
ui(cron): avoid duplicate history load call from History action

### DIFF
--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -1569,7 +1569,7 @@ function renderJob(job: CronJob, props: CronProps) {
             ?disabled=${props.busy}
             @click=${(event: Event) => {
               event.stopPropagation();
-              selectAnd(() => props.onLoadRuns(job.id));
+              props.onLoadRuns(job.id);
             }}
           >
             ${t("cron.jobList.history")}


### PR DESCRIPTION
## Summary
- stop calling `onLoadRuns` twice when clicking the History button
- keep row-click behavior unchanged

## Validation
- verified the selected-job History interaction now triggers a single load callback