### PR TITLE
fix(discord): add User-Agent header to REST API requests

### DIFF
--- a/src/discord/api.test.ts
+++ b/src/discord/api.test.ts
@@ -42,6 +42,20 @@ describe("fetchDiscord", () => {
     ).rejects.toThrow("Discord API /users/@me/guilds failed (404): Not Found");
   });
 
+  it("sends a Discord-compliant User-Agent header", async () => {
+    let capturedHeaders: Headers | undefined;
+    const fetcher = withFetchPreconnect(async (url: string | URL | Request, init?: RequestInit) => {
+      capturedHeaders = new Headers(init?.headers);
+      return jsonResponse([{ id: "1", name: "Guild" }], 200);
+    });
+
+    await fetchDiscord("/users/@me/guilds", "test-token", fetcher);
+
+    expect(capturedHeaders).toBeDefined();
+    expect(capturedHeaders!.get("User-Agent")).toMatch(/^DiscordBot \(/);
+    expect(capturedHeaders!.get("Authorization")).toBe("Bot test-token");
+  });
+
   it("retries rate limits before succeeding", async () => {
     let calls = 0;
     const fetcher = withFetchPreconnect(async () => {

--- a/src/discord/api.ts
+++ b/src/discord/api.ts
@@ -2,6 +2,7 @@ import { resolveFetch } from "../infra/fetch.js";
 import { resolveRetryConfig, retryAsync, type RetryConfig } from "../infra/retry.js";
 
 const DISCORD_API_BASE = "https://discord.com/api/v10";
+const DISCORD_USER_AGENT = "DiscordBot (https://github.com/openclaw/openclaw, 1.0)";
 const DISCORD_API_RETRY_DEFAULTS = {
   attempts: 3,
   minDelayMs: 500,
@@ -108,7 +109,10 @@ export async function fetchDiscord<T>(
   return retryAsync(
     async () => {
       const res = await fetchImpl(`${DISCORD_API_BASE}${path}`, {
-        headers: { Authorization: `Bot ${token}` },
+        headers: {
+          Authorization: `Bot ${token}`,
+          "User-Agent": DISCORD_USER_AGENT,
+        },
       });
       if (!res.ok) {
         const text = await res.text().catch(() => "");


### PR DESCRIPTION
## Summary

`fetchDiscord()` in `src/discord/api.ts` sends REST API requests to Discord without a `User-Agent` header. Discord's Cloudflare protection returns HTTP 403 (error code 1010) for requests missing this header.

## Root Cause

The channel resolver introduced in #33142 added a `fetchChannel()` code path that calls `/channels/{channelId}` via `fetchDiscord()`. While the WebSocket gateway (discord.js) automatically includes a proper `User-Agent`, the low-level `fetchDiscord()` helper only sent `Authorization`.

The `/channels/{id}` endpoint appears to have stricter Cloudflare rules than `/users/@me/guilds` (which was the only previous code path), causing the 403s to surface after #33142 landed in 2026.3.2.

## Symptoms

- `[discord] channel resolve failed; using config entries. Discord API /channels/{id} failed (403): Missing Access` logged every ~5 minutes per guild channel
- ~200+ warnings/day (noisy but non-breaking — the resolver falls back to config entries)
- Only affects REST calls; WebSocket message handling is unaffected

## Fix

Add a [Discord-compliant `User-Agent` header](https://discord.com/developers/docs/reference#user-agents) to `fetchDiscord()`:

```
DiscordBot (https://github.com/openclaw/openclaw, 1.0)
```

## Changes

- `src/discord/api.ts` — Add `User-Agent` header constant and include it in all `fetchDiscord()` requests
- `src/discord/api.test.ts` — Add test verifying the header is sent with the correct format

## Testing

- Verified locally: adding the `User-Agent` header resolves the 403 on `/channels/{id}` calls
- Added unit test asserting `DiscordBot (` prefix format and `Authorization` header presence