### PR TITLE
fix(bluebubbles): preserve iMessage service in chat_guid routing

### DIFF
--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -275,8 +275,17 @@ export async function resolveChatGuidForTarget(params: {
       if (normalizedHandle) {
         const guid = extractChatGuid(chat);
         const directHandle = guid ? extractHandleFromChatGuid(guid) : null;
+        const targetService = params.target.kind === "handle" ? (params.target.service ?? "auto") : "auto";
         if (directHandle && directHandle === normalizedHandle) {
-          return guid;
+          if (targetService === "auto") {
+            return guid;
+          }
+          const guidServiceLower = (guid?.split(";")[0] ?? "").toLowerCase();
+          const serviceMatches =
+            (targetService === "imessage" && guidServiceLower === "imessage") ||
+            (targetService === "sms" && guidServiceLower === "sms");
+          if (serviceMatches) return guid;
+          // service mismatch: continue to next chat
         }
         if (!participantMatch && guid) {
           // Only consider DM chats (`;-;` separator) as participant matches.
@@ -284,11 +293,18 @@ export async function resolveChatGuidForTarget(params: {
           // This prevents routing "send to +1234567890" to a group chat that contains that number.
           const isDmChat = guid.includes(";-;");
           if (isDmChat) {
-            const participants = extractParticipantAddresses(chat).map((entry) =>
-              normalizeBlueBubblesHandle(entry),
-            );
-            if (participants.includes(normalizedHandle)) {
-              participantMatch = guid;
+            const guidServiceLower = guid.split(";")[0]?.toLowerCase() ?? "";
+            const serviceOk =
+              targetService === "auto" ||
+              (targetService === "imessage" && guidServiceLower === "imessage") ||
+              (targetService === "sms" && guidServiceLower === "sms");
+            if (serviceOk) {
+              const participants = extractParticipantAddresses(chat).map((entry) =>
+                normalizeBlueBubblesHandle(entry),
+              );
+              if (participants.includes(normalizedHandle)) {
+                participantMatch = guid;
+              }
             }
           }
         }

--- a/extensions/bluebubbles/src/send.ts
+++ b/extensions/bluebubbles/src/send.ts
@@ -275,7 +275,8 @@ export async function resolveChatGuidForTarget(params: {
       if (normalizedHandle) {
         const guid = extractChatGuid(chat);
         const directHandle = guid ? extractHandleFromChatGuid(guid) : null;
-        const targetService = params.target.kind === "handle" ? (params.target.service ?? "auto") : "auto";
+        const targetService =
+          params.target.kind === "handle" ? (params.target.service ?? "auto") : "auto";
         if (directHandle && directHandle === normalizedHandle) {
           if (targetService === "auto") {
             return guid;

--- a/extensions/bluebubbles/src/targets.test.ts
+++ b/extensions/bluebubbles/src/targets.test.ts
@@ -22,17 +22,27 @@ describe("normalizeBlueBubblesMessagingTarget", () => {
     );
   });
 
-  it("extracts handle from DM chat_guid for cross-context matching", () => {
+  it("preserves service prefix from DM chat_guid for correct routing", () => {
     // DM format: service;-;handle
+    // Service prefix is preserved to ensure iMessage vs SMS routing
     expect(normalizeBlueBubblesMessagingTarget("chat_guid:iMessage;-;+19257864429")).toBe(
-      "+19257864429",
+      "imessage:+19257864429",
     );
     expect(normalizeBlueBubblesMessagingTarget("chat_guid:SMS;-;+15551234567")).toBe(
-      "+15551234567",
+      "sms:+15551234567",
     );
     // Email handles
     expect(normalizeBlueBubblesMessagingTarget("chat_guid:iMessage;-;user@example.com")).toBe(
-      "user@example.com",
+      "imessage:user@example.com",
+    );
+  });
+
+  it("handles raw chat_guid with service preservation", () => {
+    expect(normalizeBlueBubblesMessagingTarget("iMessage;-;+19257864429")).toBe(
+      "imessage:+19257864429",
+    );
+    expect(normalizeBlueBubblesMessagingTarget("SMS;-;+15551234567")).toBe(
+      "sms:+15551234567",
     );
   });
 

--- a/extensions/bluebubbles/src/targets.test.ts
+++ b/extensions/bluebubbles/src/targets.test.ts
@@ -57,7 +57,9 @@ describe("normalizeBlueBubblesMessagingTarget", () => {
     expect(normalizeBlueBubblesMessagingTarget("iMessage;+;chat660250192681427962")).toBe(
       "chat_guid:iMessage;+;chat660250192681427962",
     );
-    expect(normalizeBlueBubblesMessagingTarget("iMessage;-;+19257864429")).toBe("+19257864429");
+    expect(normalizeBlueBubblesMessagingTarget("iMessage;-;+19257864429")).toBe(
+      "imessage:+19257864429",
+    );
   });
 
   it("normalizes chat<digits> pattern to chat_identifier format", () => {

--- a/extensions/bluebubbles/src/targets.test.ts
+++ b/extensions/bluebubbles/src/targets.test.ts
@@ -41,9 +41,7 @@ describe("normalizeBlueBubblesMessagingTarget", () => {
     expect(normalizeBlueBubblesMessagingTarget("iMessage;-;+19257864429")).toBe(
       "imessage:+19257864429",
     );
-    expect(normalizeBlueBubblesMessagingTarget("SMS;-;+15551234567")).toBe(
-      "sms:+15551234567",
-    );
+    expect(normalizeBlueBubblesMessagingTarget("SMS;-;+15551234567")).toBe("sms:+15551234567");
   });
 
   it("preserves group chat_guid format", () => {

--- a/extensions/bluebubbles/src/targets.ts
+++ b/extensions/bluebubbles/src/targets.ts
@@ -166,6 +166,10 @@ export function normalizeBlueBubblesMessagingTarget(raw: string): string | undef
       // This allows "chat_guid:iMessage;-;+1234567890" to match "+1234567890".
       const handle = extractHandleFromChatGuid(parsed.chatGuid);
       if (handle) {
+        // Preserve service prefix to ensure correct routing (iMessage vs SMS)
+        const guidService = parsed.chatGuid.split(";")[0]?.trim().toLowerCase();
+        if (guidService === "imessage") return `imessage:${handle}`;
+        if (guidService === "sms") return `sms:${handle}`;
         return handle;
       }
       // For group chats or unrecognized formats, keep the full chat_guid


### PR DESCRIPTION
## Summary

Fixes #35624 - When sending proactive messages to contacts with both iMessage and SMS chat histories, OpenClaw was always routing through SMS instead of iMessage, even when using the officially recommended `chat_guid:iMessage;-;+xxx` format.

## Root Cause

1. **`normalizeBlueBubblesMessagingTarget()`** in `targets.ts` stripped service info from `chat_guid`, returning just the phone number
2. **`resolveChatGuidForTarget()`** in `send.ts` returned the first matching chat without filtering by service type

## Changes

### `extensions/bluebubbles/src/targets.ts`
- Preserve service prefix (`imessage:`/`sms:`) when normalizing DM chat_guids
- Ensures service information flows through to chat resolution

### `extensions/bluebubbles/src/send.ts`
- Filter chat query results by service type when `service !== "auto"`
- Only return chats matching the requested service (iMessage vs SMS)

### `extensions/bluebubbles/src/targets.test.ts`
- Update existing tests to reflect new service-preserving behavior
- Add test cases for raw chat_guid service preservation

## Testing

Tested locally with a contact having both `iMessage;-;+xxx` and `SMS;-;+xxx` chats:

**Before:**
```
[debug] Sending message "test" to SMS;-;+8615652628246
```

**After:**
```
[debug] Sending message "test" to iMessage;-;+8615652628246
```

## Impact

- Fixes proactive sends (cron jobs, Slack commands) routing through wrong service
- Preserves iMessage features (reactions, effects, read receipts)
- Maintains backward compatibility: `service: "auto"` still returns first match
- No breaking changes for existing users

## Related

The official docs recommend using `chat_guid:iMessage;-;+xxx` format for stable routing, but this wasn't working due to normalization stripping the service info.
