### PR TITLE
feishu: prevent duplicate streaming cards for multi-payload final replies

### DIFF
--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -261,7 +261,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\npartial answer\n```");
   });
 
-  it("delivers distinct final payloads after streaming close", async () => {
+  it("delivers subsequent final payloads as standalone cards after streaming close", async () => {
     createFeishuReplyDispatcher({
       cfg: {} as never,
       agentId: "agent",
@@ -273,13 +273,13 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     await options.deliver({ text: "```md\n完整回复第一段\n```" }, { kind: "final" });
     await options.deliver({ text: "```md\n完整回复第一段 + 第二段\n```" }, { kind: "final" });
 
-    expect(streamingInstances).toHaveLength(2);
+    // Only one streaming card should be created; the second final payload
+    // should be delivered as a standalone card to avoid duplicate streaming cards.
+    expect(streamingInstances).toHaveLength(1);
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
     expect(streamingInstances[0].close).toHaveBeenCalledWith("```md\n完整回复第一段\n```");
-    expect(streamingInstances[1].close).toHaveBeenCalledTimes(1);
-    expect(streamingInstances[1].close).toHaveBeenCalledWith("```md\n完整回复第一段 + 第二段\n```");
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledTimes(1);
     expect(sendMessageFeishuMock).not.toHaveBeenCalled();
-    expect(sendMarkdownCardFeishuMock).not.toHaveBeenCalled();
   });
 
   it("skips exact duplicate final text after streaming close", async () => {

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -144,6 +144,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   let streamText = "";
   let lastPartial = "";
   const deliveredFinalTexts = new Set<string>();
+  // Track whether streaming was already closed for a final payload in this dispatch.
+  // When true, subsequent final payloads skip streaming and send as standalone cards
+  // to avoid creating duplicate streaming cards (#XXXX).
+  let streamingClosedForFinal = false;
   let partialUpdateQueue: Promise<void> = Promise.resolve();
   let streamingStartPromise: Promise<void> | null = null;
   type StreamTextUpdateMode = "snapshot" | "delta";
@@ -231,6 +235,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       humanDelay: core.channel.reply.resolveHumanDelayConfig(cfg, agentId),
       onReplyStart: () => {
         deliveredFinalTexts.clear();
+        streamingClosedForFinal = false;
         if (streamingEnabled && renderMode === "card") {
           startStreaming();
         }
@@ -269,7 +274,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             }
           }
 
-          if (info?.kind === "final" && streamingEnabled && useCard) {
+          if (info?.kind === "final" && streamingEnabled && useCard && !streamingClosedForFinal) {
             startStreaming();
             if (streamingStartPromise) {
               await streamingStartPromise;
@@ -285,6 +290,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             if (info?.kind === "final") {
               streamText = mergeStreamingText(streamText, text);
               await closeStreaming();
+              streamingClosedForFinal = true;
               deliveredFinalTexts.add(text);
             }
             // Send media even when streaming handled the text


### PR DESCRIPTION
## Summary

- Fix duplicate message delivery in Feishu channel when agent returns multiple final payloads (e.g., verbose notices + actual reply)
- After the first final payload closes a streaming card, subsequent final payloads now send as standalone cards instead of creating new streaming sessions

## Problem

When the agent returns multiple `ReplyPayload` items in a single dispatch (common with auto-compaction notices, verbose mode, model fallback notices, or usage lines), each payload triggered a new streaming card creation in Feishu. This caused users to see duplicate messages — the main reply in one card and a short notice in another.

**Root cause chain:**

1. `agent-runner.ts` prepends verbose notices to final payloads → returns array
2. `dispatch-from-config.ts` iterates the array, calling `sendFinalReply()` for each
3. Feishu `reply-dispatcher.ts` creates a streaming card for the first final, closes it, then creates a **new** streaming card for the second final (because `streaming` was set to `null` after close)

**Gateway log pattern:**
```
Closed streaming: cardId=AAA          ← first final closes
Started streaming: cardId=BBB         ← second final creates new card (bug)
Closed streaming: cardId=BBB          ← immediately closes
dispatch complete (replies=2)
```

## Fix

Added a `streamingClosedForFinal` flag that prevents re-creating streaming sessions after a final payload has already been delivered via streaming. Subsequent final payloads fall through to the standard card/message send path instead.

**Changes:**
- `extensions/feishu/src/reply-dispatcher.ts`: Add `streamingClosedForFinal` guard; reset on `onReplyStart`
- `extensions/feishu/src/reply-dispatcher.test.ts`: Update test to verify new behavior (second final goes to standalone card)

## Testing

- All 21 reply-dispatcher tests pass
- Pre-existing `media.test.ts` failures (4 tests, unrelated `timeout` parameter issue) unchanged