### PR TITLE
Telegram: normalize legacy direct target prefixes

### DIFF
--- a/src/telegram/targets.test.ts
+++ b/src/telegram/targets.test.ts
@@ -16,6 +16,11 @@ describe("stripTelegramInternalPrefixes", () => {
     expect(stripTelegramInternalPrefixes("telegram:group:-100123")).toBe("-100123");
   });
 
+  it("strips telegram+direct prefixes", () => {
+    expect(stripTelegramInternalPrefixes("telegram:direct:123456789")).toBe("123456789");
+    expect(stripTelegramInternalPrefixes("tg:direct:123456789")).toBe("123456789");
+  });
+
   it("does not strip group prefix without telegram prefix", () => {
     expect(stripTelegramInternalPrefixes("group:-100123")).toBe("group:-100123");
   });
@@ -78,6 +83,13 @@ describe("parseTelegramTarget", () => {
       chatType: "group",
     });
   });
+
+  it("parses telegram:direct prefixed targets as direct chats", () => {
+    expect(parseTelegramTarget("telegram:direct:123456789")).toEqual({
+      chatId: "123456789",
+      chatType: "direct",
+    });
+  });
 });
 
 describe("normalizeTelegramChatId", () => {
@@ -91,6 +103,7 @@ describe("normalizeTelegramChatId", () => {
   it("keeps numeric chat ids unchanged", () => {
     expect(normalizeTelegramChatId("-1001234567890")).toBe("-1001234567890");
     expect(normalizeTelegramChatId("123456789")).toBe("123456789");
+    expect(normalizeTelegramChatId("telegram:direct:123456789")).toBe("123456789");
   });
 
   it("returns undefined for empty input", () => {

--- a/src/telegram/targets.ts
+++ b/src/telegram/targets.ts
@@ -16,9 +16,11 @@ export function stripTelegramInternalPrefixes(to: string): string {
         strippedTelegramPrefix = true;
         return trimmed.replace(/^(telegram|tg):/i, "").trim();
       }
-      // Legacy internal form: `telegram:group:<id>` (still emitted by session keys).
-      if (strippedTelegramPrefix && /^group:/i.test(trimmed)) {
-        return trimmed.replace(/^group:/i, "").trim();
+      // Legacy internal forms emitted by session keys:
+      // - `telegram:group:<id>`
+      // - `telegram:direct:<id>`
+      if (strippedTelegramPrefix && /^(group|direct):/i.test(trimmed)) {
+        return trimmed.replace(/^(group|direct):/i, "").trim();
       }
       return trimmed;
     })();


### PR DESCRIPTION
## Summary
- normalize legacy `telegram:direct:<chatId>` and `tg:direct:<chatId>` targets in `stripTelegramInternalPrefixes`
- keep `telegram:group:<chatId>` behavior unchanged
- add parsing and normalization coverage to prevent direct-target delivery misses

## Validation
- `pnpm test -- src/telegram/targets.test.ts`
