### PR TITLE
fix(chat.inject): auto-create transcript file on first inject

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1124,7 +1124,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       storePath,
       sessionFile: entry?.sessionFile,
       agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
-      createIfMissing: false,
+      createIfMissing: true,
     });
     if (!appended.ok || !appended.messageId || !appended.message) {
       respond(


### PR DESCRIPTION
## Summary
- Bug: chat.inject fails with "transcript file not found" when transcript file doesn't exist (ACP oneshot/run sessions)
- Fix: Change createIfMissing from false to true in chat.inject handler

## Change Type
- [x] Bug fix

## Linked Issue
- Fixes #36170

## Testing
- Local TypeScript compilation passed