### PR TITLE
fix(windows): handle spaces in Node.js path for plugin install on Windows

### DIFF
--- a/src/process/exec.ts
+++ b/src/process/exec.ts
@@ -65,8 +65,10 @@ function resolveNpmArgvForWindows(argv: string[]): string[] | null {
 
 /**
  * Resolves a command for Windows compatibility.
- * On Windows, non-.exe commands (like pnpm, yarn) are resolved to .cmd; npm/npx
- * are handled by resolveNpmArgvForWindows to avoid spawn EINVAL (no direct .cmd).
+ * On Windows, non-.exe commands (like pnpm, yarn, npm, npx) are resolved to .cmd.
+ * npm/npx prefer resolveNpmArgvForWindows (node + cli script) to avoid spawn EINVAL,
+ * but fall back to .cmd resolution when the cli script is not found (e.g. nvm-windows,
+ * volta, fnm installs where npm-cli.js is not at the standard nodeDir path).
  */
 function resolveCommand(command: string): string {
   if (process.platform !== "win32") {
@@ -77,7 +79,7 @@ function resolveCommand(command: string): string {
   if (ext) {
     return command;
   }
-  const cmdCommands = ["pnpm", "yarn"];
+  const cmdCommands = ["pnpm", "yarn", "npm", "npx"];
   if (cmdCommands.includes(basename)) {
     return `${command}.cmd`;
   }
@@ -116,11 +118,13 @@ export async function runExec(
     const argv = [command, ...args];
     let execCommand: string;
     let execArgs: string[];
+    let wasNpmResolved = false;
     if (process.platform === "win32") {
       const resolved = resolveNpmArgvForWindows(argv);
       if (resolved) {
         execCommand = resolved[0] ?? "";
         execArgs = resolved.slice(1);
+        wasNpmResolved = true;
       } else {
         execCommand = resolveCommand(command);
         execArgs = args;
@@ -129,7 +133,9 @@ export async function runExec(
       execCommand = resolveCommand(command);
       execArgs = args;
     }
-    const useCmdWrapper = isWindowsBatchCommand(execCommand);
+    const useCmdWrapper =
+      isWindowsBatchCommand(execCommand) ||
+      (wasNpmResolved && [execCommand, ...execArgs].some((a) => a.includes(" ")));
     const { stdout, stderr } = useCmdWrapper
       ? await execFileAsync(
           process.env.ComSpec ?? "cmd.exe",
@@ -223,8 +229,13 @@ export async function runCommandWithTimeout(
 
   const stdio = resolveCommandStdio({ hasInput, preferInherit: true });
   const finalArgv = process.platform === "win32" ? (resolveNpmArgvForWindows(argv) ?? argv) : argv;
-  const resolvedCommand = finalArgv !== argv ? (finalArgv[0] ?? "") : resolveCommand(argv[0] ?? "");
-  const useCmdWrapper = isWindowsBatchCommand(resolvedCommand);
+  const wasNpmResolved = process.platform === "win32" && finalArgv !== argv;
+  const resolvedCommand = wasNpmResolved ? (finalArgv[0] ?? "") : resolveCommand(argv[0] ?? "");
+  // Use cmd.exe wrapper when the command is a .bat/.cmd file, or when npm/npx was resolved
+  // to node.exe + cli-script paths that contain spaces (e.g. C:\Program Files\nodejs\).
+  const useCmdWrapper =
+    isWindowsBatchCommand(resolvedCommand) ||
+    (wasNpmResolved && finalArgv.some((a) => a.includes(" ")));
   const child = spawn(
     useCmdWrapper ? (process.env.ComSpec ?? "cmd.exe") : resolvedCommand,
     useCmdWrapper


### PR DESCRIPTION
## What

Fix two bugs that break `openclaw plugins install` on Windows when Node.js is installed in a path containing spaces (e.g. the default `C:\Program Files\nodejs\`).

Fixes #37563

## Bug 1 (primary) — space-containing resolved paths not wrapped in cmd.exe

`resolveNpmArgvForWindows` resolves `npm pack` to:
```
["C:\Program Files\nodejs\node.exe",
 "C:\Program Files\nodejs\node_modules\npm\bin\npm-cli.js",
 "pack", ...]
```

These were passed directly to `spawn()` without the cmd.exe wrapper, causing Node's CreateProcessW escaping to garble paths with spaces:
```
npm pack failed: ': \Progran' <garbled binary output>
```

**Fix:** After `resolveNpmArgvForWindows` succeeds, check if any resolved argv entry contains a space. If so, route through `cmd.exe + buildCmdExeCommandLine` (which uses `escapeForCmdExe`), same as the existing .cmd/.bat wrapper path. Applied in both `runCommandWithTimeout` and `runExec`.

## Bug 2 (secondary) — EINVAL when npm-cli.js not found at standard path

When Node is installed via nvm-windows, volta, or fnm, `npm-cli.js` is not at `nodeDir/node_modules/npm/bin/`. `resolveNpmArgvForWindows` returns `null`, and `resolveCommand('npm')` returned bare `'npm'` (npm was removed from `cmdCommands` in a prior fix), causing spawn EINVAL on Node 18.20.2+.

**Fix:** Add `'npm'` and `'npx'` back to the `cmdCommands` list in `resolveCommand` so they resolve to `npm.cmd`/`npx.cmd` as a fallback — identical to how `pnpm`/`yarn` are handled. Updated the comment to reflect this.

## Testing

All 55 existing process tests pass. Platform-specific behavior (Windows spawn semantics) can only be fully verified on a Windows machine, but the logic paths are well-covered by the existing exec test suite.