### PR TITLE
fix(daemon): patch OPENCLAW_SERVICE_VERSION in gateway.cmd on Windows restart

### DIFF
--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -325,7 +325,7 @@ async function patchTaskScriptVersion(env: GatewayServiceEnv): Promise<void> {
     return;
   }
   const updated = content.replace(
-    /^(set OPENCLAW_SERVICE_VERSION=).+$/im,
+    /^(set OPENCLAW_SERVICE_VERSION=)[^\r\n]+$/im,
     `$1${VERSION}`,
   );
   if (updated !== content) {

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -7,6 +7,7 @@ import { formatLine, writeFormattedLines } from "./output.js";
 import { resolveGatewayStateDir } from "./paths.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
 import { execSchtasks } from "./schtasks-exec.js";
+import { VERSION } from "../version.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
 import type {
   GatewayServiceCommandConfig,
@@ -310,12 +311,36 @@ export async function stopScheduledTask({ stdout, env }: GatewayServiceControlAr
   stdout.write(`${formatLine("Stopped Scheduled Task", taskName)}\n`);
 }
 
+/**
+ * Patch OPENCLAW_SERVICE_VERSION in an existing gateway.cmd script to the
+ * current binary version. Called before restart so the Control UI always
+ * reports the correct version after an npm global update.
+ */
+async function patchTaskScriptVersion(env: GatewayServiceEnv): Promise<void> {
+  const scriptPath = resolveTaskScriptPath(env);
+  let content: string;
+  try {
+    content = await fs.readFile(scriptPath, "utf8");
+  } catch {
+    return;
+  }
+  const updated = content.replace(
+    /^(set OPENCLAW_SERVICE_VERSION=).+$/im,
+    `$1${VERSION}`,
+  );
+  if (updated !== content) {
+    await fs.writeFile(scriptPath, updated, "utf8");
+  }
+}
+
 export async function restartScheduledTask({
   stdout,
   env,
 }: GatewayServiceControlArgs): Promise<void> {
   await assertSchtasksAvailable();
-  const taskName = resolveTaskName(env ?? (process.env as GatewayServiceEnv));
+  const resolvedEnv = env ?? (process.env as GatewayServiceEnv);
+  await patchTaskScriptVersion(resolvedEnv);
+  const taskName = resolveTaskName(resolvedEnv);
   await execSchtasks(["/End", "/TN", taskName]);
   const res = await execSchtasks(["/Run", "/TN", taskName]);
   if (res.code !== 0) {

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { VERSION } from "../version.js";
 import { parseCmdScriptCommandLine, quoteCmdScriptArg } from "./cmd-argv.js";
 import { assertNoCmdLineBreak, parseCmdSetAssignment, renderCmdSetAssignment } from "./cmd-set.js";
 import { resolveGatewayServiceDescription, resolveGatewayWindowsTaskName } from "./constants.js";
@@ -7,7 +8,6 @@ import { formatLine, writeFormattedLines } from "./output.js";
 import { resolveGatewayStateDir } from "./paths.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
 import { execSchtasks } from "./schtasks-exec.js";
-import { VERSION } from "../version.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
 import type {
   GatewayServiceCommandConfig,
@@ -325,8 +325,8 @@ async function patchTaskScriptVersion(env: GatewayServiceEnv): Promise<void> {
     return;
   }
   const updated = content.replace(
-    /^(set OPENCLAW_SERVICE_VERSION=)[^\r\n]+$/im,
-    `$1${VERSION}`,
+    /^set "OPENCLAW_SERVICE_VERSION=[^\r\n"]*"$/im,
+    `set "OPENCLAW_SERVICE_VERSION=${VERSION}"`,
   );
   if (updated !== content) {
     await fs.writeFile(scriptPath, updated, "utf8");

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { VERSION } from "../version.js";
+import { VERSION, resolveUsableRuntimeVersion } from "../version.js";
 import { parseCmdScriptCommandLine, quoteCmdScriptArg } from "./cmd-argv.js";
 import { assertNoCmdLineBreak, parseCmdSetAssignment, renderCmdSetAssignment } from "./cmd-set.js";
 import { resolveGatewayServiceDescription, resolveGatewayWindowsTaskName } from "./constants.js";
@@ -317,6 +317,10 @@ export async function stopScheduledTask({ stdout, env }: GatewayServiceControlAr
  * reports the correct version after an npm global update.
  */
 async function patchTaskScriptVersion(env: GatewayServiceEnv): Promise<void> {
+  const usableVersion = resolveUsableRuntimeVersion(VERSION);
+  if (!usableVersion) {
+    return;
+  }
   const scriptPath = resolveTaskScriptPath(env);
   let content: string;
   try {
@@ -326,7 +330,7 @@ async function patchTaskScriptVersion(env: GatewayServiceEnv): Promise<void> {
   }
   const updated = content.replace(
     /^set "OPENCLAW_SERVICE_VERSION=[^\r\n"]*"$/im,
-    `set "OPENCLAW_SERVICE_VERSION=${VERSION}"`,
+    `set "OPENCLAW_SERVICE_VERSION=${usableVersion}"`,
   );
   if (updated !== content) {
     await fs.writeFile(scriptPath, updated, "utf8");


### PR DESCRIPTION
## Summary

- After `npm install -g openclaw@latest`, the Control UI **Instances** page still reports the old version because `gateway.cmd` contains a hardcoded `set OPENCLAW_SERVICE_VERSION=<old>` line that is never updated
- Manual workaround: edit `gateway.cmd` and update the line by hand
- Fix: `restartScheduledTask` now calls `patchTaskScriptVersion()` before invoking schtasks, which rewrites the `OPENCLAW_SERVICE_VERSION` line to match the current binary version

## Root Cause

`installScheduledTask` writes `gateway.cmd` once with `OPENCLAW_SERVICE_VERSION` set to the version at install time. Subsequent `npm install -g` updates replace the binary but leave `gateway.cmd` untouched. `restartScheduledTask` then re-runs the old script, so the process environment still carries the stale version.

## Change

`src/daemon/schtasks.ts`:
- Add `patchTaskScriptVersion(env)` — reads `gateway.cmd`, updates the `set OPENCLAW_SERVICE_VERSION=` line to `VERSION`, writes back (no-op if already current or file missing)
- `restartScheduledTask` calls `patchTaskScriptVersion` before stopping/starting the task

## Test plan

- [ ] Install an older openclaw version, note the version in Control UI Instances page
- [ ] Run `npm install -g openclaw@latest`
- [ ] Run `openclaw gateway restart`
- [ ] Verify Control UI Instances page now shows the updated version without manual `gateway.cmd` edits
- [ ] Verify `gateway.cmd` contains the new `OPENCLAW_SERVICE_VERSION` value

Fixes #36301