### PR TITLE
fix(telegram): suppress NO_REPLY sentinel before API call

### DIFF
--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -171,6 +171,15 @@ describe("buildInlineKeyboard", () => {
 });
 
 describe("sendMessageTelegram", () => {
+  it("suppresses NO_REPLY token before Telegram API call", async () => {
+    botApi.sendMessage.mockClear();
+
+    const res = await sendMessageTelegram("123", "  NO_REPLY  ", { token: "tok" });
+
+    expect(res).toEqual({ messageId: "suppressed", chatId: "123" });
+    expect(botApi.sendMessage).not.toHaveBeenCalled();
+  });
+
   it("applies timeoutSeconds config precedence", async () => {
     const cases = [
       {

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -180,6 +180,33 @@ describe("sendMessageTelegram", () => {
     expect(botApi.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("does not suppress NO_REPLY when inline buttons are present", async () => {
+    botApi.sendMessage.mockClear();
+    botApi.sendMessage.mockResolvedValue({ message_id: 11, chat: { id: "123" } });
+
+    const res = await sendMessageTelegram("123", "NO_REPLY", {
+      token: "tok",
+      buttons: [[{ text: "Ack", callback_data: "ack" }]],
+    });
+
+    expect(res).toEqual({ messageId: "11", chatId: "123" });
+    expect(botApi.sendMessage).toHaveBeenCalledOnce();
+  });
+
+  it("does not suppress NO_REPLY when media is present", async () => {
+    botApi.sendPhoto.mockClear();
+    mockLoadedMedia({ contentType: "image/png", fileName: "x.png" });
+    botApi.sendPhoto.mockResolvedValue({ message_id: 12, chat: { id: "123" } });
+
+    const res = await sendMessageTelegram("123", "NO_REPLY", {
+      token: "tok",
+      mediaUrl: "https://example.com/x.png",
+    });
+
+    expect(res).toEqual({ messageId: "12", chatId: "123" });
+    expect(botApi.sendPhoto).toHaveBeenCalledOnce();
+  });
+
   it("applies timeoutSeconds config precedence", async () => {
     const cases = [
       {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -5,6 +5,7 @@ import type {
   ReactionTypeEmoji,
 } from "@grammyjs/types";
 import { type ApiClientOptions, Bot, HttpError, InputFile } from "grammy";
+import { isSilentReplyText } from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import { resolveMarkdownTableMode } from "../config/markdown-tables.js";
 import { logVerbose } from "../globals.js";
@@ -465,6 +466,13 @@ export async function sendMessageTelegram(
 ): Promise<TelegramSendResult> {
   const { cfg, account, api } = resolveTelegramApiContext(opts);
   const target = parseTelegramTarget(to);
+  const mediaUrl = opts.mediaUrl?.trim();
+  const replyMarkup = buildInlineKeyboard(opts.buttons);
+  const trimmedText = text?.trim() ?? "";
+  if (isSilentReplyText(trimmedText) && !mediaUrl && !replyMarkup) {
+    logVerbose("telegram send: suppressed NO_REPLY token before API call");
+    return { messageId: "suppressed", chatId: target.chatId || to };
+  }
   const chatId = await resolveAndPersistChatId({
     cfg,
     api,
@@ -472,8 +480,6 @@ export async function sendMessageTelegram(
     persistTarget: to,
     verbose: opts.verbose,
   });
-  const mediaUrl = opts.mediaUrl?.trim();
-  const replyMarkup = buildInlineKeyboard(opts.buttons);
 
   const threadParams = buildTelegramThreadReplyParams({
     targetMessageThreadId: target.messageThreadId,


### PR DESCRIPTION
## Summary
Fixes Telegram delivery behavior where a pure `NO_REPLY` sentinel could leak into channel output as visible text.

## What changed
- `src/telegram/send.ts`
  - Added an early guard in `sendMessageTelegram`:
    - if trimmed text is `NO_REPLY`
    - and there is no media
    - and there are no inline buttons
    - then suppress delivery before hitting Telegram API.
- `src/telegram/send.test.ts`
  - Added test: `suppresses NO_REPLY token before Telegram API call`.

## Why
`NO_REPLY` is a control sentinel used to indicate silent completion. It should never be sent as user-visible content.

## Verification
- `pnpm test src/telegram/send.test.ts` ✅
- `pnpm check` ✅

Closes #36811
