### PR TITLE
Status: show session model override in /status output

### DIFF
--- a/src/auto-reply/status.test.ts
+++ b/src/auto-reply/status.test.ts
@@ -120,6 +120,27 @@ describe("buildStatusMessage", () => {
     expect(normalized).toContain("channel override");
   });
 
+  it("notes session model overrides in status output", () => {
+    const text = buildStatusMessage({
+      agent: {
+        model: "ollama/huihui_ai/qwen3.5-abliterated:2B",
+      },
+      sessionEntry: {
+        sessionId: "abc",
+        updatedAt: 0,
+        providerOverride: "zai",
+        modelOverride: "glm-4.7",
+      },
+      sessionKey: "agent:main:telegram:direct:6890541329",
+      sessionScope: "per-sender",
+      queue: { mode: "collect", depth: 0 },
+    });
+    const normalized = normalizeTestText(text);
+
+    expect(normalized).toContain("Model: zai/glm-4.7");
+    expect(normalized).toContain("session override");
+  });
+
   it("uses per-agent sandbox config when config and session key are provided", () => {
     const text = buildStatusMessage({
       config: {

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -569,11 +569,20 @@ export function buildStatusMessage(args: StatusArgs): string {
   const costLabel = showCost && hasUsage ? formatUsd(cost) : undefined;
 
   const selectedAuthLabel = selectedAuthLabelValue ? ` · 🔑 ${selectedAuthLabelValue}` : "";
+  const sessionModelNote = (() => {
+    if (!entry) {
+      return undefined;
+    }
+    if (entry.modelOverride?.trim() || entry.providerOverride?.trim()) {
+      return "session override";
+    }
+    return undefined;
+  })();
   const channelModelNote = (() => {
     if (!args.config || !entry) {
       return undefined;
     }
-    if (entry.modelOverride?.trim() || entry.providerOverride?.trim()) {
+    if (sessionModelNote) {
       return undefined;
     }
     const channelOverride = resolveChannelModelOverride({
@@ -607,7 +616,11 @@ export function buildStatusMessage(args: StatusArgs): string {
     }
     return "channel override";
   })();
-  const modelNote = channelModelNote ? ` · ${channelModelNote}` : "";
+  const modelNote = sessionModelNote
+    ? ` · ${sessionModelNote}`
+    : channelModelNote
+      ? ` · ${channelModelNote}`
+      : "";
   const modelLine = `🧠 Model: ${selectedModelLabel}${selectedAuthLabel}${modelNote}`;
   const showFallbackAuth = activeAuthLabelValue && activeAuthLabelValue !== selectedAuthLabelValue;
   const fallbackLine = fallbackState.active


### PR DESCRIPTION
## Summary
- clarify `/status` model origin when a session-specific model override is active
- append `session override` to the model line when `modelOverride/providerOverride` is present
- keep existing `channel override` note behavior for channel-scoped model overrides

## Why
TUI can run on one session while Telegram `/status` reports another session. Without an explicit override marker, it looks like the default model switch did not apply. This change makes `/status` self-explanatory.

## Testing
- `pnpm vitest src/auto-reply/status.test.ts`
