### PR TITLE
fix the regular expression error of the exe file path when using brow…

### DIFF
--- a/src/browser/chrome.executables.ts
+++ b/src/browser/chrome.executables.ts
@@ -432,11 +432,11 @@ function expandWindowsEnvVars(value: string): string {
 }
 
 function extractWindowsExecutablePath(command: string): string | null {
-  const quoted = command.match(/"([^"]+\\.exe)"/i);
+  const quoted = command.match(/"([^"]+\.exe)"/i);
   if (quoted?.[1]) {
     return quoted[1];
   }
-  const unquoted = command.match(/([^\\s]+\\.exe)/i);
+  const unquoted = command.match(/([^\\s]+\.exe)/i);
   if (unquoted?.[1]) {
     return unquoted[1];
   }

--- a/src/browser/chrome.executables.ts
+++ b/src/browser/chrome.executables.ts
@@ -436,7 +436,7 @@ function extractWindowsExecutablePath(command: string): string | null {
   if (quoted?.[1]) {
     return quoted[1];
   }
-  const unquoted = command.match(/([^\\s]+\.exe)/i);
+  const unquoted = command.match(/([^\s]+\.exe)/i);
   if (unquoted?.[1]) {
     return unquoted[1];
   }


### PR DESCRIPTION
## Summary

fix the regular expression error of the exe file path when using browser tools in windows 

When using browser tools, the path of the exe executable file will be queried in detectDefaultChromiumExecutableWindows method. Once the path is found, it will be matched with the true executable path through regularization. But the regular expression is incorrect. The regular expression has an additional back slash, resulting in a matching failure.And some users' browser installation paths are not in the candidate directory.Ultimately leading to browser tool execution failure
this update will fix it。
before fix :"([^"]+\\.exe)"
after fix:"([^"]+\.exe)"


## Change Type
Bug fix

## Scope (select all touched areas)
API 

## Linked Issue/PR

## User-visible / Behavior Changes
before fix,some windows user will see follow error: No supported browser found (Chrome/Brave/Edge/Chromium on macOS, Linux, or Windows).
after fix,this user will use  browser tools normally


## Security Impact (required)
None

## Repro + Verification

### Environment
- OS:

### Steps

### Expected

### Actual

## Evidence
Screenshot/recording
<img width="1170" height="462" alt="image" src="https://github.com/user-attachments/assets/d04067c9-80cb-496a-92d9-029b69ed5d38" />


## Human Verification (required)
I debuged on the machine with issues,after fix it works normally

## Compatibility / Migration
- Backward compatible? (No)
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)
None

## Risks and Mitigations
None
