### PR TITLE
feat: enable prompt caching for custom providers using anthropic-mess…

### DIFF
--- a/src/agents/pi-embedded-runner-extraparams.test.ts
+++ b/src/agents/pi-embedded-runner-extraparams.test.ts
@@ -990,6 +990,140 @@ describe("applyExtraParamsToAgent", () => {
     expect(calls[0]?.transport).toBe("auto");
   });
 
+  it("enables prompt caching for custom providers using anthropic-messages API", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "my-enterprise-proxy",
+      "claude-opus-4-6",
+      undefined,
+      undefined,
+      undefined,
+      "anthropic-messages",
+    );
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "my-enterprise-proxy",
+      id: "claude-opus-4-6",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cacheRetention).toBe("short");
+  });
+
+  it("respects explicit cacheRetention for custom anthropic-messages providers", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "my-enterprise-proxy/claude-opus-4-6": {
+              params: {
+                cacheRetention: "long",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(
+      agent,
+      cfg,
+      "my-enterprise-proxy",
+      "claude-opus-4-6",
+      undefined,
+      undefined,
+      undefined,
+      "anthropic-messages",
+    );
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "my-enterprise-proxy",
+      id: "claude-opus-4-6",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cacheRetention).toBe("long");
+  });
+
+  it("allows disabling caching for custom anthropic-messages providers via cacheRetention=none", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+    const cfg = {
+      agents: {
+        defaults: {
+          models: {
+            "my-enterprise-proxy/claude-opus-4-6": {
+              params: {
+                cacheRetention: "none",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    applyExtraParamsToAgent(
+      agent,
+      cfg,
+      "my-enterprise-proxy",
+      "claude-opus-4-6",
+      undefined,
+      undefined,
+      undefined,
+      "anthropic-messages",
+    );
+
+    const model = {
+      api: "anthropic-messages",
+      provider: "my-enterprise-proxy",
+      id: "claude-opus-4-6",
+    } as Model<"anthropic-messages">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cacheRetention).toBe("none");
+  });
+
+  it("does not enable caching for custom providers using openai-completions API", () => {
+    const { calls, agent } = createOptionsCaptureAgent();
+
+    applyExtraParamsToAgent(
+      agent,
+      undefined,
+      "my-enterprise-proxy",
+      "claude-opus-4-6",
+      undefined,
+      undefined,
+      undefined,
+      "openai-completions",
+    );
+
+    const model = {
+      api: "openai-completions",
+      provider: "my-enterprise-proxy",
+      id: "claude-opus-4-6",
+    } as Model<"openai-completions">;
+    const context: Context = { messages: [] };
+
+    void agent.streamFn?.(model, context, {});
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cacheRetention).toBeUndefined();
+  });
+
   it("disables prompt caching for non-Anthropic Bedrock models", () => {
     const { calls, agent } = createOptionsCaptureAgent();
 

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -58,23 +58,26 @@ type CacheRetentionStreamOptions = Partial<SimpleStreamOptions> & {
  *
  * Applies to:
  * - direct Anthropic provider
+ * - any custom provider using the `anthropic-messages` API
  * - Anthropic Claude models on Bedrock when cache retention is explicitly configured
  *
  * OpenRouter uses openai-completions API with hardcoded cache_control instead
  * of the cacheRetention stream option.
  *
- * Defaults to "short" for direct Anthropic when not explicitly configured.
+ * Defaults to "short" for Anthropic-compatible providers when not explicitly configured.
  */
 function resolveCacheRetention(
   extraParams: Record<string, unknown> | undefined,
   provider: string,
+  modelApi?: string,
 ): CacheRetention | undefined {
   const isAnthropicDirect = provider === "anthropic";
+  const isAnthropicApi = modelApi === "anthropic-messages";
   const hasBedrockOverride =
     extraParams?.cacheRetention !== undefined || extraParams?.cacheControlTtl !== undefined;
   const isAnthropicBedrock = provider === "amazon-bedrock" && hasBedrockOverride;
 
-  if (!isAnthropicDirect && !isAnthropicBedrock) {
+  if (!isAnthropicDirect && !isAnthropicApi && !isAnthropicBedrock) {
     return undefined;
   }
 
@@ -93,43 +96,42 @@ function resolveCacheRetention(
     return "long";
   }
 
-  // Default to "short" only for direct Anthropic when not explicitly configured.
+  // Default to "short" for direct Anthropic or any anthropic-messages API provider.
   // Bedrock retains upstream provider defaults unless explicitly set.
-  if (!isAnthropicDirect) {
-    return undefined;
+  if (isAnthropicDirect || isAnthropicApi) {
+    return "short";
   }
 
-  // Default to "short" for direct Anthropic when not explicitly configured
-  return "short";
+  return undefined;
 }
 
 function createStreamFnWithExtraParams(
   baseStreamFn: StreamFn | undefined,
   extraParams: Record<string, unknown> | undefined,
   provider: string,
+  modelApi?: string,
 ): StreamFn | undefined {
-  if (!extraParams || Object.keys(extraParams).length === 0) {
-    return undefined;
-  }
-
   const streamParams: CacheRetentionStreamOptions = {};
-  if (typeof extraParams.temperature === "number") {
-    streamParams.temperature = extraParams.temperature;
+
+  if (extraParams && Object.keys(extraParams).length > 0) {
+    if (typeof extraParams.temperature === "number") {
+      streamParams.temperature = extraParams.temperature;
+    }
+    if (typeof extraParams.maxTokens === "number") {
+      streamParams.maxTokens = extraParams.maxTokens;
+    }
+    const transport = extraParams.transport;
+    if (transport === "sse" || transport === "websocket" || transport === "auto") {
+      streamParams.transport = transport;
+    } else if (transport != null) {
+      const transportSummary = typeof transport === "string" ? transport : typeof transport;
+      log.warn(`ignoring invalid transport param: ${transportSummary}`);
+    }
+    if (typeof extraParams.openaiWsWarmup === "boolean") {
+      streamParams.openaiWsWarmup = extraParams.openaiWsWarmup;
+    }
   }
-  if (typeof extraParams.maxTokens === "number") {
-    streamParams.maxTokens = extraParams.maxTokens;
-  }
-  const transport = extraParams.transport;
-  if (transport === "sse" || transport === "websocket" || transport === "auto") {
-    streamParams.transport = transport;
-  } else if (transport != null) {
-    const transportSummary = typeof transport === "string" ? transport : typeof transport;
-    log.warn(`ignoring invalid transport param: ${transportSummary}`);
-  }
-  if (typeof extraParams.openaiWsWarmup === "boolean") {
-    streamParams.openaiWsWarmup = extraParams.openaiWsWarmup;
-  }
-  const cacheRetention = resolveCacheRetention(extraParams, provider);
+  const cacheRetention = resolveCacheRetention(extraParams, provider, modelApi);
   if (cacheRetention) {
     streamParams.cacheRetention = cacheRetention;
   }
@@ -1047,6 +1049,7 @@ export function applyExtraParamsToAgent(
   extraParamsOverride?: Record<string, unknown>,
   thinkingLevel?: ThinkLevel,
   agentId?: string,
+  modelApi?: string,
 ): void {
   const extraParams = resolveExtraParams({
     cfg,
@@ -1068,7 +1071,7 @@ export function applyExtraParamsToAgent(
         )
       : undefined;
   const merged = Object.assign({}, extraParams, override);
-  const wrappedStreamFn = createStreamFnWithExtraParams(agent.streamFn, merged, provider);
+  const wrappedStreamFn = createStreamFnWithExtraParams(agent.streamFn, merged, provider, modelApi);
 
   if (wrappedStreamFn) {
     log.debug(`applying extraParams to agent streamFn for ${provider}/${modelId}`);

--- a/src/agents/pi-embedded-runner/extra-params.ts
+++ b/src/agents/pi-embedded-runner/extra-params.ts
@@ -144,7 +144,7 @@ function createStreamFnWithExtraParams(
   // data_collection, ignore, sort, quantizations, etc.
   const providerRouting =
     provider === "openrouter" &&
-    extraParams.provider != null &&
+    extraParams?.provider != null &&
     typeof extraParams.provider === "object"
       ? (extraParams.provider as Record<string, unknown>)
       : undefined;

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1200,6 +1200,7 @@ export async function runEmbeddedAttempt(
         params.streamParams,
         params.thinkLevel,
         sessionAgentId,
+        typeof params.model?.api === "string" ? params.model.api : undefined,
       );
 
       if (cacheTrace) {


### PR DESCRIPTION
## Summary

- **Problem:** `resolveCacheRetention()` only enables prompt caching for hardcoded `provider === "anthropic"`, so custom providers with `api: "anthropic-messages"` never get caching
- **Why it matters:** Prompt caching can reduce costs by 80-90% for long conversations with Claude models
- **What changed:** Added `modelApi` parameter to check `modelApi === "anthropic-messages"` alongside the existing provider check
- **What did NOT change:** Existing `provider === "anthropic"` and Bedrock behavior is unchanged

## Change Type
- [x] Feature

## Scope
- [x] Gateway / orchestration

## Linked Issue/PR
- Closes #37325

## User-visible / Behavior Changes
Custom providers with `api: "anthropic-messages"` now get `cacheRetention: "short"` by default. Override via `params.cacheRetention`.

## Security Impact
- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Evidence
- 4 new test cases, all 60 tests pass

## Compatibility / Migration
- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Risks and Mitigations
- Risk: Providers that don't support caching receive `cache_control` fields
- Mitigation: Set `params.cacheRetention: "none"` to opt out