### PR TITLE
fix: treat wrapped 'fetch failed' rejections as transient network errors

### DIFF
--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -90,6 +90,7 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
         Object.assign(new TypeError("fetch failed"), {
           cause: { code: "UND_ERR_CONNECT_TIMEOUT", syscall: "connect" },
         }),
+        new Error("Failed to get gateway information from Discord: fetch failed"),
         Object.assign(new Error("DNS resolve failed"), { code: "UND_ERR_DNS_RESOLVE_FAILED" }),
         Object.assign(new Error("Connection reset"), { code: "ECONNRESET" }),
         Object.assign(new Error("Timeout"), { code: "ETIMEDOUT" }),

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -198,7 +198,7 @@ export function isTransientNetworkError(err: unknown): boolean {
     if (TRANSIENT_NETWORK_MESSAGE_CODE_RE.test(message)) {
       return true;
     }
-    if (message === "fetch failed") {
+    if (message === "fetch failed" || message.includes("fetch failed")) {
       return true;
     }
     if (TRANSIENT_NETWORK_MESSAGE_SNIPPETS.some((snippet) => message.includes(snippet))) {

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -198,7 +198,7 @@ export function isTransientNetworkError(err: unknown): boolean {
     if (TRANSIENT_NETWORK_MESSAGE_CODE_RE.test(message)) {
       return true;
     }
-    if (message === "fetch failed" || message.includes("fetch failed")) {
+    if (message.includes("fetch failed")) {
       return true;
     }
     if (TRANSIENT_NETWORK_MESSAGE_SNIPPETS.some((snippet) => message.includes(snippet))) {


### PR DESCRIPTION
## Summary

Prevent gateway crash loops when Discord startup errors are wrapped (e.g. `Failed to get gateway information from Discord: fetch failed`).

The current unhandled rejection classifier only treated exact message equality (`message === "fetch failed"`) as transient. Wrapped messages were treated as fatal and could exit the process.

## Changes

- In `src/infra/unhandled-rejections.ts`, broaden transient check to:
  - `message === "fetch failed" || message.includes("fetch failed")`
- Add regression case in `src/infra/unhandled-rejections.fatal-detection.test.ts`:
  - `new Error("Failed to get gateway information from Discord: fetch failed")`

## Validation

```bash
pnpm vitest run src/infra/unhandled-rejections.fatal-detection.test.ts
```

Passed locally.

## Context

This addresses the crash-loop symptom described in #34592 and related channel-failure isolation issues.
