### PR TITLE
feishu: mark long-running runs as busy to prevent health-monitor restarts

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1412,6 +1412,7 @@ export async function handleFeishuMessage(params: {
             threadReply,
             mentionTargets: ctx.mentionTargets,
             accountId: account.accountId,
+            sourceMessageId: ctx.messageId,
             messageCreateTimeMs,
           });
 
@@ -1510,6 +1511,7 @@ export async function handleFeishuMessage(params: {
         threadReply,
         mentionTargets: ctx.mentionTargets,
         accountId: account.accountId,
+        sourceMessageId: ctx.messageId,
         messageCreateTimeMs,
       });
 

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -1,6 +1,7 @@
 import type { ChannelMeta, ChannelPlugin, ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
 import {
   buildBaseChannelStatusSummary,
+  createRunStateMachine,
   createDefaultChannelRuntimeState,
   DEFAULT_ACCOUNT_ID,
   PAIRING_APPROVED_MESSAGE,
@@ -341,7 +342,17 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
   },
   outbound: feishuOutbound,
   status: {
-    defaultRuntime: createDefaultChannelRuntimeState(DEFAULT_ACCOUNT_ID, { port: null }),
+    defaultRuntime: createDefaultChannelRuntimeState(DEFAULT_ACCOUNT_ID, {
+      port: null,
+      connected: false,
+      reconnectAttempts: 0,
+      lastEventAt: null,
+      busy: false,
+      activeRuns: 0,
+      lastRunActivityAt: null,
+      lastInboundAt: null,
+      lastOutboundAt: null,
+    }),
     buildChannelSummary: ({ snapshot }) => ({
       ...buildBaseChannelStatusSummary(snapshot),
       port: snapshot.port ?? null,
@@ -360,8 +371,16 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
       lastStartAt: runtime?.lastStartAt ?? null,
       lastStopAt: runtime?.lastStopAt ?? null,
       lastError: runtime?.lastError ?? null,
+      connected: runtime?.connected ?? false,
+      reconnectAttempts: runtime?.reconnectAttempts,
+      lastEventAt: runtime?.lastEventAt ?? null,
+      busy: runtime?.busy ?? false,
+      activeRuns: runtime?.activeRuns ?? 0,
+      lastRunActivityAt: runtime?.lastRunActivityAt ?? null,
       port: runtime?.port ?? null,
       probe,
+      lastInboundAt: runtime?.lastInboundAt ?? null,
+      lastOutboundAt: runtime?.lastOutboundAt ?? null,
     }),
   },
   gateway: {
@@ -369,7 +388,13 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
       const { monitorFeishuProvider } = await import("./monitor.js");
       const account = resolveFeishuAccount({ cfg: ctx.cfg, accountId: ctx.accountId });
       const port = account.config?.webhookPort ?? null;
-      ctx.setStatus({ accountId: ctx.accountId, port });
+      const setStatus = (patch: Record<string, unknown>) =>
+        ctx.setStatus({ accountId: ctx.accountId, ...patch });
+      setStatus({ port });
+      const runStateMachine = createRunStateMachine({
+        setStatus,
+        abortSignal: ctx.abortSignal,
+      });
       ctx.log?.info(
         `starting feishu[${ctx.accountId}] (mode: ${account.config?.connectionMode ?? "websocket"})`,
       );
@@ -378,6 +403,8 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
         runtime: ctx.runtime,
         abortSignal: ctx.abortSignal,
         accountId: ctx.accountId,
+        statusSink: setStatus,
+        runStateMachine,
       });
     },
   },

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -20,8 +20,8 @@ import {
   warmupDedupFromDisk,
 } from "./dedup.js";
 import { isMentionForwardRequest } from "./mention.js";
-import { fetchBotOpenIdForMonitor } from "./monitor.startup.js";
-import { botOpenIds } from "./monitor.state.js";
+import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
+import { botNames, botOpenIds } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu } from "./send.js";
@@ -282,6 +282,7 @@ function registerEventHandlers(
           cfg,
           event,
           botOpenId: botOpenIds.get(accountId),
+          botName: botNames.get(accountId),
           runtime,
           chatHistories,
           accountId,
@@ -296,7 +297,7 @@ function registerEventHandlers(
   };
   const resolveDebounceText = (event: FeishuMessageEvent): string => {
     const botOpenId = botOpenIds.get(accountId);
-    const parsed = parseFeishuMessageEvent(event, botOpenId);
+    const parsed = parseFeishuMessageEvent(event, botOpenId, botNames.get(accountId));
     return parsed.content.trim();
   };
   const recordSuppressedMessageIds = async (
@@ -469,6 +470,7 @@ function registerEventHandlers(
             cfg,
             event: syntheticEvent,
             botOpenId: myBotId,
+            botName: botNames.get(accountId),
             runtime,
             chatHistories,
             accountId,
@@ -526,7 +528,9 @@ function registerEventHandlers(
   });
 }
 
-export type BotOpenIdSource = { kind: "prefetched"; botOpenId?: string } | { kind: "fetch" };
+export type BotOpenIdSource =
+  | { kind: "prefetched"; botOpenId?: string; botName?: string }
+  | { kind: "fetch" };
 
 export type MonitorSingleAccountParams = {
   cfg: ClawdbotConfig;
@@ -544,11 +548,18 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
   const log = runtime?.log ?? console.log;
 
   const botOpenIdSource = params.botOpenIdSource ?? { kind: "fetch" };
-  const botOpenId =
+  const botIdentity =
     botOpenIdSource.kind === "prefetched"
-      ? botOpenIdSource.botOpenId
-      : await fetchBotOpenIdForMonitor(account, { runtime, abortSignal });
+      ? { botOpenId: botOpenIdSource.botOpenId, botName: botOpenIdSource.botName }
+      : await fetchBotIdentityForMonitor(account, { runtime, abortSignal });
+  const botOpenId = botIdentity.botOpenId;
+  const botName = botIdentity.botName?.trim();
   botOpenIds.set(accountId, botOpenId ?? "");
+  if (botName) {
+    botNames.set(accountId, botName);
+  } else {
+    botNames.delete(accountId);
+  }
   log(`feishu[${accountId}]: bot open_id resolved: ${botOpenId ?? "unknown"}`);
 
   const connectionMode = account.config.connectionMode ?? "websocket";

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -1,6 +1,7 @@
 import * as crypto from "crypto";
 import * as Lark from "@larksuiteoapi/node-sdk";
 import type { ClawdbotConfig, RuntimeEnv, HistoryEntry } from "openclaw/plugin-sdk/feishu";
+import { recordChannelActivity } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { raceWithTimeoutAndAbort } from "./async.js";
 import {
@@ -19,14 +20,28 @@ import {
   warmupDedupFromDisk,
 } from "./dedup.js";
 import { isMentionForwardRequest } from "./mention.js";
-import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
-import { botNames, botOpenIds } from "./monitor.state.js";
+import { fetchBotOpenIdForMonitor } from "./monitor.startup.js";
+import { botOpenIds } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu } from "./send.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 const FEISHU_REACTION_VERIFY_TIMEOUT_MS = 1_500;
+
+type FeishuGatewayStatusPatch = {
+  connected?: boolean;
+  lastEventAt?: number | null;
+  lastInboundAt?: number | null;
+  lastOutboundAt?: number | null;
+};
+
+type FeishuGatewayStatusSink = (patch: FeishuGatewayStatusPatch) => void;
+
+type FeishuRunStateMachine = {
+  onRunStart: () => void;
+  onRunEnd: () => void;
+};
 
 export type FeishuReactionCreatedEvent = {
   message_id: string;
@@ -132,6 +147,8 @@ type RegisterEventHandlersContext = {
   runtime?: RuntimeEnv;
   chatHistories: Map<string, HistoryEntry[]>;
   fireAndForget?: boolean;
+  statusSink?: FeishuGatewayStatusSink;
+  runStateMachine?: FeishuRunStateMachine;
 };
 
 /**
@@ -231,7 +248,8 @@ function registerEventHandlers(
   eventDispatcher: Lark.EventDispatcher,
   context: RegisterEventHandlersContext,
 ): void {
-  const { cfg, accountId, runtime, chatHistories, fireAndForget } = context;
+  const { cfg, accountId, runtime, chatHistories, fireAndForget, statusSink, runStateMachine } =
+    context;
   const core = getFeishuRuntime();
   const inboundDebounceMs = core.channel.debounce.resolveInboundDebounceMs({
     cfg,
@@ -240,19 +258,36 @@ function registerEventHandlers(
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
   const enqueue = createChatQueue();
+
+  const recordInboundActivity = () => {
+    const ts = Date.now();
+    statusSink?.({ lastEventAt: ts, lastInboundAt: ts });
+    recordChannelActivity({ channel: "feishu", accountId, direction: "inbound", at: ts });
+  };
+
+  const runWithState = async (task: () => Promise<void>) => {
+    runStateMachine?.onRunStart();
+    try {
+      await task();
+    } finally {
+      runStateMachine?.onRunEnd();
+    }
+  };
+
   const dispatchFeishuMessage = async (event: FeishuMessageEvent) => {
     const chatId = event.message.chat_id?.trim() || "unknown";
-    const task = () =>
-      handleFeishuMessage({
-        cfg,
-        event,
-        botOpenId: botOpenIds.get(accountId),
-        botName: botNames.get(accountId),
-        runtime,
-        chatHistories,
-        accountId,
-      });
-    await enqueue(chatId, task);
+    await enqueue(chatId, () =>
+      runWithState(async () => {
+        await handleFeishuMessage({
+          cfg,
+          event,
+          botOpenId: botOpenIds.get(accountId),
+          runtime,
+          chatHistories,
+          accountId,
+        });
+      }),
+    );
   };
   const resolveSenderDebounceId = (event: FeishuMessageEvent): string | undefined => {
     const senderId =
@@ -261,7 +296,7 @@ function registerEventHandlers(
   };
   const resolveDebounceText = (event: FeishuMessageEvent): string => {
     const botOpenId = botOpenIds.get(accountId);
-    const parsed = parseFeishuMessageEvent(event, botOpenId, botNames.get(accountId));
+    const parsed = parseFeishuMessageEvent(event, botOpenId);
     return parsed.content.trim();
   };
   const recordSuppressedMessageIds = async (
@@ -380,6 +415,7 @@ function registerEventHandlers(
     "im.message.receive_v1": async (data) => {
       const processMessage = async () => {
         const event = data as unknown as FeishuMessageEvent;
+        recordInboundActivity();
         await inboundDebouncer.enqueue(event);
       };
       if (fireAndForget) {
@@ -416,6 +452,7 @@ function registerEventHandlers(
     "im.message.reaction.created_v1": async (data) => {
       const processReaction = async () => {
         const event = data as FeishuReactionCreatedEvent;
+        recordInboundActivity();
         const myBotId = botOpenIds.get(accountId);
         const syntheticEvent = await resolveReactionSyntheticEvent({
           cfg,
@@ -427,14 +464,15 @@ function registerEventHandlers(
         if (!syntheticEvent) {
           return;
         }
-        const promise = handleFeishuMessage({
-          cfg,
-          event: syntheticEvent,
-          botOpenId: myBotId,
-          botName: botNames.get(accountId),
-          runtime,
-          chatHistories,
-          accountId,
+        const promise = runWithState(async () => {
+          await handleFeishuMessage({
+            cfg,
+            event: syntheticEvent,
+            botOpenId: myBotId,
+            runtime,
+            chatHistories,
+            accountId,
+          });
         });
         if (fireAndForget) {
           promise.catch((err) => {
@@ -464,12 +502,15 @@ function registerEventHandlers(
     "card.action.trigger": async (data: unknown) => {
       try {
         const event = data as unknown as FeishuCardActionEvent;
-        const promise = handleFeishuCardAction({
-          cfg,
-          event,
-          botOpenId: botOpenIds.get(accountId),
-          runtime,
-          accountId,
+        recordInboundActivity();
+        const promise = runWithState(async () => {
+          await handleFeishuCardAction({
+            cfg,
+            event,
+            botOpenId: botOpenIds.get(accountId),
+            runtime,
+            accountId,
+          });
         });
         if (fireAndForget) {
           promise.catch((err) => {
@@ -485,9 +526,7 @@ function registerEventHandlers(
   });
 }
 
-export type BotOpenIdSource =
-  | { kind: "prefetched"; botOpenId?: string; botName?: string }
-  | { kind: "fetch" };
+export type BotOpenIdSource = { kind: "prefetched"; botOpenId?: string } | { kind: "fetch" };
 
 export type MonitorSingleAccountParams = {
   cfg: ClawdbotConfig;
@@ -495,26 +534,21 @@ export type MonitorSingleAccountParams = {
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   botOpenIdSource?: BotOpenIdSource;
+  statusSink?: FeishuGatewayStatusSink;
+  runStateMachine?: FeishuRunStateMachine;
 };
 
 export async function monitorSingleAccount(params: MonitorSingleAccountParams): Promise<void> {
-  const { cfg, account, runtime, abortSignal } = params;
+  const { cfg, account, runtime, abortSignal, statusSink, runStateMachine } = params;
   const { accountId } = account;
   const log = runtime?.log ?? console.log;
 
   const botOpenIdSource = params.botOpenIdSource ?? { kind: "fetch" };
-  const botIdentity =
+  const botOpenId =
     botOpenIdSource.kind === "prefetched"
-      ? { botOpenId: botOpenIdSource.botOpenId, botName: botOpenIdSource.botName }
-      : await fetchBotIdentityForMonitor(account, { runtime, abortSignal });
-  const botOpenId = botIdentity.botOpenId;
-  const botName = botIdentity.botName?.trim();
+      ? botOpenIdSource.botOpenId
+      : await fetchBotOpenIdForMonitor(account, { runtime, abortSignal });
   botOpenIds.set(accountId, botOpenId ?? "");
-  if (botName) {
-    botNames.set(accountId, botName);
-  } else {
-    botNames.delete(accountId);
-  }
   log(`feishu[${accountId}]: bot open_id resolved: ${botOpenId ?? "unknown"}`);
 
   const connectionMode = account.config.connectionMode ?? "websocket";
@@ -536,10 +570,26 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
     runtime,
     chatHistories,
     fireAndForget: true,
+    statusSink,
+    runStateMachine,
   });
 
   if (connectionMode === "webhook") {
-    return monitorWebhook({ account, accountId, runtime, abortSignal, eventDispatcher });
+    return monitorWebhook({
+      account,
+      accountId,
+      runtime,
+      abortSignal,
+      eventDispatcher,
+      statusSink,
+    });
   }
-  return monitorWebSocket({ account, accountId, runtime, abortSignal, eventDispatcher });
+  return monitorWebSocket({
+    account,
+    accountId,
+    runtime,
+    abortSignal,
+    eventDispatcher,
+    statusSink,
+  });
 }

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -23,6 +23,11 @@ import { isMentionForwardRequest } from "./mention.js";
 import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
 import { botNames, botOpenIds } from "./monitor.state.js";
 import { monitorWebhook, monitorWebSocket } from "./monitor.transport.js";
+import {
+  beginFeishuActiveRun,
+  endFeishuActiveRun,
+  replayPendingFeishuFinalReplies,
+} from "./restart-recovery.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu } from "./send.js";
 import type { ResolvedFeishuAccount } from "./types.js";
@@ -265,29 +270,65 @@ function registerEventHandlers(
     recordChannelActivity({ channel: "feishu", accountId, direction: "inbound", at: ts });
   };
 
-  const runWithState = async (task: () => Promise<void>) => {
+  const runWithState = async (
+    runContext:
+      | {
+          chatId: string;
+          messageId: string;
+          replyToMessageId?: string;
+          replyInThread?: boolean;
+        }
+      | undefined,
+    task: () => Promise<void>,
+  ) => {
     runStateMachine?.onRunStart();
+    if (runContext) {
+      beginFeishuActiveRun({
+        accountId,
+        chatId: runContext.chatId,
+        messageId: runContext.messageId,
+        replyToMessageId: runContext.replyToMessageId,
+        replyInThread: runContext.replyInThread,
+      });
+    }
     try {
       await task();
     } finally {
+      if (runContext) {
+        endFeishuActiveRun({
+          accountId,
+          messageId: runContext.messageId,
+        });
+      }
       runStateMachine?.onRunEnd();
     }
   };
 
   const dispatchFeishuMessage = async (event: FeishuMessageEvent) => {
     const chatId = event.message.chat_id?.trim() || "unknown";
+    const replyToMessageId = event.message.message_id?.trim() || undefined;
+    const runMessageId = replyToMessageId || crypto.randomUUID();
+    const replyInThread = Boolean(event.message.root_id?.trim() || event.message.thread_id?.trim());
     await enqueue(chatId, () =>
-      runWithState(async () => {
-        await handleFeishuMessage({
-          cfg,
-          event,
-          botOpenId: botOpenIds.get(accountId),
-          botName: botNames.get(accountId),
-          runtime,
-          chatHistories,
-          accountId,
-        });
-      }),
+      runWithState(
+        {
+          chatId,
+          messageId: runMessageId,
+          replyToMessageId,
+          replyInThread,
+        },
+        async () => {
+          await handleFeishuMessage({
+            cfg,
+            event,
+            botOpenId: botOpenIds.get(accountId),
+            botName: botNames.get(accountId),
+            runtime,
+            chatHistories,
+            accountId,
+          });
+        },
+      ),
     );
   };
   const resolveSenderDebounceId = (event: FeishuMessageEvent): string | undefined => {
@@ -465,17 +506,31 @@ function registerEventHandlers(
         if (!syntheticEvent) {
           return;
         }
-        const promise = runWithState(async () => {
-          await handleFeishuMessage({
-            cfg,
-            event: syntheticEvent,
-            botOpenId: myBotId,
-            botName: botNames.get(accountId),
-            runtime,
-            chatHistories,
-            accountId,
-          });
-        });
+        const syntheticChatId = syntheticEvent.message.chat_id?.trim() || "unknown";
+        const syntheticReplyToMessageId = syntheticEvent.message.message_id?.trim() || undefined;
+        const syntheticRunMessageId = syntheticReplyToMessageId || crypto.randomUUID();
+        const syntheticReplyInThread = Boolean(
+          syntheticEvent.message.root_id?.trim() || syntheticEvent.message.thread_id?.trim(),
+        );
+        const promise = runWithState(
+          {
+            chatId: syntheticChatId,
+            messageId: syntheticRunMessageId,
+            replyToMessageId: syntheticReplyToMessageId,
+            replyInThread: syntheticReplyInThread,
+          },
+          async () => {
+            await handleFeishuMessage({
+              cfg,
+              event: syntheticEvent,
+              botOpenId: myBotId,
+              botName: botNames.get(accountId),
+              runtime,
+              chatHistories,
+              accountId,
+            });
+          },
+        );
         if (fireAndForget) {
           promise.catch((err) => {
             error(`feishu[${accountId}]: error handling reaction: ${String(err)}`);
@@ -505,15 +560,23 @@ function registerEventHandlers(
       try {
         const event = data as unknown as FeishuCardActionEvent;
         recordInboundActivity();
-        const promise = runWithState(async () => {
-          await handleFeishuCardAction({
-            cfg,
-            event,
-            botOpenId: botOpenIds.get(accountId),
-            runtime,
-            accountId,
-          });
-        });
+        const chatId = event.context.chat_id?.trim() || event.operator.open_id?.trim() || "unknown";
+        const messageId = `card-action-${event.token}`;
+        const promise = runWithState(
+          {
+            chatId,
+            messageId,
+          },
+          async () => {
+            await handleFeishuCardAction({
+              cfg,
+              event,
+              botOpenId: botOpenIds.get(accountId),
+              runtime,
+              accountId,
+            });
+          },
+        );
         if (fireAndForget) {
           promise.catch((err) => {
             error(`feishu[${accountId}]: error handling card action: ${String(err)}`);
@@ -571,6 +634,7 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
   if (warmupCount > 0) {
     log(`feishu[${accountId}]: dedup warmup loaded ${warmupCount} entries from disk`);
   }
+  await replayPendingFeishuFinalReplies({ cfg, accountId, runtime });
 
   const eventDispatcher = createEventDispatcher(account);
   const chatHistories = new Map<string, HistoryEntry[]>();
@@ -587,6 +651,7 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
 
   if (connectionMode === "webhook") {
     return monitorWebhook({
+      cfg,
       account,
       accountId,
       runtime,
@@ -596,6 +661,7 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
     });
   }
   return monitorWebSocket({
+    cfg,
     account,
     accountId,
     runtime,

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -2,6 +2,7 @@ import * as http from "http";
 import * as Lark from "@larksuiteoapi/node-sdk";
 import {
   applyBasicWebhookRequestGuards,
+  type ClawdbotConfig,
   type RuntimeEnv,
   installRequestBodyLimitGuard,
 } from "openclaw/plugin-sdk/feishu";
@@ -15,6 +16,7 @@ import {
   recordWebhookStatus,
   wsClients,
 } from "./monitor.state.js";
+import { sendFeishuShutdownInterruptionNotices } from "./restart-recovery.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 type FeishuGatewayStatusPatch = {
@@ -25,6 +27,7 @@ type FeishuGatewayStatusPatch = {
 type FeishuGatewayStatusSink = (patch: FeishuGatewayStatusPatch) => void;
 
 export type MonitorTransportParams = {
+  cfg: ClawdbotConfig;
   account: ResolvedFeishuAccount;
   accountId: string;
   runtime?: RuntimeEnv;
@@ -34,6 +37,7 @@ export type MonitorTransportParams = {
 };
 
 export async function monitorWebSocket({
+  cfg,
   account,
   accountId,
   runtime,
@@ -48,21 +52,46 @@ export async function monitorWebSocket({
   wsClients.set(accountId, wsClient);
 
   return new Promise((resolve, reject) => {
+    let settled = false;
     const cleanup = () => {
       wsClients.delete(accountId);
       botOpenIds.delete(accountId);
       statusSink?.({ connected: false });
     };
 
-    const handleAbort = () => {
-      log(`feishu[${accountId}]: abort signal received, stopping`);
+    const settle = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
       cleanup();
       resolve();
     };
 
+    const handleAbort = () => {
+      void (async () => {
+        log(`feishu[${accountId}]: abort signal received, stopping`);
+        try {
+          const sent = await sendFeishuShutdownInterruptionNotices({
+            cfg,
+            accountId,
+            runtime,
+          });
+          if (sent > 0) {
+            log(`feishu[${accountId}]: sent ${sent} shutdown interruption notice(s)`);
+          }
+        } catch (error) {
+          runtime?.error?.(
+            `feishu[${accountId}]: shutdown interruption notice failed: ${String(error)}`,
+          );
+        } finally {
+          settle();
+        }
+      })();
+    };
+
     if (abortSignal?.aborted) {
-      cleanup();
-      resolve();
+      handleAbort();
       return;
     }
 
@@ -73,6 +102,7 @@ export async function monitorWebSocket({
       statusSink?.({ connected: true, lastEventAt: Date.now() });
       log(`feishu[${accountId}]: WebSocket client started`);
     } catch (err) {
+      settled = true;
       cleanup();
       abortSignal?.removeEventListener("abort", handleAbort);
       reject(err);
@@ -81,6 +111,7 @@ export async function monitorWebSocket({
 }
 
 export async function monitorWebhook({
+  cfg,
   account,
   accountId,
   runtime,
@@ -142,6 +173,7 @@ export async function monitorWebhook({
   httpServers.set(accountId, server);
 
   return new Promise((resolve, reject) => {
+    let settled = false;
     const cleanup = () => {
       server.close();
       httpServers.delete(accountId);
@@ -149,15 +181,39 @@ export async function monitorWebhook({
       statusSink?.({ connected: false });
     };
 
-    const handleAbort = () => {
-      log(`feishu[${accountId}]: abort signal received, stopping Webhook server`);
+    const settle = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
       cleanup();
       resolve();
     };
 
+    const handleAbort = () => {
+      void (async () => {
+        log(`feishu[${accountId}]: abort signal received, stopping Webhook server`);
+        try {
+          const sent = await sendFeishuShutdownInterruptionNotices({
+            cfg,
+            accountId,
+            runtime,
+          });
+          if (sent > 0) {
+            log(`feishu[${accountId}]: sent ${sent} shutdown interruption notice(s)`);
+          }
+        } catch (error) {
+          runtime?.error?.(
+            `feishu[${accountId}]: shutdown interruption notice failed: ${String(error)}`,
+          );
+        } finally {
+          settle();
+        }
+      })();
+    };
+
     if (abortSignal?.aborted) {
-      cleanup();
-      resolve();
+      handleAbort();
       return;
     }
 
@@ -172,6 +228,11 @@ export async function monitorWebhook({
       error(`feishu[${accountId}]: Webhook server error: ${err}`);
       statusSink?.({ connected: false });
       abortSignal?.removeEventListener("abort", handleAbort);
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
       reject(err);
     });
   });

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -7,7 +7,6 @@ import {
 } from "openclaw/plugin-sdk/feishu";
 import { createFeishuWSClient } from "./client.js";
 import {
-  botNames,
   botOpenIds,
   FEISHU_WEBHOOK_BODY_TIMEOUT_MS,
   FEISHU_WEBHOOK_MAX_BODY_BYTES,
@@ -18,12 +17,20 @@ import {
 } from "./monitor.state.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
+type FeishuGatewayStatusPatch = {
+  connected?: boolean;
+  lastEventAt?: number | null;
+};
+
+type FeishuGatewayStatusSink = (patch: FeishuGatewayStatusPatch) => void;
+
 export type MonitorTransportParams = {
   account: ResolvedFeishuAccount;
   accountId: string;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   eventDispatcher: Lark.EventDispatcher;
+  statusSink?: FeishuGatewayStatusSink;
 };
 
 export async function monitorWebSocket({
@@ -32,6 +39,7 @@ export async function monitorWebSocket({
   runtime,
   abortSignal,
   eventDispatcher,
+  statusSink,
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
   log(`feishu[${accountId}]: starting WebSocket connection...`);
@@ -43,7 +51,7 @@ export async function monitorWebSocket({
     const cleanup = () => {
       wsClients.delete(accountId);
       botOpenIds.delete(accountId);
-      botNames.delete(accountId);
+      statusSink?.({ connected: false });
     };
 
     const handleAbort = () => {
@@ -62,6 +70,7 @@ export async function monitorWebSocket({
 
     try {
       wsClient.start({ eventDispatcher });
+      statusSink?.({ connected: true, lastEventAt: Date.now() });
       log(`feishu[${accountId}]: WebSocket client started`);
     } catch (err) {
       cleanup();
@@ -77,6 +86,7 @@ export async function monitorWebhook({
   runtime,
   abortSignal,
   eventDispatcher,
+  statusSink,
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
@@ -136,7 +146,7 @@ export async function monitorWebhook({
       server.close();
       httpServers.delete(accountId);
       botOpenIds.delete(accountId);
-      botNames.delete(accountId);
+      statusSink?.({ connected: false });
     };
 
     const handleAbort = () => {
@@ -155,10 +165,12 @@ export async function monitorWebhook({
 
     server.listen(port, host, () => {
       log(`feishu[${accountId}]: Webhook server listening on ${host}:${port}`);
+      statusSink?.({ connected: true, lastEventAt: Date.now() });
     });
 
     server.on("error", (err) => {
       error(`feishu[${accountId}]: Webhook server error: ${err}`);
+      statusSink?.({ connected: false });
       abortSignal?.removeEventListener("abort", handleAbort);
       reject(err);
     });

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -5,7 +5,7 @@ import {
   resolveReactionSyntheticEvent,
   type FeishuReactionCreatedEvent,
 } from "./monitor.account.js";
-import { fetchBotOpenIdForMonitor } from "./monitor.startup.js";
+import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
 import {
   clearFeishuWebhookRateLimitStateForTest,
   getFeishuWebhookRateLimitStateSizeForTest,
@@ -84,7 +84,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
     }
 
     // Probe sequentially so large multi-account startups do not burst Feishu's bot-info endpoint.
-    const botOpenId = await fetchBotOpenIdForMonitor(account, {
+    const { botOpenId, botName } = await fetchBotIdentityForMonitor(account, {
       runtime: opts.runtime,
       abortSignal: opts.abortSignal,
     });
@@ -100,7 +100,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
         account,
         runtime: opts.runtime,
         abortSignal: opts.abortSignal,
-        botOpenIdSource: { kind: "prefetched", botOpenId },
+        botOpenIdSource: { kind: "prefetched", botOpenId, botName },
         statusSink: opts.statusSink,
         runStateMachine: opts.runStateMachine,
       }),

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -5,7 +5,7 @@ import {
   resolveReactionSyntheticEvent,
   type FeishuReactionCreatedEvent,
 } from "./monitor.account.js";
-import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
+import { fetchBotOpenIdForMonitor } from "./monitor.startup.js";
 import {
   clearFeishuWebhookRateLimitStateForTest,
   getFeishuWebhookRateLimitStateSizeForTest,
@@ -13,11 +13,27 @@ import {
   stopFeishuMonitorState,
 } from "./monitor.state.js";
 
+export type FeishuGatewayStatusPatch = {
+  connected?: boolean;
+  lastEventAt?: number | null;
+  lastInboundAt?: number | null;
+  lastOutboundAt?: number | null;
+};
+
+export type FeishuGatewayStatusSink = (patch: FeishuGatewayStatusPatch) => void;
+
+export type FeishuRunStateMachine = {
+  onRunStart: () => void;
+  onRunEnd: () => void;
+};
+
 export type MonitorFeishuOpts = {
   config?: ClawdbotConfig;
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   accountId?: string;
+  statusSink?: FeishuGatewayStatusSink;
+  runStateMachine?: FeishuRunStateMachine;
 };
 
 export {
@@ -46,6 +62,8 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
       account,
       runtime: opts.runtime,
       abortSignal: opts.abortSignal,
+      statusSink: opts.statusSink,
+      runStateMachine: opts.runStateMachine,
     });
   }
 
@@ -66,7 +84,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
     }
 
     // Probe sequentially so large multi-account startups do not burst Feishu's bot-info endpoint.
-    const { botOpenId, botName } = await fetchBotIdentityForMonitor(account, {
+    const botOpenId = await fetchBotOpenIdForMonitor(account, {
       runtime: opts.runtime,
       abortSignal: opts.abortSignal,
     });
@@ -82,7 +100,9 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
         account,
         runtime: opts.runtime,
         abortSignal: opts.abortSignal,
-        botOpenIdSource: { kind: "prefetched", botOpenId, botName },
+        botOpenIdSource: { kind: "prefetched", botOpenId },
+        statusSink: opts.statusSink,
+        runStateMachine: opts.runStateMachine,
       }),
     );
   }

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -10,6 +10,8 @@ const resolveReceiveIdTypeMock = vi.hoisted(() => vi.fn());
 const createReplyDispatcherWithTypingMock = vi.hoisted(() => vi.fn());
 const addTypingIndicatorMock = vi.hoisted(() => vi.fn(async () => ({ messageId: "om_msg" })));
 const removeTypingIndicatorMock = vi.hoisted(() => vi.fn(async () => {}));
+const enqueuePendingFeishuFinalReplyMock = vi.hoisted(() => vi.fn(async () => undefined));
+const ackPendingFeishuFinalReplyMock = vi.hoisted(() => vi.fn(async () => {}));
 const streamingInstances = vi.hoisted(() => [] as any[]);
 
 vi.mock("./accounts.js", () => ({ resolveFeishuAccount: resolveFeishuAccountMock }));
@@ -24,6 +26,10 @@ vi.mock("./targets.js", () => ({ resolveReceiveIdType: resolveReceiveIdTypeMock 
 vi.mock("./typing.js", () => ({
   addTypingIndicator: addTypingIndicatorMock,
   removeTypingIndicator: removeTypingIndicatorMock,
+}));
+vi.mock("./restart-recovery.js", () => ({
+  enqueuePendingFeishuFinalReply: enqueuePendingFeishuFinalReplyMock,
+  ackPendingFeishuFinalReply: ackPendingFeishuFinalReplyMock,
 }));
 vi.mock("./streaming-card.js", () => ({
   mergeStreamingText: (previousText: string | undefined, nextText: string | undefined) => {
@@ -67,6 +73,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     vi.clearAllMocks();
     streamingInstances.length = 0;
     sendMediaFeishuMock.mockResolvedValue(undefined);
+    enqueuePendingFeishuFinalReplyMock.mockResolvedValue(undefined);
 
     resolveFeishuAccountMock.mockReturnValue({
       accountId: "main",

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -11,6 +11,7 @@ import { createFeishuClient } from "./client.js";
 import { sendMediaFeishu } from "./media.js";
 import type { MentionTarget } from "./mention.js";
 import { buildMentionedCardContent } from "./mention.js";
+import { ackPendingFeishuFinalReply, enqueuePendingFeishuFinalReply } from "./restart-recovery.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { sendMarkdownCardFeishu, sendMessageFeishu } from "./send.js";
 import { FeishuStreamingSession, mergeStreamingText } from "./streaming-card.js";
@@ -50,6 +51,8 @@ export type CreateFeishuReplyDispatcherParams = {
   rootId?: string;
   mentionTargets?: MentionTarget[];
   accountId?: string;
+  /** Inbound source message id used as stable recovery key for final replies. */
+  sourceMessageId?: string;
   /** Epoch ms when the inbound message was created. Used to suppress typing
    *  indicators on old/replayed messages after context compaction (#30418). */
   messageCreateTimeMs?: number;
@@ -68,11 +71,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     rootId,
     mentionTargets,
     accountId,
+    sourceMessageId,
   } = params;
   const sendReplyToMessageId = skipReplyToInMessages ? undefined : replyToMessageId;
   const threadReplyMode = threadReply === true;
   const effectiveReplyInThread = threadReplyMode ? true : replyInThread;
   const account = resolveFeishuAccount({ cfg, accountId });
+  const runMessageId = sourceMessageId?.trim() || replyToMessageId?.trim() || undefined;
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
 
   let typingState: TypingIndicatorState | null = null;
@@ -254,6 +259,20 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           return;
         }
 
+        const pendingId =
+          info?.kind === "final"
+            ? await enqueuePendingFeishuFinalReply({
+                accountId: account.accountId,
+                runMessageId: runMessageId ?? "",
+                chatId,
+                replyToMessageId: sendReplyToMessageId,
+                replyInThread: effectiveReplyInThread,
+                text: shouldDeliverText ? text : undefined,
+                mediaUrls: hasMedia ? mediaList : undefined,
+                runtime: params.runtime,
+              })
+            : undefined;
+
         if (shouldDeliverText) {
           const useCard = renderMode === "card" || (renderMode === "auto" && shouldUseCard(text));
 
@@ -299,6 +318,14 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                   accountId,
                 });
               }
+            }
+            if (pendingId) {
+              await ackPendingFeishuFinalReply({
+                accountId: account.accountId,
+                runMessageId: runMessageId ?? "",
+                pendingId,
+                runtime: params.runtime,
+              });
             }
             return;
           }
@@ -359,6 +386,15 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               accountId,
             });
           }
+        }
+
+        if (pendingId) {
+          await ackPendingFeishuFinalReply({
+            accountId: account.accountId,
+            runMessageId: runMessageId ?? "",
+            pendingId,
+            runtime: params.runtime,
+          });
         }
       },
       onError: async (error, info) => {

--- a/extensions/feishu/src/restart-recovery.test.ts
+++ b/extensions/feishu/src/restart-recovery.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const storeRef = vi.hoisted(() => ({
+  value: {
+    version: 1,
+    pendingFinalReplies: {} as Record<string, unknown>,
+  },
+}));
+
+const readJsonFileWithFallbackMock = vi.hoisted(() => vi.fn());
+const writeJsonFileAtomicallyMock = vi.hoisted(() => vi.fn());
+const sendMessageFeishuMock = vi.hoisted(() => vi.fn());
+const sendMediaFeishuMock = vi.hoisted(() => vi.fn());
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+vi.mock("openclaw/plugin-sdk/feishu", () => ({
+  readJsonFileWithFallback: readJsonFileWithFallbackMock,
+  writeJsonFileAtomically: writeJsonFileAtomicallyMock,
+}));
+
+vi.mock("./send.js", () => ({
+  sendMessageFeishu: sendMessageFeishuMock,
+}));
+
+vi.mock("./media.js", () => ({
+  sendMediaFeishu: sendMediaFeishuMock,
+}));
+
+import {
+  ackPendingFeishuFinalReply,
+  beginFeishuActiveRun,
+  endFeishuActiveRun,
+  enqueuePendingFeishuFinalReply,
+  replayPendingFeishuFinalReplies,
+  sendFeishuShutdownInterruptionNotices,
+} from "./restart-recovery.js";
+
+describe("restart-recovery", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    storeRef.value = {
+      version: 1,
+      pendingFinalReplies: {},
+    };
+
+    readJsonFileWithFallbackMock.mockImplementation(async (_path: string, fallback: unknown) => {
+      const value = storeRef.value ?? fallback;
+      return {
+        value: clone(value),
+        exists: true,
+      };
+    });
+
+    writeJsonFileAtomicallyMock.mockImplementation(async (_path: string, value: unknown) => {
+      storeRef.value = clone(value);
+    });
+
+    sendMessageFeishuMock.mockResolvedValue({ messageId: "om_sent" });
+    sendMediaFeishuMock.mockResolvedValue({ messageId: "om_media" });
+  });
+
+  it("persists a final reply via enqueue and removes it on ack", async () => {
+    const pendingId = await enqueuePendingFeishuFinalReply({
+      accountId: "acc-enqueue",
+      runMessageId: "om_run_1",
+      chatId: "oc_chat_1",
+      text: "done",
+    });
+
+    expect(pendingId).toBeTruthy();
+    const key = "acc-enqueue:om_run_1";
+    const persisted = (storeRef.value.pendingFinalReplies as Record<string, { text?: string }>)[
+      key
+    ];
+    expect(persisted?.text).toBe("done");
+
+    await ackPendingFeishuFinalReply({
+      accountId: "acc-enqueue",
+      runMessageId: "om_run_1",
+      pendingId,
+    });
+
+    expect((storeRef.value.pendingFinalReplies as Record<string, unknown>)[key]).toBeUndefined();
+  });
+
+  it("replays pending final replies and clears them after successful delivery", async () => {
+    (storeRef.value.pendingFinalReplies as Record<string, unknown>)["acc-replay-ok:om_run_2"] = {
+      pendingId: "pending-ok-1",
+      accountId: "acc-replay-ok",
+      runMessageId: "om_run_2",
+      chatId: "oc_chat_2",
+      replyToMessageId: "om_parent_2",
+      replyInThread: true,
+      text: "final text",
+      mediaUrls: ["https://example.com/a.png"],
+      createdAtMs: Date.now(),
+      attempts: 0,
+    };
+
+    await replayPendingFeishuFinalReplies({
+      cfg: {} as never,
+      accountId: "acc-replay-ok",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+    });
+
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "acc-replay-ok",
+        to: "oc_chat_2",
+        replyToMessageId: "om_parent_2",
+        replyInThread: true,
+        text: "final text",
+      }),
+    );
+    expect(sendMediaFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "acc-replay-ok",
+        to: "oc_chat_2",
+        mediaUrl: "https://example.com/a.png",
+      }),
+    );
+    expect(
+      (storeRef.value.pendingFinalReplies as Record<string, unknown>)["acc-replay-ok:om_run_2"],
+    ).toBeUndefined();
+  });
+
+  it("keeps failed pending final replies and bumps attempts/lastError", async () => {
+    sendMessageFeishuMock.mockRejectedValueOnce(new Error("network down"));
+
+    (storeRef.value.pendingFinalReplies as Record<string, unknown>)["acc-replay-fail:om_run_3"] = {
+      pendingId: "pending-fail-1",
+      accountId: "acc-replay-fail",
+      runMessageId: "om_run_3",
+      chatId: "oc_chat_3",
+      text: "will retry",
+      createdAtMs: Date.now(),
+      attempts: 0,
+    };
+
+    await replayPendingFeishuFinalReplies({
+      cfg: {} as never,
+      accountId: "acc-replay-fail",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+    });
+
+    const entry = (storeRef.value.pendingFinalReplies as Record<string, any>)[
+      "acc-replay-fail:om_run_3"
+    ];
+    expect(entry).toBeTruthy();
+    expect(entry.attempts).toBe(1);
+    expect(String(entry.lastError)).toContain("network down");
+  });
+
+  it("drops stale pending final replies older than TTL", async () => {
+    (storeRef.value.pendingFinalReplies as Record<string, unknown>)["acc-stale:om_run_4"] = {
+      pendingId: "pending-stale-1",
+      accountId: "acc-stale",
+      runMessageId: "om_run_4",
+      chatId: "oc_chat_4",
+      text: "too old",
+      createdAtMs: Date.now() - 25 * 60 * 60 * 1000,
+      attempts: 0,
+    };
+
+    await replayPendingFeishuFinalReplies({
+      cfg: {} as never,
+      accountId: "acc-stale",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+    });
+
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+    expect(
+      (storeRef.value.pendingFinalReplies as Record<string, unknown>)["acc-stale:om_run_4"],
+    ).toBeUndefined();
+  });
+
+  it("sends shutdown interruption notices for active runs and clears them", async () => {
+    beginFeishuActiveRun({
+      accountId: "acc-shutdown",
+      chatId: "oc_chat_5",
+      messageId: "om_run_5",
+      replyToMessageId: "om_parent_5",
+      replyInThread: true,
+    });
+
+    const first = await sendFeishuShutdownInterruptionNotices({
+      cfg: {} as never,
+      accountId: "acc-shutdown",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+    });
+    const second = await sendFeishuShutdownInterruptionNotices({
+      cfg: {} as never,
+      accountId: "acc-shutdown",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+    });
+
+    expect(first).toBe(1);
+    expect(second).toBe(0);
+    expect(sendMessageFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "acc-shutdown",
+        to: "oc_chat_5",
+        replyToMessageId: "om_parent_5",
+        replyInThread: true,
+      }),
+    );
+  });
+
+  it("does not notify runs that were ended before shutdown", async () => {
+    beginFeishuActiveRun({
+      accountId: "acc-shutdown-end",
+      chatId: "oc_chat_6",
+      messageId: "om_run_6",
+    });
+    endFeishuActiveRun({
+      accountId: "acc-shutdown-end",
+      messageId: "om_run_6",
+    });
+
+    const sent = await sendFeishuShutdownInterruptionNotices({
+      cfg: {} as never,
+      accountId: "acc-shutdown-end",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+    });
+
+    expect(sent).toBe(0);
+    expect(sendMessageFeishuMock).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/feishu/src/restart-recovery.ts
+++ b/extensions/feishu/src/restart-recovery.ts
@@ -1,0 +1,549 @@
+import os from "node:os";
+import path from "node:path";
+import {
+  readJsonFileWithFallback,
+  writeJsonFileAtomically,
+  type ClawdbotConfig,
+  type RuntimeEnv,
+} from "openclaw/plugin-sdk/feishu";
+import { sendMediaFeishu } from "./media.js";
+import { sendMessageFeishu } from "./send.js";
+
+const RECOVERY_STORE_VERSION = 1;
+const PENDING_FINAL_TTL_MS = 24 * 60 * 60 * 1000;
+const SHUTDOWN_NOTICE_TIMEOUT_MS = 2_000;
+const SHUTDOWN_NOTICE_TEXT =
+  "System is restarting, so this run was interrupted. If a final result was already generated, it will be resent after restart.";
+
+type FeishuActiveRun = {
+  accountId: string;
+  chatId: string;
+  messageId: string;
+  replyToMessageId?: string;
+  replyInThread?: boolean;
+  startedAtMs: number;
+};
+
+type FeishuPendingFinalReply = {
+  pendingId: string;
+  accountId: string;
+  runMessageId: string;
+  chatId: string;
+  replyToMessageId?: string;
+  replyInThread?: boolean;
+  text?: string;
+  mediaUrls?: string[];
+  createdAtMs: number;
+  attempts: number;
+  lastAttemptAtMs?: number;
+  lastError?: string;
+};
+
+type FeishuRecoveryStore = {
+  version: 1;
+  pendingFinalReplies: Record<string, FeishuPendingFinalReply>;
+};
+
+export type BeginFeishuActiveRunParams = {
+  accountId: string;
+  chatId: string;
+  messageId: string;
+  replyToMessageId?: string;
+  replyInThread?: boolean;
+};
+
+export type EndFeishuActiveRunParams = {
+  accountId: string;
+  messageId: string;
+};
+
+export type EnqueuePendingFeishuFinalReplyParams = {
+  accountId: string;
+  runMessageId: string;
+  chatId: string;
+  replyToMessageId?: string;
+  replyInThread?: boolean;
+  text?: string;
+  mediaUrls?: string[];
+  runtime?: RuntimeEnv;
+};
+
+export type AckPendingFeishuFinalReplyParams = {
+  accountId: string;
+  runMessageId: string;
+  pendingId?: string;
+  runtime?: RuntimeEnv;
+};
+
+export type ReplayPendingFeishuFinalRepliesParams = {
+  cfg: ClawdbotConfig;
+  accountId: string;
+  runtime?: RuntimeEnv;
+};
+
+export type SendFeishuShutdownInterruptionNoticesParams = {
+  cfg: ClawdbotConfig;
+  accountId: string;
+  runtime?: RuntimeEnv;
+  timeoutMs?: number;
+};
+
+const activeRuns = new Map<string, FeishuActiveRun>();
+let storeMutationQueue: Promise<void> = Promise.resolve();
+
+function withStoreMutation<T>(task: () => Promise<T>): Promise<T> {
+  const run = storeMutationQueue.then(task, task);
+  storeMutationQueue = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+function resolveStateDirFromEnv(env: NodeJS.ProcessEnv = process.env): string {
+  const stateOverride = env.OPENCLAW_STATE_DIR?.trim() || env.CLAWDBOT_STATE_DIR?.trim();
+  if (stateOverride) {
+    return stateOverride;
+  }
+  if (env.VITEST || env.NODE_ENV === "test") {
+    return path.join(os.tmpdir(), ["openclaw-vitest", String(process.pid)].join("-"));
+  }
+  return path.join(os.homedir(), ".openclaw");
+}
+
+function resolveRecoveryStorePath(env: NodeJS.ProcessEnv = process.env): string {
+  return path.join(resolveStateDirFromEnv(env), "feishu", "restart-recovery.json");
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
+}
+
+function normalizeText(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  return value.trim() ? value : undefined;
+}
+
+function normalizeMediaUrls(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const deduped: string[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    if (typeof item !== "string") {
+      continue;
+    }
+    const normalized = item.trim();
+    if (!normalized || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    deduped.push(normalized);
+  }
+  return deduped.length > 0 ? deduped : undefined;
+}
+
+function normalizePendingEntry(value: unknown): FeishuPendingFinalReply | null {
+  if (!isObjectRecord(value)) {
+    return null;
+  }
+  const pendingId = typeof value.pendingId === "string" ? value.pendingId.trim() : "";
+  const accountId = typeof value.accountId === "string" ? value.accountId.trim() : "";
+  const runMessageId = typeof value.runMessageId === "string" ? value.runMessageId.trim() : "";
+  const chatId = typeof value.chatId === "string" ? value.chatId.trim() : "";
+  if (!pendingId || !accountId || !runMessageId || !chatId) {
+    return null;
+  }
+  const text = normalizeText(value.text);
+  const mediaUrls = normalizeMediaUrls(value.mediaUrls);
+  if (!text && !mediaUrls) {
+    return null;
+  }
+  const createdAtMs =
+    typeof value.createdAtMs === "number" && Number.isFinite(value.createdAtMs)
+      ? value.createdAtMs
+      : Date.now();
+  const attempts =
+    typeof value.attempts === "number" && Number.isFinite(value.attempts)
+      ? Math.max(0, Math.floor(value.attempts))
+      : 0;
+  const lastAttemptAtMs =
+    typeof value.lastAttemptAtMs === "number" && Number.isFinite(value.lastAttemptAtMs)
+      ? value.lastAttemptAtMs
+      : undefined;
+  const replyToMessageId =
+    typeof value.replyToMessageId === "string" && value.replyToMessageId.trim()
+      ? value.replyToMessageId.trim()
+      : undefined;
+  const lastError = typeof value.lastError === "string" ? value.lastError : undefined;
+
+  return {
+    pendingId,
+    accountId,
+    runMessageId,
+    chatId,
+    replyToMessageId,
+    replyInThread: value.replyInThread === true,
+    text,
+    mediaUrls,
+    createdAtMs,
+    attempts,
+    lastAttemptAtMs,
+    lastError,
+  };
+}
+
+function normalizeRecoveryStore(raw: unknown): FeishuRecoveryStore {
+  const normalized: FeishuRecoveryStore = {
+    version: RECOVERY_STORE_VERSION,
+    pendingFinalReplies: {},
+  };
+  if (!isObjectRecord(raw)) {
+    return normalized;
+  }
+  const pendingRaw = raw.pendingFinalReplies;
+  if (!isObjectRecord(pendingRaw)) {
+    return normalized;
+  }
+  for (const [key, value] of Object.entries(pendingRaw)) {
+    const entry = normalizePendingEntry(value);
+    if (!entry) {
+      continue;
+    }
+    normalized.pendingFinalReplies[key] = entry;
+  }
+  return normalized;
+}
+
+function buildRunKey(accountId: string, messageId: string): string {
+  return `${accountId}:${messageId}`;
+}
+
+async function readRecoveryStore(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<FeishuRecoveryStore> {
+  const { value } = await readJsonFileWithFallback<FeishuRecoveryStore>(
+    resolveRecoveryStorePath(env),
+    {
+      version: RECOVERY_STORE_VERSION,
+      pendingFinalReplies: {},
+    },
+  );
+  return normalizeRecoveryStore(value);
+}
+
+async function writeRecoveryStore(store: FeishuRecoveryStore): Promise<void> {
+  await writeJsonFileAtomically(resolveRecoveryStorePath(), store);
+}
+
+function normalizeRequired(value: string | undefined): string {
+  return value?.trim() ?? "";
+}
+
+function clearActiveRunsForAccount(accountId: string): void {
+  const prefix = `${accountId}:`;
+  for (const runKey of activeRuns.keys()) {
+    if (runKey.startsWith(prefix)) {
+      activeRuns.delete(runKey);
+    }
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  if (timeoutMs <= 0) {
+    return promise;
+  }
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`timeout after ${timeoutMs}ms`));
+    }, timeoutMs);
+    timer.unref?.();
+    promise
+      .then((value) => {
+        clearTimeout(timer);
+        resolve(value);
+      })
+      .catch((error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+  });
+}
+
+async function deliverPendingFinalReply(params: {
+  cfg: ClawdbotConfig;
+  entry: FeishuPendingFinalReply;
+}): Promise<void> {
+  const { cfg, entry } = params;
+  if (entry.text) {
+    await sendMessageFeishu({
+      cfg,
+      to: entry.chatId,
+      text: entry.text,
+      replyToMessageId: entry.replyToMessageId,
+      replyInThread: entry.replyInThread,
+      accountId: entry.accountId,
+    });
+  }
+  for (const mediaUrl of entry.mediaUrls ?? []) {
+    await sendMediaFeishu({
+      cfg,
+      to: entry.chatId,
+      mediaUrl,
+      replyToMessageId: entry.replyToMessageId,
+      replyInThread: entry.replyInThread,
+      accountId: entry.accountId,
+    });
+  }
+}
+
+export function beginFeishuActiveRun(params: BeginFeishuActiveRunParams): void {
+  const accountId = normalizeRequired(params.accountId);
+  const chatId = normalizeRequired(params.chatId);
+  const messageId = normalizeRequired(params.messageId);
+  if (!accountId || !chatId || !messageId) {
+    return;
+  }
+  activeRuns.set(buildRunKey(accountId, messageId), {
+    accountId,
+    chatId,
+    messageId,
+    replyToMessageId: params.replyToMessageId?.trim() || undefined,
+    replyInThread: params.replyInThread === true,
+    startedAtMs: Date.now(),
+  });
+}
+
+export function endFeishuActiveRun(params: EndFeishuActiveRunParams): void {
+  const accountId = normalizeRequired(params.accountId);
+  const messageId = normalizeRequired(params.messageId);
+  if (!accountId || !messageId) {
+    return;
+  }
+  activeRuns.delete(buildRunKey(accountId, messageId));
+}
+
+export async function enqueuePendingFeishuFinalReply(
+  params: EnqueuePendingFeishuFinalReplyParams,
+): Promise<string | undefined> {
+  const accountId = normalizeRequired(params.accountId);
+  const runMessageId = normalizeRequired(params.runMessageId);
+  const chatId = normalizeRequired(params.chatId);
+  const text = normalizeText(params.text);
+  const mediaUrls = normalizeMediaUrls(params.mediaUrls);
+
+  if (!accountId || !runMessageId || !chatId || (!text && !mediaUrls)) {
+    return undefined;
+  }
+
+  const pendingId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  const pendingKey = buildRunKey(accountId, runMessageId);
+  const entry: FeishuPendingFinalReply = {
+    pendingId,
+    accountId,
+    runMessageId,
+    chatId,
+    replyToMessageId: params.replyToMessageId?.trim() || undefined,
+    replyInThread: params.replyInThread === true,
+    text,
+    mediaUrls,
+    createdAtMs: Date.now(),
+    attempts: 0,
+  };
+
+  try {
+    await withStoreMutation(async () => {
+      const store = await readRecoveryStore();
+      store.pendingFinalReplies[pendingKey] = entry;
+      await writeRecoveryStore(store);
+    });
+    return pendingId;
+  } catch (error) {
+    params.runtime?.error?.(
+      `feishu[${accountId}]: failed to persist pending final reply: ${String(error)}`,
+    );
+    return undefined;
+  }
+}
+
+export async function ackPendingFeishuFinalReply(
+  params: AckPendingFeishuFinalReplyParams,
+): Promise<void> {
+  const accountId = normalizeRequired(params.accountId);
+  const runMessageId = normalizeRequired(params.runMessageId);
+  if (!accountId || !runMessageId) {
+    return;
+  }
+  const pendingKey = buildRunKey(accountId, runMessageId);
+  try {
+    await withStoreMutation(async () => {
+      const store = await readRecoveryStore();
+      const current = store.pendingFinalReplies[pendingKey];
+      if (!current) {
+        return;
+      }
+      if (params.pendingId && current.pendingId !== params.pendingId) {
+        return;
+      }
+      delete store.pendingFinalReplies[pendingKey];
+      await writeRecoveryStore(store);
+    });
+  } catch (error) {
+    params.runtime?.error?.(
+      `feishu[${accountId}]: failed to acknowledge pending final reply: ${String(error)}`,
+    );
+  }
+}
+
+export async function replayPendingFeishuFinalReplies(
+  params: ReplayPendingFeishuFinalRepliesParams,
+): Promise<void> {
+  const accountId = normalizeRequired(params.accountId);
+  if (!accountId) {
+    return;
+  }
+
+  const now = Date.now();
+  const pending: Array<{ key: string; entry: FeishuPendingFinalReply }> = [];
+  let dropped = 0;
+
+  try {
+    await withStoreMutation(async () => {
+      const store = await readRecoveryStore();
+      let mutated = false;
+      for (const [key, entry] of Object.entries(store.pendingFinalReplies)) {
+        if (entry.accountId !== accountId) {
+          continue;
+        }
+        if (now - entry.createdAtMs > PENDING_FINAL_TTL_MS) {
+          delete store.pendingFinalReplies[key];
+          dropped += 1;
+          mutated = true;
+          continue;
+        }
+        pending.push({ key, entry });
+      }
+      if (mutated) {
+        await writeRecoveryStore(store);
+      }
+    });
+  } catch (error) {
+    params.runtime?.error?.(
+      `feishu[${accountId}]: failed to load pending final replies: ${String(error)}`,
+    );
+    return;
+  }
+
+  if (pending.length === 0) {
+    if (dropped > 0) {
+      params.runtime?.log?.(
+        `feishu[${accountId}]: dropped ${dropped} stale pending final repl(ies)`,
+      );
+    }
+    return;
+  }
+
+  const delivered: Array<{ key: string; pendingId: string }> = [];
+  const failed: Array<{ key: string; pendingId: string; error: string }> = [];
+
+  for (const item of pending) {
+    try {
+      await deliverPendingFinalReply({
+        cfg: params.cfg,
+        entry: item.entry,
+      });
+      delivered.push({ key: item.key, pendingId: item.entry.pendingId });
+    } catch (error) {
+      failed.push({
+        key: item.key,
+        pendingId: item.entry.pendingId,
+        error: String(error),
+      });
+    }
+  }
+
+  try {
+    await withStoreMutation(async () => {
+      const store = await readRecoveryStore();
+      let mutated = false;
+
+      for (const success of delivered) {
+        const current = store.pendingFinalReplies[success.key];
+        if (!current || current.pendingId !== success.pendingId) {
+          continue;
+        }
+        delete store.pendingFinalReplies[success.key];
+        mutated = true;
+      }
+
+      for (const failure of failed) {
+        const current = store.pendingFinalReplies[failure.key];
+        if (!current || current.pendingId !== failure.pendingId) {
+          continue;
+        }
+        current.attempts += 1;
+        current.lastAttemptAtMs = Date.now();
+        current.lastError = failure.error;
+        mutated = true;
+      }
+
+      if (mutated) {
+        await writeRecoveryStore(store);
+      }
+    });
+  } catch (error) {
+    params.runtime?.error?.(
+      `feishu[${accountId}]: failed to finalize pending final replay state: ${String(error)}`,
+    );
+  }
+
+  if (delivered.length > 0 || failed.length > 0 || dropped > 0) {
+    params.runtime?.log?.(
+      `feishu[${accountId}]: pending final replay summary delivered=${delivered.length} failed=${failed.length} dropped=${dropped}`,
+    );
+  }
+}
+
+export async function sendFeishuShutdownInterruptionNotices(
+  params: SendFeishuShutdownInterruptionNoticesParams,
+): Promise<number> {
+  const accountId = normalizeRequired(params.accountId);
+  if (!accountId) {
+    return 0;
+  }
+
+  const runs = Array.from(activeRuns.values()).filter((run) => run.accountId === accountId);
+  if (runs.length === 0) {
+    return 0;
+  }
+
+  const timeoutMs = Math.max(500, params.timeoutMs ?? SHUTDOWN_NOTICE_TIMEOUT_MS);
+  let sent = 0;
+
+  for (const run of runs) {
+    try {
+      await withTimeout(
+        sendMessageFeishu({
+          cfg: params.cfg,
+          to: run.chatId,
+          text: SHUTDOWN_NOTICE_TEXT,
+          replyToMessageId: run.replyToMessageId,
+          replyInThread: run.replyInThread,
+          accountId,
+        }),
+        timeoutMs,
+      );
+      sent += 1;
+    } catch (error) {
+      params.runtime?.error?.(
+        `feishu[${accountId}]: failed to send shutdown interruption notice (${run.messageId}): ${String(error)}`,
+      );
+    }
+  }
+
+  clearActiveRunsForAccount(accountId);
+  return sent;
+}

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -1,4 +1,5 @@
 import type { ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
+import { recordChannelActivity } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import type { MentionTarget } from "./mention.js";
@@ -279,6 +280,7 @@ export async function sendMessageFeishu(
   params: SendFeishuMessageParams,
 ): Promise<FeishuSendResult> {
   const { cfg, to, text, replyToMessageId, replyInThread, mentions, accountId } = params;
+  const resolvedAccountId = resolveFeishuAccount({ cfg, accountId }).accountId;
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
   const tableMode = getFeishuRuntime().channel.text.resolveMarkdownTableMode({
     cfg,
@@ -314,13 +316,27 @@ export async function sendMessageFeishu(
       return sendFallbackDirect(client, directParams, "Feishu send failed");
     }
     if (shouldFallbackFromReplyTarget(response)) {
-      return sendFallbackDirect(client, directParams, "Feishu send failed");
+      const result = await sendFallbackDirect(client, directParams, "Feishu send failed");
+      recordChannelActivity({
+        channel: "feishu",
+        accountId: resolvedAccountId,
+        direction: "outbound",
+      });
+      return result;
     }
     assertFeishuMessageApiSuccess(response, "Feishu reply failed");
-    return toFeishuSendResult(response, receiveId);
+    const result = toFeishuSendResult(response, receiveId);
+    recordChannelActivity({
+      channel: "feishu",
+      accountId: resolvedAccountId,
+      direction: "outbound",
+    });
+    return result;
   }
 
-  return sendFallbackDirect(client, directParams, "Feishu send failed");
+  const result = await sendFallbackDirect(client, directParams, "Feishu send failed");
+  recordChannelActivity({ channel: "feishu", accountId: resolvedAccountId, direction: "outbound" });
+  return result;
 }
 
 export type SendFeishuCardParams = {
@@ -335,6 +351,7 @@ export type SendFeishuCardParams = {
 
 export async function sendCardFeishu(params: SendFeishuCardParams): Promise<FeishuSendResult> {
   const { cfg, to, card, replyToMessageId, replyInThread, accountId } = params;
+  const resolvedAccountId = resolveFeishuAccount({ cfg, accountId }).accountId;
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({ cfg, to, accountId });
   const content = JSON.stringify(card);
 
@@ -358,13 +375,27 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
       return sendFallbackDirect(client, directParams, "Feishu card send failed");
     }
     if (shouldFallbackFromReplyTarget(response)) {
-      return sendFallbackDirect(client, directParams, "Feishu card send failed");
+      const result = await sendFallbackDirect(client, directParams, "Feishu card send failed");
+      recordChannelActivity({
+        channel: "feishu",
+        accountId: resolvedAccountId,
+        direction: "outbound",
+      });
+      return result;
     }
     assertFeishuMessageApiSuccess(response, "Feishu card reply failed");
-    return toFeishuSendResult(response, receiveId);
+    const result = toFeishuSendResult(response, receiveId);
+    recordChannelActivity({
+      channel: "feishu",
+      accountId: resolvedAccountId,
+      direction: "outbound",
+    });
+    return result;
   }
 
-  return sendFallbackDirect(client, directParams, "Feishu card send failed");
+  const result = await sendFallbackDirect(client, directParams, "Feishu card send failed");
+  recordChannelActivity({ channel: "feishu", accountId: resolvedAccountId, direction: "outbound" });
+  return result;
 }
 
 export async function updateCardFeishu(params: {

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -313,7 +313,13 @@ export async function sendMessageFeishu(
       if (!isWithdrawnReplyError(err)) {
         throw err;
       }
-      return sendFallbackDirect(client, directParams, "Feishu send failed");
+      const result = await sendFallbackDirect(client, directParams, "Feishu send failed");
+      recordChannelActivity({
+        channel: "feishu",
+        accountId: resolvedAccountId,
+        direction: "outbound",
+      });
+      return result;
     }
     if (shouldFallbackFromReplyTarget(response)) {
       const result = await sendFallbackDirect(client, directParams, "Feishu send failed");
@@ -372,7 +378,13 @@ export async function sendCardFeishu(params: SendFeishuCardParams): Promise<Feis
       if (!isWithdrawnReplyError(err)) {
         throw err;
       }
-      return sendFallbackDirect(client, directParams, "Feishu card send failed");
+      const result = await sendFallbackDirect(client, directParams, "Feishu card send failed");
+      recordChannelActivity({
+        channel: "feishu",
+        accountId: resolvedAccountId,
+        direction: "outbound",
+      });
+      return result;
     }
     if (shouldFallbackFromReplyTarget(response)) {
       const result = await sendFallbackDirect(client, directParams, "Feishu card send failed");

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -217,6 +217,106 @@ describe("runReplyAgent onAgentRunStart", () => {
   });
 });
 
+describe("runReplyAgent no-payload fallback", () => {
+  function createRun(params: { embeddedResult: unknown }) {
+    runEmbeddedPiAgentMock.mockResolvedValueOnce(params.embeddedResult);
+
+    const typing = createMockTypingController();
+    const sessionCtx = {
+      Provider: "feishu",
+      OriginatingTo: "chat:group",
+      AccountId: "primary",
+      MessageSid: "msg",
+      ChatType: "group",
+    } as unknown as TemplateContext;
+    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
+    const followupRun = {
+      prompt: "hello",
+      summaryLine: "hello",
+      enqueuedAt: Date.now(),
+      run: {
+        agentId: "main",
+        agentDir: "/tmp/agent",
+        sessionId: "session",
+        sessionKey: "main",
+        messageProvider: "feishu",
+        sessionFile: "/tmp/session.jsonl",
+        workspaceDir: "/tmp",
+        config: {},
+        skillsSnapshot: {},
+        provider: "wlai",
+        model: "gpt-5.2",
+        thinkLevel: "low",
+        verboseLevel: "off",
+        elevatedLevel: "off",
+        bashElevated: {
+          enabled: false,
+          allowed: false,
+          defaultLevel: "off",
+        },
+        timeoutMs: 1_000,
+        blockReplyBreak: "message_end",
+      },
+    } as unknown as FollowupRun;
+
+    return runReplyAgent({
+      commandBody: "hello",
+      followupRun,
+      queueKey: "main",
+      resolvedQueue,
+      shouldSteer: false,
+      shouldFollowup: false,
+      isActive: false,
+      isStreaming: false,
+      opts: undefined,
+      typing,
+      sessionCtx,
+      defaultModel: "wlai/gpt-5.2",
+      resolvedVerboseLevel: "off",
+      isNewSession: false,
+      blockStreamingEnabled: false,
+      resolvedBlockStreamingBreak: "message_end",
+      shouldInjectGroupIntro: false,
+      typingMode: "instant",
+    });
+  }
+
+  it("surfaces a fallback reply when a run ends with no payloads but stopReason indicates tool use", async () => {
+    const result = await createRun({
+      embeddedResult: {
+        payloads: undefined,
+        meta: {
+          stopReason: "toolUse",
+          aborted: true,
+          agentMeta: { provider: "wlai", model: "gpt-5.2" },
+        },
+      },
+    });
+
+    expect(result).toMatchObject({
+      isError: true,
+      text: expect.stringContaining("Agent ended without producing a reply"),
+    });
+    expect((result as { text?: string }).text).toContain("stop_reason=toolUse");
+    expect((result as { text?: string }).text).toContain("Logs: openclaw logs --follow");
+  });
+
+  it("keeps silence when a run ends with no payloads and no error/abort/tool stop reason", async () => {
+    const result = await createRun({
+      embeddedResult: {
+        payloads: undefined,
+        meta: {
+          stopReason: "end_turn",
+          aborted: false,
+          agentMeta: { provider: "wlai", model: "gpt-5.2" },
+        },
+      },
+    });
+
+    expect(result).toBeUndefined();
+  });
+});
+
 describe("runReplyAgent authProfileId fallback scoping", () => {
   it("drops authProfileId when provider changes during fallback", async () => {
     runWithModelFallbackMock.mockImplementationOnce(

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -59,6 +59,34 @@ import type { TypingController } from "./typing.js";
 
 const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
 
+function shouldSurfaceNoPayloadFallback(params: {
+  stopReason: unknown;
+  aborted: unknown;
+  embeddedError: unknown;
+  didSendViaMessagingTool: boolean;
+}): boolean {
+  if (params.didSendViaMessagingTool) {
+    return false;
+  }
+  if (params.embeddedError) {
+    return true;
+  }
+  if (params.aborted === true) {
+    return true;
+  }
+  const stopReason = typeof params.stopReason === "string" ? params.stopReason.toLowerCase() : "";
+  if (!stopReason) {
+    return false;
+  }
+  return (
+    stopReason.includes("tool") ||
+    stopReason === "error" ||
+    stopReason === "abort" ||
+    stopReason === "cancelled" ||
+    stopReason === "canceled"
+  );
+}
+
 export async function runReplyAgent(params: {
   commandBody: string;
   followupRun: FollowupRun;
@@ -472,6 +500,58 @@ export async function runReplyAgent(params: {
     // Otherwise, a late typing trigger (e.g. from a tool callback) can outlive the run and
     // keep the typing indicator stuck.
     if (payloadArray.length === 0) {
+      const didSendViaMessagingTool =
+        runResult.didSendViaMessagingTool === true ||
+        (runResult.messagingToolSentTexts?.length ?? 0) > 0 ||
+        (runResult.messagingToolSentMediaUrls?.length ?? 0) > 0;
+      const stopReason = runResult.meta?.stopReason;
+      const aborted = runResult.meta?.aborted;
+      const embeddedError = runResult.meta?.error;
+
+      if (
+        shouldSurfaceNoPayloadFallback({
+          stopReason,
+          aborted,
+          embeddedError,
+          didSendViaMessagingTool,
+        })
+      ) {
+        const stopReasonLabel =
+          typeof stopReason === "string" && stopReason.trim() ? stopReason.trim() : "unknown";
+        const abortedLabel = aborted === true ? "aborted" : "completed";
+        const errorLabel = (() => {
+          if (
+            !embeddedError ||
+            typeof embeddedError !== "object" ||
+            !("message" in embeddedError)
+          ) {
+            return "";
+          }
+          const messageValue = (embeddedError as Record<string, unknown>).message;
+          if (typeof messageValue === "string") {
+            return messageValue.trim();
+          }
+          if (messageValue === null || messageValue === undefined) {
+            return "";
+          }
+          try {
+            return JSON.stringify(messageValue);
+          } catch {
+            return "";
+          }
+        })();
+        const suffix = errorLabel ? ` error=${errorLabel}` : "";
+        return finalizeWithFollowup(
+          {
+            isError: true,
+            text:
+              `⚠️ Agent ended without producing a reply (${abortedLabel}, stop_reason=${stopReasonLabel}${suffix}). ` +
+              "Please try again.\nLogs: openclaw logs --follow",
+          },
+          queueKey,
+          runFollowupTurn,
+        );
+      }
       return finalizeWithFollowup(undefined, queueKey, runFollowupTurn);
     }
 

--- a/src/plugin-sdk/feishu.ts
+++ b/src/plugin-sdk/feishu.ts
@@ -55,7 +55,7 @@ export type { RuntimeEnv } from "../runtime.js";
 export { formatDocsLink } from "../terminal/links.js";
 export type { WizardPrompter } from "../wizard/prompts.js";
 export { buildAgentMediaPayload } from "./agent-media-payload.js";
-export { readJsonFileWithFallback } from "./json-store.js";
+export { readJsonFileWithFallback, writeJsonFileAtomically } from "./json-store.js";
 export { createScopedPairingAccess } from "./pairing-access.js";
 export { createPersistentDedupe } from "./persistent-dedupe.js";
 export {

--- a/src/plugin-sdk/feishu.ts
+++ b/src/plugin-sdk/feishu.ts
@@ -45,6 +45,7 @@ export {
 } from "../config/types.secrets.js";
 export { createDedupeCache } from "../infra/dedupe.js";
 export { installRequestBodyLimitGuard } from "../infra/http-body.js";
+export { recordChannelActivity } from "../infra/channel-activity.js";
 export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export type { PluginRuntime } from "../plugins/runtime/types.js";
@@ -62,6 +63,7 @@ export {
   createDefaultChannelRuntimeState,
 } from "./status-helpers.js";
 export { withTempDownloadPath } from "./temp-path.js";
+export { createRunStateMachine } from "../channels/run-state-machine.js";
 export {
   createFixedWindowRateLimiter,
   createWebhookAnomalyTracker,


### PR DESCRIPTION
## Problem
Feishu long-running requests can occasionally finish without sending a reply. In practice this can happen when the gateway channel health monitor restarts the Feishu provider as "stale-socket" during an active run, which aborts the in-flight work and drops the final outbound message.

This is easiest to hit when Feishu is quiet for long stretches (no inbound events), but a user triggers a long task: the channel had no runtime "busy" / run-activity signal for the health policy to short-circuit, so it may be restarted mid-run.

## Fix
- Wire the Feishu extension into the shared run-state machine so active runs patch the gateway runtime with `busy`, `activeRuns`, and a `lastRunActivityAt` heartbeat.
- Surface transport lifecycle in runtime status (`connected`, `lastEventAt`).
- Record inbound/outbound activity timestamps for better observability (`lastInboundAt`, `lastOutboundAt`).

This keeps the health monitor from restarting Feishu while it is actively running work, and makes it easier to debug channel activity from `openclaw channels status --json`.

## Tests
- `pnpm vitest extensions/feishu/src/channel.test.ts`
- `pnpm vitest extensions/feishu/src/send.test.ts`
- `pnpm vitest extensions/feishu/src/monitor.startup.test.ts`
- `pnpm vitest extensions/feishu/src/monitor.webhook-security.test.ts`
