### PR TITLE
fix(gateway): use provided env for restart probe auth

### DIFF
--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -184,6 +184,36 @@ describe("inspectGatewayRestart", () => {
     );
   });
 
+  it("uses provided env auth credentials for gateway probe", async () => {
+    const service = {
+      readRuntime: vi.fn(async () => ({ status: "running", pid: 8000 })),
+    } as unknown as GatewayService;
+
+    inspectPortUsage.mockResolvedValue({
+      port: 18789,
+      status: "busy",
+      listeners: [{ commandLine: "" }],
+      hints: [],
+    });
+    classifyPortListener.mockReturnValue("unknown");
+    probeGateway.mockResolvedValue({ ok: true, close: null });
+
+    const { inspectGatewayRestart } = await import("./restart-health.js");
+    await inspectGatewayRestart({
+      service,
+      port: 18789,
+      env: {
+        OPENCLAW_GATEWAY_TOKEN: " tok ",
+        OPENCLAW_GATEWAY_PASSWORD: " pw ",
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(probeGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth: { token: "tok", password: "pw" },
+      }),
+    );
+  });
   it("treats auth-closed probe as healthy gateway reachability", async () => {
     const service = {
       readRuntime: vi.fn(async () => ({ status: "running", pid: 8000 })),

--- a/src/cli/daemon-cli/restart-health.ts
+++ b/src/cli/daemon-cli/restart-health.ts
@@ -44,9 +44,9 @@ function looksLikeAuthClose(code: number | undefined, reason: string | undefined
   );
 }
 
-async function confirmGatewayReachable(port: number): Promise<boolean> {
-  const token = process.env.OPENCLAW_GATEWAY_TOKEN?.trim() || undefined;
-  const password = process.env.OPENCLAW_GATEWAY_PASSWORD?.trim() || undefined;
+async function confirmGatewayReachable(port: number, env: NodeJS.ProcessEnv): Promise<boolean> {
+  const token = env.OPENCLAW_GATEWAY_TOKEN?.trim() || undefined;
+  const password = env.OPENCLAW_GATEWAY_PASSWORD?.trim() || undefined;
   const probe = await probeGateway({
     url: `ws://127.0.0.1:${port}`,
     auth: token || password ? { token, password } : undefined,
@@ -108,7 +108,7 @@ export async function inspectGatewayRestart(params: {
   let healthy = running && ownsPort;
   if (!healthy && running && portUsage.status === "busy") {
     try {
-      healthy = await confirmGatewayReachable(params.port);
+      healthy = await confirmGatewayReachable(params.port, env);
     } catch {
       // best-effort probe
     }


### PR DESCRIPTION
## Summary
- pass `env` through to restart health gateway probe auth lookup
- avoid implicit `process.env` dependency in `confirmGatewayReachable`
- add regression test ensuring provided env token/password are used and trimmed

## Why
When callers pass a custom environment during daemon restart checks, auth should come from that explicit env rather than ambient process env.

## Validation
- `pnpm -s vitest run src/cli/daemon-cli/restart-health.test.ts`
- Codex ACP incremental review verdict: **Approve**