### PR TITLE
Feishu: fix streaming bootstrap text merge

### DIFF
--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -15,4 +15,26 @@ describe("mergeStreamingText", () => {
     expect(mergeStreamingText("hello wor", "ld")).toBe("hello world");
     expect(mergeStreamingText("line1", "line2")).toBe("line1line2");
   });
+
+  it("replaces bootstrap placeholders when first real content arrives", () => {
+    expect(mergeStreamingText("⏳ Thinking...", "hello")).toBe("hello");
+    expect(mergeStreamingText("⏳ 正在连接模型并等待首段输出…", "你好")).toBe("你好");
+  });
+
+  it("ignores bootstrap placeholder updates after real content is present", () => {
+    expect(mergeStreamingText("hello", "⏳ Thinking...")).toBe("hello");
+    expect(mergeStreamingText("你好", "⏳ 正在连接模型并等待首段输出…")).toBe("你好");
+  });
+
+  it("strips bootstrap placeholder prefixes from first real streaming chunk", () => {
+    expect(mergeStreamingText("⏳ Thinking...", "⏳ Thinking...Hey")).toBe("Hey");
+    expect(
+      mergeStreamingText("⏳ 正在连接模型并等待首段输出…", "⏳ 正在连接模型并等待首段输出…你好"),
+    ).toBe("你好");
+  });
+
+  it("does not duplicate the first token after placeholder bootstrap", () => {
+    const firstChunk = mergeStreamingText("⏳ Thinking...", "⏳ Thinking...Hey");
+    expect(mergeStreamingText(firstChunk, "Hey")).toBe("Hey");
+  });
 });

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -85,17 +85,38 @@ function truncateSummary(text: string, max = 50): string {
   return clean.length <= max ? clean : clean.slice(0, max - 3) + "...";
 }
 
+function isBootstrapPlaceholder(value: string): boolean {
+  const normalized = value.trim().replaceAll("…", "...");
+  // Placeholder can be configured per locale; treat both as transient scaffolding.
+  return normalized === "⏳ Thinking..." || normalized === "⏳ 正在连接模型并等待首段输出...";
+}
+
+function stripBootstrapPlaceholderPrefix(value: string): string {
+  const trimmed = value.trim();
+  return trimmed
+    .replace(/^⏳\s*Thinking(?:\.\.\.|…)\s*/u, "")
+    .replace(/^⏳\s*正在连接模型并等待首段输出(?:\.\.\.|…)\s*/u, "");
+}
+
 export function mergeStreamingText(
   previousText: string | undefined,
   nextText: string | undefined,
 ): string {
   const previous = typeof previousText === "string" ? previousText : "";
-  const next = typeof nextText === "string" ? nextText : "";
-  if (!next) {
+  const nextRaw = typeof nextText === "string" ? nextText : "";
+  const next = stripBootstrapPlaceholderPrefix(nextRaw);
+
+  if (!nextRaw || isBootstrapPlaceholder(nextRaw)) {
     return previous;
+  }
+  if (isBootstrapPlaceholder(previous)) {
+    return next;
   }
   if (!previous || next === previous || next.includes(previous)) {
     return next;
+  }
+  if (isBootstrapPlaceholder(next)) {
+    return previous;
   }
   if (previous.includes(next)) {
     return previous;


### PR DESCRIPTION
## Summary

- Problem: Feishu streaming card text merge could concatenate bootstrap placeholder text with the first real token, causing duplicate prefix artifacts like `...HeyHey`.
- Why it matters: Users see noisy/duplicated leading text in streamed replies, especially at the first chunk boundary.
- What changed: Hardened `mergeStreamingText` to detect/ignore bootstrap-only placeholders and strip placeholder prefixes when they leak into the first real chunk; added focused regression tests for English and Chinese placeholder paths.
- What did NOT change (scope boundary): No routing, transport, or non-Feishu channel behavior was changed.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Feishu streaming card first-chunk merge now removes bootstrap placeholder prefixes instead of appending them into visible answer text.
- Placeholder-only updates are ignored after real content exists.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A (unit tests)
- Integration/channel (if any): Feishu extension streaming card
- Relevant config (redacted): default

### Steps

1. Start a Feishu streaming card with bootstrap text (for example `⏳ Thinking...`).
2. Feed first stream chunk containing leaked bootstrap prefix plus first token (for example `⏳ Thinking...Hey`).
3. Continue next chunk as `Hey`.

### Expected

- Final merged text starts as `Hey`, with no duplicated `...HeyHey` style prefix artifacts.

### Actual

- Fixed by this PR.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test extensions/feishu/src/streaming-card.test.ts`
  - `pnpm test extensions/feishu/src/reply-dispatcher.test.ts extensions/feishu/src/streaming-card.test.ts`
- Edge cases checked:
  - English placeholder (`⏳ Thinking...`)
  - Chinese placeholder (`⏳ 正在连接模型并等待首段输出…`)
  - Placeholder-only updates after real content
  - First-chunk placeholder-prefix leakage
- What you did **not** verify:
  - Live Feishu API/card rendering behavior in an external environment

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `8db60cab5`.
- Files/config to restore:
  - `extensions/feishu/src/streaming-card.ts`
  - `extensions/feishu/src/streaming-card.test.ts`
- Known bad symptoms reviewers should watch for:
  - Reappearance of duplicated first-token prefix in Feishu streaming outputs.

## Risks and Mitigations

- Risk: Placeholder detection is string-based and may miss future localized placeholder variants.
  - Mitigation: Added explicit EN/ZH tests for current placeholders; future placeholder text changes should update matcher + tests together.
