### PR TITLE
fix(cli): prevent Infinity% cached in status output when totalTokens is 0

### DIFF
--- a/src/commands/status.format.test.ts
+++ b/src/commands/status.format.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { formatTokensCompact } from "./status.format.js";
+
+describe("formatTokensCompact", () => {
+  it("formats used/context with percentage", () => {
+    const result = formatTokensCompact({
+      totalTokens: 5000,
+      contextTokens: 10000,
+      percentUsed: 50,
+    });
+    expect(result).toBe("5.0k/10k (50%)");
+  });
+
+  it("appends cache hit rate when cacheRead > 0", () => {
+    const result = formatTokensCompact({
+      totalTokens: 10000,
+      contextTokens: 20000,
+      percentUsed: 50,
+      cacheRead: 8000,
+    });
+    expect(result).toContain("80% cached");
+  });
+
+  it("does not show Infinity when totalTokens is 0 and cacheRead > 0", () => {
+    const result = formatTokensCompact({
+      totalTokens: 0,
+      contextTokens: 10000,
+      percentUsed: 0,
+      cacheRead: 500,
+    });
+    expect(result).not.toContain("Infinity");
+    expect(result).not.toContain("cached");
+  });
+
+  it("does not show cache rate when cacheRead is 0", () => {
+    const result = formatTokensCompact({
+      totalTokens: 5000,
+      contextTokens: 10000,
+      percentUsed: 50,
+      cacheRead: 0,
+    });
+    expect(result).not.toContain("cached");
+  });
+
+  it("handles missing totalTokens with cacheRead", () => {
+    const result = formatTokensCompact({
+      totalTokens: undefined as unknown as number,
+      contextTokens: 10000,
+      cacheRead: 3000,
+      cacheWrite: 7000,
+    });
+    expect(result).toContain("30% cached");
+  });
+
+  it("handles used-only (no context)", () => {
+    const result = formatTokensCompact({
+      totalTokens: 5000,
+    });
+    expect(result).toBe("5.0k used");
+  });
+});

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -40,8 +40,10 @@ export const formatTokensCompact = (
       typeof used === "number"
         ? used
         : cacheRead + (typeof cacheWrite === "number" ? cacheWrite : 0);
-    const hitRate = Math.round((cacheRead / total) * 100);
-    result += ` · 🗄️ ${hitRate}% cached`;
+    if (total > 0) {
+      const hitRate = Math.round((cacheRead / total) * 100);
+      result += ` · 🗄️ ${hitRate}% cached`;
+    }
   }
 
   return result;


### PR DESCRIPTION
## Summary

- Problem: `formatTokensCompact` computed `cacheRead / total` without guarding against `total === 0`. When a session had `totalTokens: 0` but `cacheRead > 0` (e.g. a session that only consumed cached tokens before any new generation), the division produced `Infinity`, displaying `"Infinity% cached"` in `openclaw status` output.
- Why it matters: Users running `openclaw status` see broken formatting (`Infinity% cached`) instead of clean output, making the status command look buggy.
- What changed: Added a `total > 0` guard before computing the cache hit rate percentage. When `total` is 0, the cache rate line is simply omitted. Created a new test file with 6 test cases covering normal formatting, cache hit rate, the zero-total edge case, missing totalTokens, and no-cache scenarios.
- What did NOT change (scope boundary): No changes to `formatKTokens`, `formatDuration`, `formatDaemonRuntimeShort`, or any other formatting helper. Only the cache hit rate computation in `formatTokensCompact`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: CLI status output formatting

## User-visible / Behavior Changes

- Sessions with `totalTokens: 0` and `cacheRead > 0` no longer show `"Infinity% cached"` in `openclaw status`. The cache rate line is omitted when the total is 0.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS Darwin 25.3.0
- Runtime/container: Node.js
- Integration/channel: CLI

### Steps

1. Have a session with `totalTokens: 0` and `cacheRead: 500`
2. Run `openclaw status`

### Expected

- No cache rate shown (omitted cleanly)

### Actual (before fix)

- Shows `"Infinity% cached"`

## Evidence

- [x] Failing test/log before + passing after

New test `does not show Infinity when totalTokens is 0 and cacheRead > 0`:
```
expect(result).not.toContain("Infinity");
expect(result).not.toContain("cached");
```

All 6 tests pass.

## Human Verification (required)

- Verified scenarios: All 6 unit tests pass; zero-total, normal cache rate, no cache, missing totalTokens
- Edge cases checked: `totalTokens: 0` with `cacheRead > 0`; `cacheRead: 0`; `totalTokens: undefined` with `cacheRead + cacheWrite > 0`
- What you did **not** verify: Live `openclaw status` output (no running gateway in dev)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Remove the `if (total > 0)` guard
- Files/config to restore: `src/commands/status.format.ts`
- Known bad symptoms: If the guard is wrong, cache rate line would be missing for valid sessions (but the guard only triggers when total is 0, which is a degenerate case)

## Risks and Mitigations

None — the change only adds a guard around a division operation to prevent division by zero.

[AI-assisted]

Made with [Cursor](https://cursor.com)