### PR TITLE
fix: ignore empty string for legacy to/channelId params [AI-assisted]

### DIFF
--- a/src/infra/outbound/channel-target.ts
+++ b/src/infra/outbound/channel-target.ts
@@ -11,8 +11,9 @@ export function applyTargetToParams(params: {
   args: Record<string, unknown>;
 }): void {
   const target = typeof params.args.target === "string" ? params.args.target.trim() : "";
-  const hasLegacyTo = typeof params.args.to === "string";
-  const hasLegacyChannelId = typeof params.args.channelId === "string";
+  const hasLegacyTo = typeof params.args.to === "string" && params.args.to.trim() !== "";
+  const hasLegacyChannelId =
+    typeof params.args.channelId === "string" && params.args.channelId.trim() !== "";
   const mode =
     MESSAGE_ACTION_TARGET_MODE[params.action as keyof typeof MESSAGE_ACTION_TARGET_MODE] ?? "none";
 


### PR DESCRIPTION
## Summary

- **Problem:** When `channelId` is passed as an empty string `""`, the `applyTargetToParams` function incorrectly treats it as a legacy parameter and throws `Use target instead of to/channelId`, even when `target` is correctly provided.
- **Why it matters:** Any caller that passes `channelId: ""` alongside a valid `target` gets a false error, blocking the message action.
- **What changed:** Added `.trim() !== ""` check to `hasLegacyTo` and `hasLegacyChannelId` so empty/whitespace-only strings are treated as absent.
- **What did NOT change (scope boundary):** No changes to target resolution logic, action routing, or any other parameter handling.

## Change Type

- [x] Bug fix

## Scope

- [x] Gateway / orchestration
- [x] API / contracts

## User-visible / Behavior Changes

Passing `channelId: ""` or `to: ""` alongside a valid `target` no longer throws an error. Previously this was a runtime error.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Call the `message` tool with `target: "some-channel-id"` and `channelId: ""`
2. Observe error: `Use target instead of to/channelId.`

### Expected

Empty `channelId` should be ignored; action should proceed using `target`.

### Actual

Throws error because `typeof \"\" === \"string\"` is `true`.

## Evidence

- [x] Trace/log snippets: Error message reproduced in Discord bot session

## Human Verification

- Verified: Applied fix to local dist files, restarted gateway, confirmed the error no longer occurs with `channelId: ""`
- Edge cases: Checked that non-empty `channelId` still correctly triggers the legacy parameter error
- Not verified: Full CI suite (7 pre-existing test failures unrelated to this change)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- Revert this single commit
- No config changes needed

## Risks and Mitigations

None — strictly loosens a false-positive validation check.

---

🤖 **AI-assisted:** Fix identified and implemented by an OpenClaw agent (码哥/coder). Lightly tested on live instance. Prompts available on request.