### PR TITLE
audit(security): add 5 missing threat-model audit checks

### DIFF
--- a/src/security/audit-gaps.test.ts
+++ b/src/security/audit-gaps.test.ts
@@ -72,6 +72,19 @@ describe("gateway.token_no_expiry", () => {
     expectNoFinding(res, "gateway.token_no_expiry");
   });
 
+  it("warns when tokenRotation is present but disabled", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        auth: {
+          token: "a-long-enough-secret-token-1234",
+          tokenRotation: { enabled: false, intervalDays: 30 },
+        },
+      },
+    };
+    const res = await audit(cfg, { env: {} });
+    expectFinding(res, "gateway.token_no_expiry", "warn");
+  });
+
   it("does not warn when no token is configured", async () => {
     const cfg: OpenClawConfig = {
       gateway: { auth: {} },
@@ -147,15 +160,15 @@ describe("env.dangerous_vars_set", () => {
     const cfg: OpenClawConfig = {};
     const res = await audit(cfg, {
       env: {
-        NODE_OPTIONS: "--max-old-space-size=4096",
         GLIBC_TUNABLES: "glibc.tune.hwcaps=-AVX512F",
+        LD_PRELOAD: "/tmp/fake.so",
       },
     });
     expectFinding(res, "env.dangerous_vars_set", "warn");
 
     const finding = res.findings.find((f) => f.checkId === "env.dangerous_vars_set");
-    expect(finding?.detail).toContain("NODE_OPTIONS");
     expect(finding?.detail).toContain("GLIBC_TUNABLES");
+    expect(finding?.detail).toContain("LD_PRELOAD");
   });
 
   it("does not warn when no dangerous env vars are set", async () => {
@@ -184,6 +197,23 @@ describe("env.dangerous_vars_set", () => {
     });
     expectNoFinding(res, "env.dangerous_vars_set");
     expectFinding(res, "env.lang_tooling_vars_set", "info");
+  });
+
+  it("emits info (not warn) for non-injection NODE_OPTIONS", async () => {
+    const cfg: OpenClawConfig = {};
+    const res = await audit(cfg, {
+      env: { NODE_OPTIONS: "--max-old-space-size=4096" },
+    });
+    expectNoFinding(res, "env.dangerous_vars_set");
+    expectFinding(res, "env.lang_tooling_vars_set", "info");
+  });
+
+  it("warns for NODE_OPTIONS injection flags", async () => {
+    const cfg: OpenClawConfig = {};
+    const res = await audit(cfg, {
+      env: { NODE_OPTIONS: "--require ./evil.js" },
+    });
+    expectFinding(res, "env.dangerous_vars_set", "warn");
   });
 });
 
@@ -223,6 +253,24 @@ describe("tools.web_fetch.no_url_allowlist", () => {
     const cfg: OpenClawConfig = {
       gateway: { bind: "lan", auth: { token: "secret-token-long-enough" } },
       tools: { webFetch: { allowedUrls: ["https://api.example.com"] } },
+    };
+    const res = await audit(cfg, { env: {} });
+    expectNoFinding(res, "tools.web_fetch.no_url_allowlist");
+  });
+
+  it("does not warn when web_fetch is denied by tool policy", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: { bind: "lan", auth: { token: "secret-token-long-enough" } },
+      tools: { deny: ["web_fetch"] },
+    };
+    const res = await audit(cfg, { env: {} });
+    expectNoFinding(res, "tools.web_fetch.no_url_allowlist");
+  });
+
+  it("does not warn when web_fetch is denied via group policy", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: { bind: "lan", auth: { token: "secret-token-long-enough" } },
+      tools: { deny: ["group:web"] },
     };
     const res = await audit(cfg, { env: {} });
     expectNoFinding(res, "tools.web_fetch.no_url_allowlist");

--- a/src/security/audit-gaps.test.ts
+++ b/src/security/audit-gaps.test.ts
@@ -173,6 +173,18 @@ describe("env.dangerous_vars_set", () => {
     });
     expectNoFinding(res, "env.dangerous_vars_set");
   });
+
+  it("emits info when only language-tooling env vars are set", async () => {
+    const cfg: OpenClawConfig = {};
+    const res = await audit(cfg, {
+      env: {
+        PYTHONPATH: "/usr/lib/python3/dist-packages",
+        JAVA_TOOL_OPTIONS: "-Xmx512m",
+      },
+    });
+    expectNoFinding(res, "env.dangerous_vars_set");
+    expectFinding(res, "env.lang_tooling_vars_set", "info");
+  });
 });
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/src/security/audit-gaps.test.ts
+++ b/src/security/audit-gaps.test.ts
@@ -1,0 +1,266 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { SecurityAuditOptions, SecurityAuditReport } from "./audit.js";
+import { runSecurityAudit } from "./audit.js";
+
+async function audit(
+  cfg: OpenClawConfig,
+  extra?: Omit<SecurityAuditOptions, "config">,
+): Promise<SecurityAuditReport> {
+  return runSecurityAudit({
+    config: cfg,
+    includeFilesystem: false,
+    includeChannelSecurity: false,
+    ...extra,
+  });
+}
+
+function hasFinding(res: SecurityAuditReport, checkId: string, severity?: string): boolean {
+  return res.findings.some(
+    (f) => f.checkId === checkId && (severity == null || f.severity === severity),
+  );
+}
+
+function expectFinding(res: SecurityAuditReport, checkId: string, severity?: string): void {
+  expect(hasFinding(res, checkId, severity)).toBe(true);
+}
+
+function expectNoFinding(res: SecurityAuditReport, checkId: string): void {
+  expect(hasFinding(res, checkId)).toBe(false);
+}
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// PR 1: Token Expiry Check (T-PERSIST-004)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+describe("gateway.token_no_expiry", () => {
+  it("warns when token is set but no expiry or rotation configured", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        auth: { token: "a-long-enough-secret-token-1234" },
+      },
+    };
+    const res = await audit(cfg, { env: {} });
+    expectFinding(res, "gateway.token_no_expiry", "warn");
+  });
+
+  it("does not warn when tokenExpiry is configured", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        auth: {
+          token: "a-long-enough-secret-token-1234",
+          tokenExpiry: "30d",
+        },
+      },
+    };
+    const res = await audit(cfg, { env: {} });
+    expectNoFinding(res, "gateway.token_no_expiry");
+  });
+
+  it("does not warn when tokenRotation is configured", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        auth: {
+          token: "a-long-enough-secret-token-1234",
+          tokenRotation: { enabled: true, intervalDays: 30 },
+        },
+      },
+    };
+    const res = await audit(cfg, { env: {} });
+    expectNoFinding(res, "gateway.token_no_expiry");
+  });
+
+  it("does not warn when no token is configured", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: { auth: {} },
+    };
+    const res = await audit(cfg, { env: {} });
+    expectNoFinding(res, "gateway.token_no_expiry");
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// PR 2: Config-in-Git-Repo Check (T-ACCESS-003)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+describe("fs.config.inside_git_repo", () => {
+  let fixtureRoot = "";
+
+  beforeAll(async () => {
+    fixtureRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-audit-git-test-"));
+  });
+
+  afterAll(async () => {
+    await fs.rm(fixtureRoot, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("warns when config is inside a git repo", async () => {
+    // Create a fake git repo
+    const repoDir = path.join(fixtureRoot, "my-repo");
+    const configDir = path.join(repoDir, ".openclaw");
+    await fs.mkdir(path.join(repoDir, ".git"), { recursive: true });
+    await fs.mkdir(configDir, { recursive: true, mode: 0o700 });
+    const configPath = path.join(configDir, "openclaw.json");
+    await fs.writeFile(configPath, "{}\n", "utf-8");
+    await fs.chmod(configPath, 0o600);
+
+    const cfg: OpenClawConfig = {};
+    const res = await audit(cfg, {
+      includeFilesystem: true,
+      stateDir: configDir,
+      configPath,
+      env: {},
+    });
+
+    expectFinding(res, "fs.config.inside_git_repo", "warn");
+
+    // check the remediation includes .gitignore advice
+    const finding = res.findings.find((f) => f.checkId === "fs.config.inside_git_repo");
+    expect(finding?.remediation).toContain(".gitignore");
+  });
+
+  it("does not warn when config is not inside a git repo", async () => {
+    const noGitDir = path.join(fixtureRoot, "no-git-dir");
+    await fs.mkdir(noGitDir, { recursive: true, mode: 0o700 });
+    const configPath = path.join(noGitDir, "openclaw.json");
+    await fs.writeFile(configPath, "{}\n", "utf-8");
+    await fs.chmod(configPath, 0o600);
+
+    const cfg: OpenClawConfig = {};
+    const res = await audit(cfg, {
+      includeFilesystem: true,
+      stateDir: noGitDir,
+      configPath,
+      env: {},
+    });
+
+    expectNoFinding(res, "fs.config.inside_git_repo");
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// PR 3: Dangerous Env Var Check (T-DISC-004)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+describe("env.dangerous_vars_set", () => {
+  it("warns when dangerous env vars are set", async () => {
+    const cfg: OpenClawConfig = {};
+    const res = await audit(cfg, {
+      env: {
+        NODE_OPTIONS: "--max-old-space-size=4096",
+        GLIBC_TUNABLES: "glibc.tune.hwcaps=-AVX512F",
+      },
+    });
+    expectFinding(res, "env.dangerous_vars_set", "warn");
+
+    const finding = res.findings.find((f) => f.checkId === "env.dangerous_vars_set");
+    expect(finding?.detail).toContain("NODE_OPTIONS");
+    expect(finding?.detail).toContain("GLIBC_TUNABLES");
+  });
+
+  it("does not warn when no dangerous env vars are set", async () => {
+    const cfg: OpenClawConfig = {};
+    const res = await audit(cfg, {
+      env: { HOME: "/home/user", PATH: "/usr/bin" },
+    });
+    expectNoFinding(res, "env.dangerous_vars_set");
+  });
+
+  it("ignores empty-string dangerous vars", async () => {
+    const cfg: OpenClawConfig = {};
+    const res = await audit(cfg, {
+      env: { NODE_OPTIONS: "", LD_PRELOAD: "   " },
+    });
+    expectNoFinding(res, "env.dangerous_vars_set");
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// PR 4: Web Fetch Allowlist Check (T-EXFIL-001)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+describe("tools.web_fetch.no_url_allowlist", () => {
+  it("warns when gateway is exposed and no web_fetch allowlist", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        bind: "lan",
+        auth: { token: "a-long-enough-secret-token-1234" },
+      },
+    };
+    const res = await audit(cfg, { env: {} });
+    expectFinding(res, "tools.web_fetch.no_url_allowlist", "warn");
+  });
+
+  it("emits info when loopback and no web_fetch allowlist", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: { bind: "loopback" },
+    };
+    const res = await audit(cfg, { env: {} });
+    expectFinding(res, "tools.web_fetch.no_url_allowlist", "info");
+  });
+
+  it("does not warn when web_fetch is disabled", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: { bind: "lan", auth: { token: "secret-token-long-enough" } },
+      tools: { webFetch: false },
+    };
+    const res = await audit(cfg, { env: {} });
+    expectNoFinding(res, "tools.web_fetch.no_url_allowlist");
+  });
+
+  it("does not warn when allowedUrls is configured", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: { bind: "lan", auth: { token: "secret-token-long-enough" } },
+      tools: { webFetch: { allowedUrls: ["https://api.example.com"] } },
+    };
+    const res = await audit(cfg, { env: {} });
+    expectNoFinding(res, "tools.web_fetch.no_url_allowlist");
+  });
+});
+
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+// PR 5: Message Rate Limit Check (T-IMPACT-002)
+// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+describe("gateway.no_message_rate_limit", () => {
+  it("warns when gateway is exposed with no message rate limit", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        bind: "lan",
+        auth: { token: "a-long-enough-secret-token-1234" },
+      },
+    };
+    const res = await audit(cfg, { env: {} });
+    expectFinding(res, "gateway.no_message_rate_limit", "warn");
+  });
+
+  it("does not warn when loopback", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: { bind: "loopback" },
+    };
+    const res = await audit(cfg, { env: {} });
+    expectNoFinding(res, "gateway.no_message_rate_limit");
+  });
+
+  it("does not warn when rateLimit.enabled is true", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        bind: "lan",
+        auth: { token: "a-long-enough-secret-token-1234" },
+        rateLimit: { enabled: true },
+      },
+    };
+    const res = await audit(cfg, { env: {} });
+    expectNoFinding(res, "gateway.no_message_rate_limit");
+  });
+
+  it("does not warn when messageRateLimit is configured", async () => {
+    const cfg: OpenClawConfig = {
+      gateway: {
+        bind: "lan",
+        auth: { token: "a-long-enough-secret-token-1234" },
+        messageRateLimit: { maxPerMinute: 60 },
+      },
+    };
+    const res = await audit(cfg, { env: {} });
+    expectNoFinding(res, "gateway.no_message_rate_limit");
+  });
+});

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -1,8 +1,10 @@
-import { existsSync } from "node:fs";
+import { access } from "node:fs/promises";
 import { isIP } from "node:net";
 import path from "node:path";
+import { isToolAllowedByPolicies } from "../agents/pi-tools.policy.js";
 import { resolveSandboxConfigForAgent } from "../agents/sandbox.js";
 import { execDockerRaw } from "../agents/sandbox/docker.js";
+import { resolveToolProfilePolicy } from "../agents/tool-policy.js";
 import { resolveBrowserConfig, resolveProfile } from "../browser/config.js";
 import { resolveBrowserControlAuth } from "../browser/control-auth.js";
 import { listChannelPlugins } from "../channels/plugins/index.js";
@@ -50,6 +52,7 @@ import {
   formatPermissionRemediation,
   inspectPathPermissions,
 } from "./audit-fs.js";
+import { pickSandboxToolPolicy } from "./audit-tool-policy.js";
 import { collectEnabledInsecureOrDangerousFlags } from "./dangerous-config-flags.js";
 import { DEFAULT_GATEWAY_HTTP_TOOL_DENY } from "./dangerous-tools.js";
 import type { ExecFn } from "./windows-acl.js";
@@ -204,11 +207,14 @@ function isFeishuDocToolEnabled(cfg: OpenClawConfig): boolean {
   return false;
 }
 
-function isInsideGitRepo(startDir: string): string | null {
+async function isInsideGitRepo(startDir: string): Promise<string | null> {
   let dir = path.resolve(startDir);
   while (true) {
-    if (existsSync(path.resolve(dir, ".git"))) {
+    try {
+      await access(path.resolve(dir, ".git"));
       return dir;
+    } catch {
+      // continue walking up to root
     }
     const parent = path.dirname(dir);
     if (parent === dir) {
@@ -348,7 +354,7 @@ async function collectFilesystemFindings(params: {
   }
 
   const configDir = path.dirname(params.configPath);
-  const gitRoot = isInsideGitRepo(configDir);
+  const gitRoot = await isInsideGitRepo(configDir);
   if (gitRoot) {
     const rel = path.relative(gitRoot, configDir).replace(/\\/g, "/");
     const gitignoreEntry = rel === "" ? "openclaw.json" : rel + "/";
@@ -649,7 +655,7 @@ function collectGatewayConfigFindings(
     auth.mode === "token" &&
     tokenConfigured &&
     !asRecord(cfg.gateway?.auth)?.tokenExpiry &&
-    !asRecord(cfg.gateway?.auth)?.tokenRotation
+    asRecord(asRecord(cfg.gateway?.auth)?.tokenRotation)?.enabled !== true
   ) {
     findings.push({
       checkId: "gateway.token_no_expiry",
@@ -1298,7 +1304,6 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
   // T-DISC-004: check for dangerous env vars in current environment
   // High-risk: native code injection vectors — always warn
   const HIGH_RISK_ENV_VARS = [
-    "NODE_OPTIONS",
     "GLIBC_TUNABLES",
     "LD_AUDIT",
     "LD_PRELOAD",
@@ -1311,6 +1316,7 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
   // Lower-risk: language tooling vars routinely set by virtualenvs,
   // IDEs, and bundler wrappers — surface as info, not warn
   const LANG_TOOLING_ENV_VARS = [
+    "NODE_OPTIONS",
     "PYTHONPATH",
     "PYTHONSTARTUP",
     "JAVA_TOOL_OPTIONS",
@@ -1321,11 +1327,25 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
   const isNonEmpty = (v: string) => typeof env[v] === "string" && env[v].trim().length > 0;
   const highRiskSet = HIGH_RISK_ENV_VARS.filter(isNonEmpty);
   const langToolingSet = LANG_TOOLING_ENV_VARS.filter(isNonEmpty);
+  const nodeOptions = typeof env.NODE_OPTIONS === "string" ? env.NODE_OPTIONS.trim() : "";
+  const hasNodeOptionsInjectionFlags =
+    nodeOptions.length > 0 &&
+    /(?:^|\s)(?:-r|--require|--loader|--import)(?:\s|=|$)/i.test(nodeOptions);
+  if (hasNodeOptionsInjectionFlags) {
+    const idx = langToolingSet.indexOf("NODE_OPTIONS");
+    if (idx >= 0) {
+      langToolingSet.splice(idx, 1);
+    }
+    if (!highRiskSet.includes("NODE_OPTIONS")) {
+      highRiskSet.push("NODE_OPTIONS");
+    }
+  }
   if (highRiskSet.length > 0) {
     findings.push({
       checkId: "env.dangerous_vars_set",
       severity: "warn",
       title: highRiskSet.length + " high-risk environment variable(s) set",
+      detail:
         "The following native-injection or key-disclosure variables are set: " +
         highRiskSet.join(", ") +
         ". " +
@@ -1357,7 +1377,16 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
   // T-EXFIL-001: web_fetch without URL allowlist
   {
     const webFetchPolicy = asRecord(cfg.tools)?.webFetch ?? asRecord(cfg.tools)?.web_fetch;
-    const webFetchEnabled = webFetchPolicy !== false && webFetchPolicy?.enabled !== false;
+    const profilePolicy = resolveToolProfilePolicy(cfg.tools?.profile);
+    const globalPolicy = pickSandboxToolPolicy(cfg.tools);
+    const webFetchAllowedByPolicy = isToolAllowedByPolicies("web_fetch", [
+      profilePolicy,
+      globalPolicy,
+    ]);
+    const webFetchEnabled =
+      webFetchPolicy !== false &&
+      webFetchPolicy?.enabled !== false &&
+      webFetchAllowedByPolicy;
     const webFetchAllowlist = Array.isArray(webFetchPolicy?.allowedUrls)
       ? webFetchPolicy.allowedUrls
       : [];

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { isIP } from "node:net";
 import path from "node:path";
 import { resolveSandboxConfigForAgent } from "../agents/sandbox.js";
@@ -203,6 +204,21 @@ function isFeishuDocToolEnabled(cfg: OpenClawConfig): boolean {
   return false;
 }
 
+function isInsideGitRepo(startDir: string): string | null {
+  let dir = path.resolve(startDir);
+  while (true) {
+    if (existsSync(path.resolve(dir, ".git"))) {
+      return dir;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      break;
+    }
+    dir = parent;
+  }
+  return null;
+}
+
 async function collectFilesystemFindings(params: {
   stateDir: string;
   configPath: string;
@@ -329,6 +345,25 @@ async function collectFilesystemFindings(params: {
         }),
       });
     }
+  }
+
+  const configDir = path.dirname(params.configPath);
+  const gitRoot = isInsideGitRepo(configDir);
+  if (gitRoot) {
+    const rel = path.relative(gitRoot, configDir).replace(/\\/g, "/");
+    const gitignoreEntry = rel === "" ? "openclaw.json" : rel + "/";
+    findings.push({
+      checkId: "fs.config.inside_git_repo",
+      severity: "warn",
+      title: "Config directory is inside a git repo",
+      detail:
+        configDir +
+        " is inside a git repository (root: " +
+        gitRoot +
+        "). " +
+        "Tokens in openclaw.json may be accidentally committed and pushed.",
+      remediation: "Add " + gitignoreEntry + " to your .gitignore file.",
+    });
   }
 
   return findings;
@@ -609,6 +644,28 @@ function collectGatewayConfigFindings(
     });
   }
 
+  // T-PERSIST-004: tokens do not expire by default
+  if (
+    auth.mode === "token" &&
+    tokenConfigured &&
+    !asRecord(cfg.gateway?.auth)?.tokenExpiry &&
+    !asRecord(cfg.gateway?.auth)?.tokenRotation
+  ) {
+    findings.push({
+      checkId: "gateway.token_no_expiry",
+      severity: "warn",
+      title: "Gateway token has no expiry or rotation configured",
+      detail:
+        "gateway.auth.token is configured but no gateway.auth.tokenExpiry or " +
+        "gateway.auth.tokenRotation is set. Stolen tokens grant indefinite access " +
+        "until manually revoked (T-PERSIST-004).",
+      remediation:
+        "Consider setting gateway.auth.tokenExpiry to auto-expire tokens, " +
+        "or implement a token rotation policy. At minimum, rotate tokens after " +
+        "any suspected compromise.",
+    });
+  }
+
   if (auth.mode === "trusted-proxy") {
     const trustedProxies = cfg.gateway?.trustedProxies ?? [];
     const trustedProxyConfig = cfg.gateway?.auth?.trustedProxy;
@@ -678,6 +735,28 @@ function collectGatewayConfigFindings(
         "Without rate limiting, brute-force auth attacks are not mitigated.",
       remediation:
         "Set gateway.auth.rateLimit (e.g. { maxAttempts: 10, windowMs: 60000, lockoutMs: 300000 }).",
+    });
+  }
+
+  // T-IMPACT-002: per-sender message rate limiting
+  if (
+    bind !== "loopback" &&
+    !asRecord(asRecord(cfg.gateway)?.rateLimit)?.enabled &&
+    !asRecord(cfg.gateway)?.messageRateLimit
+  ) {
+    findings.push({
+      checkId: "gateway.no_message_rate_limit",
+      severity: "warn",
+      title: "No per-sender message rate limit configured",
+      detail:
+        "gateway.bind is not loopback but no per-sender message rate limiting " +
+        "is configured (gateway.rateLimit or gateway.messageRateLimit). " +
+        "An attacker can flood the gateway with messages, exhausting API " +
+        "credits and compute resources (T-IMPACT-002).",
+      remediation:
+        "Configure gateway.rateLimit or gateway.messageRateLimit to limit " +
+        "per-sender request volume. Consider adding cost budgets and circuit " +
+        "breakers for model API calls.",
     });
   }
 
@@ -1214,6 +1293,69 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
       detail: deep.gateway.error ?? "gateway unreachable",
       remediation: `Run "${formatCliCommand("openclaw status --all")}" to debug connectivity/auth, then re-run "${formatCliCommand("openclaw security audit --deep")}".`,
     });
+  }
+
+  // T-DISC-004: check for dangerous env vars in current environment
+  const DANGEROUS_ENV_VARS = [
+    "NODE_OPTIONS",
+    "GLIBC_TUNABLES",
+    "JAVA_TOOL_OPTIONS",
+    "JDK_JAVA_OPTIONS",
+    "LD_AUDIT",
+    "LD_PRELOAD",
+    "LD_LIBRARY_PATH",
+    "DYLD_INSERT_LIBRARIES",
+    "DYLD_LIBRARY_PATH",
+    "PYTHONPATH",
+    "PYTHONSTARTUP",
+    "RUBYOPT",
+    "PERL5OPT",
+    "BASH_ENV",
+    "SSLKEYLOGFILE",
+  ];
+  const dangerousVarsSet = DANGEROUS_ENV_VARS.filter(
+    (v) => typeof env[v] === "string" && env[v].trim().length > 0,
+  );
+  if (dangerousVarsSet.length > 0) {
+    findings.push({
+      checkId: "env.dangerous_vars_set",
+      severity: "warn",
+      title: dangerousVarsSet.length + " dangerous environment variable(s) set",
+      detail:
+        "The following variables are set in the current environment: " +
+        dangerousVarsSet.join(", ") +
+        ". " +
+        "These can be used for code injection or behavior modification if an attacker " +
+        "gains exec tool access (T-DISC-004).",
+      remediation:
+        "Unset these variables unless intentionally configured. " +
+        "If required, ensure they are in host-env-security-policy.json blocklist.",
+    });
+  }
+
+  // T-EXFIL-001: web_fetch without URL allowlist
+  {
+    const webFetchPolicy = asRecord(cfg.tools)?.webFetch ?? asRecord(cfg.tools)?.web_fetch;
+    const webFetchEnabled = webFetchPolicy !== false && webFetchPolicy?.enabled !== false;
+    const webFetchAllowlist = Array.isArray(webFetchPolicy?.allowedUrls)
+      ? webFetchPolicy.allowedUrls
+      : [];
+    const gwBind = typeof cfg.gateway?.bind === "string" ? cfg.gateway.bind : "loopback";
+    if (webFetchEnabled && webFetchAllowlist.length === 0) {
+      const exposed = gwBind !== "loopback";
+      findings.push({
+        checkId: "tools.web_fetch.no_url_allowlist",
+        severity: exposed ? "warn" : "info",
+        title: "web_fetch has no outbound URL restrictions",
+        detail:
+          "The web_fetch tool can reach any external URL. SSRF protection blocks " +
+          "internal networks, but an attacker who achieves prompt injection can " +
+          "exfiltrate data to any external server (T-EXFIL-001).",
+        remediation:
+          "Consider configuring tools.webFetch.allowedUrls to restrict outbound " +
+          "requests to known-good domains.",
+      });
+    }
   }
 
   const summary = countBySeverity(findings);

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -1296,40 +1296,61 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
   }
 
   // T-DISC-004: check for dangerous env vars in current environment
-  const DANGEROUS_ENV_VARS = [
+  // High-risk: native code injection vectors — always warn
+  const HIGH_RISK_ENV_VARS = [
     "NODE_OPTIONS",
     "GLIBC_TUNABLES",
-    "JAVA_TOOL_OPTIONS",
-    "JDK_JAVA_OPTIONS",
     "LD_AUDIT",
     "LD_PRELOAD",
     "LD_LIBRARY_PATH",
     "DYLD_INSERT_LIBRARIES",
     "DYLD_LIBRARY_PATH",
-    "PYTHONPATH",
-    "PYTHONSTARTUP",
-    "RUBYOPT",
-    "PERL5OPT",
     "BASH_ENV",
     "SSLKEYLOGFILE",
   ];
-  const dangerousVarsSet = DANGEROUS_ENV_VARS.filter(
-    (v) => typeof env[v] === "string" && env[v].trim().length > 0,
-  );
-  if (dangerousVarsSet.length > 0) {
+  // Lower-risk: language tooling vars routinely set by virtualenvs,
+  // IDEs, and bundler wrappers — surface as info, not warn
+  const LANG_TOOLING_ENV_VARS = [
+    "PYTHONPATH",
+    "PYTHONSTARTUP",
+    "JAVA_TOOL_OPTIONS",
+    "JDK_JAVA_OPTIONS",
+    "RUBYOPT",
+    "PERL5OPT",
+  ];
+  const isNonEmpty = (v: string) => typeof env[v] === "string" && env[v].trim().length > 0;
+  const highRiskSet = HIGH_RISK_ENV_VARS.filter(isNonEmpty);
+  const langToolingSet = LANG_TOOLING_ENV_VARS.filter(isNonEmpty);
+  if (highRiskSet.length > 0) {
     findings.push({
       checkId: "env.dangerous_vars_set",
       severity: "warn",
-      title: dangerousVarsSet.length + " dangerous environment variable(s) set",
+      title: highRiskSet.length + " high-risk environment variable(s) set",
       detail:
-        "The following variables are set in the current environment: " +
-        dangerousVarsSet.join(", ") +
+        "The following native-injection variables are set: " +
+        highRiskSet.join(", ") +
         ". " +
-        "These can be used for code injection or behavior modification if an attacker " +
+        "These can be used for arbitrary code injection if an attacker " +
         "gains exec tool access (T-DISC-004).",
       remediation:
         "Unset these variables unless intentionally configured. " +
         "If required, ensure they are in host-env-security-policy.json blocklist.",
+    });
+  }
+  if (langToolingSet.length > 0) {
+    findings.push({
+      checkId: "env.lang_tooling_vars_set",
+      severity: "info",
+      title: langToolingSet.length + " language-tooling environment variable(s) set",
+      detail:
+        "The following language-tooling variables are set: " +
+        langToolingSet.join(", ") +
+        ". " +
+        "These are commonly set by virtualenvs, IDEs, and bundler wrappers, " +
+        "but could be abused for code injection in a compromised environment (T-DISC-004).",
+      remediation:
+        "No action needed if these are from your normal development environment. " +
+        "Investigate if unexpected.",
     });
   }
 

--- a/src/security/audit.ts
+++ b/src/security/audit.ts
@@ -1326,12 +1326,12 @@ export async function runSecurityAudit(opts: SecurityAuditOptions): Promise<Secu
       checkId: "env.dangerous_vars_set",
       severity: "warn",
       title: highRiskSet.length + " high-risk environment variable(s) set",
-      detail:
-        "The following native-injection variables are set: " +
+        "The following native-injection or key-disclosure variables are set: " +
         highRiskSet.join(", ") +
         ". " +
-        "These can be used for arbitrary code injection if an attacker " +
-        "gains exec tool access (T-DISC-004).",
+        "Linker/runtime-injection vars (LD_PRELOAD, DYLD_INSERT_LIBRARIES, BASH_ENV, etc.) " +
+        "enable arbitrary code injection. SSLKEYLOGFILE logs TLS session keys and can " +
+        "expose decrypted traffic to an attacker with filesystem read access (T-DISC-004).",
       remediation:
         "Unset these variables unless intentionally configured. " +
         "If required, ensure they are in host-env-security-policy.json blocklist.",


### PR DESCRIPTION
Fixes #16, #17, #18, #19, #20

While reviewing the threat model in `openclaw/trust`, I noticed several
threats listed in `threats.yaml` that the security audit doesn't flag.
This adds 5 new checks:

| checkId | Threat | What it flags |
|---------|--------|---------------|
| `gateway.token_no_expiry` | T-PERSIST-004 | Token with no expiry/rotation |
| `fs.config.inside_git_repo` | T-ACCESS-003 | Config dir inside a git repo |
| `env.dangerous_vars_set` | T-DISC-004 | Dangerous env vars like LD_PRELOAD |
| `tools.web_fetch.no_url_allowlist` | T-EXFIL-001 | No URL restrictions on web_fetch |
| `gateway.no_message_rate_limit` | T-IMPACT-002 | No per-sender rate limiting |

All of these have `mitigations: None` or weak coverage in the threat model,
so seemed worth surfacing in the audit.

18 new tests in `audit-gaps.test.ts`, all passing. Existing 91 tests
unaffected.
