### PR TITLE
ui: add clipboard fallback for copy button (#34092)

### DIFF
--- a/ui/src/ui/chat/copy-as-markdown.ts
+++ b/ui/src/ui/chat/copy-as-markdown.ts
@@ -29,17 +29,20 @@ async function copyTextToClipboard(text: string): Promise<boolean> {
 
   // Fallback for HTTP or when Clipboard API is unavailable (secure context required)
   if (!success) {
+    const textarea = document.createElement("textarea");
     try {
-      const textarea = document.createElement("textarea");
       textarea.value = text;
       textarea.style.position = "fixed";
       textarea.style.opacity = "0";
       document.body.appendChild(textarea);
       textarea.select();
       success = document.execCommand("copy");
-      document.body.removeChild(textarea);
     } catch (err) {
       console.error("Failed to copy:", err);
+    } finally {
+      if (textarea.parentNode) {
+        document.body.removeChild(textarea);
+      }
     }
   }
 

--- a/ui/src/ui/chat/copy-as-markdown.ts
+++ b/ui/src/ui/chat/copy-as-markdown.ts
@@ -17,12 +17,33 @@ async function copyTextToClipboard(text: string): Promise<boolean> {
     return false;
   }
 
+  let success = false;
   try {
-    await navigator.clipboard.writeText(text);
-    return true;
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      success = true;
+    }
   } catch {
-    return false;
+    // Clipboard API failed (e.g. HTTP context), try fallback
   }
+
+  // Fallback for HTTP or when Clipboard API is unavailable (secure context required)
+  if (!success) {
+    try {
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      textarea.style.position = "fixed";
+      textarea.style.opacity = "0";
+      document.body.appendChild(textarea);
+      textarea.select();
+      success = document.execCommand("copy");
+      document.body.removeChild(textarea);
+    } catch (err) {
+      console.error("Failed to copy:", err);
+    }
+  }
+
+  return success;
 }
 
 function setButtonLabel(button: HTMLButtonElement, label: string) {


### PR DESCRIPTION
# PR #34092: Copy button clipboard fallback for HTTP context

## Summary

- **Problem:** On Windows 11 + Chrome, clicking the "Copy as markdown" button on chat messages does nothing; content is not copied to clipboard when accessing via `http://192.168.x.x` (non-HTTPS).
- **Why it matters:** `navigator.clipboard.writeText()` only works in secure contexts (HTTPS or localhost). Over HTTP it throws silently and the current code had no fallback.
- **What changed:** Added `document.execCommand('copy')` fallback via temporary textarea when Clipboard API fails, matching the pattern in `src/auto-reply/reply/export-html/template.js`.
- **What did NOT change:** No changes to UI layout, button styling, or other clipboard consumers.

## Change Type

- [x] Bug fix

## Scope

- [x] UI / DX

## Linked Issue/PR

- Closes #34092

## User-visible / Behavior Changes

Copy button now works when accessing the web UI over HTTP (e.g. `http://192.168.x.x`). No change for HTTPS/localhost users.

## Security Impact

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**

## Repro + Verification

### Environment

- OS: Windows 11
- Browser: Chrome
- Access: `http://192.168.x.x` (gateway web UI)

### Steps

1. Open chat UI over HTTP (not localhost/HTTPS).
2. Click "Copy as markdown" on a message.
3. Paste into another app.

### Expected

Text is copied to clipboard.

### Actual (before fix)

Nothing copied; button appears to do nothing.

## Evidence

- [x] Trace/log snippets: Clipboard API throws in HTTP context; fallback uses `execCommand('copy')`.
- [x] Reference implementation: `src/auto-reply/reply/export-html/template.js` lines 1277–1291.

## Human Verification

- Verified: Fallback logic matches template.js; `pnpm check` passes.
- Edge cases: Empty text returns false; Clipboard API success path unchanged.
- Not verified: Manual test on Windows 11 + Chrome over HTTP (reporter's environment).

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** `execCommand('copy')` is deprecated (but widely supported).
- **Mitigation:** Used only as fallback when Clipboard API fails; modern browsers still support it for this use case.
