### PR TITLE
Telegram: reject malformed replyToId values

### DIFF
--- a/src/telegram/outbound-params.test.ts
+++ b/src/telegram/outbound-params.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { parseTelegramReplyToMessageId, parseTelegramThreadId } from "./outbound-params.js";
+
+describe("parseTelegramReplyToMessageId", () => {
+  it("parses positive numeric strings", () => {
+    expect(parseTelegramReplyToMessageId("44")).toBe(44);
+    expect(parseTelegramReplyToMessageId(" 55 ")).toBe(55);
+  });
+
+  it("returns undefined for empty or invalid values", () => {
+    expect(parseTelegramReplyToMessageId(undefined)).toBeUndefined();
+    expect(parseTelegramReplyToMessageId(null)).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId(" ")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("0")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("-1")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("44abc")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("abc44")).toBeUndefined();
+    expect(parseTelegramReplyToMessageId("4.4")).toBeUndefined();
+  });
+});
+
+describe("parseTelegramThreadId", () => {
+  it("parses plain and scoped thread ids", () => {
+    expect(parseTelegramThreadId("55")).toBe(55);
+    expect(parseTelegramThreadId("12345:99")).toBe(99);
+  });
+
+  it("returns undefined for malformed scoped ids", () => {
+    expect(parseTelegramThreadId("12345:abc")).toBeUndefined();
+    expect(parseTelegramThreadId("abc:99")).toBeUndefined();
+    expect(parseTelegramThreadId("12345:")).toBeUndefined();
+  });
+});

--- a/src/telegram/outbound-params.ts
+++ b/src/telegram/outbound-params.ts
@@ -2,8 +2,12 @@ export function parseTelegramReplyToMessageId(replyToId?: string | null): number
   if (!replyToId) {
     return undefined;
   }
-  const parsed = Number.parseInt(replyToId, 10);
-  return Number.isFinite(parsed) ? parsed : undefined;
+  const trimmed = replyToId.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return undefined;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
 }
 
 function parseIntegerId(value: string): number | undefined {


### PR DESCRIPTION
## Summary
Tightens Telegram outbound reply-id parsing so malformed `replyToId` values are not silently coerced by `parseInt`.

## Changes
- `parseTelegramReplyToMessageId` now trims input, requires a full numeric string, and only accepts positive safe integers.
- Add `src/telegram/outbound-params.test.ts` with coverage for valid/invalid reply ids and baseline thread-id parsing.

## Why
Previously `parseInt("44abc", 10)` would produce `44`, which could set `reply_to_message_id` unexpectedly. This change fails closed and leaves reply id unset when malformed.

## Testing
- `pnpm vitest run src/telegram/outbound-params.test.ts src/channels/plugins/outbound/telegram.test.ts`
- `pnpm check`
