### PR TITLE
Guard known Whisper subtitle-credit hallucinations in audio transcripts

### DIFF
--- a/src/media-understanding/runner.entries.guards.test.ts
+++ b/src/media-understanding/runner.entries.guards.test.ts
@@ -51,6 +51,8 @@ describe("media-understanding formatDecisionSummary guards", () => {
 
   it("drops known whisper subtitle-credit hallucinations", () => {
     expect(sanitizeAudioTranscript("Субтитры сделал DimaTorzok")).toBe("");
+    expect(sanitizeAudioTranscript("Субтитры сделала DimaTorzok")).toBe("");
+    expect(sanitizeAudioTranscript("Субтитры сделали DimaTorzok")).toBe("");
     expect(sanitizeAudioTranscript("subtitles by someguy")).toBe("");
     expect(sanitizeAudioTranscript("translated by cool_name")).toBe("");
   });

--- a/src/media-understanding/runner.entries.guards.test.ts
+++ b/src/media-understanding/runner.entries.guards.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatDecisionSummary } from "./runner.entries.js";
+import { formatDecisionSummary, sanitizeAudioTranscript } from "./runner.entries.js";
 import type { MediaUnderstandingDecision } from "./types.js";
 
 describe("media-understanding formatDecisionSummary guards", () => {
@@ -47,5 +47,19 @@ describe("media-understanding formatDecisionSummary guards", () => {
 
     expect(run).not.toThrow();
     expect(run()).toBe("audio: failed (0/1)");
+  });
+
+  it("drops known whisper subtitle-credit hallucinations", () => {
+    expect(sanitizeAudioTranscript("Субтитры сделал DimaTorzok")).toBe("");
+    expect(sanitizeAudioTranscript("subtitles by someguy")).toBe("");
+    expect(sanitizeAudioTranscript("translated by cool_name")).toBe("");
+  });
+
+  it("preserves normal speech transcripts", () => {
+    expect(
+      sanitizeAudioTranscript(
+        "Так, давай ты мне сейчас соберешь дайджест из всех хардбитов за ночь.",
+      ),
+    ).toBe("Так, давай ты мне сейчас соберешь дайджест из всех хардбитов за ночь.");
   });
 });

--- a/src/media-understanding/runner.entries.ts
+++ b/src/media-understanding/runner.entries.ts
@@ -48,6 +48,28 @@ function trimOutput(text: string, maxChars?: number): string {
   return trimmed.slice(0, maxChars).trim();
 }
 
+const KNOWN_AUDIO_HALLUCINATION_PATTERNS = [
+  /^\s*субтитры\s+сделал[аи]?\s+[\p{L}\d_. -]{2,}\s*$/iu,
+  /^\s*subtitles?\s+by\s+[\p{L}\d_. -]{2,}\s*$/iu,
+  /^\s*translated\s+by\s+[\p{L}\d_. -]{2,}\s*$/iu,
+];
+
+export function sanitizeAudioTranscript(text: string): string {
+  const trimmed = trimOutput(text);
+  if (!trimmed) {
+    return trimmed;
+  }
+  for (const pattern of KNOWN_AUDIO_HALLUCINATION_PATTERNS) {
+    if (pattern.test(trimmed)) {
+      if (shouldLogVerbose()) {
+        logVerbose(`audio-transcription: dropped known hallucination transcript: ${trimmed}`);
+      }
+      return "";
+    }
+  }
+  return trimmed;
+}
+
 function extractSherpaOnnxText(raw: string): string | null {
   const tryParse = (value: string): string | null => {
     const trimmed = value.trim();
@@ -510,7 +532,7 @@ export async function runProviderEntry(params: {
     return {
       kind: "audio.transcription",
       attachmentIndex: params.attachmentIndex,
-      text: trimOutput(result.text, maxChars),
+      text: trimOutput(sanitizeAudioTranscript(result.text), maxChars),
       provider: providerId,
       model: result.model ?? model,
     };


### PR DESCRIPTION
## Summary

Adds a small guard against known Whisper subtitle-credit hallucinations before audio transcripts are forwarded into agent context.

## What changed

- adds `sanitizeAudioTranscript()` in the shared media runner
- drops known junk patterns like:
  - `Субтитры сделал ...`
  - `subtitles by ...`
  - `translated by ...`
- applies the sanitizer before returning `audio.transcription`
- adds unit tests for junk patterns and normal speech transcripts

## Why

Telegram voice notes can currently inject known Whisper hallucination strings into agent prompts as trusted text.

Example observed in the wild:

- `Субтитры сделал DimaTorzok`

That appears to be a Whisper-family hallucination artifact rather than real user speech, but without a guard it still gets treated as valid inbound text.

## Scope

This PR keeps the fix intentionally small:

- no VAD
- no provider-specific branching
- no complex confidence system

It only blocks obvious watermark / credit hallucinations so they do not poison agent context.

Closes #37515
