### PR TITLE
fix(plugins): share jiti instance with scoped aliases for heartbeat runs

### DIFF
--- a/src/plugin-sdk/root-alias.cjs
+++ b/src/plugin-sdk/root-alias.cjs
@@ -3,8 +3,11 @@
 const path = require("node:path");
 const fs = require("node:fs");
 
+// Global symbol for shared jiti instance (set by plugins/loader.ts)
+const JITI_LOADER_SYMBOL = Symbol.for("openclaw.pluginJitiLoader");
+
 let monolithicSdk = null;
-let jitiLoader = null;
+let localJitiLoader = null;
 
 function emptyPluginConfigSchema() {
   function error(message) {
@@ -61,17 +64,31 @@ function resolveControlCommandGate(params) {
   return { commandAuthorized, shouldBlock };
 }
 
+/**
+ * Get the jiti loader instance.
+ * Prefers the shared instance from plugins/loader.ts (which has scoped aliases configured).
+ * Falls back to creating a local instance for backwards compatibility.
+ */
 function getJiti() {
-  if (jitiLoader) {
-    return jitiLoader;
+  // First, try to use the shared jiti instance from plugins/loader.ts
+  // This instance has all the scoped aliases (openclaw/plugin-sdk/telegram, etc.)
+  const globalJiti = globalThis[JITI_LOADER_SYMBOL];
+  if (globalJiti) {
+    return globalJiti;
+  }
+
+  // Fallback: create a local jiti instance (no scoped aliases)
+  // This path is only hit if root-alias.cjs is loaded before plugins/loader.ts
+  if (localJitiLoader) {
+    return localJitiLoader;
   }
 
   const { createJiti } = require("jiti");
-  jitiLoader = createJiti(__filename, {
+  localJitiLoader = createJiti(__filename, {
     interopDefault: true,
     extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
   });
-  return jitiLoader;
+  return localJitiLoader;
 }
 
 function loadMonolithicSdk() {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -31,6 +31,9 @@ import type {
   PluginLogger,
 } from "./types.js";
 
+// Global symbol for shared jiti instance (used by plugin-sdk/root-alias.cjs)
+const JITI_LOADER_SYMBOL = Symbol.for("openclaw.pluginJitiLoader");
+
 export type PluginLoadResult = PluginRegistry;
 
 export type PluginLoadOptions = {
@@ -581,6 +584,8 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
           }
         : {}),
     });
+    // Store globally so plugin-sdk/root-alias.cjs can reuse the same instance with aliases
+    (globalThis as Record<symbol, unknown>)[JITI_LOADER_SYMBOL] = jitiLoader;
     return jitiLoader;
   };
 


### PR DESCRIPTION
## Summary

During heartbeat embedded runs, the Telegram plugin fails to load with:
```
Cannot find module '.../dist/plugin-sdk/index.js/telegram'
```

## Root Cause

Two separate jiti instances were being created with different configurations:

1. **`plugins/loader.ts`** - creates jiti with scoped aliases:
   - `openclaw/plugin-sdk/telegram` → `telegram.js`
   - `openclaw/plugin-sdk/discord` → `discord.js`
   - etc.

2. **`plugin-sdk/root-alias.cjs`** - creates its own jiti **without** aliases

When `root-alias.cjs` is loaded during embedded runs and a plugin tries to import `openclaw/plugin-sdk/telegram`, the alias-less jiti can't resolve it properly. It falls back to appending `/telegram` to the base path (`index.js`), resulting in the malformed path `index.js/telegram`.

## Fix

Share the jiti instance via a global Symbol so `root-alias.cjs` reuses the properly configured loader from `plugins/loader.ts`.

### Changes:
- **`loader.ts`**: Store jiti instance globally via `Symbol.for("openclaw.pluginJitiLoader")`
- **`root-alias.cjs`**: Check for global jiti first, use it if available, fall back to local instance for backwards compatibility

## Testing

This fix ensures that during heartbeat embedded runs:
1. Plugins load successfully  
2. Telegram messages are delivered correctly
3. No more "Cannot find module" errors

Fixes #36425