### PR TITLE
fix: The fix will allow the redirect link to recognize Chinese charac…

### DIFF
--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -75,7 +75,7 @@ openclaw channels add
 
 访问 [飞书开放平台](https://open.feishu.cn/app)，使用飞书账号登录。
 
-Lark（国际版）请使用 https://open.larksuite.com/app，并在配置中设置 `domain: "lark"`。
+Lark（国际版）请使用 [Lark Open Platform](https://open.larksuite.com/app)，并在配置中设置 `domain: "lark"`。
 
 ### 2. 创建应用
 


### PR DESCRIPTION
Summary

Problem:
The raw URL https://open.larksuite.com/app was incorrectly parsed as a clickable link including the following Chinese text (，并在配置中设置) in some Markdown renderers.

Why it matters:
This results in an invalid link and may break navigation for users.

What changed:
Replaced the raw URL with an explicit Markdown link: [Lark Open Platform](https://open.larksuite.com/app).

What did NOT change (scope boundary):
No code or functional behavior changes. Documentation only.

Change Type
[x] Docs
[ ] Bug fix
[ ] Feature
[ ] Refactor
[ ] Security hardening
[ ] Chore/infra
Scope
[ ] Gateway / orchestration
[ ] Skills / tool execution
[ ] Auth / tokens
[ ] Memory / storage
[ ] Integrations
[ ] API / contracts
[ ] UI / DX
[x] Docs
[ ] CI/CD / infra



Linked Issue/PR

如果没有 issue：

None
User-visible / Behavior Changes
Improved documentation link formatting for the Lark Open Platform login step.

或者简单点：

None (documentation formatting only).
Security Impact (required)

因为只是文档，所以全是 No：

New permissions/capabilities? No
Secrets/tokens handling changed? No
New/changed network calls? No
Command/tool execution surface changed? No
Data access scope changed? No
Repro + Verification
Steps
1. Open the documentation page
2. Locate the Lark Open Platform login instruction
3. Observe the link rendering
Expected
The link correctly points to https://open.larksuite.com/app
Actual
Previously, the link could incorrectly include trailing Chinese text.
Evidence
Screenshot of the rendered documentation before and after the change.

Human Verification (required)
Verified the documentation rendering locally and confirmed the link works correctly.

Edge cases checked:
- Link rendering with Chinese punctuation
Compatibility / Migration
Backward compatible? Yes
Config/env changes? No
Migration needed? No
Failure Recovery
Revert the documentation change if needed.
Risks and Mitigations
None