### PR TITLE
test(feishu): assert prefetched botOpenId is not re-fetched in monitorSingleAccount

### DIFF
--- a/extensions/feishu/src/monitor.startup.test.ts
+++ b/extensions/feishu/src/monitor.startup.test.ts
@@ -200,4 +200,43 @@ describe("Feishu monitor startup preflight", () => {
       abortController.abort();
     }
   });
+
+  it("does not re-fetch bot info for accounts whose preflight probe succeeded", async () => {
+    // Regression guard for #33456: prefetched botOpenId must be reused in monitorSingleAccount
+    // and probeFeishu must be called exactly once per account (preflight only, not again in monitor).
+    const probeCallCounts: Record<string, number> = {};
+    let releaseProbes!: () => void;
+    const probesReleased = new Promise<void>((resolve) => {
+      releaseProbes = () => resolve();
+    });
+
+    probeFeishuMock.mockImplementation(async (account: { accountId: string }) => {
+      probeCallCounts[account.accountId] = (probeCallCounts[account.accountId] ?? 0) + 1;
+      await probesReleased;
+      return { ok: true, botOpenId: `bot_${account.accountId}` };
+    });
+
+    const abortController = new AbortController();
+    const monitorPromise = monitorFeishuProvider({
+      config: buildMultiAccountWebsocketConfig(["alpha", "beta"]),
+      abortSignal: abortController.signal,
+    });
+
+    try {
+      // Let both preflights complete
+      releaseProbes();
+      // Yield enough for the async preflight loop to process both accounts
+      for (let i = 0; i < 20; i += 1) {
+        await Promise.resolve();
+      }
+
+      // Each account's probe should have been called exactly once (during preflight only).
+      // If monitorSingleAccount re-fetches, the count would be 2.
+      expect(probeCallCounts["alpha"]).toBe(1);
+      expect(probeCallCounts["beta"]).toBe(1);
+    } finally {
+      abortController.abort();
+      await monitorPromise;
+    }
+  });
 });


### PR DESCRIPTION
## What

Add a regression guard test for #33456: verify that when sequential preflight successfully resolves a `botOpenId`, `monitorSingleAccount` reuses the prefetched value and does **not** call `probeFeishu` a second time.

## Why

The behavior fix (passing `botOpenIdSource: { kind: "prefetched", botOpenId }` from the loop in `monitorFeishuProvider` to `monitorSingleAccount`) is present in main but has no test coverage. Without this guard:

- A future refactor removing `botOpenIdSource` from the `monitorSingleAccount` call would silently regress
- Probe burst protection on startup (sequential preflight) would be undermined — each account would generate 2× API calls
- The existing test covers the `alpha fails → beta succeeds` case but not the all-success case

Closes #33456

## Test

```bash
vitest run extensions/feishu/src/monitor.startup.test.ts
```

New test: **"does not re-fetch bot info for accounts whose preflight probe succeeded"**

- Tracks  call count per account
- Releases both preflights successfully
- Asserts each account's probe was called exactly **1** time (not 2)
- Would fail with count = 2 if `botOpenIdSource` handoff is ever dropped

All 5 startup tests pass.

## Breaking Changes

None — test-only change.