### PR TITLE
feat(feishu): support form_value in card action handler

### DIFF
--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -39,6 +39,63 @@ describe("Feishu Card Action Handler", () => {
     );
   });
 
+  it("handles card action with form_value (form submit)", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok3",
+      action: {
+        value: { command: "submit-form" },
+        form_value: { field1: "hello", field2: "world" },
+        tag: "button",
+      },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(handleFeishuMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          message: expect.objectContaining({
+            content: expect.stringContaining('"field1":"hello"'),
+            chat_id: "chat1",
+          }),
+        }),
+      }),
+    );
+
+    // Verify the merged object includes both value and form_value fields
+    const call = vi.mocked(handleFeishuMessage).mock.calls.at(-1)![0];
+    const parsed = JSON.parse(JSON.parse(call.event.message.content).text);
+    expect(parsed).toEqual({ command: "submit-form", field1: "hello", field2: "world" });
+  });
+
+  it("handles card action with empty form_value (fallback to value logic)", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok4",
+      action: {
+        value: { command: "simple-click" },
+        form_value: {},
+        tag: "button",
+      },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(handleFeishuMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          message: expect.objectContaining({
+            content: '{"text":"simple-click"}',
+            chat_id: "chat1",
+          }),
+        }),
+      }),
+    );
+  });
+
   it("handles card action with JSON object payload", async () => {
     const event: FeishuCardActionEvent = {
       operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },

--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-action.js";
 
 // Mock resolveFeishuAccount
@@ -16,6 +16,10 @@ import { handleFeishuMessage } from "./bot.js";
 describe("Feishu Card Action Handler", () => {
   const cfg = {} as any; // Minimal mock
   const runtime = { log: vi.fn(), error: vi.fn() } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   it("handles card action with text payload", async () => {
     const event: FeishuCardActionEvent = {
@@ -53,19 +57,9 @@ describe("Feishu Card Action Handler", () => {
 
     await handleFeishuCardAction({ cfg, event, runtime });
 
-    expect(handleFeishuMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event: expect.objectContaining({
-          message: expect.objectContaining({
-            content: expect.stringContaining('"field1":"hello"'),
-            chat_id: "chat1",
-          }),
-        }),
-      }),
-    );
-
     // Verify the merged object includes both value and form_value fields
     const call = vi.mocked(handleFeishuMessage).mock.calls.at(-1)![0];
+    expect(call.event.message.chat_id).toBe("chat1");
     const parsed = JSON.parse(JSON.parse(call.event.message.content).text);
     expect(parsed).toEqual({ command: "submit-form", field1: "hello", field2: "world" });
   });
@@ -106,15 +100,9 @@ describe("Feishu Card Action Handler", () => {
 
     await handleFeishuCardAction({ cfg, event, runtime });
 
-    expect(handleFeishuMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event: expect.objectContaining({
-          message: expect.objectContaining({
-            content: '{"text":"{\\"key\\":\\"val\\"}"}',
-            chat_id: "u123", // Fallback to open_id
-          }),
-        }),
-      }),
-    );
+    const call = vi.mocked(handleFeishuMessage).mock.calls.at(-1)![0];
+    expect(call.event.message.chat_id).toBe("u123"); // Fallback to open_id
+    const parsed = JSON.parse(call.event.message.content);
+    expect(parsed).toEqual({ text: JSON.stringify({ key: "val" }) });
   });
 });

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -11,6 +11,7 @@ export type FeishuCardActionEvent = {
   token: string;
   action: {
     value: Record<string, unknown>;
+    form_value?: Record<string, unknown>;
     tag: string;
   };
   context: {
@@ -31,19 +32,26 @@ export async function handleFeishuCardAction(params: {
   const account = resolveFeishuAccount({ cfg, accountId });
   const log = runtime?.log ?? console.log;
 
-  // Extract action value
+  // Extract action value; merge form_value when present (form submit)
   const actionValue = event.action.value;
+  const formValue = event.action.form_value;
+  const hasFormValue = formValue != null && Object.keys(formValue).length > 0;
+  const mergedValue = hasFormValue ? { ...actionValue, ...formValue } : actionValue;
+
   let content = "";
-  if (typeof actionValue === "object" && actionValue !== null) {
-    if ("text" in actionValue && typeof actionValue.text === "string") {
-      content = actionValue.text;
-    } else if ("command" in actionValue && typeof actionValue.command === "string") {
-      content = actionValue.command;
+  if (typeof mergedValue === "object" && mergedValue !== null) {
+    if (hasFormValue) {
+      // Form submit: serialize the full merged object so the agent receives all fields
+      content = JSON.stringify(mergedValue);
+    } else if ("text" in mergedValue && typeof mergedValue.text === "string") {
+      content = mergedValue.text;
+    } else if ("command" in mergedValue && typeof mergedValue.command === "string") {
+      content = mergedValue.command;
     } else {
-      content = JSON.stringify(actionValue);
+      content = JSON.stringify(mergedValue);
     }
   } else {
-    content = String(actionValue);
+    content = String(mergedValue);
   }
 
   // Construct a synthetic message event


### PR DESCRIPTION
## Summary

- When a Feishu card uses a `form` container with `form_action_type: "submit"`, the user-filled form data is sent in `event.action.form_value` rather than `event.action.value`. The current handler only reads `action.value`, causing form field data to be lost.
- This PR adds `form_value` support: merges it with `value` (form_value takes precedence), and serializes the full merged object when form data is present.
- Fully backward compatible — no behavior change for plain button clicks (without form_value).

## Changes

**`extensions/feishu/src/card-action.ts`**
- Added optional `form_value?: Record<string, unknown>` to `FeishuCardActionEvent.action`
- When `form_value` is present and non-empty, merges it with `value` and serializes the full object
- When `form_value` is absent or empty, falls back to existing `text` / `command` / JSON extraction logic

**`extensions/feishu/src/bot.card-action.test.ts`**
- Added test: form submit with `form_value` — verifies merged object contains both `value` and `form_value` fields
- Added test: empty `form_value` — verifies fallback to original `command` extraction

## Context

Feishu card `form` containers send user-filled data in `event.action.form_value` on submit, while `event.action.value` carries the button's own value. Without this fix, only the button value reaches the agent; with this fix, the agent receives the full merged object including all form fields.

## Test plan

- [x] Existing tests pass (text payload, JSON object payload)
- [x] New test: form_value merged correctly with value
- [x] New test: empty form_value falls back to original behavior
- [x] Verified in production: Feishu form card submit -> OpenClaw receives complete form data
