### PR TITLE
fix(telegram): skip auto-forwarded channel posts in linked groups

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1470,6 +1470,14 @@ export const registerTelegramHandlers = ({
     if (!msg) {
       return;
     }
+    // Skip auto-forwarded channel posts in linked groups. When a channel is linked
+    // to a group, Telegram re-delivers every channel post as a group message with
+    // is_automatic_forward=true. Processing these duplicates wastes tokens and can
+    // cause echo responses. The original channel_post handler already covers
+    // channel-originated content.
+    if (msg.is_automatic_forward) {
+      return;
+    }
     await handleInboundMessageLike({
       ctxForDedupe: ctx,
       ctx: buildSyntheticContext(ctx, msg),

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -494,6 +494,26 @@ describe("createTelegramBot", () => {
     expect(replySpy).toHaveBeenCalledTimes(1);
   });
 
+  it("drops auto-forwarded channel posts in linked groups", async () => {
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: -1001234567890, type: "supergroup" },
+        from: { id: 136817688, username: "Channel_Bot" },
+        text: "forwarded from linked channel",
+        date: 1736380800,
+        is_automatic_forward: true,
+        sender_chat: { id: -1001999888777, type: "channel", title: "My Channel" },
+      },
+      me: { username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).not.toHaveBeenCalled();
+  });
+
   it("does not persist update offset past pending updates", async () => {
     // For this test we need sequentialize(...) to behave like a normal middleware and call next().
     sequentializeSpy.mockImplementationOnce(


### PR DESCRIPTION
## Problem

When a Telegram channel is linked to a group as its "discussion", Telegram automatically re-delivers every channel post to the group as a regular message with `is_automatic_forward: true`. The bot's `message` handler processes these duplicates as new inbound messages, even though they already arrived via the `channel_post` handler.

This causes:
- **Duplicate processing** — the same content is handled twice (once as `channel_post`, once as auto-forwarded `message`)
- **Wasted tokens** — each duplicate triggers a full LLM round-trip
- **Echo responses** — the bot may reply to its own channel posts when they appear in the linked group

## Fix

Early-return in the `message` handler when `msg.is_automatic_forward` is set. The existing `channel_post` handler already covers channel-originated content, so no messages are lost.

## Changes

- `src/telegram/bot-handlers.ts` — guard clause in `bot.on("message", ...)` to skip auto-forwarded messages
- `src/telegram/bot.create-telegram-bot.test.ts` — test confirming auto-forwarded messages are dropped

## Context

This is a common issue for setups that use a linked channel→group pattern (e.g., for bot-to-bot communication bridges). The Telegram Bot API docs describe `is_automatic_forward` [here](https://core.telegram.org/bots/api#message).


Made with [Cursor](https://cursor.com)