### PR TITLE
fix(feishu): strip reaction suffix from message_id before API calls

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -44,6 +44,7 @@ import { createFeishuClient } from "./client.js";
 import { finalizeFeishuMessageProcessing, tryRecordMessagePersistent } from "./dedup.js";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
 import { extractMentionTargets, isMentionForwardRequest } from "./mention.js";
+import { stripReactionSuffix } from "./message-id.js";
 import {
   resolveFeishuGroupConfig,
   resolveFeishuReplyPolicy,
@@ -1040,8 +1041,11 @@ export async function handleFeishuMessage(params: {
     const configReplyInThread =
       isGroup &&
       (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
-    const replyTargetMessageId =
+    const rawReplyTargetMessageId =
       isTopicSession || configReplyInThread ? (ctx.rootId ?? ctx.messageId) : ctx.messageId;
+    // Strip synthetic :reaction:<emoji>:<uuid> suffix that resolveReactionSyntheticEvent
+    // appends for internal dedup — Feishu API endpoints expect raw message IDs (#34528).
+    const replyTargetMessageId = stripReactionSuffix(rawReplyTargetMessageId);
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
 
     if (broadcastAgents) {

--- a/extensions/feishu/src/message-id.test.ts
+++ b/extensions/feishu/src/message-id.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { stripReactionSuffix } from "./message-id.js";
+
+describe("stripReactionSuffix", () => {
+  it("strips :reaction:<emoji>:<uuid> suffix", () => {
+    const raw = "om_abc123";
+    const suffixed = `${raw}:reaction:THUMBSUP:a1b2c3d4-e5f6-7890-abcd-ef1234567890`;
+    expect(stripReactionSuffix(suffixed)).toBe(raw);
+  });
+
+  it("returns the original ID when no suffix is present", () => {
+    expect(stripReactionSuffix("om_abc123")).toBe("om_abc123");
+  });
+
+  it("handles emoji names with mixed case and underscores", () => {
+    const raw = "om_xyz";
+    const suffixed = `${raw}:reaction:Heart_Eyes:deadbeef-1234-5678-9abc-def012345678`;
+    expect(stripReactionSuffix(suffixed)).toBe(raw);
+  });
+
+  it("does not strip partial or malformed suffixes", () => {
+    // Missing UUID
+    expect(stripReactionSuffix("om_abc:reaction:THUMBSUP")).toBe("om_abc:reaction:THUMBSUP");
+    // Incomplete UUID
+    expect(stripReactionSuffix("om_abc:reaction:THUMBSUP:not-a-uuid")).toBe(
+      "om_abc:reaction:THUMBSUP:not-a-uuid",
+    );
+  });
+});

--- a/extensions/feishu/src/message-id.ts
+++ b/extensions/feishu/src/message-id.ts
@@ -1,0 +1,20 @@
+/**
+ * Regex matching the synthetic `:reaction:<emoji>:<uuid>` suffix appended by
+ * {@link resolveReactionSyntheticEvent} in `monitor.account.ts`.
+ *
+ * These suffixed IDs are necessary for internal dedup and session tracking, but
+ * must be stripped before passing the message_id to Feishu API endpoints which
+ * expect a raw Feishu message ID.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/34528
+ */
+const REACTION_SUFFIX_RE =
+  /:reaction:[^:]+:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+/**
+ * Strip the synthetic `:reaction:<emoji>:<uuid>` suffix from a Feishu message
+ * ID. Returns the ID unchanged when no suffix is present.
+ */
+export function stripReactionSuffix(messageId: string): string {
+  return messageId.replace(REACTION_SUFFIX_RE, "");
+}


### PR DESCRIPTION
## Summary

- Problem: When a user reacts to a message in Feishu, `resolveReactionSyntheticEvent()` generates a synthetic message ID with a `:reaction:<emoji>:<uuid>` suffix (e.g. `om_abc123:reaction:THUMBSUP:a1b2c3d4-...`). This suffixed ID flows through `bot.ts` → `reply-dispatcher.ts` → Feishu API call sites (`send.ts`, `typing.ts`, etc.), causing 400 errors from the Feishu API which expects a raw Feishu message ID.
- Why it matters: Any reply or typing indicator triggered by a reaction event fails with a 400 error, making reaction-based bot responses completely broken.
- What changed: Added `stripReactionSuffix()` utility in `extensions/feishu/src/message-id.ts` that removes the synthetic `:reaction:<emoji>:<uuid>` suffix from message IDs. Applied it at the single entry point in `bot.ts` where `replyTargetMessageId` is computed before entering the reply flow.
- What did NOT change (scope boundary): The synthetic suffixed ID is still used for internal dedup (`tryRecordMessage`) and session tracking (`MessageSid`), which is correct behavior — only the API-facing `replyTargetMessageId` is cleaned.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Extension / plugin

## Linked Issue/PR

- Closes #34528

## User-visible / Behavior Changes

- Feishu reaction events now correctly trigger bot replies and typing indicators instead of failing with 400 errors.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment
- OS: macOS
- Runtime: Node 22+

### Steps
1. Configure a Feishu bot with reaction notifications enabled (`reactionNotifications: "own"`)
2. Send a message from the bot in a Feishu chat
3. React to the bot's message with any emoji (e.g. THUMBSUP)

### Expected
Bot processes the reaction and can reply/add typing indicator to the original message.

### Actual (before fix)
Feishu API returns 400 error because the message_id contains the synthetic `:reaction:THUMBSUP:<uuid>` suffix, which is not a valid Feishu message ID.

## Evidence

- [x] Failing test/log before + passing after

New test file `extensions/feishu/src/message-id.test.ts` (4 tests):
```
 ✓ extensions/feishu/src/message-id.test.ts (4 tests) 1ms
   ✓ strips :reaction:<emoji>:<uuid> suffix
   ✓ returns the original ID when no suffix is present
   ✓ handles emoji names with mixed case and underscores
   ✓ does not strip partial or malformed suffixes
```

Full suite: 811 test files passed, 6580 tests passed. The single failure (`ui.presenter-next-run.test.ts`) is a pre-existing locale-dependent issue unrelated to this change.

## Human Verification (required)

- Verified scenarios: Local test suite passes (`pnpm build && pnpm check && pnpm test`)
- Edge cases checked: No suffix (passthrough), mixed-case emoji names, malformed/partial suffixes (not stripped), standard UUID format
- What you did **not** verify: Live/integration testing with real Feishu credentials and reaction events

> **Note:** This PR was created with AI assistance (Claude Code). The code changes have been reviewed and understood.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: `git revert <commit-hash>`
- Known bad symptoms: If the regex were too aggressive, it could strip legitimate parts of a Feishu message ID — but the regex is anchored to the specific `:reaction:<emoji>:<uuid>` suffix pattern and only matches at the end of the string.

## Risks and Mitigations

- Risk: Regex could fail to match future suffix format changes — mitigated by the specific UUID pattern match and the fact that `monitor.account.ts` is the only producer of this suffix.