### PR TITLE
memory: degrade to FTS on OpenAI missing_scope embedding failures

### DIFF
--- a/src/memory/manager.async-search.test.ts
+++ b/src/memory/manager.async-search.test.ts
@@ -101,4 +101,20 @@ describe("memory search async sync", () => {
     await closePromise;
     manager = null;
   });
+
+  it("degrades to FTS results when embedding query fails with missing_scope", async () => {
+    const cfg = buildConfig();
+    manager = await createMemoryManagerOrThrow(cfg);
+
+    // First search populates the index/FTS.
+    await manager.search("hello");
+
+    embedQuery.mockImplementationOnce(async () => {
+      throw new Error("401 missing_scope: model.request");
+    });
+
+    const results = await manager.search("hello");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.path).toContain("memory/2026-01-07.md");
+  });
 });

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -39,6 +39,16 @@ const BATCH_FAILURE_LIMIT = 2;
 
 const log = createSubsystemLogger("memory");
 
+function isAuthScopeError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("missing_scope") ||
+    lower.includes("missing scope") ||
+    (lower.includes("insufficient permission") && lower.includes("model")) ||
+    (lower.includes("insufficient permissions") && lower.includes("api"))
+  );
+}
+
 const INDEX_CACHE = new Map<string, MemoryIndexManager>();
 const INDEX_CACHE_PENDING = new Map<string, Promise<MemoryIndexManager>>();
 
@@ -305,7 +315,19 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
         ? await this.searchKeyword(cleaned, candidates).catch(() => [])
         : [];
 
-    const queryVec = await this.embedQueryWithTimeout(cleaned);
+    let queryVec: number[] = [];
+    try {
+      queryVec = await this.embedQueryWithTimeout(cleaned);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (isAuthScopeError(message) && this.fts.enabled && this.fts.available) {
+        log.warn(
+          `memory search: embedding provider auth scope error; degrading to FTS-only for this query: ${message}`,
+        );
+        return keywordResults.filter((entry) => entry.score >= minScore).slice(0, maxResults);
+      }
+      throw err;
+    }
     const hasVector = queryVec.some((v) => v !== 0);
     const vectorResults = hasVector
       ? await this.searchVector(queryVec, candidates).catch(() => [])


### PR DESCRIPTION
## Summary
When memory search is configured with an embedding provider and query-time embedding fails with auth scope errors (e.g. `missing_scope: model.request`), OpenClaw currently fails the query even though FTS data is available.

This PR adds a targeted fallback:
- detect auth scope errors on query embedding
- if FTS is available, degrade that query to FTS-only results instead of throwing
- keep existing behavior for non-auth embedding failures

## Why
This preserves memory recall in OAuth scope-mismatch scenarios and avoids hard failures for users who still have local FTS index data.

## Changes
- `src/memory/manager.ts`
  - add `isAuthScopeError()` helper
  - wrap `embedQueryWithTimeout()` in try/catch
  - on scope/auth error + FTS available, return keyword results
- `src/memory/manager.async-search.test.ts`
  - add regression test: falls back to FTS when embed query throws `missing_scope`

## Testing
Could not run full suite in this environment due upstream dependency install failure while preparing a git-hosted package (`@tloncorp/api` EACCES in npm cache during pnpm install).
Added focused unit regression test in-tree.
