### PR TITLE
fix(plugins): add nativeModules to jiti loader to fix sqlite3/native addon binding resolution

### DIFF
--- a/src/plugin-sdk/root-alias.cjs
+++ b/src/plugin-sdk/root-alias.cjs
@@ -69,6 +69,7 @@ function getJiti() {
   const { createJiti } = require("jiti");
   jitiLoader = createJiti(__filename, {
     interopDefault: true,
+    nativeModules: ["typescript", "sqlite3", "better-sqlite3", "bindings"],
     extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
   });
   return jitiLoader;

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -579,6 +579,7 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
     };
     jitiLoader = createJiti(import.meta.url, {
       interopDefault: true,
+      nativeModules: ["typescript", "sqlite3", "better-sqlite3", "bindings"],
       extensions: [".ts", ".tsx", ".mts", ".cts", ".mtsx", ".ctsx", ".js", ".mjs", ".cjs", ".json"],
       ...(Object.keys(aliasMap).length > 0
         ? {


### PR DESCRIPTION
## Problem

Plugins that depend on native Node.js addons (e.g. `sqlite3`, `better-sqlite3`) fail to load when installed as TypeScript plugins through OpenClaw's jiti-based plugin loader. Users see:

```
Error: Could not locate the bindings file. Tried:
 → .../node_modules/sqlite3/build/Release/node_sqlite3.node
 → ...
```

Followed by:
```
SQLITE_CANTOPEN: unable to open database file
```

This affects any plugin using SQLite in open-source/self-hosted mode, including `openclaw-mem0` with Qdrant/local vector stores.

## Root Cause

Jiti's TypeScript loader intercepts `require()` calls and transforms modules through its own resolution pipeline. Native Node.js addons (`.node` files) use the `bindings` package to locate themselves relative to their build directory — but jiti's interception breaks the path resolution, so the `.node` binary is never found.

## Fix

Jiti provides a `nativeModules` option that tells it to bypass transformation for specified packages and fall through to Node's native `require()`. Adding `sqlite3`, `better-sqlite3`, `bindings`, and `typescript` to this list restores correct binding resolution.

**Files changed:**
- `src/plugins/loader.ts` — main plugin loader (ESM)
- `src/plugin-sdk/root-alias.cjs` — plugin SDK loader (CJS)

```ts
jitiLoader = createJiti(import.meta.url, {
  interopDefault: true,
  nativeModules: ["sqlite3", "better-sqlite3", "bindings", "typescript"],
  extensions: [...],
});
```

## Testing

Verified with `openclaw-mem0` v0.1.2 in open-source mode — plugin loads successfully and memory search/store works correctly after this fix.

---

> Discovered and debugged by **Ariel Tolome** while setting up the `openclaw-mem0` plugin with a self-hosted Qdrant backend.