### PR TITLE
fix: default gateway auth mode to none for fresh installs

### DIFF
--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -113,7 +113,7 @@ describe("gateway auth", () => {
         } as NodeJS.ProcessEnv,
       }),
     ).toMatchObject({
-      mode: "token",
+      mode: "none",
       modeSource: "default",
       token: undefined,
       password: undefined,

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -270,7 +270,7 @@ export function resolveGatewayAuth(params: {
     mode = "token";
     modeSource = "token";
   } else {
-    mode = "token";
+    mode = "none";
     modeSource = "default";
   }
 


### PR DESCRIPTION
## Summary

On a fresh OpenClaw install with no auth configured, the gateway incorrectly defaulted to token auth mode. This caused the TUI to fail with token_mismatch errors (HTTP 401) when connecting, because the TUI didnt have a token configured.

This fix changes the default auth mode from token to none when no token or password is configured, allowing fresh installs to work without authentication errors.

## Changes

- src/gateway/auth.ts: Changed default mode from token to none when no auth is configured
- src/gateway/auth.test.ts: Updated test to expect the new default behavior

## Testing

- All gateway auth tests pass (31 tests)
- Fixes openclaw/openclaw#36270
