### PR TITLE
feat(gateway): resume inflight agent runs after gateway restart

### DIFF
--- a/src/agents/openclaw-gateway-tool.test.ts
+++ b/src/agents/openclaw-gateway-tool.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { __testing as restartTesting } from "../infra/restart.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import "./test-helpers/fast-core-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
@@ -37,10 +38,17 @@ vi.mock("./tools/gateway.js", () => ({
   readGatewayCallOptions: vi.fn(() => ({})),
 }));
 
-function requireGatewayTool(agentSessionKey?: string) {
+function requireGatewayTool(params?: {
+  agentSessionKey?: string;
+  config?: Record<string, unknown>;
+}) {
+  const cfg = {
+    commands: { restart: true },
+    ...params?.config,
+  };
   const tool = createOpenClawTools({
-    ...(agentSessionKey ? { agentSessionKey } : {}),
-    config: { commands: { restart: true } },
+    ...(params?.agentSessionKey ? { agentSessionKey: params.agentSessionKey } : {}),
+    config: cfg,
   }).find((candidate) => candidate.name === "gateway");
   expect(tool).toBeDefined();
   if (!tool) {
@@ -72,6 +80,10 @@ function expectConfigMutationCall(params: {
 }
 
 describe("gateway tool", () => {
+  beforeEach(() => {
+    restartTesting.resetSigusr1State();
+  });
+
   it("marks gateway as owner-only", async () => {
     const tool = requireGatewayTool();
     expect(tool.ownerOnly).toBe(true);
@@ -124,7 +136,7 @@ describe("gateway tool", () => {
   it("passes config.apply through gateway call", async () => {
     const { callGatewayTool } = await import("./tools/gateway.js");
     const sessionKey = "agent:main:whatsapp:dm:+15555550123";
-    const tool = requireGatewayTool(sessionKey);
+    const tool = requireGatewayTool({ agentSessionKey: sessionKey });
 
     const raw = '{\n  agents: { defaults: { workspace: "~/openclaw" } }\n}\n';
     await tool.execute("call2", {
@@ -143,7 +155,7 @@ describe("gateway tool", () => {
   it("passes config.patch through gateway call", async () => {
     const { callGatewayTool } = await import("./tools/gateway.js");
     const sessionKey = "agent:main:whatsapp:dm:+15555550123";
-    const tool = requireGatewayTool(sessionKey);
+    const tool = requireGatewayTool({ agentSessionKey: sessionKey });
 
     const raw = '{\n  channels: { telegram: { groups: { "*": { requireMention: false } } } }\n}\n';
     await tool.execute("call4", {
@@ -162,7 +174,7 @@ describe("gateway tool", () => {
   it("passes update.run through gateway call", async () => {
     const { callGatewayTool } = await import("./tools/gateway.js");
     const sessionKey = "agent:main:whatsapp:dm:+15555550123";
-    const tool = requireGatewayTool(sessionKey);
+    const tool = requireGatewayTool({ agentSessionKey: sessionKey });
 
     await tool.execute("call3", {
       action: "update.run",
@@ -218,5 +230,77 @@ describe("gateway tool", () => {
     const schema = (result.details as { result?: { schema?: { properties?: unknown } } }).result
       ?.schema;
     expect(schema?.properties).toBeUndefined();
+  });
+
+  it("uses zero-delay restart by default when inflight resume is enabled", async () => {
+    vi.useFakeTimers();
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+
+    try {
+      await withEnvAsync(
+        { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_PROFILE: "isolated" },
+        async () => {
+          const tool = requireGatewayTool({
+            config: {
+              gateway: {
+                restartRecovery: {
+                  resumeInflightAgentRuns: true,
+                },
+              },
+            },
+          });
+
+          const result = await tool.execute("call-restart-default-resume-on", {
+            action: "restart",
+          });
+          expect(result.details).toMatchObject({
+            ok: true,
+            pid: process.pid,
+            signal: "SIGUSR1",
+            delayMs: 0,
+          });
+
+          await vi.runAllTimersAsync();
+        },
+      );
+    } finally {
+      kill.mockRestore();
+      vi.useRealTimers();
+      await fs.rm(stateDir, { recursive: true, force: true });
+      restartTesting.resetSigusr1State();
+    }
+  });
+
+  it("keeps default restart delay when inflight resume is disabled", async () => {
+    vi.useFakeTimers();
+    const kill = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+
+    try {
+      await withEnvAsync(
+        { OPENCLAW_STATE_DIR: stateDir, OPENCLAW_PROFILE: "isolated" },
+        async () => {
+          const tool = requireGatewayTool();
+
+          const result = await tool.execute("call-restart-default-resume-off", {
+            action: "restart",
+          });
+          expect(result.details).toMatchObject({
+            ok: true,
+            pid: process.pid,
+            signal: "SIGUSR1",
+            delayMs: 2000,
+          });
+
+          await vi.runAllTimersAsync();
+        },
+      );
+    } finally {
+      kill.mockRestore();
+      vi.useRealTimers();
+      await fs.rm(stateDir, { recursive: true, force: true });
+      restartTesting.resetSigusr1State();
+    }
   });
 });

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -18,6 +18,19 @@ type EmbeddedRunWaiter = {
 };
 const EMBEDDED_RUN_WAITERS = new Map<string, Set<EmbeddedRunWaiter>>();
 
+function resolveAndClearEmbeddedRunWaiters(ended: boolean) {
+  if (EMBEDDED_RUN_WAITERS.size === 0) {
+    return;
+  }
+  for (const [, waiters] of EMBEDDED_RUN_WAITERS) {
+    for (const waiter of waiters) {
+      clearTimeout(waiter.timer);
+      waiter.resolve(ended);
+    }
+  }
+  EMBEDDED_RUN_WAITERS.clear();
+}
+
 export function queueEmbeddedPiMessage(sessionId: string, text: string): boolean {
   const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
   if (!handle) {
@@ -247,5 +260,15 @@ export const __testing = {
     ACTIVE_EMBEDDED_RUNS.clear();
   },
 };
+
+/**
+ * Clear in-memory embedded run tracking during in-process gateway restart.
+ * This prevents stale active-run bookkeeping from a torn-down lifecycle from
+ * leaking into the next startup iteration.
+ */
+export function resetEmbeddedRunTrackingForRestart(): void {
+  ACTIVE_EMBEDDED_RUNS.clear();
+  resolveAndClearEmbeddedRunWaiters(false);
+}
 
 export type { EmbeddedPiQueueHandle };

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -89,10 +89,15 @@ export function createGatewayTool(opts?: {
           typeof params.sessionKey === "string" && params.sessionKey.trim()
             ? params.sessionKey.trim()
             : opts?.agentSessionKey?.trim() || undefined;
-        const delayMs =
+        const explicitDelayMs =
           typeof params.delayMs === "number" && Number.isFinite(params.delayMs)
             ? Math.floor(params.delayMs)
             : undefined;
+        const delayMs =
+          explicitDelayMs ??
+          (opts?.config?.gateway?.restartRecovery?.resumeInflightAgentRuns === true
+            ? 0
+            : undefined);
         const reason =
           typeof params.reason === "string" && params.reason.trim()
             ? params.reason.trim().slice(0, 200)

--- a/src/agents/tools/gateway-tool.ts
+++ b/src/agents/tools/gateway-tool.ts
@@ -3,6 +3,7 @@ import { isRestartEnabled } from "../../config/commands.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { resolveConfigSnapshotHash } from "../../config/io.js";
 import { extractDeliveryInfo } from "../../config/sessions.js";
+import { isInflightAgentRunRecoveryEnabled } from "../../gateway/inflight-agent-runs.js";
 import {
   formatDoctorNonInteractiveHint,
   type RestartSentinelPayload,
@@ -95,9 +96,7 @@ export function createGatewayTool(opts?: {
             : undefined;
         const delayMs =
           explicitDelayMs ??
-          (opts?.config?.gateway?.restartRecovery?.resumeInflightAgentRuns === true
-            ? 0
-            : undefined);
+          (opts?.config && isInflightAgentRunRecoveryEnabled(opts.config) ? 0 : undefined);
         const reason =
           typeof params.reason === "string" && params.reason.trim()
             ? params.reason.trim().slice(0, 200)

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -13,12 +13,14 @@ import {
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
 import { runEmbeddedPiAgent } from "../../agents/pi-embedded.js";
+import type { AgentCommandIngressOpts } from "../../commands/agent/types.js";
 import {
   resolveGroupSessionKey,
   resolveSessionTranscriptPath,
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import { addInflightAgentRun, removeInflightAgentRun } from "../../gateway/inflight-agent-runs.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -71,6 +73,48 @@ export type AgentRunLoopResult =
       directlySentBlockKeys?: Set<string>;
     }
   | { kind: "final"; payload: ReplyPayload };
+
+function buildInflightResumeOpts(params: {
+  commandBody: string;
+  followupRun: FollowupRun;
+  sessionCtx: TemplateContext;
+  runId: string;
+}): AgentCommandIngressOpts {
+  const run = params.followupRun.run;
+  const channel = resolveMessageChannel(params.followupRun.originatingChannel, run.messageProvider);
+  const to =
+    params.followupRun.originatingTo?.trim() ||
+    params.sessionCtx.OriginatingTo?.trim() ||
+    params.sessionCtx.To?.trim() ||
+    undefined;
+  const accountId =
+    params.followupRun.originatingAccountId ??
+    run.agentAccountId ??
+    params.sessionCtx.AccountId?.trim() ??
+    undefined;
+  const threadId =
+    params.followupRun.originatingThreadId ?? params.sessionCtx.MessageThreadId ?? undefined;
+  return {
+    message: params.commandBody,
+    agentId: run.agentId,
+    to,
+    sessionId: run.sessionId,
+    sessionKey: run.sessionKey,
+    deliver: Boolean(channel && to),
+    channel,
+    accountId,
+    threadId,
+    messageChannel: channel ?? run.messageProvider,
+    groupId: run.groupId,
+    groupChannel: run.groupChannel,
+    groupSpace: run.groupSpace,
+    bestEffortDeliver: true,
+    timeout: String(run.timeoutMs),
+    runId: params.runId,
+    extraSystemPrompt: run.extraSystemPrompt,
+    senderIsOwner: run.senderIsOwner ?? true,
+  };
+}
 
 export async function runAgentTurnWithFallback(params: {
   commandBody: string;
@@ -142,156 +186,163 @@ export async function runAgentTurnWithFallback(params: {
   let bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
     params.getActiveSessionEntry()?.systemPromptReport,
   );
-
-  while (true) {
+  const shouldPersistInflight =
+    params.followupRun.run.config.gateway?.restartRecovery?.resumeInflightAgentRuns === true &&
+    !params.isHeartbeat;
+  let didPersistInflight = false;
+  if (shouldPersistInflight) {
+    const opts = buildInflightResumeOpts({
+      commandBody: params.commandBody,
+      followupRun: params.followupRun,
+      sessionCtx: params.sessionCtx,
+      runId,
+    });
     try {
-      const normalizeStreamingText = (payload: ReplyPayload): { text?: string; skip: boolean } => {
-        let text = payload.text;
-        if (!params.isHeartbeat && text?.includes("HEARTBEAT_OK")) {
-          const stripped = stripHeartbeatToken(text, {
-            mode: "message",
-          });
-          if (stripped.didStrip && !didLogHeartbeatStrip) {
-            didLogHeartbeatStrip = true;
-            logVerbose("Stripped stray HEARTBEAT_OK token from reply");
+      await addInflightAgentRun({ runId, acceptedAt: Date.now(), opts });
+      didPersistInflight = true;
+    } catch {
+      // best-effort persistence
+    }
+  }
+
+  try {
+    while (true) {
+      try {
+        const normalizeStreamingText = (
+          payload: ReplyPayload,
+        ): { text?: string; skip: boolean } => {
+          let text = payload.text;
+          if (!params.isHeartbeat && text?.includes("HEARTBEAT_OK")) {
+            const stripped = stripHeartbeatToken(text, {
+              mode: "message",
+            });
+            if (stripped.didStrip && !didLogHeartbeatStrip) {
+              didLogHeartbeatStrip = true;
+              logVerbose("Stripped stray HEARTBEAT_OK token from reply");
+            }
+            if (stripped.shouldSkip && (payload.mediaUrls?.length ?? 0) === 0) {
+              return { skip: true };
+            }
+            text = stripped.text;
           }
-          if (stripped.shouldSkip && (payload.mediaUrls?.length ?? 0) === 0) {
+          if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
             return { skip: true };
           }
-          text = stripped.text;
-        }
-        if (isSilentReplyText(text, SILENT_REPLY_TOKEN)) {
-          return { skip: true };
-        }
-        if (
-          isSilentReplyPrefixText(text, SILENT_REPLY_TOKEN) ||
-          isSilentReplyPrefixText(text, HEARTBEAT_TOKEN)
-        ) {
-          return { skip: true };
-        }
-        if (!text) {
-          // Allow media-only payloads (e.g. tool result screenshots) through.
-          if ((payload.mediaUrls?.length ?? 0) > 0) {
-            return { text: undefined, skip: false };
+          if (
+            isSilentReplyPrefixText(text, SILENT_REPLY_TOKEN) ||
+            isSilentReplyPrefixText(text, HEARTBEAT_TOKEN)
+          ) {
+            return { skip: true };
           }
-          return { skip: true };
-        }
-        const sanitized = sanitizeUserFacingText(text, {
-          errorContext: Boolean(payload.isError),
-        });
-        if (!sanitized.trim()) {
-          return { skip: true };
-        }
-        return { text: sanitized, skip: false };
-      };
-      const handlePartialForTyping = async (payload: ReplyPayload): Promise<string | undefined> => {
-        if (isSilentReplyPrefixText(payload.text, SILENT_REPLY_TOKEN)) {
-          return undefined;
-        }
-        const { text, skip } = normalizeStreamingText(payload);
-        if (skip || !text) {
-          return undefined;
-        }
-        await params.typingSignals.signalTextDelta(text);
-        return text;
-      };
-      const blockReplyPipeline = params.blockReplyPipeline;
-      const onToolResult = params.opts?.onToolResult;
-      const fallbackResult = await runWithModelFallback({
-        ...resolveModelFallbackOptions(params.followupRun.run),
-        runId,
-        run: (provider, model, runOptions) => {
-          // Notify that model selection is complete (including after fallback).
-          // This allows responsePrefix template interpolation with the actual model.
-          params.opts?.onModelSelected?.({
-            provider,
-            model,
-            thinkLevel: params.followupRun.run.thinkLevel,
+          if (!text) {
+            // Allow media-only payloads (e.g. tool result screenshots) through.
+            if ((payload.mediaUrls?.length ?? 0) > 0) {
+              return { text: undefined, skip: false };
+            }
+            return { skip: true };
+          }
+          const sanitized = sanitizeUserFacingText(text, {
+            errorContext: Boolean(payload.isError),
           });
-
-          if (isCliProvider(provider, params.followupRun.run.config)) {
-            const startedAt = Date.now();
-            notifyAgentRunStart();
-            emitAgentEvent({
-              runId,
-              stream: "lifecycle",
-              data: {
-                phase: "start",
-                startedAt,
-              },
+          if (!sanitized.trim()) {
+            return { skip: true };
+          }
+          return { text: sanitized, skip: false };
+        };
+        const handlePartialForTyping = async (
+          payload: ReplyPayload,
+        ): Promise<string | undefined> => {
+          if (isSilentReplyPrefixText(payload.text, SILENT_REPLY_TOKEN)) {
+            return undefined;
+          }
+          const { text, skip } = normalizeStreamingText(payload);
+          if (skip || !text) {
+            return undefined;
+          }
+          await params.typingSignals.signalTextDelta(text);
+          return text;
+        };
+        const blockReplyPipeline = params.blockReplyPipeline;
+        const onToolResult = params.opts?.onToolResult;
+        const fallbackResult = await runWithModelFallback({
+          ...resolveModelFallbackOptions(params.followupRun.run),
+          runId,
+          run: (provider, model, runOptions) => {
+            // Notify that model selection is complete (including after fallback).
+            // This allows responsePrefix template interpolation with the actual model.
+            params.opts?.onModelSelected?.({
+              provider,
+              model,
+              thinkLevel: params.followupRun.run.thinkLevel,
             });
-            const cliSessionId = getCliSessionId(params.getActiveSessionEntry(), provider);
-            return (async () => {
-              let lifecycleTerminalEmitted = false;
-              try {
-                const result = await runCliAgent({
-                  sessionId: params.followupRun.run.sessionId,
-                  sessionKey: params.sessionKey,
-                  agentId: params.followupRun.run.agentId,
-                  sessionFile: params.followupRun.run.sessionFile,
-                  workspaceDir: params.followupRun.run.workspaceDir,
-                  config: params.followupRun.run.config,
-                  prompt: params.commandBody,
-                  provider,
-                  model,
-                  thinkLevel: params.followupRun.run.thinkLevel,
-                  timeoutMs: params.followupRun.run.timeoutMs,
-                  runId,
-                  extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
-                  ownerNumbers: params.followupRun.run.ownerNumbers,
-                  cliSessionId,
-                  bootstrapPromptWarningSignaturesSeen,
-                  bootstrapPromptWarningSignature:
-                    bootstrapPromptWarningSignaturesSeen[
-                      bootstrapPromptWarningSignaturesSeen.length - 1
-                    ],
-                  images: params.opts?.images,
-                });
-                bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-                  result.meta?.systemPromptReport,
-                );
 
-                // CLI backends don't emit streaming assistant events, so we need to
-                // emit one with the final text so server-chat can populate its buffer
-                // and send the response to TUI/WebSocket clients.
-                const cliText = result.payloads?.[0]?.text?.trim();
-                if (cliText) {
+            if (isCliProvider(provider, params.followupRun.run.config)) {
+              const startedAt = Date.now();
+              notifyAgentRunStart();
+              emitAgentEvent({
+                runId,
+                stream: "lifecycle",
+                data: {
+                  phase: "start",
+                  startedAt,
+                },
+              });
+              const cliSessionId = getCliSessionId(params.getActiveSessionEntry(), provider);
+              return (async () => {
+                let lifecycleTerminalEmitted = false;
+                try {
+                  const result = await runCliAgent({
+                    sessionId: params.followupRun.run.sessionId,
+                    sessionKey: params.sessionKey,
+                    agentId: params.followupRun.run.agentId,
+                    sessionFile: params.followupRun.run.sessionFile,
+                    workspaceDir: params.followupRun.run.workspaceDir,
+                    config: params.followupRun.run.config,
+                    prompt: params.commandBody,
+                    provider,
+                    model,
+                    thinkLevel: params.followupRun.run.thinkLevel,
+                    timeoutMs: params.followupRun.run.timeoutMs,
+                    runId,
+                    extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+                    ownerNumbers: params.followupRun.run.ownerNumbers,
+                    cliSessionId,
+                    bootstrapPromptWarningSignaturesSeen,
+                    bootstrapPromptWarningSignature:
+                      bootstrapPromptWarningSignaturesSeen[
+                        bootstrapPromptWarningSignaturesSeen.length - 1
+                      ],
+                    images: params.opts?.images,
+                  });
+                  bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
+                    result.meta?.systemPromptReport,
+                  );
+
+                  // CLI backends don't emit streaming assistant events, so we need to
+                  // emit one with the final text so server-chat can populate its buffer
+                  // and send the response to TUI/WebSocket clients.
+                  const cliText = result.payloads?.[0]?.text?.trim();
+                  if (cliText) {
+                    emitAgentEvent({
+                      runId,
+                      stream: "assistant",
+                      data: { text: cliText },
+                    });
+                  }
+
                   emitAgentEvent({
                     runId,
-                    stream: "assistant",
-                    data: { text: cliText },
+                    stream: "lifecycle",
+                    data: {
+                      phase: "end",
+                      startedAt,
+                      endedAt: Date.now(),
+                    },
                   });
-                }
+                  lifecycleTerminalEmitted = true;
 
-                emitAgentEvent({
-                  runId,
-                  stream: "lifecycle",
-                  data: {
-                    phase: "end",
-                    startedAt,
-                    endedAt: Date.now(),
-                  },
-                });
-                lifecycleTerminalEmitted = true;
-
-                return result;
-              } catch (err) {
-                emitAgentEvent({
-                  runId,
-                  stream: "lifecycle",
-                  data: {
-                    phase: "error",
-                    startedAt,
-                    endedAt: Date.now(),
-                    error: String(err),
-                  },
-                });
-                lifecycleTerminalEmitted = true;
-                throw err;
-              } finally {
-                // Defensive backstop: never let a CLI run complete without a terminal
-                // lifecycle event, otherwise downstream consumers can hang.
-                if (!lifecycleTerminalEmitted) {
+                  return result;
+                } catch (err) {
                   emitAgentEvent({
                     runId,
                     stream: "lifecycle",
@@ -299,357 +350,386 @@ export async function runAgentTurnWithFallback(params: {
                       phase: "error",
                       startedAt,
                       endedAt: Date.now(),
-                      error: "CLI run completed without lifecycle terminal event",
+                      error: String(err),
                     },
                   });
-                }
-              }
-            })();
-          }
-          const { authProfile, embeddedContext, senderContext } = buildEmbeddedRunContexts({
-            run: params.followupRun.run,
-            sessionCtx: params.sessionCtx,
-            hasRepliedRef: params.opts?.hasRepliedRef,
-            provider,
-          });
-          const runBaseParams = buildEmbeddedRunBaseParams({
-            run: params.followupRun.run,
-            provider,
-            model,
-            runId,
-            authProfile,
-            allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
-          });
-          return (async () => {
-            const result = await runEmbeddedPiAgent({
-              ...embeddedContext,
-              trigger: params.isHeartbeat ? "heartbeat" : "user",
-              groupId: resolveGroupSessionKey(params.sessionCtx)?.id,
-              groupChannel:
-                params.sessionCtx.GroupChannel?.trim() ?? params.sessionCtx.GroupSubject?.trim(),
-              groupSpace: params.sessionCtx.GroupSpace?.trim() ?? undefined,
-              ...senderContext,
-              ...runBaseParams,
-              prompt: params.commandBody,
-              extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
-              toolResultFormat: (() => {
-                const channel = resolveMessageChannel(
-                  params.sessionCtx.Surface,
-                  params.sessionCtx.Provider,
-                );
-                if (!channel) {
-                  return "markdown";
-                }
-                return isMarkdownCapableMessageChannel(channel) ? "markdown" : "plain";
-              })(),
-              suppressToolErrorWarnings: params.opts?.suppressToolErrorWarnings,
-              bootstrapContextMode: params.opts?.bootstrapContextMode,
-              bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
-              images: params.opts?.images,
-              abortSignal: params.opts?.abortSignal,
-              blockReplyBreak: params.resolvedBlockStreamingBreak,
-              blockReplyChunking: params.blockReplyChunking,
-              onPartialReply: async (payload) => {
-                const textForTyping = await handlePartialForTyping(payload);
-                if (!params.opts?.onPartialReply || textForTyping === undefined) {
-                  return;
-                }
-                await params.opts.onPartialReply({
-                  text: textForTyping,
-                  mediaUrls: payload.mediaUrls,
-                });
-              },
-              onAssistantMessageStart: async () => {
-                await params.typingSignals.signalMessageStart();
-                await params.opts?.onAssistantMessageStart?.();
-              },
-              onReasoningStream:
-                params.typingSignals.shouldStartOnReasoning || params.opts?.onReasoningStream
-                  ? async (payload) => {
-                      await params.typingSignals.signalReasoningDelta();
-                      await params.opts?.onReasoningStream?.({
-                        text: payload.text,
-                        mediaUrls: payload.mediaUrls,
-                      });
-                    }
-                  : undefined,
-              onReasoningEnd: params.opts?.onReasoningEnd,
-              onAgentEvent: async (evt) => {
-                // Signal run start only after the embedded agent emits real activity.
-                const hasLifecyclePhase =
-                  evt.stream === "lifecycle" && typeof evt.data.phase === "string";
-                if (evt.stream !== "lifecycle" || hasLifecyclePhase) {
-                  notifyAgentRunStart();
-                }
-                // Trigger typing when tools start executing.
-                // Must await to ensure typing indicator starts before tool summaries are emitted.
-                if (evt.stream === "tool") {
-                  const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
-                  const name = typeof evt.data.name === "string" ? evt.data.name : undefined;
-                  if (phase === "start" || phase === "update") {
-                    await params.typingSignals.signalToolStart();
-                    await params.opts?.onToolStart?.({ name, phase });
+                  lifecycleTerminalEmitted = true;
+                  throw err;
+                } finally {
+                  // Defensive backstop: never let a CLI run complete without a terminal
+                  // lifecycle event, otherwise downstream consumers can hang.
+                  if (!lifecycleTerminalEmitted) {
+                    emitAgentEvent({
+                      runId,
+                      stream: "lifecycle",
+                      data: {
+                        phase: "error",
+                        startedAt,
+                        endedAt: Date.now(),
+                        error: "CLI run completed without lifecycle terminal event",
+                      },
+                    });
                   }
                 }
-                // Track auto-compaction completion
-                if (evt.stream === "compaction") {
-                  const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
-                  if (phase === "end") {
-                    autoCompactionCompleted = true;
-                  }
-                }
-              },
-              // Always pass onBlockReply so flushBlockReplyBuffer works before tool execution,
-              // even when regular block streaming is disabled. The handler sends directly
-              // via opts.onBlockReply when the pipeline isn't available.
-              onBlockReply: params.opts?.onBlockReply
-                ? createBlockReplyDeliveryHandler({
-                    onBlockReply: params.opts.onBlockReply,
-                    currentMessageId:
-                      params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid,
-                    normalizeStreamingText,
-                    applyReplyToMode: params.applyReplyToMode,
-                    normalizeMediaPaths: normalizeReplyMediaPaths,
-                    typingSignals: params.typingSignals,
-                    blockStreamingEnabled: params.blockStreamingEnabled,
-                    blockReplyPipeline,
-                    directlySentBlockKeys,
-                  })
-                : undefined,
-              onBlockReplyFlush:
-                params.blockStreamingEnabled && blockReplyPipeline
-                  ? async () => {
-                      await blockReplyPipeline.flush({ force: true });
-                    }
-                  : undefined,
-              shouldEmitToolResult: params.shouldEmitToolResult,
-              shouldEmitToolOutput: params.shouldEmitToolOutput,
-              bootstrapPromptWarningSignaturesSeen,
-              bootstrapPromptWarningSignature:
-                bootstrapPromptWarningSignaturesSeen[
-                  bootstrapPromptWarningSignaturesSeen.length - 1
-                ],
-              onToolResult: onToolResult
-                ? (() => {
-                    // Serialize tool result delivery to preserve message ordering.
-                    // Without this, concurrent tool callbacks race through typing signals
-                    // and message sends, causing out-of-order delivery to the user.
-                    // See: https://github.com/openclaw/openclaw/issues/11044
-                    let toolResultChain: Promise<void> = Promise.resolve();
-                    return (payload: ReplyPayload) => {
-                      toolResultChain = toolResultChain
-                        .then(async () => {
-                          const { text, skip } = normalizeStreamingText(payload);
-                          if (skip) {
-                            return;
-                          }
-                          await params.typingSignals.signalTextDelta(text);
-                          await onToolResult({
-                            ...payload,
-                            text,
-                          });
-                        })
-                        .catch((err) => {
-                          // Keep chain healthy after an error so later tool results still deliver.
-                          logVerbose(`tool result delivery failed: ${String(err)}`);
-                        });
-                      const task = toolResultChain.finally(() => {
-                        params.pendingToolTasks.delete(task);
-                      });
-                      params.pendingToolTasks.add(task);
-                    };
-                  })()
-                : undefined,
-            });
-            bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
-              result.meta?.systemPromptReport,
-            );
-            return result;
-          })();
-        },
-      });
-      runResult = fallbackResult.result;
-      fallbackProvider = fallbackResult.provider;
-      fallbackModel = fallbackResult.model;
-      fallbackAttempts = Array.isArray(fallbackResult.attempts)
-        ? fallbackResult.attempts.map((attempt) => ({
-            provider: String(attempt.provider ?? ""),
-            model: String(attempt.model ?? ""),
-            error: String(attempt.error ?? ""),
-            reason: attempt.reason ? String(attempt.reason) : undefined,
-            status: typeof attempt.status === "number" ? attempt.status : undefined,
-            code: attempt.code ? String(attempt.code) : undefined,
-          }))
-        : [];
-
-      // Some embedded runs surface context overflow as an error payload instead of throwing.
-      // Treat those as a session-level failure and auto-recover by starting a fresh session.
-      const embeddedError = runResult.meta?.error;
-      if (
-        embeddedError &&
-        isContextOverflowError(embeddedError.message) &&
-        !didResetAfterCompactionFailure &&
-        (await params.resetSessionAfterCompactionFailure(embeddedError.message))
-      ) {
-        didResetAfterCompactionFailure = true;
-        return {
-          kind: "final",
-          payload: {
-            text: "⚠️ Context limit exceeded. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.",
-          },
-        };
-      }
-      if (embeddedError?.kind === "role_ordering") {
-        const didReset = await params.resetSessionAfterRoleOrderingConflict(embeddedError.message);
-        if (didReset) {
-          return {
-            kind: "final",
-            payload: {
-              text: "⚠️ Message ordering conflict. I've reset the conversation - please try again.",
-            },
-          };
-        }
-      }
-
-      break;
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      const isContextOverflow = isLikelyContextOverflowError(message);
-      const isCompactionFailure = isCompactionFailureError(message);
-      const isSessionCorruption = /function call turn comes immediately after/i.test(message);
-      const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(message);
-      const isTransientHttp = isTransientHttpError(message);
-
-      if (
-        isCompactionFailure &&
-        !didResetAfterCompactionFailure &&
-        (await params.resetSessionAfterCompactionFailure(message))
-      ) {
-        didResetAfterCompactionFailure = true;
-        return {
-          kind: "final",
-          payload: {
-            text: "⚠️ Context limit exceeded during compaction. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.",
-          },
-        };
-      }
-      if (isRoleOrderingError) {
-        const didReset = await params.resetSessionAfterRoleOrderingConflict(message);
-        if (didReset) {
-          return {
-            kind: "final",
-            payload: {
-              text: "⚠️ Message ordering conflict. I've reset the conversation - please try again.",
-            },
-          };
-        }
-      }
-
-      // Auto-recover from Gemini session corruption by resetting the session
-      if (
-        isSessionCorruption &&
-        params.sessionKey &&
-        params.activeSessionStore &&
-        params.storePath
-      ) {
-        const sessionKey = params.sessionKey;
-        const corruptedSessionId = params.getActiveSessionEntry()?.sessionId;
-        defaultRuntime.error(
-          `Session history corrupted (Gemini function call ordering). Resetting session: ${params.sessionKey}`,
-        );
-
-        try {
-          // Delete transcript file if it exists
-          if (corruptedSessionId) {
-            const transcriptPath = resolveSessionTranscriptPath(corruptedSessionId);
-            try {
-              fs.unlinkSync(transcriptPath);
-            } catch {
-              // Ignore if file doesn't exist
+              })();
             }
+            const { authProfile, embeddedContext, senderContext } = buildEmbeddedRunContexts({
+              run: params.followupRun.run,
+              sessionCtx: params.sessionCtx,
+              hasRepliedRef: params.opts?.hasRepliedRef,
+              provider,
+            });
+            const runBaseParams = buildEmbeddedRunBaseParams({
+              run: params.followupRun.run,
+              provider,
+              model,
+              runId,
+              authProfile,
+              allowTransientCooldownProbe: runOptions?.allowTransientCooldownProbe,
+            });
+            return (async () => {
+              const result = await runEmbeddedPiAgent({
+                ...embeddedContext,
+                trigger: params.isHeartbeat ? "heartbeat" : "user",
+                groupId: resolveGroupSessionKey(params.sessionCtx)?.id,
+                groupChannel:
+                  params.sessionCtx.GroupChannel?.trim() ?? params.sessionCtx.GroupSubject?.trim(),
+                groupSpace: params.sessionCtx.GroupSpace?.trim() ?? undefined,
+                ...senderContext,
+                ...runBaseParams,
+                prompt: params.commandBody,
+                extraSystemPrompt: params.followupRun.run.extraSystemPrompt,
+                toolResultFormat: (() => {
+                  const channel = resolveMessageChannel(
+                    params.sessionCtx.Surface,
+                    params.sessionCtx.Provider,
+                  );
+                  if (!channel) {
+                    return "markdown";
+                  }
+                  return isMarkdownCapableMessageChannel(channel) ? "markdown" : "plain";
+                })(),
+                suppressToolErrorWarnings: params.opts?.suppressToolErrorWarnings,
+                bootstrapContextMode: params.opts?.bootstrapContextMode,
+                bootstrapContextRunKind: params.opts?.isHeartbeat ? "heartbeat" : "default",
+                images: params.opts?.images,
+                abortSignal: params.opts?.abortSignal,
+                blockReplyBreak: params.resolvedBlockStreamingBreak,
+                blockReplyChunking: params.blockReplyChunking,
+                onPartialReply: async (payload) => {
+                  const textForTyping = await handlePartialForTyping(payload);
+                  if (!params.opts?.onPartialReply || textForTyping === undefined) {
+                    return;
+                  }
+                  await params.opts.onPartialReply({
+                    text: textForTyping,
+                    mediaUrls: payload.mediaUrls,
+                  });
+                },
+                onAssistantMessageStart: async () => {
+                  await params.typingSignals.signalMessageStart();
+                  await params.opts?.onAssistantMessageStart?.();
+                },
+                onReasoningStream:
+                  params.typingSignals.shouldStartOnReasoning || params.opts?.onReasoningStream
+                    ? async (payload) => {
+                        await params.typingSignals.signalReasoningDelta();
+                        await params.opts?.onReasoningStream?.({
+                          text: payload.text,
+                          mediaUrls: payload.mediaUrls,
+                        });
+                      }
+                    : undefined,
+                onReasoningEnd: params.opts?.onReasoningEnd,
+                onAgentEvent: async (evt) => {
+                  // Signal run start only after the embedded agent emits real activity.
+                  const hasLifecyclePhase =
+                    evt.stream === "lifecycle" && typeof evt.data.phase === "string";
+                  if (evt.stream !== "lifecycle" || hasLifecyclePhase) {
+                    notifyAgentRunStart();
+                  }
+                  // Trigger typing when tools start executing.
+                  // Must await to ensure typing indicator starts before tool summaries are emitted.
+                  if (evt.stream === "tool") {
+                    const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
+                    const name = typeof evt.data.name === "string" ? evt.data.name : undefined;
+                    if (phase === "start" || phase === "update") {
+                      await params.typingSignals.signalToolStart();
+                      await params.opts?.onToolStart?.({ name, phase });
+                    }
+                  }
+                  // Track auto-compaction completion
+                  if (evt.stream === "compaction") {
+                    const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
+                    if (phase === "end") {
+                      autoCompactionCompleted = true;
+                    }
+                  }
+                },
+                // Always pass onBlockReply so flushBlockReplyBuffer works before tool execution,
+                // even when regular block streaming is disabled. The handler sends directly
+                // via opts.onBlockReply when the pipeline isn't available.
+                onBlockReply: params.opts?.onBlockReply
+                  ? createBlockReplyDeliveryHandler({
+                      onBlockReply: params.opts.onBlockReply,
+                      currentMessageId:
+                        params.sessionCtx.MessageSidFull ?? params.sessionCtx.MessageSid,
+                      normalizeStreamingText,
+                      applyReplyToMode: params.applyReplyToMode,
+                      normalizeMediaPaths: normalizeReplyMediaPaths,
+                      typingSignals: params.typingSignals,
+                      blockStreamingEnabled: params.blockStreamingEnabled,
+                      blockReplyPipeline,
+                      directlySentBlockKeys,
+                    })
+                  : undefined,
+                onBlockReplyFlush:
+                  params.blockStreamingEnabled && blockReplyPipeline
+                    ? async () => {
+                        await blockReplyPipeline.flush({ force: true });
+                      }
+                    : undefined,
+                shouldEmitToolResult: params.shouldEmitToolResult,
+                shouldEmitToolOutput: params.shouldEmitToolOutput,
+                bootstrapPromptWarningSignaturesSeen,
+                bootstrapPromptWarningSignature:
+                  bootstrapPromptWarningSignaturesSeen[
+                    bootstrapPromptWarningSignaturesSeen.length - 1
+                  ],
+                onToolResult: onToolResult
+                  ? (() => {
+                      // Serialize tool result delivery to preserve message ordering.
+                      // Without this, concurrent tool callbacks race through typing signals
+                      // and message sends, causing out-of-order delivery to the user.
+                      // See: https://github.com/openclaw/openclaw/issues/11044
+                      let toolResultChain: Promise<void> = Promise.resolve();
+                      return (payload: ReplyPayload) => {
+                        toolResultChain = toolResultChain
+                          .then(async () => {
+                            const { text, skip } = normalizeStreamingText(payload);
+                            if (skip) {
+                              return;
+                            }
+                            await params.typingSignals.signalTextDelta(text);
+                            await onToolResult({
+                              ...payload,
+                              text,
+                            });
+                          })
+                          .catch((err) => {
+                            // Keep chain healthy after an error so later tool results still deliver.
+                            logVerbose(`tool result delivery failed: ${String(err)}`);
+                          });
+                        const task = toolResultChain.finally(() => {
+                          params.pendingToolTasks.delete(task);
+                        });
+                        params.pendingToolTasks.add(task);
+                      };
+                    })()
+                  : undefined,
+              });
+              bootstrapPromptWarningSignaturesSeen = resolveBootstrapWarningSignaturesSeen(
+                result.meta?.systemPromptReport,
+              );
+              return result;
+            })();
+          },
+        });
+        runResult = fallbackResult.result;
+        fallbackProvider = fallbackResult.provider;
+        fallbackModel = fallbackResult.model;
+        fallbackAttempts = Array.isArray(fallbackResult.attempts)
+          ? fallbackResult.attempts.map((attempt) => ({
+              provider: String(attempt.provider ?? ""),
+              model: String(attempt.model ?? ""),
+              error: String(attempt.error ?? ""),
+              reason: attempt.reason ? String(attempt.reason) : undefined,
+              status: typeof attempt.status === "number" ? attempt.status : undefined,
+              code: attempt.code ? String(attempt.code) : undefined,
+            }))
+          : [];
+
+        // Some embedded runs surface context overflow as an error payload instead of throwing.
+        // Treat those as a session-level failure and auto-recover by starting a fresh session.
+        const embeddedError = runResult.meta?.error;
+        if (
+          embeddedError &&
+          isContextOverflowError(embeddedError.message) &&
+          !didResetAfterCompactionFailure &&
+          (await params.resetSessionAfterCompactionFailure(embeddedError.message))
+        ) {
+          didResetAfterCompactionFailure = true;
+          return {
+            kind: "final",
+            payload: {
+              text: "⚠️ Context limit exceeded. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.",
+            },
+          };
+        }
+        if (embeddedError?.kind === "role_ordering") {
+          const didReset = await params.resetSessionAfterRoleOrderingConflict(
+            embeddedError.message,
+          );
+          if (didReset) {
+            return {
+              kind: "final",
+              payload: {
+                text: "⚠️ Message ordering conflict. I've reset the conversation - please try again.",
+              },
+            };
+          }
+        }
+
+        break;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const isContextOverflow = isLikelyContextOverflowError(message);
+        const isCompactionFailure = isCompactionFailureError(message);
+        const isSessionCorruption = /function call turn comes immediately after/i.test(message);
+        const isRoleOrderingError = /incorrect role information|roles must alternate/i.test(
+          message,
+        );
+        const isTransientHttp = isTransientHttpError(message);
+
+        if (
+          isCompactionFailure &&
+          !didResetAfterCompactionFailure &&
+          (await params.resetSessionAfterCompactionFailure(message))
+        ) {
+          didResetAfterCompactionFailure = true;
+          return {
+            kind: "final",
+            payload: {
+              text: "⚠️ Context limit exceeded during compaction. I've reset our conversation to start fresh - please try again.\n\nTo prevent this, increase your compaction buffer by setting `agents.defaults.compaction.reserveTokensFloor` to 20000 or higher in your config.",
+            },
+          };
+        }
+        if (isRoleOrderingError) {
+          const didReset = await params.resetSessionAfterRoleOrderingConflict(message);
+          if (didReset) {
+            return {
+              kind: "final",
+              payload: {
+                text: "⚠️ Message ordering conflict. I've reset the conversation - please try again.",
+              },
+            };
+          }
+        }
+
+        // Auto-recover from Gemini session corruption by resetting the session
+        if (
+          isSessionCorruption &&
+          params.sessionKey &&
+          params.activeSessionStore &&
+          params.storePath
+        ) {
+          const sessionKey = params.sessionKey;
+          const corruptedSessionId = params.getActiveSessionEntry()?.sessionId;
+          defaultRuntime.error(
+            `Session history corrupted (Gemini function call ordering). Resetting session: ${params.sessionKey}`,
+          );
+
+          try {
+            // Delete transcript file if it exists
+            if (corruptedSessionId) {
+              const transcriptPath = resolveSessionTranscriptPath(corruptedSessionId);
+              try {
+                fs.unlinkSync(transcriptPath);
+              } catch {
+                // Ignore if file doesn't exist
+              }
+            }
+
+            // Keep the in-memory snapshot consistent with the on-disk store reset.
+            delete params.activeSessionStore[sessionKey];
+
+            // Remove session entry from store using a fresh, locked snapshot.
+            await updateSessionStore(params.storePath, (store) => {
+              delete store[sessionKey];
+            });
+          } catch (cleanupErr) {
+            defaultRuntime.error(
+              `Failed to reset corrupted session ${params.sessionKey}: ${String(cleanupErr)}`,
+            );
           }
 
-          // Keep the in-memory snapshot consistent with the on-disk store reset.
-          delete params.activeSessionStore[sessionKey];
-
-          // Remove session entry from store using a fresh, locked snapshot.
-          await updateSessionStore(params.storePath, (store) => {
-            delete store[sessionKey];
-          });
-        } catch (cleanupErr) {
-          defaultRuntime.error(
-            `Failed to reset corrupted session ${params.sessionKey}: ${String(cleanupErr)}`,
-          );
+          return {
+            kind: "final",
+            payload: {
+              text: "⚠️ Session history was corrupted. I've reset the conversation - please try again!",
+            },
+          };
         }
+
+        if (isTransientHttp && !didRetryTransientHttpError) {
+          didRetryTransientHttpError = true;
+          // Retry the full runWithModelFallback() cycle — transient errors
+          // (502/521/etc.) typically affect the whole provider, so falling
+          // back to an alternate model first would not help. Instead we wait
+          // and retry the complete primary→fallback chain.
+          defaultRuntime.error(
+            `Transient HTTP provider error before reply (${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
+          );
+          await new Promise<void>((resolve) => {
+            setTimeout(resolve, TRANSIENT_HTTP_RETRY_DELAY_MS);
+          });
+          continue;
+        }
+
+        defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
+        const safeMessage = isTransientHttp
+          ? sanitizeUserFacingText(message, { errorContext: true })
+          : message;
+        const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
+        const fallbackText = isContextOverflow
+          ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
+          : isRoleOrderingError
+            ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
+            : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
         return {
           kind: "final",
           payload: {
-            text: "⚠️ Session history was corrupted. I've reset the conversation - please try again!",
+            text: fallbackText,
           },
         };
       }
+    }
 
-      if (isTransientHttp && !didRetryTransientHttpError) {
-        didRetryTransientHttpError = true;
-        // Retry the full runWithModelFallback() cycle — transient errors
-        // (502/521/etc.) typically affect the whole provider, so falling
-        // back to an alternate model first would not help. Instead we wait
-        // and retry the complete primary→fallback chain.
-        defaultRuntime.error(
-          `Transient HTTP provider error before reply (${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
-        );
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, TRANSIENT_HTTP_RETRY_DELAY_MS);
-        });
-        continue;
-      }
-
-      defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
-      const safeMessage = isTransientHttp
-        ? sanitizeUserFacingText(message, { errorContext: true })
-        : message;
-      const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
-      const fallbackText = isContextOverflow
-        ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
-        : isRoleOrderingError
-          ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-          : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
-
+    // If the run completed but with an embedded context overflow error that
+    // wasn't recovered from (e.g. compaction reset already attempted), surface
+    // the error to the user instead of silently returning an empty response.
+    // See #26905: Slack DM sessions silently swallowed messages when context
+    // overflow errors were returned as embedded error payloads.
+    const finalEmbeddedError = runResult?.meta?.error;
+    const hasPayloadText = runResult?.payloads?.some((p) => p.text?.trim());
+    if (
+      finalEmbeddedError &&
+      isContextOverflowError(finalEmbeddedError.message) &&
+      !hasPayloadText
+    ) {
       return {
         kind: "final",
         payload: {
-          text: fallbackText,
+          text: "⚠️ Context overflow — this conversation is too large for the model. Use /new to start a fresh session.",
         },
       };
     }
-  }
 
-  // If the run completed but with an embedded context overflow error that
-  // wasn't recovered from (e.g. compaction reset already attempted), surface
-  // the error to the user instead of silently returning an empty response.
-  // See #26905: Slack DM sessions silently swallowed messages when context
-  // overflow errors were returned as embedded error payloads.
-  const finalEmbeddedError = runResult?.meta?.error;
-  const hasPayloadText = runResult?.payloads?.some((p) => p.text?.trim());
-  if (finalEmbeddedError && isContextOverflowError(finalEmbeddedError.message) && !hasPayloadText) {
     return {
-      kind: "final",
-      payload: {
-        text: "⚠️ Context overflow — this conversation is too large for the model. Use /new to start a fresh session.",
-      },
+      kind: "success",
+      runId,
+      runResult,
+      fallbackProvider,
+      fallbackModel,
+      fallbackAttempts,
+      didLogHeartbeatStrip,
+      autoCompactionCompleted,
+      directlySentBlockKeys: directlySentBlockKeys.size > 0 ? directlySentBlockKeys : undefined,
     };
+  } finally {
+    if (didPersistInflight) {
+      await removeInflightAgentRun(runId).catch(() => {});
+    }
   }
-
-  return {
-    kind: "success",
-    runId,
-    runResult,
-    fallbackProvider,
-    fallbackModel,
-    fallbackAttempts,
-    didLogHeartbeatStrip,
-    autoCompactionCompleted,
-    directlySentBlockKeys: directlySentBlockKeys.size > 0 ? directlySentBlockKeys : undefined,
-  };
 }

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -20,7 +20,11 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
-import { addInflightAgentRun, removeInflightAgentRun } from "../../gateway/inflight-agent-runs.js";
+import {
+  addInflightAgentRun,
+  isInflightAgentRunRecoveryEnabled,
+  removeInflightAgentRun,
+} from "../../gateway/inflight-agent-runs.js";
 import { logVerbose } from "../../globals.js";
 import { emitAgentEvent, registerAgentRunContext } from "../../infra/agent-events.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -187,8 +191,7 @@ export async function runAgentTurnWithFallback(params: {
     params.getActiveSessionEntry()?.systemPromptReport,
   );
   const shouldPersistInflight =
-    params.followupRun.run.config.gateway?.restartRecovery?.resumeInflightAgentRuns === true &&
-    !params.isHeartbeat;
+    isInflightAgentRunRecoveryEnabled(params.followupRun.run.config) && !params.isHeartbeat;
   let didPersistInflight = false;
   if (shouldPersistInflight) {
     const opts = buildInflightResumeOpts({

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -60,10 +60,16 @@ vi.mock("../../runtime.js", async () => {
   };
 });
 
-vi.mock("../../gateway/inflight-agent-runs.js", () => ({
-  addInflightAgentRun: (params: unknown) => addInflightAgentRunMock(params),
-  removeInflightAgentRun: (runId: string) => removeInflightAgentRunMock(runId),
-}));
+vi.mock("../../gateway/inflight-agent-runs.js", async () => {
+  const { isInflightAgentRunRecoveryEnabled } = await vi.importActual<
+    typeof import("../../gateway/inflight-agent-runs.js")
+  >("../../gateway/inflight-agent-runs.js");
+  return {
+    addInflightAgentRun: (params: unknown) => addInflightAgentRunMock(params),
+    removeInflightAgentRun: (runId: string) => removeInflightAgentRunMock(runId),
+    isInflightAgentRunRecoveryEnabled,
+  };
+});
 
 vi.mock("./queue.js", async () => {
   const actual = await vi.importActual<typeof import("./queue.js")>("./queue.js");

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -15,6 +15,8 @@ const runEmbeddedPiAgentMock = vi.fn();
 const runCliAgentMock = vi.fn();
 const runWithModelFallbackMock = vi.fn();
 const runtimeErrorMock = vi.fn();
+const addInflightAgentRunMock = vi.fn();
+const removeInflightAgentRunMock = vi.fn();
 
 vi.mock("../../agents/model-fallback.js", () => ({
   runWithModelFallback: (params: {
@@ -58,6 +60,11 @@ vi.mock("../../runtime.js", async () => {
   };
 });
 
+vi.mock("../../gateway/inflight-agent-runs.js", () => ({
+  addInflightAgentRun: (params: unknown) => addInflightAgentRunMock(params),
+  removeInflightAgentRun: (runId: string) => removeInflightAgentRunMock(runId),
+}));
+
 vi.mock("./queue.js", async () => {
   const actual = await vi.importActual<typeof import("./queue.js")>("./queue.js");
   return {
@@ -89,9 +96,13 @@ beforeEach(() => {
   runCliAgentMock.mockClear();
   runWithModelFallbackMock.mockClear();
   runtimeErrorMock.mockClear();
+  addInflightAgentRunMock.mockClear();
+  removeInflightAgentRunMock.mockClear();
   loadCronStoreMock.mockClear();
   // Default: no cron jobs in store.
   loadCronStoreMock.mockResolvedValue({ version: 1, jobs: [] });
+  addInflightAgentRunMock.mockResolvedValue(undefined);
+  removeInflightAgentRunMock.mockResolvedValue(undefined);
   resetSystemEventsForTest();
 
   // Default: no provider switch; execute the chosen provider+model.
@@ -116,7 +127,9 @@ describe("runReplyAgent onAgentRunStart", () => {
     opts?: {
       runId?: string;
       onAgentRunStart?: (runId: string) => void;
+      isHeartbeat?: boolean;
     };
+    config?: Record<string, unknown>;
   }) {
     const provider = params?.provider ?? "anthropic";
     const model = params?.model ?? "claude";
@@ -133,12 +146,13 @@ describe("runReplyAgent onAgentRunStart", () => {
       summaryLine: "hello",
       enqueuedAt: Date.now(),
       run: {
+        agentId: "main",
         sessionId: "session",
         sessionKey: "main",
         messageProvider: "webchat",
         sessionFile: "/tmp/session.jsonl",
         workspaceDir: "/tmp",
-        config: {},
+        config: params?.config ?? {},
         skillsSnapshot: {},
         provider,
         model,
@@ -214,6 +228,63 @@ describe("runReplyAgent onAgentRunStart", () => {
     expect(onAgentRunStart).toHaveBeenCalledTimes(1);
     expect(onAgentRunStart).toHaveBeenCalledWith("run-started");
     expect(result).toMatchObject({ text: "ok" });
+  });
+
+  it("persists and clears inflight run for embedded auto-reply when restart recovery is enabled", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const result = await createRun({
+      opts: { runId: "run-inflight-recovery" },
+      config: {
+        gateway: {
+          restartRecovery: {
+            resumeInflightAgentRuns: true,
+          },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({ text: "ok" });
+    expect(addInflightAgentRunMock).toHaveBeenCalledTimes(1);
+    expect(addInflightAgentRunMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runId: "run-inflight-recovery",
+        acceptedAt: expect.any(Number),
+        opts: expect.objectContaining({
+          runId: "run-inflight-recovery",
+          message: "hello",
+          agentId: "main",
+          sessionId: "session",
+        }),
+      }),
+    );
+    expect(removeInflightAgentRunMock).toHaveBeenCalledTimes(1);
+    expect(removeInflightAgentRunMock).toHaveBeenCalledWith("run-inflight-recovery");
+  });
+
+  it("does not persist inflight run for heartbeat turns", async () => {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "ok" }],
+      meta: {},
+    });
+
+    const result = await createRun({
+      opts: { runId: "run-heartbeat", isHeartbeat: true },
+      config: {
+        gateway: {
+          restartRecovery: {
+            resumeInflightAgentRuns: true,
+          },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({ text: "ok" });
+    expect(addInflightAgentRunMock).not.toHaveBeenCalled();
+    expect(removeInflightAgentRunMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -25,6 +25,7 @@ type RestartParams = {
 const service = {
   readCommand: vi.fn(),
   restart: vi.fn(),
+  isLoaded: vi.fn(),
 };
 
 const runServiceRestart = vi.fn();
@@ -102,6 +103,11 @@ vi.mock("./lifecycle-core.js", () => ({
   runServiceUninstall: vi.fn(),
 }));
 
+vi.mock("../../infra/restart-sentinel.js", () => ({
+  formatDoctorNonInteractiveHint: vi.fn(() => "Run: openclaw doctor --non-interactive"),
+  writeRestartSentinel: vi.fn(async () => "/tmp/restart-sentinel.json"),
+}));
+
 describe("runDaemonRestart health checks", () => {
   let runDaemonRestart: (opts?: { json?: boolean }) => Promise<boolean>;
   let runDaemonStop: (opts?: { json?: boolean }) => Promise<void>;
@@ -132,6 +138,7 @@ describe("runDaemonRestart health checks", () => {
       programArguments: ["openclaw", "gateway", "--port", "18789"],
       environment: {},
     });
+    service.isLoaded.mockResolvedValue(true);
 
     runServiceRestart.mockImplementation(async (params: RestartParams) => {
       const fail = (message: string, hints?: string[]) => {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -44,7 +44,10 @@ async function resolveGatewayLifecyclePort(service = resolveGatewayService()) {
   } as NodeJS.ProcessEnv;
 
   const portFromArgs = parsePortFromArgs(command?.programArguments);
-  return portFromArgs ?? resolveGatewayPort(await readBestEffortConfig(), mergedEnv);
+  return {
+    port: portFromArgs ?? resolveGatewayPort(await readBestEffortConfig(), mergedEnv),
+    mergedEnv,
+  };
 }
 
 function extractWindowsCommandLine(raw: string): string | null {
@@ -225,25 +228,41 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   const json = Boolean(opts.json);
   const service = resolveGatewayService();
   let restartedWithoutServiceManager = false;
-  const restartPort = await resolveGatewayLifecyclePort(service).catch(() =>
-    resolveGatewayPortFallback(),
+  const restartCtx = await resolveGatewayLifecyclePort(service).catch(() =>
+    resolveGatewayPortFallback().then((port) => ({ port, mergedEnv: process.env })),
   );
+  const restartPort = restartCtx.port;
   const restartWaitMs = POST_RESTART_HEALTH_ATTEMPTS * POST_RESTART_HEALTH_DELAY_MS;
   const restartWaitSeconds = Math.round(restartWaitMs / 1000);
 
-  // Best-effort: write a restart sentinel so the next gateway process can detect
-  // this restart as being triggered via the explicit restart command.
+  // Best-effort: if the service is loaded, write a restart sentinel so the next
+  // gateway process can detect this restart as being triggered via the explicit
+  // restart command. The sentinel must be written using the service environment
+  // (e.g. OPENCLAW_STATE_DIR) so the restarted daemon can read it on startup.
+  let loaded = false;
   try {
-    await writeRestartSentinel({
-      kind: "restart",
-      status: "ok",
-      ts: Date.now(),
-      message: null,
-      doctorHint: formatDoctorNonInteractiveHint(),
-      stats: { mode: "cli.gateway.restart", reason: "daemon restart" },
-    });
+    loaded = await service.isLoaded({ env: process.env });
   } catch {
-    // ignore: sentinel is best-effort
+    loaded = false;
+  }
+  if (loaded) {
+    try {
+      await writeRestartSentinel(
+        {
+          kind: "restart",
+          status: "ok",
+          ts: Date.now(),
+          message: null,
+          doctorHint: formatDoctorNonInteractiveHint(
+            restartCtx.mergedEnv as Record<string, string | undefined>,
+          ),
+          stats: { mode: "cli.gateway.restart", reason: "daemon restart" },
+        },
+        restartCtx.mergedEnv,
+      );
+    } catch {
+      // ignore: sentinel is best-effort
+    }
   }
 
   return await runServiceRestart({

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -7,6 +7,10 @@ import { resolveGatewayService } from "../../daemon/service.js";
 import { probeGateway } from "../../gateway/probe.js";
 import { isGatewayArgv, parseProcCmdline } from "../../infra/gateway-process-argv.js";
 import { findGatewayPidsOnPortSync } from "../../infra/restart.js";
+import {
+  formatDoctorNonInteractiveHint,
+  writeRestartSentinel,
+} from "../../infra/restart-sentinel.js";
 import { defaultRuntime } from "../../runtime.js";
 import { theme } from "../../terminal/theme.js";
 import { formatCliCommand } from "../command-format.js";
@@ -226,6 +230,21 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   );
   const restartWaitMs = POST_RESTART_HEALTH_ATTEMPTS * POST_RESTART_HEALTH_DELAY_MS;
   const restartWaitSeconds = Math.round(restartWaitMs / 1000);
+
+  // Best-effort: write a restart sentinel so the next gateway process can detect
+  // this restart as being triggered via the explicit restart command.
+  try {
+    await writeRestartSentinel({
+      kind: "restart",
+      status: "ok",
+      ts: Date.now(),
+      message: null,
+      doctorHint: formatDoctorNonInteractiveHint(),
+      stats: { mode: "cli.gateway.restart", reason: "daemon restart" },
+    });
+  } catch {
+    // ignore: sentinel is best-effort
+  }
 
   return await runServiceRestart({
     serviceNoun: "Gateway",

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -12,6 +12,7 @@ const getActiveTaskCount = vi.fn(() => 0);
 const markGatewayDraining = vi.fn();
 const waitForActiveTasks = vi.fn(async (_timeoutMs: number) => ({ drained: true }));
 const resetAllLanes = vi.fn();
+const resetEmbeddedRunTrackingForRestart = vi.fn();
 const restartGatewayProcessWithFreshPid = vi.fn<
   () => { mode: "spawned" | "supervised" | "disabled" | "failed"; pid?: number; detail?: string }
 >(() => ({ mode: "disabled" }));
@@ -53,6 +54,7 @@ vi.mock("../../agents/pi-embedded-runner/runs.js", () => ({
     abortEmbeddedPiRun(sessionId, opts),
   getActiveEmbeddedRunCount: () => getActiveEmbeddedRunCount(),
   waitForActiveEmbeddedRuns: (timeoutMs: number) => waitForActiveEmbeddedRuns(timeoutMs),
+  resetEmbeddedRunTrackingForRestart: () => resetEmbeddedRunTrackingForRestart(),
 }));
 
 vi.mock("../../logging/subsystem.js", () => ({
@@ -269,6 +271,7 @@ describe("runGatewayLoop", () => {
       });
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(1);
       expect(resetAllLanes).toHaveBeenCalledTimes(1);
+      expect(resetEmbeddedRunTrackingForRestart).toHaveBeenCalledTimes(1);
 
       sigusr1();
 
@@ -281,6 +284,7 @@ describe("runGatewayLoop", () => {
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalledTimes(2);
       expect(markGatewayDraining).toHaveBeenCalledTimes(2);
       expect(resetAllLanes).toHaveBeenCalledTimes(2);
+      expect(resetEmbeddedRunTrackingForRestart).toHaveBeenCalledTimes(2);
       expect(acquireGatewayLock).toHaveBeenCalledTimes(3);
 
       sigterm();
@@ -320,6 +324,29 @@ describe("runGatewayLoop", () => {
       expect(lockRelease).toHaveBeenCalled();
       expect(runtime.exit).toHaveBeenCalledWith(0);
       expect(exitCallOrder).toEqual(["lockRelease", "exit"]);
+    });
+  });
+
+  it("exits on supervised restart even when the launch helper reports a detail", async () => {
+    vi.clearAllMocks();
+
+    await withIsolatedSignals(async () => {
+      restartGatewayProcessWithFreshPid.mockReturnValueOnce({
+        mode: "supervised",
+        detail: "launchctl kickstart failed",
+      });
+
+      const { runtime, exited } = await createSignaledLoopHarness();
+      process.emit("SIGUSR1");
+
+      await exited;
+      expect(runtime.exit).toHaveBeenCalledWith(0);
+      expect(gatewayLog.info).toHaveBeenCalledWith(
+        "restart mode: full process restart (supervisor restart)",
+      );
+      expect(gatewayLog.warn).toHaveBeenCalledWith(
+        expect.stringContaining("launchctl kickstart failed"),
+      );
     });
   });
 

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1,6 +1,7 @@
 import {
   abortEmbeddedPiRun,
   getActiveEmbeddedRunCount,
+  resetEmbeddedRunTrackingForRestart,
   waitForActiveEmbeddedRuns,
 } from "../../agents/pi-embedded-runner/runs.js";
 import type { startGatewayServer } from "../../gateway/server.js";
@@ -72,6 +73,11 @@ export async function runGatewayLoop(params: {
           ? `spawned pid ${respawn.pid ?? "unknown"}`
           : "supervisor restart";
       gatewayLog.info(`restart mode: full process restart (${modeLabel})`);
+      if (respawn.detail) {
+        gatewayLog.warn(
+          `supervisor-assisted restart is falling back to process exit only (${respawn.detail})`,
+        );
+      }
       exitProcess(0);
       return;
     }
@@ -209,6 +215,7 @@ export async function runGatewayLoop(params: {
       // coordinator level — rather than inside individual subsystem init
       // functions, to avoid surprising cross-cutting side effects.
       resetAllLanes();
+      resetEmbeddedRunTrackingForRestart();
     });
 
     // Keep process alive; SIGUSR1 triggers an in-process restart (no supervisor required).

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -114,6 +114,10 @@ export const FIELD_HELP: Record<string, string> = {
     'Remote connection transport: "direct" uses configured URL connectivity, while "ssh" tunnels through SSH. Use SSH when you need encrypted tunnel semantics without exposing remote ports.',
   "gateway.reload":
     "Live config-reload policy for how edits are applied and when full restarts are triggered. Keep hybrid behavior for safest operational updates unless debugging reload internals.",
+  "gateway.restartRecovery":
+    "Restart-time recovery behavior. These settings only apply to gateway restarts that write a restart sentinel (for example `gateway restart`).",
+  "gateway.restartRecovery.resumeInflightAgentRuns":
+    "When the gateway restarts via `gateway restart`, attempt to resume in-flight agent runs that were accepted before restart. Disable if you prefer runs to fail-fast and be re-triggered manually.",
   "gateway.tls":
     "TLS certificate and key settings for terminating HTTPS directly in the gateway process. Use explicit certificates in production and avoid plaintext exposure on untrusted networks.",
   "gateway.tls.enabled":

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -115,9 +115,9 @@ export const FIELD_HELP: Record<string, string> = {
   "gateway.reload":
     "Live config-reload policy for how edits are applied and when full restarts are triggered. Keep hybrid behavior for safest operational updates unless debugging reload internals.",
   "gateway.restartRecovery":
-    "Restart-time recovery behavior. These settings only apply to gateway restarts that write a restart sentinel (for example `gateway restart`).",
+    "Restart-time recovery behavior. These settings apply when gateway startup observes a restart sentinel (for example `gateway restart`, `config patch`, or `config apply`).",
   "gateway.restartRecovery.resumeInflightAgentRuns":
-    "When the gateway restarts via `gateway restart`, attempt to resume in-flight agent runs that were accepted before restart. Disable if you prefer runs to fail-fast and be re-triggered manually.",
+    "When gateway startup sees a restart sentinel, attempt to resume in-flight agent runs that were accepted before restart. Disable if you prefer runs to fail-fast and be re-triggered manually.",
   "gateway.tls":
     "TLS certificate and key settings for terminating HTTPS directly in the gateway process. Use explicit certificates in production and avoid plaintext exposure on untrusted networks.",
   "gateway.tls.enabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -90,6 +90,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "gateway.remote": "Remote Gateway",
   "gateway.remote.transport": "Remote Gateway Transport",
   "gateway.reload": "Config Reload",
+  "gateway.restartRecovery": "Gateway Restart Recovery",
+  "gateway.restartRecovery.resumeInflightAgentRuns": "Resume In-Flight Agent Runs After Restart",
   "gateway.tls": "Gateway TLS",
   "gateway.tls.enabled": "Gateway TLS Enabled",
   "gateway.tls.autoGenerate": "Gateway TLS Auto-Generate Cert",

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -211,6 +211,17 @@ export type GatewayReloadConfig = {
   debounceMs?: number;
 };
 
+export type GatewayRestartRecoveryConfig = {
+  /**
+   * If true, when the gateway is restarted via the `gateway restart` command/tool
+   * (restart sentinel kind="restart"), attempt to resume in-flight agent runs
+   * that were accepted before the restart.
+   *
+   * Default: false.
+   */
+  resumeInflightAgentRuns?: boolean;
+};
+
 export type GatewayHttpChatCompletionsConfig = {
   /**
    * If false, the Gateway will not serve `POST /v1/chat/completions`.
@@ -391,6 +402,7 @@ export type GatewayConfig = {
   tailscale?: GatewayTailscaleConfig;
   remote?: GatewayRemoteConfig;
   reload?: GatewayReloadConfig;
+  restartRecovery?: GatewayRestartRecoveryConfig;
   tls?: GatewayTlsConfig;
   http?: GatewayHttpConfig;
   nodes?: GatewayNodesConfig;

--- a/src/config/types.gateway.ts
+++ b/src/config/types.gateway.ts
@@ -213,9 +213,9 @@ export type GatewayReloadConfig = {
 
 export type GatewayRestartRecoveryConfig = {
   /**
-   * If true, when the gateway is restarted via the `gateway restart` command/tool
-   * (restart sentinel kind="restart"), attempt to resume in-flight agent runs
-   * that were accepted before the restart.
+   * If true, when gateway startup observes a restart sentinel (for example from
+   * `gateway restart`, `config patch`, or `config apply`), attempt to resume
+   * in-flight agent runs that were accepted before the restart.
    *
    * Default: false.
    */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -720,6 +720,12 @@ export const OpenClawSchema = z
           })
           .strict()
           .optional(),
+        restartRecovery: z
+          .object({
+            resumeInflightAgentRuns: z.boolean().optional(),
+          })
+          .strict()
+          .optional(),
         tls: z
           .object({
             enabled: z.boolean().optional(),

--- a/src/gateway/inflight-agent-runs.test.ts
+++ b/src/gateway/inflight-agent-runs.test.ts
@@ -1,0 +1,77 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import type { AgentCommandIngressOpts } from "../commands/agent/types.js";
+import { emitAgentEvent } from "../infra/agent-events.js";
+import {
+  __test,
+  addInflightAgentRun,
+  ensureInflightAgentRunLifecycleCleanerStarted,
+  listInflightAgentRuns,
+  removeInflightAgentRun,
+} from "./inflight-agent-runs.js";
+
+const savedEnv = { ...process.env };
+
+async function makeTempStateDir(prefix: string) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  process.env.OPENCLAW_STATE_DIR = dir;
+  return dir;
+}
+
+afterEach(async () => {
+  process.env = { ...savedEnv };
+});
+
+describe("inflight agent runs persistence", () => {
+  it("adds and removes records", async () => {
+    const dir = await makeTempStateDir("openclaw-inflight-agent-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+    const runId = "run-1";
+    const opts: AgentCommandIngressOpts = {
+      message: "do work",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      deliver: false,
+      senderIsOwner: true,
+      runId,
+    };
+
+    await addInflightAgentRun({ runId, acceptedAt: Date.now(), opts }, env);
+    expect((await listInflightAgentRuns(env)).map((r) => r.runId)).toEqual([runId]);
+
+    await removeInflightAgentRun(runId, env);
+    expect(await listInflightAgentRuns(env)).toEqual([]);
+  });
+
+  it("cleans up on lifecycle end", async () => {
+    const dir = await makeTempStateDir("openclaw-inflight-agent-end-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+    ensureInflightAgentRunLifecycleCleanerStarted(env);
+    const runId = "run-end-1";
+    const opts: AgentCommandIngressOpts = {
+      message: "do work",
+      sessionId: "sess-1",
+      deliver: false,
+      senderIsOwner: true,
+      runId,
+    };
+
+    await addInflightAgentRun({ runId, acceptedAt: Date.now(), opts }, env);
+    expect((await listInflightAgentRuns(env)).map((r) => r.runId)).toEqual([runId]);
+
+    emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+
+    // Cleaner is async; allow a tick.
+    await new Promise((r) => setTimeout(r, 5));
+    expect(await listInflightAgentRuns(env)).toEqual([]);
+  });
+
+  it("uses the state dir in file path resolution", async () => {
+    const dir = await makeTempStateDir("openclaw-inflight-agent-path-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+    const storePath = __test.resolveStorePath(env);
+    expect(storePath).toBe(path.join(dir, "inflight-agent-runs.json"));
+  });
+});

--- a/src/gateway/inflight-agent-runs.test.ts
+++ b/src/gateway/inflight-agent-runs.test.ts
@@ -1,9 +1,14 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentCommandIngressOpts } from "../commands/agent/types.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
+import {
+  __testing as restartTesting,
+  scheduleGatewaySigusr1Restart,
+  setPreRestartDeferralCheck,
+} from "../infra/restart.js";
 import {
   __test,
   addInflightAgentRun,
@@ -22,6 +27,8 @@ async function makeTempStateDir(prefix: string) {
 
 afterEach(async () => {
   __test.reset();
+  restartTesting.resetSigusr1State();
+  vi.useRealTimers();
   process.env = { ...savedEnv };
 });
 
@@ -74,5 +81,53 @@ describe("inflight agent runs persistence", () => {
     const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
     const storePath = __test.resolveStorePath(env);
     expect(storePath).toBe(path.join(dir, "inflight-agent-runs.json"));
+  });
+
+  it("preserves records while a restart is deferred", async () => {
+    vi.useFakeTimers();
+    const dir = await makeTempStateDir("openclaw-inflight-agent-deferred-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+    const runId = "run-deferred-1";
+    const opts: AgentCommandIngressOpts = {
+      message: "do work",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      deliver: false,
+      senderIsOwner: true,
+      runId,
+    };
+
+    await addInflightAgentRun({ runId, acceptedAt: Date.now(), opts }, env);
+    setPreRestartDeferralCheck(() => 1);
+    scheduleGatewaySigusr1Restart({ delayMs: 0 });
+    await vi.advanceTimersByTimeAsync(0);
+
+    await removeInflightAgentRun(runId, env);
+    expect((await listInflightAgentRuns(env)).map((r) => r.runId)).toEqual([runId]);
+  });
+
+  it("does not clean up on lifecycle end while a restart is deferred", async () => {
+    vi.useFakeTimers();
+    const dir = await makeTempStateDir("openclaw-inflight-agent-end-deferred-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+    ensureInflightAgentRunLifecycleCleanerStarted(env);
+    const runId = "run-end-deferred-1";
+    const opts: AgentCommandIngressOpts = {
+      message: "do work",
+      sessionId: "sess-1",
+      deliver: false,
+      senderIsOwner: true,
+      runId,
+    };
+
+    await addInflightAgentRun({ runId, acceptedAt: Date.now(), opts }, env);
+    setPreRestartDeferralCheck(() => 1);
+    scheduleGatewaySigusr1Restart({ delayMs: 0 });
+    await vi.advanceTimersByTimeAsync(0);
+
+    emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+    await Promise.resolve();
+
+    expect((await listInflightAgentRuns(env)).map((r) => r.runId)).toEqual([runId]);
   });
 });

--- a/src/gateway/inflight-agent-runs.test.ts
+++ b/src/gateway/inflight-agent-runs.test.ts
@@ -106,6 +106,47 @@ describe("inflight agent runs persistence", () => {
     expect((await listInflightAgentRuns(env)).map((r) => r.runId)).toEqual([runId]);
   });
 
+  it("preserves records while an immediate restart is scheduled but not yet emitted", async () => {
+    vi.useFakeTimers();
+    const dir = await makeTempStateDir("openclaw-inflight-agent-immediate-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+    const runId = "run-immediate-1";
+    const opts: AgentCommandIngressOpts = {
+      message: "do work",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      deliver: false,
+      senderIsOwner: true,
+      runId,
+    };
+
+    await addInflightAgentRun({ runId, acceptedAt: Date.now(), opts }, env);
+    scheduleGatewaySigusr1Restart({ delayMs: 0 });
+
+    await removeInflightAgentRun(runId, env);
+    expect((await listInflightAgentRuns(env)).map((r) => r.runId)).toEqual([runId]);
+  });
+
+  it("does not preserve completed runs during a delayed restart window", async () => {
+    const dir = await makeTempStateDir("openclaw-inflight-agent-delayed-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+    const runId = "run-delayed-1";
+    const opts: AgentCommandIngressOpts = {
+      message: "do work",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      deliver: false,
+      senderIsOwner: true,
+      runId,
+    };
+
+    await addInflightAgentRun({ runId, acceptedAt: Date.now(), opts }, env);
+    scheduleGatewaySigusr1Restart({ delayMs: 1000 });
+
+    await removeInflightAgentRun(runId, env);
+    expect(await listInflightAgentRuns(env)).toEqual([]);
+  });
+
   it("does not clean up on lifecycle end while a restart is deferred", async () => {
     vi.useFakeTimers();
     const dir = await makeTempStateDir("openclaw-inflight-agent-end-deferred-");
@@ -129,5 +170,27 @@ describe("inflight agent runs persistence", () => {
     await Promise.resolve();
 
     expect((await listInflightAgentRuns(env)).map((r) => r.runId)).toEqual([runId]);
+  });
+
+  it("cleans up on lifecycle end before a delayed restart is emitted", async () => {
+    const dir = await makeTempStateDir("openclaw-inflight-agent-end-delayed-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+    ensureInflightAgentRunLifecycleCleanerStarted(env);
+    const runId = "run-end-delayed-1";
+    const opts: AgentCommandIngressOpts = {
+      message: "do work",
+      sessionId: "sess-1",
+      deliver: false,
+      senderIsOwner: true,
+      runId,
+    };
+
+    await addInflightAgentRun({ runId, acceptedAt: Date.now(), opts }, env);
+    scheduleGatewaySigusr1Restart({ delayMs: 1000 });
+
+    emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+    await vi.waitFor(async () => {
+      expect(await listInflightAgentRuns(env)).toEqual([]);
+    });
   });
 });

--- a/src/gateway/inflight-agent-runs.test.ts
+++ b/src/gateway/inflight-agent-runs.test.ts
@@ -21,6 +21,7 @@ async function makeTempStateDir(prefix: string) {
 }
 
 afterEach(async () => {
+  __test.reset();
   process.env = { ...savedEnv };
 });
 

--- a/src/gateway/inflight-agent-runs.ts
+++ b/src/gateway/inflight-agent-runs.ts
@@ -182,6 +182,14 @@ export async function listInflightAgentRuns(
   return Object.values(store.runs ?? {});
 }
 
+export async function clearInflightAgentRuns(env: NodeJS.ProcessEnv = process.env): Promise<void> {
+  const storePath = resolveStorePath(env);
+  registerStorePath(storePath);
+  await withStoreLock(storePath, async () => {
+    await writeStoreToPath(storePath, { version: STORE_VERSION, runs: {} });
+  });
+}
+
 /**
  * Start a best-effort lifecycle listener to clean up persisted inflight runs.
  *

--- a/src/gateway/inflight-agent-runs.ts
+++ b/src/gateway/inflight-agent-runs.ts
@@ -1,0 +1,187 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { AgentCommandIngressOpts } from "../commands/agent/types.js";
+import { resolveStateDir } from "../config/paths.js";
+import { onAgentEvent } from "../infra/agent-events.js";
+
+type InflightAgentRunRecord = {
+  runId: string;
+  acceptedAt: number;
+  opts: AgentCommandIngressOpts;
+  resumeCount?: number;
+  lastResumeAt?: number;
+};
+
+type InflightAgentRunsStore = {
+  version: 1;
+  runs: Record<string, InflightAgentRunRecord>;
+};
+
+const STORE_VERSION = 1 as const;
+const STORE_FILENAME = "inflight-agent-runs.json";
+
+// Mirrors the in-memory grace window in `src/gateway/server-methods/agent-job.ts`.
+// Some embedded runs can emit transient lifecycle "error" events during failover.
+const ERROR_GRACE_MS = 15_000;
+
+let lifecycleCleanerStarted = false;
+const pendingErrorTimers = new Map<string, NodeJS.Timeout>();
+
+function resolveStorePath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveStateDir(env), STORE_FILENAME);
+}
+
+async function readStore(env: NodeJS.ProcessEnv = process.env): Promise<InflightAgentRunsStore> {
+  const filePath = resolveStorePath(env);
+  try {
+    const raw = await fs.readFile(filePath, "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") {
+      return { version: STORE_VERSION, runs: {} };
+    }
+    const rec = parsed as Partial<InflightAgentRunsStore>;
+    if (rec.version !== STORE_VERSION || !rec.runs || typeof rec.runs !== "object") {
+      return { version: STORE_VERSION, runs: {} };
+    }
+    return { version: STORE_VERSION, runs: rec.runs };
+  } catch {
+    return { version: STORE_VERSION, runs: {} };
+  }
+}
+
+async function writeStore(
+  store: InflightAgentRunsStore,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const filePath = resolveStorePath(env);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.tmp.${process.pid}.${Math.random().toString(16).slice(2)}`;
+  const data = `${JSON.stringify(store, null, 2)}\n`;
+  await fs.writeFile(tmp, data, "utf-8");
+  await fs.rename(tmp, filePath);
+}
+
+function clearPendingErrorTimer(runId: string): void {
+  const t = pendingErrorTimers.get(runId);
+  if (!t) {
+    return;
+  }
+  clearTimeout(t);
+  pendingErrorTimers.delete(runId);
+}
+
+function scheduleErrorCleanup(runId: string, env: NodeJS.ProcessEnv = process.env): void {
+  clearPendingErrorTimer(runId);
+  const timer = setTimeout(() => {
+    pendingErrorTimers.delete(runId);
+    void removeInflightAgentRun(runId, env);
+  }, ERROR_GRACE_MS);
+  timer.unref?.();
+  pendingErrorTimers.set(runId, timer);
+}
+
+export async function addInflightAgentRun(
+  record: InflightAgentRunRecord,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const cleanedRunId = record.runId.trim();
+  if (!cleanedRunId) {
+    return;
+  }
+  const store = await readStore(env);
+  store.runs[cleanedRunId] = {
+    ...record,
+    runId: cleanedRunId,
+    acceptedAt: Math.floor(record.acceptedAt),
+    opts: {
+      ...record.opts,
+      runId: cleanedRunId,
+      senderIsOwner: record.opts.senderIsOwner,
+    },
+  };
+  await writeStore(store, env);
+}
+
+export async function removeInflightAgentRun(
+  runId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const cleaned = runId.trim();
+  if (!cleaned) {
+    return;
+  }
+  clearPendingErrorTimer(cleaned);
+  const store = await readStore(env);
+  if (!store.runs[cleaned]) {
+    return;
+  }
+  delete store.runs[cleaned];
+  await writeStore(store, env);
+}
+
+export async function markInflightAgentRunResumed(
+  runId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  const cleaned = runId.trim();
+  if (!cleaned) {
+    return;
+  }
+  const store = await readStore(env);
+  const existing = store.runs[cleaned];
+  if (!existing) {
+    return;
+  }
+  store.runs[cleaned] = {
+    ...existing,
+    resumeCount: (existing.resumeCount ?? 0) + 1,
+    lastResumeAt: Date.now(),
+  };
+  await writeStore(store, env);
+}
+
+export async function listInflightAgentRuns(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<InflightAgentRunRecord[]> {
+  const store = await readStore(env);
+  return Object.values(store.runs);
+}
+
+/**
+ * Start a best-effort lifecycle listener to clean up persisted inflight runs.
+ *
+ * - On lifecycle end: remove the record immediately.
+ * - On lifecycle error: remove after a grace window unless a new lifecycle start arrives.
+ *
+ * This reduces the chance of re-running completed sessions after restart.
+ */
+export function ensureInflightAgentRunLifecycleCleanerStarted(
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (lifecycleCleanerStarted) {
+    return;
+  }
+  lifecycleCleanerStarted = true;
+  onAgentEvent((evt) => {
+    if (!evt || evt.stream !== "lifecycle") {
+      return;
+    }
+    const phase = evt.data?.phase;
+    if (phase === "start") {
+      clearPendingErrorTimer(evt.runId);
+      return;
+    }
+    if (phase === "end") {
+      void removeInflightAgentRun(evt.runId, env);
+      return;
+    }
+    if (phase === "error") {
+      scheduleErrorCleanup(evt.runId, env);
+    }
+  });
+}
+
+export const __test = {
+  resolveStorePath,
+  readStore,
+};

--- a/src/gateway/inflight-agent-runs.ts
+++ b/src/gateway/inflight-agent-runs.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import type { AgentCommandIngressOpts } from "../commands/agent/types.js";
+import type { OpenClawConfig } from "../config/config.js";
 import { resolveStateDir } from "../config/paths.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { createAsyncLock, readJsonFile, writeJsonAtomic } from "../infra/json-files.js";
@@ -26,22 +27,16 @@ const STORE_FILENAME = "inflight-agent-runs.json";
 const ERROR_GRACE_MS = 15_000;
 
 let lifecycleCleanerUnsub: (() => void) | null = null;
+let lifecycleCleanerEnv: NodeJS.ProcessEnv = process.env;
 const pendingErrorTimers = new Map<string, NodeJS.Timeout>();
-const knownStorePaths = new Set<string>();
-const storeLocks = new Map<string, ReturnType<typeof createAsyncLock>>();
+const storeLock = createAsyncLock();
+
+export function isInflightAgentRunRecoveryEnabled(cfg: OpenClawConfig): boolean {
+  return cfg.gateway?.restartRecovery?.resumeInflightAgentRuns === true;
+}
 
 function resolveStorePath(env: NodeJS.ProcessEnv = process.env): string {
   return path.join(resolveStateDir(env), STORE_FILENAME);
-}
-
-function registerStorePath(storePath: string) {
-  knownStorePaths.add(storePath);
-}
-
-function withStoreLock<T>(storePath: string, fn: () => Promise<T>): Promise<T> {
-  const lock = storeLocks.get(storePath) ?? createAsyncLock();
-  storeLocks.set(storePath, lock);
-  return lock(fn);
 }
 
 function clearPendingErrorTimer(runId: string): void {
@@ -53,17 +48,17 @@ function clearPendingErrorTimer(runId: string): void {
   pendingErrorTimers.delete(runId);
 }
 
-function scheduleErrorCleanup(runId: string): void {
+function scheduleErrorCleanup(runId: string, env: NodeJS.ProcessEnv): void {
   clearPendingErrorTimer(runId);
   const timer = setTimeout(() => {
     pendingErrorTimers.delete(runId);
-    void removeInflightAgentRunFromAllKnownStores(runId);
+    void removeRunFromStore(resolveStorePath(env), runId);
   }, ERROR_GRACE_MS);
   timer.unref?.();
   pendingErrorTimers.set(runId, timer);
 }
 
-async function readStoreFromPath(storePath: string): Promise<InflightAgentRunsStore> {
+async function readStore(storePath: string): Promise<InflightAgentRunsStore> {
   const parsed = await readJsonFile<unknown>(storePath);
   if (!parsed || typeof parsed !== "object") {
     return { version: STORE_VERSION, runs: {} };
@@ -75,38 +70,23 @@ async function readStoreFromPath(storePath: string): Promise<InflightAgentRunsSt
   return { version: STORE_VERSION, runs: rec.runs };
 }
 
-async function writeStoreToPath(storePath: string, store: InflightAgentRunsStore): Promise<void> {
+async function writeStore(storePath: string, store: InflightAgentRunsStore): Promise<void> {
   await writeJsonAtomic(storePath, store, { trailingNewline: true, mode: 0o600 });
 }
 
-async function removeInflightAgentRunFromStorePath(
-  storePath: string,
-  runId: string,
-): Promise<void> {
+async function removeRunFromStore(storePath: string, runId: string): Promise<void> {
   const cleaned = runId.trim();
   if (!cleaned) {
     return;
   }
-  await withStoreLock(storePath, async () => {
-    const store = await readStoreFromPath(storePath);
+  await storeLock(async () => {
+    const store = await readStore(storePath);
     if (!store.runs[cleaned]) {
       return;
     }
     delete store.runs[cleaned];
-    await writeStoreToPath(storePath, store);
+    await writeStore(storePath, store);
   });
-}
-
-async function removeInflightAgentRunFromAllKnownStores(runId: string): Promise<void> {
-  const storePaths = Array.from(knownStorePaths);
-  if (storePaths.length === 0) {
-    return;
-  }
-  await Promise.all(
-    storePaths.map((storePath) =>
-      removeInflightAgentRunFromStorePath(storePath, runId).catch(() => {}),
-    ),
-  );
 }
 
 export async function addInflightAgentRun(
@@ -118,20 +98,14 @@ export async function addInflightAgentRun(
     return;
   }
   const storePath = resolveStorePath(env);
-  registerStorePath(storePath);
-  await withStoreLock(storePath, async () => {
-    const store = await readStoreFromPath(storePath);
+  await storeLock(async () => {
+    const store = await readStore(storePath);
     store.runs[cleanedRunId] = {
       ...record,
       runId: cleanedRunId,
       acceptedAt: Math.floor(record.acceptedAt),
-      opts: {
-        ...record.opts,
-        runId: cleanedRunId,
-        senderIsOwner: record.opts.senderIsOwner,
-      },
     };
-    await writeStoreToPath(storePath, store);
+    await writeStore(storePath, store);
   });
 }
 
@@ -147,50 +121,55 @@ export async function removeInflightAgentRun(
     return;
   }
   clearPendingErrorTimer(cleaned);
-  const storePath = resolveStorePath(env);
-  registerStorePath(storePath);
-  await removeInflightAgentRunFromStorePath(storePath, cleaned);
+  await removeRunFromStore(resolveStorePath(env), cleaned);
 }
 
-export async function markInflightAgentRunResumed(
-  runId: string,
+/**
+ * Batch-update resumeCount/lastResumeAt for all given runIds in a single
+ * read-modify-write cycle.
+ */
+export async function markInflightAgentRunsResumed(
+  runIds: string[],
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<void> {
-  const cleaned = runId.trim();
-  if (!cleaned) {
+  const cleaned = runIds.map((id) => id.trim()).filter(Boolean);
+  if (cleaned.length === 0) {
     return;
   }
   const storePath = resolveStorePath(env);
-  registerStorePath(storePath);
-  await withStoreLock(storePath, async () => {
-    const store = await readStoreFromPath(storePath);
-    const existing = store.runs[cleaned];
-    if (!existing) {
-      return;
+  const now = Date.now();
+  await storeLock(async () => {
+    const store = await readStore(storePath);
+    let changed = false;
+    for (const id of cleaned) {
+      const existing = store.runs[id];
+      if (!existing) {
+        continue;
+      }
+      store.runs[id] = {
+        ...existing,
+        resumeCount: (existing.resumeCount ?? 0) + 1,
+        lastResumeAt: now,
+      };
+      changed = true;
     }
-    store.runs[cleaned] = {
-      ...existing,
-      resumeCount: (existing.resumeCount ?? 0) + 1,
-      lastResumeAt: Date.now(),
-    };
-    await writeStoreToPath(storePath, store);
+    if (changed) {
+      await writeStore(storePath, store);
+    }
   });
 }
 
 export async function listInflightAgentRuns(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<InflightAgentRunRecord[]> {
-  const storePath = resolveStorePath(env);
-  registerStorePath(storePath);
-  const store = await readStoreFromPath(storePath);
+  const store = await readStore(resolveStorePath(env));
   return Object.values(store.runs ?? {});
 }
 
 export async function clearInflightAgentRuns(env: NodeJS.ProcessEnv = process.env): Promise<void> {
   const storePath = resolveStorePath(env);
-  registerStorePath(storePath);
-  await withStoreLock(storePath, async () => {
-    await writeStoreToPath(storePath, { version: STORE_VERSION, runs: {} });
+  await storeLock(async () => {
+    await writeStore(storePath, { version: STORE_VERSION, runs: {} });
   });
 }
 
@@ -205,7 +184,7 @@ export async function clearInflightAgentRuns(env: NodeJS.ProcessEnv = process.en
 export function ensureInflightAgentRunLifecycleCleanerStarted(
   env: NodeJS.ProcessEnv = process.env,
 ): void {
-  registerStorePath(resolveStorePath(env));
+  lifecycleCleanerEnv = env;
   if (lifecycleCleanerUnsub) {
     return;
   }
@@ -222,14 +201,14 @@ export function ensureInflightAgentRunLifecycleCleanerStarted(
       if (shouldPreserveInflightAgentRunsForPendingRestart()) {
         return;
       }
-      void removeInflightAgentRunFromAllKnownStores(evt.runId);
+      void removeRunFromStore(resolveStorePath(lifecycleCleanerEnv), evt.runId);
       return;
     }
     if (phase === "error") {
       if (shouldPreserveInflightAgentRunsForPendingRestart()) {
         return;
       }
-      scheduleErrorCleanup(evt.runId);
+      scheduleErrorCleanup(evt.runId, lifecycleCleanerEnv);
     }
   });
 }
@@ -237,18 +216,15 @@ export function ensureInflightAgentRunLifecycleCleanerStarted(
 export const __test = {
   resolveStorePath,
   readStore: async (env: NodeJS.ProcessEnv = process.env) => {
-    const storePath = resolveStorePath(env);
-    registerStorePath(storePath);
-    return await readStoreFromPath(storePath);
+    return await readStore(resolveStorePath(env));
   },
   reset: () => {
     lifecycleCleanerUnsub?.();
     lifecycleCleanerUnsub = null;
+    lifecycleCleanerEnv = process.env;
     for (const timer of pendingErrorTimers.values()) {
       clearTimeout(timer);
     }
     pendingErrorTimers.clear();
-    knownStorePaths.clear();
-    storeLocks.clear();
   },
 };

--- a/src/gateway/inflight-agent-runs.ts
+++ b/src/gateway/inflight-agent-runs.ts
@@ -3,6 +3,7 @@ import type { AgentCommandIngressOpts } from "../commands/agent/types.js";
 import { resolveStateDir } from "../config/paths.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { createAsyncLock, readJsonFile, writeJsonAtomic } from "../infra/json-files.js";
+import { shouldPreserveInflightAgentRunsForPendingRestart } from "../infra/restart.js";
 
 type InflightAgentRunRecord = {
   runId: string;
@@ -142,6 +143,9 @@ export async function removeInflightAgentRun(
   if (!cleaned) {
     return;
   }
+  if (shouldPreserveInflightAgentRunsForPendingRestart()) {
+    return;
+  }
   clearPendingErrorTimer(cleaned);
   const storePath = resolveStorePath(env);
   registerStorePath(storePath);
@@ -215,10 +219,16 @@ export function ensureInflightAgentRunLifecycleCleanerStarted(
       return;
     }
     if (phase === "end") {
+      if (shouldPreserveInflightAgentRunsForPendingRestart()) {
+        return;
+      }
       void removeInflightAgentRunFromAllKnownStores(evt.runId);
       return;
     }
     if (phase === "error") {
+      if (shouldPreserveInflightAgentRunsForPendingRestart()) {
+        return;
+      }
       scheduleErrorCleanup(evt.runId);
     }
   });

--- a/src/gateway/inflight-agent-runs.ts
+++ b/src/gateway/inflight-agent-runs.ts
@@ -1,8 +1,8 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import type { AgentCommandIngressOpts } from "../commands/agent/types.js";
 import { resolveStateDir } from "../config/paths.js";
 import { onAgentEvent } from "../infra/agent-events.js";
+import { createAsyncLock, readJsonFile, writeJsonAtomic } from "../infra/json-files.js";
 
 type InflightAgentRunRecord = {
   runId: string;
@@ -24,41 +24,23 @@ const STORE_FILENAME = "inflight-agent-runs.json";
 // Some embedded runs can emit transient lifecycle "error" events during failover.
 const ERROR_GRACE_MS = 15_000;
 
-let lifecycleCleanerStarted = false;
+let lifecycleCleanerUnsub: (() => void) | null = null;
 const pendingErrorTimers = new Map<string, NodeJS.Timeout>();
+const knownStorePaths = new Set<string>();
+const storeLocks = new Map<string, ReturnType<typeof createAsyncLock>>();
 
 function resolveStorePath(env: NodeJS.ProcessEnv = process.env): string {
   return path.join(resolveStateDir(env), STORE_FILENAME);
 }
 
-async function readStore(env: NodeJS.ProcessEnv = process.env): Promise<InflightAgentRunsStore> {
-  const filePath = resolveStorePath(env);
-  try {
-    const raw = await fs.readFile(filePath, "utf-8");
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== "object") {
-      return { version: STORE_VERSION, runs: {} };
-    }
-    const rec = parsed as Partial<InflightAgentRunsStore>;
-    if (rec.version !== STORE_VERSION || !rec.runs || typeof rec.runs !== "object") {
-      return { version: STORE_VERSION, runs: {} };
-    }
-    return { version: STORE_VERSION, runs: rec.runs };
-  } catch {
-    return { version: STORE_VERSION, runs: {} };
-  }
+function registerStorePath(storePath: string) {
+  knownStorePaths.add(storePath);
 }
 
-async function writeStore(
-  store: InflightAgentRunsStore,
-  env: NodeJS.ProcessEnv = process.env,
-): Promise<void> {
-  const filePath = resolveStorePath(env);
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  const tmp = `${filePath}.tmp.${process.pid}.${Math.random().toString(16).slice(2)}`;
-  const data = `${JSON.stringify(store, null, 2)}\n`;
-  await fs.writeFile(tmp, data, "utf-8");
-  await fs.rename(tmp, filePath);
+function withStoreLock<T>(storePath: string, fn: () => Promise<T>): Promise<T> {
+  const lock = storeLocks.get(storePath) ?? createAsyncLock();
+  storeLocks.set(storePath, lock);
+  return lock(fn);
 }
 
 function clearPendingErrorTimer(runId: string): void {
@@ -70,14 +52,60 @@ function clearPendingErrorTimer(runId: string): void {
   pendingErrorTimers.delete(runId);
 }
 
-function scheduleErrorCleanup(runId: string, env: NodeJS.ProcessEnv = process.env): void {
+function scheduleErrorCleanup(runId: string): void {
   clearPendingErrorTimer(runId);
   const timer = setTimeout(() => {
     pendingErrorTimers.delete(runId);
-    void removeInflightAgentRun(runId, env);
+    void removeInflightAgentRunFromAllKnownStores(runId);
   }, ERROR_GRACE_MS);
   timer.unref?.();
   pendingErrorTimers.set(runId, timer);
+}
+
+async function readStoreFromPath(storePath: string): Promise<InflightAgentRunsStore> {
+  const parsed = await readJsonFile<unknown>(storePath);
+  if (!parsed || typeof parsed !== "object") {
+    return { version: STORE_VERSION, runs: {} };
+  }
+  const rec = parsed as Partial<InflightAgentRunsStore>;
+  if (rec.version !== STORE_VERSION || !rec.runs || typeof rec.runs !== "object") {
+    return { version: STORE_VERSION, runs: {} };
+  }
+  return { version: STORE_VERSION, runs: rec.runs };
+}
+
+async function writeStoreToPath(storePath: string, store: InflightAgentRunsStore): Promise<void> {
+  await writeJsonAtomic(storePath, store, { trailingNewline: true, mode: 0o600 });
+}
+
+async function removeInflightAgentRunFromStorePath(
+  storePath: string,
+  runId: string,
+): Promise<void> {
+  const cleaned = runId.trim();
+  if (!cleaned) {
+    return;
+  }
+  await withStoreLock(storePath, async () => {
+    const store = await readStoreFromPath(storePath);
+    if (!store.runs[cleaned]) {
+      return;
+    }
+    delete store.runs[cleaned];
+    await writeStoreToPath(storePath, store);
+  });
+}
+
+async function removeInflightAgentRunFromAllKnownStores(runId: string): Promise<void> {
+  const storePaths = Array.from(knownStorePaths);
+  if (storePaths.length === 0) {
+    return;
+  }
+  await Promise.all(
+    storePaths.map((storePath) =>
+      removeInflightAgentRunFromStorePath(storePath, runId).catch(() => {}),
+    ),
+  );
 }
 
 export async function addInflightAgentRun(
@@ -88,18 +116,22 @@ export async function addInflightAgentRun(
   if (!cleanedRunId) {
     return;
   }
-  const store = await readStore(env);
-  store.runs[cleanedRunId] = {
-    ...record,
-    runId: cleanedRunId,
-    acceptedAt: Math.floor(record.acceptedAt),
-    opts: {
-      ...record.opts,
+  const storePath = resolveStorePath(env);
+  registerStorePath(storePath);
+  await withStoreLock(storePath, async () => {
+    const store = await readStoreFromPath(storePath);
+    store.runs[cleanedRunId] = {
+      ...record,
       runId: cleanedRunId,
-      senderIsOwner: record.opts.senderIsOwner,
-    },
-  };
-  await writeStore(store, env);
+      acceptedAt: Math.floor(record.acceptedAt),
+      opts: {
+        ...record.opts,
+        runId: cleanedRunId,
+        senderIsOwner: record.opts.senderIsOwner,
+      },
+    };
+    await writeStoreToPath(storePath, store);
+  });
 }
 
 export async function removeInflightAgentRun(
@@ -111,12 +143,9 @@ export async function removeInflightAgentRun(
     return;
   }
   clearPendingErrorTimer(cleaned);
-  const store = await readStore(env);
-  if (!store.runs[cleaned]) {
-    return;
-  }
-  delete store.runs[cleaned];
-  await writeStore(store, env);
+  const storePath = resolveStorePath(env);
+  registerStorePath(storePath);
+  await removeInflightAgentRunFromStorePath(storePath, cleaned);
 }
 
 export async function markInflightAgentRunResumed(
@@ -127,24 +156,30 @@ export async function markInflightAgentRunResumed(
   if (!cleaned) {
     return;
   }
-  const store = await readStore(env);
-  const existing = store.runs[cleaned];
-  if (!existing) {
-    return;
-  }
-  store.runs[cleaned] = {
-    ...existing,
-    resumeCount: (existing.resumeCount ?? 0) + 1,
-    lastResumeAt: Date.now(),
-  };
-  await writeStore(store, env);
+  const storePath = resolveStorePath(env);
+  registerStorePath(storePath);
+  await withStoreLock(storePath, async () => {
+    const store = await readStoreFromPath(storePath);
+    const existing = store.runs[cleaned];
+    if (!existing) {
+      return;
+    }
+    store.runs[cleaned] = {
+      ...existing,
+      resumeCount: (existing.resumeCount ?? 0) + 1,
+      lastResumeAt: Date.now(),
+    };
+    await writeStoreToPath(storePath, store);
+  });
 }
 
 export async function listInflightAgentRuns(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<InflightAgentRunRecord[]> {
-  const store = await readStore(env);
-  return Object.values(store.runs);
+  const storePath = resolveStorePath(env);
+  registerStorePath(storePath);
+  const store = await readStoreFromPath(storePath);
+  return Object.values(store.runs ?? {});
 }
 
 /**
@@ -158,11 +193,11 @@ export async function listInflightAgentRuns(
 export function ensureInflightAgentRunLifecycleCleanerStarted(
   env: NodeJS.ProcessEnv = process.env,
 ): void {
-  if (lifecycleCleanerStarted) {
+  registerStorePath(resolveStorePath(env));
+  if (lifecycleCleanerUnsub) {
     return;
   }
-  lifecycleCleanerStarted = true;
-  onAgentEvent((evt) => {
+  lifecycleCleanerUnsub = onAgentEvent((evt) => {
     if (!evt || evt.stream !== "lifecycle") {
       return;
     }
@@ -172,16 +207,30 @@ export function ensureInflightAgentRunLifecycleCleanerStarted(
       return;
     }
     if (phase === "end") {
-      void removeInflightAgentRun(evt.runId, env);
+      void removeInflightAgentRunFromAllKnownStores(evt.runId);
       return;
     }
     if (phase === "error") {
-      scheduleErrorCleanup(evt.runId, env);
+      scheduleErrorCleanup(evt.runId);
     }
   });
 }
 
 export const __test = {
   resolveStorePath,
-  readStore,
+  readStore: async (env: NodeJS.ProcessEnv = process.env) => {
+    const storePath = resolveStorePath(env);
+    registerStorePath(storePath);
+    return await readStoreFromPath(storePath);
+  },
+  reset: () => {
+    lifecycleCleanerUnsub?.();
+    lifecycleCleanerUnsub = null;
+    for (const timer of pendingErrorTimers.values()) {
+      clearTimeout(timer);
+    }
+    pendingErrorTimers.clear();
+    knownStorePaths.clear();
+    storeLocks.clear();
+  },
 };

--- a/src/gateway/restart-resume.test.ts
+++ b/src/gateway/restart-resume.test.ts
@@ -1,0 +1,79 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { CliDeps } from "../cli/deps.js";
+import type { AgentCommandIngressOpts } from "../commands/agent/types.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { writeRestartSentinel } from "../infra/restart-sentinel.js";
+import { defaultRuntime } from "../runtime.js";
+import { __test, addInflightAgentRun } from "./inflight-agent-runs.js";
+import { maybeResumeInflightAgentRunsAfterRestart } from "./restart-resume.js";
+
+type AgentCommandFromIngress = typeof import("../commands/agent.js").agentCommandFromIngress;
+
+const savedEnv = { ...process.env };
+
+async function makeTempStateDir(prefix: string) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  process.env.OPENCLAW_STATE_DIR = dir;
+  return dir;
+}
+
+afterEach(async () => {
+  process.env = { ...savedEnv };
+});
+
+describe("restart resume", () => {
+  it("resumes inflight agent runs when restart sentinel kind=restart", async () => {
+    const dir = await makeTempStateDir("openclaw-restart-resume-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+
+    await writeRestartSentinel(
+      {
+        kind: "restart",
+        status: "ok",
+        ts: Date.now(),
+        message: "restart",
+      },
+      env,
+    );
+
+    const runId = "run-resume-1";
+    const opts: AgentCommandIngressOpts = {
+      message: "original",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      deliver: false,
+      senderIsOwner: true,
+      runId,
+    };
+    await addInflightAgentRun({ runId, acceptedAt: Date.now(), opts }, env);
+
+    const runAgentMock = vi.fn(async (_o: AgentCommandIngressOpts) => undefined);
+    const cfg: OpenClawConfig = {
+      gateway: { restartRecovery: { resumeInflightAgentRuns: true } },
+    };
+
+    const result = await maybeResumeInflightAgentRunsAfterRestart({
+      cfg,
+      deps: {} as unknown as CliDeps,
+      runtime: defaultRuntime,
+      env,
+      getActiveRunCount: () => 0,
+      runAgent: runAgentMock as unknown as AgentCommandFromIngress,
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(result.considered).toBe(1);
+    expect(result.resumed).toBe(1);
+    expect(runAgentMock).toHaveBeenCalledTimes(1);
+    const calledOpts = runAgentMock.mock.calls[0]?.[0];
+    expect(calledOpts.runId).toBe(runId);
+    expect(calledOpts.senderIsOwner).toBe(true);
+    expect(calledOpts.message).toMatch(/gateway restarted/i);
+
+    const store = await __test.readStore(env);
+    expect(store.runs[runId]?.resumeCount).toBe(1);
+  });
+});

--- a/src/gateway/restart-resume.test.ts
+++ b/src/gateway/restart-resume.test.ts
@@ -122,4 +122,41 @@ describe("restart resume", () => {
     expect(result.resumed).toBe(0);
     expect(runAgentMock).toHaveBeenCalledTimes(0);
   });
+
+  it("clears inflight records when enabled but no restart sentinel is present", async () => {
+    const dir = await makeTempStateDir("openclaw-restart-resume-clear-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+
+    const runId = "run-clear-1";
+    const opts: AgentCommandIngressOpts = {
+      message: "original",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      deliver: false,
+      senderIsOwner: true,
+      runId,
+    };
+    await addInflightAgentRun({ runId, acceptedAt: Date.now(), opts }, env);
+
+    const runAgentMock = vi.fn(async (_o: AgentCommandIngressOpts) => undefined);
+    const cfg: OpenClawConfig = {
+      gateway: { restartRecovery: { resumeInflightAgentRuns: true } },
+    };
+
+    const result = await maybeResumeInflightAgentRunsAfterRestart({
+      cfg,
+      deps: {} as unknown as CliDeps,
+      runtime: defaultRuntime,
+      env,
+      getActiveRunCount: () => 0,
+      runAgent: runAgentMock as unknown as AgentCommandFromIngress,
+    });
+
+    expect(result.skipped).toBe(true);
+    expect(result.resumed).toBe(0);
+    expect(runAgentMock).toHaveBeenCalledTimes(0);
+
+    const store = await __test.readStore(env);
+    expect(Object.keys(store.runs)).toHaveLength(0);
+  });
 });

--- a/src/gateway/restart-resume.test.ts
+++ b/src/gateway/restart-resume.test.ts
@@ -204,4 +204,51 @@ describe("restart resume", () => {
     const store = await __test.readStore(env);
     expect(Object.keys(store.runs)).toHaveLength(0);
   });
+
+  it("does not resume runs for a non-success update sentinel", async () => {
+    const dir = await makeTempStateDir("openclaw-restart-resume-update-error-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+
+    await writeRestartSentinel(
+      {
+        kind: "update",
+        status: "error",
+        ts: Date.now(),
+        message: "update failed",
+      },
+      env,
+    );
+
+    const runId = "run-update-error-1";
+    const opts: AgentCommandIngressOpts = {
+      message: "original",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      deliver: false,
+      senderIsOwner: true,
+      runId,
+    };
+    await addInflightAgentRun({ runId, acceptedAt: Date.now(), opts }, env);
+
+    const runAgentMock = vi.fn(async (_o: AgentCommandIngressOpts) => undefined);
+    const cfg: OpenClawConfig = {
+      gateway: { restartRecovery: { resumeInflightAgentRuns: true } },
+    };
+
+    const result = await maybeResumeInflightAgentRunsAfterRestart({
+      cfg,
+      deps: {} as unknown as CliDeps,
+      runtime: defaultRuntime,
+      env,
+      getActiveRunCount: () => 0,
+      runAgent: runAgentMock as unknown as AgentCommandFromIngress,
+    });
+
+    expect(result.skipped).toBe(true);
+    expect(result.resumed).toBe(0);
+    expect(runAgentMock).toHaveBeenCalledTimes(0);
+
+    const store = await __test.readStore(env);
+    expect(Object.keys(store.runs)).toHaveLength(0);
+  });
 });

--- a/src/gateway/restart-resume.test.ts
+++ b/src/gateway/restart-resume.test.ts
@@ -21,6 +21,7 @@ async function makeTempStateDir(prefix: string) {
 }
 
 afterEach(async () => {
+  __test.reset();
   process.env = { ...savedEnv };
 });
 
@@ -75,5 +76,50 @@ describe("restart resume", () => {
 
     const store = await __test.readStore(env);
     expect(store.runs[runId]?.resumeCount).toBe(1);
+  });
+
+  it("skips resuming runs that exceeded the max resume attempts", async () => {
+    const dir = await makeTempStateDir("openclaw-restart-resume-cap-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+
+    await writeRestartSentinel(
+      {
+        kind: "restart",
+        status: "ok",
+        ts: Date.now(),
+        message: "restart",
+      },
+      env,
+    );
+
+    const runId = "run-resume-cap-1";
+    const opts: AgentCommandIngressOpts = {
+      message: "original",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      deliver: false,
+      senderIsOwner: true,
+      runId,
+    };
+    await addInflightAgentRun({ runId, acceptedAt: Date.now(), opts, resumeCount: 10 }, env);
+
+    const runAgentMock = vi.fn(async (_o: AgentCommandIngressOpts) => undefined);
+    const cfg: OpenClawConfig = {
+      gateway: { restartRecovery: { resumeInflightAgentRuns: true } },
+    };
+
+    const result = await maybeResumeInflightAgentRunsAfterRestart({
+      cfg,
+      deps: {} as unknown as CliDeps,
+      runtime: defaultRuntime,
+      env,
+      getActiveRunCount: () => 0,
+      runAgent: runAgentMock as unknown as AgentCommandFromIngress,
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(result.considered).toBe(1);
+    expect(result.resumed).toBe(0);
+    expect(runAgentMock).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/gateway/restart-resume.test.ts
+++ b/src/gateway/restart-resume.test.ts
@@ -78,6 +78,51 @@ describe("restart resume", () => {
     expect(store.runs[runId]?.resumeCount).toBe(1);
   });
 
+  it("resumes inflight agent runs when restart sentinel kind=config-patch", async () => {
+    const dir = await makeTempStateDir("openclaw-restart-resume-patch-");
+    const env = { ...process.env, OPENCLAW_STATE_DIR: dir };
+
+    await writeRestartSentinel(
+      {
+        kind: "config-patch",
+        status: "ok",
+        ts: Date.now(),
+        message: "config patch restart",
+      },
+      env,
+    );
+
+    const runId = "run-resume-patch-1";
+    const opts: AgentCommandIngressOpts = {
+      message: "original",
+      sessionId: "sess-1",
+      sessionKey: "main",
+      deliver: false,
+      senderIsOwner: true,
+      runId,
+    };
+    await addInflightAgentRun({ runId, acceptedAt: Date.now(), opts }, env);
+
+    const runAgentMock = vi.fn(async (_o: AgentCommandIngressOpts) => undefined);
+    const cfg: OpenClawConfig = {
+      gateway: { restartRecovery: { resumeInflightAgentRuns: true } },
+    };
+
+    const result = await maybeResumeInflightAgentRunsAfterRestart({
+      cfg,
+      deps: {} as unknown as CliDeps,
+      runtime: defaultRuntime,
+      env,
+      getActiveRunCount: () => 0,
+      runAgent: runAgentMock as unknown as AgentCommandFromIngress,
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(result.considered).toBe(1);
+    expect(result.resumed).toBe(1);
+    expect(runAgentMock).toHaveBeenCalledTimes(1);
+  });
+
   it("skips resuming runs that exceeded the max resume attempts", async () => {
     const dir = await makeTempStateDir("openclaw-restart-resume-cap-");
     const env = { ...process.env, OPENCLAW_STATE_DIR: dir };

--- a/src/gateway/restart-resume.ts
+++ b/src/gateway/restart-resume.ts
@@ -1,0 +1,73 @@
+import type { CliDeps } from "../cli/deps.js";
+import { agentCommandFromIngress } from "../commands/agent.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { type RestartSentinel, readRestartSentinel } from "../infra/restart-sentinel.js";
+import type { RuntimeEnv } from "../runtime.js";
+import {
+  ensureInflightAgentRunLifecycleCleanerStarted,
+  listInflightAgentRuns,
+  markInflightAgentRunResumed,
+} from "./inflight-agent-runs.js";
+
+const DEFAULT_RESUME_PROMPT =
+  "Continue where you left off. The OpenClaw gateway restarted while you were running.";
+
+export async function maybeResumeInflightAgentRunsAfterRestart(params: {
+  cfg: OpenClawConfig;
+  deps: CliDeps;
+  runtime: RuntimeEnv;
+  env?: NodeJS.ProcessEnv;
+  /**
+   * Optional pre-read sentinel snapshot.
+   * This avoids races with other startup code that consumes the sentinel.
+   */
+  sentinel?: RestartSentinel | null;
+  /**
+   * If provided and returns >0, resumption will be skipped to reduce duplicate
+   * work during in-process restarts where older runs may still be active.
+   */
+  getActiveRunCount?: () => number;
+  runAgent?: typeof agentCommandFromIngress;
+}): Promise<{ resumed: number; considered: number; skipped: boolean }> {
+  const enabled = params.cfg.gateway?.restartRecovery?.resumeInflightAgentRuns === true;
+  if (!enabled) {
+    return { resumed: 0, considered: 0, skipped: true };
+  }
+
+  const env = params.env ?? process.env;
+  const sentinel = params.sentinel ?? (await readRestartSentinel(env).catch(() => null));
+  if (!sentinel || sentinel.payload?.kind !== "restart") {
+    return { resumed: 0, considered: 0, skipped: true };
+  }
+
+  const active = params.getActiveRunCount?.() ?? 0;
+  if (active > 0) {
+    return { resumed: 0, considered: 0, skipped: true };
+  }
+
+  ensureInflightAgentRunLifecycleCleanerStarted(env);
+  const inflight = await listInflightAgentRuns(env);
+  const run = params.runAgent ?? agentCommandFromIngress;
+
+  let resumed = 0;
+  for (const entry of inflight) {
+    const runId = entry.runId?.trim();
+    if (!runId) {
+      continue;
+    }
+    const baseOpts = entry.opts;
+    // Force idempotency key stability and avoid re-playing the original prompt.
+    // The resumed run uses the existing session transcript as context.
+    const resumeOpts = {
+      ...baseOpts,
+      runId,
+      message: DEFAULT_RESUME_PROMPT,
+      senderIsOwner: baseOpts.senderIsOwner,
+    };
+    await markInflightAgentRunResumed(runId, env).catch(() => {});
+    void run(resumeOpts, params.runtime, params.deps).catch(() => {});
+    resumed += 1;
+  }
+
+  return { resumed, considered: inflight.length, skipped: false };
+}

--- a/src/gateway/restart-resume.ts
+++ b/src/gateway/restart-resume.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { type RestartSentinel, readRestartSentinel } from "../infra/restart-sentinel.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
+  clearInflightAgentRuns,
   ensureInflightAgentRunLifecycleCleanerStarted,
   listInflightAgentRuns,
   markInflightAgentRunResumed,
@@ -36,13 +37,17 @@ export async function maybeResumeInflightAgentRunsAfterRestart(params: {
   }
 
   const env = params.env ?? process.env;
-  const sentinel = params.sentinel ?? (await readRestartSentinel(env).catch(() => null));
-  if (!sentinel || sentinel.payload?.kind !== "restart") {
+  const active = params.getActiveRunCount?.() ?? 0;
+  if (active > 0) {
     return { resumed: 0, considered: 0, skipped: true };
   }
 
-  const active = params.getActiveRunCount?.() ?? 0;
-  if (active > 0) {
+  const sentinel = params.sentinel ?? (await readRestartSentinel(env).catch(() => null));
+  if (!sentinel || sentinel.payload?.kind !== "restart") {
+    // Best-effort: if the gateway started without an explicit restart sentinel,
+    // clear any leftover inflight records (e.g. after a hard crash) so they do
+    // not get resumed on a future unrelated restart.
+    await clearInflightAgentRuns(env).catch(() => {});
     return { resumed: 0, considered: 0, skipped: true };
   }
 

--- a/src/gateway/restart-resume.ts
+++ b/src/gateway/restart-resume.ts
@@ -14,6 +14,22 @@ const DEFAULT_RESUME_PROMPT =
   "Continue where you left off. The OpenClaw gateway restarted while you were running.";
 const MAX_RESUME_ATTEMPTS = 10;
 
+function isRestartEligibleSentinel(sentinel: RestartSentinel | null | undefined): boolean {
+  const payload = sentinel?.payload;
+  if (!payload || payload.status !== "ok") {
+    return false;
+  }
+  switch (payload.kind) {
+    case "restart":
+    case "config-apply":
+    case "config-patch":
+    case "update":
+      return true;
+    default:
+      return false;
+  }
+}
+
 export async function maybeResumeInflightAgentRunsAfterRestart(params: {
   cfg: OpenClawConfig;
   deps: CliDeps;
@@ -43,7 +59,7 @@ export async function maybeResumeInflightAgentRunsAfterRestart(params: {
   }
 
   const sentinel = params.sentinel ?? (await readRestartSentinel(env).catch(() => null));
-  if (!sentinel || !sentinel.payload) {
+  if (!isRestartEligibleSentinel(sentinel)) {
     // Best-effort: if the gateway started without a valid restart sentinel,
     // clear any leftover inflight records (e.g. after a hard crash) so they do
     // not get resumed on a future unrelated restart.

--- a/src/gateway/restart-resume.ts
+++ b/src/gateway/restart-resume.ts
@@ -1,18 +1,23 @@
 import type { CliDeps } from "../cli/deps.js";
 import { agentCommandFromIngress } from "../commands/agent.js";
 import type { OpenClawConfig } from "../config/config.js";
+import { logVerbose } from "../globals.js";
 import { type RestartSentinel, readRestartSentinel } from "../infra/restart-sentinel.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
   clearInflightAgentRuns,
   ensureInflightAgentRunLifecycleCleanerStarted,
+  isInflightAgentRunRecoveryEnabled,
   listInflightAgentRuns,
-  markInflightAgentRunResumed,
+  markInflightAgentRunsResumed,
 } from "./inflight-agent-runs.js";
 
 const DEFAULT_RESUME_PROMPT =
   "Continue where you left off. The OpenClaw gateway restarted while you were running.";
 const MAX_RESUME_ATTEMPTS = 10;
+// Skip records older than 10 minutes — stale runs are unlikely to produce
+// useful continuations after such a long gap.
+const MAX_AGE_MS = 10 * 60 * 1000;
 
 function isRestartEligibleSentinel(sentinel: RestartSentinel | null | undefined): boolean {
   const payload = sentinel?.payload;
@@ -47,8 +52,7 @@ export async function maybeResumeInflightAgentRunsAfterRestart(params: {
   getActiveRunCount?: () => number;
   runAgent?: typeof agentCommandFromIngress;
 }): Promise<{ resumed: number; considered: number; skipped: boolean }> {
-  const enabled = params.cfg.gateway?.restartRecovery?.resumeInflightAgentRuns === true;
-  if (!enabled) {
+  if (!isInflightAgentRunRecoveryEnabled(params.cfg)) {
     return { resumed: 0, considered: 0, skipped: true };
   }
 
@@ -70,8 +74,9 @@ export async function maybeResumeInflightAgentRunsAfterRestart(params: {
   ensureInflightAgentRunLifecycleCleanerStarted(env);
   const inflight = await listInflightAgentRuns(env);
   const run = params.runAgent ?? agentCommandFromIngress;
+  const now = Date.now();
 
-  let resumed = 0;
+  const resumedIds: string[] = [];
   for (const entry of inflight) {
     const runId = entry.runId?.trim();
     if (!runId) {
@@ -80,19 +85,23 @@ export async function maybeResumeInflightAgentRunsAfterRestart(params: {
     if ((entry.resumeCount ?? 0) >= MAX_RESUME_ATTEMPTS) {
       continue;
     }
+    if (now - entry.acceptedAt > MAX_AGE_MS) {
+      logVerbose(`restart recovery: skipping stale run ${runId} (age ${now - entry.acceptedAt}ms)`);
+      continue;
+    }
     const baseOpts = entry.opts;
-    // Force idempotency key stability and avoid re-playing the original prompt.
-    // The resumed run uses the existing session transcript as context.
     const resumeOpts = {
       ...baseOpts,
       runId,
       message: DEFAULT_RESUME_PROMPT,
-      senderIsOwner: baseOpts.senderIsOwner,
     };
-    await markInflightAgentRunResumed(runId, env).catch(() => {});
-    void run(resumeOpts, params.runtime, params.deps).catch(() => {});
-    resumed += 1;
+    void run(resumeOpts, params.runtime, params.deps).catch((err) => {
+      logVerbose(`restart recovery: resumed run ${runId} failed: ${String(err)}`);
+    });
+    resumedIds.push(runId);
   }
 
-  return { resumed, considered: inflight.length, skipped: false };
+  await markInflightAgentRunsResumed(resumedIds, env).catch(() => {});
+
+  return { resumed: resumedIds.length, considered: inflight.length, skipped: false };
 }

--- a/src/gateway/restart-resume.ts
+++ b/src/gateway/restart-resume.ts
@@ -11,6 +11,7 @@ import {
 
 const DEFAULT_RESUME_PROMPT =
   "Continue where you left off. The OpenClaw gateway restarted while you were running.";
+const MAX_RESUME_ATTEMPTS = 10;
 
 export async function maybeResumeInflightAgentRunsAfterRestart(params: {
   cfg: OpenClawConfig;
@@ -53,6 +54,9 @@ export async function maybeResumeInflightAgentRunsAfterRestart(params: {
   for (const entry of inflight) {
     const runId = entry.runId?.trim();
     if (!runId) {
+      continue;
+    }
+    if ((entry.resumeCount ?? 0) >= MAX_RESUME_ATTEMPTS) {
       continue;
     }
     const baseOpts = entry.opts;

--- a/src/gateway/restart-resume.ts
+++ b/src/gateway/restart-resume.ts
@@ -43,8 +43,8 @@ export async function maybeResumeInflightAgentRunsAfterRestart(params: {
   }
 
   const sentinel = params.sentinel ?? (await readRestartSentinel(env).catch(() => null));
-  if (!sentinel || sentinel.payload?.kind !== "restart") {
-    // Best-effort: if the gateway started without an explicit restart sentinel,
+  if (!sentinel || !sentinel.payload) {
+    // Best-effort: if the gateway started without a valid restart sentinel,
     // clear any leftover inflight records (e.g. after a hard crash) so they do
     // not get resumed on a future unrelated restart.
     await clearInflightAgentRuns(env).catch(() => {});

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -36,7 +36,11 @@ import {
 import { resolveAssistantIdentity } from "../assistant-identity.js";
 import { parseMessageWithAttachments } from "../chat-attachments.js";
 import { resolveAssistantAvatarUrl } from "../control-ui-shared.js";
-import { addInflightAgentRun, removeInflightAgentRun } from "../inflight-agent-runs.js";
+import {
+  addInflightAgentRun,
+  isInflightAgentRunRecoveryEnabled,
+  removeInflightAgentRun,
+} from "../inflight-agent-runs.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
 import { GATEWAY_CLIENT_CAPS, hasGatewayClientCap } from "../protocol/client-info.js";
 import {
@@ -620,7 +624,7 @@ export const agentHandlers: GatewayRequestHandlers = {
 
     const resolvedThreadId = explicitThreadId ?? deliveryPlan.resolvedThreadId;
 
-    const shouldPersistInflight = cfg.gateway?.restartRecovery?.resumeInflightAgentRuns === true;
+    const shouldPersistInflight = isInflightAgentRunRecoveryEnabled(cfg);
     const runOpts = {
       message,
       images,

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -36,6 +36,7 @@ import {
 import { resolveAssistantIdentity } from "../assistant-identity.js";
 import { parseMessageWithAttachments } from "../chat-attachments.js";
 import { resolveAssistantAvatarUrl } from "../control-ui-shared.js";
+import { addInflightAgentRun, removeInflightAgentRun } from "../inflight-agent-runs.js";
 import { ADMIN_SCOPE } from "../method-scopes.js";
 import { GATEWAY_CLIENT_CAPS, hasGatewayClientCap } from "../protocol/client-info.js";
 import {
@@ -167,58 +168,6 @@ async function runSessionResetFromAgent(params: {
       }
     })();
   });
-}
-
-function dispatchAgentRunFromGateway(params: {
-  ingressOpts: Parameters<typeof agentCommandFromIngress>[0];
-  runId: string;
-  idempotencyKey: string;
-  respond: GatewayRequestHandlerOptions["respond"];
-  context: GatewayRequestHandlerOptions["context"];
-}) {
-  void agentCommandFromIngress(params.ingressOpts, defaultRuntime, params.context.deps)
-    .then((result) => {
-      const payload = {
-        runId: params.runId,
-        status: "ok" as const,
-        summary: "completed",
-        result,
-      };
-      setGatewayDedupeEntry({
-        dedupe: params.context.dedupe,
-        key: `agent:${params.idempotencyKey}`,
-        entry: {
-          ts: Date.now(),
-          ok: true,
-          payload,
-        },
-      });
-      // Send a second res frame (same id) so TS clients with expectFinal can wait.
-      // Swift clients will typically treat the first res as the result and ignore this.
-      params.respond(true, payload, undefined, { runId: params.runId });
-    })
-    .catch((err) => {
-      const error = errorShape(ErrorCodes.UNAVAILABLE, String(err));
-      const payload = {
-        runId: params.runId,
-        status: "error" as const,
-        summary: String(err),
-      };
-      setGatewayDedupeEntry({
-        dedupe: params.context.dedupe,
-        key: `agent:${params.idempotencyKey}`,
-        entry: {
-          ts: Date.now(),
-          ok: false,
-          payload,
-          error,
-        },
-      });
-      params.respond(false, payload, error, {
-        runId: params.runId,
-        error: formatForLog(err),
-      });
-    });
 }
 
 export const agentHandlers: GatewayRequestHandlers = {
@@ -671,51 +620,104 @@ export const agentHandlers: GatewayRequestHandlers = {
 
     const resolvedThreadId = explicitThreadId ?? deliveryPlan.resolvedThreadId;
 
-    dispatchAgentRunFromGateway({
-      ingressOpts: {
-        message,
-        images,
-        to: resolvedTo,
-        sessionId: resolvedSessionId,
-        sessionKey: resolvedSessionKey,
-        thinking: request.thinking,
-        deliver,
-        deliveryTargetMode,
-        channel: resolvedChannel,
+    const shouldPersistInflight = cfg.gateway?.restartRecovery?.resumeInflightAgentRuns === true;
+    const runOpts = {
+      message,
+      images,
+      to: resolvedTo,
+      sessionId: resolvedSessionId,
+      sessionKey: resolvedSessionKey,
+      thinking: request.thinking,
+      deliver,
+      deliveryTargetMode,
+      channel: resolvedChannel,
+      accountId: resolvedAccountId,
+      threadId: resolvedThreadId,
+      runContext: {
+        messageChannel: originMessageChannel,
         accountId: resolvedAccountId,
-        threadId: resolvedThreadId,
-        runContext: {
-          messageChannel: originMessageChannel,
-          accountId: resolvedAccountId,
-          groupId: resolvedGroupId,
-          groupChannel: resolvedGroupChannel,
-          groupSpace: resolvedGroupSpace,
-          currentThreadTs: resolvedThreadId != null ? String(resolvedThreadId) : undefined,
-        },
         groupId: resolvedGroupId,
         groupChannel: resolvedGroupChannel,
         groupSpace: resolvedGroupSpace,
-        spawnedBy: spawnedByValue,
-        timeout: request.timeout?.toString(),
-        bestEffortDeliver,
-        messageChannel: originMessageChannel,
-        runId,
-        lane: request.lane,
-        extraSystemPrompt: request.extraSystemPrompt,
-        internalEvents: request.internalEvents,
-        inputProvenance,
-        // Internal-only: allow workspace override for spawned subagent runs.
-        workspaceDir: resolveIngressWorkspaceOverrideForSpawnedRun({
-          spawnedBy: spawnedByValue,
-          workspaceDir: request.workspaceDir,
-        }),
-        senderIsOwner,
+        currentThreadTs: resolvedThreadId != null ? String(resolvedThreadId) : undefined,
       },
+      groupId: resolvedGroupId,
+      groupChannel: resolvedGroupChannel,
+      groupSpace: resolvedGroupSpace,
+      spawnedBy: spawnedByValue,
+      timeout: request.timeout?.toString(),
+      bestEffortDeliver,
+      messageChannel: originMessageChannel,
       runId,
-      idempotencyKey: idem,
-      respond,
-      context,
-    });
+      lane: request.lane,
+      extraSystemPrompt: request.extraSystemPrompt,
+      internalEvents: request.internalEvents,
+      inputProvenance,
+      // Internal-only: allow workspace override for spawned subagent runs.
+      workspaceDir: resolveIngressWorkspaceOverrideForSpawnedRun({
+        spawnedBy: spawnedByValue,
+        workspaceDir: request.workspaceDir,
+      }),
+      senderIsOwner,
+    } as const;
+
+    if (shouldPersistInflight) {
+      void addInflightAgentRun({
+        runId,
+        acceptedAt: accepted.acceptedAt,
+        opts: runOpts,
+      }).catch(() => {});
+    }
+
+    void agentCommandFromIngress(runOpts, defaultRuntime, context.deps)
+      .then((result) => {
+        const payload = {
+          runId,
+          status: "ok" as const,
+          summary: "completed",
+          result,
+        };
+        if (shouldPersistInflight) {
+          void removeInflightAgentRun(runId).catch(() => {});
+        }
+        setGatewayDedupeEntry({
+          dedupe: context.dedupe,
+          key: `agent:${idem}`,
+          entry: {
+            ts: Date.now(),
+            ok: true,
+            payload,
+          },
+        });
+        // Send a second res frame (same id) so TS clients with expectFinal can wait.
+        // Swift clients will typically treat the first res as the result and ignore this.
+        respond(true, payload, undefined, { runId });
+      })
+      .catch((err) => {
+        const error = errorShape(ErrorCodes.UNAVAILABLE, String(err));
+        const payload = {
+          runId,
+          status: "error" as const,
+          summary: String(err),
+        };
+        if (shouldPersistInflight) {
+          void removeInflightAgentRun(runId).catch(() => {});
+        }
+        setGatewayDedupeEntry({
+          dedupe: context.dedupe,
+          key: `agent:${idem}`,
+          entry: {
+            ts: Date.now(),
+            ok: false,
+            payload,
+            error,
+          },
+        });
+        respond(false, payload, error, {
+          runId,
+          error: formatForLog(err),
+        });
+      });
   },
   "agent.identity.get": ({ params, respond }) => {
     if (!validateAgentIdentityParams(params)) {

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -662,10 +662,16 @@ export const agentHandlers: GatewayRequestHandlers = {
     } as const;
 
     if (shouldPersistInflight) {
+      const persistableRunOpts = {
+        ...runOpts,
+        // Avoid persisting large base64 image payloads; resumed runs use a fresh
+        // continuation prompt and existing session transcript as context.
+        images: undefined,
+      };
       void addInflightAgentRun({
         runId,
         acceptedAt: accepted.acceptedAt,
-        opts: runOpts,
+        opts: persistableRunOpts,
       }).catch(() => {});
     }
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -74,7 +74,10 @@ import {
   type GatewayUpdateAvailableEventPayload,
 } from "./events.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
-import { ensureInflightAgentRunLifecycleCleanerStarted } from "./inflight-agent-runs.js";
+import {
+  ensureInflightAgentRunLifecycleCleanerStarted,
+  isInflightAgentRunRecoveryEnabled,
+} from "./inflight-agent-runs.js";
 import { NodeRegistry } from "./node-registry.js";
 import { maybeResumeInflightAgentRunsAfterRestart } from "./restart-resume.js";
 import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
@@ -566,7 +569,7 @@ export async function startGatewayServer(
   const { wizardSessions, findRunningWizard, purgeWizardSession } = createWizardSessionTracker();
 
   const deps = createDefaultDeps();
-  if (cfgAtStart.gateway?.restartRecovery?.resumeInflightAgentRuns === true) {
+  if (isInflightAgentRunRecoveryEnabled(cfgAtStart)) {
     ensureInflightAgentRunLifecycleCleanerStarted(process.env);
   }
   let canvasHostServer: CanvasHostServer | null = null;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -35,6 +35,7 @@ import { onHeartbeatEvent } from "../infra/heartbeat-events.js";
 import { startHeartbeatRunner, type HeartbeatRunner } from "../infra/heartbeat-runner.js";
 import { getMachineDisplayName } from "../infra/machine-name.js";
 import { ensureOpenClawCliOnPath } from "../infra/path-env.js";
+import { readRestartSentinel } from "../infra/restart-sentinel.js";
 import { setGatewaySigusr1RestartPolicy, setPreRestartDeferralCheck } from "../infra/restart.js";
 import {
   primeRemoteSkillsCache,
@@ -73,7 +74,9 @@ import {
   type GatewayUpdateAvailableEventPayload,
 } from "./events.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
+import { ensureInflightAgentRunLifecycleCleanerStarted } from "./inflight-agent-runs.js";
 import { NodeRegistry } from "./node-registry.js";
+import { maybeResumeInflightAgentRunsAfterRestart } from "./restart-resume.js";
 import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { createChannelManager } from "./server-channels.js";
 import { createAgentEventHandler } from "./server-chat.js";
@@ -563,6 +566,7 @@ export async function startGatewayServer(
   const { wizardSessions, findRunningWizard, purgeWizardSession } = createWizardSessionTracker();
 
   const deps = createDefaultDeps();
+  ensureInflightAgentRunLifecycleCleanerStarted(process.env);
   let canvasHostServer: CanvasHostServer | null = null;
   const gatewayTls = await loadGatewayTlsRuntime(cfgAtStart.gateway?.tls, log.child("tls"));
   if (cfgAtStart.gateway?.tls?.enabled && !gatewayTls.enabled) {
@@ -921,6 +925,10 @@ export async function startGatewayServer(
         logTailscale,
       });
 
+  // Snapshot the restart sentinel early to avoid races with other startup code
+  // that consumes it (e.g., restart notifications).
+  const restartSentinel = await readRestartSentinel(process.env).catch(() => null);
+
   let browserControl: Awaited<ReturnType<typeof startBrowserControlServerIfEnabled>> = null;
   if (!minimalTestGateway) {
     ({ browserControl, pluginServices } = await startGatewaySidecars({
@@ -935,6 +943,25 @@ export async function startGatewayServer(
       logBrowser,
     }));
   }
+
+  void maybeResumeInflightAgentRunsAfterRestart({
+    cfg: cfgAtStart,
+    deps,
+    runtime: gatewayRuntime,
+    env: process.env,
+    sentinel: restartSentinel,
+    getActiveRunCount: getActiveEmbeddedRunCount,
+  })
+    .then((result) => {
+      if (!result.skipped && result.considered > 0) {
+        log.info(
+          `restart recovery: resumed inflight agent runs resumed=${result.resumed} considered=${result.considered}`,
+        );
+      }
+    })
+    .catch((err) => {
+      log.warn(`restart recovery: resume failed: ${String(err)}`);
+    });
 
   // Run gateway_start plugin hook (fire-and-forget)
   if (!minimalTestGateway) {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -566,7 +566,9 @@ export async function startGatewayServer(
   const { wizardSessions, findRunningWizard, purgeWizardSession } = createWizardSessionTracker();
 
   const deps = createDefaultDeps();
-  ensureInflightAgentRunLifecycleCleanerStarted(process.env);
+  if (cfgAtStart.gateway?.restartRecovery?.resumeInflightAgentRuns === true) {
+    ensureInflightAgentRunLifecycleCleanerStarted(process.env);
+  }
   let canvasHostServer: CanvasHostServer | null = null;
   const gatewayTls = await loadGatewayTlsRuntime(cfgAtStart.gateway?.tls, log.child("tls"));
   if (cfgAtStart.gateway?.tls?.enabled && !gatewayTls.enabled) {
@@ -955,7 +957,7 @@ export async function startGatewayServer(
     .then((result) => {
       if (!result.skipped && result.considered > 0) {
         log.info(
-          `restart recovery: resumed inflight agent runs resumed=${result.resumed} considered=${result.considered}`,
+          `restart recovery: inflight agent runs resumed=${result.resumed} considered=${result.considered}`,
         );
       }
     })

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -112,7 +112,9 @@ export function setPreRestartDeferralCheck(fn: () => number): void {
 }
 
 export function shouldPreserveInflightAgentRunsForPendingRestart(): boolean {
-  return pendingRestartTimer !== null || restartDeferralActive || hasUnconsumedRestartSignal();
+  const hasImminentScheduledRestart =
+    pendingRestartTimer !== null && pendingRestartDueAt > 0 && pendingRestartDueAt <= Date.now();
+  return hasImminentScheduledRestart || restartDeferralActive || hasUnconsumedRestartSignal();
 }
 
 /**

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -38,6 +38,8 @@ let lastRestartEmittedAt = 0;
 let pendingRestartTimer: ReturnType<typeof setTimeout> | null = null;
 let pendingRestartDueAt = 0;
 let pendingRestartReason: string | undefined;
+let pendingRestartDeferralPoll: ReturnType<typeof setInterval> | null = null;
+let restartDeferralActive = false;
 
 function hasUnconsumedRestartSignal(): boolean {
   return emittedRestartToken > consumedRestartToken;
@@ -50,6 +52,14 @@ function clearPendingScheduledRestart(): void {
   pendingRestartTimer = null;
   pendingRestartDueAt = 0;
   pendingRestartReason = undefined;
+}
+
+function clearRestartDeferralState(): void {
+  if (pendingRestartDeferralPoll) {
+    clearInterval(pendingRestartDeferralPoll);
+  }
+  pendingRestartDeferralPoll = null;
+  restartDeferralActive = false;
 }
 
 export type RestartAuditInfo = {
@@ -101,6 +111,10 @@ export function setPreRestartDeferralCheck(fn: () => number): void {
   preRestartCheck = fn;
 }
 
+export function shouldPreserveInflightAgentRunsForPendingRestart(): boolean {
+  return pendingRestartTimer !== null || restartDeferralActive || hasUnconsumedRestartSignal();
+}
+
 /**
  * Emit an authorized SIGUSR1 gateway restart, guarded against duplicate emissions.
  * Returns true if SIGUSR1 was emitted, false if a restart was already emitted.
@@ -110,9 +124,11 @@ export function setPreRestartDeferralCheck(fn: () => number): void {
 export function emitGatewayRestart(): boolean {
   if (hasUnconsumedRestartSignal()) {
     clearPendingScheduledRestart();
+    clearRestartDeferralState();
     return false;
   }
   clearPendingScheduledRestart();
+  clearRestartDeferralState();
   const cycleToken = ++restartCycleToken;
   emittedRestartToken = cycleToken;
   authorizeGatewaySigusr1Restart();
@@ -213,32 +229,35 @@ export function deferGatewayRestartUntilIdle(opts: {
     return;
   }
   if (pending <= 0) {
+    clearRestartDeferralState();
     opts.hooks?.onReady?.();
     emitGatewayRestart();
     return;
   }
 
+  clearRestartDeferralState();
+  restartDeferralActive = true;
   opts.hooks?.onDeferring?.(pending);
   const startedAt = Date.now();
-  const poll = setInterval(() => {
+  pendingRestartDeferralPoll = setInterval(() => {
     let current: number;
     try {
       current = opts.getPendingCount();
     } catch (err) {
-      clearInterval(poll);
+      clearRestartDeferralState();
       opts.hooks?.onCheckError?.(err);
       emitGatewayRestart();
       return;
     }
     if (current <= 0) {
-      clearInterval(poll);
+      clearRestartDeferralState();
       opts.hooks?.onReady?.();
       emitGatewayRestart();
       return;
     }
     const elapsedMs = Date.now() - startedAt;
     if (elapsedMs >= maxWaitMs) {
-      clearInterval(poll);
+      clearRestartDeferralState();
       opts.hooks?.onTimeout?.(current, elapsedMs);
       emitGatewayRestart();
     }
@@ -502,5 +521,6 @@ export const __testing = {
     consumedRestartToken = 0;
     lastRestartEmittedAt = 0;
     clearPendingScheduledRestart();
+    clearRestartDeferralState();
   },
 };


### PR DESCRIPTION
Adds an opt-in restart recovery mode so in-flight gateway RPC agent runs can resume after a CLI-driven gateway restart.

- Config: gateway.restartRecovery.resumeInflightAgentRuns (default false).
- Persists accepted runs to OPENCLAW_STATE_DIR/inflight-agent-runs.json and cleans them up on agent lifecycle end/error.
- On startup, if restart-sentinel kind=restart is present (written by openclaw gateway restart) and no embedded runs are active, resumes each persisted run with a safe continuation prompt.

Tests:
- pnpm check
- vitest: src/gateway/inflight-agent-runs.test.ts, src/gateway/restart-resume.test.ts

Refs: #16589
