### PR TITLE
fix(doctor): verify Telegram privacy-mode warning using API probe state

### DIFF
--- a/src/channels/plugins/status-issues/telegram.ts
+++ b/src/channels/plugins/status-issues/telegram.ts
@@ -122,11 +122,15 @@ export function collectTelegramStatusIssues(
           canReadAllGroupMessages === false
             ? "Telegram Bot API privacy mode is enabled for this bot"
             : "Telegram Bot API privacy mode could not be confirmed from API probe";
+        const impactText =
+          canReadAllGroupMessages === false
+            ? "Telegram Bot API will block most group messages unless privacy mode is disabled."
+            : "Telegram Bot API may block most group messages unless privacy mode is disabled.";
         issues.push({
           channel: "telegram",
           accountId,
           kind: "config",
-          message: `Config allows unmentioned group messages (requireMention=false). ${modeHint}, so Telegram Bot API may block most group messages unless privacy mode is disabled.`,
+          message: `Config allows unmentioned group messages (requireMention=false). ${modeHint}, ${impactText}`,
           fix: "In BotFather run /setprivacy → Disable for this bot (then restart the gateway).",
         });
       }

--- a/src/channels/plugins/status-issues/telegram.ts
+++ b/src/channels/plugins/status-issues/telegram.ts
@@ -6,11 +6,18 @@ import {
   resolveEnabledConfiguredAccountId,
 } from "./shared.js";
 
+type TelegramProbeSummary = {
+  bot?: {
+    canReadAllGroupMessages?: boolean | null;
+  };
+};
+
 type TelegramAccountStatus = {
   accountId?: unknown;
   enabled?: unknown;
   configured?: unknown;
   allowUnmentionedGroups?: unknown;
+  probe?: unknown;
   audit?: unknown;
 };
 
@@ -36,7 +43,23 @@ function readTelegramAccountStatus(value: ChannelAccountSnapshot): TelegramAccou
     enabled: value.enabled,
     configured: value.configured,
     allowUnmentionedGroups: value.allowUnmentionedGroups,
+    probe: value.probe,
     audit: value.audit,
+  };
+}
+
+function readTelegramProbeSummary(value: unknown): TelegramProbeSummary {
+  if (!isRecord(value)) {
+    return {};
+  }
+  const bot = isRecord(value.bot) ? value.bot : undefined;
+  const canReadAllGroupMessagesRaw = bot?.canReadAllGroupMessages;
+  const canReadAllGroupMessages =
+    typeof canReadAllGroupMessagesRaw === "boolean" ? canReadAllGroupMessagesRaw : null;
+  return {
+    bot: {
+      canReadAllGroupMessages,
+    },
   };
 }
 
@@ -92,14 +115,21 @@ export function collectTelegramStatusIssues(
     }
 
     if (account.allowUnmentionedGroups === true) {
-      issues.push({
-        channel: "telegram",
-        accountId,
-        kind: "config",
-        message:
-          "Config allows unmentioned group messages (requireMention=false). Telegram Bot API privacy mode will block most group messages unless disabled.",
-        fix: "In BotFather run /setprivacy → Disable for this bot (then restart the gateway).",
-      });
+      const probe = readTelegramProbeSummary(account.probe);
+      const canReadAllGroupMessages = probe.bot?.canReadAllGroupMessages;
+      if (canReadAllGroupMessages !== true) {
+        const modeHint =
+          canReadAllGroupMessages === false
+            ? "Telegram Bot API privacy mode is enabled for this bot"
+            : "Telegram Bot API privacy mode could not be confirmed from API probe";
+        issues.push({
+          channel: "telegram",
+          accountId,
+          kind: "config",
+          message: `Config allows unmentioned group messages (requireMention=false). ${modeHint}, so Telegram Bot API may block most group messages unless privacy mode is disabled.`,
+          fix: "In BotFather run /setprivacy → Disable for this bot (then restart the gateway).",
+        });
+      }
     }
 
     const audit = readTelegramGroupMembershipAuditSummary(account.audit);

--- a/src/commands/channels.adds-non-default-telegram-account.test.ts
+++ b/src/commands/channels.adds-non-default-telegram-account.test.ts
@@ -489,6 +489,36 @@ describe("channels command", () => {
     expect(joined).toMatch(/bot:@openclaw_bot/);
   });
 
+  it("suppresses privacy-mode warning when probe confirms canReadAllGroupMessages", () => {
+    const joined = formatChannelStatusJoined({
+      telegram: [
+        {
+          accountId: "default",
+          enabled: true,
+          configured: true,
+          allowUnmentionedGroups: true,
+          probe: { ok: true, bot: { canReadAllGroupMessages: true } },
+        },
+      ],
+    });
+    expect(joined).not.toMatch(/privacy mode/i);
+  });
+
+  it("surfaces explicit privacy-mode enabled warning when probe confirms false", () => {
+    const joined = formatChannelStatusJoined({
+      telegram: [
+        {
+          accountId: "default",
+          enabled: true,
+          configured: true,
+          allowUnmentionedGroups: true,
+          probe: { ok: true, bot: { canReadAllGroupMessages: false } },
+        },
+      ],
+    });
+    expect(joined).toMatch(/Telegram Bot API privacy mode is enabled/i);
+  });
+
   it("surfaces Telegram group membership audit issues in channels status output", () => {
     const joined = formatChannelStatusJoined({
       telegram: [


### PR DESCRIPTION
## Summary
- address #34063 by using Telegram probe API state (`bot.canReadAllGroupMessages`) in doctor/channel warnings
- only show the privacy-mode warning when unmentioned group delivery is enabled **and** probe does not confirm read-all access
- keep warning text explicit when probe confirms privacy mode is enabled

## Why
Current doctor output warns purely from config (`allowUnmentionedGroups=true`) and can produce false positives. The probe already fetches `getMe` and exposes `canReadAllGroupMessages`, so doctor should use that signal.

## Changes
- `src/channels/plugins/status-issues/telegram.ts`
  - parse Telegram probe payload
  - gate privacy warning based on `probe.bot.canReadAllGroupMessages`
  - skip warning when probe confirms read-all group messages is enabled
- `src/commands/channels.adds-non-default-telegram-account.test.ts`
  - add test: warning suppressed when probe confirms `canReadAllGroupMessages=true`
  - add test: explicit warning when probe confirms `false`

## Validation
- `corepack pnpm vitest run src/commands/channels.adds-non-default-telegram-account.test.ts`
