### PR TITLE
fix(cron): return error when payload model override is disallowed

### DIFF
--- a/src/cron/isolated-agent/run.cron-model-override.test.ts
+++ b/src/cron/isolated-agent/run.cron-model-override.test.ts
@@ -168,13 +168,13 @@ describe("runCronIsolatedAgentTurn — cron model override (#21057)", () => {
 
   it("returns error without persisting model when payload model is disallowed", async () => {
     resolveAllowedModelRefMock.mockReturnValueOnce({
-      error: "Model not allowed: anthropic/claude-sonnet-4-6",
+      error: "model not allowed: anthropic/claude-sonnet-4-6",
     });
 
     const result = await runCronIsolatedAgentTurn(makeParams());
 
     expect(result.status).toBe("error");
-    expect(result.error).toContain("Model not allowed");
+    expect(result.error).toContain("model not allowed");
     // Model should remain undefined — the early return happens before the
     // pre-run persist block, so neither the session entry nor the store
     // should be touched with a rejected model.

--- a/src/cron/isolated-agent/run.skill-filter.test.ts
+++ b/src/cron/isolated-agent/run.skill-filter.test.ts
@@ -207,30 +207,27 @@ describe("runCronIsolatedAgentTurn — skill filter", () => {
       expect(runParams.model).toBe("claude-sonnet-4-6");
     });
 
-    it("falls back to agent defaults when payload.model is not allowed", async () => {
+    it("returns error when payload.model is not allowed", async () => {
       resolveAllowedModelRefMock.mockReturnValueOnce({
         error: "model not allowed: anthropic/claude-sonnet-4-6",
       });
 
-      await runSkillFilterCase({
-        cfg: {
-          agents: {
-            defaults: {
-              model: { primary: "openai-codex/gpt-5.3-codex", fallbacks: defaultFallbacks },
+      const result = await runCronIsolatedAgentTurn(
+        makeSkillParams({
+          cfg: {
+            agents: {
+              defaults: {
+                model: { primary: "openai-codex/gpt-5.3-codex", fallbacks: defaultFallbacks },
+              },
             },
           },
-        },
-        job: makeSkillJob({
-          payload: { kind: "agentTurn", message: "test", model: "anthropic/claude-sonnet-4-6" },
+          job: makeSkillJob({
+            payload: { kind: "agentTurn", message: "test", model: "anthropic/claude-sonnet-4-6" },
+          }),
         }),
-      });
-      expect(logWarnMock).toHaveBeenCalledWith(
-        "cron: payload.model 'anthropic/claude-sonnet-4-6' not allowed, falling back to agent defaults",
       );
-      expectDefaultModelCall({
-        primary: "openai-codex/gpt-5.3-codex",
-        fallbacks: defaultFallbacks,
-      });
+      expect(result.status).toBe("error");
+      expect(result.error).toContain("model not allowed");
     });
 
     it("returns an error when payload.model is invalid", async () => {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -223,13 +223,7 @@ export async function runCronIsolatedAgentTurn(params: {
       defaultModel: resolvedDefault.model,
     });
     if ("error" in resolvedOverride) {
-      if (resolvedOverride.error.startsWith("model not allowed:")) {
-        logWarn(
-          `cron: payload.model '${modelOverride}' not allowed, falling back to agent defaults`,
-        );
-      } else {
-        return { status: "error", error: resolvedOverride.error };
-      }
+      return { status: "error", error: resolvedOverride.error };
     } else {
       provider = resolvedOverride.ref.provider;
       model = resolvedOverride.ref.model;


### PR DESCRIPTION
## Summary

- **Problem:** When a hook transform returns a `model` field, the model override is correctly merged into the job payload but silently ignored at runtime — the agent uses the default model instead.
- **Why it matters:** Users configure hook transforms expecting their model choice to be honored. Silent fallback to defaults is confusing and hard to debug.
- **What changed:** Removed the special-case silent fallback for "model not allowed" errors in `runCronIsolatedAgentTurn`. All `resolveAllowedModelRef` errors (including allowlist rejections) now return a clear error instead of silently downgrading to defaults.
- **What did NOT change (scope boundary):** No changes to `resolveAllowedModelRef`, `mergeAction`, `dispatchAgentHook`, or the hook mapping pipeline. The model still flows correctly through the entire chain — only the error handling at the consumption site changed.

## Root Cause

A case-sensitivity mismatch between the runtime code and its test masked the bug:

1. `resolveAllowedModelRef` returns `"model not allowed: ..."` (**lowercase** `m`)
2. `run.ts:226` checked `error.startsWith("model not allowed:")` — **matched** → took the warn-and-silently-fallthrough path
3. The test mocked the error as `"Model not allowed: ..."` (**uppercase** `M`) — did **not** match → took the `else` branch (return error) → test passed

So the test was verifying the wrong code path. The intended behavior (return error on disallowed model) was never actually exercised at runtime.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #36326

## User-visible / Behavior Changes

Hook transform (and cron job) payload model overrides that are rejected by the model allowlist now return a clear error (`status: "error"`) instead of silently falling back to the default model. Users will see the error and can fix their allowlist or model configuration.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: any
- Runtime: Node 22+

### Steps

1. Configure a hook transform that returns `{ model: "some-model", message: "..." }`
2. Ensure the model is NOT in the configured allowlist
3. Trigger the hook

### Expected

- Before fix: Agent silently uses default model (no error visible)
- After fix: Hook returns `{ status: "error", error: "model not allowed: ..." }`

### Actual

- Matches expected after fix

## Evidence

- [x] Failing test/log before + passing after
- All 428 cron tests pass (54 test files)
- Fixed the case mismatch in `run.cron-model-override.test.ts` mock (`"Model"` → `"model"`)
- Updated `run.skill-filter.test.ts` to expect error instead of silent fallback

## Human Verification (required)

- Verified scenarios: All 81 isolated-agent tests pass; all 428 cron tests pass
- Edge cases checked: "model not allowed" vs "invalid model" both return errors now (unified path)
- What you did **not** verify: Live hook transform trigger (no test environment with real hooks configured)

## Compatibility / Migration

- Backward compatible? `No` — previously silent fallback is now a visible error
- Config/env changes? `No`
- Migration needed? `No` — users whose model was silently rejected should fix their allowlist config
- Users relying on the silent fallback behavior should either add the model to their allowlist or remove the model override from their transform

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert this commit
- Files/config to restore: `src/cron/isolated-agent/run.ts`
- Known bad symptoms: Hook-dispatched jobs that previously succeeded (with wrong model) may now fail with "model not allowed" errors. Fix: add the model to the allowlist.

## Risks and Mitigations

- Risk: Cron jobs that relied on silent model fallback will now fail instead of running with the default model.
  - Mitigation: The error message is clear and actionable — users can add the model to their allowlist or remove the override. Running with the wrong model silently was a worse outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)