### PR TITLE
fix: use canonical sessionKey in chat broadcasts to fix TUI filtering

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -929,7 +929,7 @@ export const chatHandlers: GatewayRequestHandlers = {
             broadcastChatFinal({
               context,
               runId: clientRunId,
-              sessionKey: rawSessionKey,
+              sessionKey,
               message,
             });
           }
@@ -954,7 +954,7 @@ export const chatHandlers: GatewayRequestHandlers = {
           broadcastChatError({
             context,
             runId: clientRunId,
-            sessionKey: rawSessionKey,
+            sessionKey,
             errorMessage: String(err),
           });
         })
@@ -1000,7 +1000,7 @@ export const chatHandlers: GatewayRequestHandlers = {
 
     // Load session to find transcript file
     const rawSessionKey = p.sessionKey;
-    const { cfg, storePath, entry } = loadSessionEntry(rawSessionKey);
+    const { cfg, storePath, entry, canonicalKey: sessionKey } = loadSessionEntry(rawSessionKey);
     const sessionId = entry?.sessionId;
     if (!sessionId || !storePath) {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "session not found"));
@@ -1031,7 +1031,7 @@ export const chatHandlers: GatewayRequestHandlers = {
     // Broadcast to webchat for immediate UI update
     const chatPayload = {
       runId: `inject-${appended.messageId}`,
-      sessionKey: rawSessionKey,
+      sessionKey,
       seq: 0,
       state: "final" as const,
       message: stripInlineDirectiveTagsFromMessageForDisplay(
@@ -1039,7 +1039,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       ),
     };
     context.broadcast("chat", chatPayload);
-    context.nodeSendToSession(rawSessionKey, "chat", chatPayload);
+    context.nodeSendToSession(sessionKey, "chat", chatPayload);
 
     respond(true, { ok: true, messageId: appended.messageId });
   },


### PR DESCRIPTION
## Issue
Fixes #37168

## Problem
TUI was filtering out all assistant replies because Gateway broadcast events with `rawSessionKey` while TUI filtered using `canonicalKey` (normalized sessionKey).

This caused `evt.sessionKey !== state.currentSessionKey` to filter out all assistant messages.

## Solution
Modified `src/gateway/server-methods/chat.ts` to use `canonicalKey` in 3 broadcast locations:
1. `broadcastChatFinal` - use `sessionKey` instead of `rawSessionKey`
2. `broadcastChatError` - use `sessionKey` instead of `rawSessionKey`  
3. `chat.inject` - extract `canonicalKey` and use it in `broadcast` and `nodeSendToSession`

## Testing
- ✅ Build passes
- ✅ Code follows existing patterns in the file

## Changes
- 1 file changed, 5 insertions(+), 5 deletions(-)