### PR TITLE
ui: guard opener nulling for proxy-like window objects

### DIFF
--- a/ui/src/ui/open-external-url.ts
+++ b/ui/src/ui/open-external-url.ts
@@ -67,7 +67,12 @@ export function openExternalUrlSafe(
 
   const opened = window.open(safeUrl, "_blank", "noopener,noreferrer");
   if (opened) {
-    opened.opener = null;
+    try {
+      opened.opener = null;
+    } catch {
+      // Some browser/proxy-like WindowProxy implementations may reject opener writes.
+      // noop: noopener,noreferrer already requested in feature string.
+    }
   }
   return opened;
 }


### PR DESCRIPTION
## Summary
- wrap `opened.opener = null` in a try/catch in `openExternalUrlSafe`
- keeps safe open flow resilient when browsers/proxies reject opener writes

## Why
Some WindowProxy implementations throw on opener assignment even when open succeeds.

## Risk
Low. `noopener,noreferrer` remains in place regardless.