### PR TITLE
fix(audit): include Gemini/Grok/Kimi in web search key audit

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -329,7 +329,17 @@ function resolveToolPolicies(params: {
 function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
   return Boolean(
-    search?.apiKey || search?.perplexity?.apiKey || env.BRAVE_API_KEY || env.PERPLEXITY_API_KEY,
+    search?.apiKey ||
+    search?.perplexity?.apiKey ||
+    search?.gemini?.apiKey ||
+    search?.grok?.apiKey ||
+    search?.kimi?.apiKey ||
+    env.BRAVE_API_KEY ||
+    env.PERPLEXITY_API_KEY ||
+    env.GEMINI_API_KEY ||
+    env.XAI_API_KEY ||
+    env.KIMI_API_KEY ||
+    env.MOONSHOT_API_KEY,
   );
 }
 

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -328,6 +328,26 @@ function resolveToolPolicies(params: {
 
 function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
+  const provider = search?.provider?.trim().toLowerCase();
+
+  // If a provider is explicitly configured, only check for that provider's keys
+  if (provider === "brave") {
+    return Boolean(search?.apiKey || env.BRAVE_API_KEY);
+  }
+  if (provider === "perplexity") {
+    return Boolean(search?.perplexity?.apiKey || env.PERPLEXITY_API_KEY);
+  }
+  if (provider === "gemini") {
+    return Boolean(search?.gemini?.apiKey || env.GEMINI_API_KEY);
+  }
+  if (provider === "grok") {
+    return Boolean(search?.grok?.apiKey || env.XAI_API_KEY);
+  }
+  if (provider === "kimi") {
+    return Boolean(search?.kimi?.apiKey || env.KIMI_API_KEY || env.MOONSHOT_API_KEY);
+  }
+
+  // No provider configured - check all providers (auto-detection)
   return Boolean(
     search?.apiKey ||
     search?.perplexity?.apiKey ||


### PR DESCRIPTION
## Summary

Fixes the security audit to properly detect web search keys for Gemini, Grok, and Kimi providers.

The `hasWebSearchKey` function in `src/security/audit-extra.sync.ts` was only checking for Brave and Perplexity API keys, causing false negatives when users configured web search using Gemini, Grok, or Kimi providers.

## Changes

Added checks for:
- `search?.gemini?.apiKey` + `GEMINI_API_KEY` env var
- `search?.grok?.apiKey` + `XAI_API_KEY` env var
- `search?.kimi?.apiKey` + `KIMI_API_KEY` / `MOONSHOT_API_KEY` env vars

## Test plan

- [x] TypeScript compilation passes
- [x] Existing audit tests pass
- [ ] Verify the fix works with a config using only Gemini/Grok/Kimi keys

Fixes #34509

🤖 Generated with [Claude Code](https://claude.com/claude-code)