### PR TITLE
fix(agents): prune history images even without prior assistant reply

### DIFF
--- a/src/agents/pi-embedded-runner/run/history-image-prune.test.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.test.ts
@@ -63,4 +63,28 @@ describe("pruneProcessedHistoryImages", () => {
     const firstUser = messages[0] as Extract<AgentMessage, { role: "user" }> | undefined;
     expect(firstUser?.content).toBe("noop");
   });
+
+  it("prunes images from earlier user message when a newer user message follows without assistant reply", () => {
+    const messages: AgentMessage[] = [
+      castAgentMessage({
+        role: "user",
+        content: [{ type: "text", text: "Here are photos" }, { ...image }],
+      }),
+      castAgentMessage({
+        role: "user",
+        content: [{ type: "text", text: "why no response?" }],
+      }),
+    ];
+
+    const didMutate = pruneProcessedHistoryImages(messages);
+
+    expect(didMutate).toBe(true);
+    const firstUser = messages[0] as Extract<AgentMessage, { role: "user" }> | undefined;
+    const content = firstUser?.content as Array<{ type: string; text?: string }>;
+    expect(content[1]).toMatchObject({ type: "text", text: PRUNED_HISTORY_IMAGE_MARKER });
+    // Latest user message is untouched
+    const secondUser = messages[1] as Extract<AgentMessage, { role: "user" }> | undefined;
+    const secondContent = secondUser?.content as Array<{ type: string; text?: string }>;
+    expect(secondContent[0]).toMatchObject({ type: "text", text: "why no response?" });
+  });
 });

--- a/src/agents/pi-embedded-runner/run/history-image-prune.ts
+++ b/src/agents/pi-embedded-runner/run/history-image-prune.ts
@@ -3,8 +3,12 @@ import type { AgentMessage } from "@mariozechner/pi-agent-core";
 export const PRUNED_HISTORY_IMAGE_MARKER = "[image data removed - already processed by model]";
 
 /**
- * Idempotent cleanup for legacy sessions that persisted image blocks in history.
- * Called each run; mutates only user turns that already have an assistant reply.
+ * Idempotent cleanup: strips image blocks from historical user messages.
+ * Called each run before prompt. Prunes images from any user message that
+ * has been answered (an assistant message exists after it). Also prunes
+ * images from any user message that is NOT the last user message, even
+ * without an assistant reply — this prevents context overflow loops where
+ * a failed first turn (e.g. overflow) leaves images stuck forever.
  */
 export function pruneProcessedHistoryImages(messages: AgentMessage[]): boolean {
   let lastAssistantIndex = -1;
@@ -14,12 +18,26 @@ export function pruneProcessedHistoryImages(messages: AgentMessage[]): boolean {
       break;
     }
   }
-  if (lastAssistantIndex < 0) {
+
+  let lastUserIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "user") {
+      lastUserIndex = i;
+      break;
+    }
+  }
+
+  if (lastUserIndex < 0) {
     return false;
   }
 
+  // Prune images from user messages that are either:
+  // 1. Before the last assistant message (already answered), OR
+  // 2. Not the last user message (stale from a failed prior turn)
+  const pruneUpTo = Math.max(lastAssistantIndex, lastUserIndex);
+
   let didMutate = false;
-  for (let i = 0; i < lastAssistantIndex; i++) {
+  for (let i = 0; i < pruneUpTo; i++) {
     const message = messages[i];
     if (!message || message.role !== "user" || !Array.isArray(message.content)) {
       continue;


### PR DESCRIPTION
## Summary

- **Bug**: When a user sends images via a messaging channel (Telegram, WhatsApp, Discord) and the first model turn fails (e.g. context overflow), no assistant message is generated. `pruneProcessedHistoryImages` only pruned image blocks from user messages *before the last assistant message*, so without any assistant reply the images were never evicted. Every subsequent turn re-sent the same images, causing an infinite context overflow loop that could only be escaped via `/reset`.
- **Fix**: Expand the prune boundary from `lastAssistantIndex` to `max(lastAssistantIndex, lastUserIndex)`, so stale image-bearing user turns are cleaned up even when the model never successfully responded. The latest user message's images are preserved (it may be the current turn).
- Adds a test case covering the no-assistant-reply scenario.

## Repro

1. Send 3+ large photos via Telegram to an agent using a model with limited context
2. First turn fails with "Context overflow: prompt too large for the model"
3. Send any follow-up text message
4. Observe the same images being re-processed (resized) on every subsequent turn indefinitely
5. Agent is permanently stuck until `/reset`

## Test plan

- [x] Existing `pruneProcessedHistoryImages` tests pass (3/3)
- [x] New test case: prunes images from earlier user message when a newer user message follows without assistant reply
- [x] `oxfmt --check` passes
- [x] `oxlint --type-aware` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)