### PR TITLE
fix(sandbox): keep none workspaces writable

### DIFF
--- a/docs/gateway/sandboxing.md
+++ b/docs/gateway/sandboxing.md
@@ -58,7 +58,7 @@ Not sandboxed:
 
 `agents.defaults.sandbox.workspaceAccess` controls **what the sandbox can see**:
 
-- `"none"` (default): tools see a sandbox workspace under `~/.openclaw/sandboxes`.
+- `"none"` (default): tools see a writable sandbox workspace under `~/.openclaw/sandboxes`; the agent workspace stays off-limits.
 - `"ro"`: mounts the agent workspace read-only at `/agent` (disables `write`/`edit`/`apply_patch`).
 - `"rw"`: mounts the agent workspace read/write at `/workspace`.
 

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -305,7 +305,7 @@ Notes:
 - The default prompt/system prompt include a `NO_REPLY` hint to suppress delivery.
 - The flush runs once per compaction cycle (tracked in `sessions.json`).
 - The flush runs only for embedded Pi sessions (CLI backends skip it).
-- The flush is skipped when the session workspace is read-only (`workspaceAccess: "ro"` or `"none"`).
+- The flush is skipped when the session workspace is read-only (`workspaceAccess: "ro"`).
 - See [Memory](/concepts/memory) for the workspace file layout and write patterns.
 
 Pi also exposes a `session_before_compact` hook in the extension API, but OpenClaw’s

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-d.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-d.test.ts
@@ -90,4 +90,21 @@ describe("createOpenClawCodingTools", () => {
     expect(tools.some((tool) => tool.name === "write")).toBe(false);
     expect(tools.some((tool) => tool.name === "edit")).toBe(false);
   });
+
+  it("keeps write/edit available when workspaceAccess is none", () => {
+    const sandboxDir = path.join(os.tmpdir(), "moltbot-sandbox");
+    const sandbox = createPiToolsSandboxContext({
+      workspaceDir: sandboxDir,
+      agentWorkspaceDir: path.join(os.tmpdir(), "moltbot-workspace"),
+      workspaceAccess: "none" as const,
+      fsBridge: createHostSandboxFsBridge(sandboxDir),
+      tools: {
+        allow: ["read", "write", "edit"],
+        deny: [],
+      },
+    });
+    const tools = createOpenClawCodingTools({ sandbox });
+    expect(tools.some((tool) => tool.name === "write")).toBe(true);
+    expect(tools.some((tool) => tool.name === "edit")).toBe(true);
+  });
 });

--- a/src/agents/sandbox/browser.create.test.ts
+++ b/src/agents/sandbox/browser.create.test.ts
@@ -172,7 +172,7 @@ describe("ensureSandboxBrowser create args", () => {
     expect(result?.noVncUrl).toBeUndefined();
   });
 
-  it("mounts the main workspace read-only when workspaceAccess is none", async () => {
+  it("keeps the isolated sandbox workspace writable when workspaceAccess is none", async () => {
     const cfg = buildConfig(false);
     cfg.workspaceAccess = "none";
 
@@ -186,7 +186,8 @@ describe("ensureSandboxBrowser create args", () => {
     const createArgs = findDockerArgsCall(dockerMocks.execDocker.mock.calls, "create");
 
     expect(createArgs).toBeDefined();
-    expect(createArgs).toContain("/tmp/workspace:/workspace:ro");
+    expect(createArgs).toContain("/tmp/workspace:/workspace");
+    expect(createArgs).not.toContain("/tmp/workspace:/workspace:ro");
   });
 
   it("keeps the main workspace writable when workspaceAccess is rw", async () => {

--- a/src/agents/sandbox/docker.config-hash-recreate.test.ts
+++ b/src/agents/sandbox/docker.config-hash-recreate.test.ts
@@ -248,7 +248,7 @@ describe("ensureSandboxContainer config-hash recreation", () => {
   it.each([
     { workspaceAccess: "rw" as const, expectedMainMount: "/tmp/workspace:/workspace" },
     { workspaceAccess: "ro" as const, expectedMainMount: "/tmp/workspace:/workspace:ro" },
-    { workspaceAccess: "none" as const, expectedMainMount: "/tmp/workspace:/workspace:ro" },
+    { workspaceAccess: "none" as const, expectedMainMount: "/tmp/workspace:/workspace" },
   ])(
     "uses expected main mount permissions when workspaceAccess=$workspaceAccess",
     async ({ workspaceAccess, expectedMainMount }) => {

--- a/src/agents/sandbox/fs-bridge.test.ts
+++ b/src/agents/sandbox/fs-bridge.test.ts
@@ -1,0 +1,364 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./docker.js", () => ({
+  execDockerRaw: vi.fn(),
+}));
+
+vi.mock("../../infra/boundary-file-read.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../infra/boundary-file-read.js")>();
+  return {
+    ...actual,
+    openBoundaryFile: vi.fn(actual.openBoundaryFile),
+  };
+});
+
+import { openBoundaryFile } from "../../infra/boundary-file-read.js";
+import { execDockerRaw } from "./docker.js";
+import { createSandboxFsBridge } from "./fs-bridge.js";
+import { createSandboxTestContext } from "./test-fixtures.js";
+import type { SandboxContext } from "./types.js";
+
+const mockedExecDockerRaw = vi.mocked(execDockerRaw);
+const mockedOpenBoundaryFile = vi.mocked(openBoundaryFile);
+const DOCKER_SCRIPT_INDEX = 5;
+const DOCKER_FIRST_SCRIPT_ARG_INDEX = 7;
+
+function getDockerScript(args: string[]): string {
+  return String(args[DOCKER_SCRIPT_INDEX] ?? "");
+}
+
+function getDockerArg(args: string[], position: number): string {
+  return String(args[DOCKER_FIRST_SCRIPT_ARG_INDEX + position - 1] ?? "");
+}
+
+function getDockerPathArg(args: string[]): string {
+  return getDockerArg(args, 1);
+}
+
+function getScriptsFromCalls(): string[] {
+  return mockedExecDockerRaw.mock.calls.map(([args]) => getDockerScript(args));
+}
+
+function findCallByScriptFragment(fragment: string) {
+  return mockedExecDockerRaw.mock.calls.find(([args]) => getDockerScript(args).includes(fragment));
+}
+
+function dockerExecResult(stdout: string) {
+  return {
+    stdout: Buffer.from(stdout),
+    stderr: Buffer.alloc(0),
+    code: 0,
+  };
+}
+
+function createSandbox(overrides?: Partial<SandboxContext>): SandboxContext {
+  return createSandboxTestContext({
+    overrides: {
+      containerName: "moltbot-sbx-test",
+      ...overrides,
+    },
+    dockerOverrides: {
+      image: "moltbot-sandbox:bookworm-slim",
+      containerPrefix: "moltbot-sbx-",
+    },
+  });
+}
+
+async function withTempDir<T>(prefix: string, run: (stateDir: string) => Promise<T>): Promise<T> {
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  try {
+    return await run(stateDir);
+  } finally {
+    await fs.rm(stateDir, { recursive: true, force: true });
+  }
+}
+
+function installDockerReadMock(params?: { canonicalPath?: string }) {
+  const canonicalPath = params?.canonicalPath;
+  mockedExecDockerRaw.mockImplementation(async (args) => {
+    const script = getDockerScript(args);
+    if (script.includes('readlink -f -- "$cursor"')) {
+      return dockerExecResult(`${canonicalPath ?? getDockerArg(args, 1)}\n`);
+    }
+    if (script.includes('stat -c "%F|%s|%Y"')) {
+      return dockerExecResult("regular file|1|2");
+    }
+    if (script.includes('cat -- "$1"')) {
+      return dockerExecResult("content");
+    }
+    if (script.includes("mktemp")) {
+      return dockerExecResult("/workspace/.openclaw-write-b.txt.ABC123\n");
+    }
+    return dockerExecResult("");
+  });
+}
+
+async function createHostEscapeFixture(stateDir: string) {
+  const workspaceDir = path.join(stateDir, "workspace");
+  const outsideDir = path.join(stateDir, "outside");
+  const outsideFile = path.join(outsideDir, "secret.txt");
+  await fs.mkdir(workspaceDir, { recursive: true });
+  await fs.mkdir(outsideDir, { recursive: true });
+  await fs.writeFile(outsideFile, "classified");
+  return { workspaceDir, outsideFile };
+}
+
+async function expectMkdirpAllowsExistingDirectory(params?: { forceBoundaryIoFallback?: boolean }) {
+  await withTempDir("openclaw-fs-bridge-mkdirp-", async (stateDir) => {
+    const workspaceDir = path.join(stateDir, "workspace");
+    const nestedDir = path.join(workspaceDir, "memory", "kemik");
+    await fs.mkdir(nestedDir, { recursive: true });
+
+    if (params?.forceBoundaryIoFallback) {
+      mockedOpenBoundaryFile.mockImplementationOnce(async () => ({
+        ok: false,
+        reason: "io",
+        error: Object.assign(new Error("EISDIR"), { code: "EISDIR" }),
+      }));
+    }
+
+    const bridge = createSandboxFsBridge({
+      sandbox: createSandbox({
+        workspaceDir,
+        agentWorkspaceDir: workspaceDir,
+      }),
+    });
+
+    await expect(bridge.mkdirp({ filePath: "memory/kemik" })).resolves.toBeUndefined();
+
+    const mkdirCall = findCallByScriptFragment('mkdir -p -- "$1"');
+    expect(mkdirCall).toBeDefined();
+    const mkdirPath = mkdirCall ? getDockerPathArg(mkdirCall[0]) : "";
+    expect(mkdirPath).toBe("/workspace/memory/kemik");
+  });
+}
+
+describe("sandbox fs bridge shell compatibility", () => {
+  beforeEach(() => {
+    mockedExecDockerRaw.mockClear();
+    mockedOpenBoundaryFile.mockClear();
+    installDockerReadMock();
+  });
+
+  it("uses POSIX-safe shell prologue in all bridge commands", async () => {
+    const bridge = createSandboxFsBridge({ sandbox: createSandbox() });
+
+    await bridge.readFile({ filePath: "a.txt" });
+    await bridge.writeFile({ filePath: "b.txt", data: "hello" });
+    await bridge.mkdirp({ filePath: "nested" });
+    await bridge.remove({ filePath: "b.txt" });
+    await bridge.rename({ from: "a.txt", to: "c.txt" });
+    await bridge.stat({ filePath: "c.txt" });
+
+    expect(mockedExecDockerRaw).toHaveBeenCalled();
+
+    const scripts = getScriptsFromCalls();
+    const executables = mockedExecDockerRaw.mock.calls.map(([args]) => args[3] ?? "");
+
+    expect(executables.every((shell) => shell === "sh")).toBe(true);
+    expect(scripts.every((script) => /set -eu[;\n]/.test(script))).toBe(true);
+    expect(scripts.some((script) => script.includes("pipefail"))).toBe(false);
+  });
+
+  it("resolveCanonicalContainerPath script is valid POSIX sh (no do; token)", async () => {
+    const bridge = createSandboxFsBridge({ sandbox: createSandbox() });
+
+    await bridge.readFile({ filePath: "a.txt" });
+
+    const scripts = getScriptsFromCalls();
+    const canonicalScript = scripts.find((script) => script.includes("allow_final"));
+    expect(canonicalScript).toBeDefined();
+    // "; " joining can create "do; cmd", which is invalid in POSIX sh.
+    expect(canonicalScript).not.toMatch(/\bdo;/);
+    // Keep command on the next line after "do" for POSIX-sh safety.
+    expect(canonicalScript).toMatch(/\bdo\n\s*parent=/);
+  });
+
+  it("reads inbound media-style filenames with triple-dash ids", async () => {
+    const bridge = createSandboxFsBridge({ sandbox: createSandbox() });
+    const inboundPath = "media/inbound/file_1095---f00a04a2-99a0-4d98-99b0-dfe61c5a4198.ogg";
+
+    await bridge.readFile({ filePath: inboundPath });
+
+    const readCall = findCallByScriptFragment('cat -- "$1"');
+    expect(readCall).toBeDefined();
+    const readPath = readCall ? getDockerPathArg(readCall[0]) : "";
+    expect(readPath).toContain("file_1095---");
+  });
+
+  it("resolves dash-leading basenames into absolute container paths", async () => {
+    const bridge = createSandboxFsBridge({ sandbox: createSandbox() });
+
+    await bridge.readFile({ filePath: "--leading.txt" });
+
+    const readCall = findCallByScriptFragment('cat -- "$1"');
+    expect(readCall).toBeDefined();
+    const readPath = readCall ? getDockerPathArg(readCall[0]) : "";
+    expect(readPath).toBe("/workspace/--leading.txt");
+  });
+
+  it("resolves bind-mounted absolute container paths for reads", async () => {
+    const sandbox = createSandbox({
+      docker: {
+        ...createSandbox().docker,
+        binds: ["/tmp/workspace-two:/workspace-two:ro"],
+      },
+    });
+    const bridge = createSandboxFsBridge({ sandbox });
+
+    await bridge.readFile({ filePath: "/workspace-two/README.md" });
+
+    const args = mockedExecDockerRaw.mock.calls.at(-1)?.[0] ?? [];
+    expect(args).toEqual(
+      expect.arrayContaining(["moltbot-sbx-test", "sh", "-c", 'set -eu; cat -- "$1"']),
+    );
+    expect(getDockerPathArg(args)).toBe("/workspace-two/README.md");
+  });
+
+  it("blocks writes into read-only bind mounts", async () => {
+    const sandbox = createSandbox({
+      docker: {
+        ...createSandbox().docker,
+        binds: ["/tmp/workspace-two:/workspace-two:ro"],
+      },
+    });
+    const bridge = createSandboxFsBridge({ sandbox });
+
+    await expect(
+      bridge.writeFile({ filePath: "/workspace-two/new.txt", data: "hello" }),
+    ).rejects.toThrow(/read-only/);
+    expect(mockedExecDockerRaw).not.toHaveBeenCalled();
+  });
+
+  it("writes via temp file + atomic rename (never direct truncation)", async () => {
+    const bridge = createSandboxFsBridge({ sandbox: createSandbox() });
+
+    await bridge.writeFile({ filePath: "b.txt", data: "hello" });
+
+    const scripts = getScriptsFromCalls();
+    expect(scripts.some((script) => script.includes('cat >"$1"'))).toBe(false);
+    expect(scripts.some((script) => script.includes('cat >"$tmp"'))).toBe(true);
+    expect(scripts.some((script) => script.includes('mv -f -- "$1" "$2"'))).toBe(true);
+  });
+
+  it("allows writes in the isolated sandbox workspace when workspaceAccess is none", async () => {
+    const bridge = createSandboxFsBridge({
+      sandbox: createSandbox({ workspaceAccess: "none" }),
+    });
+
+    await expect(bridge.writeFile({ filePath: "b.txt", data: "hello" })).resolves.toBeUndefined();
+
+    const scripts = getScriptsFromCalls();
+    expect(scripts.some((script) => script.includes('mv -f -- "$1" "$2"'))).toBe(true);
+  });
+
+  it("re-validates target before final rename and cleans temp file on failure", async () => {
+    mockedOpenBoundaryFile
+      .mockImplementationOnce(async () => ({ ok: false, reason: "path" }))
+      .mockImplementationOnce(async () => ({
+        ok: false,
+        reason: "validation",
+        error: new Error("Hardlinked path is not allowed"),
+      }));
+
+    const bridge = createSandboxFsBridge({ sandbox: createSandbox() });
+    await expect(bridge.writeFile({ filePath: "b.txt", data: "hello" })).rejects.toThrow(
+      /hardlinked path/i,
+    );
+
+    const scripts = getScriptsFromCalls();
+    expect(scripts.some((script) => script.includes("mktemp"))).toBe(true);
+    expect(scripts.some((script) => script.includes('mv -f -- "$1" "$2"'))).toBe(false);
+    expect(scripts.some((script) => script.includes('rm -f -- "$1"'))).toBe(true);
+  });
+
+  it("allows mkdirp for existing in-boundary subdirectories", async () => {
+    await expectMkdirpAllowsExistingDirectory();
+  });
+
+  it("allows mkdirp when boundary open reports io for an existing directory", async () => {
+    await expectMkdirpAllowsExistingDirectory({ forceBoundaryIoFallback: true });
+  });
+
+  it("rejects mkdirp when target exists as a file", async () => {
+    await withTempDir("openclaw-fs-bridge-mkdirp-file-", async (stateDir) => {
+      const workspaceDir = path.join(stateDir, "workspace");
+      const filePath = path.join(workspaceDir, "memory", "kemik");
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, "not a directory");
+
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+        }),
+      });
+
+      await expect(bridge.mkdirp({ filePath: "memory/kemik" })).rejects.toThrow(
+        /cannot create directories/i,
+      );
+      expect(mockedExecDockerRaw).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects pre-existing host symlink escapes before docker exec", async () => {
+    await withTempDir("openclaw-fs-bridge-", async (stateDir) => {
+      const { workspaceDir, outsideFile } = await createHostEscapeFixture(stateDir);
+      // File symlinks require SeCreateSymbolicLinkPrivilege on Windows.
+      if (process.platform === "win32") {
+        return;
+      }
+      await fs.symlink(outsideFile, path.join(workspaceDir, "link.txt"));
+
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+        }),
+      });
+
+      await expect(bridge.readFile({ filePath: "link.txt" })).rejects.toThrow(/Symlink escapes/);
+      expect(mockedExecDockerRaw).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects pre-existing host hardlink escapes before docker exec", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    await withTempDir("openclaw-fs-bridge-hardlink-", async (stateDir) => {
+      const { workspaceDir, outsideFile } = await createHostEscapeFixture(stateDir);
+      const hardlinkPath = path.join(workspaceDir, "link.txt");
+      try {
+        await fs.link(outsideFile, hardlinkPath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+          return;
+        }
+        throw err;
+      }
+
+      const bridge = createSandboxFsBridge({
+        sandbox: createSandbox({
+          workspaceDir,
+          agentWorkspaceDir: workspaceDir,
+        }),
+      });
+
+      await expect(bridge.readFile({ filePath: "link.txt" })).rejects.toThrow(/hardlink|sandbox/i);
+      expect(mockedExecDockerRaw).not.toHaveBeenCalled();
+    });
+  });
+
+  it("rejects container-canonicalized paths outside allowed mounts", async () => {
+    installDockerReadMock({ canonicalPath: "/etc/passwd" });
+
+    const bridge = createSandboxFsBridge({ sandbox: createSandbox() });
+    await expect(bridge.readFile({ filePath: "a.txt" })).rejects.toThrow(/escapes allowed mounts/i);
+    const scripts = getScriptsFromCalls();
+    expect(scripts.some((script) => script.includes('cat -- "$1"'))).toBe(false);
+  });
+});

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -335,7 +335,7 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
 }
 
 function allowsWrites(access: SandboxWorkspaceAccess): boolean {
-  return access === "rw";
+  return access !== "ro";
 }
 
 function coerceStatType(typeRaw?: string): "file" | "directory" | "other" {

--- a/src/agents/sandbox/fs-paths.test.ts
+++ b/src/agents/sandbox/fs-paths.test.ts
@@ -89,6 +89,19 @@ describe("resolveSandboxFsPathWithMounts", () => {
     expect(resolved.writable).toBe(true);
   });
 
+  it("keeps the sandbox workspace writable when workspaceAccess is none", () => {
+    const sandbox = createSandbox({ workspaceAccess: "none" });
+    const mounts = buildSandboxFsMounts(sandbox);
+    const resolved = resolveSandboxFsPathWithMounts({
+      filePath: "src/index.ts",
+      cwd: sandbox.workspaceDir,
+      defaultWorkspaceRoot: sandbox.workspaceDir,
+      defaultContainerRoot: sandbox.containerWorkdir,
+      mounts,
+    });
+    expect(resolved.writable).toBe(true);
+  });
+
   it("preserves legacy sandbox-root error for outside paths", () => {
     const sandbox = createSandbox();
     const mounts = buildSandboxFsMounts(sandbox);

--- a/src/agents/sandbox/fs-paths.ts
+++ b/src/agents/sandbox/fs-paths.ts
@@ -62,7 +62,7 @@ export function buildSandboxFsMounts(sandbox: SandboxContext): SandboxFsMount[] 
     {
       hostRoot: path.resolve(sandbox.workspaceDir),
       containerRoot: normalizeContainerPath(sandbox.containerWorkdir),
-      writable: sandbox.workspaceAccess === "rw",
+      writable: sandbox.workspaceAccess !== "ro",
       source: "workspace",
     },
   ];

--- a/src/agents/sandbox/workspace-mounts.test.ts
+++ b/src/agents/sandbox/workspace-mounts.test.ts
@@ -5,7 +5,7 @@ describe("appendWorkspaceMountArgs", () => {
   it.each([
     { access: "rw" as const, expected: "/tmp/workspace:/workspace" },
     { access: "ro" as const, expected: "/tmp/workspace:/workspace:ro" },
-    { access: "none" as const, expected: "/tmp/workspace:/workspace:ro" },
+    { access: "none" as const, expected: "/tmp/workspace:/workspace" },
   ])("sets main mount permissions for workspaceAccess=$access", ({ access, expected }) => {
     const args: string[] = [];
     appendWorkspaceMountArgs({
@@ -30,7 +30,7 @@ describe("appendWorkspaceMountArgs", () => {
     });
 
     const mounts = args.filter((arg) => arg.startsWith("/tmp/"));
-    expect(mounts).toEqual(["/tmp/workspace:/workspace:ro"]);
+    expect(mounts).toEqual(["/tmp/workspace:/workspace"]);
   });
 
   it("omits agent workspace mount when paths are identical", () => {

--- a/src/agents/sandbox/workspace-mounts.ts
+++ b/src/agents/sandbox/workspace-mounts.ts
@@ -2,7 +2,9 @@ import { SANDBOX_AGENT_WORKSPACE_MOUNT } from "./constants.js";
 import type { SandboxWorkspaceAccess } from "./types.js";
 
 function mainWorkspaceMountSuffix(access: SandboxWorkspaceAccess): "" | ":ro" {
-  return access === "rw" ? "" : ":ro";
+  // `none` uses an isolated sandbox workspace at /workspace, so only `ro`
+  // should force the primary /workspace mount read-only.
+  return access === "ro" ? ":ro" : "";
 }
 
 function agentWorkspaceMountSuffix(access: SandboxWorkspaceAccess): "" | ":ro" {

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -279,7 +279,7 @@ export async function runMemoryFlushIfNeeded(params: {
       return true;
     }
     const sandboxCfg = resolveSandboxConfigForAgent(params.cfg, runtime.agentId);
-    return sandboxCfg.workspaceAccess === "rw";
+    return sandboxCfg.workspaceAccess !== "ro";
   })();
 
   const isCli = isCliProvider(params.followupRun.run.provider, params.cfg);

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1704,6 +1704,61 @@ describe("runReplyAgent memory flush", () => {
     });
   });
 
+  it("still runs memory flush when sandbox workspaceAccess is none", async () => {
+    await withTempStore(async (storePath) => {
+      const sessionKey = "main";
+      const sessionEntry = {
+        sessionId: "session",
+        updatedAt: Date.now(),
+        totalTokens: 80_000,
+        compactionCount: 1,
+      };
+
+      await seedSessionStore({ storePath, sessionKey, entry: sessionEntry });
+
+      const calls: Array<{ prompt?: string }> = [];
+      state.runEmbeddedPiAgentMock.mockImplementation(async (params: EmbeddedRunParams) => {
+        calls.push({ prompt: params.prompt });
+        if (params.prompt?.includes("Pre-compaction memory flush.")) {
+          return { payloads: [], meta: {} };
+        }
+        return {
+          payloads: [{ text: "ok" }],
+          meta: { agentMeta: { usage: { input: 1, output: 1 } } },
+        };
+      });
+
+      const baseRun = createBaseRun({
+        storePath,
+        sessionEntry,
+        config: {
+          agents: {
+            defaults: {
+              sandbox: {
+                mode: "all",
+                scope: "session",
+                workspaceAccess: "none",
+                workspaceRoot: "~/.openclaw/sandboxes",
+              },
+            },
+          },
+        },
+      });
+
+      await runReplyAgentWithBase({
+        baseRun,
+        storePath,
+        sessionKey,
+        sessionEntry,
+        commandBody: "hello",
+      });
+
+      expect(calls).toHaveLength(2);
+      expect(calls[0]?.prompt).toContain("Pre-compaction memory flush.");
+      expect(calls[1]?.prompt).toBe("hello");
+    });
+  });
+
   it("runs memory flush when transcript fallback uses a relative sessionFile path", async () => {
     await withTempStore(async (storePath) => {
       const sessionKey = "main";


### PR DESCRIPTION
## Summary
- restore `workspaceAccess: "none"` so sandbox sessions keep a writable isolated `/workspace` instead of inheriting read-only behavior from `ro`
- align sandbox mounts, fs bridge, and memory flush gating so `none` means isolated-but-writable while `ro` remains the only read-only mode
- add regression coverage for mounts, write/edit tool availability, fs bridge writes, and memory flush behavior

## Test plan
- [x] `pnpm test src/agents/sandbox/workspace-mounts.test.ts src/agents/sandbox/browser.create.test.ts src/agents/sandbox/fs-paths.test.ts src/agents/sandbox/fs-bridge.test.ts src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping-d.test.ts src/agents/sandbox/docker.config-hash-recreate.test.ts`
- [x] `pnpm exec vitest run --config vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`