### PR TITLE
fix: hide control-ui untrusted sender metadata in direct chats

### DIFF
--- a/src/auto-reply/reply/inbound-meta.test.ts
+++ b/src/auto-reply/reply/inbound-meta.test.ts
@@ -122,6 +122,19 @@ describe("buildInboundUserContextPrefix", () => {
     expect(text).toBe("");
   });
 
+  it("hides message identifiers for direct control-ui chats", () => {
+    const text = buildInboundUserContextPrefix({
+      ChatType: "direct",
+      OriginatingChannel: "openclaw-control-ui",
+      MessageSid: "short-id",
+      MessageSidFull: "provider-full-id",
+      SenderId: "openclaw-control-ui",
+      SenderName: "OpenClaw Control UI",
+    } as TemplateContext);
+
+    expect(text).toBe("");
+  });
+
   it("includes message identifiers for direct external-channel chats", () => {
     const text = buildInboundUserContextPrefix({
       ChatType: "direct",

--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -42,6 +42,14 @@ function resolveInboundChannel(ctx: TemplateContext): string | undefined {
   return channelValue;
 }
 
+function isInternalUiChannel(channel: string | undefined): boolean {
+  if (!channel) {
+    return false;
+  }
+  const normalized = channel.trim().toLowerCase();
+  return normalized === "webchat" || normalized === "openclaw-control-ui";
+}
+
 export function buildInboundMetaSystemPrompt(ctx: TemplateContext): string {
   const chatType = normalizeChatType(ctx.ChatType);
   const isDirect = !chatType || chatType === "direct";
@@ -87,7 +95,7 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
   const isDirect = !chatType || chatType === "direct";
   const directChannelValue = resolveInboundChannel(ctx);
   const includeDirectConversationInfo = Boolean(
-    directChannelValue && directChannelValue !== "webchat",
+    directChannelValue && !isInternalUiChannel(directChannelValue),
   );
   const shouldIncludeConversationInfo = !isDirect || includeDirectConversationInfo;
 
@@ -149,7 +157,8 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
     tag: safeTrim(ctx.SenderTag),
     e164: safeTrim(ctx.SenderE164),
   };
-  if (senderInfo?.label) {
+  const shouldIncludeSenderInfo = !isDirect || !isInternalUiChannel(directChannelValue);
+  if (senderInfo?.label && shouldIncludeSenderInfo) {
     blocks.push(
       ["Sender (untrusted metadata):", "```json", JSON.stringify(senderInfo, null, 2), "```"].join(
         "\n",


### PR DESCRIPTION
## Summary
Fixes #34153 by suppressing AI-facing untrusted metadata prefixes for direct Control UI messages (`openclaw-control-ui`), matching existing behavior for webchat DMs.

## Root cause
`buildInboundUserContextPrefix` treated `openclaw-control-ui` as an external channel, so direct messages included:
- `Conversation info (untrusted metadata)`
- `Sender (untrusted metadata)`

These blocks are useful for external channels, but redundant/noisy for internal UI chat and waste tokens.

## Changes
- Added internal channel helper (`webchat` + `openclaw-control-ui`).
- In direct chats, skip conversation metadata for internal UI channels.
- In direct chats, skip sender metadata for internal UI channels.
- Added regression test for direct `openclaw-control-ui` context.

## Testing
```bash
pnpm -C /tmp/openclaw exec vitest run src/auto-reply/reply/inbound-meta.test.ts
```
Passed: 24/24 tests.
