### PR TITLE
fix(telegram): model keyboard marks only the selected provider's model (#35476)

### DIFF
--- a/src/telegram/model-buttons.test.ts
+++ b/src/telegram/model-buttons.test.ts
@@ -223,6 +223,33 @@ describe("buildModelsKeyboard", () => {
     }
   });
 
+  it("only marks the model from the matching provider as selected (#35476)", () => {
+    // Two providers both expose a model with the same id "claude-opus-4-6".
+    // When the user has "nexus-d/claude-opus-4-6" selected, only that provider's
+    // entry should show the ✓ checkmark; the entry under "nexus-a" must not.
+    const nexusDResult = buildModelsKeyboard({
+      provider: "nexus-d",
+      models: ["claude-opus-4-6", "claude-sonnet-4-6"],
+      currentModel: "nexus-d/claude-opus-4-6",
+      currentPage: 1,
+      totalPages: 1,
+    });
+    // nexus-d/claude-opus-4-6 is selected → first row has ✓
+    expect(nexusDResult[0]?.[0]?.text).toBe("claude-opus-4-6 ✓");
+    expect(nexusDResult[1]?.[0]?.text).toBe("claude-sonnet-4-6");
+
+    const nexusAResult = buildModelsKeyboard({
+      provider: "nexus-a",
+      models: ["claude-opus-4-6", "claude-sonnet-4-6"],
+      currentModel: "nexus-d/claude-opus-4-6",
+      currentPage: 1,
+      totalPages: 1,
+    });
+    // nexus-a/claude-opus-4-6 is NOT selected (different provider) → no ✓
+    expect(nexusAResult[0]?.[0]?.text).toBe("claude-opus-4-6");
+    expect(nexusAResult[1]?.[0]?.text).toBe("claude-sonnet-4-6");
+  });
+
   it("renders pagination controls for first, middle, and last pages", () => {
     const cases = [
       {

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -195,10 +195,8 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
   const pageModels = models.slice(startIndex, endIndex);
 
   // Model buttons - one per row
-  const currentModelId = currentModel?.includes("/")
-    ? currentModel.split("/").slice(1).join("/")
-    : currentModel;
-
+  // currentModel is `provider/modelId`; compare full key so that models with
+  // the same id from different providers don't all appear selected (#35476).
   for (const model of pageModels) {
     const callbackData = buildModelSelectionCallbackData({ provider, model });
     // Skip models that still exceed Telegram's callback_data limit.
@@ -206,7 +204,7 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
       continue;
     }
 
-    const isCurrentModel = model === currentModelId;
+    const isCurrentModel = `${provider}/${model}` === currentModel;
     const displayText = truncateModelId(model, 38);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
 

--- a/src/telegram/model-buttons.ts
+++ b/src/telegram/model-buttons.ts
@@ -195,8 +195,9 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
   const pageModels = models.slice(startIndex, endIndex);
 
   // Model buttons - one per row
-  // currentModel is `provider/modelId`; compare full key so that models with
-  // the same id from different providers don't all appear selected (#35476).
+  // currentModel may be `provider/modelId` (fully-qualified, set by #35476) or
+  // a bare model id (legacy configs/sessions that never stored a provider prefix).
+  // Match both forms so the checkmark still appears for older sessions.
   for (const model of pageModels) {
     const callbackData = buildModelSelectionCallbackData({ provider, model });
     // Skip models that still exceed Telegram's callback_data limit.
@@ -204,7 +205,11 @@ export function buildModelsKeyboard(params: ModelsKeyboardParams): ButtonRow[] {
       continue;
     }
 
-    const isCurrentModel = `${provider}/${model}` === currentModel;
+    const fullKey = `${provider}/${model}`;
+    const isCurrentModel =
+      fullKey === currentModel ||
+      // Bare model id fallback: currentModel has no "/" — match by model name alone.
+      (!!currentModel && !currentModel.includes("/") && model === currentModel);
     const displayText = truncateModelId(model, 38);
     const text = isCurrentModel ? `${displayText} ✓` : displayText;
 


### PR DESCRIPTION
## Problem

When multiple providers expose a model with the same `id` (e.g. `claude-opus-4-6` from `nexus-d`, `nexus-a`, `yunyi-claude`), the Telegram model-switcher keyboard showed **all of them** as selected (✓) after choosing one provider's entry.

## Root cause

In `buildModelsKeyboard`, the selection comparison was:
```typescript
const currentModelId = currentModel?.includes("/")
  ? currentModel.split("/").slice(1).join("/")
  : currentModel;
// ...
const isCurrentModel = model === currentModelId;
```
`currentModel` is `"provider/modelId"`, but only the `modelId` part was extracted and compared against bare model ids — so every provider with a matching model id was marked selected.

## Fix

Compare the full `provider/model` key directly against `currentModel`:
```typescript
const isCurrentModel = `${provider}/${model}` === currentModel;
```

## Tests

Added regression test `"only marks the model from the matching provider as selected (#35476)"` that verifies:
- `nexus-d/claude-opus-4-6` selected → ✓ on `nexus-d` list, no ✓ on `nexus-a` list

All 21 existing model-buttons tests pass.

Closes #35476