### PR TITLE
Queue: preserve queued message_id through followup runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ Docs: https://docs.openclaw.ai
 - LINE/context and routing synthesis: fix group/room peer routing and command-authorization context propagation, and keep processing later events in mixed-success webhook batches. (from #21955, #24475, #27035, #28286) Thanks @lailoo, @mcaxtr, @jervyclaw, @Glucksberg, and @Takhoffman.
 - LINE/status/config/webhook synthesis: fix status false positives from snapshot/config state and accept LINE webhook HEAD probes for compatibility. (from #10487, #25726, #27537, #27908, #31387) Thanks @BlueBirdBack, @stakeswky, @loiie45e, @puritysb, and @mcaxtr.
 - LINE cleanup/test follow-ups: fold cleanup/test learnings into the synthesis review path while keeping runtime changes focused on regression fixes. (from #17630, #17289) Thanks @Clawborn and @davidahmann.
+- Queue/followup message-id continuity: preserve queued provider `message_id` through collect drain and followup execution by carrying trusted queue metadata into collect prompts and passing queued `messageId` into runtime `currentMessageId`, so native reply APIs can target original platform messages when runs are deferred. (#36212)
 
 ## 2026.3.2
 

--- a/src/auto-reply/reply/followup-runner.test.ts
+++ b/src/auto-reply/reply/followup-runner.test.ts
@@ -577,4 +577,26 @@ describe("createFollowupRunner agentDir forwarding", () => {
     const call = runEmbeddedPiAgentMock.mock.calls.at(-1)?.[0] as { agentDir?: string };
     expect(call?.agentDir).toBe(agentDir);
   });
+
+  it("passes queued messageId as currentMessageId to runEmbeddedPiAgent", async () => {
+    runEmbeddedPiAgentMock.mockClear();
+    const onBlockReply = vi.fn(async () => {});
+    runEmbeddedPiAgentMock.mockResolvedValueOnce({
+      payloads: [{ text: "hello world!" }],
+      messagingToolSentTexts: ["different message"],
+      meta: {},
+    });
+    const runner = createFollowupRunner({
+      opts: { onBlockReply },
+      typing: createMockTypingController(),
+      typingMode: "instant",
+      defaultModel: "anthropic/claude-opus-4-5",
+    });
+    const queued = createQueuedRun({ messageId: "om_platform_original_321" });
+    await runner(queued);
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const call = runEmbeddedPiAgentMock.mock.calls.at(-1)?.[0] as { currentMessageId?: string };
+    expect(call?.currentMessageId).toBe("om_platform_original_321");
+  });
 });

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -172,6 +172,7 @@ export function createFollowupRunner(params: {
               currentChannelId: queued.originatingTo,
               currentThreadTs:
                 queued.originatingThreadId != null ? String(queued.originatingThreadId) : undefined,
+              currentMessageId: queued.messageId?.trim() || undefined,
               groupId: queued.run.groupId,
               groupChannel: queued.run.groupChannel,
               groupSpace: queued.run.groupSpace,

--- a/src/auto-reply/reply/queue/drain.ts
+++ b/src/auto-reply/reply/queue/drain.ts
@@ -35,6 +35,11 @@ type OriginRoutingMetadata = Pick<
   "originatingChannel" | "originatingTo" | "originatingAccountId" | "originatingThreadId"
 >;
 
+function normalizeQueueMessageId(value: string | undefined): string | undefined {
+  const messageId = value?.trim();
+  return messageId ? messageId : undefined;
+}
+
 function resolveOriginRoutingMetadata(items: FollowupRun[]): OriginRoutingMetadata {
   return {
     originatingChannel: items.find((item) => item.originatingChannel)?.originatingChannel,
@@ -45,6 +50,29 @@ function resolveOriginRoutingMetadata(items: FollowupRun[]): OriginRoutingMetada
       (item) => item.originatingThreadId != null && item.originatingThreadId !== "",
     )?.originatingThreadId,
   };
+}
+
+function resolveQueuedMessageId(items: FollowupRun[]): string | undefined {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const messageId = normalizeQueueMessageId(items[index]?.messageId);
+    if (messageId) {
+      return messageId;
+    }
+  }
+  return undefined;
+}
+
+function buildQueuedMessageMetadataBlock(item: FollowupRun): string | undefined {
+  const messageId = normalizeQueueMessageId(item.messageId);
+  if (!messageId) {
+    return undefined;
+  }
+  return [
+    "Queued message metadata (trusted queue data):",
+    "```json",
+    JSON.stringify({ message_id: messageId }, null, 2),
+    "```",
+  ].join("\n");
 }
 
 function resolveCrossChannelKey(item: FollowupRun): { cross?: true; key?: string } {
@@ -114,11 +142,16 @@ export function scheduleFollowupDrain(
             title: "[Queued messages while agent was busy]",
             items,
             summary,
-            renderItem: (item, idx) => `---\nQueued #${idx + 1}\n${item.prompt}`.trim(),
+            renderItem: (item, idx) =>
+              ["---", `Queued #${idx + 1}`, buildQueuedMessageMetadataBlock(item), item.prompt]
+                .filter(Boolean)
+                .join("\n")
+                .trim(),
           });
           await runFollowup({
             prompt,
             run,
+            messageId: resolveQueuedMessageId(items),
             enqueuedAt: Date.now(),
             ...routing,
           });
@@ -140,6 +173,7 @@ export function scheduleFollowupDrain(
               await runFollowup({
                 prompt: summaryPrompt,
                 run,
+                messageId: normalizeQueueMessageId(item.messageId),
                 enqueuedAt: Date.now(),
                 originatingChannel: item.originatingChannel,
                 originatingTo: item.originatingTo,

--- a/src/auto-reply/reply/reply-flow.test.ts
+++ b/src/auto-reply/reply/reply-flow.test.ts
@@ -690,6 +690,43 @@ describe("followup queue deduplication", () => {
     expect(calls[0]?.prompt).toContain("[Queued messages while agent was busy]");
   });
 
+  it("includes trusted queued message_id metadata in collect prompt", async () => {
+    const key = `test-collect-message-id-metadata-${Date.now()}`;
+    const done = createDeferred<void>();
+    let collectedPrompt = "";
+    let collectedMessageId: string | undefined;
+    const runFollowup = async (run: FollowupRun) => {
+      collectedPrompt = run.prompt;
+      collectedMessageId = run.messageId;
+      done.resolve();
+    };
+    const settings: QueueSettings = {
+      mode: "collect",
+      debounceMs: 0,
+      cap: 50,
+      dropPolicy: "summarize",
+    };
+
+    enqueueFollowupRun(
+      key,
+      createRun({
+        prompt:
+          'Conversation info (untrusted metadata):\\n```json\\n{"message_id":"om_x_queue_placeholder"}\\n```',
+        messageId: "om_platform_original_123",
+        originatingChannel: "slack",
+        originatingTo: "channel:C123",
+      }),
+      settings,
+    );
+
+    scheduleFollowupDrain(key, runFollowup);
+    await done.promise;
+
+    expect(collectedPrompt).toContain("Queued message metadata (trusted queue data):");
+    expect(collectedPrompt).toContain('"message_id": "om_platform_original_123"');
+    expect(collectedMessageId).toBe("om_platform_original_123");
+  });
+
   it("deduplicates exact prompt when routing matches and no message id", async () => {
     const key = `test-dedup-whatsapp-${Date.now()}`;
     const settings: QueueSettings = {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: queued followups (especially collect mode) did not reliably preserve provider `message_id` into followup execution context, so runtime/tooling could miss original platform reply targets.
- Why it matters: channel-native reply APIs (for example Feishu reply) require original provider message IDs; fallback behavior could drift to placeholder/untrusted IDs.
- What changed: collect drain now carries trusted queued `messageId` metadata into prompt blocks and forwards a resolved queued `messageId` into followup runs; followup runner now passes queued `messageId` into runtime `currentMessageId`.
- What did NOT change (scope boundary): no queue dedupe policy changes, no routing policy changes, no channel adapter API changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36212
- Related #36222

## User-visible / Behavior Changes

- Collect-mode queued prompts now include trusted per-item queued metadata blocks with original `message_id` when available.
- Deferred followup executions now receive queued `messageId` as runtime `currentMessageId`, improving native reply-target continuity.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22 + pnpm
- Model/provider: n/a (unit tests)
- Integration/channel (if any): queue followup collect mode + followup runtime wiring
- Relevant config (redacted): `messages.queue.mode=collect`

### Steps

1. Enqueue followup runs with original `messageId` while active run is busy.
2. Drain collect queue into `[Queued messages while agent was busy]` prompt.
3. Execute followup runner and inspect `runEmbeddedPiAgent` input.

### Expected

- Collect prompt includes trusted queued `message_id` metadata per item.
- Followup runtime receives `currentMessageId` from queued `messageId`.

### Actual

- Verified via tests and implementation: both behaviors are present.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added collect-mode regression coverage for trusted queued `message_id` block + propagated `run.messageId`.
  - Added followup-runner regression coverage for `currentMessageId` forwarding from queued `messageId`.
  - Ran `pnpm test src/auto-reply/reply/reply-flow.test.ts src/auto-reply/reply/followup-runner.test.ts` (pass).
- Edge cases checked:
  - Omit trusted metadata block when queued `messageId` is missing/blank.
  - Summary drain path also forwards normalized queued `messageId` when present.
- What you did **not** verify:
  - Live end-to-end Feishu webhook + `im.message.reply` against production tenant.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `Queue: preserve queued message_id through followup runtime`.
- Files/config to restore: `src/auto-reply/reply/queue/drain.ts`, `src/auto-reply/reply/followup-runner.ts`.
- Known bad symptoms reviewers should watch for: collect prompt formatting regressions or missing followup reply targets in deferred runs.

## Risks and Mitigations

- Risk: collect prompt shape changed (additive metadata block) may affect prompt assumptions.
  - Mitigation: scoped to collect mode, additive only, and covered by targeted tests.
