### PR TITLE
fix(ui): set selected attribute on option elements to fix model select initial value

### DIFF
--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -411,7 +411,10 @@ export function buildModelOptions(
       <option value="" disabled>No configured models</option>
     `;
   }
-  return options.map((option) => html`<option value=${option.value}>${option.label}</option>`);
+  return options.map(
+    (option) =>
+      html`<option value=${option.value} ?selected=${option.value === current}>${option.label}</option>`,
+  );
 }
 
 type CompiledPattern =


### PR DESCRIPTION
Fixes #34857

## Problem
The Agents → Overview model selection `<select>` showed the wrong model on initial load. Lit commits `.value` property bindings **before** rendering `<option>` children (ChildPart), so `select.value = "configured-model"` was applied when no matching option existed yet — the browser silently ignored it and fell back to the first option.

## Fix
Added `?selected=${option.value === current}` to each `<option>` in `buildModelOptions()`. Selection is now established during the ChildPart render phase (when options are already in the DOM), making it immune to the property-before-children timing issue.

One-line change in `ui/src/ui/views/agents-utils.ts`.