### PR TITLE
fix(doctor): warn clearly when unknown config keys are stripped

### DIFF
--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -2072,7 +2072,10 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     pendingChanges = true;
     if (shouldRepair) {
       cfg = unknown.config;
-      note(lines, "Doctor changes");
+      note(
+        `The following unrecognised config keys were removed from openclaw.json.\nA backup was saved to openclaw.json.bak before any changes were made.\n\n${lines}`,
+        "Doctor: removed unknown keys",
+      );
     } else {
       note(lines, "Unknown config keys");
       fixHints.push('Run "openclaw doctor --fix" to remove these keys.');


### PR DESCRIPTION
## Summary

When `openclaw doctor --fix` removes unrecognised keys from `openclaw.json`, the previous behaviour was to show a generic `Doctor changes` note listing only the key paths — with no explanation that data was being deleted and no mention of the `.bak` backup.

This caused silent data loss for users who had added forward-compatible or custom config keys (e.g. `agents.defaults.pdfModel`, custom provider `timeoutMs`), with no way to know the keys were removed until they diffed against the backup.

### Changes

- Changed the note title from `"Doctor changes"` to `"Doctor: removed unknown keys"`
- Added an explicit message explaining that keys were removed and that a `.bak` backup exists

### Before

```
◆ Doctor changes
│ - agents.defaults.pdfModel
│ - models.providers.custom-provider.timeoutMs
```

### After

```
◆ Doctor: removed unknown keys
│ The following unrecognised config keys were removed from openclaw.json.
│ A backup was saved to openclaw.json.bak before any changes were made.
│
│ - agents.defaults.pdfModel
│ - models.providers.custom-provider.timeoutMs
```

## Test plan

- [ ] Add an unknown key to `openclaw.json` (e.g. `agents.defaults.pdfModel`)
- [ ] Run `openclaw doctor --fix`
- [ ] Confirm the new note appears with the explicit removal message and backup hint
- [ ] Confirm `openclaw.json.bak` exists with the original key

Fixes #35864