### PR TITLE
CLI: return final cron entry for --expect-final

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -159,7 +159,7 @@ async function expectCronEditWithScheduleLookupExit(
 async function runCronRunAndCaptureExit(params: { ran: boolean; args?: string[] }) {
   resetGatewayMock();
   callGatewayFromCli.mockImplementation(
-    async (method: string, _opts: unknown, callParams?: unknown) => {
+    async (method: string, _opts: unknown, callParams?: unknown, _extra?: unknown) => {
       if (method === "cron.status") {
         return { enabled: true };
       }
@@ -188,6 +188,47 @@ async function runCronRunAndCaptureExit(params: { ran: boolean; args?: string[] 
   };
 }
 
+async function runCronRunExpectFinalAndCapture(params: {
+  triggerRequestedAtMs: number;
+  finalEntry: { action: string; runAtMs: number; status: string; summary?: string };
+}) {
+  resetGatewayMock();
+  callGatewayFromCli.mockImplementation(
+    async (method: string, _opts: unknown, callParams?: unknown, _extra?: unknown) => {
+      if (method === "cron.status") {
+        return { enabled: true };
+      }
+      if (method === "cron.run") {
+        return { ok: true, params: callParams, ran: true };
+      }
+      if (method === "cron.runs") {
+        return { entries: [params.finalEntry] };
+      }
+      return { ok: true, params: callParams };
+    },
+  );
+
+  const runtimeModule = await import("../runtime.js");
+  const runtime = runtimeModule.defaultRuntime as {
+    exit: (code: number) => void;
+    log: (msg: string) => void;
+  };
+  const originalExit = runtime.exit;
+  const originalNow = Date.now;
+  const exitSpy = vi.fn();
+  const logSpy = vi.spyOn(runtime, "log");
+  runtime.exit = exitSpy;
+  vi.spyOn(Date, "now").mockImplementation(() => params.triggerRequestedAtMs);
+  try {
+    const program = buildProgram();
+    await program.parseAsync(["cron", "run", "job-1", "--expect-final"], { from: "user" });
+  } finally {
+    runtime.exit = originalExit;
+    Date.now = originalNow;
+  }
+  return { exitSpy, logSpy };
+}
+
 describe("cron cli", () => {
   it.each([
     {
@@ -203,6 +244,28 @@ describe("cron cli", () => {
   ])("$name", async ({ ran, expectedExitCode }) => {
     const { exitSpy } = await runCronRunAndCaptureExit({ ran });
     expect(exitSpy).toHaveBeenCalledWith(expectedExitCode);
+  });
+
+  it("prints the final run-log entry when cron run uses --expect-final", async () => {
+    const finalEntry = {
+      action: "finished",
+      runAtMs: 1_000,
+      status: "ok",
+      summary: "done",
+    };
+    const { exitSpy, logSpy } = await runCronRunExpectFinalAndCapture({
+      triggerRequestedAtMs: 1_000,
+      finalEntry,
+    });
+
+    expect(callGatewayFromCli).toHaveBeenCalledWith(
+      "cron.runs",
+      expect.objectContaining({ expectFinal: false }),
+      expect.objectContaining({ id: "job-1", limit: 20 }),
+      expect.objectContaining({ expectFinal: false }),
+    );
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(finalEntry, null, 2));
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
   it("trims model and thinking on cron add", { timeout: CRON_CLI_TEST_TIMEOUT_MS }, async () => {

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -4,6 +4,67 @@ import { defaultRuntime } from "../../runtime.js";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
 import { warnIfCronSchedulerDisabled } from "./shared.js";
 
+type CronRunTriggerResult = {
+  ok?: boolean;
+  ran?: boolean;
+};
+
+type CronRunsEntry = {
+  action?: string;
+  runAtMs?: number;
+  status?: string;
+};
+
+type CronRunsResult = {
+  entries?: CronRunsEntry[];
+};
+
+function parseTimeoutMs(raw: string | undefined, fallbackMs: number): number {
+  const parsed = Number.parseInt(String(raw ?? fallbackMs), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallbackMs;
+}
+
+export async function waitForCronRunFinalEntry(
+  id: string,
+  opts: { timeout?: string; expectFinal?: boolean; json?: boolean; url?: string; token?: string },
+  triggerRequestedAtMs: number,
+): Promise<CronRunsEntry | null> {
+  const timeoutMs = parseTimeoutMs(opts.timeout, 600_000);
+  const deadline = Date.now() + timeoutMs;
+  const pollOpts = {
+    ...opts,
+    expectFinal: false,
+  };
+
+  while (Date.now() <= deadline) {
+    const remainingMs = Math.max(1_000, deadline - Date.now());
+    pollOpts.timeout = String(Math.min(10_000, remainingMs));
+    const runsRes = (await callGatewayFromCli(
+      "cron.runs",
+      pollOpts,
+      {
+        id,
+        limit: 20,
+      },
+      { expectFinal: false },
+    )) as CronRunsResult;
+    const entries = Array.isArray(runsRes?.entries) ? runsRes.entries : [];
+    const match =
+      entries.find(
+        (entry) =>
+          entry?.action === "finished" &&
+          typeof entry?.runAtMs === "number" &&
+          entry.runAtMs >= triggerRequestedAtMs - 1_000,
+      ) ?? null;
+    if (match) {
+      return match;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+
+  return null;
+}
+
 function registerCronToggleCommand(params: {
   cron: Command;
   name: "enable" | "disable";
@@ -98,12 +159,24 @@ export function registerCronSimpleCommands(cron: Command) {
           if (command.getOptionValueSource("timeout") === "default") {
             opts.timeout = "600000";
           }
+          const triggerRequestedAtMs = Date.now();
           const res = await callGatewayFromCli("cron.run", opts, {
             id,
             mode: opts.due ? "due" : "force",
           });
+          const result = res as CronRunTriggerResult | undefined;
+          if (opts.expectFinal && result?.ok && result?.ran) {
+            const finalEntry = await waitForCronRunFinalEntry(id, opts, triggerRequestedAtMs);
+            if (!finalEntry) {
+              defaultRuntime.error(danger(`Timed out waiting for final cron result for job ${id}`));
+              defaultRuntime.exit(1);
+              return;
+            }
+            defaultRuntime.log(JSON.stringify(finalEntry, null, 2));
+            defaultRuntime.exit(finalEntry.status === "ok" ? 0 : 1);
+            return;
+          }
           defaultRuntime.log(JSON.stringify(res, null, 2));
-          const result = res as { ok?: boolean; ran?: boolean } | undefined;
           defaultRuntime.exit(result?.ok && result?.ran ? 0 : 1);
         } catch (err) {
           defaultRuntime.error(danger(String(err)));


### PR DESCRIPTION
## Summary
- make `openclaw cron run --expect-final` poll `cron.runs` until the matching terminal entry is available
- print that final run entry instead of stopping at the initial `{ ok, ran }` acknowledgment
- add a CLI regression test covering the `--expect-final` polling path

## Why
Manual cron debugging is much more useful when the command returns the finished run record directly. Without this, operators have to trigger a run and then make a second call to inspect the result.

## Testing
- AI-assisted: Codex
- Verified locally against a linked `openclaw` checkout by running `openclaw cron run <jobId> --expect-final --timeout 120000` and confirming it returned the finished run entry
- `npx -y pnpm vitest run --config vitest.unit.config.ts src/cli/cron-cli.test.ts`
- `npx -y pnpm check` still fails on pre-existing formatting issues in `extensions/feishu/src/bot.ts` and `extensions/feishu/src/feishu-command-handler.ts`
