### PR TITLE
fix(skill-creator): reject empty name and description in quick_validate.py

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -111,40 +111,42 @@ def validate_skill(skill_path):
     if "description" not in frontmatter:
         return False, "Missing 'description' in frontmatter"
 
-    name = frontmatter.get("name", "")
-    if not isinstance(name, str):
-        return False, f"Name must be a string, got {type(name).__name__}"
-    name = name.strip()
-    if name:
-        if not re.match(r"^[a-z0-9-]+$", name):
-            return (
-                False,
-                f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)",
-            )
-        if name.startswith("-") or name.endswith("-") or "--" in name:
-            return (
-                False,
-                f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens",
-            )
-        if len(name) > MAX_SKILL_NAME_LENGTH:
-            return (
-                False,
-                f"Name is too long ({len(name)} characters). "
-                f"Maximum is {MAX_SKILL_NAME_LENGTH} characters.",
-            )
+    raw_name = frontmatter.get("name")
+    if raw_name is None or (isinstance(raw_name, str) and not raw_name.strip()):
+        return False, "Name cannot be empty"
+    if not isinstance(raw_name, str):
+        return False, f"Name must be a string, got {type(raw_name).__name__}"
+    name = raw_name.strip()
+    if not re.match(r"^[a-z0-9-]+$", name):
+        return (
+            False,
+            f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)",
+        )
+    if name.startswith("-") or name.endswith("-") or "--" in name:
+        return (
+            False,
+            f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens",
+        )
+    if len(name) > MAX_SKILL_NAME_LENGTH:
+        return (
+            False,
+            f"Name is too long ({len(name)} characters). "
+            f"Maximum is {MAX_SKILL_NAME_LENGTH} characters.",
+        )
 
-    description = frontmatter.get("description", "")
-    if not isinstance(description, str):
-        return False, f"Description must be a string, got {type(description).__name__}"
-    description = description.strip()
-    if description:
-        if "<" in description or ">" in description:
-            return False, "Description cannot contain angle brackets (< or >)"
-        if len(description) > 1024:
-            return (
-                False,
-                f"Description is too long ({len(description)} characters). Maximum is 1024 characters.",
-            )
+    raw_description = frontmatter.get("description")
+    if raw_description is None or (isinstance(raw_description, str) and not raw_description.strip()):
+        return False, "Description cannot be empty"
+    if not isinstance(raw_description, str):
+        return False, f"Description must be a string, got {type(raw_description).__name__}"
+    description = raw_description.strip()
+    if "<" in description or ">" in description:
+        return False, "Description cannot contain angle brackets (< or >)"
+    if len(description) > 1024:
+        return (
+            False,
+            f"Description is too long ({len(description)} characters). Maximum is 1024 characters.",
+        )
 
     return True, "Skill is valid!"
 


### PR DESCRIPTION
## What

Fix `quick_validate.py` (and by extension `package_skill.py`) silently accepting skills with an empty `name` or `description` field.

## Why

The validator guarded all name/description format checks inside `if name:` / `if description:` blocks. When a field is a YAML null (`name:`) or an empty string (`name: ""`), the entire block is skipped and the skill is reported as valid. Broken skills can then be packaged and distributed without the author receiving any warning.

Fixes #35110

## How

Replace the permissive conditional with an explicit early-exit check:

```diff
-  name = name.strip()
-  if name:
-      if not re.match(...):
-          ...
+  raw_name = frontmatter.get(name)
+  if raw_name is None or (isinstance(raw_name, str) and not raw_name.strip()):
+      return False, "Name cannot be empty"
+  if not isinstance(raw_name, str):
+      return False, f"Name must be a string, got {type(raw_name).__name__}"
+  name = raw_name.strip()
+  if not re.match(...):
+      ...
```

Same pattern applied to `description`. The fix covers all three failure modes:
- YAML null (`name:`) → **"Name cannot be empty"**
- Empty string (`name: ""`) → **"Name cannot be empty"**  
- Wrong type (`name: 123`) → **"Name must be a string, got int"**

## Testing

Manually verified all cases:

```bash
# YAML null name → exit 1
echo '---\nname:\ndescription: test\n---\n# body' | ... → "Name cannot be empty"

# Empty description → exit 1
echo '---\nname: test\ndescription:\n---\n# body' | ... → "Description cannot be empty"

# Valid skill → exit 0
→ "Skill is valid!"

# Integer name → exit 1
→ "Name must be a string, got int"
```

Since `package_skill.py` imports `validate_skill` directly from `quick_validate.py`, both tools are fixed by this change.

## Breaking Changes

Skills with empty `name` or `description` that previously passed validation will now correctly fail. Any such skills are malformed and should not have been publishable.