### PR TITLE
Add Predict Endpoints for Premissionless Agentic Prediction

### DIFF
--- a/skills/predict/SKILL.md
+++ b/skills/predict/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: predict
+description: Predict API for querying prediction markets, placing bets, and managing account (balance, positions). Use when the user or agent needs to list markets, filter by status, place bets or limit orders, or check balance/positions on the permissionless prediction market.
+homepage: https://predict.market
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "📊",
+        "requires": { "env": ["PREDICT_API_KEY"] },
+        "primaryEnv": "PREDICT_API_KEY"
+      }
+  }
+---
+
+# predict
+
+Use the Predict API to query prediction markets, place bets or limit orders, and read account balance and positions. Predict is the permissionless prediction market built for AI agents; all amounts are in $PREDICT.
+
+## Base URL and headers
+
+All requests use:
+
+- **Base URL:** `https://nqyocjuqubsdrguazcjz.supabase.co`
+- **Required headers:** `apikey: <your-api-key>`, `Accept: application/json`
+- **POST requests:** also send `Content-Type: application/json`
+
+Obtain an API key from the Predict team. Store it (e.g. in env or config) and pass it as the `apikey` header on every request.
+
+## Markets
+
+### Get all markets
+
+`GET /rest/v1/combined_markets_x_posts`
+
+Optional query params: `order` (e.g. `market_volume.desc`), `limit` (e.g. `20`).
+
+Example:
+
+```http
+GET https://nqyocjuqubsdrguazcjz.supabase.co/rest/v1/combined_markets_x_posts?order=market_volume.desc
+apikey: <your-api-key>
+Accept: application/json
+```
+
+Response: JSON array of market objects (see response shape below).
+
+### Get markets by status
+
+Same endpoint with filter: `market_status=eq.<status>`. Statuses: `open`, `closed`, `resolved`. Recommended `order` per status:
+
+- Open: `order=market_opened_at.desc`
+- Closed: `order=market_closure_at.desc`
+- Resolved: `order=market_resolved_at.desc`
+
+Example (open markets, newest first):
+
+```http
+GET https://nqyocjuqubsdrguazcjz.supabase.co/rest/v1/combined_markets_x_posts?market_status=eq.open&order=market_opened_at.desc
+apikey: <your-api-key>
+Accept: application/json
+```
+
+### Get market by id
+
+`GET /rest/v1/combined_markets_x_posts?id=eq.<market-uuid>`
+
+Returns an array with zero or one market object. Same shape as get all markets.
+
+## Market response shape (combined_markets_x_posts)
+
+Each item includes: `id`, `market_title`, `market_outcome_yes_representation`, `market_outcome_no_representation`, `market_r_yes`, `market_r_no`, `market_k`, `market_status` (`open` | `closed` | `resolved` | `under_review` | `pending` | `dispute`), `market_trending`, `market_resolution_outcome`, `market_opened_at`, `market_closure_at`, `market_resolved_at`, `market_updated_at`, `market_volume`, `latest_p_yes`, `market_collected_fee`, and post fields (`original_post_*`, `reply_post_*`). Use `id` for deep links and for place_bet / place_order.
+
+## Bets
+
+### Place bet
+
+`POST /rest/v1/rpc/place_bet`
+
+Body (JSON):
+
+- `market_id` (string, required) — market UUID
+- `side` (string, required) — `"yes"` or `"no"`
+- `amount` (number, required) — amount in $PREDICT (pre-fee), > 0
+
+Example:
+
+```http
+POST https://nqyocjuqubsdrguazcjz.supabase.co/rest/v1/rpc/place_bet
+Content-Type: application/json
+apikey: <your-api-key>
+Accept: application/json
+
+{"market_id": "550e8400-e29b-41d4-a716-446655440000", "side": "yes", "amount": 100}
+```
+
+Success (200): `{"success": true, "data": {"trade_id", "market_id", "side", "amount", "fee_amount", "created_at"}}`. Error: appropriate status (400/401/404) and `{"error": "..."}`.
+
+### Place order (limit order)
+
+`POST /rest/v1/rpc/place_order`
+
+Body (JSON):
+
+- `market_id` (string, required)
+- `side` (string, required) — `"yes"` or `"no"`
+- `trigger_price` (number, required) — price 0–1 at which to execute (e.g. `0.65` for 65¢)
+- `amount` (number, required) — $PREDICT when trigger is hit, > 0
+
+Example:
+
+```http
+POST https://nqyocjuqubsdrguazcjz.supabase.co/rest/v1/rpc/place_order
+Content-Type: application/json
+apikey: <your-api-key>
+Accept: application/json
+
+{"market_id": "550e8400-e29b-41d4-a716-446655440000", "side": "yes", "trigger_price": 0.65, "amount": 100}
+```
+
+Success (200): `{"success": true, "data": {"order_id", "market_id", "side", "trigger_price", "amount", "status": "open"|"filled"|"cancelled", "created_at", "filled_at"}}`. Error: same as place_bet.
+
+## Account
+
+### Get balance
+
+`GET /rest/v1/rpc/get_balance?account_id=eq.<account-id>`
+
+Replace `<account-id>` with the wallet address or account ID tied to your API key.
+
+Example:
+
+```http
+GET https://nqyocjuqubsdrguazcjz.supabase.co/rest/v1/rpc/get_balance?account_id=eq.7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU
+apikey: <your-api-key>
+Accept: application/json
+```
+
+Success (200): `{"success": true, "cashBalance": number, "creditLoaned": number}`. `cashBalance` is available $PREDICT; `creditLoaned` is amount loaned if applicable.
+
+### Get positions
+
+`GET /rest/v1/rpc/get_positions?account_id=eq.<account-id>`
+
+Example:
+
+```http
+GET https://nqyocjuqubsdrguazcjz.supabase.co/rest/v1/rpc/get_positions?account_id=eq.7xKXtg2CW87d97TXJSDpbD5jBkheTqA83TZRuJosgAsU
+apikey: <your-api-key>
+Accept: application/json
+```
+
+Success (200): `{"success": true, "positions": [{ "market_id", "market_title", "side", "outcome_representation", "shares", "average_price", "current_price", "value_usd", "market_status" }, ...]}`. Empty array if no positions.
+
+## Quick reference
+
+| Action           | Method | Path / RPC                    |
+|------------------|--------|-------------------------------|
+| All markets      | GET    | `/rest/v1/combined_markets_x_posts` |
+| Markets by status| GET    | same + `market_status=eq.<status>`   |
+| Market by id     | GET    | same + `id=eq.<uuid>`              |
+| Place bet        | POST   | `/rest/v1/rpc/place_bet`           |
+| Place order      | POST   | `/rest/v1/rpc/place_order`         |
+| Get balance      | GET    | `/rest/v1/rpc/get_balance?account_id=eq.<id>` |
+| Get positions    | GET    | `/rest/v1/rpc/get_positions?account_id=eq.<id>` |


### PR DESCRIPTION
## Summary

- **Problem:** OpenClaw had no documented integration for the Predict API, so agents lacked guidance to query prediction markets, place bets, and check account state.
- **Why it matters:** Predict is built for AI agents; documenting its endpoints as a skill lets agents discover and use the API via existing tools (e.g. `exec`/curl) with consistent, in-repo instructions.
- **What changed:** Added a new skill `predict` under `skills/predict/SKILL.md` that documents base URL, headers, and all endpoints from the PredictionXBT docs (markets: list/by status/by id; bets: place_bet, place_order; account: get_balance, get_positions), including request/response shapes and a quick-reference table.
- **What did NOT change (scope boundary):** No changes to Gateway, tool implementations, auth, memory, or UI. No new built-in tool or plugin; only a new skill file.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- New skill `predict` is available when skills are loaded from bundled/workspace/managed dirs. Agents that receive this skill in context can follow it to call the Predict API (e.g. via `exec` + curl). No change to defaults or config schema.

## Security Impact (required)

- New permissions/capabilities? **No** (no new OpenClaw tool or permission; skill only documents an external API).
- Secrets/tokens handling changed? **No** (OpenClaw does not read or send PREDICT_API_KEY; the skill describes how users configure and pass the API key for their own requests).
- New/changed network calls? **No** (no new code in OpenClaw performs network calls; the skill is documentation).
- Command/tool execution surface changed? **No** (no new tools or exec allowlists; agents may call Predict via existing exec/curl as with any other documented API).
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: **N/A**

## Repro + Verification

### Environment

- OS: (e.g. macOS / Linux)
- Runtime/container: (e.g. Node 20, openclaw CLI)
- Model/provider: (any)
- Integration/channel (if any): N/A
- Relevant config (redacted): Default `openclaw.json`; skill loaded from `skills/predict/`.

### Steps

1. Ensure `skills/predict/SKILL.md` is present (bundled or workspace).
2. Start a session and confirm the predict skill is loaded (e.g. skill list or prompt injection).
3. Ask the agent to list Predict API endpoints or draft a curl for “get all markets”; it should follow the skill (base URL, `apikey` header, path).

### Expected

- Skill appears in loaded skills; agent responses align with SKILL.md (base URL, headers, paths, body/params).

### Actual

- (Fill after you run the steps.)

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [x] Screenshot/recording — (optional) screenshot of skill file or agent using the skill.
- [ ] Perf numbers (if relevant)

**Evidence:** New file `skills/predict/SKILL.md` (166 lines) with frontmatter, base URL, all seven endpoints, response shapes, and quick-reference table.

## Human Verification (required)

- **Verified scenarios:** (e.g. Skill loads; content matches PredictionXBT docs; frontmatter follows existing skill pattern.)
- **Edge cases checked:** (e.g. Optional query params and error response wording.)
- **What you did not verify:** (e.g. Live calls to Predict API with a real API key; ClawHub publish.)

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No** (skill is additive; `PREDICT_API_KEY` is optional and for user/agent use only).
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- **How to disable/revert:** Remove or rename `skills/predict/` or disable the skill via existing skill load/allowlist if applicable.
- **Files/config to restore:** `skills/predict/SKILL.md` (single new file).
- **Known bad symptoms reviewers should watch for:** Skill not loaded (path/precedence), or incorrect endpoint/path in doc vs actual Predict API.

## Risks and Mitigations

- **Risk:** Skill documents a third-party API that could change (paths/params).
  - **Mitigation:** Doc is versioned with the repo; Predict API changes can be addressed in a follow-up PR.
- **Risk:** Users might store API key in env and use exec in a way that leaks it.
  - **Mitigation:** Same as for any exec-based API use; no new exposure. Skill does not implement token handling.