### PR TITLE
fix(infra): treat wrapped "fetch failed" as transient network error

### DIFF
--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -145,6 +145,14 @@ describe("isTransientNetworkError", () => {
     expect(isTransientNetworkError(new Error("tlsv1 alert protocol version"))).toBe(true);
   });
 
+  it("returns true for wrapped fetch-failed with preserved cause chain (#37375)", () => {
+    const cause = new TypeError("fetch failed");
+    const error = new Error("Failed to get gateway information from Discord: fetch failed", {
+      cause,
+    });
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
   it("returns false for regular errors without network codes", () => {
     expect(isTransientNetworkError(new Error("Something went wrong"))).toBe(false);
     expect(isTransientNetworkError(new TypeError("Cannot read property"))).toBe(false);


### PR DESCRIPTION
## Summary

- **Problem:** @buape/carbon's `GatewayPlugin.registerClient()` wraps the original `TypeError("fetch failed")` into a plain `Error` without `{ cause }`, stripping the error chain. `isTransientNetworkError()` fails to recognize the wrapped message, so the unhandled rejection handler calls `process.exit(1)`, crashing the gateway.
- **Why it matters:** On systems with intermittent connectivity (WSL2, VPN, flaky ISP), this causes infinite crash loops via systemd restart — 76 crashes/day observed in the reporter's case.
- **What changed:** Added `"fetch failed"` to `TRANSIENT_NETWORK_MESSAGE_SNIPPETS` so the substring check catches any error message containing "fetch failed", including wrapped variants like `"Failed to get gateway information from Discord: fetch failed"`.
- **What did NOT change:** No modifications to the Discord provider, Carbon dependency, or error graph traversal logic.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Gateway / orchestration

## Linked Issue/PR

- Closes #37375

## User-visible / Behavior Changes

Gateway no longer crashes on transient Discord API fetch failures. Instead, the error is logged as a non-fatal warning and the process continues.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (WSL2) / any with intermittent connectivity
- Runtime: Node 22+
- Integration/channel: Discord

### Steps

1. Configure OpenClaw with Discord channel enabled
2. Simulate network failure during Discord provider startup (e.g., block `discord.com`)
3. Observe that gateway logs the error as a warning instead of crashing

### Expected

- Gateway logs: `[openclaw] Non-fatal unhandled rejection (continuing): ...`

### Actual (before fix)

- Gateway crashes: `[openclaw] Unhandled promise rejection: Error: Failed to get gateway information from Discord: fetch failed`

## Evidence

- [x] Failing test/log before + passing after

```
 ✓ src/infra/unhandled-rejections.test.ts (31 tests) 5ms
   ✓ returns true for wrapped fetch-failed from third-party libraries (#37375)
   ✓ returns true for wrapped fetch-failed with preserved cause chain
```

## Human Verification (required)

- Verified scenarios: Both wrapped (no cause) and wrapped (with cause) error patterns match
- Edge cases checked: Plain `TypeError("fetch failed")` still matches via existing exact-match check (line 157/172); new snippet is additive
- What I did **not** verify: Live Discord API failure (no Discord bot token available)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this single commit
- Files: `src/infra/unhandled-rejections.ts`

## Risks and Mitigations

- Risk: The snippet `"fetch failed"` is broad and could match non-network errors containing that substring.
  - Mitigation: The snippet check runs last in the detection chain (after code/name/exact-match checks), and "fetch failed" in an error message strongly implies a network fetch operation. The existing exact-match `message === "fetch failed"` at line 172 already catches the base case; this extends coverage to wrapped variants.