### PR TITLE
fix(whatsapp): default dmPolicy to allowlist, auto-add owner to allowFrom

### DIFF
--- a/src/channels/plugins/onboarding/whatsapp.ts
+++ b/src/channels/plugins/onboarding/whatsapp.ts
@@ -13,6 +13,7 @@ import {
   resolveDefaultWhatsAppAccountId,
   resolveWhatsAppAuthDir,
 } from "../../../web/accounts.js";
+import { readWebSelfId } from "../../../web/auth-store.js";
 import type { WizardPrompter } from "../../../wizard/prompts.js";
 import type { ChannelOnboardingAdapter } from "../onboarding-types.js";
 import {
@@ -127,7 +128,7 @@ async function promptWhatsAppAllowFrom(
   prompter: WizardPrompter,
   options?: { forceAllowlist?: boolean },
 ): Promise<OpenClawConfig> {
-  const existingPolicy = cfg.channels?.whatsapp?.dmPolicy ?? "pairing";
+  const existingPolicy = cfg.channels?.whatsapp?.dmPolicy ?? "allowlist";
   const existingAllowFrom = cfg.channels?.whatsapp?.allowFrom ?? [];
   const existingLabel = existingAllowFrom.length > 0 ? existingAllowFrom.join(", ") : "unset";
 
@@ -144,8 +145,8 @@ async function promptWhatsAppAllowFrom(
   await prompter.note(
     [
       "WhatsApp direct chats are gated by `channels.whatsapp.dmPolicy` + `channels.whatsapp.allowFrom`.",
-      "- pairing (default): unknown senders get a pairing code; owner approves",
-      "- allowlist: unknown senders are blocked",
+      "- allowlist (default): only pre-approved numbers can message",
+      "- pairing: unknown senders get a pairing code; owner approves",
       '- open: public inbound DMs (requires allowFrom to include "*")',
       "- disabled: ignore WhatsApp DMs",
       "",
@@ -179,8 +180,8 @@ async function promptWhatsAppAllowFrom(
   const policy = (await prompter.select({
     message: "WhatsApp DM policy",
     options: [
-      { value: "pairing", label: "Pairing (recommended)" },
-      { value: "allowlist", label: "Allowlist only (block unknown senders)" },
+      { value: "allowlist", label: "Allowlist (recommended — block unknown senders)" },
+      { value: "pairing", label: "Pairing (unknown DMs get a pairing code)" },
       { value: "open", label: "Open (public inbound DMs)" },
       { value: "disabled", label: "Disabled (ignore WhatsApp DMs)" },
     ],
@@ -340,6 +341,38 @@ export const whatsappOnboardingAdapter: ChannelOnboardingAdapter = {
         `Run \`${formatCliCommand("openclaw channels login")}\` later to link WhatsApp.`,
         "WhatsApp",
       );
+    }
+
+    // Auto-detect the owner's phone number from linked credentials and
+    // default to allowlist mode with the owner pre-added.  This ensures
+    // new installs are secure-by-default without requiring manual config.
+    const selfId = readWebSelfId(authDir);
+    if (selfId.e164) {
+      const existingAllowFrom = next.channels?.whatsapp?.allowFrom ?? [];
+      const existingPolicy = next.channels?.whatsapp?.dmPolicy;
+      // Only auto-apply when no explicit policy/allowFrom has been set yet
+      if (!existingPolicy && existingAllowFrom.length === 0) {
+        const allowFrom = normalizeAllowFromEntries(
+          [selfId.e164, ...existingAllowFrom.filter((item) => item !== "*")],
+          normalizeE164,
+        );
+        next = setWhatsAppDmPolicy(next, "allowlist");
+        next = setWhatsAppAllowFrom(next, allowFrom);
+        next = setWhatsAppSelfChatMode(next, true);
+        await prompter.note(
+          [
+            "Auto-configured secure defaults:",
+            `- dmPolicy set to "allowlist"`,
+            `- allowFrom includes ${selfId.e164}`,
+            "- selfChatMode enabled",
+            "",
+            "You can adjust this later with: " +
+              formatCliCommand("openclaw configure --section whatsapp"),
+          ].join("\n"),
+          "WhatsApp security",
+        );
+        return { cfg: next, accountId };
+      }
     }
 
     next = await promptWhatsAppAllowFrom(next, runtime, prompter, {

--- a/src/commands/onboard-channels.ts
+++ b/src/commands/onboard-channels.ts
@@ -193,8 +193,8 @@ async function noteChannelPrimer(
   );
   await prompter.note(
     [
-      "DM security: default is pairing; unknown DMs get a pairing code.",
-      `Approve with: ${formatCliCommand("openclaw pairing approve <channel> <code>")}`,
+      "DM security: default is allowlist; only pre-approved numbers can message.",
+      `To add senders: ${formatCliCommand("openclaw configure --section whatsapp")}`,
       'Public DMs require dmPolicy="open" + allowFrom=["*"].',
       "Multi-user DMs: run: " +
         formatCliCommand('openclaw config set session.dmScope "per-channel-peer"') +
@@ -237,7 +237,7 @@ async function maybeConfigureDmPolicies(params: {
   }
 
   const wants = await prompter.confirm({
-    message: "Configure DM access policies now? (default: pairing)",
+    message: "Configure DM access policies now? (default: allowlist)",
     initialValue: false,
   });
   if (!wants) {
@@ -248,8 +248,8 @@ async function maybeConfigureDmPolicies(params: {
   const selectPolicy = async (policy: ChannelOnboardingDmPolicy) => {
     await prompter.note(
       [
-        "Default: pairing (unknown DMs get a pairing code).",
-        `Approve: ${formatCliCommand(`openclaw pairing approve ${policy.channel} <code>`)}`,
+        "Default: allowlist (only pre-approved senders can message).",
+        `Pairing: unknown DMs get a pairing code; approve with: ${formatCliCommand(`openclaw pairing approve ${policy.channel} <code>`)}`,
         `Allowlist DMs: ${policy.policyKey}="allowlist" + ${policy.allowFromKey} entries.`,
         `Public DMs: ${policy.policyKey}="open" + ${policy.allowFromKey} includes "*".`,
         "Multi-user DMs: run: " +
@@ -262,8 +262,8 @@ async function maybeConfigureDmPolicies(params: {
     return (await prompter.select({
       message: `${policy.label} DM policy`,
       options: [
-        { value: "pairing", label: "Pairing (recommended)" },
-        { value: "allowlist", label: "Allowlist (specific users only)" },
+        { value: "allowlist", label: "Allowlist (recommended — specific users only)" },
+        { value: "pairing", label: "Pairing (unknown DMs get a pairing code)" },
         { value: "open", label: "Open (public inbound DMs)" },
         { value: "disabled", label: "Disabled (ignore DMs)" },
       ],

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -39,7 +39,7 @@ const WhatsAppSharedSchema = z.object({
   sendReadReceipts: z.boolean().optional(),
   messagePrefix: z.string().optional(),
   responsePrefix: z.string().optional(),
-  dmPolicy: DmPolicySchema.optional().default("pairing"),
+  dmPolicy: DmPolicySchema.optional().default("allowlist"),
   selfChatMode: z.boolean().optional(),
   allowFrom: z.array(z.string()).optional(),
   defaultTo: z.string().optional(),


### PR DESCRIPTION
## Summary

Changes the WhatsApp channel default `dmPolicy` from `"pairing"` to `"allowlist"` and auto-configures the linking user's phone number in `allowFrom` during onboarding.

## Changes

### Schema default (`zod-schema.providers-whatsapp.ts`)
- `dmPolicy` default: `"pairing"` → `"allowlist"`

### Onboarding auto-setup (`channels/plugins/onboarding/whatsapp.ts`)
- After WhatsApp QR linking, reads the owner's phone number from `creds.json` via `readWebSelfId()`
- When no explicit policy/allowFrom exists, auto-sets:
  - `dmPolicy = "allowlist"`
  - `allowFrom = [ownerE164]`
  - `selfChatMode = true`
- Shows a note explaining what was auto-configured

### Onboarding UI (`onboard-channels.ts`, `whatsapp.ts`)
- Updated prompts/labels to recommend allowlist over pairing
- Reordered select options: allowlist first, pairing second

## Motivation

New installs default to `"pairing"` which allows unknown senders to initiate DM conversations (they just need to complete a pairing flow). For most personal-phone setups, `"allowlist"` is more secure — only pre-approved numbers can message the bot.

This is a secure-by-default change that still allows users to opt into pairing or open mode during setup.