### PR TITLE
fix(typing): suppress typing indicator for NO_REPLY runs (#33951)

### DIFF
--- a/src/auto-reply/reply/typing-mode.ts
+++ b/src/auto-reply/reply/typing-mode.ts
@@ -128,14 +128,16 @@ export function createTypingSignaler(params: {
     if (disabled) {
       return;
     }
-    // Start typing as soon as tools begin executing, even before the first text delta.
-    if (!typing.isActive()) {
+    // Guard on hasRenderableText so NO_REPLY runs don't flash typing (#33951).
+    if (!typing.isActive() && hasRenderableText) {
       await typing.startTypingLoop();
       typing.refreshTypingTtl();
       return;
     }
     // Keep typing indicator alive during tool execution.
-    typing.refreshTypingTtl();
+    if (typing.isActive()) {
+      typing.refreshTypingTtl();
+    }
   };
 
   return {


### PR DESCRIPTION
Fixes #33951

**Problem:** In Slack groups with `requireMention: false`, a typing bubble appeared for every message — even NO_REPLY runs. `signalToolStart` started typing unconditionally during tool execution.

**Fix:** Guard `signalToolStart` with `hasRenderableText`, matching existing guards in `signalMessageStart` and `signalReasoningDelta`.

**Changed:** `src/auto-reply/reply/typing-mode.ts` — 1 file, +5/-3 lines