### PR TITLE
fix(sessions): create transcript file on chat.inject when missing

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1142,7 +1142,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       storePath,
       sessionFile: entry?.sessionFile,
       agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
-      createIfMissing: false,
+      createIfMissing: true,
     });
     if (!appended.ok || !appended.messageId || !appended.message) {
       respond(


### PR DESCRIPTION
## Summary

`chat.inject` fails with `"transcript file not found"` when the session has a valid `transcriptPath` in metadata but the file does not exist on disk. This commonly happens with ACP oneshot/run sessions.

The root cause is `createIfMissing: false` passed to `appendAssistantTranscriptMessage`. The `ensureTranscriptFile` helper already exists and handles `mkdirp` + file creation safely — it just wasn't being used.

**Fix**: `createIfMissing: false` → `createIfMissing: true` (one line)

Fixes #36170

## Test plan

- [x] Existing `chat.inject` tests pass (they pre-create fixture files, so `createIfMissing` doesn't affect them)
- [ ] Manual: create an ACP session without materializing the transcript file, call `chat.inject`, verify it succeeds and the file is created