### PR TITLE
docs(install): warn about owner-preserving rsync on migration

### DIFF
--- a/docs/install/migrating.md
+++ b/docs/install/migrating.md
@@ -105,13 +105,14 @@ Copy **both**:
 Common approaches:
 
 - `scp` the tarballs and extract
-- `rsync -a` over SSH
+- `rsync -a --no-owner --no-group` over SSH when the target is root-owned or runs as a different user
 - external drive
 
 After copying, ensure:
 
 - Hidden directories were included (e.g. `.openclaw/`)
 - File ownership is correct for the user running the gateway
+- If you used `rsync`, you did not preserve the source machine's owner/group onto root-owned target paths
 
 ### Step 3 — Run Doctor (migrations + service repair)
 
@@ -160,6 +161,10 @@ Always migrate the entire `$OPENCLAW_STATE_DIR` folder.
 If you copied as root or changed users, the gateway may fail to read credentials/sessions.
 
 Fix: ensure the state dir + workspace are owned by the user running the gateway.
+
+If you copy from another machine with owner/group preservation enabled, you can also drift ownership on
+root-owned targets. Prefer `rsync --no-owner --no-group` (or `scp` + extract) unless you are certain the
+source and destination ownership model is identical.
 
 ### Footgun: migrating between remote/local modes
 

--- a/docs/zh-CN/install/migrating.md
+++ b/docs/zh-CN/install/migrating.md
@@ -112,13 +112,14 @@ tar -czf openclaw-workspace.tgz .openclaw/workspace
 常见方法：
 
 - `scp` 压缩包并解压
-- 通过 SSH 使用 `rsync -a`
+- 如果目标路径归 root 所有或由其他用户运行，请通过 SSH 使用 `rsync -a --no-owner --no-group`
 - 外部驱动器
 
 复制后，确保：
 
 - 包含了隐藏目录（例如 `.openclaw/`）
 - 文件所有权对于运行 Gateway 网关的用户是正确的
+- 如果使用了 `rsync`，不要把源机器的 owner/group 原样保留到目标机器上的 root 路径
 
 ### 步骤 3 — 运行 Doctor（迁移 + 服务修复）
 
@@ -167,6 +168,10 @@ openclaw doctor
 如果你以 root 身份复制或更改了用户，Gateway 网关可能无法读取凭证/会话。
 
 修复：确保状态目录 + 工作区由运行 Gateway 网关的用户拥有。
+
+如果你从另一台机器复制并保留了 owner/group，也可能把 root 路径的所有权漂移到错误的用户。
+除非你非常确定源端和目标端的所有权模型完全一致，否则优先使用 `rsync --no-owner --no-group`
+或 `scp` 后再解压。
 
 ### 陷阱：在远程/本地模式之间迁移
 


### PR DESCRIPTION
## Summary / What changed
- warn against owner-preserving `rsync -a` when migrating into root-owned or different-user targets
- recommend `rsync -a --no-owner --no-group` for that case
- add the same warning to the Chinese migration doc for docs parity

## Why
I hit a live VPS recovery incident where preserving source ownership onto root-owned paths caused permission drift. The gateway state was recoverable, but the ownership drift was bad enough to break SSH checks on the host. The current migration doc says `rsync -a` in general, so it is easy to copy the wrong ownership model into a new machine.

## Tests
- `git diff --check`
- manual docs review for `docs/install/migrating.md` and `docs/zh-CN/install/migrating.md`
- did not run `pnpm build && pnpm check && pnpm test` because this is a docs-only change

## Real-world validation
- validated on my live deployment recovery on March 6, 2026 after hitting ownership drift while moving OpenClaw state between machines

## Issue
- none - docs follow-up from a real migration incident

## AI-assisted
- yes
- testing level: lightly tested
