### PR TITLE
fix(whatsapp): reject empty/non-numeric input in toWhatsappJid

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -90,6 +90,13 @@ describe("normalizeE164 & toWhatsappJid", () => {
     expect(toWhatsappJid("whatsapp:123456789-987654321@g.us")).toBe("123456789-987654321@g.us");
     expect(toWhatsappJid("1555123@s.whatsapp.net")).toBe("1555123@s.whatsapp.net");
   });
+
+  it("throws on empty or non-numeric input instead of producing invalid JID", () => {
+    expect(() => toWhatsappJid("")).toThrow("contains no digits");
+    expect(() => toWhatsappJid("   ")).toThrow("contains no digits");
+    expect(() => toWhatsappJid("whatsapp:")).toThrow("contains no digits");
+    expect(() => toWhatsappJid("abc")).toThrow("contains no digits");
+  });
 });
 
 describe("jidToE164", () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -128,6 +128,9 @@ export function toWhatsappJid(number: string): string {
   }
   const e164 = normalizeE164(withoutPrefix);
   const digits = e164.replace(/\D/g, "");
+  if (!digits) {
+    throw new Error(`Invalid WhatsApp number: input "${number}" contains no digits`);
+  }
   return `${digits}@s.whatsapp.net`;
 }
 


### PR DESCRIPTION
## Summary

- Problem: `toWhatsappJid("")`, `toWhatsappJid("   ")`, `toWhatsappJid("whatsapp:")`, and `toWhatsappJid("abc")` all produce the invalid JID `"@s.whatsapp.net"` (empty local part). `normalizeE164` strips non-digit characters, and when no digits remain, the function concatenates an empty string with `@s.whatsapp.net`.
- Why it matters: The invalid JID `"@s.whatsapp.net"` propagates to Baileys, causing confusing downstream errors (e.g. "jid not valid") instead of a clear validation failure at the point where the bad input enters the system. This makes debugging outbound WhatsApp delivery failures harder than necessary.
- What changed: Added a guard after digit extraction in `toWhatsappJid` — if no digits remain after normalization, throw an `Error` with a descriptive message. All existing callers in `web/outbound.ts` and `web/inbound/send-api.ts` already wrap the call in `try/catch`, so this surfaces cleanly as a delivery error. Added 4 test cases for empty, whitespace, bare prefix, and non-numeric inputs.
- What did NOT change (scope boundary): `normalizeE164` is unchanged — it continues to return `"+"` for empty input. Only `toWhatsappJid` now validates the extracted digits before constructing the JID.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: WhatsApp outbound delivery error handling

## User-visible / Behavior Changes

- `toWhatsappJid` now throws `Error("Invalid WhatsApp number: input \"...\" contains no digits")` instead of producing the malformed JID `"@s.whatsapp.net"`. Callers already handle this via try/catch and report a delivery failure.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel: WhatsApp (Baileys)
- Relevant config: Any WhatsApp configuration

### Steps

1. Call `toWhatsappJid("")` or `toWhatsappJid("abc")`
2. Observe the return value

### Expected

- Throw an error indicating the input contains no digits

### Actual (before fix)

- Returns `"@s.whatsapp.net"` (invalid JID with empty local part)

## Evidence

- [x] Failing test/log before + passing after

4 new test cases verify the guard:
```
expect(() => toWhatsappJid("")).toThrow("contains no digits");
expect(() => toWhatsappJid("   ")).toThrow("contains no digits");
expect(() => toWhatsappJid("whatsapp:")).toThrow("contains no digits");
expect(() => toWhatsappJid("abc")).toThrow("contains no digits");
```

All 29 tests pass (25 existing + 4 new).

## Human Verification (required)

- Verified scenarios: All 29 unit tests pass; empty string, whitespace, bare prefix, and non-numeric inputs all throw with descriptive message
- Edge cases checked: `""`, `"   "`, `"whatsapp:"`, `"abc"`, valid inputs still work correctly
- What you did **not** verify: Live WhatsApp message sending (no Baileys session in dev environment)

## Compatibility / Migration

- Backward compatible? Yes — callers already use try/catch
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the `if (!digits)` guard in `utils.ts`
- Files/config to restore: `src/utils.ts`
- Known bad symptoms reviewers should watch for: If a previously-working WhatsApp target suddenly fails with "contains no digits", it means the target was always invalid but the error was masked by Baileys

## Risks and Mitigations

- Risk: Code paths that previously silently produced `"@s.whatsapp.net"` now throw, potentially surfacing latent issues
  - Mitigation: All callers already handle errors via try/catch. The new error message is descriptive enough for users to understand and fix the root cause (invalid phone number or missing configuration).

[AI-assisted]

Made with [Cursor](https://cursor.com)