### PR TITLE
feat(telegram): implement broadcast groups for multi-agent fan-out

### DIFF
--- a/docs/channels/broadcast-groups.md
+++ b/docs/channels/broadcast-groups.md
@@ -1,8 +1,9 @@
 ---
-summary: "Broadcast a WhatsApp message to multiple agents"
+summary: "Broadcast a message to multiple agents (WhatsApp, Telegram)"
 read_when:
   - Configuring broadcast groups
   - Debugging multi-agent replies in WhatsApp
+  - Debugging multi-agent replies in Telegram
 status: experimental
 title: "Broadcast Groups"
 ---
@@ -14,11 +15,11 @@ title: "Broadcast Groups"
 
 ## Overview
 
-Broadcast Groups enable multiple agents to process and respond to the same message simultaneously. This allows you to create specialized agent teams that work together in a single WhatsApp group or DM — all using one phone number.
+Broadcast Groups enable multiple agents to process and respond to the same message simultaneously. This allows you to create specialized agent teams that work together in a single chat group or DM.
 
-Current scope: **WhatsApp only** (web channel).
+Current scope: **WhatsApp** and **Telegram**.
 
-Broadcast groups are evaluated after channel allowlists and group activation rules. In WhatsApp groups, this means broadcasts happen when OpenClaw would normally reply (for example: on mention, depending on your group settings).
+Broadcast groups are evaluated after channel allowlists and group activation rules. This means broadcasts happen when OpenClaw would normally reply (for example: on mention, depending on your group settings).
 
 ## Use Cases
 
@@ -70,20 +71,29 @@ Agents:
 
 ### Basic Setup
 
-Add a top-level `broadcast` section (next to `bindings`). Keys are WhatsApp peer ids:
+Add a top-level `broadcast` section (next to `bindings`). Keys are peer ids specific to each channel:
+
+**WhatsApp:**
 
 - group chats: group JID (e.g. `120363403215116621@g.us`)
 - DMs: E.164 phone number (e.g. `+15551234567`)
 
+**Telegram:**
+
+- Prefix with `telegram:` followed by the chat ID (e.g. `telegram:1234567890`)
+- For multi-account setups: `telegram:{accountId}:{chatId}` (e.g. `telegram:mybot:1234567890`)
+- Raw chat IDs also work (e.g. `1234567890`) but prefixed keys are recommended to avoid collisions
+
 ```json
 {
   "broadcast": {
-    "120363403215116621@g.us": ["alfred", "baerbel", "assistant3"]
+    "120363403215116621@g.us": ["alfred", "baerbel", "assistant3"],
+    "telegram:1234567890": ["main", "router"]
   }
 }
 ```
 
-**Result:** When OpenClaw would reply in this chat, it will run all three agents.
+**Result:** When OpenClaw would reply in these chats, it will run all listed agents.
 
 ### Processing Strategy
 
@@ -277,7 +287,7 @@ Result: Agent A and C respond, Agent B logs error
 Broadcast groups currently work with:
 
 - ✅ WhatsApp (implemented)
-- 🚧 Telegram (planned)
+- ✅ Telegram (implemented)
 - 🚧 Discord (planned)
 - 🚧 Slack (planned)
 
@@ -416,7 +426,9 @@ interface OpenClawConfig {
 - `strategy` (optional): How to process agents
   - `"parallel"` (default): All agents process simultaneously
   - `"sequential"`: Agents process in array order
-- `[peerId]`: WhatsApp group JID, E.164 number, or other peer ID
+- `[peerId]`: Channel-specific peer identifier
+  - WhatsApp: group JID or E.164 number
+  - Telegram: `telegram:{chatId}`, `telegram:{accountId}:{chatId}`, or raw chat ID
   - Value: Array of agent IDs that should process messages
 
 ## Limitations

--- a/src/telegram/bot-message.ts
+++ b/src/telegram/bot-message.ts
@@ -9,6 +9,7 @@ import {
 import { dispatchTelegramMessage } from "./bot-message-dispatch.js";
 import type { TelegramBotOptions } from "./bot.js";
 import type { TelegramContext, TelegramStreamMode } from "./bot/types.js";
+import { maybeBroadcastTelegramMessage } from "./broadcast.js";
 
 /** Dependencies injected once when creating the message processor. */
 type TelegramMessageProcessorDeps = Omit<
@@ -76,6 +77,22 @@ export const createTelegramMessageProcessor = (deps: TelegramMessageProcessorDep
       sendChatActionHandler,
     });
     if (!context) {
+      return;
+    }
+    // Broadcast groups: fan out to multiple agents when configured.
+    if (
+      await maybeBroadcastTelegramMessage({
+        cfg,
+        context,
+        bot,
+        runtime,
+        replyToMode,
+        streamMode,
+        textLimit,
+        telegramCfg,
+        opts,
+      })
+    ) {
       return;
     }
     await dispatchTelegramMessage({

--- a/src/telegram/broadcast.test.ts
+++ b/src/telegram/broadcast.test.ts
@@ -1,0 +1,647 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import type { TelegramMessageContext } from "./bot-message-context.js";
+import type { MaybeBroadcastTelegramMessageParams } from "./broadcast.js";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const dispatchMock = vi.hoisted(() => vi.fn(async (_params?: any) => {}));
+
+vi.mock("./bot-message-dispatch.js", () => ({
+  dispatchTelegramMessage: dispatchMock,
+}));
+
+// Suppress logVerbose output during tests.
+vi.mock("../globals.js", () => ({
+  logVerbose: () => {},
+  shouldLogVerbose: () => false,
+  danger: (s: string) => s,
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+import { maybeBroadcastTelegramMessage } from "./broadcast.js";
+
+type DispatchCall = { context: TelegramMessageContext };
+
+/** Type-safe accessor for dispatch mock call args. */
+function getDispatchContext(callIndex: number): TelegramMessageContext {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (dispatchMock.mock.calls[callIndex] as any)[0].context;
+}
+
+function getAllDispatchContexts(): TelegramMessageContext[] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return dispatchMock.mock.calls.map((call: any) => (call[0] as DispatchCall).context);
+}
+
+function buildFakeContext(overrides?: Partial<TelegramMessageContext>): TelegramMessageContext {
+  const defaults: TelegramMessageContext = {
+    ctxPayload: {
+      Body: "hello",
+      From: "telegram:1234567890",
+      SessionKey: "agent:main:telegram:default:direct:1234567890",
+      ChatType: "direct",
+    } as TelegramMessageContext["ctxPayload"],
+    primaryCtx: {} as TelegramMessageContext["primaryCtx"],
+    msg: {
+      message_id: 1,
+      chat: { id: 1234567890 },
+      date: Date.now(),
+    } as TelegramMessageContext["msg"],
+    chatId: 1234567890,
+    isGroup: false,
+    resolvedThreadId: undefined,
+    threadSpec: { scope: "none" } as TelegramMessageContext["threadSpec"],
+    replyThreadId: undefined,
+    isForum: false,
+    historyKey: undefined,
+    historyLimit: 0,
+    groupHistories: new Map(),
+    route: {
+      agentId: "main",
+      channel: "telegram",
+      sessionKey: "agent:main:telegram:default:direct:1234567890",
+      mainSessionKey: "agent:main:main",
+      accountId: "default",
+      matchedBy: "default" as const,
+    },
+    skillFilter: undefined,
+    sendTyping: async () => {},
+    sendRecordVoice: async () => {},
+    ackReactionPromise: null,
+    reactionApi: null,
+    removeAckAfterReply: false,
+    statusReactionController: null,
+    accountId: "default",
+  };
+  return { ...defaults, ...overrides };
+}
+
+function buildParams(
+  cfg: OpenClawConfig,
+  context: TelegramMessageContext,
+): MaybeBroadcastTelegramMessageParams {
+  return {
+    cfg,
+    context,
+    bot: {} as MaybeBroadcastTelegramMessageParams["bot"],
+    runtime: {} as MaybeBroadcastTelegramMessageParams["runtime"],
+    replyToMode: "off",
+    streamMode: "off",
+    textLimit: 4096,
+    telegramCfg: {} as MaybeBroadcastTelegramMessageParams["telegramCfg"],
+    opts: { token: "test-token" },
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("maybeBroadcastTelegramMessage", () => {
+  beforeEach(() => {
+    dispatchMock.mockClear();
+  });
+
+  it("returns false when no broadcast config exists", async () => {
+    const cfg: OpenClawConfig = {};
+    const context = buildFakeContext();
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(false);
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("returns false when peer ID is not in broadcast config", async () => {
+    const cfg: OpenClawConfig = {
+      broadcast: {
+        "telegram:9999999999": ["agent-a"],
+      },
+    };
+    const context = buildFakeContext();
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(false);
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("dispatches to all agents using prefixed peer ID key", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "alfred" }, { id: "baerbel" }],
+      },
+      broadcast: {
+        "telegram:1234567890": ["alfred", "baerbel"],
+      },
+    };
+    const context = buildFakeContext();
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(true);
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+
+    // Verify each dispatch received a different agentId in the route.
+    const agents = getAllDispatchContexts().map((ctx) => ctx.route.agentId);
+    expect(agents).toContain("alfred");
+    expect(agents).toContain("baerbel");
+  });
+
+  it("dispatches to all agents using raw (unprefixed) peer ID key", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "alfred" }],
+      },
+      broadcast: {
+        "1234567890": ["alfred"],
+      },
+    };
+    const context = buildFakeContext();
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(true);
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers prefixed key over raw key", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "alfred" }, { id: "baerbel" }],
+      },
+      broadcast: {
+        "telegram:1234567890": ["alfred"],
+        "1234567890": ["baerbel"],
+      },
+    };
+    const context = buildFakeContext();
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(true);
+    // Should use the prefixed key (alfred), not the raw key (baerbel).
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    const agent = getDispatchContext(0).route.agentId;
+    expect(agent).toBe("alfred");
+  });
+
+  it("skips unknown agent IDs when agents.list is present", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "alfred" }],
+      },
+      broadcast: {
+        "telegram:1234567890": ["alfred", "ghost"],
+      },
+    };
+    const context = buildFakeContext();
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(true);
+    // Only alfred should be dispatched; ghost is not in agents.list.
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    const agent = getDispatchContext(0).route.agentId;
+    expect(agent).toBe("alfred");
+  });
+
+  it("broadcasts sequentially in configured order", async () => {
+    const order: string[] = [];
+    dispatchMock.mockImplementation(async (params: unknown) => {
+      const p = params as { context: TelegramMessageContext };
+      order.push(p.context.route.agentId);
+    });
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "alfred" }, { id: "baerbel" }],
+      },
+      broadcast: {
+        strategy: "sequential",
+        "telegram:1234567890": ["alfred", "baerbel"],
+      },
+    };
+    const context = buildFakeContext();
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(true);
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+    expect(order).toEqual(["alfred", "baerbel"]);
+  });
+
+  it("broadcasts in parallel by default", async () => {
+    let started = 0;
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    dispatchMock.mockImplementation(async () => {
+      started += 1;
+      if (started < 2) {
+        await gate;
+      } else {
+        release?.();
+      }
+    });
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "alfred" }, { id: "baerbel" }],
+      },
+      broadcast: {
+        strategy: "parallel",
+        "telegram:1234567890": ["alfred", "baerbel"],
+      },
+    };
+    const context = buildFakeContext();
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(true);
+    // Both agents must have started (gate only resolves when both are in-flight).
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears group history after broadcast", async () => {
+    const groupHistories = new Map<string, Array<{ sender: string; body: string }>>();
+    groupHistories.set("-100123456", [{ sender: "Alice", body: "hi" }]);
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "alfred" }],
+      },
+      broadcast: {
+        "telegram:-100123456": ["alfred"],
+      },
+    };
+    const context = buildFakeContext({
+      chatId: -100123456,
+      isGroup: true,
+      historyKey: "-100123456",
+      groupHistories: groupHistories as TelegramMessageContext["groupHistories"],
+    });
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(true);
+    expect(groupHistories.get("-100123456")).toEqual([]);
+  });
+
+  it("account-scoped key takes precedence over generic telegram key", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "alfred" }, { id: "baerbel" }],
+      },
+      broadcast: {
+        "telegram:myaccount:1234567890": ["alfred"],
+        "telegram:1234567890": ["baerbel"],
+      },
+    };
+    const context = buildFakeContext({ accountId: "myaccount" });
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(true);
+    // Should use the account-scoped key (alfred), not the generic key (baerbel).
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    const agent = getDispatchContext(0).route.agentId;
+    expect(agent).toBe("alfred");
+  });
+
+  it("forum topic message with broadcast gives each agent thread-scoped routing", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "alfred" }, { id: "baerbel" }],
+      },
+      broadcast: {
+        "telegram:-1001234567890": ["alfred", "baerbel"],
+      },
+    };
+    const context = buildFakeContext({
+      chatId: -1001234567890,
+      isGroup: true,
+      isForum: true,
+      resolvedThreadId: 42,
+      historyKey: "-1001234567890:42",
+      ctxPayload: {
+        Body: "hello",
+        From: "telegram:-1001234567890:42",
+        SessionKey: "agent:main:telegram:default:group:-1001234567890:42",
+        ChatType: "group",
+      } as TelegramMessageContext["ctxPayload"],
+      route: {
+        agentId: "main",
+        channel: "telegram",
+        sessionKey: "agent:main:telegram:default:group:-1001234567890:42",
+        mainSessionKey: "agent:main:main",
+        accountId: "default",
+        matchedBy: "default" as const,
+      },
+    });
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(true);
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+
+    // Each agent should get the thread-scoped peer ID in its session key.
+    const contexts = getAllDispatchContexts();
+    for (const ctx of contexts) {
+      // The resolvedThreadId should flow through unchanged.
+      expect(ctx.resolvedThreadId).toBe(42);
+      expect(ctx.isForum).toBe(true);
+    }
+    // The two agents should have different session keys.
+    const keys = contexts.map((ctx) => ctx.route.sessionKey);
+    expect(keys[0]).not.toBe(keys[1]);
+  });
+
+  it("ack reaction is only sent to the first/primary broadcast agent", async () => {
+    const fakeAckPromise = Promise.resolve(true);
+    const fakeReactionApi = vi.fn();
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "alfred" }, { id: "baerbel" }],
+      },
+      broadcast: {
+        strategy: "sequential",
+        "telegram:1234567890": ["alfred", "baerbel"],
+      },
+    };
+    const context = buildFakeContext({
+      ackReactionPromise: fakeAckPromise,
+      reactionApi: fakeReactionApi as TelegramMessageContext["reactionApi"],
+    });
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(true);
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+
+    const firstCtx = getDispatchContext(0);
+    const secondCtx = getDispatchContext(1);
+
+    // First agent keeps ack reaction.
+    expect(firstCtx.ackReactionPromise).toBe(fakeAckPromise);
+    expect(firstCtx.reactionApi).toBe(fakeReactionApi);
+
+    // Second agent has ack nulled out.
+    expect(secondCtx.ackReactionPromise).toBeNull();
+    expect(secondCtx.reactionApi).toBeNull();
+  });
+
+  it("statusReactionController is only active for the primary broadcast agent", async () => {
+    const fakeController = {
+      setQueued: vi.fn(),
+    } as unknown as TelegramMessageContext["statusReactionController"];
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "alfred" }, { id: "baerbel" }],
+      },
+      broadcast: {
+        strategy: "sequential",
+        "telegram:1234567890": ["alfred", "baerbel"],
+      },
+    };
+    const context = buildFakeContext({
+      statusReactionController: fakeController,
+    });
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(true);
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+
+    const firstCtx = getDispatchContext(0);
+    const secondCtx = getDispatchContext(1);
+
+    expect(firstCtx.statusReactionController).toBe(fakeController);
+    expect(secondCtx.statusReactionController).toBeNull();
+  });
+
+  it("removeAckAfterReply is only true for the primary broadcast agent", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "alfred" }, { id: "baerbel" }],
+      },
+      broadcast: {
+        strategy: "sequential",
+        "telegram:1234567890": ["alfred", "baerbel"],
+      },
+    };
+    const context = buildFakeContext({
+      removeAckAfterReply: true,
+    });
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(true);
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+
+    const firstCtx = getDispatchContext(0);
+    const secondCtx = getDispatchContext(1);
+
+    expect(firstCtx.removeAckAfterReply).toBe(true);
+    expect(secondCtx.removeAckAfterReply).toBe(false);
+  });
+
+  it("handles large negative group chat IDs correctly", async () => {
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "alfred" }],
+      },
+      broadcast: {
+        "telegram:-1001234567890": ["alfred"],
+      },
+    };
+    const context = buildFakeContext({
+      chatId: -1001234567890,
+      isGroup: true,
+      historyKey: "-1001234567890",
+      ctxPayload: {
+        Body: "hello",
+        From: "telegram:-1001234567890",
+        SessionKey: "agent:main:telegram:default:group:-1001234567890",
+        ChatType: "group",
+      } as TelegramMessageContext["ctxPayload"],
+    });
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(true);
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+
+    expect(getDispatchContext(0).route.agentId).toBe("alfred");
+  });
+
+  // ── Stress Tests ──────────────────────────────────────────────────────────
+
+  it("handles 10 agents in parallel without deadlock or lost dispatches", async () => {
+    const agentIds = Array.from({ length: 10 }, (_, i) => `agent-${i}`);
+    const cfg: OpenClawConfig = {
+      agents: { list: agentIds.map((id) => ({ id })) },
+      broadcast: {
+        strategy: "parallel",
+        "telegram:1234567890": agentIds,
+      },
+    };
+
+    // Each agent takes a random delay (0-50ms) to simulate real LLM latency variance.
+    dispatchMock.mockImplementation(async () => {
+      await new Promise((r) => setTimeout(r, Math.random() * 50));
+    });
+
+    const context = buildFakeContext();
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(true);
+    expect(dispatchMock).toHaveBeenCalledTimes(10);
+
+    // Verify all 10 agents received unique routes.
+    const dispatched = getAllDispatchContexts().map((ctx) => ctx.route.agentId);
+    expect(new Set(dispatched).size).toBe(10);
+  });
+
+  it("rapid-fire: 20 concurrent broadcast calls don't interfere", async () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "alfred" }, { id: "baerbel" }] },
+      broadcast: {
+        strategy: "parallel",
+        "telegram:1234567890": ["alfred", "baerbel"],
+      },
+    };
+
+    dispatchMock.mockImplementation(async () => {
+      await new Promise((r) => setTimeout(r, Math.random() * 20));
+    });
+
+    // Simulate 20 messages arriving nearly simultaneously.
+    const promises = Array.from({ length: 20 }, () => {
+      const context = buildFakeContext();
+      return maybeBroadcastTelegramMessage(buildParams(cfg, context));
+    });
+
+    const results = await Promise.all(promises);
+
+    // All 20 should succeed.
+    expect(results.every((r) => r)).toBe(true);
+    // 20 messages × 2 agents each = 40 dispatches.
+    expect(dispatchMock).toHaveBeenCalledTimes(40);
+  });
+
+  it("mixed failures: some agents throw, others succeed, all are attempted", async () => {
+    const agentIds = Array.from({ length: 5 }, (_, i) => `agent-${i}`);
+    const cfg: OpenClawConfig = {
+      agents: { list: agentIds.map((id) => ({ id })) },
+      broadcast: {
+        strategy: "parallel",
+        "telegram:1234567890": agentIds,
+      },
+    };
+
+    // Agents 1 and 3 throw; 0, 2, 4 succeed.
+    dispatchMock.mockImplementation(async (params: unknown) => {
+      const p = params as { context: TelegramMessageContext };
+      const idx = Number(p.context.route.agentId.split("-")[1]);
+      if (idx % 2 === 1) {
+        throw new Error(`agent-${idx} failed`);
+      }
+    });
+
+    const context = buildFakeContext();
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(true);
+    // All 5 attempted despite failures.
+    expect(dispatchMock).toHaveBeenCalledTimes(5);
+  });
+
+  it("sequential with slow agents: maintains strict ordering", async () => {
+    const order: string[] = [];
+    const agentIds = Array.from({ length: 5 }, (_, i) => `agent-${i}`);
+    const cfg: OpenClawConfig = {
+      agents: { list: agentIds.map((id) => ({ id })) },
+      broadcast: {
+        strategy: "sequential",
+        "telegram:1234567890": agentIds,
+      },
+    };
+
+    dispatchMock.mockImplementation(async (params: unknown) => {
+      const p = params as { context: TelegramMessageContext };
+      // Random delay to verify sequential isn't accidentally parallel.
+      await new Promise((r) => setTimeout(r, Math.random() * 30));
+      order.push(p.context.route.agentId);
+    });
+
+    const context = buildFakeContext();
+    await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(order).toEqual(agentIds);
+  });
+
+  it("isFirstAgent flag is correct even under parallel dispatch race", async () => {
+    const cfg: OpenClawConfig = {
+      agents: { list: [{ id: "alfred" }, { id: "baerbel" }, { id: "charlie" }] },
+      broadcast: {
+        strategy: "parallel",
+        "telegram:1234567890": ["alfred", "baerbel", "charlie"],
+      },
+    };
+
+    const context = buildFakeContext({
+      ackReactionPromise: Promise.resolve(true),
+      reactionApi: vi.fn() as TelegramMessageContext["reactionApi"],
+      removeAckAfterReply: true,
+      statusReactionController: {
+        setQueued: vi.fn(),
+      } as unknown as TelegramMessageContext["statusReactionController"],
+    });
+
+    await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(dispatchMock).toHaveBeenCalledTimes(3);
+
+    const contexts = getAllDispatchContexts();
+
+    // Exactly one agent should have non-null ack reaction (the primary).
+    const withAck = contexts.filter((c) => c.ackReactionPromise !== null);
+    const withoutAck = contexts.filter((c) => c.ackReactionPromise === null);
+    expect(withAck.length).toBe(1);
+    expect(withoutAck.length).toBe(2);
+
+    // The primary should also keep statusReactionController and removeAckAfterReply.
+    expect(withAck[0].statusReactionController).not.toBeNull();
+    expect(withAck[0].removeAckAfterReply).toBe(true);
+    for (const ctx of withoutAck) {
+      expect(ctx.statusReactionController).toBeNull();
+      expect(ctx.removeAckAfterReply).toBe(false);
+    }
+  });
+
+  it("empty broadcast array returns false (no dispatch)", async () => {
+    const cfg: OpenClawConfig = {
+      broadcast: { "telegram:1234567890": [] },
+    };
+    const context = buildFakeContext();
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(false);
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("catches dispatch errors and continues to next agent", async () => {
+    let callCount = 0;
+    dispatchMock.mockImplementation(async () => {
+      callCount += 1;
+      if (callCount === 1) {
+        throw new Error("boom");
+      }
+    });
+
+    const cfg: OpenClawConfig = {
+      agents: {
+        list: [{ id: "alfred" }, { id: "baerbel" }],
+      },
+      broadcast: {
+        strategy: "sequential",
+        "telegram:1234567890": ["alfred", "baerbel"],
+      },
+    };
+    const context = buildFakeContext();
+    const result = await maybeBroadcastTelegramMessage(buildParams(cfg, context));
+
+    expect(result).toBe(true);
+    // Both agents attempted even though first threw.
+    expect(dispatchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/telegram/broadcast.ts
+++ b/src/telegram/broadcast.ts
@@ -1,0 +1,156 @@
+import type { Bot } from "grammy";
+import type { ReplyToMode } from "../config/config.js";
+import type { OpenClawConfig, TelegramAccountConfig } from "../config/types.js";
+import { logVerbose } from "../globals.js";
+import { buildAgentSessionKey } from "../routing/resolve-route.js";
+import {
+  buildAgentMainSessionKey,
+  DEFAULT_MAIN_KEY,
+  normalizeAgentId,
+} from "../routing/session-key.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { TelegramMessageContext } from "./bot-message-context.js";
+import { dispatchTelegramMessage } from "./bot-message-dispatch.js";
+import type { TelegramBotOptions } from "./bot.js";
+import type { TelegramStreamMode } from "./bot/types.js";
+
+export type MaybeBroadcastTelegramMessageParams = {
+  cfg: OpenClawConfig;
+  context: TelegramMessageContext;
+  bot: Bot;
+  runtime: RuntimeEnv;
+  replyToMode: ReplyToMode;
+  streamMode: TelegramStreamMode;
+  textLimit: number;
+  telegramCfg: TelegramAccountConfig;
+  opts: Pick<TelegramBotOptions, "token">;
+};
+
+/**
+ * If the sender's peer ID is configured for broadcast, dispatch the message
+ * to every listed agent and return `true`.  Returns `false` when no broadcast
+ * config matches — the caller should continue with normal single-agent dispatch.
+ */
+export async function maybeBroadcastTelegramMessage(
+  params: MaybeBroadcastTelegramMessageParams,
+): Promise<boolean> {
+  const { cfg, context } = params;
+  const chatId = String(context.chatId);
+
+  // Try account-scoped key first, then "telegram:{chatId}" (prefixed), then raw "{chatId}".
+  const accountId = context.accountId ?? context.route.accountId;
+  const broadcastAgents =
+    cfg.broadcast?.[`telegram:${accountId}:${chatId}`] ??
+    cfg.broadcast?.[`telegram:${chatId}`] ??
+    cfg.broadcast?.[chatId];
+  if (!broadcastAgents || !Array.isArray(broadcastAgents)) {
+    return false;
+  }
+  if (broadcastAgents.length === 0) {
+    return false;
+  }
+
+  const strategy = cfg.broadcast?.strategy || "parallel";
+  logVerbose(
+    `telegram broadcast: fanning message to ${broadcastAgents.length} agents (${strategy})`,
+  );
+
+  const agentIds = cfg.agents?.list?.map((agent) => normalizeAgentId(agent.id));
+  const hasKnownAgents = (agentIds?.length ?? 0) > 0;
+  const isGroup = context.isGroup;
+  const peerId = context.ctxPayload.From?.replace(/^telegram:/, "") ?? chatId;
+
+  // Snapshot group history before dispatch so every agent sees the same context.
+  const groupHistorySnapshot =
+    isGroup && context.historyKey
+      ? (context.groupHistories.get(context.historyKey) ?? [])
+      : undefined;
+
+  let isFirstAgent = true;
+
+  const dispatchForAgent = async (agentId: string): Promise<boolean> => {
+    const normalizedAgentId = normalizeAgentId(agentId);
+    if (hasKnownAgents && !agentIds?.includes(normalizedAgentId)) {
+      logVerbose(`telegram broadcast: agent ${agentId} not found in agents.list; skipping`);
+      return false;
+    }
+
+    const agentRoute = {
+      ...context.route,
+      agentId: normalizedAgentId,
+      sessionKey: buildAgentSessionKey({
+        agentId: normalizedAgentId,
+        channel: "telegram",
+        accountId: context.route.accountId,
+        peer: {
+          kind: isGroup ? "group" : ("direct" as const),
+          id: peerId,
+        },
+        dmScope: cfg.session?.dmScope,
+        identityLinks: cfg.session?.identityLinks,
+      }),
+      mainSessionKey: buildAgentMainSessionKey({
+        agentId: normalizedAgentId,
+        mainKey: DEFAULT_MAIN_KEY,
+      }),
+    };
+
+    const isPrimary = isFirstAgent;
+    isFirstAgent = false;
+
+    const broadcastContext: TelegramMessageContext = {
+      ...context,
+      route: agentRoute,
+      // Only the first/primary agent should send the ack reaction, remove it
+      // after reply, or drive status reaction lifecycle.
+      ...(isPrimary
+        ? {}
+        : {
+            ackReactionPromise: null,
+            reactionApi: null,
+            removeAckAfterReply: false,
+            statusReactionController: null,
+          }),
+      // Each agent gets its own copy of group history so dispatch doesn't
+      // clear shared state prematurely.
+      ...(groupHistorySnapshot != null
+        ? {
+            groupHistories: new Map(context.groupHistories),
+          }
+        : {}),
+    };
+
+    try {
+      await dispatchTelegramMessage({
+        context: broadcastContext,
+        bot: params.bot,
+        cfg: params.cfg,
+        runtime: params.runtime,
+        replyToMode: params.replyToMode,
+        streamMode: params.streamMode,
+        textLimit: params.textLimit,
+        telegramCfg: params.telegramCfg,
+        opts: params.opts,
+      });
+      return true;
+    } catch (err) {
+      logVerbose(`telegram broadcast: agent ${agentId} failed: ${String(err)}`);
+      return false;
+    }
+  };
+
+  if (strategy === "sequential") {
+    for (const agentId of broadcastAgents) {
+      await dispatchForAgent(agentId);
+    }
+  } else {
+    await Promise.allSettled(broadcastAgents.map(dispatchForAgent));
+  }
+
+  // Clear group history after all agents have processed (mirrors WhatsApp behavior).
+  if (isGroup && context.historyKey) {
+    context.groupHistories.set(context.historyKey, []);
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary

Implement broadcast group support for Telegram, filling the gap documented as "planned" in [broadcast-groups.md](https://github.com/openclaw/openclaw/blob/main/docs/channels/broadcast-groups.md#providers). This follows the same pattern established by the WhatsApp broadcast implementation.

Related: #18434 (Discord broadcast) follows the same pattern. If merged alongside #18434, broadcast support would cover 3 of the 4 planned channels. See also #17043 (Slack broadcast feature request).

Per CONTRIBUTING.md, new features should start with a Discussion. Since Telegram broadcast is already documented as planned and follows the established WhatsApp pattern, I went ahead with a PR. Happy to convert this to a Discussion if that's preferred.

## Changes

### New: `src/telegram/broadcast.ts`
- `maybeBroadcastTelegramMessage()` — checks `cfg.broadcast` for matching Telegram peer IDs and dispatches to every listed agent with isolated contexts
- Supports parallel (default) and sequential strategy
- Peer ID lookup precedence: `telegram:{accountId}:{chatId}` > `telegram:{chatId}` > `{chatId}`

### Modified: `src/telegram/bot-message.ts`
- Calls `maybeBroadcastTelegramMessage()` before normal single-agent dispatch
- Falls through transparently when no broadcast config matches — when no `broadcast` config is present (the default), the function returns `false` before any dispatch logic runs, so there is zero behavior change for non-broadcast users

### New: `src/telegram/broadcast.test.ts`
- 22 tests covering config matching, dispatch, isolation, error handling, and stress scenarios (details below)

### Updated: `docs/channels/broadcast-groups.md`
- Telegram status changed from planned to implemented
- Added Telegram-specific key format documentation and config examples

## Telegram-specific details

**Peer ID format:** Telegram chat IDs are numeric (positive for DMs, large negative for supergroups/forums). The `telegram:` prefix is recommended to avoid collisions with WhatsApp peer IDs.

**Session isolation:** Each broadcast agent gets its own route with a unique `sessionKey` and `mainSessionKey`. Only the first/primary agent receives ack reactions, status reactions, and `removeAckAfterReply` — secondary agents have these nulled out to prevent duplicate UI feedback.

**Group history:** Each agent gets its own copy of the group history snapshot so concurrent dispatches don't clear shared state prematurely. History is cleared once after all agents complete (mirrors WhatsApp behavior).

**Forum topics:** Thread-scoped routing (`resolvedThreadId`, `isForum`) flows through to each agent unchanged.

## Testing

- **16 unit tests:** no config, missing peer, prefixed/raw key dispatch, precedence, unknown agent skip, sequential ordering, parallel execution, group history clearing, account-scoped precedence, forum topics, ack/status/removeAck isolation, large negative chat IDs, error recovery
- **6 stress tests:** 10-agent parallel dispatch, 20-message rapid-fire concurrency, mixed agent failures, sequential ordering under latency, isFirstAgent race condition, empty array edge case
- All pass `pnpm check` (format + typecheck + lint)
- Live-tested on a local OpenClaw gateway with real Telegram messages confirming both agents dispatch and respond independently

## AI-assisted

Built with Claude Code (Opus 4.6). I understand the code, have tested it locally with live Telegram messages, and can iterate on review feedback.

cc @joshp123 @obviyus