### PR TITLE
AI Assisted feat(memory): add Bedrock embedding provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -676,7 +676,7 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "0.16.1",
     "@aws-sdk/client-bedrock": "^3.1011.0",
-    "@aws-sdk/client-bedrock-runtime": "^3.1000.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.1011.0",
     "@clack/prompts": "^1.1.0",
     "@homebridge/ciao": "^1.3.5",
     "@line/bot-sdk": "^10.6.0",

--- a/package.json
+++ b/package.json
@@ -676,6 +676,7 @@
   "dependencies": {
     "@agentclientprotocol/sdk": "0.16.1",
     "@aws-sdk/client-bedrock": "^3.1011.0",
+    "@aws-sdk/client-bedrock-runtime": "^3.1000.0",
     "@clack/prompts": "^1.1.0",
     "@homebridge/ciao": "^1.3.5",
     "@line/bot-sdk": "^10.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       '@aws-sdk/client-bedrock':
         specifier: ^3.1011.0
         version: 3.1011.0
+      '@aws-sdk/client-bedrock-runtime':
+        specifier: ^3.1011.0
+        version: 3.1011.0
       '@clack/prompts':
         specifier: ^1.1.0
         version: 1.1.0

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -17,7 +17,7 @@ export type ResolvedMemorySearchConfig = {
   sources: Array<"memory" | "sessions">;
   extraPaths: string[];
   multimodal: MemoryMultimodalSettings;
-  provider: "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama" | "auto";
+  provider: "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama" | "bedrock" | "auto";
   remote?: {
     baseUrl?: string;
     apiKey?: SecretInput;
@@ -33,7 +33,7 @@ export type ResolvedMemorySearchConfig = {
   experimental: {
     sessionMemory: boolean;
   };
-  fallback: "openai" | "gemini" | "local" | "voyage" | "mistral" | "ollama" | "none";
+  fallback: "openai" | "gemini" | "local" | "voyage" | "mistral" | "ollama" | "bedrock" | "none";
   model: string;
   outputDimensionality?: number;
   local: {

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -1,4 +1,5 @@
 import fsSync from "node:fs";
+import { BedrockRuntimeClient } from "@aws-sdk/client-bedrock-runtime";
 import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveApiKeyForProvider } from "../agents/model-auth.js";
@@ -194,9 +195,25 @@ async function hasApiKeyForProvider(
   agentDir: string,
 ): Promise<boolean> {
   // Map embedding provider names to model-auth provider names
-  const authProvider = provider === "gemini" ? "google" : provider;
+  const authProvider =
+    provider === "gemini" ? "google" : provider === "bedrock" ? "amazon-bedrock" : provider;
   try {
-    await resolveApiKeyForProvider({ provider: authProvider, cfg, agentDir });
+    const auth = await resolveApiKeyForProvider({ provider: authProvider, cfg, agentDir });
+    // Bedrock's default credential chain reports aws-sdk mode even without real credentials
+    // configured, which would cause a false-positive healthy status. Do an eager credential
+    // check (mirroring what createBedrockEmbeddingProvider does at runtime) to verify real
+    // AWS creds are present.
+    if (provider === "bedrock" && auth.mode === "aws-sdk") {
+      try {
+        const client = new BedrockRuntimeClient({});
+        const creds = await client.config.credentials();
+        if (!creds?.accessKeyId) {
+          return false;
+        }
+      } catch {
+        return false;
+      }
+    }
     return true;
   } catch {
     return false;

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -114,11 +114,13 @@ export async function noteMemorySearchHealth(
     return;
   }
 
-  // provider === "auto": check all providers in resolution order
+  // provider === "auto": check all providers in resolution order.
+  // Bedrock is excluded because its auth check (AWS default credential chain)
+  // can return a false positive without real credentials being configured.
   if (hasLocalEmbeddings(resolved.local)) {
     return;
   }
-  for (const provider of ["openai", "gemini", "voyage", "mistral", "bedrock"] as const) {
+  for (const provider of ["openai", "gemini", "voyage", "mistral"] as const) {
     if (hasRemoteApiKey || (await hasApiKeyForProvider(provider, cfg, agentDir))) {
       return;
     }

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -118,7 +118,7 @@ export async function noteMemorySearchHealth(
   if (hasLocalEmbeddings(resolved.local)) {
     return;
   }
-  for (const provider of ["openai", "gemini", "voyage", "mistral"] as const) {
+  for (const provider of ["openai", "gemini", "voyage", "mistral", "bedrock"] as const) {
     if (hasRemoteApiKey || (await hasApiKeyForProvider(provider, cfg, agentDir))) {
       return;
     }
@@ -187,7 +187,7 @@ function hasLocalEmbeddings(local: { modelPath?: string }, useDefaultFallback = 
 }
 
 async function hasApiKeyForProvider(
-  provider: "openai" | "gemini" | "voyage" | "mistral" | "ollama",
+  provider: "openai" | "gemini" | "voyage" | "mistral" | "ollama" | "bedrock",
   cfg: OpenClawConfig,
   agentDir: string,
 ): Promise<boolean> {

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -789,7 +789,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.memorySearch.experimental.sessionMemory":
     "Indexes session transcripts into memory search so responses can reference prior chat turns. Keep this off unless transcript recall is needed, because indexing cost and storage usage both increase.",
   "agents.defaults.memorySearch.provider":
-    'Selects the embedding backend used to build/query memory vectors: "openai", "gemini", "voyage", "mistral", "ollama", or "local". Keep your most reliable provider here and configure fallback for resilience.',
+    'Selects the embedding backend used to build/query memory vectors: "openai", "gemini", "voyage", "mistral", "ollama", "bedrock", or "local". Keep your most reliable provider here and configure fallback for resilience.',
   "agents.defaults.memorySearch.model":
     "Embedding model override used by the selected memory provider when a non-default model is required. Set this only when you need explicit recall quality/cost tuning beyond provider defaults.",
   "agents.defaults.memorySearch.outputDimensionality":
@@ -813,7 +813,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.memorySearch.local.modelPath":
     "Specifies the local embedding model source for local memory search, such as a GGUF file path or `hf:` URI. Use this only when provider is `local`, and verify model compatibility before large index rebuilds.",
   "agents.defaults.memorySearch.fallback":
-    'Backup provider used when primary embeddings fail: "openai", "gemini", "voyage", "mistral", "ollama", "local", or "none". Set a real fallback for production reliability; use "none" only if you prefer explicit failures.',
+    'Backup provider used when primary embeddings fail: "openai", "gemini", "voyage", "mistral", "ollama", "bedrock", "local", or "none". Set a real fallback for production reliability; use "none" only if you prefer explicit failures.',
   "agents.defaults.memorySearch.store.path":
     "Sets where the SQLite memory index is stored on disk for each agent. Keep the default `~/.openclaw/memory/{agentId}.sqlite` unless you need custom storage placement or backup policy alignment.",
   "agents.defaults.memorySearch.store.vector.enabled":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -334,7 +334,7 @@ export type MemorySearchConfig = {
     sessionMemory?: boolean;
   };
   /** Embedding provider mode. */
-  provider?: "openai" | "gemini" | "local" | "voyage" | "mistral" | "ollama";
+  provider?: "openai" | "gemini" | "local" | "voyage" | "mistral" | "ollama" | "bedrock";
   remote?: {
     baseUrl?: string;
     apiKey?: SecretInput;
@@ -353,7 +353,7 @@ export type MemorySearchConfig = {
     };
   };
   /** Fallback behavior when embeddings fail. */
-  fallback?: "openai" | "gemini" | "local" | "voyage" | "mistral" | "ollama" | "none";
+  fallback?: "openai" | "gemini" | "local" | "voyage" | "mistral" | "ollama" | "bedrock" | "none";
   /** Embedding model id (remote) or alias (local). */
   model?: string;
   /**

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -612,6 +612,7 @@ export const MemorySearchSchema = z
         z.literal("voyage"),
         z.literal("mistral"),
         z.literal("ollama"),
+        z.literal("bedrock"),
       ])
       .optional(),
     remote: z
@@ -640,6 +641,7 @@ export const MemorySearchSchema = z
         z.literal("voyage"),
         z.literal("mistral"),
         z.literal("ollama"),
+        z.literal("bedrock"),
         z.literal("none"),
       ])
       .optional(),

--- a/src/memory/embedding-model-limits.ts
+++ b/src/memory/embedding-model-limits.ts
@@ -13,6 +13,10 @@ const KNOWN_EMBEDDING_MAX_INPUT_TOKENS: Record<string, number> = {
   "voyage:voyage-3": 32000,
   "voyage:voyage-3-lite": 16000,
   "voyage:voyage-code-3": 32000,
+  "bedrock:amazon.titan-embed-text-v2:0": 8192,
+  "bedrock:amazon.titan-embed-text-v1": 8192,
+  "bedrock:cohere.embed-english-v3": 512,
+  "bedrock:cohere.embed-multilingual-v3": 512,
 };
 
 export function resolveEmbeddingMaxInputTokens(provider: EmbeddingProvider): number {

--- a/src/memory/embeddings-bedrock.ts
+++ b/src/memory/embeddings-bedrock.ts
@@ -67,16 +67,20 @@ export async function createBedrockEmbeddingProvider(
 
   const providerConfig = options.config.models?.providers?.["amazon-bedrock"];
   const baseUrl = providerConfig?.baseUrl?.trim();
-  const region = parseRegionFromBaseUrl(baseUrl) ?? "us-east-1";
+  // Prefer region extracted from an explicit base URL; otherwise let the AWS SDK
+  // resolve the region from the environment (AWS_REGION, AWS_DEFAULT_REGION,
+  // shared-config profile, EC2 metadata, etc.).  Hard-coding "us-east-1" would
+  // break users whose Bedrock model access is in another region.
+  const region = parseRegionFromBaseUrl(baseUrl);
   const model = normalizeBedrockModel(options.model);
 
   debugEmbeddingsLog("memory embeddings: bedrock client", {
-    region,
+    region: region ?? "(sdk-resolved)",
     model,
     authSource: auth.source,
   });
 
-  const bedrockClient = new BedrockRuntimeClient({ region });
+  const bedrockClient = new BedrockRuntimeClient(region ? { region } : {});
 
   // Eagerly resolve credentials to fail fast in "auto" mode when no AWS
   // creds are configured.  The default chain succeeds with empty/expired

--- a/src/memory/embeddings-bedrock.ts
+++ b/src/memory/embeddings-bedrock.ts
@@ -4,7 +4,7 @@ import { debugEmbeddingsLog } from "./embeddings-debug.js";
 import type { EmbeddingProvider, EmbeddingProviderOptions } from "./embeddings.js";
 
 export type BedrockEmbeddingClient = {
-  region: string;
+  region: string | undefined;
   model: string;
 };
 

--- a/src/memory/embeddings-bedrock.ts
+++ b/src/memory/embeddings-bedrock.ts
@@ -66,7 +66,7 @@ export async function createBedrockEmbeddingProvider(
   }
 
   const providerConfig = options.config.models?.providers?.["amazon-bedrock"];
-  const baseUrl = providerConfig?.baseUrl?.trim();
+  const baseUrl = options.remote?.baseUrl?.trim() || providerConfig?.baseUrl?.trim();
   // Prefer region extracted from an explicit base URL; otherwise let the AWS SDK
   // resolve the region from the environment (AWS_REGION, AWS_DEFAULT_REGION,
   // shared-config profile, EC2 metadata, etc.).  Hard-coding "us-east-1" would

--- a/src/memory/embeddings-bedrock.ts
+++ b/src/memory/embeddings-bedrock.ts
@@ -89,7 +89,7 @@ export async function createBedrockEmbeddingProvider(
     }
   } catch {
     throw new Error(
-      "Bedrock embedding provider could not resolve AWS credentials. " +
+      "No API key found for provider amazon-bedrock. " +
         "Set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY, AWS_PROFILE, or run on an instance with an IAM role.",
     );
   }

--- a/src/memory/embeddings-bedrock.ts
+++ b/src/memory/embeddings-bedrock.ts
@@ -1,0 +1,153 @@
+import { BedrockRuntimeClient, InvokeModelCommand } from "@aws-sdk/client-bedrock-runtime";
+import { resolveApiKeyForProvider } from "../agents/model-auth.js";
+import { debugEmbeddingsLog } from "./embeddings-debug.js";
+import type { EmbeddingProvider, EmbeddingProviderOptions } from "./embeddings.js";
+
+export type BedrockEmbeddingClient = {
+  region: string;
+  model: string;
+};
+
+export const DEFAULT_BEDROCK_EMBEDDING_MODEL = "amazon.titan-embed-text-v2:0";
+
+const BEDROCK_MAX_INPUT_TOKENS: Record<string, number> = {
+  "amazon.titan-embed-text-v2:0": 8192,
+  "amazon.titan-embed-text-v1": 8192,
+  "cohere.embed-english-v3": 512,
+  "cohere.embed-multilingual-v3": 512,
+};
+
+export function normalizeBedrockModel(model: string): string {
+  const trimmed = model.trim();
+  if (!trimmed) {
+    return DEFAULT_BEDROCK_EMBEDDING_MODEL;
+  }
+  if (trimmed.startsWith("amazon-bedrock/")) {
+    return trimmed.slice("amazon-bedrock/".length);
+  }
+  if (trimmed.startsWith("bedrock/")) {
+    return trimmed.slice("bedrock/".length);
+  }
+  return trimmed;
+}
+
+function isCohereModel(model: string): boolean {
+  return model.startsWith("cohere.");
+}
+
+function parseRegionFromBaseUrl(baseUrl?: string): string | undefined {
+  if (!baseUrl) {
+    return undefined;
+  }
+  const match = baseUrl.match(/bedrock-runtime\.([a-z0-9-]+)\.amazonaws\.com/);
+  return match?.[1];
+}
+
+export async function createBedrockEmbeddingProvider(
+  options: EmbeddingProviderOptions,
+): Promise<{ provider: EmbeddingProvider; client: BedrockEmbeddingClient }> {
+  // Resolve auth — we just need to verify AWS credentials are available.
+  // The BedrockRuntimeClient handles actual credential resolution via the
+  // default credential provider chain.
+  const auth = await resolveApiKeyForProvider({
+    provider: "amazon-bedrock",
+    cfg: options.config,
+    agentDir: options.agentDir,
+  });
+  if (auth.mode !== "aws-sdk") {
+    throw new Error(
+      `Bedrock embedding provider requires AWS SDK auth (got ${auth.mode}). ` +
+        `Set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY, AWS_PROFILE, or AWS_BEARER_TOKEN_BEDROCK.`,
+    );
+  }
+
+  const providerConfig = options.config.models?.providers?.["amazon-bedrock"];
+  const baseUrl = providerConfig?.baseUrl?.trim();
+  const region = parseRegionFromBaseUrl(baseUrl) ?? "us-east-1";
+  const model = normalizeBedrockModel(options.model);
+
+  debugEmbeddingsLog("memory embeddings: bedrock client", {
+    region,
+    model,
+    authSource: auth.source,
+  });
+
+  const bedrockClient = new BedrockRuntimeClient({ region });
+
+  const invokeModel = async (body: Record<string, unknown>): Promise<Record<string, unknown>> => {
+    const command = new InvokeModelCommand({
+      modelId: model,
+      contentType: "application/json",
+      accept: "application/json",
+      body: JSON.stringify(body),
+    });
+    const response = await bedrockClient.send(command);
+    const responseBody = new TextDecoder().decode(response.body);
+    return JSON.parse(responseBody) as Record<string, unknown>;
+  };
+
+  const embedQuery = async (text: string): Promise<number[]> => {
+    if (!text.trim()) {
+      return [];
+    }
+    if (isCohereModel(model)) {
+      const result = await invokeModel({
+        texts: [text],
+        input_type: "search_query",
+        truncate: "END",
+      });
+      const embeddings = result.embeddings as number[][];
+      return embeddings?.[0] ?? [];
+    }
+    // Titan models
+    const result = await invokeModel({
+      inputText: text,
+      dimensions: 1024,
+      normalize: true,
+    });
+    return (result.embedding as number[]) ?? [];
+  };
+
+  const embedBatch = async (texts: string[]): Promise<number[][]> => {
+    if (texts.length === 0) {
+      return [];
+    }
+    if (isCohereModel(model)) {
+      const result = await invokeModel({
+        texts,
+        input_type: "search_document",
+        truncate: "END",
+      });
+      const embeddings = result.embeddings as number[][];
+      return texts.map((_, index) => embeddings?.[index] ?? []);
+    }
+    // Titan models don't support batch — invoke individually
+    const results = await Promise.all(
+      texts.map(async (text) => {
+        if (!text.trim()) {
+          return [];
+        }
+        const result = await invokeModel({
+          inputText: text,
+          dimensions: 1024,
+          normalize: true,
+        });
+        return (result.embedding as number[]) ?? [];
+      }),
+    );
+    return results;
+  };
+
+  const client: BedrockEmbeddingClient = { region, model };
+
+  return {
+    provider: {
+      id: "bedrock",
+      model,
+      maxInputTokens: BEDROCK_MAX_INPUT_TOKENS[model],
+      embedQuery,
+      embedBatch,
+    },
+    client,
+  };
+}

--- a/src/memory/embeddings-bedrock.ts
+++ b/src/memory/embeddings-bedrock.ts
@@ -35,6 +35,10 @@ function isCohereModel(model: string): boolean {
   return model.startsWith("cohere.");
 }
 
+function isTitanV2(model: string): boolean {
+  return model.includes("v2");
+}
+
 function parseRegionFromBaseUrl(baseUrl?: string): string | undefined {
   if (!baseUrl) {
     return undefined;
@@ -74,6 +78,22 @@ export async function createBedrockEmbeddingProvider(
 
   const bedrockClient = new BedrockRuntimeClient({ region });
 
+  // Eagerly resolve credentials to fail fast in "auto" mode when no AWS
+  // creds are configured.  The default chain succeeds with empty/expired
+  // tokens that only fail at InvokeModel time, which would break users
+  // who have a working Voyage/Mistral key but no AWS setup.
+  try {
+    const creds = await bedrockClient.config.credentials();
+    if (!creds?.accessKeyId) {
+      throw new Error("No AWS credentials resolved");
+    }
+  } catch {
+    throw new Error(
+      "Bedrock embedding provider could not resolve AWS credentials. " +
+        "Set AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY, AWS_PROFILE, or run on an instance with an IAM role.",
+    );
+  }
+
   const invokeModel = async (body: Record<string, unknown>): Promise<Record<string, unknown>> => {
     const command = new InvokeModelCommand({
       modelId: model,
@@ -99,11 +119,10 @@ export async function createBedrockEmbeddingProvider(
       const embeddings = result.embeddings as number[][];
       return embeddings?.[0] ?? [];
     }
-    // Titan models
+    // Titan models — v2 supports dimensions/normalize, v1 only accepts inputText
     const result = await invokeModel({
       inputText: text,
-      dimensions: 1024,
-      normalize: true,
+      ...(isTitanV2(model) ? { dimensions: 1024, normalize: true } : {}),
     });
     return (result.embedding as number[]) ?? [];
   };
@@ -129,8 +148,7 @@ export async function createBedrockEmbeddingProvider(
         }
         const result = await invokeModel({
           inputText: text,
-          dimensions: 1024,
-          normalize: true,
+          ...(isTitanV2(model) ? { dimensions: 1024, normalize: true } : {}),
         });
         return (result.embedding as number[]) ?? [];
       }),

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -7,6 +7,10 @@ import { resolveUserPath } from "../utils.js";
 import type { EmbeddingInput } from "./embedding-inputs.js";
 import { sanitizeAndNormalizeEmbedding } from "./embedding-vectors.js";
 import {
+  createBedrockEmbeddingProvider,
+  type BedrockEmbeddingClient,
+} from "./embeddings-bedrock.js";
+import {
   createGeminiEmbeddingProvider,
   type GeminiEmbeddingClient,
   type GeminiTaskType,
@@ -20,6 +24,8 @@ import { createOpenAiEmbeddingProvider, type OpenAiEmbeddingClient } from "./emb
 import { createVoyageEmbeddingProvider, type VoyageEmbeddingClient } from "./embeddings-voyage.js";
 import { importNodeLlamaCpp } from "./node-llama.js";
 
+
+export type { BedrockEmbeddingClient } from "./embeddings-bedrock.js";
 export type { GeminiEmbeddingClient } from "./embeddings-gemini.js";
 export type { MistralEmbeddingClient } from "./embeddings-mistral.js";
 export type { OpenAiEmbeddingClient } from "./embeddings-openai.js";
@@ -35,14 +41,14 @@ export type EmbeddingProvider = {
   embedBatchInputs?: (inputs: EmbeddingInput[]) => Promise<number[][]>;
 };
 
-export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama";
+export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama" | "bedrock";
 export type EmbeddingProviderRequest = EmbeddingProviderId | "auto";
 export type EmbeddingProviderFallback = EmbeddingProviderId | "none";
 
 // Remote providers considered for auto-selection when provider === "auto".
 // Ollama is intentionally excluded here so that "auto" mode does not
 // implicitly assume a local Ollama instance is available.
-const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "voyage", "mistral"] as const;
+const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "bedrock", "voyage", "mistral"] as const;
 
 export type EmbeddingProviderResult = {
   provider: EmbeddingProvider | null;
@@ -52,6 +58,7 @@ export type EmbeddingProviderResult = {
   providerUnavailableReason?: string;
   openAi?: OpenAiEmbeddingClient;
   gemini?: GeminiEmbeddingClient;
+  bedrock?: BedrockEmbeddingClient;
   voyage?: VoyageEmbeddingClient;
   mistral?: MistralEmbeddingClient;
   ollama?: OllamaEmbeddingClient;
@@ -191,6 +198,10 @@ export async function createEmbeddingProvider(
     if (id === "mistral") {
       const { provider, client } = await createMistralEmbeddingProvider(options);
       return { provider, mistral: client };
+    }
+    if (id === "bedrock") {
+      const { provider, client } = await createBedrockEmbeddingProvider(options);
+      return { provider, bedrock: client };
     }
     const { provider, client } = await createOpenAiEmbeddingProvider(options);
     return { provider, openAi: client };

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -55,7 +55,10 @@ export type EmbeddingProviderFallback = EmbeddingProviderId | "none";
 // Remote providers considered for auto-selection when provider === "auto".
 // Ollama is intentionally excluded here so that "auto" mode does not
 // implicitly assume a local Ollama instance is available.
-const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "bedrock", "voyage", "mistral"] as const;
+// Bedrock is last because its auth check (AWS default credential chain)
+// cannot prove credentials exist without a real API call, unlike
+// key-based providers that fail fast on missing env vars.
+const REMOTE_EMBEDDING_PROVIDER_IDS = ["openai", "gemini", "voyage", "mistral", "bedrock"] as const;
 
 export type EmbeddingProviderResult = {
   provider: EmbeddingProvider | null;

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -41,7 +41,14 @@ export type EmbeddingProvider = {
   embedBatchInputs?: (inputs: EmbeddingInput[]) => Promise<number[][]>;
 };
 
-export type EmbeddingProviderId = "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama" | "bedrock";
+export type EmbeddingProviderId =
+  | "openai"
+  | "local"
+  | "gemini"
+  | "voyage"
+  | "mistral"
+  | "ollama"
+  | "bedrock";
 export type EmbeddingProviderRequest = EmbeddingProviderId | "auto";
 export type EmbeddingProviderFallback = EmbeddingProviderId | "none";
 

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -100,7 +100,14 @@ export abstract class MemoryManagerSyncOps {
   protected abstract readonly workspaceDir: string;
   protected abstract readonly settings: ResolvedMemorySearchConfig;
   protected provider: EmbeddingProvider | null = null;
-  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama";
+  protected fallbackFrom?:
+    | "openai"
+    | "local"
+    | "gemini"
+    | "voyage"
+    | "mistral"
+    | "ollama"
+    | "bedrock";
   protected openAi?: OpenAiEmbeddingClient;
   protected gemini?: GeminiEmbeddingClient;
   protected voyage?: VoyageEmbeddingClient;

--- a/src/memory/manager-sync-ops.ts
+++ b/src/memory/manager-sync-ops.ts
@@ -11,6 +11,7 @@ import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.j
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { onSessionTranscriptUpdate } from "../sessions/transcript-events.js";
 import { resolveUserPath } from "../utils.js";
+import { DEFAULT_BEDROCK_EMBEDDING_MODEL } from "./embeddings-bedrock.js";
 import { DEFAULT_GEMINI_EMBEDDING_MODEL } from "./embeddings-gemini.js";
 import { DEFAULT_MISTRAL_EMBEDDING_MODEL } from "./embeddings-mistral.js";
 import { DEFAULT_OLLAMA_EMBEDDING_MODEL } from "./embeddings-ollama.js";
@@ -1122,7 +1123,9 @@ export abstract class MemoryManagerSyncOps {
               ? DEFAULT_MISTRAL_EMBEDDING_MODEL
               : fallback === "ollama"
                 ? DEFAULT_OLLAMA_EMBEDDING_MODEL
-                : this.settings.model;
+                : fallback === "bedrock"
+                  ? DEFAULT_BEDROCK_EMBEDDING_MODEL
+                  : this.settings.model;
 
     const fallbackResult = await createEmbeddingProvider({
       config: this.cfg,

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -9,6 +9,7 @@ import type { OpenClawConfig } from "../config/config.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   createEmbeddingProvider,
+  type BedrockEmbeddingClient,
   type EmbeddingProvider,
   type EmbeddingProviderResult,
   type GeminiEmbeddingClient,
@@ -72,8 +73,16 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     | "voyage"
     | "mistral"
     | "ollama"
+    | "bedrock"
     | "auto";
-  protected fallbackFrom?: "openai" | "local" | "gemini" | "voyage" | "mistral" | "ollama";
+  protected fallbackFrom?:
+    | "openai"
+    | "local"
+    | "gemini"
+    | "voyage"
+    | "mistral"
+    | "ollama"
+    | "bedrock";
   protected fallbackReason?: string;
   private readonly providerUnavailableReason?: string;
   protected openAi?: OpenAiEmbeddingClient;
@@ -81,6 +90,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
   protected voyage?: VoyageEmbeddingClient;
   protected mistral?: MistralEmbeddingClient;
   protected ollama?: OllamaEmbeddingClient;
+  protected bedrock?: BedrockEmbeddingClient;
   protected batch: {
     enabled: boolean;
     wait: boolean;
@@ -214,6 +224,7 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     this.voyage = params.providerResult.voyage;
     this.mistral = params.providerResult.mistral;
     this.ollama = params.providerResult.ollama;
+    this.bedrock = params.providerResult.bedrock;
     this.sources = new Set(params.settings.sources);
     this.db = this.openDatabase();
     this.providerKey = this.computeProviderKey();


### PR DESCRIPTION
Add Amazon Bedrock as a native embedding provider for memory search. Supports Titan Embed Text v2 and Cohere Embed models via the AWS SDK.

- New file: embeddings-bedrock.ts
- Uses @aws-sdk/client-bedrock-runtime with InvokeModelCommand
- Auth via AWS default credential chain (same as Bedrock inference)
- Auto-selected when AWS credentials are available
- Default model: amazon.titan-embed-text-v2:0
- Added @aws-sdk/client-bedrock-runtime to package.json dependencies

Co-created with my OpenClaw Agent Felix using Claude Opus.

Closes #26289 