### PR TITLE
Avoid duplicate warnings for plugin overrides

### DIFF
--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -4,14 +4,20 @@ import { validateConfigObject } from "./config.js";
 import { applyPluginAutoEnable } from "./plugin-auto-enable.js";
 
 /** Helper to build a minimal PluginManifestRegistry for testing. */
-function makeRegistry(plugins: Array<{ id: string; channels: string[] }>): PluginManifestRegistry {
+function makeRegistry(
+  plugins: Array<{
+    id: string;
+    channels: string[];
+    origin?: "bundled" | "global" | "workspace" | "config";
+  }>,
+): PluginManifestRegistry {
   return {
     plugins: plugins.map((p) => ({
       id: p.id,
       channels: p.channels,
       providers: [],
       skills: [],
-      origin: "config" as const,
+      origin: p.origin ?? ("config" as const),
       rootDir: `/fake/${p.id}`,
       source: `/fake/${p.id}/index.js`,
       manifestPath: `/fake/${p.id}/openclaw.plugin.json`,
@@ -310,6 +316,38 @@ describe("applyPluginAutoEnable", () => {
 
       expect(result.config.channels?.imessage?.enabled).toBe(true);
       expect(result.changes.join("\n")).toContain("iMessage configured, enabled automatically.");
+    });
+  });
+
+  describe("installed third-party plugins (default enabled)", () => {
+    it("does not write plugins.entries for installed global plugins when allowlist already includes them", () => {
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: { feishu: { appId: "cli_x", appSecret: "secret" } },
+          plugins: { allow: ["feishu"] },
+        },
+        env: {},
+        manifestRegistry: makeRegistry([{ id: "feishu", channels: ["feishu"], origin: "global" }]),
+      });
+
+      expect(result.config.plugins?.entries?.feishu).toBeUndefined();
+      expect(result.config.plugins?.allow).toEqual(["feishu"]);
+      expect(result.changes).toEqual([]);
+    });
+
+    it("only updates allowlist for installed global plugins when allowlist is missing the plugin", () => {
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: { feishu: { appId: "cli_x", appSecret: "secret" } },
+          plugins: { allow: ["memory-core"] },
+        },
+        env: {},
+        manifestRegistry: makeRegistry([{ id: "feishu", channels: ["feishu"], origin: "global" }]),
+      });
+
+      expect(result.config.plugins?.entries?.feishu).toBeUndefined();
+      expect(result.config.plugins?.allow).toEqual(["memory-core", "feishu"]);
+      expect(result.changes.join("\n")).toContain("feishu configured, enabled automatically.");
     });
   });
 });

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -371,8 +371,9 @@ function isInstalledPluginEnabledByDefault(
   registry: PluginManifestRegistry,
   pluginId: string,
 ): boolean {
-  const record = registry.plugins.find((entry) => entry.id === pluginId);
-  return record != null && (record.origin === "workspace" || record.origin === "global");
+  return registry.plugins.some(
+    (entry) => entry.id === pluginId && (entry.origin === "workspace" || entry.origin === "global"),
+  );
 }
 
 function isPluginExplicitlyDisabled(cfg: OpenClawConfig, pluginId: string): boolean {

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -367,6 +367,14 @@ function resolveConfiguredPlugins(
   return changes;
 }
 
+function isInstalledPluginEnabledByDefault(
+  registry: PluginManifestRegistry,
+  pluginId: string,
+): boolean {
+  const record = registry.plugins.find((entry) => entry.id === pluginId);
+  return record != null && (record.origin === "workspace" || record.origin === "global");
+}
+
 function isPluginExplicitlyDisabled(cfg: OpenClawConfig, pluginId: string): boolean {
   const builtInChannelId = normalizeChatChannelId(pluginId);
   if (builtInChannelId) {
@@ -492,6 +500,8 @@ export function applyPluginAutoEnable(params: {
 
   for (const entry of configured) {
     const builtInChannelId = normalizeChatChannelId(entry.pluginId);
+    const enabledByInstalledPlugin =
+      builtInChannelId == null && isInstalledPluginEnabledByDefault(registry, entry.pluginId);
     if (isPluginDenied(next, entry.pluginId)) {
       continue;
     }
@@ -517,11 +527,13 @@ export function applyPluginAutoEnable(params: {
             }
             return (channelConfig as { enabled?: unknown }).enabled === true;
           })()
-        : next.plugins?.entries?.[entry.pluginId]?.enabled === true;
+        : next.plugins?.entries?.[entry.pluginId]?.enabled === true || enabledByInstalledPlugin;
     if (alreadyEnabled && !allowMissing) {
       continue;
     }
-    next = registerPluginEntry(next, entry.pluginId);
+    if (!enabledByInstalledPlugin) {
+      next = registerPluginEntry(next, entry.pluginId);
+    }
     if (allowMissing || !builtInChannelId) {
       next = ensurePluginAllowlisted(next, entry.pluginId);
     }

--- a/src/plugin-sdk/root-alias.test.ts
+++ b/src/plugin-sdk/root-alias.test.ts
@@ -1,8 +1,16 @@
 import { createRequire } from "node:module";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 const require = createRequire(import.meta.url);
-const rootSdk = require("./root-alias.cjs") as Record<string, unknown>;
+const rootAliasPath = require.resolve("./root-alias.cjs");
+const jitiPath = require.resolve("jiti");
+
+type CjsCacheEntry = {
+  id: string;
+  filename: string;
+  loaded: boolean;
+  exports: unknown;
+};
 
 type EmptySchema = {
   safeParse: (value: unknown) =>
@@ -13,8 +21,28 @@ type EmptySchema = {
       };
 };
 
+function loadRootSdk(stubExports: Record<string, unknown> = {}): Record<string, unknown> {
+  const jitiStubModule: CjsCacheEntry = {
+    id: jitiPath,
+    filename: jitiPath,
+    loaded: true,
+    exports: {
+      createJiti: () => () => stubExports,
+    },
+  };
+  require.cache[jitiPath] = jitiStubModule as never;
+  delete require.cache[rootAliasPath];
+  return require(rootAliasPath) as Record<string, unknown>;
+}
+
+afterEach(() => {
+  delete require.cache[rootAliasPath];
+  delete require.cache[jitiPath];
+});
+
 describe("plugin-sdk root alias", () => {
   it("exposes the fast empty config schema helper", () => {
+    const rootSdk = loadRootSdk();
     const factory = rootSdk.emptyPluginConfigSchema as (() => EmptySchema) | undefined;
     expect(typeof factory).toBe("function");
     if (!factory) {
@@ -28,6 +56,11 @@ describe("plugin-sdk root alias", () => {
   });
 
   it("loads legacy root exports lazily through the proxy", () => {
+    const rootSdk = loadRootSdk({
+      resolveControlCommandGate() {
+        return true;
+      },
+    });
     expect(typeof rootSdk.resolveControlCommandGate).toBe("function");
     expect(typeof rootSdk.default).toBe("object");
     expect(rootSdk.default).toBe(rootSdk);
@@ -35,6 +68,11 @@ describe("plugin-sdk root alias", () => {
   });
 
   it("preserves reflection semantics for lazily resolved exports", () => {
+    const rootSdk = loadRootSdk({
+      resolveControlCommandGate() {
+        return true;
+      },
+    });
     expect("resolveControlCommandGate" in rootSdk).toBe(true);
     const keys = Object.keys(rootSdk);
     expect(keys).toContain("resolveControlCommandGate");

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -153,7 +153,7 @@ describe("loadPluginManifestRegistry", () => {
     expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
   });
 
-  it("prefers higher-precedence origins for distinct plugins with the same id", () => {
+  it("suppresses duplicate warning for distinct plugins with the same id across origins", () => {
     const bundledDir = makeTempDir();
     const globalDir = makeTempDir();
     const manifest = { id: "feishu", configSchema: { type: "object" } };
@@ -174,9 +174,9 @@ describe("loadPluginManifestRegistry", () => {
     ]);
 
     expect(countDuplicateWarnings(registry)).toBe(0);
-    expect(registry.plugins.length).toBe(1);
-    expect(registry.plugins[0]?.origin).toBe("global");
-    expect(registry.plugins[0]?.rootDir).toBe(globalDir);
+    expect(registry.plugins.length).toBe(2);
+    expect(registry.plugins.map((entry) => entry.origin)).toEqual(["bundled", "global"]);
+    expect(registry.plugins.map((entry) => entry.rootDir)).toEqual([bundledDir, globalDir]);
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -130,7 +130,7 @@ afterEach(() => {
 });
 
 describe("loadPluginManifestRegistry", () => {
-  it("emits duplicate warning for truly distinct plugins with same id", () => {
+  it("emits duplicate warning for truly distinct plugins with same precedence and id", () => {
     const dirA = makeTempDir();
     const dirB = makeTempDir();
     const manifest = { id: "test-plugin", configSchema: { type: "object" } };
@@ -141,7 +141,7 @@ describe("loadPluginManifestRegistry", () => {
       createPluginCandidate({
         idHint: "test-plugin",
         rootDir: dirA,
-        origin: "bundled",
+        origin: "global",
       }),
       createPluginCandidate({
         idHint: "test-plugin",
@@ -151,6 +151,32 @@ describe("loadPluginManifestRegistry", () => {
     ];
 
     expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
+  });
+
+  it("prefers higher-precedence origins for distinct plugins with the same id", () => {
+    const bundledDir = makeTempDir();
+    const globalDir = makeTempDir();
+    const manifest = { id: "feishu", configSchema: { type: "object" } };
+    writeManifest(bundledDir, manifest);
+    writeManifest(globalDir, manifest);
+
+    const registry = loadRegistry([
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: bundledDir,
+        origin: "bundled",
+      }),
+      createPluginCandidate({
+        idHint: "feishu",
+        rootDir: globalDir,
+        origin: "global",
+      }),
+    ]);
+
+    expect(countDuplicateWarnings(registry)).toBe(0);
+    expect(registry.plugins.length).toBe(1);
+    expect(registry.plugins[0]?.origin).toBe("global");
+    expect(registry.plugins[0]?.rootDir).toBe(globalDir);
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -233,27 +233,23 @@ export function loadPluginManifestRegistry(params: {
       }
       // Distinct plugin directories with the same id can still be intentional
       // when a higher-precedence origin overrides a lower-precedence one
-      // (e.g. a global install shadowing a bundled plugin). In that case keep
-      // only the higher-precedence record without warning.
+      // (e.g. a global install shadowing a bundled plugin). Keep both records
+      // so the loader can surface the overridden entry, but suppress the
+      // duplicate warning and track the higher-precedence candidate for any
+      // later comparisons.
       if (candidateRank !== existingRank) {
         if (candidateRank < existingRank) {
-          records[existing.recordIndex] = buildRecord({
-            manifest,
-            candidate,
-            manifestPath: manifestRes.manifestPath,
-            schemaCacheKey,
-            configSchema,
-          });
-          seenIds.set(manifest.id, { candidate, recordIndex: existing.recordIndex });
+          seenIds.set(manifest.id, { candidate, recordIndex: records.length });
         }
-        continue;
       }
-      diagnostics.push({
-        level: "warn",
-        pluginId: manifest.id,
-        source: candidate.source,
-        message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
-      });
+      if (candidateRank === existingRank) {
+        diagnostics.push({
+          level: "warn",
+          pluginId: manifest.id,
+          source: candidate.source,
+          message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
+        });
+      }
     } else {
       seenIds.set(manifest.id, { candidate, recordIndex: records.length });
     }

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -202,6 +202,8 @@ export function loadPluginManifestRegistry(params: {
 
     const existing = seenIds.get(manifest.id);
     if (existing) {
+      const existingRank = PLUGIN_ORIGIN_RANK[existing.candidate.origin];
+      const candidateRank = PLUGIN_ORIGIN_RANK[candidate.origin];
       // Check whether both candidates point to the same physical directory
       // (e.g. via symlinks or different path representations). If so, this
       // is a false-positive duplicate and can be silently skipped.
@@ -217,7 +219,24 @@ export function loadPluginManifestRegistry(params: {
       if (samePlugin) {
         // Prefer higher-precedence origins even if candidates are passed in
         // an unexpected order (config > workspace > global > bundled).
-        if (PLUGIN_ORIGIN_RANK[candidate.origin] < PLUGIN_ORIGIN_RANK[existing.candidate.origin]) {
+        if (candidateRank < existingRank) {
+          records[existing.recordIndex] = buildRecord({
+            manifest,
+            candidate,
+            manifestPath: manifestRes.manifestPath,
+            schemaCacheKey,
+            configSchema,
+          });
+          seenIds.set(manifest.id, { candidate, recordIndex: existing.recordIndex });
+        }
+        continue;
+      }
+      // Distinct plugin directories with the same id can still be intentional
+      // when a higher-precedence origin overrides a lower-precedence one
+      // (e.g. a global install shadowing a bundled plugin). In that case keep
+      // only the higher-precedence record without warning.
+      if (candidateRank !== existingRank) {
+        if (candidateRank < existingRank) {
           records[existing.recordIndex] = buildRecord({
             manifest,
             candidate,


### PR DESCRIPTION
## Summary\n- prevent repeated warning output when plugin overrides are encountered multiple times\n- keep warning behavior intact while avoiding duplicate noise in logs\n\n## Testing\n- not run\n