### PR TITLE
fix(control-ui): show effective agent for cron jobs without explicit agentId

### DIFF
--- a/changelog/fragments/pr-cron-ui-show-default-agent-in-webui.md
+++ b/changelog/fragments/pr-cron-ui-show-default-agent-in-webui.md
@@ -1,0 +1,1 @@
+- control-ui (Cron): Always show an Agent label in the jobs list. When a job does not store `agentId`, the UI now displays the effective default agent instead of leaving the line blank.

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -166,6 +166,16 @@ export function renderApp(state: AppViewState) {
     state.agentsList?.defaultId ??
     state.agentsList?.agents?.[0]?.id ??
     null;
+  const helloSnapshot = state.hello?.snapshot as
+    | { sessionDefaults?: { defaultAgentId?: string } }
+    | undefined;
+  const cronDefaultAgentId =
+    (typeof helloSnapshot?.sessionDefaults?.defaultAgentId === "string" &&
+      helloSnapshot.sessionDefaults.defaultAgentId.trim()) ||
+    (typeof state.agentsList?.defaultId === "string" && state.agentsList.defaultId.trim()) ||
+    (typeof state.agentsList?.agents?.[0]?.id === "string" &&
+      state.agentsList.agents[0].id.trim()) ||
+    "main";
   const cronAgentSuggestions = sortLocaleStrings(
     new Set(
       [
@@ -484,6 +494,7 @@ export function renderApp(state: AppViewState) {
                 timezoneSuggestions: CRON_TIMEZONE_SUGGESTIONS,
                 deliveryToSuggestions,
                 accountSuggestions,
+                defaultAgentId: cronDefaultAgentId,
                 onFormChange: (patch) => {
                   state.cronForm = normalizeCronFormState({ ...state.cronForm, ...patch });
                   state.cronFieldErrors = validateCronForm(state.cronForm);

--- a/ui/src/ui/views/cron.test.ts
+++ b/ui/src/ui/views/cron.test.ts
@@ -136,6 +136,38 @@ describe("cron view", () => {
     expect(onLoadRuns).toHaveBeenCalledWith("job-1");
   });
 
+  it("shows explicit agent id on cron jobs", () => {
+    const container = document.createElement("div");
+    const job = { ...createJob("job-1"), agentId: "ops" };
+    render(
+      renderCron(
+        createProps({
+          jobs: [job],
+          defaultAgentId: "main",
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Agent: ops");
+  });
+
+  it("shows fallback default agent id when cron job agent is empty", () => {
+    const container = document.createElement("div");
+    const job = createJob("job-1");
+    render(
+      renderCron(
+        createProps({
+          jobs: [job],
+          defaultAgentId: "main",
+        }),
+      ),
+      container,
+    );
+
+    expect(container.textContent).toContain("Agent: main");
+  });
+
   it("marks the selected job and keeps History button to a single call", () => {
     const container = document.createElement("div");
     const onLoadRuns = vi.fn();

--- a/ui/src/ui/views/cron.ts
+++ b/ui/src/ui/views/cron.ts
@@ -62,6 +62,7 @@ export type CronProps = {
   timezoneSuggestions: string[];
   deliveryToSuggestions: string[];
   accountSuggestions: string[];
+  defaultAgentId?: string;
   onFormChange: (patch: Partial<CronFormState>) => void;
   onRefresh: () => void;
   onAdd: () => void;
@@ -1490,6 +1491,10 @@ function renderFieldError(message?: string, id?: string) {
 function renderJob(job: CronJob, props: CronProps) {
   const isSelected = props.runsJobId === job.id;
   const itemClass = `list-item list-item-clickable cron-job${isSelected ? " list-item-selected" : ""}`;
+  const effectiveAgentId =
+    (typeof job.agentId === "string" && job.agentId.trim()) ||
+    (typeof props.defaultAgentId === "string" && props.defaultAgentId.trim()) ||
+    "main";
   const selectAnd = (action: () => void) => {
     props.onLoadRuns(job.id);
     action();
@@ -1500,7 +1505,7 @@ function renderJob(job: CronJob, props: CronProps) {
         <div class="list-title">${job.name}</div>
         <div class="list-sub">${formatCronSchedule(job)}</div>
         ${renderJobPayload(job)}
-        ${job.agentId ? html`<div class="muted cron-job-agent">${t("cron.jobDetail.agent")}: ${job.agentId}</div>` : nothing}
+        <div class="muted cron-job-agent">${t("cron.jobDetail.agent")}: ${effectiveAgentId}</div>
       </div>
       <div class="list-meta">
         ${renderJobState(job)}


### PR DESCRIPTION
## Summary
- always render an Agent line in Cron job cards in Control UI
- when `job.agentId` is empty, show the effective default agent id from snapshot/agents list (fallback `main`)
- add cron view assertions for explicit and fallback agent rendering
- add changelog fragment

## Why
In the WebUI, jobs created without an explicit `agentId` currently show no Agent line, even though runtime falls back to the default agent. This makes job ownership ambiguous.

## Validation
- `pnpm vitest run --config vitest.config.ts src/cron/service.jobs.test.ts`
- `pnpm vitest run --config vitest.config.ts ui/src/ui/controllers/chat.test.ts`
- `pnpm exec oxlint ui/src/ui/app-render.ts ui/src/ui/views/cron.ts ui/src/ui/views/cron.test.ts`
