### PR TITLE
Control UI: surface hidden tool output (deliverables hint) in Chat

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -255,6 +255,23 @@ export function renderChatControls(state: AppViewState) {
         ${icons.brain}
       </button>
       <button
+        class="btn btn--sm btn--icon"
+        ?disabled=${disableThinkingToggle || showThinking}
+        @click=${() => {
+          if (disableThinkingToggle || showThinking) {
+            return;
+          }
+          state.applySettings({
+            ...state.settings,
+            chatShowThinking: true,
+          });
+        }}
+        title=${disableThinkingToggle ? t("chat.onboardingDisabled") : "Show deliverables (tool output)"}
+        aria-label="Show deliverables (tool output)"
+      >
+        ${icons.folder}
+      </button>
+      <button
         class="btn btn--sm btn--icon ${focusActive ? "active" : ""}"
         ?disabled=${disableFocusToggle}
         @click=${() => {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1052,6 +1052,15 @@ export function renderApp(state: AppViewState) {
                     chatFocusMode: !state.settings.chatFocusMode,
                   });
                 },
+                onToggleThinking: () => {
+                  if (state.onboarding) {
+                    return;
+                  }
+                  state.applySettings({
+                    ...state.settings,
+                    chatShowThinking: !state.settings.chatShowThinking,
+                  });
+                },
                 onChatScroll: (event) => state.handleChatScroll(event),
                 onDraftChange: (next) => (state.chatMessage = next),
                 attachments: state.chatAttachments,

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -358,7 +358,7 @@ export function renderChat(props: ChatProps) {
             })()
               ? html`
                 <div class="callout info" style="margin-bottom: 10px;">
-                  <strong>Deliverables hint:</strong> tool output is hidden. That’s usually where file paths and artifacts show up.
+                  <strong>Tool output hidden.</strong> Deliverables and file paths often show up there.
                   ${
                     props.onToggleThinking
                       ? html`

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -71,6 +71,7 @@ export type ChatProps = {
   // Event handlers
   onRefresh: () => void;
   onToggleFocusMode: () => void;
+  onToggleThinking?: () => void;
   onDraftChange: (next: string) => void;
   onSend: () => void;
   onAbort?: () => void;
@@ -343,6 +344,26 @@ export function renderChat(props: ChatProps) {
           class="chat-main"
           style="flex: ${sidebarOpen ? `0 0 ${splitRatio * 100}%` : "1 1 100%"}"
         >
+          ${
+            !props.showThinking && (props.toolMessages?.length ?? 0) > 0
+              ? html`
+                <div class="callout warn" style="margin-bottom: 10px;">
+                  <strong>Deliverables hint:</strong> tool output is hidden. That’s usually where file paths and artifacts show up.
+                  ${
+                    props.onToggleThinking
+                      ? html`
+                        <div style="margin-top: 10px; display: flex; gap: 8px; flex-wrap: wrap;">
+                          <button class="btn btn--sm primary" type="button" @click=${props.onToggleThinking}>
+                            Show tool output
+                          </button>
+                        </div>
+                      `
+                      : nothing
+                  }
+                </div>
+              `
+              : nothing
+          }
           ${thread}
         </div>
 

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -345,9 +345,19 @@ export function renderChat(props: ChatProps) {
           style="flex: ${sidebarOpen ? `0 0 ${splitRatio * 100}%` : "1 1 100%"}"
         >
           ${
-            !props.showThinking && (props.toolMessages?.length ?? 0) > 0
+            (() => {
+              if (props.showThinking) {
+                return false;
+              }
+              const toolStreamHasEntries = (props.toolMessages?.length ?? 0) > 0;
+              const historyHasHiddenToolResults = (props.messages ?? []).some((msg) => {
+                const role = normalizeMessage(msg).role.toLowerCase();
+                return role === "toolresult";
+              });
+              return toolStreamHasEntries || historyHasHiddenToolResults;
+            })()
               ? html`
-                <div class="callout warn" style="margin-bottom: 10px;">
+                <div class="callout info" style="margin-bottom: 10px;">
                   <strong>Deliverables hint:</strong> tool output is hidden. That’s usually where file paths and artifacts show up.
                   ${
                     props.onToggleThinking


### PR DESCRIPTION
### Problem\nDeliverables and file paths often land in tool output, but the Control UI can hide tool output when the brain (showThinking) toggle is off. This makes it easy to miss artifacts.\n\n### Change\n- In Chat view, when tool output exists but is hidden, show a callout explaining that deliverables may be hidden and provide a one-click button to enable tool output.\n\n### Notes\n- No backend changes; UI-only.\n- A follow-up could add a true Deliverables/Artifacts index once the backend exposes artifact metadata.