### PR TITLE
fix(agents): make reasoning line static to preserve prompt cache

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -593,15 +593,24 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("agent=work");
   });
 
-  it("includes reasoning visibility hint", () => {
+  it("includes static reasoning hint without dynamic level", () => {
     const prompt = buildAgentSystemPrompt({
       workspaceDir: "/tmp/openclaw",
       reasoningLevel: "off",
     });
 
-    expect(prompt).toContain("Reasoning: off");
+    // Reasoning line must NOT contain the dynamic level value — this preserves prompt cache
+    expect(prompt).not.toContain("Reasoning: off");
+    expect(prompt).not.toContain("Reasoning: on");
     expect(prompt).toContain("/reasoning");
-    expect(prompt).toContain("/status shows Reasoning");
+    expect(prompt).toContain("/status shows current level");
+
+    // Changing reasoningLevel must not change the system prompt
+    const prompt2 = buildAgentSystemPrompt({
+      workspaceDir: "/tmp/openclaw",
+      reasoningLevel: "on",
+    });
+    expect(prompt).toBe(prompt2);
   });
 
   it("builds runtime line with agent and channel details", () => {

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -360,7 +360,6 @@ export function buildAgentSystemPrompt(params: {
         "<final>Hey there! What would you like to do next?</final>",
       ].join(" ")
     : undefined;
-  const reasoningLevel = params.reasoningLevel ?? "off";
   const userTimezone = params.userTimezone?.trim();
   const skillsPrompt = params.skillsPrompt?.trim();
   const heartbeatPrompt = params.heartbeatPrompt?.trim();
@@ -678,7 +677,7 @@ export function buildAgentSystemPrompt(params: {
   lines.push(
     "## Runtime",
     buildRuntimeLine(runtimeInfo, runtimeChannel, runtimeCapabilities, params.defaultThinkLevel),
-    `Reasoning: ${reasoningLevel} (hidden unless on/stream). Toggle /reasoning; /status shows Reasoning when enabled.`,
+    "Reasoning: toggle with /reasoning; /status shows current level. Hidden unless on/stream.",
   );
 
   return lines.filter(Boolean).join("\n");


### PR DESCRIPTION
## Summary

The `## Runtime` footer in the system prompt interpolates the current `reasoningLevel` value (`off`/`on`/`stream`), causing the system prompt to mutate every time the user toggles `/reasoning`. This invalidates prompt cache for all providers — both cloud `cache_read` tokens and local KV prefix matching — on every subsequent turn.

- Replace dynamic `Reasoning: ${reasoningLevel} (hidden unless on/stream)...` with a static hint
- Remove the now-unused `reasoningLevel` local variable from `buildAgentSystemPrompt`
- Update test to verify prompt stability: changing `reasoningLevel` param must not change system prompt output

The reasoning level is already passed as a separate `reasoningLevel` parameter to the agent run and does not need to be embedded in the system prompt text.

This partially fixes #36520 — it addresses the **reasoning toggle mutation**. The runtime system events injection (the other mutation source mentioned in the issue) is a separate concern that has already been moved from system prompt to user message body with `System:` prefixes.

## Test plan

- [x] Updated `system-prompt.test.ts`: asserts prompt does NOT contain dynamic level, and that two prompts with different `reasoningLevel` values are identical (`toBe`)
- [ ] Existing system-prompt tests pass
- [ ] Manual: toggle `/reasoning` in a session, verify system prompt diff is empty between turns