### PR TITLE
feat(email): enable direct outbound sends for message.send

### DIFF
--- a/extensions/email/index.ts
+++ b/extensions/email/index.ts
@@ -1,0 +1,26 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { emailPlugin } from "./src/channel.js";
+import { setEmailRuntime } from "./src/runtime.js";
+import { createEmailInboundHandler } from "./src/inbound.js";
+
+const plugin = {
+  id: "email",
+  name: "Email",
+  description: "Email channel plugin for American Claw managed hosting",
+  configSchema: emptyPluginConfigSchema(),
+  register(api: OpenClawPluginApi) {
+    setEmailRuntime(api.runtime);
+
+    api.registerChannel({ plugin: emailPlugin });
+
+    // Register the gateway RPC method that American Claw calls
+    // when an inbound email arrives via Cloudflare Email Routing.
+    api.registerGatewayMethod(
+      "email.inbound",
+      createEmailInboundHandler(),
+    );
+  },
+};
+
+export default plugin;

--- a/extensions/email/openclaw.plugin.json
+++ b/extensions/email/openclaw.plugin.json
@@ -1,0 +1,11 @@
+{
+  "id": "email",
+  "channels": [
+    "email"
+  ],
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {}
+  }
+}

--- a/extensions/email/package.json
+++ b/extensions/email/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@openclaw/email",
+  "version": "2026.2.9-1",
+  "description": "OpenClaw email channel plugin for American Claw managed hosting",
+  "type": "module",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  }
+}

--- a/extensions/email/src/access-control.test.ts
+++ b/extensions/email/src/access-control.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import { checkSenderAccess } from "./access-control.js";
+
+describe("checkSenderAccess", () => {
+  describe("open policy", () => {
+    it("allows any sender", () => {
+      const result = checkSenderAccess("anyone@example.com", "open", []);
+      expect(result.allowed).toBe(true);
+    });
+
+    it("allows even with an empty allowFrom list", () => {
+      const result = checkSenderAccess("stranger@evil.com", "open", []);
+      expect(result.allowed).toBe(true);
+    });
+  });
+
+  describe("pairing policy (treated as allowlist)", () => {
+    it("allows exact email match", () => {
+      const result = checkSenderAccess(
+        "alice@example.com",
+        "pairing",
+        ["alice@example.com"],
+      );
+      expect(result.allowed).toBe(true);
+    });
+
+    it("rejects sender not in allowFrom", () => {
+      const result = checkSenderAccess(
+        "stranger@evil.com",
+        "pairing",
+        ["alice@example.com"],
+      );
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("not in the allowlist");
+    });
+
+    it("matches case-insensitively", () => {
+      const result = checkSenderAccess(
+        "Alice@Example.COM",
+        "pairing",
+        ["alice@example.com"],
+      );
+      expect(result.allowed).toBe(true);
+    });
+
+    it("handles allowFrom entries with mixed case", () => {
+      const result = checkSenderAccess(
+        "alice@example.com",
+        "pairing",
+        ["Alice@Example.COM"],
+      );
+      expect(result.allowed).toBe(true);
+    });
+
+    it("matches domain wildcard *@example.com", () => {
+      const result = checkSenderAccess(
+        "bob@example.com",
+        "pairing",
+        ["*@example.com"],
+      );
+      expect(result.allowed).toBe(true);
+    });
+
+    it("rejects sender from different domain with wildcard", () => {
+      const result = checkSenderAccess(
+        "bob@other.com",
+        "pairing",
+        ["*@example.com"],
+      );
+      expect(result.allowed).toBe(false);
+    });
+
+    it("domain wildcard is case-insensitive", () => {
+      const result = checkSenderAccess(
+        "bob@Example.COM",
+        "pairing",
+        ["*@example.com"],
+      );
+      expect(result.allowed).toBe(true);
+    });
+
+    it("rejects when allowFrom is empty", () => {
+      const result = checkSenderAccess("alice@example.com", "pairing", []);
+      expect(result.allowed).toBe(false);
+    });
+
+    it("handles numeric entries in allowFrom gracefully", () => {
+      const result = checkSenderAccess(
+        "alice@example.com",
+        "pairing",
+        [12345, "alice@example.com"],
+      );
+      expect(result.allowed).toBe(true);
+    });
+
+    it("handles numeric-only allowFrom without crashing", () => {
+      const result = checkSenderAccess(
+        "alice@example.com",
+        "pairing",
+        [12345, 67890],
+      );
+      expect(result.allowed).toBe(false);
+    });
+  });
+
+  describe("closed policy", () => {
+    it("allows exact match", () => {
+      const result = checkSenderAccess(
+        "alice@example.com",
+        "closed",
+        ["alice@example.com"],
+      );
+      expect(result.allowed).toBe(true);
+    });
+
+    it("rejects unlisted sender", () => {
+      const result = checkSenderAccess(
+        "stranger@evil.com",
+        "closed",
+        ["alice@example.com"],
+      );
+      expect(result.allowed).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("rejects empty sender address", () => {
+      const result = checkSenderAccess("", "pairing", ["alice@example.com"]);
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain("Empty sender");
+    });
+
+    it("handles whitespace in sender", () => {
+      const result = checkSenderAccess(
+        "  alice@example.com  ",
+        "pairing",
+        ["alice@example.com"],
+      );
+      expect(result.allowed).toBe(true);
+    });
+
+    it("handles whitespace in allowFrom entries", () => {
+      const result = checkSenderAccess(
+        "alice@example.com",
+        "pairing",
+        ["  alice@example.com  "],
+      );
+      expect(result.allowed).toBe(true);
+    });
+
+    it("skips empty string entries in allowFrom", () => {
+      const result = checkSenderAccess(
+        "alice@example.com",
+        "pairing",
+        ["", "alice@example.com"],
+      );
+      expect(result.allowed).toBe(true);
+    });
+
+    it("supports multiple allowFrom entries", () => {
+      const allowFrom = ["alice@example.com", "*@trusted.org", "bob@other.com"];
+      expect(checkSenderAccess("alice@example.com", "pairing", allowFrom).allowed).toBe(true);
+      expect(checkSenderAccess("anyone@trusted.org", "pairing", allowFrom).allowed).toBe(true);
+      expect(checkSenderAccess("bob@other.com", "pairing", allowFrom).allowed).toBe(true);
+      expect(checkSenderAccess("stranger@evil.com", "pairing", allowFrom).allowed).toBe(false);
+    });
+  });
+});

--- a/extensions/email/src/access-control.ts
+++ b/extensions/email/src/access-control.ts
@@ -1,0 +1,53 @@
+export interface AccessCheckResult {
+  allowed: boolean;
+  reason?: string;
+}
+
+/**
+ * Check whether a sender is allowed to reach the agent based on the
+ * account's dmPolicy and allowFrom list.
+ *
+ * - "open" policy: allow all senders
+ * - "pairing" or "closed" policy: check sender against allowFrom entries
+ *   - Exact email match (case-insensitive)
+ *   - Domain wildcard match: `*@example.com` allows any sender @example.com
+ */
+export function checkSenderAccess(
+  senderEmail: string,
+  dmPolicy: "open" | "pairing" | "closed",
+  allowFrom: Array<string | number>,
+): AccessCheckResult {
+  if (dmPolicy === "open") {
+    return { allowed: true };
+  }
+
+  const sender = senderEmail.toLowerCase().trim();
+  if (!sender) {
+    return { allowed: false, reason: "Empty sender address" };
+  }
+
+  const senderDomain = sender.split("@")[1];
+
+  for (const entry of allowFrom) {
+    const rule = String(entry).toLowerCase().trim();
+    if (!rule) continue;
+
+    // Exact match
+    if (rule === sender) {
+      return { allowed: true };
+    }
+
+    // Domain wildcard: *@example.com
+    if (rule.startsWith("*@") && senderDomain) {
+      const wildcardDomain = rule.slice(2);
+      if (wildcardDomain === senderDomain) {
+        return { allowed: true };
+      }
+    }
+  }
+
+  return {
+    allowed: false,
+    reason: `Sender ${sender} is not in the allowlist`,
+  };
+}

--- a/extensions/email/src/accounts.test.ts
+++ b/extensions/email/src/accounts.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { resolveEmailAccountForRecipient } from "./accounts.js";
+
+function makeCfg(accounts: Record<string, Record<string, unknown>>): OpenClawConfig {
+  return {
+    channels: {
+      email: {
+        accounts,
+      },
+    },
+  } as unknown as OpenClawConfig;
+}
+
+describe("resolveEmailAccountForRecipient", () => {
+  it("matches account by recipient address", () => {
+    const cfg = makeCfg({
+      support: {
+        address: "support@example.com",
+        outboundUrl: "https://example.com/outbound",
+        outboundToken: "tok-support",
+      },
+      sales: {
+        address: "sales@example.com",
+        outboundUrl: "https://example.com/outbound",
+        outboundToken: "tok-sales",
+      },
+    });
+
+    const account = resolveEmailAccountForRecipient({
+      cfg,
+      recipient: "sales@example.com",
+    });
+
+    expect(account.accountId).toBe("sales");
+    expect(account.address).toBe("sales@example.com");
+  });
+
+  it("falls back to default resolver when no address matches", () => {
+    const cfg = makeCfg({
+      default: {
+        address: "default@example.com",
+        outboundUrl: "https://example.com/outbound",
+        outboundToken: "tok-default",
+      },
+    });
+
+    const account = resolveEmailAccountForRecipient({
+      cfg,
+      recipient: "other@example.com",
+    });
+
+    expect(account.accountId).toBe("default");
+    expect(account.address).toBe("default@example.com");
+  });
+});

--- a/extensions/email/src/accounts.ts
+++ b/extensions/email/src/accounts.ts
@@ -1,0 +1,49 @@
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import type { EmailAccountConfig, ResolvedEmailAccount } from "./types.js";
+
+export function listEmailAccountIds(cfg: OpenClawConfig): string[] {
+  const accounts = (cfg.channels as Record<string, unknown> | undefined)?.email as
+    | { accounts?: Record<string, unknown> }
+    | undefined;
+  if (!accounts?.accounts) {
+    return [];
+  }
+  return Object.keys(accounts.accounts);
+}
+
+export function resolveDefaultEmailAccountId(cfg: OpenClawConfig): string {
+  const ids = listEmailAccountIds(cfg);
+  if (ids.length === 0) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  if (ids.includes(DEFAULT_ACCOUNT_ID)) {
+    return DEFAULT_ACCOUNT_ID;
+  }
+  return ids[0];
+}
+
+export function resolveEmailAccount(params: {
+  cfg: OpenClawConfig;
+  accountId?: string | null;
+}): ResolvedEmailAccount {
+  const { cfg, accountId } = params;
+  const resolvedId = accountId?.trim() || resolveDefaultEmailAccountId(cfg);
+
+  const emailSection = (cfg.channels as Record<string, unknown> | undefined)?.email as
+    | { accounts?: Record<string, EmailAccountConfig> }
+    | undefined;
+
+  const raw = emailSection?.accounts?.[resolvedId] ?? {};
+
+  return {
+    accountId: resolvedId,
+    name: raw.name ?? "Email",
+    enabled: raw.enabled !== false,
+    address: raw.address ?? "",
+    outboundUrl: raw.outboundUrl ?? "",
+    outboundToken: raw.outboundToken ?? "",
+    dmPolicy: raw.dmPolicy ?? "open",
+    allowFrom: raw.allowFrom ?? [],
+  };
+}

--- a/extensions/email/src/accounts.ts
+++ b/extensions/email/src/accounts.ts
@@ -47,3 +47,23 @@ export function resolveEmailAccount(params: {
     allowFrom: raw.allowFrom ?? [],
   };
 }
+
+export function resolveEmailAccountForRecipient(params: {
+  cfg: OpenClawConfig;
+  recipient: string;
+}): ResolvedEmailAccount {
+  const { cfg, recipient } = params;
+  const normalizedRecipient = recipient.trim().toLowerCase();
+  const accountIds = listEmailAccountIds(cfg);
+
+  if (normalizedRecipient) {
+    for (const accountId of accountIds) {
+      const account = resolveEmailAccount({ cfg, accountId });
+      if (account.address.trim().toLowerCase() === normalizedRecipient) {
+        return account;
+      }
+    }
+  }
+
+  return resolveEmailAccount({ cfg });
+}

--- a/extensions/email/src/channel.resolve-target.test.ts
+++ b/extensions/email/src/channel.resolve-target.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+import { emailPlugin } from "./channel.js";
+
+describe("email outbound resolveTarget", () => {
+  const resolver = emailPlugin.outbound?.resolveTarget;
+
+  it("accepts explicit to address", () => {
+    const result = resolver?.({ to: "juno@zhcinstitute.com" });
+    expect(result).toEqual({ ok: true, to: "juno@zhcinstitute.com" });
+  });
+
+  it("falls back to first non-wildcard allowFrom email", () => {
+    const result = resolver?.({
+      allowFrom: ["*@example.com", "juno@zhcinstitute.com"],
+    });
+    expect(result).toEqual({ ok: true, to: "juno@zhcinstitute.com" });
+  });
+
+  it("rejects wildcard-only allowFrom entries", () => {
+    const result = resolver?.({ allowFrom: ["*@example.com"] });
+    expect(result?.ok).toBe(false);
+    if (result?.ok === false) {
+      expect(result.error.message).toContain("Email target required");
+    }
+  });
+
+  it("ignores wildcard entries with whitespace", () => {
+    const result = resolver?.({
+      allowFrom: ["  *@example.com  ", "  team@openclaw.ai  "],
+    });
+    expect(result).toEqual({ ok: true, to: "team@openclaw.ai" });
+  });
+
+  it("keeps resolveTarget stable when cfg/accountId are passed", () => {
+    const cfg = { channels: { email: { accounts: {} } } } as unknown as OpenClawConfig;
+    const result = resolver?.({
+      cfg,
+      accountId: "default",
+      allowFrom: ["*@example.com", "ops@openclaw.ai"],
+      mode: "auto",
+    });
+    expect(result).toEqual({ ok: true, to: "ops@openclaw.ai" });
+  });
+});

--- a/extensions/email/src/channel.ts
+++ b/extensions/email/src/channel.ts
@@ -1,0 +1,175 @@
+import {
+  DEFAULT_ACCOUNT_ID,
+  getChatChannelMeta,
+  type ChannelPlugin,
+} from "openclaw/plugin-sdk";
+import type { ResolvedEmailAccount } from "./types.js";
+import {
+  listEmailAccountIds,
+  resolveDefaultEmailAccountId,
+  resolveEmailAccount,
+} from "./accounts.js";
+import { sendEmailOutbound } from "./send.js";
+
+const meta = getChatChannelMeta("email" as never);
+
+export const emailPlugin: ChannelPlugin<ResolvedEmailAccount> = {
+  id: "email" as never,
+  meta: {
+    ...meta,
+    id: "email" as never,
+    label: "Email",
+    icon: "email",
+    showConfigured: false,
+    quickstartAllowFrom: false,
+    forceAccountBinding: false,
+    preferSessionLookupForAnnounceTarget: false,
+  },
+  capabilities: {
+    chatTypes: ["direct"],
+    reactions: false,
+    threads: false,
+    media: false,
+    nativeCommands: false,
+    blockStreaming: false,
+  },
+  reload: { configPrefixes: ["channels.email"] },
+  gatewayMethods: ["email.inbound"],
+  config: {
+    listAccountIds: (cfg) => listEmailAccountIds(cfg),
+    resolveAccount: (cfg, accountId) => resolveEmailAccount({ cfg, accountId }),
+    defaultAccountId: (cfg) => resolveDefaultEmailAccountId(cfg),
+    setAccountEnabled: ({ cfg, accountId, enabled }) => {
+      const accountKey = accountId || DEFAULT_ACCOUNT_ID;
+      const channels = cfg.channels as Record<string, unknown> ?? {};
+      const emailSection = channels.email as Record<string, unknown> ?? {};
+      const accounts = (emailSection.accounts ?? {}) as Record<string, Record<string, unknown>>;
+      const existing = accounts[accountKey] ?? {};
+      return {
+        ...cfg,
+        channels: {
+          ...cfg.channels,
+          email: {
+            ...emailSection,
+            accounts: {
+              ...accounts,
+              [accountKey]: {
+                ...existing,
+                enabled,
+              },
+            },
+          },
+        },
+      } as typeof cfg;
+    },
+    deleteAccount: ({ cfg, accountId }) => {
+      const accountKey = accountId || DEFAULT_ACCOUNT_ID;
+      const channels = cfg.channels as Record<string, unknown> ?? {};
+      const emailSection = { ...(channels.email as Record<string, unknown> ?? {}) };
+      const accounts = { ...((emailSection.accounts ?? {}) as Record<string, unknown>) };
+      delete accounts[accountKey];
+      return {
+        ...cfg,
+        channels: {
+          ...cfg.channels,
+          email: {
+            ...emailSection,
+            accounts: Object.keys(accounts).length ? accounts : undefined,
+          },
+        },
+      } as typeof cfg;
+    },
+    isEnabled: (account) => account.enabled,
+    disabledReason: () => "disabled",
+    isConfigured: (account) => Boolean(account.address && account.outboundUrl),
+    unconfiguredReason: () => "not configured",
+    describeAccount: (account) => ({
+      accountId: account.accountId,
+      name: account.name,
+      enabled: account.enabled,
+      configured: Boolean(account.address && account.outboundUrl),
+      address: account.address,
+      dmPolicy: account.dmPolicy,
+    }),
+    resolveAllowFrom: ({ cfg, accountId }) =>
+      resolveEmailAccount({ cfg, accountId }).allowFrom?.map((e) => String(e)),
+    formatAllowFrom: ({ allowFrom }) =>
+      allowFrom
+        .map((entry) => String(entry).trim().toLowerCase())
+        .filter(Boolean),
+  },
+  security: {
+    resolveDmPolicy: ({ account }) => ({
+      policy: account.dmPolicy ?? "open",
+      allowFrom: account.allowFrom ?? [],
+      policyPath: `channels.email.accounts.${account.accountId}.dmPolicy`,
+      allowFromPath: `channels.email.accounts.${account.accountId}.`,
+      approveHint: "Add the sender email to channels.email.allowFrom",
+      normalizeEntry: (raw: string) => raw.toLowerCase().trim(),
+    }),
+  },
+  outbound: {
+    deliveryMode: "direct",
+    textChunkLimit: 50000,
+    resolveTarget: ({ to, allowFrom }) => {
+      const trimmed = to?.trim() ?? "";
+      if (trimmed && trimmed.includes("@")) {
+        return { ok: true, to: trimmed };
+      }
+      const firstAllow = (allowFrom ?? []).find((e) => String(e).includes("@"));
+      if (firstAllow) {
+        return { ok: true, to: String(firstAllow) };
+      }
+      return {
+        ok: false,
+        error: new Error(
+          "Email target required: provide an email address or configure channels.email.allowFrom",
+        ),
+      };
+    },
+    sendText: async ({ to, text, accountId, cfg, replyToId }) => {
+      const account = resolveEmailAccount({ cfg, accountId });
+      const subject = "Message from OpenClaw";
+      const result = await sendEmailOutbound({
+        account,
+        payload: {
+          to,
+          subject,
+          text,
+          ...(replyToId ? { inReplyTo: String(replyToId) } : {}),
+        },
+      });
+
+      return {
+        channel: "email",
+        messageId: result.messageId ?? `email-${Date.now()}`,
+      };
+    },
+    sendMedia: async ({ to, text, mediaUrl, accountId, cfg, replyToId }) => {
+      const account = resolveEmailAccount({ cfg, accountId });
+      const subject = "Message from OpenClaw";
+      const composedText = mediaUrl ? `${text}\n\nAttachment: ${mediaUrl}` : text;
+      const result = await sendEmailOutbound({
+        account,
+        payload: {
+          to,
+          subject,
+          text: composedText,
+          ...(replyToId ? { inReplyTo: String(replyToId) } : {}),
+        },
+      });
+
+      return {
+        channel: "email",
+        messageId: result.messageId ?? `email-${Date.now()}`,
+      };
+    },
+  },
+  gateway: {
+    startAccount: async (ctx) => {
+      ctx.log?.info(
+        `[${ctx.accountId}] email channel ready (${ctx.account.address})`,
+      );
+    },
+  },
+};

--- a/extensions/email/src/channel.ts
+++ b/extensions/email/src/channel.ts
@@ -81,13 +81,13 @@ export const emailPlugin: ChannelPlugin<ResolvedEmailAccount> = {
     },
     isEnabled: (account) => account.enabled,
     disabledReason: () => "disabled",
-    isConfigured: (account) => Boolean(account.address && account.outboundUrl),
+    isConfigured: (account) => Boolean(account.address && account.outboundUrl && account.outboundToken),
     unconfiguredReason: () => "not configured",
     describeAccount: (account) => ({
       accountId: account.accountId,
       name: account.name,
       enabled: account.enabled,
-      configured: Boolean(account.address && account.outboundUrl),
+      configured: Boolean(account.address && account.outboundUrl && account.outboundToken),
       address: account.address,
       dmPolicy: account.dmPolicy,
     }),
@@ -116,9 +116,14 @@ export const emailPlugin: ChannelPlugin<ResolvedEmailAccount> = {
       if (trimmed && trimmed.includes("@")) {
         return { ok: true, to: trimmed };
       }
-      const firstAllow = (allowFrom ?? []).find((e) => String(e).includes("@"));
+      const firstAllow = (allowFrom ?? [])
+        .map((entry) => String(entry).trim())
+        .find((entry) => {
+          const candidate = entry.toLowerCase();
+          return candidate.includes("@") && !candidate.startsWith("*@");
+        });
       if (firstAllow) {
-        return { ok: true, to: String(firstAllow) };
+        return { ok: true, to: firstAllow };
       }
       return {
         ok: false,

--- a/extensions/email/src/inbound.ts
+++ b/extensions/email/src/inbound.ts
@@ -1,7 +1,6 @@
 import type { GatewayRequestHandler, OpenClawConfig } from "openclaw/plugin-sdk";
-import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
 import { getEmailRuntime } from "./runtime.js";
-import { resolveEmailAccount } from "./accounts.js";
+import { resolveEmailAccountForRecipient } from "./accounts.js";
 import { checkSenderAccess } from "./access-control.js";
 import { sendEmailOutbound } from "./send.js";
 import type { EmailInboundPayload } from "./types.js";
@@ -33,7 +32,10 @@ export function createEmailInboundHandler(): GatewayRequestHandler {
     const core = getEmailRuntime();
     const cfg = core.config.loadConfig() as OpenClawConfig;
 
-    const account = resolveEmailAccount({ cfg, accountId: DEFAULT_ACCOUNT_ID });
+    const account = resolveEmailAccountForRecipient({
+      cfg,
+      recipient: payload.to,
+    });
     if (!account.enabled || !account.address) {
       respond(false, undefined, { code: 503, message: "Email channel not configured" });
       return;
@@ -61,7 +63,7 @@ export function createEmailInboundHandler(): GatewayRequestHandler {
     const route = core.channel.routing.resolveAgentRoute({
       cfg,
       channel: "email",
-      accountId: DEFAULT_ACCOUNT_ID,
+      accountId: account.accountId,
       peer: {
         kind: "direct",
         id: senderAddress,

--- a/extensions/email/src/inbound.ts
+++ b/extensions/email/src/inbound.ts
@@ -1,0 +1,158 @@
+import type { GatewayRequestHandler, OpenClawConfig } from "openclaw/plugin-sdk";
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk";
+import { getEmailRuntime } from "./runtime.js";
+import { resolveEmailAccount } from "./accounts.js";
+import { checkSenderAccess } from "./access-control.js";
+import { sendEmailOutbound } from "./send.js";
+import type { EmailInboundPayload } from "./types.js";
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, "\"")
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .trim();
+}
+
+export function createEmailInboundHandler(): GatewayRequestHandler {
+  return async (opts) => {
+    const { params, respond, context } = opts;
+    const payload = params as unknown as EmailInboundPayload;
+
+    if (!payload.from || !payload.to) {
+      respond(false, undefined, { code: 400, message: "Missing from or to" });
+      return;
+    }
+
+    const core = getEmailRuntime();
+    const cfg = core.config.loadConfig() as OpenClawConfig;
+
+    const account = resolveEmailAccount({ cfg, accountId: DEFAULT_ACCOUNT_ID });
+    if (!account.enabled || !account.address) {
+      respond(false, undefined, { code: 503, message: "Email channel not configured" });
+      return;
+    }
+
+    // Access control: check sender against dmPolicy + allowFrom
+    const senderAddress = payload.from.toLowerCase();
+    const access = checkSenderAccess(senderAddress, account.dmPolicy, account.allowFrom);
+    if (!access.allowed) {
+      respond(false, undefined, { code: 403, message: "Sender not allowed" });
+      return;
+    }
+
+    const textBody = payload.text?.trim()
+      || (payload.html ? stripHtml(payload.html) : "");
+
+    if (!textBody) {
+      respond(false, undefined, { code: 400, message: "Empty email body" });
+      return;
+    }
+
+    const subject = payload.subject ?? "(no subject)";
+    const messageId = payload.headers?.messageId;
+
+    const route = core.channel.routing.resolveAgentRoute({
+      cfg,
+      channel: "email",
+      accountId: DEFAULT_ACCOUNT_ID,
+      peer: {
+        kind: "direct",
+        id: senderAddress,
+      },
+    });
+
+    const rawBody = `Subject: ${subject}\n\n${textBody}`;
+    const body = core.channel.reply.formatAgentEnvelope({
+      channel: "Email",
+      from: senderAddress,
+      timestamp: Date.now(),
+      envelope: core.channel.reply.resolveEnvelopeFormatOptions(cfg),
+      body: rawBody,
+    });
+
+    const ctxPayload = core.channel.reply.finalizeInboundContext({
+      Body: body,
+      RawBody: rawBody,
+      CommandBody: rawBody,
+      From: `email:${senderAddress}`,
+      To: `email:${account.address}`,
+      SessionKey: route.sessionKey,
+      AccountId: route.accountId,
+      ChatType: "direct",
+      ConversationLabel: subject,
+      SenderName: senderAddress,
+      SenderId: senderAddress,
+      Provider: "email",
+      Surface: "email",
+      MessageSid: messageId,
+      OriginatingChannel: "email",
+      OriginatingTo: senderAddress,
+      UntrustedContext: [
+        `[email_message_id: ${messageId ?? "unknown"}]`,
+        `[email_subject: ${subject}]`,
+        `[email_from: ${senderAddress}]`,
+      ],
+    });
+
+    const storePath = core.channel.session.resolveStorePath(cfg.session?.store, {
+      agentId: route.agentId,
+    });
+    await core.channel.session.recordInboundSession({
+      storePath,
+      sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+      ctx: ctxPayload,
+      onRecordError: (err) => {
+        context.logGateway.error(`[email] Failed to record session: ${String(err)}`);
+      },
+    });
+
+    void core.channel.reply
+      .dispatchReplyWithBufferedBlockDispatcher({
+        ctx: ctxPayload,
+        cfg,
+        dispatcherOptions: {
+          deliver: async (replyPayload) => {
+            await deliverEmailReply({
+              account,
+              to: senderAddress,
+              subject: subject.startsWith("Re: ") ? subject : `Re: ${subject}`,
+              text: replyPayload.text ?? "",
+              inReplyTo: messageId,
+            });
+          },
+        },
+      })
+      .catch((err) => {
+        context.logGateway.error(`[email] Dispatch failed: ${String(err)}`);
+      });
+
+    respond(true, { received: true });
+  };
+}
+
+async function deliverEmailReply(params: {
+  account: { outboundUrl: string; outboundToken: string };
+  to: string;
+  subject: string;
+  text: string;
+  inReplyTo?: string;
+}): Promise<void> {
+  const { account, to, subject, text, inReplyTo } = params;
+
+  await sendEmailOutbound({
+    account,
+    payload: {
+      to,
+      subject,
+      text,
+      ...(inReplyTo ? { inReplyTo } : {}),
+    },
+  });
+}

--- a/extensions/email/src/runtime.ts
+++ b/extensions/email/src/runtime.ts
@@ -1,0 +1,14 @@
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+
+let runtime: PluginRuntime | null = null;
+
+export function setEmailRuntime(next: PluginRuntime) {
+  runtime = next;
+}
+
+export function getEmailRuntime(): PluginRuntime {
+  if (!runtime) {
+    throw new Error("Email runtime not initialized");
+  }
+  return runtime;
+}

--- a/extensions/email/src/send.test.ts
+++ b/extensions/email/src/send.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { sendEmailOutbound } from "./send.js";
+
+describe("sendEmailOutbound", () => {
+  const account = {
+    outboundUrl: "https://example.com/email/outbound",
+    outboundToken: "token-123",
+  };
+
+  const payload = {
+    to: "juno@zhcinstitute.com",
+    subject: "Test subject",
+    text: "Hello world",
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws when outbound config is missing", async () => {
+    await expect(
+      sendEmailOutbound({
+        account: { outboundUrl: "", outboundToken: "" },
+        payload,
+      }),
+    ).rejects.toThrow("Email outbound not configured");
+  });
+
+  it("posts to outbound url with auth header and payload", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ messageId: "msg-1" }), { status: 200 }));
+
+    const result = await sendEmailOutbound({ account, payload });
+
+    expect(fetchMock).toHaveBeenCalledWith(account.outboundUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${account.outboundToken}`,
+      },
+      body: JSON.stringify(payload),
+    });
+    expect(result).toEqual({ messageId: "msg-1" });
+  });
+
+  it("throws with status info on non-2xx responses", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("bad request", { status: 400, statusText: "Bad Request" }),
+    );
+
+    await expect(sendEmailOutbound({ account, payload })).rejects.toThrow(
+      "Email outbound failed (400): bad request",
+    );
+  });
+});

--- a/extensions/email/src/send.ts
+++ b/extensions/email/src/send.ts
@@ -1,0 +1,35 @@
+import type { EmailOutboundPayload } from "./types.js";
+
+export async function sendEmailOutbound(params: {
+  account: { outboundUrl: string; outboundToken: string };
+  payload: EmailOutboundPayload;
+}): Promise<{ messageId?: string }> {
+  const { account, payload } = params;
+
+  if (!account.outboundUrl || !account.outboundToken) {
+    throw new Error("Email outbound not configured: missing outboundUrl or outboundToken");
+  }
+
+  const response = await fetch(account.outboundUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${account.outboundToken}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "unknown");
+    throw new Error(`Email outbound failed (${response.status}): ${errorText}`);
+  }
+
+  const payloadJson = (await response.json().catch(() => ({}))) as {
+    messageId?: string;
+    id?: string;
+  };
+
+  return {
+    messageId: payloadJson.messageId ?? payloadJson.id,
+  };
+}

--- a/extensions/email/src/types.ts
+++ b/extensions/email/src/types.ts
@@ -1,0 +1,41 @@
+export type EmailAccountConfig = {
+  enabled?: boolean;
+  name?: string;
+  address?: string;
+  outboundUrl?: string;
+  outboundToken?: string;
+  dmPolicy?: "open" | "pairing" | "closed";
+  allowFrom?: Array<string | number>;
+};
+
+export type ResolvedEmailAccount = {
+  accountId: string;
+  name: string;
+  enabled: boolean;
+  address: string;
+  outboundUrl: string;
+  outboundToken: string;
+  dmPolicy: "open" | "pairing" | "closed";
+  allowFrom: Array<string | number>;
+};
+
+export type EmailInboundPayload = {
+  from: string;
+  to: string;
+  subject?: string;
+  text?: string;
+  html?: string;
+  headers?: {
+    messageId?: string;
+    [key: string]: unknown;
+  };
+};
+
+export type EmailOutboundPayload = {
+  to: string;
+  subject: string;
+  text: string;
+  html?: string;
+  inReplyTo?: string;
+  references?: string;
+};


### PR DESCRIPTION
## Summary
Enable proactive outbound email sends via the Email channel adapter so `message.send` can deliver to email targets.

## Changes
- add shared `sendEmailOutbound()` helper for outbound HTTP dispatch + response parsing
- switch Email channel outbound mode to `direct`
- implement `sendText` and `sendMedia` in `extensions/email/src/channel.ts`
- refactor inbound reply path to reuse the shared outbound helper
- add unit tests for outbound success and failure paths

## Why
The current Email plugin only supported inbound-triggered replies and returned a placeholder error for direct outbound sends. This prevented tool-driven proactive sends (e.g. `message.send` / assistant `message` tool) and surfaced as:

`Outbound not configured for channel: email`

This PR wires direct outbound behavior to match other channels.

## Validation
- `vitest run extensions/email/src/send.test.ts` (passes locally in source checkout)
