### PR TITLE
fix(agents): support Ollama thinking field for reasoning models

### DIFF
--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -186,6 +186,7 @@ interface OllamaChatResponse {
     role: "assistant";
     content: string;
     reasoning?: string;
+    thinking?: string;
     tool_calls?: OllamaToolCall[];
   };
   done: boolean;
@@ -323,10 +324,11 @@ export function buildAssistantMessage(
 ): AssistantMessage {
   const content: (TextContent | ToolCall)[] = [];
 
-  // Qwen 3 (and potentially other reasoning models) may return their final
-  // answer in a `reasoning` field with an empty `content`. Fall back to
-  // `reasoning` so the response isn't silently dropped.
-  const text = response.message.content || response.message.reasoning || "";
+  // Ollama thinking-capable models (Qwen 3, DeepSeek R1) may return their
+  // reasoning output in a `thinking` field with an empty `content`.
+  // Fall back to `thinking` then `reasoning` (legacy) for compatibility.
+  const text =
+    response.message.content || response.message.thinking || response.message.reasoning || "";
   if (text) {
     content.push({ type: "text", text });
   }
@@ -474,8 +476,11 @@ export function createOllamaStreamFn(
         for await (const chunk of parseNdjsonStream(reader)) {
           if (chunk.message?.content) {
             accumulatedContent += chunk.message.content;
+          } else if (chunk.message?.thinking) {
+            // Ollama thinking models (Qwen 3, DeepSeek R1): output in thinking field
+            accumulatedContent += chunk.message.thinking;
           } else if (chunk.message?.reasoning) {
-            // Qwen 3 reasoning mode: content may be empty, output in reasoning
+            // Legacy: some models may still use reasoning field
             accumulatedContent += chunk.message.reasoning;
           }
 

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -470,6 +470,7 @@ export function createOllamaStreamFn(
 
         const reader = response.body.getReader();
         let accumulatedContent = "";
+        let accumulatedThinking = "";
         const accumulatedToolCalls: OllamaToolCall[] = [];
         let finalResponse: OllamaChatResponse | undefined;
 
@@ -477,11 +478,11 @@ export function createOllamaStreamFn(
           if (chunk.message?.content) {
             accumulatedContent += chunk.message.content;
           } else if (chunk.message?.thinking) {
-            // Ollama thinking models (Qwen 3, DeepSeek R1): output in thinking field
-            accumulatedContent += chunk.message.thinking;
+            // Buffer thinking separately - only used if no content is produced
+            accumulatedThinking += chunk.message.thinking;
           } else if (chunk.message?.reasoning) {
-            // Legacy: some models may still use reasoning field
-            accumulatedContent += chunk.message.reasoning;
+            // Legacy: buffer reasoning separately - only used if no content is produced
+            accumulatedThinking += chunk.message.reasoning;
           }
 
           // Ollama sends tool_calls in intermediate (done:false) chunks,
@@ -500,7 +501,8 @@ export function createOllamaStreamFn(
           throw new Error("Ollama API stream ended without a final response");
         }
 
-        finalResponse.message.content = accumulatedContent;
+        // Use thinking/reasoning as fallback only if no content was produced
+        finalResponse.message.content = accumulatedContent || accumulatedThinking;
         if (accumulatedToolCalls.length > 0) {
           finalResponse.message.tool_calls = accumulatedToolCalls;
         }


### PR DESCRIPTION
## Summary
- Add `thinking` field to `OllamaChatResponse` type definition
- Fall back to `thinking` before `reasoning` in `buildAssistantMessage`
- Support `thinking` field in streaming chunks

Fixes #35384

## Context
Ollama's native API (`/api/chat`) uses `message.thinking` for chain-of-thought output from thinking-capable models (Qwen 3, DeepSeek R1, etc.), but the stream handler was only checking for `reasoning`.

## Testing
- TypeScript compiles without errors
- ESLint: 0 warnings, 0 errors