### PR TITLE
Slack: add unfurlLinks / unfurlMedia config to suppress link previews

### DIFF
--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -149,6 +149,10 @@ export type SlackAccountConfig = {
   /** @deprecated Legacy preview mode key; migrated automatically to `streaming`. */
   streamMode?: SlackLegacyStreamMode;
   mediaMaxMb?: number;
+  /** If false, suppress Slack link previews for text-based content in outbound messages. Default: true. */
+  unfurlLinks?: boolean;
+  /** If false, suppress Slack link previews for media content in outbound messages. Default: true. */
+  unfurlMedia?: boolean;
   /** Reaction notification mode (off|own|all|allowlist). Default: own. */
   reactionNotifications?: SlackReactionNotificationMode;
   /** Allowlist for reaction notifications when mode is allowlist. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -631,6 +631,8 @@ export const SlackAccountSchema = z
     nativeStreaming: z.boolean().optional(),
     streamMode: z.enum(["replace", "status_final", "append"]).optional(),
     mediaMaxMb: z.number().positive().optional(),
+    unfurlLinks: z.boolean().optional(),
+    unfurlMedia: z.boolean().optional(),
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
     reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
     replyToMode: ReplyToModeSchema.optional(),

--- a/src/slack/send.ts
+++ b/src/slack/send.ts
@@ -88,11 +88,15 @@ async function postSlackMessageBestEffort(params: {
   threadTs?: string;
   identity?: SlackSendIdentity;
   blocks?: (Block | KnownBlock)[];
+  unfurlLinks?: boolean;
+  unfurlMedia?: boolean;
 }) {
   const basePayload = {
     channel: params.channelId,
     text: params.text,
     thread_ts: params.threadTs,
+    ...(params.unfurlLinks !== undefined ? { unfurl_links: params.unfurlLinks } : {}),
+    ...(params.unfurlMedia !== undefined ? { unfurl_media: params.unfurlMedia } : {}),
     ...(params.blocks?.length ? { blocks: params.blocks } : {}),
   };
   try {
@@ -249,6 +253,8 @@ export async function sendMessageSlack(
   const client = opts.client ?? createSlackWebClient(token);
   const recipient = parseRecipient(to);
   const { channelId } = await resolveChannelId(client, recipient);
+  const unfurlLinks = account.config.unfurlLinks;
+  const unfurlMedia = account.config.unfurlMedia;
   if (blocks) {
     if (opts.mediaUrl) {
       throw new Error("Slack send does not support blocks with mediaUrl");
@@ -261,6 +267,8 @@ export async function sendMessageSlack(
       threadTs: opts.threadTs,
       identity: opts.identity,
       blocks,
+      unfurlLinks,
+      unfurlMedia,
     });
     return {
       messageId: response.ts ?? "unknown",
@@ -309,6 +317,8 @@ export async function sendMessageSlack(
         text: chunk,
         threadTs: opts.threadTs,
         identity: opts.identity,
+        unfurlLinks,
+        unfurlMedia,
       });
       lastMessageId = response.ts ?? lastMessageId;
     }
@@ -320,6 +330,8 @@ export async function sendMessageSlack(
         text: chunk,
         threadTs: opts.threadTs,
         identity: opts.identity,
+        unfurlLinks,
+        unfurlMedia,
       });
       lastMessageId = response.ts ?? lastMessageId;
     }

--- a/src/slack/send.unfurl.test.ts
+++ b/src/slack/send.unfurl.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../config/config.js", () => ({
+  loadConfig: () => ({}),
+}));
+
+vi.mock("./accounts.js", () => ({
+  resolveSlackAccount: vi.fn(() => ({
+    accountId: "default",
+    botToken: "xoxb-test",
+    botTokenSource: "config",
+    config: {},
+  })),
+}));
+
+const { sendMessageSlack } = await import("./send.js");
+const { resolveSlackAccount } = await import("./accounts.js");
+
+function createTestClient() {
+  return {
+    conversations: {
+      open: vi.fn(async () => ({ channel: { id: "D123" } })),
+    },
+    chat: {
+      postMessage: vi.fn(async () => ({ ts: "171234.567" })),
+    },
+  } as any;
+}
+
+describe("sendMessageSlack unfurl config", () => {
+  it("does not include unfurl flags when config is unset (preserves Slack defaults)", async () => {
+    const client = createTestClient();
+    await sendMessageSlack("channel:C123", "hello", {
+      token: "xoxb-test",
+      client,
+    });
+
+    const payload = client.chat.postMessage.mock.calls[0][0];
+    expect(payload).not.toHaveProperty("unfurl_links");
+    expect(payload).not.toHaveProperty("unfurl_media");
+  });
+
+  it("passes unfurl_links: false when config sets unfurlLinks to false", async () => {
+    vi.mocked(resolveSlackAccount).mockReturnValueOnce({
+      accountId: "default",
+      enabled: true,
+      botToken: "xoxb-test",
+      botTokenSource: "config",
+      appTokenSource: "none",
+      config: { unfurlLinks: false },
+    } as any);
+
+    const client = createTestClient();
+    await sendMessageSlack("channel:C123", "check https://example.com", {
+      token: "xoxb-test",
+      client,
+    });
+
+    const payload = client.chat.postMessage.mock.calls[0][0];
+    expect(payload.unfurl_links).toBe(false);
+    expect(payload).not.toHaveProperty("unfurl_media");
+  });
+
+  it("passes unfurl_media: false when config sets unfurlMedia to false", async () => {
+    vi.mocked(resolveSlackAccount).mockReturnValueOnce({
+      accountId: "default",
+      enabled: true,
+      botToken: "xoxb-test",
+      botTokenSource: "config",
+      appTokenSource: "none",
+      config: { unfurlMedia: false },
+    } as any);
+
+    const client = createTestClient();
+    await sendMessageSlack("channel:C123", "see https://example.com/img.png", {
+      token: "xoxb-test",
+      client,
+    });
+
+    const payload = client.chat.postMessage.mock.calls[0][0];
+    expect(payload).not.toHaveProperty("unfurl_links");
+    expect(payload.unfurl_media).toBe(false);
+  });
+
+  it("passes both unfurl flags when both are configured", async () => {
+    vi.mocked(resolveSlackAccount).mockReturnValueOnce({
+      accountId: "default",
+      enabled: true,
+      botToken: "xoxb-test",
+      botTokenSource: "config",
+      appTokenSource: "none",
+      config: { unfurlLinks: false, unfurlMedia: false },
+    } as any);
+
+    const client = createTestClient();
+    await sendMessageSlack("channel:C123", "see https://example.com", {
+      token: "xoxb-test",
+      client,
+    });
+
+    const payload = client.chat.postMessage.mock.calls[0][0];
+    expect(payload.unfurl_links).toBe(false);
+    expect(payload.unfurl_media).toBe(false);
+  });
+
+  it("allows explicitly enabling unfurling via config", async () => {
+    vi.mocked(resolveSlackAccount).mockReturnValueOnce({
+      accountId: "default",
+      enabled: true,
+      botToken: "xoxb-test",
+      botTokenSource: "config",
+      appTokenSource: "none",
+      config: { unfurlLinks: true, unfurlMedia: true },
+    } as any);
+
+    const client = createTestClient();
+    await sendMessageSlack("channel:C123", "see https://example.com", {
+      token: "xoxb-test",
+      client,
+    });
+
+    const payload = client.chat.postMessage.mock.calls[0][0];
+    expect(payload.unfurl_links).toBe(true);
+    expect(payload.unfurl_media).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `channels.slack.unfurlLinks` and `channels.slack.unfurlMedia` config keys that map to Slack's `chat.postMessage` `unfurl_links` / `unfurl_media` parameters
- When set to `false`, outbound bot messages suppress link preview cards
- Config inherits via the standard base → account merge (can be set globally or per-account)

Closes #34512

## Problem

Slack auto-generates link preview cards on all messages posted via `chat.postMessage`. For bot/agent messages, there is **no user-side mitigation** — personal Slack preferences only control unfurling on messages the user themselves posts. The only way to suppress previews on bot messages is to pass `unfurl_links: false` / `unfurl_media: false` at send time.

This creates visual noise in channels where agents frequently share links to docs, dashboards, and reports.

## Configuration

```json5
{
  channels: {
    slack: {
      unfurlLinks: false,   // suppress text-based link previews
      unfurlMedia: false,   // suppress media link previews
    }
  }
}
```

Both flags are optional. When unset, they are omitted from the API payload entirely, preserving Slack's default behavior for existing installations. Per-account overrides work via `channels.slack.accounts.<id>.unfurlLinks`.

## Changes

| File | Change |
|------|--------|
| `src/config/types.slack.ts` | Add `unfurlLinks` and `unfurlMedia` to `SlackAccountConfig` |
| `src/config/zod-schema.providers-core.ts` | Add Zod validation for both fields in `SlackAccountSchema` |
| `src/slack/send.ts` | Thread config values into `postSlackMessageBestEffort` → `basePayload` |
| `src/slack/send.unfurl.test.ts` | 5 tests covering: unset (no flags), each flag individually, both flags, and explicit `true` |

## Test plan

- [x] New tests: `src/slack/send.unfurl.test.ts` — 5 tests all passing
- [x] Existing tests: `send.blocks.test.ts` (8 tests) and `send.upload.test.ts` (4 tests) pass unchanged
- [ ] Manual verification: set `unfurlLinks: false, unfurlMedia: false` in config, restart gateway, confirm bot messages no longer show link previews

## Related

- #34512 — Feature request: Add `unfurl_links` / `unfurl_media` control for Slack channel
- #22754 — Similar feature request for Telegram `link_preview_options`
- [Slack docs: Unfurling links in messages](https://docs.slack.dev/messaging/unfurling-links-in-messages)