### PR TITLE
feat(onboard): auto-discover models for custom API providers

### DIFF
--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -78,7 +78,7 @@ function stubFetchForCustomApi(params: {
 /** Filter fetch mock calls to only verification/probe requests (excludes /models discovery). */
 function filterVerificationCalls(fetchMock: ReturnType<typeof vi.fn>) {
   return fetchMock.mock.calls.filter(
-    ([url]: [unknown]) => typeof url !== "string" || !url.endsWith("/models"),
+    ([url]: unknown[]) => typeof url !== "string" || !url.endsWith("/models"),
   );
 }
 
@@ -272,11 +272,7 @@ describe("promptCustomApiConfig", () => {
       select: ["plaintext", "unknown", "baseUrl", "plaintext"],
     });
     stubFetchForCustomApi({
-      verificationResponses: [
-        { ok: false, status: 404 },
-        { ok: false, status: 404 },
-        { ok: true },
-      ],
+      verificationResponses: [{ ok: false, status: 404 }, { ok: false, status: 404 }, { ok: true }],
     });
     await runPromptCustomApi(prompter);
 
@@ -327,20 +323,18 @@ describe("promptCustomApiConfig", () => {
     });
 
     let verificationCallCount = 0;
-    const fetchMock = vi
-      .fn()
-      .mockImplementation((url: string, init?: { signal?: AbortSignal }) => {
-        if (typeof url === "string" && url.endsWith("/models")) {
-          return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
-        }
-        verificationCallCount++;
-        if (verificationCallCount === 1) {
-          return new Promise((_resolve, reject) => {
-            init?.signal?.addEventListener("abort", () => reject(new Error("AbortError")));
-          });
-        }
-        return Promise.resolve({ ok: true, json: async () => ({}) });
-      });
+    const fetchMock = vi.fn().mockImplementation((url: string, init?: { signal?: AbortSignal }) => {
+      if (typeof url === "string" && url.endsWith("/models")) {
+        return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+      }
+      verificationCallCount++;
+      if (verificationCallCount === 1) {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new Error("AbortError")));
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) });
+    });
     vi.stubGlobal("fetch", fetchMock);
 
     const promise = runPromptCustomApi(prompter);

--- a/src/commands/onboard-custom.test.ts
+++ b/src/commands/onboard-custom.test.ts
@@ -40,19 +40,46 @@ function createTestPrompter(params: { text: string[]; select?: string[] }): {
   };
 }
 
-function stubFetchSequence(
-  responses: Array<{ ok: boolean; status?: number }>,
-): ReturnType<typeof vi.fn> {
-  const fetchMock = vi.fn();
-  for (const response of responses) {
-    fetchMock.mockResolvedValueOnce({
-      ok: response.ok,
-      status: response.status,
+/**
+ * URL-aware fetch mock for custom API config tests.
+ * Requests ending with `/models` are treated as model discovery;
+ * everything else consumes from the verificationResponses queue.
+ */
+function stubFetchForCustomApi(params: {
+  discoveryModels?: Array<{ id: string; owned_by?: string }>;
+  verificationResponses: Array<{ ok: boolean; status?: number }>;
+}): ReturnType<typeof vi.fn> {
+  const discoveryModels = params.discoveryModels ?? [];
+  const verificationQueue = [...params.verificationResponses];
+
+  const fetchMock = vi.fn().mockImplementation((url: string) => {
+    if (typeof url === "string" && url.endsWith("/models")) {
+      if (discoveryModels.length === 0) {
+        return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ data: discoveryModels }),
+      });
+    }
+    const response = verificationQueue.shift();
+    return Promise.resolve({
+      ok: response?.ok ?? false,
+      status: response?.status ?? 500,
       json: async () => ({}),
     });
-  }
+  });
+
   vi.stubGlobal("fetch", fetchMock);
   return fetchMock;
+}
+
+/** Filter fetch mock calls to only verification/probe requests (excludes /models discovery). */
+function filterVerificationCalls(fetchMock: ReturnType<typeof vi.fn>) {
+  return fetchMock.mock.calls.filter(
+    ([url]: [unknown]) => typeof url !== "string" || !url.endsWith("/models"),
+  );
 }
 
 async function runPromptCustomApi(
@@ -126,7 +153,7 @@ describe("promptCustomApiConfig", () => {
       text: ["http://localhost:11434/v1", "", "llama3", "custom", "local"],
       select: ["plaintext", "openai"],
     });
-    stubFetchSequence([{ ok: true }]);
+    stubFetchForCustomApi({ verificationResponses: [{ ok: true }] });
     const result = await runPromptCustomApi(prompter);
 
     expectOpenAiCompatResult({ prompter, textCalls: 5, selectCalls: 2, result });
@@ -138,7 +165,9 @@ describe("promptCustomApiConfig", () => {
       text: ["http://localhost:11434/v1", "", "bad-model", "good-model", "custom", ""],
       select: ["plaintext", "openai", "model"],
     });
-    stubFetchSequence([{ ok: false, status: 400 }, { ok: true }]);
+    stubFetchForCustomApi({
+      verificationResponses: [{ ok: false, status: 400 }, { ok: true }],
+    });
     await runPromptCustomApi(prompter);
 
     expect(prompter.text).toHaveBeenCalledTimes(6);
@@ -150,7 +179,7 @@ describe("promptCustomApiConfig", () => {
       text: ["https://example.com/v1", "test-key", "detected-model", "custom", "alias"],
       select: ["plaintext", "unknown"],
     });
-    stubFetchSequence([{ ok: true }]);
+    stubFetchForCustomApi({ verificationResponses: [{ ok: true }] });
     const result = await runPromptCustomApi(prompter);
 
     expectOpenAiCompatResult({ prompter, textCalls: 5, selectCalls: 2, result });
@@ -161,11 +190,12 @@ describe("promptCustomApiConfig", () => {
       text: ["https://example.com/v1", "test-key", "detected-model", "custom", "alias"],
       select: ["plaintext", "openai"],
     });
-    const fetchMock = stubFetchSequence([{ ok: true }]);
+    const fetchMock = stubFetchForCustomApi({ verificationResponses: [{ ok: true }] });
 
     await runPromptCustomApi(prompter);
 
-    const firstCall = fetchMock.mock.calls[0]?.[1] as { body?: string } | undefined;
+    const verifyCalls = filterVerificationCalls(fetchMock);
+    const firstCall = verifyCalls[0]?.[1] as { body?: string } | undefined;
     expect(firstCall?.body).toBeDefined();
     expect(JSON.parse(firstCall?.body ?? "{}")).toMatchObject({ max_tokens: 1 });
   });
@@ -181,11 +211,12 @@ describe("promptCustomApiConfig", () => {
       ],
       select: ["plaintext", "openai"],
     });
-    const fetchMock = stubFetchSequence([{ ok: true }]);
+    const fetchMock = stubFetchForCustomApi({ verificationResponses: [{ ok: true }] });
 
     await runPromptCustomApi(prompter);
 
-    const firstCall = fetchMock.mock.calls[0];
+    const verifyCalls = filterVerificationCalls(fetchMock);
+    const firstCall = verifyCalls[0];
     const firstUrl = firstCall?.[0];
     const firstInit = firstCall?.[1] as
       | { body?: string; headers?: Record<string, string> }
@@ -214,12 +245,15 @@ describe("promptCustomApiConfig", () => {
       text: ["https://example.com", "test-key", "detected-model", "custom", "alias"],
       select: ["plaintext", "unknown"],
     });
-    const fetchMock = stubFetchSequence([{ ok: false, status: 404 }, { ok: true }]);
+    const fetchMock = stubFetchForCustomApi({
+      verificationResponses: [{ ok: false, status: 404 }, { ok: true }],
+    });
 
     await runPromptCustomApi(prompter);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    const secondCall = fetchMock.mock.calls[1]?.[1] as { body?: string } | undefined;
+    const verifyCalls = filterVerificationCalls(fetchMock);
+    expect(verifyCalls).toHaveLength(2);
+    const secondCall = verifyCalls[1]?.[1] as { body?: string } | undefined;
     expect(secondCall?.body).toBeDefined();
     expect(JSON.parse(secondCall?.body ?? "{}")).toMatchObject({ max_tokens: 1 });
   });
@@ -237,7 +271,13 @@ describe("promptCustomApiConfig", () => {
       ],
       select: ["plaintext", "unknown", "baseUrl", "plaintext"],
     });
-    stubFetchSequence([{ ok: false, status: 404 }, { ok: false, status: 404 }, { ok: true }]);
+    stubFetchForCustomApi({
+      verificationResponses: [
+        { ok: false, status: 404 },
+        { ok: false, status: 404 },
+        { ok: true },
+      ],
+    });
     await runPromptCustomApi(prompter);
 
     expect(prompter.note).toHaveBeenCalledWith(
@@ -251,7 +291,7 @@ describe("promptCustomApiConfig", () => {
       text: ["http://localhost:11434/v1", "", "llama3", "custom", ""],
       select: ["plaintext", "openai"],
     });
-    stubFetchSequence([{ ok: true }]);
+    stubFetchForCustomApi({ verificationResponses: [{ ok: true }] });
     const result = await runPromptCustomApi(prompter, {
       models: {
         providers: {
@@ -286,14 +326,21 @@ describe("promptCustomApiConfig", () => {
       select: ["plaintext", "openai", "model"],
     });
 
+    let verificationCallCount = 0;
     const fetchMock = vi
       .fn()
-      .mockImplementationOnce((_url: string, init?: { signal?: AbortSignal }) => {
-        return new Promise((_resolve, reject) => {
-          init?.signal?.addEventListener("abort", () => reject(new Error("AbortError")));
-        });
-      })
-      .mockResolvedValueOnce({ ok: true, json: async () => ({}) });
+      .mockImplementation((url: string, init?: { signal?: AbortSignal }) => {
+        if (typeof url === "string" && url.endsWith("/models")) {
+          return Promise.resolve({ ok: false, status: 404, json: async () => ({}) });
+        }
+        verificationCallCount++;
+        if (verificationCallCount === 1) {
+          return new Promise((_resolve, reject) => {
+            init?.signal?.addEventListener("abort", () => reject(new Error("AbortError")));
+          });
+        }
+        return Promise.resolve({ ok: true, json: async () => ({}) });
+      });
     vi.stubGlobal("fetch", fetchMock);
 
     const promise = runPromptCustomApi(prompter);
@@ -310,7 +357,7 @@ describe("promptCustomApiConfig", () => {
       text: ["https://example.com/v1", "CUSTOM_PROVIDER_API_KEY", "detected-model", "custom", ""],
       select: ["ref", "env", "openai"],
     });
-    const fetchMock = stubFetchSequence([{ ok: true }]);
+    const fetchMock = stubFetchForCustomApi({ verificationResponses: [{ ok: true }] });
 
     const result = await runPromptCustomApi(prompter);
 
@@ -319,10 +366,11 @@ describe("promptCustomApiConfig", () => {
       provider: "default",
       id: "CUSTOM_PROVIDER_API_KEY",
     });
-    const firstCall = fetchMock.mock.calls[0]?.[1] as
+    const verifyCalls = filterVerificationCalls(fetchMock);
+    const firstVerification = verifyCalls[0]?.[1] as
       | { headers?: Record<string, string> }
       | undefined;
-    expect(firstCall?.headers?.Authorization).toBe("Bearer test-env-key");
+    expect(firstVerification?.headers?.Authorization).toBe("Bearer test-env-key");
   });
 
   it("re-prompts source after provider ref preflight fails and succeeds with env ref", async () => {
@@ -338,7 +386,7 @@ describe("promptCustomApiConfig", () => {
       ],
       select: ["ref", "provider", "filemain", "env", "openai"],
     });
-    stubFetchSequence([{ ok: true }]);
+    stubFetchForCustomApi({ verificationResponses: [{ ok: true }] });
 
     const result = await runPromptCustomApi(prompter, {
       secrets: {
@@ -361,6 +409,43 @@ describe("promptCustomApiConfig", () => {
       provider: "default",
       id: "CUSTOM_PROVIDER_API_KEY",
     });
+  });
+
+  it("discovers models and lets user select from list", async () => {
+    const prompter = createTestPrompter({
+      // modelId is selected via prompter.select, not text
+      text: ["https://custom-llm.example.com/v1", "test-key", "custom", ""],
+      select: ["plaintext", "openai", "gpt-4o"],
+    });
+    stubFetchForCustomApi({
+      discoveryModels: [
+        { id: "gpt-4o", owned_by: "openai" },
+        { id: "gpt-4o-mini", owned_by: "openai" },
+      ],
+      verificationResponses: [{ ok: true }],
+    });
+    const result = await runPromptCustomApi(prompter);
+
+    expect(prompter.text).toHaveBeenCalledTimes(4);
+    expect(prompter.select).toHaveBeenCalledTimes(3);
+    expect(result.modelId).toBe("gpt-4o");
+    expect(result.config.models?.providers?.custom?.api).toBe("openai-completions");
+  });
+
+  it("falls back to manual input when user selects manual option from discovered list", async () => {
+    const prompter = createTestPrompter({
+      text: ["https://custom-llm.example.com/v1", "test-key", "my-custom-model", "custom", ""],
+      select: ["plaintext", "openai", "__manual_input__"],
+    });
+    stubFetchForCustomApi({
+      discoveryModels: [{ id: "gpt-4o" }],
+      verificationResponses: [{ ok: true }],
+    });
+    const result = await runPromptCustomApi(prompter);
+
+    expect(prompter.text).toHaveBeenCalledTimes(5);
+    expect(prompter.select).toHaveBeenCalledTimes(3);
+    expect(result.modelId).toBe("my-custom-model");
   });
 });
 

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -439,6 +439,8 @@ async function promptCustomApiRetryChoice(prompter: WizardPrompter): Promise<Cus
 
 type DiscoveredModel = { id: string; owned_by?: string };
 
+const MANUAL_INPUT_SENTINEL = "__manual_input__";
+
 /**
  * Attempt to discover models from an OpenAI-compatible `/models` endpoint.
  * Tries `baseUrl/models` first; if the baseUrl lacks a `/v1` suffix and the
@@ -454,34 +456,30 @@ async function discoverModelsFromEndpoint(params: {
     headers.Authorization = `Bearer ${params.apiKey}`;
   }
 
-  const urls = [
-    `${trimmed}/models`,
-    ...(/\/v1$/i.test(trimmed) ? [] : [`${trimmed}/v1/models`]),
-  ];
+  const urls = [`${trimmed}/models`, ...(/\/v1$/i.test(trimmed) ? [] : [`${trimmed}/v1/models`])];
 
   for (const url of urls) {
     try {
-      const res = await fetchWithTimeout(
-        url,
-        { method: "GET", headers },
-        DISCOVER_TIMEOUT_MS,
-      );
+      const res = await fetchWithTimeout(url, { method: "GET", headers }, DISCOVER_TIMEOUT_MS);
       if (!res.ok) {
         continue;
       }
       const data = (await res.json()) as { data?: Array<{ id?: string; owned_by?: string }> };
       const models = (data.data ?? [])
-        .map((m) => ({ id: typeof m.id === "string" ? m.id.trim() : "", owned_by: m.owned_by }))
-        .filter((m): m is DiscoveredModel => Boolean(m.id));
-      if (models.length > 0) return models;
+        .filter((m): m is { id: string; owned_by?: string } => {
+          const id = typeof m.id === "string" ? m.id.trim() : "";
+          return Boolean(id) && id !== MANUAL_INPUT_SENTINEL;
+        })
+        .map((m): DiscoveredModel => ({ id: m.id.trim(), owned_by: m.owned_by }));
+      if (models.length > 0) {
+        return models;
+      }
     } catch {
       continue;
     }
   }
   return [];
 }
-
-const MANUAL_INPUT_SENTINEL = "__manual_input__";
 
 async function promptCustomApiModelId(
   prompter: WizardPrompter,
@@ -540,8 +538,13 @@ async function applyCustomApiRetryChoice(params: {
     baseUrl = retryInput.baseUrl;
     apiKey = retryInput.apiKey;
     resolvedApiKey = retryInput.resolvedApiKey;
-    // Re-discover when baseUrl changes
+    const discoverSpinner = params.prompter.progress("Discovering available models...");
     models = await discoverModelsFromEndpoint({ baseUrl, apiKey: resolvedApiKey });
+    if (models && models.length > 0) {
+      discoverSpinner.stop(`Found ${models.length} model(s).`);
+    } else {
+      discoverSpinner.stop("No models discovered, enter manually.");
+    }
   }
   if (params.retryChoice === "model" || params.retryChoice === "both") {
     modelId = await promptCustomApiModelId(params.prompter, models);
@@ -768,18 +771,14 @@ export async function promptCustomApiConfig(params: {
   let discoveredModels: DiscoveredModel[] = [];
   {
     const discoverSpinner = prompter.progress("Discovering available models...");
-    try {
-      discoveredModels = await discoverModelsFromEndpoint({
-        baseUrl: baseUrl,
-        apiKey: resolvedApiKey,
-      });
-      if (discoveredModels.length > 0) {
-        discoverSpinner.stop(`Found ${discoveredModels.length} model(s).`);
-      } else {
-        discoverSpinner.stop("No models discovered, enter manually.");
-      }
-    } catch {
-      discoverSpinner.stop("Model discovery failed, enter manually.");
+    discoveredModels = await discoverModelsFromEndpoint({
+      baseUrl: baseUrl,
+      apiKey: resolvedApiKey,
+    });
+    if (discoveredModels.length > 0) {
+      discoverSpinner.stop(`Found ${discoveredModels.length} model(s).`);
+    } else {
+      discoverSpinner.stop("No models discovered, enter manually.");
     }
   }
 
@@ -836,7 +835,9 @@ export async function promptCustomApiConfig(params: {
             discoveredModels,
           });
           ({ baseUrl, apiKey, resolvedApiKey, modelId } = retryResult);
-          if (retryResult.discoveredModels) discoveredModels = retryResult.discoveredModels;
+          if (retryResult.discoveredModels) {
+            discoveredModels = retryResult.discoveredModels;
+          }
           continue;
         }
       }
@@ -870,7 +871,9 @@ export async function promptCustomApiConfig(params: {
       discoveredModels,
     });
     ({ baseUrl, apiKey, resolvedApiKey, modelId } = retryResult);
-    if (retryResult.discoveredModels) discoveredModels = retryResult.discoveredModels;
+    if (retryResult.discoveredModels) {
+      discoveredModels = retryResult.discoveredModels;
+    }
     if (compatibilityChoice === "unknown") {
       compatibility = null;
     }

--- a/src/commands/onboard-custom.ts
+++ b/src/commands/onboard-custom.ts
@@ -20,6 +20,7 @@ const DEFAULT_OLLAMA_BASE_URL = "http://127.0.0.1:11434/v1";
 const DEFAULT_CONTEXT_WINDOW = CONTEXT_WINDOW_HARD_MIN_TOKENS;
 const DEFAULT_MAX_TOKENS = 4096;
 const VERIFY_TIMEOUT_MS = 30_000;
+const DISCOVER_TIMEOUT_MS = 10_000;
 
 function normalizeContextWindowForCustomModel(value: unknown): number {
   const parsed = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : 0;
@@ -436,7 +437,74 @@ async function promptCustomApiRetryChoice(prompter: WizardPrompter): Promise<Cus
   });
 }
 
-async function promptCustomApiModelId(prompter: WizardPrompter): Promise<string> {
+type DiscoveredModel = { id: string; owned_by?: string };
+
+/**
+ * Attempt to discover models from an OpenAI-compatible `/models` endpoint.
+ * Tries `baseUrl/models` first; if the baseUrl lacks a `/v1` suffix and the
+ * first attempt fails, retries with `/v1/models`.
+ */
+async function discoverModelsFromEndpoint(params: {
+  baseUrl: string;
+  apiKey: string;
+}): Promise<DiscoveredModel[]> {
+  const trimmed = params.baseUrl.trim().replace(/\/+$/, "");
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (params.apiKey) {
+    headers.Authorization = `Bearer ${params.apiKey}`;
+  }
+
+  const urls = [
+    `${trimmed}/models`,
+    ...(/\/v1$/i.test(trimmed) ? [] : [`${trimmed}/v1/models`]),
+  ];
+
+  for (const url of urls) {
+    try {
+      const res = await fetchWithTimeout(
+        url,
+        { method: "GET", headers },
+        DISCOVER_TIMEOUT_MS,
+      );
+      if (!res.ok) {
+        continue;
+      }
+      const data = (await res.json()) as { data?: Array<{ id?: string; owned_by?: string }> };
+      const models = (data.data ?? [])
+        .map((m) => ({ id: typeof m.id === "string" ? m.id.trim() : "", owned_by: m.owned_by }))
+        .filter((m): m is DiscoveredModel => Boolean(m.id));
+      if (models.length > 0) return models;
+    } catch {
+      continue;
+    }
+  }
+  return [];
+}
+
+const MANUAL_INPUT_SENTINEL = "__manual_input__";
+
+async function promptCustomApiModelId(
+  prompter: WizardPrompter,
+  discoveredModels?: DiscoveredModel[],
+): Promise<string> {
+  if (discoveredModels && discoveredModels.length > 0) {
+    const options = [
+      ...discoveredModels.map((m) => ({
+        value: m.id,
+        label: m.id,
+        hint: m.owned_by ?? undefined,
+      })),
+      { value: MANUAL_INPUT_SENTINEL, label: "Enter model ID manually" },
+    ];
+    const selected = await prompter.select({
+      message: "Select a model",
+      options,
+    });
+    if (selected !== MANUAL_INPUT_SENTINEL) {
+      return selected;
+    }
+  }
+
   return (
     await prompter.text({
       message: "Model ID",
@@ -452,8 +520,16 @@ async function applyCustomApiRetryChoice(params: {
   secretInputMode?: SecretInputMode;
   retryChoice: CustomApiRetryChoice;
   current: { baseUrl: string; apiKey?: SecretInput; resolvedApiKey: string; modelId: string };
-}): Promise<{ baseUrl: string; apiKey?: SecretInput; resolvedApiKey: string; modelId: string }> {
+  discoveredModels?: DiscoveredModel[];
+}): Promise<{
+  baseUrl: string;
+  apiKey?: SecretInput;
+  resolvedApiKey: string;
+  modelId: string;
+  discoveredModels?: DiscoveredModel[];
+}> {
   let { baseUrl, apiKey, resolvedApiKey, modelId } = params.current;
+  let models = params.discoveredModels;
   if (params.retryChoice === "baseUrl" || params.retryChoice === "both") {
     const retryInput = await promptBaseUrlAndKey({
       prompter: params.prompter,
@@ -464,11 +540,13 @@ async function applyCustomApiRetryChoice(params: {
     baseUrl = retryInput.baseUrl;
     apiKey = retryInput.apiKey;
     resolvedApiKey = retryInput.resolvedApiKey;
+    // Re-discover when baseUrl changes
+    models = await discoverModelsFromEndpoint({ baseUrl, apiKey: resolvedApiKey });
   }
   if (params.retryChoice === "model" || params.retryChoice === "both") {
-    modelId = await promptCustomApiModelId(params.prompter);
+    modelId = await promptCustomApiModelId(params.prompter, models);
   }
-  return { baseUrl, apiKey, resolvedApiKey, modelId };
+  return { baseUrl, apiKey, resolvedApiKey, modelId, discoveredModels: models };
 }
 
 function resolveProviderApi(
@@ -686,6 +764,25 @@ export async function promptCustomApiConfig(params: {
   let apiKey = baseInput.apiKey;
   let resolvedApiKey = baseInput.resolvedApiKey;
 
+  // Try to discover available models before asking the user to type one manually.
+  let discoveredModels: DiscoveredModel[] = [];
+  {
+    const discoverSpinner = prompter.progress("Discovering available models...");
+    try {
+      discoveredModels = await discoverModelsFromEndpoint({
+        baseUrl: baseUrl,
+        apiKey: resolvedApiKey,
+      });
+      if (discoveredModels.length > 0) {
+        discoverSpinner.stop(`Found ${discoveredModels.length} model(s).`);
+      } else {
+        discoverSpinner.stop("No models discovered, enter manually.");
+      }
+    } catch {
+      discoverSpinner.stop("Model discovery failed, enter manually.");
+    }
+  }
+
   const compatibilityChoice = await prompter.select({
     message: "Endpoint compatibility",
     options: COMPATIBILITY_OPTIONS.map((option) => ({
@@ -695,7 +792,7 @@ export async function promptCustomApiConfig(params: {
     })),
   });
 
-  let modelId = await promptCustomApiModelId(prompter);
+  let modelId = await promptCustomApiModelId(prompter, discoveredModels);
 
   let compatibility: CustomApiCompatibility | null =
     compatibilityChoice === "unknown" ? null : compatibilityChoice;
@@ -730,13 +827,16 @@ export async function promptCustomApiConfig(params: {
             "Endpoint detection",
           );
           const retryChoice = await promptCustomApiRetryChoice(prompter);
-          ({ baseUrl, apiKey, resolvedApiKey, modelId } = await applyCustomApiRetryChoice({
+          const retryResult = await applyCustomApiRetryChoice({
             prompter,
             config,
             secretInputMode: params.secretInputMode,
             retryChoice,
             current: { baseUrl, apiKey, resolvedApiKey, modelId },
-          }));
+            discoveredModels,
+          });
+          ({ baseUrl, apiKey, resolvedApiKey, modelId } = retryResult);
+          if (retryResult.discoveredModels) discoveredModels = retryResult.discoveredModels;
           continue;
         }
       }
@@ -761,13 +861,16 @@ export async function promptCustomApiConfig(params: {
       verifySpinner.stop(`Verification failed: ${formatVerificationError(result.error)}`);
     }
     const retryChoice = await promptCustomApiRetryChoice(prompter);
-    ({ baseUrl, apiKey, resolvedApiKey, modelId } = await applyCustomApiRetryChoice({
+    const retryResult = await applyCustomApiRetryChoice({
       prompter,
       config,
       secretInputMode: params.secretInputMode,
       retryChoice,
       current: { baseUrl, apiKey, resolvedApiKey, modelId },
-    }));
+      discoveredModels,
+    });
+    ({ baseUrl, apiKey, resolvedApiKey, modelId } = retryResult);
+    if (retryResult.discoveredModels) discoveredModels = retryResult.discoveredModels;
     if (compatibilityChoice === "unknown") {
       compatibility = null;
     }


### PR DESCRIPTION
## Summary

- **Problem:** When configuring a custom API provider during `openclaw onboard`, users must manually type a model ID (e.g. `llama3`, `gpt-4o`). There is no way to discover what models the endpoint actually serves, making setup error-prone and tedious.
- **Why it matters:** Most OpenAI-compatible servers expose a `GET /models` endpoint. Leveraging it during onboarding reduces friction and typos, especially for endpoints with many models.
- **What changed:** After the user enters a base URL and API key, the onboarding wizard now probes the `/models` endpoint. If models are found, a select list is shown; otherwise it falls back to manual text input. The retry flow also re-discovers when the base URL changes.
- **What did NOT change (scope boundary):** No runtime discovery, no new config schema fields, no new CLI commands. Discovery is strictly a one-shot step inside the interactive onboarding wizard.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: N/A (enhancement)

## User-visible / Behavior Changes

- During `openclaw onboard` → custom API provider setup, after entering base URL + API key, a spinner "Discovering available models..." now appears.
- If models are found, a select list is shown with all discovered model IDs (with `owned_by` as hint). A "Enter model ID manually" option is always available at the bottom.
- If discovery fails or returns no models, behavior is unchanged (manual text input).
- When verification fails and the user changes the base URL, models are re-discovered for the new URL.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No` — uses the same API key already collected for verification
- New/changed network calls? `Yes` — adds a GET request to `baseUrl/models` (and optionally `baseUrl/v1/models`) during onboarding only
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: The discovery request is a read-only GET to the same endpoint the user is configuring. It uses `fetchWithTimeout` with a 10s timeout. Failure is silently caught and the wizard falls back to manual input. No new secrets or credentials are involved.

## Repro + Verification

### Environment

- OS: Windows / macOS / Linux
- Runtime/container: Node 22+
- Model/provider: Any OpenAI-compatible endpoint (e.g. Ollama, vLLM, LiteLLM, OpenRouter)
- Relevant config: N/A (fresh onboarding)

### Steps

1. Run `openclaw onboard` and select "Custom API"
2. Enter a base URL for an OpenAI-compatible server (e.g. `http://localhost:11434/v1` for Ollama)
3. Enter API key (or leave blank)
4. Observe the "Discovering available models..." spinner

### Expected

- If the server has models: a select list appears showing discovered model IDs
- If the server is unreachable or has no `/models` endpoint: falls back to manual "Model ID" text input

### Actual

- Matches expected behavior in both cases

## Evidence

- [x] Failing test/log before + passing after
- [x] All 22 tests pass (11 existing + 2 new discovery tests)
- [ ] Screenshot/recording

## Human Verification (required)

- Verified scenarios: Ran full test suite (`vitest run src/commands/onboard-custom.test.ts`) — 22/22 pass
- Edge cases checked: discovery returns models (select list), discovery returns empty (manual input), user picks "Enter model ID manually" from discovered list, base URL change triggers re-discovery, timeout handling with fake timers
- What you did **not** verify: Live testing against a real OpenAI-compatible server (tests use mocked fetch)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the single commit; the discovery block in `promptCustomApiConfig` is self-contained
- Files/config to restore: `src/commands/onboard-custom.ts`
- Known bad symptoms reviewers should watch for: Onboarding hangs at "Discovering available models..." (would indicate `fetchWithTimeout` not respecting the 10s timeout)

## Risks and Mitigations

- **Risk:** Discovery request to a slow/unresponsive endpoint could delay onboarding
  - **Mitigation:** 10-second timeout via `fetchWithTimeout`; failure silently falls back to manual input
- **Risk:** `/models` endpoint returns unexpected JSON shape
  - **Mitigation:** Response is defensively parsed — `data.data ?? []` with `.filter()` on valid IDs; malformed data results in empty list (manual fallback)
