### PR TITLE
Fix(security-hardening): Security/Media: Strip credential headers on cross-origin redirect in media downloads

### DIFF
--- a/src/media/store.redirect.test.ts
+++ b/src/media/store.redirect.test.ts
@@ -94,6 +94,146 @@ describe("media store redirects", () => {
     expect(stat.mode & 0o777).toBe(expectedMode);
   });
 
+  it("strips all sensitive headers on cross-origin redirect", async () => {
+    const requestCalls: Array<{ url: URL; headers?: Record<string, string> }> = [];
+    mockRequest.mockImplementation((url, opts, cb) => {
+      const parsed = typeof url === "string" ? new URL(url) : (url as URL);
+      requestCalls.push({
+        url: parsed,
+        headers: opts?.headers as Record<string, string> | undefined,
+      });
+
+      const { req, res } = createMockHttpExchange();
+      if (requestCalls.length === 1) {
+        res.statusCode = 302;
+        res.headers = { location: "https://other.example.com/final" };
+        setImmediate(() => {
+          cb(res as unknown);
+          res.end();
+        });
+      } else {
+        res.statusCode = 200;
+        res.headers = { "content-type": "text/plain" };
+        setImmediate(() => {
+          cb(res as unknown);
+          res.write("ok");
+          res.end();
+        });
+      }
+      return req;
+    });
+
+    await saveMediaSource("https://example.com/start", {
+      Authorization: "Bearer secret",
+      "Proxy-Authorization": "Basic cHJveHk=",
+      Cookie: "session=abc",
+      Cookie2: "legacy=1",
+      "X-Custom": "keep",
+    });
+
+    expect(requestCalls).toHaveLength(2);
+
+    const first = requestCalls[0]!.headers!;
+    expect(first["Authorization"]).toBe("Bearer secret");
+    expect(first["Proxy-Authorization"]).toBe("Basic cHJveHk=");
+    expect(first["Cookie"]).toBe("session=abc");
+    expect(first["Cookie2"]).toBe("legacy=1");
+    expect(first["X-Custom"]).toBe("keep");
+
+    const second = requestCalls[1]!.headers!;
+    expect(second["Authorization"]).toBeUndefined();
+    expect(second["Proxy-Authorization"]).toBeUndefined();
+    expect(second["Cookie"]).toBeUndefined();
+    expect(second["Cookie2"]).toBeUndefined();
+    expect(second["X-Custom"]).toBe("keep");
+  });
+
+  it("keeps all headers when redirect stays on same origin", async () => {
+    const requestCalls: Array<{ url: URL; headers?: Record<string, string> }> = [];
+    mockRequest.mockImplementation((url, opts, cb) => {
+      const parsed = typeof url === "string" ? new URL(url) : (url as URL);
+      requestCalls.push({
+        url: parsed,
+        headers: opts?.headers as Record<string, string> | undefined,
+      });
+
+      const { req, res } = createMockHttpExchange();
+      if (requestCalls.length === 1) {
+        res.statusCode = 302;
+        res.headers = { location: "https://example.com/final" };
+        setImmediate(() => {
+          cb(res as unknown);
+          res.end();
+        });
+      } else {
+        res.statusCode = 200;
+        res.headers = { "content-type": "text/plain" };
+        setImmediate(() => {
+          cb(res as unknown);
+          res.write("ok");
+          res.end();
+        });
+      }
+      return req;
+    });
+
+    await saveMediaSource("https://example.com/start", {
+      Authorization: "Bearer token",
+      Cookie: "session=keep",
+    });
+
+    expect(requestCalls).toHaveLength(2);
+    expect(requestCalls[0]!.headers?.["Authorization"]).toBe("Bearer token");
+    expect(requestCalls[0]!.headers?.["Cookie"]).toBe("session=keep");
+    expect(requestCalls[1]!.headers?.["Authorization"]).toBe("Bearer token");
+    expect(requestCalls[1]!.headers?.["Cookie"]).toBe("session=keep");
+  });
+
+  it("keeps headers stripped through a multi-hop chain", async () => {
+    const requestCalls: Array<{ url: URL; headers?: Record<string, string> }> = [];
+    mockRequest.mockImplementation((url, opts, cb) => {
+      const parsed = typeof url === "string" ? new URL(url) : (url as URL);
+      requestCalls.push({
+        url: parsed,
+        headers: opts?.headers as Record<string, string> | undefined,
+      });
+
+      const { req, res } = createMockHttpExchange();
+      const hop = requestCalls.length;
+      if (hop === 1) {
+        // Hop 1: same-origin redirect (headers preserved)
+        res.statusCode = 302;
+        res.headers = { location: "https://example.com/mid" };
+      } else if (hop === 2) {
+        // Hop 2: cross-origin redirect (headers stripped)
+        res.statusCode = 302;
+        res.headers = { location: "https://cdn.other.com/final" };
+      } else {
+        // Hop 3: final response
+        res.statusCode = 200;
+        res.headers = { "content-type": "text/plain" };
+      }
+      setImmediate(() => {
+        cb(res as unknown);
+        if (hop >= 3) res.write("done");
+        res.end();
+      });
+      return req;
+    });
+
+    await saveMediaSource("https://example.com/start", {
+      Authorization: "Bearer secret",
+    });
+
+    expect(requestCalls).toHaveLength(3);
+    // Hop 1: same origin → headers preserved
+    expect(requestCalls[0]!.headers?.["Authorization"]).toBe("Bearer secret");
+    // Hop 2: still same origin from hop 1 → headers still present
+    expect(requestCalls[1]!.headers?.["Authorization"]).toBe("Bearer secret");
+    // Hop 3: was cross-origin from hop 2 → stripped
+    expect(requestCalls[2]!.headers?.["Authorization"]).toBeUndefined();
+  });
+
   it("fails when redirect response omits location header", async () => {
     mockRequest.mockImplementationOnce((_url, _opts, cb) => {
       const { req, res } = createMockHttpExchange();

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -130,6 +130,27 @@ function looksLikeUrl(src: string) {
   return /^https?:\/\//i.test(src);
 }
 
+// Mirror fetch-guard: strip credential headers on cross-origin redirect to prevent leak.
+const CROSS_ORIGIN_SENSITIVE_HEADERS = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "cookie2",
+]);
+
+function stripSensitiveHeadersForRedirect(
+  headers: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!headers || Object.keys(headers).length === 0) return headers;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (!CROSS_ORIGIN_SENSITIVE_HEADERS.has(k.toLowerCase())) {
+      out[k] = v;
+    }
+  }
+  return Object.keys(out).length > 0 ? out : undefined;
+}
+
 /**
  * Download media to disk while capturing the first few KB for mime sniffing.
  */
@@ -163,7 +184,12 @@ async function downloadToFile(
               return;
             }
             const redirectUrl = new URL(location, url).href;
-            resolve(downloadToFile(redirectUrl, dest, headers, maxRedirects - 1));
+            const redirectParsed = new URL(redirectUrl);
+            const isCrossOrigin = redirectParsed.origin !== parsedUrl.origin;
+            const redirectHeaders = isCrossOrigin
+              ? stripSensitiveHeadersForRedirect(headers)
+              : headers;
+            resolve(downloadToFile(redirectUrl, dest, redirectHeaders, maxRedirects - 1));
             return;
           }
           if (!res.statusCode || res.statusCode >= 400) {


### PR DESCRIPTION
# Security/Media: Strip credential headers on cross-origin redirect in media downloads

## Summary

- **Problem:** `downloadToFile` in `src/media/store.ts` forwards all request headers (including `Authorization`, `Cookie`, `Proxy-Authorization`, `Cookie2`) when following HTTP redirects, regardless of whether the redirect target is cross-origin. This can leak credentials to malicious redirect targets.
- **Why it matters:** If a future channel integration passes auth headers to `saveMediaSource` (e.g., for authenticated media URLs), a malicious server could respond with `302` to an attacker-controlled domain and receive the operator's tokens.
- **What changed:** On cross-origin redirects, we now strip the four sensitive headers before following the redirect. Same-origin redirects keep all headers for compatibility.
- **What did NOT change:** Same-origin redirect behavior, SSRF hostname validation, or the `saveMediaSource` API.

## Change Type

- [x] Security hardening

## Scope

- [x] Integrations
- [x] API / contracts

## Linked Issue/PR

- None (defense-in-depth hardening)

## User-visible / Behavior Changes

None for current callers. Future integrations that pass auth headers to `saveMediaSource` will have credentials protected on cross-origin redirects.

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **Yes** — credential headers are now stripped before cross-origin redirect requests
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- **Mitigation:** Aligns with existing `fetchWithSsrFGuard` behavior (see `src/infra/net/fetch-guard.ts`)

## Repro + Verification

### Steps

1. `pnpm install && pnpm test src/media/store.redirect.test.ts`
2. New tests: "strips Authorization and Cookie headers on cross-origin redirect", "keeps Authorization header when redirect stays on same origin"
3. Existing redirect tests remain green

### Expected

- Cross-origin redirect: second request has no `Authorization`/`Cookie`
- Same-origin redirect: headers preserved

## Evidence

- [x] Passing tests (including new cross-origin and same-origin cases)

## Human Verification

- Verified scenarios: mock-based unit tests for cross-origin strip and same-origin preserve
- Edge cases: empty headers, undefined headers, mixed-case header names
- Not verified: live integration with channel-specific auth headers (no current callers)

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No**
- Migration needed? **No**

## Risks and Mitigations

- **Risk:** If a legitimate media source requires auth headers on cross-origin CDN redirects, download could fail.
  - **Mitigation:** Same-origin redirects (e.g., CDN path changes on same host) keep headers. True cross-origin redirects with auth are rare for media; most CDNs serve from same-origin or use signed URLs.
