### PR TITLE
fix(telegram): resolve  botToken references

### DIFF
--- a/src/telegram/token.test.ts
+++ b/src/telegram/token.test.ts
@@ -58,6 +58,32 @@ describe("resolveTelegramToken", () => {
     expect(res.source).toBe("config");
   });
 
+  it("resolves top-level $ENV botToken from environment", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN_REF", "resolved-env-token");
+    const cfg = {
+      channels: { telegram: { botToken: "$TELEGRAM_BOT_TOKEN_REF" } },
+    } as OpenClawConfig;
+    const res = resolveTelegramToken(cfg);
+    expect(res.token).toBe("resolved-env-token");
+    expect(res.source).toBe("config");
+  });
+
+  it("resolves account-level $ENV botToken from environment", () => {
+    vi.stubEnv("TELEGRAM_WORK_BOT_TOKEN_REF", "resolved-work-token");
+    const cfg = {
+      channels: {
+        telegram: {
+          accounts: {
+            work: { botToken: "$TELEGRAM_WORK_BOT_TOKEN_REF" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const res = resolveTelegramToken(cfg, { accountId: "work" });
+    expect(res.token).toBe("resolved-work-token");
+    expect(res.source).toBe("config");
+  });
+
   it("does not fall back to config when tokenFile is missing", () => {
     vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
     const dir = withTempDir();

--- a/src/telegram/token.test.ts
+++ b/src/telegram/token.test.ts
@@ -84,6 +84,34 @@ describe("resolveTelegramToken", () => {
     expect(res.source).toBe("config");
   });
 
+  it("falls back to TELEGRAM_BOT_TOKEN when top-level $ENV botToken is unresolved", () => {
+    vi.stubEnv("TELEGRAM_BOT_TOKEN_REF", "");
+    vi.stubEnv("TELEGRAM_BOT_TOKEN", "fallback-env-token");
+    const cfg = {
+      channels: { telegram: { botToken: "$TELEGRAM_BOT_TOKEN_REF" } },
+    } as OpenClawConfig;
+    const res = resolveTelegramToken(cfg);
+    expect(res.token).toBe("fallback-env-token");
+    expect(res.source).toBe("env");
+  });
+
+  it("falls back to top-level token for account when account $ENV botToken is unresolved", () => {
+    vi.stubEnv("TELEGRAM_WORK_BOT_TOKEN_REF", "");
+    const cfg = {
+      channels: {
+        telegram: {
+          botToken: "top-level-token",
+          accounts: {
+            work: { botToken: "$TELEGRAM_WORK_BOT_TOKEN_REF" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const res = resolveTelegramToken(cfg, { accountId: "work" });
+    expect(res.token).toBe("top-level-token");
+    expect(res.source).toBe("config");
+  });
+
   it("does not fall back to config when tokenFile is missing", () => {
     vi.stubEnv("TELEGRAM_BOT_TOKEN", "");
     const dir = withTempDir();

--- a/src/telegram/token.ts
+++ b/src/telegram/token.ts
@@ -17,6 +17,18 @@ type ResolveTelegramTokenOpts = {
   logMissingFile?: (message: string) => void;
 };
 
+function resolveDollarEnvRef(rawToken: string | undefined, env: NodeJS.ProcessEnv): string | undefined {
+  if (!rawToken) {
+    return undefined;
+  }
+  const match = /^\$([A-Z][A-Z0-9_]*)$/.exec(rawToken.trim());
+  if (!match) {
+    return rawToken;
+  }
+  const resolved = env[match[1]]?.trim();
+  return resolved && resolved.length > 0 ? resolved : rawToken;
+}
+
 export function resolveTelegramToken(
   cfg?: OpenClawConfig,
   opts: ResolveTelegramTokenOpts = {},
@@ -70,8 +82,9 @@ export function resolveTelegramToken(
     value: accountCfg?.botToken,
     path: `channels.telegram.accounts.${accountId}.botToken`,
   });
-  if (accountToken) {
-    return { token: accountToken, source: "config" };
+  const resolvedAccountToken = resolveDollarEnvRef(accountToken, process.env);
+  if (resolvedAccountToken) {
+    return { token: resolvedAccountToken, source: "config" };
   }
 
   const allowEnv = accountId === DEFAULT_ACCOUNT_ID;
@@ -96,8 +109,9 @@ export function resolveTelegramToken(
     value: telegramCfg?.botToken,
     path: "channels.telegram.botToken",
   });
-  if (configToken) {
-    return { token: configToken, source: "config" };
+  const resolvedConfigToken = resolveDollarEnvRef(configToken, process.env);
+  if (resolvedConfigToken) {
+    return { token: resolvedConfigToken, source: "config" };
   }
 
   const envToken = allowEnv ? (opts.envToken ?? process.env.TELEGRAM_BOT_TOKEN)?.trim() : "";

--- a/src/telegram/token.ts
+++ b/src/telegram/token.ts
@@ -17,7 +17,10 @@ type ResolveTelegramTokenOpts = {
   logMissingFile?: (message: string) => void;
 };
 
-function resolveDollarEnvRef(rawToken: string | undefined, env: NodeJS.ProcessEnv): string | undefined {
+function resolveDollarEnvRef(
+  rawToken: string | undefined,
+  env: NodeJS.ProcessEnv,
+): string | undefined {
   if (!rawToken) {
     return undefined;
   }

--- a/src/telegram/token.ts
+++ b/src/telegram/token.ts
@@ -26,7 +26,9 @@ function resolveDollarEnvRef(rawToken: string | undefined, env: NodeJS.ProcessEn
     return rawToken;
   }
   const resolved = env[match[1]]?.trim();
-  return resolved && resolved.length > 0 ? resolved : rawToken;
+  // Missing env refs should continue fallback resolution instead of using the
+  // literal "$VAR" token (which causes Telegram 404s).
+  return resolved && resolved.length > 0 ? resolved : undefined;
 }
 
 export function resolveTelegramToken(


### PR DESCRIPTION
## Summary
Fixes #34247.

Telegram channel startup failed with repeated `404 Not Found` when `channels.telegram.botToken` (or account-level `botToken`) was configured as a `$VARIABLE` string. The runtime passed the literal `$VARIABLE` to Telegram instead of resolving it from environment variables.

## What changed
- Added `$ENV_VAR` resolution for Telegram bot tokens in runtime token selection:
  - `channels.telegram.botToken`
  - `channels.telegram.accounts.<id>.botToken`
- Resolution behavior:
  - If token is in `$VAR` form and `VAR` exists in env, use env value.
  - Otherwise keep existing token behavior unchanged.

## Files
- `src/telegram/token.ts`
- `src/telegram/token.test.ts`

## Tests
Added regression coverage for:
- top-level `$ENV` token resolution
- account-level `$ENV` token resolution

## Risk
Low, small scope:
- Telegram token resolution path only
- no schema changes
- no changes to non-Telegram providers