### PR TITLE
fix(inbound-meta): skip sender metadata for Control UI / webchat (#34153)

### DIFF
--- a/src/auto-reply/reply/inbound-meta.ts
+++ b/src/auto-reply/reply/inbound-meta.ts
@@ -149,7 +149,8 @@ export function buildInboundUserContextPrefix(ctx: TemplateContext): string {
     tag: safeTrim(ctx.SenderTag),
     e164: safeTrim(ctx.SenderE164),
   };
-  if (senderInfo?.label) {
+  // Skip sender metadata for webchat / Control UI (#34153).
+  if (senderInfo?.label && shouldIncludeConversationInfo) {
     blocks.push(
       ["Sender (untrusted metadata):", "```json", JSON.stringify(senderInfo, null, 2), "```"].join(
         "\n",


### PR DESCRIPTION
Fixes #34153

**Problem:** Control UI messages included sender metadata (`openclaw-control-ui`) in every LLM request, wasting tokens with no useful context.

**Fix:** Reuse the existing `shouldIncludeConversationInfo` guard for the sender block.
