### PR TITLE
feat(tui): show activity status indicator in footer bar

### DIFF
--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -707,9 +707,20 @@ export async function runTui(opts: TuiOptions) {
     }
   };
 
+  const activityStatusDisplay: Record<string, string> = {
+    idle: "💤 idle",
+    sending: "📡 sending",
+    waiting: "🧠 thinking",
+    streaming: "📝 streaming",
+    running: "⚙️ running",
+    error: "❌ error",
+    aborted: "🛑 aborted",
+  };
+
   const setActivityStatus = (text: string) => {
     activityStatus = text;
     renderStatus();
+    updateFooter();
   };
 
   const updateFooter = () => {
@@ -729,6 +740,8 @@ export async function runTui(opts: TuiOptions) {
     const reasoning = sessionInfo.reasoningLevel ?? "off";
     const reasoningLabel =
       reasoning === "on" ? "reasoning" : reasoning === "stream" ? "reasoning:stream" : null;
+    const statusIndicator =
+      activityStatusDisplay[activityStatus] ?? `❓ ${activityStatus ?? "unknown"}`;
     const footerParts = [
       `agent ${agentLabel}`,
       `session ${sessionLabel}`,
@@ -737,6 +750,7 @@ export async function runTui(opts: TuiOptions) {
       verbose !== "off" ? `verbose ${verbose}` : null,
       reasoningLabel,
       tokens,
+      statusIndicator,
     ].filter(Boolean);
     footer.setText(theme.dim(footerParts.join(" | ")));
   };


### PR DESCRIPTION
## Summary

Add emoji-prefixed activity status as the last element of the TUI footer bar, updating in real-time as the agent state changes:

```
agent main | session foo (openclaw-tui) | anthropic/claude-opus-4-6 | think high | tokens 153k/200k (76%) | 🧠 thinking
```

## Problem

When using the TUI, after sending a message there can be a long delay (30s–3+ minutes) before the agent responds — especially with extended thinking enabled. The footer bar shows static info that never changes when the activity state changes. The user has no way to tell from the footer bar whether their message was received, the LLM is thinking, or tools are executing.

There **is** a status area (the `statusContainer` spinner), but it's easy to miss — the footer bar is the line users actually fixate on.

## Changes

- Add `activityStatusDisplay` emoji map for 7 states: 💤 idle, 📡 sending, 🧠 thinking, 📝 streaming, ⚙️ running, ❌ error, 🛑 aborted
- Call `updateFooter()` from `setActivityStatus()` so the footer reflects state changes immediately
- Append `statusIndicator` as the last `footerParts` entry

14 lines added, 0 removed. Single file change (`src/tui/tui.ts`).

## Testing

Tested locally by patching the compiled dist files. The footer now shows immediate visual feedback when:
- Message sent (📡 sending → 🧠 thinking)
- Response streaming (📝 streaming)  
- Tools executing (⚙️ running)
- Back to idle (💤 idle)

Closes #26894