### PR TITLE
fix(discord): requireMention regression — guild messages misclassified as DMs

### DIFF
--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -814,6 +814,89 @@ describe("preflightDiscordMessage", () => {
     expect(result?.isGuildMessage).toBe(true);
   });
 
+  it("drops guild message without mention when channelInfo.type is stale DM (fixes #34353)", async () => {
+    const channelId = "channel-stale-dm-nomention";
+    const guildId = "guild-stale-dm-nomention";
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === channelId) {
+          // Stale or inconsistent channel info: reports DM even though the
+          // message carries a guild_id.
+          return {
+            id: channelId,
+            type: ChannelType.DM,
+            name: null,
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+    const message = {
+      id: "m-stale-dm-nomention",
+      content: "hello world",
+      timestamp: new Date().toISOString(),
+      channelId,
+      attachments: [],
+      mentionedUsers: [],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: {
+        session: {
+          mainKey: "main",
+          scope: "per-sender",
+        },
+      } as import("../../config/config.js").OpenClawConfig,
+      discordConfig: {} as NonNullable<
+        import("../../config/config.js").OpenClawConfig["channels"]
+      >["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: "openclaw-bot",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "open",
+      threadBindings: createNoopThreadBindingManager("default"),
+      guildEntries: {
+        [guildId]: {
+          requireMention: true,
+        },
+      },
+      data: {
+        channel_id: channelId,
+        guild_id: guildId,
+        guild: {
+          id: guildId,
+          name: "Guild Stale DM NoMention",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    // This is the inverse of the "with mention" test above.  Before the fix,
+    // isDirectMessage=true (stale channelInfo) would bypass the requireMention
+    // gate entirely, letting this un-mentioned message through.  With the fix,
+    // guild_id takes precedence: isDirectMessage=false, no mention detected,
+    // and the message is correctly dropped by the mention gate.
+    expect(result).toBeNull();
+  });
+
   it("drops guild message without mention even when botUserId is absent (fixes #34353)", async () => {
     const channelId = "channel-no-botid";
     const guildId = "guild-no-botid";

--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -728,6 +728,179 @@ describe("preflightDiscordMessage", () => {
     expect(result?.hasAnyMention).toBe(false);
   });
 
+  it("does not classify guild message as DM when channelInfo.type is stale DM (fixes #34353)", async () => {
+    const channelId = "channel-stale-dm";
+    const guildId = "guild-stale-dm";
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === channelId) {
+          // Stale or inconsistent channel info: reports DM even though the
+          // message carries a guild_id.
+          return {
+            id: channelId,
+            type: ChannelType.DM,
+            name: null,
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+    const message = {
+      id: "m-stale-dm-1",
+      content: "hello <@openclaw-bot>",
+      timestamp: new Date().toISOString(),
+      channelId,
+      attachments: [],
+      mentionedUsers: [{ id: "openclaw-bot" }],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: {
+        session: {
+          mainKey: "main",
+          scope: "per-sender",
+        },
+      } as import("../../config/config.js").OpenClawConfig,
+      discordConfig: {} as NonNullable<
+        import("../../config/config.js").OpenClawConfig["channels"]
+      >["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: "openclaw-bot",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "open",
+      threadBindings: createNoopThreadBindingManager("default"),
+      guildEntries: {
+        [guildId]: {
+          requireMention: true,
+        },
+      },
+      data: {
+        channel_id: channelId,
+        guild_id: guildId,
+        guild: {
+          id: guildId,
+          name: "Guild Stale DM",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    // Before the fix, isDirectMessage would be true (stale channelInfo) which
+    // forces wasMentioned=false and lets the message bypass the mention gate,
+    // or misroutes it as a DM.  With the fix, guild_id takes precedence:
+    // isDirectMessage=false, the explicit mention is detected, and the message
+    // passes through the mention gate normally.
+    expect(result).not.toBeNull();
+    expect(result?.wasMentioned).toBe(true);
+    expect(result?.isDirectMessage).toBe(false);
+    expect(result?.isGuildMessage).toBe(true);
+  });
+
+  it("drops guild message without mention even when botUserId is absent (fixes #34353)", async () => {
+    const channelId = "channel-no-botid";
+    const guildId = "guild-no-botid";
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === channelId) {
+          return {
+            id: channelId,
+            type: ChannelType.GuildText,
+            name: "general",
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+    const message = {
+      id: "m-no-botid-1",
+      content: "hello world",
+      timestamp: new Date().toISOString(),
+      channelId,
+      attachments: [],
+      mentionedUsers: [],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: {
+        session: {
+          mainKey: "main",
+          scope: "per-sender",
+        },
+        messages: {
+          groupChat: {
+            mentionPatterns: ["openclaw"],
+          },
+        },
+      } as import("../../config/config.js").OpenClawConfig,
+      discordConfig: {} as NonNullable<
+        import("../../config/config.js").OpenClawConfig["channels"]
+      >["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      // No botUserId — simulates the bot's Discord user ID being unavailable.
+      botUserId: "",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "open",
+      threadBindings: createNoopThreadBindingManager("default"),
+      guildEntries: {
+        [guildId]: {
+          requireMention: true,
+        },
+      },
+      data: {
+        channel_id: channelId,
+        guild_id: guildId,
+        guild: {
+          id: guildId,
+          name: "Guild No BotId",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    // Before the fix, the guard `if (botId && mentionGate.shouldSkip)` would
+    // short-circuit to false when botId is falsy, letting the message through
+    // even though canDetectMention is true (via mentionPatterns regex) and
+    // requireMention is set.  With the fix, the botId guard is removed so
+    // mentionGate.shouldSkip alone decides.
+    expect(result).toBeNull();
+  });
+
   it("uses attachment content_type for guild audio preflight mention detection", async () => {
     transcribeFirstAudioMock.mockResolvedValue("hey openclaw");
 

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -189,8 +189,13 @@ export async function preflightDiscordMessage(
   if (isPreflightAborted(params.abortSignal)) {
     return null;
   }
-  const isDirectMessage = channelInfo?.type === ChannelType.DM;
-  const isGroupDm = channelInfo?.type === ChannelType.GroupDM;
+  // guild_id from the event payload is the authoritative signal for guild
+  // messages.  channelInfo.type can be stale (cache, API inconsistency, or
+  // Carbon library mismatch), so never classify a message as DM/GroupDM when
+  // guild_id is present.  This prevents guild messages from accidentally
+  // bypassing the requireMention gate.  Fixes #34353.
+  const isDirectMessage = !isGuildMessage && channelInfo?.type === ChannelType.DM;
+  const isGroupDm = !isGuildMessage && channelInfo?.type === ChannelType.GroupDM;
   logDebug(
     `[discord-preflight] channelId=${messageChannelId} guild_id=${params.data.guild_id} channelType=${channelInfo?.type} isGuild=${isGuildMessage} isDM=${isDirectMessage} isGroupDm=${isGroupDm}`,
   );
@@ -661,13 +666,20 @@ export async function preflightDiscordMessage(
     `[discord-preflight] shouldRequireMention=${shouldRequireMention} baseRequireMention=${shouldRequireMentionByConfig} boundThreadSession=${isBoundThreadSession} mentionGate.shouldSkip=${mentionGate.shouldSkip} wasMentioned=${wasMentioned}`,
   );
   if (isGuildMessage && shouldRequireMention) {
-    if (botId && mentionGate.shouldSkip) {
+    // mentionGate.shouldSkip already accounts for canDetectMention; don't
+    // re-gate on botId — mention regexes (bot name / display name) can
+    // detect mentions even when the bot's Discord user ID is unavailable.
+    if (mentionGate.shouldSkip) {
       logDebug(`[discord-preflight] drop: no-mention`);
       logVerbose(`discord: drop guild message (mention required, botId=${botId})`);
       logger.info(
         {
           channelId: messageChannelId,
           reason: "no-mention",
+          requireMention: shouldRequireMention,
+          canDetectMention,
+          wasMentioned,
+          effectiveWasMentioned,
         },
         "discord: skipping guild message",
       );


### PR DESCRIPTION
## Summary

- **Problem:** Discord guild messages with `requireMention: true` were not being gated — the agent responded to every message regardless of mention (#34353). Two independent root causes:
  1. `isDirectMessage` was derived solely from `channelInfo.type` (API/cache), which can return `ChannelType.DM` for guild channels due to stale cache or Carbon library inconsistencies. This forced `wasMentioned=false` and bypassed the mention gate.
  2. The mention-gate drop was guarded by `if (botId && mentionGate.shouldSkip)`, silently disabling the gate when the bot's Discord user ID was unavailable — even though mention detection still works via `mentionPatterns` regexes.
- **Why it matters:** Users configuring `requireMention: true` expect the agent to stay silent in guild channels unless explicitly mentioned. Both bugs independently defeat this.
- **What changed:** `src/discord/monitor/message-handler.preflight.ts` — two targeted fixes + structured log fields for the drop path. Two new regression tests.
- **What did NOT change:** No changes to mention-gating logic (`mention-gating.ts`), allowlist resolution, or any other channel handler.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations

## Linked Issue/PR

- Closes #34353
- Related #34406, #34416

## User-visible / Behavior Changes

- Guild messages in servers with `requireMention: true` are now correctly dropped when the bot is not mentioned (restoring v2026.3.1 behavior).
- Guild messages are no longer misclassified as `chat_type: "direct"` when `channelInfo` is stale.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Any
- Runtime/container: Node 22+
- Integration/channel: Discord
- Relevant config: `discord.guilds.<id>.requireMention: true`

### Steps

1. Configure a Discord guild with `requireMention: true`
2. Send a message in a guild channel WITHOUT mentioning the bot
3. Observe whether the message is processed or dropped

### Expected

- Message is dropped (agent stays silent)

### Actual (before fix)

- Message is processed and agent responds

## Evidence

- [x] Failing test/log before + passing after

Two new test cases added:
- `does not classify guild message as DM when channelInfo.type is stale DM` — verifies fix #1
- `drops guild message without mention even when botUserId is absent` — verifies fix #2

Full test suite: 6587/6587 passed. Build and lint clean.

## Human Verification (required)

- Verified scenarios: Both regression tests exercise the exact code paths described in the bug. Traced the full preflight flow from `guild_id` → `isDirectMessage` → `wasMentioned` → `mentionGate` → drop/pass decision.
- Edge cases checked: Stale DM channelInfo with guild_id present; absent botUserId with mentionPatterns regex available; normal guild messages with/without mentions.
- What I did **not** verify: Live Discord bot testing (no Discord bot available in dev).

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit on `message-handler.preflight.ts`.
- Known bad symptoms reviewers should watch for: DMs being dropped (if `!isGuildMessage` guard is wrong), or guild messages still bypassing mention gate.

## Risks and Mitigations

- Risk: Real DMs might be misclassified if `guild_id` is spuriously set.
  - Mitigation: Discord DM events never carry `guild_id` per the Discord API contract. The `guild_id` field is only present on guild message events.

## AI Disclosure

- [x] AI-assisted (Claude Code)
- Degree of testing: Fully tested — `pnpm build && pnpm check && pnpm test` (6587/6587 pass)
- Code was reviewed by Codex (GPT-5.1) via codereview tool — zero issues found
- I understand what the code does: root cause traced through the full preflight flow across 5 source files