### PR TITLE
fix(feishu): strip reaction suffix from message IDs before API calls

### DIFF
--- a/extensions/feishu/src/external-keys.test.ts
+++ b/extensions/feishu/src/external-keys.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeFeishuExternalKey } from "./external-keys.js";
+import { normalizeFeishuExternalKey, stripFeishuReactionSuffix } from "./external-keys.js";
 
 describe("normalizeFeishuExternalKey", () => {
   it("accepts a normal feishu key and trims surrounding spaces", () => {
@@ -16,5 +16,27 @@ describe("normalizeFeishuExternalKey", () => {
     expect(normalizeFeishuExternalKey("   ")).toBeUndefined();
     expect(normalizeFeishuExternalKey(123)).toBeUndefined();
     expect(normalizeFeishuExternalKey("abc\u0000def")).toBeUndefined();
+  });
+});
+
+describe("stripFeishuReactionSuffix", () => {
+  it("returns plain message IDs unchanged", () => {
+    expect(stripFeishuReactionSuffix("om_abc123")).toBe("om_abc123");
+  });
+
+  it("strips :reaction: suffix from synthetic reaction IDs", () => {
+    expect(
+      stripFeishuReactionSuffix("om_abc123:reaction:THUMBSUP:550dd4ec-46af-41c9-affc-a68cd11a5e49"),
+    ).toBe("om_abc123");
+  });
+
+  it("strips other emoji reaction suffixes", () => {
+    expect(
+      stripFeishuReactionSuffix("om_xyz789:reaction:HEART:12345678-1234-1234-1234-123456789abc"),
+    ).toBe("om_xyz789");
+  });
+
+  it("handles edge case with :reaction: in the middle of a longer ID", () => {
+    expect(stripFeishuReactionSuffix("om_x100b55b7:reaction:LAUGH:uuid-here")).toBe("om_x100b55b7");
   });
 });

--- a/extensions/feishu/src/external-keys.ts
+++ b/extensions/feishu/src/external-keys.ts
@@ -17,3 +17,18 @@ export function normalizeFeishuExternalKey(value: unknown): string | undefined {
   }
   return normalized;
 }
+
+/**
+ * Strip synthetic reaction suffix from message IDs.
+ *
+ * OpenClaw generates composite IDs like `om_xxx:reaction:THUMBSUP:uuid` for
+ * reaction events (see monitor.account.ts).  When these IDs are later used
+ * as replyToMessageId in Feishu API calls, the API returns 400 because only
+ * the base `om_xxx` part is a valid open_message_id.
+ *
+ * Fixes #34528
+ */
+export function stripFeishuReactionSuffix(messageId: string): string {
+  const idx = messageId.indexOf(":reaction:");
+  return idx === -1 ? messageId : messageId.slice(0, idx);
+}

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -4,7 +4,7 @@ import { Readable } from "stream";
 import { withTempDownloadPath, type ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
-import { normalizeFeishuExternalKey } from "./external-keys.js";
+import { normalizeFeishuExternalKey, stripFeishuReactionSuffix } from "./external-keys.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
@@ -298,7 +298,7 @@ export async function sendImageFeishu(params: {
 
   if (replyToMessageId) {
     const response = await client.im.message.reply({
-      path: { message_id: replyToMessageId },
+      path: { message_id: stripFeishuReactionSuffix(replyToMessageId) },
       data: {
         content,
         msg_type: "image",
@@ -345,7 +345,7 @@ export async function sendFileFeishu(params: {
 
   if (replyToMessageId) {
     const response = await client.im.message.reply({
-      path: { message_id: replyToMessageId },
+      path: { message_id: stripFeishuReactionSuffix(replyToMessageId) },
       data: {
         content,
         msg_type: msgType,

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -1,6 +1,7 @@
 import type { ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { stripFeishuReactionSuffix } from "./external-keys.js";
 import type { MentionTarget } from "./mention.js";
 import { buildMentionedMessage, buildMentionedCardContent } from "./mention.js";
 import { parsePostContent } from "./post.js";
@@ -241,7 +242,7 @@ export async function sendMessageFeishu(
 
   if (replyToMessageId) {
     const response = await client.im.message.reply({
-      path: { message_id: replyToMessageId },
+      path: { message_id: stripFeishuReactionSuffix(replyToMessageId) },
       data: {
         content,
         msg_type: msgType,
@@ -293,7 +294,7 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
 
   if (replyToMessageId) {
     const response = await client.im.message.reply({
-      path: { message_id: replyToMessageId },
+      path: { message_id: stripFeishuReactionSuffix(replyToMessageId) },
       data: {
         content,
         msg_type: "interactive",


### PR DESCRIPTION
## Summary

Fixes #34528

When a user reacts to a message in Feishu, OpenClaw generates a synthetic composite message_id:

```
om_x100b55b75bbd1ca4:reaction:THUMBSUP:350dd4ec-46af-41c9-affc-a68cd11a5e49
```

This is used internally for event routing, but when it leaks into `replyToMessageId` for Feishu API calls (`im.message.reply`), the API returns HTTP 400:

```json
{"code": 99992354, "msg": "not a valid {open_message_id}"}
```

## Changes

- **`external-keys.ts`**: Add `stripFeishuReactionSuffix()` — strips everything after `:reaction:` to recover the base message ID
- **`send.ts`**: Apply strip before passing `replyToMessageId` to `im.message.reply` (text + card paths)
- **`media.ts`**: Apply strip before passing `replyToMessageId` to `im.message.reply` (image + file paths)

## Testing

- Added 4 unit tests for `stripFeishuReactionSuffix` (plain IDs, THUMBSUP, HEART, edge cases)
- All existing send/media tests still pass