### PR TITLE
fix(feishu): support fields_json fallback for bitable records

### DIFF
--- a/extensions/feishu/README.md
+++ b/extensions/feishu/README.md
@@ -1,0 +1,33 @@
+# @openclaw/feishu
+
+Feishu/Lark channel plugin for OpenClaw.
+
+## Bitable record payload compatibility
+
+`feishu_bitable_create_record` and `feishu_bitable_update_record` support two equivalent payload styles:
+
+- `fields`: direct object map
+- `fields_json`: JSON string fallback (for clients that cannot pass dynamic object maps reliably)
+
+Use exactly one of them in each call.
+
+### Examples
+
+```json
+{
+  "app_token": "bascnxxxx",
+  "table_id": "tblxxxx",
+  "fields": {
+    "Name": "Alice",
+    "Score": 95
+  }
+}
+```
+
+```json
+{
+  "app_token": "bascnxxxx",
+  "table_id": "tblxxxx",
+  "fields_json": "{\"Name\":\"Alice\",\"Score\":95}"
+}
+```

--- a/extensions/feishu/src/bitable.record-payload.test.ts
+++ b/extensions/feishu/src/bitable.record-payload.test.ts
@@ -1,0 +1,178 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { registerFeishuBitableTools } from "./bitable.js";
+import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
+
+const createRecordMock = vi.hoisted(() => vi.fn());
+const updateRecordMock = vi.hoisted(() => vi.fn());
+const createFeishuToolClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./tool-account.js", () => ({
+  createFeishuToolClient: (...args: unknown[]) => createFeishuToolClientMock(...args),
+}));
+
+function createConfig(): OpenClawPluginApi["config"] {
+  return {
+    channels: {
+      feishu: {
+        enabled: true,
+        accounts: {
+          main: {
+            appId: "cli_main",
+            appSecret: "sec_main",
+          },
+        },
+      },
+    },
+  } as OpenClawPluginApi["config"];
+}
+
+function setupTool(name: "feishu_bitable_create_record" | "feishu_bitable_update_record") {
+  const { api, resolveTool } = createToolFactoryHarness(createConfig());
+  registerFeishuBitableTools(api);
+  return resolveTool(name, { agentAccountId: "main" });
+}
+
+function readError(result: unknown): string | undefined {
+  const details = (result as { details?: { error?: string } })?.details;
+  return details?.error;
+}
+
+function captureToolParameters(name: string): Record<string, unknown> {
+  const registered: Array<{
+    tool: unknown;
+    opts?: { name?: string };
+  }> = [];
+
+  const api = {
+    config: createConfig(),
+    logger: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: () => {},
+    },
+    registerTool: (tool: unknown, opts?: { name?: string }) => {
+      registered.push({ tool, opts });
+    },
+  } as unknown as OpenClawPluginApi;
+
+  registerFeishuBitableTools(api);
+  const hit = registered.find((entry) => entry.opts?.name === name);
+  if (!hit || typeof hit.tool !== "function") {
+    throw new Error(`Tool not registered: ${name}`);
+  }
+
+  const resolved = (hit.tool as (ctx: { agentAccountId?: string }) => { parameters?: unknown })({
+    agentAccountId: "main",
+  });
+  return (resolved.parameters ?? {}) as Record<string, unknown>;
+}
+
+describe("feishu bitable record payload", () => {
+  beforeEach(() => {
+    createRecordMock.mockReset();
+    updateRecordMock.mockReset();
+    createFeishuToolClientMock.mockReset();
+
+    createRecordMock.mockResolvedValue({
+      code: 0,
+      data: { record: { record_id: "rec_create" } },
+    });
+    updateRecordMock.mockResolvedValue({
+      code: 0,
+      data: { record: { record_id: "rec_update" } },
+    });
+
+    createFeishuToolClientMock.mockReturnValue({
+      bitable: {
+        appTableRecord: {
+          create: createRecordMock,
+          update: updateRecordMock,
+        },
+      },
+    });
+  });
+
+  test("create/update schemas expose fields_json fallback parameter", () => {
+    const createParams = captureToolParameters("feishu_bitable_create_record");
+    const updateParams = captureToolParameters("feishu_bitable_update_record");
+
+    const createProperties = (createParams.properties ?? {}) as Record<string, { type?: string }>;
+    const updateProperties = (updateParams.properties ?? {}) as Record<string, { type?: string }>;
+
+    expect(createProperties.fields_json?.type).toBe("string");
+    expect(updateProperties.fields_json?.type).toBe("string");
+    expect(createProperties.fields).toBeTruthy();
+    expect(updateProperties.fields).toBeTruthy();
+  });
+
+  test("create_record accepts fields_json fallback payload", async () => {
+    const tool = setupTool("feishu_bitable_create_record");
+
+    await tool.execute("call", {
+      app_token: "app_x",
+      table_id: "tbl_x",
+      fields_json: '{"Name":"Alice","Score":95}',
+    });
+
+    expect(createRecordMock).toHaveBeenCalledWith({
+      path: { app_token: "app_x", table_id: "tbl_x" },
+      data: { fields: { Name: "Alice", Score: 95 } },
+    });
+  });
+
+  test("update_record keeps compatibility with object fields payload", async () => {
+    const tool = setupTool("feishu_bitable_update_record");
+
+    await tool.execute("call", {
+      app_token: "app_x",
+      table_id: "tbl_x",
+      record_id: "rec_x",
+      fields: { Status: "Done" },
+    });
+
+    expect(updateRecordMock).toHaveBeenCalledWith({
+      path: { app_token: "app_x", table_id: "tbl_x", record_id: "rec_x" },
+      data: { fields: { Status: "Done" } },
+    });
+  });
+
+  test("create_record rejects payload when fields and fields_json are both provided", async () => {
+    const tool = setupTool("feishu_bitable_create_record");
+
+    const result = await tool.execute("call", {
+      app_token: "app_x",
+      table_id: "tbl_x",
+      fields: { Name: "Alice" },
+      fields_json: '{"Name":"Bob"}',
+    });
+
+    expect(readError(result)).toContain("Provide either fields or fields_json");
+    expect(createRecordMock).not.toHaveBeenCalled();
+  });
+
+  test("update_record rejects invalid or empty fields_json", async () => {
+    const tool = setupTool("feishu_bitable_update_record");
+
+    const invalidJson = await tool.execute("call-invalid", {
+      app_token: "app_x",
+      table_id: "tbl_x",
+      record_id: "rec_x",
+      fields_json: "{bad}",
+    });
+
+    expect(readError(invalidJson)).toContain("Invalid fields_json");
+    expect(updateRecordMock).not.toHaveBeenCalled();
+
+    const emptyObject = await tool.execute("call-empty", {
+      app_token: "app_x",
+      table_id: "tbl_x",
+      record_id: "rec_x",
+      fields_json: "{}",
+    });
+
+    expect(readError(emptyObject)).toContain("Record fields cannot be empty");
+    expect(updateRecordMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/feishu/src/bitable.record-payload.test.ts
+++ b/extensions/feishu/src/bitable.record-payload.test.ts
@@ -1,4 +1,3 @@
-import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { registerFeishuBitableTools } from "./bitable.js";
 import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
@@ -11,7 +10,7 @@ vi.mock("./tool-account.js", () => ({
   createFeishuToolClient: (...args: unknown[]) => createFeishuToolClientMock(...args),
 }));
 
-function createConfig(): OpenClawPluginApi["config"] {
+function createConfig() {
   return {
     channels: {
       feishu: {
@@ -24,7 +23,7 @@ function createConfig(): OpenClawPluginApi["config"] {
         },
       },
     },
-  } as OpenClawPluginApi["config"];
+  };
 }
 
 function setupTool(name: "feishu_bitable_create_record" | "feishu_bitable_update_record") {
@@ -55,7 +54,7 @@ function captureToolParameters(name: string): Record<string, unknown> {
     registerTool: (tool: unknown, opts?: { name?: string }) => {
       registered.push({ tool, opts });
     },
-  } as unknown as OpenClawPluginApi;
+  } as Parameters<typeof registerFeishuBitableTools>[0];
 
   registerFeishuBitableTools(api);
   const hit = registered.find((entry) => entry.opts?.name === name);

--- a/extensions/feishu/src/bitable.record-payload.test.ts
+++ b/extensions/feishu/src/bitable.record-payload.test.ts
@@ -54,7 +54,7 @@ function captureToolParameters(name: string): Record<string, unknown> {
     registerTool: (tool: unknown, opts?: { name?: string }) => {
       registered.push({ tool, opts });
     },
-  } as Parameters<typeof registerFeishuBitableTools>[0];
+  } as unknown as Parameters<typeof registerFeishuBitableTools>[0];
 
   registerFeishuBitableTools(api);
   const hit = registered.find((entry) => entry.opts?.name === name);

--- a/extensions/feishu/src/bitable.record-payload.test.ts
+++ b/extensions/feishu/src/bitable.record-payload.test.ts
@@ -152,6 +152,18 @@ describe("feishu bitable record payload", () => {
     expect(createRecordMock).not.toHaveBeenCalled();
   });
 
+  test("create_record rejects payload when neither fields nor fields_json is provided", async () => {
+    const tool = setupTool("feishu_bitable_create_record");
+
+    const result = await tool.execute("call-missing", {
+      app_token: "app_x",
+      table_id: "tbl_x",
+    });
+
+    expect(readError(result)).toContain("Provide either fields or fields_json");
+    expect(createRecordMock).not.toHaveBeenCalled();
+  });
+
   test("update_record rejects invalid or empty fields_json", async () => {
     const tool = setupTool("feishu_bitable_update_record");
 

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -193,6 +193,47 @@ async function getRecord(client: Lark.Client, appToken: string, tableId: string,
   };
 }
 
+type RecordFieldsArgs = {
+  fields?: Record<string, unknown>;
+  fields_json?: string;
+};
+
+function resolveRecordFields(args: RecordFieldsArgs, actionName: string): Record<string, unknown> {
+  const hasFields = args.fields !== undefined;
+  const hasFieldsJson = args.fields_json !== undefined;
+
+  if (hasFields && hasFieldsJson) {
+    throw new Error(`Provide either fields or fields_json for ${actionName}, not both`);
+  }
+
+  let resolved: unknown;
+  if (hasFieldsJson) {
+    const raw = args.fields_json?.trim();
+    if (!raw) {
+      throw new Error(`fields_json cannot be empty for ${actionName}`);
+    }
+    try {
+      resolved = JSON.parse(raw);
+    } catch (err) {
+      throw new Error(
+        `Invalid fields_json for ${actionName}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  } else {
+    resolved = args.fields;
+  }
+
+  if (!resolved || typeof resolved !== "object" || Array.isArray(resolved)) {
+    throw new Error(`Record fields must be a JSON object for ${actionName}`);
+  }
+
+  const fields = resolved as Record<string, unknown>;
+  if (Object.keys(fields).length === 0) {
+    throw new Error(`Record fields cannot be empty for ${actionName}`);
+  }
+  return fields;
+}
+
 async function createRecord(
   client: Lark.Client,
   appToken: string,
@@ -471,10 +512,18 @@ const CreateRecordSchema = Type.Object({
     description: "Bitable app token (use feishu_bitable_get_meta to get from URL)",
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
-  fields: Type.Record(Type.String(), Type.Any(), {
-    description:
-      "Field values keyed by field name. Format by type: Text='string', Number=123, SingleSelect='Option', MultiSelect=['A','B'], DateTime=timestamp_ms, User=[{id:'ou_xxx'}], URL={text:'Display',link:'https://...'}",
-  }),
+  fields: Type.Optional(
+    Type.Record(Type.String(), Type.Any(), {
+      description:
+        "Field values keyed by field name. Preferred when the client supports dynamic object params.",
+    }),
+  ),
+  fields_json: Type.Optional(
+    Type.String({
+      description:
+        'JSON-encoded field object fallback when your client cannot pass dynamic fields. Example: {"Name":"Alice","Score":95}',
+    }),
+  ),
 });
 
 const CreateAppSchema = Type.Object({
@@ -513,9 +562,17 @@ const UpdateRecordSchema = Type.Object({
   }),
   table_id: Type.String({ description: "Table ID (from URL: ?table=YYY)" }),
   record_id: Type.String({ description: "Record ID to update" }),
-  fields: Type.Record(Type.String(), Type.Any(), {
-    description: "Field values to update (same format as create_record)",
-  }),
+  fields: Type.Optional(
+    Type.Record(Type.String(), Type.Any(), {
+      description: "Field values to update (same format as create_record)",
+    }),
+  ),
+  fields_json: Type.Optional(
+    Type.String({
+      description:
+        'JSON-encoded field object fallback when your client cannot pass dynamic fields. Example: {"Status":"Done"}',
+    }),
+  ),
 });
 
 // ============ Tool Registration ============
@@ -633,7 +690,8 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
   registerBitableTool<{
     app_token: string;
     table_id: string;
-    fields: Record<string, unknown>;
+    fields?: Record<string, unknown>;
+    fields_json?: string;
     accountId?: string;
   }>({
     name: "feishu_bitable_create_record",
@@ -645,7 +703,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
         getClient(params, defaultAccountId),
         params.app_token,
         params.table_id,
-        params.fields,
+        resolveRecordFields(params, "feishu_bitable_create_record"),
       );
     },
   });
@@ -654,7 +712,8 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     app_token: string;
     table_id: string;
     record_id: string;
-    fields: Record<string, unknown>;
+    fields?: Record<string, unknown>;
+    fields_json?: string;
     accountId?: string;
   }>({
     name: "feishu_bitable_update_record",
@@ -667,7 +726,7 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
         params.app_token,
         params.table_id,
         params.record_id,
-        params.fields,
+        resolveRecordFields(params, "feishu_bitable_update_record"),
       );
     },
   });

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -206,6 +206,10 @@ function resolveRecordFields(args: RecordFieldsArgs, actionName: string): Record
     throw new Error(`Provide either fields or fields_json for ${actionName}, not both`);
   }
 
+  if (!hasFields && !hasFieldsJson) {
+    throw new Error(`Provide either fields or fields_json for ${actionName}`);
+  }
+
   let resolved: unknown;
   if (hasFieldsJson) {
     const raw = args.fields_json?.trim();


### PR DESCRIPTION
## Summary
- add `fields_json` as a fallback input for:
  - `feishu_bitable_create_record`
  - `feishu_bitable_update_record`
- keep backward compatibility with existing `fields` object payload
- add strict payload validation:
  - reject passing `fields` and `fields_json` together
  - reject empty/invalid `fields_json`
  - require a non-empty object payload
- add regression tests and extension README notes for payload compatibility

## Why
Some clients cannot reliably pass dynamic object maps in tool calls. `fields_json` provides a safe fallback while preserving existing `fields` behavior.

## Validation
- `pnpm exec vitest run extensions/feishu/src/bitable.record-payload.test.ts`
- `pnpm exec oxfmt --check extensions/feishu/src/bitable.ts extensions/feishu/src/bitable.record-payload.test.ts extensions/feishu/README.md`

## Notes
- This PR is limited to `extensions/feishu/...` and does not include any local PoC scripts.
