### PR TITLE
UI:  Fixes #34255 - default chat to last active session

### DIFF
--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -215,6 +215,13 @@ export async function refreshActiveTab(host: SettingsHost) {
     await loadExecApprovals(host as unknown as OpenClawApp);
   }
   if (host.tab === "chat") {
+    const preferredSessionKey =
+      host.settings.lastActiveSessionKey?.trim() ||
+      host.settings.sessionKey?.trim() ||
+      host.sessionKey;
+    if (preferredSessionKey && preferredSessionKey !== host.sessionKey) {
+      host.sessionKey = preferredSessionKey;
+    }
     await refreshChat(host as unknown as Parameters<typeof refreshChat>[0]);
     scheduleChatScroll(
       host as unknown as Parameters<typeof scheduleChatScroll>[0],

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -221,6 +221,7 @@ export async function refreshActiveTab(host: SettingsHost) {
       host.sessionKey;
     if (preferredSessionKey && preferredSessionKey !== host.sessionKey) {
       host.sessionKey = preferredSessionKey;
+      syncUrlWithSessionKey(host, preferredSessionKey, true);
     }
     await refreshChat(host as unknown as Parameters<typeof refreshChat>[0]);
     scheduleChatScroll(


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** Control UI /chat always opened in the first session in the list (e.g. `agent:guest:main`), so operators landed in the guest session instead of main when using a restricted default agent.
- **Why it matters:** Common pattern is main = admin, guest = low-trust default; the Control UI should default to the operator's main session.
- **What changed:** Default /chat to last active session (persisted in settings); sync URL when switching to preferred session.
- **What did NOT change (scope boundary):** No new "pin default session" UI; only last-active default.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #34255
- Related #

## User-visible / Behavior Changes

- /chat opens in the last-used session instead of the first in the list. URL updates when switching session.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
