### PR TITLE
fix: add rolldown as dev dependency for a2ui bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -402,6 +402,7 @@
     "oxfmt": "0.35.0",
     "oxlint": "^1.50.0",
     "oxlint-tsgolint": "^0.15.0",
+    "rolldown": "1.0.0-rc.5",
     "signal-utils": "0.21.1",
     "tsdown": "0.21.0-beta.2",
     "tsx": "^4.21.0",


### PR DESCRIPTION
## Problem
The a2ui bundle build uses rolldown but it was not listed as a dev dependency, causing build failures on fresh installs or during `openclaw update` preflight checks.

```
Error: Cannot find package 'rolldown' imported from ...
```

## Solution
Add rolldown to devDependencies in package.json.

## Testing
- Build completes successfully after adding the dependency
- Verified on ARM64 (Raspberry Pi) with pnpm build