### PR TITLE
fix(sessions): always cleanup archived files in base sessions directory

### DIFF
--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -420,21 +420,21 @@ async function saveSessionStoreUnlocked(
           archivedDirs.add(path.dirname(archivedPath));
         }
       }
-      if (archivedDirs.size > 0 || maintenance.resetArchiveRetentionMs != null) {
-        const targetDirs =
-          archivedDirs.size > 0 ? [...archivedDirs] : [path.dirname(path.resolve(storePath))];
+      // Always include the base sessions directory to ensure old archived files are cleaned up,
+      // not just directories where new archives were created in this maintenance run.
+      const baseSessionsDir = path.dirname(path.resolve(storePath));
+      const targetDirs = [...new Set([baseSessionsDir, ...archivedDirs])];
+      await cleanupArchivedSessionTranscripts({
+        directories: targetDirs,
+        olderThanMs: maintenance.pruneAfterMs,
+        reason: "deleted",
+      });
+      if (maintenance.resetArchiveRetentionMs != null) {
         await cleanupArchivedSessionTranscripts({
           directories: targetDirs,
-          olderThanMs: maintenance.pruneAfterMs,
-          reason: "deleted",
+          olderThanMs: maintenance.resetArchiveRetentionMs,
+          reason: "reset",
         });
-        if (maintenance.resetArchiveRetentionMs != null) {
-          await cleanupArchivedSessionTranscripts({
-            directories: targetDirs,
-            olderThanMs: maintenance.resetArchiveRetentionMs,
-            reason: "reset",
-          });
-        }
       }
 
       // Rotate the on-disk file if it exceeds the size threshold.


### PR DESCRIPTION
## Summary

Session archive cleanup was only running on directories where NEW archives were created in the current maintenance run. Old `.deleted` and `.reset` files in the base sessions directory were missed if no new archives happened to be created there.

This caused archived files to accumulate indefinitely on disk.

## Root Cause

```typescript
// Before: only cleans specific archive directories, or falls back to base dir
const targetDirs =
  archivedDirs.size > 0 ? [...archivedDirs] : [path.dirname(path.resolve(storePath))];
```

When `archivedDirs.size > 0`, cleanup was limited to those specific directories, missing old files elsewhere.

## Fix

```typescript
// After: always includes base sessions directory
const baseSessionsDir = path.dirname(path.resolve(storePath));
const targetDirs = [...new Set([baseSessionsDir, ...archivedDirs])];
```

Now cleanup always scans the base sessions directory, ensuring old archived files are removed regardless of where new archives are created.

## Impact

- **Before:** 562 `.deleted` files (187MB) accumulated over 3 weeks
- **After:** Files cleaned up after `pruneAfter` period (default 30 days)

## Testing

- Verified cleanup logic includes base directory in all cases
- No change to retention policy or timing, just ensures cleanup actually runs on all relevant directories

Fixes #36608