### PR TITLE
fix(onboarding): default local tools.profile to full

### DIFF
--- a/changelog/fragments/pr-onboarding-tools-profile-default-full.md
+++ b/changelog/fragments/pr-onboarding-tools-profile-default-full.md
@@ -1,0 +1,1 @@
+- fix(onboarding): default local onboarding tool profile to `full` (instead of `messaging`) so new installs can execute runtime/filesystem/web tools without manual config edits.

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1650,7 +1650,7 @@ Defaults for Talk mode (macOS/iOS/Android).
 
 `tools.profile` sets a base allowlist before `tools.allow`/`tools.deny`:
 
-Local onboarding defaults new local configs to `tools.profile: "messaging"` when unset (existing explicit profiles are preserved).
+Local onboarding defaults new local configs to `tools.profile: "full"` when unset (existing explicit profiles are preserved).
 
 | Profile     | Includes                                                                                  |
 | ----------- | ----------------------------------------------------------------------------------------- |

--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -245,7 +245,7 @@ Typical fields in `~/.openclaw/openclaw.json`:
 
 - `agents.defaults.workspace`
 - `agents.defaults.model` / `models.providers` (if Minimax chosen)
-- `tools.profile` (local onboarding defaults to `"messaging"` when unset; existing explicit values are preserved)
+- `tools.profile` (local onboarding defaults to `"full"` when unset; existing explicit values are preserved)
 - `gateway.*` (mode, bind, auth, tailscale)
 - `session.dmScope` (behavior details: [CLI Onboarding Reference](/start/wizard-cli-reference#outputs-and-internals))
 - `channels.telegram.botToken`, `channels.discord.token`, `channels.signal.*`, `channels.imessage.*`

--- a/docs/start/onboarding.md
+++ b/docs/start/onboarding.md
@@ -34,7 +34,7 @@ Security trust model:
 
 - By default, OpenClaw is a personal agent: one trusted operator boundary.
 - Shared/multi-user setups require lock-down (split trust boundaries, keep tool access minimal, and follow [Security](/gateway/security)).
-- Local onboarding now defaults new configs to `tools.profile: "messaging"` so broad runtime/filesystem tools are opt-in.
+- Local onboarding now defaults new configs to `tools.profile: "full"` so agents can use runtime/filesystem tools out of the box.
 - If hooks/webhooks or other untrusted content feeds are enabled, use a strong modern model tier and keep strict tool policy/sandboxing.
 
 </Step>

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -236,7 +236,7 @@ Typical fields in `~/.openclaw/openclaw.json`:
 
 - `agents.defaults.workspace`
 - `agents.defaults.model` / `models.providers` (if Minimax chosen)
-- `tools.profile` (local onboarding defaults to `"messaging"` when unset; existing explicit values are preserved)
+- `tools.profile` (local onboarding defaults to `"full"` when unset; existing explicit values are preserved)
 - `gateway.*` (mode, bind, auth, tailscale)
 - `session.dmScope` (local onboarding defaults this to `per-channel-peer` when unset; existing explicit values are preserved)
 - `channels.telegram.botToken`, `channels.discord.token`, `channels.signal.*`, `channels.imessage.*`

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -50,7 +50,7 @@ The wizard starts with **QuickStart** (defaults) vs **Advanced** (full control).
     - Workspace default (or existing workspace)
     - Gateway port **18789**
     - Gateway auth **Token** (auto‑generated, even on loopback)
-    - Tool policy default for new local setups: `tools.profile: "messaging"` (existing explicit profile is preserved)
+    - Tool policy default for new local setups: `tools.profile: "full"` (existing explicit profile is preserved)
     - DM isolation default: local onboarding writes `session.dmScope: "per-channel-peer"` when unset. Details: [CLI Onboarding Reference](/start/wizard-cli-reference#outputs-and-internals)
     - Tailscale exposure **Off**
     - Telegram + WhatsApp DMs default to **allowlist** (you'll be prompted for your phone number)

--- a/src/commands/onboard-config.ts
+++ b/src/commands/onboard-config.ts
@@ -3,7 +3,7 @@ import type { DmScope } from "../config/types.base.js";
 import type { ToolProfileId } from "../config/types.tools.js";
 
 export const ONBOARDING_DEFAULT_DM_SCOPE: DmScope = "per-channel-peer";
-export const ONBOARDING_DEFAULT_TOOLS_PROFILE: ToolProfileId = "messaging";
+export const ONBOARDING_DEFAULT_TOOLS_PROFILE: ToolProfileId = "full";
 
 export function applyOnboardingLocalWorkspaceConfig(
   baseConfig: OpenClawConfig,

--- a/src/commands/onboard-non-interactive.gateway.test.ts
+++ b/src/commands/onboard-non-interactive.gateway.test.ts
@@ -145,7 +145,7 @@ describe("onboard (non-interactive): gateway and remote auth", () => {
       }>(configPath);
 
       expect(cfg?.agents?.defaults?.workspace).toBe(workspace);
-      expect(cfg?.tools?.profile).toBe("messaging");
+      expect(cfg?.tools?.profile).toBe("full");
       expect(cfg?.gateway?.auth?.mode).toBe("token");
       expect(cfg?.gateway?.auth?.token).toBe(token);
     });


### PR DESCRIPTION
## Summary

- **Problem:** New local onboarding currently defaults to `tools.profile: "messaging"`, which disables runtime/file/web tools (`exec`, `process`, `web_fetch`, etc.) unless users manually patch config.
- **Why it matters:** Fresh installs can feel "agent is dumb / only talks" even when model quality is fine; this causes immediate usability friction and repeated support churn.
- **What changed:** Switched local onboarding default from `messaging` to `full` in `onboard-config`, updated onboarding docs and wizard references to match, and updated the non-interactive onboarding expectation.
- **What did NOT change:** Existing explicit `tools.profile` values are still preserved; this only changes the default when profile is unset.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related user pain pattern after 2026.3.2 onboarding defaults

## User-visible / Behavior Changes

- New local onboarding writes `tools.profile: "full"` by default when unset.
- Fresh setups can run command/file/web tools without manual config patching.
- Docs now reflect `full` as the onboarding default.

## Security Impact (required)

- New permissions/capabilities? `Yes` (for newly onboarded local configs only)
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `Yes` (default profile for new local installs)
- Data access scope changed? `No`
- Risk + mitigation:
  - Risk: broader default tool surface for new local installs.
  - Mitigation: this affects only local onboarding defaults; explicit profiles are preserved; operators can still set `tools.profile: "messaging"`/`minimal` manually for stricter posture.

## Repro + Verification

### Environment

- OS: Linux (WSL2)
- Runtime: Node 24 / pnpm workspace

### Steps

1. Run local onboarding with empty config (no explicit `tools.profile`).
2. Inspect generated config.

### Expected

- `tools.profile` is `full` for new local configs.

### Evidence

- `src/commands/onboard-config.ts` default changed to `full`.
- `src/commands/onboard-non-interactive.gateway.test.ts` expectation updated.
- Docs updated:
  - `docs/start/onboarding.md`
  - `docs/start/wizard.md`
  - `docs/start/wizard-cli-reference.md`
  - `docs/reference/wizard.md`
  - `docs/gateway/configuration-reference.md`
- Changelog fragment added.

## Human Verification (required)

- Verified locally:
  - `corepack pnpm -s vitest src/commands/onboard-config.test.ts` ✅
- Note:
  - `src/commands/onboard-non-interactive.gateway.test.ts` currently has an unrelated upstream failure in `gateway/call.ts` mock shape (`hello.features` undefined) not introduced by this patch.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- Revert this PR commit to restore previous `messaging` default.

## Risks and Mitigations

- Risk: Security posture preference disagreement for default local profile.
- Mitigation: Explicit profile remains fully configurable; this only changes default UX for unset profile.
