### PR TITLE
gateway: auto-approve loopback device pairing for role/metadata upgrades

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -133,11 +133,20 @@ function shouldAllowSilentLocalPairing(params: {
   isWebchat: boolean;
   reason: "not-paired" | "role-upgrade" | "scope-upgrade" | "metadata-upgrade";
 }): boolean {
-  return (
-    params.isLocalClient &&
-    (!params.hasBrowserOriginHeader || params.isControlUi || params.isWebchat) &&
-    (params.reason === "not-paired" || params.reason === "scope-upgrade")
-  );
+  if (!params.isLocalClient) {
+    return false;
+  }
+  // Browser clients are limited to initial pairing and scope upgrades to prevent
+  // silent privilege escalation through the UI. Non-browser local clients (e.g.
+  // headless agents, CLI nodes) are trusted for all pairing reasons since they
+  // already authenticated via shared secret on loopback.
+  if (params.hasBrowserOriginHeader && !params.isControlUi && !params.isWebchat) {
+    return false;
+  }
+  if (params.hasBrowserOriginHeader) {
+    return params.reason === "not-paired" || params.reason === "scope-upgrade";
+  }
+  return true;
 }
 
 function shouldSkipBackendSelfPairing(params: {
@@ -332,15 +341,15 @@ export function attachGatewayWsMessageHandler(params: {
   if (hasUntrustedProxyHeaders) {
     logWsControl.warn(
       "Proxy headers detected from untrusted address. " +
-        "Connection will not be treated as local. " +
-        "Configure gateway.trustedProxies to restore local client detection behind your proxy.",
+      "Connection will not be treated as local. " +
+      "Configure gateway.trustedProxies to restore local client detection behind your proxy.",
     );
   }
   if (!hostIsLocalish && isLoopbackAddress(remoteAddr) && !hasProxyHeaders) {
     logWsControl.warn(
       "Loopback connection with non-local Host header. " +
-        "Treating it as remote. If you're behind a reverse proxy, " +
-        "set gateway.trustedProxies and forward X-Forwarded-For/X-Real-IP.",
+      "Treating it as remote. If you're behind a reverse proxy, " +
+      "set gateway.trustedProxies and forward X-Forwarded-For/X-Real-IP.",
     );
   }
 
@@ -1040,11 +1049,11 @@ export function attachGatewayWsMessageHandler(params: {
           canvasHostUrl: scopedCanvasHostUrl,
           auth: deviceToken
             ? {
-                deviceToken: deviceToken.token,
-                role: deviceToken.role,
-                scopes: deviceToken.scopes,
-                issuedAtMs: deviceToken.rotatedAtMs ?? deviceToken.createdAtMs,
-              }
+              deviceToken: deviceToken.token,
+              role: deviceToken.role,
+              scopes: deviceToken.scopes,
+              issuedAtMs: deviceToken.rotatedAtMs ?? deviceToken.createdAtMs,
+            }
             : undefined,
           policy: {
             maxPayload: MAX_PAYLOAD_BYTES,


### PR DESCRIPTION
## Summary

Extend `shouldAllowSilentLocalPairing` to auto-approve all pairing reasons (including `role-upgrade` and `metadata-upgrade`) for non-browser local clients.

## Root Cause

`shouldAllowSilentLocalPairing` only auto-approved `not-paired` and `scope-upgrade` reasons. When a local headless agent (e.g. `node-host` mode) reconnected with a different role or updated client metadata, the gateway rejected the connection with `1008: pairing required` — even on loopback, where the docs state pairing is auto-approved.

This affects Docker deployments with `gateway.bind = loopback` where agents generate new device keypairs and may connect with varying roles.

## Fix

Restructure the function to distinguish browser vs non-browser local clients:

- **Non-browser local clients** (headless agents, CLI nodes): auto-approve for ALL pairing reasons. These clients already authenticated via shared secret on loopback.
- **Browser local clients** (Control UI, Webchat): keep existing restricted policy (`not-paired` + `scope-upgrade` only) to prevent silent privilege escalation through the UI.

## Testing

- Verified the refactored logic preserves existing behavior for browser clients
- Non-browser local clients now auto-approve for `role-upgrade` and `metadata-upgrade`

Fixes #35763