### PR TITLE
feat: add message:beforeSend hook for outbound message mutation

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -261,7 +261,8 @@ Triggered when messages are received or sent:
 - **`message:received`**: When an inbound message is received from any channel. Fires early in processing before media understanding. Content may contain raw placeholders like `<media:audio>` for media attachments that haven't been processed yet.
 - **`message:transcribed`**: When a message has been fully processed, including audio transcription and link understanding. At this point, `transcript` contains the full transcript text for audio messages. Use this hook when you need access to transcribed audio content.
 - **`message:preprocessed`**: Fires for every message after all media + link understanding completes, giving hooks access to the fully enriched body (transcripts, image descriptions, link summaries) before the agent sees it.
-- **`message:sent`**: When an outbound message is successfully sent
+- **`message:beforeSend`**: Fires **before** an outbound message is delivered to the channel. Handlers may mutate `event.context.content` to change what gets sent, or set `event.context.suppress = true` to cancel delivery entirely. All handlers must complete within 5 seconds (configurable); if the timeout is exceeded the hook is abandoned and the message is sent with whatever mutations have been applied so far (fail-open). See [Mutating & Suppressing Messages](#mutating--suppressing-messages-messagesbeforeEnd) below.
+- **`message:sent`**: When an outbound message is successfully sent (fire-and-forget, after delivery)
 
 #### Message Event Context
 
@@ -289,7 +290,19 @@ Message events include rich context about the message:
   }
 }
 
-// message:sent context
+// message:beforeSend context  ← fires BEFORE delivery; handlers may mutate
+{
+  to: string,             // Recipient identifier
+  content: string,        // Message content — MUTATE THIS to change what gets sent
+  channelId: string,      // Channel (e.g., "whatsapp", "telegram", "discord")
+  accountId?: string,     // Provider account ID
+  conversationId?: string, // Chat/conversation ID
+  isGroup?: boolean,      // Whether this is a group/channel message
+  groupId?: string,       // Group/channel identifier
+  suppress?: boolean,     // Set to true to cancel delivery entirely
+}
+
+// message:sent context  ← fires AFTER delivery (fire-and-forget)
 {
   to: string,             // Recipient identifier
   content: string,        // Message content that was sent
@@ -344,6 +357,61 @@ const handler = async (event) => {
 
 export default handler;
 ```
+
+#### Mutating & Suppressing Messages (`message:beforeSend`)
+
+The `message:beforeSend` hook is the only message event that **blocks delivery** until handlers
+complete. Use it when you need to intercept an outbound message and either transform or discard it.
+
+**Use cases:**
+
+- **Signature injection** — append a standard footer or AI-generated signature to every reply
+- **PII filtering** — scan content for personal data and redact before it leaves your system
+- **Content transformation** — translate, reformat, or summarise replies
+- **Compliance enforcement** — log or gate messages matching certain patterns
+- **Multi-agent pipeline** — a secondary agent reviews/rewrites content before delivery
+
+**Mutating content:**
+
+```typescript
+// HOOK.md: events: ["message:beforeSend"]
+const handler = async (event) => {
+  if (event.type !== "message" || event.action !== "beforeSend") return;
+
+  // Append a signature to every outbound message.
+  event.context.content = event.context.content + "\n\n— Sent via MyBot";
+};
+
+export default handler;
+```
+
+**Suppressing delivery:**
+
+```typescript
+const BLOCKED_WORDS = ["confidential", "internal-only"];
+
+const handler = async (event) => {
+  if (event.type !== "message" || event.action !== "beforeSend") return;
+
+  const content = String(event.context.content).toLowerCase();
+  if (BLOCKED_WORDS.some((w) => content.includes(w))) {
+    event.context.suppress = true; // message will not be sent
+  }
+};
+
+export default handler;
+```
+
+**Behaviour guarantees:**
+
+- All registered handlers run sequentially (same order as registration).
+- The hook has a hard **5-second timeout**. If handlers take longer, the hook is abandoned and
+  the message is sent with whatever mutations have already been applied.
+- If a handler **throws**, the error is logged but delivery still proceeds (fail-open).
+- Content mutations from _all_ handlers are cumulative — each handler sees the result of the
+  previous one's mutation.
+- `message:beforeSend` fires **after** any `message_sending` plugin hook, so plugin-level
+  mutations are visible to internal hook handlers.
 
 ### Tool Result Hooks (Plugin API)
 

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -97,6 +97,39 @@ export type MessageSentHookEvent = InternalHookEvent & {
   context: MessageSentHookContext;
 };
 
+export type MessageBeforeSendHookContext = {
+  /** Recipient identifier */
+  to: string;
+  /**
+   * Message content — handlers MAY mutate this field to change what actually
+   * gets sent.  Read it back after all handlers complete; the delivery path
+   * will use whatever value is present.
+   */
+  content: string;
+  /** Channel identifier (e.g., "telegram", "whatsapp") */
+  channelId: string;
+  /** Provider account ID for multi-account setups */
+  accountId?: string;
+  /** Conversation/chat ID */
+  conversationId?: string;
+  /** Whether this message is being sent in a group/channel context */
+  isGroup?: boolean;
+  /** Group or channel identifier, if applicable */
+  groupId?: string;
+  /**
+   * Set to `true` inside a handler to cancel delivery of this message
+   * entirely.  All handlers still run (within the timeout window), but the
+   * message will not be sent if any handler sets this flag.
+   */
+  suppress?: boolean;
+};
+
+export type MessageBeforeSendHookEvent = InternalHookEvent & {
+  type: "message";
+  action: "beforeSend";
+  context: MessageBeforeSendHookContext;
+};
+
 export type MessageTranscribedHookContext = {
   /** Sender identifier (e.g., phone number, user ID) */
   from?: string;
@@ -417,6 +450,74 @@ export function isMessageSentEvent(event: InternalHookEvent): event is MessageSe
     hasStringContextField(context, "channelId") &&
     hasBooleanContextField(context, "success")
   );
+}
+
+/**
+ * Default timeout (ms) for the `message:beforeSend` hook.
+ *
+ * If registered handlers collectively take longer than this, the hook run is
+ * abandoned and the message is sent with whatever mutations were applied up
+ * to that point (fail-open).
+ */
+export const BEFORE_SEND_HOOK_TIMEOUT_MS = 5_000;
+
+/**
+ * Fire the `message:beforeSend` hook and wait for all handlers, with a hard
+ * timeout to avoid blocking outbound delivery forever.
+ *
+ * Semantics:
+ * - Handlers may mutate `event.context.content` to change what gets sent.
+ * - Handlers may set `event.context.suppress = true` to cancel delivery.
+ * - All handlers run sequentially (same as `triggerInternalHook`), but the
+ *   entire run is raced against `timeoutMs` (default 5 s).
+ * - If the timeout fires first, any mutations that have already been applied
+ *   are preserved; the message is still sent (fail-open).
+ * - If a handler throws, the error is logged and the next handler runs
+ *   (standard `triggerInternalHook` behaviour).
+ *
+ * @returns `{ suppress, content }` — the final suppress flag and (potentially
+ *   mutated) content that the delivery path should use.
+ */
+export async function triggerBeforeSendInternalHook(
+  event: MessageBeforeSendHookEvent,
+  timeoutMs: number = BEFORE_SEND_HOOK_TIMEOUT_MS,
+): Promise<{ suppress: boolean; content: string }> {
+  const originalContent = event.context.content;
+
+  let timedOut = false;
+  const timeoutPromise = new Promise<void>((resolve) =>
+    setTimeout(() => {
+      timedOut = true;
+      resolve();
+    }, timeoutMs),
+  );
+
+  await Promise.race([triggerInternalHook(event), timeoutPromise]);
+
+  if (timedOut) {
+    log.warn(
+      `message:beforeSend hook timed out after ${timeoutMs}ms; proceeding with current context state`,
+    );
+  }
+
+  return {
+    suppress: event.context.suppress === true,
+    content:
+      typeof event.context.content === "string" ? event.context.content : String(originalContent),
+  };
+}
+
+export function isMessageBeforeSendEvent(
+  event: InternalHookEvent,
+): event is MessageBeforeSendHookEvent {
+  if (!isHookEventTypeAndAction(event, "message", "beforeSend")) {
+    return false;
+  }
+  const context = getHookContext<MessageBeforeSendHookContext>(event);
+  if (!context) {
+    return false;
+  }
+  return hasStringContextField(context, "to") && hasStringContextField(context, "channelId");
 }
 
 export function isMessageTranscribedEvent(

--- a/src/hooks/message-hooks.test.ts
+++ b/src/hooks/message-hooks.test.ts
@@ -3,14 +3,16 @@ import {
   clearInternalHooks,
   createInternalHookEvent,
   registerInternalHook,
+  triggerBeforeSendInternalHook,
   triggerInternalHook,
   type InternalHookEvent,
+  type MessageBeforeSendHookEvent,
 } from "./internal-hooks.js";
 
 type ActionCase = {
   label: string;
   key: string;
-  action: "received" | "transcribed" | "preprocessed" | "sent";
+  action: "received" | "transcribed" | "preprocessed" | "sent" | "beforeSend";
   context: Record<string, unknown>;
   assertContext: (context: Record<string, unknown>) => void;
 };
@@ -102,6 +104,26 @@ const actionCases: ActionCase[] = [
       expect(context.channelId).toBe("discord");
       expect(context.conversationId).toBe("channel:C123");
       expect(context.threadId).toBe("thread-abc");
+    },
+  },
+  {
+    label: "message:beforeSend",
+    key: "message:beforeSend",
+    action: "beforeSend",
+    context: {
+      to: "user:789",
+      content: "Outbound message",
+      channelId: "telegram",
+      conversationId: "chat:456",
+      isGroup: false,
+      suppress: false,
+    },
+    assertContext: (context) => {
+      expect(context.to).toBe("user:789");
+      expect(context.content).toBe("Outbound message");
+      expect(context.channelId).toBe("telegram");
+      expect(context.conversationId).toBe("chat:456");
+      expect(context.suppress).toBe(false);
     },
   },
 ];
@@ -232,6 +254,102 @@ describe("message hooks", () => {
         triggerInternalHook(createInternalHookEvent("message", "sent", "s1", { content: "reply" })),
       ).resolves.not.toThrow();
       expect(asyncFailHandler).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("message:beforeSend hook", () => {
+    function makeBeforeSendEvent(content = "Hello world"): MessageBeforeSendHookEvent {
+      return createInternalHookEvent("message", "beforeSend", "session-bs", {
+        to: "user:42",
+        content,
+        channelId: "telegram",
+        conversationId: "chat:1",
+        suppress: false,
+      }) as MessageBeforeSendHookEvent;
+    }
+
+    it("returns original content when no mutation occurs", async () => {
+      registerInternalHook("message:beforeSend", (_event) => {
+        // no-op handler
+      });
+      const event = makeBeforeSendEvent("No change");
+      const result = await triggerBeforeSendInternalHook(event);
+      expect(result.content).toBe("No change");
+      expect(result.suppress).toBe(false);
+    });
+
+    it("returns mutated content when a handler updates event.context.content", async () => {
+      registerInternalHook("message:beforeSend", (event) => {
+        event.context.content = "🔏 " + (event.context.content as string);
+      });
+      const event = makeBeforeSendEvent("Original text");
+      const result = await triggerBeforeSendInternalHook(event);
+      expect(result.content).toBe("🔏 Original text");
+      expect(result.suppress).toBe(false);
+    });
+
+    it("returns suppress=true when a handler sets event.context.suppress", async () => {
+      registerInternalHook("message:beforeSend", (event) => {
+        event.context.suppress = true;
+      });
+      const event = makeBeforeSendEvent("Sensitive data");
+      const result = await triggerBeforeSendInternalHook(event);
+      expect(result.suppress).toBe(true);
+    });
+
+    it("allows multiple handlers to chain mutations", async () => {
+      registerInternalHook("message:beforeSend", (event) => {
+        event.context.content = (event.context.content as string) + " [sig1]";
+      });
+      registerInternalHook("message:beforeSend", (event) => {
+        event.context.content = (event.context.content as string) + " [sig2]";
+      });
+      const event = makeBeforeSendEvent("Base");
+      const result = await triggerBeforeSendInternalHook(event);
+      expect(result.content).toBe("Base [sig1] [sig2]");
+    });
+
+    it("is fail-open: a throwing handler does not prevent delivery", async () => {
+      registerInternalHook("message:beforeSend", (_event) => {
+        throw new Error("Handler exploded");
+      });
+      const event = makeBeforeSendEvent("Safe message");
+      const result = await triggerBeforeSendInternalHook(event);
+      // Should resolve without throwing and return the original content.
+      expect(result.content).toBe("Safe message");
+      expect(result.suppress).toBe(false);
+    });
+
+    it("respects timeout: resolves before slow handler finishes", async () => {
+      vi.useFakeTimers();
+      const slowHandler = vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            setTimeout(resolve, 60_000); // 60 s — never finishes within timeout
+          }),
+      );
+      registerInternalHook("message:beforeSend", slowHandler);
+
+      const event = makeBeforeSendEvent("Timeout test");
+      const resultPromise = triggerBeforeSendInternalHook(event, 100 /* ms */);
+
+      // Advance fake timers past the hook timeout.
+      await vi.advanceTimersByTimeAsync(200);
+      const result = await resultPromise;
+
+      expect(result.content).toBe("Timeout test");
+      expect(result.suppress).toBe(false);
+      vi.useRealTimers();
+    });
+
+    it("general 'message' handler also fires for beforeSend events", async () => {
+      const generalHandler = vi.fn();
+      registerInternalHook("message", generalHandler);
+
+      const event = makeBeforeSendEvent("broadcast");
+      await triggerBeforeSendInternalHook(event);
+
+      expect(generalHandler).toHaveBeenCalledOnce();
     });
   });
 

--- a/src/infra/outbound/deliver.ts
+++ b/src/infra/outbound/deliver.ts
@@ -19,7 +19,13 @@ import {
 } from "../../config/sessions.js";
 import type { sendMessageDiscord } from "../../discord/send.js";
 import { fireAndForgetHook } from "../../hooks/fire-and-forget.js";
-import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+import {
+  createInternalHookEvent,
+  getRegisteredEventKeys,
+  triggerBeforeSendInternalHook,
+  triggerInternalHook,
+  type MessageBeforeSendHookEvent,
+} from "../../hooks/internal-hooks.js";
 import {
   buildCanonicalSentMessageHookContext,
   toInternalMessageSentContext,
@@ -461,6 +467,69 @@ async function applyMessageSendingHook(params: {
   }
 }
 
+/**
+ * Fire the internal `message:beforeSend` hook for a single outbound payload.
+ *
+ * - Handlers may mutate `content` and/or set `suppress`.
+ * - Runs with a 5 s timeout; fail-open on errors or timeout.
+ * - Returns `cancelled: true` when any handler requests suppression.
+ */
+async function applyBeforeSendInternalHook(params: {
+  sessionKey: string;
+  payload: ReplyPayload;
+  payloadSummary: NormalizedOutboundPayload;
+  to: string;
+  channel: Exclude<OutboundChannel, "none">;
+  accountId?: string;
+  isGroup?: boolean;
+  groupId?: string;
+}): Promise<{
+  cancelled: boolean;
+  payload: ReplyPayload;
+  payloadSummary: NormalizedOutboundPayload;
+}> {
+  try {
+    const event = createInternalHookEvent("message", "beforeSend", params.sessionKey, {
+      to: params.to,
+      content: params.payloadSummary.text,
+      channelId: params.channel,
+      accountId: params.accountId ?? undefined,
+      conversationId: params.to,
+      isGroup: params.isGroup,
+      groupId: params.groupId,
+      suppress: false,
+    }) as MessageBeforeSendHookEvent;
+
+    const result = await triggerBeforeSendInternalHook(event);
+
+    if (result.suppress) {
+      log.info(
+        `message:beforeSend hook suppressed outbound payload to ${params.to} on ${params.channel}`,
+      );
+      return { cancelled: true, payload: params.payload, payloadSummary: params.payloadSummary };
+    }
+
+    if (result.content === params.payloadSummary.text) {
+      // No mutation — return originals unchanged.
+      return { cancelled: false, payload: params.payload, payloadSummary: params.payloadSummary };
+    }
+
+    // Content was mutated — propagate to payload.
+    const mutatedPayload: ReplyPayload = { ...params.payload, text: result.content };
+    return {
+      cancelled: false,
+      payload: mutatedPayload,
+      payloadSummary: { ...params.payloadSummary, text: result.content },
+    };
+  } catch (err) {
+    // Fail-open: log and proceed with original content.
+    log.error(
+      `message:beforeSend hook threw unexpectedly: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { cancelled: false, payload: params.payload, payloadSummary: params.payloadSummary };
+  }
+}
+
 export async function deliverOutboundPayloads(
   params: DeliverOutboundPayloadsParams,
 ): Promise<OutboundDeliveryResult[]> {
@@ -677,6 +746,10 @@ async function deliverOutboundPayloadsCore(
     mirrorGroupId,
   });
   const hasMessageSendingHooks = hookRunner?.hasHooks("message_sending") ?? false;
+  // Check once whether any internal message:beforeSend handlers are registered.
+  const hasBeforeSendInternalHooks =
+    sessionKeyForInternalHooks != null &&
+    getRegisteredEventKeys().some((k) => k === "message" || k === "message:beforeSend");
   if (hasMessageSentHooks && params.session?.agentId && !sessionKeyForInternalHooks) {
     log.warn(
       "deliverOutboundPayloads: session.agentId present without session key; internal message:sent hook will be skipped",
@@ -705,8 +778,27 @@ async function deliverOutboundPayloadsCore(
       if (hookResult.cancelled) {
         continue;
       }
-      const effectivePayload = hookResult.payload;
+      let effectivePayload = hookResult.payload;
       payloadSummary = hookResult.payloadSummary;
+
+      // Run message:beforeSend internal hook (may mutate content or suppress)
+      if (hasBeforeSendInternalHooks) {
+        const beforeSendResult = await applyBeforeSendInternalHook({
+          sessionKey: sessionKeyForInternalHooks,
+          payload: effectivePayload,
+          payloadSummary,
+          to,
+          channel,
+          accountId,
+          isGroup: mirrorIsGroup,
+          groupId: mirrorGroupId,
+        });
+        if (beforeSendResult.cancelled) {
+          continue;
+        }
+        effectivePayload = beforeSendResult.payload;
+        payloadSummary = beforeSendResult.payloadSummary;
+      }
 
       params.onPayload?.(payloadSummary);
       const sendOverrides = {


### PR DESCRIPTION
## Summary

Adds a new `message:beforeSend` hook event that fires **before** outbound messages are sent to channels, allowing hooks to mutate or suppress messages.

## Use Cases

- **Signature injection** — automatically append status signatures to every outbound message
- **Sensitive data filtering** — redact PII, API keys, or credentials before they reach channels
- **Content transformation** — formatting, length limits, channel-specific adjustments
- **Compliance** — audit trail, content policies, regulatory filtering

## Design

- Fires synchronously before channel send (5s timeout default)
- Handlers can **mutate** `event.context.content` — modified content is what gets sent
- Handlers can **suppress** by setting `event.context.suppress = true`
- **Fail-open** — if a handler throws, the original message is sent (broken hooks don't block delivery)
- Fully backwards compatible — no changes to existing hook behavior

## Hook Metadata

```yaml
metadata: { "openclaw": { "events": ["message:beforeSend"] } }
```

## Example

```typescript
const handler = async (event) => {
  if (event.type !== 'message' || event.action !== 'beforeSend') return;
  
  // Append signature
  event.context.content += '\n\n— sent by my agent';
  
  // Or redact sensitive data
  event.context.content = event.context.content.replace(/sk-[a-zA-Z0-9-]+/g, '[REDACTED]');
  
  // Or suppress entirely
  // event.context.suppress = true;
};
export default handler;
```

## Tests

20 unit tests covering mutation, suppression, timeout, error handling, and backwards compatibility.

---

Requested by a power user running a multi-agent setup with 5 agents across Telegram groups.