### PR TITLE
fix: Treat HTTP 500 from Codex as retryable to trigger model fallback (#35119)

### DIFF
--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -168,7 +168,8 @@ export function resolveFailoverReasonFromError(err: unknown): FailoverReason | n
   if (status === 408) {
     return "timeout";
   }
-  if (status === 502 || status === 503 || status === 504) {
+  // Treat 5xx server errors as transient to trigger failover/retry
+  if (status === 500 || status === 502 || status === 503 || status === 504) {
     return "timeout";
   }
   if (status === 529) {


### PR DESCRIPTION
## Summary

- Problem: HTTP 500 from OpenAI Codex does not trigger the model fallback chain, leaving users stuck when Codex returns server errors
- Why it matters: During OpenAI outages, agents with Codex as primary model become unresponsive even when fallback models are configured
- What changed: Added HTTP 500 to the list of timeout-eligible status codes in `resolveFailoverReasonFromError()`
- What did NOT change: No changes to other status code handling or fallback logic

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #35119

## User-visible / Behavior Changes

Agents configured with `openai-codex/gpt-5.3-codex` as primary model will now automatically fall back to alternative models (e.g., Sonnet, Gemini) when Codex returns HTTP 500 errors, instead of surfacing the raw error to users.

**Note:** While this fix was motivated by Codex issues, it applies globally to all providers (any provider returning HTTP 500 will now trigger fallback).

## Security Impact

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)

## Repro + Verification

### Environment

- OS: Any
- Model/provider: openai-codex/gpt-5.3-codex with fallback chain configured

### Steps

1. Configure an agent with Codex as primary and another model as fallback
2. Encounter (or simulate) an OpenAI 500 response
3. Observe fallback behavior

### Expected

Fallback to configured alternative model should occur automatically.

### Actual (before fix)

Raw error posted to Discord, no fallback attempted.

## Evidence

- [x] Code review: Single line change adding `status === 500` to existing timeout check
- [x] Added comment explaining 5xx transient error semantics

## Human Verification

- Verified scenarios: Code path analysis confirms HTTP 500 will now return "timeout" reason
- Edge cases checked: HTTP 500 is treated same as 502/503/504 - all transient server errors
- What you did **not** verify: Live testing against actual OpenAI 500 responses

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)

## Failure Recovery

- How to disable/revert: Revert the single line change in `src/agents/failover-error.ts`
- Known bad symptoms: N/A - change is minimal and follows existing pattern

## Risks and Mitigations

None. The change aligns HTTP 500 handling with other transient server errors (502/503/504) and is consistent with the intended behavior described in the issue.

---

**CI Note:** The security audit failures (`GHSA-qffq-2rhf-9h96`) are pre-existing vulnerabilities in the upstream main branch, not introduced by this PR.