### PR TITLE
fix(doctor): skip orphan top-level policy checks for multi-account channel configs

### DIFF
--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -850,4 +850,35 @@ describe("doctor config flow", () => {
       topAllowFrom === undefined || !Array.isArray(topAllowFrom) || topAllowFrom.length === 0,
     ).toBe(true);
   });
+
+  it("repairs inherited dmPolicy=open for accounts when policy is only on top level (#35560)", async () => {
+    const result = await runDoctorConfigWithInput({
+      repair: true,
+      config: {
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            accounts: {
+              default: {
+                enabled: true,
+                botToken: "fake:token",
+                // dmPolicy inherited from top level
+              },
+            },
+          },
+        },
+      },
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    const cfg = result.cfg as unknown as {
+      channels: {
+        telegram: {
+          accounts: { default: { allowFrom: string[] } };
+        };
+      };
+    };
+    // Account should get "*" added even though dmPolicy is inherited from parent
+    expect(cfg.channels.telegram.accounts.default.allowFrom).toContain("*");
+  });
 });

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -718,4 +718,49 @@ describe("doctor config flow", () => {
 
     expectGoogleChatDmAllowFromRepaired(result.cfg);
   });
+
+  it("does not emit false groupPolicy warning for multi-account telegram config (#35560)", async () => {
+    const warnings = await collectDoctorWarnings({
+      channels: {
+        telegram: {
+          accounts: {
+            default: {
+              enabled: true,
+              botToken: "fake:token",
+              groupPolicy: "allowlist",
+              groupAllowFrom: [123456],
+              dmPolicy: "pairing",
+              allowFrom: [123456],
+            },
+          },
+        },
+      },
+    });
+
+    const groupPolicyWarning = warnings.find((w) => w.includes("channels.telegram.groupPolicy"));
+    expect(groupPolicyWarning).toBeUndefined();
+  });
+
+  it("still warns about empty groupAllowFrom inside accounts (#35560)", async () => {
+    const warnings = await collectDoctorWarnings({
+      channels: {
+        telegram: {
+          accounts: {
+            default: {
+              enabled: true,
+              botToken: "fake:token",
+              groupPolicy: "allowlist",
+              dmPolicy: "pairing",
+              // groupAllowFrom and allowFrom intentionally omitted
+            },
+          },
+        },
+      },
+    });
+
+    const accountWarning = warnings.find((w) =>
+      w.includes("channels.telegram.accounts.default.groupPolicy"),
+    );
+    expect(accountWarning).toBeDefined();
+  });
 });

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -763,4 +763,91 @@ describe("doctor config flow", () => {
     );
     expect(accountWarning).toBeDefined();
   });
+
+  it("does not inject orphan top-level allowFrom when repairing dmPolicy=open with accounts (#35560)", async () => {
+    const result = await runDoctorConfigWithInput({
+      repair: true,
+      config: {
+        channels: {
+          telegram: {
+            accounts: {
+              default: {
+                enabled: true,
+                botToken: "fake:token",
+                dmPolicy: "open",
+              },
+            },
+          },
+        },
+      },
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    const cfg = result.cfg as unknown as {
+      channels: {
+        telegram: {
+          allowFrom?: unknown;
+          accounts: { default: { allowFrom: string[] } };
+        };
+      };
+    };
+    // Repair should add "*" to the account, not the top level
+    expect(cfg.channels.telegram.accounts.default.allowFrom).toContain("*");
+    // Top-level should NOT have an orphan allowFrom injected by repair
+    const topAllowFrom = cfg.channels.telegram.allowFrom as string[] | undefined;
+    expect(
+      topAllowFrom === undefined || !Array.isArray(topAllowFrom) || topAllowFrom.length === 0,
+    ).toBe(true);
+  });
+
+  it("does not inject orphan top-level allowFrom when repairing allowlist with accounts (#35560)", async () => {
+    const result = await withTempHome(async (home) => {
+      const configDir = path.join(home, ".openclaw");
+      await fs.mkdir(configDir, { recursive: true });
+      // Create a pairing store with entries so the repair has something to restore
+      const pairingDir = path.join(configDir, "pairing");
+      await fs.mkdir(pairingDir, { recursive: true });
+      await fs.writeFile(
+        path.join(pairingDir, "telegram.json"),
+        JSON.stringify({ default: { "99999": { paired: true } } }),
+        "utf-8",
+      );
+      await fs.writeFile(
+        path.join(configDir, "openclaw.json"),
+        JSON.stringify({
+          channels: {
+            telegram: {
+              accounts: {
+                default: {
+                  enabled: true,
+                  botToken: "fake:token",
+                  dmPolicy: "allowlist",
+                  // allowFrom intentionally omitted — should be restored from pairing store
+                },
+              },
+            },
+          },
+        }),
+        "utf-8",
+      );
+      return loadAndMaybeMigrateDoctorConfig({
+        options: { nonInteractive: true, repair: true },
+        confirm: async () => false,
+      });
+    });
+
+    const cfg = result.cfg as unknown as {
+      channels: {
+        telegram: {
+          allowFrom?: unknown;
+          accounts: { default: { allowFrom?: string[] } };
+        };
+      };
+    };
+    // Top-level should NOT have an orphan allowFrom
+    const topAllowFrom = cfg.channels.telegram.allowFrom as string[] | undefined;
+    expect(
+      topAllowFrom === undefined || !Array.isArray(topAllowFrom) || topAllowFrom.length === 0,
+    ).toBe(true);
+  });
 });

--- a/src/commands/doctor-config-flow.test.ts
+++ b/src/commands/doctor-config-flow.test.ts
@@ -881,4 +881,36 @@ describe("doctor config flow", () => {
     // Account should get "*" added even though dmPolicy is inherited from parent
     expect(cfg.channels.telegram.accounts.default.allowFrom).toContain("*");
   });
+
+  it("skips account repair when parent already has allowFrom wildcard (#35560)", async () => {
+    const result = await runDoctorConfigWithInput({
+      repair: true,
+      config: {
+        channels: {
+          telegram: {
+            dmPolicy: "open",
+            allowFrom: ["*"],
+            accounts: {
+              default: {
+                enabled: true,
+                botToken: "fake:token",
+                // inherits dmPolicy=open and allowFrom=["*"] from parent
+              },
+            },
+          },
+        },
+      },
+      run: loadAndMaybeMigrateDoctorConfig,
+    });
+
+    const cfg = result.cfg as unknown as {
+      channels: {
+        telegram: {
+          accounts: { default: { allowFrom?: string[] } };
+        };
+      };
+    };
+    // Account should NOT get its own allowFrom — parent already has "*"
+    expect(cfg.channels.telegram.accounts.default.allowFrom).toBeUndefined();
+  });
 });

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1124,12 +1124,18 @@ function maybeRepairOpenPolicyAllowFrom(cfg: OpenClawConfig): {
 
     const allowFromMode = resolveAllowFromMode(channelName);
 
-    // Check the top-level channel config
-    ensureWildcard(channelConfig, `channels.${channelName}`, allowFromMode);
-
     // Check per-account configs (e.g. channels.discord.accounts.mybot)
     const accounts = channelConfig.accounts as Record<string, Record<string, unknown>> | undefined;
-    if (accounts && typeof accounts === "object") {
+    const hasAccounts =
+      accounts && typeof accounts === "object" && Object.keys(accounts).length > 0;
+
+    // Skip top-level repair when accounts exist — top-level values are
+    // Zod-injected defaults and lack allowFrom, causing spurious repairs (#35560).
+    if (!hasAccounts) {
+      ensureWildcard(channelConfig, `channels.${channelName}`, allowFromMode);
+    }
+
+    if (hasAccounts) {
       for (const [accountName, accountConfig] of Object.entries(accounts)) {
         if (accountConfig && typeof accountConfig === "object") {
           ensureWildcard(
@@ -1276,26 +1282,33 @@ async function maybeRepairAllowlistPolicyAllowFrom(cfg: OpenClawConfig): Promise
     if (!channelConfig || typeof channelConfig !== "object") {
       continue;
     }
-    await recoverAllowFromForAccount({
-      channelName,
-      account: channelConfig,
-      prefix: `channels.${channelName}`,
-    });
 
     const accounts = channelConfig.accounts as Record<string, Record<string, unknown>> | undefined;
-    if (!accounts || typeof accounts !== "object") {
-      continue;
-    }
-    for (const [accountId, accountConfig] of Object.entries(accounts)) {
-      if (!accountConfig || typeof accountConfig !== "object") {
-        continue;
-      }
+    const hasAccounts =
+      accounts && typeof accounts === "object" && Object.keys(accounts).length > 0;
+
+    // Skip top-level repair when accounts exist — top-level values are
+    // Zod-injected defaults and lack allowFrom, causing spurious repairs (#35560).
+    if (!hasAccounts) {
       await recoverAllowFromForAccount({
         channelName,
-        account: accountConfig,
-        accountId,
-        prefix: `channels.${channelName}.accounts.${accountId}`,
+        account: channelConfig,
+        prefix: `channels.${channelName}`,
       });
+    }
+
+    if (hasAccounts) {
+      for (const [accountId, accountConfig] of Object.entries(accounts)) {
+        if (!accountConfig || typeof accountConfig !== "object") {
+          continue;
+        }
+        await recoverAllowFromForAccount({
+          channelName,
+          account: accountConfig,
+          accountId,
+          prefix: `channels.${channelName}.accounts.${accountId}`,
+        });
+      }
     }
   }
 
@@ -1414,10 +1427,19 @@ function detectEmptyAllowlistPolicy(cfg: OpenClawConfig): string[] {
     if (!channelConfig || typeof channelConfig !== "object") {
       continue;
     }
-    checkAccount(channelConfig, `channels.${channelName}`, undefined, channelName);
-
     const accounts = channelConfig.accounts;
-    if (accounts && typeof accounts === "object") {
+    const hasAccounts =
+      accounts && typeof accounts === "object" && Object.keys(accounts).length > 0;
+
+    // Skip top-level policy check when accounts exist — top-level values are
+    // Zod-injected defaults and lack allowFrom/groupAllowFrom, producing false
+    // warnings. Per-account checks below handle each account with the top-level
+    // config as parent fallback (#35560).
+    if (!hasAccounts) {
+      checkAccount(channelConfig, `channels.${channelName}`, undefined, channelName);
+    }
+
+    if (hasAccounts) {
       for (const [accountId, account] of Object.entries(
         accounts as Record<string, Record<string, unknown>>,
       )) {

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1054,14 +1054,24 @@ function maybeRepairOpenPolicyAllowFrom(cfg: OpenClawConfig): {
     account: Record<string, unknown>,
     prefix: string,
     mode: OpenPolicyAllowFromMode,
+    parent?: Record<string, unknown>,
   ) => {
     const dmEntry = account.dm;
     const dm =
       dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)
         ? (dmEntry as Record<string, unknown>)
         : undefined;
+    const parentDmEntry = parent?.dm;
+    const parentDm =
+      parentDmEntry && typeof parentDmEntry === "object" && !Array.isArray(parentDmEntry)
+        ? (parentDmEntry as Record<string, unknown>)
+        : undefined;
     const dmPolicy =
-      (account.dmPolicy as string | undefined) ?? (dm?.policy as string | undefined) ?? undefined;
+      (account.dmPolicy as string | undefined) ??
+      (dm?.policy as string | undefined) ??
+      (parent?.dmPolicy as string | undefined) ??
+      (parentDm?.policy as string | undefined) ??
+      undefined;
 
     if (dmPolicy !== "open") {
       return;
@@ -1142,6 +1152,7 @@ function maybeRepairOpenPolicyAllowFrom(cfg: OpenClawConfig): {
             accountConfig,
             `channels.${channelName}.accounts.${accountName}`,
             allowFromMode,
+            channelConfig,
           );
         }
       }
@@ -1232,14 +1243,23 @@ async function maybeRepairAllowlistPolicyAllowFrom(cfg: OpenClawConfig): Promise
     account: Record<string, unknown>;
     accountId?: string;
     prefix: string;
+    parent?: Record<string, unknown>;
   }) => {
     const dmEntry = params.account.dm;
     const dm =
       dmEntry && typeof dmEntry === "object" && !Array.isArray(dmEntry)
         ? (dmEntry as Record<string, unknown>)
         : undefined;
+    const parentDmEntry = params.parent?.dm;
+    const parentDm =
+      parentDmEntry && typeof parentDmEntry === "object" && !Array.isArray(parentDmEntry)
+        ? (parentDmEntry as Record<string, unknown>)
+        : undefined;
     const dmPolicy =
-      (params.account.dmPolicy as string | undefined) ?? (dm?.policy as string | undefined);
+      (params.account.dmPolicy as string | undefined) ??
+      (dm?.policy as string | undefined) ??
+      (params.parent?.dmPolicy as string | undefined) ??
+      (parentDm?.policy as string | undefined);
     if (dmPolicy !== "allowlist") {
       return;
     }
@@ -1307,6 +1327,7 @@ async function maybeRepairAllowlistPolicyAllowFrom(cfg: OpenClawConfig): Promise
           account: accountConfig,
           accountId,
           prefix: `channels.${channelName}.accounts.${accountId}`,
+          parent: channelConfig,
         });
       }
     }

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1079,11 +1079,15 @@ function maybeRepairOpenPolicyAllowFrom(cfg: OpenClawConfig): {
 
     const topAllowFrom = account.allowFrom as Array<string | number> | undefined;
     const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
-    // If the parent already satisfies the wildcard requirement, skip account-level repair.
-    const parentTopAllowFrom = parent?.allowFrom as Array<string | number> | undefined;
-    const parentNestedAllowFrom = parentDm?.allowFrom as Array<string | number> | undefined;
-    if (hasWildcard(parentTopAllowFrom) || hasWildcard(parentNestedAllowFrom)) {
-      return;
+    // If the account has no local allowFrom override, check whether the parent
+    // already satisfies the wildcard requirement (runtime inherits parent values).
+    const hasLocalAllowFrom = Array.isArray(topAllowFrom) || Array.isArray(nestedAllowFrom);
+    if (!hasLocalAllowFrom) {
+      const parentTopAllowFrom = parent?.allowFrom as Array<string | number> | undefined;
+      const parentNestedAllowFrom = parentDm?.allowFrom as Array<string | number> | undefined;
+      if (hasWildcard(parentTopAllowFrom) || hasWildcard(parentNestedAllowFrom)) {
+        return;
+      }
     }
 
     if (mode === "nestedOnly") {
@@ -1272,17 +1276,18 @@ async function maybeRepairAllowlistPolicyAllowFrom(cfg: OpenClawConfig): Promise
 
     const topAllowFrom = params.account.allowFrom as Array<string | number> | undefined;
     const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
-    // Also check parent's allowFrom — if the parent already has entries,
-    // the account inherits them at runtime and recovery is unnecessary.
-    const parentTopAllowFrom = params.parent?.allowFrom as Array<string | number> | undefined;
-    const parentNestedAllowFrom = parentDm?.allowFrom as Array<string | number> | undefined;
-    if (
-      hasAllowFromEntries(topAllowFrom) ||
-      hasAllowFromEntries(nestedAllowFrom) ||
-      hasAllowFromEntries(parentTopAllowFrom) ||
-      hasAllowFromEntries(parentNestedAllowFrom)
-    ) {
+    if (hasAllowFromEntries(topAllowFrom) || hasAllowFromEntries(nestedAllowFrom)) {
       return;
+    }
+    // If the account has no local allowFrom, check whether the parent already
+    // has entries — at runtime, the account inherits them and recovery is unnecessary.
+    const hasLocalAllowFrom = Array.isArray(topAllowFrom) || Array.isArray(nestedAllowFrom);
+    if (!hasLocalAllowFrom) {
+      const parentTopAllowFrom = params.parent?.allowFrom as Array<string | number> | undefined;
+      const parentNestedAllowFrom = parentDm?.allowFrom as Array<string | number> | undefined;
+      if (hasAllowFromEntries(parentTopAllowFrom) || hasAllowFromEntries(parentNestedAllowFrom)) {
+        return;
+      }
     }
 
     const normalizedChannelId = (normalizeChatChannelId(params.channelName) ?? params.channelName)

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -1079,6 +1079,12 @@ function maybeRepairOpenPolicyAllowFrom(cfg: OpenClawConfig): {
 
     const topAllowFrom = account.allowFrom as Array<string | number> | undefined;
     const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
+    // If the parent already satisfies the wildcard requirement, skip account-level repair.
+    const parentTopAllowFrom = parent?.allowFrom as Array<string | number> | undefined;
+    const parentNestedAllowFrom = parentDm?.allowFrom as Array<string | number> | undefined;
+    if (hasWildcard(parentTopAllowFrom) || hasWildcard(parentNestedAllowFrom)) {
+      return;
+    }
 
     if (mode === "nestedOnly") {
       if (hasWildcard(nestedAllowFrom)) {
@@ -1266,7 +1272,16 @@ async function maybeRepairAllowlistPolicyAllowFrom(cfg: OpenClawConfig): Promise
 
     const topAllowFrom = params.account.allowFrom as Array<string | number> | undefined;
     const nestedAllowFrom = dm?.allowFrom as Array<string | number> | undefined;
-    if (hasAllowFromEntries(topAllowFrom) || hasAllowFromEntries(nestedAllowFrom)) {
+    // Also check parent's allowFrom — if the parent already has entries,
+    // the account inherits them at runtime and recovery is unnecessary.
+    const parentTopAllowFrom = params.parent?.allowFrom as Array<string | number> | undefined;
+    const parentNestedAllowFrom = parentDm?.allowFrom as Array<string | number> | undefined;
+    if (
+      hasAllowFromEntries(topAllowFrom) ||
+      hasAllowFromEntries(nestedAllowFrom) ||
+      hasAllowFromEntries(parentTopAllowFrom) ||
+      hasAllowFromEntries(parentNestedAllowFrom)
+    ) {
       return;
     }
 


### PR DESCRIPTION
## Summary

- When a channel uses multi-account config (e.g. `channels.telegram.accounts.default`), Zod schema defaults inject orphan top-level keys (`dmPolicy`, `groupPolicy`)
without corresponding `allowFrom`/`groupAllowFrom`
- Doctor then emits false warnings like "groupPolicy is allowlist but groupAllowFrom is empty" on every CLI command
- Fix: skip top-level policy checks/repairs when `accounts` exists — per-account checks still run with top-level config as parent fallback

Closes #35560

## Test plan

- New tests verify no false `groupPolicy` warning for multi-account telegram config
- New tests verify account-level warnings still fire when `groupAllowFrom` is missing
- New tests verify `maybeRepairOpenPolicyAllowFrom` does not inject orphan top-level `allowFrom`
- New tests verify `maybeRepairAllowlistPolicyAllowFrom` does not inject orphan top-level `allowFrom`
- 25 existing + new tests pass