### PR TITLE
fix(video-frames): validate --index to prevent ffmpeg filter injection

### DIFF
--- a/skills/video-frames/scripts/frame.sh
+++ b/skills/video-frames/scripts/frame.sh
@@ -59,6 +59,10 @@ fi
 mkdir -p "$(dirname "$out")"
 
 if [[ "$index" != "" ]]; then
+  if ! [[ "$index" =~ ^[0-9]+$ ]]; then
+    echo "index must be a non-negative integer" >&2
+    exit 1
+  fi
   ffmpeg -hide_banner -loglevel error -y \
     -i "$in" \
     -vf "select=eq(n\\,${index})" \


### PR DESCRIPTION
## Summary

- The `--index` argument in `frame.sh` was interpolated directly into the ffmpeg `-vf` filter string without any validation
- An attacker who controls the `--index` value could inject arbitrary ffmpeg filters (e.g. `drawtext=textfile=/etc/passwd`) to read arbitrary files and embed their contents into the output image
- This is especially dangerous in AI agent contexts (openclaw skills) where `frame.sh` is called programmatically — a prompt injection attack could chain into this argument injection to exfiltrate files

## Fix

Added an integer validation guard before the ffmpeg call, rejecting any `--index` value that is not a non-negative integer:

```bash
if ! [[ "$index" =~ ^[0-9]+$ ]]; then
  echo "index must be a non-negative integer" >&2
  exit 1
fi
```

This matches the same pattern already used for `--timeout` and `--lines` in `wait-for-text.sh`.

## Test plan

- `--index 0` / `--index 42` → works as before
- `--index 0),drawtext=textfile=/etc/passwd` → exits with error
- `--index abc` → exits with error
- `--index -1` → exits with error (negative sign not matched by `^[0-9]+$`)

By zjiag@cse.ust.hk, Co-authored with [Claude Code](https://claude.com/claude-code)