### PR TITLE
feat(feishu): task management tools (task v2)

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -7,6 +7,7 @@ import { registerFeishuDocTools } from "./src/docx.js";
 import { registerFeishuDriveTools } from "./src/drive.js";
 import { registerFeishuPermTools } from "./src/perm.js";
 import { setFeishuRuntime } from "./src/runtime.js";
+import { registerFeishuTaskTools } from "./src/task.js";
 import { registerFeishuWikiTools } from "./src/wiki.js";
 
 export { monitorFeishuProvider } from "./src/monitor.js";
@@ -59,6 +60,7 @@ const plugin = {
     registerFeishuDriveTools(api);
     registerFeishuPermTools(api);
     registerFeishuBitableTools(api);
+    registerFeishuTaskTools(api);
   },
 };
 

--- a/extensions/feishu/skills/feishu-task/SKILL.md
+++ b/extensions/feishu/skills/feishu-task/SKILL.md
@@ -26,6 +26,11 @@ Tools:
 - `feishu_tasklist_delete`
 - `feishu_tasklist_add_members`
 - `feishu_tasklist_remove_members`
+- `feishu_task_comment_create`
+- `feishu_task_comment_list`
+- `feishu_task_comment_get`
+- `feishu_task_comment_update`
+- `feishu_task_comment_delete`
 
 ## Notes
 
@@ -180,5 +185,66 @@ Tasklists support three roles: owner (read/edit/manage), editor (read/edit), vie
   "tasklist_guid": "cc371766-6584-cf50-a222-c22cd9055004",
   "members": [{ "id": "ou_xxx", "type": "user", "role": "viewer" }],
   "user_id_type": "open_id"
+}
+```
+
+## Task Comments
+
+### Create Comment
+
+```json
+{
+  "task_guid": "e297ddff-06ca-4166-b917-4ce57cd3a7a0",
+  "content": "Looks good, please update the due date.",
+  "user_id_type": "open_id"
+}
+```
+
+### Reply to Comment
+
+```json
+{
+  "task_guid": "e297ddff-06ca-4166-b917-4ce57cd3a7a0",
+  "content": "Done, updated.",
+  "reply_to_comment_id": "7351932297202737xxx",
+  "user_id_type": "open_id"
+}
+```
+
+### List Comments
+
+```json
+{
+  "task_guid": "e297ddff-06ca-4166-b917-4ce57cd3a7a0",
+  "page_size": 50,
+  "direction": "asc",
+  "user_id_type": "open_id"
+}
+```
+
+### Get Comment
+
+```json
+{
+  "comment_id": "7351932297202737xxx",
+  "user_id_type": "open_id"
+}
+```
+
+### Update Comment
+
+```json
+{
+  "comment_id": "7351932297202737xxx",
+  "comment": { "content": "Updated comment text." },
+  "user_id_type": "open_id"
+}
+```
+
+### Delete Comment
+
+```json
+{
+  "comment_id": "7351932297202737xxx"
 }
 ```

--- a/extensions/feishu/skills/feishu-task/SKILL.md
+++ b/extensions/feishu/skills/feishu-task/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: feishu-task
+description: |
+  Feishu Task, tasklist, subtask, and attachment management. Activate when user mentions tasks, tasklists, subtasks, task attachments, or task links.
+---
+
+# Feishu Task Tools
+
+Tools:
+
+- `feishu_task_create`
+- `feishu_task_subtask_create`
+- `feishu_task_get`
+- `feishu_task_update`
+- `feishu_task_delete`
+- `feishu_task_attachment_upload`
+- `feishu_task_attachment_list`
+- `feishu_task_attachment_get`
+- `feishu_task_attachment_delete`
+- `feishu_task_add_tasklist`
+- `feishu_task_remove_tasklist`
+- `feishu_tasklist_create`
+- `feishu_tasklist_get`
+- `feishu_tasklist_list`
+- `feishu_tasklist_update`
+- `feishu_tasklist_delete`
+- `feishu_tasklist_add_members`
+- `feishu_tasklist_remove_members`
+
+## Notes
+
+- `task_guid` can be taken from a task URL (guid query param) or from `feishu_task_get` output.
+- `attachment_guid` can be obtained from `feishu_task_attachment_list` output.
+- `user_id_type` controls returned/accepted user identity type (`open_id`, `user_id`, `union_id`).
+- If no assignee is specified, set the assignee to the requesting user. Avoid creating unassigned tasks because the user may not be able to view them.
+- Task visibility: users can only view tasks when they are included as assignee.
+- Current limitation: the bot can only create subtasks for tasks created by itself.
+- Attachment upload supports local `file_path` and remote `file_url`. Remote URLs are fetched with runtime media safety checks and size limit (`mediaMaxMb`).
+- Keep tasklist owner as the bot. Add users as members to avoid losing bot access.
+- Use tasklist tools for tasklist membership changes; do not use `feishu_task_update` to move tasks between tasklists.
+
+## Create Task
+
+```json
+{
+  "summary": "Quarterly review",
+  "description": "Prepare review notes",
+  "due": { "timestamp": "1735689600000", "is_all_day": true },
+  "members": [{ "id": "ou_xxx", "role": "assignee", "type": "user" }],
+  "user_id_type": "open_id"
+}
+```
+
+## Create Subtask
+
+```json
+{
+  "task_guid": "e297ddff-06ca-4166-b917-4ce57cd3a7a0",
+  "summary": "Draft report outline",
+  "description": "Collect key metrics",
+  "due": { "timestamp": "1735689600000", "is_all_day": true },
+  "members": [{ "id": "ou_xxx", "role": "assignee", "type": "user" }],
+  "user_id_type": "open_id"
+}
+```
+
+## Upload Attachment (file_path)
+
+```json
+{
+  "task_guid": "e297ddff-06ca-4166-b917-4ce57cd3a7a0",
+  "file_path": "/path/to/report.pdf",
+  "user_id_type": "open_id"
+}
+```
+
+## Upload Attachment (file_url)
+
+```json
+{
+  "task_guid": "e297ddff-06ca-4166-b917-4ce57cd3a7a0",
+  "file_url": "https://oss-example.com/bucket/report.pdf",
+  "filename": "report.pdf",
+  "user_id_type": "open_id"
+}
+```
+
+## Tasklist Membership For Tasks
+
+### Add Task to Tasklist
+
+```json
+{
+  "task_guid": "e297ddff-06ca-4166-b917-4ce57cd3a7a0",
+  "tasklist_guid": "cc371766-6584-cf50-a222-c22cd9055004",
+  "section_guid": "6d0f9f48-2e06-4e3d-8a0f-acde196e8c61",
+  "user_id_type": "open_id"
+}
+```
+
+### Remove Task from Tasklist
+
+```json
+{
+  "task_guid": "e297ddff-06ca-4166-b917-4ce57cd3a7a0",
+  "tasklist_guid": "cc371766-6584-cf50-a222-c22cd9055004",
+  "user_id_type": "open_id"
+}
+```
+
+## Tasklists
+
+Tasklists support three roles: owner (read/edit/manage), editor (read/edit), viewer (read).
+
+### Create Tasklist
+
+```json
+{
+  "name": "Project Alpha Tasklist",
+  "members": [{ "id": "ou_xxx", "type": "user", "role": "editor" }],
+  "user_id_type": "open_id"
+}
+```
+
+### Get Tasklist
+
+```json
+{
+  "tasklist_guid": "cc371766-6584-cf50-a222-c22cd9055004",
+  "user_id_type": "open_id"
+}
+```
+
+### List Tasklists
+
+```json
+{
+  "page_size": 50,
+  "user_id_type": "open_id"
+}
+```
+
+### Update Tasklist
+
+```json
+{
+  "tasklist_guid": "cc371766-6584-cf50-a222-c22cd9055004",
+  "tasklist": {
+    "name": "Renamed Tasklist",
+    "owner": { "id": "ou_xxx", "type": "user", "role": "owner" }
+  },
+  "update_fields": ["name", "owner"],
+  "origin_owner_to_role": "editor",
+  "user_id_type": "open_id"
+}
+```
+
+### Delete Tasklist
+
+```json
+{
+  "tasklist_guid": "cc371766-6584-cf50-a222-c22cd9055004"
+}
+```
+
+### Add Tasklist Members
+
+```json
+{
+  "tasklist_guid": "cc371766-6584-cf50-a222-c22cd9055004",
+  "members": [{ "id": "ou_xxx", "type": "user", "role": "editor" }],
+  "user_id_type": "open_id"
+}
+```
+
+### Remove Tasklist Members
+
+```json
+{
+  "tasklist_guid": "cc371766-6584-cf50-a222-c22cd9055004",
+  "members": [{ "id": "ou_xxx", "type": "user", "role": "viewer" }],
+  "user_id_type": "open_id"
+}
+```

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -89,6 +89,7 @@ const FeishuToolsConfigSchema = z
     drive: z.boolean().optional(), // Cloud storage operations (default: true)
     perm: z.boolean().optional(), // Permission management (default: false, sensitive)
     scopes: z.boolean().optional(), // App scopes diagnostic (default: true)
+    task: z.boolean().optional(), // Task management (default: false, requires task v2 API)
   })
   .strict()
   .optional();

--- a/extensions/feishu/src/task-schema.ts
+++ b/extensions/feishu/src/task-schema.ts
@@ -1,6 +1,15 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import { Type } from "@sinclair/typebox";
 
+// NOTE: Avoid Type.Union([Type.Literal(...)]) which compiles to anyOf.
+// Some providers reject anyOf in tool schemas; a flat string enum is safer.
+function stringEnum<T extends readonly string[]>(
+  values: T,
+  options: { description?: string; default?: T[number] } = {},
+) {
+  return Type.Unsafe<T[number]>({ type: "string", enum: [...values], ...options });
+}
+
 type TaskCreatePayload = NonNullable<Parameters<Lark.Client["task"]["v2"]["task"]["create"]>[0]>;
 type TaskUpdatePayload = NonNullable<Parameters<Lark.Client["task"]["v2"]["task"]["patch"]>[0]>;
 type TaskDeletePayload = NonNullable<Parameters<Lark.Client["task"]["v2"]["task"]["delete"]>[0]>;
@@ -79,6 +88,7 @@ export const TASK_UPDATE_FIELD_VALUES = [
   "mode",
   "is_milestone",
 ] as const;
+export const TASK_COMMENT_UPDATE_FIELD_VALUES = ["content"] as const;
 export const TASKLIST_UPDATE_FIELD_VALUES = ["name", "owner", "archive_tasklist"] as const;
 
 export type CreateTaskParams = {
@@ -219,23 +229,17 @@ const TasklistRefSchema = Type.Object({
   section_guid: Type.Optional(Type.String({ description: "Section GUID in tasklist" })),
 });
 
-const TaskUpdateFieldSchema = Type.Union(
-  TASK_UPDATE_FIELD_VALUES.map((field) => Type.Literal(field)),
-);
+const TaskUpdateFieldSchema = stringEnum(TASK_UPDATE_FIELD_VALUES);
 
-const TasklistMemberRoleSchema = Type.Union(
-  [Type.Literal("owner"), Type.Literal("editor"), Type.Literal("viewer")],
-  { description: "Member role (owner/editor/viewer)" },
-);
+const TasklistMemberRoleSchema = stringEnum(["owner", "editor", "viewer"] as const, {
+  description: "Member role (owner/editor/viewer)",
+});
 
-const TasklistUpdateFieldSchema = Type.Union(
-  TASKLIST_UPDATE_FIELD_VALUES.map((field) => Type.Literal(field)),
-);
+const TasklistUpdateFieldSchema = stringEnum(TASKLIST_UPDATE_FIELD_VALUES);
 
-const TasklistOriginOwnerRoleSchema = Type.Union(
-  [Type.Literal("editor"), Type.Literal("viewer"), Type.Literal("none")],
-  { description: "Role for original owner after owner transfer" },
-);
+const TasklistOriginOwnerRoleSchema = stringEnum(["editor", "viewer", "none"] as const, {
+  description: "Role for original owner after owner transfer",
+});
 
 const TasklistMemberSchema = Type.Object({
   id: Type.String({ description: "Member ID (with type controlled by user_id_type)" }),
@@ -523,9 +527,7 @@ export const ListTaskCommentsSchema = Type.Object({
     Type.Number({ description: "Page size (1-100)", minimum: 1, maximum: 100 }),
   ),
   page_token: Type.Optional(Type.String({ description: "Pagination token" })),
-  direction: Type.Optional(
-    Type.Union([Type.Literal("asc"), Type.Literal("desc")], { description: "Sort direction" }),
-  ),
+  direction: Type.Optional(stringEnum(["asc", "desc"] as const, { description: "Sort direction" })),
   user_id_type: Type.Optional(Type.String({ description: "User ID type for returned creators" })),
 });
 
@@ -543,9 +545,10 @@ export const UpdateTaskCommentSchema = Type.Object({
   comment_id: Type.String({ description: "Comment ID to update" }),
   comment: TaskCommentUpdateContentSchema,
   update_fields: Type.Optional(
-    Type.Array(Type.String(), {
+    Type.Array(stringEnum(TASK_COMMENT_UPDATE_FIELD_VALUES), {
       description: "Fields to update. If omitted, infers from keys in comment (content)",
       minItems: 1,
+      uniqueItems: true,
     }),
   ),
   user_id_type: Type.Optional(Type.String({ description: "User ID type for returned creators" })),

--- a/extensions/feishu/src/task-schema.ts
+++ b/extensions/feishu/src/task-schema.ts
@@ -42,6 +42,21 @@ type TasklistAddMembersPayload = NonNullable<
 type TasklistRemoveMembersPayload = NonNullable<
   Parameters<Lark.Client["task"]["v2"]["tasklist"]["removeMembers"]>[0]
 >;
+type TaskCommentCreatePayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["comment"]["create"]>[0]
+>;
+type TaskCommentGetPayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["comment"]["get"]>[0]
+>;
+type TaskCommentListPayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["comment"]["list"]>[0]
+>;
+type TaskCommentPatchPayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["comment"]["patch"]>[0]
+>;
+type TaskCommentDeletePayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["comment"]["delete"]>[0]
+>;
 
 export type TaskCreateData = TaskCreatePayload["data"];
 export type TaskUpdateData = TaskUpdatePayload["data"];
@@ -50,6 +65,8 @@ export type TasklistCreateData = TasklistCreatePayload["data"];
 export type TasklistPatchData = TasklistPatchPayload["data"];
 export type TasklistPatchTasklist = NonNullable<TasklistPatchData["tasklist"]>;
 export type TasklistMember = NonNullable<NonNullable<TasklistCreateData["members"]>[number]>;
+export type TaskCommentPatchData = TaskCommentPatchPayload["data"];
+export type TaskCommentPatchComment = TaskCommentPatchData["comment"];
 
 export const TASK_UPDATE_FIELD_VALUES = [
   "summary",
@@ -452,4 +469,88 @@ export const GetTaskAttachmentSchema = Type.Object({
 
 export const DeleteTaskAttachmentSchema = Type.Object({
   attachment_guid: Type.String({ description: "Attachment GUID to delete" }),
+});
+
+// ============ Comment Types ============
+
+export type CreateTaskCommentParams = {
+  task_guid: string;
+  content: TaskCommentCreatePayload["data"]["content"];
+  reply_to_comment_id?: TaskCommentCreatePayload["data"]["reply_to_comment_id"];
+  user_id_type?: NonNullable<TaskCommentCreatePayload["params"]>["user_id_type"];
+};
+
+export type ListTaskCommentsParams = {
+  task_guid: string;
+  page_size?: NonNullable<TaskCommentListPayload["params"]>["page_size"];
+  page_token?: NonNullable<TaskCommentListPayload["params"]>["page_token"];
+  direction?: NonNullable<TaskCommentListPayload["params"]>["direction"];
+  user_id_type?: NonNullable<TaskCommentListPayload["params"]>["user_id_type"];
+};
+
+export type GetTaskCommentParams = {
+  comment_id: TaskCommentGetPayload["path"]["comment_id"];
+  user_id_type?: NonNullable<TaskCommentGetPayload["params"]>["user_id_type"];
+};
+
+export type UpdateTaskCommentParams = {
+  comment_id: TaskCommentPatchPayload["path"]["comment_id"];
+  comment: TaskCommentPatchComment;
+  update_fields?: TaskCommentPatchData["update_fields"];
+  user_id_type?: NonNullable<TaskCommentPatchPayload["params"]>["user_id_type"];
+};
+
+export type DeleteTaskCommentParams = {
+  comment_id: TaskCommentDeletePayload["path"]["comment_id"];
+};
+
+// ============ Comment Schemas ============
+
+export const CreateTaskCommentSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to comment on" }),
+  content: Type.String({ description: "Comment content" }),
+  reply_to_comment_id: Type.Optional(
+    Type.String({ description: "Reply to a specific comment ID" }),
+  ),
+  user_id_type: Type.Optional(
+    Type.String({ description: "User ID type when comment involves user-related fields" }),
+  ),
+});
+
+export const ListTaskCommentsSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to list comments for" }),
+  page_size: Type.Optional(
+    Type.Number({ description: "Page size (1-100)", minimum: 1, maximum: 100 }),
+  ),
+  page_token: Type.Optional(Type.String({ description: "Pagination token" })),
+  direction: Type.Optional(
+    Type.Union([Type.Literal("asc"), Type.Literal("desc")], { description: "Sort direction" }),
+  ),
+  user_id_type: Type.Optional(Type.String({ description: "User ID type for returned creators" })),
+});
+
+export const GetTaskCommentSchema = Type.Object({
+  comment_id: Type.String({ description: "Comment ID to retrieve" }),
+  user_id_type: Type.Optional(Type.String({ description: "User ID type for returned creators" })),
+});
+
+const TaskCommentUpdateContentSchema = Type.Object(
+  { content: Type.Optional(Type.String({ description: "Updated comment content" })) },
+  { minProperties: 1 },
+);
+
+export const UpdateTaskCommentSchema = Type.Object({
+  comment_id: Type.String({ description: "Comment ID to update" }),
+  comment: TaskCommentUpdateContentSchema,
+  update_fields: Type.Optional(
+    Type.Array(Type.String(), {
+      description: "Fields to update. If omitted, infers from keys in comment (content)",
+      minItems: 1,
+    }),
+  ),
+  user_id_type: Type.Optional(Type.String({ description: "User ID type for returned creators" })),
+});
+
+export const DeleteTaskCommentSchema = Type.Object({
+  comment_id: Type.String({ description: "Comment ID to delete" }),
 });

--- a/extensions/feishu/src/task-schema.ts
+++ b/extensions/feishu/src/task-schema.ts
@@ -1,0 +1,455 @@
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import { Type } from "@sinclair/typebox";
+
+type TaskCreatePayload = NonNullable<Parameters<Lark.Client["task"]["v2"]["task"]["create"]>[0]>;
+type TaskUpdatePayload = NonNullable<Parameters<Lark.Client["task"]["v2"]["task"]["patch"]>[0]>;
+type TaskDeletePayload = NonNullable<Parameters<Lark.Client["task"]["v2"]["task"]["delete"]>[0]>;
+type TaskGetPayload = NonNullable<Parameters<Lark.Client["task"]["v2"]["task"]["get"]>[0]>;
+type TaskAddTasklistPayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["task"]["addTasklist"]>[0]
+>;
+type TaskRemoveTasklistPayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["task"]["removeTasklist"]>[0]
+>;
+type TaskAttachmentUploadPayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["attachment"]["upload"]>[0]
+>;
+type TaskAttachmentGetPayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["attachment"]["get"]>[0]
+>;
+type TaskAttachmentListPayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["attachment"]["list"]>[0]
+>;
+type TaskAttachmentDeletePayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["attachment"]["delete"]>[0]
+>;
+type TasklistCreatePayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["tasklist"]["create"]>[0]
+>;
+type TasklistGetPayload = NonNullable<Parameters<Lark.Client["task"]["v2"]["tasklist"]["get"]>[0]>;
+type TasklistListPayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["tasklist"]["list"]>[0]
+>;
+type TasklistPatchPayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["tasklist"]["patch"]>[0]
+>;
+type TasklistDeletePayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["tasklist"]["delete"]>[0]
+>;
+type TasklistAddMembersPayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["tasklist"]["addMembers"]>[0]
+>;
+type TasklistRemoveMembersPayload = NonNullable<
+  Parameters<Lark.Client["task"]["v2"]["tasklist"]["removeMembers"]>[0]
+>;
+
+export type TaskCreateData = TaskCreatePayload["data"];
+export type TaskUpdateData = TaskUpdatePayload["data"];
+export type TaskUpdateTask = NonNullable<TaskUpdateData["task"]>;
+export type TasklistCreateData = TasklistCreatePayload["data"];
+export type TasklistPatchData = TasklistPatchPayload["data"];
+export type TasklistPatchTasklist = NonNullable<TasklistPatchData["tasklist"]>;
+export type TasklistMember = NonNullable<NonNullable<TasklistCreateData["members"]>[number]>;
+
+export const TASK_UPDATE_FIELD_VALUES = [
+  "summary",
+  "description",
+  "due",
+  "start",
+  "extra",
+  "completed_at",
+  "repeat_rule",
+  "mode",
+  "is_milestone",
+] as const;
+export const TASKLIST_UPDATE_FIELD_VALUES = ["name", "owner", "archive_tasklist"] as const;
+
+export type CreateTaskParams = {
+  summary: TaskCreateData["summary"];
+  description?: TaskCreateData["description"];
+  due?: TaskCreateData["due"];
+  start?: TaskCreateData["start"];
+  extra?: TaskCreateData["extra"];
+  completed_at?: TaskCreateData["completed_at"];
+  members?: TaskCreateData["members"];
+  repeat_rule?: TaskCreateData["repeat_rule"];
+  tasklists?: TaskCreateData["tasklists"];
+  mode?: TaskCreateData["mode"];
+  is_milestone?: TaskCreateData["is_milestone"];
+  user_id_type?: NonNullable<TaskCreatePayload["params"]>["user_id_type"];
+};
+
+export type CreateSubtaskParams = CreateTaskParams & {
+  task_guid: string;
+};
+
+export type DeleteTaskParams = {
+  task_guid: TaskDeletePayload["path"]["task_guid"];
+};
+
+export type GetTaskParams = {
+  task_guid: TaskGetPayload["path"]["task_guid"];
+  user_id_type?: NonNullable<TaskGetPayload["params"]>["user_id_type"];
+};
+
+export type UpdateTaskParams = {
+  task_guid: TaskUpdatePayload["path"]["task_guid"];
+  task: TaskUpdateTask;
+  update_fields?: TaskUpdateData["update_fields"];
+  user_id_type?: NonNullable<TaskUpdatePayload["params"]>["user_id_type"];
+};
+
+export type AddTaskToTasklistParams = {
+  task_guid: TaskAddTasklistPayload["path"]["task_guid"];
+  tasklist_guid: NonNullable<TaskAddTasklistPayload["data"]>["tasklist_guid"];
+  section_guid?: NonNullable<TaskAddTasklistPayload["data"]>["section_guid"];
+  user_id_type?: NonNullable<TaskAddTasklistPayload["params"]>["user_id_type"];
+};
+
+export type RemoveTaskFromTasklistParams = {
+  task_guid: TaskRemoveTasklistPayload["path"]["task_guid"];
+  tasklist_guid: NonNullable<TaskRemoveTasklistPayload["data"]>["tasklist_guid"];
+  user_id_type?: NonNullable<TaskRemoveTasklistPayload["params"]>["user_id_type"];
+};
+
+export type UploadTaskAttachmentParams = {
+  task_guid: string;
+  file_path?: string;
+  file_url?: string;
+  filename?: string;
+  user_id_type?: NonNullable<TaskAttachmentUploadPayload["params"]>["user_id_type"];
+};
+
+export type ListTaskAttachmentsParams = {
+  task_guid: NonNullable<TaskAttachmentListPayload["params"]>["resource_id"];
+  page_size?: NonNullable<TaskAttachmentListPayload["params"]>["page_size"];
+  page_token?: NonNullable<TaskAttachmentListPayload["params"]>["page_token"];
+  updated_mesc?: NonNullable<TaskAttachmentListPayload["params"]>["updated_mesc"];
+  user_id_type?: NonNullable<TaskAttachmentListPayload["params"]>["user_id_type"];
+};
+
+export type GetTaskAttachmentParams = {
+  attachment_guid: TaskAttachmentGetPayload["path"]["attachment_guid"];
+  user_id_type?: NonNullable<TaskAttachmentGetPayload["params"]>["user_id_type"];
+};
+
+export type DeleteTaskAttachmentParams = {
+  attachment_guid: NonNullable<TaskAttachmentDeletePayload["path"]>["attachment_guid"];
+};
+
+export type CreateTasklistParams = {
+  name: TasklistCreateData["name"];
+  members?: TasklistCreateData["members"];
+  archive_tasklist?: TasklistCreateData["archive_tasklist"];
+  user_id_type?: NonNullable<TasklistCreatePayload["params"]>["user_id_type"];
+};
+
+export type GetTasklistParams = {
+  tasklist_guid: NonNullable<TasklistGetPayload["path"]>["tasklist_guid"];
+  user_id_type?: NonNullable<TasklistGetPayload["params"]>["user_id_type"];
+};
+
+export type ListTasklistsParams = {
+  page_size?: NonNullable<TasklistListPayload["params"]>["page_size"];
+  page_token?: NonNullable<TasklistListPayload["params"]>["page_token"];
+  user_id_type?: NonNullable<TasklistListPayload["params"]>["user_id_type"];
+};
+
+export type UpdateTasklistParams = {
+  tasklist_guid: NonNullable<TasklistPatchPayload["path"]>["tasklist_guid"];
+  tasklist: TasklistPatchTasklist;
+  update_fields?: TasklistPatchData["update_fields"];
+  origin_owner_to_role?: TasklistPatchData["origin_owner_to_role"];
+  user_id_type?: NonNullable<TasklistPatchPayload["params"]>["user_id_type"];
+};
+
+export type DeleteTasklistParams = {
+  tasklist_guid: NonNullable<TasklistDeletePayload["path"]>["tasklist_guid"];
+};
+
+export type AddTasklistMembersParams = {
+  tasklist_guid: NonNullable<TasklistAddMembersPayload["path"]>["tasklist_guid"];
+  members: NonNullable<NonNullable<TasklistAddMembersPayload["data"]>["members"]>;
+  user_id_type?: NonNullable<TasklistAddMembersPayload["params"]>["user_id_type"];
+};
+
+export type RemoveTasklistMembersParams = {
+  tasklist_guid: NonNullable<TasklistRemoveMembersPayload["path"]>["tasklist_guid"];
+  members: NonNullable<NonNullable<TasklistRemoveMembersPayload["data"]>["members"]>;
+  user_id_type?: NonNullable<TasklistRemoveMembersPayload["params"]>["user_id_type"];
+};
+
+// ============ TypeBox Schemas ============
+
+const TaskDateSchema = Type.Object({
+  timestamp: Type.Optional(
+    Type.String({
+      description: 'Unix timestamp in milliseconds (string), e.g. "1735689600000" (13-digit ms)',
+    }),
+  ),
+  is_all_day: Type.Optional(Type.Boolean({ description: "Whether this is an all-day date" })),
+});
+
+const TaskMemberSchema = Type.Object({
+  id: Type.String({ description: "Member ID (with type controlled by user_id_type)" }),
+  type: Type.Optional(Type.String({ description: 'Member type (usually "user")' })),
+  role: Type.String({ description: 'Member role, e.g. "assignee"' }),
+  name: Type.Optional(Type.String({ description: "Optional display name" })),
+});
+
+const TasklistRefSchema = Type.Object({
+  tasklist_guid: Type.Optional(Type.String({ description: "Tasklist GUID" })),
+  section_guid: Type.Optional(Type.String({ description: "Section GUID in tasklist" })),
+});
+
+const TaskUpdateFieldSchema = Type.Union(
+  TASK_UPDATE_FIELD_VALUES.map((field) => Type.Literal(field)),
+);
+
+const TasklistMemberRoleSchema = Type.Union(
+  [Type.Literal("owner"), Type.Literal("editor"), Type.Literal("viewer")],
+  { description: "Member role (owner/editor/viewer)" },
+);
+
+const TasklistUpdateFieldSchema = Type.Union(
+  TASKLIST_UPDATE_FIELD_VALUES.map((field) => Type.Literal(field)),
+);
+
+const TasklistOriginOwnerRoleSchema = Type.Union(
+  [Type.Literal("editor"), Type.Literal("viewer"), Type.Literal("none")],
+  { description: "Role for original owner after owner transfer" },
+);
+
+const TasklistMemberSchema = Type.Object({
+  id: Type.String({ description: "Member ID (with type controlled by user_id_type)" }),
+  type: Type.Optional(Type.String({ description: "Member type (user/chat/app)" })),
+  role: Type.Optional(TasklistMemberRoleSchema),
+  name: Type.Optional(Type.String({ description: "Optional display name" })),
+});
+
+export const CreateTaskSchema = Type.Object({
+  summary: Type.String({ description: "Task title/summary" }),
+  description: Type.Optional(Type.String({ description: "Task description" })),
+  due: Type.Optional(TaskDateSchema),
+  start: Type.Optional(TaskDateSchema),
+  extra: Type.Optional(Type.String({ description: "Custom opaque metadata string" })),
+  completed_at: Type.Optional(
+    Type.String({
+      description: "Completion time as Unix timestamp in milliseconds (string, 13-digit ms)",
+    }),
+  ),
+  members: Type.Optional(Type.Array(TaskMemberSchema, { description: "Initial task members" })),
+  repeat_rule: Type.Optional(Type.String({ description: "Task repeat rule" })),
+  tasklists: Type.Optional(
+    Type.Array(TasklistRefSchema, { description: "Attach the task to tasklists/sections" }),
+  ),
+  mode: Type.Optional(Type.Number({ description: "Task mode value from Feishu Task API" })),
+  is_milestone: Type.Optional(Type.Boolean({ description: "Whether task is a milestone" })),
+  user_id_type: Type.Optional(
+    Type.String({
+      description: "User ID type for member IDs, e.g. open_id/user_id/union_id",
+    }),
+  ),
+});
+
+export const CreateSubtaskSchema = Type.Object({
+  task_guid: Type.String({ description: "Parent task GUID" }),
+  ...CreateTaskSchema.properties,
+});
+
+export const DeleteTaskSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to delete" }),
+});
+
+export const GetTaskSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to retrieve" }),
+  user_id_type: Type.Optional(
+    Type.String({
+      description: "User ID type in returned members, e.g. open_id/user_id/union_id",
+    }),
+  ),
+});
+
+const TaskUpdateContentSchema = Type.Object(
+  {
+    summary: Type.Optional(Type.String({ description: "Updated summary" })),
+    description: Type.Optional(Type.String({ description: "Updated description" })),
+    due: Type.Optional(TaskDateSchema),
+    start: Type.Optional(TaskDateSchema),
+    extra: Type.Optional(Type.String({ description: "Updated extra metadata" })),
+    completed_at: Type.Optional(
+      Type.String({
+        description:
+          "Updated completion time (Unix timestamp in milliseconds, string, 13-digit ms)",
+      }),
+    ),
+    repeat_rule: Type.Optional(Type.String({ description: "Updated repeat rule" })),
+    mode: Type.Optional(Type.Number({ description: "Updated task mode" })),
+    is_milestone: Type.Optional(Type.Boolean({ description: "Updated milestone flag" })),
+  },
+  { minProperties: 1 },
+);
+
+export const UpdateTaskSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to update" }),
+  task: TaskUpdateContentSchema,
+  update_fields: Type.Optional(
+    Type.Array(TaskUpdateFieldSchema, {
+      description:
+        "Fields to update. If omitted, this tool infers from keys in task (e.g. summary, description, due, start)",
+      minItems: 1,
+      uniqueItems: true,
+    }),
+  ),
+  user_id_type: Type.Optional(
+    Type.String({
+      description: "User ID type when task body contains user-related fields",
+    }),
+  ),
+});
+
+export const AddTaskToTasklistSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to move" }),
+  tasklist_guid: Type.String({ description: "Tasklist GUID to add the task into" }),
+  section_guid: Type.Optional(Type.String({ description: "Tasklist section GUID" })),
+  user_id_type: Type.Optional(
+    Type.String({ description: "User ID type when task body contains user-related fields" }),
+  ),
+});
+
+export const RemoveTaskFromTasklistSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to move" }),
+  tasklist_guid: Type.String({ description: "Tasklist GUID to remove the task from" }),
+  user_id_type: Type.Optional(
+    Type.String({ description: "User ID type when task body contains user-related fields" }),
+  ),
+});
+
+export const CreateTasklistSchema = Type.Object({
+  name: Type.String({ description: "Tasklist name" }),
+  members: Type.Optional(Type.Array(TasklistMemberSchema, { description: "Initial members" })),
+  archive_tasklist: Type.Optional(
+    Type.Boolean({ description: "Whether to create as archived tasklist" }),
+  ),
+  user_id_type: Type.Optional(
+    Type.String({ description: "User ID type for member IDs, e.g. open_id/user_id/union_id" }),
+  ),
+});
+
+export const GetTasklistSchema = Type.Object({
+  tasklist_guid: Type.String({ description: "Tasklist GUID to retrieve" }),
+  user_id_type: Type.Optional(
+    Type.String({
+      description: "User ID type in returned members, e.g. open_id/user_id/union_id",
+    }),
+  ),
+});
+
+export const ListTasklistsSchema = Type.Object({
+  page_size: Type.Optional(
+    Type.Number({
+      description: "Page size (1-100)",
+      minimum: 1,
+      maximum: 100,
+    }),
+  ),
+  page_token: Type.Optional(Type.String({ description: "Pagination token" })),
+  user_id_type: Type.Optional(
+    Type.String({
+      description: "User ID type in returned members, e.g. open_id/user_id/union_id",
+    }),
+  ),
+});
+
+const TasklistUpdateContentSchema = Type.Object(
+  {
+    name: Type.Optional(Type.String({ description: "Updated tasklist name" })),
+    owner: Type.Optional(TasklistMemberSchema),
+    archive_tasklist: Type.Optional(Type.Boolean({ description: "Archive/unarchive tasklist" })),
+  },
+  { minProperties: 1 },
+);
+
+export const UpdateTasklistSchema = Type.Object({
+  tasklist_guid: Type.String({ description: "Tasklist GUID to update" }),
+  tasklist: TasklistUpdateContentSchema,
+  update_fields: Type.Optional(
+    Type.Array(TasklistUpdateFieldSchema, {
+      description:
+        "Fields to update. If omitted, this tool infers from keys in tasklist (e.g. name, owner, archive_tasklist)",
+      minItems: 1,
+      uniqueItems: true,
+    }),
+  ),
+  origin_owner_to_role: Type.Optional(TasklistOriginOwnerRoleSchema),
+  user_id_type: Type.Optional(
+    Type.String({ description: "User ID type when tasklist body contains user-related fields" }),
+  ),
+});
+
+export const DeleteTasklistSchema = Type.Object({
+  tasklist_guid: Type.String({ description: "Tasklist GUID to delete" }),
+});
+
+export const AddTasklistMembersSchema = Type.Object({
+  tasklist_guid: Type.String({ description: "Tasklist GUID to add members to" }),
+  members: Type.Array(TasklistMemberSchema, {
+    description: "Members to add",
+    minItems: 1,
+  }),
+  user_id_type: Type.Optional(
+    Type.String({ description: "User ID type for member IDs, e.g. open_id/user_id/union_id" }),
+  ),
+});
+
+export const RemoveTasklistMembersSchema = Type.Object({
+  tasklist_guid: Type.String({ description: "Tasklist GUID to remove members from" }),
+  members: Type.Array(TasklistMemberSchema, {
+    description: "Members to remove",
+    minItems: 1,
+  }),
+  user_id_type: Type.Optional(
+    Type.String({ description: "User ID type for member IDs, e.g. open_id/user_id/union_id" }),
+  ),
+});
+
+export const UploadTaskAttachmentSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to upload attachment to" }),
+  file_path: Type.Optional(
+    Type.String({
+      description: "Local file path on the OpenClaw host (provide either file_path or file_url)",
+    }),
+  ),
+  file_url: Type.Optional(
+    Type.String({
+      description: "Remote file URL to download and upload (provide either file_path or file_url)",
+    }),
+  ),
+  filename: Type.Optional(
+    Type.String({ description: "Override filename for uploaded attachment (only with file_url)" }),
+  ),
+  user_id_type: Type.Optional(Type.String({ description: "User ID type for returned uploader" })),
+});
+
+export const ListTaskAttachmentsSchema = Type.Object({
+  task_guid: Type.String({ description: "Task GUID to list attachments for" }),
+  page_size: Type.Optional(
+    Type.Number({
+      description: "Page size (1-100)",
+      minimum: 1,
+      maximum: 100,
+    }),
+  ),
+  page_token: Type.Optional(Type.String({ description: "Pagination token" })),
+  updated_mesc: Type.Optional(Type.String({ description: "Updated timestamp filter" })),
+  user_id_type: Type.Optional(Type.String({ description: "User ID type for returned uploader" })),
+});
+
+export const GetTaskAttachmentSchema = Type.Object({
+  attachment_guid: Type.String({ description: "Attachment GUID to retrieve" }),
+  user_id_type: Type.Optional(Type.String({ description: "User ID type for returned uploader" })),
+});
+
+export const DeleteTaskAttachmentSchema = Type.Object({
+  attachment_guid: Type.String({ description: "Attachment GUID to delete" }),
+});

--- a/extensions/feishu/src/task-schema.ts
+++ b/extensions/feishu/src/task-schema.ts
@@ -219,27 +219,23 @@ const TasklistRefSchema = Type.Object({
   section_guid: Type.Optional(Type.String({ description: "Section GUID in tasklist" })),
 });
 
-const TaskUpdateFieldSchema = Type.Unsafe<(typeof TASK_UPDATE_FIELD_VALUES)[number]>({
-  type: "string",
-  enum: TASK_UPDATE_FIELD_VALUES,
-});
+const TaskUpdateFieldSchema = Type.Union(
+  TASK_UPDATE_FIELD_VALUES.map((field) => Type.Literal(field)),
+);
 
-const TasklistMemberRoleSchema = Type.Unsafe<"owner" | "editor" | "viewer">({
-  type: "string",
-  enum: ["owner", "editor", "viewer"],
-  description: "Member role (owner/editor/viewer)",
-});
+const TasklistMemberRoleSchema = Type.Union(
+  [Type.Literal("owner"), Type.Literal("editor"), Type.Literal("viewer")],
+  { description: "Member role (owner/editor/viewer)" },
+);
 
-const TasklistUpdateFieldSchema = Type.Unsafe<(typeof TASKLIST_UPDATE_FIELD_VALUES)[number]>({
-  type: "string",
-  enum: TASKLIST_UPDATE_FIELD_VALUES,
-});
+const TasklistUpdateFieldSchema = Type.Union(
+  TASKLIST_UPDATE_FIELD_VALUES.map((field) => Type.Literal(field)),
+);
 
-const TasklistOriginOwnerRoleSchema = Type.Unsafe<"editor" | "viewer" | "none">({
-  type: "string",
-  enum: ["editor", "viewer", "none"],
-  description: "Role for original owner after owner transfer",
-});
+const TasklistOriginOwnerRoleSchema = Type.Union(
+  [Type.Literal("editor"), Type.Literal("viewer"), Type.Literal("none")],
+  { description: "Role for original owner after owner transfer" },
+);
 
 const TasklistMemberSchema = Type.Object({
   id: Type.String({ description: "Member ID (with type controlled by user_id_type)" }),
@@ -528,11 +524,7 @@ export const ListTaskCommentsSchema = Type.Object({
   ),
   page_token: Type.Optional(Type.String({ description: "Pagination token" })),
   direction: Type.Optional(
-    Type.Unsafe<"asc" | "desc">({
-      type: "string",
-      enum: ["asc", "desc"],
-      description: "Sort direction",
-    }),
+    Type.Union([Type.Literal("asc"), Type.Literal("desc")], { description: "Sort direction" }),
   ),
   user_id_type: Type.Optional(Type.String({ description: "User ID type for returned creators" })),
 });

--- a/extensions/feishu/src/task-schema.ts
+++ b/extensions/feishu/src/task-schema.ts
@@ -219,23 +219,27 @@ const TasklistRefSchema = Type.Object({
   section_guid: Type.Optional(Type.String({ description: "Section GUID in tasklist" })),
 });
 
-const TaskUpdateFieldSchema = Type.Union(
-  TASK_UPDATE_FIELD_VALUES.map((field) => Type.Literal(field)),
-);
+const TaskUpdateFieldSchema = Type.Unsafe<(typeof TASK_UPDATE_FIELD_VALUES)[number]>({
+  type: "string",
+  enum: TASK_UPDATE_FIELD_VALUES,
+});
 
-const TasklistMemberRoleSchema = Type.Union(
-  [Type.Literal("owner"), Type.Literal("editor"), Type.Literal("viewer")],
-  { description: "Member role (owner/editor/viewer)" },
-);
+const TasklistMemberRoleSchema = Type.Unsafe<"owner" | "editor" | "viewer">({
+  type: "string",
+  enum: ["owner", "editor", "viewer"],
+  description: "Member role (owner/editor/viewer)",
+});
 
-const TasklistUpdateFieldSchema = Type.Union(
-  TASKLIST_UPDATE_FIELD_VALUES.map((field) => Type.Literal(field)),
-);
+const TasklistUpdateFieldSchema = Type.Unsafe<(typeof TASKLIST_UPDATE_FIELD_VALUES)[number]>({
+  type: "string",
+  enum: TASKLIST_UPDATE_FIELD_VALUES,
+});
 
-const TasklistOriginOwnerRoleSchema = Type.Union(
-  [Type.Literal("editor"), Type.Literal("viewer"), Type.Literal("none")],
-  { description: "Role for original owner after owner transfer" },
-);
+const TasklistOriginOwnerRoleSchema = Type.Unsafe<"editor" | "viewer" | "none">({
+  type: "string",
+  enum: ["editor", "viewer", "none"],
+  description: "Role for original owner after owner transfer",
+});
 
 const TasklistMemberSchema = Type.Object({
   id: Type.String({ description: "Member ID (with type controlled by user_id_type)" }),
@@ -524,7 +528,11 @@ export const ListTaskCommentsSchema = Type.Object({
   ),
   page_token: Type.Optional(Type.String({ description: "Pagination token" })),
   direction: Type.Optional(
-    Type.Union([Type.Literal("asc"), Type.Literal("desc")], { description: "Sort direction" }),
+    Type.Unsafe<"asc" | "desc">({
+      type: "string",
+      enum: ["asc", "desc"],
+      description: "Sort direction",
+    }),
   ),
   user_id_type: Type.Optional(Type.String({ description: "User ID type for returned creators" })),
 });

--- a/extensions/feishu/src/task.ts
+++ b/extensions/feishu/src/task.ts
@@ -525,6 +525,8 @@ async function uploadTaskAttachment(
   }
 
   try {
+    // NOTE: attachment.upload SDK method returns the response data directly (no { code, msg, data }
+    // envelope) unlike other task v2 endpoints. Access items at top level, not via res.data.
     const data = await client.task.v2.attachment.upload({
       data: {
         resource_type: "task",

--- a/extensions/feishu/src/task.ts
+++ b/extensions/feishu/src/task.ts
@@ -12,38 +12,49 @@ import {
   type AddTaskToTasklistParams,
   type AddTasklistMembersParams,
   type CreateSubtaskParams,
+  type CreateTaskCommentParams,
   type CreateTaskParams,
   type CreateTasklistParams,
   type DeleteTaskAttachmentParams,
+  type DeleteTaskCommentParams,
   type DeleteTaskParams,
   type DeleteTasklistParams,
   type GetTaskAttachmentParams,
+  type GetTaskCommentParams,
   type GetTaskParams,
   type GetTasklistParams,
   type ListTaskAttachmentsParams,
+  type ListTaskCommentsParams,
   type ListTasklistsParams,
   type RemoveTaskFromTasklistParams,
   type RemoveTasklistMembersParams,
+  type TaskCommentPatchComment,
   type TasklistPatchTasklist,
   type TaskUpdateTask,
+  type UpdateTaskCommentParams,
   type UpdateTasklistParams,
   type UpdateTaskParams,
   type UploadTaskAttachmentParams,
   AddTaskToTasklistSchema,
   AddTasklistMembersSchema,
   CreateSubtaskSchema,
+  CreateTaskCommentSchema,
   CreateTaskSchema,
   CreateTasklistSchema,
   DeleteTaskAttachmentSchema,
+  DeleteTaskCommentSchema,
   DeleteTaskSchema,
   DeleteTasklistSchema,
   GetTaskAttachmentSchema,
+  GetTaskCommentSchema,
   GetTaskSchema,
   GetTasklistSchema,
   ListTaskAttachmentsSchema,
+  ListTaskCommentsSchema,
   ListTasklistsSchema,
   RemoveTaskFromTasklistSchema,
   RemoveTasklistMembersSchema,
+  UpdateTaskCommentSchema,
   UpdateTaskSchema,
   UpdateTasklistSchema,
   UploadTaskAttachmentSchema,
@@ -150,6 +161,20 @@ function formatAttachment(attachment: Record<string, unknown> | undefined) {
   };
 }
 
+function formatComment(comment: Record<string, unknown> | undefined) {
+  if (!comment) return undefined;
+  return {
+    id: comment.id,
+    content: comment.content,
+    creator: comment.creator,
+    reply_to_comment_id: comment.reply_to_comment_id,
+    created_at: comment.created_at,
+    updated_at: comment.updated_at,
+    resource_type: comment.resource_type,
+    resource_id: comment.resource_id,
+  };
+}
+
 // ============ Attachment Upload Helpers ============
 
 function sanitizeUploadFilename(input: string) {
@@ -176,15 +201,13 @@ async function ensureUploadableLocalFile(filePath: string, maxBytes: number) {
 
 async function saveBufferToTempFile(buffer: Buffer, fileName: string) {
   const safeName = sanitizeUploadFilename(fileName);
-  const tempPath = path.join(
-    os.tmpdir(),
-    `feishu-task-attachment-${Date.now()}-${Math.random().toString(16).slice(2)}-${safeName}`,
-  );
+  const dir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "feishu-task-"));
+  const tempPath = path.join(dir, safeName);
   await fs.promises.writeFile(tempPath, buffer);
   return {
     tempPath,
     cleanup: async () => {
-      await fs.promises.unlink(tempPath).catch(() => undefined);
+      await fs.promises.rm(dir, { recursive: true, force: true }).catch(() => undefined);
     },
   };
 }
@@ -519,6 +542,86 @@ async function uploadTaskAttachment(
   }
 }
 
+async function createTaskComment(client: Lark.Client, params: CreateTaskCommentParams) {
+  const res = await client.task.v2.comment.create({
+    data: omitUndefined({
+      resource_type: "task" as const,
+      resource_id: params.task_guid,
+      content: params.content,
+      reply_to_comment_id: params.reply_to_comment_id,
+    }),
+    params: omitUndefined({ user_id_type: params.user_id_type }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  return {
+    comment: formatComment((res.data?.comment ?? undefined) as Record<string, unknown> | undefined),
+  };
+}
+
+async function listTaskComments(client: Lark.Client, params: ListTaskCommentsParams) {
+  const res = await client.task.v2.comment.list({
+    params: omitUndefined({
+      resource_type: "task" as const,
+      resource_id: params.task_guid,
+      page_size: params.page_size,
+      page_token: params.page_token,
+      direction: params.direction,
+      user_id_type: params.user_id_type,
+    }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  const items = (res.data?.items ?? []) as Record<string, unknown>[];
+  return {
+    items: items.map((item) => formatComment(item)),
+    page_token: res.data?.page_token,
+    has_more: res.data?.has_more,
+  };
+}
+
+async function getTaskComment(client: Lark.Client, params: GetTaskCommentParams) {
+  const res = await client.task.v2.comment.get({
+    path: { comment_id: params.comment_id },
+    params: omitUndefined({ user_id_type: params.user_id_type }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  return {
+    comment: formatComment((res.data?.comment ?? undefined) as Record<string, unknown> | undefined),
+  };
+}
+
+async function updateTaskComment(client: Lark.Client, params: UpdateTaskCommentParams) {
+  const comment = omitUndefined(
+    params.comment as Record<string, unknown>,
+  ) as TaskCommentPatchComment;
+  const updateFields = params.update_fields?.length
+    ? params.update_fields
+    : Object.keys(comment).filter((k) => k === "content");
+
+  if (Object.keys(comment).length === 0) {
+    throw new Error("comment update payload is empty");
+  }
+  if (updateFields.length === 0) {
+    throw new Error("no valid update_fields provided or inferred from comment payload");
+  }
+
+  const res = await client.task.v2.comment.patch({
+    path: { comment_id: params.comment_id },
+    data: { comment, update_fields: updateFields },
+    params: omitUndefined({ user_id_type: params.user_id_type }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  return {
+    comment: formatComment((res.data?.comment ?? undefined) as Record<string, unknown> | undefined),
+    update_fields: updateFields,
+  };
+}
+
+async function deleteTaskComment(client: Lark.Client, commentId: string) {
+  const res = await client.task.v2.comment.delete({ path: { comment_id: commentId } });
+  if (res.code !== 0) throw new Error(res.msg);
+  return { success: true, comment_id: commentId };
+}
+
 // ============ Registration ============
 
 export function registerFeishuTaskTools(api: OpenClawPluginApi) {
@@ -728,5 +831,47 @@ export function registerFeishuTaskTools(api: OpenClawPluginApi) {
     { name: "feishu_task_attachment_upload" },
   );
 
-  api.logger.debug?.("feishu_task: Registered task, tasklist, subtask, and attachment tools");
+  registerTaskTool<CreateTaskCommentParams>({
+    name: "feishu_task_comment_create",
+    label: "Feishu Task Comment Create",
+    description: "Add a comment to a Feishu task (task v2)",
+    parameters: CreateTaskCommentSchema,
+    run: (client, params) => createTaskComment(client, params),
+  });
+
+  registerTaskTool<ListTaskCommentsParams>({
+    name: "feishu_task_comment_list",
+    label: "Feishu Task Comment List",
+    description: "List comments on a Feishu task (task v2)",
+    parameters: ListTaskCommentsSchema,
+    run: (client, params) => listTaskComments(client, params),
+  });
+
+  registerTaskTool<GetTaskCommentParams>({
+    name: "feishu_task_comment_get",
+    label: "Feishu Task Comment Get",
+    description: "Get a specific comment on a Feishu task by comment_id (task v2)",
+    parameters: GetTaskCommentSchema,
+    run: (client, params) => getTaskComment(client, params),
+  });
+
+  registerTaskTool<UpdateTaskCommentParams>({
+    name: "feishu_task_comment_update",
+    label: "Feishu Task Comment Update",
+    description: "Update a comment on a Feishu task by comment_id (task v2 patch)",
+    parameters: UpdateTaskCommentSchema,
+    run: (client, params) => updateTaskComment(client, params),
+  });
+
+  registerTaskTool<DeleteTaskCommentParams>({
+    name: "feishu_task_comment_delete",
+    label: "Feishu Task Comment Delete",
+    description: "Delete a comment on a Feishu task by comment_id (task v2)",
+    parameters: DeleteTaskCommentSchema,
+    run: (client, { comment_id }) => deleteTaskComment(client, comment_id),
+  });
+
+  api.logger.debug?.(
+    "feishu_task: Registered task, tasklist, subtask, attachment, and comment tools",
+  );
 }

--- a/extensions/feishu/src/task.ts
+++ b/extensions/feishu/src/task.ts
@@ -1,0 +1,732 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+import { listEnabledFeishuAccounts } from "./accounts.js";
+import { createFeishuClient } from "./client.js";
+import { getFeishuRuntime } from "./runtime.js";
+import {
+  TASK_UPDATE_FIELD_VALUES,
+  TASKLIST_UPDATE_FIELD_VALUES,
+  type AddTaskToTasklistParams,
+  type AddTasklistMembersParams,
+  type CreateSubtaskParams,
+  type CreateTaskParams,
+  type CreateTasklistParams,
+  type DeleteTaskAttachmentParams,
+  type DeleteTaskParams,
+  type DeleteTasklistParams,
+  type GetTaskAttachmentParams,
+  type GetTaskParams,
+  type GetTasklistParams,
+  type ListTaskAttachmentsParams,
+  type ListTasklistsParams,
+  type RemoveTaskFromTasklistParams,
+  type RemoveTasklistMembersParams,
+  type TasklistPatchTasklist,
+  type TaskUpdateTask,
+  type UpdateTasklistParams,
+  type UpdateTaskParams,
+  type UploadTaskAttachmentParams,
+  AddTaskToTasklistSchema,
+  AddTasklistMembersSchema,
+  CreateSubtaskSchema,
+  CreateTaskSchema,
+  CreateTasklistSchema,
+  DeleteTaskAttachmentSchema,
+  DeleteTaskSchema,
+  DeleteTasklistSchema,
+  GetTaskAttachmentSchema,
+  GetTaskSchema,
+  GetTasklistSchema,
+  ListTaskAttachmentsSchema,
+  ListTasklistsSchema,
+  RemoveTaskFromTasklistSchema,
+  RemoveTasklistMembersSchema,
+  UpdateTaskSchema,
+  UpdateTasklistSchema,
+  UploadTaskAttachmentSchema,
+} from "./task-schema.js";
+import {
+  createFeishuToolClient,
+  resolveAnyEnabledFeishuToolsConfig,
+  resolveFeishuToolAccount,
+} from "./tool-account.js";
+
+// ============ Helpers ============
+
+function json(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    details: data,
+  };
+}
+
+// ============ Constants ============
+
+const BYTES_PER_MEGABYTE = 1024 * 1024;
+const DEFAULT_TASK_MEDIA_MAX_MB = 30;
+const DEFAULT_TASK_ATTACHMENT_MAX_BYTES = DEFAULT_TASK_MEDIA_MAX_MB * BYTES_PER_MEGABYTE;
+const DEFAULT_TASK_ATTACHMENT_FILENAME = "attachment";
+
+// ============ Utilities ============
+
+function omitUndefined<T extends Record<string, unknown>>(obj: T): T {
+  return Object.fromEntries(Object.entries(obj).filter(([, value]) => value !== undefined)) as T;
+}
+
+const SUPPORTED_PATCH_FIELDS = new Set<string>(TASK_UPDATE_FIELD_VALUES);
+const SUPPORTED_TASKLIST_PATCH_FIELDS = new Set<string>(TASKLIST_UPDATE_FIELD_VALUES);
+
+function inferUpdateFields(task: TaskUpdateTask): string[] {
+  return Object.keys(task).filter((field) => SUPPORTED_PATCH_FIELDS.has(field));
+}
+
+function inferTasklistUpdateFields(tasklist: TasklistPatchTasklist): string[] {
+  return Object.keys(tasklist).filter((field) => SUPPORTED_TASKLIST_PATCH_FIELDS.has(field));
+}
+
+function ensureSupportedUpdateFields(
+  updateFields: string[],
+  supported: Set<string>,
+  resource: "task" | "tasklist",
+) {
+  const invalid = updateFields.filter((field) => !supported.has(field));
+  if (invalid.length > 0) {
+    throw new Error(`unsupported ${resource} update_fields: ${invalid.join(", ")}`);
+  }
+}
+
+// ============ Formatters ============
+
+function formatTask(task: Record<string, unknown> | undefined) {
+  if (!task) return undefined;
+  return {
+    guid: task.guid,
+    task_id: task.task_id,
+    summary: task.summary,
+    description: task.description,
+    status: task.status,
+    url: task.url,
+    created_at: task.created_at,
+    updated_at: task.updated_at,
+    completed_at: task.completed_at,
+    due: task.due,
+    start: task.start,
+    is_milestone: task.is_milestone,
+    members: task.members,
+    tasklists: task.tasklists,
+  };
+}
+
+function formatTasklist(tasklist: Record<string, unknown> | undefined) {
+  if (!tasklist) return undefined;
+  return {
+    guid: tasklist.guid,
+    name: tasklist.name,
+    creator: tasklist.creator,
+    owner: tasklist.owner,
+    members: tasklist.members,
+    url: tasklist.url,
+    created_at: tasklist.created_at,
+    updated_at: tasklist.updated_at,
+    archive_msec: tasklist.archive_msec,
+  };
+}
+
+function formatAttachment(attachment: Record<string, unknown> | undefined) {
+  if (!attachment) return undefined;
+  return {
+    guid: attachment.guid,
+    file_token: attachment.file_token,
+    name: attachment.name,
+    size: attachment.size,
+    uploader: attachment.uploader,
+    is_cover: attachment.is_cover,
+    uploaded_at: attachment.uploaded_at,
+    url: attachment.url,
+    resource: attachment.resource,
+  };
+}
+
+// ============ Attachment Upload Helpers ============
+
+function sanitizeUploadFilename(input: string) {
+  const base = path.basename(input.trim());
+  return base.length > 0 ? base : DEFAULT_TASK_ATTACHMENT_FILENAME;
+}
+
+async function ensureUploadableLocalFile(filePath: string, maxBytes: number) {
+  let stat: fs.Stats;
+  try {
+    stat = await fs.promises.stat(filePath);
+  } catch {
+    throw new Error(`file_path not found: ${filePath}`);
+  }
+  if (!stat.isFile()) {
+    throw new Error(`file_path is not a regular file: ${filePath}`);
+  }
+  if (stat.size > maxBytes) {
+    throw new Error(
+      `file_path exceeds ${Math.round(maxBytes / BYTES_PER_MEGABYTE)}MB limit: ${filePath}`,
+    );
+  }
+}
+
+async function saveBufferToTempFile(buffer: Buffer, fileName: string) {
+  const safeName = sanitizeUploadFilename(fileName);
+  const tempPath = path.join(
+    os.tmpdir(),
+    `feishu-task-attachment-${Date.now()}-${Math.random().toString(16).slice(2)}-${safeName}`,
+  );
+  await fs.promises.writeFile(tempPath, buffer);
+  return {
+    tempPath,
+    cleanup: async () => {
+      await fs.promises.unlink(tempPath).catch(() => undefined);
+    },
+  };
+}
+
+async function downloadToTempFile(fileUrl: string, filename: string | undefined, maxBytes: number) {
+  const loaded = await getFeishuRuntime().media.loadWebMedia(fileUrl, {
+    maxBytes,
+    optimizeImages: false,
+  });
+  const parsedPath = (() => {
+    try {
+      return new URL(fileUrl).pathname;
+    } catch {
+      return "";
+    }
+  })();
+  const fallbackName = path.basename(parsedPath) || DEFAULT_TASK_ATTACHMENT_FILENAME;
+  const preferredName = filename?.trim() ? filename : (loaded.fileName ?? fallbackName);
+  return saveBufferToTempFile(loaded.buffer, preferredName);
+}
+
+// ============ Actions ============
+
+async function createTask(client: Lark.Client, params: CreateTaskParams) {
+  const res = await client.task.v2.task.create({
+    data: omitUndefined({
+      summary: params.summary,
+      description: params.description,
+      due: params.due,
+      start: params.start,
+      extra: params.extra,
+      completed_at: params.completed_at,
+      members: params.members,
+      repeat_rule: params.repeat_rule,
+      tasklists: params.tasklists,
+      mode: params.mode,
+      is_milestone: params.is_milestone,
+    }),
+    params: omitUndefined({ user_id_type: params.user_id_type }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  return { task: formatTask((res.data?.task ?? undefined) as Record<string, unknown> | undefined) };
+}
+
+async function createSubtask(client: Lark.Client, params: CreateSubtaskParams) {
+  const res = await client.task.v2.taskSubtask.create({
+    path: { task_guid: params.task_guid },
+    data: omitUndefined({
+      summary: params.summary,
+      description: params.description,
+      due: params.due,
+      start: params.start,
+      extra: params.extra,
+      completed_at: params.completed_at,
+      members: params.members,
+      repeat_rule: params.repeat_rule,
+      tasklists: params.tasklists,
+      mode: params.mode,
+      is_milestone: params.is_milestone,
+    }),
+    params: omitUndefined({ user_id_type: params.user_id_type }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  return {
+    subtask: formatTask((res.data?.subtask ?? undefined) as Record<string, unknown> | undefined),
+  };
+}
+
+async function deleteTask(client: Lark.Client, taskGuid: string) {
+  const res = await client.task.v2.task.delete({ path: { task_guid: taskGuid } });
+  if (res.code !== 0) throw new Error(res.msg);
+  return { success: true, task_guid: taskGuid };
+}
+
+async function getTask(client: Lark.Client, params: GetTaskParams) {
+  const res = await client.task.v2.task.get({
+    path: { task_guid: params.task_guid },
+    params: omitUndefined({ user_id_type: params.user_id_type }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  return { task: formatTask((res.data?.task ?? undefined) as Record<string, unknown> | undefined) };
+}
+
+async function updateTask(client: Lark.Client, params: UpdateTaskParams) {
+  const task = omitUndefined(params.task as Record<string, unknown>) as TaskUpdateTask;
+  const updateFields = params.update_fields?.length
+    ? params.update_fields
+    : inferUpdateFields(task);
+
+  if (params.update_fields?.length) {
+    ensureSupportedUpdateFields(updateFields, SUPPORTED_PATCH_FIELDS, "task");
+  }
+  if (Object.keys(task).length === 0) {
+    throw new Error("task update payload is empty");
+  }
+  if (updateFields.length === 0) {
+    throw new Error("no valid update_fields provided or inferred from task payload");
+  }
+
+  const res = await client.task.v2.task.patch({
+    path: { task_guid: params.task_guid },
+    data: { task, update_fields: updateFields },
+    params: omitUndefined({ user_id_type: params.user_id_type }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  return {
+    task: formatTask((res.data?.task ?? undefined) as Record<string, unknown> | undefined),
+    update_fields: updateFields,
+  };
+}
+
+async function addTaskToTasklist(client: Lark.Client, params: AddTaskToTasklistParams) {
+  const res = await client.task.v2.task.addTasklist({
+    path: { task_guid: params.task_guid },
+    data: omitUndefined({
+      tasklist_guid: params.tasklist_guid,
+      section_guid: params.section_guid,
+    }),
+    params: omitUndefined({ user_id_type: params.user_id_type }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  return { task: formatTask((res.data?.task ?? undefined) as Record<string, unknown> | undefined) };
+}
+
+async function removeTaskFromTasklist(client: Lark.Client, params: RemoveTaskFromTasklistParams) {
+  const res = await client.task.v2.task.removeTasklist({
+    path: { task_guid: params.task_guid },
+    data: omitUndefined({ tasklist_guid: params.tasklist_guid }),
+    params: omitUndefined({ user_id_type: params.user_id_type }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  return { task: formatTask((res.data?.task ?? undefined) as Record<string, unknown> | undefined) };
+}
+
+async function createTasklist(client: Lark.Client, params: CreateTasklistParams) {
+  const res = await client.task.v2.tasklist.create({
+    data: omitUndefined({
+      name: params.name,
+      members: params.members,
+      archive_tasklist: params.archive_tasklist,
+    }),
+    params: omitUndefined({ user_id_type: params.user_id_type }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  return {
+    tasklist: formatTasklist(
+      (res.data?.tasklist ?? undefined) as Record<string, unknown> | undefined,
+    ),
+  };
+}
+
+async function getTasklist(client: Lark.Client, params: GetTasklistParams) {
+  const res = await client.task.v2.tasklist.get({
+    path: { tasklist_guid: params.tasklist_guid },
+    params: omitUndefined({ user_id_type: params.user_id_type }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  return {
+    tasklist: formatTasklist(
+      (res.data?.tasklist ?? undefined) as Record<string, unknown> | undefined,
+    ),
+  };
+}
+
+async function listTasklists(client: Lark.Client, params: ListTasklistsParams) {
+  const res = await client.task.v2.tasklist.list({
+    params: omitUndefined({
+      page_size: params.page_size,
+      page_token: params.page_token,
+      user_id_type: params.user_id_type,
+    }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  const items = (res.data?.items ?? []) as Record<string, unknown>[];
+  return {
+    items: items.map((item) => formatTasklist(item)),
+    page_token: res.data?.page_token,
+    has_more: res.data?.has_more,
+  };
+}
+
+async function updateTasklist(client: Lark.Client, params: UpdateTasklistParams) {
+  const tasklist = omitUndefined(
+    params.tasklist as Record<string, unknown>,
+  ) as TasklistPatchTasklist;
+  const updateFields = params.update_fields?.length
+    ? params.update_fields
+    : inferTasklistUpdateFields(tasklist);
+
+  if (params.update_fields?.length) {
+    ensureSupportedUpdateFields(updateFields, SUPPORTED_TASKLIST_PATCH_FIELDS, "tasklist");
+  }
+  if (Object.keys(tasklist).length === 0) {
+    throw new Error("tasklist update payload is empty");
+  }
+  if (updateFields.length === 0) {
+    throw new Error("no valid update_fields provided or inferred from tasklist payload");
+  }
+
+  const res = await client.task.v2.tasklist.patch({
+    path: { tasklist_guid: params.tasklist_guid },
+    data: omitUndefined({
+      tasklist,
+      update_fields: updateFields,
+      origin_owner_to_role: params.origin_owner_to_role,
+    }),
+    params: omitUndefined({ user_id_type: params.user_id_type }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  return {
+    tasklist: formatTasklist(
+      (res.data?.tasklist ?? undefined) as Record<string, unknown> | undefined,
+    ),
+    update_fields: updateFields,
+  };
+}
+
+async function deleteTasklist(client: Lark.Client, tasklistGuid: string) {
+  const res = await client.task.v2.tasklist.delete({ path: { tasklist_guid: tasklistGuid } });
+  if (res.code !== 0) throw new Error(res.msg);
+  return { success: true, tasklist_guid: tasklistGuid };
+}
+
+async function addTasklistMembers(client: Lark.Client, params: AddTasklistMembersParams) {
+  const res = await client.task.v2.tasklist.addMembers({
+    path: { tasklist_guid: params.tasklist_guid },
+    data: { members: params.members },
+    params: omitUndefined({ user_id_type: params.user_id_type }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  return {
+    tasklist: formatTasklist(
+      (res.data?.tasklist ?? undefined) as Record<string, unknown> | undefined,
+    ),
+  };
+}
+
+async function removeTasklistMembers(client: Lark.Client, params: RemoveTasklistMembersParams) {
+  const res = await client.task.v2.tasklist.removeMembers({
+    path: { tasklist_guid: params.tasklist_guid },
+    data: { members: params.members },
+    params: omitUndefined({ user_id_type: params.user_id_type }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  return {
+    tasklist: formatTasklist(
+      (res.data?.tasklist ?? undefined) as Record<string, unknown> | undefined,
+    ),
+  };
+}
+
+async function getTaskAttachment(client: Lark.Client, params: GetTaskAttachmentParams) {
+  const res = await client.task.v2.attachment.get({
+    path: { attachment_guid: params.attachment_guid },
+    params: omitUndefined({ user_id_type: params.user_id_type }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  return {
+    attachment: formatAttachment(
+      (res.data?.attachment ?? undefined) as Record<string, unknown> | undefined,
+    ),
+  };
+}
+
+async function listTaskAttachments(client: Lark.Client, params: ListTaskAttachmentsParams) {
+  const res = await client.task.v2.attachment.list({
+    params: omitUndefined({
+      resource_type: "task",
+      resource_id: params.task_guid as string,
+      page_size: params.page_size,
+      page_token: params.page_token,
+      updated_mesc: params.updated_mesc,
+      user_id_type: params.user_id_type,
+    }),
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  const items = (res.data?.items ?? []) as Record<string, unknown>[];
+  return {
+    items: items.map((item) => formatAttachment(item)),
+    page_token: res.data?.page_token,
+    has_more: res.data?.has_more,
+  };
+}
+
+async function deleteTaskAttachment(client: Lark.Client, params: DeleteTaskAttachmentParams) {
+  const res = await client.task.v2.attachment.delete({
+    path: { attachment_guid: params.attachment_guid },
+  });
+  if (res.code !== 0) throw new Error(res.msg);
+  return { success: true, attachment_guid: params.attachment_guid };
+}
+
+async function uploadTaskAttachment(
+  client: Lark.Client,
+  params: UploadTaskAttachmentParams,
+  options?: { maxBytes?: number },
+) {
+  const maxBytes =
+    typeof options?.maxBytes === "number" && options.maxBytes > 0
+      ? options.maxBytes
+      : DEFAULT_TASK_ATTACHMENT_MAX_BYTES;
+
+  let tempCleanup: (() => Promise<void>) | undefined;
+  let filePath: string;
+
+  if (params.file_path) {
+    filePath = params.file_path;
+    await ensureUploadableLocalFile(filePath, maxBytes);
+  } else if (params.file_url) {
+    const download = await downloadToTempFile(params.file_url, params.filename, maxBytes);
+    filePath = download.tempPath;
+    tempCleanup = download.cleanup;
+  } else {
+    throw new Error("Either file_path or file_url is required");
+  }
+
+  try {
+    const data = await client.task.v2.attachment.upload({
+      data: {
+        resource_type: "task",
+        resource_id: params.task_guid,
+        file: fs.createReadStream(filePath),
+      },
+      params: omitUndefined({ user_id_type: params.user_id_type }),
+    });
+    const items = (data?.items ?? []) as Record<string, unknown>[];
+    return { items: items.map((item) => formatAttachment(item)) };
+  } finally {
+    if (tempCleanup) {
+      await tempCleanup();
+    }
+  }
+}
+
+// ============ Registration ============
+
+export function registerFeishuTaskTools(api: OpenClawPluginApi) {
+  if (!api.config) {
+    api.logger.debug?.("feishu_task: No config available, skipping task tools");
+    return;
+  }
+
+  const accounts = listEnabledFeishuAccounts(api.config);
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
+  if (!toolsCfg.task) {
+    api.logger.debug?.("feishu_task: task tools disabled in config");
+    return;
+  }
+
+  function registerTaskTool<P>(spec: {
+    name: string;
+    label: string;
+    description: string;
+    parameters: unknown;
+    run: (client: Lark.Client, params: P) => Promise<unknown>;
+  }) {
+    api.registerTool(
+      (ctx) => ({
+        name: spec.name,
+        label: spec.label,
+        description: spec.description,
+        parameters: spec.parameters,
+        async execute(_toolCallId, params) {
+          try {
+            const client = createFeishuToolClient({
+              api,
+              executeParams: params as { accountId?: string },
+              defaultAccountId: ctx.agentAccountId,
+            });
+            return json(await spec.run(client, params as P));
+          } catch (err) {
+            return json({ error: err instanceof Error ? err.message : String(err) });
+          }
+        },
+      }),
+      { name: spec.name },
+    );
+  }
+
+  registerTaskTool<CreateTaskParams>({
+    name: "feishu_task_create",
+    label: "Feishu Task Create",
+    description: "Create a Feishu task (task v2)",
+    parameters: CreateTaskSchema,
+    run: (client, params) => createTask(client, params),
+  });
+
+  registerTaskTool<CreateSubtaskParams>({
+    name: "feishu_task_subtask_create",
+    label: "Feishu Task Subtask Create",
+    description: "Create a Feishu subtask under a parent task (task v2)",
+    parameters: CreateSubtaskSchema,
+    run: (client, params) => createSubtask(client, params),
+  });
+
+  registerTaskTool<AddTaskToTasklistParams>({
+    name: "feishu_task_add_tasklist",
+    label: "Feishu Task Add Tasklist",
+    description: "Add a task into a tasklist (task v2)",
+    parameters: AddTaskToTasklistSchema,
+    run: (client, params) => addTaskToTasklist(client, params),
+  });
+
+  registerTaskTool<RemoveTaskFromTasklistParams>({
+    name: "feishu_task_remove_tasklist",
+    label: "Feishu Task Remove Tasklist",
+    description: "Remove a task from a tasklist (task v2)",
+    parameters: RemoveTaskFromTasklistSchema,
+    run: (client, params) => removeTaskFromTasklist(client, params),
+  });
+
+  registerTaskTool<CreateTasklistParams>({
+    name: "feishu_tasklist_create",
+    label: "Feishu Tasklist Create",
+    description: "Create a Feishu tasklist (task v2)",
+    parameters: CreateTasklistSchema,
+    run: (client, params) => createTasklist(client, params),
+  });
+
+  registerTaskTool<GetTasklistParams>({
+    name: "feishu_tasklist_get",
+    label: "Feishu Tasklist Get",
+    description: "Get a Feishu tasklist by tasklist_guid (task v2)",
+    parameters: GetTasklistSchema,
+    run: (client, params) => getTasklist(client, params),
+  });
+
+  registerTaskTool<ListTasklistsParams>({
+    name: "feishu_tasklist_list",
+    label: "Feishu Tasklist List",
+    description: "List Feishu tasklists (task v2)",
+    parameters: ListTasklistsSchema,
+    run: (client, params) => listTasklists(client, params),
+  });
+
+  registerTaskTool<UpdateTasklistParams>({
+    name: "feishu_tasklist_update",
+    label: "Feishu Tasklist Update",
+    description: "Update a Feishu tasklist by tasklist_guid (task v2 patch)",
+    parameters: UpdateTasklistSchema,
+    run: (client, params) => updateTasklist(client, params),
+  });
+
+  registerTaskTool<DeleteTasklistParams>({
+    name: "feishu_tasklist_delete",
+    label: "Feishu Tasklist Delete",
+    description: "Delete a Feishu tasklist by tasklist_guid (task v2)",
+    parameters: DeleteTasklistSchema,
+    run: (client, { tasklist_guid }) => deleteTasklist(client, tasklist_guid as string),
+  });
+
+  registerTaskTool<AddTasklistMembersParams>({
+    name: "feishu_tasklist_add_members",
+    label: "Feishu Tasklist Add Members",
+    description: "Add members to a Feishu tasklist (task v2)",
+    parameters: AddTasklistMembersSchema,
+    run: (client, params) => addTasklistMembers(client, params),
+  });
+
+  registerTaskTool<RemoveTasklistMembersParams>({
+    name: "feishu_tasklist_remove_members",
+    label: "Feishu Tasklist Remove Members",
+    description: "Remove members from a Feishu tasklist (task v2)",
+    parameters: RemoveTasklistMembersSchema,
+    run: (client, params) => removeTasklistMembers(client, params),
+  });
+
+  registerTaskTool<ListTaskAttachmentsParams>({
+    name: "feishu_task_attachment_list",
+    label: "Feishu Task Attachment List",
+    description: "List attachments for a Feishu task (task v2)",
+    parameters: ListTaskAttachmentsSchema,
+    run: (client, params) => listTaskAttachments(client, params),
+  });
+
+  registerTaskTool<GetTaskAttachmentParams>({
+    name: "feishu_task_attachment_get",
+    label: "Feishu Task Attachment Get",
+    description: "Get a Feishu task attachment by attachment_guid (task v2)",
+    parameters: GetTaskAttachmentSchema,
+    run: (client, params) => getTaskAttachment(client, params),
+  });
+
+  registerTaskTool<DeleteTaskAttachmentParams>({
+    name: "feishu_task_attachment_delete",
+    label: "Feishu Task Attachment Delete",
+    description: "Delete a Feishu task attachment by attachment_guid (task v2)",
+    parameters: DeleteTaskAttachmentSchema,
+    run: (client, params) => deleteTaskAttachment(client, params),
+  });
+
+  registerTaskTool<DeleteTaskParams>({
+    name: "feishu_task_delete",
+    label: "Feishu Task Delete",
+    description: "Delete a Feishu task by task_guid (task v2)",
+    parameters: DeleteTaskSchema,
+    run: (client, { task_guid }) => deleteTask(client, task_guid),
+  });
+
+  registerTaskTool<GetTaskParams>({
+    name: "feishu_task_get",
+    label: "Feishu Task Get",
+    description: "Get Feishu task details by task_guid (task v2)",
+    parameters: GetTaskSchema,
+    run: (client, params) => getTask(client, params),
+  });
+
+  registerTaskTool<UpdateTaskParams>({
+    name: "feishu_task_update",
+    label: "Feishu Task Update",
+    description: "Update a Feishu task by task_guid (task v2 patch)",
+    parameters: UpdateTaskSchema,
+    run: (client, params) => updateTask(client, params),
+  });
+
+  // Attachment upload needs account config for mediaMaxMb limit.
+  api.registerTool(
+    (ctx) => ({
+      name: "feishu_task_attachment_upload",
+      label: "Feishu Task Attachment Upload",
+      description:
+        "Upload an attachment to a Feishu task from a local file path or remote URL (task v2)",
+      parameters: UploadTaskAttachmentSchema,
+      async execute(_toolCallId, params) {
+        try {
+          const p = params as UploadTaskAttachmentParams;
+          const account = resolveFeishuToolAccount({
+            api,
+            executeParams: p as { accountId?: string },
+            defaultAccountId: ctx.agentAccountId,
+          });
+          const client = createFeishuClient(account);
+          const mediaMaxBytes =
+            (account.config?.mediaMaxMb ?? DEFAULT_TASK_MEDIA_MAX_MB) * BYTES_PER_MEGABYTE;
+          return json(await uploadTaskAttachment(client, p, { maxBytes: mediaMaxBytes }));
+        } catch (err) {
+          return json({ error: err instanceof Error ? err.message : String(err) });
+        }
+      },
+    }),
+    { name: "feishu_task_attachment_upload" },
+  );
+
+  api.logger.debug?.("feishu_task: Registered task, tasklist, subtask, and attachment tools");
+}

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -56,6 +56,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     drive: false,
     perm: false,
     scopes: false,
+    task: false,
   };
   for (const account of accounts) {
     const cfg = resolveToolsConfig(account.config.tools);
@@ -65,6 +66,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     merged.drive = merged.drive || cfg.drive;
     merged.perm = merged.perm || cfg.perm;
     merged.scopes = merged.scopes || cfg.scopes;
+    merged.task = merged.task || cfg.task;
   }
   return merged;
 }

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -4,6 +4,7 @@ import type { FeishuToolsConfig } from "./types.js";
  * Default tool configuration.
  * - doc, chat, wiki, drive, scopes: enabled by default
  * - perm: disabled by default (sensitive operation)
+ * - task: disabled by default (opt-in; requires Feishu task v2 API permissions)
  */
 export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   doc: true,
@@ -12,6 +13,7 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   drive: true,
   perm: false,
   scopes: true,
+  task: false,
 };
 
 /**

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -79,6 +79,7 @@ export type FeishuToolsConfig = {
   drive?: boolean;
   perm?: boolean;
   scopes?: boolean;
+  task?: boolean;
 };
 
 export type DynamicAgentCreationConfig = {


### PR DESCRIPTION
## Summary

- Adds full Feishu Task v2 tool integration: create/get/update/delete tasks and subtasks, manage tasklists and their members, upload/list/get/delete attachments, and create/list/get/update/delete task comments
- Tools are opt-in via `tools.task: true` in config (disabled by default — requires Feishu task v2 API permissions)
- Follows the existing `tool-account.ts` pattern (`createFeishuToolClient` / `resolveFeishuToolAccount`) used by other tool modules

## Relationship to #16337

[#16337](https://github.com/openclaw/openclaw/pull/16337) was a bulk community sync that included `task-tools/*` from `m1heng/clawdbot-feishu`, using the community repo's `tools-common/tool-exec.ts` infrastructure. That PR was closed without merging.

This PR takes a different approach: instead of porting the community repo's `tools-common` infrastructure (which upstream has already solved via `tool-account.ts`), it implements the task tools as a standalone flat module (`task.ts` + `task-schema.ts`) that integrates directly with upstream's existing `createFeishuToolClient` / `resolveFeishuToolAccount` pattern. It also incorporates task comment support from [m1heng/clawdbot-feishu#319](https://github.com/m1heng/clawdbot-feishu/pull/319), which was included in the same bulk sync but split here into this single focused PR.

## Key Changes

### New files
- **`extensions/feishu/src/task.ts`** — tool registration and action implementations (23 tools)
- **`extensions/feishu/src/task-schema.ts`** — TypeBox parameter schemas and TypeScript types derived from Lark SDK
- **`extensions/feishu/skills/feishu-task/SKILL.md`** — skill file for LLM activation and usage examples

### Modified files
- **`extensions/feishu/src/config-schema.ts`** — adds `task?: boolean` to `FeishuToolsConfigSchema`
- **`extensions/feishu/src/tools-config.ts`** — adds `task: false` default (opt-in; requires Feishu task v2 API permissions)
- **`extensions/feishu/src/types.ts`** — adds `task?: boolean` to `FeishuToolsConfig`
- **`extensions/feishu/src/tool-account.ts`** — adds `task` to `resolveAnyEnabledFeishuToolsConfig` merge
- **`extensions/feishu/index.ts`** — registers task tools via `registerFeishuTaskTools`

### Tools registered (23 total)

| Tool | Description |
|------|-------------|
| `feishu_task_create` | Create a task |
| `feishu_task_subtask_create` | Create a subtask |
| `feishu_task_get` | Get task details |
| `feishu_task_update` | Update a task (patch) |
| `feishu_task_delete` | Delete a task |
| `feishu_task_add_tasklist` | Add task to a tasklist |
| `feishu_task_remove_tasklist` | Remove task from a tasklist |
| `feishu_task_attachment_upload` | Upload attachment (local file or remote URL) |
| `feishu_task_attachment_list` | List task attachments |
| `feishu_task_attachment_get` | Get attachment by guid |
| `feishu_task_attachment_delete` | Delete attachment |
| `feishu_task_comment_create` | Add a comment to a task |
| `feishu_task_comment_list` | List task comments |
| `feishu_task_comment_get` | Get a comment by id |
| `feishu_task_comment_update` | Update a comment |
| `feishu_task_comment_delete` | Delete a comment |
| `feishu_tasklist_create` | Create a tasklist |
| `feishu_tasklist_get` | Get tasklist details |
| `feishu_tasklist_list` | List tasklists |
| `feishu_tasklist_update` | Update a tasklist (patch) |
| `feishu_tasklist_delete` | Delete a tasklist |
| `feishu_tasklist_add_members` | Add members to a tasklist |
| `feishu_tasklist_remove_members` | Remove members from a tasklist |

## Source

Ported from:
- [m1heng/clawdbot-feishu#318](https://github.com/m1heng/clawdbot-feishu/pull/318) — core task tools
- [m1heng/clawdbot-feishu#319](https://github.com/m1heng/clawdbot-feishu/pull/319) — task comments
- [m1heng/clawdbot-feishu#320](https://github.com/m1heng/clawdbot-feishu/pull/320) — attachment upload
- [m1heng/clawdbot-feishu#321](https://github.com/m1heng/clawdbot-feishu/pull/321) — tasklist tools

Original author: @txuw

AI-assisted (Claude). Testing level: lightly tested (build + type check + `pnpm check` + `pnpm test` pass; 12 pre-existing `src/memory/` failures unrelated to this PR).