### PR TITLE
feat(onboarding): add initial CLI locale selection and zh-CN prompts

### DIFF
--- a/src/i18n/cli.ts
+++ b/src/i18n/cli.ts
@@ -1,0 +1,82 @@
+export type CliLocale = "en" | "zh-CN";
+
+type CliMessageKey =
+  | "wizard.setupCancelled"
+  | "wizard.onboardingTitle"
+  | "wizard.securityTitle"
+  | "wizard.securityConfirm"
+  | "wizard.modeQuestion"
+  | "wizard.modeQuickstart"
+  | "wizard.modeQuickstartHint"
+  | "wizard.modeManual"
+  | "wizard.modeManualHint"
+  | "wizard.quickstartTitle"
+  | "wizard.quickstartSwitchToManual"
+  | "wizard.configInvalidOutro"
+  | "wizard.remoteConfigured";
+
+type CliMessages = Record<CliMessageKey, string>;
+
+const EN_MESSAGES: CliMessages = {
+  "wizard.setupCancelled": "Setup cancelled.",
+  "wizard.onboardingTitle": "OpenClaw onboarding",
+  "wizard.securityTitle": "Security",
+  "wizard.securityConfirm":
+    "I understand this is personal-by-default and shared/multi-user use requires lock-down. Continue?",
+  "wizard.modeQuestion": "Onboarding mode",
+  "wizard.modeQuickstart": "QuickStart",
+  "wizard.modeQuickstartHint": "Configure details later via openclaw configure.",
+  "wizard.modeManual": "Manual",
+  "wizard.modeManualHint": "Configure port, network, Tailscale, and auth options.",
+  "wizard.quickstartTitle": "QuickStart",
+  "wizard.quickstartSwitchToManual":
+    "QuickStart only supports local gateways. Switching to Manual mode.",
+  "wizard.configInvalidOutro":
+    "Config invalid. Run `openclaw doctor` to repair it, then re-run onboarding.",
+  "wizard.remoteConfigured": "Remote gateway configured.",
+};
+
+const ZH_CN_MESSAGES: CliMessages = {
+  "wizard.setupCancelled": "安装向导已取消。",
+  "wizard.onboardingTitle": "OpenClaw 初始化向导",
+  "wizard.securityTitle": "安全提醒",
+  "wizard.securityConfirm": "我理解默认是个人使用场景，多用户/共享场景需要额外加固。是否继续？",
+  "wizard.modeQuestion": "初始化模式",
+  "wizard.modeQuickstart": "快速开始",
+  "wizard.modeQuickstartHint": "稍后可通过 openclaw configure 继续细化配置。",
+  "wizard.modeManual": "手动配置",
+  "wizard.modeManualHint": "配置端口、网络、Tailscale 与认证选项。",
+  "wizard.quickstartTitle": "快速开始",
+  "wizard.quickstartSwitchToManual": "快速开始仅支持本地网关，已切换到手动模式。",
+  "wizard.configInvalidOutro": "配置文件无效。请先运行 `openclaw doctor` 修复，再重新执行初始化。",
+  "wizard.remoteConfigured": "远程网关已配置完成。",
+};
+
+function normalizeLocale(raw: string): CliLocale {
+  const value = raw.trim().toLowerCase();
+  if (!value) {
+    return "en";
+  }
+  if (value === "zh-cn" || value === "zh_cn" || value.startsWith("zh")) {
+    return "zh-CN";
+  }
+  return "en";
+}
+
+export function resolveCliLocale(env: NodeJS.ProcessEnv = process.env): CliLocale {
+  const explicit = env.OPENCLAW_LOCALE;
+  if (explicit) {
+    return normalizeLocale(explicit);
+  }
+  const lang = env.LANG;
+  if (lang) {
+    return normalizeLocale(lang);
+  }
+  return "en";
+}
+
+export function cliT(key: CliMessageKey, env: NodeJS.ProcessEnv = process.env): string {
+  const locale = resolveCliLocale(env);
+  const messages = locale === "zh-CN" ? ZH_CN_MESSAGES : EN_MESSAGES;
+  return messages[key] ?? EN_MESSAGES[key];
+}

--- a/src/i18n/cli.ts
+++ b/src/i18n/cli.ts
@@ -17,6 +17,8 @@ type CliMessageKey =
 
 type CliMessages = Record<CliMessageKey, string>;
 
+type CliTemplateVars = Record<string, string | number>;
+
 const EN_MESSAGES: CliMessages = {
   "wizard.setupCancelled": "Setup cancelled.",
   "wizard.onboardingTitle": "OpenClaw onboarding",
@@ -25,14 +27,14 @@ const EN_MESSAGES: CliMessages = {
     "I understand this is personal-by-default and shared/multi-user use requires lock-down. Continue?",
   "wizard.modeQuestion": "Onboarding mode",
   "wizard.modeQuickstart": "QuickStart",
-  "wizard.modeQuickstartHint": "Configure details later via openclaw configure.",
+  "wizard.modeQuickstartHint": "Configure details later via {configureCommand}.",
   "wizard.modeManual": "Manual",
   "wizard.modeManualHint": "Configure port, network, Tailscale, and auth options.",
   "wizard.quickstartTitle": "QuickStart",
   "wizard.quickstartSwitchToManual":
     "QuickStart only supports local gateways. Switching to Manual mode.",
   "wizard.configInvalidOutro":
-    "Config invalid. Run `openclaw doctor` to repair it, then re-run onboarding.",
+    "Config invalid. Run `{doctorCommand}` to repair it, then re-run onboarding.",
   "wizard.remoteConfigured": "Remote gateway configured.",
 };
 
@@ -43,12 +45,12 @@ const ZH_CN_MESSAGES: CliMessages = {
   "wizard.securityConfirm": "我理解默认是个人使用场景，多用户/共享场景需要额外加固。是否继续？",
   "wizard.modeQuestion": "初始化模式",
   "wizard.modeQuickstart": "快速开始",
-  "wizard.modeQuickstartHint": "稍后可通过 openclaw configure 继续细化配置。",
+  "wizard.modeQuickstartHint": "稍后可通过 {configureCommand} 继续细化配置。",
   "wizard.modeManual": "手动配置",
   "wizard.modeManualHint": "配置端口、网络、Tailscale 与认证选项。",
   "wizard.quickstartTitle": "快速开始",
   "wizard.quickstartSwitchToManual": "快速开始仅支持本地网关，已切换到手动模式。",
-  "wizard.configInvalidOutro": "配置文件无效。请先运行 `openclaw doctor` 修复，再重新执行初始化。",
+  "wizard.configInvalidOutro": "配置文件无效。请先运行 `{doctorCommand}` 修复，再重新执行初始化。",
   "wizard.remoteConfigured": "远程网关已配置完成。",
 };
 
@@ -57,9 +59,12 @@ function normalizeLocale(raw: string): CliLocale {
   if (!value) {
     return "en";
   }
-  if (value === "zh-cn" || value === "zh_cn" || value.startsWith("zh")) {
+
+  const normalized = value.replace(/_/g, "-").split(".")[0] ?? value;
+  if (normalized === "zh-cn" || normalized === "zh-hans") {
     return "zh-CN";
   }
+
   return "en";
 }
 
@@ -75,8 +80,23 @@ export function resolveCliLocale(env: NodeJS.ProcessEnv = process.env): CliLocal
   return "en";
 }
 
-export function cliT(key: CliMessageKey, env: NodeJS.ProcessEnv = process.env): string {
+function formatTemplate(message: string, vars?: CliTemplateVars): string {
+  if (!vars) {
+    return message;
+  }
+  return message.replace(/\{([a-zA-Z0-9_]+)\}/g, (full, key) => {
+    const value = vars[key];
+    return value === undefined ? full : String(value);
+  });
+}
+
+export function cliT(
+  key: CliMessageKey,
+  env: NodeJS.ProcessEnv = process.env,
+  vars?: CliTemplateVars,
+): string {
   const locale = resolveCliLocale(env);
   const messages = locale === "zh-CN" ? ZH_CN_MESSAGES : EN_MESSAGES;
-  return messages[key] ?? EN_MESSAGES[key];
+  const message = messages[key] ?? EN_MESSAGES[key];
+  return formatTemplate(message, vars);
 }

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -12,6 +12,7 @@ import {
   text,
 } from "@clack/prompts";
 import { createCliProgress } from "../cli/progress.js";
+import { cliT } from "../i18n/cli.js";
 import { stripAnsi } from "../terminal/ansi.js";
 import { note as emitNote } from "../terminal/note.js";
 import { stylePromptHint, stylePromptMessage, stylePromptTitle } from "../terminal/prompt-style.js";
@@ -21,7 +22,8 @@ import { WizardCancelledError } from "./prompts.js";
 
 function guardCancel<T>(value: T | symbol): T {
   if (isCancel(value)) {
-    cancel(stylePromptTitle("Setup cancelled.") ?? "Setup cancelled.");
+    const cancelled = cliT("wizard.setupCancelled");
+    cancel(stylePromptTitle(cancelled) ?? cancelled);
     throw new WizardCancelledError();
   }
   return value;

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -217,15 +217,22 @@ function createRuntime(opts?: { throwsOnExit?: boolean }): RuntimeEnv {
 describe("runOnboardingWizard", () => {
   let suiteRoot = "";
   let suiteCase = 0;
+  const previousLocale = process.env.OPENCLAW_LOCALE;
 
   beforeAll(async () => {
     suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-onboard-suite-"));
+    process.env.OPENCLAW_LOCALE = "en";
   });
 
   afterAll(async () => {
     await fs.rm(suiteRoot, { recursive: true, force: true });
     suiteRoot = "";
     suiteCase = 0;
+    if (previousLocale === undefined) {
+      delete process.env.OPENCLAW_LOCALE;
+    } else {
+      process.env.OPENCLAW_LOCALE = previousLocale;
+    }
   });
 
   async function makeCaseDir(prefix: string): Promise<string> {

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -13,12 +13,29 @@ import {
   writeConfigFile,
 } from "../config/config.js";
 import { normalizeSecretInputString } from "../config/types.secrets.js";
+import { cliT } from "../i18n/cli.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveOnboardingSecretInputString } from "./onboarding.secret-input.js";
 import type { QuickstartGatewayDefaults, WizardFlow } from "./onboarding.types.js";
 import { WizardCancelledError, type WizardPrompter } from "./prompts.js";
+
+async function promptCliLocaleSelection(prompter: WizardPrompter): Promise<void> {
+  const explicit = process.env.OPENCLAW_LOCALE?.trim();
+  if (explicit) {
+    return;
+  }
+  const locale = await prompter.select({
+    message: "Language / 语言",
+    options: [
+      { value: "en", label: "English", hint: "Default" },
+      { value: "zh-CN", label: "简体中文", hint: "推荐" },
+    ],
+    initialValue: "en",
+  });
+  process.env.OPENCLAW_LOCALE = locale;
+}
 
 async function requireRiskAcknowledgement(params: {
   opts: OnboardOptions;
@@ -57,12 +74,11 @@ async function requireRiskAcknowledgement(params: {
       "",
       "Must read: https://docs.openclaw.ai/gateway/security",
     ].join("\n"),
-    "Security",
+    cliT("wizard.securityTitle", process.env),
   );
 
   const ok = await params.prompter.confirm({
-    message:
-      "I understand this is personal-by-default and shared/multi-user use requires lock-down. Continue?",
+    message: cliT("wizard.securityConfirm", process.env),
     initialValue: false,
   });
   if (!ok) {
@@ -75,9 +91,11 @@ export async function runOnboardingWizard(
   runtime: RuntimeEnv = defaultRuntime,
   prompter: WizardPrompter,
 ) {
+  await promptCliLocaleSelection(prompter);
+  const t = (key: Parameters<typeof cliT>[0]) => cliT(key, process.env);
   const onboardHelpers = await import("../commands/onboard-helpers.js");
   onboardHelpers.printWizardHeader(runtime);
-  await prompter.intro("OpenClaw onboarding");
+  await prompter.intro(t("wizard.onboardingTitle"));
   await requireRiskAcknowledgement({ opts, prompter });
 
   const snapshot = await readConfigFileSnapshot();
@@ -96,14 +114,20 @@ export async function runOnboardingWizard(
       );
     }
     await prompter.outro(
-      `Config invalid. Run \`${formatCliCommand("openclaw doctor")}\` to repair it, then re-run onboarding.`,
+      t("wizard.configInvalidOutro").replace(
+        "openclaw doctor",
+        formatCliCommand("openclaw doctor"),
+      ),
     );
     runtime.exit(1);
     return;
   }
 
-  const quickstartHint = `Configure details later via ${formatCliCommand("openclaw configure")}.`;
-  const manualHint = "Configure port, network, Tailscale, and auth options.";
+  const quickstartHint = t("wizard.modeQuickstartHint").replace(
+    "openclaw configure",
+    formatCliCommand("openclaw configure"),
+  );
+  const manualHint = t("wizard.modeManualHint");
   const explicitFlowRaw = opts.flow?.trim();
   const normalizedExplicitFlow = explicitFlowRaw === "manual" ? "advanced" : explicitFlowRaw;
   if (
@@ -122,19 +146,16 @@ export async function runOnboardingWizard(
   let flow: WizardFlow =
     explicitFlow ??
     (await prompter.select({
-      message: "Onboarding mode",
+      message: t("wizard.modeQuestion"),
       options: [
-        { value: "quickstart", label: "QuickStart", hint: quickstartHint },
-        { value: "advanced", label: "Manual", hint: manualHint },
+        { value: "quickstart", label: t("wizard.modeQuickstart"), hint: quickstartHint },
+        { value: "advanced", label: t("wizard.modeManual"), hint: manualHint },
       ],
       initialValue: "quickstart",
     }));
 
   if (opts.mode === "remote" && flow === "quickstart") {
-    await prompter.note(
-      "QuickStart only supports local gateways. Switching to Manual mode.",
-      "QuickStart",
-    );
+    await prompter.note(t("wizard.quickstartSwitchToManual"), t("wizard.quickstartTitle"));
     flow = "advanced";
   }
 
@@ -352,7 +373,7 @@ export async function runOnboardingWizard(
     nextConfig = onboardHelpers.applyWizardMetadata(nextConfig, { command: "onboard", mode });
     await writeConfigFile(nextConfig);
     logConfigUpdated(runtime);
-    await prompter.outro("Remote gateway configured.");
+    await prompter.outro(t("wizard.remoteConfigured"));
     return;
   }
 

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -114,19 +114,17 @@ export async function runOnboardingWizard(
       );
     }
     await prompter.outro(
-      t("wizard.configInvalidOutro").replace(
-        "openclaw doctor",
-        formatCliCommand("openclaw doctor"),
-      ),
+      cliT("wizard.configInvalidOutro", process.env, {
+        doctorCommand: formatCliCommand("openclaw doctor"),
+      }),
     );
     runtime.exit(1);
     return;
   }
 
-  const quickstartHint = t("wizard.modeQuickstartHint").replace(
-    "openclaw configure",
-    formatCliCommand("openclaw configure"),
-  );
+  const quickstartHint = cliT("wizard.modeQuickstartHint", process.env, {
+    configureCommand: formatCliCommand("openclaw configure"),
+  });
   const manualHint = t("wizard.modeManualHint");
   const explicitFlowRaw = opts.flow?.trim();
   const normalizedExplicitFlow = explicitFlowRaw === "manual" ? "advanced" : explicitFlowRaw;


### PR DESCRIPTION
## Summary

This PR introduces an initial CLI localization path for onboarding with a minimal, low-risk scope:

- Adds a small CLI i18n module for onboarding/wizard strings (`src/i18n/cli.ts`)
- Adds language selection at the first interactive step of onboarding when no explicit `OPENCLAW_LOCALE` is set
- Localizes a first batch of onboarding prompts/messages (English + Simplified Chinese)
- Keeps English as the default and fallback

## Why

OpenClaw already has substantial `docs/zh-CN` coverage, but onboarding CLI prompts are primarily English-only. This change reduces first-run friction for Chinese-speaking users while preserving existing default behavior.

## Scope / Non-goals

- Scope: onboarding/wizard prompt copy only
- Non-goal: broad CLI-wide localization in this PR
- No behavioral changes to onboarding flow logic

## Behavior details

- Locale resolution:
  - `OPENCLAW_LOCALE` has priority
  - otherwise falls back to `LANG`
  - default/fallback is `en`
- Interactive selection:
  - shown only when `OPENCLAW_LOCALE` is not set
  - options: `English` / `简体中文`
  - sets `process.env.OPENCLAW_LOCALE` for the current run

## Tests

Verified with:

```bash
pnpm vitest run src/wizard/onboarding.test.ts src/wizard/clack-prompter.test.ts
```

Result: all tests passed.

## Follow-up plan

- Expand key coverage to remaining onboarding prompts
- Add persistence for locale preference (so first-run selection can be remembered)
- Consider broader CLI localization in incremental PRs
