### PR TITLE
fix(providers): recognize Gemini 3.1 models under google provider in fallback routing

### DIFF
--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -171,12 +171,13 @@ function resolveAnthropicSonnet46ForwardCompatModel(
 // gemini-3.1-pro-preview / gemini-3.1-flash-preview are not present in pi-ai's built-in
 // google-gemini-cli catalog yet. Clone the nearest gemini-3 template so users don't get
 // "Unknown model" errors when Google Gemini CLI gains new minor-version models.
-function resolveGoogleGeminiCli31ForwardCompatModel(
+function resolveGoogleGemini31ForwardCompatModel(
   provider: string,
   modelId: string,
   modelRegistry: ModelRegistry,
 ): Model<Api> | undefined {
-  if (normalizeProviderId(provider) !== "google-gemini-cli") {
+  const normalized = normalizeProviderId(provider);
+  if (normalized !== "google-gemini-cli" && normalized !== "google") {
     return undefined;
   }
   const trimmed = modelId.trim();
@@ -192,7 +193,7 @@ function resolveGoogleGeminiCli31ForwardCompatModel(
   }
 
   return cloneFirstTemplateModel({
-    normalizedProvider: "google-gemini-cli",
+    normalizedProvider: normalized,
     trimmedModelId: trimmed,
     templateIds: [...templateIds],
     modelRegistry,
@@ -252,6 +253,6 @@ export function resolveForwardCompatModel(
     resolveAnthropicOpus46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveAnthropicSonnet46ForwardCompatModel(provider, modelId, modelRegistry) ??
     resolveZaiGlm5ForwardCompatModel(provider, modelId, modelRegistry) ??
-    resolveGoogleGeminiCli31ForwardCompatModel(provider, modelId, modelRegistry)
+    resolveGoogleGemini31ForwardCompatModel(provider, modelId, modelRegistry)
   );
 }


### PR DESCRIPTION
## Summary

Gemini 3.1 models (`gemini-3.1-pro-preview`, `gemini-3.1-flash-lite-preview`) work as primary model but fail with `Unknown model` during failover when configured under the `google` provider.

**Root cause**: `resolveGoogleGeminiCli31ForwardCompatModel` only matched `google-gemini-cli` provider, not the `google` provider that most users configure.

**Fix**: Extend the provider check to also match `google`, and use the actual normalized provider name when cloning the template model (instead of hardcoding `google-gemini-cli`).

Fixes #36111

## Test plan

- [ ] Configure `google/gemini-3.1-flash-lite-preview` in fallbacks, trigger failover, verify it resolves correctly
- [ ] Verify `google-gemini-cli/gemini-3.1-*` still works (no regression)
- [ ] Verify unrelated providers are unaffected