### PR TITLE
feat(openai-http): add image_url support for multimodal chat completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Docs: https://docs.openclaw.ai
 
+## 2026.3.4
+
+### Changes
+
+- OpenAI HTTP/image_url: add `image_url` content part support for multimodal chat completions via the OpenAI-compatible HTTP API. Base64 data URIs (`data:image/*;base64,...`) are parsed and forwarded to the agent's multimodal pipeline. Image-only user turns (no accompanying text) are now handled correctly and no longer trigger a "Missing user message" error.
+
+## 2026.2.27
 ## 2026.3.3
 
 ### Changes

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -517,4 +517,155 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
       // shared server
     }
   });
+
+  it("GET /v1/models returns model list", async () => {
+    const port = enabledPort;
+
+    {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/models`, {
+        method: "GET",
+        headers: { authorization: "Bearer secret" },
+      });
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as Record<string, unknown>;
+      expect(json.object).toBe("list");
+      const data = json.data as Array<Record<string, unknown>>;
+      expect(Array.isArray(data)).toBe(true);
+      expect(data.length).toBe(2);
+      expect(data[0]?.id).toBe("openclaw");
+      expect(data[0]?.object).toBe("model");
+      expect(data[0]?.owned_by).toBe("openclaw");
+      expect(data[1]?.id).toBe("openclaw:main");
+    }
+
+    // Unauthorized
+    {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/models`, {
+        method: "GET",
+      });
+      expect(res.status).toBe(401);
+      await res.text();
+    }
+
+    // Wrong method
+    {
+      const res = await fetch(`http://127.0.0.1:${port}/v1/models`, {
+        method: "POST",
+        headers: {
+          authorization: "Bearer secret",
+          "content-type": "application/json",
+        },
+        body: "{}",
+      });
+      expect(res.status).toBe(405);
+      await res.text();
+    }
+  });
+
+  it("returns 404 for /v1/models when disabled", async () => {
+    await expectChatCompletionsDisabled(async (port) => {
+      const server = await startServerWithDefaultConfig(port);
+      const res = await fetch(`http://127.0.0.1:${port}/v1/models`, {
+        method: "GET",
+        headers: { authorization: "Bearer secret" },
+      });
+      expect(res.status).toBe(404);
+      await res.text();
+      return server;
+    });
+  });
+
+  it("passes image_url content parts as images to agent command", async () => {
+    const port = enabledPort;
+    const base64Data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk";
+
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({ payloads: [{ text: "I see an image" }] } as never);
+
+    const res = await postChatCompletions(port, {
+      model: "openclaw",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "What is in this image?" },
+            {
+              type: "image_url",
+              image_url: { url: `data:image/png;base64,${base64Data}` },
+            },
+          ],
+        },
+      ],
+    });
+    expect(res.status).toBe(200);
+
+    const opts = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0] as
+      | { message?: string; images?: Array<{ type: string; data: string; mimeType: string }> }
+      | undefined;
+    expect(opts?.message).toBe("What is in this image?");
+    expect(opts?.images).toHaveLength(1);
+    expect(opts?.images?.[0]?.type).toBe("image");
+    expect(opts?.images?.[0]?.mimeType).toBe("image/png");
+    expect(opts?.images?.[0]?.data).toBe(base64Data);
+    await res.text();
+  });
+
+  it("ignores non-data-uri image_url (no crash)", async () => {
+    const port = enabledPort;
+
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({ payloads: [{ text: "ok" }] } as never);
+
+    const res = await postChatCompletions(port, {
+      model: "openclaw",
+      messages: [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "Look at this" },
+            { type: "image_url", image_url: { url: "https://example.com/image.png" } },
+          ],
+        },
+      ],
+    });
+    expect(res.status).toBe(200);
+
+    const opts = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0] as
+      | { images?: unknown[] }
+      | undefined;
+    // Non-data-URI images are not passed (only base64 data URIs are supported)
+    expect(opts?.images).toBeUndefined();
+    await res.text();
+  });
+
+  it("handles image-only user turn without missing-message error", async () => {
+    const port = enabledPort;
+    const base64Data = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk";
+
+    agentCommand.mockClear();
+    agentCommand.mockResolvedValueOnce({ payloads: [{ text: "I see an image" }] } as never);
+
+    const res = await postChatCompletions(port, {
+      model: "openclaw",
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image_url",
+              image_url: { url: `data:image/png;base64,${base64Data}` },
+            },
+          ],
+        },
+      ],
+    });
+    expect(res.status).toBe(200);
+
+    const opts = (agentCommand.mock.calls[0] as unknown[] | undefined)?.[0] as
+      | { message?: string; images?: Array<{ type: string; data: string; mimeType: string }> }
+      | undefined;
+    expect(opts?.images).toHaveLength(1);
+    expect(opts?.images?.[0]?.mimeType).toBe("image/png");
+    await res.text();
+  });
 });

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { createDefaultDeps } from "../cli/deps.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
+import type { ImageContent } from "../commands/agent/types.js";
 import { emitAgentEvent, onAgentEvent } from "../infra/agent-events.js";
 import { logWarn } from "../logger.js";
 import { defaultRuntime } from "../runtime.js";
@@ -12,6 +13,7 @@ import {
 } from "./agent-prompt.js";
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
+import { authorizeGatewayBearerRequestOrReply } from "./http-auth-helpers.js";
 import { sendJson, setSseHeaders, writeDone } from "./http-common.js";
 import { handleGatewayPostJsonEndpoint } from "./http-endpoint-helpers.js";
 import { resolveGatewayRequestContext } from "./http-utils.js";
@@ -42,7 +44,7 @@ function writeSse(res: ServerResponse, data: unknown) {
 }
 
 function buildAgentCommandInput(params: {
-  prompt: { message: string; extraSystemPrompt?: string };
+  prompt: { message: string; extraSystemPrompt?: string; images?: ImageContent[] };
   sessionKey: string;
   runId: string;
   messageChannel: string;
@@ -50,6 +52,7 @@ function buildAgentCommandInput(params: {
   return {
     message: params.prompt.message,
     extraSystemPrompt: params.prompt.extraSystemPrompt,
+    images: params.prompt.images,
     sessionKey: params.sessionKey,
     runId: params.runId,
     deliver: false as const,
@@ -123,14 +126,50 @@ function extractTextContent(content: unknown): string {
   return "";
 }
 
+function extractImageContent(content: unknown): ImageContent[] {
+  if (!Array.isArray(content)) {
+    return [];
+  }
+  const images: ImageContent[] = [];
+  for (const part of content) {
+    if (!part || typeof part !== "object") {
+      continue;
+    }
+    const type = (part as { type?: unknown }).type;
+    if (type !== "image_url") {
+      continue;
+    }
+    const imageUrl = (part as { image_url?: unknown }).image_url;
+    if (!imageUrl || typeof imageUrl !== "object") {
+      continue;
+    }
+    const url = (imageUrl as { url?: unknown }).url;
+    if (typeof url !== "string") {
+      continue;
+    }
+    // Parse data URIs: data:<mimeType>;base64,<data>
+    const dataUriMatch = url.match(/^data:(image\/[^;]+);base64,(.+)$/);
+    if (dataUriMatch) {
+      images.push({
+        type: "image",
+        mimeType: dataUriMatch[1],
+        data: dataUriMatch[2],
+      });
+    }
+  }
+  return images;
+}
+
 function buildAgentPrompt(messagesUnknown: unknown): {
   message: string;
   extraSystemPrompt?: string;
+  images?: ImageContent[];
 } {
   const messages = asMessages(messagesUnknown);
 
   const systemParts: string[] = [];
   const conversationEntries: ConversationEntry[] = [];
+  const allImages: ImageContent[] = [];
 
   for (const msg of messages) {
     if (!msg || typeof msg !== "object") {
@@ -138,16 +177,28 @@ function buildAgentPrompt(messagesUnknown: unknown): {
     }
     const role = typeof msg.role === "string" ? msg.role.trim() : "";
     const content = extractTextContent(msg.content).trim();
-    if (!role || !content) {
+    if (!role) {
       continue;
     }
     if (role === "system" || role === "developer") {
-      systemParts.push(content);
+      if (content) {
+        systemParts.push(content);
+      }
       continue;
     }
 
     const normalizedRole = role === "function" ? "tool" : role;
     if (normalizedRole !== "user" && normalizedRole !== "assistant" && normalizedRole !== "tool") {
+      continue;
+    }
+
+    const msgImages = normalizedRole === "user" ? extractImageContent(msg.content) : [];
+    if (normalizedRole === "user") {
+      allImages.push(...msgImages);
+    }
+
+    // Skip messages with neither text nor images
+    if (!content && msgImages.length === 0) {
       continue;
     }
 
@@ -172,6 +223,7 @@ function buildAgentPrompt(messagesUnknown: unknown): {
   return {
     message,
     extraSystemPrompt: systemParts.length > 0 ? systemParts.join("\n\n") : undefined,
+    images: allImages.length > 0 ? allImages : undefined,
   };
 }
 
@@ -228,7 +280,7 @@ export async function handleOpenAiHttpRequest(
     useMessageChannelHeader: true,
   });
   const prompt = buildAgentPrompt(payload.messages);
-  if (!prompt.message) {
+  if (!prompt.message && (!prompt.images || prompt.images.length === 0)) {
     sendJson(res, 400, {
       error: {
         message: "Missing user message in `messages`.",
@@ -379,3 +431,4 @@ export async function handleOpenAiHttpRequest(
 
   return true;
 }
+


### PR DESCRIPTION
Adds `image_url` content part support for multimodal chat completions via the OpenAI-compatible HTTP API.

## Changes

- Base64 data URIs (`data:image/*;base64,...`) are parsed from `image_url` content parts and forwarded to the agent's existing multimodal pipeline
- Non-data-URI URLs (e.g. HTTPS links) are gracefully ignored — no crash, just skipped
- **Bug fix:** image-only user turns (messages with `image_url` but no text) no longer trigger a 400 "Missing user message" error. Images are now extracted before the empty-text guard; a message is only skipped when both text and images are absent

## Test coverage

- Text + image_url → images correctly passed to agent
- Non-data-URI image_url → ignored without crash
- Image-only turn (no text) → handled correctly, no 400 error

## Related

Split from #29408 per review request from @vincentkoc.