### PR TITLE
fix(control-ui): force-refresh agent files

### DIFF
--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -36,16 +36,17 @@ const renderGatewayPortHealthDiagnostics = vi.fn(() => ["diag: unhealthy port"])
 const renderRestartDiagnostics = vi.fn(() => ["diag: unhealthy runtime"]);
 const resolveGatewayPort = vi.fn(() => 18789);
 const findGatewayPidsOnPortSync = vi.fn<(port: number) => number[]>(() => []);
-const probeGateway = vi.fn<
-  (opts: {
-    url: string;
-    auth?: { token?: string; password?: string };
-    timeoutMs: number;
-  }) => Promise<{
-    ok: boolean;
-    configSnapshot: unknown;
-  }>
->();
+const probeGateway =
+  vi.fn<
+    (opts: {
+      url: string;
+      auth?: { token?: string; password?: string };
+      timeoutMs: number;
+    }) => Promise<{
+      ok: boolean;
+      configSnapshot: unknown;
+    }>
+  >();
 const isRestartEnabled = vi.fn<(config?: { commands?: unknown }) => boolean>(() => true);
 const loadConfig = vi.fn(() => ({}));
 

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -652,7 +652,30 @@ export function renderApp(state: AppViewState) {
                     void state.loadCron();
                   }
                 },
-                onLoadFiles: (agentId) => loadAgentFiles(state, agentId),
+                onLoadFiles: async (agentId) => {
+                  const activeBefore = state.agentFileActive;
+                  const refreshed = await loadAgentFiles(state, agentId);
+                  if (!refreshed) {
+                    return;
+                  }
+                  const currentAgentId =
+                    state.agentsSelectedId ??
+                    state.agentsList?.defaultId ??
+                    state.agentsList?.agents?.[0]?.id ??
+                    null;
+                  if (currentAgentId !== agentId) {
+                    return;
+                  }
+                  const list =
+                    state.agentFilesList?.agentId === agentId ? state.agentFilesList.files : null;
+                  const active = state.agentFileActive ?? activeBefore;
+                  if (active && list?.some((file) => file.name === active)) {
+                    await loadAgentFileContent(state, agentId, active, {
+                      force: true,
+                      preserveDraft: false,
+                    });
+                  }
+                },
                 onSelectFile: (name) => {
                   state.agentFileActive = name;
                   if (!resolvedAgentId) {

--- a/ui/src/ui/controllers/agent-files.ts
+++ b/ui/src/ui/controllers/agent-files.ts
@@ -32,9 +32,9 @@ function mergeFileEntry(
   return { ...list, files: nextFiles };
 }
 
-export async function loadAgentFiles(state: AgentFilesState, agentId: string) {
+export async function loadAgentFiles(state: AgentFilesState, agentId: string): Promise<boolean> {
   if (!state.client || !state.connected || state.agentFilesLoading) {
-    return;
+    return false;
   }
   state.agentFilesLoading = true;
   state.agentFilesError = null;
@@ -48,8 +48,10 @@ export async function loadAgentFiles(state: AgentFilesState, agentId: string) {
         state.agentFileActive = null;
       }
     }
+    return true;
   } catch (err) {
     state.agentFilesError = String(err);
+    return false;
   } finally {
     state.agentFilesLoading = false;
   }

--- a/ui/src/ui/controllers/agent-files.ts
+++ b/ui/src/ui/controllers/agent-files.ts
@@ -75,6 +75,12 @@ export async function loadAgentFileContent(
       name,
     });
     if (res?.file) {
+      // Reject stale responses that belong to a different selected agent.
+      // If agentFilesList is non-null and points to a different agent, ignore.
+      if (state.agentFilesList?.agentId && state.agentFilesList.agentId !== agentId) {
+        return;
+      }
+
       const content = res.file.content ?? "";
       const previousBase = state.agentFileContents[name] ?? "";
       const currentDraft = state.agentFileDrafts[name];


### PR DESCRIPTION
## Summary

- Problem: The “Core Files” Refresh button only reloads the file list metadata; the textarea keeps the first version that was loaded.
- Why it matters: Any edits made via CLI/SSH are invisible and saving from the UI silently overwrites the newer file on disk.
- What changed: After the file list reload completes, `onLoadFiles` now forces `agents.files.get` for the active file (dropping stale drafts so the textarea updates).
- What did NOT change: Gateway/file APIs, other Control UI panels, and CLI tooling remain untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #35428
- Related #

## User-visible / Behavior Changes

Core Files → Refresh now reloads the textarea with the latest on-disk content after CLI edits (instead of staying stale). No other UI changes.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.04
- Runtime/container: local npm-global OpenClaw gateway
- Model/provider: n/a
- Integration/channel: Control UI → Agents → Core Files
- Relevant config: default agent_web workspace

### Steps

1. Open Control UI → Agents → Core Files and select `MEMORY.md`.
2. In a shell: `echo "agent-web refresh test" >> /opt/agent-workspace/agent_web/MEMORY.md`
3. Click **Refresh** in the Core Files card.

### Expected

The text area shows the appended line (or provides a way to reload file contents).

### Actual

Before the fix, the textarea stayed on the original content until the entire Control UI was hard-refreshed. After this PR, the new line appears immediately.

## Evidence

- [x] Trace/log snippets
- [ ] Failing test/log before + passing after
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Snippet:

```
echo "agent-web refresh test" >> /opt/agent-workspace/agent_web/MEMORY.md
# (Refresh previously left the UI unchanged; now the new line appears, and Saving preserves it.)
```

## Human Verification (required)

- Verified scenarios: CLI edit + Control UI Refresh updates textarea; saving from UI after refresh keeps the new content.
- Edge cases checked: Refresh with no active file, panel switching back to Files.
- What you did NOT verify: Multi-user concurrency, other agent workspaces.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert the commit or checkout the previous `ui/src/ui/app-render.ts`.
- No config/files need changes; symptoms would be missing updates in Core Files again.

## Risks and Mitigations

- Risk: Refresh now overwrites unsaved text-area edits (since we purposely drop stale drafts).
- Mitigation: This matches the button’s intent (“Reload from disk”). UI already prompts users to save changes separately; doc issue #35428 covers the previous data-loss risk.
```

