### PR TITLE
ui(storage): sanitize navGroupsCollapsed to boolean map

### DIFF
--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -84,8 +84,14 @@ export function loadSettings(): UiSettings {
       navCollapsed:
         typeof parsed.navCollapsed === "boolean" ? parsed.navCollapsed : defaults.navCollapsed,
       navGroupsCollapsed:
-        typeof parsed.navGroupsCollapsed === "object" && parsed.navGroupsCollapsed !== null
-          ? parsed.navGroupsCollapsed
+        typeof parsed.navGroupsCollapsed === "object" &&
+        parsed.navGroupsCollapsed !== null &&
+        !Array.isArray(parsed.navGroupsCollapsed)
+          ? Object.fromEntries(
+              Object.entries(parsed.navGroupsCollapsed).filter(
+                ([, value]) => typeof value === "boolean",
+              ),
+            )
           : defaults.navGroupsCollapsed,
       locale: isSupportedLocale(parsed.locale) ? parsed.locale : undefined,
     };


### PR DESCRIPTION
## Summary
- harden `loadSettings()` parsing for `navGroupsCollapsed`
- only keep boolean entries from persisted data
- reject array-shaped values to avoid malformed state coercion

## Why
Persisted local storage can contain stale/corrupted values. This change ensures UI nav collapse state remains type-safe and predictable.

## Validation
- `pnpm build` in `ui/`
- Codex ACP incremental review verdict: **Approve**