### PR TITLE
feat(chrome-extension): auto-attach all tabs without manual toolbar click

### DIFF
--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -545,15 +545,16 @@ async function autoAttachTab(tabId) {
 }
 
 // Auto-attach all currently open tabs that aren't already attached.
-// Called on startup and after relay reconnects.
+// Called on startup and after relay reconnects. Parallelized with
+// Promise.allSettled so startup waits for the slowest tab, not all tabs sequentially.
 async function autoAttachAllTabs() {
   if (!(await getAutoAttach())) return
   const allTabs = await chrome.tabs.query({})
-  for (const tab of allTabs) {
-    if (tab.id && !tabs.has(tab.id) && isAutoAttachableUrl(tab.url)) {
-      await autoAttachTab(tab.id)
-    }
-  }
+  await Promise.allSettled(
+    allTabs
+      .filter(tab => tab.id && !tabs.has(tab.id) && isAutoAttachableUrl(tab.url))
+      .map(tab => autoAttachTab(tab.id))
+  )
 }
 
 async function connectOrToggleForActiveTab() {

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -60,6 +60,24 @@ async function getGatewayToken() {
   return token || ''
 }
 
+// Whether auto-attach is enabled. Defaults to true so the extension
+// attaches every eligible tab without a manual toolbar click.
+async function getAutoAttach() {
+  const stored = await chrome.storage.local.get(['autoAttach'])
+  return stored.autoAttach !== false
+}
+
+// Chrome-internal URLs that chrome.debugger cannot attach to.
+function isAutoAttachableUrl(url) {
+  if (!url) return false
+  if (url === 'about:blank') return false
+  if (url.startsWith('chrome://')) return false
+  if (url.startsWith('chrome-extension://')) return false
+  if (url.startsWith('chrome-error://')) return false
+  if (url.startsWith('devtools://')) return false
+  return true
+}
+
 function setBadge(tabId, kind) {
   const cfg = BADGE[kind]
   void chrome.action.setBadgeText({ tabId, text: cfg.text })
@@ -227,6 +245,7 @@ function scheduleReconnect() {
       reconnectAttempt = 0
       console.log('Reconnected successfully')
       await reannounceAttachedTabs()
+      await autoAttachAllTabs()
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       console.warn(`Reconnect attempt ${reconnectAttempt} failed: ${message}`)
@@ -487,6 +506,42 @@ async function detachTab(tabId, reason) {
   })
 
   await persistState()
+}
+
+// Auto-attach a single tab if eligible. Fails silently — auto-attach
+// should never show error badges or disrupt the user.
+async function autoAttachTab(tabId) {
+  if (!(await getAutoAttach())) return
+  if (tabs.has(tabId)) return
+  if (tabOperationLocks.has(tabId)) return
+  if (reattachPending.has(tabId)) return
+
+  tabOperationLocks.add(tabId)
+  try {
+    const tabInfo = await chrome.tabs.get(tabId).catch(() => null)
+    if (!tabInfo || !isAutoAttachableUrl(tabInfo.url)) return
+
+    await ensureRelayConnection()
+    await attachTab(tabId)
+    console.log(`Auto-attached tab ${tabId}: ${tabInfo.url}`)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    console.log(`Auto-attach tab ${tabId} skipped: ${message}`)
+  } finally {
+    tabOperationLocks.delete(tabId)
+  }
+}
+
+// Auto-attach all currently open tabs that aren't already attached.
+// Called on startup and after relay reconnects.
+async function autoAttachAllTabs() {
+  if (!(await getAutoAttach())) return
+  const allTabs = await chrome.tabs.query({})
+  for (const tab of allTabs) {
+    if (tab.id && !tabs.has(tab.id) && isAutoAttachableUrl(tab.url)) {
+      await autoAttachTab(tab.id)
+    }
+  }
 }
 
 async function connectOrToggleForActiveTab() {
@@ -798,13 +853,16 @@ chrome.debugger.onDetach.addListener((...args) => void whenReady(() => onDebugge
 
 chrome.action.onClicked.addListener(() => void whenReady(() => connectOrToggleForActiveTab()))
 
-// Refresh badge after navigation completes — service worker may have restarted
-// during navigation, losing ephemeral badge state.
-chrome.webNavigation.onCompleted.addListener(({ tabId, frameId }) => void whenReady(() => {
+// Refresh badge after navigation completes, and auto-attach newly loaded tabs
+// that aren't already connected. Service worker may have restarted during
+// navigation, losing ephemeral badge state.
+chrome.webNavigation.onCompleted.addListener(({ tabId, frameId, url }) => void whenReady(async () => {
   if (frameId !== 0) return
   const tab = tabs.get(tabId)
   if (tab?.state === 'connected') {
     setBadge(tabId, relayWs && relayWs.readyState === WebSocket.OPEN ? 'on' : 'connecting')
+  } else if (isAutoAttachableUrl(url)) {
+    await autoAttachTab(tabId)
   }
 }))
 
@@ -828,7 +886,9 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (alarm.name !== 'relay-keepalive') return
   await initPromise
 
-  if (tabs.size === 0) return
+  const autoAttach = await getAutoAttach()
+  // Skip keepalive when nothing to do: no attached tabs and auto-attach disabled.
+  if (tabs.size === 0 && !autoAttach) return
 
   // Refresh badges (ephemeral in MV3).
   for (const [tabId, tab] of tabs.entries()) {
@@ -854,14 +914,17 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
 })
 
 // Rehydrate state on service worker startup. Split: rehydration is the gate
-// (fast), relay reconnect runs in background (slow, non-blocking).
+// (fast), relay reconnect and auto-attach run in background (slow, non-blocking).
 const initPromise = rehydrateState()
 
-initPromise.then(() => {
-  if (tabs.size > 0) {
-    ensureRelayConnection().then(() => {
+initPromise.then(async () => {
+  const autoAttach = await getAutoAttach()
+  // Connect to relay if there are persisted tabs to reannounce or auto-attach is on.
+  if (tabs.size > 0 || autoAttach) {
+    ensureRelayConnection().then(async () => {
       reconnectAttempt = 0
-      return reannounceAttachedTabs()
+      await reannounceAttachedTabs()
+      if (autoAttach) await autoAttachAllTabs()
     }).catch(() => {
       scheduleReconnect()
     })

--- a/assets/chrome-extension/background.js
+++ b/assets/chrome-extension/background.js
@@ -34,6 +34,12 @@ const tabOperationLocks = new Set()
 /** @type {Set<number>} */
 const reattachPending = new Set()
 
+// Tabs the user explicitly detached via toolbar click. Auto-attach
+// will not re-attach these until the user manually re-attaches or
+// the tab is closed. Persisted in chrome.storage.session.
+/** @type {Set<number>} */
+const userDetachedTabs = new Set()
+
 // Reconnect state for exponential backoff.
 let reconnectAttempt = 0
 let reconnectTimer = null
@@ -70,7 +76,7 @@ async function getAutoAttach() {
 // Chrome-internal URLs that chrome.debugger cannot attach to.
 function isAutoAttachableUrl(url) {
   if (!url) return false
-  if (url === 'about:blank') return false
+  if (url.startsWith('about:')) return false
   if (url.startsWith('chrome://')) return false
   if (url.startsWith('chrome-extension://')) return false
   if (url.startsWith('chrome-error://')) return false
@@ -97,6 +103,7 @@ async function persistState() {
     await chrome.storage.session.set({
       persistedTabs: tabEntries,
       nextSession,
+      userDetached: [...userDetachedTabs],
     })
   } catch {
     // chrome.storage.session may not be available in all contexts.
@@ -107,9 +114,13 @@ async function persistState() {
 // maps and badges. Relay reconnect happens separately in background.
 async function rehydrateState() {
   try {
-    const stored = await chrome.storage.session.get(['persistedTabs', 'nextSession'])
+    const stored = await chrome.storage.session.get(['persistedTabs', 'nextSession', 'userDetached'])
     if (stored.nextSession) {
       nextSession = Math.max(nextSession, stored.nextSession)
+    }
+    // Restore tabs the user explicitly detached so auto-attach respects their intent.
+    for (const id of (stored.userDetached || [])) {
+      userDetachedTabs.add(id)
     }
     const entries = stored.persistedTabs || []
     // Phase 1: optimistically restore state and badges.
@@ -515,6 +526,7 @@ async function autoAttachTab(tabId) {
   if (tabs.has(tabId)) return
   if (tabOperationLocks.has(tabId)) return
   if (reattachPending.has(tabId)) return
+  if (userDetachedTabs.has(tabId)) return
 
   tabOperationLocks.add(tabId)
   try {
@@ -556,19 +568,25 @@ async function connectOrToggleForActiveTab() {
   try {
     if (reattachPending.has(tabId)) {
       reattachPending.delete(tabId)
+      userDetachedTabs.add(tabId)
       setBadge(tabId, 'off')
       void chrome.action.setTitle({
         tabId,
         title: 'OpenClaw Browser Relay (click to attach/detach)',
       })
+      void persistState()
       return
     }
 
     const existing = tabs.get(tabId)
     if (existing?.state === 'connected') {
+      userDetachedTabs.add(tabId)
       await detachTab(tabId, 'toggle')
       return
     }
+
+    // User is manually re-attaching — clear any previous detach exclusion.
+    userDetachedTabs.delete(tabId)
 
     // User is manually connecting — cancel any pending reconnect.
     cancelReconnect()
@@ -709,7 +727,9 @@ async function onDebuggerDetach(source, reason) {
   if (!tabs.has(tabId)) return
 
   // User explicitly cancelled or DevTools replaced the connection — respect their intent
+  // and prevent auto-attach from overriding it.
   if (reason === 'canceled_by_user' || reason === 'replaced_with_devtools') {
+    userDetachedTabs.add(tabId)
     void detachTab(tabId, reason)
     return
   }
@@ -806,6 +826,7 @@ async function onDebuggerDetach(source, reason) {
 // Tab lifecycle listeners — clean up stale entries.
 chrome.tabs.onRemoved.addListener((tabId) => void whenReady(() => {
   reattachPending.delete(tabId)
+  userDetachedTabs.delete(tabId)
   if (!tabs.has(tabId)) return
   const tab = tabs.get(tabId)
   if (tab?.sessionId) tabBySession.delete(tab.sessionId)
@@ -901,7 +922,10 @@ chrome.alarms.onAlarm.addListener(async (alarm) => {
   if (!relayWs || relayWs.readyState !== WebSocket.OPEN) {
     if (!relayConnectPromise && !reconnectTimer) {
       console.log('Keepalive: WebSocket unhealthy, triggering reconnect')
-      await ensureRelayConnection().catch(() => {
+      await ensureRelayConnection().then(async () => {
+        await reannounceAttachedTabs()
+        await autoAttachAllTabs()
+      }).catch(() => {
         // ensureRelayConnection may throw without triggering onRelayClosed
         // (e.g. preflight fetch fails before WS is created), so ensure
         // reconnect is always scheduled on failure.

--- a/assets/chrome-extension/options.html
+++ b/assets/chrome-extension/options.html
@@ -176,6 +176,21 @@
         </div>
 
         <div class="card">
+          <h2>Auto-attach</h2>
+          <div class="row">
+            <label class="toggle-label" style="display:flex;align-items:center;gap:8px;font-size:14px;color:canvasText;margin:0;cursor:pointer">
+              <input type="checkbox" id="autoAttach" style="width:auto;accent-color:var(--accent)" />
+              Automatically attach to all tabs
+            </label>
+          </div>
+          <p>
+            When enabled, the extension automatically attaches to every browser tab without
+            requiring a manual click on each one. New tabs are attached as they load.
+            You can still click the toolbar icon to detach individual tabs.
+          </p>
+        </div>
+
+        <div class="card">
           <h2>Relay connection</h2>
           <label for="port">Port</label>
           <div class="row">

--- a/assets/chrome-extension/options.js
+++ b/assets/chrome-extension/options.js
@@ -49,11 +49,13 @@ async function checkRelayReachable(port, token) {
 }
 
 async function load() {
-  const stored = await chrome.storage.local.get(['relayPort', 'gatewayToken'])
+  const stored = await chrome.storage.local.get(['relayPort', 'gatewayToken', 'autoAttach'])
   const port = clampPort(stored.relayPort)
   const token = String(stored.gatewayToken || '').trim()
   document.getElementById('port').value = String(port)
   document.getElementById('token').value = token
+  // Auto-attach defaults to true when no value is stored.
+  document.getElementById('autoAttach').checked = stored.autoAttach !== false
   updateRelayUrl(port)
   await checkRelayReachable(port, token)
 }
@@ -71,4 +73,11 @@ async function save() {
 }
 
 document.getElementById('save').addEventListener('click', () => void save())
+
+// Persist auto-attach toggle immediately on change — no save button needed.
+document.getElementById('autoAttach').addEventListener('change', async () => {
+  const checked = document.getElementById('autoAttach').checked
+  await chrome.storage.local.set({ autoAttach: checked })
+})
+
 void load()


### PR DESCRIPTION
## Summary

- Adds **auto-attach mode** to the Browser Relay Chrome extension so all eligible browser tabs are automatically attached to the relay on load — no manual toolbar click required
- Hooks into startup, relay reconnect, and `webNavigation.onCompleted` to catch all tab lifecycle events
- Adds a toggle in the extension options page (defaults to **on**); toolbar icon still works as a manual detach toggle
- Filters out non-attachable URLs (`chrome://`, `chrome-extension://`, `devtools://`, `about:blank`)
- Auto-attach failures are silent (logged to console, no error badges shown to user)

## Motivation

Agents using the Browser Relay need the extension activated before they can automate tabs. Currently this requires the user to manually click the toolbar icon on each tab, creating a human dependency that breaks autonomous agent workflows. With auto-attach, the relay is ready as soon as Chrome starts.

Closes #34557

## Test plan

- [ ] Load extension with auto-attach **on** (default) — verify all open tabs get `ON` badge and relay receives `Target.attachedToTarget` events
- [ ] Open a new tab and navigate — verify it auto-attaches on `onCompleted`
- [ ] Click toolbar icon on an auto-attached tab — verify it detaches (manual toggle still works)
- [ ] Turn auto-attach **off** in options — verify new tabs are NOT auto-attached
- [ ] Kill relay server, restart it — verify tabs re-attach automatically after reconnect
- [ ] Verify `chrome://`, `chrome-extension://`, `devtools://`, `about:blank` tabs are skipped
- [ ] Verify no error badges appear when relay is down and auto-attach fails silently


Made with [Cursor](https://cursor.com)