### PR TITLE
Abort: let /stop survive collect-mode batches

### DIFF
--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -185,10 +185,7 @@ export function stripStructuralPrefixes(text: string): string {
   // Collect-mode batches prefix each queued message with
   // "---" + "Queued #N" lines; strip them so commands like /stop
   // remain detectable even after batching.
-  const withoutQueuedMarkers = afterMarker.replace(
-    /(?:^|\n)---\s*\nQueued #[0-9]+\s*\n/g,
-    "\n",
-  );
+  const withoutQueuedMarkers = afterMarker.replace(/(?:^|\n)---\s*\nQueued #[0-9]+\s*\n/g, "\n");
 
   return withoutQueuedMarkers
     .replace(/\[[^\]]+\]\s*/g, "")

--- a/src/auto-reply/reply/mentions.ts
+++ b/src/auto-reply/reply/mentions.ts
@@ -182,7 +182,15 @@ export function stripStructuralPrefixes(text: string): string {
     ? text.slice(text.indexOf(CURRENT_MESSAGE_MARKER) + CURRENT_MESSAGE_MARKER.length).trimStart()
     : text;
 
-  return afterMarker
+  // Collect-mode batches prefix each queued message with
+  // "---" + "Queued #N" lines; strip them so commands like /stop
+  // remain detectable even after batching.
+  const withoutQueuedMarkers = afterMarker.replace(
+    /(?:^|\n)---\s*\nQueued #[0-9]+\s*\n/g,
+    "\n",
+  );
+
+  return withoutQueuedMarkers
     .replace(/\[[^\]]+\]\s*/g, "")
     .replace(/^[ \t]*[A-Za-z0-9+()\-_. ]+:\s*/gm, "")
     .replace(/\\n/g, " ")


### PR DESCRIPTION
Clarify that stripStructuralPrefixes now removes collect-mode ---/Queued #n markers so /stop (and other abort keywords) remain detectable even after the backlog is batched.