### PR TITLE
fix(ports): suppress lsof errors when ss fallback succeeds

### DIFF
--- a/src/infra/ports-inspect.ts
+++ b/src/infra/ports-inspect.ts
@@ -191,6 +191,9 @@ async function readUnixListeners(
   if (ssFallback.listeners.length > 0) {
     return ssFallback;
   }
+  if (ssFallback.errors.length === 0) {
+    return { listeners: [], detail: ssFallback.detail, errors: [] };
+  }
 
   return {
     listeners: [],

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -112,6 +112,25 @@ describeUnix("inspectPortUsage", () => {
     }
   });
 
+  it("does not report lsof errors when ss fallback succeeds with no listeners", async () => {
+    runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
+      const command = argv[0];
+      if (typeof command !== "string") {
+        return { stdout: "", stderr: "", code: 1 };
+      }
+      if (command.includes("lsof")) {
+        throw Object.assign(new Error("spawn lsof ENOENT"), { code: "ENOENT" });
+      }
+      if (command === "ss") {
+        return { stdout: "", stderr: "", code: 0 };
+      }
+      return { stdout: "", stderr: "", code: 1 };
+    });
+
+    const result = await inspectPortUsage(6553);
+    expect(result.status).toBe("free");
+    expect(result.errors).toBeUndefined();
+  });
   it("falls back to ss when lsof is unavailable", async () => {
     const server = net.createServer();
     await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));

--- a/src/infra/ports.test.ts
+++ b/src/infra/ports.test.ts
@@ -19,6 +19,14 @@ import {
 
 const describeUnix = process.platform === "win32" ? describe.skip : describe;
 
+async function allocateEphemeralPort(): Promise<number> {
+  const server = net.createServer();
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as net.AddressInfo).port;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return port;
+}
+
 describe("ports helpers", () => {
   it("ensurePortAvailable rejects when port busy", async () => {
     const server = net.createServer();
@@ -113,6 +121,8 @@ describeUnix("inspectPortUsage", () => {
   });
 
   it("does not report lsof errors when ss fallback succeeds with no listeners", async () => {
+    const port = await allocateEphemeralPort();
+
     runCommandWithTimeoutMock.mockImplementation(async (argv: string[]) => {
       const command = argv[0];
       if (typeof command !== "string") {
@@ -127,10 +137,11 @@ describeUnix("inspectPortUsage", () => {
       return { stdout: "", stderr: "", code: 1 };
     });
 
-    const result = await inspectPortUsage(6553);
+    const result = await inspectPortUsage(port);
     expect(result.status).toBe("free");
     expect(result.errors).toBeUndefined();
   });
+
   it("falls back to ss when lsof is unavailable", async () => {
     const server = net.createServer();
     await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));


### PR DESCRIPTION
## Summary
- avoid propagating `lsof` failure diagnostics when `ss` fallback succeeds with no listeners
- keep existing behavior unchanged when `ss` returns listeners or errors
- add regression test for `lsof` missing + `ss` success/no-listeners path

## Why
When fallback succeeds cleanly, surfacing stale `lsof` ENOENT errors is noisy and misleading.

## Validation
- `pnpm -s vitest run src/infra/ports.test.ts`
- Codex ACP incremental review verdict: **Approve**

## Risk Surface
- Limited to port-inspection diagnostics path in `inspectPortUsage` fallback handling.
- No changes to gateway runtime flow, network binding behavior, or user-facing command semantics.

## Test Coverage
- Unit/regression coverage in `src/infra/ports.test.ts`:
  - `lsof` missing + `ss` success/no listeners path
  - `lsof` missing + loopback listener path
  - `ss` fallback listener parsing path
  - dynamic ephemeral-port boundary case to avoid fixed-port flake

## Rollback Plan
- Revert follow-up commits on this PR branch:
  - `1ba3c985b` (dynamic-port + formatting)
- Re-run `pnpm -s vitest run src/infra/ports.test.ts` to confirm pre-change behavior is restored.
