### PR TITLE
docs(skills): add Linux install instructions for model-usage skill

### DIFF
--- a/skills/model-usage/SKILL.md
+++ b/skills/model-usage/SKILL.md
@@ -28,7 +28,21 @@ metadata:
 
 Get per-model usage cost from CodexBar's local cost logs. Supports "current model" (most recent daily entry) or "all models" summaries for Codex or Claude.
 
-TODO: add Linux CLI support guidance once CodexBar CLI install path is documented for Linux.
+## Install
+
+### macOS
+
+```bash
+brew install --cask steipete/tap/codexbar
+```
+
+Or download from [GitHub Releases](https://github.com/steipete/CodexBar/releases).
+
+### Linux
+
+Download `CodexBarCLI-v<tag>-linux-<arch>.tar.gz` from [GitHub Releases](https://github.com/steipete/CodexBar/releases), extract and add to PATH.
+
+For Omarchy users: community Waybar module and TUI available.
 
 ## Quick start
 


### PR DESCRIPTION
## What
Replaces the TODO placeholder in the model-usage skill with actual Linux installation instructions for CodexBar CLI.

## Why
The skill had a TODO comment asking for Linux CLI support guidance. CodexBar now provides Linux CLI binaries via GitHub Releases, so the documentation can be completed.

## Changes
- Added macOS install section (Homebrew cask + GitHub Releases)
- Added Linux install section (GitHub Releases tarball)
- Mentioned Omarchy Waybar/TUI support for Linux users
- Removed the TODO placeholder

## References
- CodexBar GitHub: https://github.com/steipete/CodexBar
- Linux support mentioned in README: "Or download CodexBarCLI-v<tag>-linux-<arch>.tar.gz from GitHub Releases. Linux support via Omarchy: community Waybar module and TUI, driven by the codexbar executable."