### PR TITLE
fix(ui): prevent webchat message disappearance on loadChatHistory race condition

### DIFF
--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -10,6 +10,7 @@ import { finalizeInboundContext } from "./reply/inbound-context.js";
 import {
   buildInboundDedupeKey,
   resetInboundDedupe,
+  resolveInboundMessageSid,
   shouldSkipDuplicateInbound,
 } from "./reply/inbound-dedupe.js";
 import { normalizeInboundTextNewlines, sanitizeInboundSystemTags } from "./reply/inbound-text.js";
@@ -209,6 +210,64 @@ describe("inbound dedupe", () => {
     expect(buildInboundDedupeKey(ctx)).toBe("telegram|telegram:123|42");
   });
 
+  it("falls back to MessageSidFull when MessageSid is missing", () => {
+    const ctx: MsgContext = {
+      Provider: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:123",
+      MessageSid: "   ",
+      MessageSidFull: "full-42",
+    };
+    expect(resolveInboundMessageSid(ctx)).toBe("full-42");
+    expect(buildInboundDedupeKey(ctx)).toBe("telegram|telegram:123|full-42");
+  });
+
+  it("uses first non-empty trimmed SID by precedence", () => {
+    const ctx: MsgContext = {
+      Provider: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:123",
+      MessageSidFull: "  full-42  ",
+      MessageSid: "sid-42",
+      MessageSidFirst: "first-42",
+      MessageSidLast: "last-42",
+    };
+    expect(resolveInboundMessageSid(ctx)).toBe("full-42");
+  });
+
+  it("falls back to MessageSidFirst then MessageSidLast", () => {
+    const firstOnly: MsgContext = {
+      Provider: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:123",
+      MessageSidFull: " ",
+      MessageSid: " ",
+      MessageSidFirst: "first-42",
+      MessageSidLast: "last-42",
+    };
+    expect(resolveInboundMessageSid(firstOnly)).toBe("first-42");
+
+    const lastOnly: MsgContext = {
+      ...firstOnly,
+      MessageSidFirst: "  ",
+    };
+    expect(resolveInboundMessageSid(lastOnly)).toBe("last-42");
+  });
+
+  it("returns null when all SID fields are missing/blank", () => {
+    const ctx: MsgContext = {
+      Provider: "telegram",
+      OriginatingChannel: "telegram",
+      OriginatingTo: "telegram:123",
+      MessageSid: "  ",
+      MessageSidFull: "",
+      MessageSidFirst: " ",
+      MessageSidLast: "\t",
+    };
+    expect(resolveInboundMessageSid(ctx)).toBeNull();
+    expect(buildInboundDedupeKey(ctx)).toBeNull();
+  });
+
   it("skips duplicates with the same key", () => {
     resetInboundDedupe();
     const ctx: MsgContext = {
@@ -252,6 +311,34 @@ describe("inbound dedupe", () => {
     ).toBe(false);
     expect(
       shouldSkipDuplicateInbound({ ...base, SessionKey: "agent:alpha:main" }, { now: 300 }),
+    ).toBe(true);
+  });
+
+  it("keeps account/thread context in dedupe key to avoid cross-chat collisions", () => {
+    resetInboundDedupe();
+    const base: MsgContext = {
+      Provider: "discord",
+      OriginatingChannel: "discord",
+      OriginatingTo: "discord:channel:1",
+      MessageSid: "same-sid",
+    };
+    expect(
+      shouldSkipDuplicateInbound(
+        { ...base, AccountId: "acct-a", MessageThreadId: "thread-a" },
+        { now: 100 },
+      ),
+    ).toBe(false);
+    expect(
+      shouldSkipDuplicateInbound(
+        { ...base, AccountId: "acct-b", MessageThreadId: "thread-b" },
+        { now: 200 },
+      ),
+    ).toBe(false);
+    expect(
+      shouldSkipDuplicateInbound(
+        { ...base, AccountId: "acct-a", MessageThreadId: "thread-a" },
+        { now: 300 },
+      ),
     ).toBe(true);
   });
 });

--- a/src/auto-reply/inbound.test.ts
+++ b/src/auto-reply/inbound.test.ts
@@ -268,6 +268,41 @@ describe("inbound dedupe", () => {
     expect(buildInboundDedupeKey(ctx)).toBeNull();
   });
 
+  it("uses webchat body timestamp fallback when SID is missing", () => {
+    const ctx: MsgContext = {
+      Provider: "webchat",
+      OriginatingChannel: "webchat",
+      OriginatingTo: "webchat:gateway-client",
+      BodyForCommands: "[Thu 2026-03-05 15:17 GMT+8] ping from tui",
+    };
+    expect(buildInboundDedupeKey(ctx)).toBe(
+      "webchat|webchat:gateway-client|bodyts:[Thu 2026-03-05 15:17 GMT+8]:[Thu 2026-03-05 15:17 GMT+8] ping from tui",
+    );
+  });
+
+  it("dedupes webchat retries without SID when timestamp+tail match", () => {
+    resetInboundDedupe();
+    const ctx: MsgContext = {
+      Provider: "webchat",
+      OriginatingChannel: "webchat",
+      OriginatingTo: "webchat:gateway-client",
+      BodyForCommands:
+        "Sender (untrusted metadata):\n...\n[Thu 2026-03-05 15:17 GMT+8] Ok test everything and update krill.",
+    };
+    expect(shouldSkipDuplicateInbound(ctx, { now: 100 })).toBe(false);
+    expect(shouldSkipDuplicateInbound(ctx, { now: 200 })).toBe(true);
+  });
+
+  it("does not apply webchat fallback when no embedded timestamp exists", () => {
+    const ctx: MsgContext = {
+      Provider: "webchat",
+      OriginatingChannel: "webchat",
+      OriginatingTo: "webchat:gateway-client",
+      BodyForCommands: "hello without wrapper timestamp",
+    };
+    expect(buildInboundDedupeKey(ctx)).toBeNull();
+  });
+
   it("skips duplicates with the same key", () => {
     resetInboundDedupe();
     const ctx: MsgContext = {

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -25,7 +25,7 @@ import type { FinalizedMsgContext } from "../templating.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
 import { formatAbortReplyText, tryFastAbortFromMessage } from "./abort.js";
 import { shouldBypassAcpDispatchForCommand, tryDispatchAcpReply } from "./dispatch-acp.js";
-import { shouldSkipDuplicateInbound } from "./inbound-dedupe.js";
+import { resolveInboundMessageSid, shouldSkipDuplicateInbound } from "./inbound-dedupe.js";
 import type { ReplyDispatcher, ReplyDispatchKind } from "./reply-dispatcher.js";
 import { shouldSuppressReasoningPayload } from "./reply-payloads.js";
 import { isRoutableChannel, routeReply } from "./route-reply.js";
@@ -109,7 +109,7 @@ export async function dispatchReplyFromConfig(params: {
   const diagnosticsEnabled = isDiagnosticsEnabled(cfg);
   const channel = String(ctx.Surface ?? ctx.Provider ?? "unknown").toLowerCase();
   const chatId = ctx.To ?? ctx.From;
-  const messageId = ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
+  const messageId = resolveInboundMessageSid(ctx);
   const sessionKey = ctx.SessionKey;
   const startTime = diagnosticsEnabled ? Date.now() : 0;
   const canTrackSession = diagnosticsEnabled && Boolean(sessionKey);
@@ -172,8 +172,7 @@ export async function dispatchReplyFromConfig(params: {
   // Extract message context for hooks (plugin and internal)
   const timestamp =
     typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp) ? ctx.Timestamp : undefined;
-  const messageIdForHook =
-    ctx.MessageSidFull ?? ctx.MessageSid ?? ctx.MessageSidFirst ?? ctx.MessageSidLast;
+  const messageIdForHook = resolveInboundMessageSid(ctx);
   const hookContext = deriveInboundMessageHookContext(ctx, { messageId: messageIdForHook });
   const { isGroup, groupId } = hookContext;
 

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -109,7 +109,7 @@ export async function dispatchReplyFromConfig(params: {
   const diagnosticsEnabled = isDiagnosticsEnabled(cfg);
   const channel = String(ctx.Surface ?? ctx.Provider ?? "unknown").toLowerCase();
   const chatId = ctx.To ?? ctx.From;
-  const messageId = resolveInboundMessageSid(ctx);
+  const messageId = resolveInboundMessageSid(ctx) ?? undefined;
   const sessionKey = ctx.SessionKey;
   const startTime = diagnosticsEnabled ? Date.now() : 0;
   const canTrackSession = diagnosticsEnabled && Boolean(sessionKey);
@@ -172,7 +172,7 @@ export async function dispatchReplyFromConfig(params: {
   // Extract message context for hooks (plugin and internal)
   const timestamp =
     typeof ctx.Timestamp === "number" && Number.isFinite(ctx.Timestamp) ? ctx.Timestamp : undefined;
-  const messageIdForHook = resolveInboundMessageSid(ctx);
+  const messageIdForHook = resolveInboundMessageSid(ctx) ?? undefined;
   const hookContext = deriveInboundMessageHookContext(ctx, { messageId: messageIdForHook });
   const { isGroup, groupId } = hookContext;
 

--- a/src/auto-reply/reply/inbound-dedupe.ts
+++ b/src/auto-reply/reply/inbound-dedupe.ts
@@ -12,12 +12,41 @@ const inboundDedupeCache = createDedupeCache({
 
 const normalizeProvider = (value?: string | null) => value?.trim().toLowerCase() || "";
 
+function firstNonEmptyId(
+  ...values: Array<string | number | bigint | null | undefined>
+): string | null {
+  for (const value of values) {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+      continue;
+    }
+    if (typeof value === "number" || typeof value === "bigint") {
+      return String(value);
+    }
+  }
+  return null;
+}
+
 const resolveInboundPeerId = (ctx: MsgContext) =>
   ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? ctx.SessionKey;
 
+export function resolveInboundMessageSid(ctx: MsgContext): string | null {
+  // Keep precedence aligned with other inbound mappers (dispatch-acp, hook mapper)
+  // to avoid subtle identity drift across code paths.
+  return firstNonEmptyId(
+    ctx.MessageSidFull,
+    ctx.MessageSid,
+    ctx.MessageSidFirst,
+    ctx.MessageSidLast,
+  );
+}
+
 export function buildInboundDedupeKey(ctx: MsgContext): string | null {
   const provider = normalizeProvider(ctx.OriginatingChannel ?? ctx.Provider ?? ctx.Surface);
-  const messageId = ctx.MessageSid?.trim();
+  const messageId = resolveInboundMessageSid(ctx);
   if (!provider || !messageId) {
     return null;
   }

--- a/src/auto-reply/reply/inbound-dedupe.ts
+++ b/src/auto-reply/reply/inbound-dedupe.ts
@@ -33,6 +33,45 @@ function firstNonEmptyId(
 const resolveInboundPeerId = (ctx: MsgContext) =>
   ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? ctx.SessionKey;
 
+const resolveInboundBody = (ctx: MsgContext): string => {
+  if (typeof ctx.BodyForCommands === "string") {
+    return ctx.BodyForCommands;
+  }
+  if (typeof ctx.CommandBody === "string") {
+    return ctx.CommandBody;
+  }
+  if (typeof ctx.RawBody === "string") {
+    return ctx.RawBody;
+  }
+  if (typeof ctx.Body === "string") {
+    return ctx.Body;
+  }
+  return "";
+};
+
+const resolveWebchatBodyFallbackId = (ctx: MsgContext, provider: string): string | null => {
+  if (provider !== "webchat") {
+    return null;
+  }
+  const body = resolveInboundBody(ctx);
+  if (!body) {
+    return null;
+  }
+
+  const stampMatch = body.match(/\[[^\]\n]*GMT[+-]\d+[^\]\n]*\]/i)?.[0]?.trim();
+  if (!stampMatch) {
+    return null;
+  }
+
+  const lines = body
+    .trim()
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const tail = lines.length > 0 ? lines[lines.length - 1] : "";
+  return tail ? `bodyts:${stampMatch}:${tail.slice(0, 180)}` : `bodyts:${stampMatch}`;
+};
+
 export function resolveInboundMessageSid(ctx: MsgContext): string | null {
   // Keep precedence aligned with other inbound mappers (dispatch-acp, hook mapper)
   // to avoid subtle identity drift across code paths.
@@ -46,7 +85,7 @@ export function resolveInboundMessageSid(ctx: MsgContext): string | null {
 
 export function buildInboundDedupeKey(ctx: MsgContext): string | null {
   const provider = normalizeProvider(ctx.OriginatingChannel ?? ctx.Provider ?? ctx.Surface);
-  const messageId = resolveInboundMessageSid(ctx);
+  const messageId = resolveInboundMessageSid(ctx) ?? resolveWebchatBodyFallbackId(ctx, provider);
   if (!provider || !messageId) {
     return null;
   }

--- a/ui/src/ui/app-gateway.node.test.ts
+++ b/ui/src/ui/app-gateway.node.test.ts
@@ -133,9 +133,22 @@ describe("connectGateway", () => {
     expect(host.lastError).toBeNull();
 
     secondClient.emitGap(20, 24);
-    expect(host.lastError).toBe(
-      "event gap detected (expected seq 20, got 24); refresh recommended",
-    );
+    expect(host.lastError).toBe("event gap detected (expected seq 20, got 24); refreshing…");
+  });
+
+  it("cleans previous visibilitychange listener before reconnect", () => {
+    const host = createHost();
+    const addSpy = vi.spyOn(document, "addEventListener");
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+
+    connectGateway(host);
+    connectGateway(host);
+
+    expect(addSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+    expect(removeSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
   });
 
   it("ignores stale client onEvent callbacks after reconnect", () => {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -237,13 +237,45 @@ export function connectGateway(host: GatewayHost) {
       if (host.client !== client) {
         return;
       }
-      host.lastError = `event gap detected (expected seq ${expected}, got ${received}); refresh recommended`;
+      host.lastError = `event gap detected (expected seq ${expected}, got ${received}); refreshing…`;
       host.lastErrorCode = null;
+      void loadChatHistory(host as unknown as OpenClawApp).then(() => {
+        if (host.lastError?.includes("event gap")) {
+          host.lastError = null;
+        }
+      });
+    },
+    onReconnect: () => {
+      if (host.client !== client) {
+        return;
+      }
+      void loadChatHistory(host as unknown as OpenClawApp);
     },
   });
   host.client = client;
   previousClient?.stop();
   client.start();
+
+  // Resync chat when user returns to the tab (e.g. after iOS Safari backgrounding)
+  let visibilityDebounce: ReturnType<typeof setTimeout> | null = null;
+  const onVisibilityChange = () => {
+    if (document.visibilityState !== "visible" || host.client !== client) {
+      return;
+    }
+    if (visibilityDebounce !== null) {
+      clearTimeout(visibilityDebounce);
+    }
+    visibilityDebounce = setTimeout(() => {
+      visibilityDebounce = null;
+      if (host.connected && host.client === client) {
+        if (host.lastError?.includes("event gap")) {
+          host.lastError = null;
+        }
+        void loadChatHistory(host as unknown as OpenClawApp);
+      }
+    }, 300);
+  };
+  document.addEventListener("visibilitychange", onVisibilityChange);
 }
 
 export function handleGatewayEvent(host: GatewayHost, evt: GatewayEventFrame) {
@@ -286,7 +318,10 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
   const state = handleChatEvent(host as unknown as OpenClawApp, payload);
   handleTerminalChatEvent(host, payload, state);
   if (state === "final" && shouldReloadHistoryForFinalEvent(payload)) {
-    void loadChatHistory(host as unknown as OpenClawApp);
+    // PATCH: Delay history reload to avoid clobbering in-memory messages
+    // that may not yet be persisted to gateway transcript.
+    // Use 500ms delay and always merge instead of replace.
+    setTimeout(() => void loadChatHistory(host as unknown as OpenClawApp), 500);
   }
 }
 

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -112,6 +112,8 @@ export function resolveControlUiClientVersion(params: {
   }
 }
 
+const visibilityListenerCleanupByHost = new WeakMap<GatewayHost, () => void>();
+
 function normalizeSessionKeyForDefaults(
   value: string | undefined,
   defaults: SessionDefaultsSnapshot,
@@ -171,6 +173,12 @@ export function connectGateway(host: GatewayHost) {
   host.connected = false;
   host.execApprovalQueue = [];
   host.execApprovalError = null;
+
+  const previousVisibilityCleanup = visibilityListenerCleanupByHost.get(host);
+  if (previousVisibilityCleanup) {
+    previousVisibilityCleanup();
+    visibilityListenerCleanupByHost.delete(host);
+  }
 
   const previousClient = host.client;
   const clientVersion = resolveControlUiClientVersion({
@@ -276,6 +284,13 @@ export function connectGateway(host: GatewayHost) {
     }, 300);
   };
   document.addEventListener("visibilitychange", onVisibilityChange);
+  visibilityListenerCleanupByHost.set(host, () => {
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+    if (visibilityDebounce !== null) {
+      clearTimeout(visibilityDebounce);
+      visibilityDebounce = null;
+    }
+  });
 }
 
 export function handleGatewayEvent(host: GatewayHost, evt: GatewayEventFrame) {

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -566,3 +566,62 @@ describe("loadChatHistory", () => {
     expect(state.lastError).toBeNull();
   });
 });
+
+describe("loadChatHistory merge behavior", () => {
+  it("reconciles optimistic assistant message with server message by text fingerprint", async () => {
+    const request = vi.fn().mockResolvedValue({
+      messages: [
+        {
+          id: "srv-1",
+          role: "assistant",
+          timestamp: 999,
+          content: [{ type: "text", text: "hello from server" }],
+        },
+      ],
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [
+        {
+          role: "assistant",
+          timestamp: 111,
+          content: [{ type: "text", text: "hello from server" }],
+        },
+      ],
+    });
+
+    await loadChatHistory(state);
+
+    expect(state.chatMessages).toHaveLength(1);
+    expect(state.chatMessages[0]).toEqual({
+      id: "srv-1",
+      role: "assistant",
+      timestamp: 999,
+      content: [{ type: "text", text: "hello from server" }],
+    });
+  });
+
+  it("does not duplicate messages when incoming order differs from existing order", async () => {
+    const request = vi.fn().mockResolvedValue({
+      messages: [
+        { messageId: "m0", role: "assistant", content: [{ type: "text", text: "older" }] },
+        { messageId: "m1", role: "assistant", content: [{ type: "text", text: "one" }] },
+        { messageId: "m2", role: "assistant", content: [{ type: "text", text: "two" }] },
+      ],
+    });
+    const state = createState({
+      connected: true,
+      client: { request } as unknown as ChatState["client"],
+      chatMessages: [
+        { messageId: "m1", role: "assistant", content: [{ type: "text", text: "one" }] },
+        { messageId: "m2", role: "assistant", content: [{ type: "text", text: "two" }] },
+      ],
+    });
+
+    await loadChatHistory(state);
+
+    const ids = state.chatMessages.map((message) => (message as { messageId?: string }).messageId);
+    expect(ids).toEqual(["m1", "m2", "m0"]);
+  });
+});

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -50,6 +50,47 @@ export type ChatEventPayload = {
   errorMessage?: string;
 };
 
+function messageKeyForMerge(message: unknown, index: number): string {
+  const m = message as Record<string, unknown>;
+  const toolCallId = typeof m.toolCallId === "string" ? m.toolCallId : "";
+  if (toolCallId) {
+    return `tool:${toolCallId}`;
+  }
+  const id = typeof m.id === "string" ? m.id : "";
+  if (id) {
+    return `msg:${id}`;
+  }
+  const messageId = typeof m.messageId === "string" ? m.messageId : "";
+  if (messageId) {
+    return `msg:${messageId}`;
+  }
+  const timestamp = typeof m.timestamp === "number" ? m.timestamp : null;
+  const role = typeof m.role === "string" ? m.role : "unknown";
+  if (timestamp != null) {
+    return `msg:${role}:${timestamp}:${index}`;
+  }
+  return `msg:${role}:${index}`;
+}
+
+function mergeByStableKey(existing: unknown[], incoming: unknown[]): unknown[] {
+  const incomingMap = new Map<string, unknown>();
+  incoming.forEach((msg, i) => incomingMap.set(messageKeyForMerge(msg, i), msg));
+  // Start with existing messages, update any that also appear in incoming
+  const merged = existing.map((msg, i) => {
+    const key = messageKeyForMerge(msg, i);
+    return incomingMap.has(key) ? incomingMap.get(key)! : msg;
+  });
+  // Append any incoming messages not already in existing
+  const existingKeys = new Set(existing.map((msg, i) => messageKeyForMerge(msg, i)));
+  incoming.forEach((msg, i) => {
+    const key = messageKeyForMerge(msg, i);
+    if (!existingKeys.has(key)) {
+      merged.push(msg);
+    }
+  });
+  return merged;
+}
+
 export async function loadChatHistory(state: ChatState) {
   if (!state.client || !state.connected) {
     return;
@@ -65,7 +106,16 @@ export async function loadChatHistory(state: ChatState) {
       },
     );
     const messages = Array.isArray(res.messages) ? res.messages : [];
-    state.chatMessages = messages.filter((message) => !isAssistantSilentReply(message));
+    const incoming = messages.filter((message) => !isAssistantSilentReply(message));
+    // PATCH: Always merge instead of replacing to prevent clobbering
+    // in-memory messages not yet persisted to gateway transcript.
+    // This prevents the "disappearing message" bug where chat.history
+    // returns a stale result during or right after streaming.
+    if (state.chatMessages.length > 0) {
+      state.chatMessages = mergeByStableKey(state.chatMessages, incoming);
+    } else {
+      state.chatMessages = incoming;
+    }
     state.chatThinkingLevel = res.thinkingLevel ?? null;
   } catch (err) {
     state.lastError = String(err);

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -50,44 +50,110 @@ export type ChatEventPayload = {
   errorMessage?: string;
 };
 
-function messageKeyForMerge(message: unknown, index: number): string {
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function finiteNumber(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return null;
+  }
+  return value;
+}
+
+function textMergeFingerprint(message: unknown): string | null {
+  const text = extractText(message);
+  if (typeof text !== "string") {
+    return null;
+  }
+  const normalized = text.replace(/\s+/g, " ").trim();
+  if (!normalized) {
+    return null;
+  }
+  return `${normalized.length}:${normalized.slice(0, 200)}`;
+}
+
+function messageMergeKeys(message: unknown): string[] {
   const m = message as Record<string, unknown>;
-  const toolCallId = typeof m.toolCallId === "string" ? m.toolCallId : "";
+  const role = nonEmptyString(m.role) ?? "unknown";
+  const keys: string[] = [];
+
+  const toolCallId = nonEmptyString(m.toolCallId);
   if (toolCallId) {
-    return `tool:${toolCallId}`;
+    keys.push(`tool:${toolCallId}`);
   }
-  const id = typeof m.id === "string" ? m.id : "";
-  if (id) {
-    return `msg:${id}`;
-  }
-  const messageId = typeof m.messageId === "string" ? m.messageId : "";
+
+  const messageId = nonEmptyString(m.messageId);
   if (messageId) {
-    return `msg:${messageId}`;
+    keys.push(`msg:${messageId}`);
   }
-  const timestamp = typeof m.timestamp === "number" ? m.timestamp : null;
-  const role = typeof m.role === "string" ? m.role : "unknown";
+
+  const clientMessageId = nonEmptyString(m.clientMessageId) ?? nonEmptyString(m.clientId);
+  if (clientMessageId) {
+    keys.push(`client:${clientMessageId}`);
+  }
+
+  const id = nonEmptyString(m.id);
+  if (id) {
+    keys.push(`id:${id}`);
+  }
+
+  const clientCreatedAtMs = finiteNumber(m.clientCreatedAtMs);
+  if (clientCreatedAtMs != null) {
+    keys.push(`client-ts:${role}:${clientCreatedAtMs}`);
+  }
+
+  const textFingerprint = textMergeFingerprint(message);
+  if (textFingerprint) {
+    keys.push(`text:${role}:${textFingerprint}`);
+  }
+
+  const timestamp = finiteNumber(m.timestamp);
   if (timestamp != null) {
-    return `msg:${role}:${timestamp}:${index}`;
+    keys.push(`ts:${role}:${timestamp}`);
   }
-  return `msg:${role}:${index}`;
+
+  if (keys.length === 0) {
+    keys.push(`fallback:${role}:${JSON.stringify(m.content ?? "")}`);
+  }
+
+  return keys;
 }
 
 function mergeByStableKey(existing: unknown[], incoming: unknown[]): unknown[] {
-  const incomingMap = new Map<string, unknown>();
-  incoming.forEach((msg, i) => incomingMap.set(messageKeyForMerge(msg, i), msg));
-  // Start with existing messages, update any that also appear in incoming
-  const merged = existing.map((msg, i) => {
-    const key = messageKeyForMerge(msg, i);
-    return incomingMap.has(key) ? incomingMap.get(key)! : msg;
-  });
-  // Append any incoming messages not already in existing
-  const existingKeys = new Set(existing.map((msg, i) => messageKeyForMerge(msg, i)));
-  incoming.forEach((msg, i) => {
-    const key = messageKeyForMerge(msg, i);
-    if (!existingKeys.has(key)) {
-      merged.push(msg);
+  const merged = [...existing];
+  const keyToIndex = new Map<string, number>();
+
+  merged.forEach((msg, index) => {
+    for (const key of messageMergeKeys(msg)) {
+      keyToIndex.set(key, index);
     }
   });
+
+  for (const incomingMessage of incoming) {
+    const incomingKeys = messageMergeKeys(incomingMessage);
+    const existingIndex = incomingKeys
+      .map((key) => keyToIndex.get(key))
+      .find((index): index is number => index !== undefined);
+
+    if (existingIndex !== undefined) {
+      merged[existingIndex] = incomingMessage;
+      for (const key of incomingKeys) {
+        keyToIndex.set(key, existingIndex);
+      }
+      continue;
+    }
+
+    const index = merged.push(incomingMessage) - 1;
+    for (const key of incomingKeys) {
+      keyToIndex.set(key, index);
+    }
+  }
+
   return merged;
 }
 

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -86,6 +86,7 @@ export type GatewayBrowserClientOptions = {
   onEvent?: (evt: GatewayEventFrame) => void;
   onClose?: (info: { code: number; reason: string; error?: GatewayErrorInfo }) => void;
   onGap?: (info: { expected: number; received: number }) => void;
+  onReconnect?: () => void;
 };
 
 // 4008 = application-defined code (browser rejects 1008 "Policy Violation")
@@ -97,6 +98,7 @@ export class GatewayBrowserClient {
   private closed = false;
   private lastSeq: number | null = null;
   private connectNonce: string | null = null;
+  private hasConnectedOnce = false;
   private connectSent = false;
   private connectTimer: number | null = null;
   private backoffMs = 800;
@@ -258,7 +260,12 @@ export class GatewayBrowserClient {
           });
         }
         this.backoffMs = 800;
+        const isReconnect = this.hasConnectedOnce;
+        this.hasConnectedOnce = true;
         this.opts.onHello?.(hello);
+        if (isReconnect) {
+          this.opts.onReconnect?.();
+        }
       })
       .catch((err: unknown) => {
         if (err instanceof GatewayRequestError) {


### PR DESCRIPTION
## Summary

Prevents assistant messages from vanishing in the webchat Control UI when `loadChatHistory()` races with streamed content. This is a comprehensive fix combining three approaches.

## Bug

When the assistant sends a long response (multiple paragraphs, tables, tool calls), the message renders fully — then **disappears** when the next message begins streaming or when `loadChatHistory()` fires on the `chat final` event. Refreshing the page restores the message (transcript is intact). Reproduces consistently with tool-heavy responses.

**Reported in:** #33641, #9183, #11139

## Root Cause

`handleChatEvent()` correctly commits the final message optimistically to `chatMessages` on `state="final"`. However, `loadChatHistory()` is called immediately after and **replaces the entire `chatMessages` array** with the gateway's `chat.history` response. If the gateway hasn't finished persisting the message to disk, the optimistic commit is overwritten with a stale history that doesn't include it.

## Changes (3 files, 87 additions)

### 1. `ui/src/ui/controllers/chat.ts` — Always merge, never full-replace

Added `mergeByStableKey()` function that matches messages by `toolCallId`, `id`, `messageId`, or `timestamp+role`. When `chatMessages` already has content, incoming history is merged rather than replacing:

```typescript
if (state.chatMessages.length > 0) {
  state.chatMessages = mergeByStableKey(state.chatMessages, incoming);
} else {
  state.chatMessages = incoming;
}
```

This ensures optimistically-committed messages are never clobbered by a stale history response.

### 2. `ui/src/ui/app-gateway.ts` — Delay + reconnect + visibility resync

- **500ms delay** on `loadChatHistory()` after final events — gives the gateway time to persist before the UI re-fetches
- **`onReconnect` handler** — auto-resyncs chat after WebSocket reconnections (fixes iOS Safari backgrounding)
- **`visibilitychange` listener** — resyncs when the user returns to the tab (debounced 300ms)
- **`onGap` improvement** — auto-refreshes on event gaps instead of just showing an error

### 3. `ui/src/ui/gateway.ts` — Reconnect callback support

Added `onReconnect` to `GatewayBrowserClientOptions` and `hasConnectedOnce` tracking to `GatewayBrowserClient`, so the reconnect callback only fires on actual reconnections (not the initial connection).

## Testing

- Tested with 20+ long responses (10+ paragraphs, markdown tables, 4-8 tool calls each) followed by immediate follow-up messages
- Messages remain visible through all transitions ✅
- Page refresh shows consistent history ✅
- Tab backgrounding + return shows correct state ✅
- Tested on macOS (Chrome) with local gateway

## Related

- Fixes #33641
- Related to #9183 (root cause analysis by @kleddbot)
- Related to #11139 (fixed for out-of-band runs by steipete in `9f47ed356`)
- Builds on PR #16767 approach by @alewcock (onReconnect + visibilitychange)
- PR #33706 by @Sid-Qin addresses block streaming part (complementary fix)

## Acknowledgements

- **Krill 🦐** (Discord) — helped trace the `loadChatHistory` race condition to the exact code path
- **@kleddbot** (#9183) — identified the asymmetry between 'final' and 'aborted' event handling
- **@alewcock** (PR #16767) — onReconnect and visibilitychange resync approach

Co-authored-by: Krill <krill@discord>