### PR TITLE
fix(tui): ensure immediate render for assistant messages (#35523)

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -403,6 +403,37 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(state.activeChatRunId).toBe("run-active");
   });
 
+  it("calls requestRender when delta event has no displayable content (ingestDelta returns null)", () => {
+    const { tui, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null, showThinking: false },
+    });
+
+    // First delta with actual content
+    handleChatEvent({
+      runId: "run-think",
+      sessionKey: "agent:main:main",
+      state: "delta",
+      message: { content: [{ type: "text", text: "hello" }] },
+    });
+
+    expect(tui.requestRender).toHaveBeenCalled();
+    const renderCount = tui.requestRender.mock.calls.length;
+
+    // Second delta with only thinking content (showThinking: false means no display text)
+    handleChatEvent({
+      runId: "run-think",
+      sessionKey: "agent:main:main",
+      state: "delta",
+      message: {
+        content: [{ type: "thinking", thinking: "internal thought", signature: "sig" }],
+      },
+    });
+
+    // Even though ingestDelta returns null for thinking-only with showThinking:false,
+    // requestRender should still be called
+    expect(tui.requestRender).toHaveBeenCalledTimes(renderCount + 1);
+  });
+
   it("drops streaming assistant when chat final has no message", () => {
     const { state, chatLog, handleChatEvent } = createHandlersHarness({
       state: { activeChatRunId: null },

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -170,10 +170,15 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (evt.state === "delta") {
       const displayText = streamAssembler.ingestDelta(evt.runId, evt.message, state.showThinking);
       if (!displayText) {
+        // Even if there's no new content to display, we may need to render
+        // (e.g., for thinking content updates). Always request a render.
+        tui.requestRender();
         return;
       }
       chatLog.updateAssistant(displayText, evt.runId);
       setActivityStatus("streaming");
+      tui.requestRender();
+      return;
     }
     if (evt.state === "final") {
       const wasActiveRun = state.activeChatRunId === evt.runId;
@@ -215,20 +220,25 @@ export function createEventHandlers(context: EventHandlerContext) {
         wasActiveRun,
         status: stopReason === "error" ? "error" : "idle",
       });
+      tui.requestRender();
+      return;
     }
     if (evt.state === "aborted") {
       const wasActiveRun = state.activeChatRunId === evt.runId;
       chatLog.addSystem("run aborted");
       terminateRun({ runId: evt.runId, wasActiveRun, status: "aborted" });
       maybeRefreshHistoryForRun(evt.runId);
+      tui.requestRender();
+      return;
     }
     if (evt.state === "error") {
       const wasActiveRun = state.activeChatRunId === evt.runId;
       chatLog.addSystem(`run error: ${evt.errorMessage ?? "unknown"}`);
       terminateRun({ runId: evt.runId, wasActiveRun, status: "error" });
       maybeRefreshHistoryForRun(evt.runId);
+      tui.requestRender();
+      return;
     }
-    tui.requestRender();
   };
 
   const handleAgentEvent = (payload: unknown) => {


### PR DESCRIPTION
## Summary

Fixes #35523 - TUI doesn't display assistant messages until restart

## Problem

In `handleChatEvent`, when `ingestDelta` returned `null` (indicating no new content), the function would return early **without** calling `tui.requestRender()`. This caused the UI to not update, making assistant messages invisible until the TUI was restarted.

## Changes

- **delta state**: Always call `tui.requestRender()` even when `displayText` is null (needed for thinking content updates)
- **final state**: Explicitly call `tui.requestRender()` before returning in all branches
- **aborted/error states**: Added explicit `tui.requestRender()` calls with early returns
- Removed the fallback `tui.requestRender()` at function end since all paths now handle rendering explicitly

## Testing

- All 13 existing tests in `tui-event-handlers.test.ts` pass
- Build completes successfully with no TypeScript errors

## Risk Assessment

Low risk - the fix ensures consistent rendering behavior across all event states without changing the underlying rendering logic.

---

Closes #35523