### PR TITLE
feat: add peer gateway relay for cross-gateway sessions_send

### DIFF
--- a/src/agents/tools/sessions-send-peer.ts
+++ b/src/agents/tools/sessions-send-peer.ts
@@ -1,0 +1,77 @@
+/**
+ * Peer relay integration for sessions_send.
+ *
+ * When sessions_send can't find a session on the local gateway,
+ * this module tries configured peer gateways before returning an error.
+ *
+ * @module
+ */
+
+import crypto from "node:crypto";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  resolveSessionOnPeers,
+  relayMessageToPeer,
+  resolvePeers,
+  type PeerRelayResult,
+} from "../../gateway/peer-relay.js";
+import { jsonResult } from "./common.js";
+
+/** Check whether peer relay is available (any peers configured). */
+export function hasPeers(cfg: OpenClawConfig): boolean {
+  return resolvePeers(cfg).length > 0;
+}
+
+/**
+ * Attempt to resolve and relay a sessions_send call to a peer gateway.
+ *
+ * @param cfg          The openclaw config.
+ * @param resolveParams  Parameters for session resolution (label, agentId, key, etc.).
+ * @param message      The message to send.
+ * @param timeoutMs    How long to wait for the peer agent response.
+ * @returns            A tool result JSON if the peer handled the request,
+ *                     or null if no peer could resolve the session.
+ */
+export async function tryPeerRelay(params: {
+  cfg: OpenClawConfig;
+  resolveParams: Record<string, unknown>;
+  message: string;
+  timeoutMs: number;
+  displayKey?: string;
+}): Promise<ReturnType<typeof jsonResult> | null> {
+  const { cfg, resolveParams, message, timeoutMs, displayKey } = params;
+
+  const resolved = await resolveSessionOnPeers(cfg, resolveParams);
+  if (!resolved.ok) {
+    return null; // No peer has this session; let the caller handle the error.
+  }
+
+  const relayResult: PeerRelayResult = await relayMessageToPeer(
+    resolved.peer,
+    resolved.key,
+    message,
+    timeoutMs,
+  );
+
+  if (!relayResult.ok) {
+    return jsonResult({
+      runId: crypto.randomUUID(),
+      status: "error",
+      error: relayResult.error,
+      sessionKey: displayKey ?? resolved.key,
+      relay: { peer: resolved.peer.name, attempted: true },
+    });
+  }
+
+  return jsonResult({
+    runId: relayResult.runId,
+    status: "ok",
+    reply: relayResult.reply,
+    sessionKey: displayKey ?? resolved.key,
+    relay: {
+      peer: resolved.peer.name,
+      relayed: true,
+    },
+    delivery: { status: "relayed", mode: "peer" },
+  });
+}

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -22,6 +22,7 @@ import {
   stripToolMessages,
 } from "./sessions-helpers.js";
 import { buildAgentToAgentMessageContext, resolvePingPongTurns } from "./sessions-send-helpers.js";
+import { hasPeers, tryPeerRelay } from "./sessions-send-peer.js";
 import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 
 const SessionsSendToolSchema = Type.Object({
@@ -126,6 +127,24 @@ export function createSessionsSendTool(opts?: {
               error: "Session not visible from this sandboxed agent session.",
             });
           }
+
+          // Peer relay fallback: try configured peer gateways before giving up.
+          if (hasPeers(cfg)) {
+            const timeoutSeconds =
+              typeof params.timeoutSeconds === "number" && Number.isFinite(params.timeoutSeconds)
+                ? Math.max(0, Math.floor(params.timeoutSeconds))
+                : 30;
+            const peerResult = await tryPeerRelay({
+              cfg,
+              resolveParams,
+              message,
+              timeoutMs: timeoutSeconds * 1000,
+            });
+            if (peerResult) {
+              return peerResult;
+            }
+          }
+
           return jsonResult({
             runId: crypto.randomUUID(),
             status: "error",
@@ -141,6 +160,24 @@ export function createSessionsSendTool(opts?: {
               error: "Session not visible from this sandboxed agent session.",
             });
           }
+
+          // Peer relay fallback: try configured peer gateways before giving up.
+          if (hasPeers(cfg)) {
+            const timeoutSeconds =
+              typeof params.timeoutSeconds === "number" && Number.isFinite(params.timeoutSeconds)
+                ? Math.max(0, Math.floor(params.timeoutSeconds))
+                : 30;
+            const peerResult = await tryPeerRelay({
+              cfg,
+              resolveParams,
+              message,
+              timeoutMs: timeoutSeconds * 1000,
+            });
+            if (peerResult) {
+              return peerResult;
+            }
+          }
+
           return jsonResult({
             runId: crypto.randomUUID(),
             status: "error",
@@ -165,6 +202,24 @@ export function createSessionsSendTool(opts?: {
         restrictToSpawned,
       });
       if (!resolvedSession.ok) {
+        // Peer relay fallback: try configured peer gateways before giving up.
+        if (!restrictToSpawned && hasPeers(cfg)) {
+          const timeoutSeconds =
+            typeof params.timeoutSeconds === "number" && Number.isFinite(params.timeoutSeconds)
+              ? Math.max(0, Math.floor(params.timeoutSeconds))
+              : 30;
+          const peerResult = await tryPeerRelay({
+            cfg,
+            resolveParams: { key: sessionKey },
+            message,
+            timeoutMs: timeoutSeconds * 1000,
+            displayKey: sessionKey,
+          });
+          if (peerResult) {
+            return peerResult;
+          }
+        }
+
         return jsonResult({
           runId: crypto.randomUUID(),
           status: resolvedSession.status,

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -317,6 +317,39 @@ export type GatewayToolsConfig = {
   allow?: string[];
 };
 
+/**
+ * Configuration for a peer gateway in a multi-gateway setup.
+ *
+ * When multiple openclaw gateways run on the same host (e.g. one per bot),
+ * peer configuration enables cross-gateway session routing via sessions_send.
+ * Without peers, sessions_send can only reach sessions on the local gateway.
+ *
+ * @example
+ * ```json
+ * {
+ *   "gateway": {
+ *     "peers": [
+ *       { "url": "ws://127.0.0.1:18790", "token": "peer-token", "name": "kairos" },
+ *       { "url": "ws://127.0.0.1:18791", "name": "maia", "agentIds": ["main"] }
+ *     ]
+ *   }
+ * }
+ * ```
+ */
+export type GatewayPeerConfig = {
+  /** WebSocket URL of the peer gateway (ws:// or wss://). */
+  url: string;
+  /** Auth token for the peer gateway (when it requires token auth). */
+  token?: SecretInput;
+  /** Human-readable name for this peer (used in logs and error messages). */
+  name?: string;
+  /**
+   * Optional agent ID filter. When set, this peer is only consulted for
+   * sessions belonging to the listed agent IDs. Omit to allow any agent.
+   */
+  agentIds?: string[];
+};
+
 export type GatewayConfig = {
   /** Single multiplexed port for Gateway WS + HTTP (default: 18789). */
   port?: number;
@@ -358,6 +391,14 @@ export type GatewayConfig = {
   allowRealIpFallback?: boolean;
   /** Tool access restrictions for HTTP /tools/invoke endpoint. */
   tools?: GatewayToolsConfig;
+  /**
+   * Peer gateways for cross-gateway session routing.
+   *
+   * When sessions_send targets a session not found locally, the gateway
+   * queries configured peers and relays the message to the owning gateway.
+   * Only needed in multi-gateway setups (e.g. multiple bots on different ports).
+   */
+  peers?: GatewayPeerConfig[];
   /**
    * Channel health monitor interval in minutes.
    * Periodically checks channel health and restarts unhealthy channels.

--- a/src/gateway/peer-relay.test.ts
+++ b/src/gateway/peer-relay.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolvePeers } from "./peer-relay.js";
+
+function buildConfig(peers?: Array<Record<string, unknown>>, port?: number): OpenClawConfig {
+  return {
+    gateway: {
+      port: port ?? 18789,
+      peers,
+    },
+  } as unknown as OpenClawConfig;
+}
+
+describe("resolvePeers", () => {
+  it("returns empty array when no peers configured", () => {
+    const result = resolvePeers(buildConfig());
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when peers is empty array", () => {
+    const result = resolvePeers(buildConfig([]));
+    expect(result).toEqual([]);
+  });
+
+  it("resolves valid peer entries", () => {
+    const result = resolvePeers(
+      buildConfig([
+        { url: "ws://127.0.0.1:18790", token: "tok-a", name: "kairos" },
+        { url: "ws://127.0.0.1:18791", name: "maia", agentIds: ["main"] },
+      ]),
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      url: "ws://127.0.0.1:18790",
+      token: "tok-a",
+      name: "kairos",
+      agentIds: undefined,
+    });
+    expect(result[1]).toEqual({
+      url: "ws://127.0.0.1:18791",
+      token: undefined,
+      name: "maia",
+      agentIds: ["main"],
+    });
+  });
+
+  it("skips entries without a url", () => {
+    const result = resolvePeers(
+      buildConfig([
+        { name: "no-url" },
+        { url: "", name: "empty-url" },
+        { url: "ws://127.0.0.1:18790", name: "valid" },
+      ]),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("valid");
+  });
+
+  it("skips self-referencing peers (same port on loopback)", () => {
+    const result = resolvePeers(
+      buildConfig(
+        [
+          { url: "ws://127.0.0.1:18789", name: "self" },
+          { url: "ws://localhost:18789", name: "self-localhost" },
+          { url: "ws://127.0.0.1:18790", name: "other" },
+        ],
+        18789,
+      ),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("other");
+  });
+
+  it("generates default names for unnamed peers", () => {
+    const result = resolvePeers(
+      buildConfig([{ url: "ws://127.0.0.1:18790" }, { url: "ws://127.0.0.1:18791" }]),
+    );
+    expect(result[0].name).toBe("peer-0");
+    expect(result[1].name).toBe("peer-1");
+  });
+
+  it("trims whitespace from url and token", () => {
+    const result = resolvePeers(
+      buildConfig([{ url: "  ws://127.0.0.1:18790  ", token: "  tok  ", name: "  spaced  " }]),
+    );
+    expect(result[0].url).toBe("ws://127.0.0.1:18790");
+    expect(result[0].token).toBe("tok");
+    expect(result[0].name).toBe("spaced");
+  });
+
+  it("handles non-string token gracefully", () => {
+    const result = resolvePeers(buildConfig([{ url: "ws://127.0.0.1:18790", token: 123 }]));
+    expect(result[0].token).toBeUndefined();
+  });
+
+  it("filters empty strings from agentIds", () => {
+    const result = resolvePeers(
+      buildConfig([{ url: "ws://127.0.0.1:18790", agentIds: ["main", "", "growth"] }]),
+    );
+    expect(result[0].agentIds).toEqual(["main", "growth"]);
+  });
+});

--- a/src/gateway/peer-relay.ts
+++ b/src/gateway/peer-relay.ts
@@ -1,0 +1,360 @@
+/**
+ * Gateway Peer Relay — cross-gateway session routing.
+ *
+ * When multiple openclaw gateways run on the same host (common in multi-bot setups),
+ * sessions_send can only reach sessions managed by the local gateway. This module
+ * adds a peer relay layer: when a session isn't found locally, the gateway queries
+ * configured peer gateways and relays the message to the one that owns the session.
+ *
+ * Design goals:
+ * - Zero config for single-gateway setups (no overhead when peers aren't configured).
+ * - Fail-open: if peer lookup fails, return a clear error — don't block the caller.
+ * - Minimal surface: one WebSocket round-trip per relay attempt.
+ *
+ * @module
+ */
+
+import { randomUUID } from "node:crypto";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveGatewayPort } from "../config/config.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
+import { GatewayClient } from "./client.js";
+import { PROTOCOL_VERSION } from "./protocol/index.js";
+
+/** Resolved peer entry with runtime metadata. */
+export type ResolvedPeer = {
+  url: string;
+  token?: string;
+  name: string;
+  agentIds?: string[];
+};
+
+/** Result of resolving a session across peers. */
+export type PeerResolveResult =
+  | { ok: true; peer: ResolvedPeer; key: string }
+  | { ok: false; error: string };
+
+/** Result of relaying a message to a peer gateway. */
+export type PeerRelayResult =
+  | { ok: true; peer: ResolvedPeer; runId: string; reply?: string }
+  | { ok: false; error: string };
+
+const DEFAULT_PEER_TIMEOUT_MS = 15_000;
+const RESOLVE_TIMEOUT_MS = 8_000;
+
+/**
+ * Resolve peer configurations from the gateway config.
+ * Returns an empty array when no peers are configured (zero overhead path).
+ */
+export function resolvePeers(cfg: OpenClawConfig): ResolvedPeer[] {
+  const peersConfig = cfg.gateway?.peers;
+  if (!Array.isArray(peersConfig) || peersConfig.length === 0) {
+    return [];
+  }
+
+  const localPort = resolveGatewayPort(cfg);
+  const peers: ResolvedPeer[] = [];
+
+  for (let i = 0; i < peersConfig.length; i++) {
+    const entry = peersConfig[i];
+    if (!entry || typeof entry.url !== "string" || entry.url.trim().length === 0) {
+      continue;
+    }
+
+    const url = entry.url.trim();
+
+    // Skip self-references: don't relay to ourselves.
+    if (isSelfUrl(url, localPort)) {
+      continue;
+    }
+
+    peers.push({
+      url,
+      token: typeof entry.token === "string" ? entry.token.trim() : undefined,
+      name: typeof entry.name === "string" ? entry.name.trim() : `peer-${i}`,
+      agentIds: Array.isArray(entry.agentIds) ? entry.agentIds.filter(Boolean) : undefined,
+    });
+  }
+
+  return peers;
+}
+
+/**
+ * Check if a URL points to the local gateway (self-reference detection).
+ */
+function isSelfUrl(url: string, localPort: number): boolean {
+  try {
+    const parsed = new URL(url);
+    const port = parsed.port
+      ? Number.parseInt(parsed.port, 10)
+      : parsed.protocol === "wss:"
+        ? 443
+        : 80;
+    const host = parsed.hostname;
+    const isLocalhost = host === "127.0.0.1" || host === "localhost" || host === "::1";
+    return isLocalhost && port === localPort;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Attempt to resolve a session key on a single peer gateway.
+ */
+async function resolveOnPeer(
+  peer: ResolvedPeer,
+  resolveParams: Record<string, unknown>,
+  timeoutMs: number = RESOLVE_TIMEOUT_MS,
+): Promise<{ ok: true; key: string } | { ok: false; error?: string }> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const stop = (result: { ok: true; key: string } | { ok: false; error?: string }) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const client = new GatewayClient({
+      url: peer.url,
+      token: peer.token,
+      instanceId: randomUUID(),
+      clientName: GATEWAY_CLIENT_NAMES.CLI,
+      clientDisplayName: "peer-relay",
+      clientVersion: "1.0.0",
+      mode: GATEWAY_CLIENT_MODES.CLI,
+      role: "operator",
+      scopes: ["sessions"],
+      minProtocol: PROTOCOL_VERSION,
+      maxProtocol: PROTOCOL_VERSION,
+      onHelloOk: async () => {
+        try {
+          const result = await client.request<{ key: string }>("sessions.resolve", resolveParams, {
+            expectFinal: true,
+          });
+          const key = typeof result?.key === "string" ? result.key.trim() : "";
+          if (key) {
+            stop({ ok: true, key });
+          } else {
+            stop({ ok: false });
+          }
+        } catch (err) {
+          stop({ ok: false, error: err instanceof Error ? err.message : String(err) });
+        } finally {
+          client.stop();
+        }
+      },
+      onClose: (_code, reason) => {
+        stop({ ok: false, error: reason || "connection closed" });
+      },
+    });
+
+    const timer = setTimeout(() => {
+      client.stop();
+      stop({ ok: false, error: "timeout" });
+    }, timeoutMs);
+
+    client.start();
+  });
+}
+
+/**
+ * Try to resolve a session across all configured peer gateways.
+ * Queries peers sequentially (with agentId-based filtering for efficiency).
+ *
+ * @param cfg       The openclaw config.
+ * @param params    The resolve parameters (label, agentId, key, etc.).
+ * @returns         The first peer that owns the session, or an error.
+ */
+export async function resolveSessionOnPeers(
+  cfg: OpenClawConfig,
+  params: Record<string, unknown>,
+): Promise<PeerResolveResult> {
+  const peers = resolvePeers(cfg);
+  if (peers.length === 0) {
+    return { ok: false, error: "no peers configured" };
+  }
+
+  const targetAgentId = typeof params.agentId === "string" ? params.agentId.trim() : undefined;
+
+  for (const peer of peers) {
+    // Skip peers that don't serve the target agent (when agentIds filter is set).
+    if (targetAgentId && peer.agentIds && peer.agentIds.length > 0) {
+      if (!peer.agentIds.includes(targetAgentId)) {
+        continue;
+      }
+    }
+
+    const result = await resolveOnPeer(peer, params);
+    if (result.ok) {
+      return { ok: true, peer, key: result.key };
+    }
+  }
+
+  return { ok: false, error: "session not found on any peer gateway" };
+}
+
+/**
+ * Relay an agent message to a peer gateway.
+ * Sends the message and optionally waits for a response.
+ *
+ * @param peer        The target peer gateway.
+ * @param sessionKey  The resolved session key on the peer.
+ * @param message     The message content to send.
+ * @param timeoutMs   How long to wait for the agent response (0 = fire-and-forget).
+ * @returns           The relay result with optional reply text.
+ */
+export async function relayMessageToPeer(
+  peer: ResolvedPeer,
+  sessionKey: string,
+  message: string,
+  timeoutMs: number = DEFAULT_PEER_TIMEOUT_MS,
+): Promise<PeerRelayResult> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const stop = (result: PeerRelayResult) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const idempotencyKey = randomUUID();
+
+    const client = new GatewayClient({
+      url: peer.url,
+      token: peer.token,
+      instanceId: randomUUID(),
+      clientName: GATEWAY_CLIENT_NAMES.CLI,
+      clientDisplayName: "peer-relay",
+      clientVersion: "1.0.0",
+      mode: GATEWAY_CLIENT_MODES.CLI,
+      role: "operator",
+      scopes: ["agent"],
+      minProtocol: PROTOCOL_VERSION,
+      maxProtocol: PROTOCOL_VERSION,
+      onHelloOk: async () => {
+        try {
+          // Send the message to the peer's agent endpoint.
+          const agentResult = await client.request<{ runId: string }>(
+            "agent",
+            {
+              message,
+              sessionKey,
+              idempotencyKey,
+              deliver: false,
+              channel: "internal",
+              lane: "nested",
+              inputProvenance: {
+                kind: "peer_relay",
+                sourceTool: "sessions_send",
+              },
+            },
+            { expectFinal: true },
+          );
+
+          const runId = typeof agentResult?.runId === "string" ? agentResult.runId : idempotencyKey;
+
+          if (timeoutMs === 0) {
+            stop({ ok: true, peer, runId });
+            client.stop();
+            return;
+          }
+
+          // Wait for the agent response.
+          try {
+            const waitResult = await client.request<{ status?: string; error?: string }>(
+              "agent.wait",
+              { runId, timeoutMs },
+              { expectFinal: true },
+            );
+
+            if (waitResult?.status === "timeout" || waitResult?.status === "error") {
+              stop({ ok: true, peer, runId, reply: undefined });
+              client.stop();
+              return;
+            }
+          } catch {
+            // Wait failed; we still sent the message successfully.
+            stop({ ok: true, peer, runId, reply: undefined });
+            client.stop();
+            return;
+          }
+
+          // Fetch the reply from history.
+          try {
+            const history = await client.request<{ messages: Array<unknown> }>(
+              "chat.history",
+              { sessionKey, limit: 10 },
+              { expectFinal: true },
+            );
+
+            const messages = Array.isArray(history?.messages) ? history.messages : [];
+            const lastAssistant = messages
+              .toReversed()
+              .find(
+                (m: unknown) =>
+                  typeof m === "object" &&
+                  m !== null &&
+                  (m as Record<string, unknown>).role === "assistant",
+              ) as Record<string, unknown> | undefined;
+
+            const reply = extractTextContent(lastAssistant);
+            stop({ ok: true, peer, runId, reply });
+          } catch {
+            stop({ ok: true, peer, runId, reply: undefined });
+          }
+
+          client.stop();
+        } catch (err) {
+          client.stop();
+          stop({
+            ok: false,
+            error: `relay to ${peer.name} failed: ${err instanceof Error ? err.message : String(err)}`,
+          });
+        }
+      },
+      onClose: (_code, reason) => {
+        stop({ ok: false, error: `connection to ${peer.name} closed: ${reason || "unknown"}` });
+      },
+    });
+
+    const timer = setTimeout(() => {
+      client.stop();
+      stop({ ok: false, error: `relay to ${peer.name} timed out after ${timeoutMs}ms` });
+    }, timeoutMs + 5_000); // Extra buffer for connection setup.
+
+    client.start();
+  });
+}
+
+/**
+ * Extract text content from an assistant message object.
+ */
+function extractTextContent(message: Record<string, unknown> | undefined): string | undefined {
+  if (!message) {
+    return undefined;
+  }
+
+  const content = message.content;
+  if (typeof content === "string") {
+    return content.trim() || undefined;
+  }
+  if (Array.isArray(content)) {
+    const textParts = content
+      .filter(
+        (part: unknown) =>
+          typeof part === "object" &&
+          part !== null &&
+          (part as Record<string, unknown>).type === "text",
+      )
+      .map((part: unknown) => (part as Record<string, string>).text || "")
+      .join("\n");
+    return textParts.trim() || undefined;
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

When multiple openclaw gateways run on the same host (common in multi-bot setups), `sessions_send` can only reach sessions managed by the local gateway. This adds a peer relay layer: when a session isn't found locally, the gateway queries configured peers and relays the message to the owning gateway.

## New Config Option
```json
"gateway": {
  "peers": [
    { "url": "ws://127.0.0.1:18790", "token": "peer-token", "name": "kairos" },
    { "url": "ws://127.0.0.1:18791", "name": "maia", "agentIds": ["main"] }
  ]
}
```

## Design & Safety
- **Zero overhead** when no peers are configured (empty array fast path).
- **Self-reference detection** (skips peers pointing at the local port).
- **Agent ID filtering** for efficient routing in large setups.
- **Fail-open**: peer lookup failures return clear errors, never block.
- **Security**: Sandboxed sessions are never relayed (security boundary preserved).

## Context
This provides the underlying cross-gateway routing required to enable multi-agent team coordination across different ports/processes.

Relates to / partially addresses #10010 (Agent Teams - Parallel Agent Coordination).