### PR TITLE
fix: omit sender metadata block for direct webchat chats

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -194,9 +194,10 @@ describe("buildInboundUserContextPrefix", () => {
     expect(conversationInfo["sender"]).toBe("Tyler");
   });
 
-  it("includes sender metadata block for direct chats", () => {
+  it("includes sender metadata block for direct external-channel chats", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "direct",
+      OriginatingChannel: "whatsapp",
       SenderName: "Tyler",
       SenderId: "+15551234567",
     } as TemplateContext);
@@ -204,6 +205,17 @@ describe("buildInboundUserContextPrefix", () => {
     const senderInfo = parseSenderInfoPayload(text);
     expect(senderInfo["label"]).toBe("Tyler (+15551234567)");
     expect(senderInfo["id"]).toBe("+15551234567");
+  });
+
+  it("omits sender metadata block for direct webchat chats", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "direct",
+      Surface: "webchat",
+      Provider: "webchat",
+      SenderId: "openclaw-control-ui",
+    } as TemplateContext);
+
+    expect(text).not.toContain("Sender (untrusted metadata):");
   });
 
   it("includes formatted timestamp in conversation info when provided", () => {

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -149,7 +149,7 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
     tag: safeTrim(ctx.SenderTag),
     e164: safeTrim(ctx.SenderE164),
   };
-  if (senderInfo?.label) {
+  if (senderInfo?.label && shouldIncludeConversationInfo) {
     blocks.push(
       ["Sender (untrusted metadata):", "```json", JSON.stringify(senderInfo, null, 2), "```"].join(
         "\n",


### PR DESCRIPTION
fix #34153
## Summary

This PR fixes unnecessary "Sender (untrusted metadata)" injection into LLM prompts when messages originate from the Control UI (webchat) in direct chat mode.

- **Problem**: When sending messages from the Control UI, OpenClaw injects a `Sender (untrusted metadata)` block containing `{"label": "openclaw-control-ui", "id": "openclaw-control-ui"}` into the user message sent to the LLM. This is noise — the LLM doesn't need to know the sender is the technical client ID `openclaw-control-ui`.
- **Why it matters**: Wastes prompt tokens on every webchat direct message and pollutes the prompt with meaningless technical identifiers.
- **What changed**: Gated the Sender metadata block with the existing `shouldIncludeConversationInfo` flag, which already suppresses "Conversation info" for webchat direct chats. This makes the Sender block follow the same logic.
- **What did NOT change**: Group chats and external channel (Telegram, WhatsApp, Discord, etc.) direct chats still include full sender metadata as before. The timestamp injection (`[Wed 2026-03-04 15:56 GMT+8]`) is unaffected — that's a separate mechanism.

## Use Cases

- Users chatting via the Control UI (webchat) will no longer have `openclaw-control-ui` sender metadata injected into their LLM prompts
- All external channel messages retain full sender metadata for LLM context

## Behavior Changes

- **Webchat direct chats**: "Sender (untrusted metadata)" block is no longer prepended to user messages sent to the LLM
- **External channel direct chats** (Telegram, WhatsApp, etc.): No change — sender metadata is still included
- **Group chats** (all channels): No change — sender metadata is still included
- **Backward compatible**: No config changes needed

## What Changed

- **Modified `src/auto-reply/reply/inbound-meta.ts`**:
  - Added `shouldIncludeConversationInfo` condition to the Sender metadata block emission (line 152), consistent with how "Conversation info" is already gated for webchat direct chats

- **Updated `src/auto-reply/reply/inbound-meta.test.ts`**:
  - Updated existing test "includes sender metadata block for direct chats" → "includes sender metadata block for direct external-channel chats" with realistic `OriginatingChannel: "whatsapp"` context
  - Added new test "omits sender metadata block for direct webchat chats" to verify the fix

## Tests

✅ All tests pass:

- `inbound-meta.test.ts` — 24/24 passed
- `strip-inbound-meta.test.ts` — 14/14 passed (no regressions)

## Files Changed

- `src/auto-reply/reply/inbound-meta.ts` (+1 line, -1 line)
- `src/auto-reply/reply/inbound-meta.test.ts` (+14 lines, -2 lines)

## Checklist

- [x] Test locally with OpenClaw instance
- [x] Run tests: `pnpm test src/auto-reply/reply/inbound-meta.test.ts` ✅
- [x] Keep PRs focused (one thing per PR) ✅
- [x] Describe what & why ✅

**Sign-Off**

- Models used: Claude (GPT-5 Codex)
- Submitter effort: AI-assisted with manual review and testing
- Agent notes: Minimal, targeted fix that aligns Sender metadata gating with existing Conversation info gating logic
