### PR TITLE
fix(msteams): handle invalid JSON escape sequences in Bot Framework activities

### DIFF
--- a/extensions/msteams/src/__tests__/monitor-json-repair.test.ts
+++ b/extensions/msteams/src/__tests__/monitor-json-repair.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression test for:
+ *   SyntaxError: Bad escaped character in JSON at position N
+ *
+ * Some Bot Framework clients (e.g. certain MS Teams clients) send activity
+ * payloads that contain invalid JSON escape sequences such as bare backslashes
+ * followed by characters not defined in RFC 8259 (e.g. \p, \q, \c).
+ *
+ * The previous `express.json()` strict parser threw SyntaxError on such payloads,
+ * causing non-200 responses → Azure Bot Service exponential backoff → messages dropped.
+ *
+ * This test suite verifies the two-pass JSON repair middleware introduced in monitor.ts.
+ */
+
+import { describe, it, expect } from "vitest";
+
+/** Mirrors the repair regex from monitor.ts middleware */
+const REPAIR_REGEX = /\\([^"\\\//bfnrtu])/g;
+
+/** Emulates the two-pass parse logic from the fixed middleware */
+function twoPassParse(raw: string): { body: unknown; path: "first_pass" | "repaired" } {
+  try {
+    return { body: JSON.parse(raw), path: "first_pass" };
+  } catch {
+    const fixed = raw.replace(REPAIR_REGEX, "\\\\$1");
+    return { body: JSON.parse(fixed), path: "repaired" }; // throws if still invalid
+  }
+}
+
+// ────────────────────────────────────────────────────────────
+// Fixtures
+// ────────────────────────────────────────────────────────────
+
+/** conversationUpdate payload with bare \p inside a JSON string — invalid per RFC 8259 */
+const BAD_ESCAPE_PAYLOAD = String.raw`{
+  "type": "conversationUpdate",
+  "timestamp": "2026-03-04T14:19:17.000Z",
+  "id": "f:abc123",
+  "channelId": "msteams",
+  "serviceUrl": "https://smba.trafficmanager.net/apac/",
+  "from": {"id": "29:xxx", "name": "User"},
+  "conversation": {"id": "19:meeting_abc@thread.v2", "tenantId": "tenant-id"},
+  "recipient": {"id": "28:bot-id", "name": "Bot"},
+  "membersAdded": [{"id": "28:bot-id", "name": "Bot"}],
+  "channelData": {
+    "tenant": {"id": "tenant-id"},
+    "eventType": "teamMemberAdded",
+    "team": {"id": "19:meeting\participant_abc@thread.v2", "name": "Test\Project"}
+  }
+}`;
+
+/** Well-formed message activity — must parse on first pass unchanged */
+const GOOD_MESSAGE_PAYLOAD = JSON.stringify({
+  type: "message",
+  text: "Hello",
+  from: { id: "29:user", name: "User" },
+  conversation: { id: "19:channel@thread.v2" },
+  // Windows paths with proper double-backslash — already valid JSON
+  channelData: { path: "C:\\Users\\test" },
+});
+
+/** Payload with valid JSON escape sequences — must NOT be double-escaped */
+const VALID_ESCAPES_PAYLOAD = String.raw`{"text": "line1\nline2\ttab\"quote\\backslash"}`;
+
+// ────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────
+
+describe("msteams JSON repair middleware", () => {
+  it("standard JSON.parse() throws SyntaxError on bad escape sequences", () => {
+    // This proves the original express.json() would fail
+    expect(() => JSON.parse(BAD_ESCAPE_PAYLOAD)).toThrow(SyntaxError);
+  });
+
+  it("two-pass repair recovers activities with bare backslash escape sequences", () => {
+    const { body, path } = twoPassParse(BAD_ESCAPE_PAYLOAD);
+    expect(path).toBe("repaired");
+    const activity = body as Record<string, unknown>;
+    expect(activity["type"]).toBe("conversationUpdate");
+    // After repair \p → \\p in JSON → literal backslash + p in the parsed string
+    const channelData = activity["channelData"] as Record<string, unknown>;
+    const team = channelData["team"] as Record<string, unknown>;
+    expect(team["name"]).toBe("Test\\Project");
+  });
+
+  it("well-formed message payloads pass through on the first parse (no repair)", () => {
+    const { body, path } = twoPassParse(GOOD_MESSAGE_PAYLOAD);
+    expect(path).toBe("first_pass");
+    const activity = body as Record<string, unknown>;
+    expect(activity["text"]).toBe("Hello");
+  });
+
+  it("valid JSON escape sequences (\\n \\t \\\\ etc.) are preserved and not double-escaped", () => {
+    const { body, path } = twoPassParse(VALID_ESCAPES_PAYLOAD);
+    expect(path).toBe("first_pass"); // No repair needed for valid JSON
+    const obj = body as Record<string, string>;
+    expect(obj["text"]).toBe("line1\nline2\ttab\"quote\\backslash");
+  });
+
+  it("completely malformed JSON is re-thrown (caller returns HTTP 200 to prevent backoff)", () => {
+    const garbage = "{ not valid json at all ??? }";
+    expect(() => twoPassParse(garbage)).toThrow(SyntaxError);
+  });
+});

--- a/extensions/msteams/src/__tests__/monitor-json-repair.test.ts
+++ b/extensions/msteams/src/__tests__/monitor-json-repair.test.ts
@@ -94,7 +94,7 @@ describe("msteams JSON repair middleware", () => {
     const { body, path } = twoPassParse(VALID_ESCAPES_PAYLOAD);
     expect(path).toBe("first_pass"); // No repair needed for valid JSON
     const obj = body as Record<string, string>;
-    expect(obj["text"]).toBe("line1\nline2\ttab\"quote\\backslash");
+    expect(obj["text"]).toBe('line1\nline2\ttab"quote\\backslash');
   });
 
   it("completely malformed JSON is re-thrown (caller returns HTTP 200 to prevent backoff)", () => {

--- a/extensions/msteams/src/__tests__/monitor-json-repair.test.ts
+++ b/extensions/msteams/src/__tests__/monitor-json-repair.test.ts
@@ -14,15 +14,39 @@
 
 import { describe, it, expect } from "vitest";
 
-/** Mirrors the repair regex from monitor.ts middleware */
-const REPAIR_REGEX = /\\([^"\\\//bfnrtu])/g;
+// ── Mirror `repairJsonEscapes` from monitor.ts ─────────────────────────────
+const VALID_JSON_ESCAPE_CHARS = new Set(['"', "\\", "/", "b", "f", "n", "r", "t", "u"]);
 
-/** Emulates the two-pass parse logic from the fixed middleware */
+function repairJsonEscapes(raw: string): string {
+  let fixed = "";
+  for (let i = 0; i < raw.length; i += 1) {
+    const ch = raw[i];
+    if (ch !== "\\") {
+      fixed += ch;
+      continue;
+    }
+
+    let runEnd = i;
+    while (raw[runEnd] === "\\") {
+      runEnd += 1;
+    }
+    const runLength = runEnd - i;
+    fixed += "\\".repeat(runLength);
+    const next = raw[runEnd];
+    if (runLength % 2 === 1 && next !== undefined && !VALID_JSON_ESCAPE_CHARS.has(next)) {
+      fixed += "\\";
+    }
+    i = runEnd - 1;
+  }
+  return fixed;
+}
+
+/** Emulate the two-pass middleware. Returns parsed body + which pass was used. */
 function twoPassParse(raw: string): { body: unknown; path: "first_pass" | "repaired" } {
   try {
     return { body: JSON.parse(raw), path: "first_pass" };
   } catch {
-    const fixed = raw.replace(REPAIR_REGEX, "\\\\$1");
+    const fixed = repairJsonEscapes(raw);
     return { body: JSON.parse(fixed), path: "repaired" }; // throws if still invalid
   }
 }
@@ -62,6 +86,15 @@ const GOOD_MESSAGE_PAYLOAD = JSON.stringify({
 /** Payload with valid JSON escape sequences — must NOT be double-escaped */
 const VALID_ESCAPES_PAYLOAD = String.raw`{"text": "line1\nline2\ttab\"quote\\backslash"}`;
 
+/**
+ * The edge case: a valid \\q sequence (JSON for literal \q)
+ * mixed with a separate invalid escape in the same payload.
+ */
+const MIXED_VALID_AND_INVALID_ESCAPES = String.raw`{
+  "path": "C:\\q",
+  "team": "Test\Project"
+}`;
+
 // ────────────────────────────────────────────────────────────
 // Tests
 // ────────────────────────────────────────────────────────────
@@ -100,5 +133,13 @@ describe("msteams JSON repair middleware", () => {
   it("completely malformed JSON is re-thrown (caller returns HTTP 200 to prevent backoff)", () => {
     const garbage = "{ not valid json at all ??? }";
     expect(() => twoPassParse(garbage)).toThrow(SyntaxError);
+  });
+
+  it("preserves valid escaped backslashes while repairing another field", () => {
+    const { body, path } = twoPassParse(MIXED_VALID_AND_INVALID_ESCAPES);
+    expect(path).toBe("repaired");
+    const obj = body as Record<string, string>;
+    expect(obj["path"]).toBe("C:\\q");
+    expect(obj["team"]).toBe("Test\\Project");
   });
 });

--- a/extensions/msteams/src/monitor.lifecycle.test.ts
+++ b/extensions/msteams/src/monitor.lifecycle.test.ts
@@ -47,7 +47,10 @@ vi.mock("../runtime-api.js", () => ({
 }));
 
 vi.mock("express", () => {
-  const json = vi.fn(() => {
+  // Shared no-op middleware factory used for both json() and raw().
+  // monitor.ts switched from express.json() to express.raw() so both must
+  // be provided; missing raw() would throw "express.raw is not a function".
+  const makeNoopMiddleware = vi.fn(() => {
     return (_req: unknown, _res: unknown, next?: (err?: unknown) => void) => {
       next?.();
     };
@@ -86,7 +89,8 @@ vi.mock("express", () => {
 
   return {
     default: wrappedFactory,
-    json,
+    json: makeNoopMiddleware,
+    raw: makeNoopMiddleware,
   };
 });
 
@@ -245,12 +249,12 @@ describe("monitorMSTeamsProvider lifecycle", () => {
 
     const app = expressControl.apps.at(-1);
     expect(app).toBeDefined();
-    expect(app!.use).toHaveBeenCalledTimes(4);
+    expect(app!.use).toHaveBeenCalledTimes(5);
 
-    const jsonMiddleware = vi.mocked((await import("express")).json).mock.results[0]?.value;
-    expect(jsonMiddleware).toBeDefined();
-    expect(app!.use.mock.calls[1]?.[0]).not.toBe(jsonMiddleware);
-    expect(app!.use.mock.calls[2]?.[0]).toBe(jsonMiddleware);
+    const rawMiddleware = vi.mocked((await import("express")).raw).mock.results[0]?.value;
+    expect(rawMiddleware).toBeDefined();
+    expect(app!.use.mock.calls[1]?.[0]).not.toBe(rawMiddleware);
+    expect(app!.use.mock.calls[2]?.[0]).toBe(rawMiddleware);
 
     const jwtMiddleware = app!.use.mock.calls[1]?.[0] as (
       req: Request,

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -43,6 +43,33 @@ export type MonitorMSTeamsResult = {
 };
 
 const MSTEAMS_WEBHOOK_MAX_BODY_BYTES = DEFAULT_WEBHOOK_MAX_BODY_BYTES;
+
+const VALID_JSON_ESCAPE_CHARS = new Set(['"', "\\", "/", "b", "f", "n", "r", "t", "u"]);
+
+function repairJsonEscapes(raw: string): string {
+  let fixed = "";
+  for (let i = 0; i < raw.length; i += 1) {
+    const ch = raw[i];
+    if (ch !== "\\") {
+      fixed += ch;
+      continue;
+    }
+
+    let runEnd = i;
+    while (raw[runEnd] === "\\") {
+      runEnd += 1;
+    }
+    const runLength = runEnd - i;
+    fixed += "\\".repeat(runLength);
+    const next = raw[runEnd];
+    if (runLength % 2 === 1 && next !== undefined && !VALID_JSON_ESCAPE_CHARS.has(next)) {
+      fixed += "\\";
+    }
+    i = runEnd - 1;
+  }
+  return fixed;
+}
+
 export async function monitorMSTeamsProvider(
   opts: MonitorMSTeamsOpts,
 ): Promise<MonitorMSTeamsResult> {
@@ -305,10 +332,48 @@ export async function monitorMSTeamsProvider(
       });
   });
 
-  expressApp.use(express.json({ limit: MSTEAMS_WEBHOOK_MAX_BODY_BYTES }));
+  // Use raw body parser so we can repair invalid JSON escape sequences that some
+  // Bot Framework clients include in activity payloads (e.g. conversationUpdate
+  // activities with bare backslashes like \p or \q that are not valid per RFC 8259).
+  // The strict express.json() parser throws SyntaxError on such payloads, which
+  // causes a non-200 response and puts Azure Bot Service into exponential backoff,
+  // dropping all subsequent messages until the backoff window expires.
+  expressApp.use(express.raw({ type: "application/json", limit: MSTEAMS_WEBHOOK_MAX_BODY_BYTES }));
+  expressApp.use((req: Request, _res: Response, next: (err?: unknown) => void) => {
+    if (Buffer.isBuffer(req.body)) {
+      const rawText = req.body.toString("utf-8");
+      try {
+        req.body = JSON.parse(rawText);
+      } catch {
+        const fixed = repairJsonEscapes(rawText);
+        try {
+          req.body = JSON.parse(fixed);
+          log.warn("msteams: repaired invalid JSON escape sequences in Bot Framework activity");
+        } catch (parseErr) {
+          next(parseErr);
+          return;
+        }
+      }
+    }
+    next();
+  });
   expressApp.use((err: unknown, _req: Request, res: Response, next: (err?: unknown) => void) => {
-    if (err && typeof err === "object" && "status" in err && err.status === 413) {
+    if (
+      err &&
+      typeof err === "object" &&
+      "status" in err &&
+      (err as { status: number }).status === 413
+    ) {
       res.status(413).json({ error: "Payload too large" });
+      return;
+    }
+    if (err instanceof SyntaxError) {
+      // JSON could not be repaired; acknowledge with HTTP 200 to prevent Azure
+      // Bot Service from entering exponential backoff for an unrecoverable payload.
+      log.error("msteams: unrecoverable JSON parse error in Bot Framework activity", {
+        error: String(err),
+      });
+      res.status(200).end();
       return;
     }
     next(err);

--- a/extensions/msteams/src/monitor.ts
+++ b/extensions/msteams/src/monitor.ts
@@ -44,6 +44,20 @@ export type MonitorMSTeamsResult = {
 
 const MSTEAMS_WEBHOOK_MAX_BODY_BYTES = DEFAULT_WEBHOOK_MAX_BODY_BYTES;
 
+/**
+ * Attempt to repair a JSON string that contains invalid bare-backslash escape
+ * sequences such as \p, \q, \c (not defined by RFC 8259).
+ *
+ * The repair walks each consecutive run of backslashes. Even-length runs are
+ * already made of valid `\\` pairs. Odd-length runs contain one trailing escape
+ * opener; when that opener is followed by a non-JSON escape character, we add
+ * one backslash so the character is preserved literally.
+ *
+ * Examples:
+ *   "\\q"  (valid JSON: literal \q)   → unchanged
+ *   "\q"   (invalid JSON: bare \q)    → "\\q"
+ *   "\\\q" (valid \\ + invalid \q)   → "\\\\q"
+ */
 const VALID_JSON_ESCAPE_CHARS = new Set(['"', "\\", "/", "b", "f", "n", "r", "t", "u"]);
 
 function repairJsonEscapes(raw: string): string {


### PR DESCRIPTION
## Problem

Some Bot Framework clients (e.g. certain MS Teams desktop/mobile clients) send
activity payloads that contain **invalid JSON escape sequences** — bare backslashes
followed by characters not defined in [RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259#section-7)
(e.g. `\p`, `\q`, `\c`).

The existing `express.json()` middleware uses body-parser's strict JSON parser
which throws:

```
SyntaxError: Bad escaped character in JSON at position 388
```

This causes the webhook handler to return a **non-200 response** to Azure Bot
Service. Azure Bot Service interprets non-200 responses as delivery failures and
enters **exponential backoff** — dropping all subsequent user messages until the
backoff window expires (which can be minutes to hours).

### Observed Symptom

- First message (e.g. `conversationUpdate` on channel create) triggers the
  `SyntaxError`, msteams provider replies with 4xx/5xx
- Azure Bot Service backoff begins
- All subsequent user messages are silently dropped by Azure (not delivered to
  the local endpoint)
- Users send messages in Teams but the bot never responds

## Fix

Replace `express.json()` with a **two-pass raw body parsing** approach:

1. Accept body as raw `Buffer` via `express.raw({ type: 'application/json' })`
2. **First pass**: try standard `JSON.parse()` on the raw body
3. **Second pass** (if first fails with `SyntaxError`): attempt to repair the
   payload by double-escaping bare backslashes via regex:
   `/\\([^"\\/bfnrtu])/g → \\\\$1`
4. If the repaired payload parses successfully → log a warning and continue
5. If the payload still cannot be parsed → respond **HTTP 200** to prevent
   Azure Bot Service backoff, and log the error for investigation

## Testing

Observed and confirmed with a real Teams bot deployment:

1. Azure Bot Service delivered a `conversationUpdate` activity with an invalid
   escape sequence at position 388 → previously caused SyntaxError + Azure
   backoff for subsequent messages
2. With this fix, activities with minor JSON escaping issues are repaired and
   processed normally
3. Completely unrecoverable payloads are acknowledged with 200 to prevent
   backoff loops

## Notes

- `express.raw()` is already part of Express's built-in middleware (same as
  `express.json()`), no new dependencies needed
- The regex fix targets only actual bare backslashes before non-escape chars;
  valid JSON escape sequences (`\"`, `\\`, `\/`, `\b`, `\f`, `\n`, `\r`, `\t`,
  `\uXXXX`) are preserved
- This is a conservative fix that preserves all existing behaviour for
  well-formed payloads