### PR TITLE
feat(browser): expose profile name as OPENCLAW_BROWSER_PROFILE env var

### DIFF
--- a/src/browser/chrome.ts
+++ b/src/browser/chrome.ts
@@ -280,6 +280,10 @@ export async function launchOpenClawChrome(
         ...process.env,
         // Reduce accidental sharing with the user's env.
         HOME: os.homedir(),
+        // Expose the active browser profile name so wrapper scripts
+        // (e.g. custom executablePath) can select per-profile resources
+        // such as separate user-data-dirs or proxy configs.
+        OPENCLAW_BROWSER_PROFILE: profile.name || "",
       },
     });
   };


### PR DESCRIPTION
## Summary

When Chrome is spawned via `launchOpenClawChrome`, set the `OPENCLAW_BROWSER_PROFILE` environment variable to the active profile name.

This allows custom `executablePath` wrapper scripts to select per-profile resources (separate `--user-data-dir`, proxy configs, cookie stores, etc.) based on which browser profile is being launched.

## Motivation

In multi-agent setups where each agent needs an isolated browser environment with its own cookies and session state, there is currently no way for a wrapper script to know which profile Chrome is being launched for.

The wrapper script needs to route Chrome to the appropriate `--user-data-dir` and potentially apply per-profile settings (proxies, extensions, etc.), but `profile.name` is only available inside OpenClaw's internal code.

## Solution

Add a single line to the `spawn()` env in `src/browser/chrome.ts`:

```typescript
OPENCLAW_BROWSER_PROFILE: profile.name || "",
```

### Example wrapper script

```bash
#!/bin/bash
# ~/bin/chrome-per-profile
PROFILE="${OPENCLAW_BROWSER_PROFILE:-shared}"
PROFILE_DIR="$HOME/browser-profiles/$PROFILE"
mkdir -p "$PROFILE_DIR"

REAL_CHROME="/path/to/chrome"
exec "$REAL_CHROME" \
  --user-data-dir="$PROFILE_DIR" \
  --proxy-server=socks5://127.0.0.1:1080 \
  "$@"
```

Set `browser.executablePath` to this wrapper and each profile gets its own isolated Chrome environment automatically.

## Change

- **1 file changed, 4 insertions**: `src/browser/chrome.ts` — add `OPENCLAW_BROWSER_PROFILE` to spawn env
- Zero breaking changes, zero new dependencies
- The env var is informational only — existing setups are unaffected

## Test plan

- [x] Verified the env var is available in Chrome's process environment
- [x] Wrapper script successfully reads `OPENCLAW_BROWSER_PROFILE` and routes to separate user-data-dirs
- [x] Tested with 4 concurrent agents, each getting isolated browser profiles
- [x] No impact on default behavior (profile name defaults to empty string if unset)