### PR TITLE
Gateway: fix Control UI 404 with Windows-style basePath

### DIFF
--- a/src/gateway/control-ui-shared.ts
+++ b/src/gateway/control-ui-shared.ts
@@ -14,6 +14,10 @@ export function normalizeControlUiBasePath(basePath?: string): string {
   if (!normalized) {
     return "";
   }
+  // Config values can come from Windows-style input (e.g. "\ui").
+  // Normalize to URL path separators before route matching.
+  normalized = normalized.replaceAll("\\", "/");
+  normalized = normalized.replaceAll(/\/{2,}/g, "/");
   if (!normalized.startsWith("/")) {
     normalized = `/${normalized}`;
   }

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -197,6 +197,22 @@ describe("handleControlUiHttpRequest", () => {
     });
   });
 
+  it("normalizes Windows-style basePath separators when matching routes", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const { handled, res, end } = runControlUiRequest({
+          url: "/ui/",
+          method: "GET",
+          rootPath: tmp,
+          basePath: "\\ui",
+        });
+        expect(handled).toBe(true);
+        expect(res.statusCode).toBe(200);
+        expect(String(end.mock.calls[0]?.[0] ?? "")).toContain("<html");
+      },
+    });
+  });
+
   it("serves local avatar bytes through hardened avatar handler", async () => {
     const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-avatar-http-"));
     try {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: On Windows, Control UI could return plain `404 Not Found` for `/` and configured basePath routes in 2026.3.x.
- Why it matters: Gateway runs but Dashboard is unusable, which is a user-facing regression.
- What changed: `normalizeControlUiBasePath` now normalizes Windows-style separators (`\\` -> `/`) and collapses repeated `/` before route matching.
- What did NOT change (scope boundary): No auth/pairing behavior changes, no control-ui asset lookup changes, no plugin route precedence changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34189
- Related #24938
- Related #31766

## User-visible / Behavior Changes

- `gateway.controlUi.basePath` now accepts Windows-style input such as `\\ui` and serves UI correctly under `/ui`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (test), issue repro from Windows 10/11
- Runtime/container: Node 22 + pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Gateway Control UI HTTP handling
- Relevant config (redacted): `gateway.controlUi.basePath` (including Windows-style `\\ui`)

### Steps

1. Configure `gateway.controlUi.basePath` with a Windows-style value (`\\ui`).
2. Start gateway.
3. Open `/ui/`.

### Expected

- Control UI route is recognized and serves index/bootstrap.

### Actual

- Before fix: route can fall through to global gateway 404.
- After fix: route is normalized and served by Control UI handler.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: Added and ran regression test for Windows-style basePath separator normalization.
- Edge cases checked: Existing basePath behavior unchanged for POSIX-style input; route classification tests still pass.
- What you did **not** verify: Full manual run on a Windows host in this environment.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `f7943a189`.
- Files/config to restore: `src/gateway/control-ui-shared.ts`, `src/gateway/control-ui.http.test.ts`.
- Known bad symptoms reviewers should watch for: Unexpected Control UI route matching changes for custom basePath.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: BasePath normalization could alter intentionally unusual path strings.
  - Mitigation: Normalization only targets separator style and duplicate slashes; existing route tests pass and regression test added.
