### PR TITLE
fix(google-gemini-cli-auth): respect system proxy for OAuth token exchange

### DIFF
--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -241,11 +241,16 @@ async function fetchWithTimeout(
   init: RequestInit,
   timeoutMs = DEFAULT_FETCH_TIMEOUT_MS,
 ): Promise<Response> {
+  const hasProxy = !!(
+    process.env.HTTP_PROXY || process.env.http_proxy ||
+    process.env.HTTPS_PROXY || process.env.https_proxy ||
+    process.env.ALL_PROXY || process.env.all_proxy
+  );
   const { response, release } = await fetchWithSsrFGuard({
     url,
     init,
     timeoutMs,
-    pinDns: false,
+    pinDns: !hasProxy,
   });
   try {
     const body = await response.arrayBuffer();

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -245,6 +245,7 @@ async function fetchWithTimeout(
     url,
     init,
     timeoutMs,
+    pinDns: false,
   });
   try {
     const body = await response.arrayBuffer();

--- a/extensions/google-gemini-cli-auth/oauth.ts
+++ b/extensions/google-gemini-cli-auth/oauth.ts
@@ -242,9 +242,12 @@ async function fetchWithTimeout(
   timeoutMs = DEFAULT_FETCH_TIMEOUT_MS,
 ): Promise<Response> {
   const hasProxy = !!(
-    process.env.HTTP_PROXY || process.env.http_proxy ||
-    process.env.HTTPS_PROXY || process.env.https_proxy ||
-    process.env.ALL_PROXY || process.env.all_proxy
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy ||
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.ALL_PROXY ||
+    process.env.all_proxy
   );
   const { response, release } = await fetchWithSsrFGuard({
     url,


### PR DESCRIPTION
Resolves https://github.com/openclaw/openclaw/issues/34401

This fixes an issue where the Gemini CLI OAuth token exchange would timeout or fail with `TypeError: fetch failed` when run on a machine that requires an HTTP proxy to reach Google servers.

`fetchWithSsrFGuard` uses `createPinnedDispatcher` by default (unless in `TRUSTED_ENV_PROXY` mode), which resolves the host to an IP and connects directly, bypassing the system proxy. By passing `pinDns: false`, `fetchWithSsrFGuard` falls back to the proxy-aware global agent, allowing the token exchange to succeed.