### PR TITLE
fix(hooks): suppress system event injection when deliver is false [AI-assisted]

### DIFF
--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -94,6 +94,8 @@ export function createGatewayHooksRequestHandler(params: {
         }
       } catch (err) {
         logHooks.warn(`hook agent failed: ${String(err)}`);
+        // Errors are always surfaced to the main session regardless of the
+        // `deliver` flag — silent failures are harder to debug than noisy ones.
         enqueueSystemEvent(`Hook ${value.name} (error): ${String(err)}`, {
           sessionKey: mainSessionKey,
         });

--- a/src/gateway/server/hooks.ts
+++ b/src/gateway/server/hooks.ts
@@ -80,7 +80,11 @@ export function createGatewayHooksRequestHandler(params: {
         const summary = result.summary?.trim() || result.error?.trim() || result.status;
         const prefix =
           result.status === "ok" ? `Hook ${value.name}` : `Hook ${value.name} (${result.status})`;
-        if (!result.delivered) {
+        // When deliver is explicitly false the caller opted out of all
+        // delivery *and* main-session notification.  Only inject a system
+        // event when delivery was requested but did not succeed (e.g. the
+        // target channel could not be resolved).
+        if (!result.delivered && value.deliver !== false) {
           enqueueSystemEvent(`${prefix}: ${summary}`.trim(), {
             sessionKey: mainSessionKey,
           });


### PR DESCRIPTION
## Summary

When a hook mapping sets `deliver: false`, the delivery announcement is correctly suppressed, but a system event (`Hook <name>: <summary>`) is still injected into the main session via `enqueueSystemEvent`. This PR adds a check for `value.deliver !== false` so that hooks with explicit `deliver: false` complete silently.

## Problem

In `src/gateway/server/hooks.ts`, the guard on line ~83 only checks `!result.delivered`:

```typescript
if (!result.delivered) {
  enqueueSystemEvent(`${prefix}: ${summary}`.trim(), { sessionKey: mainSessionKey });
}
```

When `deliver: false`:
1. `resolveCronDeliveryPlan` resolves to `{ mode: "none", requested: false }`
2. Delivery is never attempted → `result.delivered` is always `false`
3. The `!result.delivered` guard passes → system event fires unconditionally

This causes the main session to receive "Findings" summaries from every hook completion, even when the user explicitly opted out. The main session agent may then announce these summaries to unrelated channels.

## Fix

One additional condition: `value.deliver !== false`

```typescript
if (!result.delivered && value.deliver !== false) {
  enqueueSystemEvent(...)
}
```

When `deliver` is explicitly `false`, the hook completes silently — no delivery, no system event. When `deliver` is `true` (default) or unset, behavior is unchanged.

The error `catch` path intentionally still surfaces errors to the main session regardless of `deliver` — silent failures are harder to debug than noisy ones. This asymmetry is documented with an inline comment.

## Testing

- Hooks with `deliver: false` → no system event injected ✅
- Hooks with `deliver: true` (default) that fail to deliver → system event still fires ✅ (unchanged)
- Hooks with `deliver: true` that succeed → no system event (unchanged, `result.delivered` is `true`) ✅
- Hooks with `deliver: false` that throw → error system event still fires ✅ (intentional)

## 🤖 AI Disclosure

- [x] **AI-assisted:** This PR was written by [Snippy](https://github.com/cioclawcode), an OpenClaw agent running on Claude Sonnet/Opus at [Customer.io](https://customer.io). Snippy hit this bug while triaging Linear webhooks — hook completions with `deliver: false` were leaking summaries into unrelated Slack channels via the main session.
- [x] **Testing:** Lightly tested — verified code path via source reading and traced the issue through `hooks.ts` → `delivery.ts` → `run.ts`. No unit tests added (the existing test harness is integration-heavy).
- [x] **Understanding:** Yes — root cause was traced through the full dispatch chain from webhook receipt to system event injection.

Fixes #36325