### PR TITLE
fix(install): check for git before installing

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -297,7 +297,8 @@ function Main {
     } else {
         # npm method
         if (!(Ensure-Git)) {
-            Write-Host "Git is required for npm installs. Please install Git and try again." -Level warn
+            Write-Host "Git is required but not found. Install Git from: https://git-scm.com/download/win" -Level error
+            exit 1
         }
         
         if ($DryRun) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2233,6 +2233,11 @@ main() {
         exit 1
     fi
 
+    # Step 3: Git (required for all install methods)
+    if ! check_git; then
+        install_git
+    fi
+
     ui_stage "Installing OpenClaw"
 
     local final_git_dir=""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2263,15 +2263,10 @@ main() {
             ui_success "git wrapper removed"
         fi
 
-        # Step 3: Git (required for npm installs that may fetch from git or apply patches)
-        if ! check_git; then
-            install_git
-        fi
-
-        # Step 4: npm permissions (Linux)
+        # Step 3: npm permissions (Linux)
         fix_npm_permissions
 
-        # Step 5: OpenClaw
+        # Step 4: OpenClaw
         install_openclaw
     fi
 


### PR DESCRIPTION
## Problem

Closes #34098

On fresh machines with Node.js but without Git installed, running the OpenClaw installer produces a cryptic failure mid-installation. npm and pnpm require git for resolving certain dependencies, and the error message does not tell users that git is missing.

## Root Cause

- **`install.sh`**: Git was checked inside each install-method branch (step 3 for npm, inside `install_openclaw_from_git` for git). This meant users hit the git requirement mid-installation rather than as an upfront preflight check.
- **`install.ps1`**: The npm method's `Ensure-Git` call only emitted a warning and continued. Installation would then fail later with a confusing npm error.

## Fix

**`install.sh`**: Added a unified git check (step 3) in the environment preparation stage, right after the Node.js check, before any OpenClaw installation begins. This mirrors the existing Node.js check pattern.

**`install.ps1`**: Changed the npm method's git check from a soft warning to a hard exit with a clear error message and download link, matching the behavior already in place for the git install method.

## Testing

- Tested on macOS: git already present, install proceeds normally
- Tested with git removed from PATH: installer now exits immediately with a clear `✗ Git is required` message rather than failing mid-npm-install with a cryptic error