### PR TITLE
feat(telegram): support animated and video stickers via thumbnail fallback

### DIFF
--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -993,11 +993,10 @@ export const registerTelegramHandlers = ({
       return;
     }
 
-    // Skip sticker-only messages where the sticker was skipped (animated/video)
-    // These have no media and no text content to process.
+    // Skip sticker-only messages where the sticker was skipped entirely.
     const hasText = Boolean((msg.text ?? msg.caption ?? "").trim());
     if (msg.sticker && !media && !hasText) {
-      logVerbose("telegram: skipping sticker-only message (unsupported sticker type)");
+      logVerbose("telegram: skipping sticker-only message (no media resolved)");
       return;
     }
 

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -793,7 +793,8 @@ export const buildTelegramMessageContext = async ({
         }))
       : undefined;
   const currentMediaForContext = stickerCacheHit ? [] : allMedia;
-  const contextMedia = [...currentMediaForContext, ...replyMedia];
+  // Filter out metadata-only sticker entries (empty path) from media arrays
+  const contextMedia = [...currentMediaForContext, ...replyMedia].filter((m) => m.path);
   const ctxPayload = finalizeInboundContext({
     Body: combinedBody,
     // Agent prompt should be the raw user text only; metadata/context is provided via system prompt.

--- a/src/telegram/bot.media.stickers-and-fragments.e2e.test.ts
+++ b/src/telegram/bot.media.stickers-and-fragments.e2e.test.ts
@@ -129,14 +129,32 @@ describe("telegram stickers", () => {
   );
 
   it(
-    "skips animated and video sticker formats that cannot be downloaded",
+    "downloads thumbnail for animated (TGS) sticker and includes metadata",
     async () => {
       const { handler, replySpy, runtimeError } = await createBotHandler();
+      // Mock getFile API for thumbnail, then the actual file download
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            result: { file_path: "thumbnails/animated_thumb.webp" },
+          }),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: { get: () => "image/webp" },
+          arrayBuffer: async () => new Uint8Array([0x52, 0x49, 0x46, 0x46]).buffer,
+        } as unknown as Response);
 
-      for (const scenario of [
-        {
-          messageId: 101,
-          filePath: "stickers/animated.tgs",
+      await handler({
+        message: {
+          message_id: 101,
+          chat: { id: 1234, type: "private" },
           sticker: {
             file_id: "animated_sticker_id",
             file_unique_id: "animated_unique",
@@ -147,11 +165,59 @@ describe("telegram stickers", () => {
             is_video: false,
             emoji: "😎",
             set_name: "AnimatedPack",
+            thumbnail: {
+              file_id: "animated_thumb_id",
+              file_unique_id: "animated_thumb_unique",
+              width: 128,
+              height: 128,
+            },
           },
+          date: 1736380800,
         },
-        {
-          messageId: 102,
-          filePath: "stickers/video.webm",
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ file_path: "stickers/animated.tgs" }),
+      });
+
+      expect(runtimeError).not.toHaveBeenCalled();
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const payload = replySpy.mock.calls[0][0];
+      expect(payload.Body).toContain("<media:sticker>");
+      expect(payload.Sticker?.emoji).toBe("😎");
+      expect(payload.Sticker?.setName).toBe("AnimatedPack");
+      expect(payload.Sticker?.fileId).toBe("animated_sticker_id");
+
+      fetchSpy.mockRestore();
+    },
+    STICKER_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "downloads thumbnail for video (WEBM) sticker and includes metadata",
+    async () => {
+      const { handler, replySpy, runtimeError } = await createBotHandler();
+      // Mock getFile API for thumbnail, then the actual file download
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            ok: true,
+            result: { file_path: "thumbnails/video_thumb.webp" },
+          }),
+        } as unknown as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          headers: { get: () => "image/webp" },
+          arrayBuffer: async () => new Uint8Array([0x52, 0x49, 0x46, 0x46]).buffer,
+        } as unknown as Response);
+
+      await handler({
+        message: {
+          message_id: 102,
+          chat: { id: 1234, type: "private" },
           sticker: {
             file_id: "video_sticker_id",
             file_unique_id: "video_unique",
@@ -162,29 +228,64 @@ describe("telegram stickers", () => {
             is_video: true,
             emoji: "🎬",
             set_name: "VideoPack",
+            thumbnail: {
+              file_id: "video_thumb_id",
+              file_unique_id: "video_thumb_unique",
+              width: 128,
+              height: 128,
+            },
           },
+          date: 1736380800,
         },
-      ]) {
-        replySpy.mockClear();
-        runtimeError.mockClear();
-        const fetchSpy = vi.spyOn(globalThis, "fetch");
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({ file_path: "stickers/video.webm" }),
+      });
 
-        await handler({
-          message: {
-            message_id: scenario.messageId,
-            chat: { id: 1234, type: "private" },
-            sticker: scenario.sticker,
-            date: 1736380800,
+      expect(runtimeError).not.toHaveBeenCalled();
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const payload = replySpy.mock.calls[0][0];
+      expect(payload.Body).toContain("<media:sticker>");
+      expect(payload.Sticker?.emoji).toBe("🎬");
+      expect(payload.Sticker?.setName).toBe("VideoPack");
+      expect(payload.Sticker?.fileId).toBe("video_sticker_id");
+
+      fetchSpy.mockRestore();
+    },
+    STICKER_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "falls back to metadata-only for animated/video sticker without thumbnail",
+    async () => {
+      const { handler, replySpy, runtimeError } = await createBotHandler();
+
+      await handler({
+        message: {
+          message_id: 103,
+          chat: { id: 1234, type: "private" },
+          sticker: {
+            file_id: "animated_sticker_no_thumb",
+            file_unique_id: "animated_no_thumb_unique",
+            type: "regular",
+            width: 512,
+            height: 512,
+            is_animated: true,
+            is_video: false,
+            emoji: "🤔",
+            set_name: "NoThumbPack",
           },
-          me: { username: "openclaw_bot" },
-          getFile: async () => ({ file_path: scenario.filePath }),
-        });
+          date: 1736380800,
+        },
+        me: { username: "openclaw_bot" },
+        getFile: async () => ({}),
+      });
 
-        expect(fetchSpy).not.toHaveBeenCalled();
-        expect(replySpy).not.toHaveBeenCalled();
-        expect(runtimeError).not.toHaveBeenCalled();
-        fetchSpy.mockRestore();
-      }
+      expect(runtimeError).not.toHaveBeenCalled();
+      expect(replySpy).toHaveBeenCalledTimes(1);
+      const payload = replySpy.mock.calls[0][0];
+      expect(payload.Body).toContain("<media:sticker>");
+      expect(payload.Sticker?.emoji).toBe("🤔");
+      expect(payload.Sticker?.fileId).toBe("animated_sticker_no_thumb");
     },
     STICKER_TEST_TIMEOUT_MS,
   );

--- a/src/telegram/bot/delivery.resolve-media.ts
+++ b/src/telegram/bot/delivery.resolve-media.ts
@@ -41,6 +41,52 @@ function isRetryableGetFileError(err: unknown): boolean {
   return true;
 }
 
+/**
+ * Call the Telegram getFile API directly for a given file_id.
+ * Used for downloading sticker thumbnails where ctx.getFile() resolves the wrong file.
+ */
+async function getFileByIdWithRetry(
+  fileId: string,
+  token: string,
+  fetchImpl: typeof fetch,
+): Promise<string | null> {
+  try {
+    const result = await retryAsync(
+      async () => {
+        const res = await fetchImpl(
+          `https://api.telegram.org/bot${token}/getFile?file_id=${encodeURIComponent(fileId)}`,
+        );
+        if (!res.ok) {
+          throw new Error(`getFile API returned ${res.status}`);
+        }
+        const json = (await res.json()) as { ok: boolean; result?: { file_path?: string } };
+        if (!json.ok || !json.result?.file_path) {
+          throw new Error("getFile returned no file_path");
+        }
+        return json.result.file_path;
+      },
+      {
+        attempts: 3,
+        minDelayMs: 1000,
+        maxDelayMs: 4000,
+        jitter: 0.2,
+        label: "telegram:getFileById",
+        shouldRetry: isRetryableGetFileError,
+        onRetry: ({ attempt, maxAttempts }) =>
+          logVerbose(`telegram: getFileById retry ${attempt}/${maxAttempts}`),
+      },
+    );
+    return result;
+  } catch (err) {
+    if (isFileTooBigError(err)) {
+      logVerbose(warn("telegram: thumbnail exceeds 20MB limit (unexpected)"));
+      return null;
+    }
+    logVerbose(`telegram: getFileById failed after retries: ${String(err)}`);
+    return null;
+  }
+}
+
 function resolveMediaFileRef(msg: TelegramContext["message"]) {
   return (
     msg.photo?.[msg.photo.length - 1] ??
@@ -146,32 +192,73 @@ async function resolveStickerMedia(params: {
     return undefined;
   }
   const sticker = msg.sticker;
-  // Skip animated (TGS) and video (WEBM) stickers - only static WEBP supported
-  if (sticker.is_animated || sticker.is_video) {
-    logVerbose("telegram: skipping animated/video sticker (only static stickers supported)");
-    return null;
-  }
   if (!sticker.file_id) {
     return null;
   }
 
+  const isAnimatedOrVideo = sticker.is_animated || sticker.is_video;
+
   try {
-    const file = await resolveTelegramFileWithRetry(ctx);
-    if (!file?.file_path) {
-      logVerbose("telegram: getFile returned no file_path for sticker");
-      return null;
-    }
     const fetchImpl = proxyFetch ?? globalThis.fetch;
     if (!fetchImpl) {
       logVerbose("telegram: fetch not available for sticker download");
       return null;
     }
-    const saved = await downloadAndSaveTelegramFile({
-      filePath: file.file_path,
-      token,
-      fetchImpl,
-      maxBytes,
-    });
+
+    let saved: { path: string; contentType?: string };
+
+    if (isAnimatedOrVideo) {
+      // Animated (TGS) and video (WEBM) stickers: download the static thumbnail for vision
+      const thumbFileId = sticker.thumbnail?.file_id;
+      if (!thumbFileId) {
+        logVerbose("telegram: animated/video sticker has no thumbnail; using metadata only");
+        return {
+          path: "",
+          contentType: undefined,
+          placeholder: "<media:sticker>",
+          stickerMetadata: {
+            emoji: sticker.emoji ?? undefined,
+            setName: sticker.set_name ?? undefined,
+            fileId: sticker.file_id,
+            fileUniqueId: sticker.file_unique_id,
+          },
+        };
+      }
+      const thumbFile = await getFileByIdWithRetry(thumbFileId, token, fetchImpl);
+      if (!thumbFile) {
+        logVerbose("telegram: failed to resolve thumbnail for animated/video sticker");
+        return {
+          path: "",
+          contentType: undefined,
+          placeholder: "<media:sticker>",
+          stickerMetadata: {
+            emoji: sticker.emoji ?? undefined,
+            setName: sticker.set_name ?? undefined,
+            fileId: sticker.file_id,
+            fileUniqueId: sticker.file_unique_id,
+          },
+        };
+      }
+      saved = await downloadAndSaveTelegramFile({
+        filePath: thumbFile,
+        token,
+        fetchImpl,
+        maxBytes,
+      });
+    } else {
+      // Static (WEBP) stickers: download directly
+      const file = await resolveTelegramFileWithRetry(ctx);
+      if (!file?.file_path) {
+        logVerbose("telegram: getFile returned no file_path for sticker");
+        return null;
+      }
+      saved = await downloadAndSaveTelegramFile({
+        filePath: file.file_path,
+        token,
+        fetchImpl,
+        maxBytes,
+      });
+    }
 
     // Check sticker cache for existing description
     const cached = sticker.file_unique_id ? getCachedSticker(sticker.file_unique_id) : null;


### PR DESCRIPTION
## Summary

- **Animated (TGS) and video (WEBM) stickers** are now processed instead of being silently dropped
- Downloads the static **thumbnail** (WEBP) provided by Telegram for vision description and caching
- Preserves the original sticker `file_id` in metadata so agents can send it back via `sendSticker`
- Falls back to metadata-only (emoji + setName + file_id) if no thumbnail is available

Fixes #21984 — animated/video stickers were previously invisible to agents, covering 90%+ of modern Telegram sticker packs.

## Changes

- `src/telegram/bot/delivery.resolve-media.ts` — Add `getFileByIdWithRetry()` for thumbnail download; remove early return that dropped animated/video stickers
- `src/telegram/bot-handlers.ts` — Update skip-guard comment
- `src/telegram/bot-message-context.ts` — Filter empty-path media entries from `contextMedia`
- `src/telegram/bot.media.stickers-and-fragments.e2e.test.ts` — Replace "skips animated/video" test with: animated thumbnail, video thumbnail, no-thumbnail fallback

## Test plan

- [x] Existing unit tests pass (`delivery.resolve-media-retry`, `sticker-cache`, `bot-message-dispatch.sticker-media`)
- [x] Build succeeds
- [ ] Send animated (TGS) sticker → agent receives thumbnail + metadata
- [ ] Send video (WEBM) sticker → agent receives thumbnail + metadata
- [ ] Send static (WEBP) sticker → unchanged behavior
- [ ] `sticker-search` returns cached animated/video stickers

🤖 Generated with [Claude Code](https://claude.com/claude-code)