### PR TITLE
fix: web search key audit + onboarding miss Gemini/Grok/Kimi providers

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -329,7 +329,17 @@ function resolveToolPolicies(params: {
 function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
   return Boolean(
-    search?.apiKey || search?.perplexity?.apiKey || env.BRAVE_API_KEY || env.PERPLEXITY_API_KEY,
+    search?.apiKey ||
+    search?.perplexity?.apiKey ||
+    search?.gemini?.apiKey ||
+    search?.grok?.apiKey ||
+    search?.kimi?.apiKey ||
+    env.BRAVE_API_KEY ||
+    env.PERPLEXITY_API_KEY ||
+    env.GEMINI_API_KEY ||
+    env.XAI_API_KEY ||
+    env.KIMI_API_KEY ||
+    env.MOONSHOT_API_KEY,
   );
 }
 

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -492,7 +492,7 @@ export async function finalizeOnboardingWizard(
     }
   })();
   const envVars = webSearchEnvVars[webSearchProvider] ?? [];
-  const webSearchEnv = envVars.some((v) => (process.env[v] ?? "").trim());
+  const webSearchEnv = envVars.some((v) => Boolean((process.env[v] ?? "").trim()));
   const hasWebSearchKey = Boolean(webSearchKey || webSearchEnv);
   const providerLabel = webSearchProviderLabels[webSearchProvider] ?? webSearchProvider;
   const configKeyPath = webSearchConfigKeys[webSearchProvider] ?? "apiKey";

--- a/src/wizard/onboarding.finalize.ts
+++ b/src/wizard/onboarding.finalize.ts
@@ -455,34 +455,67 @@ export async function finalizeOnboardingWizard(
   }
 
   const webSearchProvider = nextConfig.tools?.web?.search?.provider ?? "brave";
-  const webSearchKey =
-    webSearchProvider === "perplexity"
-      ? (nextConfig.tools?.web?.search?.perplexity?.apiKey ?? "").trim()
-      : (nextConfig.tools?.web?.search?.apiKey ?? "").trim();
-  const webSearchEnv =
-    webSearchProvider === "perplexity"
-      ? (process.env.PERPLEXITY_API_KEY ?? "").trim()
-      : (process.env.BRAVE_API_KEY ?? "").trim();
+  const webSearchProviderLabels: Record<string, string> = {
+    brave: "Brave Search",
+    perplexity: "Perplexity Search",
+    gemini: "Gemini Search",
+    grok: "Grok Search",
+    kimi: "Kimi Search",
+  };
+  const webSearchConfigKeys: Record<string, string> = {
+    brave: "apiKey",
+    perplexity: "perplexity.apiKey",
+    gemini: "gemini.apiKey",
+    grok: "grok.apiKey",
+    kimi: "kimi.apiKey",
+  };
+  const webSearchEnvVars: Record<string, string[]> = {
+    brave: ["BRAVE_API_KEY"],
+    perplexity: ["PERPLEXITY_API_KEY"],
+    gemini: ["GEMINI_API_KEY"],
+    grok: ["XAI_API_KEY"],
+    kimi: ["KIMI_API_KEY", "MOONSHOT_API_KEY"],
+  };
+  const search = nextConfig.tools?.web?.search;
+  const webSearchKey = ((): string => {
+    switch (webSearchProvider) {
+      case "perplexity":
+        return (search?.perplexity?.apiKey ?? "").trim();
+      case "gemini":
+        return (search?.gemini?.apiKey ?? "").trim();
+      case "grok":
+        return (search?.grok?.apiKey ?? "").trim();
+      case "kimi":
+        return (search?.kimi?.apiKey ?? "").trim();
+      default:
+        return (search?.apiKey ?? "").trim();
+    }
+  })();
+  const envVars = webSearchEnvVars[webSearchProvider] ?? [];
+  const webSearchEnv = envVars.some((v) => (process.env[v] ?? "").trim());
   const hasWebSearchKey = Boolean(webSearchKey || webSearchEnv);
+  const providerLabel = webSearchProviderLabels[webSearchProvider] ?? webSearchProvider;
+  const configKeyPath = webSearchConfigKeys[webSearchProvider] ?? "apiKey";
+  const envVarLabel = envVars.join(" or ");
   await prompter.note(
     hasWebSearchKey
       ? [
           "Web search is enabled, so your agent can look things up online when needed.",
           "",
-          `Provider: ${webSearchProvider === "perplexity" ? "Perplexity Search" : "Brave Search"}`,
+          `Provider: ${providerLabel}`,
           webSearchKey
-            ? `API key: stored in config (tools.web.search.${webSearchProvider === "perplexity" ? "perplexity.apiKey" : "apiKey"}).`
-            : `API key: provided via ${webSearchProvider === "perplexity" ? "PERPLEXITY_API_KEY" : "BRAVE_API_KEY"} env var (Gateway environment).`,
+            ? `API key: stored in config (tools.web.search.${configKeyPath}).`
+            : `API key: provided via ${envVarLabel} env var (Gateway environment).`,
           "Docs: https://docs.openclaw.ai/tools/web",
         ].join("\n")
       : [
-          "To enable web search, your agent will need an API key for either Perplexity Search or Brave Search.",
+          "To enable web search, your agent will need an API key for a supported search provider.",
           "",
           "Set it up interactively:",
           `- Run: ${formatCliCommand("openclaw configure --section web")}`,
           "- Choose a provider and paste your API key",
           "",
-          "Alternative: set PERPLEXITY_API_KEY or BRAVE_API_KEY in the Gateway environment (no config changes).",
+          "Alternative: set BRAVE_API_KEY, PERPLEXITY_API_KEY, GEMINI_API_KEY, XAI_API_KEY, or KIMI_API_KEY in the Gateway environment (no config changes).",
           "Docs: https://docs.openclaw.ai/tools/web",
         ].join("\n"),
     "Web search (optional)",


### PR DESCRIPTION
## Summary

- **Problem:** `hasWebSearchKey` in `src/security/audit-extra.sync.ts` only checks Brave and Perplexity API keys — Gemini, Grok, and Kimi configurations produce false negatives in the security audit.
- **Why it matters:** Users relying solely on Gemini/Grok/Kimi for web search get incorrect audit output (key reported as missing when it's present).
- **What changed:** Added all 5 provider config keys and their env vars to the audit check. Also fixed the same incomplete pattern in `src/wizard/onboarding.finalize.ts` where onboarding only displayed Brave/Perplexity labels and env var hints — users with other providers saw wrong info during setup.
- **What did NOT change:** No changes to web search execution logic, provider resolution, or any other audit checks. Purely additive key detection + corrected display strings.

## Change Type

- [x] Bug fix

## Scope

- [x] Security hardening
- [x] UI / DX

## Linked Issue/PR

- Closes #34509

## User-visible / Behavior Changes

- Security audit now correctly detects Gemini (`gemini.apiKey` / `GEMINI_API_KEY`), Grok (`grok.apiKey` / `XAI_API_KEY`), and Kimi (`kimi.apiKey` / `KIMI_API_KEY` / `MOONSHOT_API_KEY`) web search keys.
- Onboarding wizard now shows the correct provider name, config key path, and env var name for all 5 supported providers instead of always falling back to "Brave Search".

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS (Darwin 25.2.0)
- Runtime: Node 22.22.0
- Relevant config: `tools.web.search.provider` set to `gemini`, `grok`, or `kimi`

### Steps

1. Configure only `tools.web.search.gemini.apiKey` (or set `GEMINI_API_KEY` env var)
2. Run the security audit path that calls `hasWebSearchKey`
3. Observe key is not recognized as present (before fix)

### Expected

`hasWebSearchKey` returns `true` when any supported provider key is configured.

### Actual (before fix)

Returns `false` for Gemini/Grok/Kimi-only configurations.

## Evidence

- [x] All 6587 existing tests pass (`pnpm test`)
- [x] `pnpm build` clean
- [x] `pnpm check` (format + lint + all custom lints) clean
- [x] Targeted test run: `audit.test.ts` + `config.web-search-provider.test.ts` + `config-misc.test.ts` — 133/133 passed

## Human Verification

- Verified: traced all 5 provider types through `src/config/types.tools.ts` to confirm config key paths and env var names match exactly
- Verified: cross-referenced env var names against `src/agents/model-auth.ts`, `src/config/config.web-search-provider.test.ts`, and `src/commands/auth-choice.test.ts`
- Verified: onboarding display strings produce correct output for each provider (label, config path, env var)
- Edge cases: Kimi has two env vars (`KIMI_API_KEY` + `MOONSHOT_API_KEY`) — both are checked
- What I did NOT verify: live onboarding wizard flow (no gateway instance), live security audit on a running deployment

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- Revert this single commit
- No config/data changes to restore
- Bad symptom: if somehow a provider key path is wrong, the audit would still report key-not-found (safe direction — false negative, not false positive)

## Risks and Mitigations

- Risk: onboarding.finalize.ts change is larger than the minimal audit fix
  - Mitigation: same root cause (incomplete provider coverage), data-driven approach is more maintainable if new providers are added, all existing tests pass

## AI Disclosure

- [x] AI-assisted (Claude Code)
- [x] Fully tested: `pnpm build && pnpm check && pnpm test` all pass
- [x] I understand what the code does: additive key checks in audit function + data-driven provider lookup replacing hardcoded if-else in onboarding