### PR TITLE
Config: add immutable operator policy overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Docs: https://docs.openclaw.ai
 - Slack/DM typing feedback: add `channels.slack.typingReaction` so Socket Mode DMs can show reaction-based processing status even when Slack native assistant typing is unavailable. (#19816) Thanks @dalefrieswthat.
 - Exec/process interactive recovery: add `process attach` plus input-wait metadata/hints (`waitingForInput`, `idleMs`, `stdinWritable`) so long-running interactive sessions can be observed and resumed without losing context. Fixes #33957. Thanks @westoque.
 - Skills/nano-banana-pro: accept public `http(s)` input images for edit/composition while keeping local path support, and return explicit errors for redirects, `file://`, and private-network URLs. Fixes #33960. Thanks @westoque and @vincentkoc.
+- Config/operator policy: add an immutable `operator-policy.json5` overlay that locks configured paths above mutable config, rejects conflicting `config set/patch/apply` writes, and surfaces the active policy in `status --all` and `openclaw doctor`. Fixes #33958. Thanks @vincentkoc.
 
 ### Fixes
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -106,6 +106,7 @@ export async function doctorCommand(
   const sourceConfigValid = configResult.sourceConfigValid ?? true;
 
   const configPath = configResult.path ?? CONFIG_PATH;
+  const configSnapshot = await readConfigFileSnapshot().catch(() => null);
   if (!cfg.gateway?.mode) {
     const lines = [
       "gateway.mode is unset; gateway start will be blocked.",
@@ -191,6 +192,23 @@ export async function doctorCommand(
   }
 
   await noteStateIntegrity(cfg, prompter, configResult.path ?? CONFIG_PATH);
+  const operatorPolicy = configSnapshot?.policy;
+  if (operatorPolicy?.exists) {
+    const lines = operatorPolicy.valid
+      ? [
+          `- Active: ${shortenHomePath(operatorPolicy.path)}`,
+          `- Locked paths: ${operatorPolicy.lockedPaths.length}`,
+          `- Config edits cannot weaken values enforced by this file.`,
+        ]
+      : [
+          `- Invalid operator policy: ${shortenHomePath(operatorPolicy.path)}`,
+          ...operatorPolicy.issues.map((issue) => {
+            const pathLabel = issue.path || "<root>";
+            return `- ${pathLabel}: ${issue.message}`;
+          }),
+        ];
+    note(lines.join("\n"), "Operator policy");
+  }
   await noteSessionLockHealth({ shouldRepair: prompter.shouldRepair });
 
   cfg = await maybeRepairSandboxImages(cfg, runtime, prompter);

--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -266,6 +266,18 @@ export async function statusAllCommand(
     ).length;
 
     const overviewRows = [
+      (() => {
+        const operatorPolicy = snap?.policy;
+        if (!operatorPolicy?.exists) {
+          return { Item: "Operator policy", Value: "not configured" };
+        }
+        return {
+          Item: "Operator policy",
+          Value: operatorPolicy.valid
+            ? `${operatorPolicy.path} · ${operatorPolicy.lockedPaths.length} locked path${operatorPolicy.lockedPaths.length === 1 ? "" : "s"}`
+            : `${operatorPolicy.path} · invalid`,
+        };
+      })(),
       { Item: "Version", Value: VERSION },
       { Item: "OS", Value: osSummary.label },
       { Item: "Node", Value: process.versions.node },

--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -43,7 +43,12 @@ import { findLegacyConfigIssues } from "./legacy.js";
 import { applyMergePatch } from "./merge-patch.js";
 import { normalizeExecSafeBinProfilesInConfig } from "./normalize-exec-safe-bin.js";
 import { normalizeConfigPaths } from "./normalize-paths.js";
-import { resolveConfigPath, resolveDefaultConfigCandidates, resolveStateDir } from "./paths.js";
+import {
+  resolveConfigPath,
+  resolveDefaultConfigCandidates,
+  resolveOperatorPolicyPath,
+  resolveStateDir,
+} from "./paths.js";
 import { isBlockedObjectKey } from "./prototype-keys.js";
 import { applyConfigOverrides } from "./runtime-overrides.js";
 import type { OpenClawConfig, ConfigFileSnapshot, LegacyConfigIssue } from "./types.js";
@@ -631,6 +636,17 @@ type ConfigReadResolution = {
   envSnapshotForRestore: Record<string, string | undefined>;
 };
 
+type OperatorPolicyState = {
+  path: string;
+  exists: boolean;
+  valid: boolean;
+  issues: ConfigFileSnapshot["issues"];
+  warnings: ConfigFileSnapshot["warnings"];
+  lockedPaths: string[];
+  lockedPathSegments: string[][];
+  resolvedConfig: OpenClawConfig;
+};
+
 function resolveConfigIncludesForRead(
   parsed: unknown,
   configPath: string,
@@ -663,6 +679,215 @@ function resolveConfigForRead(
     // Capture env snapshot after substitution for write-time ${VAR} restoration.
     envSnapshotForRestore: { ...env } as Record<string, string | undefined>,
   };
+}
+
+function resolvePolicyConfigForRead(resolvedIncludes: unknown, env: NodeJS.ProcessEnv): unknown {
+  return resolveConfigEnvVars(resolvedIncludes, env);
+}
+
+function formatConfigPathSegments(pathSegments: string[]): string {
+  if (pathSegments.length === 0) {
+    return "<root>";
+  }
+  let output = "";
+  for (const segment of pathSegments) {
+    if (isNumericPathSegment(segment)) {
+      output += `[${segment}]`;
+    } else {
+      output = output ? `${output}.${segment}` : segment;
+    }
+  }
+  return output;
+}
+
+function collectLockedPolicyPaths(value: unknown, currentPath: string[], output: string[][]): void {
+  if (Array.isArray(value)) {
+    if (currentPath.length > 0) {
+      output.push(currentPath);
+    }
+    return;
+  }
+  if (isPlainObject(value)) {
+    const entries = Object.entries(value);
+    if (entries.length === 0) {
+      if (currentPath.length > 0) {
+        output.push(currentPath);
+      }
+      return;
+    }
+    for (const [key, child] of entries) {
+      if (isBlockedObjectKey(key)) {
+        continue;
+      }
+      collectLockedPolicyPaths(child, [...currentPath, key], output);
+    }
+    return;
+  }
+  if (currentPath.length > 0) {
+    output.push(currentPath);
+  }
+}
+
+function getValueAtPath(
+  root: unknown,
+  pathSegments: string[],
+): { found: boolean; value?: unknown } {
+  let current = root;
+  for (const segment of pathSegments) {
+    if (Array.isArray(current)) {
+      if (!isNumericPathSegment(segment)) {
+        return { found: false };
+      }
+      const index = Number.parseInt(segment, 10);
+      if (!Number.isFinite(index) || index < 0 || index >= current.length) {
+        return { found: false };
+      }
+      current = current[index];
+      continue;
+    }
+    if (!isPlainObject(current) || !hasOwnObjectKey(current, segment)) {
+      return { found: false };
+    }
+    current = current[segment];
+  }
+  return { found: true, value: current };
+}
+
+function prefixPolicyIssues(
+  issues: ConfigFileSnapshot["issues"],
+  prefix = "operatorPolicy",
+): ConfigFileSnapshot["issues"] {
+  return issues.map((issue) => ({
+    ...issue,
+    path: issue.path ? `${prefix}.${issue.path}` : prefix,
+  }));
+}
+
+function createOperatorPolicyLockError(lockedPaths: string[]): Error {
+  const message =
+    lockedPaths.length === 1
+      ? `Config path locked by operator policy: ${lockedPaths[0]}`
+      : `Config paths locked by operator policy: ${lockedPaths.join(", ")}`;
+  const error = new Error(message) as Error & {
+    code?: string;
+    lockedPaths?: string[];
+  };
+  error.code = "OPERATOR_POLICY_LOCKED";
+  error.lockedPaths = lockedPaths;
+  return error;
+}
+
+function readOperatorPolicyState(deps: Required<ConfigIoDeps>): OperatorPolicyState {
+  const path = resolveOperatorPolicyPath(deps.env, resolveStateDir(deps.env, deps.homedir));
+  const exists = deps.fs.existsSync(path);
+  if (!exists) {
+    return {
+      path,
+      exists: false,
+      valid: true,
+      issues: [],
+      warnings: [],
+      lockedPaths: [],
+      lockedPathSegments: [],
+      resolvedConfig: {},
+    };
+  }
+
+  try {
+    const raw = deps.fs.readFileSync(path, "utf-8");
+    const parsedRes = parseConfigJson5(raw, deps.json5);
+    if (!parsedRes.ok) {
+      return {
+        path,
+        exists: true,
+        valid: false,
+        issues: [{ path: "", message: `JSON5 parse failed: ${parsedRes.error}` }],
+        warnings: [],
+        lockedPaths: [],
+        lockedPathSegments: [],
+        resolvedConfig: {},
+      };
+    }
+
+    let resolved: unknown;
+    try {
+      resolved = resolveConfigIncludesForRead(parsedRes.parsed, path, deps);
+    } catch (err) {
+      const message =
+        err instanceof ConfigIncludeError
+          ? err.message
+          : `Include resolution failed: ${String(err)}`;
+      return {
+        path,
+        exists: true,
+        valid: false,
+        issues: [{ path: "", message }],
+        warnings: [],
+        lockedPaths: [],
+        lockedPathSegments: [],
+        resolvedConfig: {},
+      };
+    }
+
+    let resolvedConfigRaw: unknown;
+    try {
+      resolvedConfigRaw = resolvePolicyConfigForRead(resolved, deps.env);
+    } catch (err) {
+      const message =
+        err instanceof MissingEnvVarError
+          ? err.message
+          : `Env var substitution failed: ${String(err)}`;
+      return {
+        path,
+        exists: true,
+        valid: false,
+        issues: [{ path: "", message }],
+        warnings: [],
+        lockedPaths: [],
+        lockedPathSegments: [],
+        resolvedConfig: {},
+      };
+    }
+
+    const validated = validateConfigObjectWithPlugins(resolvedConfigRaw);
+    if (!validated.ok) {
+      return {
+        path,
+        exists: true,
+        valid: false,
+        issues: validated.issues,
+        warnings: validated.warnings,
+        lockedPaths: [],
+        lockedPathSegments: [],
+        resolvedConfig: {},
+      };
+    }
+
+    const lockedPathSegments: string[][] = [];
+    collectLockedPolicyPaths(validated.config, [], lockedPathSegments);
+    const lockedPaths = lockedPathSegments.map((segments) => formatConfigPathSegments(segments));
+    return {
+      path,
+      exists: true,
+      valid: true,
+      issues: [],
+      warnings: validated.warnings,
+      lockedPaths,
+      lockedPathSegments,
+      resolvedConfig: validated.config,
+    };
+  } catch (err) {
+    return {
+      path,
+      exists: true,
+      valid: false,
+      issues: [{ path: "", message: `read failed: ${String(err)}` }],
+      warnings: [],
+      lockedPaths: [],
+      lockedPathSegments: [],
+      resolvedConfig: {},
+    };
+  }
 }
 
 type ReadConfigFileSnapshotInternalResult = {
@@ -725,19 +950,62 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         (error as { code?: string; details?: string }).details = details;
         throw error;
       }
+      const operatorPolicy = readOperatorPolicyState(deps);
+      if (!operatorPolicy.valid) {
+        const details = prefixPolicyIssues(operatorPolicy.issues)
+          .map((iss) => `- ${iss.path || "<root>"}: ${iss.message}`)
+          .join("\n");
+        if (!loggedInvalidConfigs.has(operatorPolicy.path)) {
+          loggedInvalidConfigs.add(operatorPolicy.path);
+          deps.logger.error(`Invalid operator policy at ${operatorPolicy.path}:\n${details}`);
+        }
+        const error = new Error(`Invalid operator policy at ${operatorPolicy.path}:\n${details}`);
+        (error as { code?: string; details?: string }).code = "INVALID_CONFIG";
+        (error as { code?: string; details?: string }).details = details;
+        throw error;
+      }
+      const effectiveConfigRaw = operatorPolicy.exists
+        ? applyMergePatch(resolvedConfig, operatorPolicy.resolvedConfig, {
+            mergeObjectArraysById: true,
+          })
+        : resolvedConfig;
+      const effectiveValidated = validateConfigObjectWithPlugins(effectiveConfigRaw);
+      if (!effectiveValidated.ok) {
+        const details = effectiveValidated.issues
+          .map((iss) => `- ${iss.path || "<root>"}: ${iss.message}`)
+          .join("\n");
+        if (!loggedInvalidConfigs.has(operatorPolicy.path)) {
+          loggedInvalidConfigs.add(operatorPolicy.path);
+          deps.logger.error(`Operator policy merge invalid at ${operatorPolicy.path}:\n${details}`);
+        }
+        const error = new Error(
+          `Operator policy merge invalid at ${operatorPolicy.path}:\n${details}`,
+        );
+        (error as { code?: string; details?: string }).code = "INVALID_CONFIG";
+        (error as { code?: string; details?: string }).details = details;
+        throw error;
+      }
       if (validated.warnings.length > 0) {
         const details = validated.warnings
           .map((iss) => `- ${iss.path || "<root>"}: ${iss.message}`)
           .join("\n");
         deps.logger.warn(`Config warnings:\\n${details}`);
       }
-      warnIfConfigFromFuture(validated.config, deps.logger);
+      if (operatorPolicy.warnings.length > 0) {
+        const details = prefixPolicyIssues(operatorPolicy.warnings)
+          .map((iss) => `- ${iss.path || "<root>"}: ${iss.message}`)
+          .join("\n");
+        deps.logger.warn(`Operator policy warnings:\n${details}`);
+      }
+      warnIfConfigFromFuture(effectiveValidated.config, deps.logger);
       const cfg = applyTalkConfigNormalization(
         applyModelDefaults(
           applyCompactionDefaults(
             applyContextPruningDefaults(
               applyAgentDefaults(
-                applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
+                applySessionDefaults(
+                  applyLoggingDefaults(applyMessageDefaults(effectiveValidated.config)),
+                ),
               ),
             ),
           ),
@@ -819,20 +1087,38 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
 
   async function readConfigFileSnapshotInternal(): Promise<ReadConfigFileSnapshotInternalResult> {
     maybeLoadDotEnvForConfig(deps.env);
+    const operatorPolicy = readOperatorPolicyState(deps);
     const exists = deps.fs.existsSync(configPath);
     if (!exists) {
+      const policyIssues = operatorPolicy.valid ? [] : prefixPolicyIssues(operatorPolicy.issues);
+      const policyWarnings = operatorPolicy.valid
+        ? []
+        : prefixPolicyIssues(operatorPolicy.warnings);
       const hash = hashConfigRaw(null);
-      const config = applyTalkApiKey(
-        applyTalkConfigNormalization(
-          applyModelDefaults(
-            applyCompactionDefaults(
-              applyContextPruningDefaults(
-                applyAgentDefaults(applySessionDefaults(applyMessageDefaults({}))),
+      const mergedRaw = operatorPolicy.valid
+        ? applyMergePatch({}, operatorPolicy.resolvedConfig, {
+            mergeObjectArraysById: true,
+          })
+        : {};
+      const mergedValidated = validateConfigObjectWithPlugins(mergedRaw);
+      const valid = operatorPolicy.valid && mergedValidated.ok;
+      const issues = [...policyIssues, ...(mergedValidated.ok ? [] : mergedValidated.issues)];
+      const warnings = [...policyWarnings, ...(mergedValidated.ok ? mergedValidated.warnings : [])];
+      const config = valid
+        ? applyTalkApiKey(
+            applyTalkConfigNormalization(
+              applyModelDefaults(
+                applyCompactionDefaults(
+                  applyContextPruningDefaults(
+                    applyAgentDefaults(
+                      applySessionDefaults(applyMessageDefaults(mergedValidated.config)),
+                    ),
+                  ),
+                ),
               ),
             ),
-          ),
-        ),
-      );
+          )
+        : {};
       const legacyIssues: LegacyConfigIssue[] = [];
       return {
         snapshot: {
@@ -841,12 +1127,20 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           raw: null,
           parsed: {},
           resolved: {},
-          valid: true,
+          valid,
           config,
           hash,
-          issues: [],
-          warnings: [],
+          issues,
+          warnings,
           legacyIssues,
+          policy: {
+            path: operatorPolicy.path,
+            exists: operatorPolicy.exists,
+            valid: operatorPolicy.valid,
+            lockedPaths: operatorPolicy.lockedPaths,
+            issues: operatorPolicy.issues,
+            warnings: operatorPolicy.warnings,
+          },
         },
       };
     }
@@ -869,6 +1163,14 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
             issues: [{ path: "", message: `JSON5 parse failed: ${parsedRes.error}` }],
             warnings: [],
             legacyIssues: [],
+            policy: {
+              path: operatorPolicy.path,
+              exists: operatorPolicy.exists,
+              valid: operatorPolicy.valid,
+              lockedPaths: operatorPolicy.lockedPaths,
+              issues: operatorPolicy.issues,
+              warnings: operatorPolicy.warnings,
+            },
           },
         };
       }
@@ -895,6 +1197,14 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
             issues: [{ path: "", message }],
             warnings: [],
             legacyIssues: [],
+            policy: {
+              path: operatorPolicy.path,
+              exists: operatorPolicy.exists,
+              valid: operatorPolicy.valid,
+              lockedPaths: operatorPolicy.lockedPaths,
+              issues: operatorPolicy.issues,
+              warnings: operatorPolicy.warnings,
+            },
           },
         };
       }
@@ -920,6 +1230,14 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
             issues: [{ path: "", message }],
             warnings: [],
             legacyIssues: [],
+            policy: {
+              path: operatorPolicy.path,
+              exists: operatorPolicy.exists,
+              valid: operatorPolicy.valid,
+              lockedPaths: operatorPolicy.lockedPaths,
+              issues: operatorPolicy.issues,
+              warnings: operatorPolicy.warnings,
+            },
           },
         };
       }
@@ -928,6 +1246,32 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
       // Detect legacy keys on resolved config, but only mark source-literal legacy
       // entries (for auto-migration) when they are present in the parsed source.
       const legacyIssues = findLegacyConfigIssues(resolvedConfigRaw, parsedRes.parsed);
+
+      if (!operatorPolicy.valid) {
+        return {
+          snapshot: {
+            path: configPath,
+            exists: true,
+            raw,
+            parsed: parsedRes.parsed,
+            resolved: coerceConfig(resolvedConfigRaw),
+            valid: false,
+            config: coerceConfig(resolvedConfigRaw),
+            hash,
+            issues: prefixPolicyIssues(operatorPolicy.issues),
+            warnings: prefixPolicyIssues(operatorPolicy.warnings),
+            legacyIssues,
+            policy: {
+              path: operatorPolicy.path,
+              exists: operatorPolicy.exists,
+              valid: false,
+              lockedPaths: operatorPolicy.lockedPaths,
+              issues: operatorPolicy.issues,
+              warnings: operatorPolicy.warnings,
+            },
+          },
+        };
+      }
 
       const validated = validateConfigObjectWithPlugins(resolvedConfigRaw);
       if (!validated.ok) {
@@ -944,17 +1288,62 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
             issues: validated.issues,
             warnings: validated.warnings,
             legacyIssues,
+            policy: {
+              path: operatorPolicy.path,
+              exists: operatorPolicy.exists,
+              valid: operatorPolicy.valid,
+              lockedPaths: operatorPolicy.lockedPaths,
+              issues: operatorPolicy.issues,
+              warnings: operatorPolicy.warnings,
+            },
+          },
+        };
+      }
+      const effectiveConfigRaw = operatorPolicy.exists
+        ? applyMergePatch(resolvedConfigRaw, operatorPolicy.resolvedConfig, {
+            mergeObjectArraysById: true,
+          })
+        : resolvedConfigRaw;
+      const effectiveValidated = validateConfigObjectWithPlugins(effectiveConfigRaw);
+      if (!effectiveValidated.ok) {
+        return {
+          snapshot: {
+            path: configPath,
+            exists: true,
+            raw,
+            parsed: parsedRes.parsed,
+            resolved: coerceConfig(resolvedConfigRaw),
+            valid: false,
+            config: coerceConfig(effectiveConfigRaw),
+            hash,
+            issues: effectiveValidated.issues,
+            warnings: [
+              ...validated.warnings,
+              ...operatorPolicy.warnings,
+              ...effectiveValidated.warnings,
+            ],
+            legacyIssues,
+            policy: {
+              path: operatorPolicy.path,
+              exists: operatorPolicy.exists,
+              valid: operatorPolicy.valid,
+              lockedPaths: operatorPolicy.lockedPaths,
+              issues: operatorPolicy.issues,
+              warnings: operatorPolicy.warnings,
+            },
           },
         };
       }
 
-      warnIfConfigFromFuture(validated.config, deps.logger);
+      warnIfConfigFromFuture(effectiveValidated.config, deps.logger);
       const snapshotConfig = normalizeConfigPaths(
         applyTalkApiKey(
           applyTalkConfigNormalization(
             applyModelDefaults(
               applyAgentDefaults(
-                applySessionDefaults(applyLoggingDefaults(applyMessageDefaults(validated.config))),
+                applySessionDefaults(
+                  applyLoggingDefaults(applyMessageDefaults(effectiveValidated.config)),
+                ),
               ),
             ),
           ),
@@ -974,8 +1363,20 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           config: snapshotConfig,
           hash,
           issues: [],
-          warnings: validated.warnings,
+          warnings: [
+            ...validated.warnings,
+            ...operatorPolicy.warnings,
+            ...effectiveValidated.warnings,
+          ],
           legacyIssues,
+          policy: {
+            path: operatorPolicy.path,
+            exists: operatorPolicy.exists,
+            valid: operatorPolicy.valid,
+            lockedPaths: operatorPolicy.lockedPaths,
+            issues: operatorPolicy.issues,
+            warnings: operatorPolicy.warnings,
+          },
         },
         envSnapshotForRestore: readResolution.envSnapshotForRestore,
       };
@@ -1012,6 +1413,14 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
           issues: [{ path: "", message }],
           warnings: [],
           legacyIssues: [],
+          policy: {
+            path: operatorPolicy.path,
+            exists: operatorPolicy.exists,
+            valid: operatorPolicy.valid,
+            lockedPaths: operatorPolicy.lockedPaths,
+            issues: operatorPolicy.issues,
+            warnings: operatorPolicy.warnings,
+          },
         },
       };
     }
@@ -1037,6 +1446,14 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
     clearConfigCache();
     let persistCandidate: unknown = cfg;
     const { snapshot } = await readConfigFileSnapshotInternal();
+    const operatorPolicy = readOperatorPolicyState(deps);
+    if (!operatorPolicy.valid) {
+      const prefixedIssues = prefixPolicyIssues(operatorPolicy.issues);
+      const details = prefixedIssues
+        .map((issue) => `${issue.path || "<root>"}: ${issue.message}`)
+        .join("; ");
+      throw new Error(`Invalid operator policy at ${operatorPolicy.path}: ${details}`);
+    }
     let envRefMap: Map<string, string> | null = null;
     let changedPaths: Set<string> | null = null;
     if (snapshot.valid && snapshot.exists) {
@@ -1063,6 +1480,22 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         }
       } catch {
         envRefMap = null;
+      }
+    }
+
+    if (operatorPolicy.valid && operatorPolicy.exists) {
+      const conflictingLockedPaths = operatorPolicy.lockedPathSegments
+        .filter((pathSegments) => {
+          const candidateValue = getValueAtPath(persistCandidate, pathSegments);
+          if (!candidateValue.found) {
+            return false;
+          }
+          const policyValue = getValueAtPath(operatorPolicy.resolvedConfig, pathSegments);
+          return !policyValue.found || !isDeepStrictEqual(candidateValue.value, policyValue.value);
+        })
+        .map((pathSegments) => formatConfigPathSegments(pathSegments));
+      if (conflictingLockedPaths.length > 0) {
+        throw createOperatorPolicyLockError(conflictingLockedPaths);
       }
     }
 
@@ -1117,8 +1550,12 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
         ? (restoreEnvRefsFromMap(cfgToWrite, "", envRefMap, changedPaths) as OpenClawConfig)
         : cfgToWrite;
     let outputConfig = outputConfigBase;
-    if (options.unsetPaths?.length) {
-      for (const unsetPath of options.unsetPaths) {
+    const effectiveUnsetPaths = [
+      ...(options.unsetPaths ?? []),
+      ...(operatorPolicy.valid ? operatorPolicy.lockedPathSegments : []),
+    ];
+    if (effectiveUnsetPaths.length) {
+      for (const unsetPath of effectiveUnsetPaths) {
         if (!Array.isArray(unsetPath) || unsetPath.length === 0) {
           continue;
         }

--- a/src/config/io.write-config.test.ts
+++ b/src/config/io.write-config.test.ts
@@ -47,6 +47,13 @@ describe("config io write", () => {
     return { configPath, io, snapshot };
   }
 
+  async function writeOperatorPolicy(params: { home: string; policy: Record<string, unknown> }) {
+    const policyPath = path.join(params.home, ".openclaw", "operator-policy.json5");
+    await fs.mkdir(path.dirname(policyPath), { recursive: true });
+    await fs.writeFile(policyPath, JSON.stringify(params.policy, null, 2), "utf-8");
+    return policyPath;
+  }
+
   async function writeTokenAuthAndReadConfig(params: {
     io: { writeConfigFile: (config: Record<string, unknown>) => Promise<void> };
     snapshot: { config: Record<string, unknown> };
@@ -139,6 +146,86 @@ describe("config io write", () => {
       expect(persisted).not.toHaveProperty("agents.defaults");
       expect(persisted).not.toHaveProperty("messages.ackReaction");
       expect(persisted).not.toHaveProperty("sessions.persistence");
+    });
+  });
+
+  it("applies immutable operator policy to the effective config snapshot", async () => {
+    await withSuiteHome(async (home) => {
+      await writeOperatorPolicy({
+        home,
+        policy: {
+          tools: { profile: "messaging" },
+          approvals: { exec: { enabled: false } },
+        },
+      });
+      const { io, snapshot } = await writeConfigAndCreateIo({
+        home,
+        initialConfig: { gateway: { mode: "local" } },
+      });
+
+      const reloaded = await io.readConfigFileSnapshot();
+      expect(reloaded.valid).toBe(true);
+      expect(reloaded.config.gateway?.mode).toBe("local");
+      expect(reloaded.config.tools?.profile).toBe("messaging");
+      expect(reloaded.config.approvals?.exec?.enabled).toBe(false);
+      expect(reloaded.resolved.tools?.profile).toBeUndefined();
+      expect(reloaded.policy?.exists).toBe(true);
+      expect(reloaded.policy?.valid).toBe(true);
+      expect(reloaded.policy?.lockedPaths).toEqual(
+        expect.arrayContaining(["tools.profile", "approvals.exec.enabled"]),
+      );
+      expect(snapshot.policy?.lockedPaths).toEqual(reloaded.policy?.lockedPaths);
+    });
+  });
+
+  it("rejects writes that conflict with locked operator policy paths", async () => {
+    await withSuiteHome(async (home) => {
+      await writeOperatorPolicy({
+        home,
+        policy: {
+          tools: { profile: "messaging" },
+        },
+      });
+      const { io, snapshot } = await writeConfigAndCreateIo({
+        home,
+        initialConfig: { gateway: { mode: "local" } },
+      });
+
+      const next = structuredClone(snapshot.config);
+      next.tools = {
+        ...next.tools,
+        profile: "full",
+      };
+
+      await expect(io.writeConfigFile(next)).rejects.toThrow(
+        "Config path locked by operator policy: tools.profile",
+      );
+    });
+  });
+
+  it("keeps locked operator policy paths out of the mutable config file", async () => {
+    await withSuiteHome(async (home) => {
+      await writeOperatorPolicy({
+        home,
+        policy: {
+          tools: { profile: "messaging" },
+        },
+      });
+      const { configPath, io, snapshot } = await writeConfigAndCreateIo({
+        home,
+        initialConfig: { gateway: { mode: "local" } },
+      });
+
+      const next = structuredClone(snapshot.config);
+      next.gateway = { mode: "remote" };
+      await io.writeConfigFile(next);
+
+      const persisted = JSON.parse(await fs.readFile(configPath, "utf-8")) as {
+        gateway?: { mode?: string };
+        tools?: { profile?: string };
+      };
+      expect(persisted.gateway?.mode).toBe("remote");
+      expect(persisted.tools?.profile).toBeUndefined();
     });
   });
 

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -21,6 +21,7 @@ export const isNixMode = resolveIsNixMode();
 const LEGACY_STATE_DIRNAMES = [".clawdbot", ".moldbot", ".moltbot"] as const;
 const NEW_STATE_DIRNAME = ".openclaw";
 const CONFIG_FILENAME = "openclaw.json";
+const OPERATOR_POLICY_FILENAME = "operator-policy.json5";
 const LEGACY_CONFIG_FILENAMES = ["clawdbot.json", "moldbot.json", "moltbot.json"] as const;
 
 function resolveDefaultHomeDir(): string {
@@ -192,6 +193,22 @@ export function resolveConfigPath(
 }
 
 export const CONFIG_PATH = resolveConfigPathCandidate();
+
+/**
+ * Immutable operator policy overlay file (JSON5 subset of OpenClawConfig).
+ * Can be overridden via OPENCLAW_OPERATOR_POLICY_PATH.
+ * Default: ~/.openclaw/operator-policy.json5 (or $OPENCLAW_STATE_DIR/operator-policy.json5)
+ */
+export function resolveOperatorPolicyPath(
+  env: NodeJS.ProcessEnv = process.env,
+  stateDir: string = resolveStateDir(env, envHomedir(env)),
+): string {
+  const override = env.OPENCLAW_OPERATOR_POLICY_PATH?.trim();
+  if (override) {
+    return resolveUserPath(override, env, envHomedir(env));
+  }
+  return path.join(stateDir, OPERATOR_POLICY_FILENAME);
+}
 
 /**
  * Resolve default config path candidates across default locations.

--- a/src/config/types.openclaw.ts
+++ b/src/config/types.openclaw.ts
@@ -128,6 +128,15 @@ export type LegacyConfigIssue = {
   message: string;
 };
 
+export type ConfigOperatorPolicySnapshot = {
+  path: string;
+  exists: boolean;
+  valid: boolean;
+  lockedPaths: string[];
+  issues: ConfigValidationIssue[];
+  warnings: ConfigValidationIssue[];
+};
+
 export type ConfigFileSnapshot = {
   path: string;
   exists: boolean;
@@ -145,4 +154,5 @@ export type ConfigFileSnapshot = {
   issues: ConfigValidationIssue[];
   warnings: ConfigValidationIssue[];
   legacyIssues: LegacyConfigIssue[];
+  policy?: ConfigOperatorPolicySnapshot;
 };

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -47,6 +47,19 @@ import { parseRestartRequestParams } from "./restart-request.js";
 import type { GatewayRequestHandlers, RespondFn } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
+function respondConfigWriteError(respond: RespondFn, error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const code =
+    error && typeof error === "object" && "code" in error && typeof error.code === "string"
+      ? error.code
+      : undefined;
+  if (code === "OPERATOR_POLICY_LOCKED" || message.startsWith("Invalid operator policy at ")) {
+    respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, message));
+    return true;
+  }
+  return false;
+}
+
 function requireConfigBaseHash(
   params: unknown,
   snapshot: Awaited<ReturnType<typeof readConfigFileSnapshot>>,
@@ -270,7 +283,14 @@ export const configHandlers: GatewayRequestHandlers = {
     if (!parsed) {
       return;
     }
-    await writeConfigFile(parsed.config, writeOptions);
+    try {
+      await writeConfigFile(parsed.config, writeOptions);
+    } catch (error) {
+      if (respondConfigWriteError(respond, error)) {
+        return;
+      }
+      throw error;
+    }
     respond(
       true,
       {
@@ -360,7 +380,14 @@ export const configHandlers: GatewayRequestHandlers = {
     context?.logGateway?.info(
       `config.patch write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.patch`,
     );
-    await writeConfigFile(validated.config, writeOptions);
+    try {
+      await writeConfigFile(validated.config, writeOptions);
+    } catch (error) {
+      if (respondConfigWriteError(respond, error)) {
+        return;
+      }
+      throw error;
+    }
 
     const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
       resolveConfigRestartRequest(params);
@@ -420,7 +447,14 @@ export const configHandlers: GatewayRequestHandlers = {
     context?.logGateway?.info(
       `config.apply write ${formatControlPlaneActor(actor)} changedPaths=${summarizeChangedPaths(changedPaths)} restartReason=config.apply`,
     );
-    await writeConfigFile(parsed.config, writeOptions);
+    try {
+      await writeConfigFile(parsed.config, writeOptions);
+    } catch (error) {
+      if (respondConfigWriteError(respond, error)) {
+        return;
+      }
+      throw error;
+    }
 
     const { sessionKey, note, restartDelayMs, deliveryContext, threadId } =
       resolveConfigRestartRequest(params);


### PR DESCRIPTION
## Summary

- Problem: OpenClaw had no immutable operator-owned config layer, so runtime config writes could weaken tool and system defaults.
- Why it matters: enterprise deployments need a locked baseline that agents cannot rewrite at runtime.
- What changed: added an `operator-policy.json5` overlay, surfaced it in `status --all` and `doctor`, and blocked conflicting config writes while keeping locked values out of mutable config files.
- What did NOT change (scope boundary): this does not add a markdown-based policy format or new policy semantics beyond the existing config schema.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #33958
- Related #37247

## User-visible / Behavior Changes

- OpenClaw now loads an optional immutable operator policy from `~/.openclaw/operator-policy.json5` or `OPENCLAW_OPERATOR_POLICY_PATH`.
- Effective config reflects locked operator policy values even when mutable config omits them.
- `status --all` and `doctor` report operator policy presence, invalid state, and locked path counts.
- `config.set`, `config.patch`, and `config.apply` reject writes that conflict with locked policy values.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: n/a
- Integration/channel (if any): gateway config methods
- Relevant config (redacted): operator policy file with locked `tools.profile`

### Steps

1. Create `~/.openclaw/operator-policy.json5` with a locked config subset.
2. Load config or call status/doctor.
3. Attempt `config.set` or `config.patch` with a conflicting value.

### Expected

- Effective config includes the policy values.
- Status/doctor show policy metadata.
- Conflicting writes fail with an operator policy lock error.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: operator policy overlay applied to config snapshots; conflicting writes rejected; locked values stripped from mutable config persistence; status/doctor surface the policy metadata.
- Edge cases checked: invalid policy file reports prefixed validation issues; mutable config can omit locked values without failing writes.
- What you did **not** verify: end-to-end gateway UI flows beyond the config RPC layer.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`Yes`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: remove `~/.openclaw/operator-policy.json5` or unset `OPENCLAW_OPERATOR_POLICY_PATH`.
- Files/config to restore: the operator policy file path only.
- Known bad symptoms reviewers should watch for: invalid operator policy file causing config load failures or rejected config writes.

## Risks and Mitigations

- Risk: operator policy conflicts could surprise operators if they forget a path is locked.
  - Mitigation: surfaced policy status and locked path counts in `status --all` and `doctor`, and return explicit lock errors on config writes.
