### PR TITLE
feat(browser): add ignoreCertificateErrors config option

### DIFF
--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -262,6 +262,9 @@ export async function launchOpenClawChrome(
       args.push("--no-sandbox");
       args.push("--disable-setuid-sandbox");
     }
+    if (resolved.ignoreCertificateErrors) {
+      args.push("--ignore-certificate-errors");
+    }
     if (process.platform === "linux") {
       args.push("--disable-dev-shm-usage");
     }

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -35,6 +35,7 @@ export type ResolvedBrowserConfig = {
   defaultProfile: string;
   profiles: Record<string, BrowserProfileConfig>;
   ssrfPolicy?: SsrFPolicy;
+  ignoreCertificateErrors: boolean;
   extraArgs: string[];
 };
 
@@ -253,6 +254,7 @@ export function resolveBrowserConfig(
   const headless = cfg?.headless === true;
   const noSandbox = cfg?.noSandbox === true;
   const attachOnly = cfg?.attachOnly === true;
+  const ignoreCertificateErrors = cfg?.ignoreCertificateErrors === true;
   const executablePath = cfg?.executablePath?.trim() || undefined;
 
   const defaultProfileFromConfig = cfg?.defaultProfile?.trim() || undefined;
@@ -296,6 +298,7 @@ export function resolveBrowserConfig(
     defaultProfile,
     profiles,
     ssrfPolicy,
+    ignoreCertificateErrors,
     extraArgs,
   };
 }

--- a/src/config/types.browser.ts
+++ b/src/config/types.browser.ts
@@ -61,6 +61,13 @@ export type BrowserConfig = {
   /** SSRF policy for browser navigation/open-tab operations. */
   ssrfPolicy?: BrowserSsrFPolicyConfig;
   /**
+   * If true, pass --ignore-certificate-errors to Chrome.
+   * Useful for testing against self-signed certificates.
+   * Warning: This reduces security - only use in trusted environments.
+   * Default: false
+   */
+  ignoreCertificateErrors?: boolean;
+  /**
    * Additional Chrome launch arguments.
    * Useful for stealth flags, window size overrides, or custom user-agent strings.
    * Example: ["--window-size=1920,1080", "--disable-infobars"]


### PR DESCRIPTION
## Problem
When testing against servers with self-signed certificates, Chrome blocks navigation with net::ERR_CERT_AUTHORITY_INVALID. There was no config option to pass --ignore-certificate-errors to Chrome.

## Solution
Add browser.ignoreCertificateErrors config option that passes the --ignore-certificate-errors flag to Chrome when launching.

## Changes
- src/config/types.browser.ts: Add ignoreCertificateErrors boolean to BrowserConfig
- src/browser/config.ts: Add to ResolvedBrowserConfig and resolve logic
- src/browser/chrome.ts: Pass --ignore-certificate-errors when enabled

Fixes #35858

---

AI-assisted PR - Testing: untested (CI will verify)