### PR TITLE
fix(telegram): avoid global network mutations when proxy fetch is injected

### DIFF
--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -190,6 +190,13 @@ describe("resolveTelegramFetch", () => {
   });
 
   it("keeps an existing proxy-like global dispatcher", async () => {
+    vi.stubEnv("HTTP_PROXY", "");
+    vi.stubEnv("HTTPS_PROXY", "");
+    vi.stubEnv("ALL_PROXY", "");
+    vi.stubEnv("http_proxy", "");
+    vi.stubEnv("https_proxy", "");
+    vi.stubEnv("all_proxy", "");
+
     getGlobalDispatcherState.value = {
       constructor: { name: "ProxyAgent" },
     };

--- a/src/telegram/fetch.test.ts
+++ b/src/telegram/fetch.test.ts
@@ -130,6 +130,18 @@ describe("resolveTelegramFetch", () => {
     expect(resolved).toBe(alreadyWrapped);
   });
 
+  it("does not mutate global network defaults when a proxy fetch is injected", async () => {
+    const proxyFetch = vi.fn(async () => ({ ok: true }) as Response) as unknown as typeof fetch;
+
+    resolveTelegramFetch(proxyFetch, {
+      network: { autoSelectFamily: true, dnsResultOrder: "verbatim" },
+    });
+
+    expect(setDefaultAutoSelectFamily).not.toHaveBeenCalled();
+    expect(setDefaultResultOrder).not.toHaveBeenCalled();
+    expect(setGlobalDispatcher).not.toHaveBeenCalled();
+  });
+
   it("honors env enable override", async () => {
     vi.stubEnv("OPENCLAW_TELEGRAM_ENABLE_AUTO_SELECT_FAMILY", "1");
     globalThis.fetch = vi.fn(async () => ({})) as unknown as typeof fetch;

--- a/src/telegram/fetch.ts
+++ b/src/telegram/fetch.ts
@@ -178,16 +178,19 @@ export function resolveTelegramFetch(
   proxyFetch?: typeof fetch,
   options?: { network?: TelegramNetworkConfig },
 ): typeof fetch | undefined {
-  applyTelegramNetworkWorkarounds(options?.network);
   const sourceFetch = proxyFetch ? resolveFetch(proxyFetch) : resolveFetch();
   if (!sourceFetch) {
     throw new Error("fetch is not available; set channels.telegram.proxy in config");
   }
-  // When Telegram media fetch hits dual-stack edge cases (ENETUNREACH/ETIMEDOUT),
-  // switch to IPv4-safe network mode and retry once.
+  // Injected proxy fetches should stay self-contained and must not mutate
+  // process-wide network defaults/dispatchers used by other subsystems.
   if (proxyFetch) {
     return sourceFetch;
   }
+
+  applyTelegramNetworkWorkarounds(options?.network);
+  // When Telegram media fetch hits dual-stack edge cases (ENETUNREACH/ETIMEDOUT),
+  // switch to IPv4-safe network mode and retry once.
   return (async (input: RequestInfo | URL, init?: RequestInit) => {
     try {
       return await sourceFetch(input, init);


### PR DESCRIPTION
## Summary
This PR prevents global network/runtime mutation when `resolveTelegramFetch` is called with an injected `proxyFetch`, and adds test hardening for proxy-env-dependent behavior.

## Problem
In the injected `proxyFetch` path, `resolveTelegramFetch` still applied Telegram network workarounds before returning, which could mutate process-wide network defaults (e.g., global undici dispatcher, autoSelectFamily/dns defaults).
This can unintentionally affect unrelated subsystems in the same process.

Separately, one dispatcher-related test could be influenced by host proxy environment variables, making expectations environment-dependent.

## Root Cause
`applyTelegramNetworkWorkarounds(...)` was executed before the early return for injected `proxyFetch`.

## Changes
1. **Runtime fix (`src/telegram/fetch.ts`)**
   - Reordered logic in `resolveTelegramFetch(...)`:
     - Resolve fetch
     - Return early for injected `proxyFetch`
     - Only apply Telegram network workarounds on the non-injected path
   - This keeps injected proxy fetch behavior self-contained and avoids process-wide side effects.

2. **Test update (`src/telegram/fetch.test.ts`)**
   - Hardened proxy-dispatcher expectation by stubbing proxy env vars to empty in the relevant test:
     - `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`
     - `http_proxy`, `https_proxy`, `all_proxy`
   - Prevents ambient machine config from changing test intent.

## Validation
Executed:
- `pnpm vitest run src/telegram/fetch.test.ts`

Result:
- **17/17 tests passed**

## Risk / Compatibility
- Low risk.
- Runtime change is scoped to the injected `proxyFetch` path.
- No API surface changes.
