### PR TITLE
fix: update sessionEntry.contextTokens on model switch

### DIFF
--- a/src/auto-reply/reply/directive-handling.persist.ts
+++ b/src/auto-reply/reply/directive-handling.persist.ts
@@ -173,6 +173,14 @@ export async function persistInlineDirectives(params: {
           });
           provider = resolved.ref.provider;
           model = resolved.ref.model;
+          // Update contextTokens to match the new model so session state
+          // reflects the correct context window after a model switch (#35372).
+          const newContextTokens =
+            agentCfg?.contextTokens ?? lookupContextTokens(model) ?? DEFAULT_CONTEXT_TOKENS;
+          if (sessionEntry.contextTokens !== newContextTokens) {
+            sessionEntry.contextTokens = newContextTokens;
+            updated = true;
+          }
           const nextLabel = `${provider}/${model}`;
           if (nextLabel !== initialModelLabel) {
             enqueueSystemEvent(formatModelSwitchEvent(nextLabel, resolved.alias), {


### PR DESCRIPTION
## Summary
- When switching models via inline directive (e.g., `/model`), `applyModelOverrideToSessionEntry` updated the model/provider override but left `sessionEntry.contextTokens` unchanged
- This caused `contextTokens` to get stuck at a lower value after switching to a model with a smaller context window and back (e.g., 198k → 160k → stays 160k)
- Now `persistInlineDirectives` explicitly updates `sessionEntry.contextTokens` to match the new model's context window before persisting the session store

Fixes #35372

## Test plan
- [ ] Start a session with Model A (e.g., 198k context window)
- [ ] Switch to Model B (e.g., 160k context window) via `/model`
- [ ] Verify `/status` shows the correct context window for Model B
- [ ] Switch back to Model A
- [ ] Verify `/status` shows Model A's context window (198k), not Model B's (160k)
- [ ] Check session store file to confirm `contextTokens` is updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)