### PR TITLE
fix(cli): allow devices remove by unique alias

### DIFF
--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -139,6 +139,79 @@ describe("devices cli remove", () => {
       }),
     );
   });
+
+  it("resolves a unique alias and removes the matched device", async () => {
+    callGateway
+      .mockRejectedValueOnce(new Error("unknown deviceId"))
+      .mockResolvedValueOnce({
+        paired: [
+          { deviceId: "device-1", displayName: "Office iPad" },
+          { deviceId: "device-2", displayName: "Lab Node" },
+        ],
+        pending: [],
+      })
+      .mockResolvedValueOnce({ deviceId: "device-1" });
+
+    await runDevicesCommand(["remove", "Office iPad"]);
+
+    expect(callGateway).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: "device.pair.remove",
+        params: { deviceId: "Office iPad" },
+      }),
+    );
+    expect(callGateway).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        method: "device.pair.list",
+      }),
+    );
+    expect(callGateway).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        method: "device.pair.remove",
+        params: { deviceId: "device-1" },
+      }),
+    );
+  });
+
+  it("aborts removal when alias matches multiple devices", async () => {
+    callGateway
+      .mockRejectedValueOnce(new Error("unknown deviceId"))
+      .mockResolvedValueOnce({
+        paired: [
+          { deviceId: "device-1", displayName: "Office iPad" },
+          { deviceId: "device-2", displayName: "Office iPad" },
+        ],
+        pending: [],
+      });
+
+    await runDevicesCommand(["remove", "Office iPad"]);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      'Multiple paired devices match alias "Office iPad". Use an exact deviceId from `openclaw devices list`.',
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(callGateway).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts removal when alias matches no devices", async () => {
+    callGateway
+      .mockRejectedValueOnce(new Error("unknown deviceId"))
+      .mockResolvedValueOnce({
+        paired: [{ deviceId: "device-1", displayName: "Office iPad" }],
+        pending: [],
+      });
+
+    await runDevicesCommand(["remove", "Unknown Device"]);
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      'No paired device matches alias "Unknown Device". Use an exact deviceId from `openclaw devices list`.',
+    );
+    expect(runtime.exit).toHaveBeenCalledWith(1);
+    expect(callGateway).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("devices cli clear", () => {

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -177,15 +177,13 @@ describe("devices cli remove", () => {
   });
 
   it("aborts removal when alias matches multiple devices", async () => {
-    callGateway
-      .mockRejectedValueOnce(new Error("unknown deviceId"))
-      .mockResolvedValueOnce({
-        paired: [
-          { deviceId: "device-1", displayName: "Office iPad" },
-          { deviceId: "device-2", displayName: "Office iPad" },
-        ],
-        pending: [],
-      });
+    callGateway.mockRejectedValueOnce(new Error("unknown deviceId")).mockResolvedValueOnce({
+      paired: [
+        { deviceId: "device-1", displayName: "Office iPad" },
+        { deviceId: "device-2", displayName: "Office iPad" },
+      ],
+      pending: [],
+    });
 
     await runDevicesCommand(["remove", "Office iPad"]);
 
@@ -197,12 +195,10 @@ describe("devices cli remove", () => {
   });
 
   it("aborts removal when alias matches no devices", async () => {
-    callGateway
-      .mockRejectedValueOnce(new Error("unknown deviceId"))
-      .mockResolvedValueOnce({
-        paired: [{ deviceId: "device-1", displayName: "Office iPad" }],
-        pending: [],
-      });
+    callGateway.mockRejectedValueOnce(new Error("unknown deviceId")).mockResolvedValueOnce({
+      paired: [{ deviceId: "device-1", displayName: "Office iPad" }],
+      pending: [],
+    });
 
     await runDevicesCommand(["remove", "Unknown Device"]);
 

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -259,9 +259,7 @@ export function registerDevicesCli(program: Command) {
               width: tableWidth,
               columns: [
                 { key: "Request", header: "Request", minWidth: 10 },
-                { key: "Type", header: "Type", minWidth: 8 },
-                { key: "Name", header: "Name", minWidth: 16, flex: true },
-                { key: "deviceId", header: "deviceId", minWidth: 16, flex: true },
+                { key: "Device", header: "Device", minWidth: 16, flex: true },
                 { key: "Role", header: "Role", minWidth: 8 },
                 { key: "IP", header: "IP", minWidth: 12 },
                 { key: "Age", header: "Age", minWidth: 8 },
@@ -269,9 +267,7 @@ export function registerDevicesCli(program: Command) {
               ],
               rows: list.pending.map((req) => ({
                 Request: req.requestId,
-                Type: "pending",
-                Name: req.displayName ?? "",
-                deviceId: req.deviceId,
+                Device: req.displayName || req.deviceId,
                 Role: req.role ?? "",
                 IP: req.remoteIp ?? "",
                 Age: typeof req.ts === "number" ? formatTimeAgo(Date.now() - req.ts) : "",
@@ -289,18 +285,14 @@ export function registerDevicesCli(program: Command) {
             renderTable({
               width: tableWidth,
               columns: [
-                { key: "Type", header: "Type", minWidth: 8 },
-                { key: "Name", header: "Name", minWidth: 16, flex: true },
-                { key: "deviceId", header: "deviceId", minWidth: 16, flex: true },
+                { key: "Device", header: "Device", minWidth: 16, flex: true },
                 { key: "Roles", header: "Roles", minWidth: 12, flex: true },
                 { key: "Scopes", header: "Scopes", minWidth: 12, flex: true },
                 { key: "Tokens", header: "Tokens", minWidth: 12, flex: true },
                 { key: "IP", header: "IP", minWidth: 12 },
               ],
               rows: list.paired.map((device) => ({
-                Type: "paired",
-                Name: device.displayName ?? "",
-                deviceId: device.deviceId,
+                Device: device.displayName || device.deviceId,
                 Roles: device.roles?.length ? device.roles.join(", ") : "",
                 Scopes: device.scopes?.length ? device.scopes.join(", ") : "",
                 Tokens: formatTokenSummary(device.tokens),

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -328,9 +328,7 @@ export function registerDevicesCli(program: Command) {
             defaultRuntime.log(JSON.stringify(result, null, 2));
             return;
           }
-          defaultRuntime.log(
-            `${theme.warn("Removed")} ${theme.command(resolvedDeviceId)}${resolvedDeviceId === trimmed ? "" : theme.muted(` (from alias: ${trimmed})`)}`,
-          );
+          defaultRuntime.log(`${theme.warn("Removed")} ${theme.command(resolvedDeviceId)}`);
           return;
         } catch (error) {
           if (!isUnknownDeviceIdError(error)) {

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -203,21 +203,23 @@ function isUnknownDeviceIdError(error: unknown): boolean {
 
 function resolvePairedDeviceIdByAlias(
   paired: PairedDevice[] | undefined,
-  aliasOrName: string,
+  alias: string,
 ): { deviceId?: string; error?: string } {
-  const alias = aliasOrName.trim();
-  const devices = Array.isArray(paired) ? paired : [];
-  const matches = devices.filter((device) => (device.displayName ?? "").trim() === alias);
-  if (matches.length === 1) {
-    return { deviceId: matches[0]?.deviceId?.trim() };
+  const normalizedAlias = alias.trim();
+  const pairedDevices = Array.isArray(paired) ? paired : [];
+  const matchedDevices = pairedDevices.filter(
+    (device) => (device.displayName ?? "").trim() === normalizedAlias,
+  );
+  if (matchedDevices.length === 1) {
+    return { deviceId: matchedDevices[0]?.deviceId?.trim() };
   }
-  if (matches.length > 1) {
+  if (matchedDevices.length > 1) {
     return {
-      error: `Multiple paired devices match alias \"${alias}\". Use an exact deviceId from \`openclaw devices list\`.`,
+      error: `Multiple paired devices match alias "${normalizedAlias}". Use an exact deviceId from \`openclaw devices list\`.`,
     };
   }
   return {
-    error: `No paired device matches alias \"${alias}\". Use an exact deviceId from \`openclaw devices list\`.`,
+    error: `No paired device matches alias "${normalizedAlias}". Use an exact deviceId from \`openclaw devices list\`.`,
   };
 }
 

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -197,6 +197,30 @@ function formatTokenSummary(tokens: DeviceTokenSummary[] | undefined) {
   return parts.join(", ");
 }
 
+function isUnknownDeviceIdError(error: unknown): boolean {
+  return normalizeErrorMessage(error).toLowerCase().includes("unknown deviceid");
+}
+
+function resolvePairedDeviceIdByAlias(
+  paired: PairedDevice[] | undefined,
+  aliasOrName: string,
+): { deviceId?: string; error?: string } {
+  const alias = aliasOrName.trim();
+  const devices = Array.isArray(paired) ? paired : [];
+  const matches = devices.filter((device) => (device.displayName ?? "").trim() === alias);
+  if (matches.length === 1) {
+    return { deviceId: matches[0]?.deviceId?.trim() };
+  }
+  if (matches.length > 1) {
+    return {
+      error: `Multiple paired devices match alias \"${alias}\". Use an exact deviceId from \`openclaw devices list\`.`,
+    };
+  }
+  return {
+    error: `No paired device matches alias \"${alias}\". Use an exact deviceId from \`openclaw devices list\`.`,
+  };
+}
+
 function resolveRequiredDeviceRole(
   opts: DevicesRpcOpts,
 ): { deviceId: string; role: string } | null {
@@ -233,7 +257,9 @@ export function registerDevicesCli(program: Command) {
               width: tableWidth,
               columns: [
                 { key: "Request", header: "Request", minWidth: 10 },
-                { key: "Device", header: "Device", minWidth: 16, flex: true },
+                { key: "Type", header: "Type", minWidth: 8 },
+                { key: "Name", header: "Name", minWidth: 16, flex: true },
+                { key: "deviceId", header: "deviceId", minWidth: 16, flex: true },
                 { key: "Role", header: "Role", minWidth: 8 },
                 { key: "IP", header: "IP", minWidth: 12 },
                 { key: "Age", header: "Age", minWidth: 8 },
@@ -241,7 +267,9 @@ export function registerDevicesCli(program: Command) {
               ],
               rows: list.pending.map((req) => ({
                 Request: req.requestId,
-                Device: req.displayName || req.deviceId,
+                Type: "pending",
+                Name: req.displayName ?? "",
+                deviceId: req.deviceId,
                 Role: req.role ?? "",
                 IP: req.remoteIp ?? "",
                 Age: typeof req.ts === "number" ? formatTimeAgo(Date.now() - req.ts) : "",
@@ -259,14 +287,18 @@ export function registerDevicesCli(program: Command) {
             renderTable({
               width: tableWidth,
               columns: [
-                { key: "Device", header: "Device", minWidth: 16, flex: true },
+                { key: "Type", header: "Type", minWidth: 8 },
+                { key: "Name", header: "Name", minWidth: 16, flex: true },
+                { key: "deviceId", header: "deviceId", minWidth: 16, flex: true },
                 { key: "Roles", header: "Roles", minWidth: 12, flex: true },
                 { key: "Scopes", header: "Scopes", minWidth: 12, flex: true },
                 { key: "Tokens", header: "Tokens", minWidth: 12, flex: true },
                 { key: "IP", header: "IP", minWidth: 12 },
               ],
               rows: list.paired.map((device) => ({
-                Device: device.displayName || device.deviceId,
+                Type: "paired",
+                Name: device.displayName ?? "",
+                deviceId: device.deviceId,
                 Roles: device.roles?.length ? device.roles.join(", ") : "",
                 Scopes: device.scopes?.length ? device.scopes.join(", ") : "",
                 Tokens: formatTokenSummary(device.tokens),
@@ -285,20 +317,47 @@ export function registerDevicesCli(program: Command) {
     devices
       .command("remove")
       .description("Remove a paired device entry")
-      .argument("<deviceId>", "Paired device id")
-      .action(async (deviceId: string, opts: DevicesRpcOpts) => {
-        const trimmed = deviceId.trim();
+      .argument("<identifier>", "Paired deviceId or unique alias/display name")
+      .action(async (identifier: string, opts: DevicesRpcOpts) => {
+        const trimmed = identifier.trim();
         if (!trimmed) {
-          defaultRuntime.error("deviceId is required");
+          defaultRuntime.error("deviceId or alias is required");
           defaultRuntime.exit(1);
           return;
         }
-        const result = await callGatewayCli("device.pair.remove", opts, { deviceId: trimmed });
+        let resolvedDeviceId = trimmed;
+        try {
+          const result = await callGatewayCli("device.pair.remove", opts, { deviceId: resolvedDeviceId });
+          if (opts.json) {
+            defaultRuntime.log(JSON.stringify(result, null, 2));
+            return;
+          }
+          defaultRuntime.log(
+            `${theme.warn("Removed")} ${theme.command(resolvedDeviceId)}${resolvedDeviceId === trimmed ? "" : theme.muted(` (from alias: ${trimmed})`)}`,
+          );
+          return;
+        } catch (error) {
+          if (!isUnknownDeviceIdError(error)) {
+            throw error;
+          }
+        }
+
+        const list = await listPairingWithFallback(opts);
+        const resolved = resolvePairedDeviceIdByAlias(list.paired, trimmed);
+        if (!resolved.deviceId) {
+          defaultRuntime.error(resolved.error ?? "Unable to resolve paired device alias");
+          defaultRuntime.exit(1);
+          return;
+        }
+        resolvedDeviceId = resolved.deviceId;
+        const result = await callGatewayCli("device.pair.remove", opts, { deviceId: resolvedDeviceId });
         if (opts.json) {
           defaultRuntime.log(JSON.stringify(result, null, 2));
           return;
         }
-        defaultRuntime.log(`${theme.warn("Removed")} ${theme.command(trimmed)}`);
+        defaultRuntime.log(
+          `${theme.warn("Removed")} ${theme.command(resolvedDeviceId)}${theme.muted(` (from alias: ${trimmed})`)}`,
+        );
       }),
   );
 

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -327,7 +327,9 @@ export function registerDevicesCli(program: Command) {
         }
         let resolvedDeviceId = trimmed;
         try {
-          const result = await callGatewayCli("device.pair.remove", opts, { deviceId: resolvedDeviceId });
+          const result = await callGatewayCli("device.pair.remove", opts, {
+            deviceId: resolvedDeviceId,
+          });
           if (opts.json) {
             defaultRuntime.log(JSON.stringify(result, null, 2));
             return;
@@ -350,7 +352,9 @@ export function registerDevicesCli(program: Command) {
           return;
         }
         resolvedDeviceId = resolved.deviceId;
-        const result = await callGatewayCli("device.pair.remove", opts, { deviceId: resolvedDeviceId });
+        const result = await callGatewayCli("device.pair.remove", opts, {
+          deviceId: resolvedDeviceId,
+        });
         if (opts.json) {
           defaultRuntime.log(JSON.stringify(result, null, 2));
           return;


### PR DESCRIPTION
## Summary

- Allow `openclaw devices remove <identifier>` to accept a display alias/name **only when it resolves to exactly one paired device**.
- Keep exact `deviceId` behavior unchanged.
- Abort on 0 or >1 alias matches (no deletion).

Refs #27087

## Safety

- We only fall back to alias resolution after an initial remove attempt fails with an unknown `deviceId` error.
- Alias matching is strict (trimmed exact displayName match) to avoid accidental deletion.

## Tests

- Added tests covering:
  - unique alias match
  - ambiguous alias match
  - unknown alias
- Ran: `pnpm vitest run src/cli/devices-cli.test.ts`
