### PR TITLE
fix(canvas-host): add missing MIME types for CSS and common web assets

### DIFF
--- a/src/media/mime.ts
+++ b/src/media/mime.ts
@@ -39,6 +39,13 @@ const MIME_BY_EXT: Record<string, string> = {
   // Additional extension aliases
   ".jpeg": "image/jpeg",
   ".js": "text/javascript",
+  ".css": "text/css",
+  ".svg": "image/svg+xml",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".ico": "image/x-icon",
+  ".xml": "application/xml",
 };
 
 const AUDIO_FILE_EXTENSIONS = new Set([


### PR DESCRIPTION
## Summary

- Problem: Canvas host serves `.css`, `.svg`, `.woff`, `.woff2`, `.ttf`, `.ico`, and `.xml` files with `application/octet-stream` MIME type
- Why it matters: Browsers enforce strict MIME checking for stylesheets and reject CSS delivered as `application/octet-stream`, breaking external stylesheets in canvas-hosted pages
- What changed: Added missing web asset extensions to the `MIME_BY_EXT` map in `src/media/mime.ts`
- What did NOT change: No changes to `detectMime()` logic, binary format detection, or canvas host serving behavior

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## User-visible / Behavior Changes

Canvas host now serves `.css`, `.svg`, `.woff`, `.woff2`, `.ttf`, `.ico`, and `.xml` files with correct Content-Type headers. Previously these were served as `application/octet-stream`.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS 26.3.0 (arm64)
- Runtime: Node v22.22.0
- OpenClaw: 2026.3.3

### Steps

1. Enable canvas host with `canvasHost.enabled: true` and a root directory containing an `index.html` that references an external `shared.css`
2. Open the canvas page in a browser
3. Check DevTools Network tab — `shared.css` is served as `application/octet-stream`
4. Browser silently ignores the stylesheet

### Expected

CSS file served with `Content-Type: text/css`

### Actual

CSS file served with `Content-Type: application/octet-stream` — browser rejects it

## Evidence

Verified locally by building the fix branch and checking with curl:
- Before: `curl -s -o /dev/null -w "%{content_type}" .../shared.css` → `application/octet-stream`
- After: `curl -s -o /dev/null -w "%{content_type}" .../shared.css` → `text/css`

## Human Verification (required)

- Verified: Built fix branch locally, restarted gateway, confirmed CSS and JS MIME types via curl
- Edge cases: Existing binary format detection unaffected (`.png`, `.jpg`, `.pdf` still use sniff-based detection)
- Not verified: `.woff`/`.woff2`/`.ttf` serving (added by extension map parity, not tested directly)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this commit; the only change is additive entries in a static map
- No config changes needed
- Bad symptom: incorrect MIME types on other file extensions (extremely unlikely — only adds new entries)

## Risks and Mitigations

None — purely additive entries to an existing extension-to-MIME map.