### PR TITLE
fix(docs): remove broken anchor link in FAQ Xfinity/SSL section

### DIFF
--- a/docs/help/faq.md
+++ b/docs/help/faq.md
@@ -448,8 +448,7 @@ section is the latest shipped version. Entries are grouped by **Highlights**, **
 ### I can't access docs.openclaw.ai SSL error What now
 
 Some Comcast/Xfinity connections incorrectly block `docs.openclaw.ai` via Xfinity
-Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry. More
-detail: [Troubleshooting](/help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity).
+Advanced Security. Disable it or allowlist `docs.openclaw.ai`, then retry.
 Please help us unblock it by reporting here: [https://spa.xfinity.com/check_url_status](https://spa.xfinity.com/check_url_status).
 
 If you still can't reach the site, the docs are mirrored on GitHub:


### PR DESCRIPTION
## Problem

The FAQ section "I can't access docs.openclaw.ai SSL error" (line 452) contains a cross-reference link to `/help/troubleshooting#docsopenclawai-shows-an-ssl-error-comcastxfinity`, but that anchor does not exist in `docs/help/troubleshooting.md`.

Clicking the link from docs.openclaw.ai or GitHub file view leads to a page with no matching section, or an "Error loading page" on GitHub.

## Fix

Remove the broken `[Troubleshooting](...)` link. The FAQ section already contains the complete workaround (disable Xfinity Advanced Security or allowlist `docs.openclaw.ai`), making the cross-reference redundant.

## Testing

- Verified `docs/help/troubleshooting.md` contains no `ssl`, `xfinity`, or `comcast` references
- Confirmed the remaining FAQ text is self-contained and readable
- Single file changed, 1 line removed

Fixes #36970