### PR TITLE
fix: send authorization hint when bot is @mentioned but unauthorized

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,5 +1,5 @@
-import type { Bot } from "grammy";
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
+import type { Bot } from "grammy";
 import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import {
   createInboundDebouncer,
@@ -518,20 +518,24 @@ export const registerTelegramHandlers = ({
       ctx,
       bot,
     } = params;
-    
+
     // Helper to send auth hint if bot is mentioned
     const sendAuthHint = async () => {
       if (msg && botUsername && hasBotMention(msg, botUsername)) {
         try {
-          await bot.api.sendMessage(chatId, "You are not authorized to use this bot in this group.", {
-            reply_parameters: { message_id: msg.message_id },
-          });
+          await bot.api.sendMessage(
+            chatId,
+            "You are not authorized to use this bot in this group.",
+            {
+              reply_parameters: { message_id: msg.message_id },
+            },
+          );
         } catch (err) {
           logVerbose(`Failed to send auth hint: ${err}`);
         }
       }
     };
-    
+
     const baseAccess = evaluateTelegramGroupBaseAccess({
       isGroup,
       groupConfig,
@@ -688,7 +692,8 @@ export const registerTelegramHandlers = ({
     context: TelegramEventAuthorizationContext;
     bot: Bot;
   }): Promise<TelegramEventAuthorizationResult> => {
-    const { chatId, chatTitle, isGroup, senderId, senderUsername, mode, context, ctx, bot } = params;
+    const { chatId, chatTitle, isGroup, senderId, senderUsername, mode, context, ctx, bot } =
+      params;
     const {
       dmPolicy,
       resolvedThreadId,

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1,3 +1,4 @@
+import type { Bot } from "grammy";
 import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
 import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import {
@@ -499,6 +500,7 @@ export const registerTelegramHandlers = ({
     msg?: Message;
     ctx: TelegramContext;
     botUsername?: string;
+    bot: Bot;
   }) => {
     const {
       isGroup,
@@ -514,13 +516,14 @@ export const registerTelegramHandlers = ({
       msg,
       botUsername,
       ctx,
+      bot,
     } = params;
     
     // Helper to send auth hint if bot is mentioned
     const sendAuthHint = async () => {
       if (msg && botUsername && hasBotMention(msg, botUsername)) {
         try {
-          await ctx.reply("You are not authorized to use this bot in this group.", {
+          await bot.api.sendMessage(chatId, "You are not authorized to use this bot in this group.", {
             reply_parameters: { message_id: msg.message_id },
           });
         } catch (err) {
@@ -543,20 +546,20 @@ export const registerTelegramHandlers = ({
     if (!baseAccess.allowed) {
       if (baseAccess.reason === "group-disabled") {
         logVerbose(`Blocked telegram group ${chatId} (group disabled)`);
-        await sendAuthHint(baseAccess.reason);
+        await sendAuthHint();
         return true;
       }
       if (baseAccess.reason === "topic-disabled") {
         logVerbose(
           `Blocked telegram topic ${chatId} (${resolvedThreadId ?? "unknown"}) (topic disabled)`,
         );
-        await sendAuthHint(baseAccess.reason);
+        await sendAuthHint();
         return true;
       }
       logVerbose(
         `Blocked telegram group sender ${senderId || "unknown"} (group allowFrom override)`,
       );
-      await sendAuthHint(baseAccess.reason);
+      await sendAuthHint();
       return true;
     }
     if (!isGroup) {
@@ -583,28 +586,28 @@ export const registerTelegramHandlers = ({
     if (!policyAccess.allowed) {
       if (policyAccess.reason === "group-policy-disabled") {
         logVerbose("Blocked telegram group message (groupPolicy: disabled)");
-        await sendAuthHint(policyAccess.reason);
+        await sendAuthHint();
         return true;
       }
       if (policyAccess.reason === "group-policy-allowlist-no-sender") {
         logVerbose("Blocked telegram group message (no sender ID, groupPolicy: allowlist)");
-        await sendAuthHint(policyAccess.reason);
+        await sendAuthHint();
         return true;
       }
       if (policyAccess.reason === "group-policy-allowlist-empty") {
         logVerbose(
           "Blocked telegram group message (groupPolicy: allowlist, no group allowlist entries)",
         );
-        await sendAuthHint(policyAccess.reason);
+        await sendAuthHint();
         return true;
       }
       if (policyAccess.reason === "group-policy-allowlist-unauthorized") {
         logVerbose(`Blocked telegram group message from ${senderId} (groupPolicy: allowlist)`);
-        await sendAuthHint(policyAccess.reason);
+        await sendAuthHint();
         return true;
       }
       logger.info({ chatId, title: chatTitle, reason: "not-allowed" }, "skipping group message");
-      await sendAuthHint(policyAccess.reason);
+      await sendAuthHint();
       return true;
     }
     return false;
@@ -683,8 +686,9 @@ export const registerTelegramHandlers = ({
     mode: TelegramEventAuthorizationMode;
     ctx: TelegramContext;
     context: TelegramEventAuthorizationContext;
+    bot: Bot;
   }): Promise<TelegramEventAuthorizationResult> => {
-    const { chatId, chatTitle, isGroup, senderId, senderUsername, mode, context, ctx } = params;
+    const { chatId, chatTitle, isGroup, senderId, senderUsername, mode, context, ctx, bot } = params;
     const {
       dmPolicy,
       resolvedThreadId,
@@ -715,6 +719,7 @@ export const registerTelegramHandlers = ({
         groupConfig,
         topicConfig,
         ctx,
+        bot,
       })
     ) {
       return { allowed: false, reason: "group-policy" };
@@ -794,6 +799,7 @@ export const registerTelegramHandlers = ({
         mode: "reaction",
         context: eventAuthContext,
         ctx,
+        bot,
       });
       if (!senderAuthorization.allowed) {
         return;
@@ -1164,6 +1170,7 @@ export const registerTelegramHandlers = ({
         mode: authorizationMode,
         context: eventAuthContext,
         ctx,
+        bot,
       });
       if (!senderAuthorization.allowed) {
         return;
@@ -1465,6 +1472,7 @@ export const registerTelegramHandlers = ({
           msg: event.msg,
           botUsername: ctx.me?.username,
           ctx,
+          bot,
         })
       ) {
         return;

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -515,7 +515,7 @@ export const registerTelegramHandlers = ({
       topicConfig,
       msg,
       botUsername,
-      ctx,
+      _ctx,
       bot,
     } = params;
 
@@ -531,7 +531,7 @@ export const registerTelegramHandlers = ({
             },
           );
         } catch (err) {
-          logVerbose(`Failed to send auth hint: ${err}`);
+          logVerbose(`Failed to send auth hint: ${err instanceof Error ? err.message : String(err)}`);
         }
       }
     };

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -485,7 +485,7 @@ export const registerTelegramHandlers = ({
         senderUsername,
       }));
 
-  const shouldSkipGroupMessage = (params: {
+  const shouldSkipGroupMessage = async (params: {
     isGroup: boolean;
     chatId: string | number;
     chatTitle?: string;
@@ -497,6 +497,7 @@ export const registerTelegramHandlers = ({
     groupConfig?: TelegramGroupConfig;
     topicConfig?: TelegramTopicConfig;
     msg?: Message;
+    ctx: TelegramContext;
     botUsername?: string;
   }) => {
     const {
@@ -512,10 +513,11 @@ export const registerTelegramHandlers = ({
       topicConfig,
       msg,
       botUsername,
+      ctx,
     } = params;
     
     // Helper to send auth hint if bot is mentioned
-    const sendAuthHint = async (reason: string) => {
+    const sendAuthHint = async () => {
       if (msg && botUsername && hasBotMention(msg, botUsername)) {
         try {
           await ctx.reply("You are not authorized to use this bot in this group.", {
@@ -672,16 +674,17 @@ export const registerTelegramHandlers = ({
     return { dmPolicy: effectiveDmPolicy, ...groupAllowContext };
   };
 
-  const authorizeTelegramEventSender = (params: {
+  const authorizeTelegramEventSender = async (params: {
     chatId: number;
     chatTitle?: string;
     isGroup: boolean;
     senderId: string;
     senderUsername: string;
     mode: TelegramEventAuthorizationMode;
+    ctx: TelegramContext;
     context: TelegramEventAuthorizationContext;
-  }): TelegramEventAuthorizationResult => {
-    const { chatId, chatTitle, isGroup, senderId, senderUsername, mode, context } = params;
+  }): Promise<TelegramEventAuthorizationResult> => {
+    const { chatId, chatTitle, isGroup, senderId, senderUsername, mode, context, ctx } = params;
     const {
       dmPolicy,
       resolvedThreadId,
@@ -700,7 +703,7 @@ export const registerTelegramHandlers = ({
       deniedGroupReason,
     } = authRules;
     if (
-      shouldSkipGroupMessage({
+      await shouldSkipGroupMessage({
         isGroup,
         chatId,
         chatTitle,
@@ -711,6 +714,7 @@ export const registerTelegramHandlers = ({
         hasGroupAllowOverride,
         groupConfig,
         topicConfig,
+        ctx,
       })
     ) {
       return { allowed: false, reason: "group-policy" };
@@ -781,7 +785,7 @@ export const registerTelegramHandlers = ({
         isGroup,
         isForum,
       });
-      const senderAuthorization = authorizeTelegramEventSender({
+      const senderAuthorization = await authorizeTelegramEventSender({
         chatId,
         chatTitle: reaction.chat.title,
         isGroup,
@@ -789,6 +793,7 @@ export const registerTelegramHandlers = ({
         senderUsername,
         mode: "reaction",
         context: eventAuthContext,
+        ctx,
       });
       if (!senderAuthorization.allowed) {
         return;
@@ -1150,7 +1155,7 @@ export const registerTelegramHandlers = ({
       const senderUsername = callback.from?.username ?? "";
       const authorizationMode: TelegramEventAuthorizationMode =
         inlineButtonsScope === "allowlist" ? "callback-allowlist" : "callback-scope";
-      const senderAuthorization = authorizeTelegramEventSender({
+      const senderAuthorization = await authorizeTelegramEventSender({
         chatId,
         chatTitle: callbackMessage.chat.title,
         isGroup,
@@ -1158,6 +1163,7 @@ export const registerTelegramHandlers = ({
         senderUsername,
         mode: authorizationMode,
         context: eventAuthContext,
+        ctx,
       });
       if (!senderAuthorization.allowed) {
         return;
@@ -1445,7 +1451,7 @@ export const registerTelegramHandlers = ({
       }
 
       if (
-        shouldSkipGroupMessage({
+        await shouldSkipGroupMessage({
           isGroup: event.isGroup,
           chatId: event.chatId,
           chatTitle: event.msg.chat.title,
@@ -1458,6 +1464,7 @@ export const registerTelegramHandlers = ({
           topicConfig,
           msg: event.msg,
           botUsername: ctx.me?.username,
+          ctx,
         })
       ) {
         return;

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -498,7 +498,7 @@ export const registerTelegramHandlers = ({
     groupConfig?: TelegramGroupConfig;
     topicConfig?: TelegramTopicConfig;
     msg?: Message;
-    ctx: TelegramContext;
+    ctx?: TelegramContext;
     botUsername?: string;
     bot: Bot;
   }) => {
@@ -684,7 +684,7 @@ export const registerTelegramHandlers = ({
     senderId: string;
     senderUsername: string;
     mode: TelegramEventAuthorizationMode;
-    ctx: TelegramContext;
+    ctx?: TelegramContext;
     context: TelegramEventAuthorizationContext;
     bot: Bot;
   }): Promise<TelegramEventAuthorizationResult> => {
@@ -798,7 +798,6 @@ export const registerTelegramHandlers = ({
         senderUsername,
         mode: "reaction",
         context: eventAuthContext,
-        ctx,
         bot,
       });
       if (!senderAuthorization.allowed) {
@@ -1169,7 +1168,6 @@ export const registerTelegramHandlers = ({
         senderUsername,
         mode: authorizationMode,
         context: eventAuthContext,
-        ctx,
         bot,
       });
       if (!senderAuthorization.allowed) {
@@ -1470,8 +1468,8 @@ export const registerTelegramHandlers = ({
           groupConfig,
           topicConfig,
           msg: event.msg,
-          botUsername: ctx.me?.username,
-          ctx,
+          botUsername: event.ctx.me?.username,
+          ctx: event.ctx,
           bot,
         })
       ) {

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -48,6 +48,7 @@ import {
   buildTelegramParentPeer,
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
+  hasBotMention,
 } from "./bot/helpers.js";
 import type { TelegramContext } from "./bot/types.js";
 import { enforceTelegramDmAccess } from "./dm-access.js";
@@ -495,6 +496,8 @@ export const registerTelegramHandlers = ({
     hasGroupAllowOverride: boolean;
     groupConfig?: TelegramGroupConfig;
     topicConfig?: TelegramTopicConfig;
+    msg?: Message;
+    botUsername?: string;
   }) => {
     const {
       isGroup,
@@ -507,7 +510,23 @@ export const registerTelegramHandlers = ({
       hasGroupAllowOverride,
       groupConfig,
       topicConfig,
+      msg,
+      botUsername,
     } = params;
+    
+    // Helper to send auth hint if bot is mentioned
+    const sendAuthHint = async (reason: string) => {
+      if (msg && botUsername && hasBotMention(msg, botUsername)) {
+        try {
+          await ctx.reply("You are not authorized to use this bot in this group.", {
+            reply_parameters: { message_id: msg.message_id },
+          });
+        } catch (err) {
+          logVerbose(`Failed to send auth hint: ${err}`);
+        }
+      }
+    };
+    
     const baseAccess = evaluateTelegramGroupBaseAccess({
       isGroup,
       groupConfig,
@@ -522,17 +541,20 @@ export const registerTelegramHandlers = ({
     if (!baseAccess.allowed) {
       if (baseAccess.reason === "group-disabled") {
         logVerbose(`Blocked telegram group ${chatId} (group disabled)`);
+        await sendAuthHint(baseAccess.reason);
         return true;
       }
       if (baseAccess.reason === "topic-disabled") {
         logVerbose(
           `Blocked telegram topic ${chatId} (${resolvedThreadId ?? "unknown"}) (topic disabled)`,
         );
+        await sendAuthHint(baseAccess.reason);
         return true;
       }
       logVerbose(
         `Blocked telegram group sender ${senderId || "unknown"} (group allowFrom override)`,
       );
+      await sendAuthHint(baseAccess.reason);
       return true;
     }
     if (!isGroup) {
@@ -559,23 +581,28 @@ export const registerTelegramHandlers = ({
     if (!policyAccess.allowed) {
       if (policyAccess.reason === "group-policy-disabled") {
         logVerbose("Blocked telegram group message (groupPolicy: disabled)");
+        await sendAuthHint(policyAccess.reason);
         return true;
       }
       if (policyAccess.reason === "group-policy-allowlist-no-sender") {
         logVerbose("Blocked telegram group message (no sender ID, groupPolicy: allowlist)");
+        await sendAuthHint(policyAccess.reason);
         return true;
       }
       if (policyAccess.reason === "group-policy-allowlist-empty") {
         logVerbose(
           "Blocked telegram group message (groupPolicy: allowlist, no group allowlist entries)",
         );
+        await sendAuthHint(policyAccess.reason);
         return true;
       }
       if (policyAccess.reason === "group-policy-allowlist-unauthorized") {
         logVerbose(`Blocked telegram group message from ${senderId} (groupPolicy: allowlist)`);
+        await sendAuthHint(policyAccess.reason);
         return true;
       }
       logger.info({ chatId, title: chatTitle, reason: "not-allowed" }, "skipping group message");
+      await sendAuthHint(policyAccess.reason);
       return true;
     }
     return false;
@@ -1429,6 +1456,8 @@ export const registerTelegramHandlers = ({
           hasGroupAllowOverride,
           groupConfig,
           topicConfig,
+          msg: event.msg,
+          botUsername: ctx.me?.username,
         })
       ) {
         return;

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -281,8 +281,9 @@ export function buildGroupLabel(msg: Message, chatId: number | string, messageTh
 }
 
 export function hasBotMention(msg: Message, botUsername: string) {
+  const normalizedBotUsername = botUsername.toLowerCase();
   const text = (msg.text ?? msg.caption ?? "").toLowerCase();
-  if (text.includes(`@${botUsername}`)) {
+  if (text.includes(`@${normalizedBotUsername}`)) {
     return true;
   }
   const entities = msg.entities ?? msg.caption_entities ?? [];
@@ -291,7 +292,7 @@ export function hasBotMention(msg: Message, botUsername: string) {
       continue;
     }
     const slice = (msg.text ?? msg.caption ?? "").slice(ent.offset, ent.offset + ent.length);
-    if (slice.toLowerCase() === `@${botUsername}`) {
+    if (slice.toLowerCase() === `@${normalizedBotUsername}`) {
       return true;
     }
   }


### PR DESCRIPTION
## Summary

When a bot is @mentioned in a group but not authorized, it now sends a brief authorization hint instead of silently dropping the message.

## Changes

- Added hasBotMention import from bot/helpers
- Extended shouldSkipGroupMessage to accept optional msg and botUsername parameters
- Added sendAuthHint helper that checks for @mentions before sending auth messages
- Applied auth hints to all authorization failure points (5 locations)
- Updated handleInboundMessageLike to pass msg and botUsername to shouldSkipGroupMessage

## Testing

The fix reuses the existing message reply mechanism and only responds when the bot is explicitly @mentioned, avoiding spam.

Fixes #34056