### PR TITLE
fix(auth-profiles): sync runtime snapshot and rotate profiles on /new

### DIFF
--- a/changelog/fragments/pr-auth-profile-rotation-snapshot-sync.md
+++ b/changelog/fragments/pr-auth-profile-rotation-snapshot-sync.md
@@ -1,0 +1,1 @@
+- Auth/profile rotation: sync runtime auth store snapshot after disk writes so auth profile round-robin actually rotates in gateway mode instead of always picking the same profile. (#32444)

--- a/src/agents/auth-profiles/store.test.ts
+++ b/src/agents/auth-profiles/store.test.ts
@@ -1,0 +1,58 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { withStateDirEnv } from "../../test-helpers/state-dir-env.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  ensureAuthProfileStore,
+  replaceRuntimeAuthProfileStoreSnapshots,
+  updateAuthProfileStoreWithLock,
+} from "./store.js";
+import type { AuthProfileStore } from "./types.js";
+
+async function writeAuthStore(agentDir: string, store: AuthProfileStore) {
+  const authPath = path.join(agentDir, "auth-profiles.json");
+  await fs.writeFile(authPath, JSON.stringify(store), "utf-8");
+}
+
+describe("updateAuthProfileStoreWithLock", () => {
+  afterEach(() => clearRuntimeAuthProfileStoreSnapshots());
+
+  it("syncs updated usageStats back to runtime snapshot", async () => {
+    await withStateDirEnv("openclaw-store-sync-", async ({ stateDir }) => {
+      const agentDir = path.join(stateDir, "agent");
+      await fs.mkdir(agentDir, { recursive: true });
+
+      const initial: AuthProfileStore = {
+        version: 1,
+        profiles: {
+          "google:key-1": { type: "api_key", provider: "google", key: "sk-1" },
+          "google:key-2": { type: "api_key", provider: "google", key: "sk-2" },
+        },
+      };
+      await writeAuthStore(agentDir, initial);
+
+      // Populate runtime snapshot (simulates gateway startup)
+      replaceRuntimeAuthProfileStoreSnapshots([{ agentDir, store: initial }]);
+
+      // Verify snapshot has no usageStats initially
+      const before = ensureAuthProfileStore(agentDir);
+      expect(before.usageStats?.["google:key-1"]?.lastUsed).toBeUndefined();
+
+      // Update via lock (simulates markAuthProfileUsed after run completion)
+      await updateAuthProfileStoreWithLock({
+        agentDir,
+        updater: (store) => {
+          store.usageStats = store.usageStats ?? {};
+          store.usageStats["google:key-1"] = { lastUsed: 1000 };
+          return true;
+        },
+      });
+
+      // Subsequent snapshot read should see the updated lastUsed
+      const after = ensureAuthProfileStore(agentDir);
+      expect(after.usageStats?.["google:key-1"]?.lastUsed).toBe(1000);
+      expect(after.usageStats?.["google:key-2"]).toBeUndefined();
+    });
+  });
+});

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -140,6 +140,12 @@ export async function updateAuthProfileStoreWithLock(params: {
       const shouldSave = params.updater(store);
       if (shouldSave) {
         saveAuthProfileStore(store, params.agentDir);
+        // Keep runtime snapshot in sync so subsequent in-memory reads
+        // (e.g. orderProfilesByMode round-robin) see updated usageStats.
+        const snapshotKey = resolveRuntimeStoreKey(params.agentDir);
+        if (runtimeAuthStoreSnapshots.has(snapshotKey)) {
+          runtimeAuthStoreSnapshots.set(snapshotKey, cloneAuthProfileStore(store));
+        }
       }
       return store;
     });


### PR DESCRIPTION
## Summary

- **Problem:** Auth profile round-robin never rotates in gateway mode — every new session picks the same profile.
- **Root cause:** `updateAuthProfileStoreWithLock` writes `usageStats` (including `lastUsed`) to disk but never syncs back to `runtimeAuthStoreSnapshots`. In gateway mode, `ensureAuthProfileStore` always returns a startup-frozen snapshot clone, so `orderProfilesByMode`'s `lastUsed` sort is permanently stale.
- **Fix:** After disk write, sync the updated store back to the runtime snapshot (6 lines in `store.ts`). All subsequent in-memory reads now see current `usageStats`, and the existing `lastUsed`-based round-robin in `orderProfilesByMode` works as designed.
- **What did NOT change:** No new functions, no new behavior. The existing `markAuthProfileUsed` (called after run completion) and `orderProfilesByMode` (sorts by `lastUsed` ascending) already implement correct round-robin — they just couldn't see each other's updates through the stale snapshot.

### Why this PR exists alongside #32455 and #32822

Both PRs attempt to fix the symptom (selection logic in `session-override.ts`) but miss the root cause (stale runtime snapshot in `store.ts`). Their tests pass only because test environments don't populate `runtimeAuthStoreSnapshots` — they fall through to disk reads. In production gateway mode, neither fix works. This 6-line fix makes the existing rotation logic work correctly and is also a prerequisite for either PR to function in production.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Auth / tokens

## Linked Issue/PR

- Closes #32444
- Related #32455, #32822

## User-visible / Behavior Changes

Auth profiles now rotate correctly on `/new` in gateway mode. No config changes required.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (Docker)
- Runtime/container: Node 22.22.0
- Model/provider: Google (3 API key profiles across separate GCP projects), Ollama (2 profiles)

### Steps

1. Configure multiple auth profiles for the same provider
2. Start gateway
3. Send `/new` multiple times (with normal intervals between)
4. Check `cache-trace.jsonl` for API key values

### Expected

Different API keys used across sessions (round-robin).

### Actual (before)

Same key every time.

### Actual (after)

Keys rotate: confirmed via cache-trace with 3 Google keys and 2 Ollama keys.

## Evidence

- [x] Trace/log snippets

Production verification on Docker gateway: 3 Google keys (`...yFk8eWUA`, `...iKcIypN0`, `...ZZ9qgJJw`) and 2 Ollama keys (`...aVDaYp9o`, `...mDXuCDtu`) confirmed rotating via `cache-trace.jsonl`.

## Human Verification (required)

- Verified scenarios: `/new` with 3 Google profiles, subagent spawn with 2 Ollama profiles
- Edge cases checked: single-profile provider (no-op), cooldown profiles (sorted to end by existing logic)
- What you did **not** verify: OAuth/token profile types (only tested api_key)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Remove the 6 added lines in `store.ts` (snapshot sync block)
- Files/config to restore: `src/agents/auth-profiles/store.ts`
- Known bad symptoms: auth profile stuck on same key every session

## Risks and Mitigations

- Risk: Extra `structuredClone` + `Map.set` on every store write.
  - Mitigation: Only runs when snapshot exists (gateway mode) and after file lock + disk write — negligible overhead.


## AI Disclosure

- [x] AI-assisted (Copilot CLI, Claude Opus 4.6)
- Degree of testing: **Fully tested** — unit test added (`store.test.ts`), verified in production Docker gateway with 5 auth profiles (3 Google, 2 Ollama) rotating correctly via `cache-trace.jsonl`
- I understand the 6-line fix: it syncs `runtimeAuthStoreSnapshots` after disk write so that in-memory reads via `ensureAuthProfileStore` see current `usageStats`, unblocking the existing `lastUsed`-based round-robin in `orderProfilesByMode`
