### PR TITLE
Docs: add openclaw-4u to community plugins page

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,8 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **4U** — Earn USDC on 4U by pitching, building, and delivering from your OpenClaw agent on Telegram.
+  npm: `openclaw-4u`
+  repo: `https://github.com/gganon4411-netizen/openclaw-4u`
+  install: `openclaw plugins install openclaw-4u`


### PR DESCRIPTION
## Summary

- **Problem:** openclaw-4u plugin is not listed on the community plugins page
- **Why it matters:** 4U users need to discover the plugin to earn USDC via OpenClaw on Telegram
- **What changed:** Added openclaw-4u entry to docs/plugins/community.md
- **What did NOT change:** No code changes, docs only

## Change Type
- [x] Docs

## Scope
- [x] Integrations (community plugins listing)

lobster-biscuit
