### PR TITLE
fix: chat-bash ignores elevated defaultLevel, always prompts for approval

### DIFF
--- a/src/auto-reply/reply/bash-command.ts
+++ b/src/auto-reply/reply/bash-command.ts
@@ -185,6 +185,7 @@ export async function handleBashChatCommand(params: {
   elevated: {
     enabled: boolean;
     allowed: boolean;
+    defaultLevel?: "on" | "off" | "ask" | "full";
     failures: Array<{ gate: string; key: string }>;
   };
 }): Promise<ReplyPayload> {
@@ -346,7 +347,7 @@ export async function handleBashChatCommand(params: {
       elevated: {
         enabled: params.elevated.enabled,
         allowed: params.elevated.allowed,
-        defaultLevel: "on",
+        defaultLevel: params.elevated.defaultLevel ?? "on",
       },
     });
     const result = await execTool.execute("chat-bash", {

--- a/src/auto-reply/reply/commands-types.ts
+++ b/src/auto-reply/reply/commands-types.ts
@@ -35,6 +35,7 @@ export type HandleCommandsParams = {
   elevated: {
     enabled: boolean;
     allowed: boolean;
+    defaultLevel?: ElevatedLevel;
     failures: Array<{ gate: string; key: string }>;
   };
   sessionEntry?: SessionEntry;

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -342,6 +342,7 @@ export async function handleInlineActions(params: {
       elevated: {
         enabled: elevatedEnabled,
         allowed: elevatedAllowed,
+        defaultLevel: resolvedElevatedLevel,
         failures: elevatedFailures,
       },
       sessionEntry,


### PR DESCRIPTION
## Summary

- The chat-bash command handler (`handleBashChatCommand` in `src/auto-reply/reply/bash-command.ts`) hardcodes `defaultLevel: "on"` when creating the exec tool, ignoring the resolved elevated level from agent config (`agents.defaults.elevatedDefault`).
- This causes users who configure `elevatedDefault: "full"` to still be prompted for approval on every `!command` / `/bash` execution from messaging channels (Telegram, etc.), because `"on"` maps to `"ask"` mode where `bypassApprovals` is always `false`.
- The fix threads `defaultLevel` through the elevated params pipeline: `get-reply-inline-actions` → `commands-types` → `bash-command`, with a fallback to `"on"` to preserve existing behavior for callers that don't set a level.

### Root cause

In `bash-command.ts:349`:
```typescript
elevated: {
  enabled: params.elevated.enabled,
  allowed: params.elevated.allowed,
  defaultLevel: "on",  // ← hardcoded, ignores config
},
```

The `elevated` type in `commands-types.ts` and `bash-command.ts` did not include a `defaultLevel` field, so even though `resolvedElevatedLevel` was available in the calling scope (`get-reply-inline-actions.ts`), it was never passed through.

### Changes

1. **`commands-types.ts`**: Add optional `defaultLevel` to the `elevated` type in `HandleCommandsParams`
2. **`get-reply-inline-actions.ts`**: Pass `resolvedElevatedLevel` into the `elevated` object
3. **`bash-command.ts`**: Add `defaultLevel` to param type; use `params.elevated.defaultLevel ?? "on"` instead of hardcoded `"on"`

## Test plan

- [ ] Verify `pnpm build` passes (type-check)
- [ ] Set `agents.defaults.elevatedDefault: "full"` in config
- [ ] Send `!<command>` via Telegram → should execute without approval prompt
- [ ] Without `elevatedDefault` set → should still default to `"on"` (approval required), preserving backward compatibility