### PR TITLE
Expose reply-to context in message hook events

### DIFF
--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -99,6 +99,51 @@ describe("message hook mappers", () => {
     });
   });
 
+  it("exposes reply-to context in canonical, plugin, and internal hook payloads", () => {
+    const canonical = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        ReplyToId: "reply-msg-99",
+        ReplyToBody: "original message text",
+        ReplyToSender: "OriginalUser",
+        ReplyToIsQuote: true,
+      }),
+    );
+
+    expect(canonical.replyToId).toBe("reply-msg-99");
+    expect(canonical.replyToBody).toBe("original message text");
+    expect(canonical.replyToSender).toBe("OriginalUser");
+    expect(canonical.replyToIsQuote).toBe(true);
+
+    const pluginEvent = toPluginMessageReceivedEvent(canonical);
+    expect(pluginEvent.metadata).toEqual(
+      expect.objectContaining({
+        replyToId: "reply-msg-99",
+        replyToBody: "original message text",
+        replyToSender: "OriginalUser",
+        replyToIsQuote: true,
+      }),
+    );
+
+    const internalCtx = toInternalMessageReceivedContext(canonical);
+    expect(internalCtx.metadata).toEqual(
+      expect.objectContaining({
+        replyToId: "reply-msg-99",
+        replyToBody: "original message text",
+        replyToSender: "OriginalUser",
+        replyToIsQuote: true,
+      }),
+    );
+  });
+
+  it("omits reply-to fields when message is not a reply", () => {
+    const canonical = deriveInboundMessageHookContext(makeInboundCtx());
+
+    expect(canonical.replyToId).toBeUndefined();
+    expect(canonical.replyToBody).toBeUndefined();
+    expect(canonical.replyToSender).toBeUndefined();
+    expect(canonical.replyToIsQuote).toBeUndefined();
+  });
+
   it("maps transcribed and preprocessed internal payloads", () => {
     const cfg = {} as OpenClawConfig;
     const canonical = deriveInboundMessageHookContext(makeInboundCtx({ Transcript: undefined }));

--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -135,6 +135,27 @@ describe("message hook mappers", () => {
     );
   });
 
+  it("prefers ReplyToIdFull over ReplyToId (matching messageId pattern)", () => {
+    const canonical = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        ReplyToIdFull: "full-reply-id-99",
+        ReplyToId: "short-reply-99",
+      }),
+    );
+
+    expect(canonical.replyToId).toBe("full-reply-id-99");
+  });
+
+  it("falls back to ReplyToId when ReplyToIdFull is absent", () => {
+    const canonical = deriveInboundMessageHookContext(
+      makeInboundCtx({
+        ReplyToId: "reply-msg-99",
+      }),
+    );
+
+    expect(canonical.replyToId).toBe("reply-msg-99");
+  });
+
   it("omits reply-to fields when message is not a reply", () => {
     const canonical = deriveInboundMessageHookContext(makeInboundCtx());
 

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -39,6 +39,10 @@ export type CanonicalInboundMessageHookContext = {
   channelName?: string;
   isGroup: boolean;
   groupId?: string;
+  replyToId?: string;
+  replyToBody?: string;
+  replyToSender?: string;
+  replyToIsQuote?: boolean;
 };
 
 export type CanonicalSentMessageHookContext = {
@@ -108,6 +112,10 @@ export function deriveInboundMessageHookContext(
     channelName: ctx.GroupChannel,
     isGroup,
     groupId: isGroup ? conversationId : undefined,
+    replyToId: ctx.ReplyToId,
+    replyToBody: ctx.ReplyToBody,
+    replyToSender: ctx.ReplyToSender,
+    replyToIsQuote: ctx.ReplyToIsQuote,
   };
 }
 
@@ -168,6 +176,10 @@ export function toPluginMessageReceivedEvent(
       senderE164: canonical.senderE164,
       guildId: canonical.guildId,
       channelName: canonical.channelName,
+      replyToId: canonical.replyToId,
+      replyToBody: canonical.replyToBody,
+      replyToSender: canonical.replyToSender,
+      replyToIsQuote: canonical.replyToIsQuote,
     },
   };
 }
@@ -205,6 +217,10 @@ export function toInternalMessageReceivedContext(
       senderE164: canonical.senderE164,
       guildId: canonical.guildId,
       channelName: canonical.channelName,
+      replyToId: canonical.replyToId,
+      replyToBody: canonical.replyToBody,
+      replyToSender: canonical.replyToSender,
+      replyToIsQuote: canonical.replyToIsQuote,
     },
   };
 }

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -112,7 +112,7 @@ export function deriveInboundMessageHookContext(
     channelName: ctx.GroupChannel,
     isGroup,
     groupId: isGroup ? conversationId : undefined,
-    replyToId: ctx.ReplyToId,
+    replyToId: ctx.ReplyToIdFull ?? ctx.ReplyToId,
     replyToBody: ctx.ReplyToBody,
     replyToSender: ctx.ReplyToSender,
     replyToIsQuote: ctx.ReplyToIsQuote,


### PR DESCRIPTION
Passes reply-to fields through the hook event pipeline so hooks can access reply context.