### PR TITLE
docs(cron): enhance troubleshooting guide and add config path warning

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -73,6 +73,13 @@ The Gateway loads the file into memory and writes it back on changes, so manual 
 are only safe when the Gateway is stopped. Prefer `openclaw cron add/edit` or the cron
 tool call API for changes.
 
+<Warning>
+Cron jobs are **not** part of `openclaw.json`. Adding `cron.jobs` to the config file
+causes a validation error. Use the CLI (`openclaw cron add/edit/remove`) or the gateway
+cron tool to manage jobs. The `cron.*` keys in `openclaw.json` control scheduler settings
+(enabled, concurrency, retry policy, failure alerts), not job definitions.
+</Warning>
+
 ## Beginner-friendly overview
 
 Think of a cron job as: **when** to run + **what** to do.

--- a/docs/automation/troubleshooting.md
+++ b/docs/automation/troubleshooting.md
@@ -4,6 +4,9 @@ read_when:
   - Cron did not run
   - Cron ran but no message was delivered
   - Heartbeat seems silent or skipped
+  - nextRunAtMs stuck or wrong
+  - Cron job late or skipped
+  - Timezone issues with cron
 title: "Automation Troubleshooting"
 ---
 
@@ -12,6 +15,8 @@ title: "Automation Troubleshooting"
 Use this page for scheduler and delivery issues (`cron` + `heartbeat`).
 
 ## Command ladder
+
+Start with the general health checks, then drill into automation:
 
 ```bash
 openclaw status
@@ -26,6 +31,7 @@ Then run automation checks:
 ```bash
 openclaw cron status
 openclaw cron list
+openclaw cron runs --id <jobId> --limit 20
 openclaw system heartbeat last
 ```
 
@@ -46,9 +52,42 @@ Good output looks like:
 
 Common signatures:
 
-- `cron: scheduler disabled; jobs will not run automatically` → cron disabled in config/env.
-- `cron: timer tick failed` → scheduler tick crashed; inspect surrounding stack/log context.
-- `reason: not-due` in run output → manual run called without `--force` and job not due yet.
+| Log / output | Cause | Fix |
+|---|---|---|
+| `cron: scheduler disabled` | Cron disabled in config or env | `openclaw config set cron.enabled true` and restart gateway |
+| `cron: timer tick failed` | Scheduler tick crashed | Inspect surrounding stack in logs; run `openclaw doctor` |
+| `reason: not-due` in run output | Manual run without `--force` and job not due | Use `openclaw cron run <id>` (defaults to force mode) |
+| Job enabled but no `nextRunAtMs` | Schedule expression invalid or could not compute next time | Check `cron list --json` for the job; verify expr/tz are valid |
+| `cron: auto-disabled job after repeated schedule errors` | 3+ consecutive schedule computation failures | Fix the cron expression or timezone, then re-enable with `openclaw cron edit <id> --enable` |
+| Job shows `lastStatus: skipped` | Execution skipped (e.g. empty payload, unsupported config) | Check `lastError` in `cron list --json` for the skip reason |
+
+### nextRunAtMs stuck or wrong
+
+If `nextRunAtMs` seems pinned to an unexpected time:
+
+1. Verify the schedule and timezone are correct:
+   ```bash
+   openclaw cron list --json | jq '.[] | select(.id == "<jobId>") | {schedule, state}'
+   ```
+
+2. Check if the schedule was recently edited. Editing the schedule or timezone via `openclaw cron edit` recomputes `nextRunAtMs` automatically. If you edited `jobs.json` directly while the gateway was running, the in-memory state may be stale.
+
+3. Restart the gateway. On startup, the scheduler recomputes `nextRunAtMs` for all jobs with missing or past-due values.
+
+4. As a last resort, force a recompute by toggling the job:
+   ```bash
+   openclaw cron edit <id> --disable
+   openclaw cron edit <id> --enable
+   ```
+
+### Job fires late
+
+Cron jobs can fire later than scheduled for several reasons:
+
+- **Gateway was offline** during the scheduled time. On restart, missed `cron` expression jobs are replayed if their previous run slot was missed.
+- **Another job was running** and hit the concurrency limit. Check `cron.maxConcurrentRuns` (default: 1).
+- **Error backoff** is active. After consecutive failures, the scheduler applies exponential backoff (30s, 1m, 5m, 15m, 60m). Check `consecutiveErrors` in `cron list --json`.
+- **Stagger window** is configured. Cron expression jobs have a default stagger window to prevent all jobs from firing at the exact same second. Use `--exact` to disable.
 
 ## Cron fired but no delivery
 
@@ -67,9 +106,18 @@ Good output looks like:
 
 Common signatures:
 
-- Run succeeded but delivery mode is `none` → no external message is expected.
-- Delivery target missing/invalid (`channel`/`to`) → run may succeed internally but skip outbound.
-- Channel auth errors (`unauthorized`, `missing_scope`, `Forbidden`) → delivery blocked by channel credentials/permissions.
+| Log / output | Cause | Fix |
+|---|---|---|
+| Run succeeded, delivery mode `none` | No external message expected | Set `--announce` on the job if delivery is wanted |
+| Delivery target missing/invalid | `channel`/`to` not configured | Edit job with `--channel <channel> --to <dest>` |
+| `unauthorized`, `missing_scope`, `Forbidden` | Channel credentials/permissions issue | Re-authenticate the channel; check bot permissions |
+| `lastDeliveryStatus: not-delivered` | Delivery attempted but failed | Check `lastDeliveryError` in `cron list --json` |
+| Main session job, no visible output | Main jobs enqueue a system event for the next heartbeat | Ensure heartbeat is enabled and not in quiet hours |
+
+### Main vs isolated delivery
+
+- **Main session** jobs (`--session main`) enqueue a system event. The agent processes it on the next heartbeat. If `wakeMode` is `now`, a heartbeat runs immediately. If `next-heartbeat`, it waits for the regular interval.
+- **Isolated** jobs (`--session isolated`) run a dedicated agent turn. Delivery happens via `--announce` to the specified channel/destination.
 
 ## Heartbeat suppressed or skipped
 
@@ -87,10 +135,13 @@ Good output looks like:
 
 Common signatures:
 
-- `heartbeat skipped` with `reason=quiet-hours` → outside `activeHours`.
-- `requests-in-flight` → main lane busy; heartbeat deferred.
-- `empty-heartbeat-file` → interval heartbeat skipped because `HEARTBEAT.md` has no actionable content and no tagged cron event is queued.
-- `alerts-disabled` → visibility settings suppress outbound heartbeat messages.
+| Log / output | Cause | Fix |
+|---|---|---|
+| `reason=quiet-hours` | Outside configured `activeHours` | Adjust `activeHours` or timezone |
+| `requests-in-flight` | Main lane busy; heartbeat deferred | Wait for current request to finish |
+| `empty-heartbeat-file` | `HEARTBEAT.md` empty and no tagged cron events queued | Add content to `HEARTBEAT.md`, or use `wakeMode: now` for cron jobs |
+| `alerts-disabled` | Visibility settings suppress outbound | Check heartbeat visibility config |
+| Heartbeat runs but produces no output | Agent has nothing to do | Add system events or check `HEARTBEAT.md` instructions |
 
 ## Timezone and activeHours gotchas
 
@@ -104,15 +155,62 @@ openclaw logs --follow
 
 Quick rules:
 
+- Cron expression jobs without `--tz` use the **gateway host timezone** (resolved via `Intl.DateTimeFormat`).
+- One-shot `--at` schedules: ISO strings with an offset (e.g. `+08:00`) are unambiguous. Strings without offset and without `--tz` are treated as UTC.
 - `Config path not found: agents.defaults.userTimezone` means the key is unset; heartbeat falls back to host timezone (or `activeHours.timezone` if set).
-- Cron without `--tz` uses gateway host timezone.
 - Heartbeat `activeHours` uses configured timezone resolution (`user`, `local`, or explicit IANA tz).
-- ISO timestamps without timezone are treated as UTC for cron `at` schedules.
 
 Common signatures:
 
-- Jobs run at the wrong wall-clock time after host timezone changes.
-- Heartbeat always skipped during your daytime because `activeHours.timezone` is wrong.
+- Jobs run at the wrong wall-clock time after host timezone changes. Fix: set explicit `--tz` on cron jobs.
+- Heartbeat always skipped during your daytime because `activeHours.timezone` is wrong. Fix: set the timezone explicitly.
+- VPS/Docker host in UTC but you expect local time. Fix: always use `--tz` with an IANA timezone (e.g. `America/New_York`).
+
+## Cron configuration path
+
+Cron jobs are **not** configured in `openclaw.json`. Adding `cron.jobs` to the config file causes a validation error.
+
+Jobs are managed via the CLI and stored at `~/.openclaw/cron/jobs.json`:
+
+```bash
+# Manage jobs
+openclaw cron add ...
+openclaw cron edit <id> ...
+openclaw cron remove <id>
+
+# Cron-related config (in openclaw.json)
+openclaw config set cron.enabled true
+openclaw config set cron.maxConcurrentRuns 2
+```
+
+The `cron.*` keys in `openclaw.json` control scheduler behavior (enabled, concurrency, retry, failure alerts), not job definitions.
+
+## System cron fallback
+
+If the OpenClaw gateway is unreliable (frequent restarts, resource constraints), you can use your OS cron as a fallback to trigger jobs:
+
+```bash
+# Add to crontab (crontab -e)
+0 7 * * * openclaw cron run <jobId> 2>&1 >> /tmp/openclaw-cron.log
+```
+
+This calls the CLI, which sends an RPC to the running gateway. The gateway must be running for this to work. Benefits:
+
+- OS cron is more reliable for timing than in-process timers.
+- Missed runs during gateway downtime are not replayed (use this when you prefer skip-on-miss).
+
+For Pi or constrained environments, this can be more reliable than relying on the gateway's internal timer, especially if the gateway restarts frequently.
+
+## Quick reference
+
+| Symptom | First check |
+|---|---|
+| Job never fires | `openclaw cron status` (is cron enabled?) |
+| Job fires but nothing happens | `openclaw cron runs --id <id>` (check status/error) |
+| Delivery missing | `openclaw cron list --json` (check delivery config) |
+| Wrong time | `openclaw cron list --json` (check tz and nextRunAtMs) |
+| Job disabled unexpectedly | Check `lastError` for schedule errors or max retry exhaustion |
+| Gateway restart lost schedule | Jobs persist in `~/.openclaw/cron/jobs.json`; verify file exists |
 
 Related:
 


### PR DESCRIPTION
## Summary

- Enhanced `docs/automation/troubleshooting.md` with structured diagnostic tables, new sections for common issues, and a quick reference table
- Added warning admonition to `docs/automation/cron-jobs.md` about `cron.jobs` not being valid in `openclaw.json`

### New sections added to troubleshooting guide:
- **nextRunAtMs stuck or wrong** - step-by-step diagnosis
- **Job fires late** - causes (offline gateway, concurrency, backoff, stagger)
- **Main vs isolated delivery** - explains the two delivery models
- **Cron configuration path** - clarifies CLI vs config file
- **System cron fallback** - OS cron as reliability backup
- **Quick reference table** - symptom-to-first-check mapping

## Change Type

- [x] Docs

## Scope

- [x] UI / DX

## Linked Issues

- Closes #13598
- Closes #27947

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No

## Test plan

- [ ] Verify docs render correctly on Mintlify
- [ ] Verify internal doc links use correct format (root-relative, no .md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)