### PR TITLE
fix(plugins): suppress duplicate id warnings for same source paths

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PluginCandidate } from "./discovery.js";
 import { loadPluginManifestRegistry } from "./manifest-registry.js";
 
@@ -206,6 +206,39 @@ describe("loadPluginManifestRegistry", () => {
     ];
 
     expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
+  });
+
+  it("suppresses duplicate warning when source path matches but realpath is unavailable", () => {
+    const dir = makeTempDir();
+    const manifest = { id: "same-source-plugin", configSchema: { type: "object" } };
+    writeManifest(dir, manifest);
+
+    const source = path.join(dir, "index.ts");
+    fs.writeFileSync(source, "export default {};\n", "utf-8");
+
+    const candidates: PluginCandidate[] = [
+      {
+        idHint: "same-source-plugin",
+        source,
+        rootDir: dir,
+        origin: "bundled",
+      },
+      {
+        idHint: "same-source-plugin",
+        source,
+        rootDir: path.join(dir, "sub", ".."),
+        origin: "global",
+      },
+    ];
+
+    const realpathSpy = vi.spyOn(fs, "realpathSync").mockImplementation(() => {
+      throw new Error("realpath unavailable");
+    });
+    try {
+      expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(0);
+    } finally {
+      realpathSpy.mockRestore();
+    }
   });
 
   it("prefers higher-precedence origins for the same physical directory (config > workspace > global > bundled)", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveUserPath } from "../utils.js";
 import { normalizePluginsConfig, type NormalizedPluginsConfig } from "./config-state.js";
@@ -48,6 +49,10 @@ const registryCache = new Map<string, { expiresAt: number; registry: PluginManif
 
 // Keep a short cache window to collapse bursty reloads during startup flows.
 const DEFAULT_MANIFEST_CACHE_MS = 1000;
+
+function pathsMatch(a: string, b: string): boolean {
+  return path.resolve(a) === path.resolve(b);
+}
 
 export function clearPluginManifestRegistryCache(): void {
   registryCache.clear();
@@ -205,7 +210,9 @@ export function loadPluginManifestRegistry(params: {
       // Check whether both candidates point to the same physical directory
       // (e.g. via symlinks or different path representations). If so, this
       // is a false-positive duplicate and can be silently skipped.
-      const samePath = existing.candidate.rootDir === candidate.rootDir;
+      const samePath =
+        pathsMatch(existing.candidate.rootDir, candidate.rootDir) ||
+        pathsMatch(existing.candidate.source, candidate.source);
       const samePlugin = (() => {
         if (samePath) {
           return true;


### PR DESCRIPTION
## Summary

- **Problem**: After upgrading OpenClaw, the feishu extension triggers a false-positive "duplicate plugin id" warning even though it's the same plugin from the same source path.
- **Why it matters**: This cosmetic issue confuses users after each upgrade, even though the extension works correctly.
- **What changed**:
  - Added `pathsMatch()` helper that uses `path.resolve()` to normalize path comparisons
  - Modified duplicate detection to compare both `rootDir` and `source` paths using normalized comparison
  - This suppresses false-positive warnings when the same plugin ID comes from the same physical source
- **What did NOT change**:
  - Legitimate duplicate plugin warnings (different sources with same ID) are still emitted
  - Plugin loading behavior and precedence rules remain unchanged

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #34394

## User-visible / Behavior Changes

- False-positive "duplicate plugin id" warnings for the feishu extension (and other extensions) will no longer appear when the same plugin is detected from the same source path

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- Any platform where feishu extension is installed
- OpenClaw 2026.3.1

### Steps

1. Install @openclaw/feishu extension
2. Start OpenClaw gateway
3. Check for "duplicate plugin id" warnings in startup output

### Expected

No warning when the same plugin ID comes from the same source path.

### Actual (before fix)

False-positive warning appears even for same-source duplicates.

## Evidence

- Test results: `pnpm exec vitest run src/plugins/manifest-registry.test.ts` - all 8 tests passed
- New test case added: `suppresses duplicate warning when source path matches but realpath is unavailable`

## Human Verification (required)

- **Verified scenarios**:
  - All existing manifest-registry tests pass
  - New test case covers realpath failure scenario
- **Edge cases checked**:
  - Same source path with different path representations (e.g., relative vs absolute)
  - realpath unavailability (e.g., filesystem errors)
- **Did not verify**: Manual testing with actual feishu extension installation (requires user verification)

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- **How to disable/revert**: Revert commit or cherry-pick previous version of `src/plugins/manifest-registry.ts`
- **Files/config to restore**: `src/plugins/manifest-registry.ts`, `src/plugins/manifest-registry.test.ts`
- **Known bad symptoms**: None - this only suppresses false-positive warnings

## Risks and Mitigations

None. This change only affects when warnings are emitted; it does not change plugin loading behavior or precedence rules.
