### PR TITLE
docs: clarify workspace profile paths vs media local roots

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -27,8 +27,9 @@ inside a sandbox workspace under `~/.openclaw/sandboxes`, not your host workspac
 - If `OPENCLAW_PROFILE` is set and not `"default"`, the default becomes
   `~/.openclaw/workspace-<profile>`.
 - For strict local-media path checks, prefer a stable subdirectory layout such as
-  `~/.openclaw/workspace/<profile>` (or add your custom workspace path to
-  `tools.media.localRoots` when using profile-suffixed/custom workspaces).
+  `~/.openclaw/workspace/<profile>` **with an explicit** `agent.workspace` override
+  (or add your custom workspace path to `tools.media.localRoots` when using
+  profile-suffixed/custom workspaces).
 - Override in `~/.openclaw/openclaw.json`:
 
 ```json5

--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -26,6 +26,9 @@ inside a sandbox workspace under `~/.openclaw/sandboxes`, not your host workspac
 - Default: `~/.openclaw/workspace`
 - If `OPENCLAW_PROFILE` is set and not `"default"`, the default becomes
   `~/.openclaw/workspace-<profile>`.
+- For strict local-media path checks, prefer a stable subdirectory layout such as
+  `~/.openclaw/workspace/<profile>` (or add your custom workspace path to
+  `tools.media.localRoots` when using profile-suffixed/custom workspaces).
 - Override in `~/.openclaw/openclaw.json`:
 
 ```json5

--- a/docs/zh-CN/concepts/agent-workspace.md
+++ b/docs/zh-CN/concepts/agent-workspace.md
@@ -5,10 +5,10 @@ read_when:
 summary: 智能体工作区：位置、布局和备份策略
 title: 智能体工作区
 x-i18n:
-  generated_at: "2026-02-03T07:45:49Z"
+  generated_at: "2026-03-04T08:42:18Z"
   model: claude-opus-4-5
   provider: pi
-  source_hash: 84c550fd89b5f2474aeae586795485fd29d36effbb462f13342b31540fc18b82
+  source_hash: e306ebb731c0259123818cbfa0117f75ee6ebfb69abb1438a0cdb2ab686c8244
   source_path: concepts/agent-workspace.md
   workflow: 15
 ---
@@ -29,8 +29,8 @@ x-i18n:
 - 如果设置了 `OPENCLAW_PROFILE` 且不是 `"default"`，默认值变为
   `~/.openclaw/workspace-<profile>`。
 - 对于严格的本地媒体路径校验，推荐使用稳定的子目录布局（例如
-  `~/.openclaw/workspace/<profile>`）；如果使用后缀/自定义工作区，记得把路径加入
-  `tools.media.localRoots`。
+  `~/.openclaw/workspace/<profile>`，并显式配置 `agent.workspace`）；
+  如果使用后缀/自定义工作区，记得把路径加入 `tools.media.localRoots`。
 - 在 `~/.openclaw/openclaw.json` 中覆盖：
 
 ```json5

--- a/docs/zh-CN/concepts/agent-workspace.md
+++ b/docs/zh-CN/concepts/agent-workspace.md
@@ -28,6 +28,9 @@ x-i18n:
 - 默认：`~/.openclaw/workspace`
 - 如果设置了 `OPENCLAW_PROFILE` 且不是 `"default"`，默认值变为
   `~/.openclaw/workspace-<profile>`。
+- 对于严格的本地媒体路径校验，推荐使用稳定的子目录布局（例如
+  `~/.openclaw/workspace/<profile>`）；如果使用后缀/自定义工作区，记得把路径加入
+  `tools.media.localRoots`。
 - 在 `~/.openclaw/openclaw.json` 中覆盖：
 
 ```json5


### PR DESCRIPTION
## Summary
- clarify that `OPENCLAW_PROFILE` may default workspace to `~/.openclaw/workspace-<profile>`
- add guidance for strict local-media path checks to either use `~/.openclaw/workspace/<profile>` layout or include custom paths in `tools.media.localRoots`
- mirror the same clarification in the Chinese docs

## Why
Issue #34161 reports a docs/runtime mismatch confusion around profile-suffixed workspace paths and local media allowlist checks. This PR clarifies the docs behavior and mitigation path for custom/profile workspaces.

Closes #34161
