### PR TITLE
gateway: keep health runtime channel state consistent with selected account

### DIFF
--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -1,11 +1,117 @@
+import type { ChannelAccountSnapshot } from "../../channels/plugins/types.js";
+import type {
+  ChannelAccountHealthSummary,
+  ChannelHealthSummary,
+  HealthSummary,
+} from "../../commands/health.js";
 import { getStatusSummary } from "../../commands/status.js";
 import { ErrorCodes, errorShape } from "../protocol/index.js";
+import type { ChannelRuntimeSnapshot } from "../server-channels.js";
 import { HEALTH_REFRESH_INTERVAL_MS } from "../server-constants.js";
 import { formatError } from "../server-utils.js";
 import { formatForLog } from "../ws-log.js";
 import type { GatewayRequestHandlers } from "./types.js";
 
 const ADMIN_SCOPE = "operator.admin";
+const RUNTIME_MIRROR_FIELDS = [
+  "running",
+  "connected",
+  "reconnectAttempts",
+  "lastConnectedAt",
+  "lastDisconnect",
+  "lastMessageAt",
+  "lastEventAt",
+  "lastError",
+  "lastStartAt",
+  "lastStopAt",
+] as const;
+
+type RuntimeMirrorField = (typeof RUNTIME_MIRROR_FIELDS)[number];
+
+function mergeRuntimeFields(
+  base: ChannelAccountHealthSummary,
+  runtime?: ChannelAccountSnapshot,
+): ChannelAccountHealthSummary {
+  if (!runtime) {
+    return base;
+  }
+  let changed = false;
+  const next: ChannelAccountHealthSummary = { ...base };
+  for (const field of RUNTIME_MIRROR_FIELDS) {
+    const runtimeValue = runtime[field as RuntimeMirrorField];
+    if (runtimeValue === undefined) {
+      continue;
+    }
+    if (next[field] === runtimeValue) {
+      continue;
+    }
+    next[field] = runtimeValue;
+    changed = true;
+  }
+  return changed ? next : base;
+}
+
+function mergeRuntimeSnapshot(
+  summary: HealthSummary,
+  runtime: ChannelRuntimeSnapshot,
+): HealthSummary {
+  const runtimeChannels = runtime.channels ?? {};
+  const runtimeAccounts = runtime.channelAccounts ?? {};
+  let channels = summary.channels;
+  let changed = false;
+
+  for (const [channelId, runtimeChannel] of Object.entries(runtimeChannels)) {
+    const currentChannel = channels[channelId];
+    if (!currentChannel || !runtimeChannel) {
+      continue;
+    }
+    const accountRuntimeMap = runtimeAccounts[channelId];
+    const hasAccountRuntimeMap = !!accountRuntimeMap && Object.keys(accountRuntimeMap).length > 0;
+    const preferredRuntimeAccount =
+      hasAccountRuntimeMap && currentChannel.accountId
+        ? accountRuntimeMap[currentChannel.accountId]
+        : undefined;
+    const channelRuntime =
+      preferredRuntimeAccount ?? (hasAccountRuntimeMap ? undefined : runtimeChannel);
+    let nextChannel = mergeRuntimeFields(currentChannel, channelRuntime) as ChannelHealthSummary;
+    if (hasAccountRuntimeMap) {
+      const currentAccounts = currentChannel.accounts ?? {};
+      let nextAccounts = currentAccounts;
+      for (const [accountId, runtimeAccount] of Object.entries(accountRuntimeMap)) {
+        if (!runtimeAccount) {
+          continue;
+        }
+        const currentAccount = currentAccounts[accountId];
+        if (!currentAccount) {
+          continue;
+        }
+        const mergedAccount = mergeRuntimeFields(currentAccount, runtimeAccount);
+        if (mergedAccount === currentAccount) {
+          continue;
+        }
+        if (nextAccounts === currentAccounts) {
+          nextAccounts = { ...currentAccounts };
+        }
+        nextAccounts[accountId] = mergedAccount;
+      }
+      if (nextAccounts !== currentAccounts) {
+        if (nextChannel === currentChannel) {
+          nextChannel = { ...nextChannel };
+        }
+        nextChannel.accounts = nextAccounts;
+      }
+    }
+    if (nextChannel !== currentChannel) {
+      if (!changed) {
+        channels = { ...channels };
+        changed = true;
+      }
+      channels[channelId] = nextChannel;
+    }
+  }
+
+  return changed ? { ...summary, channels } : summary;
+}
 
 export const healthHandlers: GatewayRequestHandlers = {
   health: async ({ respond, context, params }) => {
@@ -14,7 +120,8 @@ export const healthHandlers: GatewayRequestHandlers = {
     const now = Date.now();
     const cached = getHealthCache();
     if (!wantsProbe && cached && now - cached.ts < HEALTH_REFRESH_INTERVAL_MS) {
-      respond(true, cached, undefined, { cached: true });
+      const runtime = context.getRuntimeSnapshot();
+      respond(true, mergeRuntimeSnapshot(cached, runtime), undefined, { cached: true });
       void refreshHealthSnapshot({ probe: false }).catch((err) =>
         logHealth.error(`background health refresh failed: ${formatError(err)}`),
       );
@@ -22,7 +129,8 @@ export const healthHandlers: GatewayRequestHandlers = {
     }
     try {
       const snap = await refreshHealthSnapshot({ probe: wantsProbe });
-      respond(true, snap, undefined);
+      const runtime = context.getRuntimeSnapshot();
+      respond(true, mergeRuntimeSnapshot(snap, runtime), undefined);
     } catch (err) {
       respond(false, undefined, errorShape(ErrorCodes.UNAVAILABLE, formatForLog(err)));
     }

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -745,6 +745,40 @@ describe("gateway healthHandlers.status scope handling", () => {
     vi.mocked(statusModule.getStatusSummary).mockClear();
   });
 
+  const createHealthSummary = (running = false, connected = false) => ({
+    ok: true as const,
+    ts: 1,
+    durationMs: 1,
+    channels: {
+      whatsapp: {
+        accountId: "default",
+        configured: true,
+        linked: true,
+        running,
+        connected,
+        accounts: {
+          default: {
+            accountId: "default",
+            configured: true,
+            linked: true,
+            running,
+            connected,
+          },
+        },
+      },
+    },
+    channelOrder: ["whatsapp"],
+    channelLabels: { whatsapp: "WhatsApp" },
+    heartbeatSeconds: 1800,
+    defaultAgentId: "main",
+    agents: [],
+    sessions: {
+      path: "/tmp/sessions.json",
+      count: 0,
+      recent: [],
+    },
+  });
+
   async function runHealthStatus(scopes: string[]) {
     const respond = vi.fn();
 
@@ -760,6 +794,44 @@ describe("gateway healthHandlers.status scope handling", () => {
     return respond;
   }
 
+  async function runHealth(params: {
+    cached?: ReturnType<typeof createHealthSummary> | null;
+    refreshed?: ReturnType<typeof createHealthSummary>;
+    runtime?: {
+      channels: Record<string, Record<string, unknown>>;
+      channelAccounts: Record<string, Record<string, Record<string, unknown>>>;
+    };
+    probe?: boolean;
+  }) {
+    const respond = vi.fn();
+    const getHealthCache = vi.fn().mockReturnValue(params.cached ?? null);
+    const refreshHealthSnapshot = vi
+      .fn()
+      .mockResolvedValue(params.refreshed ?? createHealthSummary(false, false));
+    const getRuntimeSnapshot = vi.fn().mockReturnValue(
+      params.runtime ?? {
+        channels: {},
+        channelAccounts: {},
+      },
+    );
+
+    await healthHandlers.health({
+      req: {} as never,
+      params: (params.probe ? { probe: true } : {}) as never,
+      respond: respond as never,
+      context: {
+        getHealthCache,
+        refreshHealthSnapshot,
+        logHealth: { error: vi.fn() },
+        getRuntimeSnapshot,
+      } as never,
+      client: { connect: { role: "operator", scopes: ["operator.read"] } } as never,
+      isWebchatConnect: () => false,
+    });
+
+    return { respond, getHealthCache, refreshHealthSnapshot, getRuntimeSnapshot };
+  }
+
   it.each([
     { scopes: ["operator.read"], includeSensitive: false },
     { scopes: ["operator.admin"], includeSensitive: true },
@@ -772,6 +844,260 @@ describe("gateway healthHandlers.status scope handling", () => {
       expect(respond).toHaveBeenCalledWith(true, { ok: true }, undefined);
     },
   );
+
+  it("merges runtime channel state into cached health responses", async () => {
+    const cached = createHealthSummary(false, false);
+    cached.ts = Date.now();
+    const runtime = {
+      channels: {
+        whatsapp: {
+          accountId: "default",
+          running: true,
+          connected: true,
+        },
+      },
+      channelAccounts: {
+        whatsapp: {
+          default: {
+            accountId: "default",
+            running: true,
+            connected: true,
+          },
+        },
+      },
+    };
+
+    const { respond, refreshHealthSnapshot } = await runHealth({ cached, runtime });
+    const payload = respond.mock.calls[0]?.[1] as ReturnType<typeof createHealthSummary>;
+
+    expect(payload.channels.whatsapp.running).toBe(true);
+    expect(payload.channels.whatsapp.connected).toBe(true);
+    expect(payload.channels.whatsapp.accounts.default.running).toBe(true);
+    expect(payload.channels.whatsapp.accounts.default.connected).toBe(true);
+    expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined, { cached: true });
+    expect(refreshHealthSnapshot).toHaveBeenCalledWith({ probe: false });
+  });
+
+  it("merges runtime channel state into refreshed health responses", async () => {
+    const refreshed = createHealthSummary(false, false);
+    const runtime = {
+      channels: {
+        whatsapp: {
+          accountId: "default",
+          running: true,
+          connected: true,
+        },
+      },
+      channelAccounts: {
+        whatsapp: {
+          default: {
+            accountId: "default",
+            running: true,
+            connected: true,
+          },
+        },
+      },
+    };
+
+    const { respond, refreshHealthSnapshot } = await runHealth({
+      cached: null,
+      refreshed,
+      runtime,
+      probe: true,
+    });
+    const payload = respond.mock.calls[0]?.[1] as ReturnType<typeof createHealthSummary>;
+
+    expect(payload.channels.whatsapp.running).toBe(true);
+    expect(payload.channels.whatsapp.connected).toBe(true);
+    expect(payload.channels.whatsapp.accounts.default.running).toBe(true);
+    expect(payload.channels.whatsapp.accounts.default.connected).toBe(true);
+    expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+    expect(refreshHealthSnapshot).toHaveBeenCalledWith({ probe: true });
+  });
+
+  it("reads runtime snapshot after refresh in the probe path", async () => {
+    const refreshed = createHealthSummary(false, false);
+    const runtime = {
+      channels: {
+        whatsapp: {
+          accountId: "default",
+          running: true,
+          connected: true,
+        },
+      },
+      channelAccounts: {
+        whatsapp: {
+          default: {
+            accountId: "default",
+            running: true,
+            connected: true,
+          },
+        },
+      },
+    };
+
+    const { refreshHealthSnapshot, getRuntimeSnapshot } = await runHealth({
+      cached: null,
+      refreshed,
+      runtime,
+      probe: true,
+    });
+
+    expect(refreshHealthSnapshot).toHaveBeenCalledWith({ probe: true });
+    expect(getRuntimeSnapshot).toHaveBeenCalledTimes(1);
+    expect(refreshHealthSnapshot.mock.invocationCallOrder[0]).toBeLessThan(
+      getRuntimeSnapshot.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not inject sparse runtime-only accounts into health summaries", async () => {
+    const refreshed = createHealthSummary(false, false);
+    const runtime = {
+      channels: {
+        whatsapp: {
+          accountId: "default",
+          running: true,
+          connected: true,
+        },
+      },
+      channelAccounts: {
+        whatsapp: {
+          default: {
+            accountId: "default",
+            running: true,
+            connected: true,
+          },
+          secondary: {
+            accountId: "secondary",
+            running: true,
+            connected: true,
+          },
+        },
+      },
+    };
+
+    const { respond } = await runHealth({
+      cached: null,
+      refreshed,
+      runtime,
+      probe: true,
+    });
+    const payload = respond.mock.calls[0]?.[1] as ReturnType<typeof createHealthSummary>;
+
+    expect(payload.channels.whatsapp.accounts.default.running).toBe(true);
+    expect(payload.channels.whatsapp.accounts.secondary).toBeUndefined();
+  });
+
+  it("prefers runtime state for the selected channel account in multi-account setups", async () => {
+    const refreshed = createHealthSummary(false, false);
+    refreshed.channels.whatsapp.accountId = "secondary";
+    refreshed.channels.whatsapp.accounts = {
+      default: {
+        accountId: "default",
+        configured: true,
+        linked: true,
+        running: false,
+        connected: false,
+      },
+      secondary: {
+        accountId: "secondary",
+        configured: true,
+        linked: true,
+        running: false,
+        connected: false,
+      },
+    };
+    const runtime = {
+      channels: {
+        whatsapp: {
+          accountId: "default",
+          running: false,
+          connected: false,
+        },
+      },
+      channelAccounts: {
+        whatsapp: {
+          default: {
+            accountId: "default",
+            running: false,
+            connected: false,
+          },
+          secondary: {
+            accountId: "secondary",
+            running: true,
+            connected: true,
+          },
+        },
+      },
+    };
+
+    const { respond } = await runHealth({
+      cached: null,
+      refreshed,
+      runtime,
+      probe: true,
+    });
+    const payload = respond.mock.calls[0]?.[1] as ReturnType<typeof createHealthSummary>;
+
+    expect(payload.channels.whatsapp.accountId).toBe("secondary");
+    expect(payload.channels.whatsapp.running).toBe(true);
+    expect(payload.channels.whatsapp.connected).toBe(true);
+  });
+
+  it("does not apply default runtime channel state when selected account has no runtime entry", async () => {
+    const refreshed = createHealthSummary(false, false);
+    refreshed.channels.whatsapp.accountId = "ghost";
+    refreshed.channels.whatsapp.accounts = {
+      default: {
+        accountId: "default",
+        configured: true,
+        linked: true,
+        running: false,
+        connected: false,
+      },
+      ghost: {
+        accountId: "ghost",
+        configured: false,
+        linked: false,
+        running: false,
+        connected: false,
+      },
+    };
+    const runtime = {
+      channels: {
+        whatsapp: {
+          accountId: "default",
+          running: true,
+          connected: true,
+        },
+      },
+      channelAccounts: {
+        whatsapp: {
+          default: {
+            accountId: "default",
+            running: true,
+            connected: true,
+          },
+        },
+      },
+    };
+
+    const { respond } = await runHealth({
+      cached: null,
+      refreshed,
+      runtime,
+      probe: true,
+    });
+    const payload = respond.mock.calls[0]?.[1] as ReturnType<typeof createHealthSummary>;
+
+    expect(payload.channels.whatsapp.accountId).toBe("ghost");
+    expect(payload.channels.whatsapp.running).toBe(false);
+    expect(payload.channels.whatsapp.connected).toBe(false);
+    expect(payload.channels.whatsapp.accounts.default.running).toBe(true);
+    expect(payload.channels.whatsapp.accounts.default.connected).toBe(true);
+    expect(payload.channels.whatsapp.accounts.ghost.running).toBe(false);
+    expect(payload.channels.whatsapp.accounts.ghost.connected).toBe(false);
+  });
 });
 
 describe("logs.tail", () => {


### PR DESCRIPTION
## Problem
`openclaw health` and `openclaw channels status --probe` can disagree on live channel runtime fields (`running`, `connected`, timestamps, error markers). In multi-account setups, health could also show channel-level runtime from the default account while the reported `accountId` points to a different selected account.

## Root cause
Health responses were built from snapshot/probe summaries without overlaying live runtime state. Where runtime overlay was introduced, edge cases still existed around snapshot timing and account selection.

## What this PR changes
- Merge live runtime fields into health responses for both cached and refreshed paths.
- Read runtime snapshot after `refreshHealthSnapshot(...)` in the probe/refresh path to avoid stale merge windows.
- Skip runtime-only accounts that are not present in the health summary to avoid injecting sparse/incomplete account entries.
- For channel-level fields in multi-account mode, use the selected summary account runtime when available.
- Do not fall back to default-account channel runtime when per-account runtime exists but the selected account is missing (stale binding case).
- Add regression tests covering cached merge, refreshed merge, post-refresh snapshot timing, sparse-account guard, selected-account merge, and stale-binding fallback behavior.

## Result
`openclaw health` now reports runtime state that is consistent with live channel runtime and with the selected account semantics exposed in the health payload.
