### PR TITLE
fix(macOS): fatal access conflict in overlay present() crashes app on launch when talk mode enabled

### DIFF
--- a/apps/macos/Sources/OpenClaw/NotifyOverlay.swift
+++ b/apps/macos/Sources/OpenClaw/NotifyOverlay.swift
@@ -61,11 +61,14 @@ final class NotifyOverlayController {
         self.ensureWindow()
         self.hostingView?.rootView = NotifyOverlayView(controller: self)
         let target = self.targetFrame()
-        OverlayPanelFactory.present(
-            window: self.window,
-            isVisible: &self.model.isVisible,
-            target: target)
-        { window in
+        guard let window = self.window else { return }
+        // Avoid passing &model.isVisible as inout — the exclusive modify access
+        // on `model` would overlap with SwiftUI reads triggered by
+        // orderFrontRegardless(), causing a fatal access conflict.
+        if !self.model.isVisible {
+            self.model.isVisible = true
+            OverlayPanelFactory.animatePresent(window: window, from: target.offsetBy(dx: 0, dy: -6), to: target)
+        } else {
             self.updateWindowFrame(animate: true)
             window.orderFrontRegardless()
         }

--- a/apps/macos/Sources/OpenClaw/OverlayPanelFactory.swift
+++ b/apps/macos/Sources/OpenClaw/OverlayPanelFactory.swift
@@ -62,26 +62,6 @@ enum OverlayPanelFactory {
     }
 
     @MainActor
-    static func present(
-        window: NSWindow?,
-        isVisible: inout Bool,
-        target: NSRect,
-        startOffsetY: CGFloat = -6,
-        onFirstPresent: (() -> Void)? = nil,
-        onAlreadyVisible: (NSWindow) -> Void)
-    {
-        guard let window else { return }
-        if !isVisible {
-            isVisible = true
-            onFirstPresent?()
-            let start = target.offsetBy(dx: 0, dy: startOffsetY)
-            self.animatePresent(window: window, from: start, to: target)
-        } else {
-            onAlreadyVisible(window)
-        }
-    }
-
-    @MainActor
     static func animateDismiss(
         window: NSWindow,
         offsetX: CGFloat = 6,

--- a/apps/macos/Sources/OpenClaw/TalkOverlay.swift
+++ b/apps/macos/Sources/OpenClaw/TalkOverlay.swift
@@ -30,11 +30,14 @@ final class TalkOverlayController {
         self.ensureWindow()
         self.hostingView?.rootView = TalkOverlayView(controller: self)
         let target = self.targetFrame()
-        OverlayPanelFactory.present(
-            window: self.window,
-            isVisible: &self.model.isVisible,
-            target: target)
-        { window in
+        guard let window = self.window else { return }
+        // Avoid passing &model.isVisible as inout — the exclusive modify access
+        // on `model` would overlap with SwiftUI reads triggered by
+        // orderFrontRegardless(), causing a fatal access conflict on launch.
+        if !self.model.isVisible {
+            self.model.isVisible = true
+            OverlayPanelFactory.animatePresent(window: window, from: target.offsetBy(dx: 0, dy: -6), to: target)
+        } else {
             window.setFrame(target, display: true)
             window.orderFrontRegardless()
         }

--- a/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift
+++ b/apps/macos/Sources/OpenClaw/VoiceWakeOverlayController+Window.swift
@@ -13,21 +13,22 @@ extension VoiceWakeOverlayController {
         self.ensureWindow()
         self.hostingView?.rootView = VoiceWakeOverlayView(controller: self)
         let target = self.targetFrame()
-        OverlayPanelFactory.present(
-            window: self.window,
-            isVisible: &self.model.isVisible,
-            target: target,
-            onFirstPresent: {
-                self.logger.log(
-                    level: .info,
-                    "overlay present windowShown textLen=\(self.model.text.count, privacy: .public)")
-                // Keep the status item in “listening” mode until we explicitly dismiss the overlay.
-                AppStateStore.shared.triggerVoiceEars(ttl: nil)
-            },
-            onAlreadyVisible: { window in
-                self.updateWindowFrame(animate: true)
-                window.orderFrontRegardless()
-            })
+        guard let window = self.window else { return }
+        // Avoid passing &model.isVisible as inout — the exclusive modify access
+        // on `model` would overlap with SwiftUI reads triggered by
+        // orderFrontRegardless(), causing a fatal access conflict.
+        if !self.model.isVisible {
+            self.model.isVisible = true
+            self.logger.log(
+                level: .info,
+                "overlay present windowShown textLen=\(self.model.text.count, privacy: .public)")
+            // Keep the status item in "listening" mode until we explicitly dismiss the overlay.
+            AppStateStore.shared.triggerVoiceEars(ttl: nil)
+            OverlayPanelFactory.animatePresent(window: window, from: target.offsetBy(dx: 0, dy: -6), to: target)
+        } else {
+            self.updateWindowFrame(animate: true)
+            window.orderFrontRegardless()
+        }
     }
 
     private func ensureWindow() {


### PR DESCRIPTION
## Summary
- **Problem:** App crashes on launch with `Fatal access conflict detected` when Talk Mode is enabled — `TalkOverlayController.present()` passes `&model.isVisible` as `inout` to `OverlayPanelFactory.present()`, holding an exclusive modify access on the `@Observable` model. When `orderFrontRegardless()` fires inside that call, SwiftUI reads `model.phase/level/isPaused` to render the view — Swift's exclusivity enforcement crashes the app.
- **What changed:** Inlined the visibility check in `present()` across all three overlay controllers (`TalkOverlay`, `VoiceWakeOverlayController+Window`, `NotifyOverlay`), writing `model.isVisible` as a discrete assignment before calling `animatePresent()`.
- **What did NOT change:** Animation behavior is identical. All dismiss paths, `TalkModeController`, `AppState`, and the runtime/view layers are untouched.

## Change Type
- [x] Bug fix

## Scope
- [x] UI / DX

## Linked Issue/PR
- Closes #34903

## User-visible / Behavior Changes
App no longer crashes on launch when Talk Mode or Voice Wake is enabled.

## Security Impact (required)
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification
### Environment
- OS: macOS 25.3.0 (arm64)
- OpenClaw: 2026.3.2

### Steps
1. Enable Talk Mode in OpenClaw Mac app settings
2. Restart the app
3. Previously crashed immediately; now launches cleanly

### Expected
App launches. Talk Mode overlay appears at top-right as normal.

### Actual (before fix)
TalkOverlayController.present() + 676
TalkModeController.setEnabled(_:) + 556
_dispatch_main_queue_drain
Fatal access conflict detected.

## Evidence
- [x] Existing overlay and voice wake test suites pass without modification

## Human Verification (required)
- Verified scenarios: Talk mode enabled on launch, toggle at runtime, overlay dismiss/re-present, voice wake present/dismiss, notify overlay present/dismiss
- Edge cases checked: `bringToFrontIfVisible()` while animating, `updateLevel()` guard during animation, `onChange(of: model.isVisible)` in SwiftUI view
- What you did **not** verify: Full speech recognition session on physical hardware

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No