### PR TITLE
fix: doctor should check per-group allowFrom configuration

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1394,27 +1394,14 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
       const effectiveGroupAllowFrom =
         groupAllowFrom ?? (fallbackToAllowFrom ? effectiveAllowFrom : undefined);
 
-      // Check if any per-group allowFrom is configured
-      const groups = asObjectRecord(account.groups);
-      let hasPerGroupAllowFrom = false;
-      if (groups) {
-        for (const groupId of Object.keys(groups)) {
-          const group = asObjectRecord(groups[groupId]);
-          if (group && group.enabled !== false && hasAllowFromEntries(group.allowFrom as Array<string | number> | undefined)) {
-            hasPerGroupAllowFrom = true;
-            break;
-          }
-        }
-      }
-
-      if (!hasAllowFromEntries(effectiveGroupAllowFrom) && !hasPerGroupAllowFrom) {
+      if (!hasAllowFromEntries(effectiveGroupAllowFrom)) {
         if (fallbackToAllowFrom) {
           warnings.push(
-            `- ${prefix}.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to ${prefix}.groupAllowFrom or ${prefix}.allowFrom, or set groupPolicy to "open".`,
+            `- ${prefix}.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — groups without per-group allowFrom will have all messages silently dropped. Add sender IDs to ${prefix}.groupAllowFrom or ${prefix}.allowFrom, or set groupPolicy to "open".`,
           );
         } else {
           warnings.push(
-            `- ${prefix}.groupPolicy is "allowlist" but groupAllowFrom is empty — this channel does not fall back to allowFrom, so all group messages will be silently dropped. Add sender IDs to ${prefix}.groupAllowFrom, or set groupPolicy to "open".`,
+            `- ${prefix}.groupPolicy is "allowlist" but groupAllowFrom is empty — this channel does not fall back to allowFrom, so groups without per-group allowFrom will have all messages silently dropped. Add sender IDs to ${prefix}.groupAllowFrom, or set groupPolicy to "open".`,
           );
         }
       }

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1394,7 +1394,20 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
       const effectiveGroupAllowFrom =
         groupAllowFrom ?? (fallbackToAllowFrom ? effectiveAllowFrom : undefined);
 
-      if (!hasAllowFromEntries(effectiveGroupAllowFrom)) {
+      // Check if any per-group allowFrom is configured
+      const groups = asObjectRecord(account.groups);
+      let hasPerGroupAllowFrom = false;
+      if (groups) {
+        for (const groupId of Object.keys(groups)) {
+          const group = asObjectRecord(groups[groupId]);
+          if (group && hasAllowFromEntries(group.allowFrom as Array<string | number> | undefined)) {
+            hasPerGroupAllowFrom = true;
+            break;
+          }
+        }
+      }
+
+      if (!hasAllowFromEntries(effectiveGroupAllowFrom) && !hasPerGroupAllowFrom) {
         if (fallbackToAllowFrom) {
           warnings.push(
             `- ${prefix}.groupPolicy is "allowlist" but groupAllowFrom (and allowFrom) is empty — all group messages will be silently dropped. Add sender IDs to ${prefix}.groupAllowFrom or ${prefix}.allowFrom, or set groupPolicy to "open".`,

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1400,7 +1400,7 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
       if (groups) {
         for (const groupId of Object.keys(groups)) {
           const group = asObjectRecord(groups[groupId]);
-          if (group && hasAllowFromEntries(group.allowFrom as Array<string | number> | undefined)) {
+          if (group && group.enabled !== false && hasAllowFromEntries(group.allowFrom as Array<string | number> | undefined)) {
             hasPerGroupAllowFrom = true;
             break;
           }
@@ -1413,7 +1413,7 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
         if (parentGroups) {
           for (const groupId of Object.keys(parentGroups)) {
             const group = asObjectRecord(parentGroups[groupId]);
-            if (group && hasAllowFromEntries(group.allowFrom as Array<string | number> | undefined)) {
+            if (group && group.enabled !== false && hasAllowFromEntries(group.allowFrom as Array<string | number> | undefined)) {
               hasPerGroupAllowFrom = true;
               break;
             }

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1407,20 +1407,6 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
         }
       }
 
-      // Also check parent?.groups for consistency with parent?.groupAllowFrom handling
-      if (!hasPerGroupAllowFrom && parent) {
-        const parentGroups = asObjectRecord(parent.groups);
-        if (parentGroups) {
-          for (const groupId of Object.keys(parentGroups)) {
-            const group = asObjectRecord(parentGroups[groupId]);
-            if (group && group.enabled !== false && hasAllowFromEntries(group.allowFrom as Array<string | number> | undefined)) {
-              hasPerGroupAllowFrom = true;
-              break;
-            }
-          }
-        }
-      }
-
       if (!hasAllowFromEntries(effectiveGroupAllowFrom) && !hasPerGroupAllowFrom) {
         if (fallbackToAllowFrom) {
           warnings.push(

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1407,6 +1407,20 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
         }
       }
 
+      // Also check parent?.groups for consistency with parent?.groupAllowFrom handling
+      if (!hasPerGroupAllowFrom && parent) {
+        const parentGroups = asObjectRecord(parent.groups);
+        if (parentGroups) {
+          for (const groupId of Object.keys(parentGroups)) {
+            const group = asObjectRecord(parentGroups[groupId]);
+            if (group && hasAllowFromEntries(group.allowFrom as Array<string | number> | undefined)) {
+              hasPerGroupAllowFrom = true;
+              break;
+            }
+          }
+        }
+      }
+
       if (!hasAllowFromEntries(effectiveGroupAllowFrom) && !hasPerGroupAllowFrom) {
         if (fallbackToAllowFrom) {
           warnings.push(


### PR DESCRIPTION
## Summary

Doctor now correctly recognizes per-group `allowFrom` configurations and no longer produces false warnings when `groupAllowFrom` is empty but individual groups have `allowFrom` set.

## Changes

- Modified doctor-config-flow.ts to scan groups.{groupId}.allowFrom
- Maintains backward compatibility with groupAllowFrom
- Aligns Doctor behavior with runtime authorization logic

## Testing

Manual code review confirms the logic matches runtime behavior in bot-message-context.ts where `groupConfig?.allowFrom` is checked with higher priority than `groupAllowFrom`.

Fixes #34062