### PR TITLE
feat(feishu): urgent/buzz notification tool

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -7,6 +7,7 @@ import { registerFeishuDocTools } from "./src/docx.js";
 import { registerFeishuDriveTools } from "./src/drive.js";
 import { registerFeishuPermTools } from "./src/perm.js";
 import { setFeishuRuntime } from "./src/runtime.js";
+import { registerFeishuUrgentTools } from "./src/urgent.js";
 import { registerFeishuWikiTools } from "./src/wiki.js";
 
 export { monitorFeishuProvider } from "./src/monitor.js";
@@ -59,6 +60,7 @@ const plugin = {
     registerFeishuDriveTools(api);
     registerFeishuPermTools(api);
     registerFeishuBitableTools(api);
+    registerFeishuUrgentTools(api);
   },
 };
 

--- a/extensions/feishu/skills/feishu-urgent/SKILL.md
+++ b/extensions/feishu/skills/feishu-urgent/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: feishu-urgent
+description: |
+  Feishu urgent/buzz push notifications. Activate when user asks to urgently notify, buzz, or escalate a message to specific people.
+---
+
+# Feishu Urgent Tool
+
+Single tool `feishu_urgent` for sending urgent (buzz) push notifications for an already-sent message.
+
+## Usage
+
+The message must already exist (already sent). Obtain `message_id` first (e.g. from a prior send result), then buzz the recipients.
+
+```json
+{
+  "message_id": "om_xxx",
+  "user_ids": ["ou_xxx", "ou_yyy"]
+}
+```
+
+Default `urgent_type` is `app` (in-app buzz). Specify `sms` or `phone` for stronger delivery:
+
+```json
+{
+  "message_id": "om_xxx",
+  "user_ids": ["ou_xxx"],
+  "urgent_type": "sms"
+}
+```
+
+## Urgent Types
+
+| Type    | Delivery method          | Cost           |
+| ------- | ------------------------ | -------------- |
+| `app`   | In-app buzz notification | Free           |
+| `sms`   | SMS to recipient's phone | May incur cost |
+| `phone` | Voice call to recipient  | May incur cost |
+
+## Response
+
+```json
+{
+  "ok": true,
+  "message_id": "om_xxx",
+  "urgent_type": "app",
+  "invalid_user_list": []
+}
+```
+
+`invalid_user_list`: user IDs that could not be buzzed (not members of the chat, or invalid).
+
+## Common Errors
+
+- **Code 230024**: Quota exceeded ("Reach the upper limit of urgent message"). Check tenant quota in Feishu admin console → Cost Center.
+- **HTTP 400**: One or more `user_ids` are invalid or not members of the chat.
+
+## Configuration
+
+```yaml
+channels:
+  feishu:
+    tools:
+      urgent: true # default: false (opt-in)
+```
+
+**Note:** Disabled by default to prevent accidental quota consumption. Enable explicitly when urgent notification capability is needed.
+
+## Permissions
+
+Required scopes (add to app in Feishu Open Platform):
+
+| urgent_type | Required scope            |
+| ----------- | ------------------------- |
+| `app`       | `im:message.urgent_app`   |
+| `sms`       | `im:message.urgent_sms`   |
+| `phone`     | `im:message.urgent_phone` |

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -89,6 +89,7 @@ const FeishuToolsConfigSchema = z
     drive: z.boolean().optional(), // Cloud storage operations (default: true)
     perm: z.boolean().optional(), // Permission management (default: false, sensitive)
     scopes: z.boolean().optional(), // App scopes diagnostic (default: true)
+    urgent: z.boolean().optional(), // Urgent/buzz notifications (default: false, requires im:message.urgent scope)
   })
   .strict()
   .optional();

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -56,6 +56,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     drive: false,
     perm: false,
     scopes: false,
+    urgent: false,
   };
   for (const account of accounts) {
     const cfg = resolveToolsConfig(account.config.tools);
@@ -65,6 +66,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     merged.drive = merged.drive || cfg.drive;
     merged.perm = merged.perm || cfg.perm;
     merged.scopes = merged.scopes || cfg.scopes;
+    merged.urgent = merged.urgent || cfg.urgent;
   }
   return merged;
 }

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -4,6 +4,7 @@ import type { FeishuToolsConfig } from "./types.js";
  * Default tool configuration.
  * - doc, chat, wiki, drive, scopes: enabled by default
  * - perm: disabled by default (sensitive operation)
+ * - urgent: disabled by default (opt-in; requires im:message.urgent scope)
  */
 export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   doc: true,
@@ -12,6 +13,7 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   drive: true,
   perm: false,
   scopes: true,
+  urgent: false,
 };
 
 /**

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -79,6 +79,7 @@ export type FeishuToolsConfig = {
   drive?: boolean;
   perm?: boolean;
   scopes?: boolean;
+  urgent?: boolean;
 };
 
 export type DynamicAgentCreationConfig = {

--- a/extensions/feishu/src/urgent.ts
+++ b/extensions/feishu/src/urgent.ts
@@ -1,0 +1,179 @@
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import { Type, type Static } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+import { listEnabledFeishuAccounts } from "./accounts.js";
+import { createFeishuToolClient, resolveAnyEnabledFeishuToolsConfig } from "./tool-account.js";
+
+// ============ Helpers ============
+
+function json(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    details: data,
+  };
+}
+
+// ============ Schema ============
+
+const URGENT_TYPE_VALUES = ["app", "sms", "phone"] as const;
+
+export type FeishuUrgentType = (typeof URGENT_TYPE_VALUES)[number];
+
+const FeishuUrgentSchema = Type.Object({
+  message_id: Type.String({
+    description:
+      "Message ID to send urgent notification for (e.g. om_xxx). The message must already be sent.",
+  }),
+  user_ids: Type.Array(Type.String(), {
+    description:
+      "List of open_id values to buzz. Recipients must be members of the chat where the message was sent.",
+    minItems: 1,
+  }),
+  urgent_type: Type.Optional(
+    Type.Unsafe<FeishuUrgentType>({
+      type: "string",
+      enum: [...URGENT_TYPE_VALUES],
+      description:
+        "Urgency delivery method: app (in-app buzz, default), sms (SMS push), phone (voice call). " +
+        "Note: sms and phone may incur cost on the tenant.",
+      default: "app",
+    }),
+  ),
+  accountId: Type.Optional(
+    Type.String({ description: "Feishu account ID to use. Defaults to the agent's account." }),
+  ),
+});
+
+type FeishuUrgentParams = Static<typeof FeishuUrgentSchema>;
+
+// ============ Actions ============
+
+type UrgentPayload = {
+  data: { user_id_list: string[] };
+  params: { user_id_type: "open_id" | "user_id" | "union_id" };
+  path: { message_id: string };
+};
+
+type UrgentResponse = { code?: number; msg?: string; data?: { invalid_user_id_list?: string[] } };
+
+type LarkMessageWithUrgent = Lark.Client["im"]["message"] & {
+  urgentApp?: (payload: UrgentPayload) => Promise<UrgentResponse>;
+  urgentSms?: (payload: UrgentPayload) => Promise<UrgentResponse>;
+  urgentPhone?: (payload: UrgentPayload) => Promise<UrgentResponse>;
+};
+
+/**
+ * Send an urgent (buzz) notification for an existing Feishu message.
+ *
+ * Calls the Feishu "urgent" API which sends a strong push notification
+ * to the specified recipients. The message must already be sent.
+ *
+ * Requires `im:message.urgent` scope (or `im:message.urgent:sms` / `im:message.urgent:phone`
+ * variants for the respective types).
+ *
+ * Common errors:
+ * - Code 230024: Quota exceeded ("Reach the upper limit of urgent message").
+ *   Check tenant quota in Feishu admin console > Cost Center.
+ *
+ * @see https://open.feishu.cn/document/server-docs/im-v1/message/urgent_app
+ * @see https://open.feishu.cn/document/server-docs/im-v1/message/urgent_sms
+ * @see https://open.feishu.cn/document/server-docs/im-v1/message/urgent_phone
+ */
+async function urgentMessage(
+  client: Lark.Client,
+  messageId: string,
+  userIds: string[],
+  urgentType: FeishuUrgentType = "app",
+): Promise<{ invalidUserList: string[] }> {
+  const larkMessage = client.im.message as LarkMessageWithUrgent;
+
+  const payload: UrgentPayload = {
+    path: { message_id: messageId },
+    params: { user_id_type: "open_id" },
+    data: { user_id_list: userIds },
+  };
+
+  const methodMap = {
+    app: larkMessage.urgentApp?.bind(larkMessage),
+    sms: larkMessage.urgentSms?.bind(larkMessage),
+    phone: larkMessage.urgentPhone?.bind(larkMessage),
+  } as const;
+
+  const method = methodMap[urgentType];
+  if (typeof method !== "function") {
+    throw new Error(
+      `Feishu urgent: SDK method not available for urgentType="${urgentType}". ` +
+        `Check that @larksuiteoapi/node-sdk is up to date.`,
+    );
+  }
+
+  const res = await method(payload);
+  if (res.code !== undefined && res.code !== 0) {
+    throw new Error(
+      `Feishu urgent message (${urgentType}) failed: ${res.msg ?? `code ${res.code}`}`,
+    );
+  }
+
+  return { invalidUserList: res.data?.invalid_user_id_list ?? [] };
+}
+
+// ============ Tool Registration ============
+
+export function registerFeishuUrgentTools(api: OpenClawPluginApi) {
+  if (!api.config) {
+    api.logger.debug?.("feishu_urgent: No config available, skipping");
+    return;
+  }
+
+  const accounts = listEnabledFeishuAccounts(api.config);
+  if (accounts.length === 0) {
+    api.logger.debug?.("feishu_urgent: No Feishu accounts configured, skipping");
+    return;
+  }
+
+  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(accounts);
+  if (!toolsCfg.urgent) {
+    api.logger.debug?.("feishu_urgent: urgent tool disabled in config");
+    return;
+  }
+
+  api.registerTool(
+    (ctx) => ({
+      name: "feishu_urgent",
+      label: "Feishu Urgent",
+      description:
+        "Send an urgent (buzz) notification for an existing Feishu message. " +
+        "Supported urgent_type values: app (in-app buzz, default), sms (SMS push), phone (voice call). " +
+        "Requires the message_id of an already-sent message and the open_id list of recipients to buzz. " +
+        "Use this to escalate important messages that require immediate attention.",
+      parameters: FeishuUrgentSchema,
+      async execute(_toolCallId, params) {
+        const p = params as FeishuUrgentParams;
+        try {
+          const client = createFeishuToolClient({
+            api,
+            executeParams: p,
+            defaultAccountId: ctx.agentAccountId,
+          });
+          const result = await urgentMessage(
+            client,
+            p.message_id,
+            p.user_ids,
+            p.urgent_type ?? "app",
+          );
+          return json({
+            ok: true,
+            message_id: p.message_id,
+            urgent_type: p.urgent_type ?? "app",
+            invalid_user_list: result.invalidUserList,
+          });
+        } catch (err) {
+          return json({ error: err instanceof Error ? err.message : String(err) });
+        }
+      },
+    }),
+    { name: "feishu_urgent" },
+  );
+
+  api.logger.debug?.("feishu_urgent: Registered feishu_urgent tool");
+}


### PR DESCRIPTION
## Context
This PR is part of an ongoing series of incremental sync PRs building on top of [#16337](https://github.com/openclaw/openclaw/pull/16337) (community plugin sync from \`clawdbot-feishu\` v0.1.10).

## Summary
- Add \`feishu_urgent\` tool that sends urgent (buzz) push notifications for an already-sent Feishu message
- Supports three delivery methods: \`app\` (in-app, default), \`sms\`, \`phone\`
- Disabled by default via \`tools.urgent: false\`; users must opt in to avoid accidental quota use

## Key Changes
### \`src/urgent.ts\` (new)
- **\`registerFeishuUrgentTools\`** — registers the \`feishu_urgent\` tool following the same \`(ctx) => ({...})\` factory pattern as \`wiki.ts\` / \`bitable.ts\`
- **\`urgentMessage\`** — calls \`client.im.message.urgentApp/urgentSms/urgentPhone\` based on \`urgent_type\`, returns \`invalid_user_id_list\`
- SDK method availability is checked at call time (throws a clear error if the SDK version doesn't expose the method)

### \`skills/feishu-urgent/SKILL.md\` (new)
- Usage examples, urgent type table, error codes, config and permission reference

### Config changes (5 files)
- **\`types.ts\`** — add \`urgent?: boolean\` to \`FeishuToolsConfig\`
- **\`config-schema.ts\`** — add \`urgent\` zod field to \`FeishuToolsConfigSchema\`
- **\`tools-config.ts\`** — add \`urgent: false\` to \`DEFAULT_TOOLS_CONFIG\`
- **\`tool-account.ts\`** — add \`urgent\` to \`resolveAnyEnabledFeishuToolsConfig\` merge loop
- **\`index.ts\`** — import and call \`registerFeishuUrgentTools\`

## Source
Ported from [m1heng/clawdbot-feishu#345](https://github.com/m1heng/clawdbot-feishu/pull/345)
Original author: @wmgx

AI-assisted (Claude). Testing level: lightly tested.