### PR TITLE
fix: add confirmation dialog for Webchat New session button (#34047)

### DIFF
--- a/src/plugin-sdk/root-alias.test.ts
+++ b/src/plugin-sdk/root-alias.test.ts
@@ -27,16 +27,12 @@ describe("plugin-sdk root alias", () => {
     expect(parsed.success).toBe(false);
   });
 
-  it(
-    "loads legacy root exports lazily through the proxy",
-    () => {
-      expect(typeof rootSdk.resolveControlCommandGate).toBe("function");
-      expect(typeof rootSdk.default).toBe("object");
-      expect(rootSdk.default).toBe(rootSdk);
-      expect(rootSdk.__esModule).toBe(true);
-    },
-    180_000,
-  );
+  it("loads legacy root exports lazily through the proxy", () => {
+    expect(typeof rootSdk.resolveControlCommandGate).toBe("function");
+    expect(typeof rootSdk.default).toBe("object");
+    expect(rootSdk.default).toBe(rootSdk);
+    expect(rootSdk.__esModule).toBe(true);
+  }, 180_000);
 
   it("preserves reflection semantics for lazily resolved exports", () => {
     expect("resolveControlCommandGate" in rootSdk).toBe(true);

--- a/src/plugin-sdk/root-alias.test.ts
+++ b/src/plugin-sdk/root-alias.test.ts
@@ -27,12 +27,16 @@ describe("plugin-sdk root alias", () => {
     expect(parsed.success).toBe(false);
   });
 
-  it("loads legacy root exports lazily through the proxy", () => {
-    expect(typeof rootSdk.resolveControlCommandGate).toBe("function");
-    expect(typeof rootSdk.default).toBe("object");
-    expect(rootSdk.default).toBe(rootSdk);
-    expect(rootSdk.__esModule).toBe(true);
-  });
+  it(
+    "loads legacy root exports lazily through the proxy",
+    () => {
+      expect(typeof rootSdk.resolveControlCommandGate).toBe("function");
+      expect(typeof rootSdk.default).toBe("object");
+      expect(rootSdk.default).toBe(rootSdk);
+      expect(rootSdk.__esModule).toBe(true);
+    },
+    180_000,
+  );
 
   it("preserves reflection semantics for lazily resolved exports", () => {
     expect("resolveControlCommandGate" in rootSdk).toBe(true);

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -50,6 +50,10 @@ function createProps(overrides: Partial<ChatProps> = {}): ChatProps {
 }
 
 describe("chat view", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("renders compacting indicator as a badge", () => {
     const container = document.createElement("div");
     render(
@@ -224,7 +228,6 @@ describe("chat view", () => {
     newSessionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(onNewSession).toHaveBeenCalledTimes(1);
     expect(container.textContent).not.toContain("Stop");
-    vi.restoreAllMocks();
   });
 
   it("does not start new session when user cancels confirmation", () => {
@@ -247,6 +250,5 @@ describe("chat view", () => {
     expect(newSessionButton).not.toBeUndefined();
     newSessionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(onNewSession).not.toHaveBeenCalled();
-    vi.restoreAllMocks();
   });
 });

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -1,5 +1,5 @@
 import { render } from "lit";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { SessionsListResult } from "../types.ts";
 import { renderChat, type ChatProps } from "./chat.ts";
 

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -206,6 +206,7 @@ describe("chat view", () => {
   it("shows a new session button when aborting is unavailable", () => {
     const container = document.createElement("div");
     const onNewSession = vi.fn();
+    vi.spyOn(window, "confirm").mockReturnValue(true);
     render(
       renderChat(
         createProps({
@@ -223,5 +224,29 @@ describe("chat view", () => {
     newSessionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(onNewSession).toHaveBeenCalledTimes(1);
     expect(container.textContent).not.toContain("Stop");
+    vi.restoreAllMocks();
+  });
+
+  it("does not start new session when user cancels confirmation", () => {
+    const container = document.createElement("div");
+    const onNewSession = vi.fn();
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    render(
+      renderChat(
+        createProps({
+          canAbort: false,
+          onNewSession,
+        }),
+      ),
+      container,
+    );
+
+    const newSessionButton = Array.from(container.querySelectorAll("button")).find(
+      (btn) => btn.textContent?.trim() === "New session",
+    );
+    expect(newSessionButton).not.toBeUndefined();
+    newSessionButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onNewSession).not.toHaveBeenCalled();
+    vi.restoreAllMocks();
   });
 });

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -85,6 +85,15 @@ export type ChatProps = {
 const COMPACTION_TOAST_DURATION_MS = 5000;
 const FALLBACK_TOAST_DURATION_MS = 8000;
 
+const NEW_SESSION_CONFIRM_MESSAGE = "Start new session? Current context will be lost.";
+
+function handleNewSessionClick(props: ChatProps): void {
+  const confirmed = window.confirm(NEW_SESSION_CONFIRM_MESSAGE);
+  if (confirmed) {
+    props.onNewSession();
+  }
+}
+
 function adjustTextareaHeight(el: HTMLTextAreaElement) {
   el.style.height = "auto";
   el.style.height = `${el.scrollHeight}px`;
@@ -461,7 +470,7 @@ export function renderChat(props: ChatProps) {
             <button
               class="btn"
               ?disabled=${!props.connected || (!canAbort && props.sending)}
-              @click=${canAbort ? props.onAbort : props.onNewSession}
+              @click=${canAbort ? props.onAbort : () => handleNewSessionClick(props)}
             >
               ${canAbort ? "Stop" : "New session"}
             </button>


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** The "New session" button in Webchat can be triggered accidentally via keyboard (e.g. Tab + Enter while typing in the chat input), resetting the session immediately with no way to recover.
- **Why it matters:** Users lose current context by mistake; the button has no guard against accidental activation.
- **What changed:** Before starting a new session, the chat view now shows a confirmation dialog ("Start new session? Current context will be lost."). The session is reset only when the user confirms; cancel keeps the current session.
- **What did NOT change (scope boundary):** Only the Webchat "New session" button flow; no change to Stop button, Send, or other channels/UI. Confirmation is implemented with `window.confirm` consistent with existing usage in sessions and devices.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34047
- Related #

## User-visible / Behavior Changes

In Webchat, clicking "New session" (or focusing it and pressing Enter) now opens a confirmation dialog. Session resets only after the user confirms; cancelling leaves the current session and context unchanged.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: any
- Runtime/container: Browser (Webchat)
- Model/provider: N/A
- Integration/channel (if any): Webchat UI
- Relevant config (redacted): N/A

### Steps

1. Open Webchat and type in the chat input.
2. Press Tab until focus moves to the "New session" button.
3. Press Enter (or click the button).

### Expected

- A confirmation dialog appears: "Start new session? Current context will be lost."
- Session resets only if user confirms; cancelling keeps the current session.

### Actual

- Before fix: Session reset immediately with no confirmation. After fix: Confirmation shown; session resets only on confirm.

## Evidence

- [x] Failing test/log before + passing after: New test "does not start new session when user cancels confirmation" plus existing test updated with `window.confirm` mock.
- [ ] Trace/log snippets: N/A
- [ ] Screenshot/recording: Optional for reviewer.

## Human Verification (required)

- **Verified scenarios:** Click "New session" with confirm=true → session resets; with confirm=false → no reset. Tab + Enter flow triggers the same confirmation.
- **Edge cases checked:** Stop button unchanged; confirmation only for "New session" when not aborting.
- **What you did not verify:** No long E2E run across multiple channels.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- Revert this PR; restore direct `props.onNewSession` on the button and remove `handleNewSessionClick` / confirmation constant.
- Files: `ui/src/ui/views/chat.ts`, `ui/src/ui/views/chat.test.ts`.
- Known bad symptoms: Dialog not shown, or new session never starts even when user confirms.

## Risks and Mitigations

- **Risk:** One extra click for users who intentionally start a new session.
  - **Mitigation:** Single confirmation with clear copy; aligns with avoiding accidental data loss.
- Otherwise: `None`.