### PR TITLE
CLI: make parsePort strict

### DIFF
--- a/src/cli/shared/parse-port.test.ts
+++ b/src/cli/shared/parse-port.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { parsePort } from "./parse-port.js";
+
+describe("parsePort", () => {
+  it.each([
+    { raw: undefined, expected: null },
+    { raw: null, expected: null },
+    { raw: "", expected: null },
+    { raw: " ", expected: null },
+    { raw: "0", expected: null },
+    { raw: "-1", expected: null },
+    { raw: "1", expected: 1 },
+    { raw: " 443 ", expected: 443 },
+    { raw: 443, expected: 443 },
+    { raw: "65535", expected: 65535 },
+    { raw: "65536", expected: null },
+    { raw: "22abc", expected: null },
+    { raw: "22.2", expected: null },
+    { raw: "abc22", expected: null },
+  ])("parses %j", ({ raw, expected }) => {
+    expect(parsePort(raw)).toBe(expected);
+  });
+
+  it("accepts bigint ports", () => {
+    expect(parsePort(443n)).toBe(443);
+  });
+});

--- a/src/cli/shared/parse-port.ts
+++ b/src/cli/shared/parse-port.ts
@@ -11,8 +11,12 @@ export function parsePort(raw: unknown): number | null {
   if (value === null) {
     return null;
   }
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) {
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) {
+    return null;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0 || parsed > 65535) {
     return null;
   }
   return parsed;


### PR DESCRIPTION
## Summary
Make CLI port parsing strict to avoid silently accepting malformed inputs.

## Changes
- `parsePort` now:
  - trims string inputs,
  - requires the full string to be digits (`^\d+$`),
  - enforces `1..65535` and `Number.isSafeInteger`.
- Add `src/cli/shared/parse-port.test.ts` coverage for valid/invalid cases.

## Why
`Number.parseInt("18789foo", 10)` previously returned `18789`, which could cause unexpected behavior when users pass malformed values to `--port` flags.

## Testing
- `pnpm vitest run src/cli/shared/parse-port.test.ts`
- `pnpm check`
