### PR TITLE
fix(browser): improve browser control disabled/error hints

### DIFF
--- a/src/browser/client-fetch.error-hints.test.ts
+++ b/src/browser/client-fetch.error-hints.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./control-service.js", () => ({
+  createBrowserControlContext: vi.fn(() => ({})),
+  startBrowserControlServiceFromConfig: vi.fn(async () => false),
+}));
+
+vi.mock("./routes/dispatcher.js", () => ({
+  createBrowserRouteDispatcher: vi.fn(() => ({
+    dispatch: vi.fn(async () => ({ status: 200, body: { ok: true } })),
+  })),
+}));
+
+import { fetchBrowserJson } from "./client-fetch.js";
+
+function stubAbortableFetch() {
+  const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(
+    async (_input, init) => {
+      // Never resolve; only reject on abort to emulate real fetch + AbortController.
+      return await new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        if (signal?.aborted) {
+          reject(signal.reason ?? new Error("aborted"));
+          return;
+        }
+        signal?.addEventListener("abort", () => reject(signal.reason ?? new Error("aborted")), {
+          once: true,
+        });
+      });
+    },
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("fetchBrowserJson error hints", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("surfaces 'browser control disabled' as a config issue (not reachability)", async () => {
+    await expect(fetchBrowserJson("/")).rejects.toThrow(/browser control is disabled/i);
+  });
+
+  it("wraps absolute URL timeouts with non-retry guidance", async () => {
+    stubAbortableFetch();
+
+    await expect(fetchBrowserJson("http://127.0.0.1:18888/", { timeoutMs: 5 })).rejects.toThrow(
+      /Do NOT retry the browser tool/i,
+    );
+
+    await expect(fetchBrowserJson("http://127.0.0.1:18888/", { timeoutMs: 5 })).rejects.toThrow(
+      /timed out after 5ms/i,
+    );
+  });
+});

--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -101,8 +101,10 @@ function withLoopbackBrowserAuth(
 function enhanceBrowserFetchError(url: string, err: unknown, timeoutMs: number): Error {
   const isLocal = !isAbsoluteHttp(url);
   // Human-facing hint for logs/diagnostics.
+  // NOTE: prefer non-disruptive guidance here — repeated gateway restarts can turn
+  // intermittent browser issues into restart loops.
   const operatorHint = isLocal
-    ? `Restart the OpenClaw gateway (OpenClaw.app menubar, or \`${formatCliCommand("openclaw gateway")}\`).`
+    ? `Check whether browser control is enabled/running. If needed, restart the OpenClaw gateway (OpenClaw.app menubar, or \`${formatCliCommand("openclaw gateway")}\`).`
     : "If this is a sandboxed session, ensure the sandbox browser is running.";
   // Model-facing suffix: explicitly tell the LLM NOT to retry.
   // Without this, models see "try again" and enter an infinite tool-call loop.
@@ -111,6 +113,14 @@ function enhanceBrowserFetchError(url: string, err: unknown, timeoutMs: number):
     "Use an alternative approach or inform the user that the browser is currently unavailable.";
   const msg = String(err);
   const msgLower = msg.toLowerCase();
+
+  // Avoid misleading reachability errors for local config issues.
+  if (msgLower.includes("browser control disabled")) {
+    return new Error(
+      `OpenClaw browser control is disabled. Enable it in config before using the browser tool. ${modelHint}`,
+    );
+  }
+
   const looksLikeTimeout =
     msgLower.includes("timed out") ||
     msgLower.includes("timeout") ||


### PR DESCRIPTION
## Summary

- **Problem:** When the browser tool can’t talk to the browser control service, the current messaging can over-suggest restarting the gateway.
- **Why it matters:** During intermittent browser-control failures this can contribute to disruptive restart loops; additionally, when browser control is disabled in config the error is currently misleading (presented as a reachability failure).
- **What changed:** Improve error classification + operator guidance for browser fetch failures; add unit tests to lock behavior.
- **What did NOT change (scope boundary):** No changes to browser control service implementation/enablement logic; no changes to routing/dispatcher behavior beyond messaging.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- When browser control is disabled, errors now clearly state it’s a **config/enablement** issue (not “can’t reach service”).
- For local browser-tool failures, operator hint is less disruptive: **check enablement/running first**, restart gateway only if needed.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: N/A
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): browser control disabled scenario

### Steps

1. Call `fetchBrowserJson("/")` while browser control is disabled.
2. Call `fetchBrowserJson("http://127.0.0.1:18888/", { timeoutMs: 5 })` with an aborting timeout.

### Expected

- Disabled browser control surfaces a clear “browser control is disabled” config message.
- Timeout path includes the model-facing “Do NOT retry the browser tool” guidance.

### Actual

- Matches expected (covered by unit tests below).

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Local unit test:

```bash
bunx vitest run --config vitest.unit.config.ts src/browser/client-fetch.error-hints.test.ts
```

## Human Verification (required)

- Verified scenarios:
  - Browser control disabled produces config-specific error (not reachability wrapper)
  - Absolute URL timeout produces non-retry guidance
- Edge cases checked:
  - Local vs absolute URL error-hint paths
- What I did **not** verify:
  - Full end-to-end browser tool execution against a live browser control service

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert the PR / commit(s) affecting `src/browser/client-fetch.ts`
- Known bad symptoms reviewers should watch for:
  - Browser tool failures no longer include useful operator guidance
  - Error messages regress to misleading “can’t reach service” for disabled config

## Risks and Mitigations

- Risk: Error-message wording changes could break brittle string-matching in downstream tooling.
  - Mitigation: This is user-facing guidance; behavior is covered with unit tests and can be adjusted if a stable contract is required.

---

### CI note

Current CI failure on this PR appears unrelated to code changes: `oven-sh/setup-bun@v2` attempts to download `bun-v1.3.9+cf6cdbbba` and receives **HTTP 404**.
