### PR TITLE
Telegram: validate and normalize t.me lookup targets

### DIFF
--- a/src/telegram/targets.test.ts
+++ b/src/telegram/targets.test.ts
@@ -101,6 +101,8 @@ describe("normalizeTelegramChatId", () => {
 describe("normalizeTelegramLookupTarget", () => {
   it("normalizes legacy t.me and username targets", () => {
     expect(normalizeTelegramLookupTarget("telegram:https://t.me/MyChannel")).toBe("@MyChannel");
+    expect(normalizeTelegramLookupTarget("https://t.me/MyChannel/")).toBe("@MyChannel");
+    expect(normalizeTelegramLookupTarget("https://t.me/MyChannel/123")).toBe("@MyChannel");
     expect(normalizeTelegramLookupTarget("tg:t.me/mychannel")).toBe("@mychannel");
     expect(normalizeTelegramLookupTarget("@MyChannel")).toBe("@MyChannel");
     expect(normalizeTelegramLookupTarget("MyChannel")).toBe("@MyChannel");
@@ -115,6 +117,8 @@ describe("normalizeTelegramLookupTarget", () => {
     expect(normalizeTelegramLookupTarget("@bad-handle")).toBeUndefined();
     expect(normalizeTelegramLookupTarget("bad-handle")).toBeUndefined();
     expect(normalizeTelegramLookupTarget("ab")).toBeUndefined();
+    expect(normalizeTelegramLookupTarget("t.me/ab")).toBeUndefined();
+    expect(normalizeTelegramLookupTarget("https://t.me/c/123/456")).toBeUndefined();
   });
 });
 

--- a/src/telegram/targets.ts
+++ b/src/telegram/targets.ts
@@ -52,8 +52,11 @@ export function normalizeTelegramLookupTarget(raw: string): string | undefined {
   if (isNumericTelegramChatId(stripped)) {
     return stripped;
   }
-  const tmeMatch = /^(?:https?:\/\/)?t\.me\/([A-Za-z0-9_]+)$/i.exec(stripped);
+  const tmeMatch = /^(?:https?:\/\/)?t\.me\/([A-Za-z0-9_]+)(?:\/\d+)?\/?$/i.exec(stripped);
   if (tmeMatch?.[1]) {
+    if (!TELEGRAM_USERNAME_REGEX.test(tmeMatch[1])) {
+      return undefined;
+    }
     return `@${tmeMatch[1]}`;
   }
   if (stripped.startsWith("@")) {


### PR DESCRIPTION
## Summary
- validate usernames extracted from `t.me` links using Telegram username constraints
- normalize `t.me/<username>/` and `t.me/<username>/<messageId>` message links to `@<username>`
- reject invalid link forms like short handles and private `t.me/c/...` links

## Validation
- `pnpm test -- src/telegram/targets.test.ts`
