### PR TITLE
fix(cron): manual `cron run` must not displace schedule anchor (#33940)

### DIFF
--- a/src/cron/service.issue-33940-manual-run-schedule.test.ts
+++ b/src/cron/service.issue-33940-manual-run-schedule.test.ts
@@ -126,3 +126,44 @@ describe("Cron issue #33940 — manual run must not displace schedule anchor", (
     expect(job.state.nextRunAtMs).toBe(scheduledRunMs + DAY_MS);
   });
 });
+
+describe("issue-33940: manual run on at-schedule job updates lastRunAtMs (#34110 review)", () => {
+  const { makeStorePath } = createCronStoreHarness();
+  const log = createNoopLogger();
+
+  function createAtJob(params: { atMs: number }): CronJob {
+    return {
+      id: "one-shot",
+      schedule: { kind: "at", at: new Date(params.atMs).toISOString(), atMs: params.atMs },
+      payload: { kind: "systemEvent", text: "ping" },
+      sessionTarget: "main",
+      enabled: true,
+      createdAtMs: params.atMs - 1000,
+      updatedAtMs: params.atMs - 1000,
+      state: {
+        nextRunAtMs: params.atMs,
+      },
+    };
+  }
+
+  it("force-run of an at-schedule job updates lastRunAtMs so computeJobNextRunAtMs works correctly", async () => {
+    const atMs = 1_700_000_000_000;
+    const manualMs = atMs + 60_000; // trigger 1 minute after scheduled time
+
+    const { storePath } = await makeStorePath();
+    const state = createRunningCronServiceState({
+      storePath,
+      log,
+      nowMs: () => manualMs,
+      jobs: [createAtJob({ atMs })],
+    });
+
+    await run(state, "one-shot", "force");
+
+    const job = state.store!.jobs.find((j) => j.id === "one-shot")!;
+    // For at-schedule jobs, lastRunAtMs must be set even on manual triggers
+    // so that computeJobNextRunAtMs can detect the job as already-run.
+    expect(job.state.lastRunAtMs).toBe(manualMs);
+    expect(job.state.lastStatus).toBe("ok");
+  });
+});

--- a/src/cron/service.issue-33940-manual-run-schedule.test.ts
+++ b/src/cron/service.issue-33940-manual-run-schedule.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  createRunningCronServiceState,
+  createCronStoreHarness,
+  createNoopLogger,
+} from "./service.test-harness.js";
+import { computeJobNextRunAtMs } from "./service/jobs.js";
+import { run } from "./service/ops.js";
+import type { CronJob } from "./types.js";
+
+// Regression test for https://github.com/openclaw/openclaw/issues/33940
+// "Executing a Daily Cron Task Manually Changes the Timing of the Execution of the Cron Task"
+//
+// When a user manually triggers `openclaw cron run <id>` (force mode), the
+// next automatic run should still fire at the original scheduled time.
+// Before the fix, `lastRunAtMs` was updated to the manual trigger time, causing
+// `computeJobNextRunAtMs` to schedule the next run as `manualTime + everyMs`
+// instead of staying on the original anchor cadence.
+
+const DAY_MS = 24 * 60 * 60_000;
+
+// 7:00 AM anchor — simulates "morning affirmation at 7am"
+const ANCHOR_7AM = Date.parse("2026-03-04T07:00:00.000Z");
+
+function createDailyJob(state: CronJob["state"] = {}): CronJob {
+  return {
+    id: "daily-morning",
+    name: "Morning Affirmation",
+    enabled: true,
+    createdAtMs: ANCHOR_7AM,
+    updatedAtMs: ANCHOR_7AM,
+    schedule: { kind: "every", everyMs: DAY_MS, anchorMs: ANCHOR_7AM },
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    payload: { kind: "systemEvent", text: "Morning affirmation!" },
+    state,
+  };
+}
+
+describe("Cron issue #33940 — manual run must not displace schedule anchor", () => {
+  const { makeStorePath } = createCronStoreHarness({ prefix: "openclaw-cron-33940-" });
+  const log = createNoopLogger();
+
+  it("computeJobNextRunAtMs: normal run at 7am schedules next at tomorrow 7am", () => {
+    const job = createDailyJob({ lastRunAtMs: ANCHOR_7AM });
+    const nowMs = ANCHOR_7AM + 100;
+    const next = computeJobNextRunAtMs(job, nowMs);
+    expect(next).toBe(ANCHOR_7AM + DAY_MS);
+  });
+
+  it("computeJobNextRunAtMs: with lastRunAtMs=1pm, gives 1pm+1day (demonstrates the pre-fix bug at computation level)", () => {
+    const manualRunMs = ANCHOR_7AM + 6 * 60 * 60_000; // 13:00
+    const job = createDailyJob({ lastRunAtMs: manualRunMs });
+    const nowMs = manualRunMs + 100;
+    const next = computeJobNextRunAtMs(job, nowMs);
+    // Without the fix, setting lastRunAtMs to a manual run time causes the
+    // next scheduled run to shift from anchor-based to manual-time + interval.
+    expect(next).toBe(manualRunMs + DAY_MS);
+  });
+
+  it("manual force-run at 1pm must NOT shift next scheduled run to tomorrow 1pm", async () => {
+    const lastAutoRunMs = ANCHOR_7AM; // 07:00 today
+    const manualRunMs = ANCHOR_7AM + 6 * 60 * 60_000; // 13:00 today
+
+    const { storePath } = await makeStorePath();
+    const state = createRunningCronServiceState({
+      storePath,
+      log,
+      nowMs: () => manualRunMs,
+      jobs: [createDailyJob({ lastRunAtMs: lastAutoRunMs })],
+    });
+
+    const result = await run(state, "daily-morning", "force");
+    expect(result.ran).toBe(true);
+
+    const job = state.store!.jobs.find((j) => j.id === "daily-morning")!;
+    expect(job).toBeDefined();
+
+    // lastRunAtMs must NOT be updated — must stay at last auto-run (7am)
+    expect(job.state.lastRunAtMs).toBe(lastAutoRunMs);
+
+    // Next run must be tomorrow 7am — NOT tomorrow 1pm
+    const tomorrowAt7am = lastAutoRunMs + DAY_MS;
+    const tomorrowAt1pm = manualRunMs + DAY_MS;
+    expect(job.state.nextRunAtMs).toBe(tomorrowAt7am);
+    expect(job.state.nextRunAtMs).not.toBe(tomorrowAt1pm);
+  });
+
+  it("manual force-run with no prior lastRunAtMs schedules from anchor (not from trigger time)", async () => {
+    const manualRunMs = ANCHOR_7AM + 6 * 60 * 60_000; // 13:00
+
+    const { storePath } = await makeStorePath();
+    const state = createRunningCronServiceState({
+      storePath,
+      log,
+      nowMs: () => manualRunMs,
+      jobs: [createDailyJob({})], // no lastRunAtMs
+    });
+
+    await run(state, "daily-morning", "force");
+
+    const job = state.store!.jobs.find((j) => j.id === "daily-morning")!;
+    // lastRunAtMs stays undefined (was never set by an auto-run)
+    expect(job.state.lastRunAtMs).toBeUndefined();
+    // Next run should be anchor-based: next 7am after 1pm = tomorrow 7am
+    const tomorrowAt7am = ANCHOR_7AM + DAY_MS;
+    expect(job.state.nextRunAtMs).toBe(tomorrowAt7am);
+  });
+
+  it("due-mode run (normal timer tick) still updates lastRunAtMs correctly", async () => {
+    const scheduledRunMs = ANCHOR_7AM;
+
+    const { storePath } = await makeStorePath();
+    const state = createRunningCronServiceState({
+      storePath,
+      log,
+      nowMs: () => scheduledRunMs,
+      jobs: [createDailyJob({ nextRunAtMs: scheduledRunMs })],
+    });
+
+    await run(state, "daily-morning", "due");
+
+    const job = state.store!.jobs.find((j) => j.id === "daily-morning")!;
+    // For due (scheduled) runs, lastRunAtMs must be updated
+    expect(job.state.lastRunAtMs).toBe(scheduledRunMs);
+    expect(job.state.nextRunAtMs).toBe(scheduledRunMs + DAY_MS);
+  });
+});

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -404,6 +404,7 @@ export async function run(state: CronServiceState, id: string, mode?: "due" | "f
       delivered: coreResult.delivered,
       startedAt,
       endedAt,
+      manual: mode === "force",
     });
 
     emit(state, {

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -292,11 +292,16 @@ export function applyJobResult(
   },
 ): boolean {
   job.state.runningAtMs = undefined;
-  // For manual triggers, preserve the existing lastRunAtMs so that the
-  // schedule anchor is not displaced.  The next automatic run should still
-  // fire at its original cadence (e.g. 07:00 daily) rather than being
-  // shifted to `now + interval` (#33940).
-  if (!result.manual) {
+  // For manual triggers on recurring schedules (every/cron), preserve the
+  // existing lastRunAtMs so that the schedule anchor is not displaced.  The
+  // next automatic run should still fire at its original cadence (e.g. 07:00
+  // daily) rather than being shifted to `now + interval` (#33940).
+  //
+  // One-shot `at` jobs must always update lastRunAtMs so that
+  // computeJobNextRunAtMs can correctly identify them as already-run and
+  // avoid re-firing or miscalculating their next state.
+  const isRecurring = job.schedule.kind === "every" || job.schedule.kind === "cron";
+  if (!result.manual || !isRecurring) {
     job.state.lastRunAtMs = result.startedAt;
   }
   job.state.lastRunStatus = result.status;

--- a/src/cron/service/timer.ts
+++ b/src/cron/service/timer.ts
@@ -285,10 +285,20 @@ export function applyJobResult(
     delivered?: boolean;
     startedAt: number;
     endedAt: number;
+    /** When true, this was a manual trigger (e.g. `openclaw cron run`).
+     *  The schedule anchor should not be displaced — next run is computed
+     *  from the existing anchor / lastRunAtMs rather than the manual start time. */
+    manual?: boolean;
   },
 ): boolean {
   job.state.runningAtMs = undefined;
-  job.state.lastRunAtMs = result.startedAt;
+  // For manual triggers, preserve the existing lastRunAtMs so that the
+  // schedule anchor is not displaced.  The next automatic run should still
+  // fire at its original cadence (e.g. 07:00 daily) rather than being
+  // shifted to `now + interval` (#33940).
+  if (!result.manual) {
+    job.state.lastRunAtMs = result.startedAt;
+  }
   job.state.lastRunStatus = result.status;
   job.state.lastStatus = result.status;
   job.state.lastDurationMs = Math.max(0, result.endedAt - result.startedAt);


### PR DESCRIPTION
## Problem

When a user manually triggers `openclaw cron run <id>` (force mode), the next automatic run is incorrectly shifted to `manualTime + interval` instead of the original cadence.

**Example:** A daily job scheduled at 07:00 that is manually triggered at 13:00 will then fire at 13:00 the next day instead of 07:00.

**Root cause:** `applyJobResult` always set `job.state.lastRunAtMs = result.startedAt`. For `every` schedules, `computeJobNextRunAtMs` prioritises `lastRunAtMs + everyMs` over the anchor-based calculation. Updating `lastRunAtMs` to the manual trigger time therefore displaced the anchor.

## Fix

Pass `manual: true` to `applyJobResult` when `mode === "force"` in `ops.run()`. The function now skips the `lastRunAtMs` update for manual triggers, preserving the existing anchor-based cadence.

The `due` path (normal timer ticks) is unchanged.

## Tests

Added `service.issue-33940-manual-run-schedule.test.ts` with 5 tests:
- Pure unit tests on `computeJobNextRunAtMs` (demonstrating the broken state)
- Integration tests via `ops.run()` for force mode (must preserve anchor)
- Integration tests for due mode (must still update `lastRunAtMs`)

All 383 existing cron tests continue to pass.

Closes #33940