### PR TITLE
fix(feishu): deliver block-only replies via onIdle fallback

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -202,7 +202,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
-  it("suppresses internal block payload delivery", async () => {
+  it("buffers internal block payloads and flushes on idle when final is missing", async () => {
     createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
@@ -217,6 +217,15 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
     expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
     expect(sendMediaFeishuMock).not.toHaveBeenCalled();
+
+    await options.onIdle?.();
+    expect(sendMessageFeishuMock).toHaveBeenCalledTimes(1);
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "oc_chat",
+        text: "internal reasoning chunk",
+      }),
+    );
   });
 
   it("uses streaming session for auto mode markdown payloads", async () => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -146,6 +146,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   const deliveredFinalTexts = new Set<string>();
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
+  let bufferedBlockText = "";
+  let bufferedBlockLast = "";
+  const bufferedBlockMedia: string[] = [];
+  let sawFinalPayload = false;
   type StreamTextUpdateMode = "snapshot" | "delta";
 
   const queueStreamingUpdate = (
@@ -224,6 +228,100 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     lastPartial = "";
   };
 
+  const resetBufferedBlockFallback = () => {
+    bufferedBlockText = "";
+    bufferedBlockLast = "";
+    bufferedBlockMedia.length = 0;
+  };
+
+  const mergeBufferedBlockText = (nextText: string) => {
+    if (!nextText) {
+      return;
+    }
+    if (!bufferedBlockText) {
+      bufferedBlockText = nextText;
+      bufferedBlockLast = nextText;
+      return;
+    }
+    if (nextText === bufferedBlockLast) {
+      return;
+    }
+    if (nextText.startsWith(bufferedBlockText)) {
+      bufferedBlockText = nextText;
+      bufferedBlockLast = nextText;
+      return;
+    }
+    if (!bufferedBlockText.endsWith(nextText)) {
+      bufferedBlockText += nextText;
+    }
+    bufferedBlockLast = nextText;
+  };
+
+  const sendMediaReplies = async (mediaList: string[]) => {
+    for (const mediaUrl of mediaList) {
+      await sendMediaFeishu({
+        cfg,
+        to: chatId,
+        mediaUrl,
+        replyToMessageId: sendReplyToMessageId,
+        replyInThread: effectiveReplyInThread,
+        accountId,
+      });
+    }
+  };
+
+  const sendTextReply = async (text: string) => {
+    const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
+    let first = true;
+    if (useCard) {
+      for (const chunk of core.channel.text.chunkTextWithMode(text, textChunkLimit, chunkMode)) {
+        await sendMarkdownCardFeishu({
+          cfg,
+          to: chatId,
+          text: chunk,
+          replyToMessageId: sendReplyToMessageId,
+          replyInThread: effectiveReplyInThread,
+          mentions: first ? mentionTargets : undefined,
+          accountId,
+        });
+        first = false;
+      }
+      return;
+    }
+
+    const converted = core.channel.text.convertMarkdownTables(text, tableMode);
+    for (const chunk of core.channel.text.chunkTextWithMode(converted, textChunkLimit, chunkMode)) {
+      await sendMessageFeishu({
+        cfg,
+        to: chatId,
+        text: chunk,
+        replyToMessageId: sendReplyToMessageId,
+        replyInThread: effectiveReplyInThread,
+        mentions: first ? mentionTargets : undefined,
+        accountId,
+      });
+      first = false;
+    }
+  };
+
+  const flushBufferedBlockFallback = async () => {
+    if (sawFinalPayload) {
+      resetBufferedBlockFallback();
+      return;
+    }
+
+    const text = bufferedBlockText;
+    const mediaList = [...bufferedBlockMedia];
+    resetBufferedBlockFallback();
+
+    if (text.trim()) {
+      await sendTextReply(text);
+    }
+    if (mediaList.length > 0) {
+      await sendMediaReplies(mediaList);
+    }
+  };
+
   const { dispatcher, replyOptions, markDispatchIdle } =
     core.channel.reply.createReplyDispatcherWithTyping({
       responsePrefix: prefixContext.responsePrefix,
@@ -231,6 +329,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
       onReplyStart: () => {
         deliveredFinalTexts.clear();
+        sawFinalPayload = false;
+        resetBufferedBlockFallback();
         if (streamingEnabled && renderMode === "card") {
           startStreaming();
         }
@@ -254,6 +354,16 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           return;
         }
 
+        if (info?.kind === "final") {
+          sawFinalPayload = true;
+          resetBufferedBlockFallback();
+        }
+
+        if (info?.kind === "block" && !shouldDeliverText && hasMedia) {
+          bufferedBlockMedia.push(...mediaList);
+          return;
+        }
+
         if (shouldDeliverText) {
           const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
 
@@ -261,6 +371,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             // Drop internal block chunks unless we can safely consume them as
             // streaming-card fallback content.
             if (!(streamingEnabled && useCard)) {
+              mergeBufferedBlockText(text);
+              if (hasMedia) {
+                bufferedBlockMedia.push(...mediaList);
+              }
               return;
             }
             startStreaming();
@@ -289,76 +403,19 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             }
             // Send media even when streaming handled the text
             if (hasMedia) {
-              for (const mediaUrl of mediaList) {
-                await sendMediaFeishu({
-                  cfg,
-                  to: chatId,
-                  mediaUrl,
-                  replyToMessageId: sendReplyToMessageId,
-                  replyInThread: effectiveReplyInThread,
-                  accountId,
-                });
-              }
+              await sendMediaReplies(mediaList);
             }
             return;
           }
 
-          let first = true;
-          if (useCard) {
-            for (const chunk of core.channel.text.chunkTextWithMode(
-              text,
-              textChunkLimit,
-              chunkMode,
-            )) {
-              await sendMarkdownCardFeishu({
-                cfg,
-                to: chatId,
-                text: chunk,
-                replyToMessageId: sendReplyToMessageId,
-                replyInThread: effectiveReplyInThread,
-                mentions: first ? mentionTargets : undefined,
-                accountId,
-              });
-              first = false;
-            }
-            if (info?.kind === "final") {
-              deliveredFinalTexts.add(text);
-            }
-          } else {
-            const converted = core.channel.text.convertMarkdownTables(text, tableMode);
-            for (const chunk of core.channel.text.chunkTextWithMode(
-              converted,
-              textChunkLimit,
-              chunkMode,
-            )) {
-              await sendMessageFeishu({
-                cfg,
-                to: chatId,
-                text: chunk,
-                replyToMessageId: sendReplyToMessageId,
-                replyInThread: effectiveReplyInThread,
-                mentions: first ? mentionTargets : undefined,
-                accountId,
-              });
-              first = false;
-            }
-            if (info?.kind === "final") {
-              deliveredFinalTexts.add(text);
-            }
+          await sendTextReply(text);
+          if (info?.kind === "final") {
+            deliveredFinalTexts.add(text);
           }
         }
 
         if (hasMedia) {
-          for (const mediaUrl of mediaList) {
-            await sendMediaFeishu({
-              cfg,
-              to: chatId,
-              mediaUrl,
-              replyToMessageId: sendReplyToMessageId,
-              replyInThread: effectiveReplyInThread,
-              accountId,
-            });
-          }
+          await sendMediaReplies(mediaList);
         }
       },
       onError: async (error, info) => {
@@ -366,10 +423,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           `feishu[${account.accountId}] ${info.kind} reply failed: ${String(error)}`,
         );
         await closeStreaming();
+        resetBufferedBlockFallback();
+        sawFinalPayload = false;
         typingCallbacks.onIdle?.();
       },
       onIdle: async () => {
         await closeStreaming();
+        await flushBufferedBlockFallback();
+        sawFinalPayload = false;
         typingCallbacks.onIdle?.();
       },
       onCleanup: () => {


### PR DESCRIPTION
## Summary

Feishu currently drops non-card `block` payloads in `reply-dispatcher`, which can cause DM replies to disappear when a model emits block-only output and no final payload.

This change buffers dropped block payloads and flushes them on `onIdle` if no final payload was seen.

Closes #36033.

## Root Cause

In `extensions/feishu/src/reply-dispatcher.ts`, block payloads were returned early when `!(streamingEnabled && useCard)`.
When the model/runtime produced only block content for a turn, nothing was sent back to Feishu.

## Changes

- Add buffered fallback for block payloads (text + media).
- Flush buffered block content on `onIdle` when no final payload was observed.
- Keep existing streaming/card behavior unchanged for normal final flows.
- Reset fallback state on reply start/error/idle boundaries.

## Test

- Updated `reply-dispatcher` test to verify block payloads are flushed on idle when final is missing.
- Ran:

```bash
npx vitest run extensions/feishu/src/reply-dispatcher.test.ts
```

Result: 1 file passed, 21 tests passed.
