### PR TITLE
fix(memory): use WAL journal mode for SQLite memory index

### DIFF
--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -258,7 +258,11 @@ export abstract class MemoryManagerSyncOps {
     const dir = path.dirname(dbPath);
     ensureDir(dir);
     const { DatabaseSync } = requireNodeSqlite();
-    return new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    const db = new DatabaseSync(dbPath, { allowExtension: this.settings.store.vector.enabled });
+    // WAL survives SIGTERM/SIGKILL mid-write and allows concurrent readers.
+    db.exec("PRAGMA journal_mode = WAL");
+    db.exec("PRAGMA busy_timeout = 5000");
+    return db;
   }
 
   private seedEmbeddingCache(sourceDb: DatabaseSync): void {

--- a/src/memory/manager.wal-journal.test.ts
+++ b/src/memory/manager.wal-journal.test.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import { resetEmbeddingMocks } from "./embedding.test-mocks.js";
+import type { MemoryIndexManager } from "./index.js";
+import { getRequiredMemoryIndexManager } from "./test-manager-helpers.js";
+
+describe("memory manager WAL journal mode", () => {
+  let workspaceDir: string;
+  let indexPath: string;
+  let manager: MemoryIndexManager | null = null;
+
+  function createMemoryConfig(): OpenClawConfig {
+    return {
+      agents: {
+        defaults: {
+          workspace: workspaceDir,
+          memorySearch: {
+            provider: "openai",
+            model: "mock-embed",
+            store: { path: indexPath },
+            sync: { watch: false, onSessionStart: false, onSearch: false },
+          },
+        },
+        list: [{ id: "main", default: true }],
+      },
+    } as OpenClawConfig;
+  }
+
+  beforeEach(async () => {
+    resetEmbeddingMocks();
+    workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-mem-wal-"));
+    indexPath = path.join(workspaceDir, "index.sqlite");
+    await fs.mkdir(path.join(workspaceDir, "memory"), { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "MEMORY.md"), "Hello memory.");
+  });
+
+  afterEach(async () => {
+    if (manager) {
+      await manager.close();
+      manager = null;
+    }
+    await fs.rm(workspaceDir, { recursive: true, force: true });
+  });
+
+  it("opens the memory index database with WAL journal mode", async () => {
+    manager = await getRequiredMemoryIndexManager({ cfg: createMemoryConfig(), agentId: "main" });
+
+    const db = (manager as unknown as { db: import("node:sqlite").DatabaseSync }).db;
+    const row = db.prepare("PRAGMA journal_mode").get() as { journal_mode: string };
+    expect(row.journal_mode).toBe("wal");
+  });
+
+  it("sets busy_timeout to avoid SQLITE_BUSY under contention", async () => {
+    manager = await getRequiredMemoryIndexManager({ cfg: createMemoryConfig(), agentId: "main" });
+
+    const db = (manager as unknown as { db: import("node:sqlite").DatabaseSync }).db;
+    const row = db.prepare("PRAGMA busy_timeout").get() as { timeout: number };
+    expect(row.timeout).toBe(5000);
+  });
+
+  it("preserves WAL mode after a full reindex", async () => {
+    manager = await getRequiredMemoryIndexManager({ cfg: createMemoryConfig(), agentId: "main" });
+
+    await manager.sync({ reason: "test", force: true });
+
+    const db = (manager as unknown as { db: import("node:sqlite").DatabaseSync }).db;
+    const row = db.prepare("PRAGMA journal_mode").get() as { journal_mode: string };
+    expect(row.journal_mode).toBe("wal");
+  });
+});


### PR DESCRIPTION
Set PRAGMA journal_mode=WAL and PRAGMA busy_timeout=5000 when opening the memory index database. WAL mode survives SIGTERM/SIGKILL mid-write and prevents database corruption that occurs with the default rollback journal when the gateway is killed during write operations.

busy_timeout prevents immediate SQLITE_BUSY errors under contention.

Closes #36035

## Summary

- **Problem:** Memory index SQLite database uses `journal_mode=delete` (SQLite default). If the gateway is killed mid-write (SIGTERM during restart/update/config change), the journal file is deleted before the write completes, corrupting the database.
- **Why it matters:** Users hit "database disk image is malformed" and memory search stops working entirely. The only fix is manual deletion and full reindex (`rm + openclaw memory index`). Gateway restarts are frequent.
- **What changed:** Added `PRAGMA journal_mode = WAL` and `PRAGMA busy_timeout = 5000` in `openDatabaseAtPath()` — the single entry point where all memory SQLite databases are opened (main index + temp reindex). Added 3 tests.
- **What did NOT change (scope boundary):** No schema changes, no config surface changes, no migration. QMD manager (read-only, separate code path) is not touched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes [#36035](https://github.com/openclaw/openclaw/issues/36035)

## User-visible / Behavior Changes

None visible. Existing databases are transparently converted to WAL on first open (SQLite handles this automatically). Two sidecar files (`-wal`, `-shm`) will appear next to the database file — `moveIndexFiles()` and `removeIndexFiles()` already handle these suffixes.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 24.04)
- Runtime/container: Node.js 22.22.0
- Model/provider: Mock embeddings (unit tests)

### Steps

1. `pnpm install`
2. `vitest run src/memory/manager.wal-journal.test.ts` (focused WAL tests)
3. `vitest run src/memory/` (full memory suite)
4. `pnpm test` (full project suite)

### Expected

- All tests pass, `PRAGMA journal_mode` returns `wal` on opened databases.

### Actual

- 3/3 new WAL tests pass. 35/35 memory test files pass (237 tests). 817/817 full suite passes (6664 tests).

## Evidence

- [x] Failing test/log before + passing after

New test `src/memory/manager.wal-journal.test.ts` asserts:
1. `PRAGMA journal_mode` returns `wal` after opening
2. `PRAGMA busy_timeout` returns `5000`
3. WAL mode persists after a full safe reindex (temp DB swap)

## Human Verification (required)

- Verified scenarios: WAL active on fresh DB, WAL persists after forced reindex, busy_timeout correctly set, all 35 memory test files pass, full project suite passes.
- Edge cases checked: Safe reindex (temp DB also gets WAL via same code path), unsafe reindex (test-only path), readonly recovery reopens through `openDatabase()` which calls `openDatabaseAtPath()`.
- What you did **not** verify: Live migration of a pre-existing production database from DELETE to WAL mode (SQLite documents this as automatic and transparent, but not tested against a real user index).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No` — SQLite converts automatically on first `PRAGMA journal_mode = WAL`.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the two `db.exec("PRAGMA ...")` lines in `manager-sync-ops.ts:openDatabaseAtPath()`.
- Files/config to restore: `src/memory/manager-sync-ops.ts`
- Known bad symptoms reviewers should watch for: `SQLITE_BUSY` errors (unlikely with 5s busy_timeout), unexpected `-wal`/`-shm` files appearing alongside `main.sqlite` (expected behavior).

## Risks and Mitigations

- Risk: WAL sidecar files (`-wal`, `-shm`) must travel with the database during atomic reindex swaps.
  - Mitigation: `moveIndexFiles()` and `removeIndexFiles()` already handle `["", "-wal", "-shm"]` suffixes — this was designed for WAL from the start.