### PR TITLE
fix(feishu): normalize markdown URLs in rendered messages

### DIFF
--- a/extensions/feishu/src/markdown-links.test.ts
+++ b/extensions/feishu/src/markdown-links.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { normalizeFeishuMarkdownLinks } from "./markdown-links.js";
+
+describe("markdown-links", () => {
+  it("wraps bare URL and normalizes fragile URL characters", () => {
+    const out = normalizeFeishuMarkdownLinks("Visit https://example.com/a_b(c).");
+    expect(out).toBe("Visit [https://example.com/a%5Fb%28c%29](https://example.com/a%5Fb%28c%29).");
+  });
+
+  it("normalizes URL chars in existing markdown link destination without double-wrapping", () => {
+    const out = normalizeFeishuMarkdownLinks("[site](https://example.com/a_b)");
+    expect(out).toBe("[site](https://example.com/a%5Fb)");
+  });
+
+  it("keeps inline code untouched and rewrites plain URL", () => {
+    const out = normalizeFeishuMarkdownLinks(
+      "`https://example.com/a_b` and https://example.com/a_b",
+    );
+    expect(out).toBe(
+      "`https://example.com/a_b` and [https://example.com/a%5Fb](https://example.com/a%5Fb)",
+    );
+  });
+
+  it("keeps fenced code block untouched", () => {
+    const input = "```txt\nhttps://example.com/a_b\n```\nhttps://example.com/a_b";
+    const out = normalizeFeishuMarkdownLinks(input);
+    expect(out).toBe(
+      "```txt\nhttps://example.com/a_b\n```\n[https://example.com/a%5Fb](https://example.com/a%5Fb)",
+    );
+  });
+
+  it("converts autolink to stable markdown link", () => {
+    const out = normalizeFeishuMarkdownLinks("<https://example.com/a_b>");
+    expect(out.includes("<https://")).toBe(false);
+    expect(out).toContain("example.com");
+    expect(out).toContain("%5F");
+  });
+
+  it("keeps trailing punctuation outside markdown destination", () => {
+    const out = normalizeFeishuMarkdownLinks("See https://example.com/path).");
+    expect(out).toBe("See [https://example.com/path](https://example.com/path)).");
+  });
+});

--- a/extensions/feishu/src/markdown-links.test.ts
+++ b/extensions/feishu/src/markdown-links.test.ts
@@ -43,4 +43,16 @@ describe("markdown-links", () => {
     const out = normalizeFeishuMarkdownLinks("[https://example.com/a_b](https://example.com/a_b)");
     expect(out).toBe("[https://example.com/a_b](https://example.com/a%5Fb)");
   });
+
+  it("does not wrap URL inside a label that does not start immediately after [", () => {
+    const out = normalizeFeishuMarkdownLinks(
+      "[docs https://example.com/a_b](https://example.com/a_b)",
+    );
+    expect(out).toBe("[docs https://example.com/a_b](https://example.com/a%5Fb)");
+  });
+
+  it("leaves autolink inside markdown angle-bracket destination untouched", () => {
+    const out = normalizeFeishuMarkdownLinks("[site](<https://example.com/a_b>)");
+    expect(out).toBe("[site](<https://example.com/a_b>)");
+  });
 });

--- a/extensions/feishu/src/markdown-links.test.ts
+++ b/extensions/feishu/src/markdown-links.test.ts
@@ -38,4 +38,9 @@ describe("markdown-links", () => {
     const out = normalizeFeishuMarkdownLinks("See https://example.com/path).");
     expect(out).toBe("See [https://example.com/path](https://example.com/path)).");
   });
+
+  it("normalizes destination of URL-labeled markdown link without double-wrapping label", () => {
+    const out = normalizeFeishuMarkdownLinks("[https://example.com/a_b](https://example.com/a_b)");
+    expect(out).toBe("[https://example.com/a_b](https://example.com/a%5Fb)");
+  });
 });

--- a/extensions/feishu/src/markdown-links.test.ts
+++ b/extensions/feishu/src/markdown-links.test.ts
@@ -29,11 +29,9 @@ describe("markdown-links", () => {
     );
   });
 
-  it("converts autolink to stable markdown link", () => {
+  it("converts autolink to stable markdown link without double-wrapping", () => {
     const out = normalizeFeishuMarkdownLinks("<https://example.com/a_b>");
-    expect(out.includes("<https://")).toBe(false);
-    expect(out).toContain("example.com");
-    expect(out).toContain("%5F");
+    expect(out).toBe("[https://example.com/a%5Fb](https://example.com/a%5Fb)");
   });
 
   it("keeps trailing punctuation outside markdown destination", () => {

--- a/extensions/feishu/src/markdown-links.ts
+++ b/extensions/feishu/src/markdown-links.ts
@@ -1,0 +1,110 @@
+const FENCED_CODE_BLOCK_RE = /(```[\s\S]*?```)/g;
+const INLINE_CODE_RE = /(`[^`\n]*`)/g;
+const URL_RE = /https?:\/\/[^\s<>"'`]+/g;
+const TRAILING_PUNCT_RE = /[.,;!?\u3002\uff0c\uff1b\uff01\uff1f\u3001]/u;
+const AUTO_LINK_RE = /<\s*(https?:\/\/[^>\s]+)\s*>/g;
+
+// Feishu markdown can mis-handle some URL characters in edge cases.
+// Encode a minimal safe subset while preserving URL semantics.
+function normalizeUrlForFeishu(url: string): string {
+  return url.replace(/_/g, "%5F").replace(/\(/g, "%28").replace(/\)/g, "%29");
+}
+
+// We intentionally convert raw/autolink URLs into explicit markdown links.
+// Why: in Feishu message rendering, plain URLs (including "<...>" autolinks)
+// can be re-tokenized and visually split/truncated on characters like "_"
+// or around long query strings. The explicit "[label](url)" form is more stable
+// in post/card markdown parsing and keeps the link clickable end-to-end.
+function buildMarkdownLink(url: string): string {
+  const label = url.replace(/[\[\]]/g, "\\$&");
+  return `[${label}](${url})`;
+}
+
+// We only need balance info to detect whether a trailing ")" belongs to the URL.
+function countParens(text: string): { open: number; close: number } {
+  let open = 0;
+  let close = 0;
+  for (const c of text) {
+    if (c === "(") {
+      open += 1;
+    } else if (c === ")") {
+      close += 1;
+    }
+  }
+  return { open, close };
+}
+
+function splitTrailingPunctuation(rawUrl: string): { url: string; trailing: string } {
+  let url = rawUrl;
+  let trailing = "";
+  let { open, close } = countParens(rawUrl);
+
+  while (url.length > 0) {
+    const tail = url.slice(-1);
+    // Many links appear as ".../path),". Strip punctuation that is not part of the URL.
+    const closeParenOverflow = tail === ")" && close > open;
+    if (!TRAILING_PUNCT_RE.test(tail) && !closeParenOverflow) {
+      break;
+    }
+    if (tail === ")") {
+      close -= 1;
+    }
+    trailing = tail + trailing;
+    url = url.slice(0, -1);
+  }
+
+  return { url, trailing };
+}
+
+function wrapBareUrls(text: string): string {
+  // Normalize "<https://...>" to explicit markdown links for better Feishu stability.
+  const convertedAutoLinks = text.replace(AUTO_LINK_RE, (_full, rawUrl: string) => {
+    const { url, trailing } = splitTrailingPunctuation(rawUrl);
+    if (!url) {
+      return _full;
+    }
+    return `${buildMarkdownLink(normalizeUrlForFeishu(url))}${trailing}`;
+  });
+
+  return convertedAutoLinks.replace(URL_RE, (raw, offset, input) => {
+    const { url, trailing } = splitTrailingPunctuation(raw);
+    if (!url) {
+      return raw;
+    }
+
+    // Do not rebuild existing markdown destinations, only normalize URL chars in-place.
+    const isMarkdownDestination = offset >= 2 && input.slice(offset - 2, offset) === "](";
+    const normalizedUrl = normalizeUrlForFeishu(url);
+    if (isMarkdownDestination) {
+      return `${normalizedUrl}${trailing}`;
+    }
+
+    return `${buildMarkdownLink(normalizedUrl)}${trailing}`;
+  });
+}
+
+function normalizeNonCodeSegments(text: string): string {
+  // Keep inline code untouched, normalize only plain markdown text.
+  return text
+    .split(INLINE_CODE_RE)
+    .map((segment, idx) =>
+      idx % 2 === 1 && segment.startsWith("`") ? segment : wrapBareUrls(segment),
+    )
+    .join("");
+}
+
+export function normalizeFeishuMarkdownLinks(text: string): string {
+  if (!text || (!text.includes("http://") && !text.includes("https://"))) {
+    return text;
+  }
+
+  return (
+    text
+      // Keep fenced code blocks untouched to avoid changing examples/snippets.
+      .split(FENCED_CODE_BLOCK_RE)
+      .map((block, idx) =>
+        idx % 2 === 1 && block.startsWith("```") ? block : normalizeNonCodeSegments(block),
+      )
+      .join("")
+  );
+}

--- a/extensions/feishu/src/markdown-links.ts
+++ b/extensions/feishu/src/markdown-links.ts
@@ -56,15 +56,36 @@ function splitTrailingPunctuation(rawUrl: string): { url: string; trailing: stri
   return { url, trailing };
 }
 
+// Scan backwards from `offset` to detect if the position is inside a markdown
+// link label [...]. Returns true if an unmatched "[" is found before "]" or
+// newline, meaning this URL sits somewhere inside a label (not necessarily
+// starting right after "[").
+function isInsideMarkdownLinkLabel(offset: number, input: string): boolean {
+  for (let i = offset - 1; i >= 0; i--) {
+    const ch = input[i];
+    if (ch === "[") return true;
+    if (ch === "]" || ch === "\n") return false;
+  }
+  return false;
+}
+
 function wrapBareUrls(text: string): string {
   // Normalize "<https://...>" to explicit markdown links for better Feishu stability.
-  const convertedAutoLinks = text.replace(AUTO_LINK_RE, (_full, rawUrl: string) => {
-    const { url, trailing } = splitTrailingPunctuation(rawUrl);
-    if (!url) {
-      return _full;
-    }
-    return `${buildMarkdownLink(normalizeUrlForFeishu(url))}${trailing}`;
-  });
+  // Skip autolinks that appear inside a markdown destination: ](<https://...>).
+  const convertedAutoLinks = text.replace(
+    AUTO_LINK_RE,
+    (_full, rawUrl: string, offset: number, input: string) => {
+      // ](<https://...>) — angle-bracket destination form; leave as-is.
+      if (offset >= 2 && input.slice(offset - 2, offset) === "](") {
+        return _full;
+      }
+      const { url, trailing } = splitTrailingPunctuation(rawUrl);
+      if (!url) {
+        return _full;
+      }
+      return `${buildMarkdownLink(normalizeUrlForFeishu(url))}${trailing}`;
+    },
+  );
 
   return convertedAutoLinks.replace(URL_RE, (raw, offset, input) => {
     const { url, trailing } = splitTrailingPunctuation(raw);
@@ -72,17 +93,25 @@ function wrapBareUrls(text: string): string {
       return raw;
     }
 
-    // Skip URLs that are already inside a markdown link (label or destination).
-    // Label: preceded by "[" → already a link label, leave as-is.
-    // Destination: preceded by "](" → normalize chars in-place, no re-wrap.
-    const isMarkdownLabel = offset >= 1 && input.slice(offset - 1, offset) === "[";
-    const isMarkdownDestination = offset >= 2 && input.slice(offset - 2, offset) === "](";
-    const normalizedUrl = normalizeUrlForFeishu(url);
-    if (isMarkdownLabel) {
+    // Skip URLs inside a markdown link label (anywhere in [...], not just at start).
+    if (isInsideMarkdownLinkLabel(offset, input)) {
       return raw;
     }
+
+    // Destination: preceded by "](" → normalize chars in-place, no re-wrap.
+    const isMarkdownDestination = offset >= 2 && input.slice(offset - 2, offset) === "](";
+    // Angle-bracket destination: ](<https://...>) — leave completely untouched.
+    const isAngleBracketDest =
+      offset >= 1 &&
+      input[offset - 1] === "<" &&
+      offset >= 3 &&
+      input.slice(offset - 3, offset - 1) === "](";
+    const normalizedUrl = normalizeUrlForFeishu(url);
     if (isMarkdownDestination) {
       return `${normalizedUrl}${trailing}`;
+    }
+    if (isAngleBracketDest) {
+      return raw;
     }
 
     return `${buildMarkdownLink(normalizedUrl)}${trailing}`;

--- a/extensions/feishu/src/markdown-links.ts
+++ b/extensions/feishu/src/markdown-links.ts
@@ -1,6 +1,6 @@
 const FENCED_CODE_BLOCK_RE = /(```[\s\S]*?```)/g;
 const INLINE_CODE_RE = /(`[^`\n]*`)/g;
-const URL_RE = /https?:\/\/[^\s<>"'`]+/g;
+const URL_RE = /https?:\/\/[^\s<>"'`\]]+/g;
 const TRAILING_PUNCT_RE = /[.,;!?\u3002\uff0c\uff1b\uff01\uff1f\u3001]/u;
 const AUTO_LINK_RE = /<\s*(https?:\/\/[^>\s]+)\s*>/g;
 

--- a/extensions/feishu/src/markdown-links.ts
+++ b/extensions/feishu/src/markdown-links.ts
@@ -72,9 +72,15 @@ function wrapBareUrls(text: string): string {
       return raw;
     }
 
-    // Do not rebuild existing markdown destinations, only normalize URL chars in-place.
+    // Skip URLs that are already inside a markdown link (label or destination).
+    // Label: preceded by "[" → already a link label, leave as-is.
+    // Destination: preceded by "](" → normalize chars in-place, no re-wrap.
+    const isMarkdownLabel = offset >= 1 && input.slice(offset - 1, offset) === "[";
     const isMarkdownDestination = offset >= 2 && input.slice(offset - 2, offset) === "](";
     const normalizedUrl = normalizeUrlForFeishu(url);
+    if (isMarkdownLabel) {
+      return raw;
+    }
     if (isMarkdownDestination) {
       return `${normalizedUrl}${trailing}`;
     }

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -173,7 +173,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         await streamingStartPromise;
       }
       if (streaming?.isActive()) {
-        await streaming.update(streamText);
+        await streaming.update(normalizeFeishuMarkdownLinks(streamText));
       }
     });
   };

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -8,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { normalizeFeishuMarkdownLinks } from "./markdown-links.js";
 import { sendMediaFeishu } from "./media.js";
 import type { MentionTarget } from "./mention.js";
 import { buildMentionedCardContent } from "./mention.js";
@@ -216,7 +217,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       if (mentionTargets?.length) {
         text = buildMentionedCardContent(mentionTargets, text);
       }
-      await streaming.close(text);
+      await streaming.close(normalizeFeishuMarkdownLinks(text));
     }
     streaming = null;
     streamingStartPromise = null;

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -1,6 +1,7 @@
 import type { ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { normalizeFeishuMarkdownLinks } from "./markdown-links.js";
 import type { MentionTarget } from "./mention.js";
 import { buildMentionedMessage, buildMentionedCardContent } from "./mention.js";
 import { parsePostContent } from "./post.js";
@@ -290,7 +291,9 @@ export async function sendMessageFeishu(
   if (mentions && mentions.length > 0) {
     rawText = buildMentionedMessage(mentions, rawText);
   }
-  const messageText = getFeishuRuntime().channel.text.convertMarkdownTables(rawText, tableMode);
+  const messageText = normalizeFeishuMarkdownLinks(
+    getFeishuRuntime().channel.text.convertMarkdownTables(rawText, tableMode),
+  );
 
   const { content, msgType } = buildFeishuPostMessagePayload({ messageText });
 
@@ -434,6 +437,7 @@ export async function sendMarkdownCardFeishu(params: {
   if (mentions && mentions.length > 0) {
     cardText = buildMentionedCardContent(mentions, text);
   }
+  cardText = normalizeFeishuMarkdownLinks(cardText);
   const card = buildMarkdownCard(cardText);
   return sendCardFeishu({ cfg, to, card, replyToMessageId, replyInThread, accountId });
 }
@@ -459,7 +463,9 @@ export async function editMessageFeishu(params: {
     cfg,
     channel: "feishu",
   });
-  const messageText = getFeishuRuntime().channel.text.convertMarkdownTables(text ?? "", tableMode);
+  const messageText = normalizeFeishuMarkdownLinks(
+    getFeishuRuntime().channel.text.convertMarkdownTables(text ?? "", tableMode),
+  );
 
   const { content, msgType } = buildFeishuPostMessagePayload({ messageText });
 


### PR DESCRIPTION
## Summary

- **Problem:** Feishu's markdown renderer mis-handles URLs containing underscores, parentheses, or angle-bracket autolinks. Plain URLs get visually split or truncated (e.g. a URL with `_word_` renders as italic); bare `<https://...>` autolinks are not always clickable in post/card messages.
- **Why it matters:** Any agent reply containing documentation links, GitHub URLs, or query strings with underscores renders incorrectly for the end user — links appear broken or non-clickable.
- **What changed:** Added `normalizeFeishuMarkdownLinks()` in `markdown-links.ts`, applied at all text-emission sites in `send.ts` and `reply-dispatcher.ts`.
- **What did NOT change:** Message content, routing, delivery logic, or any non-URL text are unaffected. The function is a no-op when the text contains no URLs.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Related #16337

## User-visible / Behavior Changes

URLs in agent replies sent via Feishu are now:
- Wrapped in explicit `[label](url)` markdown links (prevents rendering truncation)
- `_`, `(`, `)` in URL paths are percent-encoded to avoid Feishu markdown tokenizer artifacts
- `<https://...>` autolinks converted to stable markdown form
- Trailing punctuation (`.`, `,`, `)`, CJK punctuation) stripped from URL before wrapping

Text without any URLs is returned unchanged (fast-path check).

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Integration/channel: Feishu (飞书)

### Steps

1. Ask the Feishu bot a question that produces a reply with a URL containing underscores, e.g. pointing to a GitHub file path like `https://github.com/org/repo/blob/main/src/some_file.ts`
2. Observe the rendered message in the Feishu client

### Expected

URL is rendered as a clickable link without visual breaks.

### Actual (before fix)

The `_` characters cause Feishu to interpret parts of the URL as italic markdown, splitting the link and breaking clickability.

## Evidence

- [x] Failing test/log before + passing after

`markdown-links.test.ts` — 6 unit tests covering: bare URL wrapping, existing markdown link normalization, inline code preservation, fenced code block preservation, autolink conversion, trailing punctuation stripping.

```
✓ markdown-links > wraps bare URL and normalizes fragile URL characters
✓ markdown-links > normalizes URL chars in existing markdown link destination without double-wrapping
✓ markdown-links > keeps inline code untouched and rewrites plain URL
✓ markdown-links > keeps fenced code block untouched
✓ markdown-links > converts autolink to stable markdown link
✓ markdown-links > keeps trailing punctuation outside markdown destination

Test Files  1 passed (1)
      Tests  6 passed (6)
```

Full feishu suite: **33 files, 303 tests passed**.

## Human Verification (required)

- Verified scenarios: unit tests cover all transformation cases
- Edge cases checked: inline code, fenced code blocks, existing markdown links (no double-wrapping), trailing punctuation, CJK punctuation, autolinks
- What you did **not** verify: live Feishu client rendering (requires bot deployment)

## Compatibility / Migration

- Backward compatible? Yes — purely additive, no config changes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the three `normalizeFeishuMarkdownLinks(...)` call-site wraps in `send.ts` and `reply-dispatcher.ts`
- Files/config to restore: `send.ts`, `reply-dispatcher.ts`, `markdown-links.ts`
- Known bad symptoms reviewers should watch for: any URL that was previously rendered correctly now renders differently (unlikely given the no-op fast path)

## Risks and Mitigations

- Risk: percent-encoding `_`/`(`/`)` in URLs may affect URLs where these chars are semantically significant
  - Mitigation: only applied to Feishu card/post rendering path, not to raw text or tool outputs; encoding is idempotent for already-encoded URLs

## Source

Ported from [m1heng/clawdbot-feishu#292](https://github.com/m1heng/clawdbot-feishu/pull/292)

> Context: [openclaw#16337](https://github.com/openclaw/openclaw/pull/16337)