### PR TITLE
feat(config): add agents.defaults.systemPromptFile for operator system prompt injection

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -1,4 +1,6 @@
 import crypto from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
 import { resolveSessionAuthProfileOverride } from "../../agents/auth-profiles/session-override.js";
 import type { ExecToolDefaults } from "../../agents/bash-tools.js";
 import {
@@ -16,6 +18,7 @@ import {
   updateSessionStore,
 } from "../../config/sessions.js";
 import { logVerbose } from "../../globals.js";
+import { CONFIG_PATH } from "../../config/paths.js";
 import { clearCommandLane, getQueueSize } from "../../process/command-queue.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
@@ -273,6 +276,25 @@ export async function runPreparedReply(
     groupIntro,
     groupSystemPrompt,
   ].filter(Boolean);
+
+  // Inject operator-controlled system prompt from file (agents.defaults.systemPromptFile).
+  // Resolved relative to the config file; agent cannot modify it. Fails open on read error.
+  const systemPromptFilePath = cfg.agents?.defaults?.systemPromptFile;
+  if (systemPromptFilePath) {
+    const resolvedPath = path.isAbsolute(systemPromptFilePath)
+      ? systemPromptFilePath
+      : path.resolve(path.dirname(CONFIG_PATH), systemPromptFilePath);
+    try {
+      const fileContent = (await readFile(resolvedPath, "utf8")).trim();
+      if (fileContent) {
+        extraSystemPromptParts.push(fileContent);
+      }
+    } catch (err) {
+      logVerbose(
+        `[system-prompt-file] Could not read systemPromptFile "${resolvedPath}": ${(err as NodeJS.ErrnoException).message}`,
+      );
+    }
+  }
   const baseBody = sessionCtx.BodyStripped ?? sessionCtx.Body ?? "";
   // Use CommandBody/RawBody for bare reset detection (clean message without structural context).
   const rawBodyTrimmed = (ctx.CommandBody ?? ctx.RawBody ?? ctx.Body ?? "").trim();

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -277,26 +277,7 @@ export async function runPreparedReply(
     groupSystemPrompt,
   ].filter(Boolean);
 
-  // Inject operator-controlled system prompt from file (agents.defaults.systemPromptFile).
-  // Resolved relative to the config file; agent cannot modify it. Fails open on read error.
-  const systemPromptFilePath = cfg.agents?.defaults?.systemPromptFile;
-  if (systemPromptFilePath) {
-    const resolvedPath = path.isAbsolute(systemPromptFilePath)
-      ? systemPromptFilePath
-      : path.resolve(path.dirname(CONFIG_PATH), systemPromptFilePath);
-    try {
-      const fileContent = (await readFile(resolvedPath, "utf8")).trim();
-      if (fileContent) {
-        extraSystemPromptParts.push(fileContent);
-      }
-    } catch (err) {
-      logVerbose(
-        `[system-prompt-file] Could not read systemPromptFile "${resolvedPath}": ${(err as NodeJS.ErrnoException).message}`,
-      );
-    }
-  }
   const baseBody = sessionCtx.BodyStripped ?? sessionCtx.Body ?? "";
-  // Use CommandBody/RawBody for bare reset detection (clean message without structural context).
   const rawBodyTrimmed = (ctx.CommandBody ?? ctx.RawBody ?? ctx.Body ?? "").trim();
   const baseBodyTrimmedRaw = baseBody.trim();
   if (
@@ -362,6 +343,26 @@ export async function runPreparedReply(
   });
   if (queuedSystemPrompt) {
     extraSystemPromptParts.push(queuedSystemPrompt);
+  }
+  // Inject operator-controlled system prompt from file (agents.defaults.systemPromptFile).
+  // Injected AFTER queuedSystemPrompt so it appears last in the system prompt, giving it the
+  // highest LLM weight and ensuring it cannot be overridden by queued/deferred content.
+  // Resolved relative to the config file; agent cannot modify it. Fails open on read error.
+  const systemPromptFilePath = cfg.agents?.defaults?.systemPromptFile;
+  if (systemPromptFilePath) {
+    const resolvedPath = path.isAbsolute(systemPromptFilePath)
+      ? systemPromptFilePath
+      : path.resolve(path.dirname(CONFIG_PATH), systemPromptFilePath);
+    try {
+      const fileContent = (await readFile(resolvedPath, "utf8")).trim();
+      if (fileContent) {
+        extraSystemPromptParts.push(fileContent);
+      }
+    } catch (err) {
+      logVerbose(
+        `[system-prompt-file] Could not read systemPromptFile "${resolvedPath}": ${(err as NodeJS.ErrnoException).message}`,
+      );
+    }
   }
   prefixedBodyBase = appendUntrustedContext(prefixedBodyBase, sessionCtx.UntrustedContext);
   const threadStarterBody = ctx.ThreadStarterBody?.trim();

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -134,6 +134,13 @@ export type AgentDefaultsConfig = {
   workspace?: string;
   /** Optional repository root for system prompt runtime line (overrides auto-detect). */
   repoRoot?: string;
+  /**
+   * Path to a file whose contents are injected into the system prompt for every session.
+   * Absolute or relative to the config file. The agent cannot modify this file (it lives
+   * outside the agent workspace). Fails open: if the file is missing or unreadable, a
+   * warning is logged and injection is skipped.
+   */
+  systemPromptFile?: string;
   /** Skip bootstrap (BOOTSTRAP.md creation, etc.) for pre-configured deployments. */
   skipBootstrap?: boolean;
   /** Max chars for injected bootstrap files before truncation (default: 20000). */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -37,6 +37,7 @@ export const AgentDefaultsSchema = z
       .optional(),
     workspace: z.string().optional(),
     repoRoot: z.string().optional(),
+    systemPromptFile: z.string().optional(),
     skipBootstrap: z.boolean().optional(),
     bootstrapMaxChars: z.number().int().positive().optional(),
     bootstrapTotalMaxChars: z.number().int().positive().optional(),

--- a/src/config/zod-schema.system-prompt-file.test.ts
+++ b/src/config/zod-schema.system-prompt-file.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { AgentDefaultsSchema } from "./zod-schema.agent-defaults.js";
+
+describe("agents.defaults.systemPromptFile schema", () => {
+  it("accepts an absolute path for systemPromptFile", () => {
+    expect(() =>
+      AgentDefaultsSchema.parse({ systemPromptFile: "/etc/openclaw/system-prompt.md" }),
+    ).not.toThrow();
+  });
+
+  it("accepts a relative path for systemPromptFile", () => {
+    expect(() =>
+      AgentDefaultsSchema.parse({ systemPromptFile: "./prompts/operator.md" }),
+    ).not.toThrow();
+  });
+
+  it("accepts absence of systemPromptFile (field is optional)", () => {
+    expect(() => AgentDefaultsSchema.parse({})).not.toThrow();
+  });
+
+  it("rejects a non-string systemPromptFile value", () => {
+    expect(() => AgentDefaultsSchema.parse({ systemPromptFile: 42 })).toThrow();
+  });
+});


### PR DESCRIPTION
## What

Add `agents.defaults.systemPromptFile` — a new config field that reads a file from disk and injects its contents into the system prompt for every session.

## Why

Operators need to enforce behavioral guardrails (persona, rules, restrictions) that the agent cannot override. The existing options all have gaps:

| Option | Gap |
|---|---|
| Workspace bootstrap files (AGENTS.md, SOUL.md) | Agent can overwrite these at runtime |
| Channel-level `systemPrompt` | Only applies to group/channel sessions |
| Hardcoding in source | Requires redeployment for every prompt iteration |
| Gateway API `extraSystemPrompt` | Requires programmatic API calls per request |

Closes #36190

## How

```json
{
  "agents": {
    "defaults": {
      "systemPromptFile": "/etc/openclaw/guardrails.md"
    }
  }
}
```

**Behavior:**
- Path resolved relative to the config file; absolute paths used as-is
- File content is read on each turn and pushed into `extraSystemPromptParts`
- Applied to all session types: DM, group, main, sub-agent
- Injected alongside existing bootstrap files and channel `systemPrompt`
- **Fails open:** missing or unreadable file logs a `logVerbose` warning and is skipped — same behavior as missing bootstrap files

**Changes:**
- `src/config/types.agent-defaults.ts` — add `systemPromptFile?: string` to `AgentDefaultsConfig`
- `src/config/zod-schema.agent-defaults.ts` — add `z.string().optional()` to `AgentDefaultsSchema`
- `src/auto-reply/reply/get-reply-run.ts` — read file and push to `extraSystemPromptParts` after existing parts are assembled
- `src/config/zod-schema.system-prompt-file.test.ts` — 4 schema tests (absolute path, relative path, absent, non-string)

## Testing

```bash
vitest run src/config/zod-schema.system-prompt-file.test.ts
vitest run src/config/
```

4 new tests pass. All 690 config tests pass.

## Breaking Changes

None. The field is optional and absent by default.