### PR TITLE
feat: make channel health stale-socket threshold configurable

### DIFF
--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -364,4 +364,11 @@ export type GatewayConfig = {
    * Set to 0 to disable. Default: 5.
    */
   channelHealthCheckMinutes?: number;
+  /**
+   * Milliseconds before the health monitor treats a connected channel as stale.
+   * Channels that go this long without any event are restarted.
+   * Increase for low-traffic channels (e.g. iMessage) to avoid unnecessary restarts.
+   * Default: 1 800 000 (30 minutes).
+   */
+  channelHealthStaleThresholdMs?: number;
 };

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -653,6 +653,7 @@ export const OpenClawSchema = z
           .strict()
           .optional(),
         channelHealthCheckMinutes: z.number().int().min(0).optional(),
+        channelHealthStaleThresholdMs: z.number().int().min(1).optional(),
         tailscale: z
           .object({
             mode: z.union([z.literal("off"), z.literal("serve"), z.literal("funnel")]).optional(),

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -41,6 +41,11 @@ const BASE_RELOAD_RULES: ReloadRule[] = [
     kind: "hot",
     actions: ["restart-health-monitor"],
   },
+  {
+    prefix: "gateway.channelHealthStaleThresholdMs",
+    kind: "hot",
+    actions: ["restart-health-monitor"],
+  },
   // Stuck-session warning threshold is read by the diagnostics heartbeat loop.
   { prefix: "diagnostics.stuckSessionWarnMs", kind: "none" },
   { prefix: "hooks.gmail", kind: "hot", actions: ["restart-gmail-watcher"] },

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -47,7 +47,7 @@ export function createGatewayReloadHandlers(params: {
   logChannels: { info: (msg: string) => void; error: (msg: string) => void };
   logCron: { error: (msg: string) => void };
   logReload: { info: (msg: string) => void; warn: (msg: string) => void };
-  createHealthMonitor: (checkIntervalMs: number) => ChannelHealthMonitor;
+  createHealthMonitor: (checkIntervalMs: number, staleEventThresholdMs?: number) => ChannelHealthMonitor;
 }) {
   const applyHotReload = async (
     plan: GatewayReloadPlan,
@@ -98,7 +98,12 @@ export function createGatewayReloadHandlers(params: {
       state.channelHealthMonitor?.stop();
       const minutes = nextConfig.gateway?.channelHealthCheckMinutes;
       nextState.channelHealthMonitor =
-        minutes === 0 ? null : params.createHealthMonitor((minutes ?? 5) * 60_000);
+        minutes === 0
+          ? null
+          : params.createHealthMonitor(
+              (minutes ?? 5) * 60_000,
+              nextConfig.gateway?.channelHealthStaleThresholdMs,
+            );
     }
 
     if (plan.restartGmailWatcher) {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -697,6 +697,7 @@ export async function startGatewayServer(
     : startChannelHealthMonitor({
         channelManager,
         checkIntervalMs: (healthCheckMinutes ?? 5) * 60_000,
+        staleEventThresholdMs: cfgAtStart.gateway?.channelHealthStaleThresholdMs,
       });
 
   if (!minimalTestGateway) {
@@ -906,8 +907,8 @@ export async function startGatewayServer(
           logChannels,
           logCron,
           logReload,
-          createHealthMonitor: (checkIntervalMs: number) =>
-            startChannelHealthMonitor({ channelManager, checkIntervalMs }),
+          createHealthMonitor: (checkIntervalMs: number, staleEventThresholdMs?: number) =>
+            startChannelHealthMonitor({ channelManager, checkIntervalMs, staleEventThresholdMs }),
         });
 
         return startGatewayConfigReloader({


### PR DESCRIPTION
## Summary
- The channel health monitor uses a fixed 30-minute `staleEventThresholdMs` to detect dead sockets, causing unnecessary provider restarts for low-traffic channels like iMessage (59 restarts in 48 hours reported)
- Added `gateway.channelHealthStaleThresholdMs` config option to control this threshold
- Default remains 30 minutes (backward compatible); low-traffic channels can set a higher value (e.g., 7200000 for 2 hours)
- The option supports hot-reload via the existing `restart-health-monitor` action

Fixes #35072

### Config example
```json
{
  "gateway": {
    "channelHealthStaleThresholdMs": 7200000
  }
}
```

## Test plan
- [ ] Verify default behavior unchanged (30-minute threshold when config is unset)
- [ ] Set `gateway.channelHealthStaleThresholdMs` to a higher value and verify health monitor uses it
- [ ] Verify hot-reload: change the value while gateway is running, confirm the monitor restarts with the new threshold
- [ ] Verify `gateway.channelHealthCheckMinutes: 0` still disables the monitor entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)