### PR TITLE
doctor: ignore HOME path when scanning gateway-like services

### DIFF
--- a/src/cli/daemon-cli.coverage.test.ts
+++ b/src/cli/daemon-cli.coverage.test.ts
@@ -17,12 +17,31 @@ const serviceReadCommand = vi.fn().mockResolvedValue(null);
 const serviceReadRuntime = vi.fn().mockResolvedValue({ status: "running" });
 const resolveGatewayProbeAuthWithSecretInputs = vi.fn(async (_opts?: unknown) => ({}));
 const findExtraGatewayServices = vi.fn(async (_env: unknown, _opts?: unknown) => []);
+const auditGatewayServiceConfig = vi.fn(async (_opts?: unknown) => undefined);
 const inspectPortUsage = vi.fn(async (port: number) => ({
   port,
   status: "free",
   listeners: [],
   hints: [],
 }));
+const resolveGatewayBindHost = vi.fn(
+  async (_bindMode?: string, _customBindHost?: string) => "127.0.0.1",
+);
+const pickPrimaryTailnetIPv4 = vi.fn(() => "100.64.0.9");
+const loadGatewayTlsRuntime = vi.fn(async (_cfg?: unknown) => ({
+  enabled: false,
+  required: false,
+}));
+const resolveGatewayPort = vi.fn((_cfg?: unknown, env?: NodeJS.ProcessEnv) => {
+  const fromEnv = env?.OPENCLAW_GATEWAY_PORT;
+  return fromEnv ? Number(fromEnv) : 18789;
+});
+const resolveStateDir = vi.fn(
+  (env: NodeJS.ProcessEnv) => env.OPENCLAW_STATE_DIR ?? "/tmp/openclaw-cli-state",
+);
+const resolveConfigPath = vi.fn((env: NodeJS.ProcessEnv, stateDir: string) => {
+  return env.OPENCLAW_CONFIG_PATH ?? `${stateDir}/openclaw.json`;
+});
 const buildGatewayInstallPlan = vi.fn(
   async (params: { port: number; token?: string; env?: NodeJS.ProcessEnv }) => ({
     programArguments: ["/bin/node", "cli", "gateway", "--port", String(params.port)],
@@ -100,9 +119,43 @@ vi.mock("../daemon/inspect.js", () => ({
   renderGatewayServiceCleanupHints: () => [],
 }));
 
+vi.mock("../daemon/service-audit.js", () => ({
+  auditGatewayServiceConfig: (opts: unknown) => auditGatewayServiceConfig(opts),
+}));
+
 vi.mock("../infra/ports.js", () => ({
   inspectPortUsage: (port: number) => inspectPortUsage(port),
   formatPortDiagnostics: () => ["Port 18789 is already in use."],
+}));
+
+vi.mock("../gateway/net.js", () => ({
+  resolveGatewayBindHost: (bindMode: string, customBindHost?: string) =>
+    resolveGatewayBindHost(bindMode, customBindHost),
+}));
+
+vi.mock("../infra/tailnet.js", () => ({
+  pickPrimaryTailnetIPv4: () => pickPrimaryTailnetIPv4(),
+}));
+
+vi.mock("../infra/tls/gateway.js", () => ({
+  loadGatewayTlsRuntime: (cfg: unknown) => loadGatewayTlsRuntime(cfg),
+}));
+
+vi.mock("../config/config.js", () => ({
+  createConfigIO: ({ configPath }: { configPath: string }) => ({
+    readConfigFileSnapshot: async () => ({
+      path: configPath,
+      exists: true,
+      valid: true,
+      issues: [],
+    }),
+    loadConfig: () => ({}),
+  }),
+  loadConfig: () => ({}),
+  readBestEffortConfig: async () => ({}),
+  resolveConfigPath: (env: NodeJS.ProcessEnv, stateDir: string) => resolveConfigPath(env, stateDir),
+  resolveGatewayPort: (cfg?: unknown, env?: NodeJS.ProcessEnv) => resolveGatewayPort(cfg, env),
+  resolveStateDir: (env: NodeJS.ProcessEnv) => resolveStateDir(env),
 }));
 
 vi.mock("../runtime.js", async () => ({
@@ -156,6 +209,16 @@ describe("daemon-cli coverage", () => {
     process.env.OPENCLAW_CONFIG_PATH = "/tmp/openclaw-cli-state/openclaw.json";
     delete process.env.OPENCLAW_GATEWAY_PORT;
     delete process.env.OPENCLAW_PROFILE;
+    serviceInstall.mockClear();
+    serviceUninstall.mockClear();
+    serviceStop.mockClear();
+    serviceRestart.mockClear();
+    serviceIsLoaded.mockReset().mockResolvedValue(false);
+    serviceReadRuntime.mockReset().mockResolvedValue({ status: "running" });
+    findExtraGatewayServices.mockClear();
+    inspectPortUsage.mockClear();
+    probeGatewayStatus.mockClear();
+    auditGatewayServiceConfig.mockClear();
     serviceReadCommand.mockResolvedValue(null);
     resolveGatewayProbeAuthWithSecretInputs.mockClear();
     buildGatewayInstallPlan.mockClear();

--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -1,8 +1,10 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { detectMarkerLineWithGateway, findExtraGatewayServices } from "./inspect.js";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+let findExtraGatewayServices: typeof import("./inspect.js").findExtraGatewayServices;
+let inspectTestUtils: typeof import("./inspect.js").__test__;
 
 const { execSchtasksMock } = vi.hoisted(() => ({
   execSchtasksMock: vi.fn(),
@@ -12,129 +14,92 @@ vi.mock("./schtasks-exec.js", () => ({
   execSchtasks: (...args: unknown[]) => execSchtasksMock(...args),
 }));
 
-// Real content from the openclaw-gateway.service unit file (the canonical gateway unit).
-const GATEWAY_SERVICE_CONTENTS = `\
-[Unit]
-Description=OpenClaw Gateway (v2026.3.8)
-After=network-online.target
-Wants=network-online.target
-
-[Service]
-ExecStart=/usr/bin/node /home/openclaw/.npm-global/lib/node_modules/openclaw/dist/entry.js gateway --port 18789
-Restart=always
-Environment=OPENCLAW_SERVICE_MARKER=openclaw
-Environment=OPENCLAW_SERVICE_KIND=gateway
-Environment=OPENCLAW_SERVICE_VERSION=2026.3.8
-
-[Install]
-WantedBy=default.target
-`;
-
-// Real content from the openclaw-test.service unit file (a non-gateway openclaw service).
-const TEST_SERVICE_CONTENTS = `\
-[Unit]
-Description=OpenClaw test service
-After=default.target
-
-[Service]
-Type=simple
-ExecStart=/bin/sh -c 'while true; do sleep 60; done'
-Restart=on-failure
-
-[Install]
-WantedBy=default.target
-`;
-
-const CLAWDBOT_GATEWAY_CONTENTS = `\
-[Unit]
-Description=Clawdbot Gateway
-[Service]
-ExecStart=/usr/bin/node /opt/clawdbot/dist/entry.js gateway --port 18789
-Environment=HOME=/home/clawdbot
-`;
-
-describe("detectMarkerLineWithGateway", () => {
-  it("returns null for openclaw-test.service (openclaw only in description, no gateway on same line)", () => {
-    expect(detectMarkerLineWithGateway(TEST_SERVICE_CONTENTS)).toBeNull();
-  });
-
-  it("returns openclaw for the canonical gateway unit (ExecStart has both openclaw and gateway)", () => {
-    expect(detectMarkerLineWithGateway(GATEWAY_SERVICE_CONTENTS)).toBe("openclaw");
-  });
-
-  it("returns clawdbot for a clawdbot gateway unit", () => {
-    expect(detectMarkerLineWithGateway(CLAWDBOT_GATEWAY_CONTENTS)).toBe("clawdbot");
-  });
-
-  it("handles line continuations — marker and gateway split across physical lines", () => {
-    const contents = `[Service]\nExecStart=/usr/bin/node /opt/openclaw/dist/entry.js \\\n  gateway --port 18789\n`;
-    expect(detectMarkerLineWithGateway(contents)).toBe("openclaw");
-  });
+beforeAll(async () => {
+  ({ findExtraGatewayServices, __test__: inspectTestUtils } = await import("./inspect.js"));
 });
 
-describe("findExtraGatewayServices (linux / scanSystemdDir) — real filesystem", () => {
-  // These tests write real .service files to a temp dir and call findExtraGatewayServices
-  // with that dir as HOME. No platform mocking or fs mocking needed.
-  // Only runs on Linux/macOS where the linux branch of findExtraGatewayServices is active.
-  const isLinux = process.platform === "linux";
-
-  it.skipIf(!isLinux)("does not report openclaw-test.service as a gateway service", async () => {
-    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
-    const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
-    try {
-      await fs.mkdir(systemdDir, { recursive: true });
-      await fs.writeFile(path.join(systemdDir, "openclaw-test.service"), TEST_SERVICE_CONTENTS);
-      const result = await findExtraGatewayServices({ HOME: tmpHome });
-      expect(result).toEqual([]);
-    } finally {
-      await fs.rm(tmpHome, { recursive: true, force: true });
-    }
+describe("detectMarker", () => {
+  it("ignores markers that only appear in a POSIX HOME path", () => {
+    const marker = inspectTestUtils.detectMarker("ExecStart=/home/moltbot/.local/bin/helper", {
+      HOME: "/home/moltbot",
+    });
+    expect(marker).toBeNull();
   });
 
-  it.skipIf(!isLinux)(
-    "does not report the canonical openclaw-gateway.service as an extra service",
-    async () => {
-      const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
-      const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
-      try {
-        await fs.mkdir(systemdDir, { recursive: true });
-        await fs.writeFile(
-          path.join(systemdDir, "openclaw-gateway.service"),
-          GATEWAY_SERVICE_CONTENTS,
-        );
-        const result = await findExtraGatewayServices({ HOME: tmpHome });
-        expect(result).toEqual([]);
-      } finally {
-        await fs.rm(tmpHome, { recursive: true, force: true });
-      }
-    },
-  );
+  it("ignores markers that only appear in a Windows HOME path", () => {
+    const marker = inspectTestUtils.detectMarker(
+      "ExecStart=C:\\Users\\MoltBot\\tools\\helper.exe",
+      { HOME: "C:\\Users\\MoltBot" },
+    );
+    expect(marker).toBeNull();
+  });
 
-  it.skipIf(!isLinux)(
-    "reports a legacy clawdbot-gateway service as an extra gateway service",
-    async () => {
-      const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
-      const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
-      const unitPath = path.join(systemdDir, "clawdbot-gateway.service");
-      try {
-        await fs.mkdir(systemdDir, { recursive: true });
-        await fs.writeFile(unitPath, CLAWDBOT_GATEWAY_CONTENTS);
-        const result = await findExtraGatewayServices({ HOME: tmpHome });
-        expect(result).toEqual([
-          {
-            platform: "linux",
-            label: "clawdbot-gateway.service",
-            detail: `unit: ${unitPath}`,
-            scope: "user",
-            marker: "clawdbot",
-            legacy: true,
-          },
-        ]);
-      } finally {
-        await fs.rm(tmpHome, { recursive: true, force: true });
-      }
-    },
-  );
+  it("scrubs markers when Windows HOME separators use slash variants", () => {
+    const marker = inspectTestUtils.detectMarker("ExecStart=C:/Users/MoltBot/tools/helper.exe", {
+      HOME: "C:\\Users\\MoltBot",
+    });
+    expect(marker).toBeNull();
+  });
+
+  it("scrubs HOME paths inside XML string boundaries", () => {
+    const marker = inspectTestUtils.detectMarker("<string>/Users/MoltBot/tools/helper</string>", {
+      HOME: "/Users/MoltBot",
+    });
+    expect(marker).toBeNull();
+  });
+
+  it("scrubs HOME paths at CRLF line endings", () => {
+    const marker = inspectTestUtils.detectMarker("Environment=HOME=/home/moltbot\r\n", {
+      HOME: "/home/moltbot",
+    });
+    expect(marker).toBeNull();
+  });
+
+  it("scrubs XML HOME paths before CRLF line endings", () => {
+    const marker = inspectTestUtils.detectMarker(
+      "<string>/Users/MoltBot/tools/helper</string>\r\n",
+      {
+        HOME: "/Users/MoltBot",
+      },
+    );
+    expect(marker).toBeNull();
+  });
+
+  it("scrubs POSIX HOME paths when HOME has a trailing slash", () => {
+    const marker = inspectTestUtils.detectMarker("ExecStart=/home/moltbot/.local/bin/helper", {
+      HOME: "/home/moltbot/",
+    });
+    expect(marker).toBeNull();
+  });
+
+  it("scrubs Windows task paths when HOME uses POSIX drive syntax", () => {
+    const marker = inspectTestUtils.detectMarker("Task To Run: C:\\Users\\MoltBot\\helper.exe", {
+      HOME: "/c/Users/MoltBot",
+    });
+    expect(marker).toBeNull();
+  });
+
+  it("scrubs Windows HOME paths when USERPROFILE has a trailing slash", () => {
+    const marker = inspectTestUtils.detectMarker("Task To Run: C:\\Users\\MoltBot\\helper.exe", {
+      USERPROFILE: "C:\\Users\\MoltBot\\",
+    });
+    expect(marker).toBeNull();
+  });
+
+  it("still detects markers that appear outside HOME", () => {
+    const marker = inspectTestUtils.detectMarker("ExecStart=/opt/clawdbot/bin/clawdbot run", {
+      HOME: "/home/openclaw",
+    });
+    expect(marker).toBe("clawdbot");
+  });
+
+  it("does not scrub HOME when it appears mid-path", () => {
+    const marker = inspectTestUtils.detectMarker(
+      "ExecStart=/home/useropenclaw/bin/openclaw gateway run",
+      { HOME: "/home/user" },
+    );
+    expect(marker).toBe("openclaw");
+  });
 });
 
 describe("findExtraGatewayServices (win32)", () => {
@@ -200,5 +165,97 @@ describe("findExtraGatewayServices (win32)", () => {
         legacy: true,
       },
     ]);
+  });
+});
+
+describe("findExtraGatewayServices (linux)", () => {
+  const originalPlatform = process.platform;
+  const originalHome = process.env.HOME;
+  let tempHome: string;
+
+  beforeEach(async () => {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: "linux",
+    });
+    tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-home-"));
+    process.env.HOME = tempHome;
+    await fs.mkdir(path.join(tempHome, ".config", "systemd", "user"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: originalPlatform,
+    });
+    process.env.HOME = originalHome;
+    if (tempHome) {
+      await fs.rm(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps legacy systemd units when only the unit name carries the marker", async () => {
+    const servicePath = path.join(
+      tempHome,
+      ".config",
+      "systemd",
+      "user",
+      "clawdbot-gateway.service",
+    );
+    await fs.writeFile(
+      servicePath,
+      ["[Service]", `ExecStart=${tempHome}/bin/gateway run`].join("\n"),
+    );
+
+    const result = await findExtraGatewayServices({ HOME: tempHome });
+    expect(result).toEqual([
+      {
+        platform: "linux",
+        label: "clawdbot-gateway.service",
+        detail: `unit: ${servicePath}`,
+        scope: "user",
+        marker: "clawdbot",
+        legacy: true,
+      },
+    ]);
+  });
+
+  it("does not report non-gateway openclaw helper units", async () => {
+    const servicePath = path.join(tempHome, ".config", "systemd", "user", "openclaw-node.service");
+    await fs.writeFile(
+      servicePath,
+      ["[Service]", "ExecStart=/opt/openclaw/bin/helper run"].join("\n"),
+    );
+
+    const result = await findExtraGatewayServices({ HOME: tempHome });
+    expect(result).toEqual([]);
+  });
+
+  it("does not report legacy-prefixed units that are not gateway services", async () => {
+    const servicePath = path.join(tempHome, ".config", "systemd", "user", "moltbot-backup.service");
+    await fs.writeFile(
+      servicePath,
+      ["[Service]", `ExecStart=${tempHome}/bin/backup run`].join("\n"),
+    );
+
+    const result = await findExtraGatewayServices({ HOME: tempHome });
+    expect(result).toEqual([]);
+  });
+
+  it("does not report legacy gateway near-matches that are not exact legacy unit names", async () => {
+    const servicePath = path.join(
+      tempHome,
+      ".config",
+      "systemd",
+      "user",
+      "moltbot-gateway-helper.service",
+    );
+    await fs.writeFile(
+      servicePath,
+      ["[Service]", `ExecStart=${tempHome}/bin/helper run`].join("\n"),
+    );
+
+    const result = await findExtraGatewayServices({ HOME: tempHome });
+    expect(result).toEqual([]);
   });
 });

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import {
   GATEWAY_SERVICE_KIND,
   GATEWAY_SERVICE_MARKER,
+  LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES,
   resolveGatewayLaunchAgentLabel,
   resolveGatewaySystemdServiceName,
   resolveGatewayWindowsTaskName,
@@ -52,25 +53,139 @@ export function renderGatewayServiceCleanupHints(
 
 type Marker = (typeof EXTRA_MARKERS)[number];
 
-function detectMarker(content: string): Marker | null {
-  const lower = content.toLowerCase();
+type PathChar = string;
+
+const PATH_BOUNDARY_CHARS = new Set<PathChar>([
+  "",
+  "/",
+  "\\",
+  "\n",
+  "\r",
+  "\t",
+  " ",
+  '"',
+  "'",
+  ":",
+  "=",
+  "<",
+  ">",
+]);
+
+function isBoundaryChar(char: PathChar | undefined): boolean {
+  return PATH_BOUNDARY_CHARS.has(char ?? "");
+}
+
+function scrubHomePath(lower: string, home: string): string {
+  if (!home) {
+    return lower;
+  }
+  const homeLower = home.toLowerCase();
+  let out = "";
+  let idx = 0;
+  while (idx < lower.length) {
+    const hit = lower.indexOf(homeLower, idx);
+    if (hit === -1) {
+      out += lower.slice(idx);
+      break;
+    }
+    const before = hit === 0 ? "" : lower[hit - 1];
+    const after = lower[hit + homeLower.length] ?? "";
+    const isStartBoundary = hit === 0 || isBoundaryChar(before);
+    const isEndBoundary = isBoundaryChar(after);
+    if (isStartBoundary && isEndBoundary) {
+      out += lower.slice(idx, hit);
+      idx = hit + homeLower.length;
+      continue;
+    }
+    out += lower.slice(idx, hit + homeLower.length);
+    idx = hit + homeLower.length;
+  }
+  return out;
+}
+
+function toWindowsDrivePath(home: string): string | null {
+  const match = home.match(/^\/([a-z])\/(.+)$/i);
+  if (!match) {
+    return null;
+  }
+  const drive = match[1]?.toLowerCase();
+  const rest = match[2];
+  if (!drive || !rest) {
+    return null;
+  }
+  return `${drive}:/${rest}`;
+}
+
+function normalizeHomeVariant(home: string): string {
+  if (!home) {
+    return home;
+  }
+  if (home === "/" || home === "\\") {
+    return home;
+  }
+  if (/^[a-z]:[/\\]?$/i.test(home)) {
+    return `${home[0]}:`;
+  }
+  return home.replace(/[/\\]+$/g, "");
+}
+
+function resolveHomeVariants(env: Record<string, string | undefined>): string[] {
+  const variants = new Set<string>();
+  const addVariant = (value: string | undefined) => {
+    const lowered = value?.trim().toLowerCase();
+    const trimmed = lowered ? normalizeHomeVariant(lowered) : "";
+    if (!trimmed) {
+      return;
+    }
+    variants.add(trimmed);
+    variants.add(trimmed.replaceAll("\\", "/"));
+    variants.add(trimmed.replaceAll("/", "\\"));
+    const windowsDrive = toWindowsDrivePath(trimmed);
+    if (windowsDrive) {
+      variants.add(windowsDrive);
+      variants.add(windowsDrive.replaceAll("/", "\\"));
+    }
+  };
+
+  addVariant(env.HOME);
+  addVariant(env.USERPROFILE);
+  return [...variants];
+}
+
+function scrubHomeVariants(content: string, env: Record<string, string | undefined>): string {
+  let scrubbed = content.toLowerCase();
+  try {
+    const homes = resolveHomeVariants(env);
+    for (const home of homes) {
+      scrubbed = scrubHomePath(scrubbed, home);
+    }
+  } catch {}
+  return scrubbed;
+}
+
+function detectMarker(content: string, env: Record<string, string | undefined>): Marker | null {
+  const scrubbed = scrubHomeVariants(content, env);
   for (const marker of EXTRA_MARKERS) {
-    if (lower.includes(marker)) {
+    if (scrubbed.includes(marker)) {
       return marker;
     }
   }
   return null;
 }
 
-export function detectMarkerLineWithGateway(contents: string): Marker | null {
+export function detectMarkerLineWithGateway(
+  contents: string,
+  env: Record<string, string | undefined>,
+): Marker | null {
   // Join line continuations (trailing backslash) into single lines
   const lower = contents.replace(/\\\r?\n\s*/g, " ").toLowerCase();
   for (const line of lower.split(/\r?\n/)) {
     if (!line.includes("gateway")) {
       continue;
     }
+    const scrubbed = scrubHomeVariants(line, env);
     for (const marker of EXTRA_MARKERS) {
-      if (line.includes(marker)) {
+      if (scrubbed.includes(marker)) {
         return marker;
       }
     }
@@ -145,6 +260,11 @@ function isLegacyLabel(label: string): boolean {
   return lower.includes("clawdbot");
 }
 
+function isLegacyGatewayUnitName(name: string): boolean {
+  const lower = name.toLowerCase();
+  return LEGACY_GATEWAY_SYSTEMD_SERVICE_NAMES.includes(lower);
+}
+
 async function readDirEntries(dir: string): Promise<string[]> {
   try {
     return await fs.readdir(dir);
@@ -196,6 +316,7 @@ async function collectServiceFiles(params: {
 async function scanLaunchdDir(params: {
   dir: string;
   scope: "user" | "system";
+  env: Record<string, string | undefined>;
 }): Promise<ExtraGatewayService[]> {
   const results: ExtraGatewayService[] = [];
   const candidates = await collectServiceFiles({
@@ -205,7 +326,7 @@ async function scanLaunchdDir(params: {
   });
 
   for (const { name: labelFromName, fullPath, contents } of candidates) {
-    const marker = detectMarker(contents);
+    const marker = detectMarker(contents, params.env);
     const label = tryExtractPlistLabel(contents) ?? labelFromName;
     if (!marker) {
       const legacyLabel = isLegacyLabel(labelFromName) || isLegacyLabel(label);
@@ -244,6 +365,7 @@ async function scanLaunchdDir(params: {
 async function scanSystemdDir(params: {
   dir: string;
   scope: "user" | "system";
+  env: Record<string, string | undefined>;
 }): Promise<ExtraGatewayService[]> {
   const results: ExtraGatewayService[] = [];
   const candidates = await collectServiceFiles({
@@ -253,7 +375,9 @@ async function scanSystemdDir(params: {
   });
 
   for (const { entry, name, fullPath, contents } of candidates) {
-    const marker = detectMarkerLineWithGateway(contents);
+    const marker =
+      detectMarkerLineWithGateway(contents, params.env) ??
+      (isLegacyGatewayUnitName(name) ? detectMarker(entry, params.env) : null);
     if (!marker) {
       continue;
     }
@@ -321,6 +445,11 @@ function parseSchtasksList(output: string): ScheduledTaskInfo[] {
   return tasks;
 }
 
+export const __test__ = {
+  detectMarker,
+  scrubHomePath,
+};
+
 export async function findExtraGatewayServices(
   env: Record<string, string | undefined>,
   opts: FindExtraGatewayServicesOptions = {},
@@ -343,6 +472,7 @@ export async function findExtraGatewayServices(
       for (const svc of await scanLaunchdDir({
         dir: userDir,
         scope: "user",
+        env,
       })) {
         push(svc);
       }
@@ -350,12 +480,14 @@ export async function findExtraGatewayServices(
         for (const svc of await scanLaunchdDir({
           dir: path.join(path.sep, "Library", "LaunchAgents"),
           scope: "system",
+          env,
         })) {
           push(svc);
         }
         for (const svc of await scanLaunchdDir({
           dir: path.join(path.sep, "Library", "LaunchDaemons"),
           scope: "system",
+          env,
         })) {
           push(svc);
         }
@@ -373,6 +505,7 @@ export async function findExtraGatewayServices(
       for (const svc of await scanSystemdDir({
         dir: userDir,
         scope: "user",
+        env,
       })) {
         push(svc);
       }
@@ -385,6 +518,7 @@ export async function findExtraGatewayServices(
           for (const svc of await scanSystemdDir({
             dir,
             scope: "system",
+            env,
           })) {
             push(svc);
           }
@@ -413,15 +547,7 @@ export async function findExtraGatewayServices(
       if (isOpenClawGatewayTaskName(name)) {
         continue;
       }
-      const lowerName = name.toLowerCase();
-      const lowerCommand = task.taskToRun?.toLowerCase() ?? "";
-      let marker: Marker | null = null;
-      for (const candidate of EXTRA_MARKERS) {
-        if (lowerName.includes(candidate) || lowerCommand.includes(candidate)) {
-          marker = candidate;
-          break;
-        }
-      }
+      const marker = detectMarker(`${name}\n${task.taskToRun ?? ""}`, env);
       if (!marker) {
         continue;
       }


### PR DESCRIPTION
## Summary

- Problem: Doctor flags unrelated services when marker strings appear in $HOME paths.
- Why: False positives + noisy cleanup hints.
- Change: Scrub $HOME from service file contents before marker detection.
- Scope: Heuristic scan only; no gateway logic changes.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

Doctor no longer reports unrelated user services when marker strings appear only in HOME paths.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

* OS: Ubuntu 24.04 (noble)
* Runtime/container: host
* Model/provider: N/A
* Integration/channel (if any): N/A
* Relevant config (redacted): systemd user service under ~/.config/systemd/user/

### Steps
1. Create a user service with paths under /home/moltbot/...
2. Run openclaw doctor
3. Observe “Other gateway-like services detected” pointing at your-other-service.service

### Expected
Doctor does not flag services where markers appear only inside HOME paths.

### Actual
Before fix: false positive flagged
After fix: no warning.

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Reproduced the false positive on Linux by using a username that includes a marker string (`moltbot`), so marker text appeared in `$HOME` paths.
  - Ran `openclaw doctor` before this change and confirmed it reported an unrelated gateway-like service.
  - Ran `openclaw doctor` after this change and confirmed the false positive no longer appears.

- Edge cases checked:
  - Marker string present via username/home path (`/home/moltbot/...`) rather than true gateway service content.

- What you did **not** verify:
  - Windows behavior.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

* How to disable/revert this change quickly: revert this commit
* Files/config to restore: src/daemon/inspect.ts, src/daemon/inspect.test.ts
* Known bad symptoms reviewers should watch for: gateway-like services no longer detected if marker only appears in HOME path (expected)

## Risks and Mitigations

* Risk: A real gateway service whose only marker is inside $HOME path might be missed.
* Mitigation: Gateway detection also checks service name/labels; markers in non-home paths (e.g., ExecStart) still detected.


