### PR TITLE
fix(cron): preserve explicit delivery.to in announce flow

### DIFF
--- a/src/agents/subagent-announce.ts
+++ b/src/agents/subagent-announce.ts
@@ -448,12 +448,32 @@ async function buildCompactAnnounceStatsLine(params: {
 
 type DeliveryContextSource = Parameters<typeof deliveryContextFromSession>[0];
 
+/**
+ * Resolve the delivery origin for announce flow.
+ * @param entry - Session entry that may contain lastTo/lastChannel
+ * @param requesterOrigin - Origin from the requester (e.g., cron delivery config)
+ * @param explicitTo - If set, this explicit target should be preserved and not overridden by session values
+ */
 function resolveAnnounceOrigin(
   entry?: DeliveryContextSource,
   requesterOrigin?: DeliveryContext,
+  explicitTo?: string,
 ): DeliveryContext | undefined {
   const normalizedRequester = normalizeDeliveryContext(requesterOrigin);
   const normalizedEntry = deliveryContextFromSession(entry);
+
+  // If we have an explicit 'to' from delivery config, preserve it and don't let
+  // session-derived values override it. This prevents hallucinated IDs from
+  // cron subagent sessions from polluting the delivery target.
+  if (explicitTo) {
+    return {
+      channel: normalizedRequester?.channel,
+      to: explicitTo,
+      accountId: normalizedRequester?.accountId,
+      threadId: normalizedRequester?.threadId ?? normalizedEntry?.threadId,
+    };
+  }
+
   if (normalizedRequester?.channel && isInternalMessageChannel(normalizedRequester.channel)) {
     // Ignore internal channel hints (webchat) so a valid persisted route
     // can still be used for outbound delivery. Non-standard channels that
@@ -706,7 +726,11 @@ async function maybeQueueSubagentAnnounce(params: {
     queueSettings.mode === "steer-backlog" ||
     queueSettings.mode === "interrupt";
   if (isActive && (shouldFollowup || queueSettings.mode === "steer")) {
-    const origin = resolveAnnounceOrigin(entry, params.requesterOrigin);
+    const origin = resolveAnnounceOrigin(
+      entry,
+      params.requesterOrigin,
+      params.requesterOrigin?.to, // Pass explicit 'to' to preserve it
+    );
     enqueueAnnounce({
       key: buildAnnounceQueueKey(canonicalKey, origin),
       item: {
@@ -1370,7 +1394,9 @@ export async function runSubagentAnnounceFlow(params: {
     let directOrigin = targetRequesterOrigin;
     if (!requesterIsSubagent) {
       const { entry } = loadRequesterSessionEntry(targetRequesterSessionKey);
-      directOrigin = resolveAnnounceOrigin(entry, targetRequesterOrigin);
+      // Pass explicit 'to' from requesterOrigin to preserve it and prevent
+      // session-derived hallucinated IDs from overriding the configured target
+      directOrigin = resolveAnnounceOrigin(entry, targetRequesterOrigin, targetRequesterOrigin?.to);
     }
     const completionResolution =
       expectsCompletionMessage && !requesterIsSubagent


### PR DESCRIPTION
## Summary

When a cron job is configured with an explicit `delivery.to` recipient (e.g., Feishu open_id), the announce delivery flow can deliver messages to **wrong, non-existent recipient IDs** instead of the configured target. These IDs are hallucinated by the LLM agent during the announce formatting step.

- The LLM hallucinates fake user IDs during the announce step
- These hallucinated IDs get written to the session's `lastTo` field
- `resolveAnnounceOrigin()` merges session context, allowing the hallucinated `lastTo` to override the explicitly configured `delivery.to`

## Fix

Add an `explicitTo` parameter to `resolveAnnounceOrigin()` that short-circuits the merge logic when an explicit delivery target is provided. This preserves the configured `to` from cron delivery config and prevents session-derived values from overriding it. The `threadId` fallback from session entry is maintained for compatibility with thread-scoped delivery.

Both call sites (`maybeQueueSubagentAnnounce` and `runSubagentAnnounceFlow`) pass `requesterOrigin?.to` as the explicit target.

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes (format, typecheck, lint, all custom lints)
- [x] `pnpm test` passes (816 files, 6660 tests)
- [ ] Manual verification: configure a cron job with explicit `delivery.to`, confirm messages are delivered to the correct recipient after multiple runs

Fixes #35830
