### PR TITLE
docs(readme): add gateway status check in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Full beginner guide (auth, pairing, channels): [Getting started](https://docs.op
 ```bash
 openclaw onboard --install-daemon
 
+# Check daemon state first
+openclaw gateway status
+
 openclaw gateway --port 18789 --verbose
 
 # Send a message


### PR DESCRIPTION
## Summary
- add openclaw gateway status before running gateway in Quick Start

## Why
- helps users verify daemon/runtime state before running service commands

## Scope
- README only

## Risk
- docs-only change, no runtime behavior changes