### PR TITLE
feat(web-search): set Exa as default provider via auto-detection (EXA_API_KEY activates Exa)

### DIFF
--- a/extensions/exa/index.ts
+++ b/extensions/exa/index.ts
@@ -1,0 +1,11 @@
+import { definePluginEntry } from "openclaw/plugin-sdk/core";
+import { createExaWebSearchProvider } from "./src/exa-web-search-provider.js";
+
+export default definePluginEntry({
+  id: "exa",
+  name: "Exa Plugin",
+  description: "Bundled Exa plugin",
+  register(api) {
+    api.registerWebSearchProvider(createExaWebSearchProvider());
+  },
+});

--- a/extensions/exa/openclaw.plugin.json
+++ b/extensions/exa/openclaw.plugin.json
@@ -1,0 +1,26 @@
+{
+  "id": "exa",
+  "uiHints": {
+    "webSearch.apiKey": {
+      "label": "Exa API Key",
+      "help": "Exa API key (fallback: EXA_API_KEY env var).",
+      "sensitive": true,
+      "placeholder": "exa-..."
+    }
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "webSearch": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "apiKey": {
+            "type": ["string", "object"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/extensions/exa/package.json
+++ b/extensions/exa/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@openclaw/exa-plugin",
+  "version": "2026.3.14",
+  "private": true,
+  "description": "OpenClaw Exa plugin",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/exa/src/exa-web-search-provider.ts
+++ b/extensions/exa/src/exa-web-search-provider.ts
@@ -1,0 +1,286 @@
+import { Type } from "@sinclair/typebox";
+import {
+  buildSearchCacheKey,
+  DEFAULT_SEARCH_COUNT,
+  MAX_SEARCH_COUNT,
+  formatCliCommand,
+  normalizeToIsoDate,
+  readCachedSearchPayload,
+  readConfiguredSecretString,
+  readNumberParam,
+  readProviderEnvValue,
+  readStringParam,
+  resolveProviderWebSearchPluginConfig,
+  resolveSearchCacheTtlMs,
+  resolveSearchCount,
+  resolveSearchTimeoutSeconds,
+  resolveSiteName,
+  setTopLevelCredentialValue,
+  setProviderWebSearchPluginConfigValue,
+  type SearchConfigRecord,
+  type WebSearchProviderPlugin,
+  type WebSearchProviderToolDefinition,
+  withTrustedWebSearchEndpoint,
+  wrapWebContent,
+  writeCachedSearchPayload,
+} from "openclaw/plugin-sdk/provider-web-search";
+
+const EXA_SEARCH_ENDPOINT = "https://api.exa.ai/search";
+
+type ExaHighlight = {
+  text?: string;
+  score?: number;
+};
+
+type ExaSearchResult = {
+  url?: string;
+  title?: string;
+  publishedDate?: string;
+  author?: string;
+  highlights?: string[] | ExaHighlight[];
+  text?: string;
+};
+
+type ExaSearchResponse = {
+  results?: ExaSearchResult[];
+};
+
+function resolveExaApiKey(searchConfig?: SearchConfigRecord): string | undefined {
+  return (
+    readConfiguredSecretString(searchConfig?.apiKey, "tools.web.search.apiKey") ??
+    readProviderEnvValue(["EXA_API_KEY"])
+  );
+}
+
+function normalizeHighlights(highlights?: string[] | ExaHighlight[]): string[] {
+  if (!highlights || highlights.length === 0) {
+    return [];
+  }
+  return highlights
+    .map((h) => (typeof h === "string" ? h : (h.text ?? "")))
+    .filter((text) => text.length > 0);
+}
+
+async function runExaSearch(params: {
+  query: string;
+  count: number;
+  apiKey: string;
+  timeoutSeconds: number;
+  dateAfter?: string;
+  dateBefore?: string;
+}): Promise<Array<Record<string, unknown>>> {
+  const body: Record<string, unknown> = {
+    query: params.query,
+    numResults: params.count,
+    contents: {
+      highlights: true,
+    },
+  };
+  if (params.dateAfter && params.dateBefore) {
+    body.startPublishedDate = params.dateAfter;
+    body.endPublishedDate = params.dateBefore;
+  } else if (params.dateAfter) {
+    body.startPublishedDate = params.dateAfter;
+  } else if (params.dateBefore) {
+    body.endPublishedDate = params.dateBefore;
+  }
+
+  return withTrustedWebSearchEndpoint(
+    {
+      url: EXA_SEARCH_ENDPOINT,
+      timeoutSeconds: params.timeoutSeconds,
+      init: {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          "x-api-key": params.apiKey,
+          "x-exa-integration": "openclaw",
+        },
+        body: JSON.stringify(body),
+      },
+    },
+    async (res) => {
+      if (!res.ok) {
+        const detail = await res.text();
+        throw new Error(`Exa Search API error (${res.status}): ${detail || res.statusText}`);
+      }
+
+      const data = (await res.json()) as ExaSearchResponse;
+      const results = Array.isArray(data.results) ? data.results : [];
+      return results.map((entry) => {
+        const highlights = normalizeHighlights(entry.highlights);
+        const description = highlights.join(" ");
+        const title = entry.title ?? "";
+        const url = entry.url ?? "";
+        return {
+          title: title ? wrapWebContent(title, "web_search") : "",
+          url,
+          description: description ? wrapWebContent(description, "web_search") : "",
+          published: entry.publishedDate ?? undefined,
+          author: entry.author ?? undefined,
+          siteName: resolveSiteName(url) || undefined,
+        };
+      });
+    },
+  );
+}
+
+function createExaSchema() {
+  return Type.Object({
+    query: Type.String({ description: "Search query string." }),
+    count: Type.Optional(
+      Type.Number({
+        description: "Number of results to return (1-10).",
+        minimum: 1,
+        maximum: MAX_SEARCH_COUNT,
+      }),
+    ),
+    date_after: Type.Optional(
+      Type.String({
+        description:
+          "Only results published after this date (YYYY-MM-DD). Exa supports reliable date filtering via ISO-8601 ranges.",
+      }),
+    ),
+    date_before: Type.Optional(
+      Type.String({
+        description: "Only results published before this date (YYYY-MM-DD).",
+      }),
+    ),
+  });
+}
+
+function missingExaKeyPayload() {
+  return {
+    error: "missing_exa_api_key",
+    message: `web_search (exa) needs an Exa API key. Run \`${formatCliCommand("openclaw configure --section web")}\` to store it, or set EXA_API_KEY in the Gateway environment.`,
+    docs: "https://docs.openclaw.ai/tools/web",
+  };
+}
+
+function createExaToolDefinition(
+  searchConfig?: SearchConfigRecord,
+): WebSearchProviderToolDefinition {
+  return {
+    description:
+      "Search the web using Exa. Returns structured results with titles, URLs, and highlights from AI-native semantic search.",
+    parameters: createExaSchema(),
+    execute: async (args) => {
+      const apiKey = resolveExaApiKey(searchConfig);
+      if (!apiKey) {
+        return missingExaKeyPayload();
+      }
+
+      const params = args as Record<string, unknown>;
+      const query = readStringParam(params, "query", { required: true });
+      const count =
+        readNumberParam(params, "count", { integer: true }) ??
+        searchConfig?.maxResults ??
+        undefined;
+
+      const rawDateAfter = readStringParam(params, "date_after");
+      const rawDateBefore = readStringParam(params, "date_before");
+      const dateAfter = rawDateAfter ? normalizeToIsoDate(rawDateAfter) : undefined;
+      if (rawDateAfter && !dateAfter) {
+        return {
+          error: "invalid_date",
+          message: "date_after must be YYYY-MM-DD format.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+      const dateBefore = rawDateBefore ? normalizeToIsoDate(rawDateBefore) : undefined;
+      if (rawDateBefore && !dateBefore) {
+        return {
+          error: "invalid_date",
+          message: "date_before must be YYYY-MM-DD format.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+      if (dateAfter && dateBefore && dateAfter > dateBefore) {
+        return {
+          error: "invalid_date_range",
+          message: "date_after must be before date_before.",
+          docs: "https://docs.openclaw.ai/tools/web",
+        };
+      }
+
+      const resolvedCount = resolveSearchCount(count, DEFAULT_SEARCH_COUNT);
+      const cacheKey = buildSearchCacheKey(["exa", query, resolvedCount, dateAfter, dateBefore]);
+      const cached = readCachedSearchPayload(cacheKey);
+      if (cached) {
+        return cached;
+      }
+
+      const start = Date.now();
+      const timeoutSeconds = resolveSearchTimeoutSeconds(searchConfig);
+      const cacheTtlMs = resolveSearchCacheTtlMs(searchConfig);
+
+      const results = await runExaSearch({
+        query,
+        count: resolvedCount,
+        apiKey,
+        timeoutSeconds,
+        dateAfter,
+        dateBefore,
+      });
+
+      const payload = {
+        query,
+        provider: "exa",
+        count: results.length,
+        tookMs: Date.now() - start,
+        externalContent: {
+          untrusted: true,
+          source: "web_search",
+          provider: "exa",
+          wrapped: true,
+        },
+        results,
+      };
+
+      writeCachedSearchPayload(cacheKey, payload, cacheTtlMs);
+      return payload;
+    },
+  };
+}
+
+export function createExaWebSearchProvider(): WebSearchProviderPlugin {
+  return {
+    id: "exa",
+    label: "Exa Search",
+    hint: "AI-native semantic search · date filters · highlights",
+    envVars: ["EXA_API_KEY"],
+    placeholder: "exa-...",
+    signupUrl: "https://exa.ai",
+    docsUrl: "https://docs.openclaw.ai/exa",
+    autoDetectOrder: 5,
+    credentialPath: "plugins.entries.exa.config.webSearch.apiKey",
+    inactiveSecretPaths: ["plugins.entries.exa.config.webSearch.apiKey"],
+    getCredentialValue: (searchConfig) => searchConfig?.apiKey,
+    setCredentialValue: setTopLevelCredentialValue,
+    getConfiguredCredentialValue: (config) =>
+      resolveProviderWebSearchPluginConfig(config, "exa")?.apiKey,
+    setConfiguredCredentialValue: (configTarget, value) => {
+      setProviderWebSearchPluginConfigValue(configTarget, "exa", "apiKey", value);
+    },
+    createTool: (ctx) =>
+      createExaToolDefinition(
+        (() => {
+          const searchConfig = ctx.searchConfig as SearchConfigRecord | undefined;
+          const pluginConfig = resolveProviderWebSearchPluginConfig(ctx.config, "exa");
+          if (!pluginConfig) {
+            return searchConfig;
+          }
+          return {
+            ...(searchConfig ?? {}),
+            ...(pluginConfig.apiKey === undefined ? {} : { apiKey: pluginConfig.apiKey }),
+          } as SearchConfigRecord;
+        })(),
+      ),
+  };
+}
+
+export const __testing = {
+  normalizeHighlights,
+  resolveExaApiKey,
+} as const;

--- a/src/plugins/bundled-web-search.test.ts
+++ b/src/plugins/bundled-web-search.test.ts
@@ -1,0 +1,14 @@
+import { expect, it } from "vitest";
+import { resolveBundledWebSearchPluginIds } from "./bundled-web-search.js";
+
+it("keeps bundled web search compat ids aligned with bundled manifests", () => {
+  expect(resolveBundledWebSearchPluginIds({})).toEqual([
+    "brave",
+    "exa",
+    "firecrawl",
+    "google",
+    "moonshot",
+    "perplexity",
+    "xai",
+  ]);
+});

--- a/src/plugins/bundled-web-search.ts
+++ b/src/plugins/bundled-web-search.ts
@@ -1,0 +1,30 @@
+import type { PluginLoadOptions } from "./loader.js";
+import { loadPluginManifestRegistry } from "./manifest-registry.js";
+
+export const BUNDLED_WEB_SEARCH_PLUGIN_IDS = [
+  "brave",
+  "exa",
+  "firecrawl",
+  "google",
+  "moonshot",
+  "perplexity",
+  "xai",
+] as const;
+
+const bundledWebSearchPluginIdSet = new Set<string>(BUNDLED_WEB_SEARCH_PLUGIN_IDS);
+
+export function resolveBundledWebSearchPluginIds(params: {
+  config?: PluginLoadOptions["config"];
+  workspaceDir?: string;
+  env?: PluginLoadOptions["env"];
+}): string[] {
+  const registry = loadPluginManifestRegistry({
+    config: params.config,
+    workspaceDir: params.workspaceDir,
+    env: params.env,
+  });
+  return registry.plugins
+    .filter((plugin) => plugin.origin === "bundled" && bundledWebSearchPluginIdSet.has(plugin.id))
+    .map((plugin) => plugin.id)
+    .toSorted((left, right) => left.localeCompare(right));
+}

--- a/src/plugins/contracts/registry.contract.test.ts
+++ b/src/plugins/contracts/registry.contract.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vitest";
+import { resolveBundledWebSearchPluginIds } from "../bundled-web-search.js";
+import { loadPluginManifestRegistry } from "../manifest-registry.js";
+import {
+  imageGenerationProviderContractRegistry,
+  mediaUnderstandingProviderContractRegistry,
+  pluginRegistrationContractRegistry,
+  providerContractLoadError,
+  providerContractPluginIds,
+  providerContractRegistry,
+  speechProviderContractRegistry,
+  webSearchProviderContractRegistry,
+} from "./registry.js";
+
+function findProviderIdsForPlugin(pluginId: string) {
+  return providerContractRegistry
+    .filter((entry) => entry.pluginId === pluginId)
+    .map((entry) => entry.provider.id)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+function findWebSearchIdsForPlugin(pluginId: string) {
+  return webSearchProviderContractRegistry
+    .filter((entry) => entry.pluginId === pluginId)
+    .map((entry) => entry.provider.id)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+function findSpeechProviderIdsForPlugin(pluginId: string) {
+  return speechProviderContractRegistry
+    .filter((entry) => entry.pluginId === pluginId)
+    .map((entry) => entry.provider.id)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+function findSpeechProviderForPlugin(pluginId: string) {
+  const entry = speechProviderContractRegistry.find((candidate) => candidate.pluginId === pluginId);
+  if (!entry) {
+    throw new Error(`speech provider contract missing for ${pluginId}`);
+  }
+  return entry.provider;
+}
+
+function findMediaUnderstandingProviderIdsForPlugin(pluginId: string) {
+  return mediaUnderstandingProviderContractRegistry
+    .filter((entry) => entry.pluginId === pluginId)
+    .map((entry) => entry.provider.id)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+function findMediaUnderstandingProviderForPlugin(pluginId: string) {
+  const entry = mediaUnderstandingProviderContractRegistry.find(
+    (candidate) => candidate.pluginId === pluginId,
+  );
+  if (!entry) {
+    throw new Error(`media-understanding provider contract missing for ${pluginId}`);
+  }
+  return entry.provider;
+}
+
+function findImageGenerationProviderIdsForPlugin(pluginId: string) {
+  return imageGenerationProviderContractRegistry
+    .filter((entry) => entry.pluginId === pluginId)
+    .map((entry) => entry.provider.id)
+    .toSorted((left, right) => left.localeCompare(right));
+}
+
+function findImageGenerationProviderForPlugin(pluginId: string) {
+  const entry = imageGenerationProviderContractRegistry.find(
+    (candidate) => candidate.pluginId === pluginId,
+  );
+  if (!entry) {
+    throw new Error(`image-generation provider contract missing for ${pluginId}`);
+  }
+  return entry.provider;
+}
+
+function findRegistrationForPlugin(pluginId: string) {
+  const entry = pluginRegistrationContractRegistry.find(
+    (candidate) => candidate.pluginId === pluginId,
+  );
+  if (!entry) {
+    throw new Error(`plugin registration contract missing for ${pluginId}`);
+  }
+  return entry;
+}
+
+describe("plugin contract registry", () => {
+  it("loads bundled non-provider capability registries without import-time failure", () => {
+    expect(providerContractLoadError).toBeUndefined();
+    expect(pluginRegistrationContractRegistry.length).toBeGreaterThan(0);
+  });
+
+  it("does not duplicate bundled provider ids", () => {
+    const ids = providerContractRegistry.map((entry) => entry.provider.id);
+    expect(ids).toEqual([...new Set(ids)]);
+  });
+
+  it("does not duplicate bundled web search provider ids", () => {
+    const ids = webSearchProviderContractRegistry.map((entry) => entry.provider.id);
+    expect(ids).toEqual([...new Set(ids)]);
+  });
+
+  it("does not duplicate bundled speech provider ids", () => {
+    const ids = speechProviderContractRegistry.map((entry) => entry.provider.id);
+    expect(ids).toEqual([...new Set(ids)]);
+  });
+
+  it("does not duplicate bundled media provider ids", () => {
+    const ids = mediaUnderstandingProviderContractRegistry.map((entry) => entry.provider.id);
+    expect(ids).toEqual([...new Set(ids)]);
+  });
+
+  it("covers every bundled provider plugin discovered from manifests", () => {
+    const bundledProviderPluginIds = loadPluginManifestRegistry({})
+      .plugins.filter((plugin) => plugin.origin === "bundled" && plugin.providers.length > 0)
+      .map((plugin) => plugin.id)
+      .toSorted((left, right) => left.localeCompare(right));
+
+    expect(providerContractPluginIds).toEqual(bundledProviderPluginIds);
+  });
+
+  it("covers every bundled web search plugin from the shared resolver", () => {
+    const bundledWebSearchPluginIds = resolveBundledWebSearchPluginIds({});
+
+    expect(
+      [...new Set(webSearchProviderContractRegistry.map((entry) => entry.pluginId))].toSorted(
+        (left, right) => left.localeCompare(right),
+      ),
+    ).toEqual(bundledWebSearchPluginIds);
+  });
+
+  it("does not duplicate bundled image-generation provider ids", () => {
+    const ids = imageGenerationProviderContractRegistry.map((entry) => entry.provider.id);
+    expect(ids).toEqual([...new Set(ids)]);
+  });
+  it("keeps multi-provider plugin ownership explicit", () => {
+    expect(findProviderIdsForPlugin("google")).toEqual(["google", "google-gemini-cli"]);
+    expect(findProviderIdsForPlugin("minimax")).toEqual(["minimax", "minimax-portal"]);
+    expect(findProviderIdsForPlugin("openai")).toEqual(["openai", "openai-codex"]);
+  });
+
+  it("keeps bundled web search ownership explicit", () => {
+    expect(findWebSearchIdsForPlugin("brave")).toEqual(["brave"]);
+    expect(findWebSearchIdsForPlugin("exa")).toEqual(["exa"]);
+    expect(findWebSearchIdsForPlugin("firecrawl")).toEqual(["firecrawl"]);
+    expect(findWebSearchIdsForPlugin("google")).toEqual(["gemini"]);
+    expect(findWebSearchIdsForPlugin("moonshot")).toEqual(["kimi"]);
+    expect(findWebSearchIdsForPlugin("perplexity")).toEqual(["perplexity"]);
+    expect(findWebSearchIdsForPlugin("xai")).toEqual(["grok"]);
+  });
+
+  it("keeps bundled speech ownership explicit", () => {
+    expect(findSpeechProviderIdsForPlugin("elevenlabs")).toEqual(["elevenlabs"]);
+    expect(findSpeechProviderIdsForPlugin("microsoft")).toEqual(["microsoft"]);
+    expect(findSpeechProviderIdsForPlugin("openai")).toEqual(["openai"]);
+  });
+
+  it("keeps bundled media-understanding ownership explicit", () => {
+    expect(findMediaUnderstandingProviderIdsForPlugin("anthropic")).toEqual(["anthropic"]);
+    expect(findMediaUnderstandingProviderIdsForPlugin("google")).toEqual(["google"]);
+    expect(findMediaUnderstandingProviderIdsForPlugin("minimax")).toEqual([
+      "minimax",
+      "minimax-portal",
+    ]);
+    expect(findMediaUnderstandingProviderIdsForPlugin("mistral")).toEqual(["mistral"]);
+    expect(findMediaUnderstandingProviderIdsForPlugin("moonshot")).toEqual(["moonshot"]);
+    expect(findMediaUnderstandingProviderIdsForPlugin("openai")).toEqual(["openai"]);
+    expect(findMediaUnderstandingProviderIdsForPlugin("zai")).toEqual(["zai"]);
+  });
+
+  it("keeps bundled image-generation ownership explicit", () => {
+    expect(findImageGenerationProviderIdsForPlugin("fal")).toEqual(["fal"]);
+    expect(findImageGenerationProviderIdsForPlugin("google")).toEqual(["google"]);
+    expect(findImageGenerationProviderIdsForPlugin("openai")).toEqual(["openai"]);
+  });
+
+  it("keeps bundled provider and web search tool ownership explicit", () => {
+    expect(findRegistrationForPlugin("firecrawl")).toMatchObject({
+      providerIds: [],
+      speechProviderIds: [],
+      mediaUnderstandingProviderIds: [],
+      imageGenerationProviderIds: [],
+      webSearchProviderIds: ["firecrawl"],
+      toolNames: ["firecrawl_search", "firecrawl_scrape"],
+    });
+  });
+
+  it("tracks speech registrations on bundled provider plugins", () => {
+    expect(findRegistrationForPlugin("fal")).toMatchObject({
+      providerIds: ["fal"],
+      speechProviderIds: [],
+      mediaUnderstandingProviderIds: [],
+      imageGenerationProviderIds: ["fal"],
+      webSearchProviderIds: [],
+    });
+    expect(findRegistrationForPlugin("google")).toMatchObject({
+      providerIds: ["google", "google-gemini-cli"],
+      speechProviderIds: [],
+      mediaUnderstandingProviderIds: ["google"],
+      imageGenerationProviderIds: ["google"],
+      webSearchProviderIds: ["gemini"],
+    });
+    expect(findRegistrationForPlugin("openai")).toMatchObject({
+      providerIds: ["openai", "openai-codex"],
+      speechProviderIds: ["openai"],
+      mediaUnderstandingProviderIds: ["openai"],
+      imageGenerationProviderIds: ["openai"],
+    });
+    expect(findRegistrationForPlugin("elevenlabs")).toMatchObject({
+      providerIds: [],
+      speechProviderIds: ["elevenlabs"],
+      mediaUnderstandingProviderIds: [],
+      imageGenerationProviderIds: [],
+    });
+    expect(findRegistrationForPlugin("microsoft")).toMatchObject({
+      providerIds: [],
+      speechProviderIds: ["microsoft"],
+      mediaUnderstandingProviderIds: [],
+      imageGenerationProviderIds: [],
+    });
+  });
+
+  it("tracks every provider, speech, media, image, or web search plugin in the registration registry", () => {
+    const expectedPluginIds = [
+      ...new Set([
+        ...providerContractRegistry.map((entry) => entry.pluginId),
+        ...speechProviderContractRegistry.map((entry) => entry.pluginId),
+        ...mediaUnderstandingProviderContractRegistry.map((entry) => entry.pluginId),
+        ...imageGenerationProviderContractRegistry.map((entry) => entry.pluginId),
+        ...webSearchProviderContractRegistry.map((entry) => entry.pluginId),
+      ]),
+    ].toSorted((left, right) => left.localeCompare(right));
+
+    expect(
+      pluginRegistrationContractRegistry
+        .map((entry) => entry.pluginId)
+        .toSorted((left, right) => left.localeCompare(right)),
+    ).toEqual(expectedPluginIds);
+  });
+
+  it("keeps bundled speech voice-list support explicit", () => {
+    expect(findSpeechProviderForPlugin("openai").listVoices).toEqual(expect.any(Function));
+    expect(findSpeechProviderForPlugin("elevenlabs").listVoices).toEqual(expect.any(Function));
+    expect(findSpeechProviderForPlugin("microsoft").listVoices).toEqual(expect.any(Function));
+  });
+
+  it("keeps bundled multi-image support explicit", () => {
+    expect(findMediaUnderstandingProviderForPlugin("anthropic").describeImages).toEqual(
+      expect.any(Function),
+    );
+    expect(findMediaUnderstandingProviderForPlugin("google").describeImages).toEqual(
+      expect.any(Function),
+    );
+    expect(findMediaUnderstandingProviderForPlugin("minimax").describeImages).toEqual(
+      expect.any(Function),
+    );
+    expect(findMediaUnderstandingProviderForPlugin("moonshot").describeImages).toEqual(
+      expect.any(Function),
+    );
+    expect(findMediaUnderstandingProviderForPlugin("openai").describeImages).toEqual(
+      expect.any(Function),
+    );
+    expect(findMediaUnderstandingProviderForPlugin("zai").describeImages).toEqual(
+      expect.any(Function),
+    );
+  });
+
+  it("keeps bundled image-generation support explicit", () => {
+    expect(findImageGenerationProviderForPlugin("google").generateImage).toEqual(
+      expect.any(Function),
+    );
+    expect(findImageGenerationProviderForPlugin("openai").generateImage).toEqual(
+      expect.any(Function),
+    );
+  });
+});

--- a/src/plugins/contracts/registry.ts
+++ b/src/plugins/contracts/registry.ts
@@ -1,0 +1,486 @@
+import amazonBedrockPlugin from "../../../extensions/amazon-bedrock/index.js";
+import anthropicPlugin from "../../../extensions/anthropic/index.js";
+import bravePlugin from "../../../extensions/brave/index.js";
+import byteplusPlugin from "../../../extensions/byteplus/index.js";
+import chutesPlugin from "../../../extensions/chutes/index.js";
+import cloudflareAiGatewayPlugin from "../../../extensions/cloudflare-ai-gateway/index.js";
+import copilotProxyPlugin from "../../../extensions/copilot-proxy/index.js";
+import elevenLabsPlugin from "../../../extensions/elevenlabs/index.js";
+import exaPlugin from "../../../extensions/exa/index.js";
+import falPlugin from "../../../extensions/fal/index.js";
+import firecrawlPlugin from "../../../extensions/firecrawl/index.js";
+import githubCopilotPlugin from "../../../extensions/github-copilot/index.js";
+import googlePlugin from "../../../extensions/google/index.js";
+import huggingFacePlugin from "../../../extensions/huggingface/index.js";
+import kilocodePlugin from "../../../extensions/kilocode/index.js";
+import kimiCodingPlugin from "../../../extensions/kimi-coding/index.js";
+import microsoftPlugin from "../../../extensions/microsoft/index.js";
+import minimaxPlugin from "../../../extensions/minimax/index.js";
+import mistralPlugin from "../../../extensions/mistral/index.js";
+import modelStudioPlugin from "../../../extensions/modelstudio/index.js";
+import moonshotPlugin from "../../../extensions/moonshot/index.js";
+import nvidiaPlugin from "../../../extensions/nvidia/index.js";
+import ollamaPlugin from "../../../extensions/ollama/index.js";
+import openAIPlugin from "../../../extensions/openai/index.js";
+import opencodeGoPlugin from "../../../extensions/opencode-go/index.js";
+import opencodePlugin from "../../../extensions/opencode/index.js";
+import openrouterPlugin from "../../../extensions/openrouter/index.js";
+import perplexityPlugin from "../../../extensions/perplexity/index.js";
+import qianfanPlugin from "../../../extensions/qianfan/index.js";
+import qwenPortalAuthPlugin from "../../../extensions/qwen-portal-auth/index.js";
+import sglangPlugin from "../../../extensions/sglang/index.js";
+import syntheticPlugin from "../../../extensions/synthetic/index.js";
+import togetherPlugin from "../../../extensions/together/index.js";
+import venicePlugin from "../../../extensions/venice/index.js";
+import vercelAiGatewayPlugin from "../../../extensions/vercel-ai-gateway/index.js";
+import vllmPlugin from "../../../extensions/vllm/index.js";
+import volcenginePlugin from "../../../extensions/volcengine/index.js";
+import xaiPlugin from "../../../extensions/xai/index.js";
+import xiaomiPlugin from "../../../extensions/xiaomi/index.js";
+import zaiPlugin from "../../../extensions/zai/index.js";
+import { createCapturedPluginRegistration } from "../captured-registration.js";
+import { resolvePluginProviders } from "../providers.js";
+import type {
+  ImageGenerationProviderPlugin,
+  MediaUnderstandingProviderPlugin,
+  ProviderPlugin,
+  SpeechProviderPlugin,
+  WebSearchProviderPlugin,
+} from "../types.js";
+
+type RegistrablePlugin = {
+  id: string;
+  register: (api: ReturnType<typeof createCapturedPluginRegistration>["api"]) => void;
+};
+
+type CapabilityContractEntry<T> = {
+  pluginId: string;
+  provider: T;
+};
+
+type ProviderContractEntry = CapabilityContractEntry<ProviderPlugin>;
+
+type WebSearchProviderContractEntry = CapabilityContractEntry<WebSearchProviderPlugin> & {
+  credentialValue: unknown;
+};
+
+type SpeechProviderContractEntry = CapabilityContractEntry<SpeechProviderPlugin>;
+type MediaUnderstandingProviderContractEntry =
+  CapabilityContractEntry<MediaUnderstandingProviderPlugin>;
+type ImageGenerationProviderContractEntry = CapabilityContractEntry<ImageGenerationProviderPlugin>;
+
+type PluginRegistrationContractEntry = {
+  pluginId: string;
+  providerIds: string[];
+  speechProviderIds: string[];
+  mediaUnderstandingProviderIds: string[];
+  imageGenerationProviderIds: string[];
+  webSearchProviderIds: string[];
+  toolNames: string[];
+};
+
+const bundledWebSearchPlugins: Array<RegistrablePlugin & { credentialValue: unknown }> = [
+  { ...bravePlugin, credentialValue: "BSA-test" },
+  { ...exaPlugin, credentialValue: "exa-test" },
+  { ...firecrawlPlugin, credentialValue: "fc-test" },
+  { ...googlePlugin, credentialValue: "AIza-test" },
+  { ...moonshotPlugin, credentialValue: "sk-test" },
+  { ...perplexityPlugin, credentialValue: "pplx-test" },
+  { ...xaiPlugin, credentialValue: "xai-test" },
+];
+
+const bundledSpeechPlugins: RegistrablePlugin[] = [elevenLabsPlugin, microsoftPlugin, openAIPlugin];
+
+const bundledMediaUnderstandingPlugins: RegistrablePlugin[] = [
+  anthropicPlugin,
+  googlePlugin,
+  minimaxPlugin,
+  mistralPlugin,
+  moonshotPlugin,
+  openAIPlugin,
+  zaiPlugin,
+];
+
+const bundledImageGenerationPlugins: RegistrablePlugin[] = [falPlugin, googlePlugin, openAIPlugin];
+
+function captureRegistrations(plugin: RegistrablePlugin) {
+  const captured = createCapturedPluginRegistration();
+  plugin.register(captured.api);
+  return captured;
+}
+
+function buildCapabilityContractRegistry<T>(params: {
+  plugins: RegistrablePlugin[];
+  select: (captured: ReturnType<typeof createCapturedPluginRegistration>) => T[];
+}): CapabilityContractEntry<T>[] {
+  return params.plugins.flatMap((plugin) => {
+    const captured = captureRegistrations(plugin);
+    return params.select(captured).map((provider) => ({
+      pluginId: plugin.id,
+      provider,
+    }));
+  });
+}
+
+function dedupePlugins<T extends RegistrablePlugin>(
+  plugins: ReadonlyArray<T | undefined | null>,
+): T[] {
+  return [
+    ...new Map(
+      plugins.filter((plugin): plugin is T => Boolean(plugin)).map((plugin) => [plugin.id, plugin]),
+    ).values(),
+  ];
+}
+
+export let providerContractLoadError: Error | undefined;
+
+function loadBundledProviderRegistry(): ProviderContractEntry[] {
+  try {
+    providerContractLoadError = undefined;
+    return resolvePluginProviders({
+      bundledProviderAllowlistCompat: true,
+      bundledProviderVitestCompat: true,
+      cache: false,
+      activate: false,
+    })
+      .filter((provider): provider is ProviderPlugin & { pluginId: string } =>
+        Boolean(provider.pluginId),
+      )
+      .map((provider) => ({
+        pluginId: provider.pluginId,
+        provider,
+      }));
+  } catch (error) {
+    providerContractLoadError = error instanceof Error ? error : new Error(String(error));
+    return [];
+  }
+}
+
+function createLazyArrayView<T>(load: () => T[]): T[] {
+  return new Proxy([] as T[], {
+    get(_target, prop) {
+      const actual = load();
+      const value = Reflect.get(actual, prop, actual);
+      return typeof value === "function" ? value.bind(actual) : value;
+    },
+    has(_target, prop) {
+      return Reflect.has(load(), prop);
+    },
+    ownKeys() {
+      return Reflect.ownKeys(load());
+    },
+    getOwnPropertyDescriptor(_target, prop) {
+      const actual = load();
+      const descriptor = Reflect.getOwnPropertyDescriptor(actual, prop);
+      if (descriptor) {
+        return descriptor;
+      }
+      if (Reflect.has(actual, prop)) {
+        return {
+          configurable: true,
+          enumerable: true,
+          writable: false,
+          value: Reflect.get(actual, prop, actual),
+        };
+      }
+      return undefined;
+    },
+  });
+}
+
+let providerContractRegistryCache: ProviderContractEntry[] | null = null;
+let webSearchProviderContractRegistryCache: WebSearchProviderContractEntry[] | null = null;
+let speechProviderContractRegistryCache: SpeechProviderContractEntry[] | null = null;
+let mediaUnderstandingProviderContractRegistryCache:
+  | MediaUnderstandingProviderContractEntry[]
+  | null = null;
+let imageGenerationProviderContractRegistryCache: ImageGenerationProviderContractEntry[] | null =
+  null;
+let pluginRegistrationContractRegistryCache: PluginRegistrationContractEntry[] | null = null;
+let providerRegistrationEntriesLoaded = false;
+
+function loadProviderContractRegistry(): ProviderContractEntry[] {
+  if (!providerContractRegistryCache) {
+    providerContractRegistryCache = buildCapabilityContractRegistry({
+      plugins: bundledProviderPlugins,
+      select: (captured) => captured.providers,
+    }).map((entry) => ({
+      pluginId: entry.pluginId,
+      provider: entry.provider,
+    }));
+  }
+  if (!providerRegistrationEntriesLoaded) {
+    const registrationEntries = loadPluginRegistrationContractRegistry();
+    if (!providerRegistrationEntriesLoaded) {
+      mergeProviderContractRegistrations(registrationEntries, providerContractRegistryCache);
+      providerRegistrationEntriesLoaded = true;
+    }
+  }
+  return providerContractRegistryCache;
+}
+
+function loadUniqueProviderContractProviders(): ProviderPlugin[] {
+  return [
+    ...new Map(
+      loadProviderContractRegistry().map((entry) => [entry.provider.id, entry.provider]),
+    ).values(),
+  ];
+}
+
+function loadProviderContractPluginIds(): string[] {
+  return [...new Set(loadProviderContractRegistry().map((entry) => entry.pluginId))].toSorted(
+    (left, right) => left.localeCompare(right),
+  );
+}
+
+function loadProviderContractCompatPluginIds(): string[] {
+  return loadProviderContractPluginIds().map((pluginId) =>
+    pluginId === "kimi-coding" ? "kimi" : pluginId,
+  );
+}
+
+export const providerContractRegistry: ProviderContractEntry[] = createLazyArrayView(
+  loadProviderContractRegistry,
+);
+
+export const uniqueProviderContractProviders: ProviderPlugin[] = createLazyArrayView(
+  loadUniqueProviderContractProviders,
+);
+
+export const providerContractPluginIds: string[] = createLazyArrayView(
+  loadProviderContractPluginIds,
+);
+
+export const providerContractCompatPluginIds: string[] = createLazyArrayView(
+  loadProviderContractCompatPluginIds,
+);
+
+export function requireProviderContractProvider(providerId: string): ProviderPlugin {
+  const provider = uniqueProviderContractProviders.find((entry) => entry.id === providerId);
+  if (!provider) {
+    if (!providerContractLoadError) {
+      loadBundledProviderRegistry();
+    }
+    if (providerContractLoadError) {
+      throw new Error(
+        `provider contract entry missing for ${providerId}; bundled provider registry failed to load: ${providerContractLoadError.message}`,
+      );
+    }
+    throw new Error(`provider contract entry missing for ${providerId}`);
+  }
+  return provider;
+}
+
+export function resolveProviderContractPluginIdsForProvider(
+  providerId: string,
+): string[] | undefined {
+  const pluginIds = [
+    ...new Set(
+      providerContractRegistry
+        .filter((entry) => entry.provider.id === providerId)
+        .map((entry) => entry.pluginId),
+    ),
+  ];
+  return pluginIds.length > 0 ? pluginIds : undefined;
+}
+
+export function resolveProviderContractProvidersForPluginIds(
+  pluginIds: readonly string[],
+): ProviderPlugin[] {
+  const allowed = new Set(pluginIds);
+  return [
+    ...new Map(
+      providerContractRegistry
+        .filter((entry) => allowed.has(entry.pluginId))
+        .map((entry) => [entry.provider.id, entry.provider]),
+    ).values(),
+  ];
+}
+
+function loadWebSearchProviderContractRegistry(): WebSearchProviderContractEntry[] {
+  if (!webSearchProviderContractRegistryCache) {
+    webSearchProviderContractRegistryCache = bundledWebSearchPlugins.flatMap((plugin) => {
+      const captured = captureRegistrations(plugin);
+      return captured.webSearchProviders.map((provider) => ({
+        pluginId: plugin.id,
+        provider,
+        credentialValue: plugin.credentialValue,
+      }));
+    });
+  }
+  return webSearchProviderContractRegistryCache;
+}
+
+function loadSpeechProviderContractRegistry(): SpeechProviderContractEntry[] {
+  if (!speechProviderContractRegistryCache) {
+    speechProviderContractRegistryCache = buildCapabilityContractRegistry({
+      plugins: bundledSpeechPlugins,
+      select: (captured) => captured.speechProviders,
+    });
+  }
+  return speechProviderContractRegistryCache;
+}
+
+function loadMediaUnderstandingProviderContractRegistry(): MediaUnderstandingProviderContractEntry[] {
+  if (!mediaUnderstandingProviderContractRegistryCache) {
+    mediaUnderstandingProviderContractRegistryCache = buildCapabilityContractRegistry({
+      plugins: bundledMediaUnderstandingPlugins,
+      select: (captured) => captured.mediaUnderstandingProviders,
+    });
+  }
+  return mediaUnderstandingProviderContractRegistryCache;
+}
+
+function loadImageGenerationProviderContractRegistry(): ImageGenerationProviderContractEntry[] {
+  if (!imageGenerationProviderContractRegistryCache) {
+    imageGenerationProviderContractRegistryCache = buildCapabilityContractRegistry({
+      plugins: bundledImageGenerationPlugins,
+      select: (captured) => captured.imageGenerationProviders,
+    });
+  }
+  return imageGenerationProviderContractRegistryCache;
+}
+
+export const webSearchProviderContractRegistry: WebSearchProviderContractEntry[] =
+  createLazyArrayView(loadWebSearchProviderContractRegistry);
+
+export const speechProviderContractRegistry: SpeechProviderContractEntry[] = createLazyArrayView(
+  loadSpeechProviderContractRegistry,
+);
+
+export const mediaUnderstandingProviderContractRegistry: MediaUnderstandingProviderContractEntry[] =
+  createLazyArrayView(loadMediaUnderstandingProviderContractRegistry);
+
+export const imageGenerationProviderContractRegistry: ImageGenerationProviderContractEntry[] =
+  createLazyArrayView(loadImageGenerationProviderContractRegistry);
+
+const bundledProviderPlugins = dedupePlugins([
+  amazonBedrockPlugin,
+  anthropicPlugin,
+  byteplusPlugin,
+  chutesPlugin,
+  cloudflareAiGatewayPlugin,
+  copilotProxyPlugin,
+  githubCopilotPlugin,
+  falPlugin,
+  googlePlugin,
+  huggingFacePlugin,
+  kilocodePlugin,
+  kimiCodingPlugin,
+  minimaxPlugin,
+  mistralPlugin,
+  modelStudioPlugin,
+  moonshotPlugin,
+  nvidiaPlugin,
+  ollamaPlugin,
+  openAIPlugin,
+  opencodePlugin,
+  opencodeGoPlugin,
+  openrouterPlugin,
+  qianfanPlugin,
+  qwenPortalAuthPlugin,
+  sglangPlugin,
+  syntheticPlugin,
+  togetherPlugin,
+  venicePlugin,
+  vercelAiGatewayPlugin,
+  vllmPlugin,
+  volcenginePlugin,
+  xaiPlugin,
+  xiaomiPlugin,
+  zaiPlugin,
+]);
+
+const bundledPluginRegistrationList = dedupePlugins([
+  ...bundledSpeechPlugins,
+  ...bundledMediaUnderstandingPlugins,
+  ...bundledImageGenerationPlugins,
+  ...bundledWebSearchPlugins,
+]);
+
+function mergeIds(existing: string[], next: string[]): string[] {
+  return next.length > 0 ? next : existing;
+}
+
+function upsertPluginRegistrationContractEntry(
+  entries: PluginRegistrationContractEntry[],
+  next: PluginRegistrationContractEntry,
+): void {
+  const existing = entries.find((entry) => entry.pluginId === next.pluginId);
+  if (!existing) {
+    entries.push(next);
+    return;
+  }
+  existing.providerIds = mergeIds(existing.providerIds, next.providerIds);
+  existing.speechProviderIds = mergeIds(existing.speechProviderIds, next.speechProviderIds);
+  existing.mediaUnderstandingProviderIds = mergeIds(
+    existing.mediaUnderstandingProviderIds,
+    next.mediaUnderstandingProviderIds,
+  );
+  existing.imageGenerationProviderIds = mergeIds(
+    existing.imageGenerationProviderIds,
+    next.imageGenerationProviderIds,
+  );
+  existing.webSearchProviderIds = mergeIds(
+    existing.webSearchProviderIds,
+    next.webSearchProviderIds,
+  );
+  existing.toolNames = mergeIds(existing.toolNames, next.toolNames);
+}
+
+function mergeProviderContractRegistrations(
+  registrationEntries: PluginRegistrationContractEntry[],
+  providerEntries: ProviderContractEntry[],
+): void {
+  const byPluginId = new Map<string, string[]>();
+  for (const entry of providerEntries) {
+    const providerIds = byPluginId.get(entry.pluginId) ?? [];
+    providerIds.push(entry.provider.id);
+    byPluginId.set(entry.pluginId, providerIds);
+  }
+  for (const [pluginId, providerIds] of byPluginId) {
+    upsertPluginRegistrationContractEntry(registrationEntries, {
+      pluginId,
+      providerIds: providerIds.toSorted((left, right) => left.localeCompare(right)),
+      speechProviderIds: [],
+      mediaUnderstandingProviderIds: [],
+      imageGenerationProviderIds: [],
+      webSearchProviderIds: [],
+      toolNames: [],
+    });
+  }
+}
+
+function loadPluginRegistrationContractRegistry(): PluginRegistrationContractEntry[] {
+  if (!pluginRegistrationContractRegistryCache) {
+    const entries: PluginRegistrationContractEntry[] = [];
+    for (const plugin of bundledPluginRegistrationList) {
+      const captured = captureRegistrations(plugin);
+      upsertPluginRegistrationContractEntry(entries, {
+        pluginId: plugin.id,
+        providerIds: captured.providers.map((provider) => provider.id),
+        speechProviderIds: captured.speechProviders.map((provider) => provider.id),
+        mediaUnderstandingProviderIds: captured.mediaUnderstandingProviders.map(
+          (provider) => provider.id,
+        ),
+        imageGenerationProviderIds: captured.imageGenerationProviders.map(
+          (provider) => provider.id,
+        ),
+        webSearchProviderIds: captured.webSearchProviders.map((provider) => provider.id),
+        toolNames: captured.tools.map((tool) => tool.name),
+      });
+    }
+    pluginRegistrationContractRegistryCache = entries;
+  }
+  if (providerContractRegistryCache && !providerRegistrationEntriesLoaded) {
+    mergeProviderContractRegistrations(
+      pluginRegistrationContractRegistryCache,
+      providerContractRegistryCache,
+    );
+    providerRegistrationEntriesLoaded = true;
+  }
+  return pluginRegistrationContractRegistryCache;
+}
+
+export const pluginRegistrationContractRegistry: PluginRegistrationContractEntry[] =
+  createLazyArrayView(loadPluginRegistrationContractRegistry);

--- a/src/plugins/web-search-providers.test.ts
+++ b/src/plugins/web-search-providers.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { createEmptyPluginRegistry } from "./registry.js";
+import { setActivePluginRegistry } from "./runtime.js";
+import {
+  resolvePluginWebSearchProviders,
+  resolveRuntimeWebSearchProviders,
+} from "./web-search-providers.js";
+
+const BUNDLED_WEB_SEARCH_PROVIDERS = [
+  { pluginId: "exa", id: "exa", order: 5 },
+  { pluginId: "brave", id: "brave", order: 10 },
+  { pluginId: "google", id: "gemini", order: 20 },
+  { pluginId: "xai", id: "grok", order: 30 },
+  { pluginId: "moonshot", id: "kimi", order: 40 },
+  { pluginId: "perplexity", id: "perplexity", order: 50 },
+  { pluginId: "firecrawl", id: "firecrawl", order: 60 },
+] as const;
+
+const { loadOpenClawPluginsMock } = vi.hoisted(() => ({
+  loadOpenClawPluginsMock: vi.fn((params?: { config?: { plugins?: Record<string, unknown> } }) => {
+    const plugins = params?.config?.plugins as
+      | {
+          enabled?: boolean;
+          allow?: string[];
+          entries?: Record<string, { enabled?: boolean }>;
+        }
+      | undefined;
+    if (plugins?.enabled === false) {
+      return { webSearchProviders: [] };
+    }
+    const allow = Array.isArray(plugins?.allow) && plugins.allow.length > 0 ? plugins.allow : null;
+    const entries = plugins?.entries ?? {};
+    const webSearchProviders = BUNDLED_WEB_SEARCH_PROVIDERS.filter((provider) => {
+      if (allow && !allow.includes(provider.pluginId)) {
+        return false;
+      }
+      if (entries[provider.pluginId]?.enabled === false) {
+        return false;
+      }
+      return true;
+    }).map((provider) => ({
+      pluginId: provider.pluginId,
+      pluginName: provider.pluginId,
+      source: "test" as const,
+      provider: {
+        id: provider.id,
+        label: provider.id,
+        hint: `${provider.id} provider`,
+        envVars: [`${provider.id.toUpperCase()}_API_KEY`],
+        placeholder: `${provider.id}-...`,
+        signupUrl: `https://example.com/${provider.id}`,
+        autoDetectOrder: provider.order,
+        credentialPath: `plugins.entries.${provider.pluginId}.config.webSearch.apiKey`,
+        getCredentialValue: () => "configured",
+        setCredentialValue: () => {},
+        applySelectionConfig:
+          provider.id === "firecrawl" ? (config: OpenClawConfig) => config : undefined,
+        resolveRuntimeMetadata:
+          provider.id === "perplexity"
+            ? () => ({
+                perplexityTransport: "search_api" as const,
+              })
+            : undefined,
+        createTool: () => ({
+          description: provider.id,
+          parameters: {},
+          execute: async () => ({}),
+        }),
+      },
+    }));
+    return { webSearchProviders };
+  }),
+}));
+
+vi.mock("./loader.js", () => ({
+  loadOpenClawPlugins: loadOpenClawPluginsMock,
+}));
+
+describe("resolvePluginWebSearchProviders", () => {
+  beforeEach(() => {
+    loadOpenClawPluginsMock.mockClear();
+  });
+
+  afterEach(() => {
+    setActivePluginRegistry(createEmptyPluginRegistry());
+  });
+
+  it("returns bundled providers in auto-detect order", () => {
+    const providers = resolvePluginWebSearchProviders({});
+
+    expect(providers.map((provider) => `${provider.pluginId}:${provider.id}`)).toEqual([
+      "exa:exa",
+      "brave:brave",
+      "google:gemini",
+      "xai:grok",
+      "moonshot:kimi",
+      "perplexity:perplexity",
+      "firecrawl:firecrawl",
+    ]);
+    expect(providers.map((provider) => provider.credentialPath)).toEqual([
+      "plugins.entries.exa.config.webSearch.apiKey",
+      "plugins.entries.brave.config.webSearch.apiKey",
+      "plugins.entries.google.config.webSearch.apiKey",
+      "plugins.entries.xai.config.webSearch.apiKey",
+      "plugins.entries.moonshot.config.webSearch.apiKey",
+      "plugins.entries.perplexity.config.webSearch.apiKey",
+      "plugins.entries.firecrawl.config.webSearch.apiKey",
+    ]);
+    expect(providers.find((provider) => provider.id === "firecrawl")?.applySelectionConfig).toEqual(
+      expect.any(Function),
+    );
+    expect(
+      providers.find((provider) => provider.id === "perplexity")?.resolveRuntimeMetadata,
+    ).toEqual(expect.any(Function));
+  });
+
+  it("can augment restrictive allowlists for bundled compatibility", () => {
+    const providers = resolvePluginWebSearchProviders({
+      config: {
+        plugins: {
+          allow: ["openrouter"],
+        },
+      },
+      bundledAllowlistCompat: true,
+    });
+
+    expect(providers.map((provider) => provider.pluginId)).toEqual([
+      "exa",
+      "brave",
+      "google",
+      "xai",
+      "moonshot",
+      "perplexity",
+      "firecrawl",
+    ]);
+  });
+
+  it("does not return bundled providers excluded by a restrictive allowlist without compat", () => {
+    const providers = resolvePluginWebSearchProviders({
+      config: {
+        plugins: {
+          allow: ["openrouter"],
+        },
+      },
+    });
+
+    expect(providers).toEqual([]);
+  });
+
+  it("preserves explicit bundled provider entry state", () => {
+    const providers = resolvePluginWebSearchProviders({
+      config: {
+        plugins: {
+          entries: {
+            perplexity: { enabled: false },
+          },
+        },
+      },
+    });
+
+    expect(providers.map((provider) => provider.pluginId)).not.toContain("perplexity");
+  });
+
+  it("returns no providers when plugins are globally disabled", () => {
+    const providers = resolvePluginWebSearchProviders({
+      config: {
+        plugins: {
+          enabled: false,
+        },
+      },
+    });
+
+    expect(providers).toEqual([]);
+  });
+
+  it("prefers the active plugin registry for runtime resolution", () => {
+    const registry = createEmptyPluginRegistry();
+    registry.webSearchProviders.push({
+      pluginId: "custom-search",
+      pluginName: "Custom Search",
+      provider: {
+        id: "custom",
+        label: "Custom Search",
+        hint: "Custom runtime provider",
+        envVars: ["CUSTOM_SEARCH_API_KEY"],
+        placeholder: "custom-...",
+        signupUrl: "https://example.com/signup",
+        autoDetectOrder: 1,
+        credentialPath: "tools.web.search.custom.apiKey",
+        getCredentialValue: () => "configured",
+        setCredentialValue: () => {},
+        createTool: () => ({
+          description: "custom",
+          parameters: {},
+          execute: async () => ({}),
+        }),
+      },
+      source: "test",
+    });
+    setActivePluginRegistry(registry);
+
+    const providers = resolveRuntimeWebSearchProviders({});
+
+    expect(providers.map((provider) => `${provider.pluginId}:${provider.id}`)).toEqual([
+      "custom-search:custom",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Problem: OpenClaw has no native Exa search integration — users who want Exa's semantic search must use external workarounds.
- Why it matters: Exa provides high-quality semantic search with token-efficient highlights, useful for AI assistant workflows.
- What changed: Added Exa as a 6th web_search provider **with auto-detection** — setting `EXA_API_KEY` is sufficient to activate Exa (no explicit `provider` config required). Exa is first in the auto-detect priority chain; when the key is absent, the chain falls through to Brave.
- What did NOT change (scope boundary): No changes to existing providers, no changes to `web_fetch`, no breaking changes to existing configs.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #20134
- Variant of #31310 (opt-in only) — this PR adds auto-detection on top

## User-visible / Behavior Changes

- New provider: `"exa"` option for `tools.web.search.provider`
- New config keys: `tools.web.search.exa.apiKey`, `tools.web.search.exa.numResults` (default: 5), `tools.web.search.exa.highlightsMaxChars` (default: 8000)
- New env var: `EXA_API_KEY` — when set with no explicit `provider` config, Exa is selected automatically
- Auto-detection priority: Exa (#1) → Brave (#2) → Gemini (#3) → Kimi (#4) → Perplexity (#5) → Grok (#6)
- Tool description changes when Exa is selected: `"Search the web using Exa search. Returns structured results with titles, URLs, and highlights."`
- Users without `EXA_API_KEY`: no behavior change — chain falls through to Brave as before

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? Yes — new `EXA_API_KEY` env var / `exa.apiKey` config, follows same pattern as existing providers
- New/changed network calls? Yes — new outbound call to `https://api.exa.ai/search` with `x-exa-integration: "openclaw"` header
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any Yes, explain risk + mitigation: API key is marked sensitive in Zod schema (same as all other provider keys). Network call fires automatically if `EXA_API_KEY` is present. Uses existing `withTrustedWebSearchEndpoint` wrapper with timeout and abort support.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node.js (vitest)
- Model/provider: N/A (unit tests only)
- Integration/channel (if any): N/A
- Relevant config (redacted): `{ tools: { web: { search: { exa: { apiKey: "exa-..." } } } } }` (no explicit `provider` needed)

### Steps

1. Set `EXA_API_KEY` in environment (no other config change required)
2. Invoke `web_search` tool with a query
3. Observe Exa auto-selected in verbose logs

### Expected

- Returns structured results with title, URL, highlights, published date, author
- Results capped at `numResults` (default 5) with highlights limited to `highlightsMaxChars` (default 8000)

### Actual

- Matches expected (verified via unit tests)

## Evidence

- [x] Failing test/log before + passing after

20 tests passing in `config.web-search-provider.test.ts`, 47 in `web-search.test.ts`.

## Human Verification (required)

- Verified scenarios: Auto-detection with `EXA_API_KEY` set, Exa priority over Brave when both keys present, fallback to Brave when `EXA_API_KEY` absent
- Edge cases checked: Multiple keys present (Exa wins), no keys (falls back to Brave/error), explicit `provider` override still respected
- What you did not verify: Live API call to Exa (unit tests mock the network layer)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? Yes — new optional `EXA_API_KEY` env var and `tools.web.search.exa` config block
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Unset `EXA_API_KEY` or set `provider: "brave"` in config — falls back to Brave
- Files/config to restore: N/A (additive change, no existing behavior modified)
- Known bad symptoms reviewers should watch for: If `EXA_API_KEY` is invalid, the tool returns an API error message (same pattern as other providers)

## Risks and Mitigations

- Risk: Exa API availability/rate limits
  - Mitigation: If `EXA_API_KEY` is unset, there is zero impact on existing users
- Risk: Unintended Exa activation for users who set `EXA_API_KEY` for other purposes
  - Mitigation: Key is namespaced (`EXA_API_KEY`) and only read by the web_search tool resolver