### PR TITLE
Telegram: accept telegram.me lookup targets

### DIFF
--- a/src/telegram/targets.test.ts
+++ b/src/telegram/targets.test.ts
@@ -101,6 +101,8 @@ describe("normalizeTelegramChatId", () => {
 describe("normalizeTelegramLookupTarget", () => {
   it("normalizes legacy t.me and username targets", () => {
     expect(normalizeTelegramLookupTarget("telegram:https://t.me/MyChannel")).toBe("@MyChannel");
+    expect(normalizeTelegramLookupTarget("https://telegram.me/MyChannel")).toBe("@MyChannel");
+    expect(normalizeTelegramLookupTarget("telegram.me/mychannel/")).toBe("@mychannel");
     expect(normalizeTelegramLookupTarget("tg:t.me/mychannel")).toBe("@mychannel");
     expect(normalizeTelegramLookupTarget("@MyChannel")).toBe("@MyChannel");
     expect(normalizeTelegramLookupTarget("MyChannel")).toBe("@MyChannel");

--- a/src/telegram/targets.ts
+++ b/src/telegram/targets.ts
@@ -52,7 +52,7 @@ export function normalizeTelegramLookupTarget(raw: string): string | undefined {
   if (isNumericTelegramChatId(stripped)) {
     return stripped;
   }
-  const tmeMatch = /^(?:https?:\/\/)?t\.me\/([A-Za-z0-9_]+)$/i.exec(stripped);
+  const tmeMatch = /^(?:https?:\/\/)?(?:t|telegram)\.me\/([A-Za-z0-9_]+)\/?$/i.exec(stripped);
   if (tmeMatch?.[1]) {
     return `@${tmeMatch[1]}`;
   }


### PR DESCRIPTION
## Summary
- accept `telegram.me/<username>` as a valid Telegram lookup target
- keep existing `t.me/<username>` behavior unchanged
- keep username normalization behavior unchanged (`@<handle>`)

## Why
Users often paste `telegram.me` links interchangeably with `t.me`. Previously only `t.me` links were normalized, which caused avoidable lookup failures for equivalent valid targets.

## Changes
- `src/telegram/targets.ts`
  - extend link normalization regex to accept both `t.me` and `telegram.me`
- `src/telegram/targets.test.ts`
  - add regression coverage for `https://telegram.me/<username>` and `telegram.me/<username>/`

## Validation
- `pnpm test -- src/telegram/targets.test.ts`
