### PR TITLE
docs(readme): add gateway daemon command quick-reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,13 @@ Full beginner guide (auth, pairing, channels): [Getting started](https://docs.op
 ```bash
 openclaw onboard --install-daemon
 
+# Check daemon state first
+openclaw gateway status
+
 openclaw gateway --port 18789 --verbose
+
+# Manage the gateway daemon service
+openclaw gateway restart
 
 # Send a message
 openclaw message send --to +1234567890 --message "Hello from OpenClaw"

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ openclaw gateway --port 18789 --verbose
 
 # Manage the gateway daemon service
 openclaw gateway restart
+openclaw gateway stop
+openclaw gateway start
 
 # Send a message
 openclaw message send --to +1234567890 --message "Hello from OpenClaw"


### PR DESCRIPTION
## Summary
- add quick-reference daemon commands in README Quick Start:
  - openclaw gateway restart
  - openclaw gateway stop
  - openclaw gateway start

## Why
- clarifies background-service lifecycle commands for first-time users

## Scope
- README only

## Risk
- docs-only change, no runtime behavior changes