### PR TITLE
reply: add automatic 85/95 context pressure warnings

### DIFF
--- a/changelog/fragments/context-alerts-threshold-warnings.md
+++ b/changelog/fragments/context-alerts-threshold-warnings.md
@@ -1,0 +1,1 @@
+- reply runtime now emits session context pressure warnings at 85% and 95% utilization (with cooldown + hysteresis to avoid noisy repeats).

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -521,43 +521,48 @@ export async function runReplyAgent(params: {
       contextAlertDecision.nextLevel === 95 || contextAlertDecision.nextLevel === 85
         ? contextAlertDecision.nextLevel
         : undefined;
+    const persistContextAlertState = async (update: {
+      includeLevel?: boolean;
+      contextAlertLevel?: SessionEntry["contextAlertLevel"];
+      includeAlertAt?: boolean;
+      contextAlertAt?: number;
+    }): Promise<void> => {
+      if (activeSessionEntry) {
+        if (update.includeLevel) {
+          activeSessionEntry.contextAlertLevel = update.contextAlertLevel;
+        }
+        if (update.includeAlertAt) {
+          activeSessionEntry.contextAlertAt = update.contextAlertAt;
+        }
+      }
+      if (sessionKey && activeSessionStore && activeSessionEntry) {
+        activeSessionStore[sessionKey] = activeSessionEntry;
+      }
+      if (sessionKey && storePath) {
+        await updateSessionStoreEntry({
+          storePath,
+          sessionKey,
+          update: async () => {
+            const patch: Partial<SessionEntry> = {};
+            if (update.includeLevel) {
+              patch.contextAlertLevel = update.contextAlertLevel;
+            }
+            if (update.includeAlertAt) {
+              patch.contextAlertAt = update.contextAlertAt;
+            }
+            return patch;
+          },
+        });
+      }
+    };
 
-    if (contextAlertDecision.nextLevel !== previousAlertLevel) {
-      const nextAlertAt = contextAlertDecision.shouldAlert ? Date.now() : undefined;
-      if (activeSessionEntry) {
-        activeSessionEntry.contextAlertLevel = nextPersistedAlertLevel;
-        activeSessionEntry.contextAlertAt = nextAlertAt;
-      }
-      if (sessionKey && activeSessionStore && activeSessionEntry) {
-        activeSessionStore[sessionKey] = activeSessionEntry;
-      }
-      if (sessionKey && storePath) {
-        await updateSessionStoreEntry({
-          storePath,
-          sessionKey,
-          update: async () => ({
-            contextAlertLevel: nextPersistedAlertLevel,
-            contextAlertAt: nextAlertAt,
-          }),
-        });
-      }
-    } else if (contextAlertDecision.shouldAlert) {
-      const nextAlertAt = Date.now();
-      if (activeSessionEntry) {
-        activeSessionEntry.contextAlertAt = nextAlertAt;
-      }
-      if (sessionKey && activeSessionStore && activeSessionEntry) {
-        activeSessionStore[sessionKey] = activeSessionEntry;
-      }
-      if (sessionKey && storePath) {
-        await updateSessionStoreEntry({
-          storePath,
-          sessionKey,
-          update: async () => ({
-            contextAlertAt: nextAlertAt,
-          }),
-        });
-      }
+    if (contextAlertDecision.nextLevel < previousAlertLevel) {
+      await persistContextAlertState({
+        includeLevel: true,
+        contextAlertLevel: nextPersistedAlertLevel,
+        includeAlertAt: true,
+        contextAlertAt: undefined,
+      });
     }
 
     // Drain any late tool/block deliveries before deciding there's "nothing to send".
@@ -594,6 +599,15 @@ export async function runReplyAgent(params: {
 
     if (replyPayloads.length === 0) {
       return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
+    }
+
+    if (contextAlertDecision.shouldAlert) {
+      await persistContextAlertState({
+        includeLevel: contextAlertDecision.nextLevel !== previousAlertLevel,
+        contextAlertLevel: nextPersistedAlertLevel,
+        includeAlertAt: true,
+        contextAlertAt: Date.now(),
+      });
     }
 
     const successfulCronAdds = runResult.successfulCronAdds ?? 0;

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -4,7 +4,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "../../agents/defaults.js";
 import { resolveModelAuthMode } from "../../agents/model-auth.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import { queueEmbeddedPiMessage } from "../../agents/pi-embedded.js";
-import { hasNonzeroUsage } from "../../agents/usage.js";
+import { deriveSessionTotalTokens, hasNonzeroUsage } from "../../agents/usage.js";
 import {
   resolveAgentIdFromSessionKey,
   resolveSessionFilePath,
@@ -47,6 +47,11 @@ import {
 import { appendUsageLine, formatResponseUsageLine } from "./agent-runner-utils.js";
 import { createAudioAsVoiceBuffer, createBlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
+import {
+  buildContextAlertMessage,
+  evaluateContextAlert,
+  type ContextAlertLevel,
+} from "./context-alerts.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
@@ -253,6 +258,7 @@ export async function runReplyAgent(params: {
   });
 
   let responseUsageLine: string | undefined;
+  let contextAlertNotice: ReplyPayload | undefined;
   type SessionResetOptions = {
     failureLabel: string;
     buildLogMessage: (nextSessionId: string) => string;
@@ -478,6 +484,82 @@ export async function runReplyAgent(params: {
       cliSessionId,
     });
 
+    const contextTokensSnapshot = deriveSessionTotalTokens({
+      usage: runResult.meta?.agentMeta?.lastCallUsage ?? usage,
+      contextTokens: contextTokensUsed,
+      promptTokens,
+    });
+    const parseAlertLevel = (value: unknown): ContextAlertLevel =>
+      value === 95 || value === 85 ? value : 0;
+    const previousAlertLevel = parseAlertLevel(activeSessionEntry?.contextAlertLevel);
+    const previousAlertAt =
+      typeof activeSessionEntry?.contextAlertAt === "number"
+        ? activeSessionEntry.contextAlertAt
+        : undefined;
+    const contextAlertDecision = evaluateContextAlert({
+      usedTokens: contextTokensSnapshot,
+      contextTokens: contextTokensUsed,
+      previousLevel: previousAlertLevel,
+      previousAt: previousAlertAt,
+    });
+
+    if (
+      contextAlertDecision.shouldAlert &&
+      contextAlertDecision.alertLevel &&
+      contextTokensSnapshot
+    ) {
+      contextAlertNotice = {
+        text: buildContextAlertMessage({
+          level: contextAlertDecision.alertLevel,
+          usedTokens: contextTokensSnapshot,
+          contextTokens: contextTokensUsed,
+        }),
+      };
+    }
+
+    const nextPersistedAlertLevel: SessionEntry["contextAlertLevel"] =
+      contextAlertDecision.nextLevel === 95 || contextAlertDecision.nextLevel === 85
+        ? contextAlertDecision.nextLevel
+        : undefined;
+
+    if (contextAlertDecision.nextLevel !== previousAlertLevel) {
+      const nextAlertAt = contextAlertDecision.shouldAlert ? Date.now() : undefined;
+      if (activeSessionEntry) {
+        activeSessionEntry.contextAlertLevel = nextPersistedAlertLevel;
+        activeSessionEntry.contextAlertAt = nextAlertAt;
+      }
+      if (sessionKey && activeSessionStore && activeSessionEntry) {
+        activeSessionStore[sessionKey] = activeSessionEntry;
+      }
+      if (sessionKey && storePath) {
+        await updateSessionStoreEntry({
+          storePath,
+          sessionKey,
+          update: async () => ({
+            contextAlertLevel: nextPersistedAlertLevel,
+            contextAlertAt: nextAlertAt,
+          }),
+        });
+      }
+    } else if (contextAlertDecision.shouldAlert) {
+      const nextAlertAt = Date.now();
+      if (activeSessionEntry) {
+        activeSessionEntry.contextAlertAt = nextAlertAt;
+      }
+      if (sessionKey && activeSessionStore && activeSessionEntry) {
+        activeSessionStore[sessionKey] = activeSessionEntry;
+      }
+      if (sessionKey && storePath) {
+        await updateSessionStoreEntry({
+          storePath,
+          sessionKey,
+          update: async () => ({
+            contextAlertAt: nextAlertAt,
+          }),
+        });
+      }
+    }
+
     // Drain any late tool/block deliveries before deciding there's "nothing to send".
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and
     // keep the typing indicator stuck.
@@ -604,6 +686,9 @@ export async function runReplyAgent(params: {
 
     // If verbose is enabled, prepend operational run notices.
     let finalPayloads = guardedReplyPayloads;
+    if (contextAlertNotice) {
+      finalPayloads = [contextAlertNotice, ...finalPayloads];
+    }
     const verboseNotices: ReplyPayload[] = [];
 
     if (verboseEnabled && activeIsNewSession) {

--- a/src/auto-reply/reply/context-alerts.test.ts
+++ b/src/auto-reply/reply/context-alerts.test.ts
@@ -25,6 +25,18 @@ describe("evaluateContextAlert", () => {
 
   it("suppresses repeated same-level alerts during cooldown", () => {
     const out = evaluateContextAlert({
+      usedTokens: 86,
+      contextTokens: 100,
+      previousLevel: 85,
+      previousAt: 10_000,
+      now: 20_000,
+      cooldownMs: 30_000,
+    });
+    expect(out).toEqual({ nextLevel: 85, shouldAlert: false, alertLevel: null });
+  });
+
+  it("alerts on 85% to 95% escalation even during cooldown", () => {
+    const out = evaluateContextAlert({
       usedTokens: 96,
       contextTokens: 100,
       previousLevel: 85,
@@ -32,7 +44,19 @@ describe("evaluateContextAlert", () => {
       now: 20_000,
       cooldownMs: 30_000,
     });
-    expect(out).toEqual({ nextLevel: 95, shouldAlert: false, alertLevel: null });
+    expect(out).toEqual({ nextLevel: 95, shouldAlert: true, alertLevel: 95 });
+  });
+
+  it("re-alerts at the same level after cooldown elapses", () => {
+    const out = evaluateContextAlert({
+      usedTokens: 86,
+      contextTokens: 100,
+      previousLevel: 85,
+      previousAt: 0,
+      now: 31_000,
+      cooldownMs: 30_000,
+    });
+    expect(out).toEqual({ nextLevel: 85, shouldAlert: true, alertLevel: 85 });
   });
 
   it("re-arms 85% alert after dropping below hysteresis and crossing again", () => {

--- a/src/auto-reply/reply/context-alerts.test.ts
+++ b/src/auto-reply/reply/context-alerts.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import { buildContextAlertMessage, evaluateContextAlert } from "./context-alerts.js";
+
+describe("evaluateContextAlert", () => {
+  it("triggers at 85% when crossing upward", () => {
+    const out = evaluateContextAlert({
+      usedTokens: 85,
+      contextTokens: 100,
+      previousLevel: 0,
+      now: 1_000,
+    });
+    expect(out).toEqual({ nextLevel: 85, shouldAlert: true, alertLevel: 85 });
+  });
+
+  it("triggers at 95% when crossing upward", () => {
+    const out = evaluateContextAlert({
+      usedTokens: 95,
+      contextTokens: 100,
+      previousLevel: 85,
+      previousAt: 0,
+      now: 31 * 60 * 1000,
+    });
+    expect(out).toEqual({ nextLevel: 95, shouldAlert: true, alertLevel: 95 });
+  });
+
+  it("suppresses repeated same-level alerts during cooldown", () => {
+    const out = evaluateContextAlert({
+      usedTokens: 96,
+      contextTokens: 100,
+      previousLevel: 85,
+      previousAt: 10_000,
+      now: 20_000,
+      cooldownMs: 30_000,
+    });
+    expect(out).toEqual({ nextLevel: 95, shouldAlert: false, alertLevel: null });
+  });
+
+  it("re-arms 85% alert after dropping below hysteresis and crossing again", () => {
+    const dropped = evaluateContextAlert({
+      usedTokens: 79,
+      contextTokens: 100,
+      previousLevel: 85,
+      previousAt: 0,
+      now: 1_000,
+    });
+    expect(dropped.nextLevel).toBe(0);
+
+    const recross = evaluateContextAlert({
+      usedTokens: 86,
+      contextTokens: 100,
+      previousLevel: dropped.nextLevel,
+      previousAt: 0,
+      now: 40 * 60 * 1000,
+    });
+    expect(recross).toEqual({ nextLevel: 85, shouldAlert: true, alertLevel: 85 });
+  });
+
+  it("returns no alert when usage data is unavailable", () => {
+    const out = evaluateContextAlert({
+      usedTokens: undefined,
+      contextTokens: 100,
+      previousLevel: 0,
+    });
+    expect(out).toEqual({ nextLevel: 0, shouldAlert: false, alertLevel: null });
+  });
+});
+
+describe("buildContextAlertMessage", () => {
+  it("formats 85% warning", () => {
+    const text = buildContextAlertMessage({
+      level: 85,
+      usedTokens: 340_000,
+      contextTokens: 400_000,
+    });
+    expect(text).toContain("85%");
+    expect(text).toContain("/compact");
+  });
+
+  it("formats 95% warning", () => {
+    const text = buildContextAlertMessage({
+      level: 95,
+      usedTokens: 390_000,
+      contextTokens: 400_000,
+    });
+    expect(text).toContain("98%");
+    expect(text).toContain("may overflow");
+  });
+});

--- a/src/auto-reply/reply/context-alerts.ts
+++ b/src/auto-reply/reply/context-alerts.ts
@@ -1,0 +1,100 @@
+export type ContextAlertLevel = 0 | 85 | 95;
+
+export type ContextAlertDecision = {
+  nextLevel: ContextAlertLevel;
+  shouldAlert: boolean;
+  alertLevel: Exclude<ContextAlertLevel, 0> | null;
+};
+
+export function evaluateContextAlert(params: {
+  usedTokens: number | undefined;
+  contextTokens: number | undefined;
+  previousLevel?: ContextAlertLevel;
+  previousAt?: number;
+  now?: number;
+  cooldownMs?: number;
+}): ContextAlertDecision {
+  const used = params.usedTokens;
+  const limit = params.contextTokens;
+  if (
+    typeof used !== "number" ||
+    !Number.isFinite(used) ||
+    used <= 0 ||
+    typeof limit !== "number" ||
+    !Number.isFinite(limit) ||
+    limit <= 0
+  ) {
+    return { nextLevel: 0, shouldAlert: false, alertLevel: null };
+  }
+
+  const ratio = used / limit;
+  const previousLevel = params.previousLevel ?? 0;
+  const previousAt = params.previousAt;
+  const now = params.now ?? Date.now();
+  const cooldownMs = params.cooldownMs ?? 30 * 60 * 1000;
+
+  let nextLevel: ContextAlertLevel = 0;
+  if (ratio >= 0.95) {
+    nextLevel = 95;
+  } else if (ratio >= 0.85) {
+    nextLevel = 85;
+  }
+
+  // Hysteresis to prevent noisy oscillation around thresholds.
+  if (previousLevel === 95 && ratio >= 0.92 && nextLevel < 95) {
+    nextLevel = 95;
+  }
+  if (previousLevel >= 85 && ratio >= 0.82 && nextLevel < 85) {
+    nextLevel = 85;
+  }
+
+  const crossedUp = nextLevel > previousLevel;
+  const cooledDown =
+    typeof previousAt !== "number" ||
+    !Number.isFinite(previousAt) ||
+    now - previousAt >= cooldownMs;
+
+  if (crossedUp && cooledDown && nextLevel > 0) {
+    const alertLevel: Exclude<ContextAlertLevel, 0> = nextLevel === 95 ? 95 : 85;
+    return {
+      nextLevel,
+      shouldAlert: true,
+      alertLevel,
+    };
+  }
+
+  return {
+    nextLevel,
+    shouldAlert: false,
+    alertLevel: null,
+  };
+}
+
+function formatK(n: number): string {
+  if (!Number.isFinite(n)) {
+    return "?";
+  }
+  if (n >= 1_000_000) {
+    return `${(n / 1_000_000).toFixed(1)}M`;
+  }
+  if (n >= 1_000) {
+    return `${(n / 1_000).toFixed(0)}k`;
+  }
+  return String(Math.round(n));
+}
+
+export function buildContextAlertMessage(params: {
+  level: Exclude<ContextAlertLevel, 0>;
+  usedTokens: number;
+  contextTokens: number;
+}): string {
+  const pct = Math.min(
+    999,
+    Math.max(0, Math.round((params.usedTokens / params.contextTokens) * 100)),
+  );
+  const usage = `${formatK(params.usedTokens)}/${formatK(params.contextTokens)}`;
+  if (params.level >= 95) {
+    return `⚠️ Context warning: ${pct}% (${usage}) used. Next turn may overflow. Consider /compact now.`;
+  }
+  return `⚠️ Context warning: ${pct}% (${usage}) used. Consider /compact to keep this session stable.`;
+}

--- a/src/auto-reply/reply/context-alerts.ts
+++ b/src/auto-reply/reply/context-alerts.ts
@@ -49,12 +49,15 @@ export function evaluateContextAlert(params: {
   }
 
   const crossedUp = nextLevel > previousLevel;
+  const repeatedSameLevel = nextLevel > 0 && nextLevel === previousLevel;
   const cooledDown =
     typeof previousAt !== "number" ||
     !Number.isFinite(previousAt) ||
     now - previousAt >= cooldownMs;
 
-  if (crossedUp && cooledDown && nextLevel > 0) {
+  const shouldAlert = nextLevel > 0 && (crossedUp || (repeatedSameLevel && cooledDown));
+
+  if (shouldAlert) {
     const alertLevel: Exclude<ContextAlertLevel, 0> = nextLevel === 95 ? 95 : 85;
     return {
       nextLevel,

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -150,6 +150,10 @@ export type SessionEntry = {
   fallbackNoticeActiveModel?: string;
   fallbackNoticeReason?: string;
   contextTokens?: number;
+  /** Highest context alert threshold already surfaced for this session (85/95). */
+  contextAlertLevel?: 85 | 95;
+  /** Timestamp (ms) for the last emitted context alert. */
+  contextAlertAt?: number;
   compactionCount?: number;
   memoryFlushAt?: number;
   memoryFlushCompactionCount?: number;


### PR DESCRIPTION
## Summary
Add built-in context pressure alerts at **85%** and **95%** session utilization.

- emits a warning notice when a session crosses 85% or 95% context usage
- stores per-session alert state to avoid noisy repeated warnings
- uses cooldown + hysteresis so alerts re-arm only after meaningful drop

## Behavior
- thresholds: **85%**, **95%**
- same-level repeats are suppressed by default cooldown (30 minutes)
- alert state is persisted per session (`contextAlertLevel`, `contextAlertAt`)
- warning text suggests `/compact` before hard overflow

## Files changed
- `src/auto-reply/reply/agent-runner.ts`
- `src/auto-reply/reply/context-alerts.ts` (new)
- `src/auto-reply/reply/context-alerts.test.ts` (new)
- `src/config/sessions/types.ts`
- `changelog/fragments/context-alerts-threshold-warnings.md`

## Validation
- `corepack pnpm exec vitest run src/auto-reply/reply/context-alerts.test.ts src/auto-reply/status.test.ts --reporter=dot`
- `corepack pnpm build:plugin-sdk:dts`

Both pass locally.
