### PR TITLE
feat(doctor): detect duplicate openclaw installations

### DIFF
--- a/src/commands/doctor-install.test.ts
+++ b/src/commands/doctor-install.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  realpathSync: vi.fn((p: string) => p),
+  readFileSync: vi.fn().mockReturnValue("{}"),
+  readdirSync: vi.fn().mockReturnValue([]),
+  execSync: vi.fn().mockReturnValue(""),
+  note: vi.fn(),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal();
+  return {
+    ...actual,
+    default: {
+      ...(actual.default as Record<string, unknown>),
+      existsSync: mocks.existsSync,
+      realpathSync: mocks.realpathSync,
+      readFileSync: mocks.readFileSync,
+      readdirSync: mocks.readdirSync,
+    },
+    existsSync: mocks.existsSync,
+    realpathSync: mocks.realpathSync,
+    readFileSync: mocks.readFileSync,
+    readdirSync: mocks.readdirSync,
+  };
+});
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual: Record<string, unknown> = await importOriginal();
+  return {
+    ...actual,
+    execSync: mocks.execSync,
+  };
+});
+
+vi.mock("../terminal/note.js", () => ({
+  note: mocks.note,
+}));
+
+import { detectDuplicateInstallations } from "./doctor-install.js";
+
+describe("detectDuplicateInstallations", () => {
+  const savedEnv = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.existsSync.mockReturnValue(false);
+    mocks.realpathSync.mockImplementation((p: string) => p);
+    mocks.readFileSync.mockReturnValue("{}");
+    mocks.readdirSync.mockReturnValue([]);
+    mocks.execSync.mockReturnValue("");
+    process.env = { ...savedEnv, HOME: "/home/testuser" };
+  });
+
+  it("emits nothing when no installations are found", () => {
+    detectDuplicateInstallations();
+    expect(mocks.note).not.toHaveBeenCalled();
+  });
+
+  it("emits nothing when only one installation exists", () => {
+    mocks.existsSync.mockImplementation((p: string) => p === "/usr/bin/openclaw");
+    mocks.realpathSync.mockReturnValue("/usr/bin/openclaw");
+
+    detectDuplicateInstallations();
+
+    expect(mocks.note).not.toHaveBeenCalledWith(
+      expect.stringContaining("Duplicate"),
+      expect.anything(),
+    );
+  });
+
+  it("emits nothing when two paths resolve to the same realpath", () => {
+    mocks.existsSync.mockImplementation(
+      (p: string) => p === "/usr/bin/openclaw" || p === "/usr/local/bin/openclaw",
+    );
+    // Both symlink to same physical file
+    mocks.realpathSync.mockReturnValue("/opt/openclaw/bin/openclaw");
+
+    detectDuplicateInstallations();
+
+    expect(mocks.note).not.toHaveBeenCalledWith(
+      expect.stringContaining("Duplicate"),
+      expect.anything(),
+    );
+  });
+
+  it("detects duplicate installations at different realpaths", () => {
+    mocks.existsSync.mockImplementation(
+      (p: string) => p === "/usr/bin/openclaw" || p === "/home/testuser/.npm-global/bin/openclaw",
+    );
+    mocks.realpathSync.mockImplementation((p: string) => p);
+
+    detectDuplicateInstallations();
+
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("Found 2 openclaw installations"),
+      "Duplicate installations",
+    );
+  });
+
+  it("includes version info from package.json", () => {
+    mocks.existsSync.mockImplementation((p: string) => {
+      if (p === "/usr/bin/openclaw") {
+        return true;
+      }
+      if (p === "/usr/local/bin/openclaw") {
+        return true;
+      }
+      if (p.endsWith("package.json")) {
+        return true;
+      }
+      return false;
+    });
+    mocks.realpathSync.mockImplementation((p: string) => p);
+    mocks.readFileSync.mockImplementation((p: string) => {
+      if (p.includes("/usr/bin/")) {
+        return JSON.stringify({ version: "2026.2.25" });
+      }
+      return JSON.stringify({ version: "2026.3.2" });
+    });
+
+    detectDuplicateInstallations();
+
+    const call = mocks.note.mock.calls.find((c: unknown[]) => c[1] === "Duplicate installations");
+    expect(call).toBeDefined();
+    expect(call![0]).toContain("v2026.2.25");
+    expect(call![0]).toContain("v2026.3.2");
+  });
+
+  it("includes remediation steps", () => {
+    mocks.existsSync.mockImplementation(
+      (p: string) => p === "/usr/bin/openclaw" || p === "/usr/local/bin/openclaw",
+    );
+    mocks.realpathSync.mockImplementation((p: string) => p);
+
+    detectDuplicateInstallations();
+
+    const call = mocks.note.mock.calls.find((c: unknown[]) => c[1] === "Duplicate installations");
+    expect(call).toBeDefined();
+    expect(call![0]).toContain("sudo npm uninstall -g openclaw");
+    expect(call![0]).toContain("which openclaw");
+  });
+
+  it("reports duplicate systemd services when found", () => {
+    mocks.existsSync.mockImplementation((p: string) => {
+      if (p === "/usr/bin/openclaw") {
+        return true;
+      }
+      if (p === "/usr/local/bin/openclaw") {
+        return true;
+      }
+      if (p === "/etc/systemd/system") {
+        return true;
+      }
+      if (p === "/home/testuser/.config/systemd/user") {
+        return true;
+      }
+      return false;
+    });
+    mocks.realpathSync.mockImplementation((p: string) => p);
+    mocks.readdirSync.mockImplementation((dir: string) => {
+      if (dir === "/etc/systemd/system") {
+        return ["openclaw.service"];
+      }
+      if (dir === "/home/testuser/.config/systemd/user") {
+        return ["openclaw-gateway.service"];
+      }
+      return [];
+    });
+
+    detectDuplicateInstallations();
+
+    const call = mocks.note.mock.calls.find((c: unknown[]) => c[1] === "Duplicate installations");
+    expect(call).toBeDefined();
+    expect(call![0]).toContain("openclaw.service");
+    expect(call![0]).toContain("openclaw-gateway.service");
+    expect(call![0]).toContain("2 OpenClaw-related systemd services");
+  });
+});

--- a/src/commands/doctor-install.ts
+++ b/src/commands/doctor-install.ts
@@ -1,3 +1,4 @@
+import { execSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { note } from "../terminal/note.js";
@@ -37,4 +38,189 @@ export function noteSourceInstallIssues(root: string | null) {
   if (warnings.length > 0) {
     note(warnings.join("\n"), "Install");
   }
+}
+
+/**
+ * Scan well-known locations for multiple openclaw binaries.
+ * If two or more *distinct* installations exist (different realpath),
+ * emit a doctor note listing each location + version and remediation steps.
+ *
+ * Binary-level scan always runs. Systemd service scan is lightweight
+ * (only reads directory listings) so it also runs unconditionally.
+ */
+export function detectDuplicateInstallations(): void {
+  // Map<realPath, displayPath> — dedup by resolved path, display the user-facing one
+  const seen = new Map<string, string>();
+
+  const candidatePaths = buildCandidatePaths();
+
+  for (const p of candidatePaths) {
+    try {
+      if (!fs.existsSync(p)) {
+        continue;
+      }
+      const real = fs.realpathSync(p);
+      if (!seen.has(real)) {
+        seen.set(real, p);
+      }
+    } catch {
+      // realpath failed (broken symlink, permission denied) — skip
+    }
+  }
+
+  if (seen.size < 2) {
+    return;
+  }
+
+  // Collect version info for each distinct installation
+  const entries = [...seen.entries()].map(([real, display]) => ({
+    path: display,
+    version: resolveVersion(real, display),
+  }));
+
+  // Scan for duplicate systemd services
+  const services = scanSystemdServices();
+
+  // Build the note
+  const lines: string[] = [
+    `Found ${entries.length} openclaw installations:`,
+    ...entries.map((e) => (e.version ? `- ${e.path} (v${e.version})` : `- ${e.path}`)),
+    "",
+    "Multiple installations can cause:",
+    "- Gateway port conflicts and infinite restart loops",
+    "- Confusing `which openclaw` output",
+    "- Version mixing between installations",
+  ];
+
+  if (services.length > 1) {
+    lines.push(
+      "",
+      `Also found ${services.length} OpenClaw-related systemd services:`,
+      ...services.map((s) => `  - ${s}`),
+    );
+  }
+
+  lines.push(
+    "",
+    "Recommendation: Keep one installation and remove the others.",
+    "For npm global installs:",
+    "  Remove system-level: sudo npm uninstall -g openclaw",
+    "  Remove user-level:   npm uninstall -g openclaw",
+    "",
+    "After removal, verify with: which openclaw && openclaw --version",
+  );
+
+  note(lines.join("\n"), "Duplicate installations");
+}
+
+function buildCandidatePaths(): string[] {
+  const home = process.env.HOME || "";
+  const paths: string[] = [
+    "/usr/bin/openclaw",
+    "/usr/local/bin/openclaw",
+    "/bin/openclaw",
+    "/opt/bin/openclaw",
+  ];
+
+  // npm global root (system-level)
+  try {
+    const npmRoot = execSync("npm root -g", {
+      encoding: "utf8",
+      timeout: 5000,
+    }).trim();
+    if (npmRoot) {
+      paths.push(path.join(npmRoot, "..", "bin", "openclaw"));
+    }
+  } catch {
+    // npm not available
+  }
+
+  // User-level npm global (PREFIX=~/.npm-global convention)
+  if (home) {
+    paths.push(path.join(home, ".npm-global", "bin", "openclaw"));
+    // volta
+    paths.push(path.join(home, ".volta", "bin", "openclaw"));
+    // fnm
+    paths.push(
+      path.join(
+        home,
+        ".local",
+        "share",
+        "fnm",
+        "node-versions",
+        "default",
+        "installation",
+        "bin",
+        "openclaw",
+      ),
+    );
+  }
+
+  // nvm current
+  if (process.env.NVM_DIR) {
+    paths.push(path.join(process.env.NVM_DIR, "current", "bin", "openclaw"));
+  }
+
+  return paths;
+}
+
+function resolveVersion(realPath: string, displayPath: string): string | undefined {
+  // Prefer package.json near the module root
+  // Typical layout: <prefix>/lib/node_modules/openclaw/bin/openclaw → package.json is ../../package.json from the binary
+  for (const rel of [
+    path.join(realPath, "..", "package.json"),
+    path.join(realPath, "..", "..", "package.json"),
+  ]) {
+    try {
+      if (fs.existsSync(rel)) {
+        const pkg = JSON.parse(fs.readFileSync(rel, "utf8"));
+        if (typeof pkg.version === "string") {
+          return pkg.version;
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  // Fallback: run the binary
+  try {
+    const out = execSync(`"${displayPath}" --version 2>/dev/null`, {
+      encoding: "utf8",
+      timeout: 5000,
+    });
+    const first = out.trim().split("\n")[0];
+    if (first) {
+      return first;
+    }
+  } catch {
+    // ignore
+  }
+
+  return undefined;
+}
+
+function scanSystemdServices(): string[] {
+  const home = process.env.HOME || "";
+  const dirs = [
+    "/etc/systemd/system",
+    home ? path.join(home, ".config", "systemd", "user") : "",
+  ].filter(Boolean);
+
+  const found: string[] = [];
+  for (const dir of dirs) {
+    try {
+      if (!fs.existsSync(dir)) {
+        continue;
+      }
+      for (const file of fs.readdirSync(dir)) {
+        if (file.includes("openclaw") && file.endsWith(".service")) {
+          found.push(`${file} (${dir})`);
+        }
+      }
+    } catch {
+      // permission denied
+    }
+  }
+  return found;
 }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,5 +1,7 @@
-import fs from "node:fs";
 import { intro as clackIntro, outro as clackOutro } from "@clack/prompts";
+import fs from "node:fs";
+import type { OpenClawConfig } from "../config/config.js";
+import type { RuntimeEnv } from "../runtime.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
@@ -9,14 +11,12 @@ import {
   resolveHooksGmailModel,
 } from "../agents/model-selection.js";
 import { formatCliCommand } from "../cli/command-format.js";
-import type { OpenClawConfig } from "../config/config.js";
 import { CONFIG_PATH, readConfigFileSnapshot, writeConfigFile } from "../config/config.js";
 import { logConfigUpdated } from "../config/logging.js";
 import { resolveGatewayService } from "../daemon/service.js";
 import { resolveGatewayAuth } from "../gateway/auth.js";
 import { buildGatewayConnectionDetails } from "../gateway/call.js";
 import { resolveOpenClawPackageRoot } from "../infra/openclaw-root.js";
-import type { RuntimeEnv } from "../runtime.js";
 import { defaultRuntime } from "../runtime.js";
 import { note } from "../terminal/note.js";
 import { stylePromptTitle } from "../terminal/prompt-style.js";
@@ -35,7 +35,7 @@ import {
   maybeRepairGatewayServiceConfig,
   maybeScanExtraGatewayServices,
 } from "./doctor-gateway-services.js";
-import { noteSourceInstallIssues } from "./doctor-install.js";
+import { detectDuplicateInstallations, noteSourceInstallIssues } from "./doctor-install.js";
 import { noteMemorySearchHealth } from "./doctor-memory-search.js";
 import {
   noteMacLaunchAgentOverrides,
@@ -94,6 +94,7 @@ export async function doctorCommand(
 
   await maybeRepairUiProtocolFreshness(runtime, prompter);
   noteSourceInstallIssues(root);
+  detectDuplicateInstallations();
   noteDeprecatedLegacyEnvVars();
   noteStartupOptimizationHints();
 
@@ -303,7 +304,10 @@ export async function doctorCommand(
   const shouldWriteConfig =
     configResult.shouldWriteConfig || JSON.stringify(cfg) !== JSON.stringify(cfgForPersistence);
   if (shouldWriteConfig) {
-    cfg = applyWizardMetadata(cfg, { command: "doctor", mode: resolveMode(cfg) });
+    cfg = applyWizardMetadata(cfg, {
+      command: "doctor",
+      mode: resolveMode(cfg),
+    });
     await writeConfigFile(cfg);
     logConfigUpdated(runtime);
     const backupPath = `${CONFIG_PATH}.bak`;


### PR DESCRIPTION
## Summary

Adds `detectDuplicateInstallations()` to `openclaw doctor` to catch the class of issues described in #35129, where two openclaw installations (e.g. system-level `sudo npm install -g` and user-level `~/.npm-global`) fight over port 18789 in an infinite restart loop.

## What it does

1. **Scans well-known locations** for openclaw binaries — `/usr/bin`, `/usr/local/bin`, npm global (`npm root -g`), user-level `~/.npm-global`, volta, nvm, fnm
2. **Deduplicates by realpath** so symlinks to the same physical binary don't false-positive
3. **Resolves versions** from nearby `package.json` (preferred) or `--version` fallback
4. **Scans for multiple systemd services** referencing openclaw in both `/etc/systemd/system/` and `~/.config/systemd/user/`
5. **Emits a clear note** with each location + version and remediation steps

## Example output

```
╭ Duplicate installations
│ Found 2 openclaw installations:
│ - /home/user/.npm-global/bin/openclaw (v2026.3.2)
│ - /usr/bin/openclaw (v2026.2.25)
│
│ Multiple installations can cause:
│ - Gateway port conflicts and infinite restart loops
│ - Confusing \`which openclaw\` output
│ - Version mixing between installations
│
│ Also found 2 OpenClaw-related systemd services:
│   - openclaw.service (/etc/systemd/system)
│   - openclaw-gateway.service (~/.config/systemd/user)
│
│ Recommendation: Keep one installation and remove the others.
│ For npm global installs:
│   Remove system-level: sudo npm uninstall -g openclaw
│   Remove user-level:   npm uninstall -g openclaw
│
│ After removal, verify with: which openclaw && openclaw --version
╰
```

## Tests

7 new tests covering:
- No installations → no note
- Single installation → no note
- Two paths with same realpath (symlinks) → no note
- Two distinct installations → detects and reports
- Version info from package.json included
- Remediation steps included
- Duplicate systemd services reported

All existing tests pass unchanged.

Closes #35129