### PR TITLE
fix(discord): circuit breaker for consecutive WS drop escalation

### DIFF
--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -447,3 +447,105 @@ describe("runDiscordGatewayLifecycle", () => {
     expect(connectedTrue).toBeUndefined();
   });
 });
+
+describe("circuit breaker — consecutive drop escalation", () => {
+  it("forces fresh IDENTIFY and logs after MAX_CONSECUTIVE_DROPS close events", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const emitter = new EventEmitter();
+      const gateway = {
+        isConnected: false,
+        options: { reconnect: { maxAttempts: 50 } },
+        state: { sessionId: "test-session", resumeGatewayUrl: "wss://resume.discord.gg", sequence: 42 },
+        sequence: 42,
+        disconnect: vi.fn(),
+        connect: vi.fn(),
+        emitter,
+      };
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+      let resolveWait: (() => void) | undefined;
+      waitForDiscordGatewayStopMock.mockImplementationOnce(
+        (waitParams: WaitForDiscordGatewayStopParams) =>
+          new Promise<void>((resolve, reject) => {
+            resolveWait = resolve;
+            waitParams.registerForceStop?.((err) => reject(err));
+          }),
+      );
+
+      const { lifecycleParams, runtimeLog } = createLifecycleHarness({ gateway });
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+
+      // Fire 5 consecutive close events within the reset window
+      for (let i = 0; i < 5; i++) {
+        emitter.emit("debug", "WebSocket connection closed with code 1006");
+        await vi.advanceTimersByTimeAsync(100);
+      }
+
+      // Circuit breaker should have tripped and cleared resume state
+      expect(runtimeLog).toHaveBeenCalledWith(
+        expect.stringContaining("circuit breaker tripped"),
+      );
+      expect(gateway.state.sessionId).toBeNull();
+      expect(gateway.state.resumeGatewayUrl).toBeNull();
+
+      resolveWait?.();
+      await expect(lifecyclePromise).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resets drop counter after DROP_RESET_WINDOW_MS", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+      const emitter = new EventEmitter();
+      const gateway = {
+        isConnected: false,
+        options: { reconnect: { maxAttempts: 50 } },
+        state: { sessionId: "test-session", resumeGatewayUrl: "wss://resume.discord.gg", sequence: 1 },
+        sequence: 1,
+        disconnect: vi.fn(),
+        connect: vi.fn(),
+        emitter,
+      };
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+      let resolveWait: (() => void) | undefined;
+      waitForDiscordGatewayStopMock.mockImplementationOnce(
+        (waitParams: WaitForDiscordGatewayStopParams) =>
+          new Promise<void>((resolve, reject) => {
+            resolveWait = resolve;
+            waitParams.registerForceStop?.((err) => reject(err));
+          }),
+      );
+
+      const { lifecycleParams, runtimeLog } = createLifecycleHarness({ gateway });
+      const lifecyclePromise = runDiscordGatewayLifecycle(lifecycleParams);
+
+      // Fire 4 drops, then wait past the reset window, then fire 4 more
+      for (let i = 0; i < 4; i++) {
+        emitter.emit("debug", "WebSocket connection closed with code 1006");
+        await vi.advanceTimersByTimeAsync(100);
+      }
+      // Advance past DROP_RESET_WINDOW_MS (10 min)
+      await vi.advanceTimersByTimeAsync(11 * 60_000);
+      for (let i = 0; i < 4; i++) {
+        emitter.emit("debug", "WebSocket connection closed with code 1006");
+        await vi.advanceTimersByTimeAsync(100);
+      }
+
+      // Circuit breaker should NOT have tripped (counter reset after 10 min)
+      expect(runtimeLog).not.toHaveBeenCalledWith(
+        expect.stringContaining("circuit breaker tripped"),
+      );
+
+      resolveWait?.();
+      await expect(lifecyclePromise).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -32,6 +32,9 @@ export async function runDiscordGatewayLifecycle(params: {
   const HELLO_CONNECTED_POLL_MS = 250;
   const MAX_CONSECUTIVE_HELLO_STALLS = 3;
   const RECONNECT_STALL_TIMEOUT_MS = 5 * 60_000;
+  // Circuit breaker: force fresh IDENTIFY after N consecutive drops within window
+  const MAX_CONSECUTIVE_DROPS = 5;
+  const DROP_RESET_WINDOW_MS = 10 * 60_000;
   const gateway = params.client.getPlugin<GatewayPlugin>("gateway");
   if (gateway) {
     registerGateway(params.accountId, gateway);
@@ -110,6 +113,8 @@ export async function runDiscordGatewayLifecycle(params: {
   let helloTimeoutId: ReturnType<typeof setTimeout> | undefined;
   let helloConnectedPollId: ReturnType<typeof setInterval> | undefined;
   let consecutiveHelloStalls = 0;
+  let consecutiveDrops = 0;
+  let lastDropAt = 0;
   const clearHelloWatch = () => {
     if (helloTimeoutId) {
       clearTimeout(helloTimeoutId);
@@ -155,10 +160,24 @@ export async function runDiscordGatewayLifecycle(params: {
     const at = Date.now();
     pushStatus({ lastEventAt: at });
     if (message.includes("WebSocket connection closed")) {
-      // Carbon marks `isConnected` true only after READY/RESUMED and flips it
-      // false during reconnect handling after this debug line is emitted.
-      if (gateway?.isConnected) {
-        resetHelloStallCounter();
+      // Circuit breaker: track consecutive drops and force fresh IDENTIFY after threshold.
+      // NOTE: do NOT reset the hello stall counter here — a brief isConnected=true
+      // is unreliable and was masking the stall counter, allowing infinite resume loops.
+      const now = Date.now();
+      if (now - lastDropAt > DROP_RESET_WINDOW_MS) {
+        consecutiveDrops = 0;
+      }
+      consecutiveDrops += 1;
+      lastDropAt = now;
+      if (consecutiveDrops >= MAX_CONSECUTIVE_DROPS) {
+        consecutiveDrops = 0;
+        consecutiveHelloStalls = 0;
+        clearResumeState();
+        params.runtime.log?.(
+          danger(
+            `discord: circuit breaker tripped after ${MAX_CONSECUTIVE_DROPS} consecutive drops — forcing fresh IDENTIFY`,
+          ),
+        );
       }
       reconnectStallWatchdog.arm(at);
       pushStatus({


### PR DESCRIPTION
## Problem

The Discord gateway enters an infinite resume loop when connections drop repeatedly. Observed in production: **264 reconnects in 24 hours**, all silent drops (no close code logged).

Two bugs in `provider.lifecycle.ts`:

**Bug 1 — Stall counter reset on close (the main culprit):**
```ts
if (gateway?.isConnected) {
  resetHelloStallCounter(); // BUG: resets to 0 on every close where isConnected is briefly true
}
```
This is a race condition. `isConnected` can still be `true` at the moment a close event fires. Resetting the stall counter here means `MAX_CONSECUTIVE_HELLO_STALLS` is never reached, so the code never escalates to a fresh IDENTIFY.

**Bug 2 — No independent drop tracking:**
Silent drops (code 1006, or no code at all) do not go through the HELLO stall path. They simply reconnect and try to RESUME again indefinitely, until the 5-minute stall watchdog fires and restarts the whole provider.

## Fix

1. **Remove** the `resetHelloStallCounter()` call in the close handler — let the stall counter accumulate correctly.
2. **Add a circuit breaker**: track consecutive close events in a 10-minute window. After `MAX_CONSECUTIVE_DROPS` (5), clear resume state (`sessionId`, `resumeGatewayUrl`, `sequence`) and force a fresh IDENTIFY. Reset the drop counter after `DROP_RESET_WINDOW_MS` (10 min) of stability.

## Evidence

Production log pattern (macOS, OpenClaw 2026.2.26):
- 264 reconnects in 24h (one every ~5.4 min)
- Only 8 coded drops (1006); 256 were silent
- Watchdog catching them within 5-8 min but messages lost in gap
- caffeinate running, not a sleep issue

## Tests

Two new tests in `provider.lifecycle.test.ts`:
- Circuit breaker trips after 5 consecutive drops and clears resume state
- Drop counter resets after DROP_RESET_WINDOW_MS, preventing false positives

Fixes #13688, #20668. Related: #18410, #21099.