### PR TITLE
fix: use msg_type=media for Feishu mp4 attachments

### DIFF
--- a/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/macos/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1322,6 +1322,7 @@ public struct SessionsPatchParams: Codable, Sendable {
     public let key: String
     public let label: AnyCodable?
     public let thinkinglevel: AnyCodable?
+    public let fastmode: AnyCodable?
     public let verboselevel: AnyCodable?
     public let reasoninglevel: AnyCodable?
     public let responseusage: AnyCodable?
@@ -1343,6 +1344,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         key: String,
         label: AnyCodable?,
         thinkinglevel: AnyCodable?,
+        fastmode: AnyCodable?,
         verboselevel: AnyCodable?,
         reasoninglevel: AnyCodable?,
         responseusage: AnyCodable?,
@@ -1363,6 +1365,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         self.key = key
         self.label = label
         self.thinkinglevel = thinkinglevel
+        self.fastmode = fastmode
         self.verboselevel = verboselevel
         self.reasoninglevel = reasoninglevel
         self.responseusage = responseusage
@@ -1385,6 +1388,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         case key
         case label
         case thinkinglevel = "thinkingLevel"
+        case fastmode = "fastMode"
         case verboselevel = "verboseLevel"
         case reasoninglevel = "reasoningLevel"
         case responseusage = "responseUsage"

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -1322,6 +1322,7 @@ public struct SessionsPatchParams: Codable, Sendable {
     public let key: String
     public let label: AnyCodable?
     public let thinkinglevel: AnyCodable?
+    public let fastmode: AnyCodable?
     public let verboselevel: AnyCodable?
     public let reasoninglevel: AnyCodable?
     public let responseusage: AnyCodable?
@@ -1343,6 +1344,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         key: String,
         label: AnyCodable?,
         thinkinglevel: AnyCodable?,
+        fastmode: AnyCodable?,
         verboselevel: AnyCodable?,
         reasoninglevel: AnyCodable?,
         responseusage: AnyCodable?,
@@ -1363,6 +1365,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         self.key = key
         self.label = label
         self.thinkinglevel = thinkinglevel
+        self.fastmode = fastmode
         self.verboselevel = verboselevel
         self.reasoninglevel = reasoninglevel
         self.responseusage = responseusage
@@ -1385,6 +1388,7 @@ public struct SessionsPatchParams: Codable, Sendable {
         case key
         case label
         case thinkinglevel = "thinkingLevel"
+        case fastmode = "fastMode"
         case verboselevel = "verboseLevel"
         case reasoninglevel = "reasoningLevel"
         case responseusage = "responseUsage"

--- a/dist/protocol.schema.json
+++ b/dist/protocol.schema.json
@@ -1,0 +1,8822 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://openclaw.ai/protocol.schema.json",
+  "title": "OpenClaw Gateway Protocol",
+  "description": "Handshake, request/response, and event frames for the Gateway WebSocket.",
+  "oneOf": [
+    {
+      "$ref": "#/definitions/RequestFrame"
+    },
+    {
+      "$ref": "#/definitions/ResponseFrame"
+    },
+    {
+      "$ref": "#/definitions/EventFrame"
+    }
+  ],
+  "discriminator": {
+    "propertyName": "type",
+    "mapping": {
+      "req": "#/definitions/RequestFrame",
+      "res": "#/definitions/ResponseFrame",
+      "event": "#/definitions/EventFrame"
+    }
+  },
+  "definitions": {
+    "ConnectParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "minProtocol",
+        "maxProtocol",
+        "client"
+      ],
+      "properties": {
+        "minProtocol": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "maxProtocol": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "client": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "id",
+            "version",
+            "platform",
+            "mode"
+          ],
+          "properties": {
+            "id": {
+              "anyOf": [
+                {
+                  "const": "webchat-ui",
+                  "type": "string"
+                },
+                {
+                  "const": "openclaw-control-ui",
+                  "type": "string"
+                },
+                {
+                  "const": "webchat",
+                  "type": "string"
+                },
+                {
+                  "const": "cli",
+                  "type": "string"
+                },
+                {
+                  "const": "gateway-client",
+                  "type": "string"
+                },
+                {
+                  "const": "openclaw-macos",
+                  "type": "string"
+                },
+                {
+                  "const": "openclaw-ios",
+                  "type": "string"
+                },
+                {
+                  "const": "openclaw-android",
+                  "type": "string"
+                },
+                {
+                  "const": "node-host",
+                  "type": "string"
+                },
+                {
+                  "const": "test",
+                  "type": "string"
+                },
+                {
+                  "const": "fingerprint",
+                  "type": "string"
+                },
+                {
+                  "const": "openclaw-probe",
+                  "type": "string"
+                }
+              ]
+            },
+            "displayName": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "version": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "platform": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "deviceFamily": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "modelIdentifier": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "mode": {
+              "anyOf": [
+                {
+                  "const": "webchat",
+                  "type": "string"
+                },
+                {
+                  "const": "cli",
+                  "type": "string"
+                },
+                {
+                  "const": "ui",
+                  "type": "string"
+                },
+                {
+                  "const": "backend",
+                  "type": "string"
+                },
+                {
+                  "const": "node",
+                  "type": "string"
+                },
+                {
+                  "const": "probe",
+                  "type": "string"
+                },
+                {
+                  "const": "test",
+                  "type": "string"
+                }
+              ]
+            },
+            "instanceId": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        },
+        "caps": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "commands": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "permissions": {
+          "type": "object",
+          "patternProperties": {
+            "^(.*)$": {
+              "type": "boolean"
+            }
+          }
+        },
+        "pathEnv": {
+          "type": "string"
+        },
+        "role": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "device": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "id",
+            "publicKey",
+            "signature",
+            "signedAt",
+            "nonce"
+          ],
+          "properties": {
+            "id": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "publicKey": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "signature": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "signedAt": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "nonce": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        },
+        "auth": {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "token": {
+              "type": "string"
+            },
+            "bootstrapToken": {
+              "type": "string"
+            },
+            "deviceToken": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            }
+          }
+        },
+        "locale": {
+          "type": "string"
+        },
+        "userAgent": {
+          "type": "string"
+        }
+      }
+    },
+    "HelloOk": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type",
+        "protocol",
+        "server",
+        "features",
+        "snapshot",
+        "policy"
+      ],
+      "properties": {
+        "type": {
+          "const": "hello-ok",
+          "type": "string"
+        },
+        "protocol": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "server": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "version",
+            "connId"
+          ],
+          "properties": {
+            "version": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "connId": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        },
+        "features": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "methods",
+            "events"
+          ],
+          "properties": {
+            "methods": {
+              "type": "array",
+              "items": {
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "events": {
+              "type": "array",
+              "items": {
+                "minLength": 1,
+                "type": "string"
+              }
+            }
+          }
+        },
+        "snapshot": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "presence",
+            "health",
+            "stateVersion",
+            "uptimeMs"
+          ],
+          "properties": {
+            "presence": {
+              "type": "array",
+              "items": {
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                  "ts"
+                ],
+                "properties": {
+                  "host": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "ip": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "version": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "platform": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "deviceFamily": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "modelIdentifier": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "mode": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "lastInputSeconds": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "reason": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "text": {
+                    "type": "string"
+                  },
+                  "ts": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "deviceId": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "roles": {
+                    "type": "array",
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "scopes": {
+                    "type": "array",
+                    "items": {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  },
+                  "instanceId": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "health": {},
+            "stateVersion": {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "presence",
+                "health"
+              ],
+              "properties": {
+                "presence": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "health": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              }
+            },
+            "uptimeMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "configPath": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "stateDir": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "sessionDefaults": {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "defaultAgentId",
+                "mainKey",
+                "mainSessionKey"
+              ],
+              "properties": {
+                "defaultAgentId": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "mainKey": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "mainSessionKey": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "scope": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              }
+            },
+            "authMode": {
+              "anyOf": [
+                {
+                  "const": "none",
+                  "type": "string"
+                },
+                {
+                  "const": "token",
+                  "type": "string"
+                },
+                {
+                  "const": "password",
+                  "type": "string"
+                },
+                {
+                  "const": "trusted-proxy",
+                  "type": "string"
+                }
+              ]
+            },
+            "updateAvailable": {
+              "type": "object",
+              "required": [
+                "currentVersion",
+                "latestVersion",
+                "channel"
+              ],
+              "properties": {
+                "currentVersion": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "latestVersion": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "channel": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "canvasHostUrl": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "auth": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "deviceToken",
+            "role",
+            "scopes"
+          ],
+          "properties": {
+            "deviceToken": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "role": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "scopes": {
+              "type": "array",
+              "items": {
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "issuedAtMs": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        },
+        "policy": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "maxPayload",
+            "maxBufferedBytes",
+            "tickIntervalMs"
+          ],
+          "properties": {
+            "maxPayload": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "maxBufferedBytes": {
+              "minimum": 1,
+              "type": "integer"
+            },
+            "tickIntervalMs": {
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
+    "RequestFrame": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type",
+        "id",
+        "method"
+      ],
+      "properties": {
+        "type": {
+          "const": "req",
+          "type": "string"
+        },
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "method": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "params": {}
+      }
+    },
+    "ResponseFrame": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type",
+        "id",
+        "ok"
+      ],
+      "properties": {
+        "type": {
+          "const": "res",
+          "type": "string"
+        },
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "ok": {
+          "type": "boolean"
+        },
+        "payload": {},
+        "error": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "code",
+            "message"
+          ],
+          "properties": {
+            "code": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "message": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "details": {},
+            "retryable": {
+              "type": "boolean"
+            },
+            "retryAfterMs": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
+    "EventFrame": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "type",
+        "event"
+      ],
+      "properties": {
+        "type": {
+          "const": "event",
+          "type": "string"
+        },
+        "event": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "payload": {},
+        "seq": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "stateVersion": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "presence",
+            "health"
+          ],
+          "properties": {
+            "presence": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "health": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
+    "GatewayFrame": {
+      "discriminator": "type",
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "type",
+            "id",
+            "method"
+          ],
+          "properties": {
+            "type": {
+              "const": "req",
+              "type": "string"
+            },
+            "id": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "method": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "params": {}
+          }
+        },
+        {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "type",
+            "id",
+            "ok"
+          ],
+          "properties": {
+            "type": {
+              "const": "res",
+              "type": "string"
+            },
+            "id": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "ok": {
+              "type": "boolean"
+            },
+            "payload": {},
+            "error": {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "code",
+                "message"
+              ],
+              "properties": {
+                "code": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "message": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "details": {},
+                "retryable": {
+                  "type": "boolean"
+                },
+                "retryAfterMs": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "type",
+            "event"
+          ],
+          "properties": {
+            "type": {
+              "const": "event",
+              "type": "string"
+            },
+            "event": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "payload": {},
+            "seq": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "stateVersion": {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "presence",
+                "health"
+              ],
+              "properties": {
+                "presence": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "health": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "PresenceEntry": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ts"
+      ],
+      "properties": {
+        "host": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "ip": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "version": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "platform": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "deviceFamily": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "modelIdentifier": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "mode": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "lastInputSeconds": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "reason": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "text": {
+          "type": "string"
+        },
+        "ts": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "deviceId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "instanceId": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "StateVersion": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "presence",
+        "health"
+      ],
+      "properties": {
+        "presence": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "health": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      }
+    },
+    "Snapshot": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "presence",
+        "health",
+        "stateVersion",
+        "uptimeMs"
+      ],
+      "properties": {
+        "presence": {
+          "type": "array",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "ts"
+            ],
+            "properties": {
+              "host": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "ip": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "version": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "platform": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "deviceFamily": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "modelIdentifier": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "mode": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "lastInputSeconds": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "reason": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "text": {
+                "type": "string"
+              },
+              "ts": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "deviceId": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "roles": {
+                "type": "array",
+                "items": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "scopes": {
+                "type": "array",
+                "items": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "instanceId": {
+                "minLength": 1,
+                "type": "string"
+              }
+            }
+          }
+        },
+        "health": {},
+        "stateVersion": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "presence",
+            "health"
+          ],
+          "properties": {
+            "presence": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "health": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        },
+        "uptimeMs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "configPath": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "stateDir": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "sessionDefaults": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "defaultAgentId",
+            "mainKey",
+            "mainSessionKey"
+          ],
+          "properties": {
+            "defaultAgentId": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "mainKey": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "mainSessionKey": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "scope": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        },
+        "authMode": {
+          "anyOf": [
+            {
+              "const": "none",
+              "type": "string"
+            },
+            {
+              "const": "token",
+              "type": "string"
+            },
+            {
+              "const": "password",
+              "type": "string"
+            },
+            {
+              "const": "trusted-proxy",
+              "type": "string"
+            }
+          ]
+        },
+        "updateAvailable": {
+          "type": "object",
+          "required": [
+            "currentVersion",
+            "latestVersion",
+            "channel"
+          ],
+          "properties": {
+            "currentVersion": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "latestVersion": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "channel": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "ErrorShape": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "message": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "details": {},
+        "retryable": {
+          "type": "boolean"
+        },
+        "retryAfterMs": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      }
+    },
+    "AgentEvent": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "runId",
+        "seq",
+        "stream",
+        "ts",
+        "data"
+      ],
+      "properties": {
+        "runId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "seq": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "stream": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "ts": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "data": {
+          "type": "object",
+          "patternProperties": {
+            "^(.*)$": {}
+          }
+        }
+      }
+    },
+    "SendParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "to",
+        "idempotencyKey"
+      ],
+      "properties": {
+        "to": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "mediaUrl": {
+          "type": "string"
+        },
+        "mediaUrls": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "gifPlayback": {
+          "type": "boolean"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "agentId": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "sessionKey": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "PollParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "to",
+        "question",
+        "options",
+        "idempotencyKey"
+      ],
+      "properties": {
+        "to": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "question": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "options": {
+          "minItems": 2,
+          "maxItems": 12,
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "maxSelections": {
+          "minimum": 1,
+          "maximum": 12,
+          "type": "integer"
+        },
+        "durationSeconds": {
+          "minimum": 1,
+          "maximum": 604800,
+          "type": "integer"
+        },
+        "durationHours": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "silent": {
+          "type": "boolean"
+        },
+        "isAnonymous": {
+          "type": "boolean"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "AgentParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "message",
+        "idempotencyKey"
+      ],
+      "properties": {
+        "message": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "to": {
+          "type": "string"
+        },
+        "replyTo": {
+          "type": "string"
+        },
+        "sessionId": {
+          "type": "string"
+        },
+        "sessionKey": {
+          "type": "string"
+        },
+        "thinking": {
+          "type": "string"
+        },
+        "deliver": {
+          "type": "boolean"
+        },
+        "attachments": {
+          "type": "array",
+          "items": {}
+        },
+        "channel": {
+          "type": "string"
+        },
+        "replyChannel": {
+          "type": "string"
+        },
+        "accountId": {
+          "type": "string"
+        },
+        "replyAccountId": {
+          "type": "string"
+        },
+        "threadId": {
+          "type": "string"
+        },
+        "groupId": {
+          "type": "string"
+        },
+        "groupChannel": {
+          "type": "string"
+        },
+        "groupSpace": {
+          "type": "string"
+        },
+        "timeout": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "bestEffortDeliver": {
+          "type": "boolean"
+        },
+        "lane": {
+          "type": "string"
+        },
+        "extraSystemPrompt": {
+          "type": "string"
+        },
+        "internalEvents": {
+          "type": "array",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "type",
+              "source",
+              "childSessionKey",
+              "announceType",
+              "taskLabel",
+              "status",
+              "statusLabel",
+              "result",
+              "replyInstruction"
+            ],
+            "properties": {
+              "type": {
+                "const": "task_completion",
+                "type": "string"
+              },
+              "source": {
+                "enum": [
+                  "subagent",
+                  "cron"
+                ],
+                "type": "string"
+              },
+              "childSessionKey": {
+                "type": "string"
+              },
+              "childSessionId": {
+                "type": "string"
+              },
+              "announceType": {
+                "type": "string"
+              },
+              "taskLabel": {
+                "type": "string"
+              },
+              "status": {
+                "enum": [
+                  "ok",
+                  "timeout",
+                  "error",
+                  "unknown"
+                ],
+                "type": "string"
+              },
+              "statusLabel": {
+                "type": "string"
+              },
+              "result": {
+                "type": "string"
+              },
+              "statsLine": {
+                "type": "string"
+              },
+              "replyInstruction": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "inputProvenance": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "enum": [
+                "external_user",
+                "inter_session",
+                "internal_system"
+              ],
+              "type": "string"
+            },
+            "originSessionId": {
+              "type": "string"
+            },
+            "sourceSessionKey": {
+              "type": "string"
+            },
+            "sourceChannel": {
+              "type": "string"
+            },
+            "sourceTool": {
+              "type": "string"
+            }
+          }
+        },
+        "idempotencyKey": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "label": {
+          "minLength": 1,
+          "maxLength": 64,
+          "type": "string"
+        }
+      }
+    },
+    "AgentIdentityParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "sessionKey": {
+          "type": "string"
+        }
+      }
+    },
+    "AgentIdentityResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "agentId"
+      ],
+      "properties": {
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "avatar": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "emoji": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "AgentWaitParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "runId"
+      ],
+      "properties": {
+        "runId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "timeoutMs": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      }
+    },
+    "WakeParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "mode",
+        "text"
+      ],
+      "properties": {
+        "mode": {
+          "anyOf": [
+            {
+              "const": "now",
+              "type": "string"
+            },
+            {
+              "const": "next-heartbeat",
+              "type": "string"
+            }
+          ]
+        },
+        "text": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "NodePairRequestParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "nodeId"
+      ],
+      "properties": {
+        "nodeId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "displayName": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "platform": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "version": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "coreVersion": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "uiVersion": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "deviceFamily": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "modelIdentifier": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "caps": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "commands": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "remoteIp": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "silent": {
+          "type": "boolean"
+        }
+      }
+    },
+    "NodePairListParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {}
+    },
+    "NodePairApproveParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "requestId"
+      ],
+      "properties": {
+        "requestId": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "NodePairRejectParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "requestId"
+      ],
+      "properties": {
+        "requestId": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "NodePairVerifyParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "nodeId",
+        "token"
+      ],
+      "properties": {
+        "nodeId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "token": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "NodeRenameParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "nodeId",
+        "displayName"
+      ],
+      "properties": {
+        "nodeId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "displayName": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "NodeListParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {}
+    },
+    "NodePendingAckParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ids"
+      ],
+      "properties": {
+        "ids": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      }
+    },
+    "NodeDescribeParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "nodeId"
+      ],
+      "properties": {
+        "nodeId": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "NodeInvokeParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "nodeId",
+        "command",
+        "idempotencyKey"
+      ],
+      "properties": {
+        "nodeId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "command": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "params": {},
+        "timeoutMs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "idempotencyKey": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "NodeInvokeResultParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "nodeId",
+        "ok"
+      ],
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "nodeId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "ok": {
+          "type": "boolean"
+        },
+        "payload": {},
+        "payloadJSON": {
+          "type": "string"
+        },
+        "error": {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "code": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "message": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "NodeEventParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "event"
+      ],
+      "properties": {
+        "event": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "payload": {},
+        "payloadJSON": {
+          "type": "string"
+        }
+      }
+    },
+    "NodePendingDrainParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "maxItems": {
+          "minimum": 1,
+          "maximum": 10,
+          "type": "integer"
+        }
+      }
+    },
+    "NodePendingDrainResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "nodeId",
+        "revision",
+        "items",
+        "hasMore"
+      ],
+      "properties": {
+        "nodeId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "revision": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "id",
+              "type",
+              "priority",
+              "createdAtMs"
+            ],
+            "properties": {
+              "id": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "status.request",
+                  "location.request"
+                ],
+                "type": "string"
+              },
+              "priority": {
+                "enum": [
+                  "default",
+                  "normal",
+                  "high"
+                ],
+                "type": "string"
+              },
+              "createdAtMs": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "expiresAtMs": {
+                "anyOf": [
+                  {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "payload": {
+                "type": "object",
+                "patternProperties": {
+                  "^(.*)$": {}
+                }
+              }
+            }
+          }
+        },
+        "hasMore": {
+          "type": "boolean"
+        }
+      }
+    },
+    "NodePendingEnqueueParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "nodeId",
+        "type"
+      ],
+      "properties": {
+        "nodeId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "status.request",
+            "location.request"
+          ],
+          "type": "string"
+        },
+        "priority": {
+          "enum": [
+            "normal",
+            "high"
+          ],
+          "type": "string"
+        },
+        "expiresInMs": {
+          "minimum": 1000,
+          "maximum": 86400000,
+          "type": "integer"
+        },
+        "wake": {
+          "type": "boolean"
+        }
+      }
+    },
+    "NodePendingEnqueueResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "nodeId",
+        "revision",
+        "queued",
+        "wakeTriggered"
+      ],
+      "properties": {
+        "nodeId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "revision": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "queued": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "id",
+            "type",
+            "priority",
+            "createdAtMs"
+          ],
+          "properties": {
+            "id": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "type": {
+              "enum": [
+                "status.request",
+                "location.request"
+              ],
+              "type": "string"
+            },
+            "priority": {
+              "enum": [
+                "default",
+                "normal",
+                "high"
+              ],
+              "type": "string"
+            },
+            "createdAtMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "expiresAtMs": {
+              "anyOf": [
+                {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "payload": {
+              "type": "object",
+              "patternProperties": {
+                "^(.*)$": {}
+              }
+            }
+          }
+        },
+        "wakeTriggered": {
+          "type": "boolean"
+        }
+      }
+    },
+    "NodeInvokeRequestEvent": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "nodeId",
+        "command"
+      ],
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "nodeId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "command": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "paramsJSON": {
+          "type": "string"
+        },
+        "timeoutMs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "idempotencyKey": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "PushTestParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "nodeId"
+      ],
+      "properties": {
+        "nodeId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "environment": {
+          "enum": [
+            "sandbox",
+            "production"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "PushTestResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ok",
+        "status",
+        "tokenSuffix",
+        "topic",
+        "environment",
+        "transport"
+      ],
+      "properties": {
+        "ok": {
+          "type": "boolean"
+        },
+        "status": {
+          "type": "integer"
+        },
+        "apnsId": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "tokenSuffix": {
+          "type": "string"
+        },
+        "topic": {
+          "type": "string"
+        },
+        "environment": {
+          "enum": [
+            "sandbox",
+            "production"
+          ],
+          "type": "string"
+        },
+        "transport": {
+          "enum": [
+            "direct",
+            "relay"
+          ],
+          "type": "string"
+        }
+      }
+    },
+    "SecretsReloadParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {}
+    },
+    "SecretsResolveParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "commandName",
+        "targetIds"
+      ],
+      "properties": {
+        "commandName": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "targetIds": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SecretsResolveAssignment": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "pathSegments",
+        "value"
+      ],
+      "properties": {
+        "path": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "pathSegments": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "value": {}
+      }
+    },
+    "SecretsResolveResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "ok": {
+          "type": "boolean"
+        },
+        "assignments": {
+          "type": "array",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "pathSegments",
+              "value"
+            ],
+            "properties": {
+              "path": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "pathSegments": {
+                "type": "array",
+                "items": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              },
+              "value": {}
+            }
+          }
+        },
+        "diagnostics": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "inactiveRefPaths": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SessionsListParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "limit": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "activeMinutes": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "includeGlobal": {
+          "type": "boolean"
+        },
+        "includeUnknown": {
+          "type": "boolean"
+        },
+        "includeDerivedTitles": {
+          "type": "boolean"
+        },
+        "includeLastMessage": {
+          "type": "boolean"
+        },
+        "label": {
+          "minLength": 1,
+          "maxLength": 64,
+          "type": "string"
+        },
+        "spawnedBy": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "search": {
+          "type": "string"
+        }
+      }
+    },
+    "SessionsPreviewParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "keys"
+      ],
+      "properties": {
+        "keys": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "limit": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "maxChars": {
+          "minimum": 20,
+          "type": "integer"
+        }
+      }
+    },
+    "SessionsResolveParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "key": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "sessionId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "label": {
+          "minLength": 1,
+          "maxLength": 64,
+          "type": "string"
+        },
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "spawnedBy": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "includeGlobal": {
+          "type": "boolean"
+        },
+        "includeUnknown": {
+          "type": "boolean"
+        }
+      }
+    },
+    "SessionsPatchParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "key"
+      ],
+      "properties": {
+        "key": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "label": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "maxLength": 64,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "thinkingLevel": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "fastMode": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "verboseLevel": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "reasoningLevel": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "responseUsage": {
+          "anyOf": [
+            {
+              "const": "off",
+              "type": "string"
+            },
+            {
+              "const": "tokens",
+              "type": "string"
+            },
+            {
+              "const": "full",
+              "type": "string"
+            },
+            {
+              "const": "on",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "elevatedLevel": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "execHost": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "execSecurity": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "execAsk": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "execNode": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "model": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "spawnedBy": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "spawnedWorkspaceDir": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "spawnDepth": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subagentRole": {
+          "anyOf": [
+            {
+              "const": "orchestrator",
+              "type": "string"
+            },
+            {
+              "const": "leaf",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "subagentControlScope": {
+          "anyOf": [
+            {
+              "const": "children",
+              "type": "string"
+            },
+            {
+              "const": "none",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sendPolicy": {
+          "anyOf": [
+            {
+              "const": "allow",
+              "type": "string"
+            },
+            {
+              "const": "deny",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "groupActivation": {
+          "anyOf": [
+            {
+              "const": "mention",
+              "type": "string"
+            },
+            {
+              "const": "always",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "SessionsResetParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "key"
+      ],
+      "properties": {
+        "key": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "reason": {
+          "anyOf": [
+            {
+              "const": "new",
+              "type": "string"
+            },
+            {
+              "const": "reset",
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "SessionsDeleteParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "key"
+      ],
+      "properties": {
+        "key": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "deleteTranscript": {
+          "type": "boolean"
+        },
+        "emitLifecycleHooks": {
+          "type": "boolean"
+        }
+      }
+    },
+    "SessionsCompactParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "key"
+      ],
+      "properties": {
+        "key": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "maxLines": {
+          "minimum": 1,
+          "type": "integer"
+        }
+      }
+    },
+    "SessionsUsageParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "key": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "startDate": {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "type": "string"
+        },
+        "endDate": {
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+          "type": "string"
+        },
+        "mode": {
+          "anyOf": [
+            {
+              "const": "utc",
+              "type": "string"
+            },
+            {
+              "const": "gateway",
+              "type": "string"
+            },
+            {
+              "const": "specific",
+              "type": "string"
+            }
+          ]
+        },
+        "utcOffset": {
+          "pattern": "^UTC[+-]\\d{1,2}(?::[0-5]\\d)?$",
+          "type": "string"
+        },
+        "limit": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "includeContextWeight": {
+          "type": "boolean"
+        }
+      }
+    },
+    "ConfigGetParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {}
+    },
+    "ConfigSetParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "raw"
+      ],
+      "properties": {
+        "raw": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "baseHash": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "ConfigApplyParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "raw"
+      ],
+      "properties": {
+        "raw": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "baseHash": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "sessionKey": {
+          "type": "string"
+        },
+        "note": {
+          "type": "string"
+        },
+        "restartDelayMs": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      }
+    },
+    "ConfigPatchParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "raw"
+      ],
+      "properties": {
+        "raw": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "baseHash": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "sessionKey": {
+          "type": "string"
+        },
+        "note": {
+          "type": "string"
+        },
+        "restartDelayMs": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      }
+    },
+    "ConfigSchemaParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {}
+    },
+    "ConfigSchemaLookupParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "path"
+      ],
+      "properties": {
+        "path": {
+          "minLength": 1,
+          "maxLength": 1024,
+          "pattern": "^[A-Za-z0-9_./\\[\\]\\-*]+$",
+          "type": "string"
+        }
+      }
+    },
+    "ConfigSchemaResponse": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "schema",
+        "uiHints",
+        "version",
+        "generatedAt"
+      ],
+      "properties": {
+        "schema": {},
+        "uiHints": {
+          "type": "object",
+          "patternProperties": {
+            "^(.*)$": {
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "label": {
+                  "type": "string"
+                },
+                "help": {
+                  "type": "string"
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "group": {
+                  "type": "string"
+                },
+                "order": {
+                  "type": "integer"
+                },
+                "advanced": {
+                  "type": "boolean"
+                },
+                "sensitive": {
+                  "type": "boolean"
+                },
+                "placeholder": {
+                  "type": "string"
+                },
+                "itemTemplate": {}
+              }
+            }
+          }
+        },
+        "version": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "generatedAt": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "ConfigSchemaLookupResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "path",
+        "schema",
+        "children"
+      ],
+      "properties": {
+        "path": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "schema": {},
+        "hint": {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "label": {
+              "type": "string"
+            },
+            "help": {
+              "type": "string"
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "group": {
+              "type": "string"
+            },
+            "order": {
+              "type": "integer"
+            },
+            "advanced": {
+              "type": "boolean"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "placeholder": {
+              "type": "string"
+            },
+            "itemTemplate": {}
+          }
+        },
+        "hintPath": {
+          "type": "string"
+        },
+        "children": {
+          "type": "array",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "key",
+              "path",
+              "required",
+              "hasChildren"
+            ],
+            "properties": {
+              "key": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "path": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "type": {
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                ]
+              },
+              "required": {
+                "type": "boolean"
+              },
+              "hasChildren": {
+                "type": "boolean"
+              },
+              "hint": {
+                "additionalProperties": false,
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "type": "string"
+                  },
+                  "help": {
+                    "type": "string"
+                  },
+                  "tags": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "group": {
+                    "type": "string"
+                  },
+                  "order": {
+                    "type": "integer"
+                  },
+                  "advanced": {
+                    "type": "boolean"
+                  },
+                  "sensitive": {
+                    "type": "boolean"
+                  },
+                  "placeholder": {
+                    "type": "string"
+                  },
+                  "itemTemplate": {}
+                }
+              },
+              "hintPath": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "WizardStartParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "mode": {
+          "anyOf": [
+            {
+              "const": "local",
+              "type": "string"
+            },
+            {
+              "const": "remote",
+              "type": "string"
+            }
+          ]
+        },
+        "workspace": {
+          "type": "string"
+        }
+      }
+    },
+    "WizardNextParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "sessionId"
+      ],
+      "properties": {
+        "sessionId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "answer": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "stepId"
+          ],
+          "properties": {
+            "stepId": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "value": {}
+          }
+        }
+      }
+    },
+    "WizardCancelParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "sessionId"
+      ],
+      "properties": {
+        "sessionId": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "WizardStatusParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "sessionId"
+      ],
+      "properties": {
+        "sessionId": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "WizardStep": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "type"
+      ],
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "type": {
+          "anyOf": [
+            {
+              "const": "note",
+              "type": "string"
+            },
+            {
+              "const": "select",
+              "type": "string"
+            },
+            {
+              "const": "text",
+              "type": "string"
+            },
+            {
+              "const": "confirm",
+              "type": "string"
+            },
+            {
+              "const": "multiselect",
+              "type": "string"
+            },
+            {
+              "const": "progress",
+              "type": "string"
+            },
+            {
+              "const": "action",
+              "type": "string"
+            }
+          ]
+        },
+        "title": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "value",
+              "label"
+            ],
+            "properties": {
+              "value": {},
+              "label": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "hint": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "initialValue": {},
+        "placeholder": {
+          "type": "string"
+        },
+        "sensitive": {
+          "type": "boolean"
+        },
+        "executor": {
+          "anyOf": [
+            {
+              "const": "gateway",
+              "type": "string"
+            },
+            {
+              "const": "client",
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "WizardNextResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "done"
+      ],
+      "properties": {
+        "done": {
+          "type": "boolean"
+        },
+        "step": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "id",
+            "type"
+          ],
+          "properties": {
+            "id": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "type": {
+              "anyOf": [
+                {
+                  "const": "note",
+                  "type": "string"
+                },
+                {
+                  "const": "select",
+                  "type": "string"
+                },
+                {
+                  "const": "text",
+                  "type": "string"
+                },
+                {
+                  "const": "confirm",
+                  "type": "string"
+                },
+                {
+                  "const": "multiselect",
+                  "type": "string"
+                },
+                {
+                  "const": "progress",
+                  "type": "string"
+                },
+                {
+                  "const": "action",
+                  "type": "string"
+                }
+              ]
+            },
+            "title": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "options": {
+              "type": "array",
+              "items": {
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                  "value",
+                  "label"
+                ],
+                "properties": {
+                  "value": {},
+                  "label": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "hint": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "initialValue": {},
+            "placeholder": {
+              "type": "string"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "executor": {
+              "anyOf": [
+                {
+                  "const": "gateway",
+                  "type": "string"
+                },
+                {
+                  "const": "client",
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        },
+        "status": {
+          "anyOf": [
+            {
+              "const": "running",
+              "type": "string"
+            },
+            {
+              "const": "done",
+              "type": "string"
+            },
+            {
+              "const": "cancelled",
+              "type": "string"
+            },
+            {
+              "const": "error",
+              "type": "string"
+            }
+          ]
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "WizardStartResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "sessionId",
+        "done"
+      ],
+      "properties": {
+        "sessionId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "done": {
+          "type": "boolean"
+        },
+        "step": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "id",
+            "type"
+          ],
+          "properties": {
+            "id": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "type": {
+              "anyOf": [
+                {
+                  "const": "note",
+                  "type": "string"
+                },
+                {
+                  "const": "select",
+                  "type": "string"
+                },
+                {
+                  "const": "text",
+                  "type": "string"
+                },
+                {
+                  "const": "confirm",
+                  "type": "string"
+                },
+                {
+                  "const": "multiselect",
+                  "type": "string"
+                },
+                {
+                  "const": "progress",
+                  "type": "string"
+                },
+                {
+                  "const": "action",
+                  "type": "string"
+                }
+              ]
+            },
+            "title": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "options": {
+              "type": "array",
+              "items": {
+                "additionalProperties": false,
+                "type": "object",
+                "required": [
+                  "value",
+                  "label"
+                ],
+                "properties": {
+                  "value": {},
+                  "label": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "hint": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "initialValue": {},
+            "placeholder": {
+              "type": "string"
+            },
+            "sensitive": {
+              "type": "boolean"
+            },
+            "executor": {
+              "anyOf": [
+                {
+                  "const": "gateway",
+                  "type": "string"
+                },
+                {
+                  "const": "client",
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        },
+        "status": {
+          "anyOf": [
+            {
+              "const": "running",
+              "type": "string"
+            },
+            {
+              "const": "done",
+              "type": "string"
+            },
+            {
+              "const": "cancelled",
+              "type": "string"
+            },
+            {
+              "const": "error",
+              "type": "string"
+            }
+          ]
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "WizardStatusResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "status"
+      ],
+      "properties": {
+        "status": {
+          "anyOf": [
+            {
+              "const": "running",
+              "type": "string"
+            },
+            {
+              "const": "done",
+              "type": "string"
+            },
+            {
+              "const": "cancelled",
+              "type": "string"
+            },
+            {
+              "const": "error",
+              "type": "string"
+            }
+          ]
+        },
+        "error": {
+          "type": "string"
+        }
+      }
+    },
+    "TalkModeParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "enabled"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "phase": {
+          "type": "string"
+        }
+      }
+    },
+    "TalkConfigParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "includeSecrets": {
+          "type": "boolean"
+        }
+      }
+    },
+    "TalkConfigResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "config"
+      ],
+      "properties": {
+        "config": {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "talk": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "voiceId": {
+                      "type": "string"
+                    },
+                    "voiceAliases": {
+                      "type": "object",
+                      "patternProperties": {
+                        "^(.*)$": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "modelId": {
+                      "type": "string"
+                    },
+                    "outputFormat": {
+                      "type": "string"
+                    },
+                    "apiKey": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "required": [
+                                "source",
+                                "provider",
+                                "id"
+                              ],
+                              "properties": {
+                                "source": {
+                                  "const": "env",
+                                  "type": "string"
+                                },
+                                "provider": {
+                                  "pattern": "^[a-z][a-z0-9_-]{0,63}$",
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "pattern": "^[A-Z][A-Z0-9_]{0,127}$",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "required": [
+                                "source",
+                                "provider",
+                                "id"
+                              ],
+                              "properties": {
+                                "source": {
+                                  "const": "file",
+                                  "type": "string"
+                                },
+                                "provider": {
+                                  "pattern": "^[a-z][a-z0-9_-]{0,63}$",
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "pattern": "^(?:value|\\/(?:[^~]|~0|~1)*(?:\\/(?:[^~]|~0|~1)*)*)$",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "required": [
+                                "source",
+                                "provider",
+                                "id"
+                              ],
+                              "properties": {
+                                "source": {
+                                  "const": "exec",
+                                  "type": "string"
+                                },
+                                "provider": {
+                                  "pattern": "^[a-z][a-z0-9_-]{0,63}$",
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "pattern": "^(?!.*(?:^|/)\\.{1,2}(?:/|$))[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "interruptOnSpeech": {
+                      "type": "boolean"
+                    },
+                    "silenceTimeoutMs": {
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  }
+                },
+                {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "resolved"
+                  ],
+                  "properties": {
+                    "provider": {
+                      "type": "string"
+                    },
+                    "providers": {
+                      "type": "object",
+                      "patternProperties": {
+                        "^(.*)$": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "properties": {
+                            "voiceId": {
+                              "type": "string"
+                            },
+                            "voiceAliases": {
+                              "type": "object",
+                              "patternProperties": {
+                                "^(.*)$": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "modelId": {
+                              "type": "string"
+                            },
+                            "outputFormat": {
+                              "type": "string"
+                            },
+                            "apiKey": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "anyOf": [
+                                    {
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "required": [
+                                        "source",
+                                        "provider",
+                                        "id"
+                                      ],
+                                      "properties": {
+                                        "source": {
+                                          "const": "env",
+                                          "type": "string"
+                                        },
+                                        "provider": {
+                                          "pattern": "^[a-z][a-z0-9_-]{0,63}$",
+                                          "type": "string"
+                                        },
+                                        "id": {
+                                          "pattern": "^[A-Z][A-Z0-9_]{0,127}$",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "required": [
+                                        "source",
+                                        "provider",
+                                        "id"
+                                      ],
+                                      "properties": {
+                                        "source": {
+                                          "const": "file",
+                                          "type": "string"
+                                        },
+                                        "provider": {
+                                          "pattern": "^[a-z][a-z0-9_-]{0,63}$",
+                                          "type": "string"
+                                        },
+                                        "id": {
+                                          "pattern": "^(?:value|\\/(?:[^~]|~0|~1)*(?:\\/(?:[^~]|~0|~1)*)*)$",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "required": [
+                                        "source",
+                                        "provider",
+                                        "id"
+                                      ],
+                                      "properties": {
+                                        "source": {
+                                          "const": "exec",
+                                          "type": "string"
+                                        },
+                                        "provider": {
+                                          "pattern": "^[a-z][a-z0-9_-]{0,63}$",
+                                          "type": "string"
+                                        },
+                                        "id": {
+                                          "pattern": "^(?!.*(?:^|/)\\.{1,2}(?:/|$))[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "resolved": {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "required": [
+                        "provider",
+                        "config"
+                      ],
+                      "properties": {
+                        "provider": {
+                          "type": "string"
+                        },
+                        "config": {
+                          "additionalProperties": true,
+                          "type": "object",
+                          "properties": {
+                            "voiceId": {
+                              "type": "string"
+                            },
+                            "voiceAliases": {
+                              "type": "object",
+                              "patternProperties": {
+                                "^(.*)$": {
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            "modelId": {
+                              "type": "string"
+                            },
+                            "outputFormat": {
+                              "type": "string"
+                            },
+                            "apiKey": {
+                              "anyOf": [
+                                {
+                                  "type": "string"
+                                },
+                                {
+                                  "anyOf": [
+                                    {
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "required": [
+                                        "source",
+                                        "provider",
+                                        "id"
+                                      ],
+                                      "properties": {
+                                        "source": {
+                                          "const": "env",
+                                          "type": "string"
+                                        },
+                                        "provider": {
+                                          "pattern": "^[a-z][a-z0-9_-]{0,63}$",
+                                          "type": "string"
+                                        },
+                                        "id": {
+                                          "pattern": "^[A-Z][A-Z0-9_]{0,127}$",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "required": [
+                                        "source",
+                                        "provider",
+                                        "id"
+                                      ],
+                                      "properties": {
+                                        "source": {
+                                          "const": "file",
+                                          "type": "string"
+                                        },
+                                        "provider": {
+                                          "pattern": "^[a-z][a-z0-9_-]{0,63}$",
+                                          "type": "string"
+                                        },
+                                        "id": {
+                                          "pattern": "^(?:value|\\/(?:[^~]|~0|~1)*(?:\\/(?:[^~]|~0|~1)*)*)$",
+                                          "type": "string"
+                                        }
+                                      }
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "type": "object",
+                                      "required": [
+                                        "source",
+                                        "provider",
+                                        "id"
+                                      ],
+                                      "properties": {
+                                        "source": {
+                                          "const": "exec",
+                                          "type": "string"
+                                        },
+                                        "provider": {
+                                          "pattern": "^[a-z][a-z0-9_-]{0,63}$",
+                                          "type": "string"
+                                        },
+                                        "id": {
+                                          "pattern": "^(?!.*(?:^|/)\\.{1,2}(?:/|$))[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$",
+                                          "type": "string"
+                                        }
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "voiceId": {
+                      "type": "string"
+                    },
+                    "voiceAliases": {
+                      "type": "object",
+                      "patternProperties": {
+                        "^(.*)$": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "modelId": {
+                      "type": "string"
+                    },
+                    "outputFormat": {
+                      "type": "string"
+                    },
+                    "apiKey": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "required": [
+                                "source",
+                                "provider",
+                                "id"
+                              ],
+                              "properties": {
+                                "source": {
+                                  "const": "env",
+                                  "type": "string"
+                                },
+                                "provider": {
+                                  "pattern": "^[a-z][a-z0-9_-]{0,63}$",
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "pattern": "^[A-Z][A-Z0-9_]{0,127}$",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "required": [
+                                "source",
+                                "provider",
+                                "id"
+                              ],
+                              "properties": {
+                                "source": {
+                                  "const": "file",
+                                  "type": "string"
+                                },
+                                "provider": {
+                                  "pattern": "^[a-z][a-z0-9_-]{0,63}$",
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "pattern": "^(?:value|\\/(?:[^~]|~0|~1)*(?:\\/(?:[^~]|~0|~1)*)*)$",
+                                  "type": "string"
+                                }
+                              }
+                            },
+                            {
+                              "additionalProperties": false,
+                              "type": "object",
+                              "required": [
+                                "source",
+                                "provider",
+                                "id"
+                              ],
+                              "properties": {
+                                "source": {
+                                  "const": "exec",
+                                  "type": "string"
+                                },
+                                "provider": {
+                                  "pattern": "^[a-z][a-z0-9_-]{0,63}$",
+                                  "type": "string"
+                                },
+                                "id": {
+                                  "pattern": "^(?!.*(?:^|/)\\.{1,2}(?:/|$))[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$",
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    "interruptOnSpeech": {
+                      "type": "boolean"
+                    },
+                    "silenceTimeoutMs": {
+                      "minimum": 1,
+                      "type": "integer"
+                    }
+                  }
+                }
+              ]
+            },
+            "session": {
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "mainKey": {
+                  "type": "string"
+                }
+              }
+            },
+            "ui": {
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "seamColor": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ChannelsStatusParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "probe": {
+          "type": "boolean"
+        },
+        "timeoutMs": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      }
+    },
+    "ChannelsStatusResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ts",
+        "channelOrder",
+        "channelLabels",
+        "channels",
+        "channelAccounts",
+        "channelDefaultAccountId"
+      ],
+      "properties": {
+        "ts": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "channelOrder": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "channelLabels": {
+          "type": "object",
+          "patternProperties": {
+            "^(.*)$": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        },
+        "channelDetailLabels": {
+          "type": "object",
+          "patternProperties": {
+            "^(.*)$": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        },
+        "channelSystemImages": {
+          "type": "object",
+          "patternProperties": {
+            "^(.*)$": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        },
+        "channelMeta": {
+          "type": "array",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "id",
+              "label",
+              "detailLabel"
+            ],
+            "properties": {
+              "id": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "label": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "detailLabel": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "systemImage": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "channels": {
+          "type": "object",
+          "patternProperties": {
+            "^(.*)$": {}
+          }
+        },
+        "channelAccounts": {
+          "type": "object",
+          "patternProperties": {
+            "^(.*)$": {
+              "type": "array",
+              "items": {
+                "additionalProperties": true,
+                "type": "object",
+                "required": [
+                  "accountId"
+                ],
+                "properties": {
+                  "accountId": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "configured": {
+                    "type": "boolean"
+                  },
+                  "linked": {
+                    "type": "boolean"
+                  },
+                  "running": {
+                    "type": "boolean"
+                  },
+                  "connected": {
+                    "type": "boolean"
+                  },
+                  "reconnectAttempts": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "lastConnectedAt": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "lastError": {
+                    "type": "string"
+                  },
+                  "lastStartAt": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "lastStopAt": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "lastInboundAt": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "lastOutboundAt": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "busy": {
+                    "type": "boolean"
+                  },
+                  "activeRuns": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "lastRunActivityAt": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "lastProbeAt": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "mode": {
+                    "type": "string"
+                  },
+                  "dmPolicy": {
+                    "type": "string"
+                  },
+                  "allowFrom": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "tokenSource": {
+                    "type": "string"
+                  },
+                  "botTokenSource": {
+                    "type": "string"
+                  },
+                  "appTokenSource": {
+                    "type": "string"
+                  },
+                  "baseUrl": {
+                    "type": "string"
+                  },
+                  "allowUnmentionedGroups": {
+                    "type": "boolean"
+                  },
+                  "cliPath": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "dbPath": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "port": {
+                    "anyOf": [
+                      {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "probe": {},
+                  "audit": {},
+                  "application": {}
+                }
+              }
+            }
+          }
+        },
+        "channelDefaultAccountId": {
+          "type": "object",
+          "patternProperties": {
+            "^(.*)$": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "ChannelsLogoutParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "channel"
+      ],
+      "properties": {
+        "channel": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "accountId": {
+          "type": "string"
+        }
+      }
+    },
+    "WebLoginStartParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "force": {
+          "type": "boolean"
+        },
+        "timeoutMs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "verbose": {
+          "type": "boolean"
+        },
+        "accountId": {
+          "type": "string"
+        }
+      }
+    },
+    "WebLoginWaitParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "timeoutMs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "accountId": {
+          "type": "string"
+        }
+      }
+    },
+    "AgentSummary": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "identity": {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "name": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "theme": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "emoji": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "avatar": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "avatarUrl": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "AgentsCreateParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "workspace"
+      ],
+      "properties": {
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "workspace": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "emoji": {
+          "type": "string"
+        },
+        "avatar": {
+          "type": "string"
+        }
+      }
+    },
+    "AgentsCreateResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ok",
+        "agentId",
+        "name",
+        "workspace"
+      ],
+      "properties": {
+        "ok": {
+          "const": true,
+          "type": "boolean"
+        },
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "workspace": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "AgentsUpdateParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "agentId"
+      ],
+      "properties": {
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "workspace": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "model": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "avatar": {
+          "type": "string"
+        }
+      }
+    },
+    "AgentsUpdateResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ok",
+        "agentId"
+      ],
+      "properties": {
+        "ok": {
+          "const": true,
+          "type": "boolean"
+        },
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "AgentsDeleteParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "agentId"
+      ],
+      "properties": {
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "deleteFiles": {
+          "type": "boolean"
+        }
+      }
+    },
+    "AgentsDeleteResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ok",
+        "agentId",
+        "removedBindings"
+      ],
+      "properties": {
+        "ok": {
+          "const": true,
+          "type": "boolean"
+        },
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "removedBindings": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      }
+    },
+    "AgentsFileEntry": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "path",
+        "missing"
+      ],
+      "properties": {
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "path": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "missing": {
+          "type": "boolean"
+        },
+        "size": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "updatedAtMs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "content": {
+          "type": "string"
+        }
+      }
+    },
+    "AgentsFilesListParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "agentId"
+      ],
+      "properties": {
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "AgentsFilesListResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "agentId",
+        "workspace",
+        "files"
+      ],
+      "properties": {
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "workspace": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "files": {
+          "type": "array",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "name",
+              "path",
+              "missing"
+            ],
+            "properties": {
+              "name": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "path": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "missing": {
+                "type": "boolean"
+              },
+              "size": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "updatedAtMs": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "content": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "AgentsFilesGetParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "agentId",
+        "name"
+      ],
+      "properties": {
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "AgentsFilesGetResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "agentId",
+        "workspace",
+        "file"
+      ],
+      "properties": {
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "workspace": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "file": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "name",
+            "path",
+            "missing"
+          ],
+          "properties": {
+            "name": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "path": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "missing": {
+              "type": "boolean"
+            },
+            "size": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "updatedAtMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "content": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "AgentsFilesSetParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "agentId",
+        "name",
+        "content"
+      ],
+      "properties": {
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "content": {
+          "type": "string"
+        }
+      }
+    },
+    "AgentsFilesSetResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ok",
+        "agentId",
+        "workspace",
+        "file"
+      ],
+      "properties": {
+        "ok": {
+          "const": true,
+          "type": "boolean"
+        },
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "workspace": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "file": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "name",
+            "path",
+            "missing"
+          ],
+          "properties": {
+            "name": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "path": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "missing": {
+              "type": "boolean"
+            },
+            "size": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "updatedAtMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "content": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "AgentsListParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {}
+    },
+    "AgentsListResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "defaultId",
+        "mainKey",
+        "scope",
+        "agents"
+      ],
+      "properties": {
+        "defaultId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "mainKey": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "scope": {
+          "anyOf": [
+            {
+              "const": "per-sender",
+              "type": "string"
+            },
+            {
+              "const": "global",
+              "type": "string"
+            }
+          ]
+        },
+        "agents": {
+          "type": "array",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "name": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "identity": {
+                "additionalProperties": false,
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "theme": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "emoji": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "avatar": {
+                    "minLength": 1,
+                    "type": "string"
+                  },
+                  "avatarUrl": {
+                    "minLength": 1,
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ModelChoice": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "provider"
+      ],
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "provider": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "contextWindow": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "reasoning": {
+          "type": "boolean"
+        }
+      }
+    },
+    "ModelsListParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {}
+    },
+    "ModelsListResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "models"
+      ],
+      "properties": {
+        "models": {
+          "type": "array",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "id",
+              "name",
+              "provider"
+            ],
+            "properties": {
+              "id": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "name": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "provider": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "contextWindow": {
+                "minimum": 1,
+                "type": "integer"
+              },
+              "reasoning": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      }
+    },
+    "SkillsStatusParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "ToolsCatalogParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "includePlugins": {
+          "type": "boolean"
+        }
+      }
+    },
+    "ToolCatalogProfile": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "label"
+      ],
+      "properties": {
+        "id": {
+          "anyOf": [
+            {
+              "const": "minimal",
+              "type": "string"
+            },
+            {
+              "const": "coding",
+              "type": "string"
+            },
+            {
+              "const": "messaging",
+              "type": "string"
+            },
+            {
+              "const": "full",
+              "type": "string"
+            }
+          ]
+        },
+        "label": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "ToolCatalogEntry": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "label",
+        "description",
+        "source",
+        "defaultProfiles"
+      ],
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "label": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "source": {
+          "anyOf": [
+            {
+              "const": "core",
+              "type": "string"
+            },
+            {
+              "const": "plugin",
+              "type": "string"
+            }
+          ]
+        },
+        "pluginId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "optional": {
+          "type": "boolean"
+        },
+        "defaultProfiles": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "const": "minimal",
+                "type": "string"
+              },
+              {
+                "const": "coding",
+                "type": "string"
+              },
+              {
+                "const": "messaging",
+                "type": "string"
+              },
+              {
+                "const": "full",
+                "type": "string"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "ToolCatalogGroup": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "label",
+        "source",
+        "tools"
+      ],
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "label": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "source": {
+          "anyOf": [
+            {
+              "const": "core",
+              "type": "string"
+            },
+            {
+              "const": "plugin",
+              "type": "string"
+            }
+          ]
+        },
+        "pluginId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "id",
+              "label",
+              "description",
+              "source",
+              "defaultProfiles"
+            ],
+            "properties": {
+              "id": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "label": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "source": {
+                "anyOf": [
+                  {
+                    "const": "core",
+                    "type": "string"
+                  },
+                  {
+                    "const": "plugin",
+                    "type": "string"
+                  }
+                ]
+              },
+              "pluginId": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "optional": {
+                "type": "boolean"
+              },
+              "defaultProfiles": {
+                "type": "array",
+                "items": {
+                  "anyOf": [
+                    {
+                      "const": "minimal",
+                      "type": "string"
+                    },
+                    {
+                      "const": "coding",
+                      "type": "string"
+                    },
+                    {
+                      "const": "messaging",
+                      "type": "string"
+                    },
+                    {
+                      "const": "full",
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ToolsCatalogResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "agentId",
+        "profiles",
+        "groups"
+      ],
+      "properties": {
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "profiles": {
+          "type": "array",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "id",
+              "label"
+            ],
+            "properties": {
+              "id": {
+                "anyOf": [
+                  {
+                    "const": "minimal",
+                    "type": "string"
+                  },
+                  {
+                    "const": "coding",
+                    "type": "string"
+                  },
+                  {
+                    "const": "messaging",
+                    "type": "string"
+                  },
+                  {
+                    "const": "full",
+                    "type": "string"
+                  }
+                ]
+              },
+              "label": {
+                "minLength": 1,
+                "type": "string"
+              }
+            }
+          }
+        },
+        "groups": {
+          "type": "array",
+          "items": {
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+              "id",
+              "label",
+              "source",
+              "tools"
+            ],
+            "properties": {
+              "id": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "label": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "source": {
+                "anyOf": [
+                  {
+                    "const": "core",
+                    "type": "string"
+                  },
+                  {
+                    "const": "plugin",
+                    "type": "string"
+                  }
+                ]
+              },
+              "pluginId": {
+                "minLength": 1,
+                "type": "string"
+              },
+              "tools": {
+                "type": "array",
+                "items": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "label",
+                    "description",
+                    "source",
+                    "defaultProfiles"
+                  ],
+                  "properties": {
+                    "id": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "label": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "description": {
+                      "type": "string"
+                    },
+                    "source": {
+                      "anyOf": [
+                        {
+                          "const": "core",
+                          "type": "string"
+                        },
+                        {
+                          "const": "plugin",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "pluginId": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "optional": {
+                      "type": "boolean"
+                    },
+                    "defaultProfiles": {
+                      "type": "array",
+                      "items": {
+                        "anyOf": [
+                          {
+                            "const": "minimal",
+                            "type": "string"
+                          },
+                          {
+                            "const": "coding",
+                            "type": "string"
+                          },
+                          {
+                            "const": "messaging",
+                            "type": "string"
+                          },
+                          {
+                            "const": "full",
+                            "type": "string"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "SkillsBinsParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {}
+    },
+    "SkillsBinsResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "bins"
+      ],
+      "properties": {
+        "bins": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      }
+    },
+    "SkillsInstallParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "installId"
+      ],
+      "properties": {
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "installId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "timeoutMs": {
+          "minimum": 1000,
+          "type": "integer"
+        }
+      }
+    },
+    "SkillsUpdateParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "skillKey"
+      ],
+      "properties": {
+        "skillKey": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "apiKey": {
+          "type": "string"
+        },
+        "env": {
+          "type": "object",
+          "patternProperties": {
+            "^(.*)$": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "CronJob": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "name",
+        "enabled",
+        "createdAtMs",
+        "updatedAtMs",
+        "schedule",
+        "sessionTarget",
+        "wakeMode",
+        "payload",
+        "state"
+      ],
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "agentId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "sessionKey": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "deleteAfterRun": {
+          "type": "boolean"
+        },
+        "createdAtMs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "updatedAtMs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "schedule": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "kind",
+                "at"
+              ],
+              "properties": {
+                "kind": {
+                  "const": "at",
+                  "type": "string"
+                },
+                "at": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "kind",
+                "everyMs"
+              ],
+              "properties": {
+                "kind": {
+                  "const": "every",
+                  "type": "string"
+                },
+                "everyMs": {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "anchorMs": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              }
+            },
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "kind",
+                "expr"
+              ],
+              "properties": {
+                "kind": {
+                  "const": "cron",
+                  "type": "string"
+                },
+                "expr": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "tz": {
+                  "type": "string"
+                },
+                "staggerMs": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              }
+            }
+          ]
+        },
+        "sessionTarget": {
+          "anyOf": [
+            {
+              "const": "main",
+              "type": "string"
+            },
+            {
+              "const": "isolated",
+              "type": "string"
+            }
+          ]
+        },
+        "wakeMode": {
+          "anyOf": [
+            {
+              "const": "next-heartbeat",
+              "type": "string"
+            },
+            {
+              "const": "now",
+              "type": "string"
+            }
+          ]
+        },
+        "payload": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "kind",
+                "text"
+              ],
+              "properties": {
+                "kind": {
+                  "const": "systemEvent",
+                  "type": "string"
+                },
+                "text": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "kind",
+                "message"
+              ],
+              "properties": {
+                "kind": {
+                  "const": "agentTurn",
+                  "type": "string"
+                },
+                "message": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                },
+                "fallbacks": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "thinking": {
+                  "type": "string"
+                },
+                "timeoutSeconds": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "allowUnsafeExternalContent": {
+                  "type": "boolean"
+                },
+                "lightContext": {
+                  "type": "boolean"
+                },
+                "deliver": {
+                  "type": "boolean"
+                },
+                "channel": {
+                  "type": "string"
+                },
+                "to": {
+                  "type": "string"
+                },
+                "bestEffortDeliver": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        },
+        "delivery": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "mode"
+              ],
+              "properties": {
+                "mode": {
+                  "const": "none",
+                  "type": "string"
+                },
+                "channel": {
+                  "anyOf": [
+                    {
+                      "const": "last",
+                      "type": "string"
+                    },
+                    {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  ]
+                },
+                "accountId": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "bestEffort": {
+                  "type": "boolean"
+                },
+                "failureDestination": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "channel": {
+                      "anyOf": [
+                        {
+                          "const": "last",
+                          "type": "string"
+                        },
+                        {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "to": {
+                      "type": "string"
+                    },
+                    "accountId": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "mode": {
+                      "anyOf": [
+                        {
+                          "const": "announce",
+                          "type": "string"
+                        },
+                        {
+                          "const": "webhook",
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "to": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "mode"
+              ],
+              "properties": {
+                "mode": {
+                  "const": "announce",
+                  "type": "string"
+                },
+                "channel": {
+                  "anyOf": [
+                    {
+                      "const": "last",
+                      "type": "string"
+                    },
+                    {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  ]
+                },
+                "accountId": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "bestEffort": {
+                  "type": "boolean"
+                },
+                "failureDestination": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "channel": {
+                      "anyOf": [
+                        {
+                          "const": "last",
+                          "type": "string"
+                        },
+                        {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "to": {
+                      "type": "string"
+                    },
+                    "accountId": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "mode": {
+                      "anyOf": [
+                        {
+                          "const": "announce",
+                          "type": "string"
+                        },
+                        {
+                          "const": "webhook",
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "to": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "mode",
+                "to"
+              ],
+              "properties": {
+                "mode": {
+                  "const": "webhook",
+                  "type": "string"
+                },
+                "channel": {
+                  "anyOf": [
+                    {
+                      "const": "last",
+                      "type": "string"
+                    },
+                    {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  ]
+                },
+                "accountId": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "bestEffort": {
+                  "type": "boolean"
+                },
+                "failureDestination": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "channel": {
+                      "anyOf": [
+                        {
+                          "const": "last",
+                          "type": "string"
+                        },
+                        {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "to": {
+                      "type": "string"
+                    },
+                    "accountId": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "mode": {
+                      "anyOf": [
+                        {
+                          "const": "announce",
+                          "type": "string"
+                        },
+                        {
+                          "const": "webhook",
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "to": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
+        "failureAlert": {
+          "anyOf": [
+            {
+              "const": false,
+              "type": "boolean"
+            },
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "after": {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "channel": {
+                  "anyOf": [
+                    {
+                      "const": "last",
+                      "type": "string"
+                    },
+                    {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  ]
+                },
+                "to": {
+                  "type": "string"
+                },
+                "cooldownMs": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "mode": {
+                  "anyOf": [
+                    {
+                      "const": "announce",
+                      "type": "string"
+                    },
+                    {
+                      "const": "webhook",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "accountId": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
+        "state": {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "nextRunAtMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "runningAtMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "lastRunAtMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "lastRunStatus": {
+              "anyOf": [
+                {
+                  "const": "ok",
+                  "type": "string"
+                },
+                {
+                  "const": "error",
+                  "type": "string"
+                },
+                {
+                  "const": "skipped",
+                  "type": "string"
+                }
+              ]
+            },
+            "lastStatus": {
+              "anyOf": [
+                {
+                  "const": "ok",
+                  "type": "string"
+                },
+                {
+                  "const": "error",
+                  "type": "string"
+                },
+                {
+                  "const": "skipped",
+                  "type": "string"
+                }
+              ]
+            },
+            "lastError": {
+              "type": "string"
+            },
+            "lastErrorReason": {
+              "anyOf": [
+                {
+                  "const": "auth",
+                  "type": "string"
+                },
+                {
+                  "const": "format",
+                  "type": "string"
+                },
+                {
+                  "const": "rate_limit",
+                  "type": "string"
+                },
+                {
+                  "const": "billing",
+                  "type": "string"
+                },
+                {
+                  "const": "timeout",
+                  "type": "string"
+                },
+                {
+                  "const": "model_not_found",
+                  "type": "string"
+                },
+                {
+                  "const": "unknown",
+                  "type": "string"
+                }
+              ]
+            },
+            "lastDurationMs": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "consecutiveErrors": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "lastDelivered": {
+              "type": "boolean"
+            },
+            "lastDeliveryStatus": {
+              "anyOf": [
+                {
+                  "const": "delivered",
+                  "type": "string"
+                },
+                {
+                  "const": "not-delivered",
+                  "type": "string"
+                },
+                {
+                  "const": "unknown",
+                  "type": "string"
+                },
+                {
+                  "const": "not-requested",
+                  "type": "string"
+                }
+              ]
+            },
+            "lastDeliveryError": {
+              "type": "string"
+            },
+            "lastFailureAlertAtMs": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
+    "CronListParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "includeDisabled": {
+          "type": "boolean"
+        },
+        "limit": {
+          "minimum": 1,
+          "maximum": 200,
+          "type": "integer"
+        },
+        "offset": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "query": {
+          "type": "string"
+        },
+        "enabled": {
+          "anyOf": [
+            {
+              "const": "all",
+              "type": "string"
+            },
+            {
+              "const": "enabled",
+              "type": "string"
+            },
+            {
+              "const": "disabled",
+              "type": "string"
+            }
+          ]
+        },
+        "sortBy": {
+          "anyOf": [
+            {
+              "const": "nextRunAtMs",
+              "type": "string"
+            },
+            {
+              "const": "updatedAtMs",
+              "type": "string"
+            },
+            {
+              "const": "name",
+              "type": "string"
+            }
+          ]
+        },
+        "sortDir": {
+          "anyOf": [
+            {
+              "const": "asc",
+              "type": "string"
+            },
+            {
+              "const": "desc",
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "CronStatusParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {}
+    },
+    "CronAddParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "schedule",
+        "sessionTarget",
+        "wakeMode",
+        "payload"
+      ],
+      "properties": {
+        "name": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "agentId": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sessionKey": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "deleteAfterRun": {
+          "type": "boolean"
+        },
+        "schedule": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "kind",
+                "at"
+              ],
+              "properties": {
+                "kind": {
+                  "const": "at",
+                  "type": "string"
+                },
+                "at": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "kind",
+                "everyMs"
+              ],
+              "properties": {
+                "kind": {
+                  "const": "every",
+                  "type": "string"
+                },
+                "everyMs": {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "anchorMs": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              }
+            },
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "kind",
+                "expr"
+              ],
+              "properties": {
+                "kind": {
+                  "const": "cron",
+                  "type": "string"
+                },
+                "expr": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "tz": {
+                  "type": "string"
+                },
+                "staggerMs": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              }
+            }
+          ]
+        },
+        "sessionTarget": {
+          "anyOf": [
+            {
+              "const": "main",
+              "type": "string"
+            },
+            {
+              "const": "isolated",
+              "type": "string"
+            }
+          ]
+        },
+        "wakeMode": {
+          "anyOf": [
+            {
+              "const": "next-heartbeat",
+              "type": "string"
+            },
+            {
+              "const": "now",
+              "type": "string"
+            }
+          ]
+        },
+        "payload": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "kind",
+                "text"
+              ],
+              "properties": {
+                "kind": {
+                  "const": "systemEvent",
+                  "type": "string"
+                },
+                "text": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "kind",
+                "message"
+              ],
+              "properties": {
+                "kind": {
+                  "const": "agentTurn",
+                  "type": "string"
+                },
+                "message": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "model": {
+                  "type": "string"
+                },
+                "fallbacks": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "thinking": {
+                  "type": "string"
+                },
+                "timeoutSeconds": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "allowUnsafeExternalContent": {
+                  "type": "boolean"
+                },
+                "lightContext": {
+                  "type": "boolean"
+                },
+                "deliver": {
+                  "type": "boolean"
+                },
+                "channel": {
+                  "type": "string"
+                },
+                "to": {
+                  "type": "string"
+                },
+                "bestEffortDeliver": {
+                  "type": "boolean"
+                }
+              }
+            }
+          ]
+        },
+        "delivery": {
+          "anyOf": [
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "mode"
+              ],
+              "properties": {
+                "mode": {
+                  "const": "none",
+                  "type": "string"
+                },
+                "channel": {
+                  "anyOf": [
+                    {
+                      "const": "last",
+                      "type": "string"
+                    },
+                    {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  ]
+                },
+                "accountId": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "bestEffort": {
+                  "type": "boolean"
+                },
+                "failureDestination": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "channel": {
+                      "anyOf": [
+                        {
+                          "const": "last",
+                          "type": "string"
+                        },
+                        {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "to": {
+                      "type": "string"
+                    },
+                    "accountId": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "mode": {
+                      "anyOf": [
+                        {
+                          "const": "announce",
+                          "type": "string"
+                        },
+                        {
+                          "const": "webhook",
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "to": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "mode"
+              ],
+              "properties": {
+                "mode": {
+                  "const": "announce",
+                  "type": "string"
+                },
+                "channel": {
+                  "anyOf": [
+                    {
+                      "const": "last",
+                      "type": "string"
+                    },
+                    {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  ]
+                },
+                "accountId": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "bestEffort": {
+                  "type": "boolean"
+                },
+                "failureDestination": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "channel": {
+                      "anyOf": [
+                        {
+                          "const": "last",
+                          "type": "string"
+                        },
+                        {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "to": {
+                      "type": "string"
+                    },
+                    "accountId": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "mode": {
+                      "anyOf": [
+                        {
+                          "const": "announce",
+                          "type": "string"
+                        },
+                        {
+                          "const": "webhook",
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "to": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "required": [
+                "mode",
+                "to"
+              ],
+              "properties": {
+                "mode": {
+                  "const": "webhook",
+                  "type": "string"
+                },
+                "channel": {
+                  "anyOf": [
+                    {
+                      "const": "last",
+                      "type": "string"
+                    },
+                    {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  ]
+                },
+                "accountId": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "bestEffort": {
+                  "type": "boolean"
+                },
+                "failureDestination": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "channel": {
+                      "anyOf": [
+                        {
+                          "const": "last",
+                          "type": "string"
+                        },
+                        {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "to": {
+                      "type": "string"
+                    },
+                    "accountId": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "mode": {
+                      "anyOf": [
+                        {
+                          "const": "announce",
+                          "type": "string"
+                        },
+                        {
+                          "const": "webhook",
+                          "type": "string"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "to": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        },
+        "failureAlert": {
+          "anyOf": [
+            {
+              "const": false,
+              "type": "boolean"
+            },
+            {
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "after": {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "channel": {
+                  "anyOf": [
+                    {
+                      "const": "last",
+                      "type": "string"
+                    },
+                    {
+                      "minLength": 1,
+                      "type": "string"
+                    }
+                  ]
+                },
+                "to": {
+                  "type": "string"
+                },
+                "cooldownMs": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "mode": {
+                  "anyOf": [
+                    {
+                      "const": "announce",
+                      "type": "string"
+                    },
+                    {
+                      "const": "webhook",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "accountId": {
+                  "minLength": 1,
+                  "type": "string"
+                }
+              }
+            }
+          ]
+        }
+      }
+    },
+    "CronUpdateParams": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "id",
+            "patch"
+          ],
+          "properties": {
+            "id": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "patch": {
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "name": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "agentId": {
+                  "anyOf": [
+                    {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "sessionKey": {
+                  "anyOf": [
+                    {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "description": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "deleteAfterRun": {
+                  "type": "boolean"
+                },
+                "schedule": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "required": [
+                        "kind",
+                        "at"
+                      ],
+                      "properties": {
+                        "kind": {
+                          "const": "at",
+                          "type": "string"
+                        },
+                        "at": {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      }
+                    },
+                    {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "required": [
+                        "kind",
+                        "everyMs"
+                      ],
+                      "properties": {
+                        "kind": {
+                          "const": "every",
+                          "type": "string"
+                        },
+                        "everyMs": {
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "anchorMs": {
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "required": [
+                        "kind",
+                        "expr"
+                      ],
+                      "properties": {
+                        "kind": {
+                          "const": "cron",
+                          "type": "string"
+                        },
+                        "expr": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "tz": {
+                          "type": "string"
+                        },
+                        "staggerMs": {
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "sessionTarget": {
+                  "anyOf": [
+                    {
+                      "const": "main",
+                      "type": "string"
+                    },
+                    {
+                      "const": "isolated",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "wakeMode": {
+                  "anyOf": [
+                    {
+                      "const": "next-heartbeat",
+                      "type": "string"
+                    },
+                    {
+                      "const": "now",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "payload": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "required": [
+                        "kind"
+                      ],
+                      "properties": {
+                        "kind": {
+                          "const": "systemEvent",
+                          "type": "string"
+                        },
+                        "text": {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      }
+                    },
+                    {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "required": [
+                        "kind"
+                      ],
+                      "properties": {
+                        "kind": {
+                          "const": "agentTurn",
+                          "type": "string"
+                        },
+                        "message": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "model": {
+                          "type": "string"
+                        },
+                        "fallbacks": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "thinking": {
+                          "type": "string"
+                        },
+                        "timeoutSeconds": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "allowUnsafeExternalContent": {
+                          "type": "boolean"
+                        },
+                        "lightContext": {
+                          "type": "boolean"
+                        },
+                        "deliver": {
+                          "type": "boolean"
+                        },
+                        "channel": {
+                          "type": "string"
+                        },
+                        "to": {
+                          "type": "string"
+                        },
+                        "bestEffortDeliver": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "delivery": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "anyOf": [
+                        {
+                          "const": "none",
+                          "type": "string"
+                        },
+                        {
+                          "const": "announce",
+                          "type": "string"
+                        },
+                        {
+                          "const": "webhook",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "channel": {
+                      "anyOf": [
+                        {
+                          "const": "last",
+                          "type": "string"
+                        },
+                        {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "accountId": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "bestEffort": {
+                      "type": "boolean"
+                    },
+                    "failureDestination": {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "properties": {
+                        "channel": {
+                          "anyOf": [
+                            {
+                              "const": "last",
+                              "type": "string"
+                            },
+                            {
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "to": {
+                          "type": "string"
+                        },
+                        "accountId": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "mode": {
+                          "anyOf": [
+                            {
+                              "const": "announce",
+                              "type": "string"
+                            },
+                            {
+                              "const": "webhook",
+                              "type": "string"
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "to": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "failureAlert": {
+                  "anyOf": [
+                    {
+                      "const": false,
+                      "type": "boolean"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "properties": {
+                        "after": {
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "channel": {
+                          "anyOf": [
+                            {
+                              "const": "last",
+                              "type": "string"
+                            },
+                            {
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "to": {
+                          "type": "string"
+                        },
+                        "cooldownMs": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "mode": {
+                          "anyOf": [
+                            {
+                              "const": "announce",
+                              "type": "string"
+                            },
+                            {
+                              "const": "webhook",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "accountId": {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "state": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "nextRunAtMs": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "runningAtMs": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "lastRunAtMs": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "lastRunStatus": {
+                      "anyOf": [
+                        {
+                          "const": "ok",
+                          "type": "string"
+                        },
+                        {
+                          "const": "error",
+                          "type": "string"
+                        },
+                        {
+                          "const": "skipped",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "lastStatus": {
+                      "anyOf": [
+                        {
+                          "const": "ok",
+                          "type": "string"
+                        },
+                        {
+                          "const": "error",
+                          "type": "string"
+                        },
+                        {
+                          "const": "skipped",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "lastError": {
+                      "type": "string"
+                    },
+                    "lastErrorReason": {
+                      "anyOf": [
+                        {
+                          "const": "auth",
+                          "type": "string"
+                        },
+                        {
+                          "const": "format",
+                          "type": "string"
+                        },
+                        {
+                          "const": "rate_limit",
+                          "type": "string"
+                        },
+                        {
+                          "const": "billing",
+                          "type": "string"
+                        },
+                        {
+                          "const": "timeout",
+                          "type": "string"
+                        },
+                        {
+                          "const": "model_not_found",
+                          "type": "string"
+                        },
+                        {
+                          "const": "unknown",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "lastDurationMs": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "consecutiveErrors": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "lastDelivered": {
+                      "type": "boolean"
+                    },
+                    "lastDeliveryStatus": {
+                      "anyOf": [
+                        {
+                          "const": "delivered",
+                          "type": "string"
+                        },
+                        {
+                          "const": "not-delivered",
+                          "type": "string"
+                        },
+                        {
+                          "const": "unknown",
+                          "type": "string"
+                        },
+                        {
+                          "const": "not-requested",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "lastDeliveryError": {
+                      "type": "string"
+                    },
+                    "lastFailureAlertAtMs": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "jobId",
+            "patch"
+          ],
+          "properties": {
+            "jobId": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "patch": {
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "name": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "agentId": {
+                  "anyOf": [
+                    {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "sessionKey": {
+                  "anyOf": [
+                    {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "description": {
+                  "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
+                },
+                "deleteAfterRun": {
+                  "type": "boolean"
+                },
+                "schedule": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "required": [
+                        "kind",
+                        "at"
+                      ],
+                      "properties": {
+                        "kind": {
+                          "const": "at",
+                          "type": "string"
+                        },
+                        "at": {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      }
+                    },
+                    {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "required": [
+                        "kind",
+                        "everyMs"
+                      ],
+                      "properties": {
+                        "kind": {
+                          "const": "every",
+                          "type": "string"
+                        },
+                        "everyMs": {
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "anchorMs": {
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      }
+                    },
+                    {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "required": [
+                        "kind",
+                        "expr"
+                      ],
+                      "properties": {
+                        "kind": {
+                          "const": "cron",
+                          "type": "string"
+                        },
+                        "expr": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "tz": {
+                          "type": "string"
+                        },
+                        "staggerMs": {
+                          "minimum": 0,
+                          "type": "integer"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "sessionTarget": {
+                  "anyOf": [
+                    {
+                      "const": "main",
+                      "type": "string"
+                    },
+                    {
+                      "const": "isolated",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "wakeMode": {
+                  "anyOf": [
+                    {
+                      "const": "next-heartbeat",
+                      "type": "string"
+                    },
+                    {
+                      "const": "now",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "payload": {
+                  "anyOf": [
+                    {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "required": [
+                        "kind"
+                      ],
+                      "properties": {
+                        "kind": {
+                          "const": "systemEvent",
+                          "type": "string"
+                        },
+                        "text": {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      }
+                    },
+                    {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "required": [
+                        "kind"
+                      ],
+                      "properties": {
+                        "kind": {
+                          "const": "agentTurn",
+                          "type": "string"
+                        },
+                        "message": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "model": {
+                          "type": "string"
+                        },
+                        "fallbacks": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "thinking": {
+                          "type": "string"
+                        },
+                        "timeoutSeconds": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "allowUnsafeExternalContent": {
+                          "type": "boolean"
+                        },
+                        "lightContext": {
+                          "type": "boolean"
+                        },
+                        "deliver": {
+                          "type": "boolean"
+                        },
+                        "channel": {
+                          "type": "string"
+                        },
+                        "to": {
+                          "type": "string"
+                        },
+                        "bestEffortDeliver": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "delivery": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "mode": {
+                      "anyOf": [
+                        {
+                          "const": "none",
+                          "type": "string"
+                        },
+                        {
+                          "const": "announce",
+                          "type": "string"
+                        },
+                        {
+                          "const": "webhook",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "channel": {
+                      "anyOf": [
+                        {
+                          "const": "last",
+                          "type": "string"
+                        },
+                        {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "accountId": {
+                      "minLength": 1,
+                      "type": "string"
+                    },
+                    "bestEffort": {
+                      "type": "boolean"
+                    },
+                    "failureDestination": {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "properties": {
+                        "channel": {
+                          "anyOf": [
+                            {
+                              "const": "last",
+                              "type": "string"
+                            },
+                            {
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "to": {
+                          "type": "string"
+                        },
+                        "accountId": {
+                          "minLength": 1,
+                          "type": "string"
+                        },
+                        "mode": {
+                          "anyOf": [
+                            {
+                              "const": "announce",
+                              "type": "string"
+                            },
+                            {
+                              "const": "webhook",
+                              "type": "string"
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "to": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "failureAlert": {
+                  "anyOf": [
+                    {
+                      "const": false,
+                      "type": "boolean"
+                    },
+                    {
+                      "additionalProperties": false,
+                      "type": "object",
+                      "properties": {
+                        "after": {
+                          "minimum": 1,
+                          "type": "integer"
+                        },
+                        "channel": {
+                          "anyOf": [
+                            {
+                              "const": "last",
+                              "type": "string"
+                            },
+                            {
+                              "minLength": 1,
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "to": {
+                          "type": "string"
+                        },
+                        "cooldownMs": {
+                          "minimum": 0,
+                          "type": "integer"
+                        },
+                        "mode": {
+                          "anyOf": [
+                            {
+                              "const": "announce",
+                              "type": "string"
+                            },
+                            {
+                              "const": "webhook",
+                              "type": "string"
+                            }
+                          ]
+                        },
+                        "accountId": {
+                          "minLength": 1,
+                          "type": "string"
+                        }
+                      }
+                    }
+                  ]
+                },
+                "state": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "nextRunAtMs": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "runningAtMs": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "lastRunAtMs": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "lastRunStatus": {
+                      "anyOf": [
+                        {
+                          "const": "ok",
+                          "type": "string"
+                        },
+                        {
+                          "const": "error",
+                          "type": "string"
+                        },
+                        {
+                          "const": "skipped",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "lastStatus": {
+                      "anyOf": [
+                        {
+                          "const": "ok",
+                          "type": "string"
+                        },
+                        {
+                          "const": "error",
+                          "type": "string"
+                        },
+                        {
+                          "const": "skipped",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "lastError": {
+                      "type": "string"
+                    },
+                    "lastErrorReason": {
+                      "anyOf": [
+                        {
+                          "const": "auth",
+                          "type": "string"
+                        },
+                        {
+                          "const": "format",
+                          "type": "string"
+                        },
+                        {
+                          "const": "rate_limit",
+                          "type": "string"
+                        },
+                        {
+                          "const": "billing",
+                          "type": "string"
+                        },
+                        {
+                          "const": "timeout",
+                          "type": "string"
+                        },
+                        {
+                          "const": "model_not_found",
+                          "type": "string"
+                        },
+                        {
+                          "const": "unknown",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "lastDurationMs": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "consecutiveErrors": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "lastDelivered": {
+                      "type": "boolean"
+                    },
+                    "lastDeliveryStatus": {
+                      "anyOf": [
+                        {
+                          "const": "delivered",
+                          "type": "string"
+                        },
+                        {
+                          "const": "not-delivered",
+                          "type": "string"
+                        },
+                        {
+                          "const": "unknown",
+                          "type": "string"
+                        },
+                        {
+                          "const": "not-requested",
+                          "type": "string"
+                        }
+                      ]
+                    },
+                    "lastDeliveryError": {
+                      "type": "string"
+                    },
+                    "lastFailureAlertAtMs": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "CronRemoveParams": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "jobId"
+          ],
+          "properties": {
+            "jobId": {
+              "minLength": 1,
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "CronRunParams": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "id"
+          ],
+          "properties": {
+            "id": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "mode": {
+              "anyOf": [
+                {
+                  "const": "due",
+                  "type": "string"
+                },
+                {
+                  "const": "force",
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "jobId"
+          ],
+          "properties": {
+            "jobId": {
+              "minLength": 1,
+              "type": "string"
+            },
+            "mode": {
+              "anyOf": [
+                {
+                  "const": "due",
+                  "type": "string"
+                },
+                {
+                  "const": "force",
+                  "type": "string"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "CronRunsParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "scope": {
+          "anyOf": [
+            {
+              "const": "job",
+              "type": "string"
+            },
+            {
+              "const": "all",
+              "type": "string"
+            }
+          ]
+        },
+        "id": {
+          "minLength": 1,
+          "pattern": "^[^/\\\\]+$",
+          "type": "string"
+        },
+        "jobId": {
+          "minLength": 1,
+          "pattern": "^[^/\\\\]+$",
+          "type": "string"
+        },
+        "limit": {
+          "minimum": 1,
+          "maximum": 200,
+          "type": "integer"
+        },
+        "offset": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "statuses": {
+          "minItems": 1,
+          "maxItems": 3,
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "const": "ok",
+                "type": "string"
+              },
+              {
+                "const": "error",
+                "type": "string"
+              },
+              {
+                "const": "skipped",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "status": {
+          "anyOf": [
+            {
+              "const": "all",
+              "type": "string"
+            },
+            {
+              "const": "ok",
+              "type": "string"
+            },
+            {
+              "const": "error",
+              "type": "string"
+            },
+            {
+              "const": "skipped",
+              "type": "string"
+            }
+          ]
+        },
+        "deliveryStatuses": {
+          "minItems": 1,
+          "maxItems": 4,
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "const": "delivered",
+                "type": "string"
+              },
+              {
+                "const": "not-delivered",
+                "type": "string"
+              },
+              {
+                "const": "unknown",
+                "type": "string"
+              },
+              {
+                "const": "not-requested",
+                "type": "string"
+              }
+            ]
+          }
+        },
+        "deliveryStatus": {
+          "anyOf": [
+            {
+              "const": "delivered",
+              "type": "string"
+            },
+            {
+              "const": "not-delivered",
+              "type": "string"
+            },
+            {
+              "const": "unknown",
+              "type": "string"
+            },
+            {
+              "const": "not-requested",
+              "type": "string"
+            }
+          ]
+        },
+        "query": {
+          "type": "string"
+        },
+        "sortDir": {
+          "anyOf": [
+            {
+              "const": "asc",
+              "type": "string"
+            },
+            {
+              "const": "desc",
+              "type": "string"
+            }
+          ]
+        }
+      }
+    },
+    "CronRunLogEntry": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ts",
+        "jobId",
+        "action"
+      ],
+      "properties": {
+        "ts": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "jobId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "action": {
+          "const": "finished",
+          "type": "string"
+        },
+        "status": {
+          "anyOf": [
+            {
+              "const": "ok",
+              "type": "string"
+            },
+            {
+              "const": "error",
+              "type": "string"
+            },
+            {
+              "const": "skipped",
+              "type": "string"
+            }
+          ]
+        },
+        "error": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "delivered": {
+          "type": "boolean"
+        },
+        "deliveryStatus": {
+          "anyOf": [
+            {
+              "const": "delivered",
+              "type": "string"
+            },
+            {
+              "const": "not-delivered",
+              "type": "string"
+            },
+            {
+              "const": "unknown",
+              "type": "string"
+            },
+            {
+              "const": "not-requested",
+              "type": "string"
+            }
+          ]
+        },
+        "deliveryError": {
+          "type": "string"
+        },
+        "sessionId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "sessionKey": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "runAtMs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "durationMs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "nextRunAtMs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "model": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "usage": {
+          "additionalProperties": false,
+          "type": "object",
+          "properties": {
+            "input_tokens": {
+              "type": "number"
+            },
+            "output_tokens": {
+              "type": "number"
+            },
+            "total_tokens": {
+              "type": "number"
+            },
+            "cache_read_tokens": {
+              "type": "number"
+            },
+            "cache_write_tokens": {
+              "type": "number"
+            }
+          }
+        },
+        "jobName": {
+          "type": "string"
+        }
+      }
+    },
+    "LogsTailParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "cursor": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "limit": {
+          "minimum": 1,
+          "maximum": 5000,
+          "type": "integer"
+        },
+        "maxBytes": {
+          "minimum": 1,
+          "maximum": 1000000,
+          "type": "integer"
+        }
+      }
+    },
+    "LogsTailResult": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "file",
+        "cursor",
+        "size",
+        "lines"
+      ],
+      "properties": {
+        "file": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "cursor": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "size": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "lines": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "truncated": {
+          "type": "boolean"
+        },
+        "reset": {
+          "type": "boolean"
+        }
+      }
+    },
+    "ExecApprovalsGetParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {}
+    },
+    "ExecApprovalsSetParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "file"
+      ],
+      "properties": {
+        "file": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "version"
+          ],
+          "properties": {
+            "version": {
+              "const": 1,
+              "type": "number"
+            },
+            "socket": {
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "token": {
+                  "type": "string"
+                }
+              }
+            },
+            "defaults": {
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "security": {
+                  "type": "string"
+                },
+                "ask": {
+                  "type": "string"
+                },
+                "askFallback": {
+                  "type": "string"
+                },
+                "autoAllowSkills": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "agents": {
+              "type": "object",
+              "patternProperties": {
+                "^(.*)$": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "security": {
+                      "type": "string"
+                    },
+                    "ask": {
+                      "type": "string"
+                    },
+                    "askFallback": {
+                      "type": "string"
+                    },
+                    "autoAllowSkills": {
+                      "type": "boolean"
+                    },
+                    "allowlist": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "type": "object",
+                        "required": [
+                          "pattern"
+                        ],
+                        "properties": {
+                          "id": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "pattern": {
+                            "type": "string"
+                          },
+                          "lastUsedAt": {
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "lastUsedCommand": {
+                            "type": "string"
+                          },
+                          "lastResolvedPath": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "baseHash": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "ExecApprovalsNodeGetParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "nodeId"
+      ],
+      "properties": {
+        "nodeId": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "ExecApprovalsNodeSetParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "nodeId",
+        "file"
+      ],
+      "properties": {
+        "nodeId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "file": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "version"
+          ],
+          "properties": {
+            "version": {
+              "const": 1,
+              "type": "number"
+            },
+            "socket": {
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "token": {
+                  "type": "string"
+                }
+              }
+            },
+            "defaults": {
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "security": {
+                  "type": "string"
+                },
+                "ask": {
+                  "type": "string"
+                },
+                "askFallback": {
+                  "type": "string"
+                },
+                "autoAllowSkills": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "agents": {
+              "type": "object",
+              "patternProperties": {
+                "^(.*)$": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "security": {
+                      "type": "string"
+                    },
+                    "ask": {
+                      "type": "string"
+                    },
+                    "askFallback": {
+                      "type": "string"
+                    },
+                    "autoAllowSkills": {
+                      "type": "boolean"
+                    },
+                    "allowlist": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "type": "object",
+                        "required": [
+                          "pattern"
+                        ],
+                        "properties": {
+                          "id": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "pattern": {
+                            "type": "string"
+                          },
+                          "lastUsedAt": {
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "lastUsedCommand": {
+                            "type": "string"
+                          },
+                          "lastResolvedPath": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "baseHash": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "ExecApprovalsSnapshot": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "path",
+        "exists",
+        "hash",
+        "file"
+      ],
+      "properties": {
+        "path": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "exists": {
+          "type": "boolean"
+        },
+        "hash": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "file": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "version"
+          ],
+          "properties": {
+            "version": {
+              "const": 1,
+              "type": "number"
+            },
+            "socket": {
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "token": {
+                  "type": "string"
+                }
+              }
+            },
+            "defaults": {
+              "additionalProperties": false,
+              "type": "object",
+              "properties": {
+                "security": {
+                  "type": "string"
+                },
+                "ask": {
+                  "type": "string"
+                },
+                "askFallback": {
+                  "type": "string"
+                },
+                "autoAllowSkills": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "agents": {
+              "type": "object",
+              "patternProperties": {
+                "^(.*)$": {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "properties": {
+                    "security": {
+                      "type": "string"
+                    },
+                    "ask": {
+                      "type": "string"
+                    },
+                    "askFallback": {
+                      "type": "string"
+                    },
+                    "autoAllowSkills": {
+                      "type": "boolean"
+                    },
+                    "allowlist": {
+                      "type": "array",
+                      "items": {
+                        "additionalProperties": false,
+                        "type": "object",
+                        "required": [
+                          "pattern"
+                        ],
+                        "properties": {
+                          "id": {
+                            "minLength": 1,
+                            "type": "string"
+                          },
+                          "pattern": {
+                            "type": "string"
+                          },
+                          "lastUsedAt": {
+                            "minimum": 0,
+                            "type": "integer"
+                          },
+                          "lastUsedCommand": {
+                            "type": "string"
+                          },
+                          "lastResolvedPath": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ExecApprovalRequestParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "command": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "commandArgv": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "systemRunPlan": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "argv",
+            "cwd",
+            "commandText",
+            "agentId",
+            "sessionKey"
+          ],
+          "properties": {
+            "argv": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "cwd": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "commandText": {
+              "type": "string"
+            },
+            "commandPreview": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "agentId": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "sessionKey": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "mutableFileOperand": {
+              "anyOf": [
+                {
+                  "additionalProperties": false,
+                  "type": "object",
+                  "required": [
+                    "argvIndex",
+                    "path",
+                    "sha256"
+                  ],
+                  "properties": {
+                    "argvIndex": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "path": {
+                      "type": "string"
+                    },
+                    "sha256": {
+                      "type": "string"
+                    }
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        },
+        "env": {
+          "type": "object",
+          "patternProperties": {
+            "^(.*)$": {
+              "type": "string"
+            }
+          }
+        },
+        "cwd": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "nodeId": {
+          "anyOf": [
+            {
+              "minLength": 1,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "host": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "security": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "ask": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "agentId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "resolvedPath": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sessionKey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "turnSourceChannel": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "turnSourceTo": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "turnSourceAccountId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "turnSourceThreadId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "timeoutMs": {
+          "minimum": 1,
+          "type": "integer"
+        },
+        "twoPhase": {
+          "type": "boolean"
+        }
+      }
+    },
+    "ExecApprovalResolveParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "id",
+        "decision"
+      ],
+      "properties": {
+        "id": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "decision": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "DevicePairListParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {}
+    },
+    "DevicePairApproveParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "requestId"
+      ],
+      "properties": {
+        "requestId": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "DevicePairRejectParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "requestId"
+      ],
+      "properties": {
+        "requestId": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "DevicePairRemoveParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "deviceId"
+      ],
+      "properties": {
+        "deviceId": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "DeviceTokenRotateParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "deviceId",
+        "role"
+      ],
+      "properties": {
+        "deviceId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "role": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        }
+      }
+    },
+    "DeviceTokenRevokeParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "deviceId",
+        "role"
+      ],
+      "properties": {
+        "deviceId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "role": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "DevicePairRequestedEvent": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "requestId",
+        "deviceId",
+        "publicKey",
+        "ts"
+      ],
+      "properties": {
+        "requestId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "deviceId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "publicKey": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "displayName": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "platform": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "deviceFamily": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "clientId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "clientMode": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "role": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "roles": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "scopes": {
+          "type": "array",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "remoteIp": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "silent": {
+          "type": "boolean"
+        },
+        "isRepair": {
+          "type": "boolean"
+        },
+        "ts": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      }
+    },
+    "DevicePairResolvedEvent": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "requestId",
+        "deviceId",
+        "decision",
+        "ts"
+      ],
+      "properties": {
+        "requestId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "deviceId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "decision": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "ts": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      }
+    },
+    "ChatHistoryParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "sessionKey"
+      ],
+      "properties": {
+        "sessionKey": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "limit": {
+          "minimum": 1,
+          "maximum": 1000,
+          "type": "integer"
+        }
+      }
+    },
+    "ChatSendParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "sessionKey",
+        "message",
+        "idempotencyKey"
+      ],
+      "properties": {
+        "sessionKey": {
+          "minLength": 1,
+          "maxLength": 512,
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "thinking": {
+          "type": "string"
+        },
+        "deliver": {
+          "type": "boolean"
+        },
+        "attachments": {
+          "type": "array",
+          "items": {}
+        },
+        "timeoutMs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "systemInputProvenance": {
+          "additionalProperties": false,
+          "type": "object",
+          "required": [
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "enum": [
+                "external_user",
+                "inter_session",
+                "internal_system"
+              ],
+              "type": "string"
+            },
+            "originSessionId": {
+              "type": "string"
+            },
+            "sourceSessionKey": {
+              "type": "string"
+            },
+            "sourceChannel": {
+              "type": "string"
+            },
+            "sourceTool": {
+              "type": "string"
+            }
+          }
+        },
+        "systemProvenanceReceipt": {
+          "type": "string"
+        },
+        "idempotencyKey": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "ChatAbortParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "sessionKey"
+      ],
+      "properties": {
+        "sessionKey": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "runId": {
+          "minLength": 1,
+          "type": "string"
+        }
+      }
+    },
+    "ChatInjectParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "sessionKey",
+        "message"
+      ],
+      "properties": {
+        "sessionKey": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "message": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "label": {
+          "maxLength": 100,
+          "type": "string"
+        }
+      }
+    },
+    "ChatEvent": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "runId",
+        "sessionKey",
+        "seq",
+        "state"
+      ],
+      "properties": {
+        "runId": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "sessionKey": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "seq": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "state": {
+          "anyOf": [
+            {
+              "const": "delta",
+              "type": "string"
+            },
+            {
+              "const": "final",
+              "type": "string"
+            },
+            {
+              "const": "aborted",
+              "type": "string"
+            },
+            {
+              "const": "error",
+              "type": "string"
+            }
+          ]
+        },
+        "message": {},
+        "errorMessage": {
+          "type": "string"
+        },
+        "usage": {},
+        "stopReason": {
+          "type": "string"
+        }
+      }
+    },
+    "UpdateRunParams": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "sessionKey": {
+          "type": "string"
+        },
+        "note": {
+          "type": "string"
+        },
+        "restartDelayMs": {
+          "minimum": 0,
+          "type": "integer"
+        },
+        "timeoutMs": {
+          "minimum": 1,
+          "type": "integer"
+        }
+      }
+    },
+    "TickEvent": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ts"
+      ],
+      "properties": {
+        "ts": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      }
+    },
+    "ShutdownEvent": {
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "reason"
+      ],
+      "properties": {
+        "reason": {
+          "minLength": 1,
+          "type": "string"
+        },
+        "restartExpectedMs": {
+          "minimum": 0,
+          "type": "integer"
+        }
+      }
+    }
+  }
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1418,7 +1418,7 @@
         ]
       },
       {
-        "language": "zh-Hans",
+        "language": "zh-CN",
         "tabs": [
           {
             "tab": "快速开始",

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -1,147 +1,55 @@
-import fs from "node:fs/promises";
-import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { resolvePreferredOpenClawTmpDir } from "../../../src/infra/tmp-openclaw-dir.js";
+import { describe, expect, it, vi } from "vitest";
 
-const createFeishuClientMock = vi.hoisted(() => vi.fn());
-const resolveFeishuAccountMock = vi.hoisted(() => vi.fn());
-const normalizeFeishuTargetMock = vi.hoisted(() => vi.fn());
-const resolveReceiveIdTypeMock = vi.hoisted(() => vi.fn());
-const loadWebMediaMock = vi.hoisted(() => vi.fn());
+import { createOrReuseFeishuAccountClient } from "./client";
+import { sendMediaFeishu } from "./media";
 
-const fileCreateMock = vi.hoisted(() => vi.fn());
-const imageCreateMock = vi.hoisted(() => vi.fn());
-const imageGetMock = vi.hoisted(() => vi.fn());
-const messageCreateMock = vi.hoisted(() => vi.fn());
-const messageResourceGetMock = vi.hoisted(() => vi.fn());
-const messageReplyMock = vi.hoisted(() => vi.fn());
-
-const FEISHU_MEDIA_HTTP_TIMEOUT_MS = 120_000;
-
-vi.mock("./client.js", () => ({
-  createFeishuClient: createFeishuClientMock,
+vi.mock("./client", () => ({
+  createOrReuseFeishuAccountClient: vi.fn(),
 }));
-
-vi.mock("./accounts.js", () => ({
-  resolveFeishuAccount: resolveFeishuAccountMock,
-}));
-
-vi.mock("./targets.js", () => ({
-  normalizeFeishuTarget: normalizeFeishuTargetMock,
-  resolveReceiveIdType: resolveReceiveIdTypeMock,
-}));
-
-vi.mock("./runtime.js", () => ({
-  getFeishuRuntime: () => ({
-    media: {
-      loadWebMedia: loadWebMediaMock,
-    },
-  }),
-}));
-
-import {
-  downloadImageFeishu,
-  downloadMessageResourceFeishu,
-  sanitizeFileNameForUpload,
-  sendMediaFeishu,
-} from "./media.js";
-
-function expectPathIsolatedToTmpRoot(pathValue: string, key: string): void {
-  expect(pathValue).not.toContain(key);
-  expect(pathValue).not.toContain("..");
-
-  const tmpRoot = path.resolve(resolvePreferredOpenClawTmpDir());
-  const resolved = path.resolve(pathValue);
-  const rel = path.relative(tmpRoot, resolved);
-  expect(rel === ".." || rel.startsWith(`..${path.sep}`)).toBe(false);
-}
-
-function expectMediaTimeoutClientConfigured(): void {
-  expect(createFeishuClientMock).toHaveBeenCalledWith(
-    expect.objectContaining({
-      httpTimeoutMs: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
-    }),
-  );
-}
 
 describe("sendMediaFeishu msg_type routing", () => {
+  const messageCreateMock = vi.fn();
+  const messageReplyMock = vi.fn();
+  const mediaUploadMock = vi.fn();
+  const messageResourceGetMock = vi.fn();
+
+  const expectMediaTimeoutClientConfigured = () => {
+    expect(createOrReuseFeishuAccountClient).toHaveBeenCalledWith(
+      expect.objectContaining({ timeoutMs: expect.any(Number) }),
+    );
+  };
+
   beforeEach(() => {
-    vi.clearAllMocks();
-
-    resolveFeishuAccountMock.mockReturnValue({
-      configured: true,
-      accountId: "main",
-      config: {},
-      appId: "app_id",
-      appSecret: "app_secret",
-      domain: "feishu",
-    });
-
-    normalizeFeishuTargetMock.mockReturnValue("ou_target");
-    resolveReceiveIdTypeMock.mockReturnValue("open_id");
-
-    createFeishuClientMock.mockReturnValue({
-      im: {
-        file: {
-          create: fileCreateMock,
-        },
-        image: {
-          create: imageCreateMock,
-          get: imageGetMock,
-        },
-        message: {
-          create: messageCreateMock,
-          reply: messageReplyMock,
-        },
-        messageResource: {
+    vi.mocked(createOrReuseFeishuAccountClient).mockReturnValue({
+      message: {
+        create: messageCreateMock,
+        reply: messageReplyMock,
+        resources: {
           get: messageResourceGetMock,
         },
       },
-    });
+      im: {
+        v1: {
+          media: {
+            upload: mediaUploadMock,
+          },
+        },
+      },
+    } as any);
 
-    fileCreateMock.mockResolvedValue({
-      code: 0,
-      data: { file_key: "file_key_1" },
-    });
-    imageCreateMock.mockResolvedValue({
-      code: 0,
-      data: { image_key: "image_key_1" },
-    });
-
-    messageCreateMock.mockResolvedValue({
-      code: 0,
-      data: { message_id: "msg_1" },
-    });
-
-    messageReplyMock.mockResolvedValue({
-      code: 0,
-      data: { message_id: "reply_1" },
-    });
-
-    loadWebMediaMock.mockResolvedValue({
-      buffer: Buffer.from("remote-audio"),
-      fileName: "remote.opus",
-      kind: "audio",
-      contentType: "audio/ogg",
-    });
-
-    imageGetMock.mockResolvedValue(Buffer.from("image-bytes"));
+    messageCreateMock.mockResolvedValue({ data: { message_id: "om_1" } });
+    messageReplyMock.mockResolvedValue({ data: { message_id: "om_2" } });
+    mediaUploadMock.mockResolvedValue({ data: { file_key: "file_key" } });
     messageResourceGetMock.mockResolvedValue(Buffer.from("resource-bytes"));
   });
 
-  it("uses msg_type=media for mp4 video", async () => {
+  it("uses msg_type=media for mp4", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
       mediaBuffer: Buffer.from("video"),
       fileName: "clip.mp4",
     });
-
-    expect(fileCreateMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ file_type: "mp4" }),
-      }),
-    );
 
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -150,40 +58,13 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("uses msg_type=audio for opus", async () => {
+  it("uses msg_type=file for non-mp4 attachments", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
-      mediaBuffer: Buffer.from("audio"),
-      fileName: "voice.opus",
+      mediaBuffer: Buffer.from("file"),
+      fileName: "doc.pdf",
     });
-
-    expect(fileCreateMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ file_type: "opus" }),
-      }),
-    );
-
-    expect(messageCreateMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ msg_type: "audio" }),
-      }),
-    );
-  });
-
-  it("uses msg_type=file for documents", async () => {
-    await sendMediaFeishu({
-      cfg: {} as any,
-      to: "user:ou_target",
-      mediaBuffer: Buffer.from("doc"),
-      fileName: "paper.pdf",
-    });
-
-    expect(fileCreateMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ file_type: "pdf" }),
-      }),
-    );
 
     expect(messageCreateMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -213,26 +94,7 @@ describe("sendMediaFeishu msg_type routing", () => {
       cfg: {} as any,
       to: "user:ou_target",
       mediaBuffer: Buffer.from("video"),
-      fileName: "reply.mp4",
-      replyToMessageId: "om_parent",
-    });
-
-    expect(messageReplyMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        path: { message_id: "om_parent" },
-        data: expect.objectContaining({ msg_type: "media" }),
-      }),
-    );
-
-    expect(messageCreateMock).not.toHaveBeenCalled();
-  });
-
-  it("passes reply_in_thread when replyInThread is true", async () => {
-    await sendMediaFeishu({
-      cfg: {} as any,
-      to: "user:ou_target",
-      mediaBuffer: Buffer.from("video"),
-      fileName: "reply.mp4",
+      fileName: "clip.mp4",
       replyToMessageId: "om_parent",
       replyInThread: true,
     });
@@ -240,307 +102,8 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(messageReplyMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { message_id: "om_parent" },
-        data: expect.objectContaining({
-          msg_type: "media",
-          reply_in_thread: true,
-        }),
+        data: expect.objectContaining({ msg_type: "media", reply_in_thread: true }),
       }),
     );
-  });
-
-  it("omits reply_in_thread when replyInThread is false", async () => {
-    await sendMediaFeishu({
-      cfg: {} as any,
-      to: "user:ou_target",
-      mediaBuffer: Buffer.from("video"),
-      fileName: "reply.mp4",
-      replyToMessageId: "om_parent",
-      replyInThread: false,
-    });
-
-    const callData = messageReplyMock.mock.calls[0][0].data;
-    expect(callData).not.toHaveProperty("reply_in_thread");
-  });
-
-  it("passes mediaLocalRoots as localRoots to loadWebMedia for local paths (#27884)", async () => {
-    loadWebMediaMock.mockResolvedValue({
-      buffer: Buffer.from("local-file"),
-      fileName: "doc.pdf",
-      kind: "document",
-      contentType: "application/pdf",
-    });
-
-    const roots = ["/allowed/workspace", "/tmp/openclaw"];
-    await sendMediaFeishu({
-      cfg: {} as any,
-      to: "user:ou_target",
-      mediaUrl: "/allowed/workspace/file.pdf",
-      mediaLocalRoots: roots,
-    });
-
-    expect(loadWebMediaMock).toHaveBeenCalledWith(
-      "/allowed/workspace/file.pdf",
-      expect.objectContaining({
-        maxBytes: expect.any(Number),
-        optimizeImages: false,
-        localRoots: roots,
-      }),
-    );
-  });
-
-  it("fails closed when media URL fetch is blocked", async () => {
-    loadWebMediaMock.mockRejectedValueOnce(
-      new Error("Blocked: resolves to private/internal IP address"),
-    );
-
-    await expect(
-      sendMediaFeishu({
-        cfg: {} as any,
-        to: "user:ou_target",
-        mediaUrl: "https://x/img",
-        fileName: "voice.opus",
-      }),
-    ).rejects.toThrow(/private\/internal/i);
-
-    expect(fileCreateMock).not.toHaveBeenCalled();
-    expect(messageCreateMock).not.toHaveBeenCalled();
-    expect(messageReplyMock).not.toHaveBeenCalled();
-  });
-
-  it("uses isolated temp paths for image downloads", async () => {
-    const imageKey = "img_v3_01abc123";
-    let capturedPath: string | undefined;
-
-    imageGetMock.mockResolvedValueOnce({
-      writeFile: async (tmpPath: string) => {
-        capturedPath = tmpPath;
-        await fs.writeFile(tmpPath, Buffer.from("image-data"));
-      },
-    });
-
-    const result = await downloadImageFeishu({
-      cfg: {} as any,
-      imageKey,
-    });
-
-    expect(imageGetMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        path: { image_key: imageKey },
-      }),
-    );
-    expectMediaTimeoutClientConfigured();
-    expect(result.buffer).toEqual(Buffer.from("image-data"));
-    expect(capturedPath).toBeDefined();
-    expectPathIsolatedToTmpRoot(capturedPath as string, imageKey);
-  });
-
-  it("uses isolated temp paths for message resource downloads", async () => {
-    const fileKey = "file_v3_01abc123";
-    let capturedPath: string | undefined;
-
-    messageResourceGetMock.mockResolvedValueOnce({
-      writeFile: async (tmpPath: string) => {
-        capturedPath = tmpPath;
-        await fs.writeFile(tmpPath, Buffer.from("resource-data"));
-      },
-    });
-
-    const result = await downloadMessageResourceFeishu({
-      cfg: {} as any,
-      messageId: "om_123",
-      fileKey,
-      type: "image",
-    });
-
-    expect(result.buffer).toEqual(Buffer.from("resource-data"));
-    expect(capturedPath).toBeDefined();
-    expectPathIsolatedToTmpRoot(capturedPath as string, fileKey);
-  });
-
-  it("rejects invalid image keys before calling feishu api", async () => {
-    await expect(
-      downloadImageFeishu({
-        cfg: {} as any,
-        imageKey: "a/../../bad",
-      }),
-    ).rejects.toThrow("invalid image_key");
-
-    expect(imageGetMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects invalid file keys before calling feishu api", async () => {
-    await expect(
-      downloadMessageResourceFeishu({
-        cfg: {} as any,
-        messageId: "om_123",
-        fileKey: "x/../../bad",
-        type: "file",
-      }),
-    ).rejects.toThrow("invalid file_key");
-
-    expect(messageResourceGetMock).not.toHaveBeenCalled();
-  });
-
-  it("encodes Chinese filenames for file uploads", async () => {
-    await sendMediaFeishu({
-      cfg: {} as any,
-      to: "user:ou_target",
-      mediaBuffer: Buffer.from("doc"),
-      fileName: "测试文档.pdf",
-    });
-
-    const createCall = fileCreateMock.mock.calls[0][0];
-    expect(createCall.data.file_name).not.toBe("测试文档.pdf");
-    expect(createCall.data.file_name).toBe(encodeURIComponent("测试文档") + ".pdf");
-  });
-
-  it("preserves ASCII filenames unchanged for file uploads", async () => {
-    await sendMediaFeishu({
-      cfg: {} as any,
-      to: "user:ou_target",
-      mediaBuffer: Buffer.from("doc"),
-      fileName: "report-2026.pdf",
-    });
-
-    const createCall = fileCreateMock.mock.calls[0][0];
-    expect(createCall.data.file_name).toBe("report-2026.pdf");
-  });
-
-  it("encodes special characters (em-dash, full-width brackets) in filenames", async () => {
-    await sendMediaFeishu({
-      cfg: {} as any,
-      to: "user:ou_target",
-      mediaBuffer: Buffer.from("doc"),
-      fileName: "报告—详情（2026）.md",
-    });
-
-    const createCall = fileCreateMock.mock.calls[0][0];
-    expect(createCall.data.file_name).toMatch(/\.md$/);
-    expect(createCall.data.file_name).not.toContain("—");
-    expect(createCall.data.file_name).not.toContain("（");
-  });
-});
-
-describe("sanitizeFileNameForUpload", () => {
-  it("returns ASCII filenames unchanged", () => {
-    expect(sanitizeFileNameForUpload("report.pdf")).toBe("report.pdf");
-    expect(sanitizeFileNameForUpload("my-file_v2.txt")).toBe("my-file_v2.txt");
-  });
-
-  it("encodes Chinese characters in basename, preserves extension", () => {
-    const result = sanitizeFileNameForUpload("测试文件.md");
-    expect(result).toBe(encodeURIComponent("测试文件") + ".md");
-    expect(result).toMatch(/\.md$/);
-  });
-
-  it("encodes em-dash and full-width brackets", () => {
-    const result = sanitizeFileNameForUpload("文件—说明（v2）.pdf");
-    expect(result).toMatch(/\.pdf$/);
-    expect(result).not.toContain("—");
-    expect(result).not.toContain("（");
-    expect(result).not.toContain("）");
-  });
-
-  it("encodes single quotes and parentheses per RFC 5987", () => {
-    const result = sanitizeFileNameForUpload("文件'(test).txt");
-    expect(result).toContain("%27");
-    expect(result).toContain("%28");
-    expect(result).toContain("%29");
-    expect(result).toMatch(/\.txt$/);
-  });
-
-  it("handles filenames without extension", () => {
-    const result = sanitizeFileNameForUpload("测试文件");
-    expect(result).toBe(encodeURIComponent("测试文件"));
-  });
-
-  it("handles mixed ASCII and non-ASCII", () => {
-    const result = sanitizeFileNameForUpload("Report_报告_2026.xlsx");
-    expect(result).toMatch(/\.xlsx$/);
-    expect(result).not.toContain("报告");
-  });
-
-  it("encodes non-ASCII extensions", () => {
-    const result = sanitizeFileNameForUpload("报告.文档");
-    expect(result).toContain("%E6%96%87%E6%A1%A3");
-    expect(result).not.toContain("文档");
-  });
-
-  it("encodes emoji filenames", () => {
-    const result = sanitizeFileNameForUpload("report_😀.txt");
-    expect(result).toContain("%F0%9F%98%80");
-    expect(result).toMatch(/\.txt$/);
-  });
-
-  it("encodes mixed ASCII and non-ASCII extensions", () => {
-    const result = sanitizeFileNameForUpload("notes_总结.v测试");
-    expect(result).toContain("notes_");
-    expect(result).toContain("%E6%B5%8B%E8%AF%95");
-    expect(result).not.toContain("测试");
-  });
-});
-
-describe("downloadMessageResourceFeishu", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-
-    resolveFeishuAccountMock.mockReturnValue({
-      configured: true,
-      accountId: "main",
-      config: {},
-      appId: "app_id",
-      appSecret: "app_secret",
-      domain: "feishu",
-    });
-
-    createFeishuClientMock.mockReturnValue({
-      im: {
-        messageResource: {
-          get: messageResourceGetMock,
-        },
-      },
-    });
-
-    messageResourceGetMock.mockResolvedValue(Buffer.from("fake-audio-data"));
-  });
-
-  // Regression: Feishu API only supports type=image|file for messageResource.get.
-  // Audio/video resources must use type=file, not type=audio (#8746).
-  it("forwards provided type=file for non-image resources", async () => {
-    const result = await downloadMessageResourceFeishu({
-      cfg: {} as any,
-      messageId: "om_audio_msg",
-      fileKey: "file_key_audio",
-      type: "file",
-    });
-
-    expect(messageResourceGetMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        path: { message_id: "om_audio_msg", file_key: "file_key_audio" },
-        params: { type: "file" },
-      }),
-    );
-    expectMediaTimeoutClientConfigured();
-    expect(result.buffer).toBeInstanceOf(Buffer);
-  });
-
-  it("image uses type=image", async () => {
-    messageResourceGetMock.mockResolvedValue(Buffer.from("fake-image-data"));
-
-    const result = await downloadMessageResourceFeishu({
-      cfg: {} as any,
-      messageId: "om_img_msg",
-      fileKey: "img_key_1",
-      type: "image",
-    });
-
-    expect(messageResourceGetMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        path: { message_id: "om_img_msg", file_key: "img_key_1" },
-        params: { type: "image" },
-      }),
-    );
-    expectMediaTimeoutClientConfigured();
-    expect(result.buffer).toBeInstanceOf(Buffer);
   });
 });

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -342,7 +342,7 @@ export async function sendFileFeishu(params: {
   cfg: ClawdbotConfig;
   to: string;
   fileKey: string;
-  /** Use "audio" for audio, "media" for video (mp4), "file" for documents */
+  /** Use "audio" for audio, "media" for video, and "file" for documents */
   msgType?: "file" | "audio" | "media";
   replyToMessageId?: string;
   replyInThread?: boolean;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -191,10 +191,14 @@ export async function runAgentTurnWithFallback(params: {
           return undefined;
         }
         const { text, skip } = normalizeStreamingText(payload);
-        if (skip || !text) {
+        if (skip) {
           return undefined;
         }
-        await params.typingSignals.signalTextDelta(text, payload.mediaUrls);
+        const mediaUrls = payload.mediaUrls;
+        if (!text && (mediaUrls?.length ?? 0) === 0) {
+          return undefined;
+        }
+        await params.typingSignals.signalTextDelta(text, mediaUrls);
         return text;
       };
       const blockReplyPipeline = params.blockReplyPipeline;

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -194,7 +194,7 @@ export async function runAgentTurnWithFallback(params: {
         if (skip || !text) {
           return undefined;
         }
-        await params.typingSignals.signalTextDelta(text);
+        await params.typingSignals.signalTextDelta(text, payload.mediaUrls);
         return text;
       };
       const blockReplyPipeline = params.blockReplyPipeline;
@@ -445,7 +445,7 @@ export async function runAgentTurnWithFallback(params: {
                           if (skip) {
                             return;
                           }
-                          await params.typingSignals.signalTextDelta(text);
+                          await params.typingSignals.signalTextDelta(text, payload.mediaUrls);
                           await onToolResult({
                             ...payload,
                             text,

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -91,7 +91,10 @@ export function createFollowupRunner(params: {
       ) {
         continue;
       }
-      await typingSignals.signalTextDelta(payload.text);
+      await typingSignals.signalTextDelta(
+        payload.text,
+        payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : undefined),
+      );
 
       // Route to originating channel if set, otherwise fall back to dispatcher.
       if (shouldRouteToOriginating) {

--- a/src/auto-reply/reply/reply-delivery.test.ts
+++ b/src/auto-reply/reply/reply-delivery.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { createBlockReplyDeliveryHandler } from "./reply-delivery.js";
+import { createMockTypingController } from "./test-helpers.js";
+
+describe("createBlockReplyDeliveryHandler", () => {
+  it("signals typing for media-only block replies", async () => {
+    const typing = createMockTypingController();
+    const onBlockReply = vi.fn(async () => {});
+
+    const handler = createBlockReplyDeliveryHandler({
+      onBlockReply,
+      currentMessageId: "m1",
+      normalizeStreamingText: (payload) => ({ text: payload.text, skip: false }),
+      applyReplyToMode: (payload) => payload,
+      typingSignals: {
+        mode: "message",
+        shouldStartImmediately: false,
+        shouldStartOnMessageStart: true,
+        shouldStartOnText: true,
+        shouldStartOnReasoning: false,
+        signalRunStart: async () => {},
+        signalMessageStart: async () => {},
+        signalTextDelta: async (text?: string, mediaUrls?: string[]) => {
+          await typing.startTypingOnText(text);
+          if ((mediaUrls?.length ?? 0) > 0 && !text?.trim()) {
+            await typing.startTypingLoop();
+          }
+        },
+        signalReasoningDelta: async () => {},
+        signalToolStart: async () => {},
+      },
+      blockStreamingEnabled: true,
+      blockReplyPipeline: null,
+      directlySentBlockKeys: new Set<string>(),
+    });
+
+    await handler({ mediaUrls: ["https://example.com/image.png"] });
+
+    expect(onBlockReply).toHaveBeenCalled();
+    expect(typing.startTypingLoop).toHaveBeenCalled();
+  });
+});

--- a/src/auto-reply/reply/reply-delivery.ts
+++ b/src/auto-reply/reply/reply-delivery.ts
@@ -116,10 +116,15 @@ export function createBlockReplyDeliveryHandler(params: {
       return;
     }
 
-    if (blockPayload.text) {
-      void params.typingSignals.signalTextDelta(blockPayload.text).catch((err) => {
-        logVerbose(`block reply typing signal failed: ${String(err)}`);
-      });
+    if (blockPayload.text || blockHasMedia) {
+      void params.typingSignals
+        .signalTextDelta(
+          blockPayload.text,
+          blockPayload.mediaUrls ?? (blockPayload.mediaUrl ? [blockPayload.mediaUrl] : undefined),
+        )
+        .catch((err) => {
+          logVerbose(`block reply typing signal failed: ${String(err)}`);
+        });
     }
 
     // Use pipeline if available (block streaming enabled), otherwise send directly.

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -517,7 +517,7 @@ describe("createTypingSignaler", () => {
     expect(typing.startTypingOnText).not.toHaveBeenCalled();
   });
 
-  it("handles tool-start typing before and after active text mode", async () => {
+  it("does not start tool typing in message mode before renderable text", async () => {
     const typing = createMockTypingController();
     const signaler = createTypingSignaler({
       typing,
@@ -527,16 +527,32 @@ describe("createTypingSignaler", () => {
 
     await signaler.signalToolStart();
 
-    expect(typing.startTypingLoop).toHaveBeenCalled();
-    expect(typing.refreshTypingTtl).toHaveBeenCalled();
-    expect(typing.startTypingOnText).not.toHaveBeenCalled();
-    (typing.isActive as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).not.toHaveBeenCalled();
+
+    await signaler.signalTextDelta("hello");
     (typing.startTypingLoop as ReturnType<typeof vi.fn>).mockClear();
     (typing.refreshTypingTtl as ReturnType<typeof vi.fn>).mockClear();
+    (typing.isActive as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
     await signaler.signalToolStart();
 
     expect(typing.refreshTypingTtl).toHaveBeenCalled();
     expect(typing.startTypingLoop).not.toHaveBeenCalled();
+  });
+
+  it("starts tool typing immediately in instant mode", async () => {
+    const typing = createMockTypingController();
+    const signaler = createTypingSignaler({
+      typing,
+      mode: "instant",
+      isHeartbeat: false,
+    });
+
+    await signaler.signalToolStart();
+
+    expect(typing.startTypingLoop).toHaveBeenCalled();
+    expect(typing.refreshTypingTtl).toHaveBeenCalled();
   });
 
   it("suppresses typing when disabled", async () => {

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -541,6 +541,27 @@ describe("createTypingSignaler", () => {
     expect(typing.startTypingLoop).not.toHaveBeenCalled();
   });
 
+  it("keeps tool typing available for media-only replies in message mode", async () => {
+    const typing = createMockTypingController();
+    const signaler = createTypingSignaler({
+      typing,
+      mode: "message",
+      isHeartbeat: false,
+    });
+
+    await signaler.signalTextDelta(undefined, ["https://example.com/image.png"]);
+    expect(typing.startTypingLoop).toHaveBeenCalledTimes(1);
+
+    (typing.startTypingLoop as ReturnType<typeof vi.fn>).mockClear();
+    (typing.refreshTypingTtl as ReturnType<typeof vi.fn>).mockClear();
+    (typing.isActive as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+    await signaler.signalToolStart();
+
+    expect(typing.refreshTypingTtl).toHaveBeenCalledTimes(1);
+    expect(typing.startTypingLoop).not.toHaveBeenCalled();
+  });
+
   it("starts tool typing immediately in instant mode", async () => {
     const typing = createMockTypingController();
     const signaler = createTypingSignaler({

--- a/src/auto-reply/reply/typing-mode.ts
+++ b/src/auto-reply/reply/typing-mode.ts
@@ -48,7 +48,7 @@ export type TypingSignaler = {
   shouldStartOnReasoning: boolean;
   signalRunStart: () => Promise<void>;
   signalMessageStart: () => Promise<void>;
-  signalTextDelta: (text?: string) => Promise<void>;
+  signalTextDelta: (text?: string, mediaUrls?: string[]) => Promise<void>;
   signalReasoningDelta: () => Promise<void>;
   signalToolStart: () => Promise<void>;
 };
@@ -65,6 +65,7 @@ export function createTypingSignaler(params: {
   const shouldStartOnReasoning = mode === "thinking";
   const disabled = isHeartbeat || mode === "never";
   let hasRenderableText = false;
+  let hasRenderableMedia = false;
 
   const isRenderableText = (text?: string): boolean => {
     const trimmed = text?.trim();
@@ -85,24 +86,31 @@ export function createTypingSignaler(params: {
     if (disabled || !shouldStartOnMessageStart) {
       return;
     }
-    if (!hasRenderableText) {
+    if (!hasRenderableText && !hasRenderableMedia) {
       return;
     }
     await typing.startTypingLoop();
   };
 
-  const signalTextDelta = async (text?: string) => {
+  const signalTextDelta = async (text?: string, mediaUrls?: string[]) => {
     if (disabled) {
       return;
     }
+    const hasMedia = (mediaUrls?.length ?? 0) > 0;
     const renderable = isRenderableText(text);
     if (renderable) {
       hasRenderableText = true;
+    } else if (hasMedia) {
+      hasRenderableMedia = true;
     } else if (text?.trim()) {
       return;
     }
     if (shouldStartOnText) {
-      await typing.startTypingOnText(text);
+      if (hasMedia && !text?.trim()) {
+        await typing.startTypingLoop();
+      } else {
+        await typing.startTypingOnText(text);
+      }
       return;
     }
     if (shouldStartOnReasoning) {
@@ -117,7 +125,7 @@ export function createTypingSignaler(params: {
     if (disabled || !shouldStartOnReasoning) {
       return;
     }
-    if (!hasRenderableText) {
+    if (!hasRenderableText && !hasRenderableMedia) {
       return;
     }
     await typing.startTypingLoop();
@@ -130,7 +138,7 @@ export function createTypingSignaler(params: {
     }
     // In message mode, only type after we have renderable assistant text.
     // This prevents brief typing blinks for runs that end up NO_REPLY.
-    if (mode === "message" && !hasRenderableText) {
+    if (mode === "message" && !hasRenderableText && !hasRenderableMedia) {
       return;
     }
     if (!typing.isActive()) {

--- a/src/auto-reply/reply/typing-mode.ts
+++ b/src/auto-reply/reply/typing-mode.ts
@@ -128,7 +128,11 @@ export function createTypingSignaler(params: {
     if (disabled) {
       return;
     }
-    // Start typing as soon as tools begin executing, even before the first text delta.
+    // In message mode, only type after we have renderable assistant text.
+    // This prevents brief typing blinks for runs that end up NO_REPLY.
+    if (mode === "message" && !hasRenderableText) {
+      return;
+    }
     if (!typing.isActive()) {
       await typing.startTypingLoop();
       typing.refreshTypingTtl();


### PR DESCRIPTION
## Summary
Feishu rejects uploaded mp4 attachments when they are sent as msg_type "file" (error 230055).
This patch routes video uploads to msg_type "media", while keeping existing behavior for audio (audio) and documents (file).

## Changes
- extend sendFileFeishu msgType union to allow media
- map detected video file type (mp4) to msg_type "media"
- update Feishu media tests to assert media for mp4 send/reply paths

## Testing
- pnpm -s vitest extensions/feishu/src/media.test.ts
- Result: 26 passed

Fixes openclaw/openclaw#34188
