### PR TITLE
feat(github-copilot): add gpt-5.4 to supported GitHub Copilot model list and add test case

### DIFF
--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -52,14 +52,14 @@ openclaw models auth login-github-copilot --yes
 ## Set a default model
 
 ```bash
-openclaw models set github-copilot/gpt-5.4
+openclaw models set github-copilot/gpt-4o
 ```
 
 ### Config snippet
 
 ```json5
 {
-  agents: { defaults: { model: { primary: "github-copilot/gpt-5.4" } } },
+  agents: { defaults: { model: { primary: "github-copilot/gpt-4o" } } },
 }
 ```
 
@@ -67,6 +67,6 @@ openclaw models set github-copilot/gpt-5.4
 
 - Requires an interactive TTY; run it directly in a terminal.
 - Copilot model availability depends on your plan; if a model is rejected, try
-  another ID (for example `github-copilot/gpt-5.4` or `github-copilot/gpt-4.1`).
+  another ID (for example `github-copilot/gpt-4.1`).
 - The login stores a GitHub token in the auth profile store and exchanges it for a
   Copilot API token when OpenClaw runs.

--- a/docs/providers/github-copilot.md
+++ b/docs/providers/github-copilot.md
@@ -52,14 +52,14 @@ openclaw models auth login-github-copilot --yes
 ## Set a default model
 
 ```bash
-openclaw models set github-copilot/gpt-4o
+openclaw models set github-copilot/gpt-5.4
 ```
 
 ### Config snippet
 
 ```json5
 {
-  agents: { defaults: { model: { primary: "github-copilot/gpt-4o" } } },
+  agents: { defaults: { model: { primary: "github-copilot/gpt-5.4" } } },
 }
 ```
 
@@ -67,6 +67,6 @@ openclaw models set github-copilot/gpt-4o
 
 - Requires an interactive TTY; run it directly in a terminal.
 - Copilot model availability depends on your plan; if a model is rejected, try
-  another ID (for example `github-copilot/gpt-4.1`).
+  another ID (for example `github-copilot/gpt-5.4` or `github-copilot/gpt-4.1`).
 - The login stores a GitHub token in the auth profile store and exchanges it for a
   Copilot API token when OpenClaw runs.

--- a/src/providers/github-copilot-models.test.ts
+++ b/src/providers/github-copilot-models.test.ts
@@ -11,6 +11,10 @@ describe("github-copilot-models", () => {
       expect(getDefaultCopilotModelIds()).toContain("claude-sonnet-4.5");
     });
 
+    it("includes gpt-5.4", () => {
+      expect(getDefaultCopilotModelIds()).toContain("gpt-5.4");
+    });
+
     it("returns a mutable copy", () => {
       const a = getDefaultCopilotModelIds();
       const b = getDefaultCopilotModelIds();

--- a/src/providers/github-copilot-models.ts
+++ b/src/providers/github-copilot-models.ts
@@ -9,6 +9,7 @@ const DEFAULT_MAX_TOKENS = 8192;
 const DEFAULT_MODEL_IDS = [
   "claude-sonnet-4.6",
   "claude-sonnet-4.5",
+  "gpt-5.4",
   "gpt-4o",
   "gpt-4.1",
   "gpt-4.1-mini",


### PR DESCRIPTION
## Summary
This PR updates the GitHub Copilot provider supported model list to include GPT-5.4 and keeps the related docs and tests in sync.

## Changes
- add gpt-5.4 to supported GitHub Copilot model list
- add a regression test asserting that getDefaultCopilotModelIds() includes gpt-5.4

## Why
- add the GitHub Copilot supported model list with GPT-5.4 

## Testing
- added automated test coverage for the new default model entry
