### PR TITLE
browser: make profile color optional, auto-assign from palette when omitted

### DIFF
--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -14,7 +14,7 @@ import {
   DEFAULT_BROWSER_DEFAULT_PROFILE_NAME,
   DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
 } from "./constants.js";
-import { CDP_PORT_RANGE_START, getUsedPorts } from "./profiles.js";
+import { CDP_PORT_RANGE_START, allocateColor, getUsedColors, getUsedPorts } from "./profiles.js";
 
 export type ResolvedBrowserConfig = {
   enabled: boolean;
@@ -336,7 +336,7 @@ export function resolveProfile(
     cdpUrl,
     cdpHost,
     cdpIsLoopback: isLoopbackHost(cdpHost),
-    color: profile.color,
+    color: profile.color ?? allocateColor(getUsedColors(resolved.profiles)),
     driver,
     attachOnly: profile.attachOnly ?? resolved.attachOnly,
   };

--- a/src/browser/profiles.ts
+++ b/src/browser/profiles.ts
@@ -104,10 +104,14 @@ export function allocateColor(usedColors: Set<string>): string {
 }
 
 export function getUsedColors(
-  profiles: Record<string, { color: string }> | undefined,
+  profiles: Record<string, { color?: string }> | undefined,
 ): Set<string> {
   if (!profiles) {
     return new Set();
   }
-  return new Set(Object.values(profiles).map((p) => p.color.toUpperCase()));
+  return new Set(
+    Object.values(profiles)
+      .filter((p) => p.color)
+      .map((p) => p.color!.toUpperCase()),
+  );
 }

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -7,8 +7,8 @@ export type BrowserProfileConfig = {
   driver?: "openclaw" | "extension";
   /** If true, never launch a browser for this profile; only attach. Falls back to browser.attachOnly. */
   attachOnly?: boolean;
-  /** Profile color (hex). Auto-assigned at creation. */
-  color: string;
+  /** Profile color (hex). Auto-assigned at creation if omitted. */
+  color?: string;
 };
 export type BrowserSnapshotDefaults = {
   /** Default snapshot mode (applies when mode is not provided). */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -311,7 +311,7 @@ export const OpenClawSchema = z
                 cdpUrl: z.string().optional(),
                 driver: z.union([z.literal("clawd"), z.literal("extension")]).optional(),
                 attachOnly: z.boolean().optional(),
-                color: HexColorSchema,
+                color: HexColorSchema.optional(),
               })
               .strict()
               .refine((value) => value.cdpPort || value.cdpUrl, {


### PR DESCRIPTION
## Problem

When a user manually defines a `browser.profiles.chrome` entry in `openclaw.json` to connect to an existing Chrome instance via `--remote-debugging-port`, they must also specify a `color` field or the gateway refuses to start with a cryptic error:

```
browser.profiles.chrome.color: Invalid input: expected string, received undefined
```

There is no indication in the error that `color` is required, what format it expects, or that it can be any hex value.

## Fix

- Make `color` optional in `BrowserProfileConfig` type and Zod schema
- Auto-assign a color from the palette (via existing `allocateColor`) when `color` is omitted
- Update `getUsedColors` to handle profiles with no color set

## Motivation

This came up when trying to connect openclaw to an existing Chrome instance launched with `--remote-debugging-port=9222`. The workaround for bypassing the extension relay requires manually defining the `chrome` profile, but the required `color` field is undocumented and the error message gives no hint.

No behavior change when `color` is already set.