### PR TITLE
feat(test): add trackedMkdtemp utilities to prevent /tmp/openclaw-* accumulation

### DIFF
--- a/src/infra/device-pairing.test.ts
+++ b/src/infra/device-pairing.test.ts
@@ -1,7 +1,5 @@
-import { mkdtemp } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { describe, expect, test } from "vitest";
+import { trackedMkdtemp } from "../../test/test-env.js";
 import {
   approveDevicePairing,
   clearDevicePairing,
@@ -26,7 +24,7 @@ async function setupPairedOperatorDevice(baseDir: string, scopes: string[]) {
 }
 
 async function setupOperatorToken(scopes: string[]) {
-  const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+  const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
   await setupPairedOperatorDevice(baseDir, scopes);
   const paired = await getPairedDevice("device-1", baseDir);
   const token = requireToken(paired?.tokens?.operator?.token);
@@ -53,7 +51,7 @@ function requireToken(token: string | undefined): string {
 
 describe("device pairing tokens", () => {
   test("reuses existing pending requests for the same device", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
     const first = await requestDevicePairing(
       {
         deviceId: "device-1",
@@ -75,7 +73,7 @@ describe("device pairing tokens", () => {
   });
 
   test("merges pending roles/scopes for the same device before approval", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
     const first = await requestDevicePairing(
       {
         deviceId: "device-1",
@@ -107,7 +105,7 @@ describe("device pairing tokens", () => {
   });
 
   test("generates base64url device tokens with 256-bit entropy output length", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
     await setupPairedOperatorDevice(baseDir, ["operator.admin"]);
 
     const paired = await getPairedDevice("device-1", baseDir);
@@ -117,7 +115,7 @@ describe("device pairing tokens", () => {
   });
 
   test("allows down-scoping from admin and preserves approved scope baseline", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
     await setupPairedOperatorDevice(baseDir, ["operator.admin"]);
 
     await rotateDeviceToken({
@@ -141,7 +139,7 @@ describe("device pairing tokens", () => {
   });
 
   test("preserves existing token scopes when approving a repair without requested scopes", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
     await setupPairedOperatorDevice(baseDir, ["operator.admin"]);
 
     const repair = await requestDevicePairing(
@@ -161,7 +159,7 @@ describe("device pairing tokens", () => {
   });
 
   test("rejects scope escalation when rotating a token and leaves state unchanged", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
     await setupPairedOperatorDevice(baseDir, ["operator.read"]);
     const before = await getPairedDevice("device-1", baseDir);
 
@@ -232,7 +230,7 @@ describe("device pairing tokens", () => {
   });
 
   test("removes paired devices by device id", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
     await setupPairedOperatorDevice(baseDir, ["operator.read"]);
 
     const removed = await removePairedDevice("device-1", baseDir);
@@ -243,7 +241,7 @@ describe("device pairing tokens", () => {
   });
 
   test("clears paired device state by device id", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-device-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-device-pairing-");
     await setupPairedOperatorDevice(baseDir, ["operator.read"]);
 
     await expect(clearDevicePairing("device-1", baseDir)).resolves.toBe(true);

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { trackedMkdtemp } from "../../test/test-env.js";
 import { loadDotEnv } from "./dotenv.js";
 
 async function writeEnvFile(filePath: string, contents: string) {
@@ -38,7 +38,7 @@ type DotEnvFixture = {
 };
 
 async function withDotEnvFixture(run: (fixture: DotEnvFixture) => Promise<void>) {
-  const base = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-dotenv-test-"));
+  const base = await trackedMkdtemp("openclaw-dotenv-test-");
   const cwdDir = path.join(base, "cwd");
   const stateDir = path.join(base, "state");
   process.env.OPENCLAW_STATE_DIR = stateDir;

--- a/src/infra/exec-approvals-test-helpers.ts
+++ b/src/infra/exec-approvals-test-helpers.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
+import { trackedMkdtempSync } from "../../test/test-env.js";
 
 export function makePathEnv(binDir: string): NodeJS.ProcessEnv {
   if (process.platform !== "win32") {
@@ -10,7 +10,7 @@ export function makePathEnv(binDir: string): NodeJS.ProcessEnv {
 }
 
 export function makeTempDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-exec-approvals-"));
+  return trackedMkdtempSync("openclaw-exec-approvals-");
 }
 
 export type ShellParserParityFixtureCase = {

--- a/src/infra/git-root.test.ts
+++ b/src/infra/git-root.test.ts
@@ -1,11 +1,11 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { trackedMkdtemp } from "../../test/test-env.js";
 import { findGitRoot, resolveGitHeadPath } from "./git-root.js";
 
 async function makeTempDir(label: string): Promise<string> {
-  return fs.mkdtemp(path.join(os.tmpdir(), `openclaw-${label}-`));
+  return trackedMkdtemp(`openclaw-${label}-`);
 }
 
 describe("git-root", () => {

--- a/src/infra/node-pairing.test.ts
+++ b/src/infra/node-pairing.test.ts
@@ -1,7 +1,5 @@
-import { mkdtemp } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { describe, expect, test } from "vitest";
+import { trackedMkdtemp } from "../../test/test-env.js";
 import {
   approveNodePairing,
   getPairedNode,
@@ -29,7 +27,7 @@ async function setupPairedNode(baseDir: string): Promise<string> {
 
 describe("node pairing tokens", () => {
   test("reuses existing pending requests for the same node", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-node-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-node-pairing-");
     const first = await requestNodePairing(
       {
         nodeId: "node-1",
@@ -51,14 +49,14 @@ describe("node pairing tokens", () => {
   });
 
   test("generates base64url node tokens with 256-bit entropy output length", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-node-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-node-pairing-");
     const token = await setupPairedNode(baseDir);
     expect(token).toMatch(/^[A-Za-z0-9_-]{43}$/);
     expect(Buffer.from(token, "base64url")).toHaveLength(32);
   });
 
   test("verifies token and rejects mismatches", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-node-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-node-pairing-");
     const token = await setupPairedNode(baseDir);
     await expect(verifyNodeToken("node-1", token, baseDir)).resolves.toEqual({
       ok: true,
@@ -70,7 +68,7 @@ describe("node pairing tokens", () => {
   });
 
   test("treats multibyte same-length token input as mismatch without throwing", async () => {
-    const baseDir = await mkdtemp(join(tmpdir(), "openclaw-node-pairing-"));
+    const baseDir = await trackedMkdtemp("openclaw-node-pairing-");
     const token = await setupPairedNode(baseDir);
     const multibyteToken = "é".repeat(token.length);
     expect(Buffer.from(multibyteToken).length).not.toBe(Buffer.from(token).length);

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { trackedMkdtemp } from "../../test/test-env.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
@@ -17,7 +17,7 @@ describe("session cost usage", () => {
     await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, fn);
 
   it("aggregates daily totals with log cost and pricing fallback", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-"));
+    const root = await trackedMkdtemp("openclaw-cost-");
     const sessionsDir = path.join(root, "agents", "main", "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });
     const sessionFile = path.join(sessionsDir, "sess-1.jsonl");
@@ -111,7 +111,7 @@ describe("session cost usage", () => {
   });
 
   it("summarizes a single session file", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-session-"));
+    const root = await trackedMkdtemp("openclaw-cost-session-");
     const sessionFile = path.join(root, "session.jsonl");
     const now = new Date();
 
@@ -144,7 +144,7 @@ describe("session cost usage", () => {
   });
 
   it("captures message counts, tool usage, and model usage", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-session-meta-"));
+    const root = await trackedMkdtemp("openclaw-cost-session-meta-");
     const sessionFile = path.join(root, "session.jsonl");
     const start = new Date("2026-02-01T10:00:00.000Z");
     const end = new Date("2026-02-01T10:05:00.000Z");
@@ -212,7 +212,7 @@ describe("session cost usage", () => {
   });
 
   it("does not exclude sessions with mtime after endMs during discovery", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-"));
+    const root = await trackedMkdtemp("openclaw-discover-");
     const sessionsDir = path.join(root, "agents", "main", "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });
     const sessionFile = path.join(sessionsDir, "sess-late.jsonl");
@@ -232,7 +232,7 @@ describe("session cost usage", () => {
   });
 
   it("resolves non-main absolute sessionFile using explicit agentId for cost summary", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-agent-"));
+    const root = await trackedMkdtemp("openclaw-cost-agent-");
     const workerSessionsDir = path.join(root, "agents", "worker1", "sessions");
     await fs.mkdir(workerSessionsDir, { recursive: true });
     const workerSessionFile = path.join(workerSessionsDir, "sess-worker-1.jsonl");
@@ -274,7 +274,7 @@ describe("session cost usage", () => {
   });
 
   it("resolves non-main absolute sessionFile using explicit agentId for timeseries", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-timeseries-agent-"));
+    const root = await trackedMkdtemp("openclaw-timeseries-agent-");
     const workerSessionsDir = path.join(root, "agents", "worker2", "sessions");
     await fs.mkdir(workerSessionsDir, { recursive: true });
     const workerSessionFile = path.join(workerSessionsDir, "sess-worker-2.jsonl");
@@ -312,7 +312,7 @@ describe("session cost usage", () => {
   });
 
   it("resolves non-main absolute sessionFile using explicit agentId for logs", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-logs-agent-"));
+    const root = await trackedMkdtemp("openclaw-logs-agent-");
     const workerSessionsDir = path.join(root, "agents", "worker3", "sessions");
     await fs.mkdir(workerSessionsDir, { recursive: true });
     const workerSessionFile = path.join(workerSessionsDir, "sess-worker-3.jsonl");
@@ -349,7 +349,7 @@ describe("session cost usage", () => {
   });
 
   it("strips inbound and untrusted metadata blocks from session usage logs", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-logs-sanitize-"));
+    const root = await trackedMkdtemp("openclaw-logs-sanitize-");
     const sessionsDir = path.join(root, "agents", "main", "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });
     const sessionFile = path.join(sessionsDir, "sess-sanitize.jsonl");
@@ -391,7 +391,7 @@ example
   });
 
   it("preserves totals and cumulative values when downsampling timeseries", async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-timeseries-downsample-"));
+    const root = await trackedMkdtemp("openclaw-timeseries-downsample-");
     const sessionsDir = path.join(root, "agents", "main", "sessions");
     await fs.mkdir(sessionsDir, { recursive: true });
     const sessionFile = path.join(sessionsDir, "sess-downsample.jsonl");

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -61,7 +61,7 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
   // The default test env isolates HOME to avoid touching real state.
   if (live) {
     loadProfileEnv();
-    return { cleanup: () => {}, tempHome: process.env.HOME ?? "" };
+    return { cleanup: () => cleanupTrackedTempDirs(), tempHome: process.env.HOME ?? "" };
   }
 
   const restore: RestoreEntry[] = [

--- a/test/test-env.ts
+++ b/test/test-env.ts
@@ -132,6 +132,7 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
 
   const cleanup = () => {
     restoreEnv(restore);
+    cleanupTrackedTempDirs();
     try {
       fs.rmSync(tempHome, { recursive: true, force: true });
     } catch {
@@ -144,4 +145,29 @@ export function installTestEnv(): { cleanup: () => void; tempHome: string } {
 
 export function withIsolatedTestHome(): { cleanup: () => void; tempHome: string } {
   return installTestEnv();
+}
+
+const trackedTempDirs: string[] = [];
+
+export function trackedMkdtempSync(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  trackedTempDirs.push(dir);
+  return dir;
+}
+
+export async function trackedMkdtemp(prefix: string): Promise<string> {
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), prefix));
+  trackedTempDirs.push(dir);
+  return dir;
+}
+
+export function cleanupTrackedTempDirs(): void {
+  for (const dir of trackedTempDirs) {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+  trackedTempDirs.length = 0;
 }


### PR DESCRIPTION
## Summary

- Add `trackedMkdtempSync` / `trackedMkdtemp` utilities to `test/test-env.ts` that automatically track and clean up temp directories via the existing `installTestEnv().cleanup()` hook
- Migrate 6 `src/infra/` test files as proof-of-concept

Fixes #34286

## Context

44 test files create `/tmp/openclaw-*` directories via `mkdtemp` without cleanup, causing 192+ stale directories to accumulate. This PR introduces a centralized solution — remaining files will be migrated in follow-up PRs.

## Test plan

- [x] All 104 tests in the 6 migrated files pass
- [ ] Verify `/tmp/openclaw-*` count does not increase after running migrated tests