### PR TITLE
fix(restart): increase launchctl/systemctl spawn timeout

### DIFF
--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -15,7 +15,22 @@ export type RestartAttempt = {
   tried?: string[];
 };
 
-const SPAWN_TIMEOUT_MS = 2000;
+const DEFAULT_SPAWN_TIMEOUT_MS = 15_000;
+
+function parseSpawnTimeoutMsFromEnv(): number {
+  const raw = process.env.OPENCLAW_RESTART_SPAWN_TIMEOUT_MS;
+  if (!raw) {
+    return DEFAULT_SPAWN_TIMEOUT_MS;
+  }
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    return DEFAULT_SPAWN_TIMEOUT_MS;
+  }
+  // Clamp: avoid too-small timeouts (flaky) and too-large timeouts (hangy).
+  return Math.min(60_000, Math.max(1_000, Math.floor(n)));
+}
+
+const SPAWN_TIMEOUT_MS = parseSpawnTimeoutMsFromEnv();
 const SIGUSR1_AUTH_GRACE_MS = 5000;
 const DEFAULT_DEFERRAL_POLL_MS = 500;
 const DEFAULT_DEFERRAL_MAX_WAIT_MS = 30_000;
@@ -349,8 +364,18 @@ export function triggerOpenClawRestart(): RestartAttempt {
     return { ok: true, method: "launchctl", tried };
   }
 
-  // kickstart fails when the service was previously booted out (deregistered from launchd).
-  // Fall back to bootstrap (re-register from plist) + kickstart.
+  const kickstartCode = (res.error as NodeJS.ErrnoException | undefined)?.code;
+  if (kickstartCode === "ETIMEDOUT") {
+    return {
+      ok: false,
+      method: "launchctl",
+      detail: `launchctl kickstart timed out after ${SPAWN_TIMEOUT_MS}ms`,
+      tried,
+    };
+  }
+
+  // kickstart can fail when the service was previously booted out (deregistered from launchd)
+  // or otherwise not registered. Fall back to bootstrap (re-register from plist) + kickstart.
   // Use env HOME to match how launchd.ts resolves the plist install path.
   const home = process.env.HOME?.trim() || os.homedir();
   const plistPath = path.join(home, "Library", "LaunchAgents", `${label}.plist`);
@@ -361,13 +386,19 @@ export function triggerOpenClawRestart(): RestartAttempt {
     timeout: SPAWN_TIMEOUT_MS,
   });
   if (boot.error || (boot.status !== 0 && boot.status !== null)) {
+    const bootCode = (boot.error as NodeJS.ErrnoException | undefined)?.code;
+    const detail =
+      bootCode === "ETIMEDOUT"
+        ? `launchctl bootstrap timed out after ${SPAWN_TIMEOUT_MS}ms`
+        : formatSpawnDetail(boot);
     return {
       ok: false,
       method: "launchctl",
-      detail: formatSpawnDetail(boot),
+      detail,
       tried,
     };
   }
+
   const retryArgs = ["kickstart", "-k", target];
   tried.push(`launchctl ${retryArgs.join(" ")}`);
   const retry = spawnSync("launchctl", retryArgs, {
@@ -377,10 +408,17 @@ export function triggerOpenClawRestart(): RestartAttempt {
   if (!retry.error && retry.status === 0) {
     return { ok: true, method: "launchctl", tried };
   }
+
+  const retryCode = (retry.error as NodeJS.ErrnoException | undefined)?.code;
+  const detail =
+    retryCode === "ETIMEDOUT"
+      ? `launchctl kickstart timed out after ${SPAWN_TIMEOUT_MS}ms`
+      : formatSpawnDetail(retry);
+
   return {
     ok: false,
     method: "launchctl",
-    detail: formatSpawnDetail(retry),
+    detail: detail,
     tried,
   };
 }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: On supervised gateway restarts, OpenClaw invokes `launchctl`/`systemctl` via `spawnSync` with a hard-coded **2s** timeout.
- Why it matters: Under load this frequently trips `ETIMEDOUT`, producing noisy/ambiguous restart failure logs and increasing restart flakiness.
- What changed: Increase the default `spawnSync` timeout to **15s**, add an env override (`OPENCLAW_RESTART_SPAWN_TIMEOUT_MS`, clamped 1s–60s), and surface clearer `ETIMEDOUT` detail strings.
- What did NOT change (scope boundary): No changes to restart decision logic, daemon/service configuration, or non-supervised in-process restart behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Fewer false-negative supervised restart failures under load (longer supervisor command timeout).
- Restart failures due to `ETIMEDOUT` now include a clearer detail message, e.g. `launchctl kickstart timed out after <ms>ms`.
- Optional: operators can tune timeout via `OPENCLAW_RESTART_SPAWN_TIMEOUT_MS` (1s–60s).

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS / Linux (supervised restart paths)
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Trigger a supervised gateway restart while the machine is under load.
2. Observe `spawnSync("launchctl"|"systemctl", ...)` behavior and error detail on timeout.
3. (Optional) Set `OPENCLAW_RESTART_SPAWN_TIMEOUT_MS=1000` and confirm it clamps to ≥1s.

### Expected

- Default restart supervisor command timeout is 15s (not 2s).
- On timeout, detail reports `... timed out after <ms>ms`.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Env parsing + clamping for `OPENCLAW_RESTART_SPAWN_TIMEOUT_MS`
  - `ETIMEDOUT` paths produce the intended detail message
- Edge cases checked:
  - Missing/invalid env values fall back to default
- What you did **not** verify:
  - Real-world supervised restarts across a wide range of macOS versions / launchd states

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Unset `OPENCLAW_RESTART_SPAWN_TIMEOUT_MS` (if set) and/or revert this PR.
- Known bad symptoms reviewers should watch for:
  - Supervisor restarts appear to “hang” longer than expected (timeout too large)

## Risks and Mitigations

- Risk: Increasing the timeout could make a genuinely stuck `launchctl`/`systemctl` invocation take longer to fail.
  - Mitigation: Timeout is still bounded (default 15s; env override clamped to 60s) and operators can tune down if needed.
