### PR TITLE
Discord: fix inlineButtons capability to emit Components v2 guidance instead of Telegram button format

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -564,6 +564,37 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("`style` can be `primary`, `success`, or `danger`");
   });
 
+  it("includes Discord Components v2 guidance when discord runtime supports inlineButtons", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["message"],
+      runtimeInfo: {
+        channel: "discord",
+        capabilities: ["inlineButtons"],
+      },
+    });
+
+    // Should use Components v2 API, not Telegram buttons
+    expect(prompt).toContain("Discord Components v2");
+    expect(prompt).toContain("components=");
+    expect(prompt).toContain("type:\"actions\"");
+    expect(prompt).not.toContain("buttons=[[{text,callback_data");
+  });
+
+  it("does not show inline buttons not-enabled hint on discord for missing inlineButtons capability", () => {
+    const prompt = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      toolNames: ["message"],
+      runtimeInfo: {
+        channel: "discord",
+        capabilities: [],
+      },
+    });
+
+    // Discord never shows the "set inlineButtons" nag — Components v2 is always available
+    expect(prompt).not.toContain("Inline buttons not enabled for discord");
+  });
+
   it("includes runtime provider capabilities when present", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -143,8 +143,14 @@ function buildMessagingSection(params: {
           `- If multiple channels are configured, pass \`channel\` (${params.messageChannelOptions}).`,
           `- If you use \`message\` (\`action=send\`) to deliver your user-visible reply, respond with ONLY: ${SILENT_REPLY_TOKEN} (avoid duplicate replies).`,
           params.inlineButtonsEnabled
-            ? "- Inline buttons supported. Use `action=send` with `buttons=[[{text,callback_data,style?}]]`; `style` can be `primary`, `success`, or `danger`."
-            : params.runtimeChannel
+            ? params.runtimeChannel === "discord"
+              ? "- Discord Components v2 available. Use `action=send` with `components={text?:string,reusable?:bool,blocks:[...]}`." +
+                " Block types: `{type:\"actions\",buttons:[{label,style?:\"primary\"|\"secondary\"|\"success\"|\"danger\",url?,emoji?,disabled?,allowedUsers?:[id,...]}]}`," +
+                " `{type:\"text\",text}`, `{type:\"section\",text?,texts?:[],accessory?:{type:\"thumbnail\",url}|{type:\"button\",button:{...}}}`," +
+                " `{type:\"separator\",spacing?:\"small\"|\"large\",divider?:bool}`, `{type:\"media-gallery\",items:[{url,description?,spoiler?}]}`." +
+                " Set `reusable:true` to keep buttons active after a click (default: single-use)."
+              : "- Inline buttons supported. Use `action=send` with `buttons=[[{text,callback_data,style?}]]`; `style` can be `primary`, `success`, or `danger`."
+            : params.runtimeChannel && params.runtimeChannel !== "discord"
               ? `- Inline buttons not enabled for ${params.runtimeChannel}. If you need them, ask to set ${params.runtimeChannel}.capabilities.inlineButtons ("dm"|"group"|"all"|"allowlist").`
               : "",
           ...(params.messageToolHints ?? []),

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -359,6 +359,19 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
         hasRepliedRef,
       }),
     },
+    agentPrompt: {
+      messageToolHints: ({ cfg, accountId }) => {
+        const account = resolveDiscordAccount({ cfg, accountId });
+        if (account.config.agentComponents?.enabled === false) {
+          return [];
+        }
+        return [
+          "- Discord Components v2 (`components=`) lets you send rich interactive messages:" +
+            " buttons, select menus, text sections, separators, and media galleries." +
+            " Example: `components={text:\"Pick an option:\",reusable:true,blocks:[{type:\"actions\",buttons:[{label:\"Yes\",style:\"success\"},{label:\"No\",style:\"danger\"}]}]}`.",
+        ];
+      },
+    },
   },
   irc: {
     id: "irc",


### PR DESCRIPTION
## Summary

- **Problem:** When `capabilities: ["inlineButtons"]` is set on a Discord account, the agent system prompt emitted Telegram-style button guidance (`buttons=[[{text,callback_data}]]`). Discord's `sendMessage` action does not accept a `buttons` parameter at all — it uses `components` (Discord Components v2 via `@buape/carbon`). Messages sent fine but buttons were silently dropped and never rendered.
- **Why it matters:** Users following the documented `inlineButtons` capability hint saw no buttons in Discord, with no error or warning. The feature appeared broken/unsupported.
- **What changed:**
  - `src/agents/system-prompt.ts`: The `inlineButtonsEnabled` branch in `buildMessagingSection` now checks `runtimeChannel`. On `discord` it emits the full Components v2 API hint (`components=`, block types, button styles, `reusable`). On all other channels the existing Telegram `buttons=[[...]]` hint is preserved unchanged.
  - The "not enabled" nag line is suppressed for Discord (Components v2 is always available regardless of the capability flag).
  - `src/channels/dock.ts`: Adds `agentPrompt.messageToolHints` to the Discord dock so agents on Discord always get a proactive Components v2 hint even without `inlineButtons` in capabilities. Suppressed only when `agentComponents.enabled === false`.
  - `src/agents/system-prompt.test.ts`: Two new tests covering the Discord Components v2 branch and the suppression of the "not enabled" nag.
- **What did NOT change:** Telegram inline button behaviour is completely unchanged. Discord send/components infrastructure (`send.components.ts`, `components.ts`, `agent-components.ts`) is untouched.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Integrations
- [x] UI / DX

## Linked Issue/PR

- Closes #

## User-visible / Behavior Changes

Agents running on Discord with `capabilities: ["inlineButtons"]` (or any Discord session) now receive correct Components v2 syntax in their system prompt and will render buttons, select menus, and other components correctly.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Channel: Discord
- Relevant config: `channels.discord.capabilities: ["inlineButtons"]`

### Steps

1. Configure a Discord account with `capabilities: ["inlineButtons"]`
2. Send a message to the bot asking it to send a message with buttons
3. **Before:** bot sends text only, no buttons rendered
4. **After:** bot uses `components={...,blocks:[{type:"actions",buttons:[...]}]}` and buttons render correctly in Discord
