### PR TITLE
fix(pi-ai): resolve 404 URL resolution bug for versioned baseUrls

### DIFF
--- a/package.json
+++ b/package.json
@@ -443,6 +443,9 @@
       "node-llama-cpp",
       "protobufjs",
       "sharp"
-    ]
+    ],
+    "patchedDependencies": {
+      "@mariozechner/pi-ai": "patches/@mariozechner__pi-ai.patch"
+    }
   }
 }

--- a/patches/@mariozechner__pi-ai.patch
+++ b/patches/@mariozechner__pi-ai.patch
@@ -1,0 +1,47 @@
+diff --git a/dist/providers/openai-completions.js b/dist/providers/openai-completions.js
+index a41870fb5e57330db135d11f3fbbdde78abc2c99..71cd7b4c63b25327b8364d5efaf3bfb2fbf66eed 100644
+--- a/dist/providers/openai-completions.js
++++ b/dist/providers/openai-completions.js
+@@ -302,7 +302,7 @@ function createClient(model, context, apiKey, optionsHeaders) {
+     }
+     return new OpenAI({
+         apiKey,
+-        baseURL: model.baseUrl,
++        baseURL: model.baseUrl ? (model.baseUrl.endsWith("/") ? model.baseUrl : `${model.baseUrl}/`) : undefined,
+         dangerouslyAllowBrowser: true,
+         defaultHeaders: headers,
+     });
+@@ -525,13 +525,13 @@ export function convertMessages(model, context, compat) {
+                 const reasoningDetails = toolCalls
+                     .filter((tc) => tc.thoughtSignature)
+                     .map((tc) => {
+-                    try {
+-                        return JSON.parse(tc.thoughtSignature);
+-                    }
+-                    catch {
+-                        return null;
+-                    }
+-                })
++                        try {
++                            return JSON.parse(tc.thoughtSignature);
++                        }
++                        catch {
++                            return null;
++                        }
++                    })
+                     .filter(Boolean);
+                 if (reasoningDetails.length > 0) {
+                     assistantMsg.reasoning_details = reasoningDetails;
+diff --git a/dist/providers/openai-responses.js b/dist/providers/openai-responses.js
+index ebb642dc7677906866c7125de98c6c3dd3d43d81..4a7bed58f6e54e5e892c85e9d037cc034b80441e 100644
+--- a/dist/providers/openai-responses.js
++++ b/dist/providers/openai-responses.js
+@@ -122,7 +122,7 @@ function createClient(model, context, apiKey, optionsHeaders) {
+     }
+     return new OpenAI({
+         apiKey,
+-        baseURL: model.baseUrl,
++        baseURL: model.baseUrl ? (model.baseUrl.endsWith("/") ? model.baseUrl : `${model.baseUrl}/`) : undefined,
+         dangerouslyAllowBrowser: true,
+         defaultHeaders: headers,
+     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,11 @@ overrides:
   tar: 7.5.10
   tough-cookie: 4.1.3
 
+patchedDependencies:
+  '@mariozechner/pi-ai':
+    hash: 2887b1293a79de30a27e05d7509b9ba571847028cb6b4c4f7722bf1cf46d4ae1
+    path: patches/@mariozechner__pi-ai.patch
+
 importers:
 
   .:
@@ -57,7 +62,7 @@ importers:
         version: 0.55.3(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai':
         specifier: 0.55.3
-        version: 0.55.3(ws@8.19.0)(zod@4.3.6)
+        version: 0.55.3(patch_hash=2887b1293a79de30a27e05d7509b9ba571847028cb6b4c4f7722bf1cf46d4ae1)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.55.3
         version: 0.55.3(ws@8.19.0)(zod@4.3.6)
@@ -7435,7 +7440,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.55.3(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.55.3(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.3(patch_hash=2887b1293a79de30a27e05d7509b9ba571847028cb6b4c4f7722bf1cf46d4ae1)(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -7445,7 +7450,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.55.3(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.55.3(patch_hash=2887b1293a79de30a27e05d7509b9ba571847028cb6b4c4f7722bf1cf46d4ae1)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.1000.0
@@ -7473,7 +7478,7 @@ snapshots:
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.55.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.55.3(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.3(patch_hash=2887b1293a79de30a27e05d7509b9ba571847028cb6b4c4f7722bf1cf46d4ae1)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.55.3
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -11203,7 +11208,7 @@ snapshots:
       '@line/bot-sdk': 10.6.0
       '@lydell/node-pty': 1.2.0-beta.3
       '@mariozechner/pi-agent-core': 0.55.3(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.55.3(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.55.3(patch_hash=2887b1293a79de30a27e05d7509b9ba571847028cb6b4c4f7722bf1cf46d4ae1)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent': 0.55.3(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.55.3
       '@mozilla/readability': 0.6.0


### PR DESCRIPTION
Ensures the baseURL ends with a trailing slash to prevent relative path mapping from stripping path segments like /v4. Verified with local mock-server testing.
