### PR TITLE
feat(feishu): support replyToMode config to control reply attachment behavior

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1340,6 +1340,15 @@ export async function handleFeishuMessage(params: {
     const replyTargetMessageId = ctx.rootId ?? ctx.messageId;
     const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
 
+    // Resolve replyToMode: controls whether replies are attached to the
+    // triggering message or sent as standalone messages.
+    // - "off": always send as new top-level messages (skipReplyTo = true)
+    // - "all": always reply to the triggering message
+    // - "first" / undefined: default behavior (reply in groups, skip in DMs)
+    const replyToMode = account.config?.replyToMode;
+    const skipReplyToInMessages =
+      replyToMode === "off" ? true : replyToMode === "all" ? false : !isGroup;
+
     if (broadcastAgents) {
       // Cross-account dedup: in multi-account setups, Feishu delivers the same
       // event to every bot account in the group. Only one account should handle
@@ -1389,7 +1398,7 @@ export async function handleFeishuMessage(params: {
             runtime: runtime as RuntimeEnv,
             chatId: ctx.chatId,
             replyToMessageId: replyTargetMessageId,
-            skipReplyToInMessages: !isGroup,
+            skipReplyToInMessages,
             replyInThread,
             rootId: ctx.rootId,
             threadReply,
@@ -1487,7 +1496,7 @@ export async function handleFeishuMessage(params: {
         runtime: runtime as RuntimeEnv,
         chatId: ctx.chatId,
         replyToMessageId: replyTargetMessageId,
-        skipReplyToInMessages: !isGroup,
+        skipReplyToInMessages,
         replyInThread,
         rootId: ctx.rootId,
         threadReply,

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -128,6 +128,19 @@ const ReactionNotificationModeSchema = z.enum(["off", "own", "all"]).optional();
  */
 const ReplyInThreadSchema = z.enum(["disabled", "enabled"]).optional();
 
+/**
+ * Reply-to mode for controlling whether bot replies are attached to the
+ * triggering message or sent as standalone messages in the chat.
+ *
+ * - "off": Send replies as new top-level messages (not attached to any message)
+ * - "first": Reply to the first message in the conversation (default for groups)
+ * - "all": Reply to every triggering message
+ *
+ * In group chats, "off" prevents replies from being collapsed under the
+ * original message, keeping them visible in the main chat flow.
+ */
+const ReplyToModeSchema = z.enum(["off", "first", "all"]).optional();
+
 export const FeishuGroupSchema = z
   .object({
     requireMention: z.boolean().optional(),
@@ -167,6 +180,7 @@ const FeishuSharedConfigShape = {
   streaming: StreamingModeSchema,
   tools: FeishuToolsConfigSchema,
   replyInThread: ReplyInThreadSchema,
+  replyToMode: ReplyToModeSchema,
   reactionNotifications: ReactionNotificationModeSchema,
   typingIndicator: z.boolean().optional(),
   resolveSenderNames: z.boolean().optional(),


### PR DESCRIPTION
## Problem

In Feishu group chats, bot replies are always attached to the triggering message via Feishu's reply API (`client.im.message.reply`). This causes replies to be **collapsed/folded under the original message**, making them hard to find in active group conversations.

The `replyToMode` config option exists in the core SDK schema and is used by other channels (Discord, Telegram, etc.), but the Feishu extension hardcodes `skipReplyToInMessages: !isGroup` — always replying to the triggering message in groups, ignoring any `replyToMode` configuration.

## Solution

Add `replyToMode` support to the Feishu extension:

- **`config-schema.ts`**: Add `ReplyToModeSchema` (`'off' | 'first' | 'all'`) to `FeishuSharedConfigShape`, making it available at both top-level and per-account config.
- **`bot.ts`**: Read `account.config?.replyToMode` and compute `skipReplyToInMessages` accordingly:
  - `'off'`: Always send as new top-level messages (not attached to any message)
  - `'all'`: Always reply to the triggering message  
  - `'first'` / unset: Default behavior preserved (reply in groups, skip in DMs)

Both the broadcast dispatch path and single-agent dispatch path are updated.

## Usage

```yaml
channels:
  feishu:
    replyToMode: 'off'  # Replies appear as new messages in chat flow
```

## Backward Compatibility

When `replyToMode` is not set, behavior is identical to before (groups reply to triggering message, DMs send standalone). This is a non-breaking addition.