### PR TITLE
fix: Feishu group @mention bot-by-name detection

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -216,8 +216,12 @@ function parseMessageContent(content: string, messageType: string): string {
 function checkBotMentioned(event: FeishuMessageEvent, botOpenId?: string): boolean {
   const mentions = event.message.mentions ?? [];
   if (mentions.length === 0) return false;
-  if (!botOpenId) return false;
-  return mentions.some((m) => m.id.open_id === botOpenId);
+  return mentions.some((m) => {
+    const mentionIds = [m.id.open_id, m.id.user_id].filter(Boolean);
+    if (mentionIds.includes("all")) return true;
+    if (!botOpenId) return false;
+    return mentionIds.includes(botOpenId);
+  });
 }
 
 function stripBotMention(

--- a/extensions/feishu/src/mention.ts
+++ b/extensions/feishu/src/mention.ts
@@ -17,11 +17,13 @@ export function extractMentionTargets(
   botOpenId?: string,
 ): MentionTarget[] {
   const mentions = event.message.mentions ?? [];
+  const isBotMention = (m: (typeof mentions)[number]) =>
+    !!botOpenId && [m.id.open_id, m.id.user_id].includes(botOpenId);
 
   return mentions
     .filter((m) => {
       // Exclude the bot itself
-      if (botOpenId && m.id.open_id === botOpenId) {
+      if (isBotMention(m)) {
         return false;
       }
       // Must have open_id
@@ -45,16 +47,18 @@ export function isMentionForwardRequest(event: FeishuMessageEvent, botOpenId?: s
   if (mentions.length === 0) {
     return false;
   }
+  const isBotMention = (m: (typeof mentions)[number]) =>
+    !!botOpenId && [m.id.open_id, m.id.user_id].includes(botOpenId);
 
   const isDirectMessage = event.message.chat_type === "p2p";
-  const hasOtherMention = mentions.some((m) => m.id.open_id !== botOpenId);
+  const hasOtherMention = mentions.some((m) => !!m.id.open_id && !isBotMention(m));
 
   if (isDirectMessage) {
     // DM: trigger if any non-bot user is mentioned
     return hasOtherMention;
   } else {
     // Group: need to mention both bot and other users
-    const hasBotMention = mentions.some((m) => m.id.open_id === botOpenId);
+    const hasBotMention = mentions.some((m) => isBotMention(m));
     return hasBotMention && hasOtherMention;
   }
 }


### PR DESCRIPTION
Closes #34271

## Problem
Feishu group mention parsing only compared mentions id open_id with bot identity, which missed valid bot mentions when user_id was present and could misclassify mention-forward detection when bot id was unavailable.

## Fix
Normalize bot mention matching to check both open_id and user_id, keep @all as explicit mention, and reuse the same normalized check in forward-request target extraction to avoid conflicting mention decisions.
