### PR TITLE
Telegram: honor text_mention in requireMention gating

### DIFF
--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -71,6 +71,7 @@ import {
   normalizeForwardedContext,
   describeReplyTarget,
   extractTelegramLocation,
+  hasAnyMentionEntity,
   hasBotMention,
   resolveTelegramThreadSpec,
 } from "./bot/helpers.js";
@@ -378,7 +379,25 @@ export const buildTelegramMessageContext = async ({
     direction: "inbound",
   });
 
-  const botUsername = primaryCtx.me?.username?.toLowerCase();
+  let botUsername =
+    primaryCtx.me?.username?.toLowerCase() ??
+    (
+      bot as Bot & {
+        botInfo?: {
+          id?: number;
+          username?: string;
+        };
+      }
+    ).botInfo?.username?.toLowerCase();
+  let botId =
+    primaryCtx.me?.id ??
+    (
+      bot as Bot & {
+        botInfo?: {
+          id?: number;
+        };
+      }
+    ).botInfo?.id;
   const allowForCommands = isGroup ? effectiveGroupAllow : effectiveDmAllow;
   const senderAllowedForCommands = isSenderAllowed({
     allow: allowForCommands,
@@ -482,10 +501,22 @@ export const buildTelegramMessageContext = async ({
     }
   }
 
-  const hasAnyMention = (msg.entities ?? msg.caption_entities ?? []).some(
-    (ent) => ent.type === "mention",
-  );
-  const explicitlyMentioned = botUsername ? hasBotMention(msg, botUsername) : false;
+  const hasAnyMention = hasAnyMentionEntity(msg);
+  if (
+    !botUsername &&
+    isGroup &&
+    requireMention &&
+    (hasAnyMention || (msg.text ?? msg.caption ?? "").includes("@"))
+  ) {
+    try {
+      const me = await bot.api.getMe();
+      botUsername = me.username?.toLowerCase();
+      botId = me.id;
+    } catch (err) {
+      logVerbose(`telegram: failed to resolve bot username for mention detection: ${String(err)}`);
+    }
+  }
+  const explicitlyMentioned = botUsername ? hasBotMention(msg, botUsername, botId) : false;
 
   const computedWasMentioned = matchesMentionWithExplicit({
     text: msg.text ?? msg.caption ?? "",
@@ -514,7 +545,6 @@ export const buildTelegramMessageContext = async ({
   // We detect service messages by the presence of Telegram's forum_topic_* fields
   // rather than by the absence of text/caption, because legitimate bot media messages
   // (stickers, voice notes, captionless photos) also lack text/caption.
-  const botId = primaryCtx.me?.id;
   const replyFromId = msg.reply_to_message?.from?.id;
   const replyToBotMessage = botId != null && replyFromId === botId;
   const isReplyToServiceMessage =

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -10,6 +10,7 @@ import {
   botCtorSpy,
   commandSpy,
   getLoadConfigMock,
+  getMeSpy,
   getLoadWebMediaMock,
   getOnHandler,
   getReadChannelAllowFromStoreMock,
@@ -1068,6 +1069,12 @@ describe("createTelegramBot", () => {
     onSpy.mockClear();
     replySpy.mockClear();
     sendMessageSpy.mockClear();
+    getMeSpy.mockReset();
+    getMeSpy.mockResolvedValue({
+      id: 1234,
+      username: "openclaw_bot",
+      has_topics_enabled: true,
+    });
     setMessageReactionSpy.mockClear();
     setMyCommandsSpy.mockClear();
   }
@@ -1279,6 +1286,82 @@ describe("createTelegramBot", () => {
         expect(payload.WasMentioned, testCase.name).toBe(testCase.expectedWasMentioned);
       }
     }
+  });
+  it("falls back to getMe when ctx.me is missing for explicit mention detection", async () => {
+    resetHarnessSpies();
+    getMeSpy.mockResolvedValue({
+      id: 1234,
+      username: "openclaw_bot",
+      has_topics_enabled: true,
+    });
+    loadConfig.mockReturnValue({
+      messages: { groupChat: { mentionPatterns: ["\\bbert\\b"] } },
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: { "*": { requireMention: true } },
+        },
+      },
+    });
+
+    await dispatchMessage({
+      message: {
+        chat: { id: 7, type: "group", title: "Test Group" },
+        text: "@openclaw_bot hello",
+        entities: [{ type: "mention", offset: 0, length: 13 }],
+        date: 1_736_380_900,
+        message_id: 200,
+        from: { id: 9, first_name: "Ada" },
+      },
+      me: {},
+    });
+
+    expect(getMeSpy).toHaveBeenCalledTimes(1);
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = replySpy.mock.calls[0][0];
+    expect(payload.WasMentioned).toBe(true);
+  });
+
+  it("treats text_mention entities as explicit mention when ctx.me is missing", async () => {
+    resetHarnessSpies();
+    getMeSpy.mockResolvedValue({
+      id: 1234,
+      username: "openclaw_bot",
+      has_topics_enabled: true,
+    });
+    loadConfig.mockReturnValue({
+      messages: { groupChat: { mentionPatterns: ["\\bbert\\b"] } },
+      channels: {
+        telegram: {
+          groupPolicy: "open",
+          groups: { "*": { requireMention: true } },
+        },
+      },
+    });
+
+    await dispatchMessage({
+      message: {
+        chat: { id: 7, type: "group", title: "Test Group" },
+        text: "OpenClaw hello",
+        entities: [
+          {
+            type: "text_mention",
+            offset: 0,
+            length: 8,
+            user: { id: 1234, is_bot: true, first_name: "OpenClaw" },
+          },
+        ],
+        date: 1_736_380_901,
+        message_id: 201,
+        from: { id: 9, first_name: "Ada" },
+      },
+      me: {},
+    });
+
+    expect(getMeSpy).toHaveBeenCalledTimes(1);
+    expect(replySpy).toHaveBeenCalledTimes(1);
+    const payload = replySpy.mock.calls[0][0];
+    expect(payload.WasMentioned).toBe(true);
   });
   it("includes reply-to context when a Telegram reply is received", async () => {
     resetHarnessSpies();

--- a/src/telegram/bot/helpers.test.ts
+++ b/src/telegram/bot/helpers.test.ts
@@ -4,6 +4,8 @@ import {
   buildTypingThreadParams,
   describeReplyTarget,
   expandTextLinks,
+  hasAnyMentionEntity,
+  hasBotMention,
   normalizeForwardedContext,
   resolveTelegramDirectPeerId,
   resolveTelegramForumThreadId,
@@ -393,5 +395,55 @@ describe("expandTextLinks", () => {
     const text = " Hello world";
     const entities = [{ type: "text_link", offset: 1, length: 5, url: "https://example.com" }];
     expect(expandTextLinks(text, entities)).toBe(" [Hello](https://example.com) world");
+  });
+});
+
+describe("hasBotMention", () => {
+  it("matches username mentions", () => {
+    const message = {
+      text: "@openclaw_bot hello",
+      entities: [{ type: "mention", offset: 0, length: 13 }],
+      chat: { id: 1, type: "private" },
+      date: 0,
+      message_id: 1,
+    };
+    expect(hasBotMention(message as never, "openclaw_bot")).toBe(true);
+  });
+
+  it("matches text_mention entities by bot id", () => {
+    const message = {
+      text: "OpenClaw hello",
+      entities: [
+        {
+          type: "text_mention",
+          offset: 0,
+          length: 8,
+          user: { id: 42, is_bot: true, first_name: "OpenClaw" },
+        },
+      ],
+      chat: { id: 1, type: "private" },
+      date: 0,
+      message_id: 1,
+    };
+    expect(hasBotMention(message as never, "openclaw_bot", 42)).toBe(true);
+    expect(hasAnyMentionEntity(message as never)).toBe(true);
+  });
+
+  it("does not match text_mention entities for a different bot id", () => {
+    const message = {
+      text: "OpenClaw hello",
+      entities: [
+        {
+          type: "text_mention",
+          offset: 0,
+          length: 8,
+          user: { id: 77, is_bot: true, first_name: "OpenClaw" },
+        },
+      ],
+      chat: { id: 1, type: "private" },
+      date: 0,
+      message_id: 1,
+    };
+    expect(hasBotMention(message as never, "openclaw_bot", 42)).toBe(false);
   });
 });

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -280,18 +280,34 @@ export function buildGroupLabel(msg: Message, chatId: number | string, messageTh
   return `group:${chatId}${topicSuffix}`;
 }
 
-export function hasBotMention(msg: Message, botUsername: string) {
+export function hasBotMention(msg: Message, botUsername: string, botId?: number) {
   const text = (msg.text ?? msg.caption ?? "").toLowerCase();
   if (text.includes(`@${botUsername}`)) {
     return true;
   }
   const entities = msg.entities ?? msg.caption_entities ?? [];
   for (const ent of entities) {
-    if (ent.type !== "mention") {
+    if (ent.type === "mention") {
+      const slice = (msg.text ?? msg.caption ?? "").slice(ent.offset, ent.offset + ent.length);
+      if (slice.toLowerCase() === `@${botUsername}`) {
+        return true;
+      }
       continue;
     }
-    const slice = (msg.text ?? msg.caption ?? "").slice(ent.offset, ent.offset + ent.length);
-    if (slice.toLowerCase() === `@${botUsername}`) {
+    if (ent.type === "text_mention" && botId != null) {
+      const mentionedUser = (ent as typeof ent & { user?: { id?: number } }).user;
+      if (mentionedUser?.id === botId) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+export function hasAnyMentionEntity(msg: Message): boolean {
+  const entities = msg.entities ?? msg.caption_entities ?? [];
+  for (const ent of entities) {
+    if (ent.type === "mention" || ent.type === "text_mention") {
       return true;
     }
   }


### PR DESCRIPTION
## Summary
- treat Telegram `text_mention` entities as mention signals in group require-mention flows
- include bot id fallback (`ctx.me` / `botInfo` / `getMe`) when resolving explicit mentions
- extend mention detection helper coverage for both `mention` and `text_mention`

## Validation
- `pnpm test -- src/telegram/bot/helpers.test.ts src/telegram/bot.create-telegram-bot.test.ts`
