### PR TITLE
OpenAI: complete GPT-5.4 support, thinking docs, and Codex 1M metadata

### DIFF
--- a/docs/automation/cron-jobs.md
+++ b/docs/automation/cron-jobs.md
@@ -224,7 +224,7 @@ Behavior details:
 Isolated jobs (`agentTurn`) can override the model and thinking level:
 
 - `model`: Provider/model string (e.g., `anthropic/claude-sonnet-4-20250514`) or alias (e.g., `opus`)
-- `thinking`: Thinking level (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`; GPT-5.2 + Codex models only)
+- `thinking`: Thinking level (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `adaptive`; `xhigh` is available on supported OpenAI/Codex GPT-5.x models including `openai/gpt-5.4`, `openai/gpt-5.4-pro`, and `openai-codex/gpt-5.4`)
 
 Note: You can set `model` on main-session jobs too, but it changes the shared main
 session model. We recommend model overrides only for isolated jobs to avoid

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -559,7 +559,7 @@ Options:
 
 - `--to <dest>` (for session key and optional delivery)
 - `--session-id <id>`
-- `--thinking <off|minimal|low|medium|high|xhigh>` (GPT-5.2 + Codex models only)
+- `--thinking <off|minimal|low|medium|high|xhigh|adaptive>` (dynamic by model/provider; `xhigh` is available on supported OpenAI/Codex GPT-5.x models including `openai/gpt-5.4`, `openai/gpt-5.4-pro`, and `openai-codex/gpt-5.4`)
 - `--verbose <on|full|off>`
 - `--channel <whatsapp|telegram|discord|slack|mattermost|signal|imessage|msteams>`
 - `--local`

--- a/docs/reference/wizard.md
+++ b/docs/reference/wizard.md
@@ -35,7 +35,7 @@ For a high-level overview, see [Onboarding Wizard](/start/wizard).
     - **Anthropic token (paste setup-token)**: run `claude setup-token` on any machine, then paste the token (you can name it; blank = default).
     - **OpenAI Code (Codex) subscription (Codex CLI)**: if `~/.codex/auth.json` exists, the wizard can reuse it.
     - **OpenAI Code (Codex) subscription (OAuth)**: browser flow; paste the `code#state`.
-      - Sets `agents.defaults.model` to `openai-codex/gpt-5.2` when model is unset or `openai/*`.
+      - Sets `agents.defaults.model` to `openai-codex/gpt-5.4` when model is unset or `openai/*`.
     - **OpenAI API key**: uses `OPENAI_API_KEY` if present or prompts for a key, then stores it in auth profiles.
     - **xAI (Grok) API key**: prompts for `XAI_API_KEY` and configures xAI as a model provider.
     - **OpenCode Zen (multi-model proxy)**: prompts for `OPENCODE_API_KEY` (or `OPENCODE_ZEN_API_KEY`, get it at https://opencode.ai/auth).
@@ -239,7 +239,7 @@ openclaw onboard --non-interactive \
 ```bash
 openclaw agents add work \
   --workspace ~/.openclaw/workspace-work \
-  --model openai/gpt-5.2 \
+  --model openai/gpt-5.4 \
   --bind whatsapp:biz \
   --non-interactive \
   --json

--- a/docs/start/wizard-cli-automation.md
+++ b/docs/start/wizard-cli-automation.md
@@ -178,7 +178,7 @@ sessions, and auth profiles. Running without `--workspace` launches the wizard.
 ```bash
 openclaw agents add work \
   --workspace ~/.openclaw/workspace-work \
-  --model openai/gpt-5.2 \
+  --model openai/gpt-5.4 \
   --bind whatsapp:biz \
   --non-interactive \
   --json

--- a/docs/start/wizard-cli-reference.md
+++ b/docs/start/wizard-cli-reference.md
@@ -149,7 +149,7 @@ What you set:
   <Accordion title="OpenAI API key">
     Uses `OPENAI_API_KEY` if present or prompts for a key, then stores the credential in auth profiles.
 
-    Sets `agents.defaults.model` to `openai/gpt-5.1-codex` when model is unset, `openai/*`, or `openai-codex/*`.
+    Sets `agents.defaults.model` to `openai/gpt-5.4` when model is unset, `openai/*`, or `openai-codex/*`.
 
   </Accordion>
   <Accordion title="xAI (Grok) API key">

--- a/docs/tools/agent-send.md
+++ b/docs/tools/agent-send.md
@@ -47,7 +47,7 @@ openclaw agent --agent ops --message "Generate report" --deliver --reply-channel
 - `--reply-to`: delivery target override
 - `--reply-channel`: delivery channel override
 - `--reply-account`: delivery account id override
-- `--thinking <off|minimal|low|medium|high|xhigh>`: persist thinking level (GPT-5.2 + Codex models only)
+- `--thinking <off|minimal|low|medium|high|xhigh|adaptive>`: persist thinking level (dynamic by model/provider; `xhigh` is available on supported OpenAI/Codex GPT-5.x models including `openai/gpt-5.4`, `openai/gpt-5.4-pro`, and `openai-codex/gpt-5.4`)
 - `--verbose <on|full|off>`: persist verbose level
 - `--timeout <seconds>`: override agent timeout
 - `--json`: output structured JSON

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -101,7 +101,7 @@ Text + native (when enabled):
 - `/activation mention|always` (groups only)
 - `/send on|off|inherit` (owner-only)
 - `/reset` or `/new [model]` (optional model hint; remainder is passed through)
-- `/think <off|minimal|low|medium|high|xhigh>` (dynamic choices by model/provider; aliases: `/thinking`, `/t`)
+- `/think <off|minimal|low|medium|high|xhigh|adaptive>` (dynamic choices by model/provider; `xhigh` is available on supported OpenAI/Codex GPT-5.x models; aliases: `/thinking`, `/t`)
 - `/verbose on|full|off` (alias: `/v`)
 - `/reasoning on|off|stream` (alias: `/reason`; when on, sends a separate message prefixed `Reasoning:`; `stream` = Telegram draft only)
 - `/elevated on|off|ask|full` (alias: `/elev`; `full` skips exec approvals)
@@ -160,7 +160,7 @@ Examples:
 /model
 /model list
 /model 3
-/model openai/gpt-5.2
+/model openai/gpt-5.4
 /model opus@anthropic:default
 /model status
 ```

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -15,7 +15,7 @@ title: "Thinking Levels"
   - low → “think hard”
   - medium → “think harder”
   - high → “ultrathink” (max budget)
-  - xhigh → “ultrathink+” (GPT-5.2 + Codex models only)
+  - xhigh → “ultrathink+” (available on supported OpenAI/Codex GPT-5.x models, including `openai/gpt-5.4`, `openai/gpt-5.4-pro`, and `openai-codex/gpt-5.4`)
   - adaptive → provider-managed adaptive reasoning budget (supported for Anthropic Claude 4.6 model family)
   - `x-high`, `x_high`, `extra-high`, `extra high`, and `extra_high` map to `xhigh`.
   - `highest`, `max` map to `high`.

--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -91,7 +91,7 @@ Core:
 
 Session controls:
 
-- `/think <off|minimal|low|medium|high>`
+- `/think <off|minimal|low|medium|high|xhigh|adaptive>` (dynamic by model/provider)
 - `/verbose <on|full|off>`
 - `/reasoning <on|off|stream>`
 - `/usage <off|tokens|full>`

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -149,6 +149,8 @@ describe("loadModelCatalog", () => {
         provider: "openai",
         id: "gpt-5.4",
         name: "gpt-5.4",
+        contextWindow: 1_050_000,
+        maxTokens: 128_000,
       }),
     );
     expect(result).toContainEqual(
@@ -156,6 +158,8 @@ describe("loadModelCatalog", () => {
         provider: "openai",
         id: "gpt-5.4-pro",
         name: "gpt-5.4-pro",
+        contextWindow: 1_050_000,
+        maxTokens: 128_000,
       }),
     );
     expect(result).toContainEqual(
@@ -164,6 +168,7 @@ describe("loadModelCatalog", () => {
         id: "gpt-5.4",
         name: "gpt-5.4",
         contextWindow: 1_050_000,
+        maxTokens: 128_000,
       }),
     );
   });

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -163,6 +163,7 @@ describe("loadModelCatalog", () => {
         provider: "openai-codex",
         id: "gpt-5.4",
         name: "gpt-5.4",
+        contextWindow: 1_050_000,
       }),
     );
   });

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -36,6 +36,8 @@ const CODEX_PROVIDER = "openai-codex";
 const OPENAI_PROVIDER = "openai";
 const OPENAI_GPT54_MODEL_ID = "gpt-5.4";
 const OPENAI_GPT54_PRO_MODEL_ID = "gpt-5.4-pro";
+const OPENAI_GPT54_CONTEXT_TOKENS = 1_050_000;
+const OPENAI_GPT54_MAX_TOKENS = 128_000;
 const OPENAI_CODEX_GPT53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_GPT53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 const OPENAI_CODEX_GPT54_MODEL_ID = "gpt-5.4";
@@ -45,6 +47,7 @@ type SyntheticCatalogFallback = {
   provider: string;
   id: string;
   templateIds: readonly string[];
+  patch?: Partial<ModelCatalogEntry>;
 };
 
 const SYNTHETIC_CATALOG_FALLBACKS: readonly SyntheticCatalogFallback[] = [
@@ -52,16 +55,19 @@ const SYNTHETIC_CATALOG_FALLBACKS: readonly SyntheticCatalogFallback[] = [
     provider: OPENAI_PROVIDER,
     id: OPENAI_GPT54_MODEL_ID,
     templateIds: ["gpt-5.2"],
+    patch: { contextWindow: OPENAI_GPT54_CONTEXT_TOKENS },
   },
   {
     provider: OPENAI_PROVIDER,
     id: OPENAI_GPT54_PRO_MODEL_ID,
     templateIds: ["gpt-5.2-pro", "gpt-5.2"],
+    patch: { contextWindow: OPENAI_GPT54_CONTEXT_TOKENS },
   },
   {
     provider: CODEX_PROVIDER,
     id: OPENAI_CODEX_GPT54_MODEL_ID,
     templateIds: ["gpt-5.3-codex", "gpt-5.2-codex"],
+    patch: { contextWindow: OPENAI_GPT54_CONTEXT_TOKENS },
   },
   {
     provider: CODEX_PROVIDER,
@@ -90,6 +96,7 @@ function applySyntheticCatalogFallbacks(models: ModelCatalogEntry[]): void {
     }
     models.push({
       ...template,
+      ...fallback.patch,
       id: fallback.id,
       name: fallback.id,
     });

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -12,6 +12,7 @@ export type ModelCatalogEntry = {
   name: string;
   provider: string;
   contextWindow?: number;
+  maxTokens?: number;
   reasoning?: boolean;
   input?: ModelInputType[];
 };
@@ -21,6 +22,7 @@ type DiscoveredModel = {
   name?: string;
   provider: string;
   contextWindow?: number;
+  maxTokens?: number;
   reasoning?: boolean;
   input?: ModelInputType[];
 };
@@ -55,19 +57,28 @@ const SYNTHETIC_CATALOG_FALLBACKS: readonly SyntheticCatalogFallback[] = [
     provider: OPENAI_PROVIDER,
     id: OPENAI_GPT54_MODEL_ID,
     templateIds: ["gpt-5.2"],
-    patch: { contextWindow: OPENAI_GPT54_CONTEXT_TOKENS },
+    patch: {
+      contextWindow: OPENAI_GPT54_CONTEXT_TOKENS,
+      maxTokens: OPENAI_GPT54_MAX_TOKENS,
+    },
   },
   {
     provider: OPENAI_PROVIDER,
     id: OPENAI_GPT54_PRO_MODEL_ID,
     templateIds: ["gpt-5.2-pro", "gpt-5.2"],
-    patch: { contextWindow: OPENAI_GPT54_CONTEXT_TOKENS },
+    patch: {
+      contextWindow: OPENAI_GPT54_CONTEXT_TOKENS,
+      maxTokens: OPENAI_GPT54_MAX_TOKENS,
+    },
   },
   {
     provider: CODEX_PROVIDER,
     id: OPENAI_CODEX_GPT54_MODEL_ID,
     templateIds: ["gpt-5.3-codex", "gpt-5.2-codex"],
-    patch: { contextWindow: OPENAI_GPT54_CONTEXT_TOKENS },
+    patch: {
+      contextWindow: OPENAI_GPT54_CONTEXT_TOKENS,
+      maxTokens: OPENAI_GPT54_MAX_TOKENS,
+    },
   },
   {
     provider: CODEX_PROVIDER,
@@ -151,10 +162,13 @@ function readConfiguredOptInProviderModels(config: OpenClawConfig): ModelCatalog
       const contextWindowRaw = (configuredModel as { contextWindow?: unknown }).contextWindow;
       const contextWindow =
         typeof contextWindowRaw === "number" && contextWindowRaw > 0 ? contextWindowRaw : undefined;
+      const maxTokensRaw = (configuredModel as { maxTokens?: unknown }).maxTokens;
+      const maxTokens =
+        typeof maxTokensRaw === "number" && maxTokensRaw > 0 ? maxTokensRaw : undefined;
       const reasoningRaw = (configuredModel as { reasoning?: unknown }).reasoning;
       const reasoning = typeof reasoningRaw === "boolean" ? reasoningRaw : undefined;
       const input = normalizeConfiguredModelInput((configuredModel as { input?: unknown }).input);
-      out.push({ id, name, provider, contextWindow, reasoning, input });
+      out.push({ id, name, provider, contextWindow, maxTokens, reasoning, input });
     }
   }
 
@@ -254,9 +268,11 @@ export async function loadModelCatalog(params?: {
           typeof entry?.contextWindow === "number" && entry.contextWindow > 0
             ? entry.contextWindow
             : undefined;
+        const maxTokens =
+          typeof entry?.maxTokens === "number" && entry.maxTokens > 0 ? entry.maxTokens : undefined;
         const reasoning = typeof entry?.reasoning === "boolean" ? entry.reasoning : undefined;
         const input = Array.isArray(entry?.input) ? entry.input : undefined;
-        models.push({ id, name, provider, contextWindow, reasoning, input });
+        models.push({ id, name, provider, contextWindow, maxTokens, reasoning, input });
       }
       mergeConfiguredOptInProviderModels({ config: cfg, models });
       applySyntheticCatalogFallbacks(models);

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -363,7 +363,7 @@ describe("resolveForwardCompatModel", () => {
     expectResolvedForwardCompat(model, { provider: "openai-codex", id: "gpt-5.4" });
     expect(model?.api).toBe("openai-codex-responses");
     expect(model?.baseUrl).toBe("https://chatgpt.com/backend-api");
-    expect(model?.contextWindow).toBe(272_000);
+    expect(model?.contextWindow).toBe(1_050_000);
     expect(model?.maxTokens).toBe(128_000);
   });
 

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -172,9 +172,13 @@ function resolveOpenAICodexForwardCompatModel(
     input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     contextWindow:
-      lower === OPENAI_CODEX_GPT_54_MODEL_ID ? OPENAI_CODEX_GPT_54_CONTEXT_TOKENS : DEFAULT_CONTEXT_TOKENS,
+      lower === OPENAI_CODEX_GPT_54_MODEL_ID
+        ? OPENAI_CODEX_GPT_54_CONTEXT_TOKENS
+        : DEFAULT_CONTEXT_TOKENS,
     maxTokens:
-      lower === OPENAI_CODEX_GPT_54_MODEL_ID ? OPENAI_CODEX_GPT_54_MAX_TOKENS : DEFAULT_CONTEXT_TOKENS,
+      lower === OPENAI_CODEX_GPT_54_MODEL_ID
+        ? OPENAI_CODEX_GPT_54_MAX_TOKENS
+        : DEFAULT_CONTEXT_TOKENS,
   } as Model<Api>);
 }
 

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -12,6 +12,8 @@ const OPENAI_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.2"] as const;
 const OPENAI_GPT_54_PRO_TEMPLATE_MODEL_IDS = ["gpt-5.2-pro", "gpt-5.2"] as const;
 
 const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
+const OPENAI_CODEX_GPT_54_CONTEXT_TOKENS = 1_050_000;
+const OPENAI_CODEX_GPT_54_MAX_TOKENS = 128_000;
 const OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex", "gpt-5.2-codex"] as const;
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
@@ -146,6 +148,17 @@ function resolveOpenAICodexForwardCompatModel(
       ...template,
       id: trimmedModelId,
       name: trimmedModelId,
+      ...(lower === OPENAI_CODEX_GPT_54_MODEL_ID
+        ? {
+            api: "openai-codex-responses",
+            provider: normalizedProvider,
+            baseUrl: "https://chatgpt.com/backend-api",
+            reasoning: true,
+            input: ["text", "image"],
+            contextWindow: OPENAI_CODEX_GPT_54_CONTEXT_TOKENS,
+            maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
+          }
+        : {}),
     } as Model<Api>);
   }
 
@@ -158,8 +171,10 @@ function resolveOpenAICodexForwardCompatModel(
     reasoning: true,
     input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_TOKENS,
-    maxTokens: DEFAULT_CONTEXT_TOKENS,
+    contextWindow:
+      lower === OPENAI_CODEX_GPT_54_MODEL_ID ? OPENAI_CODEX_GPT_54_CONTEXT_TOKENS : DEFAULT_CONTEXT_TOKENS,
+    maxTokens:
+      lower === OPENAI_CODEX_GPT_54_MODEL_ID ? OPENAI_CODEX_GPT_54_MAX_TOKENS : DEFAULT_CONTEXT_TOKENS,
   } as Model<Api>);
 }
 

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -82,7 +82,10 @@ export function registerCronAddCommand(cron: Command) {
       .option("--exact", "Disable cron staggering (set stagger to 0)", false)
       .option("--system-event <text>", "System event payload (main session)")
       .option("--message <text>", "Agent message payload")
-      .option("--thinking <level>", "Thinking level for agent jobs (off|minimal|low|medium|high)")
+      .option(
+        "--thinking <level>",
+        "Thinking level for agent jobs (off|minimal|low|medium|high|xhigh|adaptive)",
+      )
       .option("--model <model>", "Model override for agent jobs (provider/model or alias)")
       .option("--timeout-seconds <n>", "Timeout seconds for agent jobs")
       .option("--light-context", "Use lightweight bootstrap context for agent jobs", false)

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -49,7 +49,10 @@ export function registerCronEditCommand(cron: Command) {
       .option("--exact", "Disable cron staggering (set stagger to 0)")
       .option("--system-event <text>", "Set systemEvent payload")
       .option("--message <text>", "Set agentTurn payload message")
-      .option("--thinking <level>", "Thinking level for agent jobs")
+      .option(
+        "--thinking <level>",
+        "Thinking level for agent jobs (off|minimal|low|medium|high|xhigh|adaptive)",
+      )
       .option("--model <model>", "Model override for agent jobs")
       .option("--timeout-seconds <n>", "Timeout seconds for agent jobs")
       .option("--light-context", "Enable lightweight bootstrap context for agent jobs")

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -27,7 +27,10 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
     .option("-t, --to <number>", "Recipient number in E.164 used to derive the session key")
     .option("--session-id <id>", "Use an explicit session id")
     .option("--agent <id>", "Agent id (overrides routing bindings)")
-    .option("--thinking <level>", "Thinking level: off | minimal | low | medium | high")
+    .option(
+      "--thinking <level>",
+      "Thinking level: off | minimal | low | medium | high | xhigh | adaptive",
+    )
     .option("--verbose <on|off>", "Persist agent verbose level for the session")
     .option(
       "--channel <channel>",

--- a/src/commands/auth-choice.apply.openai.test.ts
+++ b/src/commands/auth-choice.apply.openai.test.ts
@@ -50,7 +50,7 @@ describe("applyAuthChoiceOpenAI", () => {
     });
     const defaultModel = result?.config.agents?.defaults?.model;
     const primaryModel = typeof defaultModel === "string" ? defaultModel : defaultModel?.primary;
-    expect(primaryModel).toBe("openai/gpt-5.1-codex");
+    expect(primaryModel).toBe("openai/gpt-5.4");
     expect(text).not.toHaveBeenCalled();
 
     const parsed = await readAuthProfilesForAgent<{

--- a/src/commands/openai-model-default.test.ts
+++ b/src/commands/openai-model-default.test.ts
@@ -116,7 +116,7 @@ describe("applyDefaultModelChoice", () => {
   });
 
   it("uses applyDefaultConfig path when setDefaultModel is true", async () => {
-    const defaultModel = "openai/gpt-5.1-codex";
+    const defaultModel = "openai/gpt-5.4";
     const applied = await applyDefaultModelChoice({
       config: {},
       setDefaultModel: true,

--- a/src/commands/openai-model-default.ts
+++ b/src/commands/openai-model-default.ts
@@ -1,7 +1,7 @@
 import type { OpenClawConfig } from "../config/config.js";
 import { ensureModelAllowlistEntry } from "./model-allowlist.js";
 
-export const OPENAI_DEFAULT_MODEL = "openai/gpt-5.1-codex";
+export const OPENAI_DEFAULT_MODEL = "openai/gpt-5.4";
 
 export function applyOpenAIProviderConfig(cfg: OpenClawConfig): OpenClawConfig {
   const next = ensureModelAllowlistEntry({

--- a/src/config/schema.help.quality.test.ts
+++ b/src/config/schema.help.quality.test.ts
@@ -395,7 +395,15 @@ const ENUM_EXPECTATIONS: Record<string, string[]> = {
   "hooks.mappings[].action": ['"wake"', '"agent"'],
   "hooks.mappings[].wakeMode": ['"now"', '"next-heartbeat"'],
   "hooks.gmail.tailscale.mode": ['"off"', '"serve"', '"funnel"'],
-  "hooks.gmail.thinking": ['"off"', '"minimal"', '"low"', '"medium"', '"high"'],
+  "hooks.gmail.thinking": [
+    '"off"',
+    '"minimal"',
+    '"low"',
+    '"medium"',
+    '"high"',
+    '"xhigh"',
+    '"adaptive"',
+  ],
   "messages.queue.mode": [
     '"steer"',
     '"followup"',

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1268,7 +1268,7 @@ export const FIELD_HELP: Record<string, string> = {
   "hooks.gmail.model":
     "Optional model override for Gmail-triggered runs when mailbox automations should use dedicated model behavior. Keep unset to inherit agent defaults unless mailbox tasks need specialization.",
   "hooks.gmail.thinking":
-    'Thinking effort override for Gmail-driven agent runs: "off", "minimal", "low", "medium", or "high". Keep modest defaults for routine inbox automations to control cost and latency.',
+    'Thinking effort override for Gmail-driven agent runs: "off", "minimal", "low", "medium", "high", "xhigh", or "adaptive". Use "adaptive" for provider-managed reasoning (for example Anthropic Claude 4.6); "xhigh" is available on supported OpenAI/Codex GPT-5.x models. Keep modest defaults for routine inbox automations to control cost and latency.',
   "hooks.internal":
     "Internal hook runtime settings for bundled/custom event handlers loaded from module paths. Use this for trusted in-process automations and keep handler loading tightly scoped.",
   "hooks.internal.enabled":


### PR DESCRIPTION
## Summary
- finish the remaining GPT-5.4 user-facing support updates across docs and CLI help text
- update OpenAI API onboarding defaults from `openai/gpt-5.1-codex` to `openai/gpt-5.4`
- align `openai-codex/gpt-5.4` forward-compat/catalog metadata with Codex's experimental 1M context window

## What changed
- docs/help: add `adaptive` where thinking levels are listed and replace stale wording that said `xhigh` was only for GPT-5.2 + Codex models
- CLI help: update agent/cron thinking descriptions to include `xhigh` and `adaptive`
- onboarding/config: switch the OpenAI API default model to `openai/gpt-5.4`
- model metadata: make `openai-codex/gpt-5.4` use 1,050,000 context tokens / 128,000 max output tokens in forward-compat + synthetic catalog paths

## Verification
- passed targeted tests:
  - `src/agents/model-catalog.test.ts`
  - `src/agents/model-compat.test.ts`
  - `src/commands/openai-model-default.test.ts`
  - `src/commands/auth-choice.apply.openai.test.ts`
  - `src/config/schema.help.quality.test.ts`