### PR TITLE
UI: persist agent model edits when config view is in raw mode

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -66,7 +66,11 @@ import {
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "./external-link.ts";
 import { icons } from "./icons.ts";
 import { normalizeBasePath, TAB_GROUPS, subtitleForTab, titleForTab } from "./navigation.ts";
-import { resolveConfiguredCronModelSuggestions, sortLocaleStrings } from "./views/agents-utils.ts";
+import {
+  findAgentConfigIndex,
+  resolveConfiguredCronModelSuggestions,
+  sortLocaleStrings,
+} from "./views/agents-utils.ts";
 import { renderAgents } from "./views/agents.ts";
 import { renderChannels } from "./views/channels.ts";
 import { renderChat } from "./views/chat.ts";
@@ -816,13 +820,7 @@ export function renderApp(state: AppViewState) {
                   if (!Array.isArray(list)) {
                     return;
                   }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
+                  const index = findAgentConfigIndex(list, agentId);
                   if (index < 0) {
                     return;
                   }
@@ -852,13 +850,7 @@ export function renderApp(state: AppViewState) {
                   if (!Array.isArray(list)) {
                     return;
                   }
-                  const index = list.findIndex(
-                    (entry) =>
-                      entry &&
-                      typeof entry === "object" &&
-                      "id" in entry &&
-                      (entry as { id?: string }).id === agentId,
-                  );
+                  const index = findAgentConfigIndex(list, agentId);
                   if (index < 0) {
                     return;
                   }

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -212,6 +212,55 @@ describe("applyConfig", () => {
 });
 
 describe("saveConfig", () => {
+  it("uses form payload in raw mode when raw text is unchanged but form is dirty", async () => {
+    const request = createRequestWithConfigGet();
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.configFormMode = "raw";
+    state.configFormDirty = true;
+    state.configRawOriginal = "{\n}\n";
+    state.configRaw = "{\n}\n";
+    state.configForm = {
+      agents: {
+        list: [{ id: "momo", model: "openai-codex/gpt-5.3-codex" }],
+      },
+    };
+    state.configSnapshot = { hash: "hash-save-raw-form" };
+
+    await saveConfig(state);
+
+    expect(request.mock.calls[0]?.[0]).toBe("config.set");
+    const params = request.mock.calls[0]?.[1] as { raw: string; baseHash: string };
+    const parsed = JSON.parse(params.raw) as {
+      agents: { list: Array<{ id: string; model: string }> };
+    };
+    expect(parsed.agents.list[0]?.model).toBe("openai-codex/gpt-5.3-codex");
+    expect(params.baseHash).toBe("hash-save-raw-form");
+  });
+
+  it("keeps raw payload in raw mode when raw text changed", async () => {
+    const request = createRequestWithConfigGet();
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.configFormMode = "raw";
+    state.configFormDirty = true;
+    state.configRawOriginal = "{\n}\n";
+    state.configRaw = '{\n  "gateway": { "mode": "local" }\n}\n';
+    state.configForm = {
+      gateway: { mode: "remote" },
+    };
+    state.configSnapshot = { hash: "hash-save-raw-raw" };
+
+    await saveConfig(state);
+
+    expect(request.mock.calls[0]?.[0]).toBe("config.set");
+    const params = request.mock.calls[0]?.[1] as { raw: string; baseHash: string };
+    expect(params.raw).toBe('{\n  "gateway": { "mode": "local" }\n}\n');
+    expect(params.baseHash).toBe("hash-save-raw-raw");
+  });
+
   it("coerces schema-typed values before config.set in form mode", async () => {
     const request = createRequestWithConfigGet();
     const state = createState();

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -117,8 +117,18 @@ function asJsonSchema(value: unknown): JsonSchema | null {
  * gateway's Zod validation always sees correctly typed values.
  */
 function serializeFormForSubmit(state: ConfigState): string {
-  if (state.configFormMode !== "form" || !state.configForm) {
+  if (!state.configForm) {
     return state.configRaw;
+  }
+
+  if (state.configFormMode === "raw") {
+    // Other UI panels (Agents/Channels/Nodes) edit `configForm` directly even when
+    // the Config view is in raw mode. If raw text is untouched, prefer form data
+    // so those edits are persisted by Save/Apply.
+    const rawUnchanged = state.configRaw === state.configRawOriginal;
+    if (!state.configFormDirty || !rawUnchanged) {
+      return state.configRaw;
+    }
   }
   const schema = asJsonSchema(state.configSchema);
   const form = schema

--- a/ui/src/ui/views/agents-utils.test.ts
+++ b/ui/src/ui/views/agents-utils.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  findAgentConfigIndex,
+  normalizeAgentIdForUi,
   resolveConfiguredCronModelSuggestions,
   resolveEffectiveModelFallbacks,
   sortLocaleStrings,
@@ -96,5 +98,24 @@ describe("sortLocaleStrings", () => {
 
   it("accepts any iterable input, including sets", () => {
     expect(sortLocaleStrings(new Set(["beta", "alpha"]))).toEqual(["alpha", "beta"]);
+  });
+});
+
+describe("agent id normalization", () => {
+  it("normalizes ids with casing and separators", () => {
+    expect(normalizeAgentIdForUi(" Main Agent ")).toBe("main-agent");
+    expect(normalizeAgentIdForUi("MAIN")).toBe("main");
+  });
+
+  it("matches config entries by normalized id", () => {
+    const list = [
+      { id: "Main Agent", model: "zai/glm-4.7" },
+      { id: "atlas", model: "openai-codex/gpt-5.3-codex" },
+    ];
+
+    expect(findAgentConfigIndex(list, "main-agent")).toBe(0);
+    expect(findAgentConfigIndex(list, "MAIN AGENT")).toBe(0);
+    expect(findAgentConfigIndex(list, "atlas")).toBe(1);
+    expect(findAgentConfigIndex(list, "unknown")).toBe(-1);
   });
 });

--- a/ui/src/ui/views/agents-utils.ts
+++ b/ui/src/ui/views/agents-utils.ts
@@ -47,6 +47,36 @@ type ConfigSnapshot = {
   };
 };
 
+const AGENT_ID_INVALID_CHARS_RE = /[^a-z0-9_-]+/g;
+const AGENT_ID_LEADING_DASH_RE = /^-+/;
+const AGENT_ID_TRAILING_DASH_RE = /-+$/;
+
+export function normalizeAgentIdForUi(value: string | undefined | null): string {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) {
+    return "main";
+  }
+  return (
+    trimmed
+      .toLowerCase()
+      .replace(AGENT_ID_INVALID_CHARS_RE, "-")
+      .replace(AGENT_ID_LEADING_DASH_RE, "")
+      .replace(AGENT_ID_TRAILING_DASH_RE, "")
+      .slice(0, 64) || "main"
+  );
+}
+
+export function findAgentConfigIndex(list: unknown[], agentId: string): number {
+  const targetId = normalizeAgentIdForUi(agentId);
+  return list.findIndex((entry) => {
+    if (!entry || typeof entry !== "object" || !("id" in entry)) {
+      return false;
+    }
+    const id = (entry as { id?: unknown }).id;
+    return normalizeAgentIdForUi(typeof id === "string" ? id : "") === targetId;
+  });
+}
+
 export function normalizeAgentLabel(agent: {
   id: string;
   name?: string;
@@ -126,7 +156,9 @@ export function formatBytes(bytes?: number) {
 export function resolveAgentConfig(config: Record<string, unknown> | null, agentId: string) {
   const cfg = config as ConfigSnapshot | null;
   const list = cfg?.agents?.list ?? [];
-  const entry = list.find((agent) => agent?.id === agentId);
+  const entry = list.find(
+    (agent) => normalizeAgentIdForUi(agent?.id) === normalizeAgentIdForUi(agentId),
+  );
   return {
     entry,
     defaults: cfg?.agents?.defaults,


### PR DESCRIPTION
## Summary
- fix config save serialization to persist form-driven edits even when Config view is currently in `raw` mode
- apply this specifically when raw text is unchanged, so edits made from Agents/Channels/Nodes panels are not dropped
- keep existing raw behavior when raw text has been edited

## Root Cause
When `configFormMode === "raw"`, save/apply always submitted `configRaw`.
Agents model selection edits update `configForm` directly. If the user saved from Agents while Config stayed in raw mode and raw text was untouched, the updated form state was ignored and old raw was written.

## Changes
- `ui/src/ui/controllers/config.ts`
  - `serializeFormForSubmit` now:
    - returns form payload in raw mode only when `configFormDirty` is true and `configRaw === configRawOriginal`
    - continues returning raw payload when raw text changed
- `ui/src/ui/controllers/config.test.ts`
  - add regression test for raw mode + unchanged raw + dirty form -> save uses form payload
  - add guard test for raw mode + changed raw -> save keeps raw payload

## Validation
- `cd ui && pnpm vitest --config vitest.config.ts src/ui/controllers/config.test.ts`
