### PR TITLE
fix: properly import ModelProviderConfig type

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.test.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.test.ts
@@ -4,6 +4,7 @@ import {
   composeSystemPromptWithHookContext,
   isOllamaCompatProvider,
   resolveAttemptFsWorkspaceOnly,
+  resolveProviderAuthHeaderEnabled,
   resolveOllamaBaseUrlForRun,
   resolveOllamaCompatNumCtxEnabled,
   resolvePromptBuildHookResult,
@@ -11,6 +12,7 @@ import {
   shouldInjectOllamaCompatNumCtx,
   decodeHtmlEntitiesInObject,
   wrapOllamaCompatNumCtx,
+  wrapStreamFnAuthorizationHeader,
   wrapStreamFnTrimToolCallNames,
 } from "./attempt.js";
 
@@ -178,6 +180,87 @@ describe("resolveAttemptFsWorkspaceOnly", () => {
         sessionAgentId: "main",
       }),
     ).toBe(false);
+  });
+});
+
+describe("resolveProviderAuthHeaderEnabled", () => {
+  it("returns true when provider has authHeader enabled", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          minimax: {
+            baseUrl: "https://api.minimaxi.com/anthropic",
+            api: "anthropic-messages",
+            authHeader: true,
+            models: [],
+          },
+        },
+      },
+    };
+
+    expect(resolveProviderAuthHeaderEnabled({ config: cfg, providerId: "minimax" })).toBe(true);
+  });
+
+  it("matches normalized provider ids", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          minimax: {
+            baseUrl: "https://api.minimaxi.com/anthropic",
+            api: "anthropic-messages",
+            authHeader: true,
+            models: [],
+          },
+        },
+      },
+    };
+
+    expect(resolveProviderAuthHeaderEnabled({ config: cfg, providerId: " MiniMax " })).toBe(true);
+  });
+
+  it("returns false when authHeader is not enabled", () => {
+    const cfg: OpenClawConfig = {
+      models: {
+        providers: {
+          custom: {
+            baseUrl: "https://example.com",
+            api: "anthropic-messages",
+            models: [],
+          },
+        },
+      },
+    };
+
+    expect(resolveProviderAuthHeaderEnabled({ config: cfg, providerId: "custom" })).toBe(false);
+  });
+});
+
+describe("wrapStreamFnAuthorizationHeader", () => {
+  it("injects Authorization header from runtime apiKey", async () => {
+    const baseFn = vi.fn(async () => ({ ok: true }));
+    const wrapped = wrapStreamFnAuthorizationHeader(baseFn as never);
+
+    await wrapped({} as never, {} as never, { apiKey: "sk-minimax-test" } as never);
+
+    const options = baseFn.mock.calls[0]?.[2] as { headers?: Record<string, string> };
+    expect(options?.headers?.Authorization).toBe("Bearer sk-minimax-test");
+  });
+
+  it("preserves existing Authorization header", async () => {
+    const baseFn = vi.fn(async () => ({ ok: true }));
+    const wrapped = wrapStreamFnAuthorizationHeader(baseFn as never);
+
+    await wrapped(
+      {} as never,
+      {} as never,
+      {
+        apiKey: "sk-minimax-test",
+        headers: { Authorization: "Bearer existing" },
+      } as never,
+    );
+
+    const options = baseFn.mock.calls[0]?.[2] as { headers?: Record<string, string> };
+    expect(options?.headers?.Authorization).toBe("Bearer existing");
   });
 });
 

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -10,6 +10,7 @@ import {
 import { resolveHeartbeatPrompt } from "../../../auto-reply/heartbeat.js";
 import { resolveChannelCapabilities } from "../../../config/channel-capabilities.js";
 import type { OpenClawConfig } from "../../../config/config.js";
+import type { ModelProviderConfig } from "../../../config/types.models.js";
 import { getMachineDisplayName } from "../../../infra/machine-name.js";
 import { ensureGlobalUndiciStreamTimeouts } from "../../../infra/net/undici-global-dispatcher.js";
 import { MAX_IMAGE_BYTES } from "../../../media/constants.js";
@@ -200,6 +201,38 @@ export function resolveOllamaCompatNumCtxEnabled(params: {
   return true;
 }
 
+function resolveProviderConfigById(params: {
+  config?: OpenClawConfig;
+  providerId?: string;
+}): ModelProviderConfig | undefined {
+  const providerId = params.providerId?.trim();
+  if (!providerId) {
+    return undefined;
+  }
+  const providers = params.config?.models?.providers;
+  if (!providers) {
+    return undefined;
+  }
+  const direct = providers[providerId];
+  if (direct) {
+    return direct;
+  }
+  const normalized = normalizeProviderId(providerId);
+  for (const [candidateId, candidate] of Object.entries(providers)) {
+    if (normalizeProviderId(candidateId) === normalized) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+export function resolveProviderAuthHeaderEnabled(params: {
+  config?: OpenClawConfig;
+  providerId?: string;
+}): boolean {
+  return Boolean(resolveProviderConfigById(params)?.authHeader);
+}
+
 export function shouldInjectOllamaCompatNumCtx(params: {
   model: { api?: string; provider?: string; baseUrl?: string };
   config?: OpenClawConfig;
@@ -236,6 +269,29 @@ export function wrapOllamaCompatNumCtx(baseFn: StreamFn | undefined, numCtx: num
         options?.onPayload?.(payload);
       },
     });
+}
+
+export function wrapStreamFnAuthorizationHeader(baseFn: StreamFn | undefined): StreamFn {
+  const streamFn = baseFn ?? streamSimple;
+  return (model, context, options) => {
+    const apiKey = typeof options?.apiKey === "string" ? options.apiKey.trim() : "";
+    if (!apiKey) {
+      return streamFn(model, context, options);
+    }
+    const headers = { ...options?.headers };
+    const existingAuthKey = Object.keys(headers).find(
+      (key) => key.toLowerCase() === "authorization",
+    );
+    const existingAuthValue = existingAuthKey ? headers[existingAuthKey] : undefined;
+    if (typeof existingAuthValue === "string" && existingAuthValue.trim()) {
+      return streamFn(model, context, options);
+    }
+    headers[existingAuthKey ?? "Authorization"] = `Bearer ${apiKey}`;
+    return streamFn(model, context, {
+      ...options,
+      headers,
+    });
+  };
 }
 
 function normalizeToolCallNameForDispatch(rawName: string, allowedToolNames?: Set<string>): string {
@@ -1201,6 +1257,21 @@ export async function runEmbeddedAttempt(
         params.thinkLevel,
         sessionAgentId,
       );
+
+      const providerIdForAuthHeader =
+        typeof params.model.provider === "string" && params.model.provider.trim().length > 0
+          ? params.model.provider
+          : params.provider;
+      if (
+        resolveProviderAuthHeaderEnabled({
+          config: params.config,
+          providerId: providerIdForAuthHeader,
+        })
+      ) {
+        activeSession.agent.streamFn = wrapStreamFnAuthorizationHeader(
+          activeSession.agent.streamFn,
+        );
+      }
 
       if (cacheTrace) {
         cacheTrace.recordStage("session:loaded", {


### PR DESCRIPTION
Fixes #37142

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
