### PR TITLE
fix(agents): exclude attachment paths from message tool fingerprint

### DIFF
--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -65,6 +65,53 @@ describe("tool mutation helpers", () => {
     ).toBe(false);
   });
 
+  it("excludes attachment path from message tool fingerprint so retries match (#37430)", () => {
+    // First call: send with file from /tmp (will fail)
+    const firstAttempt = buildToolActionFingerprint("message", {
+      action: "send",
+      to: "telegram:413",
+      filePath: "/tmp/report.pdf",
+    });
+    // Retry: same target, file copied to workspace
+    const retry = buildToolActionFingerprint("message", {
+      action: "send",
+      to: "telegram:413",
+      filePath: "/home/user/.openclaw/workspace/report.pdf",
+    });
+    expect(firstAttempt).toBeDefined();
+    expect(retry).toBeDefined();
+    expect(firstAttempt).toBe(retry);
+    // Both should match on target, not file path
+    expect(firstAttempt).toContain("to=telegram:413");
+    expect(firstAttempt).not.toContain("filepath=");
+    expect(firstAttempt).not.toContain("path=");
+  });
+
+  it("retains path in fingerprint for file-mutating tools", () => {
+    const fp = buildToolActionFingerprint("write", { path: "/tmp/demo.txt" });
+    expect(fp).toContain("path=/tmp/demo.txt");
+  });
+
+  it("clears lastToolError when message retry with different path succeeds (#37430)", () => {
+    const failedRef = {
+      toolName: "message",
+      actionFingerprint: buildToolActionFingerprint("message", {
+        action: "send",
+        to: "telegram:413",
+        filePath: "/tmp/report.pdf",
+      }),
+    };
+    const retryRef = {
+      toolName: "message",
+      actionFingerprint: buildToolActionFingerprint("message", {
+        action: "send",
+        to: "telegram:413",
+        filePath: "/home/user/workspace/report.pdf",
+      }),
+    };
+    expect(isSameToolMutationAction(failedRef, retryRef)).toBe(true);
+  });
+
   it("keeps legacy name-only mutating heuristics for payload fallback", () => {
     expect(isLikelyMutatingToolName("sessions_send")).toBe(true);
     expect(isLikelyMutatingToolName("browser_actions")).toBe(true);

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -92,7 +92,7 @@ describe("tool mutation helpers", () => {
     expect(fp).toContain("path=/tmp/demo.txt");
   });
 
-  it("clears lastToolError when message retry with different path succeeds (#37430)", () => {
+  it("isSameToolMutationAction returns true for message retry with different attachment path (#37430)", () => {
     const failedRef = {
       toolName: "message",
       actionFingerprint: buildToolActionFingerprint("message", {

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -151,20 +151,30 @@ export function buildToolActionFingerprint(
   if (action) {
     parts.push(`action=${action}`);
   }
+  // For messaging tools, path/filePath represent attachments — not the core
+  // action identity.  Exclude them so a retry with a corrected file path
+  // still matches the original failed action (same target, same intent).
+  const isMessageTool =
+    normalizedTool === "message" ||
+    normalizedTool.startsWith("message_") ||
+    normalizedTool.includes("send");
+  const fingerprintKeys = isMessageTool
+    ? ["to", "target", "messageId", "sessionKey", "jobId", "id"]
+    : [
+        "path",
+        "filePath",
+        "oldPath",
+        "newPath",
+        "to",
+        "target",
+        "messageId",
+        "sessionKey",
+        "jobId",
+        "id",
+        "model",
+      ];
   let hasStableTarget = false;
-  for (const key of [
-    "path",
-    "filePath",
-    "oldPath",
-    "newPath",
-    "to",
-    "target",
-    "messageId",
-    "sessionKey",
-    "jobId",
-    "id",
-    "model",
-  ]) {
+  for (const key of fingerprintKeys) {
     const value = normalizeFingerprintValue(record?.[key]);
     if (value) {
       parts.push(`${key.toLowerCase()}=${value}`);


### PR DESCRIPTION
## Summary

- **Problem:** When the `message` tool fails on a first attempt (e.g., file path not allowed) and the LLM retries with a corrected path, `isSameToolMutationAction` returns `false` because the fingerprint includes `path`/`filePath` which changed between attempts. The stale `lastToolError` is never cleared, causing a confusing error notification after the successful retry.
- **Why it matters:** Users see "⚠️ Message: send failed" after a message was successfully delivered, creating confusion about whether the action actually worked.
- **What changed:** Message-like tools (`message`, `message_*`, `*send*`) now use only messaging target keys (`to`, `target`, `messageId`, etc.) for action fingerprinting, excluding file system keys (`path`, `filePath`, etc.). File-mutating tools (`write`, `edit`, etc.) retain full path-based fingerprints unchanged.
- **What did NOT change:** `isMutatingToolCall`, `isSameToolMutationAction`, and the error notification rendering logic are unchanged. Only the key selection in `buildToolActionFingerprint` is scoped per tool type.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution

## Linked Issue/PR

- Closes #37430

## User-visible / Behavior Changes

When a `message` tool call fails and is retried with a different file path but the same target, the error notification from the first failed attempt is now correctly suppressed after the retry succeeds.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- Channel: Telegram (or any)
- Scenario: `message` tool with `filePath` + `threadId`

### Steps

1. Use `message` tool to send file from `/tmp/` → fails (path not allowed)
2. Copy file to workspace, retry with same target
3. Retry succeeds

### Expected

- No error notification after successful retry

### Actual (before fix)

- `⚠️ ✉️ Message: 413 failed` notification appears after successful delivery

## Evidence

- [x] Failing test/log before + passing after

```
 ✓ excludes attachment path from message tool fingerprint so retries match (#37430)
 ✓ retains path in fingerprint for file-mutating tools
 ✓ clears lastToolError when message retry with different path succeeds (#37430)
```

## Human Verification (required)

- Verified scenarios: Message tool fingerprint matches across path changes; write tool fingerprint still distinguishes paths
- Edge cases checked: `message_slack` and `sessions_send` variants covered by `isMessageTool` heuristic; `model` key excluded for message tools (not relevant for messaging)
- What I did **not** verify: Live Telegram message retry (no bot token available)

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this single commit
- Files: `src/agents/tool-mutation.ts`

## Risks and Mitigations

- Risk: Broader fingerprint matching for message tools could suppress legitimate error notifications when truly different actions share the same target.
  - Mitigation: The fingerprint still includes action type and target. Two calls to the same target with the same action type (e.g., both `send`) are semantically the same action even if attachments differ. Different action types (e.g., `send` vs `delete`) produce different fingerprints and are not affected.