### PR TITLE
fix: resolve node_sqlite3 native binding load failure under jiti

### DIFF
--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { createJiti } from "jiti";
 import type { OpenClawConfig } from "../config/config.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
@@ -701,7 +701,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
 
     let mod: OpenClawPluginModule | null = null;
     try {
-      mod = getJiti()(safeSource) as OpenClawPluginModule;
+      mod = getJiti()(pathToFileURL(safeSource).href) as OpenClawPluginModule;
     } catch (err) {
       recordPluginError({
         logger,


### PR DESCRIPTION
Closes #35078

**Problem:** Plugin native bindings (e.g. `node_sqlite3`) fail to load under the Jiti loader because Jiti resolves module paths relative to its own directory instead of the plugin's.

**Fix:** Pass a `file://` URL via `pathToFileURL(safeSource).href` when invoking jiti. This anchors module/native binding resolution to the plugin file location.

**Changes:** 2-line surgical fix to `src/plugins/loader.ts` — no API surface changes, no behavioural changes beyond fixing the resolution path.

This supersedes #35090 which had merge conflicts due to being based on an older branch state.
