### PR TITLE
fix(telegram): add suppressPrivacyModeWarning option to silence false-positive doctor warning

### DIFF
--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -435,6 +435,9 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         Object.entries(groups ?? {}).some(
           ([key, value]) => key !== "*" && value?.requireMention === false,
         );
+      const suppressPrivacyModeWarning =
+        Boolean(cfg.channels?.telegram?.accounts?.[account.accountId]?.suppressPrivacyModeWarning) ||
+        Boolean(cfg.channels?.telegram?.suppressPrivacyModeWarning);
       return {
         accountId: account.accountId,
         name: account.name,
@@ -449,6 +452,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         probe,
         audit,
         allowUnmentionedGroups,
+        suppressPrivacyModeWarning,
         lastInboundAt: runtime?.lastInboundAt ?? null,
         lastOutboundAt: runtime?.lastOutboundAt ?? null,
       };

--- a/src/channels/plugins/status-issues/telegram.ts
+++ b/src/channels/plugins/status-issues/telegram.ts
@@ -11,6 +11,7 @@ type TelegramAccountStatus = {
   enabled?: unknown;
   configured?: unknown;
   allowUnmentionedGroups?: unknown;
+  suppressPrivacyModeWarning?: unknown;
   audit?: unknown;
 };
 
@@ -36,6 +37,7 @@ function readTelegramAccountStatus(value: ChannelAccountSnapshot): TelegramAccou
     enabled: value.enabled,
     configured: value.configured,
     allowUnmentionedGroups: value.allowUnmentionedGroups,
+    suppressPrivacyModeWarning: value.suppressPrivacyModeWarning,
     audit: value.audit,
   };
 }

--- a/src/channels/plugins/status-issues/telegram.ts
+++ b/src/channels/plugins/status-issues/telegram.ts
@@ -91,14 +91,14 @@ export function collectTelegramStatusIssues(
       continue;
     }
 
-    if (account.allowUnmentionedGroups === true) {
+    if (account.allowUnmentionedGroups === true && account.suppressPrivacyModeWarning !== true) {
       issues.push({
         channel: "telegram",
         accountId,
         kind: "config",
         message:
           "Config allows unmentioned group messages (requireMention=false). Telegram Bot API privacy mode will block most group messages unless disabled.",
-        fix: "In BotFather run /setprivacy → Disable for this bot (then restart the gateway).",
+        fix: "In BotFather run /setprivacy → Disable for this bot (then restart the gateway). If you have already disabled privacy mode, set suppressPrivacyModeWarning: true in your Telegram channel config to suppress this warning.",
       });
     }
 


### PR DESCRIPTION
## Problem

Closes #34063

`openclaw doctor` warns about Telegram Bot API privacy mode every time it runs, even when the user has already disabled privacy mode in BotFather. The check is purely config-inference-based and has no way to verify that the bot's actual privacy setting has been changed.

This creates a persistent false-positive warning that erodes trust in the doctor output — users who did everything right still get flagged on every run.

## Solution (Option A — config opt-out)

Add a `suppressPrivacyModeWarning: true` config option that lets users acknowledge they have already handled privacy mode, suppressing the warning without removing the underlying detection logic.

The flag can be set at either the channel level or per-account level:

```yaml
# Channel-wide (applies to all accounts)
channels:
  telegram:
    suppressPrivacyModeWarning: true

# Per-account
channels:
  telegram:
    accounts:
      mybot:
        suppressPrivacyModeWarning: true
```

## Changes

- **`extensions/telegram/src/channel.ts`**: Read `suppressPrivacyModeWarning` from both the channel-level and per-account config in `buildAccountSnapshot`, exposing it as part of the account snapshot.
- **`src/channels/plugins/status-issues/telegram.ts`**: Skip the privacy mode warning when `suppressPrivacyModeWarning` is `true`. Also updated the fix message to mention the new option.

## Non-breaking

- Default behavior unchanged: warning still fires for all users who haven't set the flag
- The underlying detection logic is preserved (not deleted)
- Option B (actual API verification via `getMe()`) can be layered on top in a future PR