### PR TITLE
fix: add missing web search providers to security audit key check

### DIFF
--- a/src/security/audit-extra.sync.ts
+++ b/src/security/audit-extra.sync.ts
@@ -329,7 +329,17 @@ function resolveToolPolicies(params: {
 function hasWebSearchKey(cfg: OpenClawConfig, env: NodeJS.ProcessEnv): boolean {
   const search = cfg.tools?.web?.search;
   return Boolean(
-    search?.apiKey || search?.perplexity?.apiKey || env.BRAVE_API_KEY || env.PERPLEXITY_API_KEY,
+    search?.apiKey ||
+      search?.perplexity?.apiKey ||
+      search?.gemini?.apiKey ||
+      search?.grok?.apiKey ||
+      search?.kimi?.apiKey ||
+      env.BRAVE_API_KEY ||
+      env.PERPLEXITY_API_KEY ||
+      env.GEMINI_API_KEY ||
+      env.XAI_API_KEY ||
+      env.KIMI_API_KEY ||
+      env.MOONSHOT_API_KEY,
   );
 }
 


### PR DESCRIPTION
## Summary
- `hasWebSearchKey` in the security audit only checked Brave and Perplexity providers
- Added Gemini, Grok, and Kimi provider config keys and their environment variables (`GEMINI_API_KEY`, `XAI_API_KEY`, `KIMI_API_KEY`, `MOONSHOT_API_KEY`)
- Ensures the audit correctly reports web search capability when any supported provider is configured

Fixes #34509

## Test plan
- [ ] Verify `hasWebSearchKey` returns true when Gemini API key is configured (config or env)
- [ ] Verify `hasWebSearchKey` returns true when Grok/XAI API key is configured
- [ ] Verify `hasWebSearchKey` returns true when Kimi/Moonshot API key is configured
- [ ] Verify existing Brave/Perplexity checks still work
- [ ] Verify returns false when no search keys are configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)