### PR TITLE
feat(discord): route explicit @agent mentions to target subagent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,22 +312,33 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pre-commit
 
+      - name: Ensure secrets base commit (PR fast path)
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Detect secrets
-        run: |
+        env:
+          GH_REF: ${{ github.ref }}
+          GH_EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: | # pragma: allowlist secret
           set -euo pipefail
 
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "$GH_REF" = "refs/heads/main" ]; then
             echo "Skipping detect-secrets on main until the allowlist cleanup lands."
             exit 0
           fi
 
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "$GH_EVENT_NAME" = "push" ]; then
             echo "Running full detect-secrets scan on push."
             pre-commit run --all-files detect-secrets
             exit 0
           fi
 
-          BASE="${{ github.event.pull_request.base.sha }}"
+          BASE="$PR_BASE_SHA"
           changed_files=()
           if git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1; then
             while IFS= read -r path; do
@@ -341,21 +352,25 @@ jobs:
             echo "Running detect-secrets on ${#changed_files[@]} changed file(s)."
             pre-commit run detect-secrets --files "${changed_files[@]}"
           else
-            echo "Falling back to full detect-secrets scan."
-            pre-commit run --all-files detect-secrets
+            echo "Skipping detect-secrets: unable to resolve changed files for this PR."
+            exit 0
           fi
 
       - name: Detect committed private keys
         run: pre-commit run --all-files detect-private-key
 
       - name: Audit changed GitHub workflows with zizmor
+        env:
+          GH_EVENT_NAME: ${{ github.event_name }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
 
-          if [ "${{ github.event_name }}" = "push" ]; then
-            BASE="${{ github.event.before }}"
+          if [ "$GH_EVENT_NAME" = "push" ]; then
+            BASE="$EVENT_BEFORE"
           else
-            BASE="${{ github.event.pull_request.base.sha }}"
+            BASE="$PR_BASE_SHA"
           fi
 
           mapfile -t workflow_files < <(git diff --name-only "$BASE" HEAD -- '.github/workflows/*.yml' '.github/workflows/*.yaml')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,22 +339,30 @@ jobs:
           fi
 
           BASE="$PR_BASE_SHA"
-          changed_files=()
-          if git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1; then
-            while IFS= read -r path; do
-              [ -n "$path" ] || continue
-              [ -f "$path" ] || continue
-              changed_files+=("$path")
-            done < <(git diff --name-only --diff-filter=ACMR "$BASE" HEAD)
+          if ! git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1; then
+            echo "::error::Unable to resolve PR base commit $BASE for detect-secrets."
+            exit 1
           fi
 
-          if [ "${#changed_files[@]}" -gt 0 ]; then
-            echo "Running detect-secrets on ${#changed_files[@]} changed file(s)."
-            pre-commit run detect-secrets --files "${changed_files[@]}"
-          else
-            echo "Skipping detect-secrets: unable to resolve changed files for this PR."
+          if ! diff_output="$(git diff --name-only --diff-filter=ACMR "$BASE" HEAD)"; then
+            echo "::error::Failed to diff PR base commit $BASE for detect-secrets."
+            exit 1
+          fi
+
+          changed_files=()
+          while IFS= read -r path; do
+            [ -n "$path" ] || continue
+            [ -f "$path" ] || continue
+            changed_files+=("$path")
+          done <<< "$diff_output"
+
+          if [ "${#changed_files[@]}" -eq 0 ]; then
+            echo "No scan-eligible changed files detected; skipping detect-secrets."
             exit 0
           fi
+
+          echo "Running detect-secrets on ${#changed_files[@]} changed file(s)."
+          pre-commit run detect-secrets --files "${changed_files[@]}"
 
       - name: Detect committed private keys
         run: pre-commit run --all-files detect-private-key

--- a/extensions/mattermost/src/group-mentions.ts
+++ b/extensions/mattermost/src/group-mentions.ts
@@ -1,5 +1,7 @@
-import { resolveChannelGroupRequireMention } from "openclaw/plugin-sdk/compat";
-import type { ChannelGroupContext } from "openclaw/plugin-sdk/mattermost";
+import {
+  resolveChannelGroupRequireMention,
+  type ChannelGroupContext,
+} from "openclaw/plugin-sdk/mattermost";
 import { resolveMattermostAccount } from "./mattermost/accounts.js";
 
 export function resolveMattermostGroupRequireMention(

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -814,18 +814,14 @@ async function dispatchDiscordComponentEvent(params: {
 }): Promise<void> {
   const { ctx, interaction, interactionCtx, channelCtx, guildInfo, eventText } = params;
   const runtime = ctx.runtime ?? createNonExitingRuntime();
-  const route = resolveAgentRoute({
-    cfg: ctx.cfg,
-    channel: "discord",
-    accountId: ctx.accountId,
-    guildId: interactionCtx.rawGuildId,
+  const route = resolveAgentComponentRoute({
+    ctx,
+    rawGuildId: interactionCtx.rawGuildId,
     memberRoleIds: interactionCtx.memberRoleIds,
-    text: eventText,
-    peer: {
-      kind: interactionCtx.isDirectMessage ? "direct" : "channel",
-      id: interactionCtx.isDirectMessage ? interactionCtx.userId : interactionCtx.channelId,
-    },
-    parentPeer: channelCtx.parentId ? { kind: "channel", id: channelCtx.parentId } : undefined,
+    isDirectMessage: interactionCtx.isDirectMessage,
+    userId: interactionCtx.userId,
+    channelId: interactionCtx.channelId,
+    parentId: channelCtx.parentId,
   });
   const sessionKey = params.routeOverrides?.sessionKey ?? route.sessionKey;
   const agentId = params.routeOverrides?.agentId ?? route.agentId;

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -820,6 +820,7 @@ async function dispatchDiscordComponentEvent(params: {
     accountId: ctx.accountId,
     guildId: interactionCtx.rawGuildId,
     memberRoleIds: interactionCtx.memberRoleIds,
+    text: eventText,
     peer: {
       kind: interactionCtx.isDirectMessage ? "direct" : "channel",
       id: interactionCtx.isDirectMessage ? interactionCtx.userId : interactionCtx.channelId,

--- a/src/discord/monitor/listeners.ts
+++ b/src/discord/monitor/listeners.ts
@@ -504,13 +504,14 @@ async function handleDiscordReactionEvent(
       return reactionBase;
     };
     const emitReaction = (text: string, parentPeerId?: string) => {
-      const { contextKey } = resolveReactionBase();
+      const { contextKey, baseText } = resolveReactionBase();
       const route = resolveAgentRoute({
         cfg: params.cfg,
         channel: "discord",
         accountId: params.accountId,
         guildId: data.guild_id ?? undefined,
         memberRoleIds,
+        text: baseText,
         peer: {
           kind: isDirectMessage ? "direct" : isGroupDm ? "group" : "channel",
           id: isDirectMessage ? user.id : data.channel_id,

--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -751,6 +751,92 @@ describe("preflightDiscordMessage", () => {
     expect(result?.route.matchedBy).toBe("mention");
   });
 
+  it("does not route @everyone to an agent alias", async () => {
+    const channelId = "channel-broadcast-mention-route-protection";
+    const guildId = "guild-broadcast-mention-route-protection";
+    const runtimeCfg = {
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        list: [
+          { id: "main", default: true },
+          { id: "everyone" },
+        ],
+      },
+    } satisfies import("../../config/config.js").OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeCfg);
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === channelId) {
+          return {
+            id: channelId,
+            type: ChannelType.GuildText,
+            name: "general",
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+    const message = {
+      id: "m-broadcast-mention-route",
+      content: "@everyone heads up",
+      timestamp: new Date().toISOString(),
+      channelId,
+      attachments: [],
+      mentionedUsers: [],
+      mentionedRoles: [],
+      mentionedEveryone: true,
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: runtimeCfg,
+      discordConfig: {} as NonNullable<
+        import("../../config/config.js").OpenClawConfig["channels"]
+      >["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: "openclaw-bot",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "open",
+      threadBindings: createNoopThreadBindingManager("default"),
+      guildEntries: {
+        [guildId]: {
+          requireMention: false,
+        },
+      },
+      data: {
+        channel_id: channelId,
+        guild_id: guildId,
+        guild: {
+          id: guildId,
+          name: "Guild One",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.route.agentId).toBe("main");
+    expect(result?.route.matchedBy).not.toBe("mention");
+  });
+
   it("does not drop @everyone messages when ignoreOtherMentions=true", async () => {
     const channelId = "channel-other-mention-everyone";
     const guildId = "guild-other-mention-everyone";

--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -1,5 +1,6 @@
 import { ChannelType } from "@buape/carbon";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/config.js";
 
 const transcribeFirstAudioMock = vi.hoisted(() => vi.fn());
 
@@ -81,6 +82,10 @@ describe("preflightDiscordMessage", () => {
   beforeEach(() => {
     sessionBindingTesting.resetSessionBindingAdaptersForTests();
     transcribeFirstAudioMock.mockReset();
+  });
+
+  afterEach(() => {
+    clearRuntimeConfigSnapshot();
   });
 
   it("drops bound-thread bot system messages to prevent ACP self-loop", async () => {
@@ -571,6 +576,179 @@ describe("preflightDiscordMessage", () => {
     });
 
     expect(result).toBeNull();
+  });
+
+  it("does not reroute when a Discord user mention resolves to an agent-like display name", async () => {
+    const channelId = "channel-human-mention-route";
+    const guildId = "guild-human-mention-route";
+    const runtimeCfg = {
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        list: [
+          { id: "main", default: true },
+          { id: "steve", name: "Steve" },
+        ],
+      },
+    } satisfies import("../../config/config.js").OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeCfg);
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === channelId) {
+          return {
+            id: channelId,
+            type: ChannelType.GuildText,
+            name: "general",
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+    const message = {
+      id: "m-human-mention-route",
+      content: "hello <@999>",
+      timestamp: new Date().toISOString(),
+      channelId,
+      attachments: [],
+      mentionedUsers: [{ id: "999", username: "steve" }],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: runtimeCfg,
+      discordConfig: {} as NonNullable<
+        import("../../config/config.js").OpenClawConfig["channels"]
+      >["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: "openclaw-bot",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "open",
+      threadBindings: createNoopThreadBindingManager("default"),
+      guildEntries: {
+        [guildId]: {
+          requireMention: false,
+        },
+      },
+      data: {
+        channel_id: channelId,
+        guild_id: guildId,
+        guild: {
+          id: guildId,
+          name: "Guild One",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.baseText).toBe("hello @steve");
+    expect(result?.route.agentId).toBe("main");
+    expect(result?.route.matchedBy).toBe("default");
+  });
+
+  it("still routes literal @agent text to the target agent", async () => {
+    const channelId = "channel-literal-agent-route";
+    const guildId = "guild-literal-agent-route";
+    const runtimeCfg = {
+      session: {
+        mainKey: "main",
+        scope: "per-sender",
+      },
+      agents: {
+        list: [
+          { id: "main", default: true },
+          { id: "steve", name: "Steve" },
+        ],
+      },
+    } satisfies import("../../config/config.js").OpenClawConfig;
+    setRuntimeConfigSnapshot(runtimeCfg);
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === channelId) {
+          return {
+            id: channelId,
+            type: ChannelType.GuildText,
+            name: "general",
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+    const message = {
+      id: "m-literal-agent-route",
+      content: "hello @steve",
+      timestamp: new Date().toISOString(),
+      channelId,
+      attachments: [],
+      mentionedUsers: [],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: runtimeCfg,
+      discordConfig: {} as NonNullable<
+        import("../../config/config.js").OpenClawConfig["channels"]
+      >["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: "openclaw-bot",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "open",
+      threadBindings: createNoopThreadBindingManager("default"),
+      guildEntries: {
+        [guildId]: {
+          requireMention: false,
+        },
+      },
+      data: {
+        channel_id: channelId,
+        guild_id: guildId,
+        guild: {
+          id: guildId,
+          name: "Guild One",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.route.agentId).toBe("steve");
+    expect(result?.route.matchedBy).toBe("mention");
   });
 
   it("does not drop @everyone messages when ignoreOtherMentions=true", async () => {

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -58,6 +58,7 @@ import {
   resolveDiscordChannelInfo,
   resolveDiscordMessageChannelId,
   resolveDiscordMessageText,
+  resolveDiscordRouteText as resolveDiscordRouteTextFromMessage,
 } from "./message-utils.js";
 import { resolveDiscordPreflightAudioMentionContext } from "./preflight-audio.js";
 import { resolveDiscordSenderIdentity, resolveDiscordWebhookId } from "./sender-identity.js";
@@ -71,25 +72,13 @@ export type {
 } from "./message-handler.preflight.types.js";
 
 const DISCORD_BOUND_THREAD_SYSTEM_PREFIXES = ["⚙️", "🤖", "🧰"];
-const DISCORD_NATIVE_MENTION_ENTITY_REGEX = /<@[!&]?\d+>/g;
-const DISCORD_BROADCAST_MENTION_REGEX =
-  /(^|[\s([{"'.,;:!?<`])@(everyone|here)\b(?=$|[^a-zA-Z0-9_-])/gi;
 
 function isPreflightAborted(abortSignal?: AbortSignal): boolean {
   return Boolean(abortSignal?.aborted);
 }
 
 function resolveDiscordRouteText(message: import("@buape/carbon").Message): string {
-  const rawText = message.content?.trim() ?? "";
-  if (!rawText) {
-    return "";
-  }
-  // Keep literal `@agent` text routable, but ignore Discord-native mention entities such as
-  // `<@123>`, `<@!123>`, and `<@&123>` so human/role mentions never masquerade as agent aliases.
-  const withMentionsRemoved = rawText.replace(DISCORD_NATIVE_MENTION_ENTITY_REGEX, " ");
-  // Broadcast mentions are always platform-wide mass notifications and should not be interpreted
-  // as explicit agent aliases (for example, in environments with agents named `everyone`/`here`).
-  return withMentionsRemoved.replace(DISCORD_BROADCAST_MENTION_REGEX, "$1").trim();
+  return resolveDiscordRouteTextFromMessage(message.content);
 }
 
 function isBoundThreadBotSystemMessage(params: {

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -72,6 +72,8 @@ export type {
 
 const DISCORD_BOUND_THREAD_SYSTEM_PREFIXES = ["⚙️", "🤖", "🧰"];
 const DISCORD_NATIVE_MENTION_ENTITY_REGEX = /<@[!&]?\d+>/g;
+const DISCORD_BROADCAST_MENTION_REGEX =
+  /(^|[\s([{"'.,;:!?<`])@(everyone|here)\b(?=$|[^a-zA-Z0-9_-])/gi;
 
 function isPreflightAborted(abortSignal?: AbortSignal): boolean {
   return Boolean(abortSignal?.aborted);
@@ -84,7 +86,10 @@ function resolveDiscordRouteText(message: import("@buape/carbon").Message): stri
   }
   // Keep literal `@agent` text routable, but ignore Discord-native mention entities such as
   // `<@123>`, `<@!123>`, and `<@&123>` so human/role mentions never masquerade as agent aliases.
-  return rawText.replace(DISCORD_NATIVE_MENTION_ENTITY_REGEX, " ").trim();
+  const withMentionsRemoved = rawText.replace(DISCORD_NATIVE_MENTION_ENTITY_REGEX, " ");
+  // Broadcast mentions are always platform-wide mass notifications and should not be interpreted
+  // as explicit agent aliases (for example, in environments with agents named `everyone`/`here`).
+  return withMentionsRemoved.replace(DISCORD_BROADCAST_MENTION_REGEX, "$1").trim();
 }
 
 function isBoundThreadBotSystemMessage(params: {

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -71,9 +71,20 @@ export type {
 } from "./message-handler.preflight.types.js";
 
 const DISCORD_BOUND_THREAD_SYSTEM_PREFIXES = ["⚙️", "🤖", "🧰"];
+const DISCORD_NATIVE_MENTION_ENTITY_REGEX = /<@[!&]?\d+>/g;
 
 function isPreflightAborted(abortSignal?: AbortSignal): boolean {
   return Boolean(abortSignal?.aborted);
+}
+
+function resolveDiscordRouteText(message: import("@buape/carbon").Message): string {
+  const rawText = message.content?.trim() ?? "";
+  if (!rawText) {
+    return "";
+  }
+  // Keep literal `@agent` text routable, but ignore Discord-native mention entities such as
+  // `<@123>`, `<@!123>`, and `<@&123>` so human/role mentions never masquerade as agent aliases.
+  return rawText.replace(DISCORD_NATIVE_MENTION_ENTITY_REGEX, " ").trim();
 }
 
 function isBoundThreadBotSystemMessage(params: {
@@ -282,6 +293,7 @@ export async function preflightDiscordMessage(
   const baseText = resolveDiscordMessageText(message, {
     includeForwarded: false,
   });
+  const routeText = resolveDiscordRouteText(message);
   const messageText = resolveDiscordMessageText(message, {
     includeForwarded: true,
   });
@@ -339,6 +351,7 @@ export async function preflightDiscordMessage(
     accountId: params.accountId,
     guildId: params.data.guild_id ?? undefined,
     memberRoleIds,
+    text: routeText,
     peer: {
       kind: isDirectMessage ? "direct" : isGroupDm ? "group" : "channel",
       id: isDirectMessage ? author.id : messageChannelId,

--- a/src/discord/monitor/message-utils.ts
+++ b/src/discord/monitor/message-utils.ts
@@ -13,6 +13,19 @@ const DISCORD_CDN_HOSTNAMES = [
   "*.discordapp.net",
 ];
 
+const DISCORD_NATIVE_MENTION_ENTITY_REGEX = /<@[!&]?\d+>/g;
+export const DISCORD_BROADCAST_MENTION_REGEX =
+  /(^|[\s([{"'.,;:!?<`])@(everyone|here)\b(?=$|[^a-zA-Z0-9_-])/gi;
+
+export function resolveDiscordRouteText(rawText?: string | null): string {
+  const trimmed = rawText?.trim() ?? "";
+  if (!trimmed) {
+    return "";
+  }
+  const withoutNative = trimmed.replace(DISCORD_NATIVE_MENTION_ENTITY_REGEX, " ");
+  return withoutNative.replace(DISCORD_BROADCAST_MENTION_REGEX, "$1").trim();
+}
+
 // Allow Discord CDN downloads when VPN/proxy DNS resolves to RFC2544 benchmark ranges.
 const DISCORD_MEDIA_SSRF_POLICY: SsrFPolicy = {
   hostnameAllowlist: DISCORD_CDN_HOSTNAMES,

--- a/src/discord/monitor/monitor.test.ts
+++ b/src/discord/monitor/monitor.test.ts
@@ -429,6 +429,56 @@ describe("discord component interactions", () => {
     expect(resolveDiscordModalEntry({ id: "mdl_1" })).toBeNull();
   });
 
+  it("does not let modal values alter routing via mention parsing", async () => {
+    registerDiscordComponentEntries({
+      entries: [],
+      modals: [
+        createModalEntry({
+          id: "mdl_1",
+          title: "Details",
+          sessionKey: undefined,
+          agentId: undefined,
+          accountId: undefined,
+          fields: [{ id: "fld_1", name: "name", label: "Name", type: "text" }],
+        }),
+      ],
+    });
+
+    const modal = createDiscordComponentModal(
+      createComponentContext({
+        cfg: {
+          channels: { discord: { replyToMode: "first" } },
+          agents: {
+            list: [
+              { id: "main", default: true },
+              { id: "steve" },
+            ],
+          },
+        } as OpenClawConfig,
+      }),
+    );
+    const { interaction, acknowledge } = createModalInteraction({
+      fields: {
+        getText: (key: string) => (key === "fld_1" ? "@steve" : undefined),
+        getStringSelect: (_key: string) => undefined,
+        getRoleSelect: (_key: string) => [],
+        getUserSelect: (_key: string) => [],
+      },
+    });
+
+    await modal.run(interaction, { mid: "mdl_1" } as ComponentData);
+
+    expect(acknowledge).toHaveBeenCalledTimes(1);
+    expect(lastDispatchCtx?.SessionKey).toBe(
+      buildAgentSessionKey({
+        agentId: "main",
+        channel: "discord",
+        peer: { kind: "direct", id: "123456789" },
+      }),
+    );
+    expect(lastDispatchCtx?.SessionKey).not.toContain(":agent:steve:");
+  });
+
   it("does not mark guild modal events as command-authorized for non-allowlisted users", async () => {
     registerDiscordComponentEntries({
       entries: [],

--- a/src/discord/monitor/native-command.plugin-dispatch.test.ts
+++ b/src/discord/monitor/native-command.plugin-dispatch.test.ts
@@ -4,6 +4,7 @@ import type { NativeCommandSpec } from "../../auto-reply/commands-registry.js";
 import * as dispatcherModule from "../../auto-reply/reply/provider-dispatcher.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import * as pluginCommandsModule from "../../plugins/commands.js";
+import * as resolveRouteModule from "../../routing/resolve-route.js";
 import { createDiscordNativeCommand } from "./native-command.js";
 import { createNoopThreadBindingManager } from "./thread-bindings.js";
 
@@ -332,5 +333,73 @@ describe("Discord native plugin command dispatch", () => {
     expect(dispatchCall.ctx?.CommandTargetSessionKey).toBe(boundSessionKey);
     expect(persistentBindingMocks.resolveConfiguredAcpBindingRecord).toHaveBeenCalledTimes(1);
     expect(persistentBindingMocks.ensureConfiguredAcpBindingSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not route slash command @everyone as an agent alias", async () => {
+    const guildId = "1459246755253325866";
+    const channelId = "1478836151241412758";
+    const cfg = {
+      agents: {
+        list: [{ id: "main", default: true }, { id: "everyone" }],
+      },
+      commands: {
+        useAccessGroups: false,
+      },
+      channels: {
+        discord: {
+          dm: { enabled: true, policy: "open" },
+        },
+      },
+    } as OpenClawConfig;
+    const commandSpec: NativeCommandSpec = {
+      name: "echo",
+      description: "Echo input",
+      acceptsArgs: true,
+    };
+    const command = createDiscordNativeCommand({
+      command: commandSpec,
+      cfg,
+      discordConfig: cfg.channels?.discord ?? {},
+      accountId: "default",
+      sessionPrefix: "discord:slash",
+      ephemeralDefault: true,
+      threadBindings: createNoopThreadBindingManager("default"),
+    });
+    const interaction = createInteraction({
+      channelType: ChannelType.GuildText,
+      channelId,
+      guildId,
+      guildName: "Routing Lab",
+    });
+    interaction.options.getString.mockReturnValue("@everyone urgent build broken");
+
+    const routeSpy = vi
+      .spyOn(resolveRouteModule, "resolveAgentRoute")
+      .mockReturnValue({
+        agentId: "main",
+        channel: "discord",
+        accountId: "default",
+        sessionKey: "agent:main:discord:channel:1478836151241412758",
+        mainSessionKey: "agent:main:main",
+        matchedBy: "default",
+      });
+
+    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
+    const dispatchSpy = vi
+      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
+      .mockResolvedValue({
+        counts: {
+          final: 1,
+          block: 0,
+          tool: 0,
+        },
+      } as never);
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(routeSpy).toHaveBeenCalledTimes(1);
+    const routeInput = routeSpy.mock.calls[0]?.[0];
+    expect(routeInput?.text).toBe("/echo  urgent build broken");
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -69,7 +69,10 @@ import {
 } from "./allow-list.js";
 import { resolveDiscordDmCommandAccess } from "./dm-command-auth.js";
 import { handleDiscordDmCommandDecision } from "./dm-command-decision.js";
-import { resolveDiscordChannelInfo } from "./message-utils.js";
+import {
+  resolveDiscordChannelInfo,
+  resolveDiscordRouteText,
+} from "./message-utils.js";
 import {
   readDiscordModelPickerRecentModels,
   recordDiscordModelPickerRecentModel,
@@ -1539,7 +1542,7 @@ async function dispatchDiscordCommandInteraction(params: {
     accountId,
     guildId: interaction.guild?.id ?? undefined,
     memberRoleIds,
-    text: prompt,
+    text: resolveDiscordRouteText(prompt),
     peer: {
       kind: isDirectMessage ? "direct" : isGroupDm ? "group" : "channel",
       id: isDirectMessage ? user.id : channelId,

--- a/src/discord/monitor/native-command.ts
+++ b/src/discord/monitor/native-command.ts
@@ -1539,6 +1539,7 @@ async function dispatchDiscordCommandInteraction(params: {
     accountId,
     guildId: interaction.guild?.id ?? undefined,
     memberRoleIds,
+    text: prompt,
     peer: {
       kind: isDirectMessage ? "direct" : isGroupDm ? "group" : "channel",
       id: isDirectMessage ? user.id : channelId,

--- a/src/plugin-sdk/mattermost.ts
+++ b/src/plugin-sdk/mattermost.ts
@@ -49,6 +49,7 @@ export {
   resolveDefaultGroupPolicy,
   warnMissingProviderGroupPolicyFallbackOnce,
 } from "../config/runtime-group-policy.js";
+export { resolveChannelGroupRequireMention } from "../config/group-policy.js";
 export type { BlockStreamingCoalesceConfig, DmPolicy, GroupPolicy } from "../config/types.js";
 export type { SecretInput } from "../config/types.secrets.js";
 export {

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -809,3 +809,226 @@ describe("binding evaluation cache scalability", () => {
     }
   });
 });
+
+describe("mention-based explicit routing", () => {
+  const cfg: OpenClawConfig = {
+    agents: {
+      list: [
+        { id: "main", default: true },
+        { id: "tim", name: "Tim" },
+        { id: "steve", name: "Steve" },
+        { id: "project-manager", name: "Project Manager" },
+      ],
+    },
+    bindings: [
+      {
+        agentId: "tim",
+        match: {
+          channel: "discord",
+          peer: { kind: "channel", id: "c-tim" },
+        },
+      },
+    ],
+  };
+
+  test("@agent mention overrides peer binding", () => {
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "c-tim" },
+      text: "@steve please check this",
+    });
+    expect(route.agentId).toBe("steve");
+    expect(route.matchedBy).toBe("mention");
+    expect(route.sessionKey).toBe("agent:steve:discord:channel:c-tim");
+  });
+
+  test("unknown mention falls back to normal binding resolution", () => {
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "c-tim" },
+      text: "@unknown check this",
+    });
+    expect(route.agentId).toBe("tim");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+
+  test("display name alias works without spaces", () => {
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "c-tim" },
+      text: "@projectmanager please join",
+    });
+    expect(route.agentId).toBe("project-manager");
+    expect(route.matchedBy).toBe("mention");
+  });
+
+  test("exact id wins over earlier display-name alias collisions", () => {
+    const collisionCfg: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "main", default: true },
+          { id: "pm-fuzzy", name: "Project Manager" },
+          { id: "projectmanager", name: "Real Project Manager" },
+        ],
+      },
+      bindings: [
+        {
+          agentId: "pm-fuzzy",
+          match: { channel: "discord", peer: { kind: "channel", id: "c-tim" } },
+        },
+      ],
+    };
+
+    const route = resolveAgentRoute({
+      cfg: collisionCfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "c-tim" },
+      text: "@projectmanager please join",
+    });
+    expect(route.agentId).toBe("projectmanager");
+    expect(route.matchedBy).toBe("mention");
+  });
+
+  test("exact ids with punctuation route via canonical mention form", () => {
+    const punctuationCfg: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "main", default: true },
+          { id: "sales.v2", name: "Sales V2" },
+        ],
+      },
+      bindings: [
+        {
+          agentId: "main",
+          match: { channel: "discord", peer: { kind: "channel", id: "c-main" } },
+        },
+      ],
+    };
+
+    const route = resolveAgentRoute({
+      cfg: punctuationCfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "c-main" },
+      text: "@sales-v2 please check this",
+    });
+    expect(route.agentId).toBe("sales-v2");
+    expect(route.matchedBy).toBe("mention");
+  });
+
+  test("email-like text does not trigger mention routing", () => {
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "c-tim" },
+      text: "please contact alice@steve.com for details",
+    });
+    expect(route.agentId).toBe("tim");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+
+  test("url path segment does not trigger mention routing", () => {
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "c-tim" },
+      text: "check https://x.com/@steve and summarize",
+    });
+    expect(route.agentId).toBe("tim");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+
+  test("package scopes do not trigger mention routing", () => {
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "c-tim" },
+      text: "install @steve/tools in this workspace",
+    });
+    expect(route.agentId).toBe("tim");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+
+  test("standalone mention with punctuation still routes correctly", () => {
+    const route = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "c-tim" },
+      text: "please ask (@steve), thanks",
+    });
+    expect(route.agentId).toBe("steve");
+    expect(route.matchedBy).toBe("mention");
+  });
+
+  test("mention alias cache refreshes when agents reference changes", () => {
+    const mutableCfg: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "main", default: true },
+          { id: "tim", name: "Tim" },
+        ],
+      },
+    };
+
+    const first = resolveAgentRoute({
+      cfg: mutableCfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "c-tim" },
+      text: "@tim first ping",
+    });
+    expect(first.agentId).toBe("tim");
+    expect(first.matchedBy).toBe("mention");
+
+    mutableCfg.agents = {
+      list: [
+        { id: "main", default: true },
+        { id: "tim", name: "Tim" },
+        { id: "steve", name: "Steve" },
+      ],
+    };
+
+    const second = resolveAgentRoute({
+      cfg: mutableCfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "c-tim" },
+      text: "@steve second ping",
+    });
+    expect(second.agentId).toBe("steve");
+    expect(second.matchedBy).toBe("mention");
+  });
+
+  test("mention routes do not poison cache for subsequent plain messages", () => {
+    const mentioned = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "c-tim" },
+      text: "@steve ping",
+    });
+    expect(mentioned.agentId).toBe("steve");
+    expect(mentioned.matchedBy).toBe("mention");
+
+    const plain = resolveAgentRoute({
+      cfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "c-tim" },
+      text: "plain message",
+    });
+    expect(plain.agentId).toBe("tim");
+    expect(plain.matchedBy).toBe("binding.peer");
+  });
+});

--- a/src/routing/resolve-route.test.ts
+++ b/src/routing/resolve-route.test.ts
@@ -923,6 +923,33 @@ describe("mention-based explicit routing", () => {
     expect(route.matchedBy).toBe("mention");
   });
 
+  test("non-token-only aliases do not steal @main via fallback canonicalization", () => {
+    const nonTokenAliasCfg: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "tim", default: true },
+          { id: "pm-cn", name: "项目经理" },
+        ],
+      },
+      bindings: [
+        {
+          agentId: "tim",
+          match: { channel: "discord", peer: { kind: "channel", id: "c-tim" } },
+        },
+      ],
+    };
+
+    const route = resolveAgentRoute({
+      cfg: nonTokenAliasCfg,
+      channel: "discord",
+      accountId: "default",
+      peer: { kind: "channel", id: "c-tim" },
+      text: "@main please join",
+    });
+    expect(route.agentId).toBe("tim");
+    expect(route.matchedBy).toBe("binding.peer");
+  });
+
   test("email-like text does not trigger mention routing", () => {
     const route = resolveAgentRoute({
       cfg,

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -27,6 +27,8 @@ export type ResolveAgentRouteInput = {
   cfg: OpenClawConfig;
   channel: string;
   accountId?: string | null;
+  /** Optional inbound text for mention-based explicit agent routing (e.g. "@tim"). */
+  text?: string | null;
   peer?: RoutePeer | null;
   /** Parent peer for threads — used for binding inheritance when peer doesn't match directly. */
   parentPeer?: RoutePeer | null;
@@ -53,6 +55,7 @@ export type ResolvedAgentRoute = {
     | "binding.team"
     | "binding.account"
     | "binding.channel"
+    | "mention"
     | "default";
 };
 
@@ -72,6 +75,158 @@ function normalizeId(value: unknown): string {
   return "";
 }
 
+function normalizeMentionAlias(value: unknown): string {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  return normalizeAgentId(trimmed);
+}
+
+type AgentMentionAliasCache = {
+  agentsRef: OpenClawConfig["agents"] | undefined;
+  aliases: Map<string, string>;
+};
+
+const agentMentionAliasCacheByCfg = new WeakMap<OpenClawConfig, AgentMentionAliasCache>();
+const MENTION_TOKEN_REGEX = /@([a-zA-Z0-9_-]+)/g;
+const MENTION_PREFIX_PUNCTUATION = new Set(["(", "[", "{", "<", '"', "'", "`"]);
+const MENTION_SUFFIX_PUNCTUATION = new Set([
+  ")",
+  "]",
+  "}",
+  ">",
+  ",",
+  ".",
+  "!",
+  "?",
+  ":",
+  ";",
+  '"',
+  "'",
+  "`",
+]);
+
+function isMentionTokenChar(value: string | undefined): boolean {
+  return Boolean(value && /[a-zA-Z0-9_-]/.test(value));
+}
+
+function isStandaloneMentionPrefix(value: string | undefined): boolean {
+  if (!value) {
+    return true;
+  }
+  return /\s/.test(value) || MENTION_PREFIX_PUNCTUATION.has(value);
+}
+
+function isStandaloneMentionSuffix(value: string | undefined, next: string | undefined): boolean {
+  if (!value) {
+    return true;
+  }
+  if (/\s/.test(value)) {
+    return true;
+  }
+  if (!MENTION_SUFFIX_PUNCTUATION.has(value)) {
+    return false;
+  }
+  // Do not treat "alice@steve.com" as a standalone mention token.
+  if (value === "." && isMentionTokenChar(next)) {
+    return false;
+  }
+  return true;
+}
+
+function extractStandaloneMentionTokens(text: string): string[] {
+  const tokens: string[] = [];
+  for (const match of text.matchAll(MENTION_TOKEN_REGEX)) {
+    const token = match[1];
+    const atIndex = match.index ?? -1;
+    if (!token || atIndex < 0) {
+      continue;
+    }
+    const tokenStart = atIndex;
+    const tokenEnd = tokenStart + 1 + token.length;
+    const prefix = tokenStart > 0 ? text[tokenStart - 1] : undefined;
+    const suffix = tokenEnd < text.length ? text[tokenEnd] : undefined;
+    const suffixNext = tokenEnd + 1 < text.length ? text[tokenEnd + 1] : undefined;
+    if (!isStandaloneMentionPrefix(prefix)) {
+      continue;
+    }
+    if (!isStandaloneMentionSuffix(suffix, suffixNext)) {
+      continue;
+    }
+    tokens.push(token);
+  }
+  return tokens;
+}
+
+function buildAgentMentionAliasMap(cfg: OpenClawConfig): Map<string, string> {
+  const agentsRef = cfg.agents;
+  const existing = agentMentionAliasCacheByCfg.get(cfg);
+  if (existing && existing.agentsRef === agentsRef) {
+    return existing.aliases;
+  }
+
+  const aliases = new Map<string, string>();
+  const addAliasIfAbsent = (alias: unknown, agentId: string) => {
+    const normalized = normalizeMentionAlias(alias);
+    if (!normalized || aliases.has(normalized)) {
+      return;
+    }
+    aliases.set(normalized, sanitizeAgentId(agentId));
+  };
+
+  const agents = listAgents(cfg);
+
+  // Exact IDs should always win over display-name aliases, regardless of list order.
+  for (const agent of agents) {
+    const rawId = agent.id?.trim();
+    if (!rawId) {
+      continue;
+    }
+    addAliasIfAbsent(rawId, rawId);
+  }
+
+  for (const agent of agents) {
+    const rawId = agent.id?.trim();
+    if (!rawId) {
+      continue;
+    }
+    addAliasIfAbsent(agent.name, rawId);
+    addAliasIfAbsent(agent.name?.replace(/\s+/g, ""), rawId);
+    addAliasIfAbsent(agent.identity?.name, rawId);
+    addAliasIfAbsent(agent.identity?.name?.replace(/\s+/g, ""), rawId);
+  }
+  agentMentionAliasCacheByCfg.set(cfg, { agentsRef, aliases });
+  return aliases;
+}
+
+function resolveMentionTargetAgentId(
+  cfg: OpenClawConfig,
+  text: string | null | undefined,
+): string | null {
+  if (!text || !text.includes("@")) {
+    return null;
+  }
+  const aliases = buildAgentMentionAliasMap(cfg);
+  if (aliases.size === 0) {
+    return null;
+  }
+
+  for (const token of extractStandaloneMentionTokens(text)) {
+    const key = normalizeMentionAlias(token);
+    if (!key) {
+      continue;
+    }
+    const matched = aliases.get(key);
+    if (matched) {
+      return matched;
+    }
+  }
+  return null;
+}
 export function buildAgentSessionKey(params: {
   agentId: string;
   channel: string;
@@ -611,6 +766,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const dmScope = input.cfg.session?.dmScope ?? "main";
   const identityLinks = input.cfg.session?.identityLinks;
   const shouldLogDebug = shouldLogVerbose();
+  const mentionTargetAgentId = resolveMentionTargetAgentId(input.cfg, input.text);
   const parentPeer = input.parentPeer
     ? {
         kind: normalizeChatType(input.parentPeer.kind) ?? input.parentPeer.kind,
@@ -619,7 +775,9 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     : null;
 
   const routeCache =
-    !shouldLogDebug && !identityLinks ? resolveRouteCacheForConfig(input.cfg) : null;
+    !shouldLogDebug && !identityLinks && !mentionTargetAgentId
+      ? resolveRouteCacheForConfig(input.cfg)
+      : null;
   const routeCacheKey = routeCache
     ? buildResolvedRouteCacheKey({
         channel,
@@ -642,7 +800,12 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   const bindings = getEvaluatedBindingsForChannelAccount(input.cfg, channel, accountId);
   const bindingsIndex = getEvaluatedBindingIndexForChannelAccount(input.cfg, channel, accountId);
 
-  const choose = (agentId: string, matchedBy: ResolvedAgentRoute["matchedBy"]) => {
+  const choose = (
+    agentId: string,
+    matchedBy: ResolvedAgentRoute["matchedBy"],
+    opts?: { cache?: boolean },
+  ) => {
+    const shouldCache = opts?.cache !== false;
     const resolvedAgentId = pickFirstExistingAgentId(input.cfg, agentId);
     const sessionKey = buildAgentSessionKey({
       agentId: resolvedAgentId,
@@ -664,7 +827,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
       mainSessionKey,
       matchedBy,
     };
-    if (routeCache && routeCacheKey) {
+    if (shouldCache && routeCache && routeCacheKey) {
       routeCache.set(routeCacheKey, route);
       if (routeCache.size > MAX_RESOLVED_ROUTE_CACHE_KEYS) {
         routeCache.clear();
@@ -686,6 +849,13 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
     return `${value.kind}:${value.id}`;
   };
 
+  if (mentionTargetAgentId) {
+    if (shouldLogDebug) {
+      logDebug(`[routing] match: matchedBy=mention agentId=${mentionTargetAgentId}`);
+    }
+    return choose(mentionTargetAgentId, "mention", { cache: false });
+  }
+
   if (shouldLogDebug) {
     logDebug(
       `[routing] resolveAgentRoute: channel=${channel} accountId=${accountId} peer=${formatPeer(peer)} guildId=${guildId || "none"} teamId=${teamId || "none"} bindings=${bindings.length}`,
@@ -704,7 +874,7 @@ export function resolveAgentRoute(input: ResolveAgentRouteInput): ResolvedAgentR
   };
 
   const tiers: Array<{
-    matchedBy: Exclude<ResolvedAgentRoute["matchedBy"], "default">;
+    matchedBy: Exclude<ResolvedAgentRoute["matchedBy"], "default" | "mention">;
     enabled: boolean;
     scopePeer: RoutePeer | null;
     candidates: EvaluatedBinding[];

--- a/src/routing/resolve-route.ts
+++ b/src/routing/resolve-route.ts
@@ -9,6 +9,7 @@ import {
   buildAgentMainSessionKey,
   buildAgentPeerSessionKey,
   DEFAULT_ACCOUNT_ID,
+  DEFAULT_AGENT_ID,
   DEFAULT_MAIN_KEY,
   normalizeAccountId,
   normalizeAgentId,
@@ -83,7 +84,14 @@ function normalizeMentionAlias(value: unknown): string {
   if (!trimmed) {
     return "";
   }
-  return normalizeAgentId(trimmed);
+  const normalized = normalizeAgentId(trimmed);
+  if (normalized !== DEFAULT_AGENT_ID) {
+    return normalized;
+  }
+  // Drop aliases that only resolved via the default-id fallback path, so
+  // non-token-only display names cannot silently steal @main.
+  const hasCanonicalizableToken = /[a-z0-9_-]/i.test(trimmed.replace(/^-+|-+$/g, ""));
+  return hasCanonicalizableToken ? normalized : "";
 }
 
 type AgentMentionAliasCache = {


### PR DESCRIPTION
## Summary
- add explicit mention-based routing in `resolveAgentRoute` so messages like `@tim` / `@projectmanager` can target a specific agent
- pass inbound text into Discord routing entry points (`message preflight`, `native command`, `component`, `reaction`) so mention routing works consistently
- prevent mention-based decisions from polluting the resolved-route cache
- add tests for mention override, alias matching, fallback behavior, and cache safety

## Why
This preserves channel-level isolation by default while allowing deliberate cross-agent invocation in shared Discord workflows.

## Tests
- `pnpm vitest run src/routing/resolve-route.test.ts`
- `pnpm vitest run src/discord/monitor/message-handler.preflight.test.ts src/discord/monitor/listeners.test.ts src/discord/monitor/agent-components.wildcard.test.ts src/discord/monitor/native-command.options.test.ts src/discord/monitor/native-command.plugin-dispatch.test.ts`
