### PR TITLE
fix(installer): fail early on Windows npm install when Git is missing

### DIFF
--- a/docs/install/installer.md
+++ b/docs/install/installer.md
@@ -324,7 +324,7 @@ Designed for environments where you want everything under a local prefix (defaul
 </AccordionGroup>
 
 <Note>
-If `-InstallMethod git` is used and Git is missing, the script exits and prints the Git for Windows link.
+If Git is missing, the script exits for both `-InstallMethod git` and default `npm` installs, and prints the Git for Windows link.
 </Note>
 
 ---

--- a/docs/zh-CN/install/installer.md
+++ b/docs/zh-CN/install/installer.md
@@ -120,7 +120,7 @@ iwr -useb https://openclaw.ai/install.ps1 | iex -InstallMethod git -GitDir "C:\\
 
 Git 要求：
 
-如果你选择 `-InstallMethod git` 但未安装 Git，安装器会打印 Git for Windows 的链接（`https://git-scm.com/download/win`）并退出。
+如果系统未安装 Git（无论是 `-InstallMethod git` 还是默认 `npm` 安装），安装器都会打印 Git for Windows 的链接（`https://git-scm.com/download/win`）并退出。
 
 常见 Windows 问题：
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -297,7 +297,8 @@ function Main {
     } else {
         # npm method
         if (!(Ensure-Git)) {
-            Write-Host "Git is required for npm installs. Please install Git and try again." -Level warn
+            Write-Host "Git is required for npm installs. Please install Git first: https://git-scm.com/download/win" -Level error
+            exit 1
         }
         
         if ($DryRun) {


### PR DESCRIPTION
Fixes #34098

## Summary
- Exit before npm install on Windows when Git is unavailable
- Provide explicit Git for Windows download link in error output
- Align EN + zh-CN installer docs with actual behavior

## Checklist
- [x] Reproduced logic gap from issue description
- [x] Minimal code change
- [x] Docs updated (EN + zh-CN)
- [ ] PowerShell runtime verification on Windows host