### PR TITLE
fix: ensure OPENCLAW_VERSION is set in service environment

### DIFF
--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -264,6 +264,10 @@ export function buildServiceEnvironment(params: {
     OPENCLAW_SYSTEMD_UNIT: systemdUnit,
     OPENCLAW_SERVICE_MARKER: GATEWAY_SERVICE_MARKER,
     OPENCLAW_SERVICE_KIND: GATEWAY_SERVICE_KIND,
+    // Set OPENCLAW_VERSION to ensure runtime version takes precedence over
+    // OPENCLAW_SERVICE_VERSION from any existing service scripts.
+    // This fixes version display issues after npm global updates.
+    OPENCLAW_VERSION: VERSION,
     OPENCLAW_SERVICE_VERSION: VERSION,
   };
 }
@@ -287,6 +291,10 @@ export function buildNodeServiceEnvironment(params: {
     OPENCLAW_LOG_PREFIX: "node",
     OPENCLAW_SERVICE_MARKER: NODE_SERVICE_MARKER,
     OPENCLAW_SERVICE_KIND: NODE_SERVICE_KIND,
+    // Set OPENCLAW_VERSION to ensure runtime version takes precedence over
+    // OPENCLAW_SERVICE_VERSION from any existing service scripts.
+    // This fixes version display issues after npm global updates.
+    OPENCLAW_VERSION: VERSION,
     OPENCLAW_SERVICE_VERSION: VERSION,
   };
 }


### PR DESCRIPTION
## Summary

Fixes issue #36301: Gateway UI/Service Version Discrepancy After NPM Global Update.

Adds OPENCLAW_VERSION to the service environment builder to ensure the gateway always reports the correct version after npm global updates.

## Changes

- src/daemon/service-env.ts: Added OPENCLAW_VERSION to buildServiceEnvironment() and buildNodeServiceEnvironment()

## Testing

Existing tests pass (76 tests in daemon package).

Fixes openclaw/openclaw#36301