### PR TITLE
fix: Control UI (ACP) model fallback for rate limits

### DIFF
--- a/src/commands/agent.acp.test.ts
+++ b/src/commands/agent.acp.test.ts
@@ -62,6 +62,24 @@ function mockConfigWithAcpOverrides(
   loadConfigSpy.mockReturnValue(cfg);
 }
 
+function createAcpConfigWithModelFallbacks(home: string, storePath: string): OpenClawConfig {
+  const cfg = createAcpEnabledConfig(home, storePath);
+  cfg.agents = {
+    defaults: {
+      model: {
+        primary: "openai/gpt-5.3-codex",
+        fallbacks: ["openai/gpt-4"],
+      },
+      models: {
+        "openai/gpt-5.3-codex": {},
+        "openai/gpt-4": {},
+      },
+      workspace: path.join(home, "openclaw"),
+    },
+  };
+  return cfg;
+}
+
 function writeAcpSessionStore(storePath: string, agent = "codex") {
   const sessionKey = `agent:${agent}:acp:test`;
   fs.mkdirSync(path.dirname(storePath), { recursive: true });
@@ -157,6 +175,24 @@ describe("agentCommand ACP runtime routing", () => {
         durationMs: 5,
       },
     } as never);
+  });
+
+  it("skips ACP path when model fallbacks are configured and uses embedded path (runWithModelFallback)", async () => {
+    await withTempHome(async (home) => {
+      const storePath = path.join(home, "sessions.json");
+      writeAcpSessionStore(storePath);
+      loadConfigSpy.mockReturnValue(createAcpConfigWithModelFallbacks(home, storePath));
+
+      const runTurn = vi.fn(async (_params: unknown) => {});
+      mockAcpManager({
+        runTurn: (params: unknown) => runTurn(params),
+      });
+
+      await agentCommand({ message: "ping", sessionKey: "agent:codex:acp:test" }, runtime);
+
+      expect(runTurn).not.toHaveBeenCalled();
+      expect(runEmbeddedPiAgentSpy).toHaveBeenCalled();
+    });
   });
 
   it("routes ACP sessions through AcpSessionManager instead of embedded agent", async () => {

--- a/src/commands/agent.test.ts
+++ b/src/commands/agent.test.ts
@@ -513,6 +513,67 @@ describe("agentCommand", () => {
     });
   });
 
+  it("triggers model fallback when embedded runner returns error payload (rate limit) instead of throwing", async () => {
+    const rateLimitPayloadText = "⚠️ API rate limit reached. Please try again later.";
+    await withTempHome(async (home) => {
+      const store = path.join(home, "sessions.json");
+      writeSessionStoreSeed(store, {
+        "agent:main:subagent:test": {
+          sessionId: "session-subagent",
+          updatedAt: Date.now(),
+          providerOverride: "anthropic",
+          modelOverride: "claude-opus-4-5",
+        },
+      });
+
+      mockConfig(home, store, {
+        model: {
+          primary: "openai/gpt-4.1-mini",
+          fallbacks: ["openai/gpt-5.2"],
+        },
+        models: {
+          "anthropic/claude-opus-4-5": {},
+          "openai/gpt-4.1-mini": {},
+          "openai/gpt-5.2": {},
+        },
+      });
+
+      vi.mocked(loadModelCatalog).mockResolvedValueOnce([
+        { id: "claude-opus-4-5", name: "Opus", provider: "anthropic" },
+        { id: "gpt-4.1-mini", name: "GPT-4.1 Mini", provider: "openai" },
+        { id: "gpt-5.2", name: "GPT-5.2", provider: "openai" },
+      ]);
+      vi.mocked(runEmbeddedPiAgent)
+        .mockResolvedValueOnce({
+          payloads: [{ text: rateLimitPayloadText, isError: true }],
+          meta: { durationMs: 1 },
+        })
+        .mockResolvedValueOnce({
+          payloads: [{ text: "ok" }],
+          meta: {
+            durationMs: 5,
+            agentMeta: { sessionId: "session-subagent", provider: "openai", model: "gpt-5.2" },
+          },
+        });
+
+      await agentCommand(
+        {
+          message: "hi",
+          sessionKey: "agent:main:subagent:test",
+        },
+        runtime,
+      );
+
+      const attempts = vi
+        .mocked(runEmbeddedPiAgent)
+        .mock.calls.map((call) => ({ provider: call[0]?.provider, model: call[0]?.model }));
+      expect(attempts).toEqual([
+        { provider: "anthropic", model: "claude-opus-4-5" },
+        { provider: "openai", model: "gpt-5.2" },
+      ]);
+    });
+  });
+
   it("keeps stored session model override when models allowlist is empty", async () => {
     await withTempHome(async (home) => {
       const store = path.join(home, "sessions.json");

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -11,6 +11,7 @@ import {
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
   resolveAgentWorkspaceDir,
+  hasConfiguredModelFallbacks,
 } from "../agents/agent-scope.js";
 import { ensureAuthProfileStore } from "../agents/auth-profiles.js";
 import { clearSessionAuthProfileOverride } from "../agents/auth-profiles/session-override.js";
@@ -18,7 +19,7 @@ import { resolveBootstrapWarningSignaturesSeen } from "../agents/bootstrap-budge
 import { runCliAgent } from "../agents/cli-runner.js";
 import { getCliSessionId, setCliSessionId } from "../agents/cli-session.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
-import { FailoverError } from "../agents/failover-error.js";
+import { FailoverError, resolveFailoverStatus } from "../agents/failover-error.js";
 import { formatAgentInternalEventsForPrompt } from "../agents/internal-events.js";
 import { AGENT_LANE_SUBAGENT } from "../agents/lanes.js";
 import { loadModelCatalog } from "../agents/model-catalog.js";
@@ -33,6 +34,7 @@ import {
   resolveDefaultModelForAgent,
   resolveThinkingDefault,
 } from "../agents/model-selection.js";
+import { classifyFailoverReason, isFailoverErrorMessage } from "../agents/pi-embedded-helpers.js";
 import { runEmbeddedPiAgent } from "../agents/pi-embedded.js";
 import { buildWorkspaceSkillSnapshot } from "../agents/skills.js";
 import { getSkillsSnapshotVersion } from "../agents/skills/refresh.js";
@@ -476,7 +478,22 @@ async function agentCommandInternal(
       throw acpResolution.error;
     }
 
-    if (acpResolution?.kind === "ready" && sessionKey) {
+    // When model fallbacks are configured, use the embedded path so runWithModelFallback
+    // is applied (e.g. rate limit on primary → try fallback). The ACP path does not
+    // support model fallback, so skip it when fallbacks exist.
+    const hasFallbacks = hasConfiguredModelFallbacks({
+      cfg,
+      agentId: sessionAgentId,
+      sessionKey,
+    });
+    const useAcpPath = acpResolution?.kind === "ready" && sessionKey && !hasFallbacks;
+
+    if (hasFallbacks && acpResolution?.kind === "ready" && sessionKey) {
+      log.info(
+        `Skipping ACP path (model fallbacks configured); using embedded path for sessionKey=${sessionKey.slice(0, 30)}…`,
+      );
+    }
+    if (useAcpPath) {
       const startedAt = Date.now();
       registerAgentRunContext(runId, {
         sessionKey,
@@ -838,10 +855,10 @@ async function agentCommandInternal(
         model,
         agentDir,
         fallbacksOverride: effectiveFallbacksOverride,
-        run: (providerOverride, modelOverride) => {
+        run: async (providerOverride, modelOverride) => {
           const isFallbackRetry = fallbackAttemptIndex > 0;
           fallbackAttemptIndex += 1;
-          return runAgentAttempt({
+          const result = await runAgentAttempt({
             providerOverride,
             modelOverride,
             cfg,
@@ -877,6 +894,25 @@ async function agentCommandInternal(
               }
             },
           });
+          // Embedded runner can return an error payload instead of throwing. Throw
+          // here so runWithModelFallback treats it as failure and tries the next model.
+          const singlePayload = result?.payloads?.length === 1 ? result.payloads[0] : undefined;
+          const errorText =
+            singlePayload &&
+            singlePayload.isError === true &&
+            typeof singlePayload.text === "string"
+              ? singlePayload.text
+              : "";
+          if (errorText && isFailoverErrorMessage(errorText)) {
+            const reason = classifyFailoverReason(errorText) ?? "rate_limit";
+            throw new FailoverError(errorText, {
+              reason,
+              status: resolveFailoverStatus(reason),
+              provider: providerOverride,
+              model: modelOverride,
+            });
+          }
+          return result;
         },
       });
       result = fallbackResult.result;

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -904,7 +904,7 @@ async function agentCommandInternal(
               ? singlePayload.text
               : "";
           if (errorText && isFailoverErrorMessage(errorText)) {
-            const reason = classifyFailoverReason(errorText) ?? "rate_limit";
+            const reason = classifyFailoverReason(errorText)!;
             throw new FailoverError(errorText, {
               reason,
               status: resolveFailoverStatus(reason),


### PR DESCRIPTION
# Fix: Control UI (ACP) model fallback for rate limits

## Problem
When using the Control UI (web), agent requests go through the ACP path. That path never used `runWithModelFallback`, so configured fallback models (e.g. OpenAI after Anthropic) were never tried on rate limit (429). Only the embedded path (CLI, etc.) applied fallback.

Additionally, when the embedded path *was* used, the embedded runner can **return** a result with an error payload (e.g. "API rate limit reached") instead of throwing. So `runWithModelFallback` treated the attempt as success and did not try the next model.

## Solution
1. **Skip ACP when fallbacks exist:** If the agent has model fallbacks configured, skip the ACP path and use the embedded path so `runWithModelFallback` runs. When no fallbacks are configured, keep using ACP when the session is ready (no behavior change).
2. **Throw on returned error payload:** In the `run` callback passed to `runWithModelFallback`, after `runAgentAttempt` returns, detect a single error payload that is a failover error (rate limit, auth, etc.) and throw `FailoverError` so the fallback loop tries the next model.

## Changes
- `commands/agent.ts`:
  - Import `hasConfiguredModelFallbacks`; only take the ACP branch when `acpResolution.kind === "ready"` **and** there are no configured fallbacks. Otherwise fall through to the embedded path.
  - Optional info log when skipping ACP due to fallbacks (for diagnostics).
  - Import `classifyFailoverReason`, `isFailoverErrorMessage` (pi-embedded-helpers), `resolveFailoverStatus` (failover-error). Make the `run` callback async; after `runAgentAttempt` returns, if the result is a single failover error payload, throw `FailoverError` so `runWithModelFallback` tries the next candidate.

## Testing
- `pnpm run test -- --run src/commands/agent.test.ts src/commands/agent.acp.test.ts` — all tests pass, including new tests that replicate the issue: (1) ACP path skipped when fallbacks configured, (2) embedded error payload triggers fallback to next model.
- Manual: Start gateway, use Control UI with primary + fallbacks in config; when primary is rate-limited, fallback model should be used.
