### PR TITLE
feat(config): add reasoningDefault config option

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -876,6 +876,7 @@ Time format in system prompt. Default: `auto` (OS preference).
       pdfMaxPages: 20,
       thinkingDefault: "low",
       verboseDefault: "off",
+      reasoningDefault: "off",
       elevatedDefault: "on",
       timeoutSeconds: 600,
       mediaMaxMb: 5,

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -61,6 +61,7 @@ title: "Thinking Levels"
 - `stream` (Telegram only): streams reasoning into the Telegram draft bubble while the reply is generating, then sends the final answer without reasoning.
 - Alias: `/reason`.
 - Send `/reasoning` (or `/reasoning:`) with no argument to see the current reasoning level.
+- Global default: `agents.defaults.reasoningDefault` in config (default: `off`).
 
 ## Related
 

--- a/src/auto-reply/reply/directive-handling.levels.ts
+++ b/src/auto-reply/reply/directive-handling.levels.ts
@@ -10,6 +10,7 @@ export async function resolveCurrentDirectiveLevels(params: {
   agentCfg?: {
     thinkingDefault?: unknown;
     verboseDefault?: unknown;
+    reasoningDefault?: unknown;
     elevatedDefault?: unknown;
   };
   resolveDefaultThinkingLevel: () => Promise<ThinkLevel | undefined>;
@@ -28,7 +29,9 @@ export async function resolveCurrentDirectiveLevels(params: {
     (params.sessionEntry?.verboseLevel as VerboseLevel | undefined) ??
     (params.agentCfg?.verboseDefault as VerboseLevel | undefined);
   const currentReasoningLevel =
-    (params.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ?? "off";
+    (params.sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (params.agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
+    "off";
   const currentElevatedLevel =
     (params.sessionEntry?.elevatedLevel as ElevatedLevel | undefined) ??
     (params.agentCfg?.elevatedDefault as ElevatedLevel | undefined);

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -394,13 +394,14 @@ export async function resolveReplyDirectives(params: {
     (await modelState.resolveDefaultThinkingLevel()) ??
     (agentCfg?.thinkingDefault as ThinkLevel | undefined);
 
-  // When neither directive nor session set reasoning, default to model capability
+  // When neither directive, session, nor config set reasoning, default to model capability
   // (e.g. OpenRouter with reasoning: true). Skip auto-enabling when thinking is
   // active, including model-inferred defaults, or internal thinking blocks can
   // be emitted as visible "Reasoning:" messages.
   const reasoningExplicitlySet =
     directives.reasoningLevel !== undefined ||
-    (sessionEntry?.reasoningLevel !== undefined && sessionEntry?.reasoningLevel !== null);
+    (sessionEntry?.reasoningLevel !== undefined && sessionEntry?.reasoningLevel !== null) ||
+    agentCfg?.reasoningDefault !== undefined;
   const thinkingActive = resolvedThinkLevelWithDefault !== "off";
   if (!reasoningExplicitlySet && resolvedReasoningLevel === "off" && !thinkingActive) {
     resolvedReasoningLevel = await modelState.resolveDefaultReasoningLevel();

--- a/src/auto-reply/reply/get-reply-directives.ts
+++ b/src/auto-reply/reply/get-reply-directives.ts
@@ -348,6 +348,7 @@ export async function resolveReplyDirectives(params: {
   let resolvedReasoningLevel: ReasoningLevel =
     directives.reasoningLevel ??
     (sessionEntry?.reasoningLevel as ReasoningLevel | undefined) ??
+    (agentCfg?.reasoningDefault as ReasoningLevel | undefined) ??
     "off";
   const resolvedElevatedLevel = elevatedAllowed
     ? (directives.elevatedLevel ??

--- a/src/auto-reply/status.ts
+++ b/src/auto-reply/status.ts
@@ -510,7 +510,11 @@ export function buildStatusMessage(args: StatusArgs): string {
     args.resolvedThink ?? args.sessionEntry?.thinkingLevel ?? args.agent?.thinkingDefault ?? "off";
   const verboseLevel =
     args.resolvedVerbose ?? args.sessionEntry?.verboseLevel ?? args.agent?.verboseDefault ?? "off";
-  const reasoningLevel = args.resolvedReasoning ?? args.sessionEntry?.reasoningLevel ?? "off";
+  const reasoningLevel =
+    args.resolvedReasoning ??
+    args.sessionEntry?.reasoningLevel ??
+    args.agent?.reasoningDefault ??
+    "off";
   const elevatedLevel =
     args.resolvedElevated ??
     args.sessionEntry?.elevatedLevel ??

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -187,6 +187,8 @@ export type AgentDefaultsConfig = {
   thinkingDefault?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "adaptive";
   /** Default verbose level when no /verbose directive is present. */
   verboseDefault?: "off" | "on" | "full";
+  /** Default reasoning visibility level when no /reasoning directive is present. */
+  reasoningDefault?: "off" | "on" | "stream";
   /** Default elevated level when no /elevated directive is present. */
   elevatedDefault?: "off" | "on" | "ask" | "full";
   /** Default block streaming level when no override is present. */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -135,6 +135,7 @@ export const AgentDefaultsSchema = z
       ])
       .optional(),
     verboseDefault: z.union([z.literal("off"), z.literal("on"), z.literal("full")]).optional(),
+    reasoningDefault: z.union([z.literal("off"), z.literal("on"), z.literal("stream")]).optional(),
     elevatedDefault: z
       .union([z.literal("off"), z.literal("on"), z.literal("ask"), z.literal("full")])
       .optional(),

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -125,6 +125,11 @@ function resolveTelegramReasoningLevel(params: {
   } catch {
     // Fall through to default.
   }
+  // Check config default before falling back to "off"
+  const configDefault = cfg.agents?.defaults?.reasoningDefault;
+  if (configDefault === "on" || configDefault === "stream") {
+    return configDefault;
+  }
   return "off";
 }
 

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -119,13 +119,17 @@ function resolveTelegramReasoningLevel(params: {
     const store = loadSessionStore(storePath, { skipCache: true });
     const entry = store[sessionKey.toLowerCase()] ?? store[sessionKey];
     const level = entry?.reasoningLevel;
+    // If session has an explicit value (including "off"), respect it
     if (level === "on" || level === "stream") {
       return level;
+    }
+    if (level === "off") {
+      return "off";
     }
   } catch {
     // Fall through to default.
   }
-  // Check config default before falling back to "off"
+  // Only check config default when session has no explicit value
   const configDefault = cfg.agents?.defaults?.reasoningDefault;
   if (configDefault === "on" || configDefault === "stream") {
     return configDefault;


### PR DESCRIPTION
## Summary

Add `agents.defaults.reasoningDefault` to allow configuring the default reasoning visibility level (`off`|`on`|`stream`) without requiring per-session `/reasoning` directives.

This brings parity with `thinkingDefault`, `verboseDefault`, and `elevatedDefault`.

## Changes

- `src/config/types.agent-defaults.ts`: Add `reasoningDefault` type
- `src/config/zod-schema.agent-defaults.ts`: Add zod validation
- `src/auto-reply/reply/get-reply-directives.ts`: Use config default in resolution chain
- `src/auto-reply/reply/directive-handling.levels.ts`: Use config default in level resolution
- `src/auto-reply/status.ts`: Use config default in /status output
- `src/telegram/bot-message-dispatch.ts`: Check config default for Telegram streaming mode
- `docs/tools/thinking.md`: Document the new config option
- `docs/gateway/configuration-reference.md`: Add to example config

## Resolution order

1. Inline directive on the message
2. Session override  
3. Global default (`agents.defaults.reasoningDefault`)
4. Fallback: `off`

## Example config

```json5
{
  agents: {
    defaults: {
      reasoningDefault: "off",  // hide reasoning by default
    }
  }
}
```

## Testing

- [x] TypeScript compiles (`pnpm tsgo`)
- [ ] Existing tests pass