### PR TITLE
fix(infra): classify SQLITE_CANTOPEN and related codes as transient errors

### DIFF
--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -20,6 +20,14 @@ const FATAL_ERROR_CODES = new Set([
 
 const CONFIG_ERROR_CODES = new Set(["INVALID_CONFIG", "MISSING_API_KEY", "MISSING_CREDENTIALS"]);
 
+// SQLite error codes that indicate transient failures (shouldn't crash the gateway)
+const TRANSIENT_SQLITE_CODES = new Set([
+  "SQLITE_CANTOPEN",
+  "SQLITE_BUSY",
+  "SQLITE_LOCKED",
+  "SQLITE_IOERR",
+]);
+
 // Network error codes that indicate transient failures (shouldn't crash the gateway)
 const TRANSIENT_NETWORK_CODES = new Set([
   "ECONNRESET",
@@ -180,6 +188,14 @@ export function isTransientNetworkError(err: unknown): boolean {
   return false;
 }
 
+/**
+ * Checks if an error is a transient SQLite error that shouldn't crash the gateway.
+ */
+export function isTransientSqliteError(err: unknown): boolean {
+  const code = extractErrorCodeWithCause(err);
+  return code !== undefined && TRANSIENT_SQLITE_CODES.has(code.toUpperCase());
+}
+
 export function registerUnhandledRejectionHandler(handler: UnhandledRejectionHandler): () => void {
   handlers.add(handler);
   return () => {
@@ -231,6 +247,14 @@ export function installUnhandledRejectionHandler(): void {
     if (isTransientNetworkError(reason)) {
       console.warn(
         "[openclaw] Non-fatal unhandled rejection (continuing):",
+        formatUncaughtError(reason),
+      );
+      return;
+    }
+
+    if (isTransientSqliteError(reason)) {
+      console.warn(
+        "[openclaw] Non-fatal SQLite transient error (continuing):",
         formatUncaughtError(reason),
       );
       return;


### PR DESCRIPTION
Fixes #34678

## Problem
`SQLITE_CANTOPEN`, `SQLITE_BUSY`, `SQLITE_LOCKED`, and `SQLITE_IOERR` were not in any safe-list in `src/infra/unhandled-rejections.ts`, causing them to fall through to the catch-all `process.exit(1)` path. On macOS with LaunchAgent, this triggers a crash loop.

## Changes
- Added `TRANSIENT_SQLITE_CODES` set with the four transient SQLite error codes
- Added `isTransientSqliteError()` helper (checks error code and its cause)
- Added check in `installUnhandledRejectionHandler` — logs a warning and continues instead of exiting