### PR TITLE
docs(config): fix legacy 'Clawdbot' reference in GatewayTrustedProxyConfig comment

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -110,7 +110,7 @@ export type GatewayAuthMode = "none" | "token" | "password" | "trusted-proxy";
 
 /**
  * Configuration for trusted reverse proxy authentication.
- * Used when Clawdbot runs behind an identity-aware proxy (Pomerium, Caddy + OAuth, etc.)
+ * Used when OpenClaw runs behind an identity-aware proxy (Pomerium, Caddy + OAuth, etc.)
  * that handles authentication and passes user identity via headers.
  */
 export type GatewayTrustedProxyConfig = {


### PR DESCRIPTION
## What
Fixes a legacy project name reference in the JSDoc comment for `GatewayTrustedProxyConfig`.

## Why
The comment still referenced the old project name "Clawdbot" (pre-January 2026). Updated to use the current project name "OpenClaw" for consistency.

## Changes
- `src/config/types.gateway.ts`: Changed "Used when Clawdbot runs behind..." to "Used when OpenClaw runs behind..."

## Testing
- [x] Verified the change is documentation-only (no functional impact)
- [x] Checked for other non-legacy "Clawdbot" references in source code (this was the only one outside of intentional backward-compatibility code)