### PR TITLE
fix: surface error message when LLM fails mid-turn after tool calls

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -9,6 +9,8 @@ import {
   isCompactionFailureError,
   isContextOverflowError,
   isLikelyContextOverflowError,
+  isRateLimitErrorMessage,
+  isOverloadedErrorMessage,
   isTransientHttpError,
   sanitizeUserFacingText,
 } from "../../agents/pi-embedded-helpers.js";
@@ -609,20 +611,44 @@ export async function runAgentTurnWithFallback(params: {
     }
   }
 
-  // If the run completed but with an embedded context overflow error that
-  // wasn't recovered from (e.g. compaction reset already attempted), surface
-  // the error to the user instead of silently returning an empty response.
+  // If the run completed but with an embedded error that wasn't recovered
+  // from, surface the error to the user instead of silently returning an
+  // empty response.
   // See #26905: Slack DM sessions silently swallowed messages when context
   // overflow errors were returned as embedded error payloads.
+  // See #35039: Rate limit errors mid-turn (after tool calls) produced
+  // empty assistant responses with no user-facing error message.
   const finalEmbeddedError = runResult?.meta?.error;
   const hasPayloadText = runResult?.payloads?.some((p) => p.text?.trim());
-  if (finalEmbeddedError && isContextOverflowError(finalEmbeddedError.message) && !hasPayloadText) {
-    return {
-      kind: "final",
-      payload: {
-        text: "⚠️ Context overflow — this conversation is too large for the model. Use /new to start a fresh session.",
-      },
-    };
+  if (finalEmbeddedError && !hasPayloadText) {
+    const errorMsg = finalEmbeddedError.message ?? "";
+    if (isContextOverflowError(errorMsg)) {
+      return {
+        kind: "final",
+        payload: {
+          text: "⚠️ Context overflow — this conversation is too large for the model. Use /new to start a fresh session.",
+        },
+      };
+    }
+    if (isRateLimitErrorMessage(errorMsg) || isOverloadedErrorMessage(errorMsg)) {
+      return {
+        kind: "final",
+        payload: {
+          text: "⚠️ API rate limit reached mid-turn — the model couldn't generate a response after tool calls completed. Please try again in a moment.",
+        },
+      };
+    }
+    // Generic fallback: any embedded error with no payload text should be
+    // surfaced rather than swallowed silently.
+    if (errorMsg) {
+      const safeMsg = sanitizeUserFacingText(errorMsg, { errorContext: true });
+      return {
+        kind: "final",
+        payload: {
+          text: `⚠️ Agent error mid-turn: ${safeMsg.replace(/\.\s*$/, "")}.\nThe model ran tools but couldn't complete its response. Please try again.`,
+        },
+      };
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary

Fixes #36142 — Silent empty response when LLM rate limit hits mid-turn after tool calls.

## Problem

When a rate limit, overload, or other API error occurs **after tool calls have already completed** (mid-turn), the agent run ends with an embedded error but no payload text. This resulted in a completely empty/silent assistant response — no error shown to the user.

The existing #26905 fix only handled context overflow errors in this path. Rate limit and other transient errors were not caught.

## Changes

**`src/auto-reply/reply/agent-runner-execution.ts`**:
- Import `isRateLimitErrorMessage` and `isOverloadedErrorMessage` from pi-embedded-helpers
- Extend the post-run embedded error guard to handle:
  1. Context overflow (existing behavior, unchanged)
  2. **Rate limit errors** → user-facing message about rate limit
  3. **Overloaded/capacity errors** → same treatment  
  4. **Generic fallback** → any embedded error with no payload text gets surfaced

Each case returns a `kind: "final"` payload with an appropriate user-facing error message, matching the behavior of pre-tool-call errors which already surface properly via the "Embedded agent failed before reply" path.

## Testing

- Verified TypeScript compilation passes (no new type errors in our code)
- The fix is narrowly scoped: only fires when `finalEmbeddedError` exists AND `hasPayloadText` is false
- Existing context overflow behavior is preserved (same code path, same message)

## Risk Assessment

**Low risk** — This only adds error surfacing for cases that currently produce silent failures. No change to happy-path behavior.