### PR TITLE
fix(doctor): check per-group allowFrom before warning about empty groupAllowFrom

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1394,7 +1394,23 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
       const effectiveGroupAllowFrom =
         groupAllowFrom ?? (fallbackToAllowFrom ? effectiveAllowFrom : undefined);
 
-      if (!hasAllowFromEntries(effectiveGroupAllowFrom)) {
+      // Check if per-group allowFrom configs exist — if every configured group
+      // has its own allowFrom, the top-level groupAllowFrom is not required.
+      const perGroupAllowFromConfigured = (() => {
+        const groups = account.groups;
+        if (!groups || typeof groups !== "object" || Array.isArray(groups)) {
+          return false;
+        }
+        const groupEntries = Object.values(groups as Record<string, unknown>).filter(
+          (g) => g && typeof g === "object" && !Array.isArray(g),
+        ) as Array<Record<string, unknown>>;
+        return (
+          groupEntries.length > 0 &&
+          groupEntries.every((g) => hasAllowFromEntries(g.allowFrom as Array<string | number> | undefined))
+        );
+      })();
+
+      if (!hasAllowFromEntries(effectiveGroupAllowFrom) && !perGroupAllowFromConfigured) {
         if (fallbackToAllowFrom) {
           warnings.push(
             `- ${prefix}.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to ${prefix}.groupAllowFrom or ${prefix}.allowFrom, or set groupPolicy to "open".`,


### PR DESCRIPTION
## Problem

Closes #34062

`openclaw doctor` incorrectly warns:

```
channels.telegram.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped.
```

...even when every configured group has a per-group `allowFrom` entry. This is a false positive that causes confusion for users who have correctly set up per-group sender allowlists.

## Root Cause

The runtime (`bot-message-context.ts`) correctly checks `groupConfig?.allowFrom` at the per-group level first. However, the Doctor check (`doctor-config-flow.ts`, `checkAccount` function) only looks at top-level `groupAllowFrom` and the `allowFrom` fallback — it never inspects per-group configs under `account.groups`.

So a valid config like this:

```yaml
channels:
  telegram:
    groupPolicy: allowlist
    groups:
      "-12345678":
        allowFrom: [111222333]
      "-98765432":
        allowFrom: [444555666]
```

...triggers the warning even though every group is properly gated.

## Fix

Before emitting the warning, check whether every configured group (under `account.groups`) has its own `allowFrom` entries. If so, the top-level `groupAllowFrom` is not required, and the warning is suppressed.

The check is conservative: it only suppresses the warning if **all** configured groups have explicit `allowFrom` entries — partial coverage still triggers the warning.

## Testing

- Config with per-group `allowFrom` on all groups → no false positive warning ✓
- Config with `groupPolicy: allowlist` and no `allowFrom` anywhere → warning still fires ✓
- Config with some groups having `allowFrom` and some not → warning still fires ✓
- Existing top-level `groupAllowFrom` behavior unchanged ✓