### PR TITLE
fix(sanitize): strip leaked XML tool tags and template delimiters (#34156)

### DIFF
--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -142,7 +142,36 @@ export function sanitizeTextContent(text: string): string {
   if (!text) {
     return text;
   }
-  return stripThinkingTagsFromText(stripDowngradedToolCallText(stripMinimaxToolCallXml(text)));
+  let cleaned = stripMinimaxToolCallXml(text);
+  cleaned = stripDowngradedToolCallText(cleaned);
+  cleaned = stripThinkingTagsFromText(cleaned);
+  cleaned = stripLeakedXmlToolTags(cleaned);
+  cleaned = stripTemplateDelimiters(cleaned);
+  return cleaned;
+}
+
+/**
+ * Strip generic XML tool invocation tags that leak from provider responses.
+ * Matches: <tool_call>, </tool_call>, <arg_value>, </arg_value>, <function_call>, etc.
+ */
+function stripLeakedXmlToolTags(text: string): string {
+  if (!/<\/?\w*(?:tool_call|arg_value|function_call|tool_result)\b/i.test(text)) {
+    return text;
+  }
+  return text
+    .replace(/<\/?(?:tool_call|arg_value|function_call|tool_result)\b[^>]*>/gi, "")
+    .replace(/\n{3,}/g, "\n\n");
+}
+
+/**
+ * Strip template delimiters that leak from model responses.
+ * Matches: <|assistant|>, <|user|>, <|system|>, <|end|>, <|im_start|>, <|im_end|>, etc.
+ */
+function stripTemplateDelimiters(text: string): string {
+  if (!/<\|/.test(text)) {
+    return text;
+  }
+  return text.replace(/<\|\w+\|>/g, "").replace(/\n{3,}/g, "\n\n");
 }
 
 export function extractAssistantText(message: unknown): string | undefined {


### PR DESCRIPTION
Fixes #34156

**Problem:** Raw XML tags (`</arg_value>`, `</tool_call>`) and template delimiters (`<|assistant|>`) leaked into user-visible subagent output. Existing `sanitizeTextContent` only handled Minimax XML and downgraded tool call markers.

**Fix:** Add two sanitizers to the pipeline:
- `stripLeakedXmlToolTags`: removes tool_call, arg_value, function_call, tool_result tags
- `stripTemplateDelimiters`: removes `<|...|>` template markers

Both use fast-path regex tests to skip clean strings.

**Changed:** `src/agents/tools/sessions-helpers.ts` — 1 file, +30/-1 lines