### PR TITLE
feat(webchat): add PDF attachment support

### DIFF
--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -69,6 +69,7 @@ export async function runCliAgent(params: {
   /** Backward-compat fallback when only the previous signature is available. */
   bootstrapPromptWarningSignature?: string;
   images?: ImageContent[];
+  documents?: Array<{ type: "document"; data: string; mimeType: string; fileName?: string }>;
 }): Promise<EmbeddedPiRunResult> {
   const started = Date.now();
   const workspaceResolution = resolveRunWorkspaceDir({

--- a/src/agents/cli-runner.ts
+++ b/src/agents/cli-runner.ts
@@ -19,6 +19,7 @@ import {
 import { makeBootstrapWarn, resolveBootstrapContextForRun } from "./bootstrap-files.js";
 import { resolveCliBackendConfig } from "./cli-backends.js";
 import {
+  appendDocumentPathsToPrompt,
   appendImagePathsToPrompt,
   buildCliSupervisorScopeKey,
   buildCliArgs,
@@ -31,6 +32,7 @@ import {
   resolvePromptInput,
   resolveSessionIdToSend,
   resolveSystemPromptUsage,
+  writeCliDocuments,
   writeCliImages,
 } from "./cli-runner/helpers.js";
 import { resolveOpenClawDocsPath } from "./docs-path.js";
@@ -211,6 +213,7 @@ export async function runCliAgent(params: {
 
     let imagePaths: string[] | undefined;
     let cleanupImages: (() => Promise<void>) | undefined;
+    let cleanupDocuments: (() => Promise<void>) | undefined;
     let prompt = params.prompt;
     if (params.images && params.images.length > 0) {
       const imagePayload = await writeCliImages(params.images);
@@ -219,6 +222,15 @@ export async function runCliAgent(params: {
       if (!backend.imageArg) {
         prompt = appendImagePathsToPrompt(prompt, imagePaths);
       }
+    }
+
+    // CLI backends don't support binary document injection (no onPayload hook).
+    // Write PDFs to temp files and append their paths to the prompt so the
+    // underlying CLI agent (e.g. claude-code, codex) can read them directly.
+    if (params.documents && params.documents.length > 0) {
+      const docPayload = await writeCliDocuments(params.documents);
+      cleanupDocuments = docPayload.cleanup;
+      prompt = appendDocumentPathsToPrompt(prompt, docPayload.paths);
     }
 
     const { argsPrompt, stdin } = resolvePromptInput({
@@ -401,6 +413,9 @@ export async function runCliAgent(params: {
     } finally {
       if (cleanupImages) {
         await cleanupImages();
+      }
+      if (cleanupDocuments) {
+        await cleanupDocuments();
       }
     }
   };

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -344,7 +344,9 @@ export async function writeCliDocuments(
   for (let i = 0; i < documents.length; i += 1) {
     const doc = documents[i];
     const ext = doc.mimeType === "application/pdf" ? "pdf" : "bin";
-    const baseName = doc.fileName ?? `document-${i + 1}.${ext}`;
+    // Sanitize fileName: strip any path separators to prevent directory
+    // traversal (e.g. "../../../etc/passwd" from a crafted attachment name).
+    const baseName = path.basename(doc.fileName ?? `document-${i + 1}.${ext}`);
     const filePath = path.join(tempDir, baseName);
     const buffer = Buffer.from(doc.data, "base64");
     await fs.writeFile(filePath, buffer, { mode: 0o600 });

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -347,7 +347,7 @@ export async function writeCliDocuments(
     // Sanitize fileName: strip any path separators to prevent directory
     // traversal (e.g. "../../../etc/passwd" from a crafted attachment name).
     const baseName = path.basename(doc.fileName ?? `document-${i + 1}.${ext}`);
-    const filePath = path.join(tempDir, baseName);
+    const filePath = path.join(tempDir, `${i + 1}-${baseName}`);
     const buffer = Buffer.from(doc.data, "base64");
     await fs.writeFile(filePath, buffer, { mode: 0o600 });
     paths.push(filePath);

--- a/src/agents/cli-runner/helpers.ts
+++ b/src/agents/cli-runner/helpers.ts
@@ -326,6 +326,36 @@ export function appendImagePathsToPrompt(prompt: string, paths: string[]): strin
   return `${trimmed}${separator}${paths.join("\n")}`;
 }
 
+export function appendDocumentPathsToPrompt(prompt: string, paths: string[]): string {
+  if (!paths.length) {
+    return prompt;
+  }
+  const trimmed = prompt.trimEnd();
+  const separator = trimmed ? "\n\n" : "";
+  const fileLines = paths.map((p) => `[Attached document: ${p}]`).join("\n");
+  return `${trimmed}${separator}${fileLines}`;
+}
+
+export async function writeCliDocuments(
+  documents: Array<{ type: "document"; data: string; mimeType: string; fileName?: string }>,
+): Promise<{ paths: string[]; cleanup: () => Promise<void> }> {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cli-documents-"));
+  const paths: string[] = [];
+  for (let i = 0; i < documents.length; i += 1) {
+    const doc = documents[i];
+    const ext = doc.mimeType === "application/pdf" ? "pdf" : "bin";
+    const baseName = doc.fileName ?? `document-${i + 1}.${ext}`;
+    const filePath = path.join(tempDir, baseName);
+    const buffer = Buffer.from(doc.data, "base64");
+    await fs.writeFile(filePath, buffer, { mode: 0o600 });
+    paths.push(filePath);
+  }
+  const cleanup = async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  };
+  return { paths, cleanup };
+}
+
 export async function writeCliImages(
   images: ImageContent[],
 ): Promise<{ paths: string[]; cleanup: () => Promise<void> }> {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -785,6 +785,7 @@ export async function runEmbeddedPiAgent(
             skillsSnapshot: params.skillsSnapshot,
             prompt,
             images: params.images,
+            documents: params.documents,
             disableTools: params.disableTools,
             provider,
             modelId,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -122,6 +122,7 @@ import {
   selectCompactionTimeoutSnapshot,
   shouldFlagCompactionTimeout,
 } from "./compaction-timeout.js";
+import { createDocumentInjectionWrapper } from "./document-injection.js";
 import { pruneProcessedHistoryImages } from "./history-image-prune.js";
 import { detectAndLoadPromptImages } from "./images.js";
 import type { EmbeddedRunAttemptParams, EmbeddedRunAttemptResult } from "./types.js";
@@ -1621,12 +1622,29 @@ export async function runEmbeddedAttempt(
               });
           }
 
+          // Install document injection wrapper if PDFs are attached.
+          // This uses the onPayload hook to inject raw Anthropic document
+          // blocks that pi-ai's type system doesn't support natively.
+          const prevStreamFn = activeSession.agent.streamFn;
+          if (params.documents && params.documents.length > 0) {
+            activeSession.agent.streamFn = createDocumentInjectionWrapper(
+              prevStreamFn,
+              params.documents,
+            );
+          }
+
           // Only pass images option if there are actually images to pass
           // This avoids potential issues with models that don't expect the images parameter
           if (imageResult.images.length > 0) {
             await abortable(activeSession.prompt(effectivePrompt, { images: imageResult.images }));
           } else {
             await abortable(activeSession.prompt(effectivePrompt));
+          }
+
+          // Restore original streamFn after prompt (wrapper is one-shot
+          // but restore explicitly for safety in case of retries).
+          if (params.documents && params.documents.length > 0) {
+            activeSession.agent.streamFn = prevStreamFn;
           }
         } catch (err) {
           promptError = err;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1633,18 +1633,23 @@ export async function runEmbeddedAttempt(
             );
           }
 
-          // Only pass images option if there are actually images to pass
-          // This avoids potential issues with models that don't expect the images parameter
-          if (imageResult.images.length > 0) {
-            await abortable(activeSession.prompt(effectivePrompt, { images: imageResult.images }));
-          } else {
-            await abortable(activeSession.prompt(effectivePrompt));
-          }
-
-          // Restore original streamFn after prompt (wrapper is one-shot
-          // but restore explicitly for safety in case of retries).
-          if (params.documents && params.documents.length > 0) {
-            activeSession.agent.streamFn = prevStreamFn;
+          try {
+            // Only pass images option if there are actually images to pass
+            // This avoids potential issues with models that don't expect the images parameter
+            if (imageResult.images.length > 0) {
+              await abortable(
+                activeSession.prompt(effectivePrompt, { images: imageResult.images }),
+              );
+            } else {
+              await abortable(activeSession.prompt(effectivePrompt));
+            }
+          } finally {
+            // Restore original streamFn unconditionally (success AND error paths).
+            // Without this, a thrown error leaves the one-shot wrapper installed,
+            // causing nested wrappers to accumulate on subsequent retries/turns.
+            if (params.documents && params.documents.length > 0) {
+              activeSession.agent.streamFn = prevStreamFn;
+            }
           }
         } catch (err) {
           promptError = err;

--- a/src/agents/pi-embedded-runner/run/document-injection.ts
+++ b/src/agents/pi-embedded-runner/run/document-injection.ts
@@ -50,9 +50,19 @@ export function createDocumentInjectionWrapper(
     }
     injected = true;
 
-    // Check if this is an Anthropic-compatible provider
+    // Check if this is an Anthropic-compatible provider.
+    // For amazon-bedrock, only Claude models support Anthropic document blocks
+    // and the anthropic-beta header. Non-Claude Bedrock models (e.g. amazon.nova-*)
+    // must use the non-Anthropic fallback path to avoid invalid payloads/headers.
     const provider = (model as { provider?: string }).provider ?? "";
-    const isAnthropic = provider === "anthropic" || provider === "amazon-bedrock";
+    const modelId = (model as { id?: string; model?: string }).id ?? (model as { model?: string }).model ?? "";
+    const isAnthropicBedrockModel = (id: string) => {
+      const normalized = id.toLowerCase();
+      return normalized.includes("anthropic.claude") || normalized.includes("anthropic/claude");
+    };
+    const isAnthropic =
+      provider === "anthropic" ||
+      (provider === "amazon-bedrock" && isAnthropicBedrockModel(modelId));
 
     if (!isAnthropic) {
       // For non-Anthropic providers (OpenAI, Gemini, etc.), inject document

--- a/src/agents/pi-embedded-runner/run/document-injection.ts
+++ b/src/agents/pi-embedded-runner/run/document-injection.ts
@@ -61,14 +61,40 @@ export function createDocumentInjectionWrapper(
       return underlying(model, context, options);
     }
 
-    // Inject the Anthropic PDF beta header
+    // Inject the Anthropic PDF beta header, preserving existing values.
+    // pi-ai's createClient injects its own defaultHeaders["anthropic-beta"] which
+    // can include critical betas like oauth-2025-04-20 (required for OAuth tokens)
+    // and fine-grained-tool-streaming-2025-05-14. Since pi-ai uses Object.assign
+    // (last-wins), setting options.headers["anthropic-beta"] overwrites those
+    // defaults. We must re-include them here, identical to the approach in
+    // createAnthropicBetaHeadersWrapper (extra-params.ts).
+    const PI_AI_DEFAULT_BETAS = [
+      "fine-grained-tool-streaming-2025-05-14",
+      "interleaved-thinking-2025-05-14",
+    ];
+    const PI_AI_OAUTH_BETAS = ["claude-code-20250219", "oauth-2025-04-20", ...PI_AI_DEFAULT_BETAS];
+    const isOAuth = typeof options?.apiKey === "string" && options.apiKey.includes("sk-ant-oat");
+    const piAiBetas = isOAuth ? PI_AI_OAUTH_BETAS : PI_AI_DEFAULT_BETAS;
+
     const existingHeaders =
       options && typeof options === "object" && "headers" in options
         ? (options as Record<string, unknown>).headers
         : undefined;
+    const headerMap =
+      existingHeaders && typeof existingHeaders === "object"
+        ? (existingHeaders as Record<string, string>)
+        : {};
+    const existingBeta = headerMap["anthropic-beta"] ?? "";
+    const existingBetas = existingBeta
+      ? existingBeta
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : [];
+    const mergedBetas = [...new Set([...existingBetas, ...piAiBetas, "pdfs-2024-09-25"])];
     const pdfBetaHeaders = {
-      ...(existingHeaders && typeof existingHeaders === "object" ? existingHeaders : {}),
-      "anthropic-beta": "pdfs-2024-09-25",
+      ...headerMap,
+      "anthropic-beta": mergedBetas.join(","),
     };
 
     const originalOnPayload = options?.onPayload;
@@ -84,16 +110,21 @@ export function createDocumentInjectionWrapper(
             for (let i = messages.length - 1; i >= 0; i--) {
               if (messages[i].role === "user") {
                 const content = messages[i].content;
-                if (Array.isArray(content)) {
-                  const docBlocks: AnthropicDocBlock[] = documents.map((doc) => ({
-                    type: "document",
-                    source: {
-                      type: "base64",
-                      media_type: "application/pdf",
-                      data: doc.data,
-                    },
-                  }));
-                  // Prepend documents before text/image content
+                const docBlocks: AnthropicDocBlock[] = documents.map((doc) => ({
+                  type: "document",
+                  source: {
+                    type: "base64",
+                    media_type: "application/pdf",
+                    data: doc.data,
+                  },
+                }));
+                if (typeof content === "string") {
+                  // pi-ai may serialize a simple text prompt as a plain string.
+                  // Convert it to a text block and prepend document blocks so the
+                  // documents are never silently dropped.
+                  messages[i].content = [...docBlocks, { type: "text", text: content }];
+                } else if (Array.isArray(content)) {
+                  // Prepend documents before existing text/image content blocks.
                   messages[i].content = [...docBlocks, ...content];
                 }
                 break;

--- a/src/agents/pi-embedded-runner/run/document-injection.ts
+++ b/src/agents/pi-embedded-runner/run/document-injection.ts
@@ -52,8 +52,7 @@ export function createDocumentInjectionWrapper(
 
     // Check if this is an Anthropic-compatible provider
     const provider = (model as { provider?: string }).provider ?? "";
-    const isAnthropic =
-      provider === "anthropic" || provider.startsWith("anthropic") || provider.includes("bedrock");
+    const isAnthropic = provider === "anthropic" || provider === "amazon-bedrock";
 
     if (!isAnthropic) {
       // For non-Anthropic providers (OpenAI, Gemini, etc.), inject document
@@ -139,8 +138,10 @@ export function createDocumentInjectionWrapper(
           const messages = p.messages as Array<{ role: string; content: unknown }> | undefined;
           if (messages) {
             // Find the last user message and append document blocks
+            let userMessageFound = false;
             for (let i = messages.length - 1; i >= 0; i--) {
               if (messages[i].role === "user") {
+                userMessageFound = true;
                 const content = messages[i].content;
                 const docBlocks: AnthropicDocBlock[] = documents.map((doc) => ({
                   type: "document",
@@ -161,6 +162,12 @@ export function createDocumentInjectionWrapper(
                 }
                 break;
               }
+            }
+            if (!userMessageFound) {
+              // No user message found — documents were not injected
+              console.warn?.(
+                "[document-injection] No user-role message found in payload; PDF documents were not injected",
+              );
             }
           }
         }

--- a/src/agents/pi-embedded-runner/run/document-injection.ts
+++ b/src/agents/pi-embedded-runner/run/document-injection.ts
@@ -55,7 +55,8 @@ export function createDocumentInjectionWrapper(
     // and the anthropic-beta header. Non-Claude Bedrock models (e.g. amazon.nova-*)
     // must use the non-Anthropic fallback path to avoid invalid payloads/headers.
     const provider = (model as { provider?: string }).provider ?? "";
-    const modelId = (model as { id?: string; model?: string }).id ?? (model as { model?: string }).model ?? "";
+    const modelId =
+      (model as { id?: string; model?: string }).id ?? (model as { model?: string }).model ?? "";
     const isAnthropicBedrockModel = (id: string) => {
       const normalized = id.toLowerCase();
       return normalized.includes("anthropic.claude") || normalized.includes("anthropic/claude");

--- a/src/agents/pi-embedded-runner/run/document-injection.ts
+++ b/src/agents/pi-embedded-runner/run/document-injection.ts
@@ -1,0 +1,108 @@
+/**
+ * StreamFn wrapper that injects PDF document blocks into Anthropic API requests.
+ *
+ * The pi-ai library's type system only supports TextContent | ImageContent.
+ * PDF documents require Anthropic's { type: "document" } content block format,
+ * which pi-ai doesn't handle. This wrapper uses the onPayload hook to inject
+ * raw document blocks directly into the API request body after pi-ai has
+ * built the request but before it's sent to the provider.
+ *
+ * This pattern is consistent with how extra-params.ts uses onPayload for
+ * OpenAI Responses store/compaction injection.
+ */
+
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import { streamSimple } from "@mariozechner/pi-ai";
+
+export type DocumentInput = {
+  data: string;
+  mimeType: string;
+  fileName?: string;
+};
+
+type AnthropicDocBlock = {
+  type: "document";
+  source: {
+    type: "base64";
+    media_type: "application/pdf";
+    data: string;
+  };
+};
+
+/**
+ * Create a streamFn wrapper that injects PDF document blocks into the last
+ * user message of the Anthropic API request payload.
+ *
+ * Only activates once (for the initial prompt that includes documents).
+ * Subsequent calls (tool results, continue) pass through unchanged.
+ */
+export function createDocumentInjectionWrapper(
+  baseStreamFn: StreamFn | undefined,
+  documents: DocumentInput[],
+): StreamFn {
+  const underlying = baseStreamFn ?? (streamSimple as unknown as StreamFn);
+  let injected = false;
+
+  return (model, context, options) => {
+    // Only inject once (on the first prompt call with documents)
+    if (injected || documents.length === 0) {
+      return underlying(model, context, options);
+    }
+    injected = true;
+
+    // Check if this is an Anthropic-compatible provider
+    const provider = (model as { provider?: string }).provider ?? "";
+    const isAnthropic =
+      provider === "anthropic" || provider.startsWith("anthropic") || provider.includes("bedrock");
+
+    if (!isAnthropic) {
+      // For non-Anthropic providers, append document info as text
+      // (fallback: the model sees the document metadata but not content)
+      return underlying(model, context, options);
+    }
+
+    // Inject the Anthropic PDF beta header
+    const existingHeaders =
+      options && typeof options === "object" && "headers" in options
+        ? (options as Record<string, unknown>).headers
+        : undefined;
+    const pdfBetaHeaders = {
+      ...(existingHeaders && typeof existingHeaders === "object" ? existingHeaders : {}),
+      "anthropic-beta": "pdfs-2024-09-25",
+    };
+
+    const originalOnPayload = options?.onPayload;
+    return underlying(model, context, {
+      ...options,
+      headers: pdfBetaHeaders,
+      onPayload: (payload) => {
+        if (payload && typeof payload === "object") {
+          const p = payload as Record<string, unknown>;
+          const messages = p.messages as Array<{ role: string; content: unknown }> | undefined;
+          if (messages) {
+            // Find the last user message and append document blocks
+            for (let i = messages.length - 1; i >= 0; i--) {
+              if (messages[i].role === "user") {
+                const content = messages[i].content;
+                if (Array.isArray(content)) {
+                  const docBlocks: AnthropicDocBlock[] = documents.map((doc) => ({
+                    type: "document",
+                    source: {
+                      type: "base64",
+                      media_type: "application/pdf",
+                      data: doc.data,
+                    },
+                  }));
+                  // Prepend documents before text/image content
+                  messages[i].content = [...docBlocks, ...content];
+                }
+                break;
+              }
+            }
+          }
+        }
+        originalOnPayload?.(payload);
+      },
+    });
+  };
+}

--- a/src/agents/pi-embedded-runner/run/document-injection.ts
+++ b/src/agents/pi-embedded-runner/run/document-injection.ts
@@ -56,9 +56,41 @@ export function createDocumentInjectionWrapper(
       provider === "anthropic" || provider.startsWith("anthropic") || provider.includes("bedrock");
 
     if (!isAnthropic) {
-      // For non-Anthropic providers, append document info as text
-      // (fallback: the model sees the document metadata but not content)
-      return underlying(model, context, options);
+      // For non-Anthropic providers (OpenAI, Gemini, etc.), inject document
+      // metadata as a text block via onPayload so the model at least knows a
+      // PDF was attached. Full Anthropic { type: "document" } blocks are
+      // provider-specific and can't be used here, but a text note preserves
+      // context instead of silently dropping the attachment entirely.
+      const originalOnPayloadNonAnthropic = options?.onPayload;
+      return underlying(model, context, {
+        ...options,
+        onPayload: (payload) => {
+          if (payload && typeof payload === "object") {
+            const p = payload as Record<string, unknown>;
+            const messages = p.messages as Array<{ role: string; content: unknown }> | undefined;
+            if (messages) {
+              for (let i = messages.length - 1; i >= 0; i--) {
+                if (messages[i].role === "user") {
+                  const content = messages[i].content;
+                  const noteText = documents
+                    .map((doc, idx) => {
+                      const name = doc.fileName ?? `document-${idx + 1}.pdf`;
+                      return `[Attached PDF: ${name}]`;
+                    })
+                    .join("\n");
+                  if (typeof content === "string") {
+                    messages[i].content = content ? `${noteText}\n\n${content}` : noteText;
+                  } else if (Array.isArray(content)) {
+                    messages[i].content = [{ type: "text", text: noteText }, ...content];
+                  }
+                  break;
+                }
+              }
+            }
+          }
+          originalOnPayloadNonAnthropic?.(payload);
+        },
+      });
     }
 
     // Inject the Anthropic PDF beta header, preserving existing values.

--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -67,6 +67,7 @@ export type RunEmbeddedPiAgentParams = {
   skillsSnapshot?: SkillSnapshot;
   prompt: string;
   images?: ImageContent[];
+  documents?: Array<{ type: "document"; data: string; mimeType: string; fileName?: string }>;
   /** Optional client-provided tools (OpenResponses hosted tools). */
   clientTools?: ClientToolDefinition[];
   /** Disable built-in tools for this run (LLM-only mode). */

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -232,6 +232,7 @@ export async function runAgentTurnWithFallback(params: {
                       bootstrapPromptWarningSignaturesSeen.length - 1
                     ],
                   images: params.opts?.images,
+                  documents: params.opts?.documents,
                 });
                 bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
                   result.meta?.systemPromptReport,
@@ -331,6 +332,7 @@ export async function runAgentTurnWithFallback(params: {
               bootstrapContextMode: params.opts?.bootstrapContextMode,
               bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
               images: params.opts?.images,
+              documents: params.opts?.documents,
               abortSignal: params.opts?.abortSignal,
               blockReplyBreak: params.resolvedBlockStreamingBreak,
               blockReplyChunking: params.blockReplyChunking,

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -27,6 +27,8 @@ export type GetReplyOptions = {
   abortSignal?: AbortSignal;
   /** Optional inbound images (used for webchat attachments). */
   images?: ImageContent[];
+  /** Optional inbound documents/PDFs (used for webchat attachments). */
+  documents?: Array<{ type: "document"; data: string; mimeType: string; fileName?: string }>;
   /** Notifies when an agent run actually starts (useful for webchat command handling). */
   onAgentRunStart?: (runId: string) => void;
   onReplyStart?: () => Promise<void> | void;

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -205,6 +205,7 @@ function runAgentAttempt(params: {
         bootstrapPromptWarningSignaturesSeen,
         bootstrapPromptWarningSignature,
         images: params.isFallbackRetry ? undefined : params.opts.images,
+        documents: params.isFallbackRetry ? undefined : params.opts.documents,
         streamParams: params.opts.streamParams,
       });
     return runCliWithSession(cliSessionId).catch(async (err) => {
@@ -309,6 +310,7 @@ function runAgentAttempt(params: {
     skillsSnapshot: params.skillsSnapshot,
     prompt: effectivePrompt,
     images: params.isFallbackRetry ? undefined : params.opts.images,
+    documents: params.isFallbackRetry ? undefined : params.opts.documents,
     clientTools: params.opts.clientTools,
     provider: params.providerOverride,
     model: params.modelOverride,

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -205,7 +205,14 @@ function runAgentAttempt(params: {
         bootstrapPromptWarningSignaturesSeen,
         bootstrapPromptWarningSignature,
         images: params.isFallbackRetry ? undefined : params.opts.images,
-        documents: params.isFallbackRetry ? undefined : params.opts.documents,
+        documents: (() => {
+          if (params.isFallbackRetry && params.opts.documents?.length) {
+            log?.warn?.(
+              `Dropping ${params.opts.documents.length} document(s) for fallback retry to ${params.modelOverride}`,
+            );
+          }
+          return params.isFallbackRetry ? undefined : params.opts.documents;
+        })(),
         streamParams: params.opts.streamParams,
       });
     return runCliWithSession(cliSessionId).catch(async (err) => {
@@ -310,7 +317,14 @@ function runAgentAttempt(params: {
     skillsSnapshot: params.skillsSnapshot,
     prompt: effectivePrompt,
     images: params.isFallbackRetry ? undefined : params.opts.images,
-    documents: params.isFallbackRetry ? undefined : params.opts.documents,
+    documents: (() => {
+      if (params.isFallbackRetry && params.opts.documents?.length) {
+        log?.warn?.(
+          `Dropping ${params.opts.documents.length} document(s) for fallback retry to ${params.modelOverride}`,
+        );
+      }
+      return params.isFallbackRetry ? undefined : params.opts.documents;
+    })(),
     clientTools: params.opts.clientTools,
     provider: params.providerOverride,
     model: params.modelOverride,

--- a/src/commands/agent/types.ts
+++ b/src/commands/agent/types.ts
@@ -10,6 +10,14 @@ export type ImageContent = {
   mimeType: string;
 };
 
+/** Document content block for Claude API PDF attachments. */
+export type DocumentContent = {
+  type: "document";
+  data: string;
+  mimeType: string;
+  fileName?: string;
+};
+
 export type AgentStreamParams = {
   /** Provider stream params override (best-effort). */
   temperature?: number;
@@ -32,6 +40,8 @@ export type AgentCommandOpts = {
   message: string;
   /** Optional image attachments for multimodal messages. */
   images?: ImageContent[];
+  /** Optional document attachments (PDFs) for multimodal messages. */
+  documents?: DocumentContent[];
   /** Optional client-provided tools (OpenResponses hosted tools). */
   clientTools?: ClientToolDefinition[];
   /** Agent id override (must exist in config). */

--- a/src/gateway/chat-attachments.test.ts
+++ b/src/gateway/chat-attachments.test.ts
@@ -86,9 +86,11 @@ describe("parseMessageWithAttachments", () => {
         content: pdf,
       },
     ]);
+    // PDF is now routed to documents instead of being dropped
     expect(parsed.images).toHaveLength(0);
-    expect(logs).toHaveLength(1);
-    expect(logs[0]).toMatch(/non-image/i);
+    expect(parsed.documents).toHaveLength(1);
+    expect(parsed.documents[0]?.mimeType).toBe("application/pdf");
+    expect(logs).toHaveLength(0);
   });
 
   it("prefers sniffed mime type and logs mismatch", async () => {
@@ -113,12 +115,12 @@ describe("parseMessageWithAttachments", () => {
     ]);
     expect(parsed.images).toHaveLength(0);
     expect(logs).toHaveLength(1);
-    expect(logs[0]).toMatch(/unable to detect image mime type/i);
+    expect(logs[0]).toMatch(/unable to detect mime type/i);
   });
 
   it("keeps valid images and drops invalid ones", async () => {
     const pdf = Buffer.from("%PDF-1.4\n").toString("base64");
-    const { parsed, logs } = await parseWithWarnings("x", [
+    const { parsed } = await parseWithWarnings("x", [
       {
         type: "image",
         mimeType: "image/png",
@@ -135,7 +137,9 @@ describe("parseMessageWithAttachments", () => {
     expect(parsed.images).toHaveLength(1);
     expect(parsed.images[0]?.mimeType).toBe("image/png");
     expect(parsed.images[0]?.data).toBe(PNG_1x1);
-    expect(logs.some((l) => /non-image/i.test(l))).toBe(true);
+    // PDF is routed to documents, not dropped
+    expect(parsed.documents).toHaveLength(1);
+    expect(parsed.documents[0]?.mimeType).toBe("application/pdf");
   });
 });
 

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -145,7 +145,7 @@ export async function parseMessageWithAttachments(
         type: "document",
         data: b64,
         mimeType: "application/pdf",
-        fileName: att.fileName || label,
+        fileName: att.fileName || `document-${idx + 1}.pdf`,
       });
       continue;
     }

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -135,8 +135,12 @@ export async function parseMessageWithAttachments(
     const sniffedMime = normalizeMime(await sniffMimeFromBase64(b64));
     const effectiveMime = sniffedMime ?? providedMime ?? mime;
 
-    // PDF documents
-    if (isPdfMime(sniffedMime) || isPdfMime(providedMime)) {
+    // PDF documents — trust sniffed MIME over client-provided MIME.
+    // If sniffing identified a type, use it exclusively; only fall back to
+    // providedMime when sniffing produced no result. This prevents a mislabeled
+    // file (e.g. a PNG renamed to .pdf) from being forced into a document block
+    // with the wrong media_type, which would cause provider-side validation errors.
+    if (isPdfMime(sniffedMime) || (!sniffedMime && isPdfMime(providedMime))) {
       documents.push({
         type: "document",
         data: b64,

--- a/src/gateway/chat-attachments.ts
+++ b/src/gateway/chat-attachments.ts
@@ -14,9 +14,17 @@ export type ChatImageContent = {
   mimeType: string;
 };
 
+export type ChatDocumentContent = {
+  type: "document";
+  data: string;
+  mimeType: string;
+  fileName?: string;
+};
+
 export type ParsedMessageWithImages = {
   message: string;
   images: ChatImageContent[];
+  documents: ChatDocumentContent[];
 };
 
 type AttachmentLog = {
@@ -39,6 +47,10 @@ function normalizeMime(mime?: string): string | undefined {
 
 function isImageMime(mime?: string): boolean {
   return typeof mime === "string" && mime.startsWith("image/");
+}
+
+function isPdfMime(mime?: string): boolean {
+  return mime === "application/pdf";
 }
 
 function isValidBase64(value: string): boolean {
@@ -102,10 +114,11 @@ export async function parseMessageWithAttachments(
   const maxBytes = opts?.maxBytes ?? 5_000_000; // decoded bytes (5,000,000)
   const log = opts?.log;
   if (!attachments || attachments.length === 0) {
-    return { message, images: [] };
+    return { message, images: [], documents: [] };
   }
 
   const images: ChatImageContent[] = [];
+  const documents: ChatDocumentContent[] = [];
 
   for (const [idx, att] of attachments.entries()) {
     if (!att) {
@@ -120,12 +133,26 @@ export async function parseMessageWithAttachments(
 
     const providedMime = normalizeMime(mime);
     const sniffedMime = normalizeMime(await sniffMimeFromBase64(b64));
+    const effectiveMime = sniffedMime ?? providedMime ?? mime;
+
+    // PDF documents
+    if (isPdfMime(sniffedMime) || isPdfMime(providedMime)) {
+      documents.push({
+        type: "document",
+        data: b64,
+        mimeType: "application/pdf",
+        fileName: att.fileName || label,
+      });
+      continue;
+    }
+
+    // Images
     if (sniffedMime && !isImageMime(sniffedMime)) {
-      log?.warn(`attachment ${label}: detected non-image (${sniffedMime}), dropping`);
+      log?.warn(`attachment ${label}: detected unsupported type (${sniffedMime}), dropping`);
       continue;
     }
     if (!sniffedMime && !isImageMime(providedMime)) {
-      log?.warn(`attachment ${label}: unable to detect image mime type, dropping`);
+      log?.warn(`attachment ${label}: unable to detect mime type, dropping`);
       continue;
     }
     if (sniffedMime && providedMime && sniffedMime !== providedMime) {
@@ -137,11 +164,11 @@ export async function parseMessageWithAttachments(
     images.push({
       type: "image",
       data: b64,
-      mimeType: sniffedMime ?? providedMime ?? mime,
+      mimeType: effectiveMime,
     });
   }
 
-  return { message, images };
+  return { message, images, documents };
 }
 
 /**

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -30,7 +30,7 @@ import {
   normalizeMessageChannel,
 } from "../../utils/message-channel.js";
 import { resolveAssistantIdentity } from "../assistant-identity.js";
-import { parseMessageWithAttachments } from "../chat-attachments.js";
+import { type ChatDocumentContent, parseMessageWithAttachments } from "../chat-attachments.js";
 import { resolveAssistantAvatarUrl } from "../control-ui-shared.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
 import { GATEWAY_CLIENT_CAPS, hasGatewayClientCap } from "../protocol/client-info.js";
@@ -238,6 +238,7 @@ export const agentHandlers: GatewayRequestHandlers = {
 
     let message = (request.message ?? "").trim();
     let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
+    let documents: ChatDocumentContent[] = [];
     if (normalizedAttachments.length > 0) {
       try {
         const parsed = await parseMessageWithAttachments(message, normalizedAttachments, {
@@ -246,6 +247,7 @@ export const agentHandlers: GatewayRequestHandlers = {
         });
         message = parsed.message.trim();
         images = parsed.images;
+        documents = parsed.documents;
       } catch (err) {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
         return;
@@ -616,6 +618,7 @@ export const agentHandlers: GatewayRequestHandlers = {
       {
         message,
         images,
+        documents: documents.length > 0 ? documents : undefined,
         to: resolvedTo,
         sessionId: resolvedSessionId,
         sessionKey: resolvedSessionKey,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -30,7 +30,11 @@ import {
   isChatStopCommandText,
   resolveChatRunExpiresAtMs,
 } from "../chat-abort.js";
-import { type ChatImageContent, parseMessageWithAttachments } from "../chat-attachments.js";
+import {
+  type ChatDocumentContent,
+  type ChatImageContent,
+  parseMessageWithAttachments,
+} from "../chat-attachments.js";
 import { stripEnvelopeFromMessage, stripEnvelopeFromMessages } from "../chat-sanitize.js";
 import {
   GATEWAY_CLIENT_CAPS,
@@ -776,6 +780,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     }
     let parsedMessage = inboundMessage;
     let parsedImages: ChatImageContent[] = [];
+    let parsedDocuments: ChatDocumentContent[] = [];
     if (normalizedAttachments.length > 0) {
       try {
         const parsed = await parseMessageWithAttachments(inboundMessage, normalizedAttachments, {
@@ -784,6 +789,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         });
         parsedMessage = parsed.message;
         parsedImages = parsed.images;
+        parsedDocuments = parsed.documents;
       } catch (err) {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, String(err)));
         return;
@@ -982,6 +988,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           runId: clientRunId,
           abortSignal: abortController.signal,
           images: parsedImages.length > 0 ? parsedImages : undefined,
+          documents: parsedDocuments.length > 0 ? parsedDocuments : undefined,
           onAgentRunStart: (runId) => {
             agentRunStarted = true;
             const connId = typeof client?.connId === "string" ? client.connId : undefined;

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -12,7 +12,7 @@ import { registerApnsToken } from "../infra/push-apns.js";
 import { enqueueSystemEvent } from "../infra/system-events.js";
 import { normalizeMainKey, scopedHeartbeatWakeOptions } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
-import { parseMessageWithAttachments } from "./chat-attachments.js";
+import { type ChatDocumentContent, parseMessageWithAttachments } from "./chat-attachments.js";
 import { normalizeRpcAttachmentsToChatAttachments } from "./server-methods/attachment-normalize.js";
 import type { NodeEvent, NodeEventContext } from "./server-node-events-types.js";
 import {
@@ -358,6 +358,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         link?.attachments ?? undefined,
       );
       let images: Array<{ type: "image"; data: string; mimeType: string }> = [];
+      let documents: ChatDocumentContent[] = [];
       if (normalizedAttachments.length > 0) {
         try {
           const parsed = await parseMessageWithAttachments(message, normalizedAttachments, {
@@ -366,6 +367,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
           });
           message = parsed.message.trim();
           images = parsed.images;
+          documents = parsed.documents;
         } catch {
           return;
         }
@@ -438,6 +440,7 @@ export const handleNodeEvent = async (ctx: NodeEventContext, nodeId: string, evt
         {
           message,
           images,
+          documents: documents.length > 0 ? documents : undefined,
           sessionId,
           sessionKey: canonicalKey,
           thinking: link?.thinking ?? undefined,

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -259,6 +259,76 @@
   justify-content: flex-end;
 }
 
+/* Hidden file inputs for attach/camera */
+.chat-compose__file-input {
+  display: none;
+}
+
+/* Attach & camera buttons column */
+.chat-compose__attach-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  flex-shrink: 0;
+  align-self: flex-end;
+}
+
+.chat-compose__attach-btn,
+.chat-compose__camera-btn {
+  width: 36px !important;
+  height: 36px !important;
+  min-width: 36px !important;
+  padding: 0 !important;
+}
+
+.chat-compose__attach-btn svg,
+.chat-compose__camera-btn svg {
+  width: 16px;
+  height: 16px;
+}
+
+/* Drag-and-drop overlay */
+.chat-drop-overlay {
+  display: none;
+  position: absolute;
+  inset: 0;
+  z-index: 50;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  border-radius: 12px;
+  border: 2px dashed var(--accent);
+  align-items: center;
+  justify-content: center;
+}
+
+.chat--drag-over .chat-drop-overlay {
+  display: flex;
+}
+
+.chat-drop-overlay__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  color: var(--accent);
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.chat-drop-overlay__content svg {
+  width: 48px;
+  height: 48px;
+  stroke: var(--accent);
+  fill: none;
+  stroke-width: 1.5px;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+:root[data-theme="light"] .chat-drop-overlay {
+  background: rgba(255, 255, 255, 0.8);
+}
+
 /* Compose input row - horizontal layout */
 .chat-compose__row {
   display: flex;
@@ -458,6 +528,12 @@
     gap: 8px;
   }
 
+  /* Mobile: attach buttons go horizontal */
+  .chat-compose__attach-buttons {
+    flex-direction: row;
+    align-self: flex-start;
+  }
+
   /* Mobile: stack action buttons vertically */
   .chat-compose__actions {
     flex-direction: column;
@@ -468,6 +544,11 @@
   /* Mobile: full-width buttons */
   .chat-compose .chat-compose__actions .btn {
     width: 100%;
+  }
+
+  /* Mobile: hide camera button label, keep icon */
+  .chat-compose__camera-btn {
+    display: inline-flex;
   }
 
   .chat-controls {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -182,6 +182,35 @@
   object-fit: contain;
 }
 
+.chat-attachment__document {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  gap: 4px;
+  padding: 6px;
+  color: var(--text-muted, #94a3b8);
+}
+
+.chat-attachment__document svg {
+  flex-shrink: 0;
+}
+
+.chat-attachment__document-name {
+  font-size: 9px;
+  line-height: 1.2;
+  text-align: center;
+  word-break: break-all;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  color: var(--text-muted, #94a3b8);
+  max-width: 100%;
+}
+
 .chat-attachment__remove {
   position: absolute;
   top: 4px;

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -152,13 +152,21 @@ export async function sendChatMessage(
   if (msg) {
     contentBlocks.push({ type: "text", text: msg });
   }
-  // Add image previews to the message for display
+  // Add attachment previews to the message for display
   if (hasAttachments) {
     for (const att of attachments) {
-      contentBlocks.push({
-        type: "image",
-        source: { type: "base64", media_type: att.mimeType, data: att.dataUrl },
-      });
+      if (att.mimeType === "application/pdf") {
+        // PDFs can't be previewed inline; show as text indicator
+        contentBlocks.push({
+          type: "text",
+          text: `[PDF attached]`,
+        });
+      } else {
+        contentBlocks.push({
+          type: "image",
+          source: { type: "base64", media_type: att.mimeType, data: att.dataUrl },
+        });
+      }
     }
   }
 
@@ -186,8 +194,9 @@ export async function sendChatMessage(
           if (!parsed) {
             return null;
           }
+          const isPdf = parsed.mimeType === "application/pdf";
           return {
-            type: "image",
+            type: isPdf ? "document" : "image",
             mimeType: parsed.mimeType,
             content: parsed.content,
           };

--- a/ui/src/ui/icons.ts
+++ b/ui/src/ui/icons.ts
@@ -204,6 +204,14 @@ export const icons = {
       <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
     </svg>
   `,
+  camera: html`
+    <svg viewBox="0 0 24 24">
+      <path
+        d="M14.5 4h-5L7 7H4a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2h-3l-2.5-3z"
+      />
+      <circle cx="12" cy="13" r="3" />
+    </svg>
+  `,
   smartphone: html`
     <svg viewBox="0 0 24 24">
       <rect width="14" height="20" x="5" y="2" rx="2" ry="2" />

--- a/ui/src/ui/ui-types.ts
+++ b/ui/src/ui/ui-types.ts
@@ -2,6 +2,7 @@ export type ChatAttachment = {
   id: string;
   dataUrl: string;
   mimeType: string;
+  fileName?: string;
 };
 
 export type ChatQueueItem = {

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -234,11 +234,33 @@ function addFilesAsAttachments(files: File[]) {
 const ACCEPTED_MIME_PREFIXES = ["image/"];
 const ACCEPTED_MIME_EXACT = new Set(["application/pdf"]);
 
-function isAcceptedMime(mime: string): boolean {
-  return (
+/** File extensions accepted as a fallback when the MIME type is empty or non-standard. */
+const ACCEPTED_EXTENSIONS = new Set([".pdf"]);
+
+/**
+ * Returns true if the file should be accepted based on its MIME type or,
+ * as a fallback, its filename extension. The extension fallback covers cases
+ * where browsers report an empty or non-standard MIME string for valid PDFs
+ * (common with drag/drop and certain OS file pickers).
+ */
+function isAcceptedFile(mime: string, filename?: string): boolean {
+  if (
     ACCEPTED_MIME_PREFIXES.some((prefix) => mime.startsWith(prefix)) ||
     ACCEPTED_MIME_EXACT.has(mime)
-  );
+  ) {
+    return true;
+  }
+  // Extension fallback: only used when MIME is absent/unrecognised
+  if (filename) {
+    const dot = filename.lastIndexOf(".");
+    if (dot !== -1) {
+      const ext = filename.slice(dot).toLowerCase();
+      if (ACCEPTED_EXTENSIONS.has(ext)) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 function handlePaste(e: ClipboardEvent, props: ChatProps) {
@@ -250,11 +272,9 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
   const files: File[] = [];
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
-    if (isAcceptedMime(item.type)) {
-      const file = item.getAsFile();
-      if (file) {
-        files.push(file);
-      }
+    const file = item.getAsFile();
+    if (file && isAcceptedFile(item.type, file.name)) {
+      files.push(file);
     }
   }
 
@@ -278,7 +298,7 @@ function handleFileInput(e: Event, props: ChatProps) {
   const files: File[] = [];
   for (let i = 0; i < fileList.length; i++) {
     const file = fileList[i];
-    if (file && isAcceptedMime(file.type)) {
+    if (file && isAcceptedFile(file.type, file.name)) {
       files.push(file);
     }
   }
@@ -308,7 +328,7 @@ function handleDrop(e: DragEvent, props: ChatProps) {
   const files: File[] = [];
   for (let i = 0; i < fileList.length; i++) {
     const file = fileList[i];
-    if (file && isAcceptedMime(file.type)) {
+    if (file && isAcceptedFile(file.type, file.name)) {
       files.push(file);
     }
   }

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -162,44 +162,177 @@ function generateAttachmentId(): string {
   return `att-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 }
 
+/** Read a single File into a ChatAttachment via FileReader. */
+function readFileAsAttachment(file: File): Promise<ChatAttachment | null> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => {
+      resolve({
+        id: generateAttachmentId(),
+        dataUrl: reader.result as string,
+        mimeType: file.type,
+      });
+    });
+    // Resolve null on error/abort so Promise.all always settles
+    // and a single bad file doesn't block the entire batch.
+    reader.addEventListener("error", () => resolve(null));
+    reader.addEventListener("abort", () => resolve(null));
+    reader.readAsDataURL(file);
+  });
+}
+
+// Mutable refs to the latest attachments state, updated on every render.
+// Async callbacks read from these refs instead of stale props closures.
+let latestAttachments: ChatAttachment[] = [];
+let latestOnAttachmentsChange: ((attachments: ChatAttachment[]) => void) | undefined;
+
+// Accumulator for concurrent async batches. When multiple addFilesAsAttachments
+// calls resolve before a render (e.g. rapid paste + drop), their results collect
+// here and are flushed together in a single microtask, preventing one batch from
+// overwriting another's files.
+let pendingAttachments: ChatAttachment[] = [];
+let flushScheduled = false;
+
+function flushPendingAttachments() {
+  flushScheduled = false;
+  if (pendingAttachments.length === 0 || !latestOnAttachmentsChange) {
+    return;
+  }
+  const toAdd = pendingAttachments;
+  pendingAttachments = [];
+  const merged = [...latestAttachments, ...toAdd];
+  // Update the module-level ref immediately so that if another batch
+  // flushes before Lit re-renders, it sees the combined state — not
+  // the stale pre-flush snapshot.
+  latestAttachments = merged;
+  latestOnAttachmentsChange(merged);
+}
+
+/**
+ * Batch-read files and append via accumulator to avoid race conditions.
+ * Multiple concurrent calls (rapid paste + drop) collect into pendingAttachments
+ * and flush together in a single microtask, ensuring no batch overwrites another.
+ */
+function addFilesAsAttachments(files: File[]) {
+  if (!latestOnAttachmentsChange || files.length === 0) {
+    return;
+  }
+  void Promise.all(files.map(readFileAsAttachment)).then((results) => {
+    const newAttachments = results.filter((att): att is ChatAttachment => att !== null);
+    if (newAttachments.length === 0) {
+      return;
+    }
+    pendingAttachments.push(...newAttachments);
+    if (!flushScheduled) {
+      flushScheduled = true;
+      queueMicrotask(flushPendingAttachments);
+    }
+  });
+}
+
 function handlePaste(e: ClipboardEvent, props: ChatProps) {
   const items = e.clipboardData?.items;
   if (!items || !props.onAttachmentsChange) {
     return;
   }
 
-  const imageItems: DataTransferItem[] = [];
+  const files: File[] = [];
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
     if (item.type.startsWith("image/")) {
-      imageItems.push(item);
+      const file = item.getAsFile();
+      if (file) {
+        files.push(file);
+      }
     }
   }
 
-  if (imageItems.length === 0) {
+  if (files.length === 0) {
     return;
   }
 
   e.preventDefault();
+  addFilesAsAttachments(files);
+}
 
-  for (const item of imageItems) {
-    const file = item.getAsFile();
-    if (!file) {
-      continue;
+/** Handle file input change (from attach or camera buttons). */
+function handleFileInput(e: Event, props: ChatProps) {
+  const input = e.target as HTMLInputElement;
+  const fileList = input.files;
+  if (!fileList || !props.onAttachmentsChange) {
+    return;
+  }
+  // Filter to image/* even though the input has accept="image/*",
+  // as some browsers may allow non-image files through the picker.
+  const files: File[] = [];
+  for (let i = 0; i < fileList.length; i++) {
+    const file = fileList[i];
+    if (file && file.type.startsWith("image/")) {
+      files.push(file);
     }
+  }
+  addFilesAsAttachments(files);
+  // Reset so re-selecting the same file triggers change again
+  input.value = "";
+}
 
-    const reader = new FileReader();
-    reader.addEventListener("load", () => {
-      const dataUrl = reader.result as string;
-      const newAttachment: ChatAttachment = {
-        id: generateAttachmentId(),
-        dataUrl,
-        mimeType: file.type,
-      };
-      const current = props.attachments ?? [];
-      props.onAttachmentsChange?.([...current, newAttachment]);
-    });
-    reader.readAsDataURL(file);
+/** Handle drag-and-drop of files onto the chat area. */
+function handleDrop(e: DragEvent, props: ChatProps) {
+  const target = e.currentTarget as HTMLElement;
+  target.classList.remove("chat--drag-over");
+
+  const fileList = e.dataTransfer?.files;
+  if (!fileList || fileList.length === 0) {
+    return; // Not a file drop — let native behavior handle it
+  }
+
+  // Always cancel file drops to prevent the browser from navigating away
+  // (its default action for dropped files). We filter to images below.
+  e.preventDefault();
+  e.stopPropagation();
+
+  if (!props.onAttachmentsChange || !props.connected) {
+    return;
+  }
+  const files: File[] = [];
+  for (let i = 0; i < fileList.length; i++) {
+    const file = fileList[i];
+    if (file && file.type.startsWith("image/")) {
+      files.push(file);
+    }
+  }
+  if (files.length > 0) {
+    addFilesAsAttachments(files);
+  }
+}
+
+function handleDragOver(e: DragEvent, props: ChatProps) {
+  // Only show the drop overlay when the drag payload contains files
+  // and the chat is connected (compose is enabled).
+  if (!props.connected) {
+    return;
+  }
+  const hasFiles = e.dataTransfer?.types?.includes("Files") ?? false;
+  if (!hasFiles) {
+    return; // Let non-file drags (text, URLs) pass through to native behavior
+  }
+  e.preventDefault();
+  e.stopPropagation();
+  const target = e.currentTarget as HTMLElement;
+  target.classList.add("chat--drag-over");
+}
+
+function handleDragLeave(e: DragEvent) {
+  const hasFiles = e.dataTransfer?.types?.includes("Files") ?? false;
+  if (!hasFiles) {
+    return;
+  }
+  e.preventDefault();
+  e.stopPropagation();
+  const target = e.currentTarget as HTMLElement;
+  // Only remove overlay if leaving the container entirely, not child elements
+  if (!target.contains(e.relatedTarget as Node)) {
+    target.classList.remove("chat--drag-over");
   }
 }
 
@@ -237,7 +370,15 @@ function renderAttachmentPreview(props: ChatProps) {
   `;
 }
 
+// Scoped element refs for file inputs (avoids global ID collisions)
+let fileInputEl: HTMLInputElement | null = null;
+let cameraInputEl: HTMLInputElement | null = null;
+
 export function renderChat(props: ChatProps) {
+  // Update mutable refs so async attachment callbacks always read latest state
+  latestAttachments = props.attachments ?? [];
+  latestOnAttachmentsChange = props.onAttachmentsChange;
+
   const canCompose = props.connected;
   const isBusy = props.sending || props.stream !== null;
   const canAbort = Boolean(props.canAbort && props.onAbort);
@@ -315,7 +456,19 @@ export function renderChat(props: ChatProps) {
   `;
 
   return html`
-    <section class="card chat">
+    <section
+      class="card chat"
+      @drop=${(e: DragEvent) => handleDrop(e, props)}
+      @dragover=${(e: DragEvent) => handleDragOver(e, props)}
+      @dragleave=${handleDragLeave}
+    >
+      <div class="chat-drop-overlay" aria-hidden="true">
+        <div class="chat-drop-overlay__content">
+          ${icons.image}
+          <span>Drop images here</span>
+        </div>
+      </div>
+
       ${props.disabledReason ? html`<div class="callout">${props.disabledReason}</div>` : nothing}
 
       ${props.error ? html`<div class="callout danger">${props.error}</div>` : nothing}
@@ -423,6 +576,51 @@ export function renderChat(props: ChatProps) {
       <div class="chat-compose">
         ${renderAttachmentPreview(props)}
         <div class="chat-compose__row">
+          <!-- Hidden file inputs (scoped via ref to avoid global ID collisions) -->
+          <input
+            type="file"
+            accept="image/*"
+            multiple
+            class="chat-compose__file-input"
+            ${ref((el) => {
+              fileInputEl = el as HTMLInputElement | null;
+            })}
+            @change=${(e: Event) => handleFileInput(e, props)}
+          />
+          <input
+            type="file"
+            accept="image/*"
+            capture="environment"
+            class="chat-compose__file-input"
+            ${ref((el) => {
+              cameraInputEl = el as HTMLInputElement | null;
+            })}
+            @change=${(e: Event) => handleFileInput(e, props)}
+          />
+
+          <div class="chat-compose__attach-buttons">
+            <button
+              class="btn btn--icon chat-compose__attach-btn"
+              type="button"
+              title="Attach image"
+              aria-label="Attach image"
+              ?disabled=${!props.connected}
+              @click=${() => fileInputEl?.click()}
+            >
+              ${icons.paperclip}
+            </button>
+            <button
+              class="btn btn--icon chat-compose__camera-btn"
+              type="button"
+              title="Take photo"
+              aria-label="Take photo"
+              ?disabled=${!props.connected}
+              @click=${() => cameraInputEl?.click()}
+            >
+              ${icons.camera}
+            </button>
+          </div>
+
           <label class="field chat-compose__field">
             <span>Message</span>
             <textarea

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -230,6 +230,17 @@ function addFilesAsAttachments(files: File[]) {
   });
 }
 
+/** MIME types accepted for chat attachments. */
+const ACCEPTED_MIME_PREFIXES = ["image/"];
+const ACCEPTED_MIME_EXACT = new Set(["application/pdf"]);
+
+function isAcceptedMime(mime: string): boolean {
+  return (
+    ACCEPTED_MIME_PREFIXES.some((prefix) => mime.startsWith(prefix)) ||
+    ACCEPTED_MIME_EXACT.has(mime)
+  );
+}
+
 function handlePaste(e: ClipboardEvent, props: ChatProps) {
   const items = e.clipboardData?.items;
   if (!items || !props.onAttachmentsChange) {
@@ -239,7 +250,7 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
   const files: File[] = [];
   for (let i = 0; i < items.length; i++) {
     const item = items[i];
-    if (item.type.startsWith("image/")) {
+    if (isAcceptedMime(item.type)) {
       const file = item.getAsFile();
       if (file) {
         files.push(file);
@@ -262,12 +273,12 @@ function handleFileInput(e: Event, props: ChatProps) {
   if (!fileList || !props.onAttachmentsChange) {
     return;
   }
-  // Filter to image/* even though the input has accept="image/*",
-  // as some browsers may allow non-image files through the picker.
+  // Runtime-filter even though the input has an accept attribute,
+  // as some browsers may allow non-matching files through the picker.
   const files: File[] = [];
   for (let i = 0; i < fileList.length; i++) {
     const file = fileList[i];
-    if (file && file.type.startsWith("image/")) {
+    if (file && isAcceptedMime(file.type)) {
       files.push(file);
     }
   }
@@ -297,7 +308,7 @@ function handleDrop(e: DragEvent, props: ChatProps) {
   const files: File[] = [];
   for (let i = 0; i < fileList.length; i++) {
     const file = fileList[i];
-    if (file && file.type.startsWith("image/")) {
+    if (file && isAcceptedMime(file.type)) {
       files.push(file);
     }
   }
@@ -465,7 +476,7 @@ export function renderChat(props: ChatProps) {
       <div class="chat-drop-overlay" aria-hidden="true">
         <div class="chat-drop-overlay__content">
           ${icons.image}
-          <span>Drop images here</span>
+          <span>Drop files here</span>
         </div>
       </div>
 
@@ -579,7 +590,7 @@ export function renderChat(props: ChatProps) {
           <!-- Hidden file inputs (scoped via ref to avoid global ID collisions) -->
           <input
             type="file"
-            accept="image/*"
+            accept="image/*,.pdf,application/pdf"
             multiple
             class="chat-compose__file-input"
             ${ref((el) => {
@@ -602,8 +613,8 @@ export function renderChat(props: ChatProps) {
             <button
               class="btn btn--icon chat-compose__attach-btn"
               type="button"
-              title="Attach image"
-              aria-label="Attach image"
+              title="Attach file"
+              aria-label="Attach file"
               ?disabled=${!props.connected}
               @click=${() => fileInputEl?.click()}
             >

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -171,6 +171,7 @@ function readFileAsAttachment(file: File): Promise<ChatAttachment | null> {
         id: generateAttachmentId(),
         dataUrl: reader.result as string,
         mimeType: file.type,
+        fileName: file.name,
       });
     });
     // Resolve null on error/abort so Promise.all always settles
@@ -378,11 +379,34 @@ function renderAttachmentPreview(props: ChatProps) {
       ${attachments.map(
         (att) => html`
           <div class="chat-attachment">
-            <img
-              src=${att.dataUrl}
-              alt="Attachment preview"
-              class="chat-attachment__img"
-            />
+            ${
+              att.mimeType.startsWith("image/")
+                ? html`<img
+                  src=${att.dataUrl}
+                  alt="Attachment preview"
+                  class="chat-attachment__img"
+                />`
+                : html`<div class="chat-attachment__document">
+                  <svg
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                  >
+                    <path
+                      d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"
+                    />
+                    <polyline points="14 2 14 8 20 8" />
+                    <line x1="16" y1="13" x2="8" y2="13" />
+                    <line x1="16" y1="17" x2="8" y2="17" />
+                  </svg>
+                  <span class="chat-attachment__document-name"
+                    >${att.fileName ?? "PDF"}</span
+                  >
+                </div>`
+            }
             <button
               class="chat-attachment__remove"
               type="button"

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -243,7 +243,7 @@ function isAcceptedMime(mime: string): boolean {
 
 function handlePaste(e: ClipboardEvent, props: ChatProps) {
   const items = e.clipboardData?.items;
-  if (!items || !props.onAttachmentsChange) {
+  if (!items || !props.onAttachmentsChange || !props.connected) {
     return;
   }
 
@@ -270,7 +270,7 @@ function handlePaste(e: ClipboardEvent, props: ChatProps) {
 function handleFileInput(e: Event, props: ChatProps) {
   const input = e.target as HTMLInputElement;
   const fileList = input.files;
-  if (!fileList || !props.onAttachmentsChange) {
+  if (!fileList || !props.onAttachmentsChange || !props.connected) {
     return;
   }
   // Runtime-filter even though the input has an accept attribute,


### PR DESCRIPTION
## Summary

Extends the webchat attachment UI to support PDF files alongside images. PDFs are processed through the existing attachment pipeline and injected into Anthropic API requests as native document blocks.

## Architecture

The `pi-ai` library's type system only supports `TextContent | ImageContent` — no `DocumentContent`. This PR uses the established `onPayload` hook pattern (consistent with `extra-params.ts`) to inject raw Anthropic document blocks into the API request after `pi-ai` builds it.

```
UI (file picker + drop + paste)
  → gateway/chat-attachments.ts (MIME sniff → route to images[] or documents[])
    → commands/agent.ts (thread documents)
      → pi-embedded-runner/attempt.ts (install StreamFn wrapper)
        → document-injection.ts (onPayload: inject document blocks + beta header)
```

## Changes

### UI (2 files)
- File picker accepts `image/*,.pdf,application/pdf`; camera remains image-only
- `isAcceptedMime()` helper ensures all 3 input paths (paste/drop/file-input) validate identically
- PDF preview shows `[PDF attached]` text indicator (no thumbnail)
- Button label: "Attach file" (was "Attach image")

### Gateway (2 files)
- New `ChatDocumentContent` type with `data`, `mimeType`, `fileName`
- `parseMessageWithAttachments()` returns `{ images, documents }` — PDF detected via `sniffMimeFromBase64()` (`file-type` lib detects `%PDF` magic bytes)
- Existing image validation unchanged

### Agent pipeline (6 files)
- `DocumentContent` type added to `AgentCommandOpts`
- `documents` threaded: `chat.ts` → `agent.ts` → `cli-runner.ts` → `run.ts` → `params.ts` → `attempt.ts`

### Document injection (1 new file)
- `createDocumentInjectionWrapper()` — one-shot `StreamFn` wrapper
- Uses `onPayload` hook to inject `{ type: "document", source: { type: "base64", media_type: "application/pdf", data } }` blocks into last user message
- Adds `pdfs-2024-09-25` beta header for Anthropic
- Only activates for Anthropic-compatible providers
- Wrapper auto-deactivates after first prompt (documents are prompt-local)

### Tests (1 file)
- Updated `chat-attachments.test.ts` — PDFs now route to `documents[]` instead of being dropped
- Existing image tests unchanged

## QA
- format ✅ | types ✅ | lint ✅ | build ✅ | tests (35/35) ✅

## Depends on
- #35524 (webchat image attachments) — this PR includes those changes via cherry-pick

## Edge cases handled
- MIME validation parity across all input paths (Pattern #4)
- Disconnected state gating on drop/dragover (Pattern #11)
- Mixed attachments (images + PDFs in same message)
- One-shot wrapper restoration after prompt
- Fallback for non-Anthropic providers (passthrough, no injection)