### PR TITLE
fix(macOS): enable undo/redo in webchat composer text input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Docs: https://docs.openclaw.ai
 - Reply/block streaming: preserve post-stream incomplete-turn error payloads after block streaming already emitted content, so users get the warning instead of silence. (#67991) Thanks @obviyus.
 - Telegram/streaming: clear the compaction replay guard after visible non-final boundaries so a post-tool assistant reply rotates to a fresh preview instead of editing the pre-compaction message. (#67993) Thanks @obviyus.
 - Matrix: fix `sessions_spawn --thread` subagent session spawning — thread binding creation, cleanup on session end, and completion-message delivery target resolution now work end-to-end. (#67643) Thanks @eejohnso-ops and @gumadeiras.
+- macOS/webchat: enable Undo and Redo in the composer text input by turning on the native `NSTextView` undo manager. (#34962) Thanks @tylerbittner.
 
 ## 2026.4.15
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -457,6 +457,7 @@ private struct ChatComposerTextView: NSViewRepresentable {
         textView.textContainer?.lineFragmentPadding = 0
         textView.textContainerInset = NSSize(width: 2, height: 4)
         textView.focusRingType = .none
+        textView.allowsUndo = true
 
         textView.minSize = .zero
         textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)

--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift
@@ -444,35 +444,18 @@ private struct ChatComposerTextView: NSViewRepresentable {
     func makeCoordinator() -> Coordinator { Coordinator(self) }
 
     func makeNSView(context: Context) -> NSScrollView {
-        let textView = ChatComposerNSTextView()
-        textView.delegate = context.coordinator
-        textView.drawsBackground = false
-        textView.isRichText = false
-        textView.isAutomaticQuoteSubstitutionEnabled = false
-        textView.isAutomaticTextReplacementEnabled = false
-        textView.isAutomaticDashSubstitutionEnabled = false
-        textView.isAutomaticSpellingCorrectionEnabled = false
-        textView.font = .systemFont(ofSize: 14, weight: .regular)
-        textView.textContainer?.lineBreakMode = .byWordWrapping
-        textView.textContainer?.lineFragmentPadding = 0
-        textView.textContainerInset = NSSize(width: 2, height: 4)
-        textView.focusRingType = .none
-        textView.allowsUndo = true
+        let textView = ChatComposerTextViewFactory.makeConfiguredTextView()
+        guard let composerTextView = textView as? ChatComposerNSTextView else {
+            preconditionFailure("ChatComposerTextViewFactory must return ChatComposerNSTextView")
+        }
+        composerTextView.delegate = context.coordinator
 
-        textView.minSize = .zero
-        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
-        textView.isHorizontallyResizable = false
-        textView.isVerticallyResizable = true
-        textView.autoresizingMask = [.width]
-        textView.textContainer?.containerSize = NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
-        textView.textContainer?.widthTracksTextView = true
-
-        textView.string = self.text
-        textView.onSend = { [weak textView] in
-            textView?.window?.makeFirstResponder(nil)
+        composerTextView.string = self.text
+        composerTextView.onSend = { [weak composerTextView] in
+            composerTextView?.window?.makeFirstResponder(nil)
             self.onSend()
         }
-        textView.onPasteImageAttachment = self.onPasteImageAttachment
+        composerTextView.onPasteImageAttachment = self.onPasteImageAttachment
 
         let scroll = NSScrollView()
         scroll.drawsBackground = false
@@ -520,6 +503,34 @@ private struct ChatComposerTextView: NSViewRepresentable {
             guard view.window?.firstResponder === view else { return }
             self.parent.text = view.string
         }
+    }
+}
+
+enum ChatComposerTextViewFactory {
+    // Internal for @testable import coverage of composer text view defaults.
+    @MainActor
+    static func makeConfiguredTextView() -> NSTextView {
+        let textView = ChatComposerNSTextView()
+        textView.drawsBackground = false
+        textView.isRichText = false
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticSpellingCorrectionEnabled = false
+        textView.font = .systemFont(ofSize: 14, weight: .regular)
+        textView.textContainer?.lineBreakMode = .byWordWrapping
+        textView.textContainer?.lineFragmentPadding = 0
+        textView.textContainerInset = NSSize(width: 2, height: 4)
+        textView.focusRingType = .none
+        textView.allowsUndo = true
+        textView.minSize = .zero
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.isHorizontallyResizable = false
+        textView.isVerticallyResizable = true
+        textView.autoresizingMask = [.width]
+        textView.textContainer?.containerSize = NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude)
+        textView.textContainer?.widthTracksTextView = true
+        return textView
     }
 }
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ChatComposerTextViewTests.swift
@@ -1,0 +1,15 @@
+#if os(macOS)
+import AppKit
+import Testing
+@testable import OpenClawChatUI
+
+@Suite
+@MainActor
+struct ChatComposerTextViewTests {
+    @Test func configuredComposerTextViewEnablesUndo() {
+        let textView = ChatComposerTextViewFactory.makeConfiguredTextView()
+
+        #expect(textView.allowsUndo)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Enables Cmd+Z (Undo) and Cmd+Shift+Z (Redo) in the webchat message composer on macOS.

## Problem

The webchat text input field did not support undo/redo:
- `Cmd+Z` produced the system alert sound
- **Edit → Undo / Redo** menu items were permanently greyed out

## Root Cause

`ChatComposerNSTextView` (a custom `NSTextView` subclass) is created in `ChatComposerTextView.makeNSView()` without setting `allowsUndo`. Per [Apple docs](https://developer.apple.com/documentation/appkit/nstextview/1449309-allowsundo), `NSTextView.allowsUndo` **defaults to `false`**.

## Fix

One-line change: set `textView.allowsUndo = true` in `makeNSView()`, grouped with the other textView property assignments.

### Undo stack integrity

The `updateNSView` method guards against programmatic string replacement while editing:

```swift
let isEditing = scrollView.window?.firstResponder == textView
let shouldClear = self.text.isEmpty && !textView.string.isEmpty
if isEditing, !shouldClear { return }
```

This means:
- ✅ **During editing**: `updateNSView` returns early → undo stack is preserved
- ✅ **After send** (`shouldClear = true`): `textView.string = self.text` clears the field and resets the undo stack — this is expected/correct behavior (you would not want to undo back to a sent message)
- ✅ **When not editing**: programmatic updates may reset the undo stack, which is acceptable since the user is not actively typing

## Testing

- [x] Build macOS app locally
- [x] Type text in webchat composer → Cmd+Z undoes typing
- [x] Edit → Undo / Redo menu items are enabled during editing
- [x] Multi-step undo: type "hello", type " world", Cmd+Z removes " world", Cmd+Z removes "hello"

## AI Disclosure

🤖 **AI-assisted** (Bobby / Claude via OpenClaw). Root cause identified by reading source code and Apple NSTextView documentation. Fix is a single property assignment.

<details>
<summary>Prompt given to AI agent</summary>

> You are fixing a bug in the OpenClaw macOS desktop app. Read CONTRIBUTING.md and AGENTS.md first for coding standards.
>
> **Bug**: GitHub issue #34898: Undo/Redo not functional in webchat text input on macOS. Cmd+Z produces system alert sound, Edit > Undo/Redo are permanently greyed out.
>
> **Root Cause (already identified)**: In `apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatComposer.swift`, the `ChatComposerNSTextView` (custom NSTextView subclass) is created in `makeNSView()` but `allowsUndo` is never set to `true`. Per Apple docs, `NSTextView.allowsUndo` defaults to `false`.
>
> **Task**: Add `textView.allowsUndo = true` in the `makeNSView` function. Verify that `updateNSView` does not break undo by clearing the undo stack during normal editing.

</details>

Fixes #34898