### PR TITLE
fix(telegram): add HTML parse fallback for media captions

### DIFF
--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -480,6 +480,40 @@ describe("sendMessageTelegram", () => {
     });
   });
 
+  it("retries media caption as plain text on HTML parse error", async () => {
+    const chatId = "123";
+    const parseErr = new Error(
+      "400: Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 5",
+    );
+    const sendPhoto = vi
+      .fn()
+      .mockRejectedValueOnce(parseErr)
+      .mockResolvedValueOnce({ message_id: 80, chat: { id: chatId } });
+    const api = { sendPhoto } as unknown as {
+      sendPhoto: typeof sendPhoto;
+    };
+
+    mockLoadedMedia({
+      buffer: Buffer.from("fake-image"),
+      contentType: "image/jpeg",
+      fileName: "test.jpg",
+    });
+
+    const result = await sendMessageTelegram(chatId, "_bad<html_", {
+      token: "tok",
+      api,
+      mediaUrl: "https://example.com/photo.jpg",
+    });
+
+    expect(sendPhoto).toHaveBeenCalledTimes(2);
+    const firstCall = sendPhoto.mock.calls[0];
+    expect(firstCall[2]).toMatchObject({ parse_mode: "HTML" });
+    const secondCall = sendPhoto.mock.calls[1];
+    expect(secondCall[2]).not.toHaveProperty("parse_mode");
+    expect(secondCall[2]).toHaveProperty("caption");
+    expect(result.messageId).toBe("80");
+  });
+
   it("splits long captions into media + text messages when text exceeds 1024 chars", async () => {
     const chatId = "123";
     const longText = "A".repeat(1100);

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -612,7 +612,22 @@ export async function sendMessageTelegram(
         label,
         opts.verbose,
         async (effectiveParams, retryLabel) =>
-          requestWithChatNotFound(() => sender(effectiveParams), retryLabel),
+          htmlCaption
+            ? withTelegramHtmlParseFallback({
+                label: retryLabel,
+                verbose: opts.verbose,
+                requestHtml: (htmlLabel) =>
+                  requestWithChatNotFound(() => sender(effectiveParams), htmlLabel),
+                requestPlain: (plainLabel) => {
+                  const plainParams = { ...effectiveParams };
+                  delete plainParams.parse_mode;
+                  if (caption) {
+                    plainParams.caption = caption;
+                  }
+                  return requestWithChatNotFound(() => sender(plainParams), plainLabel);
+                },
+              })
+            : requestWithChatNotFound(() => sender(effectiveParams), retryLabel),
       );
 
     const mediaSender = (() => {


### PR DESCRIPTION
## Summary

- Problem: Text messages use `withTelegramHtmlParseFallback` to retry as plain text when Telegram rejects HTML entities (e.g. unmatched `<`, `>`), but media captions (sendPhoto, sendDocument, sendVideo, sendAnimation, sendAudio, sendVoice) did not have this fallback. An HTML parse error in a caption caused the entire media send to fail with a 400 error.
- Why it matters: Users sending media with captions containing special characters (e.g. code snippets, mathematical notation, user-generated content) would get a hard failure instead of a graceful fallback to plain text. The text message path already handles this correctly, so the media path was inconsistent.
- What changed: Wrapped the media send callback inside `withTelegramHtmlParseFallback`. On an HTML parse error, the send is retried without `parse_mode` and with the raw caption text instead of the HTML-rendered version. This applies to all media types (photo, document, video, animation, audio, voice, video note).
- What did NOT change (scope boundary): The text message path, edit message path, thread fallback logic, and caption splitting logic are all unchanged. Only the media send's inner callback was modified to add the HTML fallback.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Telegram media delivery reliability

## User-visible / Behavior Changes

- Media with captions containing problematic HTML entities now falls back to plain text instead of failing with a 400 error. The media is still delivered successfully.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No (same API calls, just retried with different formatting)
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0
- Runtime/container: Node.js
- Model/provider: N/A
- Integration/channel: Telegram
- Relevant config: Any Telegram bot configuration

### Steps

1. Send a media message (photo, document, etc.) with a caption containing unmatched HTML entities (e.g. `_bad<html_`)
2. Observe the Telegram API returns a 400 "can't parse entities" error

### Expected

- Media is sent with the caption as plain text (no HTML formatting)

### Actual (before fix)

- Media send fails entirely with a 400 error

## Evidence

- [x] Failing test/log before + passing after

New test `retries media caption as plain text on HTML parse error`:
- Mocks `sendPhoto` to reject first with parse error, then succeed
- Verifies first call has `parse_mode: "HTML"`, second call has no `parse_mode`
- Verifies the caption is present in the retry call

All 52 tests pass (51 existing + 1 new).

## Human Verification (required)

- Verified scenarios: All 52 unit tests pass; HTML parse error triggers plain text retry; no-caption media sends unaffected
- Edge cases checked: Media with no caption (skips HTML fallback correctly), media with long caption (split logic unchanged)
- What you did **not** verify: Live Telegram bot media sending (no bot token in dev environment)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the `sendMedia` function in `send.ts` to remove the `withTelegramHtmlParseFallback` wrapper
- Files/config to restore: `src/telegram/send.ts`
- Known bad symptoms reviewers should watch for: If plain text captions appear when HTML was expected, it means the HTML rendering produced invalid output (which is a separate issue in the markdown-to-HTML converter)

## Risks and Mitigations

- Risk: The plain text fallback sends raw markdown instead of rendered HTML, which may look different from the intended formatting
  - Mitigation: This is the same trade-off the text message path already makes. Delivering media with slightly different caption formatting is strictly better than failing to deliver the media at all.

[AI-assisted]

Made with [Cursor](https://cursor.com)