### PR TITLE
fix(ollama): support thinking field in native stream and response

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -120,6 +120,23 @@ describe("buildAssistantMessage", () => {
     expect(result.content).toEqual([{ type: "text", text: "Reasoning output" }]);
   });
 
+  it("prefers thinking over reasoning when content is empty", () => {
+    const response = {
+      model: "qwen3:32b",
+      created_at: "2026-01-01T00:00:00Z",
+      message: {
+        role: "assistant" as const,
+        content: "",
+        thinking: "Thinking output",
+        reasoning: "Reasoning output",
+      },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, modelInfo);
+    expect(result.stopReason).toBe("stop");
+    expect(result.content).toEqual([{ type: "text", text: "Thinking output" }]);
+  });
+
   it("builds response with tool calls", () => {
     const response = {
       model: "qwen3:32b",
@@ -414,6 +431,27 @@ describe("createOllamaStreamFn", () => {
         }
 
         expect(doneEvent.message.content).toEqual([{ type: "text", text: "reasoned output" }]);
+      },
+    );
+  });
+
+  it("accumulates thinking chunks when content is empty", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":"thinking"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":" output"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":2}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
+        const events = await collectStreamEvents(stream);
+
+        const doneEvent = events.at(-1);
+        if (!doneEvent || doneEvent.type !== "done") {
+          throw new Error("Expected done event");
+        }
+
+        expect(doneEvent.message.content).toEqual([{ type: "text", text: "thinking output" }]);
       },
     );
   });

--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -455,4 +455,26 @@ describe("createOllamaStreamFn", () => {
       },
     );
   });
+
+  it("prefers content over earlier thinking and reasoning chunks", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","thinking":"hidden thinking"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"","reasoning":"hidden reasoning"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"visible answer"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true,"prompt_eval_count":1,"eval_count":2}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
+        const events = await collectStreamEvents(stream);
+
+        const doneEvent = events.at(-1);
+        if (!doneEvent || doneEvent.type !== "done") {
+          throw new Error("Expected done event");
+        }
+
+        expect(doneEvent.message.content).toEqual([{ type: "text", text: "visible answer" }]);
+      },
+    );
+  });
 });

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -185,6 +185,7 @@ interface OllamaChatResponse {
   message: {
     role: "assistant";
     content: string;
+    thinking?: string;
     reasoning?: string;
     tool_calls?: OllamaToolCall[];
   };
@@ -323,10 +324,10 @@ export function buildAssistantMessage(
 ): AssistantMessage {
   const content: (TextContent | ToolCall)[] = [];
 
-  // Qwen 3 (and potentially other reasoning models) may return their final
-  // answer in a `reasoning` field with an empty `content`. Fall back to
-  // `reasoning` so the response isn't silently dropped.
-  const text = response.message.content || response.message.reasoning || "";
+  // Some models return the answer in `thinking` (Ollama native API), while
+  // others use `reasoning`. Fall back to both when `content` is empty.
+  const text =
+    response.message.content || response.message.thinking || response.message.reasoning || "";
   if (text) {
     content.push({ type: "text", text });
   }
@@ -474,8 +475,11 @@ export function createOllamaStreamFn(
         for await (const chunk of parseNdjsonStream(reader)) {
           if (chunk.message?.content) {
             accumulatedContent += chunk.message.content;
+          } else if (chunk.message?.thinking) {
+            // Ollama native thinking models may emit text in `thinking`.
+            accumulatedContent += chunk.message.thinking;
           } else if (chunk.message?.reasoning) {
-            // Qwen 3 reasoning mode: content may be empty, output in reasoning
+            // Backward compatibility for models that emit `reasoning`.
             accumulatedContent += chunk.message.reasoning;
           }
 

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -469,6 +469,8 @@ export function createOllamaStreamFn(
 
         const reader = response.body.getReader();
         let accumulatedContent = "";
+        let accumulatedThinking = "";
+        let accumulatedReasoning = "";
         const accumulatedToolCalls: OllamaToolCall[] = [];
         let finalResponse: OllamaChatResponse | undefined;
 
@@ -477,10 +479,10 @@ export function createOllamaStreamFn(
             accumulatedContent += chunk.message.content;
           } else if (chunk.message?.thinking) {
             // Ollama native thinking models may emit text in `thinking`.
-            accumulatedContent += chunk.message.thinking;
+            accumulatedThinking += chunk.message.thinking;
           } else if (chunk.message?.reasoning) {
             // Backward compatibility for models that emit `reasoning`.
-            accumulatedContent += chunk.message.reasoning;
+            accumulatedReasoning += chunk.message.reasoning;
           }
 
           // Ollama sends tool_calls in intermediate (done:false) chunks,
@@ -499,7 +501,8 @@ export function createOllamaStreamFn(
           throw new Error("Ollama API stream ended without a final response");
         }
 
-        finalResponse.message.content = accumulatedContent;
+        finalResponse.message.content =
+          accumulatedContent || accumulatedThinking || accumulatedReasoning;
         if (accumulatedToolCalls.length > 0) {
           finalResponse.message.tool_calls = accumulatedToolCalls;
         }


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Ollama native `/api/chat` responses can emit assistant text in `message.thinking`, but OpenClaw only consumed `message.reasoning` for fallback paths.
- Why it matters: thinking-capable models can appear to return empty/partial responses when `content` is empty.
- What changed: added `thinking` support in non-streaming and streaming fallback paths, while preserving `reasoning` compatibility.
- What did NOT change (scope boundary): no provider routing/model-selection changes; no protocol/schema changes outside Ollama stream handling.

AI-assisted: Yes (Codex)
Testing level: Fully tested (project-level + targeted tests)

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34722
- Related #0

## User-visible / Behavior Changes

Ollama-native responses now preserve assistant text when it is emitted in `message.thinking` (with `content` empty), while still supporting legacy `message.reasoning` fallback.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local dev)
- Runtime/container: Node 22 + pnpm
- Model/provider: Ollama native API
- Integration/channel (if any): Ollama provider stream path
- Relevant config (redacted): provider with `api: "ollama"`

### Steps

1. Send/receive a response where `message.content` is empty and `message.thinking` has text.
2. Run assistant message build and stream accumulation flow.
3. Verify final assistant text is present.

### Expected

- Thinking text is surfaced as assistant output when `content` is empty.

### Actual

- Before fix, `thinking`-only output could be dropped.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Added tests:
- `src/agents/ollama-stream.test.ts`
  - prefers `thinking` over `reasoning` when both exist
  - accumulates `thinking` chunks during streaming

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run --config vitest.config.ts src/agents/ollama-stream.test.ts`
  - full project gate: `pnpm build && pnpm check && pnpm test`
- Edge cases checked:
  - `thinking + reasoning` coexistence
  - streaming `thinking` chunk concatenation
- What you did **not** verify:
  - live end-to-end call against hosted Ollama cloud endpoints

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR commit.
- Files/config to restore: `src/agents/ollama-stream.ts` and related test.
- Known bad symptoms reviewers should watch for: missing assistant text in Ollama thinking-mode outputs.

## Risks and Mitigations

- Risk: Model payloads with unexpected fields could still need additional future fallbacks.
  - Mitigation: preserves existing `reasoning` fallback and adds regression tests for `thinking` handling.
