### PR TITLE
TUI: prevent duplicate render after reconnect

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -219,6 +219,34 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(tui.requestRender).not.toHaveBeenCalled();
   });
 
+  it("resets run tracking on disconnect to avoid stale-run duplication after reconnect", () => {
+    const { state, chatLog, tui, handleChatEvent, handleAgentEvent, resetRunTracking } =
+      createHandlersHarness({
+        state: { activeChatRunId: null },
+      });
+
+    handleChatEvent({
+      runId: "run-stale",
+      sessionKey: state.currentSessionKey,
+      state: "delta",
+      message: { content: "partial" },
+    });
+    expect(state.activeChatRunId).toBe("run-stale");
+
+    resetRunTracking();
+    expect(state.activeChatRunId).toBeNull();
+    tui.requestRender.mockClear();
+
+    handleAgentEvent({
+      runId: "run-stale",
+      stream: "tool",
+      data: { phase: "start", toolCallId: "tc-stale", name: "exec" },
+    });
+
+    expect(chatLog.startTool).not.toHaveBeenCalledWith("tc-stale", "exec", undefined);
+    expect(tui.requestRender).not.toHaveBeenCalled();
+  });
+
   it("accepts tool events after chat final for the same run", () => {
     const { state, chatLog, tui, handleChatEvent, handleAgentEvent } = createHandlersHarness({
       state: { activeChatRunId: null },

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -82,6 +82,14 @@ export function createEventHandlers(context: EventHandlerContext) {
     clearLocalRunIds?.();
   };
 
+  const resetRunTracking = () => {
+    finalizedRuns.clear();
+    sessionRuns.clear();
+    streamAssembler = new TuiStreamAssembler();
+    state.activeChatRunId = null;
+    clearLocalRunIds?.();
+  };
+
   const noteSessionRun = (runId: string) => {
     sessionRuns.set(runId, Date.now());
     pruneRunMap(sessionRuns);
@@ -298,5 +306,5 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
   };
 
-  return { handleChatEvent, handleAgentEvent };
+  return { handleChatEvent, handleAgentEvent, resetRunTracking };
 }

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -776,7 +776,7 @@ export async function runTui(opts: TuiOptions) {
     abortActive,
   } = sessionActions;
 
-  const { handleChatEvent, handleAgentEvent } = createEventHandlers({
+  const { handleChatEvent, handleAgentEvent, resetRunTracking } = createEventHandlers({
     chatLog,
     tui,
     state,
@@ -923,6 +923,7 @@ export async function runTui(opts: TuiOptions) {
     isConnected = false;
     wasDisconnected = true;
     historyLoaded = false;
+    resetRunTracking();
     const disconnectState = resolveGatewayDisconnectState(reason);
     setConnectionStatus(disconnectState.connectionStatus, 5000);
     setActivityStatus(disconnectState.activityStatus);


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: TUI could render duplicated messages after websocket disconnect/reconnect cycles.
- Why it matters: User-visible chat output becomes noisy/inaccurate, while actual delivery remains single-send.
- What changed: Added explicit run-tracking reset on disconnect (`resetRunTracking`) and invoked it in TUI disconnect handling before reconnect history reload.
- What did NOT change (scope boundary): No gateway protocol changes, no message send semantics changes, no channel delivery changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34331

## User-visible / Behavior Changes

- TUI now clears stale run-tracking state when gateway disconnects, reducing duplicate rendering after reconnect.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (dev verification), issue repro reports macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): TUI + gateway websocket stream
- Relevant config (redacted): gateway on default port with TUI session

### Steps

1. Start TUI and stream events for an active run.
2. Simulate disconnect/reconnect cycle.
3. Continue receiving events.

### Expected

- Stale pre-disconnect run state is cleared and not replayed as duplicate rendered entries.

### Actual

- After fix, stale run ids are cleared on disconnect; reconnect flow renders without stale-run duplication.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added unit test for disconnect reset behavior in `tui-event-handlers`.
  - Ran focused TUI test suite.
- Edge cases checked:
  - Stale run tool events are ignored after reset.
  - Existing active-run and concurrent-run handler tests still pass.
- What you did **not** verify:
  - Manual long-running TUI session on macOS host.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit `3e055f3a7`.
- Files/config to restore: `src/tui/tui.ts`, `src/tui/tui-event-handlers.ts`, `src/tui/tui-event-handlers.test.ts`.
- Known bad symptoms reviewers should watch for: missing tool/lifecycle updates right after reconnect due to over-aggressive reset.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Resetting run tracking on disconnect could hide valid late events from a pre-disconnect run.
  - Mitigation: This is intentional to prevent stale-run replay; fresh post-reconnect history/event stream remains source of truth and tests cover behavior.
