### PR TITLE
feat(feishu): add filter, sort, field_names, view_id to feishu_bitable_list_records

### DIFF
--- a/extensions/feishu/src/bitable.list-records.test.ts
+++ b/extensions/feishu/src/bitable.list-records.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerFeishuBitableTools } from "./bitable.js";
+import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+
+const mockListRecords = vi.fn();
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: () => ({
+    bitable: {
+      appTableRecord: {
+        list: mockListRecords,
+      },
+    },
+  }),
+}));
+
+function successResponse(items: unknown[] = []) {
+  return {
+    code: 0,
+    data: { items, has_more: false, page_token: undefined, total: items.length },
+  };
+}
+
+function setupHarness() {
+  const cfg = {
+    channels: {
+      feishu: {
+        enabled: true,
+        accounts: {
+          default: { appId: "app-1", appSecret: "sec-1" },
+        },
+      },
+    },
+  } as OpenClawPluginApi["config"];
+  const { api, resolveTool } = createToolFactoryHarness(cfg);
+  registerFeishuBitableTools(api);
+  return resolveTool;
+}
+
+describe("feishu_bitable_list_records filter/sort/field_names passthrough", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("passes filter expression to the Feishu API", async () => {
+    mockListRecords.mockResolvedValue(successResponse());
+    const resolveTool = setupHarness();
+    const tool = resolveTool("feishu_bitable_list_records");
+
+    await tool.execute("call-1", {
+      app_token: "tok",
+      table_id: "tbl",
+      filter: 'CurrentValue.[Status]="Open"',
+    });
+
+    expect(mockListRecords).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({ filter: 'CurrentValue.[Status]="Open"' }),
+      }),
+    );
+  });
+
+  it("serializes sort array to JSON string for the Feishu API", async () => {
+    mockListRecords.mockResolvedValue(successResponse());
+    const resolveTool = setupHarness();
+    const tool = resolveTool("feishu_bitable_list_records");
+
+    await tool.execute("call-2", {
+      app_token: "tok",
+      table_id: "tbl",
+      sort: ["Score:desc", "Name:asc"],
+    });
+
+    expect(mockListRecords).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({ sort: JSON.stringify(["Score:desc", "Name:asc"]) }),
+      }),
+    );
+  });
+
+  it("serializes field_names array to JSON string for the Feishu API", async () => {
+    mockListRecords.mockResolvedValue(successResponse());
+    const resolveTool = setupHarness();
+    const tool = resolveTool("feishu_bitable_list_records");
+
+    await tool.execute("call-3", {
+      app_token: "tok",
+      table_id: "tbl",
+      field_names: ["Name", "Status"],
+    });
+
+    expect(mockListRecords).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({ field_names: JSON.stringify(["Name", "Status"]) }),
+      }),
+    );
+  });
+
+  it("passes view_id to the Feishu API", async () => {
+    mockListRecords.mockResolvedValue(successResponse());
+    const resolveTool = setupHarness();
+    const tool = resolveTool("feishu_bitable_list_records");
+
+    await tool.execute("call-4", { app_token: "tok", table_id: "tbl", view_id: "vew_abc123" });
+
+    expect(mockListRecords).toHaveBeenCalledWith(
+      expect.objectContaining({
+        params: expect.objectContaining({ view_id: "vew_abc123" }),
+      }),
+    );
+  });
+
+  it("omits filter/sort/field_names/view_id from params when not provided", async () => {
+    mockListRecords.mockResolvedValue(successResponse());
+    const resolveTool = setupHarness();
+    const tool = resolveTool("feishu_bitable_list_records");
+
+    await tool.execute("call-5", { app_token: "tok", table_id: "tbl" });
+
+    const callParams = mockListRecords.mock.calls[0][0].params;
+    expect(callParams).not.toHaveProperty("filter");
+    expect(callParams).not.toHaveProperty("sort");
+    expect(callParams).not.toHaveProperty("field_names");
+    expect(callParams).not.toHaveProperty("view_id");
+  });
+});

--- a/extensions/feishu/src/bitable.list-records.test.ts
+++ b/extensions/feishu/src/bitable.list-records.test.ts
@@ -69,12 +69,12 @@ describe("feishu_bitable_list_records filter/sort/field_names passthrough", () =
     await tool.execute("call-2", {
       app_token: "tok",
       table_id: "tbl",
-      sort: ["Score:desc", "Name:asc"],
+      sort: ["Score DESC", "Name ASC"],
     });
 
     expect(mockListRecords).toHaveBeenCalledWith(
       expect.objectContaining({
-        params: expect.objectContaining({ sort: JSON.stringify(["Score:desc", "Name:asc"]) }),
+        params: expect.objectContaining({ sort: JSON.stringify(["Score DESC", "Name ASC"]) }),
       }),
     );
   });

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -179,12 +179,20 @@ async function listRecords(
   tableId: string,
   pageSize?: number,
   pageToken?: string,
+  filter?: string,
+  sort?: string[],
+  fieldNames?: string[],
+  viewId?: string,
 ) {
   const res = await client.bitable.appTableRecord.list({
     path: { app_token: appToken, table_id: tableId },
     params: {
       page_size: pageSize ?? 100,
       ...(pageToken && { page_token: pageToken }),
+      ...(filter && { filter }),
+      ...(sort && sort.length > 0 && { sort: JSON.stringify(sort) }),
+      ...(fieldNames && fieldNames.length > 0 && { field_names: JSON.stringify(fieldNames) }),
+      ...(viewId && { view_id: viewId }),
     },
   });
   ensureLarkSuccess(res, "bitable.appTableRecord.list", { appToken, tableId, pageSize });
@@ -458,6 +466,27 @@ const ListRecordsSchema = Type.Object({
     description: "Bitable app token (use feishu_bitable_get_meta to get from URL)",
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
+  view_id: Type.Optional(
+    Type.String({ description: "View ID to scope the query to a specific view" }),
+  ),
+  filter: Type.Optional(
+    Type.String({
+      description:
+        'Server-side filter expression. Syntax: AND/OR(condition1, condition2, ...). Conditions: CurrentValue.[field]="value", CurrentValue.[field]>123, etc. Example: AND(CurrentValue.[Status]="Open", CurrentValue.[Score]>7)',
+    }),
+  ),
+  sort: Type.Optional(
+    Type.Array(Type.String(), {
+      description:
+        'Array of sort expressions. Example: ["Score:desc", "Name:asc"]. Each entry is "field_name:asc" or "field_name:desc".',
+      items: { description: 'Sort expression as "field_name:asc" or "field_name:desc"' },
+    }),
+  ),
+  field_names: Type.Optional(
+    Type.Array(Type.String(), {
+      description: "Only return these fields (by name). Omit to return all fields.",
+    }),
+  ),
   page_size: Type.Optional(
     Type.Number({
       description: "Number of records per page (1-500, default 100)",
@@ -603,6 +632,10 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
   registerBitableTool<{
     app_token: string;
     table_id: string;
+    view_id?: string;
+    filter?: string;
+    sort?: string[];
+    field_names?: string[];
     page_size?: number;
     page_token?: string;
     accountId?: string;
@@ -618,6 +651,10 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
         params.table_id,
         params.page_size,
         params.page_token,
+        params.filter,
+        params.sort,
+        params.field_names,
+        params.view_id,
       );
     },
   });

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -478,8 +478,7 @@ const ListRecordsSchema = Type.Object({
   sort: Type.Optional(
     Type.Array(Type.String(), {
       description:
-        'Array of sort expressions. Example: ["Score:desc", "Name:asc"]. Each entry is "field_name:asc" or "field_name:desc".',
-      items: { description: 'Sort expression as "field_name:asc" or "field_name:desc"' },
+        'Array of sort expressions. Example: ["Score DESC", "Name ASC"]. Each entry is "field_name DESC" or "field_name ASC".',
     }),
   ),
   field_names: Type.Optional(


### PR DESCRIPTION
## What

Expose the Feishu Bitable list API's server-side filtering, sorting, field projection, and view scoping in the `feishu_bitable_list_records` tool.

## Why

The Feishu `app.table.record.list` API supports powerful server-side parameters (`filter`, `sort`, `field_names`, `view_id`) but the plugin was only passing `page_size` and `page_token`. Agents querying large tables had to fetch **all** records and filter/sort client-side, which:

- Burns unnecessary API quota and tokens
- Is slow on large tables
- Makes it impossible to use the API efficiently in agentic workflows (e.g. "find all open issues sorted by priority")

## How

All four parameters added to `ListRecordsSchema`, `listRecords()`, and the tool registration. All are optional — no behavior change when absent.

| Parameter | Type | Description |
|---|---|---|
| `filter` | `string` | Server-side filter expression. E.g. `AND(CurrentValue.[Status]="Open", CurrentValue.[Score]>7)` |
| `sort` | `string[]` | Sort specs as `["Field:desc", "Name:asc"]` — serialized to JSON string for the API |
| `field_names` | `string[]` | Only return these fields by name — serialized to JSON string for the API |
| `view_id` | `string` | Scope records to a specific table view |

**Note on serialization:** The Feishu API accepts `sort` and `field_names` as JSON strings (not arrays). The tool takes native arrays and serializes internally so agents don't need to manually JSON-encode.

## Testing

```bash
vitest run extensions/feishu/src/bitable.list-records.test.ts
```

5 new tests (one per parameter + no-op case). All pass.

## Breaking Changes

None. All new parameters are optional.