### PR TITLE
skill-creator: reject empty name and description in quick_validate

### DIFF
--- a/skills/skill-creator/scripts/quick_validate.py
+++ b/skills/skill-creator/scripts/quick_validate.py
@@ -111,10 +111,12 @@ def validate_skill(skill_path):
     if "description" not in frontmatter:
         return False, "Missing 'description' in frontmatter"
 
-    name = frontmatter.get("name", "")
+    name = frontmatter.get("name", "") or ""
     if not isinstance(name, str):
         return False, f"Name must be a string, got {type(name).__name__}"
     name = name.strip()
+    if not name:
+        return False, "Name cannot be empty"
     if name:
         if not re.match(r"^[a-z0-9-]+$", name):
             return (
@@ -133,10 +135,12 @@ def validate_skill(skill_path):
                 f"Maximum is {MAX_SKILL_NAME_LENGTH} characters.",
             )
 
-    description = frontmatter.get("description", "")
+    description = frontmatter.get("description", "") or ""
     if not isinstance(description, str):
         return False, f"Description must be a string, got {type(description).__name__}"
     description = description.strip()
+    if not description:
+        return False, "Description cannot be empty"
     if description:
         if "<" in description or ">" in description:
             return False, "Description cannot contain angle brackets (< or >)"


### PR DESCRIPTION
Fixes #35110

## Summary

`quick_validate.py` now rejects skills with empty `name` or `description` in SKILL.md frontmatter, returning a clear error and exit code 1 instead of incorrectly reporting "Skill is valid!".

## Problem

- The validator only checked that the `name` and `description` keys **exist** in frontmatter, not that they have non-empty values.
- Validation logic was wrapped in `if name:` / `if description:`, so when `name` or `description` was an empty string (or YAML `name:`/`description:` parsed as `None`), the checks were skipped and the script returned "Skill is valid!" with exit code 0.
- This allowed broken skills to be packaged and installed without warning, and can break install tooling downstream.

## Changes

1. **Empty name**
   - Use `frontmatter.get("name", "") or ""` so that YAML `name:` (parsed as `None`) is treated as empty.
   - After `name = name.strip()`, add: if the value is empty, return `False, "Name cannot be empty"`.

2. **Empty description**
   - Same for description: `frontmatter.get("description", "") or ""` and, after strip, return `False, "Description cannot be empty"` when empty.

No other behavior is changed; format and length rules for non-empty name/description are unchanged.

## Testing

- **Empty name (YAML `name:`):** Run validator on a skill with `name:` and valid `description` → prints "Name cannot be empty", exit code 1.
- **Empty description (YAML `description:`):** Run validator on a skill with valid `name` and `description:` → prints "Description cannot be empty", exit code 1.
- **Valid skill:** Run validator on `skills/skill-creator` → prints "Skill is valid!", exit code 0.

Manual repro (empty name):

```bash
mkdir -p /tmp/empty-skill
cat > /tmp/empty-skill/SKILL.md << 'EOF'
---
name:
description: A test skill
---
# Skill body
EOF
python3 skills/skill-creator/scripts/quick_validate.py /tmp/empty-skill
# Expected: "Name cannot be empty", exit 1
```
