### PR TITLE
feat(onboarding): persist selected CLI locale to config

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -44,11 +44,26 @@ runs:
         done
         exit 1
 
-    - name: Setup Node.js
+    - name: Setup Node.js (attempt 1)
+      id: setup_node_first
+      continue-on-error: true
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ inputs.node-version }}
         check-latest: false
+
+    - name: Setup Node.js (retry on transient failure)
+      if: steps.setup_node_first.outcome == 'failure'
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      with:
+        node-version: ${{ inputs.node-version }}
+        check-latest: false
+
+    - name: Verify Node.js availability
+      shell: bash
+      run: |
+        set -euo pipefail
+        node -v
 
     - name: Setup pnpm + cache store
       uses: ./.github/actions/setup-pnpm-store-cache

--- a/src/config/types.cli.ts
+++ b/src/config/types.cli.ts
@@ -1,6 +1,9 @@
 export type CliBannerTaglineMode = "random" | "default" | "off";
 
+export type CliLocale = "en" | "zh-CN";
+
 export type CliConfig = {
+  locale?: CliLocale;
   banner?: {
     /**
      * Controls CLI banner tagline behavior.

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -249,6 +249,7 @@ export const OpenClawSchema = z
       .optional(),
     cli: z
       .object({
+        locale: z.union([z.literal("en"), z.literal("zh-CN")]).optional(),
         banner: z
           .object({
             taglineMode: z

--- a/src/i18n/cli.ts
+++ b/src/i18n/cli.ts
@@ -1,0 +1,82 @@
+export type CliLocale = "en" | "zh-CN";
+
+type CliMessageKey =
+  | "wizard.setupCancelled"
+  | "wizard.onboardingTitle"
+  | "wizard.securityTitle"
+  | "wizard.securityConfirm"
+  | "wizard.modeQuestion"
+  | "wizard.modeQuickstart"
+  | "wizard.modeQuickstartHint"
+  | "wizard.modeManual"
+  | "wizard.modeManualHint"
+  | "wizard.quickstartTitle"
+  | "wizard.quickstartSwitchToManual"
+  | "wizard.configInvalidOutro"
+  | "wizard.remoteConfigured";
+
+type CliMessages = Record<CliMessageKey, string>;
+
+const EN_MESSAGES: CliMessages = {
+  "wizard.setupCancelled": "Setup cancelled.",
+  "wizard.onboardingTitle": "OpenClaw onboarding",
+  "wizard.securityTitle": "Security",
+  "wizard.securityConfirm":
+    "I understand this is personal-by-default and shared/multi-user use requires lock-down. Continue?",
+  "wizard.modeQuestion": "Onboarding mode",
+  "wizard.modeQuickstart": "QuickStart",
+  "wizard.modeQuickstartHint": "Configure details later via openclaw configure.",
+  "wizard.modeManual": "Manual",
+  "wizard.modeManualHint": "Configure port, network, Tailscale, and auth options.",
+  "wizard.quickstartTitle": "QuickStart",
+  "wizard.quickstartSwitchToManual":
+    "QuickStart only supports local gateways. Switching to Manual mode.",
+  "wizard.configInvalidOutro":
+    "Config invalid. Run `openclaw doctor` to repair it, then re-run onboarding.",
+  "wizard.remoteConfigured": "Remote gateway configured.",
+};
+
+const ZH_CN_MESSAGES: CliMessages = {
+  "wizard.setupCancelled": "安装向导已取消。",
+  "wizard.onboardingTitle": "OpenClaw 初始化向导",
+  "wizard.securityTitle": "安全提醒",
+  "wizard.securityConfirm": "我理解默认是个人使用场景，多用户/共享场景需要额外加固。是否继续？",
+  "wizard.modeQuestion": "初始化模式",
+  "wizard.modeQuickstart": "快速开始",
+  "wizard.modeQuickstartHint": "稍后可通过 openclaw configure 继续细化配置。",
+  "wizard.modeManual": "手动配置",
+  "wizard.modeManualHint": "配置端口、网络、Tailscale 与认证选项。",
+  "wizard.quickstartTitle": "快速开始",
+  "wizard.quickstartSwitchToManual": "快速开始仅支持本地网关，已切换到手动模式。",
+  "wizard.configInvalidOutro": "配置文件无效。请先运行 `openclaw doctor` 修复，再重新执行初始化。",
+  "wizard.remoteConfigured": "远程网关已配置完成。",
+};
+
+function normalizeLocale(raw: string): CliLocale {
+  const value = raw.trim().toLowerCase();
+  if (!value) {
+    return "en";
+  }
+  if (value === "zh-cn" || value === "zh_cn" || value.startsWith("zh")) {
+    return "zh-CN";
+  }
+  return "en";
+}
+
+export function resolveCliLocale(env: NodeJS.ProcessEnv = process.env): CliLocale {
+  const explicit = env.OPENCLAW_LOCALE;
+  if (explicit) {
+    return normalizeLocale(explicit);
+  }
+  const lang = env.LANG;
+  if (lang) {
+    return normalizeLocale(lang);
+  }
+  return "en";
+}
+
+export function cliT(key: CliMessageKey, env: NodeJS.ProcessEnv = process.env): string {
+  const locale = resolveCliLocale(env);
+  const messages = locale === "zh-CN" ? ZH_CN_MESSAGES : EN_MESSAGES;
+  return messages[key] ?? EN_MESSAGES[key];
+}

--- a/src/i18n/cli.ts
+++ b/src/i18n/cli.ts
@@ -13,6 +13,29 @@ type CliMessageKey =
   | "wizard.quickstartTitle"
   | "wizard.quickstartSwitchToManual"
   | "wizard.configInvalidOutro"
+  | "wizard.existingConfigDetectedTitle"
+  | "wizard.configIssuesTitle"
+  | "wizard.configHandlingQuestion"
+  | "wizard.configHandlingUseExisting"
+  | "wizard.configHandlingUpdate"
+  | "wizard.configHandlingReset"
+  | "wizard.resetScopeQuestion"
+  | "wizard.resetScopeConfigOnly"
+  | "wizard.resetScopeConfigCredsSessions"
+  | "wizard.resetScopeFull"
+  | "wizard.setupTargetQuestion"
+  | "wizard.setupTargetLocal"
+  | "wizard.setupTargetLocalReachableHint"
+  | "wizard.setupTargetLocalUnreachableHint"
+  | "wizard.setupTargetRemote"
+  | "wizard.setupTargetRemoteNoConfigHint"
+  | "wizard.setupTargetRemoteReachableHint"
+  | "wizard.setupTargetRemoteUnreachableHint"
+  | "wizard.workspaceDirectoryQuestion"
+  | "wizard.skipChannelsNote"
+  | "wizard.channelsTitle"
+  | "wizard.skipSkillsNote"
+  | "wizard.skillsTitle"
   | "wizard.remoteConfigured";
 
 type CliMessages = Record<CliMessageKey, string>;
@@ -35,6 +58,29 @@ const EN_MESSAGES: CliMessages = {
     "QuickStart only supports local gateways. Switching to Manual mode.",
   "wizard.configInvalidOutro":
     "Config invalid. Run `{doctorCommand}` to repair it, then re-run onboarding.",
+  "wizard.existingConfigDetectedTitle": "Existing config detected",
+  "wizard.configIssuesTitle": "Config issues",
+  "wizard.configHandlingQuestion": "Config handling",
+  "wizard.configHandlingUseExisting": "Use existing values",
+  "wizard.configHandlingUpdate": "Update values",
+  "wizard.configHandlingReset": "Reset",
+  "wizard.resetScopeQuestion": "Reset scope",
+  "wizard.resetScopeConfigOnly": "Config only",
+  "wizard.resetScopeConfigCredsSessions": "Config + creds + sessions",
+  "wizard.resetScopeFull": "Full reset (config + creds + sessions + workspace)",
+  "wizard.setupTargetQuestion": "What do you want to set up?",
+  "wizard.setupTargetLocal": "Local gateway (this machine)",
+  "wizard.setupTargetLocalReachableHint": "Gateway reachable ({url})",
+  "wizard.setupTargetLocalUnreachableHint": "No gateway detected ({url})",
+  "wizard.setupTargetRemote": "Remote gateway (info-only)",
+  "wizard.setupTargetRemoteNoConfigHint": "No remote URL configured yet",
+  "wizard.setupTargetRemoteReachableHint": "Gateway reachable ({url})",
+  "wizard.setupTargetRemoteUnreachableHint": "Configured but unreachable ({url})",
+  "wizard.workspaceDirectoryQuestion": "Workspace directory",
+  "wizard.skipChannelsNote": "Skipping channel setup.",
+  "wizard.channelsTitle": "Channels",
+  "wizard.skipSkillsNote": "Skipping skills setup.",
+  "wizard.skillsTitle": "Skills",
   "wizard.remoteConfigured": "Remote gateway configured.",
 };
 
@@ -51,6 +97,29 @@ const ZH_CN_MESSAGES: CliMessages = {
   "wizard.quickstartTitle": "快速开始",
   "wizard.quickstartSwitchToManual": "快速开始仅支持本地网关，已切换到手动模式。",
   "wizard.configInvalidOutro": "配置文件无效。请先运行 `{doctorCommand}` 修复，再重新执行初始化。",
+  "wizard.existingConfigDetectedTitle": "检测到已有配置",
+  "wizard.configIssuesTitle": "配置问题",
+  "wizard.configHandlingQuestion": "如何处理现有配置",
+  "wizard.configHandlingUseExisting": "沿用现有配置",
+  "wizard.configHandlingUpdate": "更新配置",
+  "wizard.configHandlingReset": "重置",
+  "wizard.resetScopeQuestion": "重置范围",
+  "wizard.resetScopeConfigOnly": "仅重置配置",
+  "wizard.resetScopeConfigCredsSessions": "重置配置 + 凭据 + 会话",
+  "wizard.resetScopeFull": "完全重置（配置 + 凭据 + 会话 + 工作区）",
+  "wizard.setupTargetQuestion": "你想配置哪一种",
+  "wizard.setupTargetLocal": "本地网关（当前机器）",
+  "wizard.setupTargetLocalReachableHint": "网关可达（{url}）",
+  "wizard.setupTargetLocalUnreachableHint": "未检测到网关（{url}）",
+  "wizard.setupTargetRemote": "远程网关（仅信息配置）",
+  "wizard.setupTargetRemoteNoConfigHint": "尚未配置远程 URL",
+  "wizard.setupTargetRemoteReachableHint": "网关可达（{url}）",
+  "wizard.setupTargetRemoteUnreachableHint": "已配置但不可达（{url}）",
+  "wizard.workspaceDirectoryQuestion": "工作区目录",
+  "wizard.skipChannelsNote": "已跳过频道配置。",
+  "wizard.channelsTitle": "频道",
+  "wizard.skipSkillsNote": "已跳过技能配置。",
+  "wizard.skillsTitle": "技能",
   "wizard.remoteConfigured": "远程网关已配置完成。",
 };
 

--- a/src/i18n/cli.ts
+++ b/src/i18n/cli.ts
@@ -17,6 +17,8 @@ type CliMessageKey =
 
 type CliMessages = Record<CliMessageKey, string>;
 
+type CliTemplateVars = Record<string, string | number>;
+
 const EN_MESSAGES: CliMessages = {
   "wizard.setupCancelled": "Setup cancelled.",
   "wizard.onboardingTitle": "OpenClaw onboarding",
@@ -25,14 +27,14 @@ const EN_MESSAGES: CliMessages = {
     "I understand this is personal-by-default and shared/multi-user use requires lock-down. Continue?",
   "wizard.modeQuestion": "Onboarding mode",
   "wizard.modeQuickstart": "QuickStart",
-  "wizard.modeQuickstartHint": "Configure details later via openclaw configure.",
+  "wizard.modeQuickstartHint": "Configure details later via {configureCommand}.",
   "wizard.modeManual": "Manual",
   "wizard.modeManualHint": "Configure port, network, Tailscale, and auth options.",
   "wizard.quickstartTitle": "QuickStart",
   "wizard.quickstartSwitchToManual":
     "QuickStart only supports local gateways. Switching to Manual mode.",
   "wizard.configInvalidOutro":
-    "Config invalid. Run `openclaw doctor` to repair it, then re-run onboarding.",
+    "Config invalid. Run `{doctorCommand}` to repair it, then re-run onboarding.",
   "wizard.remoteConfigured": "Remote gateway configured.",
 };
 
@@ -43,12 +45,12 @@ const ZH_CN_MESSAGES: CliMessages = {
   "wizard.securityConfirm": "我理解默认是个人使用场景，多用户/共享场景需要额外加固。是否继续？",
   "wizard.modeQuestion": "初始化模式",
   "wizard.modeQuickstart": "快速开始",
-  "wizard.modeQuickstartHint": "稍后可通过 openclaw configure 继续细化配置。",
+  "wizard.modeQuickstartHint": "稍后可通过 {configureCommand} 继续细化配置。",
   "wizard.modeManual": "手动配置",
   "wizard.modeManualHint": "配置端口、网络、Tailscale 与认证选项。",
   "wizard.quickstartTitle": "快速开始",
   "wizard.quickstartSwitchToManual": "快速开始仅支持本地网关，已切换到手动模式。",
-  "wizard.configInvalidOutro": "配置文件无效。请先运行 `openclaw doctor` 修复，再重新执行初始化。",
+  "wizard.configInvalidOutro": "配置文件无效。请先运行 `{doctorCommand}` 修复，再重新执行初始化。",
   "wizard.remoteConfigured": "远程网关已配置完成。",
 };
 
@@ -57,9 +59,12 @@ function normalizeLocale(raw: string): CliLocale {
   if (!value) {
     return "en";
   }
-  if (value === "zh-cn" || value === "zh_cn" || value.startsWith("zh")) {
+
+  const normalized = value.replace(/_/g, "-").split(".")[0] ?? value;
+  if (normalized === "zh-cn" || normalized === "zh-hans") {
     return "zh-CN";
   }
+
   return "en";
 }
 
@@ -75,8 +80,23 @@ export function resolveCliLocale(env: NodeJS.ProcessEnv = process.env): CliLocal
   return "en";
 }
 
-export function cliT(key: CliMessageKey, env: NodeJS.ProcessEnv = process.env): string {
+function formatTemplate(message: string, vars?: CliTemplateVars): string {
+  if (!vars) {
+    return message;
+  }
+  return message.replace(/\{([a-zA-Z0-9_]+)\}/g, (full, key) => {
+    const value = vars[key];
+    return value === undefined ? full : String(value);
+  });
+}
+
+export function cliT(
+  key: CliMessageKey,
+  env: NodeJS.ProcessEnv = process.env,
+  vars?: CliTemplateVars,
+): string {
   const locale = resolveCliLocale(env);
   const messages = locale === "zh-CN" ? ZH_CN_MESSAGES : EN_MESSAGES;
-  return messages[key] ?? EN_MESSAGES[key];
+  const message = messages[key] ?? EN_MESSAGES[key];
+  return formatTemplate(message, vars);
 }

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -12,6 +12,7 @@ import {
   text,
 } from "@clack/prompts";
 import { createCliProgress } from "../cli/progress.js";
+import { cliT } from "../i18n/cli.js";
 import { stripAnsi } from "../terminal/ansi.js";
 import { note as emitNote } from "../terminal/note.js";
 import { stylePromptHint, stylePromptMessage, stylePromptTitle } from "../terminal/prompt-style.js";
@@ -21,7 +22,8 @@ import { WizardCancelledError } from "./prompts.js";
 
 function guardCancel<T>(value: T | symbol): T {
   if (isCancel(value)) {
-    cancel(stylePromptTitle("Setup cancelled.") ?? "Setup cancelled.");
+    const cancelled = cliT("wizard.setupCancelled");
+    cancel(stylePromptTitle(cancelled) ?? cancelled);
     throw new WizardCancelledError();
   }
   return value;

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -217,15 +217,22 @@ function createRuntime(opts?: { throwsOnExit?: boolean }): RuntimeEnv {
 describe("runOnboardingWizard", () => {
   let suiteRoot = "";
   let suiteCase = 0;
+  const previousLocale = process.env.OPENCLAW_LOCALE;
 
   beforeAll(async () => {
     suiteRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-onboard-suite-"));
+    process.env.OPENCLAW_LOCALE = "en";
   });
 
   afterAll(async () => {
     await fs.rm(suiteRoot, { recursive: true, force: true });
     suiteRoot = "";
     suiteCase = 0;
+    if (previousLocale === undefined) {
+      delete process.env.OPENCLAW_LOCALE;
+    } else {
+      process.env.OPENCLAW_LOCALE = previousLocale;
+    }
   });
 
   async function makeCaseDir(prefix: string): Promise<string> {

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -312,6 +312,47 @@ describe("runOnboardingWizard", () => {
     expect(runTui).not.toHaveBeenCalled();
   });
 
+  it("persists selected onboarding locale into config", async () => {
+    const previousLocale = process.env.OPENCLAW_LOCALE;
+    delete process.env.OPENCLAW_LOCALE;
+
+    const select = vi.fn(async (params: WizardSelectParams<unknown>) => {
+      if (params.message === "Language / 语言") {
+        return "zh-CN";
+      }
+      return "quickstart";
+    }) as unknown as WizardPrompter["select"];
+    const prompter = buildWizardPrompter({ select });
+    const runtime = createRuntime({ throwsOnExit: true });
+
+    await runOnboardingWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        authChoice: "skip",
+        installDaemon: false,
+        skipProviders: true,
+        skipSkills: true,
+        skipHealth: true,
+        skipUi: true,
+      },
+      runtime,
+      prompter,
+    );
+
+    expect(writeConfigFile).toHaveBeenCalled();
+    const wroteZhLocale = writeConfigFile.mock.calls.some(
+      (call) => call[0]?.cli?.locale === "zh-CN",
+    );
+    expect(wroteZhLocale).toBe(true);
+
+    if (previousLocale === undefined) {
+      delete process.env.OPENCLAW_LOCALE;
+    } else {
+      process.env.OPENCLAW_LOCALE = previousLocale;
+    }
+  });
+
   async function runTuiHatchTest(params: {
     writeBootstrapFile: boolean;
     expectedMessage: string | undefined;

--- a/src/wizard/onboarding.test.ts
+++ b/src/wizard/onboarding.test.ts
@@ -341,8 +341,8 @@ describe("runOnboardingWizard", () => {
     );
 
     expect(writeConfigFile).toHaveBeenCalled();
-    const wroteZhLocale = writeConfigFile.mock.calls.some(
-      (call) => call[0]?.cli?.locale === "zh-CN",
+    const wroteZhLocale = (writeConfigFile.mock.calls as Array<[Record<string, unknown>?]>).some(
+      (call) => (call[0]?.cli as { locale?: string } | undefined)?.locale === "zh-CN",
     );
     expect(wroteZhLocale).toBe(true);
 

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -21,12 +21,37 @@ import { resolveOnboardingSecretInputString } from "./onboarding.secret-input.js
 import type { QuickstartGatewayDefaults, WizardFlow } from "./onboarding.types.js";
 import { WizardCancelledError, type WizardPrompter } from "./prompts.js";
 
-async function promptCliLocaleSelection(prompter: WizardPrompter): Promise<void> {
-  const explicit = process.env.OPENCLAW_LOCALE?.trim();
-  if (explicit) {
-    return;
+function normalizeCliLocale(value: string | undefined): "en" | "zh-CN" | undefined {
+  const normalized = value?.trim();
+  if (!normalized) {
+    return undefined;
   }
-  const locale = await prompter.select({
+  if (normalized === "en") {
+    return "en";
+  }
+  if (normalized === "zh-CN") {
+    return "zh-CN";
+  }
+  return undefined;
+}
+
+async function promptCliLocaleSelection(params: {
+  prompter: WizardPrompter;
+  baseConfig: OpenClawConfig;
+}): Promise<"en" | "zh-CN" | undefined> {
+  const explicit = normalizeCliLocale(process.env.OPENCLAW_LOCALE);
+  if (explicit) {
+    process.env.OPENCLAW_LOCALE = explicit;
+    return undefined;
+  }
+
+  const configured = normalizeCliLocale(params.baseConfig.cli?.locale);
+  if (configured) {
+    process.env.OPENCLAW_LOCALE = configured;
+    return undefined;
+  }
+
+  const locale = await params.prompter.select({
     message: "Language / 语言",
     options: [
       { value: "en", label: "English", hint: "Default" },
@@ -35,6 +60,7 @@ async function promptCliLocaleSelection(prompter: WizardPrompter): Promise<void>
     initialValue: "en",
   });
   process.env.OPENCLAW_LOCALE = locale;
+  return locale;
 }
 
 async function requireRiskAcknowledgement(params: {
@@ -91,13 +117,7 @@ export async function runOnboardingWizard(
   runtime: RuntimeEnv = defaultRuntime,
   prompter: WizardPrompter,
 ) {
-  await promptCliLocaleSelection(prompter);
-  const t = (key: Parameters<typeof cliT>[0]) => cliT(key, process.env);
   const onboardHelpers = await import("../commands/onboard-helpers.js");
-  onboardHelpers.printWizardHeader(runtime);
-  await prompter.intro(t("wizard.onboardingTitle"));
-  await requireRiskAcknowledgement({ opts, prompter });
-
   const snapshot = await readConfigFileSnapshot();
   let baseConfig: OpenClawConfig = snapshot.valid ? snapshot.config : {};
 
@@ -110,7 +130,7 @@ export async function runOnboardingWizard(
           "",
           "Docs: https://docs.openclaw.ai/gateway/configuration",
         ].join("\n"),
-        t("wizard.configIssuesTitle"),
+        cliT("wizard.configIssuesTitle", process.env),
       );
     }
     await prompter.outro(
@@ -121,6 +141,22 @@ export async function runOnboardingWizard(
     runtime.exit(1);
     return;
   }
+
+  const selectedLocale = await promptCliLocaleSelection({ prompter, baseConfig });
+  if (selectedLocale) {
+    baseConfig = {
+      ...baseConfig,
+      cli: {
+        ...baseConfig.cli,
+        locale: selectedLocale,
+      },
+    };
+  }
+
+  const t = (key: Parameters<typeof cliT>[0]) => cliT(key, process.env);
+  onboardHelpers.printWizardHeader(runtime);
+  await prompter.intro(t("wizard.onboardingTitle"));
+  await requireRiskAcknowledgement({ opts, prompter });
 
   const quickstartHint = cliT("wizard.modeQuickstartHint", process.env, {
     configureCommand: formatCliCommand("openclaw configure"),

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -51,7 +51,7 @@ async function promptCliLocaleSelection(params: {
     return undefined;
   }
 
-  const locale = await params.prompter.select({
+  const localeRaw = await params.prompter.select({
     message: "Language / 语言",
     options: [
       { value: "en", label: "English", hint: "Default" },
@@ -59,6 +59,7 @@ async function promptCliLocaleSelection(params: {
     ],
     initialValue: "en",
   });
+  const locale = normalizeCliLocale(String(localeRaw)) ?? "en";
   process.env.OPENCLAW_LOCALE = locale;
   return locale;
 }

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -13,12 +13,29 @@ import {
   writeConfigFile,
 } from "../config/config.js";
 import { normalizeSecretInputString } from "../config/types.secrets.js";
+import { cliT } from "../i18n/cli.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveOnboardingSecretInputString } from "./onboarding.secret-input.js";
 import type { QuickstartGatewayDefaults, WizardFlow } from "./onboarding.types.js";
 import { WizardCancelledError, type WizardPrompter } from "./prompts.js";
+
+async function promptCliLocaleSelection(prompter: WizardPrompter): Promise<void> {
+  const explicit = process.env.OPENCLAW_LOCALE?.trim();
+  if (explicit) {
+    return;
+  }
+  const locale = await prompter.select({
+    message: "Language / 语言",
+    options: [
+      { value: "en", label: "English", hint: "Default" },
+      { value: "zh-CN", label: "简体中文", hint: "推荐" },
+    ],
+    initialValue: "en",
+  });
+  process.env.OPENCLAW_LOCALE = locale;
+}
 
 async function requireRiskAcknowledgement(params: {
   opts: OnboardOptions;
@@ -57,12 +74,11 @@ async function requireRiskAcknowledgement(params: {
       "",
       "Must read: https://docs.openclaw.ai/gateway/security",
     ].join("\n"),
-    "Security",
+    cliT("wizard.securityTitle", process.env),
   );
 
   const ok = await params.prompter.confirm({
-    message:
-      "I understand this is personal-by-default and shared/multi-user use requires lock-down. Continue?",
+    message: cliT("wizard.securityConfirm", process.env),
     initialValue: false,
   });
   if (!ok) {
@@ -75,9 +91,11 @@ export async function runOnboardingWizard(
   runtime: RuntimeEnv = defaultRuntime,
   prompter: WizardPrompter,
 ) {
+  await promptCliLocaleSelection(prompter);
+  const t = (key: Parameters<typeof cliT>[0]) => cliT(key, process.env);
   const onboardHelpers = await import("../commands/onboard-helpers.js");
   onboardHelpers.printWizardHeader(runtime);
-  await prompter.intro("OpenClaw onboarding");
+  await prompter.intro(t("wizard.onboardingTitle"));
   await requireRiskAcknowledgement({ opts, prompter });
 
   const snapshot = await readConfigFileSnapshot();
@@ -96,14 +114,20 @@ export async function runOnboardingWizard(
       );
     }
     await prompter.outro(
-      `Config invalid. Run \`${formatCliCommand("openclaw doctor")}\` to repair it, then re-run onboarding.`,
+      t("wizard.configInvalidOutro").replace(
+        "openclaw doctor",
+        formatCliCommand("openclaw doctor"),
+      ),
     );
     runtime.exit(1);
     return;
   }
 
-  const quickstartHint = `Configure details later via ${formatCliCommand("openclaw configure")}.`;
-  const manualHint = "Configure port, network, Tailscale, and auth options.";
+  const quickstartHint = t("wizard.modeQuickstartHint").replace(
+    "openclaw configure",
+    formatCliCommand("openclaw configure"),
+  );
+  const manualHint = t("wizard.modeManualHint");
   const explicitFlowRaw = opts.flow?.trim();
   const normalizedExplicitFlow = explicitFlowRaw === "manual" ? "advanced" : explicitFlowRaw;
   if (
@@ -122,19 +146,16 @@ export async function runOnboardingWizard(
   let flow: WizardFlow =
     explicitFlow ??
     (await prompter.select({
-      message: "Onboarding mode",
+      message: t("wizard.modeQuestion"),
       options: [
-        { value: "quickstart", label: "QuickStart", hint: quickstartHint },
-        { value: "advanced", label: "Manual", hint: manualHint },
+        { value: "quickstart", label: t("wizard.modeQuickstart"), hint: quickstartHint },
+        { value: "advanced", label: t("wizard.modeManual"), hint: manualHint },
       ],
       initialValue: "quickstart",
     }));
 
   if (opts.mode === "remote" && flow === "quickstart") {
-    await prompter.note(
-      "QuickStart only supports local gateways. Switching to Manual mode.",
-      "QuickStart",
-    );
+    await prompter.note(t("wizard.quickstartSwitchToManual"), t("wizard.quickstartTitle"));
     flow = "advanced";
   }
 
@@ -352,7 +373,7 @@ export async function runOnboardingWizard(
     nextConfig = onboardHelpers.applyWizardMetadata(nextConfig, { command: "onboard", mode });
     await writeConfigFile(nextConfig);
     logConfigUpdated(runtime);
-    await prompter.outro("Remote gateway configured.");
+    await prompter.outro(t("wizard.remoteConfigured"));
     return;
   }
 

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -114,19 +114,17 @@ export async function runOnboardingWizard(
       );
     }
     await prompter.outro(
-      t("wizard.configInvalidOutro").replace(
-        "openclaw doctor",
-        formatCliCommand("openclaw doctor"),
-      ),
+      cliT("wizard.configInvalidOutro", process.env, {
+        doctorCommand: formatCliCommand("openclaw doctor"),
+      }),
     );
     runtime.exit(1);
     return;
   }
 
-  const quickstartHint = t("wizard.modeQuickstartHint").replace(
-    "openclaw configure",
-    formatCliCommand("openclaw configure"),
-  );
+  const quickstartHint = cliT("wizard.modeQuickstartHint", process.env, {
+    configureCommand: formatCliCommand("openclaw configure"),
+  });
   const manualHint = t("wizard.modeManualHint");
   const explicitFlowRaw = opts.flow?.trim();
   const normalizedExplicitFlow = explicitFlowRaw === "manual" ? "advanced" : explicitFlowRaw;

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -110,7 +110,7 @@ export async function runOnboardingWizard(
           "",
           "Docs: https://docs.openclaw.ai/gateway/configuration",
         ].join("\n"),
-        "Config issues",
+        t("wizard.configIssuesTitle"),
       );
     }
     await prompter.outro(
@@ -160,15 +160,15 @@ export async function runOnboardingWizard(
   if (snapshot.exists) {
     await prompter.note(
       onboardHelpers.summarizeExistingConfig(baseConfig),
-      "Existing config detected",
+      t("wizard.existingConfigDetectedTitle"),
     );
 
     const action = await prompter.select({
-      message: "Config handling",
+      message: t("wizard.configHandlingQuestion"),
       options: [
-        { value: "keep", label: "Use existing values" },
-        { value: "modify", label: "Update values" },
-        { value: "reset", label: "Reset" },
+        { value: "keep", label: t("wizard.configHandlingUseExisting") },
+        { value: "modify", label: t("wizard.configHandlingUpdate") },
+        { value: "reset", label: t("wizard.configHandlingReset") },
       ],
     });
 
@@ -176,16 +176,16 @@ export async function runOnboardingWizard(
       const workspaceDefault =
         baseConfig.agents?.defaults?.workspace ?? onboardHelpers.DEFAULT_WORKSPACE;
       const resetScope = (await prompter.select({
-        message: "Reset scope",
+        message: t("wizard.resetScopeQuestion"),
         options: [
-          { value: "config", label: "Config only" },
+          { value: "config", label: t("wizard.resetScopeConfigOnly") },
           {
             value: "config+creds+sessions",
-            label: "Config + creds + sessions",
+            label: t("wizard.resetScopeConfigCredsSessions"),
           },
           {
             value: "full",
-            label: "Full reset (config + creds + sessions + workspace)",
+            label: t("wizard.resetScopeFull"),
           },
         ],
       })) as ResetScope;
@@ -341,23 +341,25 @@ export async function runOnboardingWizard(
     (flow === "quickstart"
       ? "local"
       : ((await prompter.select({
-          message: "What do you want to set up?",
+          message: t("wizard.setupTargetQuestion"),
           options: [
             {
               value: "local",
-              label: "Local gateway (this machine)",
+              label: t("wizard.setupTargetLocal"),
               hint: localProbe.ok
-                ? `Gateway reachable (${localUrl})`
-                : `No gateway detected (${localUrl})`,
+                ? cliT("wizard.setupTargetLocalReachableHint", process.env, { url: localUrl })
+                : cliT("wizard.setupTargetLocalUnreachableHint", process.env, { url: localUrl }),
             },
             {
               value: "remote",
-              label: "Remote gateway (info-only)",
+              label: t("wizard.setupTargetRemote"),
               hint: !remoteUrl
-                ? "No remote URL configured yet"
+                ? t("wizard.setupTargetRemoteNoConfigHint")
                 : remoteProbe?.ok
-                  ? `Gateway reachable (${remoteUrl})`
-                  : `Configured but unreachable (${remoteUrl})`,
+                  ? cliT("wizard.setupTargetRemoteReachableHint", process.env, { url: remoteUrl })
+                  : cliT("wizard.setupTargetRemoteUnreachableHint", process.env, {
+                      url: remoteUrl,
+                    }),
             },
           ],
         })) as OnboardMode));
@@ -380,7 +382,7 @@ export async function runOnboardingWizard(
     (flow === "quickstart"
       ? (baseConfig.agents?.defaults?.workspace ?? onboardHelpers.DEFAULT_WORKSPACE)
       : await prompter.text({
-          message: "Workspace directory",
+          message: t("wizard.workspaceDirectoryQuestion"),
           initialValue: baseConfig.agents?.defaults?.workspace ?? onboardHelpers.DEFAULT_WORKSPACE,
         }));
 
@@ -465,7 +467,7 @@ export async function runOnboardingWizard(
   const settings = gateway.settings;
 
   if (opts.skipChannels ?? opts.skipProviders) {
-    await prompter.note("Skipping channel setup.", "Channels");
+    await prompter.note(t("wizard.skipChannelsNote"), t("wizard.channelsTitle"));
   } else {
     const { listChannelPlugins } = await import("../channels/plugins/index.js");
     const { setupChannels } = await import("../commands/onboard-channels.js");
@@ -493,7 +495,7 @@ export async function runOnboardingWizard(
   });
 
   if (opts.skipSkills) {
-    await prompter.note("Skipping skills setup.", "Skills");
+    await prompter.note(t("wizard.skipSkillsNote"), t("wizard.skillsTitle"));
   } else {
     const { setupSkills } = await import("../commands/onboard-skills.js");
     nextConfig = await setupSkills(nextConfig, workspaceDir, runtime, prompter);


### PR DESCRIPTION
## Summary

Persist onboarding language choice so users are not prompted every run:

- Add `cli.locale` to config schema (`en` | `zh-CN`)
- During onboarding locale bootstrap:
  - honor explicit `OPENCLAW_LOCALE` first
  - otherwise reuse `config.cli.locale` when present
  - otherwise prompt once at startup
- When user selects a locale interactively, persist it into config via onboarding writes
- Add onboarding test coverage for locale persistence

## Notes

- This is a follow-up to #34494.
- It currently includes those prior commits while #34494 is still open.
- If maintainers prefer, I can rebase/cherry-pick this to include only the locale-persistence delta after #34494 lands.

## Test

```bash
pnpm vitest run src/wizard/onboarding.test.ts src/wizard/clack-prompter.test.ts
```

All passing locally.
