### PR TITLE
feat(slack): add reactionTrigger config to wake agent on emoji reactions

### DIFF
--- a/docs/.generated/config-baseline.json
+++ b/docs/.generated/config-baseline.json
@@ -29321,6 +29321,22 @@
       "hasChildren": false
     },
     {
+      "path": "channels.slack.accounts.*.reactionTrigger",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": [
+        "off",
+        "own",
+        "all",
+        "allowlist"
+      ],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
       "path": "channels.slack.accounts.*.replyToMode",
       "kind": "channel",
       "type": "string",
@@ -30716,6 +30732,22 @@
     },
     {
       "path": "channels.slack.reactionNotifications",
+      "kind": "channel",
+      "type": "string",
+      "required": false,
+      "enumValues": [
+        "off",
+        "own",
+        "all",
+        "allowlist"
+      ],
+      "deprecated": false,
+      "sensitive": false,
+      "tags": [],
+      "hasChildren": false
+    },
+    {
+      "path": "channels.slack.reactionTrigger",
       "kind": "channel",
       "type": "string",
       "required": false,

--- a/docs/.generated/config-baseline.jsonl
+++ b/docs/.generated/config-baseline.jsonl
@@ -1,4 +1,4 @@
-{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5630}
+{"generatedBy":"scripts/generate-config-doc-baseline.ts","recordType":"meta","totalPaths":5632}
 {"recordType":"path","path":"acp","kind":"core","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":["advanced"],"label":"ACP","help":"ACP runtime controls for enabling dispatch, selecting backends, constraining allowed agent targets, and tuning streamed turn projection behavior.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents","kind":"core","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":["access"],"label":"ACP Allowed Agents","help":"Allowlist of ACP target agent ids permitted for ACP runtime sessions. Empty means no additional allowlist restriction.","hasChildren":true}
 {"recordType":"path","path":"acp.allowedAgents.*","kind":"core","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2649,6 +2649,7 @@
 {"recordType":"path","path":"channels.slack.accounts.*.reactionAllowlist","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.slack.accounts.*.reactionAllowlist.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.accounts.*.reactionNotifications","kind":"channel","type":"string","required":false,"enumValues":["off","own","all","allowlist"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.slack.accounts.*.reactionTrigger","kind":"channel","type":"string","required":false,"enumValues":["off","own","all","allowlist"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.accounts.*.replyToMode","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.accounts.*.replyToModeByChatType","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.slack.accounts.*.replyToModeByChatType.channel","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
@@ -2774,6 +2775,7 @@
 {"recordType":"path","path":"channels.slack.reactionAllowlist","kind":"channel","type":"array","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.slack.reactionAllowlist.*","kind":"channel","type":["number","string"],"required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.reactionNotifications","kind":"channel","type":"string","required":false,"enumValues":["off","own","all","allowlist"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
+{"recordType":"path","path":"channels.slack.reactionTrigger","kind":"channel","type":"string","required":false,"enumValues":["off","own","all","allowlist"],"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.replyToMode","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}
 {"recordType":"path","path":"channels.slack.replyToModeByChatType","kind":"channel","type":"object","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":true}
 {"recordType":"path","path":"channels.slack.replyToModeByChatType.channel","kind":"channel","type":"string","required":false,"deprecated":false,"sensitive":false,"tags":[],"hasChildren":false}

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -387,6 +387,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
       historyLimit: 50,
       allowBots: false,
       reactionNotifications: "own",
+      reactionTrigger: "off", // off | own | all | allowlist
       reactionAllowlist: ["U123"],
       replyToMode: "off", // off | first | all
       thread: {
@@ -420,6 +421,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - **Socket mode** requires both `botToken` and `appToken` (`SLACK_BOT_TOKEN` + `SLACK_APP_TOKEN` for default account env fallback).
 - **HTTP mode** requires `botToken` plus `signingSecret` (at root or per-account).
 - `configWrites: false` blocks Slack-initiated config writes.
+- `reactionTrigger`: when enabled, wakes the agent session immediately on emoji reactions instead of waiting for the next message or heartbeat. Values: `off` (default), `own` (reactions on bot messages only), `all` (any reaction), `allowlist` (from `reactionAllowlist`). Note: on Slack Free workspaces, reaction events may not be delivered by the Slack API.
 - Optional `channels.slack.defaultAccount` overrides default account selection when it matches a configured account id.
 - `channels.slack.streaming` is the canonical stream mode key. Legacy `streamMode` and boolean `streaming` values are auto-migrated.
 - Use `user:<id>` (DM) or `channel:<id>` for delivery targets.

--- a/docs/tools/reactions.md
+++ b/docs/tools/reactions.md
@@ -61,4 +61,26 @@ tool with the `react` action. Reaction behavior varies by channel.
 ## Related
 
 - [Agent Send](/tools/agent-send) — the `message` tool that includes `react`
-- [Channels](/channels) — channel-specific configuration
+
+## Reaction trigger (`reactionTrigger`)
+
+When `reactionTrigger` is enabled, receiving a reaction immediately wakes the agent session (via `requestHeartbeatNow`) instead of waiting for the next message or scheduled heartbeat. This lets the agent respond to reactions in real time.
+
+Currently supported for **Slack** only. Other channels (Telegram, Discord, Signal) can be added in follow-up PRs.
+
+**Values:**
+
+| Value       | Behavior                                                             |
+| ----------- | -------------------------------------------------------------------- |
+| `off`       | (Default) No immediate wake on reactions.                            |
+| `own`       | Wake only when a reaction is added to one of the bot's own messages. |
+| `all`       | Wake on any reaction the bot can see.                                |
+| `allowlist` | (Slack only) Wake for reactions from allowlisted users.              |
+
+**Important distinctions:**
+
+- `reactionNotifications` controls which reactions generate system events (the data the agent sees).
+- `reactionTrigger` controls whether those reactions also wake the agent immediately.
+- Both settings are independent — you can have notifications without triggering, or vice versa.
+
+**Slack Free plan limitation:** Reaction events (`reaction_added` / `reaction_removed`) are not delivered on Slack Free workspaces, so `reactionTrigger` has no effect there.

--- a/extensions/slack/src/monitor/events/reactions.test.ts
+++ b/extensions/slack/src/monitor/events/reactions.test.ts
@@ -239,7 +239,6 @@ describe("registerSlackReactionEvents", () => {
 
     it("calls requestHeartbeatNow for 'allowlist' when user is in reactionAllowlist", async () => {
       reactionQueueMock.mockReset();
-      reactionAllowMock.mockReset().mockResolvedValue([]);
       requestHeartbeatNowMock.mockReset();
       const harness = createSlackSystemEventTestHarness({
         reactionTrigger: "allowlist",
@@ -255,7 +254,6 @@ describe("registerSlackReactionEvents", () => {
 
     it("does NOT call requestHeartbeatNow for 'allowlist' when user is not in list", async () => {
       reactionQueueMock.mockReset();
-      reactionAllowMock.mockReset().mockResolvedValue([]);
       requestHeartbeatNowMock.mockReset();
       const harness = createSlackSystemEventTestHarness({
         reactionTrigger: "allowlist",

--- a/extensions/slack/src/monitor/events/reactions.test.ts
+++ b/extensions/slack/src/monitor/events/reactions.test.ts
@@ -236,5 +236,35 @@ describe("registerSlackReactionEvents", () => {
       await handler!({ event: buildReactionEventWithItemUser(), body: {} });
       expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
     });
+
+    it("calls requestHeartbeatNow for 'allowlist' when user is in reactionAllowlist", async () => {
+      reactionQueueMock.mockReset();
+      reactionAllowMock.mockReset().mockResolvedValue([]);
+      requestHeartbeatNowMock.mockReset();
+      const harness = createSlackSystemEventTestHarness({
+        reactionTrigger: "allowlist",
+        reactionAllowlist: ["U123", "U456"],
+      });
+      registerSlackReactionEvents({ ctx: harness.ctx });
+      const handler = harness.getHandler("reaction_added");
+      await handler!({ event: buildReactionEventWithItemUser({ user: "U123" }), body: {} });
+      expect(requestHeartbeatNowMock).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: "reaction" }),
+      );
+    });
+
+    it("does NOT call requestHeartbeatNow for 'allowlist' when user is not in list", async () => {
+      reactionQueueMock.mockReset();
+      reactionAllowMock.mockReset().mockResolvedValue([]);
+      requestHeartbeatNowMock.mockReset();
+      const harness = createSlackSystemEventTestHarness({
+        reactionTrigger: "allowlist",
+        reactionAllowlist: ["U456"],
+      });
+      registerSlackReactionEvents({ ctx: harness.ctx });
+      const handler = harness.getHandler("reaction_added");
+      await handler!({ event: buildReactionEventWithItemUser({ user: "U123" }), body: {} });
+      expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/extensions/slack/src/monitor/events/reactions.test.ts
+++ b/extensions/slack/src/monitor/events/reactions.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const reactionQueueMock = vi.hoisted(() => vi.fn());
+const requestHeartbeatNowMock = vi.hoisted(() => vi.fn());
 let registerSlackReactionEvents: typeof import("./reactions.js").registerSlackReactionEvents;
 let createSlackSystemEventTestHarness: typeof import("./system-event-test-harness.js").createSlackSystemEventTestHarness;
 type SlackSystemEventTestOverrides =
@@ -11,6 +12,7 @@ vi.mock("openclaw/plugin-sdk/infra-runtime", async (importOriginal) => {
   return {
     ...actual,
     enqueueSystemEvent: (...args: unknown[]) => reactionQueueMock(...args),
+    requestHeartbeatNow: (...args: unknown[]) => requestHeartbeatNowMock(...args),
   };
 });
 
@@ -79,6 +81,7 @@ describe("registerSlackReactionEvents", () => {
 
   beforeEach(() => {
     reactionQueueMock.mockClear();
+    requestHeartbeatNowMock.mockClear();
   });
 
   const cases: Array<{ name: string; input: ReactionRunInput; expectedCalls: number }> = [
@@ -175,6 +178,63 @@ describe("registerSlackReactionEvents", () => {
       channelId: "D123",
       channelType: "im",
       senderId: "U777",
+    });
+  });
+
+  describe("reactionTrigger", () => {
+    function buildReactionEventWithItemUser(overrides?: { user?: string; item_user?: string }) {
+      return {
+        type: "reaction_added",
+        user: overrides?.user ?? "U123",
+        reaction: "thumbsup",
+        item_user: overrides?.item_user ?? "UBOT",
+        item: { type: "message", channel: "C123", ts: "1234567890.000100" },
+        event_ts: "1234567890.100200",
+      };
+    }
+
+    it("calls requestHeartbeatNow when reactionTrigger is 'all'", async () => {
+      requestHeartbeatNowMock.mockReset();
+      const harness = createSlackSystemEventTestHarness({ reactionTrigger: "all" });
+      registerSlackReactionEvents({ ctx: harness.ctx });
+      const handler = harness.getHandler("reaction_added");
+      await handler!({ event: buildReactionEventWithItemUser(), body: {} });
+      expect(requestHeartbeatNowMock).toHaveBeenCalledWith(
+        expect.objectContaining({ reason: "reaction" }),
+      );
+    });
+
+    it("calls requestHeartbeatNow for 'own' when item_user matches bot", async () => {
+      requestHeartbeatNowMock.mockReset();
+      const harness = createSlackSystemEventTestHarness({
+        reactionTrigger: "own",
+        botUserId: "UBOT",
+      });
+      registerSlackReactionEvents({ ctx: harness.ctx });
+      const handler = harness.getHandler("reaction_added");
+      await handler!({ event: buildReactionEventWithItemUser({ item_user: "UBOT" }), body: {} });
+      expect(requestHeartbeatNowMock).toHaveBeenCalled();
+    });
+
+    it("does NOT call requestHeartbeatNow for 'own' when item_user differs", async () => {
+      requestHeartbeatNowMock.mockReset();
+      const harness = createSlackSystemEventTestHarness({
+        reactionTrigger: "own",
+        botUserId: "UBOT",
+      });
+      registerSlackReactionEvents({ ctx: harness.ctx });
+      const handler = harness.getHandler("reaction_added");
+      await handler!({ event: buildReactionEventWithItemUser({ item_user: "UOTHER" }), body: {} });
+      expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
+    });
+
+    it("does NOT call requestHeartbeatNow when reactionTrigger is 'off'", async () => {
+      requestHeartbeatNowMock.mockReset();
+      const harness = createSlackSystemEventTestHarness({ reactionTrigger: "off" });
+      registerSlackReactionEvents({ ctx: harness.ctx });
+      const handler = harness.getHandler("reaction_added");
+      await handler!({ event: buildReactionEventWithItemUser(), body: {} });
+      expect(requestHeartbeatNowMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/extensions/slack/src/monitor/events/reactions.ts
+++ b/extensions/slack/src/monitor/events/reactions.ts
@@ -63,8 +63,11 @@ export function registerSlackReactionEvents(params: {
       const reactionTrigger = ctx.cfg.channels?.slack?.reactionTrigger ?? "off";
       if (reactionTrigger !== "off") {
         const isBotMessage = event.item_user === ctx.botUserId;
+        const isAllowlisted =
+          reactionTrigger === "allowlist" &&
+          ctx.reactionAllowlist?.some((id) => String(id) === String(event.user));
         const shouldTrigger =
-          reactionTrigger === "all" || (reactionTrigger === "own" && isBotMessage);
+          reactionTrigger === "all" || (reactionTrigger === "own" && isBotMessage) || isAllowlisted;
         if (shouldTrigger) {
           logVerbose(`slack: reaction trigger wake for session ${ingressContext.sessionKey}`);
           requestHeartbeatNow({

--- a/extensions/slack/src/monitor/events/reactions.ts
+++ b/extensions/slack/src/monitor/events/reactions.ts
@@ -1,6 +1,7 @@
 import type { SlackEventMiddlewareArgs } from "@slack/bolt";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/infra-runtime";
-import { danger } from "openclaw/plugin-sdk/runtime-env";
+import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
+import { requestHeartbeatNow } from "openclaw/plugin-sdk/infra-runtime";
 import type { SlackMonitorContext } from "../context.js";
 import type { SlackReactionEvent } from "../types.js";
 import { authorizeAndResolveSlackSystemEventContext } from "./system-event-context.js";
@@ -10,6 +11,17 @@ export function registerSlackReactionEvents(params: {
   trackEvent?: () => void;
 }) {
   const { ctx, trackEvent } = params;
+
+  // Emit a startup diagnostic when reaction features are enabled.
+  const cfgReactionNotifications = ctx.cfg.channels?.slack?.reactionNotifications ?? "off";
+  const cfgReactionTrigger = ctx.cfg.channels?.slack?.reactionTrigger ?? "off";
+  if (cfgReactionNotifications !== "off" || cfgReactionTrigger !== "off") {
+    logVerbose(
+      `slack: reaction features enabled (notifications=${cfgReactionNotifications}, trigger=${cfgReactionTrigger}). ` +
+        `Ensure your Slack app has "reaction_added" and "reaction_removed" bot events subscribed ` +
+        `at https://api.slack.com/apps — without them, no reaction events will be delivered.`,
+    );
+  }
 
   const handleReactionEvent = async (event: SlackReactionEvent, action: string) => {
     try {
@@ -45,6 +57,22 @@ export function registerSlackReactionEvents(params: {
         sessionKey: ingressContext.sessionKey,
         contextKey: `slack:reaction:${action}:${item.channel}:${item.ts}:${event.user}:${emojiLabel}`,
       });
+
+      // When reactionTrigger is enabled, wake the agent session so it can
+      // process the reaction immediately instead of waiting for the next turn.
+      const reactionTrigger = ctx.cfg.channels?.slack?.reactionTrigger ?? "off";
+      if (reactionTrigger !== "off") {
+        const isBotMessage = event.item_user === ctx.botUserId;
+        const shouldTrigger =
+          reactionTrigger === "all" || (reactionTrigger === "own" && isBotMessage);
+        if (shouldTrigger) {
+          logVerbose(`slack: reaction trigger wake for session ${ingressContext.sessionKey}`);
+          requestHeartbeatNow({
+            reason: "reaction",
+            sessionKey: ingressContext.sessionKey,
+          });
+        }
+      }
     } catch (err) {
       ctx.runtime.error?.(danger(`slack reaction handler failed: ${String(err)}`));
     }

--- a/extensions/slack/src/monitor/events/reactions.ts
+++ b/extensions/slack/src/monitor/events/reactions.ts
@@ -1,7 +1,7 @@
 import type { SlackEventMiddlewareArgs } from "@slack/bolt";
 import { enqueueSystemEvent } from "openclaw/plugin-sdk/infra-runtime";
-import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import { requestHeartbeatNow } from "openclaw/plugin-sdk/infra-runtime";
+import { danger, logVerbose } from "openclaw/plugin-sdk/runtime-env";
 import type { SlackMonitorContext } from "../context.js";
 import type { SlackReactionEvent } from "../types.js";
 import { authorizeAndResolveSlackSystemEventContext } from "./system-event-context.js";

--- a/extensions/slack/src/monitor/events/system-event-test-harness.ts
+++ b/extensions/slack/src/monitor/events/system-event-test-harness.ts
@@ -10,6 +10,8 @@ export type SlackSystemEventTestOverrides = {
   allowFrom?: string[];
   channelType?: "im" | "channel";
   channelUsers?: string[];
+  reactionTrigger?: "off" | "own" | "all";
+  botUserId?: string;
 };
 
 export function createSlackSystemEventTestHarness(overrides?: SlackSystemEventTestOverrides) {
@@ -45,6 +47,14 @@ export function createSlackSystemEventTestHarness(overrides?: SlackSystemEventTe
     }),
     resolveUserName: async () => ({ name: "alice" }),
     resolveSlackSystemEventSessionKey: () => "agent:main:main",
+    botUserId: overrides?.botUserId ?? "UBOT",
+    cfg: {
+      channels: {
+        slack: {
+          reactionTrigger: overrides?.reactionTrigger ?? "off",
+        },
+      },
+    },
   } as unknown as SlackMonitorContext;
 
   return {

--- a/extensions/slack/src/monitor/events/system-event-test-harness.ts
+++ b/extensions/slack/src/monitor/events/system-event-test-harness.ts
@@ -10,7 +10,8 @@ export type SlackSystemEventTestOverrides = {
   allowFrom?: string[];
   channelType?: "im" | "channel";
   channelUsers?: string[];
-  reactionTrigger?: "off" | "own" | "all";
+  reactionTrigger?: "off" | "own" | "all" | "allowlist";
+  reactionAllowlist?: Array<string | number>;
   botUserId?: string;
 };
 
@@ -48,6 +49,7 @@ export function createSlackSystemEventTestHarness(overrides?: SlackSystemEventTe
     resolveUserName: async () => ({ name: "alice" }),
     resolveSlackSystemEventSessionKey: () => "agent:main:main",
     botUserId: overrides?.botUserId ?? "UBOT",
+    reactionAllowlist: overrides?.reactionAllowlist ?? [],
     cfg: {
       channels: {
         slack: {

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -159,6 +159,8 @@ export type SlackAccountConfig = {
   mediaMaxMb?: number;
   /** Reaction notification mode (off|own|all|allowlist). Default: own. */
   reactionNotifications?: SlackReactionNotificationMode;
+  /** When set, wake the agent session immediately on emoji reactions. */
+  reactionTrigger?: SlackReactionNotificationMode;
   /** Allowlist for reaction notifications when mode is allowlist. */
   reactionAllowlist?: Array<string | number>;
   /** Control reply threading when reply tags are present (off|first|all). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -890,6 +890,7 @@ export const SlackAccountSchema = z
     streamMode: z.enum(["replace", "status_final", "append"]).optional(),
     mediaMaxMb: z.number().positive().optional(),
     reactionNotifications: z.enum(["off", "own", "all", "allowlist"]).optional(),
+    reactionTrigger: z.enum(["off", "own", "all", "allowlist"]).optional(),
     reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
     replyToMode: ReplyToModeSchema.optional(),
     replyToModeByChatType: SlackReplyToModeByChatTypeSchema.optional(),

--- a/src/plugin-sdk/infra-runtime.ts
+++ b/src/plugin-sdk/infra-runtime.ts
@@ -17,6 +17,7 @@ export * from "../infra/format-time/format-duration.ts";
 export * from "../infra/fs-safe.ts";
 export * from "../infra/heartbeat-events.ts";
 export * from "../infra/heartbeat-visibility.ts";
+export * from "../infra/heartbeat-wake.ts";
 export * from "../infra/home-dir.js";
 export * from "../infra/http-body.js";
 export * from "../infra/json-files.js";


### PR DESCRIPTION
## Summary

When `reactionTrigger` is enabled on the Slack channel, receiving a reaction immediately wakes the agent session via `requestHeartbeatNow` instead of waiting for the next message or scheduled heartbeat.

## Configuration

```json5
{
  channels: {
    slack: {
      reactionTrigger: "off", // off | own | all | allowlist
    },
  },
}
```

**Values:**
| Value | Behavior |
|-------|----------|
| `off` | (Default) No immediate wake on reactions |
| `own` | Wake only for reactions on bot's own messages |
| `all` | Wake on any reaction |
| `allowlist` | Wake for reactions from `reactionAllowlist` users |

## Design decisions

- **Slack-only in this PR.** Core schema adds the optional field for Slack only. Other channels (Telegram, Discord, Signal) can follow in separate PRs with minimal effort — the pattern is identical.
- **Non-breaking.** The field is `optional` with no default — existing configs are unaffected.
- **Independent of `reactionNotifications`.** Notifications control which reactions create system events; trigger controls whether they also wake the agent.
- **Startup diagnostic** logs a warning when reaction features are enabled but Slack app event subscriptions may be missing.

## Changes

- `src/config/zod-schema.providers-core.ts` — add `reactionTrigger` schema (Slack only)
- `src/config/types.slack.ts` — add type field
- `src/slack/monitor/events/reactions.ts` — trigger logic + startup diagnostic
- `src/slack/monitor/events/reactions.test.ts` — 4 new test cases
- `src/slack/monitor/events/system-event-test-harness.ts` — test harness support
- `docs/` — config reference + reactions doc

## Note

This replaces #27932 which was auto-closed by the dirty-PR bot due to touching too many scope labels (4 channels in one PR). This version is scoped to Slack only.