### PR TITLE
fix: include Gemini/Grok/Kimi in web search key audit

### DIFF
--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { collectAttackSurfaceSummaryFindings } from "./audit-extra.sync.js";
+import {
+  collectAttackSurfaceSummaryFindings,
+  collectSmallModelRiskFindings,
+} from "./audit-extra.sync.js";
 import { safeEqualSecret } from "./secret-equal.js";
 
 describe("collectAttackSurfaceSummaryFindings", () => {
@@ -51,5 +54,39 @@ describe("safeEqualSecret", () => {
     expect(safeEqualSecret(undefined, "secret")).toBe(false);
     expect(safeEqualSecret("secret", undefined)).toBe(false);
     expect(safeEqualSecret(null, "secret")).toBe(false);
+  });
+});
+
+describe("collectSmallModelRiskFindings web search key detection", () => {
+  const baseCfg: OpenClawConfig = {
+    agents: {
+      defaults: {
+        model: "qwen2.5-3b-instruct",
+      },
+    },
+  };
+
+  it("treats GEMINI_API_KEY as enabling web_search exposure", () => {
+    const findings = collectSmallModelRiskFindings({
+      cfg: baseCfg,
+      env: { GEMINI_API_KEY: "gemini-key" } as NodeJS.ProcessEnv,
+    });
+    expect(findings[0]?.detail).toContain("web_search");
+  });
+
+  it("treats XAI_API_KEY as enabling web_search exposure", () => {
+    const findings = collectSmallModelRiskFindings({
+      cfg: baseCfg,
+      env: { XAI_API_KEY: "xai-key" } as NodeJS.ProcessEnv,
+    });
+    expect(findings[0]?.detail).toContain("web_search");
+  });
+
+  it("treats KIMI_API_KEY as enabling web_search exposure", () => {
+    const findings = collectSmallModelRiskFindings({
+      cfg: baseCfg,
+      env: { KIMI_API_KEY: "kimi-key" } as NodeJS.ProcessEnv,
+    });
+    expect(findings[0]?.detail).toContain("web_search");
   });
 });

--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -89,4 +89,20 @@ describe("collectSmallModelRiskFindings web search key detection", () => {
     });
     expect(findings[0]?.detail).toContain("web_search");
   });
+
+  it("treats OPENROUTER_API_KEY as enabling web_search exposure", () => {
+    const findings = collectSmallModelRiskFindings({
+      cfg: baseCfg,
+      env: { OPENROUTER_API_KEY: "openrouter-key" } as NodeJS.ProcessEnv,
+    });
+    expect(findings[0]?.detail).toContain("web_search");
+  });
+
+  it("treats MOONSHOT_API_KEY as enabling web_search exposure", () => {
+    const findings = collectSmallModelRiskFindings({
+      cfg: baseCfg,
+      env: { MOONSHOT_API_KEY: "moonshot-key" } as NodeJS.ProcessEnv,
+    });
+    expect(findings[0]?.detail).toContain("web_search");
+  });
 });

--- a/src/security/audit-extra.sync.test.ts
+++ b/src/security/audit-extra.sync.test.ts
@@ -90,12 +90,12 @@ describe("collectSmallModelRiskFindings web search key detection", () => {
     expect(findings[0]?.detail).toContain("web_search");
   });
 
-  it("treats OPENROUTER_API_KEY as enabling web_search exposure", () => {
+  it("does not treat OPENROUTER_API_KEY alone as enabling web_search exposure", () => {
     const findings = collectSmallModelRiskFindings({
       cfg: baseCfg,
       env: { OPENROUTER_API_KEY: "openrouter-key" } as NodeJS.ProcessEnv,
     });
-    expect(findings[0]?.detail).toContain("web_search");
+    expect(findings[0]?.detail ?? "").not.toContain("web_search");
   });
 
   it("treats MOONSHOT_API_KEY as enabling web_search exposure", () => {
@@ -104,5 +104,22 @@ describe("collectSmallModelRiskFindings web search key detection", () => {
       env: { MOONSHOT_API_KEY: "moonshot-key" } as NodeJS.ProcessEnv,
     });
     expect(findings[0]?.detail).toContain("web_search");
+  });
+
+  it("respects explicit provider pin when evaluating key exposure", () => {
+    const findings = collectSmallModelRiskFindings({
+      cfg: {
+        ...baseCfg,
+        tools: {
+          web: {
+            search: {
+              provider: "perplexity",
+            },
+          },
+        },
+      },
+      env: { GEMINI_API_KEY: "gemini-key" } as NodeJS.ProcessEnv,
+    });
+    expect(findings[0]?.detail ?? "").not.toContain("web_search");
   });
 });

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -330,7 +330,18 @@ function resolveToolPolicies(params: {
 function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
   return Boolean(
-    search?.apiKey || search?.perplexity?.apiKey || env.BRAVE_API_KEY || env.PERPLEXITY_API_KEY,
+    search?.apiKey ||
+    search?.perplexity?.apiKey ||
+    search?.grok?.apiKey ||
+    search?.gemini?.apiKey ||
+    search?.kimi?.apiKey ||
+    env.BRAVE_API_KEY ||
+    env.PERPLEXITY_API_KEY ||
+    env.OPENROUTER_API_KEY ||
+    env.XAI_API_KEY ||
+    env.GEMINI_API_KEY ||
+    env.KIMI_API_KEY ||
+    env.MOONSHOT_API_KEY,
   );
 }
 

--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -329,20 +329,32 @@ function resolveToolPolicies(params: {
 
 function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
-  return Boolean(
-    search?.apiKey ||
-    search?.perplexity?.apiKey ||
-    search?.grok?.apiKey ||
-    search?.gemini?.apiKey ||
-    search?.kimi?.apiKey ||
-    env.BRAVE_API_KEY ||
-    env.PERPLEXITY_API_KEY ||
-    env.OPENROUTER_API_KEY ||
-    env.XAI_API_KEY ||
-    env.GEMINI_API_KEY ||
-    env.KIMI_API_KEY ||
-    env.MOONSHOT_API_KEY,
-  );
+  const provider = search?.provider?.trim().toLowerCase();
+
+  const hasBrave = Boolean(search?.apiKey || env.BRAVE_API_KEY);
+  const hasPerplexity = Boolean(search?.perplexity?.apiKey || env.PERPLEXITY_API_KEY);
+  const hasGrok = Boolean(search?.grok?.apiKey || env.XAI_API_KEY);
+  const hasGemini = Boolean(search?.gemini?.apiKey || env.GEMINI_API_KEY);
+  const hasKimi = Boolean(search?.kimi?.apiKey || env.KIMI_API_KEY || env.MOONSHOT_API_KEY);
+
+  if (provider === "brave") {
+    return hasBrave;
+  }
+  if (provider === "perplexity") {
+    return hasPerplexity;
+  }
+  if (provider === "grok") {
+    return hasGrok;
+  }
+  if (provider === "gemini") {
+    return hasGemini;
+  }
+  if (provider === "kimi") {
+    return hasKimi;
+  }
+
+  // Auto-provider mode: any supported provider key can enable web_search.
+  return hasBrave || hasPerplexity || hasGrok || hasGemini || hasKimi;
 }
 
 function isWebSearchEnabled(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {


### PR DESCRIPTION
## Summary
- extend `hasWebSearchKey` to include Gemini/Grok/Kimi config keys and env fallbacks
- include OpenRouter/XAI/Gemini/Kimi/Moonshot env vars in detection
- add regression tests to verify these keys mark web_search as exposed in small-model risk audit

## Testing
- `npx vitest run src/security/audit-extra.sync.test.ts`

Fixes openclaw/openclaw#34509
