### PR TITLE
fix: return authorization error reply for unauthorized command senders

### DIFF
--- a/src/auto-reply/reply/command-gates.ts
+++ b/src/auto-reply/reply/command-gates.ts
@@ -14,7 +14,10 @@ export function rejectUnauthorizedCommand(
   logVerbose(
     `Ignoring ${commandLabel} from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
   );
-  return { shouldContinue: false };
+  return {
+    shouldContinue: false,
+    reply: { text: "You are not authorized to use this command." },
+  };
 }
 
 export function buildDisabledCommandReply(params: {

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -166,7 +166,10 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
     logVerbose(
       `Ignoring /reset from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
     );
-    return { shouldContinue: false };
+    return {
+      shouldContinue: false,
+      reply: { text: "You are not authorized to use this command." },
+    };
   }
 
   // Trigger internal hook for reset/new commands


### PR DESCRIPTION
## Summary
- When `commands.allowFrom` rejects an unauthorized sender, `rejectUnauthorizedCommand` and the `/reset` handler previously returned `{ shouldContinue: false }` with no reply payload
- For Discord native slash commands, this caused a silent timeout — the deferred interaction received no follow-up message, showing "The application did not respond"
- Now returns `{ shouldContinue: false, reply: { text: "You are not authorized to use this command." } }` so every channel delivers clear feedback

Fixes #34776

## Test plan
- [ ] Configure `commands.allowFrom` to restrict access to specific users
- [ ] Have an unauthorized user invoke a Discord native slash command (e.g., `/status`)
- [ ] Verify user receives "You are not authorized to use this command." instead of a timeout
- [ ] Verify authorized users are unaffected
- [ ] Test `/reset` and `/new` from unauthorized users also get the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)