### PR TITLE
feat(telegram): add copy_text button support

### DIFF
--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -143,7 +143,7 @@ function buildMessagingSection(params: {
           `- If multiple channels are configured, pass \`channel\` (${params.messageChannelOptions}).`,
           `- If you use \`message\` (\`action=send\`) to deliver your user-visible reply, respond with ONLY: ${SILENT_REPLY_TOKEN} (avoid duplicate replies).`,
           params.inlineButtonsEnabled
-            ? "- Inline buttons supported. Use `action=send` with `buttons=[[{text,callback_data,style?}]]`; `style` can be `primary`, `success`, or `danger`."
+            ? "- Inline buttons supported. Use `action=send` with `buttons=[[{text,callback_data,style?}]]`; `style` can be `primary`, `success`, or `danger`. For copy-to-clipboard buttons, use `{text,copy_text:{text}}` instead of `callback_data` — tapping copies the specified text to the user's clipboard automatically."
             : params.runtimeChannel
               ? `- Inline buttons not enabled for ${params.runtimeChannel}. If you need them, ask to set ${params.runtimeChannel}.capabilities.inlineButtons ("dm"|"group"|"all"|"allowlist").`
               : "",

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -203,14 +203,25 @@ function buildSendSchema(options: {
     buttons: Type.Optional(
       Type.Array(
         Type.Array(
-          Type.Object({
-            text: Type.String(),
-            callback_data: Type.String(),
-            style: Type.Optional(stringEnum(["danger", "success", "primary"])),
-          }),
+          Type.Union([
+            Type.Object({
+              text: Type.String(),
+              callback_data: Type.String(),
+              style: Type.Optional(stringEnum(["danger", "success", "primary"])),
+            }),
+            Type.Object({
+              text: Type.String(),
+              copy_text: Type.Object({
+                text: Type.String({
+                  description: "Text to copy to the user's clipboard when the button is tapped",
+                }),
+              }),
+            }),
+          ]),
         ),
         {
-          description: "Telegram inline keyboard buttons (array of button rows)",
+          description:
+            "Telegram inline keyboard buttons (array of button rows). Each button is either a callback button (callback_data) or a copy-to-clipboard button (copy_text).",
         },
       ),
     ),

--- a/src/telegram/button-types.ts
+++ b/src/telegram/button-types.ts
@@ -1,9 +1,16 @@
 export type TelegramButtonStyle = "danger" | "success" | "primary";
 
-export type TelegramInlineButton = {
+export type TelegramCallbackButton = {
   text: string;
   callback_data: string;
   style?: TelegramButtonStyle;
 };
+
+export type TelegramCopyTextButton = {
+  text: string;
+  copy_text: { text: string };
+};
+
+export type TelegramInlineButton = TelegramCallbackButton | TelegramCopyTextButton;
 
 export type TelegramInlineButtons = ReadonlyArray<ReadonlyArray<TelegramInlineButton>>;

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -442,14 +442,17 @@ export function buildInlineKeyboard(
   const rows = buttons
     .map((row) =>
       row
-        .filter((button) => button?.text && button?.callback_data)
-        .map(
-          (button): InlineKeyboardButton => ({
+        .filter((button) => button?.text && ("callback_data" in button || "copy_text" in button))
+        .map((button): InlineKeyboardButton => {
+          if ("copy_text" in button) {
+            return { text: button.text, copy_text: button.copy_text };
+          }
+          return {
             text: button.text,
             callback_data: button.callback_data,
             ...(button.style ? { style: button.style } : {}),
-          }),
-        ),
+          };
+        }),
     )
     .filter((row) => row.length > 0);
   if (rows.length === 0) {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -442,7 +442,11 @@ export function buildInlineKeyboard(
   const rows = buttons
     .map((row) =>
       row
-        .filter((button) => button?.text && ("callback_data" in button || "copy_text" in button))
+        .filter(
+          (button) =>
+            button?.text &&
+            (("callback_data" in button && button.callback_data) || "copy_text" in button),
+        )
         .map((button): InlineKeyboardButton => {
           if ("copy_text" in button) {
             return { text: button.text, copy_text: button.copy_text };


### PR DESCRIPTION
## What this does

Adds support for Telegram's native `copy_text` inline button type, which automatically copies specified text to the user's clipboard when tapped.

## Problem

Previously the button serializer filtered to only buttons with `callback_data`, silently dropping `copy_text` buttons before they reached the Telegram API. Any agent trying to send a clipboard button got nothing.

## Solution

- Extends `TelegramInlineButton` to a union type: `TelegramCallbackButton | TelegramCopyTextButton`
- Updates the button serializer in `send.ts` to handle both types correctly
- Updates the `message-tool` schema so agents can pass `copy_text` button objects
- Updates the system prompt so the model knows `copy_text` is available and how to use it

## Proof of concept

Tested via direct Telegram Bot API call before writing this PR — confirmed working on iOS and Android. One tap copies the specified text to clipboard, no long-press required.

## Usage

```json
{
  "action": "send",
  "message": "Pick a post:",
  "buttons": [[
    { "text": "📋 Copy Option 1", "copy_text": { "text": "Your post content here" } },
    { "text": "Option 2", "callback_data": "pick:2" }
  ]]
}
```

Callback buttons and copy_text buttons can be mixed freely in the same keyboard.

## Use case that surfaced this

Content workflows where an agent presents 2-3 post options and the user needs the selected text on their clipboard to paste directly into Twitter/X — one tap picks and copies, zero additional friction.