### PR TITLE
Agents UI: enable Tool Access Save when config lacks selected agent entry

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -66,7 +66,11 @@ import {
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
 import { icons } from "./icons.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
-import { resolveConfiguredCronModelSuggestions, sortLocaleStrings } from "./views/agents-utils.ts";
+import {
+  resolveAgentConfigSlot,
+  resolveConfiguredCronModelSuggestions,
+  sortLocaleStrings,
+} from "./views/agents-utils.ts";
 import { renderAgents } from "./views/agents.ts";
 import { renderChannels } from "./views/channels.ts";
 import { renderChat } from "./views/chat.ts";
@@ -666,20 +670,14 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
+                  const slot = resolveAgentConfigSlot(configValue, agentId);
+                  if (!slot) {
                     return;
                   }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
+                  if (slot.seedPath) {
+                    updateConfigFormValue(state, slot.seedPath, slot.seedValue);
                   }
+                  const index = slot.index;
                   const basePath = ["agents", "list", index, "tools"];
                   if (profile) {
                     updateConfigFormValue(state, [...basePath, "profile"], profile);
@@ -694,20 +692,14 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
+                  const slot = resolveAgentConfigSlot(configValue, agentId);
+                  if (!slot) {
                     return;
                   }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
+                  if (slot.seedPath) {
+                    updateConfigFormValue(state, slot.seedPath, slot.seedValue);
                   }
+                  const index = slot.index;
                   const basePath = ["agents", "list", index, "tools"];
                   if (alsoAllow.length > 0) {
                     updateConfigFormValue(state, [...basePath, "alsoAllow"], alsoAllow);

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -734,7 +734,9 @@ export function renderApp(state: AppViewState) {
                     updateConfigFormValue(state, slot.seedPath, slot.seedValue);
                   }
                   const index = slot.index;
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
+                  const list = (
+                    (state.configForm ?? configValue) as { agents?: { list?: unknown[] } }
+                  ).agents?.list;
                   const entry =
                     Array.isArray(list) && index < list.length
                       ? (list[index] as { skills?: unknown })
@@ -746,7 +748,7 @@ export function renderApp(state: AppViewState) {
                   const allSkills =
                     state.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
                     [];
-                  const existing = Array.isArray(entry.skills)
+                  const existing = Array.isArray(entry?.skills)
                     ? entry.skills.map((name) => String(name).trim()).filter(Boolean)
                     : undefined;
                   const base = existing ?? allSkills;

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -726,21 +726,19 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
+                  const slot = resolveAgentConfigSlot(configValue, agentId);
+                  if (!slot) {
+                    return;
+                  }
+                  if (slot.seedPath) {
+                    updateConfigFormValue(state, slot.seedPath, slot.seedValue);
+                  }
+                  const index = slot.index;
                   const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
-                    return;
-                  }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
-                  }
-                  const entry = list[index] as { skills?: unknown };
+                  const entry =
+                    Array.isArray(list) && index < list.length
+                      ? (list[index] as { skills?: unknown })
+                      : undefined;
                   const normalizedSkill = skillName.trim();
                   if (!normalizedSkill) {
                     return;
@@ -764,40 +762,28 @@ export function renderApp(state: AppViewState) {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
+                  const slot = resolveAgentConfigSlot(configValue, agentId);
+                  if (!slot) {
                     return;
                   }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
+                  if (slot.seedPath) {
+                    updateConfigFormValue(state, slot.seedPath, slot.seedValue);
                   }
+                  const index = slot.index;
                   removeConfigFormValue(state, ["agents", "list", index, "skills"]);
                 },
                 onAgentSkillsDisableAll: (agentId) => {
                   if (!configValue) {
                     return;
                   }
-                  const list = (configValue as { agents?: { list?: unknown[] } }).agents?.list;
-                  if (!Array.isArray(list)) {
+                  const slot = resolveAgentConfigSlot(configValue, agentId);
+                  if (!slot) {
                     return;
                   }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
-                  if (index < 0) {
-                    return;
+                  if (slot.seedPath) {
+                    updateConfigFormValue(state, slot.seedPath, slot.seedValue);
                   }
+                  const index = slot.index;
                   updateConfigFormValue(state, ["agents", "list", index, "skills"], []);
                 },
                 onModelChange: (agentId, modelId) => {

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  resolveAgentConfigSlot,
   resolveConfiguredCronModelSuggestions,
   resolveEffectiveModelFallbacks,
   sortLocaleStrings,
@@ -96,5 +97,67 @@ describe("sortLocaleStrings", () => {
 
   it("accepts any iterable input, including sets", () => {
     expect(sortLocaleStrings(new Set(["beta", "alpha"]))).toEqual(["alpha", "beta"]);
+  });
+});
+
+describe("resolveAgentConfigSlot", () => {
+  it("returns existing agent index without seed operation", () => {
+    const slot = resolveAgentConfigSlot(
+      {
+        agents: {
+          list: [{ id: "main" }, { id: "ops" }],
+        },
+      },
+      "ops",
+    );
+
+    expect(slot).toEqual({
+      index: 1,
+      seedPath: null,
+    });
+  });
+
+  it("returns append seed when selected agent is missing from list", () => {
+    const slot = resolveAgentConfigSlot(
+      {
+        agents: {
+          list: [{ id: "ops" }],
+        },
+      },
+      "main",
+    );
+
+    expect(slot).toEqual({
+      index: 1,
+      seedPath: ["agents", "list", 1, "id"],
+      seedValue: "main",
+    });
+  });
+
+  it("returns initial list seed when agents.list is absent", () => {
+    const slot = resolveAgentConfigSlot({}, "main");
+
+    expect(slot).toEqual({
+      index: 0,
+      seedPath: ["agents", "list"],
+      seedValue: [{ id: "main" }],
+    });
+  });
+
+  it("returns null when agentId is blank", () => {
+    expect(resolveAgentConfigSlot({}, "   ")).toBeNull();
+  });
+
+  it("returns null when agents.list is not an array", () => {
+    expect(
+      resolveAgentConfigSlot(
+        {
+          agents: {
+            list: "invalid",
+          },
+        },
+        "main",
+      ),
+    ).toBeNull();
   });
 });

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -47,6 +47,10 @@ type ConfigSnapshot = {
   };
 };
 
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
 export function normalizeAgentLabel(agent: {
   id: string;
   name?: string;
@@ -131,6 +135,62 @@ export function resolveAgentConfig(config: Record<string, unknown> | null, agent
     entry,
     defaults: cfg?.agents?.defaults,
     globalTools: cfg?.tools,
+  };
+}
+
+export type AgentConfigSlot = {
+  index: number;
+  seedPath: Array<string | number> | null;
+  seedValue?: unknown;
+};
+
+/**
+ * Resolve the config slot for an agent-backed settings panel.
+ *
+ * Some installs rely on an implicit `main` agent and may not have a matching
+ * `agents.list` entry. In that case we return a seed operation so callers can
+ * materialize an entry before writing nested fields.
+ */
+export function resolveAgentConfigSlot(
+  configValue: Record<string, unknown> | null,
+  agentId: string,
+): AgentConfigSlot | null {
+  const normalizedId = agentId.trim();
+  if (!normalizedId) {
+    return null;
+  }
+
+  const agentsValue = isObjectRecord(configValue) ? configValue.agents : undefined;
+  if (agentsValue != null && !isObjectRecord(agentsValue)) {
+    return null;
+  }
+
+  const listValue = isObjectRecord(agentsValue) ? agentsValue.list : undefined;
+  if (listValue != null && !Array.isArray(listValue)) {
+    return null;
+  }
+
+  const list = Array.isArray(listValue) ? listValue : [];
+  const index = list.findIndex(
+    (entry) =>
+      isObjectRecord(entry) && typeof entry.id === "string" && entry.id.trim() === normalizedId,
+  );
+  if (index >= 0) {
+    return { index, seedPath: null };
+  }
+
+  if (Array.isArray(listValue)) {
+    return {
+      index: list.length,
+      seedPath: ["agents", "list", list.length, "id"],
+      seedValue: normalizedId,
+    };
+  }
+
+  return {
+    index: 0,
+    seedPath: ["agents", "list"],
+    seedValue: [{ id: normalizedId }],
   };
 }
 


### PR DESCRIPTION
## Summary
- fix Tool Access handlers in the agents panel so they no longer silently no-op when the selected agent is missing from `agents.list`
- add `resolveAgentConfigSlot` to resolve an existing agent index or provide a seed operation for implicit agents (for example `main` on fresh installs)
- materialize a minimal agent entry before writing tool profile/override changes, so `configFormDirty` flips and Save becomes enabled

## Root cause
The Tool Access callbacks in `ui/src/ui/app-render.ts` returned early when `agentId` was not found in `config.agents.list`. On setups where the selected/default agent is implicit and absent from `agents.list`, toggles changed local UI state but no config mutation happened, so Save stayed disabled.

## Testing
- `corepack pnpm vitest ui/src/ui/views/agents-utils.test.ts`
- `corepack pnpm vitest ui/src/ui/controllers/agents.test.ts`

## Issue
Fixes #32812
Related: #21297
