### PR TITLE
test(config): fix backup-rotation tests and zh-CN diffs links

### DIFF
--- a/docs/zh-CN/tools/diffs.md
+++ b/docs/zh-CN/tools/diffs.md
@@ -1,0 +1,118 @@
+---
+title: "Diffs（差异对比）"
+summary: "为代理提供的只读差异查看器和文件渲染器（可选插件工具）"
+description: "使用可选的 Diffs 插件将变更内容渲染为 gateway 托管的差异视图、文件（PNG 或 PDF）或两者。"
+read_when:
+  - 你想让代理将代码或 Markdown 编辑显示为差异
+  - 你想要一个 canvas 就绪的查看器 URL 或渲染的差异文件
+  - 你需要受控的、临时的差异产物，具有安全默认值
+---
+
+# Diffs
+
+`diffs` 是一个可选的插件工具和配套技能，可将变更内容转换为代理的只读差异产物。
+
+它接受：
+
+- `before` 和 `after` 文本
+- 统一的 `patch`
+
+它可以返回：
+
+- 用于 canvas 展示的 gateway 查看器 URL
+- 用于消息传递的渲染文件路径（PNG 或 PDF）
+- 一次调用中的两种输出
+
+## 快速开始
+
+1. 启用插件。
+2. 使用 `mode: "view"` 调用 `diffs` 用于 canvas 优先流程。
+3. 使用 `mode: "file"` 调用 `diffs` 用于聊天文件传递流程。
+4. 使用 `mode: "both"` 调用 `diffs` 当你需要两种产物时。
+
+## 启用插件
+
+```json5
+{
+  plugins: {
+    entries: {
+      diffs: {
+        enabled: true,
+      },
+    },
+  },
+}
+```
+
+## 典型代理工作流
+
+1. 代理调用 `diffs`。
+2. 代理读取 `details` 字段。
+3. 代理可以：
+   - 使用 `canvas present` 打开 `details.viewerUrl`
+   - 使用 `path` 或 `filePath` 通过 `message` 发送 `details.filePath`
+   - 两者都做
+
+## 输入示例
+
+Before 和 after：
+
+```json
+{
+  "before": "# Hello\n\nOne",
+  "after": "# Hello\n\nTwo",
+  "path": "docs/example.md",
+  "mode": "view"
+}
+```
+
+Patch：
+
+```json
+{
+  "patch": "diff --git a/src/example.ts b/src/example.ts\n--- a/src/example.ts\n+++ b/src/example.ts\n@@ -1 +1 @@\n-const x = 1;\n+const x = 2;\n",
+  "mode": "both"
+}
+```
+
+## 工具输入参考
+
+所有字段都是可选的，除非另有说明：
+
+- `before` (`string`): 原始文本。当省略 `patch` 时，与 `after` 一起必需。
+- `after` (`string`): 更新后的文本。当省略 `patch` 时，与 `before` 一起必需。
+- `patch` (`string`): 统一差异文本。与 `before` 和 `after` 互斥。
+- `path` (`string`): before 和 after 模式的显示文件名。
+- `lang` (`string`): before 和 after 模式的语言覆盖提示。
+- `title` (`string`): 查看器标题覆盖。
+- `mode` (`"view" | "file" | "both"`): 输出模式。默认为插件默认值 `defaults.mode`。
+- `theme` (`"light" | "dark"`): 查看器主题。默认为插件默认值 `defaults.theme`。
+- `layout` (`"unified" | "split"`): 差异布局。默认为插件默认值 `defaults.layout`。
+- `expandUnchanged` (`boolean`): 当完整上下文可用时展开未更改的部分。仅每次调用选项（不是插件默认键）。
+- `fileFormat` (`"png" | "pdf"`): 渲染文件格式。默认为插件默认值 `defaults.fileFormat`。
+- `fileQuality` (`"standard" | "hq" | "print"`): PNG 或 PDF 渲染的质量预设。
+- `fileScale` (`number`): 设备缩放覆盖 (`1`-`4`)。
+- `fileMaxWidth` (`number`): 最大渲染宽度（CSS 像素）(`640`-`2400`)。
+- `ttlSeconds` (`number`): 查看器产物 TTL（秒）。默认 1800，最大 21600。
+- `baseUrl` (`string`): 查看器 URL 来源覆盖。必须是 `http` 或 `https`，无 query/hash。
+
+## 输出详情
+
+成功响应在 `details` 中包含产物元数据：
+
+- `mode`: 使用的输出模式
+- `viewerUrl`: 当模式为 `"view"` 或 `"both"` 时的 canvas 查看器 URL
+- `filePath`: 当模式为 `"file"` 或 `"both"` 时的渲染文件路径
+- `fileFormat`: 渲染文件格式（`"png"` 或 `"pdf"`）
+
+## 安全与清理
+
+- 查看器产物是临时的，具有可配置的 TTL（默认 30 分钟，最大 6 小时）。
+- 文件产物写入临时目录，具有受控的生命周期。
+- 所有产物在 TTL 到期后自动清理。
+
+## 相关文档
+
+- [Diffs 插件配置](/plugins/diffs)
+- [Canvas 工具](/tools/canvas)
+- [Message 工具](/tools/message)

--- a/docs/zh-CN/tools/diffs.md
+++ b/docs/zh-CN/tools/diffs.md
@@ -113,6 +113,6 @@ Patch：
 
 ## 相关文档
 
-- [Diffs 插件配置](/plugins/diffs)
-- [Canvas 工具](/tools/canvas)
-- [Message 工具](/tools/message)
+- [Tools 总览](/tools)
+- [插件文档](/tools/plugin)
+- [浏览器工具](/tools/browser)

--- a/src/config/backup-rotation.test.ts
+++ b/src/config/backup-rotation.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  CONFIG_BACKUP_COUNT,
+  rotateConfigBackups,
+  hardenBackupPermissions,
+  cleanOrphanBackups,
+  maintainConfigBackups,
+  type BackupRotationFs,
+  type BackupMaintenanceFs,
+} from "./backup-rotation.js";
+
+describe("backup-rotation", () => {
+  describe("CONFIG_BACKUP_COUNT", () => {
+    it("has expected value of 5", () => {
+      expect(CONFIG_BACKUP_COUNT).toBe(5);
+    });
+  });
+
+  describe("rotateConfigBackups", () => {
+    it("does nothing when CONFIG_BACKUP_COUNT is 1 or less", async () => {
+      const mockFs: BackupRotationFs = {
+        unlink: vi.fn().mockResolvedValue(undefined),
+        rename: vi.fn().mockResolvedValue(undefined),
+      };
+      
+      // Temporarily override the constant
+      const originalCount = CONFIG_BACKUP_COUNT;
+      // We can't easily override the constant, but we can verify the function works
+      
+      await rotateConfigBackups("/config/openclaw.json", mockFs);
+      
+      // With default count of 5, it should perform rotations
+      expect(mockFs.unlink).toHaveBeenCalled();
+    });
+
+    it("rotates backups in correct order", async () => {
+      const operations: string[] = [];
+      const mockFs: BackupRotationFs = {
+        unlink: vi.fn().mockImplementation((p) => {
+          operations.push(`unlink:${p}`);
+          return Promise.resolve();
+        }),
+        rename: vi.fn().mockImplementation((from, to) => {
+          operations.push(`rename:${from}->${to}`);
+          return Promise.resolve();
+        }),
+      };
+
+      await rotateConfigBackups("/config/openclaw.json", mockFs);
+
+      // Should unlink the highest numbered backup
+      expect(operations).toContain("unlink:/config/openclaw.json.bak.4");
+      
+      // Should rotate numbered backups
+      expect(operations).toContain("rename:/config/openclaw.json.bak.3->/config/openclaw.json.bak.4");
+      expect(operations).toContain("rename:/config/openclaw.json.bak.2->/config/openclaw.json.bak.3");
+      expect(operations).toContain("rename:/config/openclaw.json.bak.1->/config/openclaw.json.bak.2");
+      
+      // Should move primary .bak to .bak.1
+      expect(operations).toContain("rename:/config/openclaw.json.bak->/config/openclaw.json.bak.1");
+    });
+
+    it("handles errors gracefully (best-effort)", async () => {
+      const mockFs: BackupRotationFs = {
+        unlink: vi.fn().mockRejectedValue(new Error("ENOENT")),
+        rename: vi.fn().mockRejectedValue(new Error("ENOENT")),
+      };
+
+      // Should not throw
+      await expect(rotateConfigBackups("/config/openclaw.json", mockFs)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("hardenBackupPermissions", () => {
+    it("does nothing when chmod is not available", async () => {
+      const mockFs: BackupRotationFs = {
+        unlink: vi.fn(),
+        rename: vi.fn(),
+        // chmod not provided
+      };
+
+      await expect(hardenBackupPermissions("/config/openclaw.json", mockFs)).resolves.toBeUndefined();
+    });
+
+    it("hardens permissions on all backup files", async () => {
+      const chmodCalls: Array<{ path: string; mode: number }> = [];
+      const mockFs: BackupRotationFs = {
+        unlink: vi.fn(),
+        rename: vi.fn(),
+        chmod: vi.fn().mockImplementation((p, m) => {
+          chmodCalls.push({ path: p, mode: m });
+          return Promise.resolve();
+        }),
+      };
+
+      await hardenBackupPermissions("/config/openclaw.json", mockFs);
+
+      // Should chmod primary .bak and numbered backups
+      expect(chmodCalls).toHaveLength(5);
+      expect(chmodCalls[0]).toEqual({ path: "/config/openclaw.json.bak", mode: 0o600 });
+      expect(chmodCalls[1]).toEqual({ path: "/config/openclaw.json.bak.1", mode: 0o600 });
+      expect(chmodCalls[2]).toEqual({ path: "/config/openclaw.json.bak.2", mode: 0o600 });
+      expect(chmodCalls[3]).toEqual({ path: "/config/openclaw.json.bak.3", mode: 0o600 });
+      expect(chmodCalls[4]).toEqual({ path: "/config/openclaw.json.bak.4", mode: 0o600 });
+    });
+
+    it("handles chmod errors gracefully", async () => {
+      const mockFs: BackupRotationFs = {
+        unlink: vi.fn(),
+        rename: vi.fn(),
+        chmod: vi.fn().mockRejectedValue(new Error("EPERM")),
+      };
+
+      // Should not throw
+      await expect(hardenBackupPermissions("/config/openclaw.json", mockFs)).resolves.toBeUndefined();
+    });
+  });
+
+  describe("cleanOrphanBackups", () => {
+    it("does nothing when readdir is not available", async () => {
+      const mockFs: BackupRotationFs = {
+        unlink: vi.fn(),
+        rename: vi.fn(),
+        // readdir not provided
+      };
+
+      await expect(cleanOrphanBackups("/config/openclaw.json", mockFs)).resolves.toBeUndefined();
+    });
+
+    it("removes orphan backup files", async () => {
+      const unlinked: string[] = [];
+      const mockFs: BackupRotationFs = {
+        unlink: vi.fn().mockImplementation((p) => {
+          unlinked.push(p);
+          return Promise.resolve();
+        }),
+        rename: vi.fn(),
+        readdir: vi.fn().mockResolvedValue([
+          "openclaw.json",
+          "openclaw.json.bak",
+          "openclaw.json.bak.1",
+          "openclaw.json.bak.2",
+          "openclaw.json.bak.12345", // orphan - timestamp
+          "openclaw.json.bak.before-migration", // orphan - custom suffix
+          "other-file.txt",
+        ]),
+      };
+
+      await cleanOrphanBackups("/config/openclaw.json", mockFs);
+
+      // Should remove orphans
+      expect(unlinked).toContain("/config/openclaw.json.bak.12345");
+      expect(unlinked).toContain("/config/openclaw.json.bak.before-migration");
+      
+      // Should NOT remove valid numbered backups
+      expect(unlinked).not.toContain("/config/openclaw.json.bak.1");
+      expect(unlinked).not.toContain("/config/openclaw.json.bak.2");
+      
+      // Should NOT remove primary .bak
+      expect(unlinked).not.toContain("/config/openclaw.json.bak");
+    });
+
+    it("handles readdir errors gracefully", async () => {
+      const mockFs: BackupRotationFs = {
+        unlink: vi.fn(),
+        rename: vi.fn(),
+        readdir: vi.fn().mockRejectedValue(new Error("EACCES")),
+      };
+
+      // Should not throw
+      await expect(cleanOrphanBackups("/config/openclaw.json", mockFs)).resolves.toBeUndefined();
+    });
+
+    it("handles unlink errors gracefully", async () => {
+      const mockFs: BackupRotationFs = {
+        unlink: vi.fn().mockRejectedValue(new Error("EACCES")),
+        rename: vi.fn(),
+        readdir: vi.fn().mockResolvedValue(["openclaw.json.bak.999"]),
+      };
+
+      // Should not throw
+      await expect(cleanOrphanBackups("/config/openclaw.json", mockFs)).resolves.toBeUndefined();
+    });
+
+    it("ignores files without .bak. prefix", async () => {
+      const unlinked: string[] = [];
+      const mockFs: BackupRotationFs = {
+        unlink: vi.fn().mockImplementation((p) => {
+          unlinked.push(p);
+          return Promise.resolve();
+        }),
+        rename: vi.fn(),
+        readdir: vi.fn().mockResolvedValue([
+          "openclaw.json.backup.1", // different prefix
+          "openclaw.json.bak", // primary (no suffix)
+          "openclaw.json.bak.extra", // orphan
+        ]),
+      };
+
+      await cleanOrphanBackups("/config/openclaw.json", mockFs);
+
+      // Should only remove .bak.* files
+      expect(unlinked).toContain("/config/openclaw.json.bak.extra");
+      expect(unlinked).not.toContain("/config/openclaw.json.backup.1");
+      expect(unlinked).not.toContain("/config/openclaw.json.bak");
+    });
+  });
+
+  describe("maintainConfigBackups", () => {
+    it("runs full maintenance cycle in correct order", async () => {
+      const operations: string[] = [];
+      const mockFs: BackupMaintenanceFs = {
+        unlink: vi.fn().mockImplementation((p) => {
+          operations.push(`unlink:${p}`);
+          return Promise.resolve();
+        }),
+        rename: vi.fn().mockImplementation((from, to) => {
+          operations.push(`rename:${from}->${to}`);
+          return Promise.resolve();
+        }),
+        copyFile: vi.fn().mockImplementation((from, to) => {
+          operations.push(`copyFile:${from}->${to}`);
+          return Promise.resolve();
+        }),
+        chmod: vi.fn().mockImplementation((p, m) => {
+          operations.push(`chmod:${p}:${m.toString(8)}`);
+          return Promise.resolve();
+        }),
+        readdir: vi.fn().mockResolvedValue([]),
+      };
+
+      await maintainConfigBackups("/config/openclaw.json", mockFs);
+
+      // Order should be: rotate -> copy -> harden -> clean
+      const copyIndex = operations.findIndex((o) => o.startsWith("copyFile"));
+      const chmodIndex = operations.findIndex((o) => o.startsWith("chmod"));
+
+      expect(copyIndex).toBeGreaterThan(-1);
+      expect(chmodIndex).toBeGreaterThan(copyIndex);
+      
+      // Should copy current config to .bak
+      expect(operations).toContain("copyFile:/config/openclaw.json->/config/openclaw.json.bak");
+    });
+
+    it("handles errors gracefully at each step", async () => {
+      const mockFs: BackupMaintenanceFs = {
+        unlink: vi.fn().mockRejectedValue(new Error("ENOENT")),
+        rename: vi.fn().mockRejectedValue(new Error("ENOENT")),
+        copyFile: vi.fn().mockRejectedValue(new Error("EACCES")),
+        chmod: vi.fn().mockRejectedValue(new Error("EPERM")),
+        readdir: vi.fn().mockRejectedValue(new Error("EACCES")),
+      };
+
+      // Should not throw despite errors at each step
+      await expect(maintainConfigBackups("/config/openclaw.json", mockFs)).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/config/backup-rotation.test.ts
+++ b/src/config/backup-rotation.test.ts
@@ -22,13 +22,11 @@ describe("backup-rotation", () => {
         unlink: vi.fn().mockResolvedValue(undefined),
         rename: vi.fn().mockResolvedValue(undefined),
       };
-      
-      // Temporarily override the constant
-      const originalCount = CONFIG_BACKUP_COUNT;
+
       // We can't easily override the constant, but we can verify the function works
-      
+
       await rotateConfigBackups("/config/openclaw.json", mockFs);
-      
+
       // With default count of 5, it should perform rotations
       expect(mockFs.unlink).toHaveBeenCalled();
     });
@@ -50,12 +48,18 @@ describe("backup-rotation", () => {
 
       // Should unlink the highest numbered backup
       expect(operations).toContain("unlink:/config/openclaw.json.bak.4");
-      
+
       // Should rotate numbered backups
-      expect(operations).toContain("rename:/config/openclaw.json.bak.3->/config/openclaw.json.bak.4");
-      expect(operations).toContain("rename:/config/openclaw.json.bak.2->/config/openclaw.json.bak.3");
-      expect(operations).toContain("rename:/config/openclaw.json.bak.1->/config/openclaw.json.bak.2");
-      
+      expect(operations).toContain(
+        "rename:/config/openclaw.json.bak.3->/config/openclaw.json.bak.4",
+      );
+      expect(operations).toContain(
+        "rename:/config/openclaw.json.bak.2->/config/openclaw.json.bak.3",
+      );
+      expect(operations).toContain(
+        "rename:/config/openclaw.json.bak.1->/config/openclaw.json.bak.2",
+      );
+
       // Should move primary .bak to .bak.1
       expect(operations).toContain("rename:/config/openclaw.json.bak->/config/openclaw.json.bak.1");
     });
@@ -79,7 +83,9 @@ describe("backup-rotation", () => {
         // chmod not provided
       };
 
-      await expect(hardenBackupPermissions("/config/openclaw.json", mockFs)).resolves.toBeUndefined();
+      await expect(
+        hardenBackupPermissions("/config/openclaw.json", mockFs),
+      ).resolves.toBeUndefined();
     });
 
     it("hardens permissions on all backup files", async () => {
@@ -112,7 +118,9 @@ describe("backup-rotation", () => {
       };
 
       // Should not throw
-      await expect(hardenBackupPermissions("/config/openclaw.json", mockFs)).resolves.toBeUndefined();
+      await expect(
+        hardenBackupPermissions("/config/openclaw.json", mockFs),
+      ).resolves.toBeUndefined();
     });
   });
 
@@ -151,11 +159,11 @@ describe("backup-rotation", () => {
       // Should remove orphans
       expect(unlinked).toContain("/config/openclaw.json.bak.12345");
       expect(unlinked).toContain("/config/openclaw.json.bak.before-migration");
-      
+
       // Should NOT remove valid numbered backups
       expect(unlinked).not.toContain("/config/openclaw.json.bak.1");
       expect(unlinked).not.toContain("/config/openclaw.json.bak.2");
-      
+
       // Should NOT remove primary .bak
       expect(unlinked).not.toContain("/config/openclaw.json.bak");
     });
@@ -237,7 +245,7 @@ describe("backup-rotation", () => {
 
       expect(copyIndex).toBeGreaterThan(-1);
       expect(chmodIndex).toBeGreaterThan(copyIndex);
-      
+
       // Should copy current config to .bak
       expect(operations).toContain("copyFile:/config/openclaw.json->/config/openclaw.json.bak");
     });

--- a/src/config/backup-rotation.test.ts
+++ b/src/config/backup-rotation.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   CONFIG_BACKUP_COUNT,
@@ -17,18 +18,17 @@ describe("backup-rotation", () => {
   });
 
   describe("rotateConfigBackups", () => {
-    it("does nothing when CONFIG_BACKUP_COUNT is 1 or less", async () => {
+    it("rotates backups when CONFIG_BACKUP_COUNT > 1", async () => {
       const mockFs: BackupRotationFs = {
         unlink: vi.fn().mockResolvedValue(undefined),
         rename: vi.fn().mockResolvedValue(undefined),
       };
 
-      // We can't easily override the constant, but we can verify the function works
-
       await rotateConfigBackups("/config/openclaw.json", mockFs);
 
       // With default count of 5, it should perform rotations
       expect(mockFs.unlink).toHaveBeenCalled();
+      expect(mockFs.rename).toHaveBeenCalled();
     });
 
     it("rotates backups in correct order", async () => {
@@ -154,18 +154,21 @@ describe("backup-rotation", () => {
         ]),
       };
 
-      await cleanOrphanBackups("/config/openclaw.json", mockFs);
+      const configPath = "/config/openclaw.json";
+      const baseDir = path.dirname(configPath);
+
+      await cleanOrphanBackups(configPath, mockFs);
 
       // Should remove orphans
-      expect(unlinked).toContain("/config/openclaw.json.bak.12345");
-      expect(unlinked).toContain("/config/openclaw.json.bak.before-migration");
+      expect(unlinked).toContain(path.join(baseDir, "openclaw.json.bak.12345"));
+      expect(unlinked).toContain(path.join(baseDir, "openclaw.json.bak.before-migration"));
 
       // Should NOT remove valid numbered backups
-      expect(unlinked).not.toContain("/config/openclaw.json.bak.1");
-      expect(unlinked).not.toContain("/config/openclaw.json.bak.2");
+      expect(unlinked).not.toContain(path.join(baseDir, "openclaw.json.bak.1"));
+      expect(unlinked).not.toContain(path.join(baseDir, "openclaw.json.bak.2"));
 
       // Should NOT remove primary .bak
-      expect(unlinked).not.toContain("/config/openclaw.json.bak");
+      expect(unlinked).not.toContain(path.join(baseDir, "openclaw.json.bak"));
     });
 
     it("handles readdir errors gracefully", async () => {
@@ -205,12 +208,15 @@ describe("backup-rotation", () => {
         ]),
       };
 
-      await cleanOrphanBackups("/config/openclaw.json", mockFs);
+      const configPath = "/config/openclaw.json";
+      const baseDir = path.dirname(configPath);
+
+      await cleanOrphanBackups(configPath, mockFs);
 
       // Should only remove .bak.* files
-      expect(unlinked).toContain("/config/openclaw.json.bak.extra");
-      expect(unlinked).not.toContain("/config/openclaw.json.backup.1");
-      expect(unlinked).not.toContain("/config/openclaw.json.bak");
+      expect(unlinked).toContain(path.join(baseDir, "openclaw.json.bak.extra"));
+      expect(unlinked).not.toContain(path.join(baseDir, "openclaw.json.backup.1"));
+      expect(unlinked).not.toContain(path.join(baseDir, "openclaw.json.bak"));
     });
   });
 


### PR DESCRIPTION
## Summary

- Fix `backup-rotation` tests so they no longer contradict the implementation and pass on Windows.
- Update `docs/zh-CN/tools/diffs.md` related-links section to use existing docs routes so `pnpm check:docs` passes.

## Details

- The test case previously named "does nothing when CONFIG_BACKUP_COUNT is 1 or less" actually exercised the normal rotation path (`CONFIG_BACKUP_COUNT = 5`) and asserted that `unlink` was called. It has been renamed to "rotates backups when CONFIG_BACKUP_COUNT > 1" and now also asserts that `rename` is called.
- `cleanOrphanBackups` uses `path.join` to build unlink targets; tests now assert against `path.join(dirname(configPath), ...)` instead of hard-coding POSIX paths, which fixes failures on Windows runners.
- `docs/zh-CN/tools/diffs.md` previously linked to `/plugins/diffs`, `/tools/canvas`, and `/tools/message`, which do not exist as docs pages and caused `docs-link-audit` to fail. The links now mirror the English source: `/tools`, `/tools/plugin`, and `/tools/browser`, with Chinese link text.

## Relation to #34481

This PR is a follow-up to #34481, addressing the CI failures in `check-docs` and `checks-windows` that block merging the original Chinese translation. Once this lands, #34481 can either cherry-pick these changes or close in favor of this PR.

