### PR TITLE
Cleanup: migrate remaining plugin-sdk imports & remove stale lint directives

### DIFF
--- a/src/config/includes-scan.ts
+++ b/src/config/includes-scan.ts
@@ -76,7 +76,6 @@ export async function collectIncludePathsRecursive(params: {
         }
       })();
       if (nestedParsed) {
-        // eslint-disable-next-line no-await-in-loop
         await walk(resolved, nestedParsed, depth + 1);
       }
     }

--- a/src/cron/service.read-ops-nonblocking.test.ts
+++ b/src/cron/service.read-ops-nonblocking.test.ts
@@ -150,7 +150,6 @@ describe("CronService read ops while job is running", () => {
         if (!internal.state?.running) {
           break;
         }
-        // eslint-disable-next-line no-await-in-loop
         await Promise.resolve();
       }
       expect(internal.state?.running).toBe(false);

--- a/src/gateway/server-restart-deferral.test.ts
+++ b/src/gateway/server-restart-deferral.test.ts
@@ -8,7 +8,6 @@ import { getTotalQueueSize } from "../process/command-queue.js";
 
 async function flushMicrotasks(count = 10): Promise<void> {
   for (let i = 0; i < count; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
     await Promise.resolve();
   }
 }

--- a/src/security/audit-extra.async.ts
+++ b/src/security/audit-extra.async.ts
@@ -733,7 +733,6 @@ export async function collectPluginsTrustFindings(params: {
         continue;
       }
       const installPath = record.installPath ?? path.join(params.stateDir, "extensions", pluginId);
-      // eslint-disable-next-line no-await-in-loop
       const installedVersion = await readInstalledPackageVersion(installPath);
       if (!installedVersion || installedVersion === recordedVersion) {
         continue;
@@ -796,7 +795,6 @@ export async function collectPluginsTrustFindings(params: {
         continue;
       }
       const installPath = record.installPath ?? path.join(params.stateDir, "hooks", hookId);
-      // eslint-disable-next-line no-await-in-loop
       const installedVersion = await readInstalledPackageVersion(installPath);
       if (!installedVersion || installedVersion === recordedVersion) {
         continue;
@@ -913,7 +911,6 @@ export async function collectIncludeFilePermFindings(params: {
   }
 
   for (const p of includePaths) {
-    // eslint-disable-next-line no-await-in-loop
     const perms = await inspectPathPermissions(p, {
       env: params.env,
       platform: params.platform,
@@ -1028,7 +1025,6 @@ export async function collectStateDeepFilesystemFindings(params: {
   for (const agentId of ids) {
     const agentDir = path.join(params.stateDir, "agents", agentId, "agent");
     const authPath = path.join(agentDir, "auth-profiles.json");
-    // eslint-disable-next-line no-await-in-loop
     const authPerms = await inspectPathPermissions(authPath, {
       env: params.env,
       platform: params.platform,
@@ -1067,7 +1063,6 @@ export async function collectStateDeepFilesystemFindings(params: {
     }
 
     const storePath = path.join(params.stateDir, "agents", agentId, "sessions", "sessions.json");
-    // eslint-disable-next-line no-await-in-loop
     const storePerms = await inspectPathPermissions(storePath, {
       env: params.env,
       platform: params.platform,

--- a/src/security/fix.ts
+++ b/src/security/fix.ts
@@ -325,7 +325,6 @@ async function chmodCredentialsAndAgentState(params: {
       continue;
     }
     const p = path.join(credsDir, entry.name);
-    // eslint-disable-next-line no-await-in-loop
     params.actions.push(await safeChmod({ path: p, mode: 0o600, require: "file" }));
   }
 
@@ -349,26 +348,20 @@ async function chmodCredentialsAndAgentState(params: {
     const agentDir = path.join(agentRoot, "agent");
     const sessionsDir = path.join(agentRoot, "sessions");
 
-    // eslint-disable-next-line no-await-in-loop
     params.actions.push(await safeChmod({ path: agentRoot, mode: 0o700, require: "dir" }));
-    // eslint-disable-next-line no-await-in-loop
     params.actions.push(await params.applyPerms({ path: agentDir, mode: 0o700, require: "dir" }));
 
     const authPath = path.join(agentDir, "auth-profiles.json");
-    // eslint-disable-next-line no-await-in-loop
     params.actions.push(await params.applyPerms({ path: authPath, mode: 0o600, require: "file" }));
 
-    // eslint-disable-next-line no-await-in-loop
     params.actions.push(
       await params.applyPerms({ path: sessionsDir, mode: 0o700, require: "dir" }),
     );
 
     const storePath = path.join(sessionsDir, "sessions.json");
-    // eslint-disable-next-line no-await-in-loop
     params.actions.push(await params.applyPerms({ path: storePath, mode: 0o600, require: "file" }));
 
     // Fix permissions on session transcript files (*.jsonl)
-    // eslint-disable-next-line no-await-in-loop
     const sessionEntries = await fs.readdir(sessionsDir, { withFileTypes: true }).catch(() => []);
     for (const entry of sessionEntries) {
       if (!entry.isFile()) {
@@ -378,7 +371,6 @@ async function chmodCredentialsAndAgentState(params: {
         continue;
       }
       const p = path.join(sessionsDir, entry.name);
-      // eslint-disable-next-line no-await-in-loop
       params.actions.push(await params.applyPerms({ path: p, mode: 0o600, require: "file" }));
     }
   }
@@ -450,7 +442,6 @@ export async function fixSecurityFootguns(opts?: {
       parsed: snap.parsed,
     }).catch(() => []);
     for (const p of includePaths) {
-      // eslint-disable-next-line no-await-in-loop
       actions.push(await applyPerms({ path: p, mode: 0o600, require: "file" }));
     }
   }

--- a/src/test-utils/ports.ts
+++ b/src/test-utils/ports.ts
@@ -66,7 +66,6 @@ export async function getDeterministicFreePortBlock(params?: {
   // so probing every single offset is wasted work and slows large suites.
   for (let attempt = 0; attempt < usable; attempt += blockSize) {
     const start = base + ((nextTestPortOffset + attempt) % usable);
-    // eslint-disable-next-line no-await-in-loop
     const ok = (await Promise.all(offsets.map((offset) => isPortFree(start + offset)))).every(
       Boolean,
     );
@@ -79,9 +78,7 @@ export async function getDeterministicFreePortBlock(params?: {
 
   // Fallback: let the OS pick a port block (best effort).
   for (let attempt = 0; attempt < 25; attempt += 1) {
-    // eslint-disable-next-line no-await-in-loop
     const port = await getOsFreePort();
-    // eslint-disable-next-line no-await-in-loop
     const ok = (await Promise.all(offsets.map((offset) => isPortFree(port + offset)))).every(
       Boolean,
     );


### PR DESCRIPTION
## Summary

- **Migrate last 6 extension test files** from monolithic `openclaw/plugin-sdk` to scoped `openclaw/plugin-sdk/compat` subpath imports, fixing the `lint:plugins:no-monolithic-plugin-sdk-entry-imports` check failure
- **Remove 20 redundant `eslint-disable-next-line no-await-in-loop` comments** across 6 source files — the `no-await-in-loop` rule is globally disabled in `.oxlintrc.json`, making these directives dead code

## Changed files

### Plugin-SDK import migration (6 files)
- `extensions/googlechat/src/channel.outbound.test.ts`
- `extensions/googlechat/src/resolve-target.test.ts` (3 import sites)
- `extensions/matrix/src/outbound.test.ts`
- `extensions/msteams/src/outbound.test.ts`
- `extensions/nostr/src/channel.outbound.test.ts`
- `extensions/whatsapp/src/channel.outbound.test.ts`

### Stale lint directive removal (6 files, 20 lines)
- `src/security/fix.ts` — 9 directives
- `src/security/audit-extra.async.ts` — 5 directives
- `src/test-utils/ports.ts` — 3 directives
- `src/config/includes-scan.ts` — 1 directive
- `src/gateway/server-restart-deferral.test.ts` — 1 directive
- `src/cron/service.read-ops-nonblocking.test.ts` — 1 directive

## Test plan

- [x] `pnpm check` — all lint/format checks pass (including previously-failing plugin-sdk import check)
- [x] `pnpm tsgo` — TypeScript checks pass
- [x] `pnpm format` — formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)