### PR TITLE
feat: add command-exec frontmatter for deterministic skill dispatch

### DIFF
--- a/src/agents/skills/types.ts
+++ b/src/agents/skills/types.ts
@@ -46,6 +46,13 @@ export type SkillCommandDispatchSpec = {
    * - raw: forward the raw args string (no core parsing).
    */
   argMode?: "raw";
+  /**
+   * Fixed shell command to execute directly via `sh -c`.
+   * When set, the command runs deterministically at the gateway level
+   * without invoking the tool by name.  The command string comes from
+   * operator-authored SKILL.md frontmatter (`command-exec`).
+   */
+  commandExec?: string;
 };
 
 export type SkillCommandSpec = {

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -746,7 +746,18 @@ export function buildWorkspaceSkillCommandSpecs(
         );
       }
 
-      return { kind: "tool", toolName, argMode: "raw" } as const;
+      const commandExec = (
+        entry.frontmatter?.["command-exec"] ??
+        entry.frontmatter?.["command_exec"] ??
+        ""
+      ).trim();
+
+      return {
+        kind: "tool",
+        toolName,
+        argMode: "raw",
+        ...(commandExec ? { commandExec } : {}),
+      } as const;
     })();
 
     specs.push({

--- a/src/auto-reply/reply/command-exec.test.ts
+++ b/src/auto-reply/reply/command-exec.test.ts
@@ -1,0 +1,56 @@
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Tests that command-exec skill dispatch passes user args safely as
+ * positional parameters ($1) rather than interpolating them into
+ * the shell command string.  This prevents shell injection from
+ * user-supplied skill arguments.
+ */
+describe("command-exec arg safety", () => {
+  // Mirror the exact spawn pattern used in get-reply-inline-actions.ts:
+  //   spawnSync("sh", ["-c", commandExec, "--", rawArgs], ...)
+  function execCommand(commandExec: string, rawArgs?: string) {
+    const spawnArgs = ["-c", commandExec, "--"];
+    if (rawArgs) {
+      spawnArgs.push(rawArgs);
+    }
+    return spawnSync("sh", spawnArgs, {
+      encoding: "utf-8",
+      timeout: 5_000,
+      env: { ...process.env },
+    });
+  }
+
+  it("passes clean args as $1", () => {
+    const result = execCommand('echo "got: $1"', "hello world");
+    expect(result.stdout.trim()).toBe("got: hello world");
+  });
+
+  it("semicolon injection is treated as literal $1", () => {
+    const result = execCommand('echo "got: $1"', "; echo INJECTED");
+    expect(result.stdout.trim()).toBe("got: ; echo INJECTED");
+    // If injection worked, stdout would have two lines. Verify single line.
+    expect(result.stdout.trim().split("\n")).toHaveLength(1);
+  });
+
+  it("$(...) subshell injection is treated as literal $1", () => {
+    const result = execCommand('echo "got: $1"', "$(echo INJECTED)");
+    expect(result.stdout.trim()).toBe("got: $(echo INJECTED)");
+  });
+
+  it("pipe injection is treated as literal $1", () => {
+    const result = execCommand('echo "got: $1"', "| echo INJECTED");
+    expect(result.stdout.trim()).toBe("got: | echo INJECTED");
+  });
+
+  it("backtick injection is treated as literal $1", () => {
+    const result = execCommand('echo "got: $1"', "`echo INJECTED`");
+    expect(result.stdout.trim()).toBe("got: `echo INJECTED`");
+  });
+
+  it("runs without args when none provided", () => {
+    const result = execCommand('echo "no args"');
+    expect(result.stdout.trim()).toBe("no args");
+  });
+});

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -195,14 +195,27 @@ export async function handleInlineActions(params: {
     const dispatch = skillInvocation.command.dispatch;
     if (dispatch?.kind === "tool" && dispatch.commandExec) {
       // command-exec: run a fixed shell command directly (no tool lookup).
+      // Args are passed as $1 to avoid shell injection from user input.
       const rawArgs = (skillInvocation.args ?? "").trim();
-      const fullCommand = rawArgs ? `${dispatch.commandExec} ${rawArgs}` : dispatch.commandExec;
+      const spawnArgs = ["sh", "-c", dispatch.commandExec, "--"];
+      if (rawArgs) {
+        spawnArgs.push(rawArgs);
+      }
       try {
-        const result = spawnSync("sh", ["-c", fullCommand], {
+        const result = spawnSync(spawnArgs[0], spawnArgs.slice(1), {
           encoding: "utf-8",
           timeout: 15_000,
           env: { ...process.env },
         });
+        if (result.error) {
+          const isTimeout =
+            result.error.message.includes("ETIMEDOUT") || result.signal === "SIGTERM";
+          typing.cleanup();
+          return {
+            kind: "reply",
+            reply: { text: isTimeout ? "❌ Command timed out." : `❌ ${result.error.message}` },
+          };
+        }
         const text = (result.stdout ?? "").trim() || (result.stderr ?? "").trim() || "✅ Done.";
         if (result.status !== 0) {
           typing.cleanup();

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process";
 import { collectTextContentBlocks } from "../../agents/content-blocks.js";
 import { createOpenClawTools } from "../../agents/openclaw-tools.js";
 import type { SkillCommandSpec } from "../../agents/skills.js";
@@ -192,6 +193,34 @@ export async function handleInlineActions(params: {
     }
 
     const dispatch = skillInvocation.command.dispatch;
+    if (dispatch?.kind === "tool" && dispatch.commandExec) {
+      // command-exec: run a fixed shell command directly (no tool lookup).
+      const rawArgs = (skillInvocation.args ?? "").trim();
+      const fullCommand = rawArgs ? `${dispatch.commandExec} ${rawArgs}` : dispatch.commandExec;
+      try {
+        const result = spawnSync("sh", ["-c", fullCommand], {
+          encoding: "utf-8",
+          timeout: 15_000,
+          env: { ...process.env },
+        });
+        const text = (result.stdout ?? "").trim() || (result.stderr ?? "").trim() || "✅ Done.";
+        if (result.status !== 0) {
+          typing.cleanup();
+          return {
+            kind: "reply",
+            reply: {
+              text: `❌ Exit ${result.status}: ${(result.stderr ?? "").trim() || text}`,
+            },
+          };
+        }
+        typing.cleanup();
+        return { kind: "reply", reply: { text } };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        typing.cleanup();
+        return { kind: "reply", reply: { text: `❌ ${message}` } };
+      }
+    }
     if (dispatch?.kind === "tool") {
       const rawArgs = (skillInvocation.args ?? "").trim();
       const channel =


### PR DESCRIPTION
## Summary

Adds a `command-exec` frontmatter key for SKILL.md files that lets skill authors define a fixed shell command to run directly at the gateway level — no tool lookup, no LLM involvement.

**Problem**: `command-dispatch: tool` + `command-tool: exec` is documented but non-functional because the `exec` tool isn't included in `createOpenClawTools()`. Skills that want deterministic command execution (e.g., `/ping`, `/status`) fall through to the LLM, which responds conversationally instead of running the intended command.

**Solution**: A new optional `command-exec` frontmatter key. When present alongside `command-dispatch: tool`, the gateway runs the specified command via `sh -c` and returns the output directly — bypassing the tool lookup entirely. Skills without `command-exec` are unaffected and use the existing tool dispatch path.

### Example SKILL.md

```yaml
---
name: ping
description: "System ping — returns uptime and timestamp"
user-invocable: true
command-dispatch: tool
command-tool: exec
command-exec: echo "pong — $(date '+%Y-%m-%d %H:%M:%S') — up $(uptime | sed 's/.*up //' | sed 's/,.*//')"
---
```

### Changes

- **`src/agents/skills/types.ts`** — Add optional `commandExec` field to `SkillCommandDispatchSpec`
- **`src/agents/skills/workspace.ts`** — Read `command-exec` / `command_exec` from frontmatter and include it in the dispatch object
- **`src/auto-reply/reply/get-reply-inline-actions.ts`** — When `dispatch.commandExec` is set, run the command via `spawnSync` and return the result, short-circuiting the tool lookup

### Design notes

- **Backwards compatible**: Skills without `command-exec` follow the existing code path unchanged
- **Operator-authored only**: The command string comes from SKILL.md frontmatter (workspace files), which are written by the gateway operator
- **15-second timeout**: Prevents runaway commands from blocking the gateway
- **Error reporting**: Non-zero exit codes and exceptions are surfaced to the user with status information

## Test plan

- [ ] Type-check passes (`pnpm tsgo`)
- [ ] Lint/format passes (`pnpm check`)
- [ ] Skill with `command-exec` frontmatter executes the shell command and returns output
- [ ] Skill with `command-dispatch: tool` but no `command-exec` follows existing tool lookup path
- [ ] Non-zero exit code returns error message with exit status
- [ ] Command timeout (>15s) returns timeout error
- [ ] Skills without `command-dispatch` are unaffected