### PR TITLE
fix(respawn): guard launchd restart helper result before ok check

### DIFF
--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -95,18 +95,6 @@ describe("restartGatewayProcessWithFreshPid", () => {
     expect(result.detail).toContain("spawn failed");
   });
 
-  it("returns supervised when launchd kickstart helper returns null", () => {
-    setPlatform("darwin");
-    process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
-    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
-    triggerOpenClawRestartMock.mockReturnValue(null);
-
-    const result = restartGatewayProcessWithFreshPid();
-
-    expect(result.mode).toBe("supervised");
-    expect(triggerOpenClawRestartMock).toHaveBeenCalledOnce();
-  });
-
   it("does not schedule kickstart on non-darwin platforms", () => {
     setPlatform("linux");
     process.env.INVOCATION_ID = "abc123";

--- a/src/infra/process-respawn.test.ts
+++ b/src/infra/process-respawn.test.ts
@@ -69,6 +69,7 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
   it("returns supervised when launchd/systemd hints are present", () => {
     process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
+    delete process.env.OPENCLAW_LAUNCHD_LABEL;
     const result = restartGatewayProcessWithFreshPid();
     expect(result.mode).toBe("supervised");
     expect(spawnMock).not.toHaveBeenCalled();
@@ -92,6 +93,18 @@ describe("restartGatewayProcessWithFreshPid", () => {
 
     expect(result.mode).toBe("failed");
     expect(result.detail).toContain("spawn failed");
+  });
+
+  it("returns supervised when launchd kickstart helper returns null", () => {
+    setPlatform("darwin");
+    process.env.LAUNCH_JOB_LABEL = "ai.openclaw.gateway";
+    process.env.OPENCLAW_LAUNCHD_LABEL = "ai.openclaw.gateway";
+    triggerOpenClawRestartMock.mockReturnValue(null);
+
+    const result = restartGatewayProcessWithFreshPid();
+
+    expect(result.mode).toBe("supervised");
+    expect(triggerOpenClawRestartMock).toHaveBeenCalledOnce();
   });
 
   it("does not schedule kickstart on non-darwin platforms", () => {

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -37,7 +37,9 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
     // bypass ThrottleInterval delays for intentional restarts.
     if (process.platform === "darwin" && process.env.OPENCLAW_LAUNCHD_LABEL?.trim()) {
       const restart = triggerOpenClawRestart();
-      if (!restart.ok) {
+      // Be defensive: if helper unexpectedly returns undefined/null,
+      // keep supervisor-based restart behavior instead of crashing.
+      if (restart && !restart.ok) {
         return {
           mode: "failed",
           detail: restart.detail ?? "launchctl kickstart failed",

--- a/src/infra/process-respawn.ts
+++ b/src/infra/process-respawn.ts
@@ -37,9 +37,7 @@ export function restartGatewayProcessWithFreshPid(): GatewayRespawnResult {
     // bypass ThrottleInterval delays for intentional restarts.
     if (process.platform === "darwin" && process.env.OPENCLAW_LAUNCHD_LABEL?.trim()) {
       const restart = triggerOpenClawRestart();
-      // Be defensive: if helper unexpectedly returns undefined/null,
-      // keep supervisor-based restart behavior instead of crashing.
-      if (restart && !restart.ok) {
+      if (!restart.ok) {
         return {
           mode: "failed",
           detail: restart.detail ?? "launchctl kickstart failed",


### PR DESCRIPTION
## Summary
- Guard `triggerOpenClawRestart()` result before reading `.ok`
- Prevent runtime crash when helper unexpectedly returns null/undefined

## Testing
- pnpm vitest src/infra/process-respawn.test.ts
