### PR TITLE
fix(anthropic): inject OAuth beta headers without explicit beta config

### DIFF
--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -177,7 +177,7 @@ describe("resolveProfilesUnavailableReason", () => {
     ).toBe("auth");
   });
 
-  it("falls back to rate_limit when active cooldown has no reason history", () => {
+  it("falls back to auth when active cooldown has no reason history", () => {
     const now = Date.now();
     const store = makeStore({
       "anthropic:default": {
@@ -191,7 +191,7 @@ describe("resolveProfilesUnavailableReason", () => {
         profileIds: ["anthropic:default"],
         now,
       }),
-    ).toBe("rate_limit");
+    ).toBe("auth");
   });
 
   it("ignores expired windows and returns null when no profile is actively unavailable", () => {

--- a/src/agents/auth-profiles/usage.ts
+++ b/src/agents/auth-profiles/usage.ts
@@ -107,7 +107,10 @@ export function resolveProfilesUnavailableReason(params: {
       recordedReason = true;
     }
     if (!recordedReason) {
-      addScore("rate_limit", 1);
+      // Default to auth when a profile is in cooldown but has no recorded failure reason.
+      // Previously defaulted to "rate_limit", causing 401 auth errors to be misreported
+      // as "API rate limit reached" (#34792).
+      addScore("auth", 1);
     }
   }
 

--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -954,7 +954,9 @@ describe("applyExtraParamsToAgent", () => {
       options: { headers: { "X-Custom": "1" } },
     });
 
-    expect(headers).toEqual({ "X-Custom": "1" });
+    expect(headers?.["X-Custom"]).toBe("1");
+    // Default pi-ai betas are always present for Anthropic, but context1m must be absent
+    expect(headers?.["anthropic-beta"]).not.toContain("context-1m-2025-08-07");
   });
 
   it("skips context1m beta for OAuth tokens but preserves OAuth-required betas", () => {
@@ -1001,6 +1003,36 @@ describe("applyExtraParamsToAgent", () => {
     expect(betaHeader).not.toContain("context-1m-2025-08-07");
   });
 
+  it("injects OAuth betas for sk-ant-oat tokens even without configured betas (#34792)", () => {
+    const calls: Array<SimpleStreamOptions | undefined> = [];
+    const baseStreamFn: StreamFn = (_model, _context, options) => {
+      calls.push(options);
+      return {} as ReturnType<StreamFn>;
+    };
+    const agent = { streamFn: baseStreamFn };
+    // No anthropicBeta or context1m configured — reproduces the regression
+    const cfg = {};
+
+    applyExtraParamsToAgent(agent, cfg, "anthropic", "claude-sonnet-4-6");
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "anthropic",
+      id: "claude-sonnet-4-6",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {
+      apiKey: "sk-ant-oat01-test-oauth-token",
+      headers: { "X-Custom": "1" },
+    });
+
+    expect(calls).toHaveLength(1);
+    const betaHeader = calls[0]?.headers?.["anthropic-beta"] as string;
+    expect(betaHeader).toContain("oauth-2025-04-20");
+    expect(betaHeader).toContain("claude-code-20250219");
+  });
+
   it("merges existing anthropic-beta headers with configured betas", () => {
     const cfg = buildAnthropicModelConfig("anthropic/claude-sonnet-4-5", {
       context1m: true,
@@ -1028,7 +1060,9 @@ describe("applyExtraParamsToAgent", () => {
       modelId: "claude-haiku-3-5",
       options: { headers: { "X-Custom": "1" } },
     });
-    expect(headers).toEqual({ "X-Custom": "1" });
+    expect(headers?.["X-Custom"]).toBe("1");
+    // context1m must not be present for non-Opus/Sonnet models
+    expect(headers?.["anthropic-beta"]).not.toContain("context-1m-2025-08-07");
   });
 
   it("forces store=true for direct OpenAI Responses payloads", () => {

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -895,11 +895,14 @@ export function applyExtraParamsToAgent(
   }
 
   const anthropicBetas = resolveAnthropicBetas(merged, provider, modelId);
-  if (anthropicBetas?.length) {
+  // Always apply the wrapper for Anthropic so OAuth tokens (sk-ant-oat-*) get
+  // the required betas injected even when no explicit betas are configured.
+  if (provider === "anthropic" || anthropicBetas?.length) {
+    const betas = anthropicBetas ?? [];
     log.debug(
-      `applying Anthropic beta header for ${provider}/${modelId}: ${anthropicBetas.join(",")}`,
+      `applying Anthropic beta header for ${provider}/${modelId}: ${betas.join(",") || "(oauth-only)"}`,
     );
-    agent.streamFn = createAnthropicBetaHeadersWrapper(agent.streamFn, anthropicBetas);
+    agent.streamFn = createAnthropicBetaHeadersWrapper(agent.streamFn, betas);
   }
 
   if (shouldApplySiliconFlowThinkingOffCompat({ provider, modelId, thinkingLevel })) {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -491,7 +491,7 @@ export async function runEmbeddedPiAgent(
             resolveProfilesUnavailableReason({
               store: authStore,
               profileIds,
-            }) ?? "rate_limit"
+            }) ?? "auth"
           );
         }
         const classified = classifyFailoverReason(params.message);


### PR DESCRIPTION
## Summary

Fixes #34792 — two bugs:

- **Missing OAuth beta header**: The `createAnthropicBetaHeadersWrapper` was only applied when explicit betas (`anthropicBeta` or `context1m`) were configured via model params. OAuth tokens (`sk-ant-oat-*`) require `oauth-2025-04-20` and `claude-code-20250219` injected regardless of config. Now the wrapper is always applied for the Anthropic provider.
- **Misleading error message**: Auth failures (401) were misreported as "API rate limit reached" because the default failover reason for profiles in cooldown without recorded failure counts was `"rate_limit"`. Changed to `"auth"`.

## Test plan

- [x] Added regression test: OAuth token with empty config still gets required betas injected
- [x] Updated existing tests for new wrapper-always-applied behavior
- [x] Updated `resolveProfilesUnavailableReason` test for `"auth"` default
- [x] Full test suite passes (6587 tests, 812 files)
- [x] Lint clean (`pnpm check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)