### PR TITLE
fix: validate tailscale/bind compatibility at config-write time

### DIFF
--- a/src/gateway/server-methods/config.tailscale-compat.test.ts
+++ b/src/gateway/server-methods/config.tailscale-compat.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { validateTailscaleBindCompat } from "./config.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+
+function makeConfig(gateway: NonNullable<OpenClawConfig["gateway"]>): OpenClawConfig {
+  return { gateway } as OpenClawConfig;
+}
+
+describe("validateTailscaleBindCompat", () => {
+  // ── Passes (returns null) ─────────────────────────────────────────────────
+
+  it("passes when tailscale mode is off", () => {
+    expect(validateTailscaleBindCompat(makeConfig({ tailscale: { mode: "off" } }))).toBeNull();
+  });
+
+  it("passes when tailscale mode is unset", () => {
+    expect(validateTailscaleBindCompat(makeConfig({}))).toBeNull();
+  });
+
+  it("passes when tailscale=serve and bind=loopback", () => {
+    expect(
+      validateTailscaleBindCompat(makeConfig({ tailscale: { mode: "serve" }, bind: "loopback" })),
+    ).toBeNull();
+  });
+
+  it("passes when tailscale=funnel and bind=loopback", () => {
+    expect(
+      validateTailscaleBindCompat(makeConfig({ tailscale: { mode: "funnel" }, bind: "loopback" })),
+    ).toBeNull();
+  });
+
+  it("passes when tailscale=serve and bind=custom with loopback customBindHost (127.0.0.1)", () => {
+    // bind=custom + customBindHost=127.0.0.1 is loopback at runtime — must be allowed at write-time too.
+    expect(
+      validateTailscaleBindCompat(
+        makeConfig({
+          tailscale: { mode: "serve" },
+          bind: "custom",
+          customBindHost: "127.0.0.1",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("passes when tailscale=funnel and bind=custom with customBindHost=::1", () => {
+    expect(
+      validateTailscaleBindCompat(
+        makeConfig({ tailscale: { mode: "funnel" }, bind: "custom", customBindHost: "::1" }),
+      ),
+    ).toBeNull();
+  });
+
+  // ── Rejects (returns error string) ───────────────────────────────────────
+
+  it("rejects when tailscale=serve and bind=lan", () => {
+    const err = validateTailscaleBindCompat(
+      makeConfig({ tailscale: { mode: "serve" }, bind: "lan" }),
+    );
+    expect(err).toMatch(/gateway\.tailscale\.mode="serve"/);
+    expect(err).toMatch(/gateway\.bind="loopback"/);
+  });
+
+  it("rejects when tailscale=funnel and bind=lan", () => {
+    const err = validateTailscaleBindCompat(
+      makeConfig({ tailscale: { mode: "funnel" }, bind: "lan" }),
+    );
+    expect(err).toMatch(/gateway\.tailscale\.mode="funnel"/);
+  });
+
+  it("rejects when tailscale=serve, bind=custom, and customBindHost is a non-loopback IP", () => {
+    const err = validateTailscaleBindCompat(
+      makeConfig({
+        tailscale: { mode: "serve" },
+        bind: "custom",
+        customBindHost: "192.168.1.100",
+      }),
+    );
+    expect(err).toMatch(/gateway\.bind="custom"/);
+  });
+
+  it("rejects when tailscale=serve, bind=custom, and customBindHost is empty", () => {
+    const err = validateTailscaleBindCompat(
+      makeConfig({ tailscale: { mode: "serve" }, bind: "custom", customBindHost: "" }),
+    );
+    expect(err).not.toBeNull();
+  });
+});

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -251,9 +251,13 @@ function loadSchemaWithPlugins(): ConfigSchemaResponse {
  */
 function validateTailscaleBindCompat(config: OpenClawConfig): string | null {
   const tailscaleMode = config.gateway?.tailscale?.mode;
-  if (tailscaleMode !== "serve" && tailscaleMode !== "funnel") return null;
+  if (tailscaleMode !== "serve" && tailscaleMode !== "funnel") {
+    return null;
+  }
   const bind = config.gateway?.bind ?? "loopback";
-  if (bind === "loopback") return null;
+  if (bind === "loopback") {
+    return null;
+  }
   return `gateway.tailscale.mode="${tailscaleMode}" requires gateway.bind="loopback", but gateway.bind="${bind}". Change gateway.bind to "loopback" or set gateway.tailscale.mode to "off".`;
 }
 

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -243,6 +243,20 @@ function loadSchemaWithPlugins(): ConfigSchemaResponse {
   });
 }
 
+/**
+ * Validate that gateway.tailscale.mode and gateway.bind are compatible.
+ * When tailscale mode is "serve" or "funnel", bind must be "loopback" (or unset,
+ * which defaults to "loopback"). Rejecting at config-write time prevents the
+ * gateway from entering an unrecoverable crash loop on next restart.
+ */
+function validateTailscaleBindCompat(config: OpenClawConfig): string | null {
+  const tailscaleMode = config.gateway?.tailscale?.mode;
+  if (tailscaleMode !== "serve" && tailscaleMode !== "funnel") return null;
+  const bind = config.gateway?.bind ?? "loopback";
+  if (bind === "loopback") return null;
+  return `gateway.tailscale.mode="${tailscaleMode}" requires gateway.bind="loopback", but gateway.bind="${bind}". Change gateway.bind to "loopback" or set gateway.tailscale.mode to "off".`;
+}
+
 export const configHandlers: GatewayRequestHandlers = {
   "config.get": async ({ params, respond }) => {
     if (!assertValidParams(params, validateConfigGetParams, "config.get", respond)) {
@@ -268,6 +282,11 @@ export const configHandlers: GatewayRequestHandlers = {
     }
     const parsed = parseValidateConfigFromRawOrRespond(params, "config.set", snapshot, respond);
     if (!parsed) {
+      return;
+    }
+    const compatError = validateTailscaleBindCompat(parsed.config);
+    if (compatError) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, compatError));
       return;
     }
     await writeConfigFile(parsed.config, writeOptions);
@@ -355,6 +374,11 @@ export const configHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    const patchCompatError = validateTailscaleBindCompat(validated.config);
+    if (patchCompatError) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, patchCompatError));
+      return;
+    }
     const changedPaths = diffConfigPaths(snapshot.config, validated.config);
     const actor = resolveControlPlaneActor(client);
     context?.logGateway?.info(
@@ -413,6 +437,11 @@ export const configHandlers: GatewayRequestHandlers = {
     }
     const parsed = parseValidateConfigFromRawOrRespond(params, "config.apply", snapshot, respond);
     if (!parsed) {
+      return;
+    }
+    const applyCompatError = validateTailscaleBindCompat(parsed.config);
+    if (applyCompatError) {
+      respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, applyCompatError));
       return;
     }
     const changedPaths = diffConfigPaths(snapshot.config, parsed.config);

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -1,4 +1,5 @@
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
+import { isLoopbackHost } from "../net.js";
 import { listChannelPlugins } from "../../channels/plugins/index.js";
 import {
   CONFIG_PATH,
@@ -249,7 +250,7 @@ function loadSchemaWithPlugins(): ConfigSchemaResponse {
  * which defaults to "loopback"). Rejecting at config-write time prevents the
  * gateway from entering an unrecoverable crash loop on next restart.
  */
-function validateTailscaleBindCompat(config: OpenClawConfig): string | null {
+export function validateTailscaleBindCompat(config: OpenClawConfig): string | null {
   const tailscaleMode = config.gateway?.tailscale?.mode;
   if (tailscaleMode !== "serve" && tailscaleMode !== "funnel") {
     return null;
@@ -257,6 +258,15 @@ function validateTailscaleBindCompat(config: OpenClawConfig): string | null {
   const bind = config.gateway?.bind ?? "loopback";
   if (bind === "loopback") {
     return null;
+  }
+  // A custom bind with a loopback IP is equivalent to bind=loopback at runtime
+  // (server-runtime-config.ts uses isLoopbackHost on the resolved IP). Allow it
+  // at write-time too so we don't reject a valid config.
+  if (bind === "custom") {
+    const customBindHost = config.gateway?.customBindHost?.trim();
+    if (customBindHost && isLoopbackHost(customBindHost)) {
+      return null;
+    }
   }
   return `gateway.tailscale.mode="${tailscaleMode}" requires gateway.bind="loopback", but gateway.bind="${bind}". Change gateway.bind to "loopback" or set gateway.tailscale.mode to "off".`;
 }

--- a/src/gateway/server-runtime-config.test.ts
+++ b/src/gateway/server-runtime-config.test.ts
@@ -232,6 +232,58 @@ describe("resolveGatewayRuntimeConfig", () => {
     });
   });
 
+  describe("tailscale/bind compatibility", () => {
+    it("rejects tailscale serve with non-loopback bind", async () => {
+      await expect(
+        resolveGatewayRuntimeConfig({
+          cfg: {
+            gateway: {
+              bind: "lan" as const,
+              auth: TOKEN_AUTH,
+              tailscale: { mode: "serve" as const },
+              controlUi: { allowedOrigins: ["https://control.example.com"] },
+            },
+          },
+          port: 18789,
+        }),
+      ).rejects.toThrow("tailscale serve/funnel requires gateway bind=loopback (127.0.0.1)");
+    });
+
+    it("rejects tailscale funnel with non-loopback bind", async () => {
+      await expect(
+        resolveGatewayRuntimeConfig({
+          cfg: {
+            gateway: {
+              bind: "lan" as const,
+              auth: {
+                mode: "password" as const,
+                password: "test-password",
+              },
+              tailscale: { mode: "funnel" as const },
+              controlUi: { allowedOrigins: ["https://control.example.com"] },
+            },
+          },
+          port: 18789,
+        }),
+      ).rejects.toThrow("tailscale serve/funnel requires gateway bind=loopback (127.0.0.1)");
+    });
+
+    it("allows tailscale serve with loopback bind", async () => {
+      const result = await resolveGatewayRuntimeConfig({
+        cfg: {
+          gateway: {
+            bind: "loopback" as const,
+            auth: TOKEN_AUTH,
+            tailscale: { mode: "serve" as const },
+          },
+        },
+        port: 18789,
+      });
+      expect(result.tailscaleMode).toBe("serve");
+      expect(result.bindHost).toBe("127.0.0.1");
+    });
+  });
+
   describe("HTTP security headers", () => {
     it("resolves strict transport security header from config", async () => {
       const result = await resolveGatewayRuntimeConfig({

--- a/src/i18n/registry.test.ts
+++ b/src/i18n/registry.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 import {
   DEFAULT_LOCALE,
   SUPPORTED_LOCALES,
   loadLazyLocaleTranslation,
   resolveNavigatorLocale,
 } from "../../ui/src/i18n/lib/registry.ts";
+import type { TranslationMap } from "../../ui/src/i18n/lib/types.ts";
 
 function getNestedTranslation(map: TranslationMap | null, ...path: string[]): string | undefined {
   let value: string | TranslationMap | undefined = map ?? undefined;


### PR DESCRIPTION
## Summary

- Add `validateTailscaleBindCompat()` cross-field validation to `config.set`, `config.patch`, and `config.apply` handlers
- Rejects incompatible `gateway.tailscale.mode` + `gateway.bind` combinations **before writing config**, preventing unrecoverable crash loops on gateway restart
- Add runtime config tests covering tailscale serve/funnel with non-loopback bind rejection and the happy path

## Problem

When `gateway.tailscale.mode` is `"serve"` or `"funnel"` and `gateway.bind` is anything other than `"loopback"`, the gateway crashes on every startup:

```
Gateway failed to start: Error: tailscale serve/funnel requires gateway bind=loopback (127.0.0.1)
```

Combined with `Restart=always` in systemd, this creates an infinite crash loop. In production, the restart counter reached **170+** in under an hour, with each restart allocating ~340MB before failing.

The validation already exists at runtime (`server-runtime-config.ts:94`), but it runs **after** the config is persisted — so once the bad config is written, every restart hits the same error.

## Fix

Add the same bind/tailscale compatibility check to the config write path (`config.set`, `config.patch`, `config.apply`), so incompatible combinations are rejected before the config file is updated.

## Test plan

- [x] Added tests for tailscale serve + non-loopback bind (rejected)
- [x] Added tests for tailscale funnel + non-loopback bind (rejected)
- [x] Added tests for tailscale serve + loopback bind (allowed)
- [ ] Manual: `openclaw config set gateway.tailscale.mode serve` with `gateway.bind=lan` → should error
- [ ] Manual: `openclaw config set gateway.bind lan` with `gateway.tailscale.mode=serve` → should error

Closes #35113

🤖 Generated with [Claude Code](https://claude.com/claude-code)