### PR TITLE
fix(logging): subsystem loggers now follow root logger rotation

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -241,6 +241,7 @@ export function getLogger(): TsLogger<LogObj> {
   if (!cachedLogger || settingsChanged(cachedSettings, settings)) {
     loggingState.cachedLogger = buildLogger(settings);
     loggingState.cachedSettings = settings;
+    loggingState.loggerGeneration++;
   }
   return loggingState.cachedLogger as TsLogger<LogObj>;
 }
@@ -303,6 +304,7 @@ export function setLoggerOverride(settings: LoggerSettings | null) {
   loggingState.cachedLogger = null;
   loggingState.cachedSettings = null;
   loggingState.cachedConsoleSettings = null;
+  loggingState.loggerGeneration++;
 }
 
 export function resetLogger() {
@@ -310,6 +312,7 @@ export function resetLogger() {
   loggingState.cachedSettings = null;
   loggingState.cachedConsoleSettings = null;
   loggingState.overrideSettings = null;
+  loggingState.loggerGeneration++;
 }
 
 export function registerLogTransport(transport: LogTransport): () => void {

--- a/src/logging/state.ts
+++ b/src/logging/state.ts
@@ -1,6 +1,8 @@
 export const loggingState = {
   cachedLogger: null as unknown,
   cachedSettings: null as unknown,
+  /** Incremented each time the root file logger is rebuilt (e.g. date-based rotation). */
+  loggerGeneration: 0,
   cachedConsoleSettings: null as unknown,
   overrideSettings: null as unknown,
   invalidEnvLogLevelValue: null as string | null,

--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -1,3 +1,7 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { setConsoleSubsystemFilter } from "./console.js";
 import { resetLogger, setLoggerOverride } from "./logger.js";
@@ -163,5 +167,38 @@ describe("createSubsystemLogger().isEnabled", () => {
     });
 
     expect(warn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("subsystem logger follows root logger rotation (#37388)", () => {
+  it("writes to new log file after root logger is rebuilt", () => {
+    const tmpDir = path.join(os.tmpdir(), `openclaw-log-rotate-${crypto.randomUUID()}`);
+    fs.mkdirSync(tmpDir, { recursive: true });
+
+    const file1 = path.join(tmpDir, "openclaw-day1.log");
+    const file2 = path.join(tmpDir, "openclaw-day2.log");
+
+    try {
+      // Start with file1
+      setLoggerOverride({ level: "info", file: file1 });
+      const log = createSubsystemLogger("test-subsystem");
+      log.info("message-day1");
+
+      // Simulate date change: switch to file2 (setLoggerOverride
+      // clears the cached logger and bumps generation, just like
+      // resolveSettings would when the date rolls over).
+      setLoggerOverride({ level: "info", file: file2 });
+      // Write via the same subsystem logger instance
+      log.info("message-day2");
+
+      const content1 = fs.existsSync(file1) ? fs.readFileSync(file1, "utf8") : "";
+      const content2 = fs.existsSync(file2) ? fs.readFileSync(file2, "utf8") : "";
+
+      expect(content1).toContain("message-day1");
+      expect(content1).not.toContain("message-day2");
+      expect(content2).toContain("message-day2");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -322,7 +322,9 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
     const currentGen = loggingState.loggerGeneration;
     if (!fileLogger || fileLoggerGeneration !== currentGen) {
       fileLogger = getChildLogger({ subsystem });
-      fileLoggerGeneration = currentGen;
+      // Read generation after getChildLogger — the getLogger() call inside
+      // may itself increment the counter, so capture the final value.
+      fileLoggerGeneration = loggingState.loggerGeneration;
     }
     return fileLogger;
   };

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -314,7 +314,18 @@ function logToFile(
 
 export function createSubsystemLogger(subsystem: string): SubsystemLogger {
   let fileLogger: TsLogger<LogObj> | null = null;
-
+  let fileLoggerGeneration = -1;
+  const getFileLogger = () => {
+    // Re-create the child logger when the root logger has been rebuilt
+    // (e.g. after midnight date-based log rotation). Without this,
+    // subsystem loggers keep writing to the previous day's file (#37388).
+    const currentGen = loggingState.loggerGeneration;
+    if (!fileLogger || fileLoggerGeneration !== currentGen) {
+      fileLogger = getChildLogger({ subsystem });
+      fileLoggerGeneration = currentGen;
+    }
+    return fileLogger;
+  };
   const emitLog = (level: LogLevel, message: string, meta?: Record<string, unknown>) => {
     const consoleSettings = getConsoleSettings();
     const consoleEnabled =
@@ -336,10 +347,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
       fileMeta = Object.keys(rest).length > 0 ? rest : undefined;
     }
     if (fileEnabled) {
-      if (!fileLogger) {
-        fileLogger = getChildLogger({ subsystem });
-      }
-      logToFile(fileLogger, level, message, fileMeta);
+      logToFile(getFileLogger(), level, message, fileMeta);
     }
     if (!consoleEnabled) {
       return;

--- a/src/logging/subsystem.ts
+++ b/src/logging/subsystem.ts
@@ -319,8 +319,7 @@ export function createSubsystemLogger(subsystem: string): SubsystemLogger {
     // Re-create the child logger when the root logger has been rebuilt
     // (e.g. after midnight date-based log rotation). Without this,
     // subsystem loggers keep writing to the previous day's file (#37388).
-    const currentGen = loggingState.loggerGeneration;
-    if (!fileLogger || fileLoggerGeneration !== currentGen) {
+    if (!fileLogger || fileLoggerGeneration !== loggingState.loggerGeneration) {
       fileLogger = getChildLogger({ subsystem });
       // Read generation after getChildLogger — the getLogger() call inside
       // may itself increment the counter, so capture the final value.


### PR DESCRIPTION
## Summary

Fixes #37388 — log files do not rotate automatically at midnight. After date change, all logs continue writing to the previous day's file until gateway restart.

## Root Cause

Subsystem loggers (created via `createSubsystemLogger`) lazily create a child file-logger and cache it indefinitely. When the root logger is rebuilt after midnight (the rolling date in the log filename changes, triggering `settingsChanged()` → `buildLogger()`), subsystem loggers keep their stale child logger pointing to the old parent's transport — which still writes to yesterday's file.

Since nearly all gateway log output goes through subsystem loggers (feishu, discord, telegram, gateway, agent, etc.), this means effectively zero logs appear in the new day's file.

## Fix

Add a `loggerGeneration` counter to `loggingState` that increments each time the root logger is rebuilt. Subsystem loggers compare their cached generation against the current one and re-create their child logger when it diverges.

Changes:
- `src/logging/state.ts` — add `loggerGeneration` field
- `src/logging/logger.ts` — increment generation on rebuild and reset
- `src/logging/subsystem.ts` — check generation in `getFileLogger()`

## Tests

Added a regression test that:
1. Creates a subsystem logger writing to file1
2. Simulates date change by switching to file2 (via `setLoggerOverride`)
3. Writes via the **same** subsystem logger instance
4. Asserts day1 message is in file1, day2 message is in file2

All 63 logging tests pass.