### PR TITLE
feat(compaction): add fallbackModel to retry compaction on quota/rate-limit errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Agents/Compaction: add `agents.defaults.compaction.fallbackModel` to retry compaction with a different model on quota or rate-limit errors. Set to `"fallback"` to use the `agents.defaults.model.fallbacks` chain. Defaults to `"off"` (no fallback). Auth errors and timeouts use their own retry mechanisms and are not affected.
 - Discord/allowBots mention gating: add `allowBots: "mentions"` to only accept bot-authored messages that mention the bot. Thanks @thewilloftheshadow.
 - Docs/Web search: remove outdated Brave free-tier wording and replace prescriptive AI ToS guidance with neutral compliance language in Brave setup docs. (#26860) Thanks @HenryLoenwind.
 - Tools/Web search: switch Perplexity provider to Search API with structured results plus new language/region/time filters. (#33822) Thanks @kesku.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -993,6 +993,8 @@ Periodic heartbeat runs.
     defaults: {
       compaction: {
         mode: "safeguard", // default | safeguard
+        thinking: "off", // off | on — defaults to "off"; "on" inherits the session model's current thinking level
+        fallbackModel: "fallback", // "off" (default) | "fallback" (use model.fallbacks chain)
         reserveTokensFloor: 24000,
         identifierPolicy: "strict", // strict | off | custom
         identifierInstructions: "Preserve deployment IDs, ticket IDs, and host:port pairs exactly.", // used when identifierPolicy=custom
@@ -1012,6 +1014,8 @@ Periodic heartbeat runs.
 - `identifierPolicy`: `strict` (default), `off`, or `custom`. `strict` prepends built-in opaque identifier retention guidance during compaction summarization.
 - `identifierInstructions`: optional custom identifier-preservation text used when `identifierPolicy=custom`.
 - `memoryFlush`: silent agentic turn before auto-compaction to store durable memories. Skipped when workspace is read-only.
+- `thinking`: thinking override for compaction summarization. Defaults to `"off"` — compaction always runs without extended thinking regardless of the session model, preventing timeout races on channels with strict reply windows (Discord 30s, Telegram 240s). Set to `"on"` to inherit the session model's current thinking level. When a compaction run times out with thinking enabled, it automatically retries once without thinking.
+- `fallbackModel`: fallback model when compaction fails due to quota or rate-limit errors. `"off"` (default) disables fallback. `"fallback"` uses the `agents.defaults.model.fallbacks` chain in order. Auth errors and timeouts are not retried via this mechanism.
 
 ### `agents.defaults.contextPruning`
 

--- a/docs/images/pr-33396-after.svg
+++ b/docs/images/pr-33396-after.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="480" height="214" viewBox="0 0 480 214">
+  <defs>
+    <style>text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }</style>
+  </defs>
+  <!-- Card -->
+  <rect x="1" y="1" width="478" height="212" rx="6" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <!-- Section label -->
+  <text x="16" y="24" font-size="11" font-weight="600" fill="#8c959f" letter-spacing="0.5">COMPACTION</text>
+  <!-- Mode field -->
+  <text x="16" y="50" font-size="13" font-weight="600" fill="#24292f">Compaction Mode</text>
+  <rect x="16" y="58" width="88" height="28" rx="5" fill="#0969da" stroke="#0969da"/>
+  <text x="60" y="77" font-size="12" font-weight="600" fill="#ffffff" text-anchor="middle">default</text>
+  <rect x="104" y="58" width="96" height="28" rx="5" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="152" y="77" font-size="12" fill="#57606a" text-anchor="middle">safeguard</text>
+  <!-- Divider -->
+  <line x1="16" y1="98" x2="464" y2="98" stroke="#d0d7de" stroke-width="1"/>
+  <!-- NEW: Fallback Model field (highlighted) -->
+  <rect x="8" y="104" width="464" height="66" rx="4" fill="#ddf4ff" stroke="#54aeff" stroke-width="1" stroke-dasharray="4,2"/>
+  <text x="16" y="122" font-size="13" font-weight="600" fill="#24292f">Compaction Fallback Model</text>
+  <text x="16" y="137" font-size="11" fill="#57606a">"off" surfaces the error. "fallback" retries using the model.fallbacks chain, skipping the current model.</text>
+  <rect x="16" y="143" width="48" height="16" rx="3" fill="#0969da"/>
+  <text x="40" y="155" font-size="11" font-weight="600" fill="#ffffff" text-anchor="middle">off</text>
+  <rect x="64" y="143" width="64" height="16" rx="3" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="96" y="155" font-size="11" fill="#57606a" text-anchor="middle">fallback</text>
+  <text x="140" y="155" font-size="10" fill="#0969da" font-weight="600">← NEW</text>
+  <!-- Divider -->
+  <line x1="16" y1="178" x2="464" y2="178" stroke="#d0d7de" stroke-width="1"/>
+  <!-- Reserve Tokens field -->
+  <text x="16" y="200" font-size="13" font-weight="600" fill="#24292f">Compaction Reserve Tokens</text>
+</svg>

--- a/docs/images/pr-33396-before.svg
+++ b/docs/images/pr-33396-before.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="480" height="168" viewBox="0 0 480 168">
+  <defs>
+    <style>text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; }</style>
+  </defs>
+  <!-- Card -->
+  <rect x="1" y="1" width="478" height="166" rx="6" fill="#ffffff" stroke="#d0d7de" stroke-width="1"/>
+  <!-- Section label -->
+  <text x="16" y="24" font-size="11" font-weight="600" fill="#8c959f" letter-spacing="0.5">COMPACTION</text>
+  <!-- Mode field -->
+  <text x="16" y="50" font-size="13" font-weight="600" fill="#24292f">Compaction Mode</text>
+  <rect x="16" y="58" width="88" height="28" rx="5" fill="#0969da" stroke="#0969da"/>
+  <text x="60" y="77" font-size="12" font-weight="600" fill="#ffffff" text-anchor="middle">default</text>
+  <rect x="104" y="58" width="96" height="28" rx="5" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="152" y="77" font-size="12" fill="#57606a" text-anchor="middle">safeguard</text>
+  <!-- Divider -->
+  <line x1="16" y1="98" x2="464" y2="98" stroke="#d0d7de" stroke-width="1"/>
+  <!-- Reserve Tokens field -->
+  <text x="16" y="120" font-size="13" font-weight="600" fill="#24292f">Compaction Reserve Tokens</text>
+  <rect x="16" y="128" width="120" height="28" rx="5" fill="#f6f8fa" stroke="#d0d7de"/>
+  <text x="28" y="147" font-size="12" fill="#57606a">24000</text>
+  <!-- No fallback field annotation -->
+  <text x="16" y="160" font-size="11" fill="#8c959f" font-style="italic">← no Compaction Fallback Model field (upstream main)</text>
+</svg>

--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -31,6 +31,7 @@ import { listChannelSupportedActions, resolveChannelMessageToolHints } from "../
 import { formatUserTime, resolveUserTimeFormat, resolveUserTimezone } from "../date-time.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
 import { resolveOpenClawDocsPath } from "../docs-path.js";
+import { isTimeoutError, resolveFailoverReasonFromError } from "../failover-error.js";
 import { getApiKeyForModel, resolveModelAuthMode } from "../model-auth.js";
 import { ensureOpenClawModelsJson } from "../models-config.js";
 import { resolveOwnerDisplaySetting } from "../owner-display.js";
@@ -57,6 +58,11 @@ import {
   type SkillSnapshot,
 } from "../skills.js";
 import { resolveTranscriptPolicy } from "../transcript-policy.js";
+import {
+  type CompactionModelCandidate,
+  resolveCompactionFallbackCandidates,
+} from "./compaction-fallback.js";
+import { resolveCompactionThinkLevel } from "./compaction-overrides.js";
 import {
   compactWithSafetyTimeout,
   EMBEDDED_COMPACTION_TIMEOUT_MS,
@@ -283,6 +289,19 @@ export async function compactEmbeddedPiSessionDirect(
     const reason = error ?? `Unknown model: ${provider}/${modelId}`;
     return fail(reason);
   }
+  // Fallback candidates for quota/rate-limit retries. Primary is always first.
+  const allCandidates: CompactionModelCandidate[] = [
+    { provider, model: modelId },
+    ...resolveCompactionFallbackCandidates({
+      cfg: params.config,
+      currentProvider: provider,
+      currentModel: modelId,
+    }),
+  ];
+  // Mutable model state — updated when falling back to a different candidate.
+  let currentModel = model;
+  let currentAuthStorage = authStorage;
+  let currentModelRegistry = modelRegistry;
   try {
     const apiKeyInfo = await getApiKeyForModel({
       model,
@@ -545,195 +564,304 @@ export async function compactEmbeddedPiSessionDirect(
         agentDir,
         cfg: params.config,
       });
-      // Sets compaction/pruning runtime state and returns extension factories
-      // that must be passed to the resource loader for the safeguard to be active.
-      const extensionFactories = buildEmbeddedExtensionFactories({
-        cfg: params.config,
-        sessionManager,
-        provider,
-        modelId,
-        model,
-      });
-      // Only create an explicit resource loader when there are extension factories
-      // to register; otherwise let createAgentSession use its built-in default.
-      let resourceLoader: DefaultResourceLoader | undefined;
-      if (extensionFactories.length > 0) {
-        resourceLoader = new DefaultResourceLoader({
-          cwd: resolvedWorkspace,
-          agentDir,
-          settingsManager,
-          extensionFactories,
-        });
-        await resourceLoader.reload();
-      }
-
       const { builtInTools, customTools } = splitSdkTools({
         tools,
         sandboxEnabled: !!sandbox?.enabled,
       });
 
-      const { session } = await createAgentSession({
-        cwd: resolvedWorkspace,
-        agentDir,
-        authStorage,
-        modelRegistry,
-        model,
-        thinkingLevel: mapThinkingLevel(params.thinkLevel),
-        tools: builtInTools,
-        customTools,
-        sessionManager,
-        settingsManager,
-        resourceLoader,
-      });
-      applySystemPromptOverrideToSession(session, systemPromptOverride());
+      // before_compaction hook fires exactly once per compaction event regardless of retries.
+      let hookFired = false;
+      // Last quota/rate-limit error — rethrown if all candidates are exhausted.
+      let lastQuotaErr: unknown;
 
-      try {
-        const prior = await sanitizeSessionHistory({
-          messages: session.messages,
-          modelApi: model.api,
-          modelId,
-          provider,
-          allowedToolNames,
-          config: params.config,
-          sessionManager,
-          sessionId: params.sessionId,
-          policy: transcriptPolicy,
-        });
-        const validatedGemini = transcriptPolicy.validateGeminiTurns
-          ? validateGeminiTurns(prior)
-          : prior;
-        const validated = transcriptPolicy.validateAnthropicTurns
-          ? validateAnthropicTurns(validatedGemini)
-          : validatedGemini;
-        // Capture full message history BEFORE limiting — plugins need the complete conversation
-        const preCompactionMessages = [...session.messages];
-        const truncated = limitHistoryTurns(
-          validated,
-          getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
-        );
-        // Re-run tool_use/tool_result pairing repair after truncation, since
-        // limitHistoryTurns can orphan tool_result blocks by removing the
-        // assistant message that contained the matching tool_use.
-        const limited = transcriptPolicy.repairToolUseResultPairing
-          ? sanitizeToolUseResultPairing(truncated)
-          : truncated;
-        if (limited.length > 0) {
-          session.agent.replaceMessages(limited);
-        }
-        // Run before_compaction hooks (fire-and-forget).
-        // The session JSONL already contains all messages on disk, so plugins
-        // can read sessionFile asynchronously and process in parallel with
-        // the compaction LLM call — no need to block or wait for after_compaction.
-        const hookRunner = getGlobalHookRunner();
-        const hookCtx = {
-          agentId: params.sessionKey?.split(":")[0] ?? "main",
-          sessionKey: params.sessionKey,
-          sessionId: params.sessionId,
-          workspaceDir: params.workspaceDir,
-          messageProvider: params.messageChannel ?? params.messageProvider,
-        };
-        if (hookRunner?.hasHooks("before_compaction")) {
-          hookRunner
-            .runBeforeCompaction(
-              {
-                messageCount: preCompactionMessages.length,
-                compactingCount: limited.length,
-                messages: preCompactionMessages,
-                sessionFile: params.sessionFile,
-              },
-              hookCtx,
-            )
-            .catch((hookErr: unknown) => {
-              log.warn(`before_compaction hook failed: ${String(hookErr)}`);
-            });
-        }
-
-        const diagEnabled = log.isEnabled("debug");
-        const preMetrics = diagEnabled ? summarizeCompactionMessages(session.messages) : undefined;
-        if (diagEnabled && preMetrics) {
-          log.debug(
-            `[compaction-diag] start runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
-              `diagId=${diagId} trigger=${trigger} provider=${provider}/${modelId} ` +
-              `attempt=${attempt} maxAttempts=${maxAttempts} ` +
-              `pre.messages=${preMetrics.messages} pre.historyTextChars=${preMetrics.historyTextChars} ` +
-              `pre.toolResultChars=${preMetrics.toolResultChars} pre.estTokens=${preMetrics.estTokens ?? "unknown"}`,
-          );
-          log.debug(
-            `[compaction-diag] contributors diagId=${diagId} top=${JSON.stringify(preMetrics.contributors)}`,
-          );
-        }
-
-        const compactStartedAt = Date.now();
-        const result = await compactWithSafetyTimeout(() =>
-          session.compact(params.customInstructions),
-        );
-        // Estimate tokens after compaction by summing token estimates for remaining messages
-        let tokensAfter: number | undefined;
-        try {
-          tokensAfter = 0;
-          for (const message of session.messages) {
-            tokensAfter += estimateTokens(message);
+      // Outer loop: model fallback on quota/rate-limit errors.
+      // Inner loop: thinking retry on timeout (at most 2 attempts per candidate).
+      for (let candidateIdx = 0; candidateIdx < allCandidates.length; candidateIdx++) {
+        if (candidateIdx > 0) {
+          // Resolve model + auth for fallback candidate.
+          const cand = allCandidates[candidateIdx];
+          const {
+            model: nextModel,
+            error: nextError,
+            authStorage: nextAuth,
+            modelRegistry: nextRegistry,
+          } = resolveModel(cand.provider, cand.model, agentDir, params.config);
+          if (!nextModel) {
+            log.warn(
+              `[compaction] fallback model ${cand.provider}/${cand.model} not found: ${nextError ?? "unknown"}; skipping`,
+            );
+            continue;
           }
-          // Sanity check: tokensAfter should be less than tokensBefore
-          if (tokensAfter > result.tokensBefore) {
-            tokensAfter = undefined; // Don't trust the estimate
-          }
-        } catch {
-          // If estimation fails, leave tokensAfter undefined
-          tokensAfter = undefined;
-        }
-        // Run after_compaction hooks (fire-and-forget).
-        // Also includes sessionFile for plugins that only need to act after
-        // compaction completes (e.g. analytics, cleanup).
-        if (hookRunner?.hasHooks("after_compaction")) {
-          hookRunner
-            .runAfterCompaction(
-              {
-                messageCount: session.messages.length,
-                tokenCount: tokensAfter,
-                compactedCount: limited.length - session.messages.length,
-                sessionFile: params.sessionFile,
-              },
-              hookCtx,
-            )
-            .catch((hookErr) => {
-              log.warn(`after_compaction hook failed: ${hookErr}`);
+          try {
+            const nextKeyInfo = await getApiKeyForModel({
+              model: nextModel,
+              cfg: params.config,
+              agentDir,
             });
-        }
-
-        const postMetrics = diagEnabled ? summarizeCompactionMessages(session.messages) : undefined;
-        if (diagEnabled && preMetrics && postMetrics) {
-          log.debug(
-            `[compaction-diag] end runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
-              `diagId=${diagId} trigger=${trigger} provider=${provider}/${modelId} ` +
-              `attempt=${attempt} maxAttempts=${maxAttempts} outcome=compacted reason=none ` +
-              `durationMs=${Date.now() - compactStartedAt} retrying=false ` +
-              `post.messages=${postMetrics.messages} post.historyTextChars=${postMetrics.historyTextChars} ` +
-              `post.toolResultChars=${postMetrics.toolResultChars} post.estTokens=${postMetrics.estTokens ?? "unknown"} ` +
-              `delta.messages=${postMetrics.messages - preMetrics.messages} ` +
-              `delta.historyTextChars=${postMetrics.historyTextChars - preMetrics.historyTextChars} ` +
-              `delta.toolResultChars=${postMetrics.toolResultChars - preMetrics.toolResultChars} ` +
-              `delta.estTokens=${typeof preMetrics.estTokens === "number" && typeof postMetrics.estTokens === "number" ? postMetrics.estTokens - preMetrics.estTokens : "unknown"}`,
+            if (!nextKeyInfo.apiKey && nextKeyInfo.mode !== "aws-sdk") {
+              log.warn(
+                `[compaction] no API key for fallback ${cand.provider}/${cand.model}; skipping`,
+              );
+              continue;
+            }
+            if (nextKeyInfo.apiKey) {
+              nextAuth.setRuntimeApiKey(cand.provider, nextKeyInfo.apiKey);
+            }
+          } catch {
+            log.warn(
+              `[compaction] auth failed for fallback ${cand.provider}/${cand.model}; skipping`,
+            );
+            continue;
+          }
+          currentModel = nextModel;
+          currentAuthStorage = nextAuth;
+          currentModelRegistry = nextRegistry;
+          log.warn(
+            `[compaction] quota/rate-limit on ${allCandidates[candidateIdx - 1].provider}/${allCandidates[candidateIdx - 1].model}; retrying with ${cand.provider}/${cand.model}`,
           );
         }
-        return {
-          ok: true,
-          compacted: true,
-          result: {
-            summary: result.summary,
-            firstKeptEntryId: result.firstKeptEntryId,
-            tokensBefore: result.tokensBefore,
-            tokensAfter,
-            details: result.details,
-          },
-        };
-      } finally {
-        await flushPendingToolResultsAfterIdle({
-          agent: session?.agent,
-          sessionManager,
+
+        // Sets compaction/pruning runtime state and returns extension factories
+        // that must be passed to the resource loader for the safeguard to be active.
+        const cand = allCandidates[candidateIdx];
+        // Re-resolve transcript policy per candidate so provider-specific flags
+        // (validateGeminiTurns, validateAnthropicTurns, etc.) are correct for
+        // cross-provider fallbacks. Shadows the outer transcriptPolicy used for
+        // sessionManager setup above.
+        const transcriptPolicy = resolveTranscriptPolicy({
+          modelApi: currentModel.api,
+          provider: cand.provider,
+          modelId: cand.model,
         });
-        session.dispose();
+        const extensionFactories = buildEmbeddedExtensionFactories({
+          cfg: params.config,
+          sessionManager,
+          provider: cand.provider,
+          modelId: cand.model,
+          model: currentModel,
+        });
+        // Only create an explicit resource loader when there are extension factories
+        // to register; otherwise let createAgentSession use its built-in default.
+        let resourceLoader: DefaultResourceLoader | undefined;
+        if (extensionFactories.length > 0) {
+          resourceLoader = new DefaultResourceLoader({
+            cwd: resolvedWorkspace,
+            agentDir,
+            settingsManager,
+            extensionFactories,
+          });
+          await resourceLoader.reload();
+        }
+
+        // Thinking retry loop: on timeout with thinking enabled, retry once without thinking.
+        let effectiveThinkLevel = resolveCompactionThinkLevel({
+          cfg: params.config,
+          sessionThinkLevel: params.thinkLevel,
+        });
+        for (let thinkAttempt = 0; thinkAttempt <= 1; thinkAttempt++) {
+          const { session } = await createAgentSession({
+            cwd: resolvedWorkspace,
+            agentDir,
+            authStorage: currentAuthStorage,
+            modelRegistry: currentModelRegistry,
+            model: currentModel,
+            thinkingLevel: mapThinkingLevel(effectiveThinkLevel),
+            tools: builtInTools,
+            customTools,
+            sessionManager,
+            settingsManager,
+            resourceLoader,
+          });
+          applySystemPromptOverrideToSession(session, systemPromptOverride());
+
+          try {
+            const prior = await sanitizeSessionHistory({
+              messages: session.messages,
+              modelApi: currentModel.api,
+              modelId: cand.model,
+              provider: cand.provider,
+              allowedToolNames,
+              config: params.config,
+              sessionManager,
+              sessionId: params.sessionId,
+              policy: transcriptPolicy,
+            });
+            const validatedGemini = transcriptPolicy.validateGeminiTurns
+              ? validateGeminiTurns(prior)
+              : prior;
+            const validated = transcriptPolicy.validateAnthropicTurns
+              ? validateAnthropicTurns(validatedGemini)
+              : validatedGemini;
+            // Capture full message history BEFORE limiting — plugins need the complete conversation
+            const preCompactionMessages = [...session.messages];
+            const truncated = limitHistoryTurns(
+              validated,
+              getDmHistoryLimitFromSessionKey(params.sessionKey, params.config),
+            );
+            // Re-run tool_use/tool_result pairing repair after truncation, since
+            // limitHistoryTurns can orphan tool_result blocks by removing the
+            // assistant message that contained the matching tool_use.
+            const limited = transcriptPolicy.repairToolUseResultPairing
+              ? sanitizeToolUseResultPairing(truncated)
+              : truncated;
+            if (limited.length > 0) {
+              session.agent.replaceMessages(limited);
+            }
+            // Run before_compaction hooks (fire-and-forget).
+            // The session JSONL already contains all messages on disk, so plugins
+            // can read sessionFile asynchronously and process in parallel with
+            // the compaction LLM call — no need to block or wait for after_compaction.
+            const hookRunner = getGlobalHookRunner();
+            const hookCtx = {
+              agentId: params.sessionKey?.split(":")[0] ?? "main",
+              sessionKey: params.sessionKey,
+              sessionId: params.sessionId,
+              workspaceDir: params.workspaceDir,
+              messageProvider: params.messageChannel ?? params.messageProvider,
+            };
+            if (!hookFired && hookRunner?.hasHooks("before_compaction")) {
+              hookFired = true;
+              hookRunner
+                .runBeforeCompaction(
+                  {
+                    messageCount: preCompactionMessages.length,
+                    compactingCount: limited.length,
+                    messages: preCompactionMessages,
+                    sessionFile: params.sessionFile,
+                  },
+                  hookCtx,
+                )
+                .catch((hookErr: unknown) => {
+                  log.warn(`before_compaction hook failed: ${String(hookErr)}`);
+                });
+            }
+
+            const diagEnabled = log.isEnabled("debug");
+            const preMetrics = diagEnabled
+              ? summarizeCompactionMessages(session.messages)
+              : undefined;
+            if (diagEnabled && preMetrics) {
+              log.debug(
+                `[compaction-diag] start runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
+                  `diagId=${diagId} trigger=${trigger} provider=${cand.provider}/${cand.model} ` +
+                  `attempt=${attempt} maxAttempts=${maxAttempts} ` +
+                  `thinking=${effectiveThinkLevel} thinkAttempt=${thinkAttempt} ` +
+                  `pre.messages=${preMetrics.messages} pre.historyTextChars=${preMetrics.historyTextChars} ` +
+                  `pre.toolResultChars=${preMetrics.toolResultChars} pre.estTokens=${preMetrics.estTokens ?? "unknown"}`,
+              );
+              log.debug(
+                `[compaction-diag] contributors diagId=${diagId} top=${JSON.stringify(preMetrics.contributors)}`,
+              );
+            }
+
+            const compactStartedAt = Date.now();
+            const result = await compactWithSafetyTimeout(() =>
+              session.compact(params.customInstructions),
+            );
+            // Estimate tokens after compaction by summing token estimates for remaining messages
+            let tokensAfter: number | undefined;
+            try {
+              tokensAfter = 0;
+              for (const message of session.messages) {
+                tokensAfter += estimateTokens(message);
+              }
+              // Sanity check: tokensAfter should be less than tokensBefore
+              if (tokensAfter > result.tokensBefore) {
+                tokensAfter = undefined; // Don't trust the estimate
+              }
+            } catch {
+              // If estimation fails, leave tokensAfter undefined
+              tokensAfter = undefined;
+            }
+            // Run after_compaction hooks (fire-and-forget).
+            // Also includes sessionFile for plugins that only need to act after
+            // compaction completes (e.g. analytics, cleanup).
+            if (hookRunner?.hasHooks("after_compaction")) {
+              hookRunner
+                .runAfterCompaction(
+                  {
+                    messageCount: session.messages.length,
+                    tokenCount: tokensAfter,
+                    compactedCount: limited.length - session.messages.length,
+                    sessionFile: params.sessionFile,
+                  },
+                  hookCtx,
+                )
+                .catch((hookErr) => {
+                  log.warn(`after_compaction hook failed: ${hookErr}`);
+                });
+            }
+
+            const postMetrics = diagEnabled
+              ? summarizeCompactionMessages(session.messages)
+              : undefined;
+            if (diagEnabled && preMetrics && postMetrics) {
+              log.debug(
+                `[compaction-diag] end runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
+                  `diagId=${diagId} trigger=${trigger} provider=${cand.provider}/${cand.model} ` +
+                  `attempt=${attempt} maxAttempts=${maxAttempts} outcome=compacted reason=none ` +
+                  `thinking=${effectiveThinkLevel} thinkAttempt=${thinkAttempt} ` +
+                  `durationMs=${Date.now() - compactStartedAt} retrying=false ` +
+                  `post.messages=${postMetrics.messages} post.historyTextChars=${postMetrics.historyTextChars} ` +
+                  `post.toolResultChars=${postMetrics.toolResultChars} post.estTokens=${postMetrics.estTokens ?? "unknown"} ` +
+                  `delta.messages=${postMetrics.messages - preMetrics.messages} ` +
+                  `delta.historyTextChars=${postMetrics.historyTextChars - preMetrics.historyTextChars} ` +
+                  `delta.toolResultChars=${postMetrics.toolResultChars - preMetrics.toolResultChars} ` +
+                  `delta.estTokens=${typeof preMetrics.estTokens === "number" && typeof postMetrics.estTokens === "number" ? postMetrics.estTokens - preMetrics.estTokens : "unknown"}`,
+              );
+            }
+            return {
+              ok: true,
+              compacted: true,
+              result: {
+                summary: result.summary,
+                firstKeptEntryId: result.firstKeptEntryId,
+                tokensBefore: result.tokensBefore,
+                tokensAfter,
+                details: result.details,
+              },
+            };
+          } catch (compactionErr) {
+            // On timeout with thinking enabled: retry once without thinking.
+            if (
+              thinkAttempt === 0 &&
+              effectiveThinkLevel !== "off" &&
+              isTimeoutError(compactionErr)
+            ) {
+              log.warn(
+                `[compaction] timed out with thinking=${effectiveThinkLevel}; retrying without thinking`,
+              );
+              effectiveThinkLevel = "off";
+              // Fall through to finally (dispose session), then inner loop continues.
+            } else {
+              // On quota/rate-limit: if a fallback candidate is available, break inner
+              // loop and let the outer loop retry with the next model.
+              const failReason = resolveFailoverReasonFromError(compactionErr);
+              if (
+                (failReason === "rate_limit" || failReason === "billing") &&
+                candidateIdx < allCandidates.length - 1
+              ) {
+                lastQuotaErr = compactionErr;
+                break; // break thinking loop; outer loop continues to next candidate
+              }
+              throw compactionErr;
+            }
+          } finally {
+            await flushPendingToolResultsAfterIdle({
+              agent: session?.agent,
+              sessionManager,
+            });
+            session.dispose();
+          }
+        } // end thinking retry loop
+      } // end model fallback loop
+
+      // All candidates exhausted due to quota/rate-limit errors.
+      if (lastQuotaErr) {
+        throw lastQuotaErr;
       }
+      // Unreachable: loop either returns on success or throws.
+      return fail("unexpected exit from compaction retry loop");
     } finally {
       await sessionLock.release();
     }

--- a/src/agents/pi-embedded-runner/compaction-fallback.test.ts
+++ b/src/agents/pi-embedded-runner/compaction-fallback.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveCompactionFallbackCandidates } from "./compaction-fallback.js";
+
+describe("resolveCompactionFallbackCandidates", () => {
+  const current = { currentProvider: "anthropic", currentModel: "claude-sonnet-4-6" };
+
+  it("returns [] with no config", () => {
+    expect(resolveCompactionFallbackCandidates({ ...current })).toEqual([]);
+  });
+
+  it("returns [] when fallbackModel is absent", () => {
+    const cfg = {
+      agents: { defaults: { compaction: {} } },
+    } as unknown as OpenClawConfig;
+    expect(resolveCompactionFallbackCandidates({ cfg, ...current })).toEqual([]);
+  });
+
+  it('returns [] when fallbackModel is "off"', () => {
+    const cfg = {
+      agents: { defaults: { compaction: { fallbackModel: "off" } } },
+    } as unknown as OpenClawConfig;
+    expect(resolveCompactionFallbackCandidates({ cfg, ...current })).toEqual([]);
+  });
+
+  it('"fallback" returns candidates from model.fallbacks', () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          compaction: { fallbackModel: "fallback" },
+          model: {
+            primary: "anthropic/claude-sonnet-4-6",
+            fallbacks: ["anthropic/claude-haiku-4-5"],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    expect(resolveCompactionFallbackCandidates({ cfg, ...current })).toEqual([
+      { provider: "anthropic", model: "claude-haiku-4-5" },
+    ]);
+  });
+
+  it('"fallback" filters out the current model if it appears in fallbacks', () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          compaction: { fallbackModel: "fallback" },
+          model: {
+            primary: "anthropic/claude-opus-4-6",
+            fallbacks: ["anthropic/claude-sonnet-4-6", "anthropic/claude-haiku-4-5"],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    expect(
+      resolveCompactionFallbackCandidates({
+        cfg,
+        currentProvider: "anthropic",
+        currentModel: "claude-sonnet-4-6",
+      }),
+    ).toEqual([{ provider: "anthropic", model: "claude-haiku-4-5" }]);
+  });
+
+  it('"fallback" returns [] when model.fallbacks is empty', () => {
+    const cfg = {
+      agents: {
+        defaults: {
+          compaction: { fallbackModel: "fallback" },
+          model: { primary: "anthropic/claude-sonnet-4-6", fallbacks: [] },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    expect(resolveCompactionFallbackCandidates({ cfg, ...current })).toEqual([]);
+  });
+});

--- a/src/agents/pi-embedded-runner/compaction-fallback.ts
+++ b/src/agents/pi-embedded-runner/compaction-fallback.ts
@@ -1,0 +1,53 @@
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
+import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../defaults.js";
+import {
+  buildModelAliasIndex,
+  resolveConfiguredModelRef,
+  resolveModelRefFromString,
+} from "../model-selection.js";
+
+export type CompactionModelCandidate = { provider: string; model: string };
+
+/**
+ * Resolves the ordered fallback model candidates for compaction quota/rate-limit retries.
+ *
+ * Returns [] when fallbackModel is absent or "off".
+ * Returns candidates (excluding the current model) when fallbackModel is "fallback".
+ */
+export function resolveCompactionFallbackCandidates(params: {
+  cfg?: OpenClawConfig;
+  currentProvider: string;
+  currentModel: string;
+}): CompactionModelCandidate[] {
+  const fallbackModel = params.cfg?.agents?.defaults?.compaction?.fallbackModel;
+  if (!fallbackModel || fallbackModel === "off") {
+    return [];
+  }
+
+  const primary = params.cfg
+    ? resolveConfiguredModelRef({
+        cfg: params.cfg,
+        defaultProvider: DEFAULT_PROVIDER,
+        defaultModel: DEFAULT_MODEL,
+      })
+    : null;
+  const defaultProvider = primary?.provider ?? DEFAULT_PROVIDER;
+  const aliasIndex = buildModelAliasIndex({ cfg: params.cfg ?? {}, defaultProvider });
+
+  const isCurrent = (ref: CompactionModelCandidate) =>
+    ref.provider === params.currentProvider && ref.model === params.currentModel;
+
+  const candidates: CompactionModelCandidate[] = [];
+  for (const raw of resolveAgentModelFallbackValues(params.cfg?.agents?.defaults?.model)) {
+    const resolved = resolveModelRefFromString({
+      raw: String(raw ?? ""),
+      defaultProvider,
+      aliasIndex,
+    });
+    if (resolved && !isCurrent(resolved.ref)) {
+      candidates.push(resolved.ref);
+    }
+  }
+  return candidates;
+}

--- a/src/agents/pi-embedded-runner/compaction-overrides.test.ts
+++ b/src/agents/pi-embedded-runner/compaction-overrides.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import { resolveCompactionThinkLevel } from "./compaction-overrides.js";
+
+describe("resolveCompactionThinkLevel", () => {
+  it("defaults to off with no config", () => {
+    expect(resolveCompactionThinkLevel({})).toBe("off");
+  });
+
+  it("defaults to off when compaction.thinking is not set", () => {
+    const cfg = { agents: { defaults: { compaction: {} } } } as unknown as OpenClawConfig;
+    expect(resolveCompactionThinkLevel({ cfg })).toBe("off");
+  });
+
+  it("returns off when thinking is explicitly off", () => {
+    const cfg = {
+      agents: { defaults: { compaction: { thinking: "off" } } },
+    } as unknown as OpenClawConfig;
+    expect(resolveCompactionThinkLevel({ cfg })).toBe("off");
+  });
+
+  it("inherits session thinking level when thinking is on", () => {
+    const cfg = {
+      agents: { defaults: { compaction: { thinking: "on" } } },
+    } as unknown as OpenClawConfig;
+    expect(resolveCompactionThinkLevel({ cfg, sessionThinkLevel: "medium" })).toBe("medium");
+  });
+
+  it("falls back to off when thinking is on but no session level is provided", () => {
+    const cfg = {
+      agents: { defaults: { compaction: { thinking: "on" } } },
+    } as unknown as OpenClawConfig;
+    expect(resolveCompactionThinkLevel({ cfg })).toBe("off");
+  });
+});

--- a/src/agents/pi-embedded-runner/compaction-overrides.ts
+++ b/src/agents/pi-embedded-runner/compaction-overrides.ts
@@ -1,0 +1,25 @@
+import type { ThinkLevel } from "../../auto-reply/thinking.js";
+import type { OpenClawConfig } from "../../config/config.js";
+
+/**
+ * Resolves the thinking level to use for a compaction run.
+ *
+ * Priority:
+ * 1. `agents.defaults.compaction.thinking` if explicitly configured
+ *    - "off" (default): disable thinking regardless of session model
+ *    - "on": inherit the session model's current thinking level
+ * 2. "off" — compaction defaults to no thinking regardless of session model,
+ *    since extended thinking on slow models can exceed channel timeout windows
+ *    (e.g. Discord 30s, Telegram 240s) and compaction is a summarization task
+ *    that does not benefit from extended reasoning.
+ */
+export function resolveCompactionThinkLevel(params: {
+  cfg?: OpenClawConfig;
+  sessionThinkLevel?: ThinkLevel;
+}): ThinkLevel {
+  const configured = params.cfg?.agents?.defaults?.compaction?.thinking;
+  if (configured === "on") {
+    return params.sessionThinkLevel ?? "off";
+  }
+  return "off";
+}

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -955,6 +955,8 @@ export const FIELD_HELP: Record<string, string> = {
     "User-prompt template used for the pre-compaction memory flush turn when generating memory candidates. Use this only when you need custom extraction instructions beyond the default memory flush behavior.",
   "agents.defaults.compaction.memoryFlush.systemPrompt":
     "System-prompt override for the pre-compaction memory flush turn to control extraction style and safety constraints. Use carefully so custom instructions do not reduce memory quality or leak sensitive context.",
+  "agents.defaults.compaction.fallbackModel":
+    'Fallback model strategy when compaction fails with a quota or rate-limit error. "off" (default) disables fallback and lets the error surface. "fallback" retries using the agents.defaults.model.fallbacks chain in order, skipping the current model.',
   "agents.defaults.embeddedPi":
     "Embedded Pi runner hardening controls for how workspace-local Pi settings are trusted and applied in OpenClaw sessions.",
   "agents.defaults.embeddedPi.projectSettingsPolicy":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -429,6 +429,8 @@ export const FIELD_LABELS: Record<string, string> = {
     "Compaction Memory Flush Transcript Size Threshold",
   "agents.defaults.compaction.memoryFlush.prompt": "Compaction Memory Flush Prompt",
   "agents.defaults.compaction.memoryFlush.systemPrompt": "Compaction Memory Flush System Prompt",
+  "agents.defaults.compaction.thinking": "Compaction Thinking",
+  "agents.defaults.compaction.fallbackModel": "Compaction Fallback Model",
   "agents.defaults.embeddedPi": "Embedded Pi",
   "agents.defaults.embeddedPi.projectSettingsPolicy": "Embedded Pi Project Settings Policy",
   "agents.defaults.heartbeat.directPolicy": "Heartbeat Direct Policy",

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -292,6 +292,10 @@ export type AgentCompactionIdentifierPolicy = "strict" | "off" | "custom";
 export type AgentCompactionConfig = {
   /** Compaction summarization mode. */
   mode?: AgentCompactionMode;
+  /** Thinking override for compaction: "off" (default) disables thinking; "on" inherits the session model's current thinking level. */
+  thinking?: "off" | "on";
+  /** Fallback model on quota/rate-limit errors: "off" (default) or "fallback" (use model.fallbacks chain). */
+  fallbackModel?: "off" | "fallback";
   /** Pi reserve tokens target before floor enforcement. */
   reserveTokens?: number;
   /** Pi keepRecentTokens budget used for cut-point selection. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -87,6 +87,12 @@ export const AgentDefaultsSchema = z
     compaction: z
       .object({
         mode: z.union([z.literal("default"), z.literal("safeguard")]).optional(),
+        thinking: z
+          .union([z.literal("off"), z.literal("on")])
+          .optional()
+          .describe(
+            'Thinking override for compaction summarization. Defaults to "off" — compaction always runs without extended thinking regardless of the session model, preventing timeout races on channels with strict reply windows (Discord 30s, Telegram 240s). Set to "on" to inherit the session model\'s current thinking level.',
+          ),
         reserveTokens: z.number().int().nonnegative().optional(),
         keepRecentTokens: z.number().int().positive().optional(),
         reserveTokensFloor: z.number().int().nonnegative().optional(),
@@ -95,6 +101,12 @@ export const AgentDefaultsSchema = z
           .union([z.literal("strict"), z.literal("off"), z.literal("custom")])
           .optional(),
         identifierInstructions: z.string().optional(),
+        fallbackModel: z
+          .union([z.literal("off"), z.literal("fallback")])
+          .optional()
+          .describe(
+            'Fallback model for compaction on quota or rate-limit errors. "off" (default) disables fallback. "fallback" uses the agents.defaults.model.fallbacks chain in order.',
+          ),
         memoryFlush: z
           .object({
             enabled: z.boolean().optional(),


### PR DESCRIPTION
> **AI-assisted** — drafted and iterated with Claude Code (claude-sonnet-4-6). Lightly tested: unit tests pass, `pnpm tsgo` clean, `pnpm check` passes; fallback retry path validated by code review; not exercised against live quota exhaustion. I have personally reviewed all code changes prior to this commit and take responsibility for their correctness.

## Summary

- **Problem**: when compaction hits a quota or rate-limit error on the primary model, the error surfaces directly to the session with no recovery path.
- **Why it matters**: users with aggressive compaction thresholds on paid tiers hit quota limits mid-session; without a fallback, the session stalls until quota resets.
- **What changed**: new `agents.defaults.compaction.fallbackModel` key. Set to `"fallback"` to retry compaction using the `agents.defaults.model.fallbacks` chain in order, skipping the current model. Defaults to `"off"`.
- **What did NOT change**: auth errors and timeouts use their own retry mechanisms; fallback only activates on HTTP 429 / 402 billing errors.

## Schema

`agents.defaults.compaction.fallbackModel`: `"off"` (default) | `"fallback"`

- `"off"`: quota/rate-limit errors surface as-is.
- `"fallback"`: retries each model in `agents.defaults.model.fallbacks` in order, skipping the current model. Re-throws after exhausting all candidates.

Renders as a two-button segmented control in the config UI, with a help tooltip.

## UI — Before / After

**Before** (upstream `main` — no Compaction Fallback Model field):

![before](https://raw.githubusercontent.com/iamcobolt/openclaw/d4bb4deb09d833aeabe42c48ab891f85348f78ec/docs/images/pr-33396-before.svg)

**After** — new `Compaction Fallback Model` field with `off / fallback` segmented control:

![after](https://raw.githubusercontent.com/iamcobolt/openclaw/d4bb4deb09d833aeabe42c48ab891f85348f78ec/docs/images/pr-33396-after.svg)

## Change Type

- [x] Feature
- [x] Docs

## Scope

- [x] Gateway / orchestration
- [x] API / contracts
- [x] UI / DX

## Linked Issue/PR

- Discussion: #33431
- Companion: #34554 (`compaction.thinking`)

## Key Changes

- **`compaction-fallback.ts`** (new) — `resolveCompactionFallbackCandidates()` resolves the ordered candidate list from config; filters out the current model
- **`compaction-fallback.test.ts`** (new) — 6 unit tests covering all states
- **`compact.ts`** — outer model-fallback loop wrapping the thinking-retry inner loop; `transcriptPolicy` and `sanitizeSessionHistory` re-resolved per candidate; `before_compaction` hook guarded by `hookFired` (fires exactly once per compaction event)
- **`compaction-overrides.ts`** — also ships `resolveCompactionThinkLevel` (companion to #34554); both features share this helper
- **`types.agent-defaults.ts` / `zod-schema.agent-defaults.ts`** — both `fallbackModel` and `thinking` fields narrowed to their 2-option unions

## Notes for Reviewers

- The outer loop breaks on `rate_limit`/`billing` errors with remaining candidates; after exhausting all candidates the last quota error is re-thrown.
- `before_compaction` hook: guarded by `hookFired` so it fires exactly once regardless of model or thinking retry depth.
- `transcriptPolicy` and `sanitizeSessionHistory` re-resolved per candidate — provider-specific flags correct for cross-provider fallbacks.
- This PR includes the `compaction-overrides.ts` helper from companion #34554. If #34554 merges first, this diff will shrink accordingly.

## User-visible / Behavior Changes

- New config key `agents.defaults.compaction.fallbackModel` (opt-in; defaults to `"off"`, no change in behaviour).
- When set to `"fallback"` and compaction hits a quota error, it retries silently with the next model in the fallbacks chain.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No — uses existing auth resolution per candidate
- New/changed network calls? Only when a fallback is triggered (same API surface as primary)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

1. Set `agents.defaults.compaction.fallbackModel: "fallback"` with a `model.fallbacks` chain
2. Exhaust primary model quota or simulate a 429 response
3. Trigger compaction → expect silent retry on next fallback model

## Evidence

- [x] 6 unit tests covering all `resolveCompactionFallbackCandidates` cases
- [ ] Live quota-exhaustion trace (not yet available)

## Human Verification

- Verified: unit tests pass, `pnpm tsgo` clean, `pnpm check` passes
- Edge cases: absent config, `"off"`, `"fallback"` with empty fallbacks, `"fallback"` filtering current model, `hookFired` guard across model and thinking retry loops
- Not verified: live quota exhaustion

## Compatibility / Migration

- Backward compatible: `fallbackModel` is optional; default is `"off"` (no behaviour change)
- To enable: `agents.defaults.compaction.fallbackModel: "fallback"` with `agents.defaults.model.fallbacks` populated

## Failure Recovery

- To disable: remove or set `agents.defaults.compaction.fallbackModel: "off"`
- Bad symptom: compaction retries when it shouldn't — check `fallbackModel` config value

## Risks and Mitigations

- Risk: fallback model may produce a lower-quality compaction summary.
  - Mitigation: `"fallback"` is opt-in; users configure their own fallbacks chain.
- Risk: cross-provider fallback (e.g. anthropic → openai) could fail on provider-specific message formats.
  - Mitigation: `transcriptPolicy` and `sanitizeSessionHistory` are re-resolved per candidate.