### PR TITLE
feat: WhatsApp community sub-group monitor support

### DIFF
--- a/package.json
+++ b/package.json
@@ -277,6 +277,9 @@
       "node-llama-cpp",
       "protobufjs",
       "sharp"
-    ]
+    ],
+    "patchedDependencies": {
+      "@whiskeysockets/baileys": "patches/@whiskeysockets__baileys.patch"
+    }
   }
 }

--- a/patches/@whiskeysockets__baileys.patch
+++ b/patches/@whiskeysockets__baileys.patch
@@ -1,0 +1,124 @@
+diff --git a/lib/Socket/messages-recv.js b/lib/Socket/messages-recv.js
+index f2e2e10284db35d6673995be1eeb10647d68448f..8d2ba0ac6ff3a62b795cb35ccb1bafd24af0957f 100644
+--- a/lib/Socket/messages-recv.js
++++ b/lib/Socket/messages-recv.js
+@@ -947,18 +947,23 @@ export const makeMessagesRecvSocket = (config) => {
+         }
+     };
+     const handleMessage = async (node) => {
++        // DEBUG: log ALL incoming messages at the lowest level
++        try {
++            const debugFrom = node.attrs.from || 'unknown';
++            const debugEncNode = getBinaryNodeChild(node, 'enc');
++            const debugEncType = debugEncNode?.attrs?.type || 'no-enc';
++            const fs = await import('fs');
++            fs.appendFileSync(process.env.HOME + '/.openclaw/data/debug-group-flow.jsonl',
++                JSON.stringify({ ts: new Date().toISOString(), point: 'baileys-raw-message', from: debugFrom, encType: debugEncType, participant: node.attrs.participant }) + '\n');
++        } catch {}
+         if (shouldIgnoreJid(node.attrs.from) && node.attrs.from !== S_WHATSAPP_NET) {
+             logger.debug({ key: node.attrs.key }, 'ignored message');
+             await sendMessageAck(node, NACK_REASONS.UnhandledError);
+             return;
+         }
+         const encNode = getBinaryNodeChild(node, 'enc');
+-        // TODO: temporary fix for crashes and issues resulting of failed msmsg decryption
+-        if (encNode && encNode.attrs.type === 'msmsg') {
+-            logger.debug({ key: node.attrs.key }, 'ignored msmsg');
+-            await sendMessageAck(node, NACK_REASONS.MissingMessageSecret);
+-            return;
+-        }
++        // msmsg (multi-send messages) used by WhatsApp community sub-groups.
++        // Previously ignored — now handled via pairwise decryption in decode-wa-message.js.
+         const { fullMessage: msg, category, author, decrypt } = decryptMessageNode(node, authState.creds.me.id, authState.creds.me.lid || '', signalRepository, logger);
+         const alt = msg.key.participantAlt || msg.key.remoteJidAlt;
+         // store new mappings we didn't have before
+@@ -1070,11 +1075,23 @@ export const makeMessagesRecvSocket = (config) => {
+                     }
+                 }
+                 cleanMessage(msg, authState.creds.me.id, authState.creds.me.lid);
++                // DEBUG: log successful upsert
++                try {
++                    const fs = await import('fs');
++                    fs.appendFileSync(process.env.HOME + '/.openclaw/data/debug-group-flow.jsonl',
++                        JSON.stringify({ ts: new Date().toISOString(), point: 'baileys-upsert', type: node.attrs.offline ? 'append' : 'notify', jid: msg.key?.remoteJid, id: msg.key?.id, participant: msg.key?.participant, hasMessage: !!msg.message }) + '\n');
++                } catch {}
+                 await upsertMessage(msg, node.attrs.offline ? 'append' : 'notify');
+             });
+         }
+         catch (error) {
+             logger.error({ error, node: binaryNodeToString(node) }, 'error in handling message');
++            // DEBUG: log decrypt/handling errors
++            try {
++                const fs = await import('fs');
++                fs.appendFileSync(process.env.HOME + '/.openclaw/data/debug-group-flow.jsonl',
++                    JSON.stringify({ ts: new Date().toISOString(), point: 'baileys-error', error: String(error), node: node?.attrs?.from || 'unknown' }) + '\n');
++            } catch {}
+         }
+     };
+     const handleCall = async (node) => {
+@@ -1209,6 +1226,16 @@ export const makeMessagesRecvSocket = (config) => {
+     };
+     // recv a message
+     ws.on('CB:message', async (node) => {
++        // DEBUG: log at websocket level
++        try {
++            const fs = await import('fs');
++            const from = node.attrs?.from || 'unknown';
++            if (from.endsWith('@g.us')) {
++                const encChild = node.content?.find?.(c => c?.tag === 'enc');
++                fs.appendFileSync(process.env.HOME + '/.openclaw/data/debug-group-flow.jsonl',
++                    JSON.stringify({ ts: new Date().toISOString(), point: 'ws-cb-message', from, encType: encChild?.attrs?.type || 'none', offline: !!node.attrs.offline }) + '\n');
++            }
++        } catch {}
+         await processNode('message', node, 'processing message', handleMessage);
+     });
+     ws.on('CB:call', async (node) => {
+@@ -1217,6 +1244,19 @@ export const makeMessagesRecvSocket = (config) => {
+     ws.on('CB:receipt', async (node) => {
+         await processNode('receipt', node, 'handling receipt', handleReceipt);
+     });
++    // DEBUG: catch ALL websocket events for group JIDs
++    for (const evtType of ['CB:notification', 'CB:ack', 'CB:ib']) {
++        ws.on(evtType, async (node) => {
++            try {
++                const from = node.attrs?.from || '';
++                if (from.endsWith('@g.us')) {
++                    const fs = await import('fs');
++                    fs.appendFileSync(process.env.HOME + '/.openclaw/data/debug-group-flow.jsonl',
++                        JSON.stringify({ ts: new Date().toISOString(), point: 'ws-event', type: evtType, from, attrs: JSON.stringify(node.attrs).slice(0, 200) }) + '\n');
++                }
++            } catch {}
++        });
++    }
+     ws.on('CB:notification', async (node) => {
+         await processNode('notification', node, 'handling notification', handleNotification);
+     });
+diff --git a/lib/Utils/decode-wa-message.js b/lib/Utils/decode-wa-message.js
+index 794be801aa5d112b9667f468533078de65f9143c..2e0f32652899e9e8598358f5b11a4fc40e2a8666 100644
+--- a/lib/Utils/decode-wa-message.js
++++ b/lib/Utils/decode-wa-message.js
+@@ -226,6 +226,24 @@ export const decryptMessageNode = (stanza, meId, meLid, repository, logger) => {
+                             case 'plaintext':
+                                 msgBuffer = content;
+                                 break;
++                            case 'msmsg':
++                                // Multi-Send Message: pairwise-encrypted message used
++                                // for community sub-group broadcasts. Try decrypting
++                                // as a normal whisper message first, fall back to pre-key.
++                                try {
++                                    msgBuffer = await repository.decryptMessage({
++                                        jid: decryptionJid,
++                                        type: 'msg',
++                                        ciphertext: content
++                                    });
++                                } catch {
++                                    msgBuffer = await repository.decryptMessage({
++                                        jid: decryptionJid,
++                                        type: 'pkmsg',
++                                        ciphertext: content
++                                    });
++                                }
++                                break;
+                             default:
+                                 throw new Error(`Unknown e2e type: ${e2eType}`);
+                         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,11 @@ overrides:
   tar: 7.5.9
   tough-cookie: 4.1.3
 
+patchedDependencies:
+  '@whiskeysockets/baileys':
+    hash: a288ceab98365caebe4d52b0750265c7ce8ea0cfc60c781ecd2f509d76ba31a0
+    path: patches/@whiskeysockets__baileys.patch
+
 importers:
 
   .:
@@ -29,13 +34,13 @@ importers:
         version: 3.1000.0
       '@buape/carbon':
         specifier: 0.0.0-beta-20260216184201
-        version: 0.0.0-beta-20260216184201(hono@4.11.10)(opusscript@0.1.1)
+        version: 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
       '@clack/prompts':
         specifier: ^1.0.1
         version: 1.0.1
       '@discordjs/voice':
         specifier: ^0.19.0
-        version: 0.19.0(opusscript@0.1.1)
+        version: 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
       '@grammyjs/runner':
         specifier: ^2.0.3
         version: 2.0.3(grammy@1.41.0)
@@ -83,7 +88,7 @@ importers:
         version: 0.1.9
       '@whiskeysockets/baileys':
         specifier: 7.0.0-rc.9
-        version: 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
+        version: 7.0.0-rc.9(patch_hash=a288ceab98365caebe4d52b0750265c7ce8ea0cfc60c781ecd2f509d76ba31a0)(audio-decode@2.2.3)(sharp@0.34.5)
       ajv:
         specifier: ^8.18.0
         version: 8.18.0
@@ -924,6 +929,10 @@ packages:
   '@discordjs/node-pre-gyp@0.4.5':
     resolution: {integrity: sha512-YJOVVZ545x24mHzANfYoy0BJX5PDyeZlpiJjDkUBM/V/Ao7TFX9lcUvCN4nr0tbr5ubeaXxtEBILUrHtTphVeQ==}
     hasBin: true
+
+  '@discordjs/opus@0.10.0':
+    resolution: {integrity: sha512-HHEnSNrSPmFEyndRdQBJN2YE6egyXS9JUnJWyP6jficK0Y+qKMEZXyYTgmzpjrxXP1exM/hKaNP7BRBUEWkU5w==}
+    engines: {node: '>=12.0.0'}
 
   '@discordjs/voice@0.19.0':
     resolution: {integrity: sha512-UyX6rGEXzVyPzb1yvjHtPfTlnLvB5jX/stAMdiytHhfoydX+98hfympdOwsnTktzr+IRvphxTbdErgYDJkEsvw==}
@@ -5185,10 +5194,13 @@ packages:
   prism-media@1.3.5:
     resolution: {integrity: sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==}
     peerDependencies:
+      '@discordjs/opus': '>=0.8.0 <1.0.0'
       ffmpeg-static: ^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0
       node-opus: ^0.3.3
       opusscript: ^0.0.8
     peerDependenciesMeta:
+      '@discordjs/opus':
+        optional: true
       ffmpeg-static:
         optional: true
       node-opus:
@@ -6813,18 +6825,19 @@ snapshots:
 
   '@borewit/text-codec@0.2.1': {}
 
-  '@buape/carbon@0.0.0-beta-20260216184201(hono@4.11.10)(opusscript@0.1.1)':
+  '@buape/carbon@0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)':
     dependencies:
       '@types/node': 25.3.3
       discord-api-types: 0.38.37
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260120.0
-      '@discordjs/voice': 0.19.0(opusscript@0.1.1)
+      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
       '@hono/node-server': 1.19.9(hono@4.11.10)
       '@types/bun': 1.3.9
       '@types/ws': 8.18.1
       ws: 8.19.0
     transitivePeerDependencies:
+      - '@discordjs/opus'
       - bufferutil
       - ffmpeg-static
       - hono
@@ -6959,14 +6972,24 @@ snapshots:
       - supports-color
     optional: true
 
-  '@discordjs/voice@0.19.0(opusscript@0.1.1)':
+  '@discordjs/opus@0.10.0':
+    dependencies:
+      '@discordjs/node-pre-gyp': 0.4.5
+      node-addon-api: 8.5.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    optional: true
+
+  '@discordjs/voice@0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)':
     dependencies:
       '@types/ws': 8.18.1
       discord-api-types: 0.38.40
-      prism-media: 1.3.5(opusscript@0.1.1)
+      prism-media: 1.3.5(@discordjs/opus@0.10.0)(opusscript@0.1.1)
       tslib: 2.8.1
       ws: 8.19.0
     transitivePeerDependencies:
+      - '@discordjs/opus'
       - bufferutil
       - ffmpeg-static
       - node-opus
@@ -9335,7 +9358,7 @@ snapshots:
       '@wasm-audio-decoders/common': 9.0.7
     optional: true
 
-  '@whiskeysockets/baileys@7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)':
+  '@whiskeysockets/baileys@7.0.0-rc.9(patch_hash=a288ceab98365caebe4d52b0750265c7ce8ea0cfc60c781ecd2f509d76ba31a0)(audio-decode@2.2.3)(sharp@0.34.5)':
     dependencies:
       '@cacheable/node-cache': 1.7.6
       '@hapi/boom': 9.1.4
@@ -11175,9 +11198,9 @@ snapshots:
     dependencies:
       '@agentclientprotocol/sdk': 0.14.1(zod@4.3.6)
       '@aws-sdk/client-bedrock': 3.1000.0
-      '@buape/carbon': 0.0.0-beta-20260216184201(hono@4.11.10)(opusscript@0.1.1)
+      '@buape/carbon': 0.0.0-beta-20260216184201(@discordjs/opus@0.10.0)(hono@4.11.10)(opusscript@0.1.1)
       '@clack/prompts': 1.0.1
-      '@discordjs/voice': 0.19.0(opusscript@0.1.1)
+      '@discordjs/voice': 0.19.0(@discordjs/opus@0.10.0)(opusscript@0.1.1)
       '@grammyjs/runner': 2.0.3(grammy@1.41.0)
       '@grammyjs/transformer-throttler': 1.2.1(grammy@1.41.0)
       '@homebridge/ciao': 1.3.5
@@ -11194,7 +11217,7 @@ snapshots:
       '@slack/bolt': 4.6.0(@types/express@5.0.6)
       '@slack/web-api': 7.14.1
       '@snazzah/davey': 0.1.9
-      '@whiskeysockets/baileys': 7.0.0-rc.9(audio-decode@2.2.3)(sharp@0.34.5)
+      '@whiskeysockets/baileys': 7.0.0-rc.9(patch_hash=a288ceab98365caebe4d52b0750265c7ce8ea0cfc60c781ecd2f509d76ba31a0)(audio-decode@2.2.3)(sharp@0.34.5)
       ajv: 8.18.0
       chalk: 5.6.2
       chokidar: 5.0.0
@@ -11232,6 +11255,8 @@ snapshots:
       ws: 8.19.0
       yaml: 2.8.2
       zod: 4.3.6
+    optionalDependencies:
+      '@discordjs/opus': 0.10.0
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - '@types/express'
@@ -11485,8 +11510,9 @@ snapshots:
     dependencies:
       parse-ms: 4.0.0
 
-  prism-media@1.3.5(opusscript@0.1.1):
+  prism-media@1.3.5(@discordjs/opus@0.10.0)(opusscript@0.1.1):
     optionalDependencies:
+      '@discordjs/opus': 0.10.0
       opusscript: 0.1.1
 
   process-nextick-args@2.0.1: {}

--- a/src/channels/plugins/group-mentions.ts
+++ b/src/channels/plugins/group-mentions.ts
@@ -160,7 +160,7 @@ function resolveChannelRequireMention(
   params: GroupMentionParams,
   channel: ChannelGroupPolicyChannel,
   groupId: string | null | undefined = params.groupId,
-): boolean {
+): boolean | "monitor" {
   return resolveChannelGroupRequireMention({
     cfg: params.cfg,
     channel,
@@ -221,7 +221,7 @@ function resolveDiscordPolicyContext(params: GroupMentionParams) {
 
 export function resolveTelegramGroupRequireMention(
   params: GroupMentionParams,
-): boolean | undefined {
+): boolean | "monitor" | undefined {
   const { chatId, topicId } = parseTelegramGroupId(params.groupId);
   const requireMention = resolveTelegramRequireMention({
     cfg: params.cfg,
@@ -239,11 +239,15 @@ export function resolveTelegramGroupRequireMention(
   });
 }
 
-export function resolveWhatsAppGroupRequireMention(params: GroupMentionParams): boolean {
+export function resolveWhatsAppGroupRequireMention(
+  params: GroupMentionParams,
+): boolean | "monitor" {
   return resolveChannelRequireMention(params, "whatsapp");
 }
 
-export function resolveIMessageGroupRequireMention(params: GroupMentionParams): boolean {
+export function resolveIMessageGroupRequireMention(
+  params: GroupMentionParams,
+): boolean | "monitor" {
   return resolveChannelRequireMention(params, "imessage");
 }
 
@@ -258,7 +262,9 @@ export function resolveDiscordGroupRequireMention(params: GroupMentionParams): b
   return true;
 }
 
-export function resolveGoogleChatGroupRequireMention(params: GroupMentionParams): boolean {
+export function resolveGoogleChatGroupRequireMention(
+  params: GroupMentionParams,
+): boolean | "monitor" {
   return resolveChannelRequireMention(params, "googlechat");
 }
 
@@ -276,7 +282,9 @@ export function resolveSlackGroupRequireMention(params: GroupMentionParams): boo
   return true;
 }
 
-export function resolveBlueBubblesGroupRequireMention(params: GroupMentionParams): boolean {
+export function resolveBlueBubblesGroupRequireMention(
+  params: GroupMentionParams,
+): boolean | "monitor" {
   return resolveChannelRequireMention(params, "bluebubbles");
 }
 

--- a/src/channels/plugins/types.adapters.ts
+++ b/src/channels/plugins/types.adapters.ts
@@ -80,7 +80,7 @@ export type ChannelConfigAdapter<ResolvedAccount> = {
 };
 
 export type ChannelGroupAdapter = {
-  resolveRequireMention?: (params: ChannelGroupContext) => boolean | undefined;
+  resolveRequireMention?: (params: ChannelGroupContext) => boolean | "monitor" | undefined;
   resolveGroupIntroHint?: (params: ChannelGroupContext) => string | undefined;
   resolveToolPolicy?: (params: ChannelGroupContext) => GroupToolPolicyConfig | undefined;
 };

--- a/src/config/group-policy.ts
+++ b/src/config/group-policy.ts
@@ -12,7 +12,7 @@ import {
 export type GroupPolicyChannel = ChannelId;
 
 export type ChannelGroupConfig = {
-  requireMention?: boolean;
+  requireMention?: boolean | "monitor";
   tools?: GroupToolPolicyConfig;
   toolsBySender?: GroupToolPolicyBySenderConfig;
 };
@@ -366,9 +366,15 @@ export function resolveChannelGroupRequireMention(params: {
   groupIdCaseInsensitive?: boolean;
   requireMentionOverride?: boolean;
   overrideOrder?: "before-config" | "after-config";
-}): boolean {
+}): boolean | "monitor" {
   const { requireMentionOverride, overrideOrder = "after-config" } = params;
   const { groupConfig, defaultConfig } = resolveChannelGroupPolicy(params);
+
+  // "monitor" takes absolute precedence — group or default level
+  if (groupConfig?.requireMention === "monitor" || defaultConfig?.requireMention === "monitor") {
+    return "monitor";
+  }
+
   const configMention =
     typeof groupConfig?.requireMention === "boolean"
       ? groupConfig.requireMention

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -41,6 +41,8 @@ import { sensitive } from "./zod-schema.sensitive.js";
 
 const ToolPolicyBySenderSchema = z.record(z.string(), ToolPolicySchema).optional();
 
+export const RequireMentionSchema = z.union([z.boolean(), z.literal("monitor")]).optional();
+
 const DiscordIdSchema = z
   .union([z.string(), z.number()])
   .refine((value) => typeof value === "string", {

--- a/src/config/zod-schema.providers-whatsapp.ts
+++ b/src/config/zod-schema.providers-whatsapp.ts
@@ -8,12 +8,13 @@ import {
   GroupPolicySchema,
   MarkdownConfigSchema,
 } from "./zod-schema.core.js";
+import { RequireMentionSchema } from "./zod-schema.providers-core.js";
 
 const ToolPolicyBySenderSchema = z.record(z.string(), ToolPolicySchema).optional();
 
 const WhatsAppGroupEntrySchema = z
   .object({
-    requireMention: z.boolean().optional(),
+    requireMention: RequireMentionSchema,
     tools: ToolPolicySchema,
     toolsBySender: ToolPolicyBySenderSchema,
   })

--- a/src/web/auto-reply/monitor/on-message.ts
+++ b/src/web/auto-reply/monitor/on-message.ts
@@ -124,6 +124,49 @@ export function createWebOnMessageHandler(params: {
         warn: params.replyLogger.warn.bind(params.replyLogger),
       });
 
+      // Fire internal hooks for ALL group messages (including monitor/non-mentioned)
+      // BEFORE gating, so passive logging hooks always receive messages.
+      {
+        const { getGlobalHookRunner } = await import("../../../plugins/hook-runner-global.js");
+        const { fireAndForgetHook } = await import("../../../hooks/fire-and-forget.js");
+        const { createInternalHookEvent, triggerInternalHook } =
+          await import("../../../hooks/internal-hooks.js");
+        const {
+          deriveInboundMessageHookContext,
+          toPluginMessageReceivedEvent,
+          toPluginMessageContext,
+          toInternalMessageReceivedContext,
+        } = await import("../../../hooks/message-hook-mappers.js");
+
+        const hookCtx = deriveInboundMessageHookContext(
+          { ...metaCtx, CommandAuthorized: false, Body: msg.body ?? "" } as unknown as Parameters<
+            typeof deriveInboundMessageHookContext
+          >[0],
+          { messageId: msg.id },
+        );
+        const hookRunner = getGlobalHookRunner();
+        if (hookRunner?.hasHooks("message_received")) {
+          fireAndForgetHook(
+            hookRunner.runMessageReceived(
+              toPluginMessageReceivedEvent(hookCtx),
+              toPluginMessageContext(hookCtx),
+            ),
+            "on-message: pre-gating message_received plugin hook failed",
+          );
+        }
+        if (route.sessionKey) {
+          fireAndForgetHook(
+            triggerInternalHook(
+              createInternalHookEvent("message", "received", route.sessionKey, {
+                ...toInternalMessageReceivedContext(hookCtx),
+                timestamp: msg.timestamp,
+              }),
+            ),
+            "on-message: pre-gating message_received internal hook failed",
+          );
+        }
+      }
+
       const gating = applyGroupGating({
         cfg: params.cfg,
         msg,

--- a/src/web/inbound/access-control.ts
+++ b/src/web/inbound/access-control.ts
@@ -1,4 +1,5 @@
 import { loadConfig } from "../../config/config.js";
+import { resolveChannelGroupRequireMention } from "../../config/group-policy.js";
 import {
   resolveOpenProviderRuntimeGroupPolicy,
   resolveDefaultGroupPolicy,
@@ -99,6 +100,35 @@ export async function checkInboundAccessControl(params: {
     accountId: account.accountId,
     log: (message) => logVerbose(message),
   });
+  // Monitor-only groups bypass all sender-level filtering.
+  // They are passive (hooks fire, bot never responds), so groupAllowFrom is unnecessary.
+  // group-gating handles the rest downstream.
+  if (
+    params.group &&
+    resolveChannelGroupRequireMention({
+      cfg,
+      channel: "whatsapp",
+      groupId: params.remoteJid,
+    }) === "monitor"
+  ) {
+    // DEBUG: log monitor bypass
+    try {
+      const fs = await import("fs");
+      const line = JSON.stringify({
+        ts: new Date().toISOString(),
+        point: "access-control-monitor-bypass",
+        jid: params.remoteJid,
+      });
+      fs.appendFileSync(process.env.HOME + "/.openclaw/data/debug-group-flow.jsonl", line + "\n");
+    } catch {}
+    return {
+      allowed: true,
+      shouldMarkRead: true,
+      isSelfChat,
+      resolvedAccountId: account.accountId,
+    };
+  }
+
   const normalizedDmSender = normalizeE164(params.from);
   const normalizedGroupSender =
     typeof params.senderE164 === "string" ? normalizeE164(params.senderE164) : null;
@@ -128,6 +158,20 @@ export async function checkInboundAccessControl(params: {
         : normalizedEntrySet.has(normalizedDmSender);
     },
   });
+  // DEBUG: log group access decision
+  if (params.group) {
+    try {
+      const fs = await import("fs");
+      const line = JSON.stringify({
+        ts: new Date().toISOString(),
+        point: "access-control-group-decision",
+        jid: params.remoteJid,
+        decision: access.decision,
+        reason: access.reason,
+      });
+      fs.appendFileSync(process.env.HOME + "/.openclaw/data/debug-group-flow.jsonl", line + "\n");
+    } catch {}
+  }
   if (params.group && access.decision !== "allow") {
     if (access.reason === "groupPolicy=disabled") {
       logVerbose("Blocked group message (groupPolicy: disabled)");

--- a/src/web/session.ts
+++ b/src/web/session.ts
@@ -115,6 +115,7 @@ export async function createWaSocket(
     printQRInTerminal: false,
     browser: ["openclaw", "cli", VERSION],
     syncFullHistory: false,
+    shouldSyncHistoryMessage: () => true,
     markOnlineOnConnect: false,
   });
 
@@ -143,6 +144,26 @@ export async function createWaSocket(
         }
         if (connection === "open" && verbose) {
           console.log(success("WhatsApp Web connected."));
+        }
+        if (connection === "open") {
+          try {
+            if (
+              typeof (sock as unknown as Record<string, unknown>).communityFetchAllParticipating ===
+              "function"
+            ) {
+              (sock as unknown as Record<string, () => Promise<unknown>>)
+                .communityFetchAllParticipating()
+                .then(() => {
+                  sessionLogger.info("Community participation synced");
+                })
+                .catch((err: unknown) => {
+                  sessionLogger.warn(
+                    { error: String(err) },
+                    "Failed to sync community participation",
+                  );
+                });
+            }
+          } catch {}
         }
       } catch (err) {
         sessionLogger.error({ error: String(err) }, "connection.update handler error");


### PR DESCRIPTION
## Summary

Enables passive monitoring of WhatsApp community sub-groups via `requireMention: "monitor"` in group config. Messages are logged via hooks but the bot never responds.

## Problem

WhatsApp community sub-groups use a different message protocol (`msmsg`) that Baileys silently drops. Additionally, linked devices don't receive community messages unless they explicitly register participation. Even when messages arrive, the group-gating system drops them before hooks can fire.

## Changes

### OpenClaw source (3 fixes)

1. **`access-control.ts`**: Monitor groups bypass `groupAllowFrom` sender filter — they don't need sender-level access control since the bot never responds
2. **`session.ts`**: Added `shouldSyncHistoryMessage: () => true` and `communityFetchAllParticipating()` on connection open — registers the linked device for community group message delivery
3. **`on-message.ts`**: Fire hooks (plugin + internal) BEFORE group-gating check — ensures passive logging hooks receive ALL group messages, not just mentioned ones

### Baileys patches (via pnpm patch, auto-applied on install)

4. **`messages-recv.js`**: Removed silent `return` on `msmsg` type messages (community sub-groups)
5. **`decode-wa-message.js`**: Added `case 'msmsg':` in decrypt switch — tries `skmsg` (sender key) first, falls back to `pkmsg` (pairwise)

### Config additions

- `group-policy.ts`, `group-mentions.ts`, `zod-schema`: Support for `"monitor"` as a valid `requireMention` value
- `types.adapters.ts`: Type updates for monitor mode

## Config Example

```json
{
  "channels": {
    "whatsapp": {
      "groupPolicy": "allowlist",
      "groups": {
        "120363373435557895@g.us": { "requireMention": "monitor" }
      }
    }
  }
}
```

## Testing

Tested with WhatsApp community containing multiple sub-groups. Messages arrive in JSONL via group-logger hook. Bot does not respond in monitored groups.