### PR TITLE
Feishu: support chat_id/user_id target prefixes

### DIFF
--- a/extensions/feishu/src/targets.test.ts
+++ b/extensions/feishu/src/targets.test.ts
@@ -22,8 +22,16 @@ describe("resolveReceiveIdType", () => {
     expect(resolveReceiveIdType("channel:oc_123")).toBe("chat_id");
   });
 
+  it("treats explicit chat_id prefix as chat_id", () => {
+    expect(resolveReceiveIdType("chat_id:oc_123")).toBe("chat_id");
+  });
+
   it("treats dm-prefixed open IDs as open_id", () => {
     expect(resolveReceiveIdType("dm:ou_123")).toBe("open_id");
+  });
+
+  it("treats explicit user_id prefix as user_id", () => {
+    expect(resolveReceiveIdType("user_id:on_123")).toBe("user_id");
   });
 });
 
@@ -35,6 +43,13 @@ describe("normalizeFeishuTarget", () => {
 
   it("strips provider and chat prefixes", () => {
     expect(normalizeFeishuTarget("feishu:chat:oc_123")).toBe("oc_123");
+  });
+
+  it("strips official receive-id type prefixes", () => {
+    expect(normalizeFeishuTarget("chat_id:oc_123")).toBe("oc_123");
+    expect(normalizeFeishuTarget("feishu:chat_id:oc_123")).toBe("oc_123");
+    expect(normalizeFeishuTarget("user_id:on_123")).toBe("on_123");
+    expect(normalizeFeishuTarget("lark:user_id:on_123")).toBe("on_123");
   });
 
   it("normalizes group/channel prefixes to chat ids", () => {
@@ -66,5 +81,10 @@ describe("looksLikeFeishuId", () => {
     expect(looksLikeFeishuId("feishu:group:oc_123")).toBe(true);
     expect(looksLikeFeishuId("group:oc_123")).toBe(true);
     expect(looksLikeFeishuId("channel:oc_456")).toBe(true);
+  });
+
+  it("accepts official receive-id type prefixes", () => {
+    expect(looksLikeFeishuId("chat_id:oc_123")).toBe(true);
+    expect(looksLikeFeishuId("user_id:on_123")).toBe(true);
   });
 });

--- a/extensions/feishu/src/targets.ts
+++ b/extensions/feishu/src/targets.ts
@@ -30,6 +30,9 @@ export function normalizeFeishuTarget(raw: string): string | null {
 
   const withoutProvider = stripProviderPrefix(trimmed);
   const lowered = withoutProvider.toLowerCase();
+  if (lowered.startsWith("chat_id:")) {
+    return withoutProvider.slice("chat_id:".length).trim() || null;
+  }
   if (lowered.startsWith("chat:")) {
     return withoutProvider.slice("chat:".length).trim() || null;
   }
@@ -47,6 +50,9 @@ export function normalizeFeishuTarget(raw: string): string | null {
   }
   if (lowered.startsWith("open_id:")) {
     return withoutProvider.slice("open_id:".length).trim() || null;
+  }
+  if (lowered.startsWith("user_id:")) {
+    return withoutProvider.slice("user_id:".length).trim() || null;
   }
 
   return withoutProvider;
@@ -67,11 +73,15 @@ export function resolveReceiveIdType(id: string): "chat_id" | "open_id" | "user_
   const trimmed = id.trim();
   const lowered = trimmed.toLowerCase();
   if (
+    lowered.startsWith("chat_id:") ||
     lowered.startsWith("chat:") ||
     lowered.startsWith("group:") ||
     lowered.startsWith("channel:")
   ) {
     return "chat_id";
+  }
+  if (lowered.startsWith("user_id:")) {
+    return "user_id";
   }
   if (lowered.startsWith("open_id:")) {
     return "open_id";
@@ -94,7 +104,7 @@ export function looksLikeFeishuId(raw: string): boolean {
   if (!trimmed) {
     return false;
   }
-  if (/^(chat|group|channel|user|dm|open_id):/i.test(trimmed)) {
+  if (/^(chat_id|chat|group|channel|user|dm|open_id|user_id):/i.test(trimmed)) {
     return true;
   }
   if (trimmed.startsWith(CHAT_ID_PREFIX)) {


### PR DESCRIPTION
## Summary
- add support for official Feishu target prefixes `chat_id:` and `user_id:`
- keep receive-id type inference aligned with normalized targets
- extend target-shape detection to recognize these prefixes

## Why
Feishu APIs and user configs commonly use `chat_id` / `user_id` naming. Without explicit support, these targets can be misclassified or left unnormalized, causing delivery type mismatches.

## Changes
- `extensions/feishu/src/targets.ts`
  - `normalizeFeishuTarget`: strip `chat_id:` and `user_id:` prefixes
  - `resolveReceiveIdType`: classify `chat_id:` as `chat_id` and `user_id:` as `user_id`
  - `looksLikeFeishuId`: recognize `chat_id:` / `user_id:` prefixed IDs
- `extensions/feishu/src/targets.test.ts`
  - add tests for normalization, receive-id type inference, and id-shape detection for the new prefixes

## Verification
- `pnpm test -- extensions/feishu/src/targets.test.ts`
