### PR TITLE
Feishu: pass audio/video duration to upload API

### DIFF
--- a/extensions/feishu/package.json
+++ b/extensions/feishu/package.json
@@ -7,6 +7,7 @@
     "@larksuiteoapi/node-sdk": "^1.59.0",
     "@sinclair/typebox": "0.34.48",
     "https-proxy-agent": "^7.0.6",
+    "music-metadata": "^11.12.1",
     "zod": "^4.3.6"
   },
   "openclaw": {

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -9,6 +9,8 @@ import { getFeishuRuntime } from "./runtime.js";
 import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
 
+type IFileInfo = import("music-metadata").IFileInfo;
+
 const FEISHU_MEDIA_HTTP_TIMEOUT_MS = 120_000;
 
 export type DownloadImageResult = {
@@ -414,6 +416,35 @@ export function detectFileType(
 }
 
 /**
+ * Extract duration in milliseconds from an audio/video buffer.
+ * Returns undefined for non-media files or when parsing fails.
+ */
+async function resolveMediaDurationMs(
+  buffer: Buffer,
+  fileName: string,
+  fileType: "opus" | "mp4" | "pdf" | "doc" | "xls" | "ppt" | "stream",
+): Promise<number | undefined> {
+  if (fileType !== "opus" && fileType !== "mp4") return undefined;
+  try {
+    const { parseBuffer } = await import("music-metadata");
+    const fileInfo: IFileInfo | undefined = fileName
+      ? { size: buffer.byteLength, path: fileName }
+      : undefined;
+    const metadata = await parseBuffer(buffer, fileInfo, {
+      duration: true,
+      skipCovers: true,
+    });
+    const durationSeconds = metadata.format.duration;
+    if (typeof durationSeconds === "number" && Number.isFinite(durationSeconds)) {
+      return Math.max(0, Math.round(durationSeconds * 1000));
+    }
+  } catch {
+    // Duration is optional; ignore parse failures.
+  }
+  return undefined;
+}
+
+/**
  * Upload and send media (image or file) from URL, local path, or buffer.
  * When mediaUrl is a local path, mediaLocalRoots (from core outbound context)
  * must be passed so loadWebMedia allows the path (post CVE-2026-26321).
@@ -474,11 +505,13 @@ export async function sendMediaFeishu(params: {
     return sendImageFeishu({ cfg, to, imageKey, replyToMessageId, replyInThread, accountId });
   } else {
     const fileType = detectFileType(name);
+    const duration = await resolveMediaDurationMs(buffer, name, fileType);
     const { fileKey } = await uploadFileFeishu({
       cfg,
       file: buffer,
       fileName: name,
       fileType,
+      duration,
       accountId,
     });
     // Feishu API: opus -> "audio", mp4/video -> "media" (playable), others -> "file"

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -422,14 +422,12 @@ export function detectFileType(
 async function resolveMediaDurationMs(
   buffer: Buffer,
   fileName: string,
-  fileType: "opus" | "mp4" | "pdf" | "doc" | "xls" | "ppt" | "stream",
+  fileType: ReturnType<typeof detectFileType>,
 ): Promise<number | undefined> {
   if (fileType !== "opus" && fileType !== "mp4") return undefined;
   try {
     const { parseBuffer } = await import("music-metadata");
-    const fileInfo: IFileInfo | undefined = fileName
-      ? { size: buffer.byteLength, path: fileName }
-      : undefined;
+    const fileInfo: IFileInfo = { size: buffer.byteLength, path: fileName };
     const metadata = await parseBuffer(buffer, fileInfo, {
       duration: true,
       skipCovers: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,6 +330,9 @@ importers:
       https-proxy-agent:
         specifier: ^7.0.6
         version: 7.0.6
+      music-metadata:
+        specifier: ^11.12.1
+        version: 11.12.1
       zod:
         specifier: ^4.3.6
         version: 4.3.6


### PR DESCRIPTION
## Summary

- `sendMediaFeishu()` calls `uploadFileFeishu()` without the `duration` parameter, causing Feishu to display **"0:00"** for all audio and video messages
- `uploadFileFeishu()` already accepts and forwards `duration` to the Feishu API — the gap is purely in `sendMediaFeishu()` never extracting it
- Adds `resolveMediaDurationMs()` (adapted from the Matrix extension's existing implementation) to parse duration from the media buffer using `music-metadata`, and wires it into `sendMediaFeishu()` for opus and mp4 files

## Approach: `music-metadata` vs `ffprobe`

This PR uses `music-metadata` (pure JS/TS npm package) instead of `ffprobe` (external binary). Rationale:

- **Already used in the codebase**: the Matrix extension uses `music-metadata` for the same purpose (`extensions/matrix/src/matrix/send/media.ts:157-188`)
- **No external binary dependency**: works on any host without requiring `ffprobe` installed
- **Minimal change surface**: 2 files changed, ~30 lines added — extension-only, no core changes needed

Related PRs solving the same problem with `ffprobe`:
- #31717
- #33060

## Test plan

- [x] `pnpm build` passes (no `[INEFFECTIVE_DYNAMIC_IMPORT]` warnings)
- [x] `pnpm check` passes (lint + format)
- [x] Verified `music-metadata` correctly parses duration from real TTS opus files (4194ms, 4474ms)
- [ ] Send an opus audio message via Feishu — verify duration displays correctly (not "0:00")
- [ ] Send an mp4 video message via Feishu — verify duration displays correctly
- [ ] Send a non-media file (pdf, doc) — verify no regression (duration param not passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)