### PR TITLE
Telegram: resolve legacy  botToken references

### DIFF
--- a/src/telegram/token.test.ts
+++ b/src/telegram/token.test.ts
@@ -58,6 +58,42 @@ describe("resolveTelegramToken", () => {
     expect(res.source).toBe("config");
   });
 
+  it("resolves legacy $ENV references in top-level botToken", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "resolved-env-token");
+    const cfg = {
+      channels: { telegram: { botToken: "$TELEGRAM_BOT_TOKEN" } },
+    } as OpenClawConfig;
+    const res = resolveTelegramToken(cfg);
+    expect(res.token).toBe("resolved-env-token");
+    expect(res.source).toBe("config");
+  });
+
+  it("resolves legacy $ENV references in per-account botToken", () => {
+    vi.stubEnv("WORK_TG_TOKEN", "resolved-work-token");
+    const cfg = {
+      channels: {
+        telegram: {
+          accounts: {
+            work: { botToken: "$WORK_TG_TOKEN" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const res = resolveTelegramToken(cfg, { accountId: "work" });
+    expect(res.token).toBe("resolved-work-token");
+    expect(res.source).toBe("config");
+  });
+
+  it("throws when legacy $ENV token reference is missing", () => {
+    vi.stubEnv("MISSING_TG_TOKEN", "");
+    const cfg = {
+      channels: { telegram: { botToken: "$MISSING_TG_TOKEN" } },
+    } as OpenClawConfig;
+    expect(() => resolveTelegramToken(cfg)).toThrow(
+      /channels\.telegram\.botToken: unresolved \$MISSING_TG_TOKEN token reference/i,
+    );
+  });
+
   it("does not fall back to config when tokenFile is missing", () => {
     vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
     const dir = withTempDir();

--- a/src/telegram/token.ts
+++ b/src/telegram/token.ts
@@ -17,6 +17,28 @@ type ResolveTelegramTokenOpts = {
   logMissingFile?: (message: string) => void;
 };
 
+const LEGACY_ENV_TOKEN_REF_RE = /^\$([A-Z_][A-Z0-9_]*)$/;
+
+function resolveLegacyEnvTokenReference(params: {
+  token: string;
+  path: string;
+  env: NodeJS.ProcessEnv;
+}): string {
+  const token = params.token.trim();
+  const match = LEGACY_ENV_TOKEN_REF_RE.exec(token);
+  if (!match?.[1]) {
+    return token;
+  }
+  const envName = match[1];
+  const envValue = params.env[envName]?.trim();
+  if (!envValue) {
+    throw new Error(
+      `${params.path}: unresolved $${envName} token reference (env var "${envName}" is not set)`,
+    );
+  }
+  return envValue;
+}
+
 export function resolveTelegramToken(
   cfg?: OpenClawConfig,
   opts: ResolveTelegramTokenOpts = {},
@@ -71,7 +93,14 @@ export function resolveTelegramToken(
     path: `channels.telegram.accounts.${accountId}.botToken`,
   });
   if (accountToken) {
-    return { token: accountToken, source: "config" };
+    return {
+      token: resolveLegacyEnvTokenReference({
+        token: accountToken,
+        path: `channels.telegram.accounts.${accountId}.botToken`,
+        env: process.env,
+      }),
+      source: "config",
+    };
   }
 
   const allowEnv = accountId === DEFAULT_ACCOUNT_ID;
@@ -97,7 +126,14 @@ export function resolveTelegramToken(
     path: "channels.telegram.botToken",
   });
   if (configToken) {
-    return { token: configToken, source: "config" };
+    return {
+      token: resolveLegacyEnvTokenReference({
+        token: configToken,
+        path: "channels.telegram.botToken",
+        env: process.env,
+      }),
+      source: "config",
+    };
   }
 
   const envToken = allowEnv ? (opts.envToken ?? process.env.TELEGRAM_BOT_TOKEN)?.trim() : "";


### PR DESCRIPTION
## Summary
- resolve legacy `$ENV_VAR` token strings in `channels.telegram.botToken`
- resolve legacy `$ENV_VAR` token strings in per-account `channels.telegram.accounts.<id>.botToken`
- fail fast with a clear configuration error when the referenced environment variable is missing

## Why
Telegram would otherwise receive a literal token like `$TELEGRAM_BOT_TOKEN`, causing repeated 404 retries. This addresses #34247.

## Changes
- `src/telegram/token.ts`
  - add a narrow parser for legacy `$ENV_VAR` token references
  - resolve the reference from runtime environment before returning config token values
  - throw a descriptive error when the env var is unset
- `src/telegram/token.test.ts`
  - add coverage for top-level and per-account `$ENV_VAR` resolution
  - add coverage for missing env var failure path

## Verification
- `pnpm test -- src/telegram/token.test.ts`
