### PR TITLE
fix(agents): skip tool-call id sanitization for custom-ollama-com

### DIFF
--- a/src/agents/transcript-policy.test.ts
+++ b/src/agents/transcript-policy.test.ts
@@ -83,5 +83,17 @@ describe("resolveTranscriptPolicy", () => {
       modelApi: "openai-completions",
     });
     expect(policy.validateAnthropicTurns).toBe(false);
+    expect(policy.sanitizeToolCallIds).toBe(false);
+  });
+
+  it("disables openai-compatible tool id sanitization for custom-ollama-com", () => {
+    const policy = resolveTranscriptPolicy({
+      provider: "custom-ollama-com",
+      modelId: "kimi-k2.5",
+      modelApi: "openai-completions",
+    });
+    expect(policy.validateAnthropicTurns).toBe(false);
+    expect(policy.sanitizeToolCallIds).toBe(false);
+    expect(policy.toolCallIdMode).toBeUndefined();
   });
 });

--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -38,7 +38,11 @@ const OPENAI_MODEL_APIS = new Set([
   "openai-codex-responses",
 ]);
 const OPENAI_PROVIDERS = new Set(["openai", "openai-codex"]);
-const OPENAI_COMPAT_TURN_MERGE_EXCLUDED_PROVIDERS = new Set(["openrouter", "opencode"]);
+const OPENAI_COMPAT_TURN_MERGE_EXCLUDED_PROVIDERS = new Set([
+  "openrouter",
+  "opencode",
+  "custom-ollama-com",
+]);
 
 function isOpenAiApi(modelApi?: string | null): boolean {
   if (!modelApi) {
@@ -94,7 +98,9 @@ export function resolveTranscriptPolicy(params: {
     (provider === "openrouter" || provider === "opencode" || provider === "kilocode") &&
     modelId.toLowerCase().includes("gemini");
   const isCopilotClaude = provider === "github-copilot" && modelId.toLowerCase().includes("claude");
-  const requiresOpenAiCompatibleToolIdSanitization = params.modelApi === "openai-completions";
+  const requiresOpenAiCompatibleToolIdSanitization =
+    params.modelApi === "openai-completions" &&
+    !OPENAI_COMPAT_TURN_MERGE_EXCLUDED_PROVIDERS.has(provider);
 
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").


### PR DESCRIPTION
Closes #33438

## Summary
- exclude `custom-ollama-com` from strict OpenAI-compatible turn/tool id sanitization path
- keep existing behavior for other strict OpenAI-compatible providers
- add regression assertions in `src/agents/transcript-policy.test.ts`

## Testing
- corepack pnpm test src/agents/transcript-policy.test.ts
  - Test Files: 1 passed
  - Tests: 9 passed