### PR TITLE
fix(chat): create transcript file in chat.inject when missing

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1142,7 +1142,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       storePath,
       sessionFile: entry?.sessionFile,
       agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
-      createIfMissing: false,
+      createIfMissing: true,
     });
     if (!appended.ok || !appended.messageId || !appended.message) {
       respond(


### PR DESCRIPTION
## Summary

- `chat.inject` was calling `appendAssistantTranscriptMessage` with `createIfMissing: false`
- When the transcript file didn't exist on disk (e.g. ACP oneshot/run sessions), this caused a hard error: `failed to write transcript: transcript file not found`
- Fix: change to `createIfMissing: true` so the file is created automatically on first inject

## Root Cause

In `src/gateway/server-methods/chat.ts` line 1145, the `chat.inject` handler passes `createIfMissing: false`, unlike other call sites in the same file which already use `createIfMissing: true`.

## Test plan

- [ ] Start an ACP oneshot session (transcript file not pre-created)
- [ ] Call `chat.inject` with a message
- [ ] Verify message is persisted and `chat.history` returns it
- [ ] Verify existing sessions with transcript files continue to work normally

Fixes #36170