### PR TITLE
fix: normalizeToolParams file_path alias skipped when path is empty string [AI-assisted]

### DIFF
--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -92,7 +92,10 @@ export function normalizeToolParams(params: unknown): Record<string, unknown> | 
   const record = params as Record<string, unknown>;
   const normalized = { ...record };
   // file_path → path (read, write, edit)
-  if ("file_path" in normalized && !("path" in normalized)) {
+  // Use truthy checks: when a model emits both file_path (non-empty) and path (""),
+  // the "in" operator sees path as present, skipping the alias and leaving path as ""
+  // which causes lstat("") → EISDIR/ENOENT.
+  if (normalized.file_path && !normalized.path) {
     normalized.path = normalized.file_path;
     delete normalized.file_path;
   }


### PR DESCRIPTION
## Summary

- **Problem:** When a model emits both `file_path` (non-empty) and `path` (`""`), the `"path" in normalized` check returns `true` (key exists), so the `file_path→path` alias is skipped. The empty `path` then causes `lstat("")` → `EISDIR` or `ENOENT`.
- **Why it matters:** Models (especially Claude Code-trained ones) sometimes emit both fields simultaneously.
- **What changed:** Switched from `"key" in obj` to truthy checks (`normalized.file_path && !normalized.path`) for the `file_path→path` alias pair only.
- **What did NOT change:** `old_string→oldText` and `new_string→newText` aliases are left unchanged, since `new_string: ""` is a valid deletion operation (`allowEmpty: true` in `CLAUDE_PARAM_GROUPS`).

## Change Type

- [x] Bug fix

## Scope

- [x] Skills / tool execution

## Linked Issue/PR

- Supersedes #36072 (closed — that PR over-applied truthy checks to all three alias pairs, introducing a regression for `new_string: ""` content deletion)

## User-visible / Behavior Changes

Passing `file_path: "/some/file"` alongside `path: ""` now correctly resolves to `/some/file` instead of throwing `EISDIR`.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Have a model call `read` with `{ file_path: "/some/file.md", path: "", offset: 1, limit: 400 }`
2. Observe error: `EISDIR: illegal operation on a directory, read`

### Expected

`file_path` alias applies, file is read correctly.

### Actual

`path: ""` blocks the alias, `lstat("")` fails.

## Evidence

- [x] Trace/log snippets: Error reproduced and documented in local OpenClaw instance

## Human Verification

- Verified: Applied fix to local dist files, confirmed `file_path` alias works when `path` is empty string
- Edge cases: Verified `new_string: ""` deletion still works (unchanged alias logic)
- Not verified: Full CI suite (pre-existing failures unrelated to this change)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery

- Revert this single commit
- No config changes needed

## Risks and Mitigations

None — only the `file_path→path` alias is changed. Empty strings are never valid file paths.

---

🤖 **AI-assisted:** Fix identified and implemented by an OpenClaw agent (码哥/coder). Reviewed after bot feedback on #36072 identified the `new_string: ""` regression.