### PR TITLE
docs: add Teams academic chat Canvas MVP host-side guide

### DIFF
--- a/docs/automation/teams-academic-chat-canvas-mvp.md
+++ b/docs/automation/teams-academic-chat-canvas-mvp.md
@@ -1,0 +1,137 @@
+---
+title: "Teams Academic Chat Canvas MVP"
+summary: "Host-side pattern for Teams DM academic chat using an external Canvas LMS plugin"
+read_when:
+  - Designing Teams DM-first academic assistant workflows
+  - Integrating external/community plugins with host automation
+---
+
+# Teams Academic Chat Canvas MVP (host-side pattern)
+
+## Purpose
+
+Provide a practical host-side pattern to implement a **Teams DM academic assistant MVP** in OpenClaw using an external Canvas LMS community plugin.
+
+## When to use this pattern
+
+Use this pattern when you need:
+
+- Teams DM interactions for students and staff.
+- Read-only academic assistance (deadlines, announcements, calendar, submission status).
+- Host-controlled automation that consumes plugin output and sends final responses to Teams.
+
+## Non-goals
+
+- No changes to OpenClaw gateway runtime behavior.
+- No changes to Microsoft Teams channel semantics.
+- No Canvas LMS logic in OpenClaw core.
+- No direct publishing from Canvas digest tools in the external plugin.
+
+## MVP scope
+
+- DM-only rollout in Teams.
+- Read-only intents.
+- Account linking between Teams identity and Canvas identity.
+- Host-side orchestration for tool invocation and response delivery.
+
+## Architecture overview
+
+OpenClaw provides Teams channel support and host automation surfaces. Canvas-specific data access is provided by an external community plugin (for example `@kansodata/openclaw-canvas-lms`, plugin id `canvas-lms`).
+
+```mermaid
+flowchart LR
+  User[Teams DM user] --> Teams[OpenClaw Teams channel]
+  Teams --> Host[OpenClaw host automation]
+  Host --> Linking[Account linking and identity map]
+  Host --> CanvasPlugin[External Canvas LMS plugin]
+  CanvasPlugin --> CanvasAPI[Canvas LMS API]
+  CanvasAPI --> CanvasPlugin
+  CanvasPlugin --> Host
+  Host --> Teams
+  Teams --> User
+
+  Linking --> OAuth[Canvas OAuth2 layer]
+  OAuth --> TokenStore[Encrypted token store]
+  TokenStore --> Host
+```
+
+## Components
+
+### Microsoft Teams DM
+
+- User entrypoint for the MVP.
+- Keep the initial rollout in direct messages only.
+
+### OpenClaw host and gateway
+
+- Receives Teams messages through the configured Teams channel.
+- Runs host-side orchestration and policy checks.
+
+### Host-side automation
+
+- Resolves intent.
+- Verifies account link and authorization context.
+- Calls Canvas-facing tools from the external plugin.
+- Formats and sends response back to Teams DM.
+
+### External Canvas LMS plugin
+
+- Community plugin outside OpenClaw core.
+- Owns Canvas-specific tools/digest logic.
+- Returns structured data or digest payloads.
+
+### Canvas OAuth and account linking layer
+
+- Maps Teams user identity to institution-scoped Canvas identity.
+- Stores user tokens securely in host infrastructure.
+
+## End-to-end flow
+
+1. User sends a DM in Teams (for example: "What is due today?").
+2. Host automation validates sender policy and checks linked account state.
+3. Host invokes the Canvas plugin tool/digest action.
+4. Host normalizes/filters the plugin output.
+5. Host sends a concise Teams DM response.
+6. Host writes minimal audit metadata (without secret/token leakage).
+
+## Security guidance
+
+- Start with **DM-only**. Do not roll out to channels/groups initially.
+- Use **minimum OAuth scopes** required for read-only intents.
+- Store access and refresh tokens **encrypted at rest**.
+- Apply **safe logging**: redact tokens, identifiers, and sensitive payload fields.
+- Add **rate limiting** on DM request handling and plugin calls.
+- Enforce **institution boundaries** and user-to-tenant ownership checks.
+- Keep host automation deterministic and avoid implicit cross-user context reuse.
+
+## External plugin boundary statement
+
+Canvas-specific logic is not part of OpenClaw core in this pattern. It is supplied by an external/community plugin and consumed by host-side automation.
+
+## Suggested MVP intents
+
+- Today digest
+- Week digest
+- Announcements
+- Calendar events
+- Submission or assignment status
+
+## Rollout guidance
+
+### Prototype
+
+- Single institution test tenant.
+- Small DM-only user set.
+- Read-only intents only.
+
+### Pilot
+
+- Limited cohort by program or department.
+- Monitor request volume and response quality.
+- Tighten policy, logging redaction, and rate limits.
+
+### Institutional rollout
+
+- Formal ownership model and support process.
+- Tenant boundary enforcement and key rotation policy.
+- Operational dashboards and alerting for abuse and failures.

--- a/docs/automation/teams-academic-chat-mvp-example.md
+++ b/docs/automation/teams-academic-chat-mvp-example.md
@@ -1,0 +1,122 @@
+---
+title: "Teams Academic Chat MVP Example"
+summary: "Practical host-side message-to-tool-to-DM flow for Teams with an external Canvas plugin"
+read_when:
+  - Implementing intent routing from Teams DM to external Canvas plugin tools
+---
+
+# Teams Academic Chat MVP Example (host-side)
+
+This example shows a **read-only DM-first** flow in OpenClaw. Canvas data is provided by an external plugin and delivered to users by host automation.
+
+## Assumptions
+
+- Teams channel is configured in OpenClaw.
+- The external Canvas plugin is installed and enabled in the host environment.
+- Account linking and token storage are handled by host infrastructure.
+
+## Prompt examples and host-side flow
+
+### Prompt: "What is due today?"
+
+Host-side flow:
+
+1. Resolve sender as a Teams DM user.
+2. Confirm linked Canvas account and tenant boundary.
+3. Invoke external Canvas plugin digest action for `today`.
+4. Format concise DM output with due items and time context.
+5. Send final Teams DM response.
+
+Example tool invocation shape:
+
+```json
+{
+  "tool": "canvas_lms",
+  "args": {
+    "action": "sync_academic_digest",
+    "range": "today"
+  }
+}
+```
+
+Example response style in Teams DM:
+
+- "You have 2 items due today."
+- "Course: Intro Biology - Quiz 3 due at 17:00."
+- "Course: Calculus I - Problem Set 5 due at 23:59."
+
+### Prompt: "What is due this week?"
+
+Host-side flow:
+
+1. Validate DM policy and linked account.
+2. Invoke digest action for `week`.
+3. Group by date and course.
+4. Return a compact DM summary.
+
+Example tool invocation shape:
+
+```json
+{
+  "tool": "canvas_lms",
+  "args": {
+    "action": "sync_academic_digest",
+    "range": "week"
+  }
+}
+```
+
+### Prompt: "Any new announcements?"
+
+Host-side flow:
+
+1. Resolve course context (explicit selection or preferred default).
+2. Invoke external plugin announcements action.
+3. Return latest announcement titles with timestamps.
+
+Example tool invocation shape:
+
+```json
+{
+  "tool": "canvas_lms",
+  "args": {
+    "action": "list_announcements",
+    "courseId": "<COURSE_ID>"
+  }
+}
+```
+
+### Prompt: "Show my calendar this week"
+
+Host-side flow:
+
+1. Validate user scope and course visibility.
+2. Invoke calendar events action for window.
+3. Return date-grouped events in DM.
+
+### Prompt: "Did I submit Assignment 4?"
+
+Host-side flow:
+
+1. Validate linked account.
+2. Invoke submissions or assignment-status action.
+3. Return current status and missing requirements.
+
+## Mapping guidance for host automation
+
+- Normalize plugin payload into a channel-friendly response model.
+- Enforce max message length and chunking policy for Teams.
+- Keep timestamps user-friendly and timezone-aware.
+- Do not include raw tokens, internal IDs, or debug payloads in user responses.
+
+## Security reminders
+
+- Keep the MVP **DM-only**.
+- Keep queries **read-only**.
+- Treat Canvas plugin output as untrusted input until validated by host formatting logic.
+- Apply rate limits and audit metadata logging.
+- Keep tenant/institution boundaries explicit in account-linking checks.
+
+## Boundary reminder
+
+This example does not claim Canvas support in OpenClaw core. It documents a host-side integration pattern using an external/community plugin.

--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -70,6 +70,13 @@ Note: group chats are blocked by default (`channels.msteams.groupPolicy: "allowl
 - Keep routing deterministic: replies always go back to the channel they arrived on.
 - Default to safe channel behavior (mentions required unless configured otherwise).
 
+## Host-side recipe for academic chat MVP
+
+For a practical DM-first academic assistant pattern that uses an external Canvas LMS community plugin with host automation, see:
+
+- [Teams Academic Chat Canvas MVP](/automation/teams-academic-chat-canvas-mvp)
+- [Teams Academic Chat MVP Example](/automation/teams-academic-chat-mvp-example)
+
 ## Config writes
 
 By default, Microsoft Teams is allowed to write config updates triggered by `/config set|unset` (requires `commands.config: true`).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1057,7 +1057,9 @@
                   "automation/webhook",
                   "automation/gmail-pubsub",
                   "automation/poll",
-                  "automation/auth-monitoring"
+                  "automation/auth-monitoring",
+                  "automation/teams-academic-chat-canvas-mvp",
+                  "automation/teams-academic-chat-mvp-example"
                 ]
               },
               {


### PR DESCRIPTION
## Summary
Adds a host-side guide and recipe for implementing a Teams DM academic chat MVP in OpenClaw using an external Canvas LMS community plugin.

## What’s included
- Architecture and security guidance for Teams DM + account linking + host automation
- A practical host-side recipe showing how OpenClaw can consume Canvas-side digest/tool output and return responses in Teams
- Documentation links to the new guide and example

## Notes
Docs/examples only. No runtime change to the gateway, Teams channel behavior, plugin execution semantics, or dependency requirements.
