### PR TITLE
feat(secrets): add HashiCorp Vault KV v2 secret provider

### DIFF
--- a/src/agents/auth-profiles.resolve-auth-profile-order.uses-stored-profiles-no-config-exists.test.ts
+++ b/src/agents/auth-profiles.resolve-auth-profile-order.uses-stored-profiles-no-config-exists.test.ts
@@ -13,7 +13,7 @@ describe("resolveAuthProfileOrder", () => {
     type: "token";
     provider: "minimax";
     token?: string;
-    tokenRef?: { source: "env" | "file" | "exec"; provider: string; id: string };
+    tokenRef?: { source: "env" | "file" | "exec" | "vault"; provider: string; id: string };
     expires?: number;
   }) {
     return resolveAuthProfileOrder({

--- a/src/commands/auth-choice.apply.anthropic.ts
+++ b/src/commands/auth-choice.apply.anthropic.ts
@@ -40,7 +40,7 @@ export async function applyAuthChoiceAnthropic(
       },
     });
     let token = "";
-    let tokenRef: { source: "env" | "file" | "exec"; provider: string; id: string } | undefined;
+    let tokenRef: { source: "env" | "file" | "exec" | "vault"; provider: string; id: string } | undefined;
     if (selectedMode === "ref") {
       const resolved = await promptSecretRefForOnboarding({
         provider: "anthropic-setup-token",

--- a/src/config/types.secrets.ts
+++ b/src/config/types.secrets.ts
@@ -1,11 +1,12 @@
-export type SecretRefSource = "env" | "file" | "exec";
+export type SecretRefSource = "env" | "file" | "exec" | "vault";
 
 /**
  * Stable identifier for a secret in a configured source.
  * Examples:
  * - env source: provider "default", id "OPENAI_API_KEY"
  * - file source: provider "mounted-json", id "/providers/openai/apiKey"
- * - exec source: provider "vault", id "openai/api-key"
+ * - exec source: provider "my-exec", id "openai/api-key"
+ * - vault source: provider "my-vault", id "notion/apikey#api_key"
  */
 export type SecretRef = {
   source: SecretRefSource;
@@ -34,7 +35,10 @@ export function isSecretRef(value: unknown): value is SecretRef {
     return false;
   }
   return (
-    (value.source === "env" || value.source === "file" || value.source === "exec") &&
+    (value.source === "env" ||
+      value.source === "file" ||
+      value.source === "exec" ||
+      value.source === "vault") &&
     typeof value.provider === "string" &&
     value.provider.trim().length > 0 &&
     typeof value.id === "string" &&
@@ -49,7 +53,10 @@ function isLegacySecretRefWithoutProvider(
     return false;
   }
   return (
-    (value.source === "env" || value.source === "file" || value.source === "exec") &&
+    (value.source === "env" ||
+      value.source === "file" ||
+      value.source === "exec" ||
+      value.source === "vault") &&
     typeof value.id === "string" &&
     value.id.trim().length > 0 &&
     value.provider === undefined
@@ -199,10 +206,51 @@ export type ExecSecretProviderConfig = {
   allowSymlinkCommand?: boolean;
 };
 
+/**
+ * HashiCorp Vault KV v2 secret provider.
+ *
+ * Refs use the format: `{ source: "vault", provider: "<name>", id: "path/to/secret#fieldName" }`
+ *
+ * Example config:
+ * ```json
+ * {
+ *   "secrets": {
+ *     "providers": {
+ *       "my-vault": {
+ *         "source": "vault",
+ *         "addr": "http://192.168.1.100:8200",
+ *         "tokenEnv": "VAULT_TOKEN",
+ *         "mountPath": "demo"
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * Example ref in auth-profiles.json:
+ * ```json
+ * { "source": "vault", "provider": "my-vault", "id": "notion/apikey#api_key" }
+ * ```
+ */
+export type VaultSecretProviderConfig = {
+  source: "vault";
+  /** Vault server address, e.g. "http://192.168.1.100:8200" */
+  addr: string;
+  /** Static Vault token. Prefer tokenEnv to avoid storing tokens in config. */
+  token?: string;
+  /** Name of the environment variable that holds the Vault token. */
+  tokenEnv?: string;
+  /** KV v2 mount path (default: "secret"). */
+  mountPath?: string;
+  /** Request timeout in milliseconds (default: 5000). */
+  timeoutMs?: number;
+};
+
 export type SecretProviderConfig =
   | EnvSecretProviderConfig
   | FileSecretProviderConfig
-  | ExecSecretProviderConfig;
+  | ExecSecretProviderConfig
+  | VaultSecretProviderConfig;
 
 export type SecretsConfig = {
   providers?: Record<string, SecretProviderConfig>;
@@ -210,6 +258,7 @@ export type SecretsConfig = {
     env?: string;
     file?: string;
     exec?: string;
+    vault?: string;
   };
   resolution?: {
     maxProviderConcurrency?: number;

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -74,10 +74,31 @@ const ExecSecretRefSchema = z
   })
   .strict();
 
+const VAULT_SECRET_REF_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,254}#[A-Za-z0-9_-]{1,128}$/;
+
+const VaultSecretRefSchema = z
+  .object({
+    source: z.literal("vault"),
+    provider: z
+      .string()
+      .regex(
+        SECRET_PROVIDER_ALIAS_PATTERN,
+        'Secret reference provider must match /^[a-z][a-z0-9_-]{0,63}$/ (example: "proxmox-vault").',
+      ),
+    id: z
+      .string()
+      .regex(
+        VAULT_SECRET_REF_ID_PATTERN,
+        'Vault secret reference id must match "path/to/secret#fieldName" (example: "telegram-bot#token").',
+      ),
+  })
+  .strict();
+
 export const SecretRefSchema = z.discriminatedUnion("source", [
   EnvSecretRefSchema,
   FileSecretRefSchema,
   ExecSecretRefSchema,
+  VaultSecretRefSchema,
 ]);
 
 export const SecretInputSchema = z.union([z.string(), SecretRefSchema]);
@@ -141,10 +162,26 @@ const SecretsExecProviderSchema = z
   })
   .strict();
 
+const SecretsVaultProviderSchema = z
+  .object({
+    source: z.literal("vault"),
+    addr: z.string().url("secrets.providers.*.addr must be a valid URL."),
+    token: z.string().min(1).optional(),
+    tokenEnv: z.string().regex(ENV_SECRET_REF_ID_PATTERN).optional(),
+    mountPath: z.string().min(1).optional(),
+    timeoutMs: z.number().int().positive().max(120000).optional(),
+  })
+  .strict()
+  .refine(
+    (v) => v.token !== undefined || v.tokenEnv !== undefined,
+    "Vault provider requires either 'token' or 'tokenEnv'.",
+  );
+
 export const SecretProviderSchema = z.discriminatedUnion("source", [
   SecretsEnvProviderSchema,
   SecretsFileProviderSchema,
   SecretsExecProviderSchema,
+  SecretsVaultProviderSchema,
 ]);
 
 export const SecretsConfigSchema = z
@@ -160,6 +197,7 @@ export const SecretsConfigSchema = z
         env: z.string().regex(SECRET_PROVIDER_ALIAS_PATTERN).optional(),
         file: z.string().regex(SECRET_PROVIDER_ALIAS_PATTERN).optional(),
         exec: z.string().regex(SECRET_PROVIDER_ALIAS_PATTERN).optional(),
+        vault: z.string().regex(SECRET_PROVIDER_ALIAS_PATTERN).optional(),
       })
       .strict()
       .optional(),

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -8,6 +8,7 @@ import type {
   SecretProviderConfig,
   SecretRef,
   SecretRefSource,
+  VaultSecretProviderConfig,
 } from "../config/types.secrets.js";
 import { inspectPathPermissions, safeStat } from "../security/audit-fs.js";
 import { isPathInside } from "../security/scan-paths.js";
@@ -33,12 +34,14 @@ const DEFAULT_FILE_MAX_BYTES = 1024 * 1024;
 const DEFAULT_FILE_TIMEOUT_MS = 5_000;
 const DEFAULT_EXEC_TIMEOUT_MS = 5_000;
 const DEFAULT_EXEC_MAX_OUTPUT_BYTES = 1024 * 1024;
+const DEFAULT_VAULT_TIMEOUT_MS = 5_000;
 const WINDOWS_ABS_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
 const WINDOWS_UNC_PATH_PATTERN = /^\\\\[^\\]+\\[^\\]+/;
 
 export type SecretRefResolveCache = {
   resolvedByRefKey?: Map<string, Promise<unknown>>;
   filePayloadByProvider?: Map<string, Promise<unknown>>;
+  vaultPayloadByPath?: Map<string, Promise<unknown>>;
 };
 
 type ResolveSecretRefOptions = {
@@ -782,6 +785,154 @@ async function resolveExecRefs(params: {
   return resolved;
 }
 
+async function resolveVaultRefs(params: {
+  refs: SecretRef[];
+  providerName: string;
+  providerConfig: VaultSecretProviderConfig;
+  env: NodeJS.ProcessEnv;
+  cache?: SecretRefResolveCache;
+}): Promise<ProviderResolutionOutput> {
+  // Resolve the Vault token
+  let token: string;
+  if (params.providerConfig.token) {
+    token = params.providerConfig.token;
+  } else if (params.providerConfig.tokenEnv) {
+    const envToken = params.env[params.providerConfig.tokenEnv];
+    if (!envToken) {
+      throw providerResolutionError({
+        source: "vault",
+        provider: params.providerName,
+        message: `Vault provider "${params.providerName}": environment variable "${params.providerConfig.tokenEnv}" is missing or empty.`,
+      });
+    }
+    token = envToken;
+  } else {
+    throw providerResolutionError({
+      source: "vault",
+      provider: params.providerName,
+      message: `Vault provider "${params.providerName}": either "token" or "tokenEnv" must be configured.`,
+    });
+  }
+
+  const addr = params.providerConfig.addr.replace(/\/$/, "");
+  const mount = (params.providerConfig.mountPath ?? "secret").replace(/^\/|\/$/g, "");
+  const timeoutMs = normalizePositiveInt(params.providerConfig.timeoutMs, DEFAULT_VAULT_TIMEOUT_MS);
+
+  // Validate ref format and group by KV path (everything before '#')
+  const byPath = new Map<string, SecretRef[]>();
+  for (const ref of params.refs) {
+    const hashIdx = ref.id.indexOf("#");
+    if (hashIdx <= 0 || hashIdx === ref.id.length - 1) {
+      throw refResolutionError({
+        source: "vault",
+        provider: params.providerName,
+        refId: ref.id,
+        message: `Vault ref id "${ref.id}" must be in format "path/to/secret#fieldName".`,
+      });
+    }
+    const secretPath = ref.id.slice(0, hashIdx);
+    const existing = byPath.get(secretPath);
+    if (existing) {
+      existing.push(ref);
+    } else {
+      byPath.set(secretPath, [ref]);
+    }
+  }
+
+  const resolved = new Map<string, unknown>();
+
+  for (const [secretPath, pathRefs] of byPath) {
+    const url = `${addr}/v1/${mount}/data/${secretPath}`;
+    const cacheKey = `${params.providerName}:${url}`;
+
+    let payload: unknown;
+    if (params.cache?.vaultPayloadByPath?.has(cacheKey)) {
+      payload = await (params.cache.vaultPayloadByPath.get(cacheKey) as Promise<unknown>);
+    } else {
+      const fetchPromise = (async (): Promise<unknown> => {
+        const controller = new AbortController();
+        const timeoutHandle = setTimeout(() => controller.abort(), timeoutMs);
+        try {
+          const response = await fetch(url, {
+            headers: {
+              "X-Vault-Token": token,
+              "Content-Type": "application/json",
+            },
+            signal: controller.signal,
+          });
+          if (!response.ok) {
+            if (response.status === 403) {
+              throw new Error(
+                `Permission denied (HTTP 403). Verify the Vault token has read access to "${secretPath}".`,
+              );
+            }
+            if (response.status === 404) {
+              throw new Error(`Secret not found at path "${secretPath}" (HTTP 404).`);
+            }
+            throw new Error(`Vault returned HTTP ${response.status} for path "${secretPath}".`);
+          }
+          return (await response.json()) as unknown;
+        } catch (err) {
+          if (err instanceof Error && err.name === "AbortError") {
+            throw new Error(
+              `Vault provider "${params.providerName}" timed out after ${timeoutMs}ms fetching "${secretPath}".`,
+            );
+          }
+          throw err;
+        } finally {
+          clearTimeout(timeoutHandle);
+        }
+      })();
+
+      if (params.cache) {
+        params.cache.vaultPayloadByPath ??= new Map();
+        params.cache.vaultPayloadByPath.set(cacheKey, fetchPromise);
+      }
+      payload = await fetchPromise;
+    }
+
+    // KV v2 response shape: { data: { data: { fieldName: value, ... } } }
+    if (!isRecord(payload)) {
+      throw providerResolutionError({
+        source: "vault",
+        provider: params.providerName,
+        message: `Vault provider "${params.providerName}": invalid response for path "${secretPath}".`,
+      });
+    }
+    const outerData = (payload as Record<string, unknown>).data;
+    if (!isRecord(outerData)) {
+      throw providerResolutionError({
+        source: "vault",
+        provider: params.providerName,
+        message: `Vault provider "${params.providerName}": response missing "data" for path "${secretPath}".`,
+      });
+    }
+    const kvData = (outerData as Record<string, unknown>).data;
+    if (!isRecord(kvData)) {
+      throw providerResolutionError({
+        source: "vault",
+        provider: params.providerName,
+        message: `Vault provider "${params.providerName}": response missing "data.data" for path "${secretPath}". Is this a KV v2 mount?`,
+      });
+    }
+
+    for (const ref of pathRefs) {
+      const fieldName = ref.id.slice(ref.id.indexOf("#") + 1);
+      if (!(fieldName in kvData)) {
+        throw refResolutionError({
+          source: "vault",
+          provider: params.providerName,
+          refId: ref.id,
+          message: `Vault secret at "${secretPath}" does not contain field "${fieldName}".`,
+        });
+      }
+      resolved.set(ref.id, kvData[fieldName]);
+    }
+  }
+
+  return resolved;
+}
+
 async function resolveProviderRefs(params: {
   refs: SecretRef[];
   source: SecretRefSource;
@@ -814,6 +965,15 @@ async function resolveProviderRefs(params: {
         providerConfig: params.providerConfig,
         env: params.options.env ?? process.env,
         limits: params.limits,
+      });
+    }
+    if (params.providerConfig.source === "vault") {
+      return await resolveVaultRefs({
+        refs: params.refs,
+        providerName: params.providerName,
+        providerConfig: params.providerConfig,
+        env: params.options.env ?? process.env,
+        cache: params.options.cache,
       });
     }
     throw providerResolutionError({


### PR DESCRIPTION
## Summary

- Adds a native `vault` source type to the secrets provider system
- Enables fetching secrets directly from HashiCorp Vault KV v2 at runtime instead of storing them in plain-text config files
- Groups refs by path to minimise HTTP round-trips, with per-path response caching within a resolution cycle

## Usage

Configure a vault provider in `openclaw.json`:

```json
{
  "secrets": {
    "providers": {
      "my-vault": {
        "source": "vault",
        "addr": "http://192.168.1.100:8200",
        "tokenEnv": "VAULT_TOKEN",
        "mountPath": "demo"
      }
    }
  }
}
```

Reference secrets anywhere a `SecretRef` is accepted (e.g. `auth-profiles.json`):

```json
{ "source": "vault", "provider": "my-vault", "id": "notion/apikey#api_key" }
```

The `id` format is `path/to/secret#fieldName`, matching the KV v2 path structure.

## Provider config options

| Field | Required | Description |
|---|---|---|
| `addr` | ✅ | Vault server URL |
| `token` | one of | Static Vault token (prefer `tokenEnv`) |
| `tokenEnv` | one of | Env var name holding the token |
| `mountPath` | | KV v2 mount (default: `"secret"`) |
| `timeoutMs` | | Request timeout (default: `5000`) |

## Test plan

- [ ] Configure a local Vault dev server and verify secrets resolve at gateway startup
- [ ] Verify HTTP 403 produces a clear "check token policy" error
- [ ] Verify HTTP 404 produces a clear "secret not found" error
- [ ] Verify missing `#fieldName` in ref id produces a validation error
- [ ] Verify multiple refs from the same path make only one HTTP request (cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)