### PR TITLE
feat(plugins): add truncateBefore cursor to before_prompt_build hook result

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -580,6 +580,9 @@ export async function resolvePromptBuildHookResult(params: {
       promptBuildResult?.appendSystemContext,
       legacyResult?.appendSystemContext,
     ]),
+    truncateBefore:
+      Math.max(promptBuildResult?.truncateBefore ?? 0, legacyResult?.truncateBefore ?? 0) ||
+      undefined,
   };
 }
 
@@ -1562,6 +1565,21 @@ export async function runEmbeddedAttempt(
               `hooks: applied prependSystemContext/appendSystemContext (${prependSystemLen}+${appendSystemLen} chars)`,
             );
           }
+        }
+        const truncateBefore = hookResult?.truncateBefore;
+        if (truncateBefore) {
+          const originalMessageCount = activeSession.messages.length;
+          const truncatedMessages = activeSession.messages.filter((msg) => {
+            const timestamp = (msg as { timestamp?: unknown }).timestamp;
+            return typeof timestamp !== "number" || timestamp >= truncateBefore;
+          });
+          const removedCount = originalMessageCount - truncatedMessages.length;
+          // Repair orphaned tool_result blocks left by the truncation cut.
+          const repaired = sanitizeToolUseResultPairing(truncatedMessages);
+          activeSession.messages.splice(0, activeSession.messages.length, ...repaired);
+          log.debug(
+            `hooks: truncated prompt history before ${truncateBefore} (removed ${removedCount} messages, repaired tool pairing)`,
+          );
         }
 
         log.debug(`embedded run prompt start: runId=${params.runId} sessionId=${params.sessionId}`);

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -153,6 +153,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       left: acc?.appendSystemContext,
       right: next.appendSystemContext,
     }),
+    truncateBefore: Math.max(acc?.truncateBefore ?? 0, next.truncateBefore ?? 0) || undefined,
   });
 
   const mergeSubagentSpawningResult = (

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -379,6 +379,7 @@ export type PluginHookBeforePromptBuildResult = {
    * Use for static plugin guidance instead of prependContext to avoid per-turn token cost.
    */
   appendSystemContext?: string;
+  truncateBefore?: number;
 };
 
 // before_agent_start hook (legacy compatibility: combines both phases)


### PR DESCRIPTION
## Summary

Adds `truncateBefore?: number` to `PluginHookBeforePromptBuildResult`, allowing plugins to drop old messages from prompt context by timestamp.

Fixes #35414

## Problem

Plugins that manage context (memory systems, conversation summarizers, context compressors) often inject compressed representations of older messages into the prompt. However, the original messages remain alongside the compressed version, doubling token usage and creating redundancy.

Plugins need a way to say: "I've captured everything before timestamp X — those messages can be excluded from the prompt context."

## Solution

When a plugin returns `truncateBefore` from `before_prompt_build` or `before_agent_start`, messages with `timestamp < truncateBefore` are filtered from the prompt context.

Key properties:
- **Prompt-only** — JSONL is untouched, messages are fully recoverable
- **Non-destructive** — disable the plugin and full history returns
- **Multiple plugins** — merged via `Math.max` (latest timestamp wins)

## Changes

3 files, 18 lines added:
- `src/plugins/types.ts` — add `truncateBefore?: number` to result type
- `src/plugins/hooks.ts` — merge logic: `Math.max(acc, next) || undefined`
- `src/agents/pi-embedded-runner/run/attempt.ts` — resolve from both hook phases, filter `activeSession.messages` in-place before model prompt

## Example

A context compression plugin:
```typescript
return {
  prependContext: compressedSummary,
  truncateBefore: lastProcessedTimestamp,
};
```

## Related

- #34727 / #34730 — `appendSystemPrompt` (complements this feature for full plugin context management)