### PR TITLE
fix(cli): show deviceId column in devices list

### DIFF
--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -234,7 +234,7 @@ export function registerDevicesCli(program: Command) {
               columns: [
                 { key: "Request", header: "Request", minWidth: 10 },
                 { key: "Name", header: "Name", minWidth: 16, flex: true },
-                { key: "deviceId", header: "Device ID", minWidth: 16, flex: true },
+                { key: "deviceId", header: "deviceId", minWidth: 16, flex: true },
                 { key: "Role", header: "Role", minWidth: 8 },
                 { key: "IP", header: "IP", minWidth: 12 },
                 { key: "Age", header: "Age", minWidth: 8 },
@@ -262,7 +262,7 @@ export function registerDevicesCli(program: Command) {
               width: tableWidth,
               columns: [
                 { key: "Name", header: "Name", minWidth: 16, flex: true },
-                { key: "deviceId", header: "Device ID", minWidth: 16, flex: true },
+                { key: "deviceId", header: "deviceId", minWidth: 16, flex: true },
                 { key: "Roles", header: "Roles", minWidth: 12, flex: true },
                 { key: "Scopes", header: "Scopes", minWidth: 12, flex: true },
                 { key: "Tokens", header: "Tokens", minWidth: 12, flex: true },

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -233,7 +233,8 @@ export function registerDevicesCli(program: Command) {
               width: tableWidth,
               columns: [
                 { key: "Request", header: "Request", minWidth: 10 },
-                { key: "Device", header: "Device", minWidth: 16, flex: true },
+                { key: "Name", header: "Name", minWidth: 16, flex: true },
+                { key: "deviceId", header: "deviceId", minWidth: 16, flex: true },
                 { key: "Role", header: "Role", minWidth: 8 },
                 { key: "IP", header: "IP", minWidth: 12 },
                 { key: "Age", header: "Age", minWidth: 8 },
@@ -241,7 +242,8 @@ export function registerDevicesCli(program: Command) {
               ],
               rows: list.pending.map((req) => ({
                 Request: req.requestId,
-                Device: req.displayName || req.deviceId,
+                Name: req.displayName ?? "",
+                deviceId: req.deviceId,
                 Role: req.role ?? "",
                 IP: req.remoteIp ?? "",
                 Age: typeof req.ts === "number" ? formatTimeAgo(Date.now() - req.ts) : "",
@@ -259,14 +261,16 @@ export function registerDevicesCli(program: Command) {
             renderTable({
               width: tableWidth,
               columns: [
-                { key: "Device", header: "Device", minWidth: 16, flex: true },
+                { key: "Name", header: "Name", minWidth: 16, flex: true },
+                { key: "deviceId", header: "deviceId", minWidth: 16, flex: true },
                 { key: "Roles", header: "Roles", minWidth: 12, flex: true },
                 { key: "Scopes", header: "Scopes", minWidth: 12, flex: true },
                 { key: "Tokens", header: "Tokens", minWidth: 12, flex: true },
                 { key: "IP", header: "IP", minWidth: 12 },
               ],
               rows: list.paired.map((device) => ({
-                Device: device.displayName || device.deviceId,
+                Name: device.displayName ?? "",
+                deviceId: device.deviceId,
                 Roles: device.roles?.length ? device.roles.join(", ") : "",
                 Scopes: device.scopes?.length ? device.scopes.join(", ") : "",
                 Tokens: formatTokenSummary(device.tokens),

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -234,7 +234,7 @@ export function registerDevicesCli(program: Command) {
               columns: [
                 { key: "Request", header: "Request", minWidth: 10 },
                 { key: "Name", header: "Name", minWidth: 16, flex: true },
-                { key: "deviceId", header: "deviceId", minWidth: 16, flex: true },
+                { key: "deviceId", header: "Device ID", minWidth: 16, flex: true },
                 { key: "Role", header: "Role", minWidth: 8 },
                 { key: "IP", header: "IP", minWidth: 12 },
                 { key: "Age", header: "Age", minWidth: 8 },
@@ -262,7 +262,7 @@ export function registerDevicesCli(program: Command) {
               width: tableWidth,
               columns: [
                 { key: "Name", header: "Name", minWidth: 16, flex: true },
-                { key: "deviceId", header: "deviceId", minWidth: 16, flex: true },
+                { key: "deviceId", header: "Device ID", minWidth: 16, flex: true },
                 { key: "Roles", header: "Roles", minWidth: 12, flex: true },
                 { key: "Scopes", header: "Scopes", minWidth: 12, flex: true },
                 { key: "Tokens", header: "Tokens", minWidth: 12, flex: true },

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -234,7 +234,7 @@ export function registerDevicesCli(program: Command) {
               columns: [
                 { key: "Request", header: "Request", minWidth: 10 },
                 { key: "Name", header: "Name", minWidth: 16, flex: true },
-                { key: "deviceId", header: "deviceId", minWidth: 16, flex: true },
+                { key: "DeviceId", header: "deviceId", minWidth: 16, flex: true },
                 { key: "Role", header: "Role", minWidth: 8 },
                 { key: "IP", header: "IP", minWidth: 12 },
                 { key: "Age", header: "Age", minWidth: 8 },
@@ -243,7 +243,7 @@ export function registerDevicesCli(program: Command) {
               rows: list.pending.map((req) => ({
                 Request: req.requestId,
                 Name: req.displayName ?? "",
-                deviceId: req.deviceId,
+                DeviceId: req.deviceId,
                 Role: req.role ?? "",
                 IP: req.remoteIp ?? "",
                 Age: typeof req.ts === "number" ? formatTimeAgo(Date.now() - req.ts) : "",
@@ -262,7 +262,7 @@ export function registerDevicesCli(program: Command) {
               width: tableWidth,
               columns: [
                 { key: "Name", header: "Name", minWidth: 16, flex: true },
-                { key: "deviceId", header: "deviceId", minWidth: 16, flex: true },
+                { key: "DeviceId", header: "deviceId", minWidth: 16, flex: true },
                 { key: "Roles", header: "Roles", minWidth: 12, flex: true },
                 { key: "Scopes", header: "Scopes", minWidth: 12, flex: true },
                 { key: "Tokens", header: "Tokens", minWidth: 12, flex: true },
@@ -270,7 +270,7 @@ export function registerDevicesCli(program: Command) {
               ],
               rows: list.paired.map((device) => ({
                 Name: device.displayName ?? "",
-                deviceId: device.deviceId,
+                DeviceId: device.deviceId,
                 Roles: device.roles?.length ? device.roles.join(", ") : "",
                 Scopes: device.scopes?.length ? device.scopes.join(", ") : "",
                 Tokens: formatTokenSummary(device.tokens),


### PR DESCRIPTION
## Summary
- keep the patch minimal for issue #27087 list clarity
- replace mixed Device display with explicit Name and deviceId columns in `openclaw devices list`
- keep behavior scoped to list output only

## Test plan
- [x] `pnpm vitest src/cli/devices-cli.test.ts`

Refs #27087