### PR TITLE
fix(slack): include actual channel ID in inbound context for DM reactions

### DIFF
--- a/src/plugin-sdk/slack-message-actions.ts
+++ b/src/plugin-sdk/slack-message-actions.ts
@@ -21,13 +21,22 @@ export async function handleSlackMessageAction(params: {
   includeReadThreadId?: boolean;
 }): Promise<AgentToolResult<unknown>> {
   const { providerId, ctx, invoke, normalizeChannelId, includeReadThreadId = false } = params;
-  const { action, cfg, params: actionParams } = ctx;
+  const { action, cfg, params: actionParams, toolContext } = ctx;
   const accountId = ctx.accountId ?? undefined;
   const resolveChannelId = () => {
+    // First try explicit channelId param, then try to/from params
     const channelId =
       readStringParam(actionParams, "channelId") ??
-      readStringParam(actionParams, "to", { required: true });
-    return normalizeChannelId ? normalizeChannelId(channelId) : channelId;
+      readStringParam(actionParams, "to") ??
+      readStringParam(actionParams, "from");
+    if (channelId) {
+      return normalizeChannelId ? normalizeChannelId(channelId) : channelId;
+    }
+    // Fall back to currentChannelId from toolContext (contains actual Slack channel ID for DMs)
+    if (toolContext?.currentChannelId) {
+      return toolContext.currentChannelId;
+    }
+    throw new Error("Channel ID is required (use channelId, to, or from parameter).");
   };
 
   if (action === "send") {

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -689,6 +689,7 @@ export async function prepareSlackMessage(params: {
     BodyForCommands: commandBody,
     From: slackFrom,
     To: slackTo,
+    Channel: message.channel,
     SessionKey: sessionKey,
     AccountId: route.accountId,
     ChatType: isDirectMessage ? "direct" : "channel",

--- a/src/slack/threading-tool-context.test.ts
+++ b/src/slack/threading-tool-context.test.ts
@@ -144,4 +144,40 @@ describe("buildSlackThreadingToolContext", () => {
     });
     expect(result.replyToMode).toBe("off");
   });
+
+  it("extracts currentChannelId from To when it starts with channel:", () => {
+    const result = buildSlackThreadingToolContext({
+      cfg: emptyCfg,
+      accountId: null,
+      context: { To: "channel:C12345678" },
+    });
+    expect(result.currentChannelId).toBe("C12345678");
+  });
+
+  it("falls back to Channel field when To does not start with channel:", () => {
+    const result = buildSlackThreadingToolContext({
+      cfg: emptyCfg,
+      accountId: null,
+      context: { To: "user:U8SUVSVGS", Channel: "D8SRXRDNF" },
+    });
+    expect(result.currentChannelId).toBe("D8SRXRDNF");
+  });
+
+  it("returns undefined currentChannelId when To is user: format and Channel is not set", () => {
+    const result = buildSlackThreadingToolContext({
+      cfg: emptyCfg,
+      accountId: null,
+      context: { To: "user:U8SUVSVGS" },
+    });
+    expect(result.currentChannelId).toBeUndefined();
+  });
+
+  it("uses Channel field when To is not a channel target", () => {
+    const result = buildSlackThreadingToolContext({
+      cfg: emptyCfg,
+      accountId: null,
+      context: { To: "group:G12345678", Channel: "G12345678" },
+    });
+    expect(result.currentChannelId).toBe("G12345678");
+  });
 });

--- a/src/slack/threading-tool-context.ts
+++ b/src/slack/threading-tool-context.ts
@@ -19,10 +19,13 @@ export function buildSlackThreadingToolContext(params: {
   const hasExplicitThreadTarget = params.context.MessageThreadId != null;
   const effectiveReplyToMode = hasExplicitThreadTarget ? "all" : configuredReplyToMode;
   const threadId = params.context.MessageThreadId ?? params.context.ReplyToId;
+  // Extract channel ID from To if it's a channel target, otherwise fall back to Channel field
+  // (which contains the actual Slack channel ID, e.g., D123 for DMs, C123 for channels)
+  const currentChannelId = params.context.To?.startsWith("channel:")
+    ? params.context.To.slice("channel:".length)
+    : params.context.Channel?.trim();
   return {
-    currentChannelId: params.context.To?.startsWith("channel:")
-      ? params.context.To.slice("channel:".length)
-      : undefined,
+    currentChannelId,
     currentThreadTs: threadId != null ? String(threadId) : undefined,
     replyToMode: effectiveReplyToMode,
     hasRepliedRef: params.hasRepliedRef,


### PR DESCRIPTION
## Summary

Fixes #34414 - Slack reactions now work for direct messages by including the actual Slack channel ID in the inbound metadata.

## Root Cause

When a Slack DM message arrives:
- `message.channel` contains the actual channel ID (e.g., `D8SRXRDNF`)
- But the inbound `To` field was set to `user:${message.user}` (e.g., `user:U8SUVSVGS`)
- `buildSlackThreadingToolContext` only extracted `currentChannelId` from `To` when it started with `"channel:"`
- For DMs, this left `currentChannelId` as `undefined`
- When the react action was executed, it couldn't resolve the actual channel ID needed for the Slack API call

## Changes

1. **`src/slack/monitor/message-handler/prepare.ts`**: Add `Channel: message.channel` to the inbound context payload
2. **`src/slack/threading-tool-context.ts`**: Modify `buildSlackThreadingToolContext` to fall back to `context.Channel` when `To` doesn't start with `"channel:"`
3. **`src/plugin-sdk/slack-message-actions.ts`**: Update `resolveChannelId` to use `toolContext.currentChannelId` as a fallback when no explicit channel ID is provided
4. **`src/slack/threading-tool-context.test.ts`**: Add test cases for the new behavior

## Testing

- All existing tests pass
- New test cases verify that:
  - When `To` is `channel:C123`, `currentChannelId` is `C123`
  - When `To` is `user:U123` and `Channel` is `D123`, `currentChannelId` is `D123`
  - When `To` is `user:U123` without `Channel`, `currentChannelId` is `undefined`

## Risk & Rollback

Low risk - changes are additive and backward compatible:
- The `Channel` field is now populated but was previously unused
- The fallback logic only activates when the primary path fails
- Rollback: revert commit to restore previous behavior

Closes #34414