### PR TITLE
fix(feishu): parse interactive card content in quoted messages and merge_forward

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -442,6 +442,32 @@ function formatSubMessageContent(content: string, contentType: string): string {
         return "[Sticker]";
       case "merge_forward":
         return "[Nested Merged Forward]";
+      case "interactive": {
+        // Parse interactive card to extract readable content (#34571, #32712)
+        const title = parsed.header?.title?.content || "";
+        const elements = parsed.elements || parsed.body?.elements || [];
+        const texts: string[] = [];
+        for (const el of elements) {
+          if (el.tag === "markdown" && el.content) {
+            texts.push(el.content);
+          } else if (el.tag === "div") {
+            const t = el.text?.content || el.content || "";
+            if (t) texts.push(t);
+          } else if (el.tag === "column_set") {
+            for (const col of el.columns || []) {
+              for (const inner of col.elements || []) {
+                const t = inner.text?.content || inner.content || "";
+                if (t) texts.push(t);
+              }
+            }
+          }
+        }
+        const body = texts.join(" ").trim();
+        if (title && body) return `[Card: ${title}] ${body}`;
+        if (title) return `[Card: ${title}]`;
+        if (body) return `[Card] ${body}`;
+        return "[Interactive Card]";
+      }
       default:
         return `[${contentType}]`;
     }

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -456,8 +456,12 @@ function formatSubMessageContent(content: string, contentType: string): string {
           } else if (el.tag === "column_set") {
             for (const col of el.columns || []) {
               for (const inner of col.elements || []) {
-                const t = inner.text?.content || inner.content || "";
-                if (t) texts.push(t);
+                // Only extract text from markdown/div elements, skip buttons/images/actions
+                if (inner.tag === "markdown" && inner.content) {
+                  texts.push(inner.content);
+                } else if (inner.tag === "div" && inner.text?.content) {
+                  texts.push(inner.text.content);
+                }
               }
             }
           }

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -35,13 +35,22 @@ function parseInteractiveCardContent(parsed: unknown): string {
     return "[Interactive Card]";
   }
 
-  const candidate = parsed as { elements?: unknown };
-  if (!Array.isArray(candidate.elements)) {
-    return "[Interactive Card]";
-  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- card structure varies
+  const card = parsed as any;
+
+  // Extract title from card header (Feishu cards often have header.title.content)
+  const title: string =
+    (typeof card.header?.title?.content === "string" && card.header.title.content) || "";
+
+  // Support both top-level elements and body.elements (Card Kit v2 structure)
+  const elements: unknown[] = Array.isArray(card.elements)
+    ? card.elements
+    : Array.isArray(card.body?.elements)
+      ? card.body.elements
+      : [];
 
   const texts: string[] = [];
-  for (const element of candidate.elements) {
+  for (const element of elements) {
     if (!element || typeof element !== "object") {
       continue;
     }
@@ -49,6 +58,7 @@ function parseInteractiveCardContent(parsed: unknown): string {
       tag?: string;
       content?: string;
       text?: { content?: string };
+      columns?: Array<{ elements?: unknown[] }>;
     };
     if (item.tag === "div" && typeof item.text?.content === "string") {
       texts.push(item.text.content);
@@ -56,9 +66,33 @@ function parseInteractiveCardContent(parsed: unknown): string {
     }
     if (item.tag === "markdown" && typeof item.content === "string") {
       texts.push(item.content);
+      continue;
+    }
+    // Handle column_set layout containers
+    if (item.tag === "column_set" && Array.isArray(item.columns)) {
+      for (const col of item.columns) {
+        for (const inner of col.elements ?? []) {
+          if (!inner || typeof inner !== "object") continue;
+          const innerItem = inner as {
+            tag?: string;
+            content?: string;
+            text?: { content?: string };
+          };
+          if (innerItem.tag === "markdown" && typeof innerItem.content === "string") {
+            texts.push(innerItem.content);
+          } else if (innerItem.tag === "div" && typeof innerItem.text?.content === "string") {
+            texts.push(innerItem.text.content);
+          }
+        }
+      }
     }
   }
-  return texts.join("\n").trim() || "[Interactive Card]";
+
+  const body = texts.join("\n").trim();
+  if (title && body) return `${title}\n${body}`;
+  if (title) return title;
+  if (body) return body;
+  return "[Interactive Card]";
 }
 
 function parseQuotedMessageContent(rawContent: string, msgType: string): string {


### PR DESCRIPTION
## Summary

Two related fixes for interactive card content parsing:

### 1. Quoted message card parsing (fixes #32712)

`parseInteractiveCardContent` only checked top-level `elements` array, missing:
- **Card header title** (`header.title.content`)
- **Card Kit v2 structure** (`body.elements` instead of top-level `elements`)
- **column_set layout containers** with nested text/markdown elements

This caused quoted interactive cards to display as `[Interactive Card]` instead of showing their content.

### 2. Merge-forward sub-message card parsing (fixes #34571)

`formatSubMessageContent` in `bot.ts` had no case for `interactive` message type, falling through to the default `[interactive]` placeholder. Added explicit handling using the same enhanced parsing logic.

## Testing

- All existing send.ts tests pass (4/4)
- Both `parseInteractiveCardContent` (quoted messages) and `formatSubMessageContent` (merge_forward) now handle cards