### PR TITLE
feat: add before skills load hook

### DIFF
--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -40,6 +40,7 @@ export type SkillStatusEntry = {
   homepage?: string;
   always: boolean;
   disabled: boolean;
+  security?: { securityInfo?: string };
   blockedByAllowlist: boolean;
   eligible: boolean;
   requirements: Requirements;
@@ -176,6 +177,8 @@ function buildSkillStatus(
   const skillKey = resolveSkillKey(entry);
   const skillConfig = resolveSkillConfig(config, skillKey);
   const disabled = skillConfig?.enabled === false;
+  const securityInfo = (skillConfig as { security?: { securityInfo?: string } })?.security
+    ?.securityInfo;
   const allowBundled = resolveBundledAllowlist(config);
   const blockedByAllowlist = !isBundledSkillAllowed(entry, allowBundled);
   const always = entry.metadata?.always === true;
@@ -215,6 +218,7 @@ function buildSkillStatus(
     homepage,
     always,
     disabled,
+    security: { securityInfo: securityInfo },
     blockedByAllowlist,
     eligible,
     requirements: required,

--- a/src/agents/skills/refresh.ts
+++ b/src/agents/skills/refresh.ts
@@ -6,7 +6,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { CONFIG_DIR, resolveUserPath } from "../../utils.js";
 import { resolvePluginSkillDirs } from "./plugin-skills.js";
 
-type SkillsChangeEvent = {
+export type SkillsChangeEvent = {
   workspaceDir?: string;
   reason: "watch" | "manual" | "remote-node";
   changedPath?: string;

--- a/src/config/types.skills.ts
+++ b/src/config/types.skills.ts
@@ -5,6 +5,10 @@ export type SkillConfig = {
   apiKey?: SecretInput;
   env?: Record<string, string>;
   config?: Record<string, unknown>;
+  security?: {
+    securityInfo?: string;
+    securityBlocked?: boolean;
+  };
 };
 
 export type SkillsLoadConfig = {

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -143,6 +143,13 @@ const SkillEntrySchema = z
     apiKey: SecretInputSchema.optional().register(sensitive),
     env: z.record(z.string(), z.string()).optional(),
     config: z.record(z.string(), z.unknown()).optional(),
+    security: z
+      .object({
+        securityInfo: z.string().optional(),
+        securityBlocked: z.boolean().optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict();
 

--- a/src/gateway/protocol/schema/agents-models-skills.ts
+++ b/src/gateway/protocol/schema/agents-models-skills.ts
@@ -204,6 +204,8 @@ export const SkillsUpdateParamsSchema = Type.Object(
     enabled: Type.Optional(Type.Boolean()),
     apiKey: Type.Optional(Type.String()),
     env: Type.Optional(Type.Record(NonEmptyString, Type.String())),
+    securityInfo: Type.Optional(Type.String()),
+    securityBlocked: Type.Optional(Type.Boolean()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -160,6 +160,8 @@ export const skillsHandlers: GatewayRequestHandlers = {
       enabled?: boolean;
       apiKey?: string;
       env?: Record<string, string>;
+      securityInfo?: string;
+      securityBlocked?: boolean;
     };
     const cfg = loadConfig();
     const skills = cfg.skills ? { ...cfg.skills } : {};
@@ -191,6 +193,21 @@ export const skillsHandlers: GatewayRequestHandlers = {
         }
       }
       current.env = nextEnv;
+    }
+    if (typeof p.securityInfo === "string") {
+      const trimmed = p.securityInfo.trim();
+      const nextSec = current.security ? { ...current.security } : {};
+      if (trimmed) {
+        nextSec["securityInfo"] = trimmed;
+      } else {
+        delete (nextSec as Record<string, unknown>)["securityInfo"];
+      }
+      current.security = nextSec;
+    }
+    if (typeof p.securityBlocked === "boolean") {
+      const nextSec = current.security ? { ...current.security } : {};
+      nextSec["securityBlocked"] = p.securityBlocked;
+      current.security = nextSec;
     }
     entries[p.skillKey] = current;
     skills.entries = entries;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1,7 +1,9 @@
+import fs from "node:fs";
 import path from "node:path";
+import { loadSkillsFromDir, type Skill } from "@mariozechner/pi-coding-agent";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
-import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
+import { registerSkillsChangeListener, type SkillsChangeEvent } from "../agents/skills/refresh.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
 import type { CanvasHostServer } from "../canvas-host/server.js";
@@ -62,6 +64,7 @@ import {
   prepareSecretsRuntimeSnapshot,
   resolveCommandSecretsFromActiveRuntimeSnapshot,
 } from "../secrets/runtime.js";
+import { CONFIG_DIR, resolveUserPath } from "../utils.js";
 import { runOnboardingWizard } from "../wizard/onboarding.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { startChannelHealthMonitor } from "./channel-health-monitor.js";
@@ -73,6 +76,7 @@ import {
 } from "./events.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { NodeRegistry } from "./node-registry.js";
+import type { RequestFrame } from "./protocol/index.js";
 import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { createChannelManager } from "./server-channels.js";
 import { createAgentEventHandler } from "./server-chat.js";
@@ -86,6 +90,8 @@ import { coreGatewayHandlers } from "./server-methods.js";
 import { createExecApprovalHandlers } from "./server-methods/exec-approval.js";
 import { safeParseJson } from "./server-methods/nodes.helpers.js";
 import { createSecretsHandlers } from "./server-methods/secrets.js";
+import { skillsHandlers } from "./server-methods/skills.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
 import { hasConnectedMobileNode } from "./server-mobile-nodes.js";
 import { loadGatewayModelCatalog } from "./server-model-catalog.js";
 import { createNodeSubscriptionManager } from "./server-node-subscriptions.js";
@@ -618,6 +624,171 @@ export async function startGatewayServer(
     setSkillsRemoteRegistry(nodeRegistry);
     void primeRemoteSkillsCache();
   }
+
+  /**
+   * Handle skills change event for security hook.
+   * This function is called when a skills file is changed.
+   * It runs the before_skills_load hook to allow plugins to modify or block skill loading.
+   */
+  async function handleSkillsChangeForSecurityHook(event: SkillsChangeEvent): Promise<void> {
+    const runner = getGlobalHookRunner();
+    const hasHooks = runner?.hasHooks("before_skills_load") ?? false;
+    if (!hasHooks) {
+      return;
+    }
+    if (!event.changedPath || event.changedPath?.trim() === "") {
+      return;
+    }
+    if (!fs.existsSync(event.changedPath)) {
+      logHooks.info(`watched skills file removed: ${event.changedPath}`);
+      return;
+    }
+    logHooks.info(`watched skills file changed: ${event?.changedPath}`);
+    const cfg = loadConfig();
+    const skillsRootPath = new Set<string>();
+    if (event.workspaceDir?.trim()) {
+      skillsRootPath.add(path.join(event.workspaceDir, "skills"));
+    }
+    skillsRootPath.add(path.join(CONFIG_DIR, "skills"));
+    const extraSkillsDirs = cfg?.skills?.load?.extraDirs ?? [];
+    const extraSkillsDirsPath = extraSkillsDirs
+      .map((d) => (typeof d === "string" ? d.trim() : ""))
+      .filter(Boolean)
+      .map((dir) => resolveUserPath(dir));
+    for (const d of extraSkillsDirsPath) {
+      if (d.trim()) {
+        skillsRootPath.add(d);
+      }
+    }
+    logHooks.info(`skillsRootPath path is ${JSON.stringify(Array.from(skillsRootPath))}`);
+    const p = path.resolve(event.changedPath);
+    let skillsFileDir: string | null = null;
+    let skillsPackageDirName: string | null = null;
+    let skillsName: string | null = null;
+    let matchedRoot: string | null = null;
+    for (const root of skillsRootPath) {
+      const r = path.resolve(root);
+      if (p === r || p.startsWith(r + path.sep)) {
+        if (!matchedRoot || r.length > matchedRoot.length) {
+          matchedRoot = r;
+        }
+      }
+    }
+    if (matchedRoot) {
+      const rel = path.relative(matchedRoot, p);
+      const segs = rel.split(path.sep).filter(Boolean);
+      if (segs.length >= 1) {
+        skillsPackageDirName = segs[0];
+        skillsFileDir = path.join(matchedRoot, skillsPackageDirName);
+      }
+    }
+    if (skillsFileDir) {
+      try {
+        const workspaceSkillsRoot = path.join(event.workspaceDir ?? "", "skills");
+        const configSkillsRoot = path.join(CONFIG_DIR, "skills");
+        const root = matchedRoot ?? path.dirname(skillsFileDir);
+        const sourceLabel =
+          root === workspaceSkillsRoot
+            ? "openclaw-workspace"
+            : root === configSkillsRoot
+              ? "openclaw-managed"
+              : extraSkillsDirsPath.includes(root)
+                ? "openclaw-extra"
+                : "not-support";
+        logHooks.info(`skills file dir is ${skillsFileDir} and source is ${sourceLabel}`);
+        const loaded = loadSkillsFromDir({ dir: skillsFileDir, source: sourceLabel });
+        let skills: Skill[] = [];
+        if (Array.isArray(loaded)) {
+          skills = loaded;
+        } else if (
+          loaded &&
+          typeof loaded === "object" &&
+          "skills" in loaded &&
+          Array.isArray((loaded as { skills?: unknown }).skills)
+        ) {
+          skills = (loaded as { skills: Skill[] }).skills;
+        }
+        const target = path.resolve(skillsFileDir);
+        const matchedSkills = skills.find((s) => {
+          const base = path.resolve((s as { baseDir?: string }).baseDir ?? "");
+          return base === target;
+        });
+        if (matchedSkills?.name) {
+          skillsName = matchedSkills.name;
+        }
+      } catch {}
+      logHooks.info(
+        `skills name is ${skillsName}, skills package dir name is ${skillsPackageDirName}`,
+      );
+      if (!skillsName && skillsPackageDirName) {
+        skillsName = skillsPackageDirName;
+      }
+    }
+
+    if (skillsFileDir && skillsName) {
+      const loadSkill = { skillsName: skillsName, skillsFileDir: skillsFileDir };
+      runner
+        ?.runBeforeSkillsLoad({ loadSkill }, { workspaceDir: event.workspaceDir ?? "" })
+        .then((hookResult) => {
+          if (!hookResult) {
+            // no hook result, skip
+            return;
+          }
+          logHooks.info(`skills hook security scan result blocked is ${hookResult?.blocked}`);
+          const securityInfo = `security info:${hookResult?.securityInfo}(severity:${hookResult?.severity}, risk score:${hookResult?.riskScore})`;
+          const req: RequestFrame = {
+            type: "req",
+            id: `internal-${skillsName}-disable`,
+            method: "skills.update",
+          };
+          const ctx = {} as GatewayRequestContext;
+          let params = {};
+          if (hookResult?.blocked === true) {
+            params = {
+              skillKey: skillsName,
+              enabled: false,
+              securityInfo: securityInfo,
+              securityBlocked: true,
+            };
+          } else {
+            params = {
+              skillKey: skillsName,
+              securityInfo: "",
+              securityBlocked: false,
+            };
+          }
+          void skillsHandlers["skills.update"]({
+            req,
+            params: params,
+            client: null,
+            isWebchatConnect: () => false,
+            respond: (ok, error) => {
+              if (!ok) {
+                logHooks.error(
+                  `[skills.update] skillsName: "${skillsName}" , failed: ${JSON.stringify(
+                    error ?? {},
+                  )}}`,
+                );
+              }
+            },
+            context: ctx,
+          });
+          broadcast(
+            "skills",
+            {
+              kind: "skills_security_scan",
+              name: skillsName,
+              enabled: hookResult?.blocked === false,
+              blocked: hookResult?.blocked === true,
+              reason: securityInfo,
+            },
+            { dropIfSlow: true },
+          );
+        })
+        .catch(() => {});
+    }
+  }
+
   // Debounce skills-triggered node probes to avoid feedback loops and rapid-fire invokes.
   // Skills changes can happen in bursts (e.g., file watcher events), and each probe
   // takes time to complete. A 30-second delay ensures we batch changes together.
@@ -636,6 +807,7 @@ export async function startGatewayServer(
           skillsRefreshTimer = null;
           const latest = loadConfig();
           void refreshRemoteBinsForConnectedNodes(latest);
+          void handleSkillsChangeForSecurityHook(event);
         }, skillsRefreshDelayMs);
       });
 

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -390,7 +390,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       event,
       ctx,
       (acc, next) => ({
-        blocked: next.blocked ?? acc?.blocked,
+        blocked:
+          acc?.blocked === true || next.blocked === true ? true : (acc?.blocked ?? next.blocked),
         securityInfo: next.securityInfo ?? acc?.securityInfo,
         riskScore: next.riskScore ?? acc?.riskScore,
         severity: next.severity ?? acc?.severity,

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -49,6 +49,9 @@ import type {
   PluginHookToolResultPersistResult,
   PluginHookBeforeMessageWriteEvent,
   PluginHookBeforeMessageWriteResult,
+  PluginHookBeforeSkillsLoadContext,
+  PluginHookBeforeSkillsLoadEvent,
+  PluginHookBeforeSkillsLoadResult,
 } from "./types.js";
 
 // Re-export types for consumers
@@ -369,6 +372,30 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     ctx: PluginHookAgentContext,
   ): Promise<void> {
     return runVoidHook("before_reset", event, ctx);
+  }
+
+  // =========================================================================
+  // Skill Hooks
+  // =========================================================================
+  /**
+   * Run before_skills_load hook.
+   * Allows plugins to modify or block skill loading.
+   */
+  async function runBeforeSkillsLoad(
+    event: PluginHookBeforeSkillsLoadEvent,
+    ctx: PluginHookBeforeSkillsLoadContext,
+  ): Promise<PluginHookBeforeSkillsLoadResult | undefined> {
+    return runModifyingHook<"before_skills_load", PluginHookBeforeSkillsLoadResult>(
+      "before_skills_load",
+      event,
+      ctx,
+      (acc, next) => ({
+        blocked: next.blocked ?? acc?.blocked,
+        securityInfo: next.securityInfo ?? acc?.securityInfo,
+        riskScore: next.riskScore ?? acc?.riskScore,
+        severity: next.severity ?? acc?.severity,
+      }),
+    );
   }
 
   // =========================================================================
@@ -724,6 +751,8 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
     runBeforeCompaction,
     runAfterCompaction,
     runBeforeReset,
+    // Skills hooks
+    runBeforeSkillsLoad,
     // Message hooks
     runMessageReceived,
     runMessageSending,

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -331,7 +331,8 @@ export type PluginHookName =
   | "subagent_spawned"
   | "subagent_ended"
   | "gateway_start"
-  | "gateway_stop";
+  | "gateway_stop"
+  | "before_skills_load";
 
 // Agent context shared across agent hooks
 export type PluginHookAgentContext = {
@@ -677,6 +678,28 @@ export type PluginHookGatewayStopEvent = {
   reason?: string;
 };
 
+// before_skills_load context
+export type PluginHookBeforeSkillsLoadContext = {
+  workspaceDir: string;
+  agentId?: string;
+  sessionKey?: string;
+};
+
+// before_skills_load hook
+export type PluginHookBeforeSkillsLoadEvent = {
+  loadSkill?: {
+    skillsName: string;
+    skillsFileDir: string;
+  };
+};
+
+export type PluginHookBeforeSkillsLoadResult = {
+  blocked?: boolean;
+  securityInfo?: string;
+  riskScore?: number;
+  severity?: string;
+};
+
 // Hook handler types mapped by hook name
 export type PluginHookHandlerMap = {
   before_model_resolve: (
@@ -775,6 +798,10 @@ export type PluginHookHandlerMap = {
     event: PluginHookGatewayStopEvent,
     ctx: PluginHookGatewayContext,
   ) => Promise<void> | void;
+  before_skills_load: (
+    event: PluginHookBeforeSkillsLoadEvent,
+    ctx: PluginHookBeforeSkillsLoadContext,
+  ) => Promise<PluginHookBeforeSkillsLoadResult | void> | PluginHookBeforeSkillsLoadResult | void;
 };
 
 export type PluginHookRegistration<K extends PluginHookName = PluginHookName> = {

--- a/ui/src/ui/types.ts
+++ b/ui/src/ui/types.ts
@@ -587,6 +587,7 @@ export type SkillStatusEntry = {
   homepage?: string;
   always: boolean;
   disabled: boolean;
+  security?: { securityInfo?: string };
   blockedByAllowlist: boolean;
   eligible: boolean;
   requirements: {

--- a/ui/src/ui/views/skills-shared.ts
+++ b/ui/src/ui/views/skills-shared.ts
@@ -18,6 +18,9 @@ export function computeSkillReasons(skill: SkillStatusEntry): string[] {
   if (skill.blockedByAllowlist) {
     reasons.push("blocked by allowlist");
   }
+  if (skill.security?.securityInfo) {
+    reasons.push(skill.security.securityInfo);
+  }
   return reasons;
 }
 


### PR DESCRIPTION
PR Describe

This PR introduces the “before skills load” hook feature and wires it into the gateway’s security flow.

Note:This change integrates the gateway skills-change path with the plugin hook runner;

Changes Included:

- Implement HookRunner.runBeforeSkillsLoad and the typed hook execution for before_skills_load hooks.ts.
- Invoke the global hook runner from the gateway security handler on skills change server.impl.ts.
- Enable plugins to intercept, validate, or augment skill definitions prior to loading via PluginHookBeforeSkillsLoadEvent.
- Leverage existing hook priority ordering for deterministic execution; environments without registered hooks continue unchanged.
- Add security risk blocked evaluation that marks affected skills disabled and exposes a UI-visible reason field; administrators can re-enable those skills.
- Route skills-change metadata into the hook context to support security checks and controlled loading behavior.