### PR TITLE
fix(llm-task): add explicit type to input/schema params for llama.cpp compat

### DIFF
--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -74,9 +74,20 @@ export function createLlmTaskTool(api: OpenClawPluginApi) {
       "Run a generic JSON-only LLM task and return schema-validated JSON. Designed for orchestration from Lobster workflows via openclaw.invoke.",
     parameters: Type.Object({
       prompt: Type.String({ description: "Task instruction for the LLM." }),
-      input: Type.Optional(Type.Unknown({ description: "Optional input payload for the task." })),
+      // NOTE: Use Type.Unsafe with explicit type instead of Type.Unknown();
+      // Type.Unknown() emits schema without a "type" field, which llama.cpp
+      // rejects during JSON schema-to-grammar conversion (400 Bad Request).
+      input: Type.Optional(
+        Type.Unsafe<unknown>({
+          type: "object",
+          description: "Optional input payload for the task.",
+        }),
+      ),
       schema: Type.Optional(
-        Type.Unknown({ description: "Optional JSON Schema to validate the returned JSON." }),
+        Type.Unsafe<unknown>({
+          type: "object",
+          description: "Optional JSON Schema to validate the returned JSON.",
+        }),
       ),
       provider: Type.Optional(
         Type.String({ description: "Provider override (e.g. openai-codex, anthropic)." }),

--- a/extensions/llm-task/src/llm-task-tool.ts
+++ b/extensions/llm-task/src/llm-task-tool.ts
@@ -78,14 +78,16 @@ export function createLlmTaskTool(api: OpenClawPluginApi) {
       // Type.Unknown() emits schema without a "type" field, which llama.cpp
       // rejects during JSON schema-to-grammar conversion (400 Bad Request).
       input: Type.Optional(
-        Type.Unsafe<unknown>({
+        Type.Unsafe<Record<string, unknown>>({
           type: "object",
-          description: "Optional input payload for the task.",
+          additionalProperties: true,
+          description: "Optional input payload for the task. Must be a JSON object.",
         }),
       ),
       schema: Type.Optional(
-        Type.Unsafe<unknown>({
+        Type.Unsafe<Record<string, unknown>>({
           type: "object",
+          additionalProperties: true,
           description: "Optional JSON Schema to validate the returned JSON.",
         }),
       ),
@@ -171,7 +173,10 @@ export function createLlmTaskTool(api: OpenClawPluginApi) {
       };
 
       // oxlint-disable-next-line typescript/no-explicit-any
-      const input = (params as any).input as unknown;
+      const input = (params as any).input as Record<string, unknown> | undefined;
+      if (input != null && (typeof input !== "object" || Array.isArray(input))) {
+        throw new Error("input must be a JSON object (not an array, string, or scalar)");
+      }
       let inputJson: string;
       try {
         inputJson = JSON.stringify(input ?? null, null, 2);


### PR DESCRIPTION
## Problem

The `llm-task` plugin defines `input` and `schema` parameters using `Type.Unknown()`, which emits JSON Schema without a `type` field:

```json
{"description": "Optional input payload for the task."}
```

llama.cpp rejects this during schema-to-grammar conversion with `400 Bad Request`:

```
JSON schema conversion failed: Unrecognized schema: {"description":"Optional input payload for the task."}
```

This breaks any agent with `llm-task` enabled that routes through llama.cpp-based backends.

## Fix

Replace `Type.Unknown()` with `Type.Unsafe<unknown>({type: "object", ...})`, following the existing pattern used in lobster (`lobster-tool.ts:218`) and feishu extensions.

## Verified

- **Before fix:** llama.cpp returns 400 on every tool-enabled request
- **After fix:** llama.cpp accepts the schema, streaming works correctly
- Tested with Qwen3.5-35B-A3B and Qwen3.5-9B via TensorZero routing
- TypeScript compiles clean (`npx tsc --noEmit` — no errors in changed file)
- Linter passes (0 warnings, 0 errors)
- No behavior change for cloud LLM providers (schema is still valid JSON Schema, now with an explicit type)

Fixes #35443.