### PR TITLE
fix(ui): support output_text content type in message extractor

### DIFF
--- a/ui/src/ui/chat/message-extract.test.ts
+++ b/ui/src/ui/chat/message-extract.test.ts
@@ -42,6 +42,26 @@ describe("extractTextCached", () => {
     expect(extractText(message)).toBe("Final user answer");
     expect(extractTextCached(message)).toBe("Final user answer");
   });
+
+  it("extracts output_text blocks for assistant replies", () => {
+    const message = {
+      role: "assistant",
+      content: [{ type: "output_text", text: "OpenResponses reply" }],
+    };
+    expect(extractText(message)).toBe("OpenResponses reply");
+    expect(extractTextCached(message)).toBe("OpenResponses reply");
+  });
+
+  it("extracts mixed input/output text blocks", () => {
+    const message = {
+      role: "assistant",
+      content: [
+        { type: "input_text", text: "Prompt mirror" },
+        { type: "output_text", text: "Final answer" },
+      ],
+    };
+    expect(extractText(message)).toBe("Prompt mirror\nFinal answer");
+  });
 });
 
 describe("extractThinkingCached", () => {

--- a/ui/src/ui/chat/message-extract.ts
+++ b/ui/src/ui/chat/message-extract.ts
@@ -6,8 +6,9 @@ const textCache = new WeakMap<object, string | null>();
 const thinkingCache = new WeakMap<object, string | null>();
 
 function processMessageText(text: string, role: string): string {
-  const shouldStripInboundMetadata = role.toLowerCase() === "user";
-  if (role === "assistant") {
+  const normalizedRole = role.toLowerCase();
+  const shouldStripInboundMetadata = normalizedRole === "user";
+  if (normalizedRole === "assistant") {
     return stripThinkingTags(text);
   }
   return shouldStripInboundMetadata
@@ -92,7 +93,11 @@ export function extractRawText(message: unknown): string | null {
     const parts = content
       .map((p) => {
         const item = p as Record<string, unknown>;
-        if (item.type === "text" && typeof item.text === "string") {
+        const type = typeof item.type === "string" ? item.type : "";
+        if (
+          (type === "text" || type === "output_text" || type === "input_text") &&
+          typeof item.text === "string"
+        ) {
           return item.text;
         }
         return null;

--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -70,6 +70,23 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe("Hello");
   });
 
+  it("accepts output_text delta updates", () => {
+    const state = createState({
+      sessionKey: "main",
+      chatRunId: "run-1",
+      chatStream: null,
+    });
+    const payload: ChatEventPayload = {
+      runId: "run-1",
+      sessionKey: "main",
+      state: "delta",
+      message: { role: "assistant", content: [{ type: "output_text", text: "From Responses" }] },
+    };
+
+    expect(handleChatEvent(state, payload)).toBe("delta");
+    expect(state.chatStream).toBe("From Responses");
+  });
+
   it("appends final payload from another run without clearing active stream", () => {
     const state = createState({
       sessionKey: "main",


### PR DESCRIPTION
The TUI was not displaying assistant replies because the message extractor only recognized 'text' type content blocks. OpenAI Responses API returns 'output_text' and 'input_text' types.

This fix:
- Adds support for output_text and input_text content types
- Normalizes role comparison to handle case variations
- Adds tests for the new content types

Fixes #37168

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
