### PR TITLE
fix(compaction): skip LLM API call when no real conversation messages exist

### DIFF
--- a/src/agents/pi-embedded-runner/compact.ts
+++ b/src/agents/pi-embedded-runner/compact.ts
@@ -663,6 +663,25 @@ export async function compactEmbeddedPiSessionDirect(
           );
         }
 
+        // Early check: skip compaction entirely if no real conversation messages exist.
+        // This prevents unnecessary LLM API calls when using safeguard mode.
+        // The safeguard plugin also checks, but this local check runs earlier in the flow.
+        const hasRealMessages = session.messages.some(
+          (msg) =>
+            msg.role === "user" || msg.role === "assistant" || msg.role === "toolResult",
+        );
+        if (!hasRealMessages) {
+          log.info(
+            `[compaction-diag] skip runId=${runId} sessionKey=${params.sessionKey ?? params.sessionId} ` +
+              `diagId=${diagId} trigger=${trigger} reason=no_real_messages`,
+          );
+          return {
+            ok: true,
+            compacted: false,
+            reason: "no_compactable_entries",
+          };
+        }
+
         const compactStartedAt = Date.now();
         const result = await compactWithSafetyTimeout(() =>
           session.compact(params.customInstructions),


### PR DESCRIPTION
With compaction.mode: safeguard, OpenClaw was calling the LLM API every ~30 minutes on all active sessions - including isolated cron sessions that contain no real conversation messages. The safeguard then correctly cancels the compaction, but the API call had already been made and billed.

Add an early local check before calling session.compact() to detect if there are any real conversation messages (user/assistant/toolResult). If none exist, skip compaction entirely without making any LLM API calls.

This reduces unnecessary API calls and associated costs.

Closes #34935