### PR TITLE
fix(ui): set selected attribute on option elements to fix model select initial value

### DIFF
--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -411,7 +411,7 @@ export function buildModelOptions(
       <option value="" disabled>No configured models</option>
     `;
   }
-  return options.map((option) => html`<option value=${option.value}>${option.label}</option>`);
+  return options.map((option) => html`<option value=${option.value} ?selected=${option.value === current}>${option.label}</option>`);
 }
 
 type CompiledPattern =


### PR DESCRIPTION
## Summary

Fixes #34857 - Model selection shows wrong primary model on initial load

## Problem

The Agents → Overview model selection `<select>` showed the wrong model on initial load. Lit commits `.value` property bindings **before** rendering `<option>` children.

## Fix

Added `?selected=${option.value === current}` to each `<option>` in `buildModelOptions()`:

```ts
<option value=${option.value} ?selected=${option.value === current}>${option.label}</option>
```

Closes #34933