### PR TITLE
fix(gateway): add --allow-unconfigured flag and improve control UI or…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
         "node",
         "dist/index.js",
         "gateway",
+        "--allow-unconfigured",
         "--bind",
         "${OPENCLAW_GATEWAY_BIND:-lan}",
         "--port",

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -85,22 +85,28 @@ ensure_control_ui_allowed_origins() {
     return 0
   fi
 
+  # Non-loopback bind (e.g. lan) requires explicit allowedOrigins or gateway fails to start.
   local allowed_origin_json
   local current_allowed_origins
-  allowed_origin_json="$(printf '["http://127.0.0.1:%s"]' "$OPENCLAW_GATEWAY_PORT")"
+  allowed_origin_json="$(printf '["http://127.0.0.1:%s","http://localhost:%s"]' "$OPENCLAW_GATEWAY_PORT" "$OPENCLAW_GATEWAY_PORT")"
   current_allowed_origins="$(
     docker compose "${COMPOSE_ARGS[@]}" run --rm openclaw-cli \
       config get gateway.controlUi.allowedOrigins 2>/dev/null || true
   )"
   current_allowed_origins="${current_allowed_origins//$'\r'/}"
+  current_allowed_origins="${current_allowed_origins#"${current_allowed_origins%%[![:space:]]*}"}"
+  current_allowed_origins="${current_allowed_origins%"${current_allowed_origins##*[![:space:]]}"}"
 
   if [[ -n "$current_allowed_origins" && "$current_allowed_origins" != "null" && "$current_allowed_origins" != "[]" ]]; then
     echo "Control UI allowlist already configured; leaving gateway.controlUi.allowedOrigins unchanged."
     return 0
   fi
 
-  docker compose "${COMPOSE_ARGS[@]}" run --rm openclaw-cli \
-    config set gateway.controlUi.allowedOrigins "$allowed_origin_json" --strict-json >/dev/null
+  if ! docker compose "${COMPOSE_ARGS[@]}" run --rm openclaw-cli \
+    config set gateway.controlUi.allowedOrigins "$allowed_origin_json" --strict-json; then
+    echo "WARNING: Failed to set gateway.controlUi.allowedOrigins. Gateway may fail to start with: non-loopback Control UI requires gateway.controlUi.allowedOrigins" >&2
+    return 1
+  fi
   echo "Set gateway.controlUi.allowedOrigins to $allowed_origin_json for non-loopback bind."
 }
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -812,6 +812,8 @@ If the gateway container logs show either of these errors:
    docker compose up -d openclaw-gateway
    ```
 
+   Replace `18789` with your `OPENCLAW_GATEWAY_PORT` value if you changed the default.
+
    Then pull the latest repo (so the compose command includes `--allow-unconfigured`) and run `./docker-setup.sh` again, or keep the manual config and restart the gateway.
 
 ### Sandbox and permissions

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -796,6 +796,26 @@ Example:
 
 ## Troubleshooting
 
+### Gateway fails to start after `./docker-setup.sh`
+
+If the gateway container logs show either of these errors:
+
+1. **`Missing config. Run openclaw setup or set gateway.mode=local (or pass --allow-unconfigured).`**  
+   The Compose command overrides the image CMD and must allow startup before config is ready. The repo’s `docker-compose.yml` includes `--allow-unconfigured` in the gateway command for this reason. If you use a custom compose file, add that flag so the gateway can start even when config is missing or `gateway.mode` is not yet `local`.
+
+2. **`non-loopback Control UI requires gateway.controlUi.allowedOrigins (set explicit origins), or set gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback=true`**  
+   When the gateway binds to a non-loopback address (e.g. `lan`), the Control UI requires an explicit origin allowlist. `docker-setup.sh` runs `ensure_control_ui_allowed_origins` and sets `gateway.controlUi.allowedOrigins` (e.g. `["http://127.0.0.1:18789","http://localhost:18789"]`) before starting the gateway. If you started the gateway without running the full setup, set it manually:
+
+   ```bash
+   docker compose run --rm openclaw-cli config set gateway.mode local
+   docker compose run --rm openclaw-cli config set gateway.controlUi.allowedOrigins '["http://127.0.0.1:18789","http://localhost:18789"]' --strict-json
+   docker compose up -d openclaw-gateway
+   ```
+
+   Then pull the latest repo (so the compose command includes `--allow-unconfigured`) and run `./docker-setup.sh` again, or keep the manual config and restart the gateway.
+
+### Sandbox and permissions
+
 - Image missing: build with [`scripts/sandbox-setup.sh`](https://github.com/openclaw/openclaw/blob/main/scripts/sandbox-setup.sh) or set `agents.defaults.sandbox.docker.image`.
 - Container not running: it will auto-create per session on demand.
 - Permission errors in sandbox: set `docker.user` to a UID:GID that matches your


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- **Problem:** After running `./docker-setup.sh`, the gateway container could fail with (1) "Missing config. Run openclaw setup or set gateway.mode=local (or pass --allow-unconfigured)" and (2) "non-loopback Control UI requires gateway.controlUi.allowedOrigins".
- **Why it matters:** Users following the Docker install guide hit a broken flow: gateway refused to start before config was fully written, and with default `--bind lan` the Control UI origin allowlist was required but setup could silently fail or not persist.
- **What changed:** (1) `docker-compose.yml` gateway command now includes `--allow-unconfigured`. (2) `docker-setup.sh` sets both `http://127.0.0.1:PORT` and `http://localhost:PORT` in `gateway.controlUi.allowedOrigins`, trims `config get` output, and surfaces failures when `config set` fails. (3) `docs/install/docker.md` Troubleshooting gained a subsection for these two errors and manual fix steps.
- **What did NOT change (scope boundary):** No change to gateway auth, bind defaults, or Control UI logic; only Compose/setup script and docs. `zh-CN` docs are i18n-generated and were not edited.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Gateway started via Docker Compose can start even when config is missing or `gateway.mode` is not yet `local` (same as image CMD with `--allow-unconfigured`).
- For non-loopback bind, setup now sets `gateway.controlUi.allowedOrigins` to include both `127.0.0.1` and `localhost` for the configured port; if that `config set` fails, the script prints a warning and exits instead of continuing silently.
- Docker install docs now document these two startup failures and how to fix them (re-run setup or manual `config set` + restart).

## Security Impact (required)

- New permissions/capabilities? **No**
- Secrets/tokens handling changed? **No**
- New/changed network calls? **No**
- Command/tool execution surface changed? **No**
- Data access scope changed? **No**
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Any (Docker host)
- Runtime/container: Docker Compose v2, repo root
- Model/provider: N/A
- Integration/channel: N/A
- Relevant config: Default `OPENCLAW_GATEWAY_BIND=lan`, `OPENCLAW_GATEWAY_PORT=18789`

### Steps

1. From repo root, run `./docker-setup.sh` and complete onboarding.
2. Confirm gateway starts; open `http://127.0.0.1:18789/` and paste token.
3. (Regression) Run manual flow: `docker compose run --rm openclaw-cli onboard --mode local --no-install-daemon`, then `docker compose up -d openclaw-gateway`; gateway should start and Control UI should connect.

### Expected

- No "Missing config" or "non-loopback Control UI requires gateway.controlUi.allowedOrigins" in gateway logs; Control UI loads and accepts token.

### Actual

- Same as expected after changes.

## Evidence

- [x] Trace/log snippets: Before: gateway log showed the two errors above. After: setup completes and gateway log shows normal startup; Control UI reachable at `http://127.0.0.1:18789/` and `http://localhost:18789/`.
- [ ] Failing test/log before + passing after (optional: add or point to `docker-setup.e2e` / Docker smoke if run).
- [ ] Screenshot/recording (optional).
- [ ] Perf numbers (if relevant): N/A

## Human Verification (required)

- **Verified scenarios:** Ran `./docker-setup.sh` from clean config dir; gateway started and Control UI worked. Confirmed `openclaw.json` contains `gateway.mode: "local"` and `gateway.controlUi.allowedOrigins` with both origins.
- **Edge cases checked:** Default bind `lan`; script exit when `config set gateway.controlUi.allowedOrigins` fails (removed `/dev/null` so failure is visible).
- **What you did NOT verify:** Non-Docker Desktop hosts (e.g. Linux Docker Engine), zh-CN doc output from i18n pipeline.

## Compatibility / Migration

- Backward compatible? **Yes**
- Config/env changes? **No** (existing env vars unchanged; we only set config that was already expected for Docker).
- Migration needed? **No**
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- **How to disable/revert:** Remove `--allow-unconfigured` from `docker-compose.yml` command and/or revert `ensure_control_ui_allowed_origins` in `docker-setup.sh`; revert doc subsection.
- **Files/config to restore:** `docker-compose.yml`, `docker-setup.sh`, `docs/install/docker.md`.
- **Known bad symptoms reviewers should watch for:** Gateway still failing to start with same two errors (would indicate config not being read or setup order issue); Control UI "origin not allowed" when using `localhost` (would indicate allowedOrigins not including both origins).

## Risks and Mitigations

- **Risk:** `--allow-unconfigured` allows gateway to start without `gateway.mode=local`; in theory an operator could rely on that and run with incomplete config.
  - **Mitigation:** Documented behavior; setup script still sets `gateway.mode=local` and `gateway.controlUi.allowedOrigins` before starting the gateway. No new network exposure.
- **Risk:** None for allowedOrigins change (only adds localhost + makes failure visible).
- **Risk:** Doc changes are additive; no behavioral change from docs alone.

<img width="1457" height="180" alt="image" src="https://github.com/user-attachments/assets/608f7727-625f-4fc6-a304-2e1369d5dfa8" />
