### PR TITLE
docs(memory): recommend STATUS.md TTL layer to avoid stale facts

### DIFF
--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -51,22 +51,27 @@ tool call in try/catch logic.
 
 ## Durable facts vs time-bounded status (TTL)
 
-OpenClaw memory is plain Markdown, but Markdown files are "timeless" by default. In practice, teams often mix durable facts (identity, preferences, long-term decisions) with short-lived status ("departs tomorrow", current location, project stage). Without an explicit time dimension, agents can mistakenly treat stale status as current truth.
+OpenClaw memory is plain Markdown, but Markdown files are "timeless" by default.
+In practice, teams often mix durable facts (identity, preferences, long-term decisions)
+with short-lived status ("departs tomorrow", current location, project stage). Without
+an explicit time dimension, agents can mistakenly treat stale status as current truth.
 
 **Best practice: split durable facts from time-bounded status.**
 
 - Keep `USER.md` for stable identity + preferences + collaboration protocol.
 - Keep `MEMORY.md` for curated, durable long-term memory.
-- Add a dedicated `STATUS.md` (or `NOW.md`) for time-sensitive state.
+- Add a dedicated `memory/STATUS.md` (or `memory/NOW.md`) for time-sensitive state.
 
-`STATUS.md` rules:
+`memory/STATUS.md` rules:
 
 - Every item should include `updatedAt` (YYYY-MM-DD) and a `review/expire` date (TTL).
 - Avoid relative time words like "tomorrow"/"next week"; use absolute dates.
 
 **Guardrail for time-sensitive inference (low-token):**
 
-Only when inferring/asserting facts about **time, location, itinerary/travel, or project stage**, prefer citing a fresh (unexpired) `STATUS.md` entry; otherwise ask one clarification question. This reduces stale-fact errors without requiring expensive full-history scans.
+Only when inferring/asserting facts about **time, location, itinerary/travel, or project stage**,
+prefer citing a fresh (unexpired) `memory/STATUS.md` entry; otherwise ask one clarification question.
+This reduces stale-fact errors without requiring expensive full-history scans.
 
 ## Automatic memory flush (pre-compaction ping)
 

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -49,6 +49,25 @@ tool call in try/catch logic.
 - This area is still evolving. It helps to remind the model to store memories; it will know what to do.
 - If you want something to stick, **ask the bot to write it** into memory.
 
+## Durable facts vs time-bounded status (TTL)
+
+OpenClaw memory is plain Markdown, but Markdown files are "timeless" by default. In practice, teams often mix durable facts (identity, preferences, long-term decisions) with short-lived status ("departs tomorrow", current location, project stage). Without an explicit time dimension, agents can mistakenly treat stale status as current truth.
+
+**Best practice: split durable facts from time-bounded status.**
+
+- Keep `USER.md` for stable identity + preferences + collaboration protocol.
+- Keep `MEMORY.md` for curated, durable long-term memory.
+- Add a dedicated `STATUS.md` (or `NOW.md`) for time-sensitive state.
+
+`STATUS.md` rules:
+
+- Every item should include `updatedAt` (YYYY-MM-DD) and a `review/expire` date (TTL).
+- Avoid relative time words like "tomorrow"/"next week"; use absolute dates.
+
+**Guardrail for time-sensitive inference (low-token):**
+
+Only when inferring/asserting facts about **time, location, itinerary/travel, or project stage**, prefer citing a fresh (unexpired) `STATUS.md` entry; otherwise ask one clarification question. This reduces stale-fact errors without requiring expensive full-history scans.
+
 ## Automatic memory flush (pre-compaction ping)
 
 When a session is **close to auto-compaction**, OpenClaw triggers a **silent,


### PR DESCRIPTION
PR: docs(memory): recommend STATUS.md TTL layer to avoid stale facts

Summary
Adds a short best-practice section to docs/concepts/memory.md explaining why durable markdown memory files can accumulate stale time-sensitive facts, and recommending a dedicated STATUS.md (TTL-aware) layer plus a narrow, low-token cross-validation guardrail.

Why
Without a time dimension, agents can treat outdated status (travel, deadlines, location, project stage) as current truth and produce incorrect outputs. This is a general issue for agentic workflows, not a single user’s edge case.

Changes
- docs/concepts/memory.md: Add “Durable facts vs time-bounded status (TTL)” section.

Notes
- This PR is documentation-only (no runtime behavior change).
