### PR TITLE
agents: retry once on tool-call JSON parse prompt errors

### DIFF
--- a/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
@@ -108,6 +108,27 @@ describe("overflow compaction in run loop", () => {
     expect(result.meta.error).toBeUndefined();
   });
 
+  it("retries once on tool-call JSON parse prompt errors and succeeds on next attempt", async () => {
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          promptError: new Error(
+            "Expected ',' or '}' after property value in JSON at position 34 (line 1 column 35)",
+          ),
+        }),
+      )
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: null }));
+
+    const result = await runEmbeddedPiAgent(baseParams);
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedCompactDirect).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining("tool-call json parse error"),
+    );
+    expect(result.meta.error).toBeUndefined();
+  });
+
   it("returns error if compaction fails", async () => {
     const overflowError = makeOverflowError();
 

--- a/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
+++ b/src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts
@@ -123,10 +123,24 @@ describe("overflow compaction in run loop", () => {
 
     expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
     expect(mockedCompactDirect).not.toHaveBeenCalled();
-    expect(log.warn).toHaveBeenCalledWith(
-      expect.stringContaining("tool-call json parse error"),
-    );
+    expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("tool-call json parse error"));
     expect(result.meta.error).toBeUndefined();
+  });
+
+  it("does not retry more than once when tool-call JSON parse errors persist", async () => {
+    const parseError = new Error(
+      "Expected ',' or '}' after property value in JSON at position 34 (line 1 column 35)",
+    );
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: parseError }))
+      .mockResolvedValueOnce(makeAttemptResult({ promptError: parseError }));
+
+    await expect(runEmbeddedPiAgent(baseParams)).rejects.toThrow(
+      "Expected ',' or '}' after property value in JSON",
+    );
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(mockedCompactDirect).not.toHaveBeenCalled();
   });
 
   it("returns error if compaction fails", async () => {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -138,12 +138,18 @@ const BASE_RUN_RETRY_ITERATIONS = 24;
 const RUN_RETRY_ITERATIONS_PER_PROFILE = 8;
 const MIN_RUN_RETRY_ITERATIONS = 32;
 const MAX_RUN_RETRY_ITERATIONS = 160;
+const TOOL_CALL_JSON_PARSE_ERROR_RE =
+  /Expected ',' or '}' after property value in JSON|Unexpected end of JSON input/i;
 
 function resolveMaxRunRetryIterations(profileCandidateCount: number): number {
   const scaled =
     BASE_RUN_RETRY_ITERATIONS +
     Math.max(1, profileCandidateCount) * RUN_RETRY_ITERATIONS_PER_PROFILE;
   return Math.min(MAX_RUN_RETRY_ITERATIONS, Math.max(MIN_RUN_RETRY_ITERATIONS, scaled));
+}
+
+function isToolCallJsonParseError(message: string): boolean {
+  return TOOL_CALL_JSON_PARSE_ERROR_RE.test(message);
 }
 
 const hasUsageValues = (
@@ -747,6 +753,7 @@ export async function runEmbeddedPiAgent(
       let autoCompactionCount = 0;
       let runLoopIterations = 0;
       let overloadFailoverAttempts = 0;
+      let toolCallJsonParseRetried = false;
       const maybeMarkAuthProfileFailure = async (failure: {
         profileId?: string;
         reason?: AuthProfileFailureReason | null;
@@ -1158,6 +1165,13 @@ export async function runEmbeddedPiAgent(
 
           if (promptError && !aborted) {
             const errorText = describeUnknownError(promptError);
+            if (!toolCallJsonParseRetried && isToolCallJsonParseError(errorText)) {
+              toolCallJsonParseRetried = true;
+              log.warn(
+                `tool-call json parse error for ${provider}/${modelId}; retrying prompt once`,
+              );
+              continue;
+            }
             if (await maybeRefreshCopilotForAuthError(errorText, copilotAuthRetry)) {
               authRetryPending = true;
               continue;


### PR DESCRIPTION
## Summary
- add a minimal guard in embedded run loop to detect transient tool-call JSON parse prompt errors
- retry the prompt exactly once when this error shape is detected
- add a focused test to verify first-attempt parse failure and second-attempt success flow

## Why
Some providers occasionally emit incomplete tool-call JSON (for example: `Expected ',' or '}' after property value in JSON...`).
Today this fails the whole run even when a single retry would recover.

## Compatibility / Risk
- minimal surface area: only `run.ts` retry branch + one test
- no channel-specific behavior changes
- no config schema changes
- retry is strictly one-time per run, so no unbounded loop risk

## Testing
- Added unit test:
  - `src/agents/pi-embedded-runner/run.overflow-compaction.loop.test.ts`
    - `retries once on tool-call JSON parse prompt errors and succeeds on next attempt`
- Local test run was not completed in this environment because `pnpm/corepack` are unavailable.
