### PR TITLE
Wire session:end internal hook for webhook and cron agent completion

### DIFF
--- a/docs/automation/hooks.md
+++ b/docs/automation/hooks.md
@@ -345,6 +345,39 @@ const handler = async (event) => {
 export default handler;
 ```
 
+#### Session Events
+
+- **`session`**: All session lifecycle events (general listener)
+- **`session:end`**: When an agent session completes (webhook-dispatched or cron-triggered). Fires after the agent finishes processing, before delivery.
+
+#### Session Event Context
+
+```typescript
+// session:end context
+{
+  sessionId: string,     // The session ID that ended
+  agentId?: string,      // Agent ID that ran the session
+  status: "ok" | "error", // How the session ended
+  error?: string,        // Error message if status is "error"
+  trigger: "webhook" | "cron" | "interactive", // What started the session
+  durationMs?: number,   // Session duration in milliseconds
+  runId?: string,        // Run ID for correlation
+}
+```
+
+#### Example: Session Completion Hook
+
+```typescript
+const handler = async (event) => {
+  if (event.type === "session" && event.action === "end") {
+    const { agentId, status, trigger, durationMs } = event.context;
+    console.log(`[session-end] ${agentId} (${trigger}): ${status} in ${durationMs}ms`);
+  }
+};
+
+export default handler;
+```
+
 ### Tool Result Hooks (Plugin API)
 
 These hooks are not event-stream listeners; they let plugins synchronously adjust tool results before OpenClaw persists them.
@@ -356,7 +389,6 @@ These hooks are not event-stream listeners; they let plugins synchronously adjus
 Planned event types:
 
 - **`session:start`**: When a new session begins
-- **`session:end`**: When a session ends
 - **`agent:error`**: When an agent encounters an error
 
 ## Creating Custom Hooks

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -40,6 +40,8 @@ import {
   updateSessionStore,
 } from "../../config/sessions.js";
 import type { AgentDefaultsConfig } from "../../config/types.js";
+import { fireAndForgetHook } from "../../hooks/fire-and-forget.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
 import { logWarn } from "../../logger.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
@@ -435,6 +437,7 @@ export async function runCronIsolatedAgentTurn(params: {
   let fallbackModel = model;
   const runStartedAt = Date.now();
   let runEndedAt = runStartedAt;
+  const sessionEndTrigger = agentSessionKey.includes(":hook:") ? "webhook" : "cron";
   try {
     const sessionFile = resolveSessionTranscriptPath(cronSession.sessionEntry.sessionId, agentId);
     const resolvedVerboseLevel =
@@ -542,8 +545,36 @@ export async function runCronIsolatedAgentTurn(params: {
     fallbackModel = fallbackResult.model;
     runEndedAt = Date.now();
   } catch (err) {
+    fireAndForgetHook(
+      triggerInternalHook(
+        createInternalHookEvent("session", "end", agentSessionKey, {
+          sessionId: runSessionId,
+          agentId,
+          status: "error",
+          error: String(err),
+          trigger: sessionEndTrigger,
+          durationMs: Date.now() - runStartedAt,
+          runId: runSessionId,
+        }),
+      ),
+      "session:end hook (cron error)",
+    );
     return withRunSession({ status: "error", error: String(err) });
   }
+
+  fireAndForgetHook(
+    triggerInternalHook(
+      createInternalHookEvent("session", "end", agentSessionKey, {
+        sessionId: runSessionId,
+        agentId,
+        status: "ok",
+        trigger: sessionEndTrigger,
+        durationMs: runEndedAt - runStartedAt,
+        runId: runSessionId,
+      }),
+    ),
+    "session:end hook (cron ok)",
+  );
 
   if (isAborted()) {
     return withRunSession({ status: "error", error: abortReason() });

--- a/src/gateway/server-methods/agent.ts
+++ b/src/gateway/server-methods/agent.ts
@@ -12,6 +12,8 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import { fireAndForgetHook } from "../../hooks/fire-and-forget.js";
+import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
 import { registerAgentRunContext } from "../../infra/agent-events.js";
 import {
   resolveAgentDeliveryPlan,
@@ -669,6 +671,19 @@ export const agentHandlers: GatewayRequestHandlers = {
         // Send a second res frame (same id) so TS clients with expectFinal can wait.
         // Swift clients will typically treat the first res as the result and ignore this.
         respond(true, payload, undefined, { runId });
+        fireAndForgetHook(
+          triggerInternalHook(
+            createInternalHookEvent("session", "end", resolvedSessionKey ?? "", {
+              sessionId: resolvedSessionId ?? "",
+              agentId: agentId ?? resolveAgentIdFromSessionKey(resolvedSessionKey ?? ""),
+              status: "ok",
+              trigger: "webhook",
+              durationMs: Date.now() - accepted.acceptedAt,
+              runId,
+            }),
+          ),
+          "session:end hook (webhook ok)",
+        );
       })
       .catch((err) => {
         const error = errorShape(ErrorCodes.UNAVAILABLE, String(err));
@@ -691,6 +706,20 @@ export const agentHandlers: GatewayRequestHandlers = {
           runId,
           error: formatForLog(err),
         });
+        fireAndForgetHook(
+          triggerInternalHook(
+            createInternalHookEvent("session", "end", resolvedSessionKey ?? "", {
+              sessionId: resolvedSessionId ?? "",
+              agentId: agentId ?? resolveAgentIdFromSessionKey(resolvedSessionKey ?? ""),
+              status: "error",
+              error: String(err),
+              trigger: "webhook",
+              durationMs: Date.now() - accepted.acceptedAt,
+              runId,
+            }),
+          ),
+          "session:end hook (webhook error)",
+        );
       });
   },
   "agent.identity.get": ({ params, respond }) => {

--- a/src/hooks/internal-hooks.test.ts
+++ b/src/hooks/internal-hooks.test.ts
@@ -7,6 +7,7 @@ import {
   isGatewayStartupEvent,
   isMessageReceivedEvent,
   isMessageSentEvent,
+  isSessionEndEvent,
   registerInternalHook,
   triggerInternalHook,
   unregisterInternalHook,
@@ -14,6 +15,7 @@ import {
   type GatewayStartupHookContext,
   type MessageReceivedHookContext,
   type MessageSentHookContext,
+  type SessionEndHookContext,
 } from "./internal-hooks.js";
 
 describe("hooks", () => {
@@ -442,6 +444,111 @@ describe("hooks", () => {
       // Both handlers were called
       expect(errorHandler).toHaveBeenCalled();
       expect(successHandler).toHaveBeenCalled();
+    });
+  });
+
+  describe("isSessionEndEvent", () => {
+    const testCases = [
+      {
+        name: "valid session:end event with ok status",
+        event: createInternalHookEvent("session", "end", "agent:main:webhook", {
+          sessionId: "sess-123",
+          agentId: "main",
+          status: "ok",
+          trigger: "webhook",
+          durationMs: 5000,
+          runId: "run-456",
+        } satisfies SessionEndHookContext),
+        expected: true,
+      },
+      {
+        name: "valid session:end event with error status",
+        event: createInternalHookEvent("session", "end", "cron:agent:main", {
+          sessionId: "sess-789",
+          agentId: "main",
+          status: "error",
+          error: "timeout",
+          trigger: "cron",
+          durationMs: 30000,
+        } satisfies SessionEndHookContext),
+        expected: true,
+      },
+      {
+        name: "wrong event type",
+        event: createInternalHookEvent("command", "end", "test-session", {
+          sessionId: "sess-123",
+          status: "ok",
+        }),
+        expected: false,
+      },
+      {
+        name: "wrong action",
+        event: createInternalHookEvent("session", "start", "test-session", {
+          sessionId: "sess-123",
+          status: "ok",
+        }),
+        expected: false,
+      },
+      {
+        name: "missing sessionId",
+        event: createInternalHookEvent("session", "end", "test-session", {
+          status: "ok",
+          trigger: "webhook",
+        }),
+        expected: false,
+      },
+      {
+        name: "missing status",
+        event: createInternalHookEvent("session", "end", "test-session", {
+          sessionId: "sess-123",
+          trigger: "webhook",
+        }),
+        expected: false,
+      },
+    ];
+
+    for (const testCase of testCases) {
+      it(`returns ${testCase.expected} for ${testCase.name}`, () => {
+        expect(isSessionEndEvent(testCase.event)).toBe(testCase.expected);
+      });
+    }
+  });
+
+  describe("session hooks", () => {
+    it("should trigger session:end handlers", async () => {
+      const handler = vi.fn();
+      registerInternalHook("session:end", handler);
+
+      const context: SessionEndHookContext = {
+        sessionId: "sess-123",
+        agentId: "harvey",
+        status: "ok",
+        trigger: "webhook",
+        durationMs: 5000,
+        runId: "run-456",
+      };
+      const event = createInternalHookEvent("session", "end", "agent:harvey:webhook", context);
+      await triggerInternalHook(event);
+
+      expect(handler).toHaveBeenCalledWith(event);
+    });
+
+    it("should trigger general session handlers for session:end", async () => {
+      const handler = vi.fn();
+      registerInternalHook("session", handler);
+
+      const context: SessionEndHookContext = {
+        sessionId: "sess-456",
+        agentId: "krish",
+        status: "error",
+        error: "timeout",
+        trigger: "cron",
+        durationMs: 30000,
+      };
+      const event = createInternalHookEvent("session", "end", "cron:agent:krish", context);
+      await triggerInternalHook(event);
+
+      expect(handler).toHaveBeenCalledWith(event);
     });
   });
 

--- a/src/hooks/internal-hooks.ts
+++ b/src/hooks/internal-hooks.ts
@@ -183,6 +183,33 @@ export type MessagePreprocessedHookEvent = InternalHookEvent & {
   context: MessagePreprocessedHookContext;
 };
 
+// ============================================================================
+// Session Hook Events
+// ============================================================================
+
+export type SessionEndHookContext = {
+  /** The session ID that ended */
+  sessionId: string;
+  /** Agent ID that ran the session */
+  agentId?: string;
+  /** How the session ended: "ok" or "error" */
+  status: "ok" | "error";
+  /** Error message if status is "error" */
+  error?: string;
+  /** What triggered the session: "webhook", "cron", or "interactive" */
+  trigger: "webhook" | "cron" | "interactive";
+  /** Duration of the session in milliseconds */
+  durationMs?: number;
+  /** Run ID for correlation */
+  runId?: string;
+};
+
+export type SessionEndHookEvent = InternalHookEvent & {
+  type: "session";
+  action: "end";
+  context: SessionEndHookContext;
+};
+
 export interface InternalHookEvent {
   /** The type of event (command, session, agent, gateway, etc.) */
   type: InternalHookEventType;
@@ -445,4 +472,15 @@ export function isMessagePreprocessedEvent(
     return false;
   }
   return hasStringContextField(context, "channelId");
+}
+
+export function isSessionEndEvent(event: InternalHookEvent): event is SessionEndHookEvent {
+  if (!isHookEventTypeAndAction(event, "session", "end")) {
+    return false;
+  }
+  const context = getHookContext<SessionEndHookContext>(event);
+  if (!context) {
+    return false;
+  }
+  return hasStringContextField(context, "sessionId") && hasStringContextField(context, "status");
 }


### PR DESCRIPTION
## Summary

- Fires a `session:end` internal hook event when webhook-dispatched or cron-triggered agent sessions complete (success or error)
- Enables user-defined hooks to react to agent completion — e.g. chaining agents, sending notifications, or logging session outcomes
- Distinguishes webhook vs cron triggers by detecting `:hook:` in the session key

## Changes

- **`src/hooks/internal-hooks.ts`**: Add `SessionEndHookContext`, `SessionEndHookEvent` types and `isSessionEndEvent` type guard
- **`src/gateway/server-methods/agent.ts`**: Fire `session:end` in webhook agent `.then()`/`.catch()` handlers (covers gateway WebSocket RPC path)
- **`src/cron/isolated-agent/run.ts`**: Fire `session:end` after cron/webhook agent run completion (covers `/hooks/agent` HTTP path)
- **`docs/automation/hooks.md`**: Document `session:end` event, context schema, and example hook. Move from "Future/Planned" to documented.
- **`src/hooks/internal-hooks.test.ts`**: Add type guard tests and session hook trigger tests

## Context

`session:end` was listed as a planned event in the hooks docs but was never wired. This implements it for the two primary agent completion paths:

1. **Cron isolated agent** (`runCronIsolatedAgentTurn`) — used by both actual cron jobs and `/hooks/agent` webhook dispatches
2. **Gateway agent RPC** (`agentCommandFromIngress`) — used by WebSocket `agent.command` calls

The hook context includes `sessionId`, `agentId`, `status` (ok/error), `trigger` (webhook/cron), `durationMs`, and `runId` for correlation.

Relates to #10142

## Test plan

- [x] Unit tests pass (`pnpm test -- src/hooks/internal-hooks.test.ts` — 38 tests)
- [x] All hook tests pass (`pnpm test -- src/hooks/` — 164 tests, 18 files)
- [x] TypeScript check passes (no errors in changed files)
- [x] Deployed to test server and verified end-to-end:
  - Webhook dispatch → agent completes → `session:end` hook fires → writes JSON with correct `trigger: "webhook"`, `status: "ok"`, `agentId`, `durationMs`