### PR TITLE
feat(daemon/macos): add `gateway restart --fast` using kickstart for non-destructive restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Gateway/macOS launchd restart safety: switch `openclaw gateway restart` to a kickstart-first flow (`launchctl kickstart -k`) and only fall back to bootout+bootstrap when the service is not healthy, preventing destructive unload-only failures on transient bootstrap issues.
 - WhatsApp/self-chat response prefix fallback: stop forcing `"[openclaw]"` as the implicit outbound response prefix when no identity name or response prefix is configured, so blank/default prefix settings no longer inject branding text unexpectedly in self-chat flows. (#27962) Thanks @ecanmor.
 - Memory/QMD search result decoding: accept `qmd search` hits that only include `file` URIs (for example `qmd://collection/path.md`) without `docid`, resolve them through managed collection roots, and keep multi-collection results keyed by file fallback so valid QMD hits no longer collapse to empty `memory_search` output. (#28181) Thanks @0x76696265.
 - Memory/QMD collection-name conflict recovery: when `qmd collection add` fails because another collection already occupies the same `path + pattern`, detect the conflicting collection from `collection list`, remove it, and retry add so agent-scoped managed collections are created deterministically instead of being silently skipped; also add warning-only fallback when qmd metadata is unavailable to avoid destructive guesses. (#25496) Thanks @Ramsbaby.

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -172,6 +172,7 @@ Notes:
 - In inferred auth mode, shell-only `OPENCLAW_GATEWAY_PASSWORD`/`CLAWDBOT_GATEWAY_PASSWORD` does not relax install token requirements; use durable config (`gateway.auth.password` or config `env`) when installing a managed service.
 - If both `gateway.auth.token` and `gateway.auth.password` are configured and `gateway.auth.mode` is unset, install is blocked until mode is set explicitly.
 - Lifecycle commands accept `--json` for scripting.
+- `gateway restart --fast` does a launchd kickstart-only restart (macOS LaunchAgent only) without reloading plist config; if fast restart fails, rerun `gateway restart` for a full reload.
 
 ## Discover gateways (Bonjour)
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -778,6 +778,7 @@ Notes:
 - `gateway status` also surfaces legacy or extra gateway services when it can detect them (`--deep` adds system-level scans). Profile-named OpenClaw services are treated as first-class and aren't flagged as "extra".
 - `gateway status` prints which config path the CLI uses vs which config the service likely uses (service env), plus the resolved probe target URL.
 - `gateway install|uninstall|start|stop|restart` support `--json` for scripting (default output stays human-friendly).
+- `gateway restart --fast` (launchd only) performs a kickstart-only restart without reloading plist config; use plain `gateway restart` for a full reload.
 - `gateway install` defaults to Node runtime; bun is **not recommended** (WhatsApp/Telegram bugs).
 - `gateway install` options: `--port`, `--runtime`, `--token`, `--force`, `--json`.
 

--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -21,6 +21,7 @@ import {
 
 type DaemonLifecycleOptions = {
   json?: boolean;
+  fast?: boolean;
 };
 
 type RestartPostCheckContext = {
@@ -315,7 +316,7 @@ export async function runServiceRestart(params: {
   }
 
   try {
-    await params.service.restart({ env: process.env, stdout });
+    await params.service.restart({ env: process.env, stdout, fast: params.opts?.fast });
     if (params.postRestartCheck) {
       await params.postRestartCheck({ json, stdout, warnings, fail });
     }

--- a/src/cli/daemon-cli/register-service-commands.ts
+++ b/src/cli/daemon-cli/register-service-commands.ts
@@ -94,6 +94,7 @@ export function addGatewayServiceCommands(parent: Command, opts?: { statusDescri
   parent
     .command("restart")
     .description("Restart the Gateway service (launchd/systemd/schtasks)")
+    .option("--fast", "Fast restart without reloading service config (launchd only)", false)
     .option("--json", "Output JSON", false)
     .action(async (cmdOpts) => {
       await runDaemonRestart(cmdOpts);

--- a/src/cli/daemon-cli/types.ts
+++ b/src/cli/daemon-cli/types.ts
@@ -24,4 +24,5 @@ export type DaemonInstallOptions = {
 
 export type DaemonLifecycleOptions = {
   json?: boolean;
+  fast?: boolean;
 };

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -17,7 +17,10 @@ const state = vi.hoisted(() => ({
   launchctlCalls: [] as string[][],
   listOutput: "",
   printOutput: "",
+  printCode: 0,
   bootstrapError: "",
+  kickstartFailuresRemaining: 0,
+  kickstartError: "",
   dirs: new Set<string>(),
   files: new Map<string, string>(),
 }));
@@ -42,10 +45,22 @@ vi.mock("./exec-file.js", () => ({
       return { stdout: state.listOutput, stderr: "", code: 0 };
     }
     if (call[0] === "print") {
-      return { stdout: state.printOutput, stderr: "", code: 0 };
+      return {
+        stdout: state.printCode === 0 ? state.printOutput : "",
+        stderr: state.printCode === 0 ? "" : "Could not find service",
+        code: state.printCode,
+      };
     }
     if (call[0] === "bootstrap" && state.bootstrapError) {
       return { stdout: "", stderr: state.bootstrapError, code: 1 };
+    }
+    if (call[0] === "kickstart" && state.kickstartFailuresRemaining > 0) {
+      state.kickstartFailuresRemaining -= 1;
+      return {
+        stdout: "",
+        stderr: state.kickstartError || "Could not find service",
+        code: 1,
+      };
     }
     return { stdout: "", stderr: "", code: 0 };
   }),
@@ -81,7 +96,10 @@ beforeEach(() => {
   state.launchctlCalls.length = 0;
   state.listOutput = "";
   state.printOutput = "";
+  state.printCode = 0;
   state.bootstrapError = "";
+  state.kickstartFailuresRemaining = 0;
+  state.kickstartError = "";
   state.dirs.clear();
   state.files.clear();
   vi.clearAllMocks();
@@ -208,7 +226,7 @@ describe("launchd install", () => {
     expect(plist).toContain(`<integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>`);
   });
 
-  it("restarts LaunchAgent with bootout-bootstrap-kickstart order", async () => {
+  it("restarts LaunchAgent with kickstart-first when service is healthy", async () => {
     const env = createDefaultLaunchdEnv();
     await restartLaunchAgent({
       env,
@@ -217,27 +235,19 @@ describe("launchd install", () => {
 
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
     const label = "ai.openclaw.gateway";
-    const plistPath = resolveLaunchAgentPlistPath(env);
-    const bootoutIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "bootout" && c[1] === `${domain}/${label}`,
-    );
-    const bootstrapIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
-    );
-    const kickstartIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === `${domain}/${label}`,
-    );
 
-    expect(bootoutIndex).toBeGreaterThanOrEqual(0);
-    expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
-    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
-    expect(bootoutIndex).toBeLessThan(bootstrapIndex);
-    expect(bootstrapIndex).toBeLessThan(kickstartIndex);
+    expect(state.launchctlCalls).toContainEqual(["kickstart", "-k", `${domain}/${label}`]);
+    expect(state.launchctlCalls).toContainEqual(["print", `${domain}/${label}`]);
+    expect(state.launchctlCalls.some((c) => c[0] === "bootout" || c[0] === "bootstrap")).toBe(
+      false,
+    );
   });
 
-  it("waits for previous launchd pid to exit before bootstrapping", async () => {
+  it("falls back to bootout-bootstrap-kickstart when initial kickstart fails", async () => {
     const env = createDefaultLaunchdEnv();
     state.printOutput = ["state = running", "pid = 4242"].join("\n");
+    state.kickstartFailuresRemaining = 1;
+    state.kickstartError = "Could not find service";
     const killSpy = vi.spyOn(process, "kill");
     killSpy
       .mockImplementationOnce(() => true)
@@ -258,17 +268,54 @@ describe("launchd install", () => {
       expect(killSpy).toHaveBeenCalledWith(4242, 0);
       const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
       const label = "ai.openclaw.gateway";
+      const plistPath = resolveLaunchAgentPlistPath(env);
+      const firstKickstartIndex = state.launchctlCalls.findIndex(
+        (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === `${domain}/${label}`,
+      );
       const bootoutIndex = state.launchctlCalls.findIndex(
         (c) => c[0] === "bootout" && c[1] === `${domain}/${label}`,
       );
-      const bootstrapIndex = state.launchctlCalls.findIndex((c) => c[0] === "bootstrap");
-      expect(bootoutIndex).toBeGreaterThanOrEqual(0);
-      expect(bootstrapIndex).toBeGreaterThanOrEqual(0);
-      expect(bootoutIndex).toBeLessThan(bootstrapIndex);
+      const bootstrapIndex = state.launchctlCalls.findIndex(
+        (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
+      );
+      const secondKickstartIndex = state.launchctlCalls.findLastIndex(
+        (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === `${domain}/${label}`,
+      );
+      expect(firstKickstartIndex).toBeGreaterThanOrEqual(0);
+      expect(bootoutIndex).toBeGreaterThan(firstKickstartIndex);
+      expect(bootstrapIndex).toBeGreaterThan(bootoutIndex);
+      expect(secondKickstartIndex).toBeGreaterThan(bootstrapIndex);
     } finally {
       vi.useRealTimers();
       killSpy.mockRestore();
     }
+  });
+
+  it("falls back when kickstart succeeds but service remains unloaded", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.printCode = 1;
+
+    await restartLaunchAgent({
+      env,
+      stdout: new PassThrough(),
+    });
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const label = "ai.openclaw.gateway";
+    const plistPath = resolveLaunchAgentPlistPath(env);
+    const kickstartIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === `${domain}/${label}`,
+    );
+    const bootoutIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "bootout" && c[1] === `${domain}/${label}`,
+    );
+    const bootstrapIndex = state.launchctlCalls.findIndex(
+      (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
+    );
+
+    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
+    expect(bootoutIndex).toBeGreaterThan(kickstartIndex);
+    expect(bootstrapIndex).toBeGreaterThan(bootoutIndex);
   });
 
   it("shows actionable guidance when launchctl gui domain does not support bootstrap", async () => {

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -226,11 +226,12 @@ describe("launchd install", () => {
     expect(plist).toContain(`<integer>${LAUNCH_AGENT_THROTTLE_INTERVAL_SECONDS}</integer>`);
   });
 
-  it("restarts LaunchAgent with kickstart-first when service is healthy", async () => {
+  it("restarts LaunchAgent with kickstart-only when fast mode is enabled", async () => {
     const env = createDefaultLaunchdEnv();
     await restartLaunchAgent({
       env,
       stdout: new PassThrough(),
+      fast: true,
     });
 
     const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
@@ -243,11 +244,51 @@ describe("launchd install", () => {
     );
   });
 
-  it("falls back to bootout-bootstrap-kickstart when initial kickstart fails", async () => {
+  it("errors in fast mode when kickstart fails", async () => {
     const env = createDefaultLaunchdEnv();
-    state.printOutput = ["state = running", "pid = 4242"].join("\n");
     state.kickstartFailuresRemaining = 1;
     state.kickstartError = "Could not find service";
+
+    await expect(
+      restartLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+        fast: true,
+      }),
+    ).rejects.toThrow(
+      "Fast restart failed — service may not be loaded. Run `openclaw gateway restart` (without --fast) to do a full reload.",
+    );
+
+    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
+    const label = "ai.openclaw.gateway";
+    expect(state.launchctlCalls).toContainEqual(["kickstart", "-k", `${domain}/${label}`]);
+    expect(state.launchctlCalls.some((c) => c[0] === "bootout" || c[0] === "bootstrap")).toBe(
+      false,
+    );
+  });
+
+  it("errors in fast mode when service remains unhealthy after kickstart", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.printCode = 1;
+
+    await expect(
+      restartLaunchAgent({
+        env,
+        stdout: new PassThrough(),
+        fast: true,
+      }),
+    ).rejects.toThrow(
+      "Fast restart failed — service may not be loaded. Run `openclaw gateway restart` (without --fast) to do a full reload.",
+    );
+
+    expect(state.launchctlCalls.some((c) => c[0] === "bootout" || c[0] === "bootstrap")).toBe(
+      false,
+    );
+  });
+
+  it("uses bootout-bootstrap-kickstart flow by default", async () => {
+    const env = createDefaultLaunchdEnv();
+    state.printOutput = ["state = running", "pid = 4242"].join("\n");
     const killSpy = vi.spyOn(process, "kill");
     killSpy
       .mockImplementationOnce(() => true)
@@ -265,57 +306,28 @@ describe("launchd install", () => {
       });
       await vi.advanceTimersByTimeAsync(250);
       await restartPromise;
+
       expect(killSpy).toHaveBeenCalledWith(4242, 0);
       const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
       const label = "ai.openclaw.gateway";
       const plistPath = resolveLaunchAgentPlistPath(env);
-      const firstKickstartIndex = state.launchctlCalls.findIndex(
-        (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === `${domain}/${label}`,
-      );
       const bootoutIndex = state.launchctlCalls.findIndex(
         (c) => c[0] === "bootout" && c[1] === `${domain}/${label}`,
       );
       const bootstrapIndex = state.launchctlCalls.findIndex(
         (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
       );
-      const secondKickstartIndex = state.launchctlCalls.findLastIndex(
+      const kickstartIndex = state.launchctlCalls.findIndex(
         (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === `${domain}/${label}`,
       );
-      expect(firstKickstartIndex).toBeGreaterThanOrEqual(0);
-      expect(bootoutIndex).toBeGreaterThan(firstKickstartIndex);
+
+      expect(bootoutIndex).toBeGreaterThanOrEqual(0);
       expect(bootstrapIndex).toBeGreaterThan(bootoutIndex);
-      expect(secondKickstartIndex).toBeGreaterThan(bootstrapIndex);
+      expect(kickstartIndex).toBeGreaterThan(bootstrapIndex);
     } finally {
       vi.useRealTimers();
       killSpy.mockRestore();
     }
-  });
-
-  it("falls back when kickstart succeeds but service remains unloaded", async () => {
-    const env = createDefaultLaunchdEnv();
-    state.printCode = 1;
-
-    await restartLaunchAgent({
-      env,
-      stdout: new PassThrough(),
-    });
-
-    const domain = typeof process.getuid === "function" ? `gui/${process.getuid()}` : "gui/501";
-    const label = "ai.openclaw.gateway";
-    const plistPath = resolveLaunchAgentPlistPath(env);
-    const kickstartIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "kickstart" && c[1] === "-k" && c[2] === `${domain}/${label}`,
-    );
-    const bootoutIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "bootout" && c[1] === `${domain}/${label}`,
-    );
-    const bootstrapIndex = state.launchctlCalls.findIndex(
-      (c) => c[0] === "bootstrap" && c[1] === domain && c[2] === plistPath,
-    );
-
-    expect(kickstartIndex).toBeGreaterThanOrEqual(0);
-    expect(bootoutIndex).toBeGreaterThan(kickstartIndex);
-    expect(bootstrapIndex).toBeGreaterThan(bootoutIndex);
   });
 
   it("shows actionable guidance when launchctl gui domain does not support bootstrap", async () => {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -450,14 +450,30 @@ export async function restartLaunchAgent({
   const domain = resolveGuiDomain();
   const label = resolveLaunchAgentLabel({ env: serviceEnv });
   const plistPath = resolveLaunchAgentPlistPath(serviceEnv);
+  const serviceId = `${domain}/${label}`;
 
-  const runtime = await execLaunchctl(["print", `${domain}/${label}`]);
+  const fastRestart = await execLaunchctl(["kickstart", "-k", serviceId]);
+  if (fastRestart.code === 0) {
+    const health = await execLaunchctl(["print", serviceId]);
+    if (health.code === 0) {
+      try {
+        stdout.write(`${formatLine("Restarted LaunchAgent", serviceId)}\n`);
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
+          throw err;
+        }
+      }
+      return;
+    }
+  }
+
+  const runtime = await execLaunchctl(["print", serviceId]);
   const previousPid =
     runtime.code === 0
       ? parseLaunchctlPrint(runtime.stdout || runtime.stderr || "").pid
       : undefined;
 
-  const stop = await execLaunchctl(["bootout", `${domain}/${label}`]);
+  const stop = await execLaunchctl(["bootout", serviceId]);
   if (stop.code !== 0 && !isLaunchctlNotLoaded(stop)) {
     throw new Error(`launchctl bootout failed: ${stop.stderr || stop.stdout}`.trim());
   }
@@ -482,12 +498,12 @@ export async function restartLaunchAgent({
     throw new Error(`launchctl bootstrap failed: ${detail}`);
   }
 
-  const start = await execLaunchctl(["kickstart", "-k", `${domain}/${label}`]);
+  const start = await execLaunchctl(["kickstart", "-k", serviceId]);
   if (start.code !== 0) {
     throw new Error(`launchctl kickstart failed: ${start.stderr || start.stdout}`.trim());
   }
   try {
-    stdout.write(`${formatLine("Restarted LaunchAgent", `${domain}/${label}`)}\n`);
+    stdout.write(`${formatLine("Restarted LaunchAgent", serviceId)}\n`);
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
       throw err;

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -445,6 +445,7 @@ export async function installLaunchAgent({
 export async function restartLaunchAgent({
   stdout,
   env,
+  fast,
 }: GatewayServiceControlArgs): Promise<void> {
   const serviceEnv = env ?? (process.env as GatewayServiceEnv);
   const domain = resolveGuiDomain();
@@ -452,19 +453,29 @@ export async function restartLaunchAgent({
   const plistPath = resolveLaunchAgentPlistPath(serviceEnv);
   const serviceId = `${domain}/${label}`;
 
-  const fastRestart = await execLaunchctl(["kickstart", "-k", serviceId]);
-  if (fastRestart.code === 0) {
-    const health = await execLaunchctl(["print", serviceId]);
-    if (health.code === 0) {
-      try {
-        stdout.write(`${formatLine("Restarted LaunchAgent", serviceId)}\n`);
-      } catch (err: unknown) {
-        if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
-          throw err;
-        }
-      }
-      return;
+  if (fast) {
+    const fastRestart = await execLaunchctl(["kickstart", "-k", serviceId]);
+    if (fastRestart.code !== 0) {
+      throw new Error(
+        "Fast restart failed — service may not be loaded. Run `openclaw gateway restart` (without --fast) to do a full reload.",
+      );
     }
+
+    const health = await execLaunchctl(["print", serviceId]);
+    if (health.code !== 0) {
+      throw new Error(
+        "Fast restart failed — service may not be loaded. Run `openclaw gateway restart` (without --fast) to do a full reload.",
+      );
+    }
+
+    try {
+      stdout.write(`${formatLine("Restarted LaunchAgent (fast)", serviceId)}\n`);
+    } catch (err: unknown) {
+      if ((err as NodeJS.ErrnoException)?.code !== "EPIPE") {
+        throw err;
+      }
+    }
+    return;
   }
 
   const runtime = await execLaunchctl(["print", serviceId]);

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -17,6 +17,7 @@ export type GatewayServiceManageArgs = {
 export type GatewayServiceControlArgs = {
   stdout: NodeJS.WritableStream;
   env?: GatewayServiceEnv;
+  fast?: boolean;
 };
 
 export type GatewayServiceEnvArgs = {


### PR DESCRIPTION
## Summary

Adds `openclaw gateway restart --fast` — a new opt-in flag for macOS that uses `launchctl kickstart -k` instead of the default bootout+bootstrap+kickstart cycle.

The default `openclaw gateway restart` behavior is **completely unchanged**.

## Motivation

The existing restart flow is destructive-first: it always does `bootout` (fully unregistering the job) before `bootstrap`. If `bootstrap` fails due to a transient macOS GUI session or domain availability issue, the service is left fully unloaded — `KeepAlive` cannot recover a bootstrapped-out job, and manual recovery via `openclaw doctor` or `openclaw gateway install --force` is required.

`--fast` is for the common case where the plist hasn't changed and you just want to restart the process quickly and safely.

## Behavior

**`openclaw gateway restart`** — unchanged:
1. Read prior PID via `launchctl print`
2. `launchctl bootout` (fully unregisters the job)
3. Wait for old PID to exit
4. `launchctl bootstrap` (re-registers from plist)
5. `launchctl kickstart -k`

**`openclaw gateway restart --fast`** — new:
1. `launchctl kickstart -k gui/$UID/<label>` (kills + restarts in-place, no plist reload)
2. Verify healthy via `launchctl print`
3. Success → done
4. Failure → clear error: *"Fast restart failed — service may not be loaded. Run `openclaw gateway restart` (without --fast) to do a full reload."*

No silent fallback — if `--fast` fails, the user knows to run the full restart.

**When to use `--fast`:** Normal process restarts where the plist hasn't changed.
**When NOT to use `--fast`:** After `openclaw gateway install` or any change to service config — use the default restart to pick up the new plist.

## Tests

- Fast path: kickstart+print only (no bootout/bootstrap called)
- Fast path: clear error on kickstart failure
- Fast path: clear error on unhealthy print
- Default path: unchanged bootout+bootstrap+kickstart behavior

18/18 daemon tests pass.

## Verification

Tested on macOS (arm64) — `gateway restart --fast` across 6 consecutive calls, all recovered cleanly without requiring doctor or manual service re-registration.

## Backward compatibility

- Default `gateway restart` behavior: completely unchanged
- Linux/Windows: unaffected (`restartLaunchAgent` is macOS-only)
- No config changes required

## AI assistance

Built with Codex. Fully tested locally (6 consecutive `openclaw gateway restart --fast` calls on macOS arm64).
