### PR TITLE
fix(telegram): ignore non-numeric replyToMessageId

### DIFF
--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -1310,6 +1310,27 @@ describe("sendStickerTelegram", () => {
 });
 
 describe("shared send behaviors", () => {
+  it("ignores non-numeric replyToMessageId and sends without reply target", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 57,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "reply text", {
+      token: "tok",
+      api,
+      replyToMessageId: Number.NaN,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "reply text", {
+      parse_mode: "HTML",
+    });
+  });
+
   it("includes reply_to_message_id for threaded replies", async () => {
     const cases = [
       {
@@ -1361,6 +1382,27 @@ describe("shared send behaviors", () => {
     for (const testCase of cases) {
       await testCase.run();
     }
+  });
+
+  it("omits reply_to_message_id when replyToMessageId is non-numeric", async () => {
+    const chatId = "123";
+    const sendMessage = vi.fn().mockResolvedValue({
+      message_id: 56,
+      chat: { id: chatId },
+    });
+    const api = { sendMessage } as unknown as {
+      sendMessage: typeof sendMessage;
+    };
+
+    await sendMessageTelegram(chatId, "reply text", {
+      token: "tok",
+      api,
+      replyToMessageId: Number.NaN,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith(chatId, "reply text", {
+      parse_mode: "HTML",
+    });
   });
 
   it("wraps chat-not-found with actionable context", async () => {

--- a/src/telegram/send.test.ts
+++ b/src/telegram/send.test.ts
@@ -1310,27 +1310,6 @@ describe("sendStickerTelegram", () => {
 });
 
 describe("shared send behaviors", () => {
-  it("ignores non-numeric replyToMessageId and sends without reply target", async () => {
-    const chatId = "123";
-    const sendMessage = vi.fn().mockResolvedValue({
-      message_id: 57,
-      chat: { id: chatId },
-    });
-    const api = { sendMessage } as unknown as {
-      sendMessage: typeof sendMessage;
-    };
-
-    await sendMessageTelegram(chatId, "reply text", {
-      token: "tok",
-      api,
-      replyToMessageId: Number.NaN,
-    });
-
-    expect(sendMessage).toHaveBeenCalledWith(chatId, "reply text", {
-      parse_mode: "HTML",
-    });
-  });
-
   it("includes reply_to_message_id for threaded replies", async () => {
     const cases = [
       {

--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -278,14 +278,19 @@ function buildTelegramThreadReplyParams(params: {
   const threadParams: Record<string, unknown> = threadIdParams ? { ...threadIdParams } : {};
 
   if (params.replyToMessageId != null) {
-    const replyToMessageId = Math.trunc(params.replyToMessageId);
-    if (params.quoteText?.trim()) {
-      threadParams.reply_parameters = {
-        message_id: replyToMessageId,
-        quote: params.quoteText.trim(),
-      };
-    } else {
-      threadParams.reply_to_message_id = replyToMessageId;
+    const replyToMessageIdRaw = Number(params.replyToMessageId);
+    const replyToMessageId = Number.isFinite(replyToMessageIdRaw)
+      ? Math.trunc(replyToMessageIdRaw)
+      : NaN;
+    if (Number.isFinite(replyToMessageId) && replyToMessageId > 0) {
+      if (params.quoteText?.trim()) {
+        threadParams.reply_parameters = {
+          message_id: replyToMessageId,
+          quote: params.quoteText.trim(),
+        };
+      } else {
+        threadParams.reply_to_message_id = replyToMessageId;
+      }
     }
   }
   return threadParams;


### PR DESCRIPTION
## What
Fix Telegram send behavior when `replyToMessageId` is non-numeric.

- In `src/telegram/send.ts`, only include `reply_to_message_id` / `reply_parameters.message_id` when the value is a finite positive integer.
- Otherwise, omit reply threading params and send normally.
- Add regression test in `src/telegram/send.test.ts` (`omits reply_to_message_id when replyToMessageId is non-numeric`).

## Why
In cross-surface/cross-channel flows, non-Telegram IDs (e.g. UUIDs) can leak into reply targeting. Without validation, this can produce Telegram API 400 errors (`message to be replied not found`) and fail delivery.

Closes #37220.

## Validation
- Added unit test for non-numeric value (`Number.NaN`) to ensure reply threading params are omitted.
- Local test execution was not run in this environment because repo dev dependencies are not installed (`vitest` missing).
