### PR TITLE
fix(cron): apply responsePrefix to direct delivery payloads

### DIFF
--- a/src/cron/isolated-agent/delivery-dispatch.ts
+++ b/src/cron/isolated-agent/delivery-dispatch.ts
@@ -1,3 +1,4 @@
+import { resolveEffectiveMessagesConfig } from "../../agents/identity.js";
 import { runSubagentAnnounceFlow } from "../../agents/subagent-announce.js";
 import { countActiveDescendantRuns } from "../../agents/subagent-registry.js";
 import { SILENT_REPLY_TOKEN } from "../../auto-reply/tokens.js";
@@ -193,13 +194,28 @@ export async function dispatchCronDelivery(
     delivery: SuccessfulDeliveryTarget,
   ): Promise<RunCronAgentTurnResult | null> => {
     const identity = resolveAgentOutboundIdentity(params.cfgWithAgentDefaults, params.agentId);
+    // Apply responsePrefix to direct delivery payloads (same logic as interactive replies).
+    const { responsePrefix } = resolveEffectiveMessagesConfig(
+      params.cfgWithAgentDefaults,
+      params.agentId,
+      { channel: delivery.channel, accountId: delivery.accountId },
+    );
+    const applyPrefix = (text: string | undefined): string | undefined => {
+      if (!responsePrefix || !text || text.startsWith(responsePrefix)) {
+        return text;
+      }
+      return `${responsePrefix} ${text}`;
+    };
     try {
-      const payloadsForDelivery =
+      const rawPayloads =
         deliveryPayloads.length > 0
           ? deliveryPayloads
           : synthesizedText
             ? [{ text: synthesizedText }]
             : [];
+      const payloadsForDelivery = responsePrefix
+        ? rawPayloads.map((p) => (p.text ? { ...p, text: applyPrefix(p.text) } : p))
+        : rawPayloads;
       if (payloadsForDelivery.length === 0) {
         return null;
       }


### PR DESCRIPTION
## Summary

- Cron direct delivery (`deliverViaDirect`) was sending raw response text without applying the configured `responsePrefix`
- Interactive replies correctly resolve the prefix via `resolveEffectiveMessagesConfig`, but the cron direct delivery path skipped this step
- Now resolves `responsePrefix` for the delivery channel/account and prepends it to payload text, matching the behavior of `route-reply` and heartbeat delivery paths

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration

## Linked Issue

- Fixes #29600

## User-visible / Behavior Changes

- Cron direct delivery messages now include the configured `responsePrefix` (e.g. `[Thames]`) matching interactive reply behavior

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No

## Test plan

- [ ] Verify `responsePrefix: "auto"` is applied to cron direct delivery messages
- [ ] Verify `responsePrefix` per-channel/account resolution works for cron delivery
- [ ] Verify no double-prefix when text already starts with the prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)