### PR TITLE
test(pdf): add Gemini baseUrl version-segment regression coverage

### DIFF
--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -142,7 +142,8 @@ export async function geminiAnalyzePdf(params: {
     "",
   );
   // Avoid duplicating /v1beta in URL path - only append if baseUrl doesn't already include it
-  const versionSegment = baseUrl.match(/\/v1beta$/i) || baseUrl.match(/\/v1$/i) ? "" : "/v1beta";
+  const hasVersionSegment = /\/v1beta$/i.test(baseUrl) || /\/v1$/i.test(baseUrl);
+  const versionSegment = hasVersionSegment ? "" : "/v1beta";
   const url = `${baseUrl}${versionSegment}/models/${encodeURIComponent(params.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
 
   const res = await fetch(url, {

--- a/src/agents/tools/pdf-native-providers.ts
+++ b/src/agents/tools/pdf-native-providers.ts
@@ -141,7 +141,9 @@ export async function geminiAnalyzePdf(params: {
     /\/+$/,
     "",
   );
-  const url = `${baseUrl}/v1beta/models/${encodeURIComponent(params.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
+  // Avoid duplicating /v1beta in URL path - only append if baseUrl doesn't already include it
+  const versionSegment = baseUrl.match(/\/v1beta$/i) || baseUrl.match(/\/v1$/i) ? "" : "/v1beta";
+  const url = `${baseUrl}${versionSegment}/models/${encodeURIComponent(params.modelId)}:generateContent?key=${encodeURIComponent(apiKey)}`;
 
   const res = await fetch(url, {
     method: "POST",

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -628,6 +628,47 @@ describe("native PDF provider API calls", () => {
     expect(body.contents[0].parts[1].text).toBe("Summarize this");
   });
 
+  it("geminiAnalyzePdf does not duplicate /v1beta when baseUrl already has version", async () => {
+    const { geminiAnalyzePdf } = await import("./pdf-native-providers.js");
+    const fetchMock = mockFetchResponse({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: { parts: [{ text: "ok" }] },
+          },
+        ],
+      }),
+    });
+
+    await geminiAnalyzePdf(
+      makeGeminiAnalyzeParams({ baseUrl: "https://generativelanguage.googleapis.com/v1beta/" }),
+    );
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("/v1beta/models/");
+    expect(url).not.toContain("/v1beta/v1beta/");
+  });
+
+  it("geminiAnalyzePdf appends /v1beta for versionless custom baseUrl", async () => {
+    const { geminiAnalyzePdf } = await import("./pdf-native-providers.js");
+    const fetchMock = mockFetchResponse({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: { parts: [{ text: "ok" }] },
+          },
+        ],
+      }),
+    });
+
+    await geminiAnalyzePdf(makeGeminiAnalyzeParams({ baseUrl: "https://my-proxy.example.com" }));
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("https://my-proxy.example.com/v1beta/models/");
+  });
+
   it("geminiAnalyzePdf throws on API error", async () => {
     const { geminiAnalyzePdf } = await import("./pdf-native-providers.js");
     mockFetchResponse({

--- a/src/agents/tools/pdf-tool.test.ts
+++ b/src/agents/tools/pdf-tool.test.ts
@@ -650,6 +650,28 @@ describe("native PDF provider API calls", () => {
     expect(url).not.toContain("/v1beta/v1beta/");
   });
 
+  it("geminiAnalyzePdf does not duplicate /v1beta when baseUrl already has /v1 version", async () => {
+    const { geminiAnalyzePdf } = await import("./pdf-native-providers.js");
+    const fetchMock = mockFetchResponse({
+      ok: true,
+      json: async () => ({
+        candidates: [
+          {
+            content: { parts: [{ text: "ok" }] },
+          },
+        ],
+      }),
+    });
+
+    await geminiAnalyzePdf(
+      makeGeminiAnalyzeParams({ baseUrl: "https://generativelanguage.googleapis.com/v1/" }),
+    );
+
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toContain("/v1/models/");
+    expect(url).not.toContain("/v1beta/");
+  });
+
   it("geminiAnalyzePdf appends /v1beta for versionless custom baseUrl", async () => {
     const { geminiAnalyzePdf } = await import("./pdf-native-providers.js");
     const fetchMock = mockFetchResponse({


### PR DESCRIPTION
Follow-up for #34316 reviewer feedback.

Adds targeted tests for geminiAnalyzePdf URL construction:
- avoid /v1beta/v1beta duplication when baseUrl already ends with /v1beta
- append /v1beta for versionless custom baseUrl

Validation:
- pnpm exec vitest run src/agents/tools/pdf-tool.test.ts --config vitest.config.ts

This PR is intended to be cherry-picked into #34316 if direct push to the source branch is unavailable.
