### PR TITLE
feat(feishu): parse interactive card content in merge_forward sub-messages

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -440,6 +440,24 @@ function formatSubMessageContent(content: string, contentType: string): string {
         return "[Video]";
       case "sticker":
         return "[Sticker]";
+      case "interactive": {
+        // Parse interactive card to extract readable content
+        const card = parsed;
+        const title = card.header?.title?.content || "";
+        const elements = card.elements || card.body?.elements || [];
+        const texts: string[] = [];
+        for (const el of elements) {
+          if (el.tag === "div" && el.text?.content) {
+            texts.push(el.text.content);
+          } else if (el.tag === "markdown" && el.content) {
+            texts.push(el.content);
+          } else if (el.tag === "plain_text" && el.content) {
+            texts.push(el.content);
+          }
+        }
+        const body = texts.join(" ").trim();
+        return title ? `[Card: ${title}] ${body}`.trim() : body || "[Interactive Card]";
+      }
       case "merge_forward":
         return "[Nested Merged Forward]";
       default:


### PR DESCRIPTION
## Summary

When receiving a `merge_forward` (合并转发) message containing interactive cards, this PR extracts readable content instead of displaying just `[interactive]`.

**Before:**
```
[Merged and Forwarded Messages]
- 希，你会写小说不？
- [interactive]
- 希，想让你写一个关于......我们的故事
- [interactive]
```

**After:**
```
[Merged and Forwarded Messages]  
- 希，你会写小说不？
- [Card: 小希看板] 当前状态: 运行中
- 希，想让你写一个关于......我们的故事
- [Card: 签到结果] ✅ 签到成功 余额: $1078.40
```

## Changes

- Added `case "interactive"` in `formatSubMessageContent()` function
- Extracts card title from `header.title.content`
- Extracts text content from `div`, `markdown`, and `plain_text` elements
- Falls back to `[Interactive Card]` if parsing fails

## Related

- Fixes #34571
- Related to #34172 (another Feishu improvement)
