### PR TITLE
Telegram: prevent self-message reply loops

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1392,6 +1392,14 @@ export const registerTelegramHandlers = ({
       if (event.ctx.me?.id != null && event.msg.from?.id === event.ctx.me.id) {
         return;
       }
+      // Channel posts often omit from.id and only expose sender_chat/chat identity.
+      // Use sent-message tracking to skip self-authored echoes in those cases.
+      if (
+        typeof event.msg.message_id === "number" &&
+        wasSentByBot(event.chatId, event.msg.message_id)
+      ) {
+        return;
+      }
       const eventAuthContext = await resolveTelegramEventAuthorizationContext({
         chatId: event.chatId,
         isGroup: event.isGroup,

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -1387,6 +1387,11 @@ export const registerTelegramHandlers = ({
       if (shouldSkipUpdate(event.ctxForDedupe)) {
         return;
       }
+      // Prevent self-reply loops by ignoring messages authored by this bot.
+      // Keep this self-only (not all bots) so bot-to-bot/channel workflows still work.
+      if (event.ctx.me?.id != null && event.msg.from?.id === event.ctx.me.id) {
+        return;
+      }
       const eventAuthContext = await resolveTelegramEventAuthorizationContext({
         chatId: event.chatId,
         isGroup: event.isGroup,

--- a/src/telegram/bot.create-telegram-bot.test.ts
+++ b/src/telegram/bot.create-telegram-bot.test.ts
@@ -28,6 +28,7 @@ import {
   setMyCommandsSpy,
   throttlerSpy,
   useSpy,
+  wasSentByBot,
 } from "./bot.create-telegram-bot.test-harness.js";
 import { createTelegramBot, getTelegramSequentialKey } from "./bot.js";
 import { resolveTelegramFetch } from "./fetch.js";
@@ -492,6 +493,44 @@ describe("createTelegramBot", () => {
       getFile: async () => ({}),
     });
     expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips self-authored channel_post echoes tracked by sent-message cache", async () => {
+    loadConfig.mockReturnValue({
+      channels: {
+        telegram: {
+          dmPolicy: "open",
+          allowFrom: ["*"],
+          groupPolicy: "open",
+          groups: {
+            "-100777111222": {
+              enabled: true,
+              requireMention: false,
+            },
+          },
+        },
+      },
+    });
+    wasSentByBot.mockReturnValueOnce(true);
+
+    createTelegramBot({ token: "tok" });
+    const channelPostHandler = getOnHandler("channel_post") as (
+      ctx: Record<string, unknown>,
+    ) => Promise<void>;
+
+    await channelPostHandler({
+      channelPost: {
+        chat: { id: -100777111222, type: "channel", title: "Wake Channel" },
+        message_id: 888,
+        text: "self echo",
+        date: 1736380800,
+      },
+      me: { id: 999, username: "openclaw_bot" },
+      getFile: async () => ({}),
+    });
+
+    expect(wasSentByBot).toHaveBeenCalledWith(-100777111222, 888);
+    expect(replySpy).not.toHaveBeenCalled();
   });
 
   it("does not persist update offset past pending updates", async () => {

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -518,6 +518,60 @@ describe("createTelegramBot", () => {
     expect(payload.SenderUsername).toBe("ada");
   });
 
+  it("ignores inbound messages authored by the bot itself", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 42, type: "private" },
+        text: "self ping",
+        date: 1736380800,
+        message_id: 3,
+        from: {
+          id: 999,
+          is_bot: true,
+          first_name: "OpenClaw",
+          username: "openclaw_bot",
+        },
+      },
+      me: { id: 999, username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).not.toHaveBeenCalled();
+  });
+
+  it("still handles inbound messages from other bots", async () => {
+    onSpy.mockClear();
+    replySpy.mockClear();
+
+    createTelegramBot({ token: "tok" });
+    const handler = getOnHandler("message") as (ctx: Record<string, unknown>) => Promise<void>;
+
+    await handler({
+      message: {
+        chat: { id: 42, type: "private" },
+        text: "foreign bot ping",
+        date: 1736380800,
+        message_id: 4,
+        from: {
+          id: 1001,
+          is_bot: true,
+          first_name: "WakeBot",
+          username: "wake_bot",
+        },
+      },
+      me: { id: 999, username: "openclaw_bot" },
+      getFile: async () => ({ download: async () => new Uint8Array() }),
+    });
+
+    expect(replySpy).toHaveBeenCalledTimes(1);
+  });
+
   it("uses quote text when a Telegram partial reply is received", async () => {
     onSpy.mockClear();
     sendMessageSpy.mockClear();
@@ -1243,6 +1297,7 @@ describe("createTelegramBot", () => {
     expect(sendMessageSpy).toHaveBeenCalledWith(
       12345,
       "You are not authorized to use this command.",
+      expect.any(Object),
     );
   });
 

--- a/src/telegram/bot.test.ts
+++ b/src/telegram/bot.test.ts
@@ -1297,7 +1297,7 @@ describe("createTelegramBot", () => {
     expect(sendMessageSpy).toHaveBeenCalledWith(
       12345,
       "You are not authorized to use this command.",
-      expect.any(Object),
+      {},
     );
   });
 


### PR DESCRIPTION
## Summary
- prevent Telegram self-reply loops by skipping inbound updates authored by the current bot account
- keep behavior self-only (do not block other bots) so channel/bot workflows continue to work
- add regression tests for self-bot skip and foreign-bot allow behavior

## Testing
- pnpm test src/telegram/bot.test.ts

Fixes #37136
