### PR TITLE
fix(models): recognize gemini-3.1 series for google provider in fallback routing

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -171,12 +171,15 @@ function resolveAnthropicSonnet46ForwardCompatModel(
 // gemini-3.1-pro-preview / gemini-3.1-flash-preview are not present in pi-ai's built-in
 // google-gemini-cli catalog yet. Clone the nearest gemini-3 template so users don't get
 // "Unknown model" errors when Google Gemini CLI gains new minor-version models.
+const GOOGLE_GEMINI_CLI_ELIGIBLE_PROVIDERS = new Set(["google-gemini-cli", "google"]);
+
 function resolveGoogleGeminiCli31ForwardCompatModel(
   provider: string,
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
-  if (normalizeProviderId(provider) !== "google-gemini-cli") {
+  const normalizedProvider = normalizeProviderId(provider);
+  if (!GOOGLE_GEMINI_CLI_ELIGIBLE_PROVIDERS.has(normalizedProvider)) {
     return undefined;
   }
   const trimmed = modelId.trim();
@@ -192,7 +195,7 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
   }
 
   return cloneFirstTemplateModel({
-    normalizedProvider: "google-gemini-cli",
+    normalizedProvider,
     trimmedModelId: trimmed,
     templateIds: [...templateIds],
     modelRegistry,

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -169,8 +169,8 @@ function resolveAnthropicSonnet46ForwardCompatModel(
 }
 
 // gemini-3.1-pro-preview / gemini-3.1-flash-preview are not present in pi-ai's built-in
-// google-gemini-cli catalog yet. Clone the nearest gemini-3 template so users don't get
-// "Unknown model" errors when Google Gemini CLI gains new minor-version models.
+// google-gemini-cli or google provider catalogs yet. Clone the nearest gemini-3 template
+// so users don't get "Unknown model" errors when either provider gains new minor-version models.
 const GOOGLE_GEMINI_CLI_ELIGIBLE_PROVIDERS = new Set(["google-gemini-cli", "google"]);
 
 function resolveGoogleGeminiCli31ForwardCompatModel(


### PR DESCRIPTION
## Summary

- `google/gemini-3.1-pro-preview` and `google/gemini-3.1-flash-lite-preview` fail with `FailoverError: Unknown model` when used in the `fallbacks` array
- Root cause: `resolveGoogleGeminiCli31ForwardCompatModel` only handled the `google-gemini-cli` provider, not the `google` provider that most users configure
- Fix: extend the eligible providers set to include `google`, and pass the actual normalized provider to `cloneFirstTemplateModel`

## Root Cause

In `src/agents/model-forward-compat.ts`, the forward-compat function had a hard-coded check:
```typescript
if (normalizeProviderId(provider) !== "google-gemini-cli") {
  return undefined;
}
```

Users configure `google/gemini-3.1-flash-lite-preview` (provider = `google`), so the function returned `undefined` and fallback routing threw `Unknown model`.

## Implementation Pattern

This fix follows the same forward-compat pattern used by `resolveOpenAICodexGpt53FallbackModel` in the same file:
- Define `PROVIDER_SET = new Set([...eligible providers...])`
- Check `PROVIDER_SET.has(normalizedProvider)` instead of equality
- Thread the actual `normalizedProvider` to registry lookups

This ensures consistency across all forward-compat resolvers.

## Test plan

- [ ] Configure `google/gemini-3.1-pro-preview` or `google/gemini-3.1-flash-lite-preview` as a fallback model
- [ ] Trigger failover (e.g. primary hits rate limit)
- [ ] Verify fallback resolves correctly without `Unknown model` error
- [ ] Verify `google-gemini-cli/gemini-3.1-*` still works as before

Fixes #36111