### PR TITLE
fix(ui): enable Save when toggling tools with missing agents.list

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -663,11 +663,15 @@ export function renderApp(state: AppViewState) {
                   void saveAgentFile(state, resolvedAgentId, name, content);
                 },
                 onToolsProfileChange: (agentId, profile, clearAllow) => {
-                  if (!configValue) {
+                  const liveConfig = (state.configForm ?? state.configSnapshot?.config) as {
+                    agents?: { list?: unknown[] };
+                  } | null;
+                  if (!liveConfig) {
                     return;
                   }
-                  const config = configValue as { agents?: { list?: unknown[] } };
-                  const list = Array.isArray(config.agents?.list) ? [...config.agents.list] : [];
+                  const list = Array.isArray(liveConfig.agents?.list)
+                    ? [...liveConfig.agents.list]
+                    : [];
                   let index = list.findIndex(
                     (entry) =>
                       entry &&
@@ -700,11 +704,15 @@ export function renderApp(state: AppViewState) {
                   }
                 },
                 onToolsOverridesChange: (agentId, alsoAllow, deny) => {
-                  if (!configValue) {
+                  const liveConfig = (state.configForm ?? state.configSnapshot?.config) as {
+                    agents?: { list?: unknown[] };
+                  } | null;
+                  if (!liveConfig) {
                     return;
                   }
-                  const config = configValue as { agents?: { list?: unknown[] } };
-                  const list = Array.isArray(config.agents?.list) ? [...config.agents.list] : [];
+                  const list = Array.isArray(liveConfig.agents?.list)
+                    ? [...liveConfig.agents.list]
+                    : [];
                   let index = list.findIndex(
                     (entry) =>
                       entry &&

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -666,11 +666,9 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
+                  const config = configValue as { agents?: { list?: unknown[] } };
+                  const list = Array.isArray(config.agents?.list) ? [...config.agents.list] : [];
+                  let index = list.findIndex(
                     (entry) =>
                       entry &&
                       typeof entry === "object" &&
@@ -678,6 +676,16 @@ export function renderApp(state: AppViewState) {
                       (entry as { id?: string }).id === agentId,
                   );
                   if (index < 0) {
+                    const newEntry: Record<string, unknown> = { id: agentId };
+                    const tools: Record<string, unknown> = {};
+                    if (profile) {
+                      tools.profile = profile;
+                    }
+                    if (Object.keys(tools).length > 0) {
+                      newEntry.tools = tools;
+                    }
+                    list.push(newEntry);
+                    updateConfigFormValue(state, ["agents", "list"], list);
                     return;
                   }
                   const basePath = ["agents", "list", index, "tools"];
@@ -694,11 +702,9 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
+                  const config = configValue as { agents?: { list?: unknown[] } };
+                  const list = Array.isArray(config.agents?.list) ? [...config.agents.list] : [];
+                  let index = list.findIndex(
                     (entry) =>
                       entry &&
                       typeof entry === "object" &&
@@ -706,6 +712,20 @@ export function renderApp(state: AppViewState) {
                       (entry as { id?: string }).id === agentId,
                   );
                   if (index < 0) {
+                    // Agent not in config yet (e.g. disk-scanned only) – add entry so Save becomes enabled
+                    const newEntry: Record<string, unknown> = { id: agentId };
+                    const tools: Record<string, unknown> = {};
+                    if (alsoAllow.length > 0) {
+                      tools.alsoAllow = alsoAllow;
+                    }
+                    if (deny.length > 0) {
+                      tools.deny = deny;
+                    }
+                    if (Object.keys(tools).length > 0) {
+                      newEntry.tools = tools;
+                    }
+                    list.push(newEntry);
+                    updateConfigFormValue(state, ["agents", "list"], list);
                     return;
                   }
                   const basePath = ["agents", "list", index, "tools"];

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -681,9 +681,10 @@ export function renderApp(state: AppViewState) {
                     if (profile) {
                       tools.profile = profile;
                     }
-                    if (Object.keys(tools).length > 0) {
-                      newEntry.tools = tools;
+                    if (Object.keys(tools).length === 0) {
+                      return; // No meaningful change – agent already inherits defaults
                     }
+                    newEntry.tools = tools;
                     list.push(newEntry);
                     updateConfigFormValue(state, ["agents", "list"], list);
                     return;
@@ -721,9 +722,10 @@ export function renderApp(state: AppViewState) {
                     if (deny.length > 0) {
                       tools.deny = deny;
                     }
-                    if (Object.keys(tools).length > 0) {
-                      newEntry.tools = tools;
+                    if (Object.keys(tools).length === 0) {
+                      return; // No meaningful override to persist
                     }
+                    newEntry.tools = tools;
                     list.push(newEntry);
                     updateConfigFormValue(state, ["agents", "list"], list);
                     return;


### PR DESCRIPTION

## Summary

- **Problem:** In the Agents tab, when toggling tools in the Tools panel, the Save button was disabled and could not be clicked.
- **Why it matters:** Users with configs that only have `agents.defaults` (no `agents.list`) could not save tool changes, even though agents were visible from workspace scanning.
- **What changed:** `onToolsOverridesChange` and `onToolsProfileChange` now create the agent entry in `agents.list` when it is missing, so `configFormDirty` is set and `updateConfigFormValue` or `removeConfigFormValue` is called.
- **What did NOT change (scope boundary):** No changes to config schema, gateway API, or other UI panels. Save behavior for other agents panels is unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- **Before:** Users with configs that only have `agents.defaults` (no `agents.list`) could not save tool changes; the Save button stayed disabled after toggling tools.
- **After:** Toggling tools in the Tools panel sets `configFormDirty` and enables Save. Saving adds the agent to `agents.list` with the correct tool overrides.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): Config with `agents.defaults` but no `agents.list`.

### Steps

1. Open the gateway control UI and go to the Agents tab.
2. Select an agent (e.g. `main`).
3. Open the Tools panel.
4. Toggle any tool on or off.

### Expected

- Save button becomes enabled and can be clicked after changes.

### Actual

- Save button was disabled and could not be clicked.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios:** Toggling tools with a config that has no `agents.list`; the Save button enabled and Save worked.
- **Edge cases checked:** Agent already in `agents.list`; profile switching; empty `alsoAllow`/`deny`.
- **What you did not verify:** UI tests with Playwright (browsers not installed).

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the commit.
- Files/config to restore: `ui/src/ui/app-render.ts`
- Known bad symptoms reviewers should watch for: Save behavior changes or incorrect config updates.

## Risks and Mitigations

- **Risk:** Agent entries added when missing might create unintended config changes.
- **Mitigation:** Only adds entries when the user explicitly toggles tools in the Tools panel; the change is limited to the same agent and tools.