### PR TITLE
fix(tui): use case-insensitive session key comparison for chat events

### DIFF
--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -426,4 +426,36 @@ describe("tui-event-handlers: handleAgentEvent", () => {
     expect(chatLog.dropAssistant).toHaveBeenCalledWith("run-silent");
     expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
   });
+
+  it("processes chat events when gateway sends sessionKey with different case than TUI state", () => {
+    // Regression test for #37566: TUI normalises session keys to lowercase
+    // (resolveTuiSessionKey) but gateway push events may carry the original-case
+    // key stored in the session transcript. The case-insensitive comparison
+    // ensures the sending TUI sees its own session's reply.
+    const { state, chatLog, tui, handleChatEvent } = createHandlersHarness({
+      state: { activeChatRunId: null },
+    });
+
+    // state.currentSessionKey is lowercase (e.g. "agent:main:mysession")
+    const uppercaseSessionKey = state.currentSessionKey.toUpperCase();
+
+    handleChatEvent({
+      runId: "run-case-test",
+      sessionKey: uppercaseSessionKey, // gateway sends with different case
+      state: "delta",
+      message: { content: "reply text" },
+    });
+
+    expect(chatLog.updateAssistant).toHaveBeenCalled();
+    expect(tui.requestRender).toHaveBeenCalled();
+
+    handleChatEvent({
+      runId: "run-case-test",
+      sessionKey: uppercaseSessionKey,
+      state: "final",
+      message: { content: "reply text" },
+    });
+
+    expect(chatLog.finalizeAssistant).toHaveBeenCalled();
+  });
 });

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -152,7 +152,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     }
     const evt = payload as ChatEvent;
     syncSessionKey();
-    if (evt.sessionKey !== state.currentSessionKey) {
+    if (evt.sessionKey?.toLowerCase() !== state.currentSessionKey) {
       return;
     }
     if (finalizedRuns.has(evt.runId)) {


### PR DESCRIPTION
## What

Fix a regression where the TUI that sends a message doesn't display the assistant reply — it must be manually refreshed, while other TUI instances and the Dashboard show it correctly.

Fixes #37566

## Root Cause

PR #34013 (`9d941949`) normalized TUI session keys to lowercase via `resolveTuiSessionKey`. This aligns with gateway canonicalization for **new** sessions.

However, gateway push events carry `sessionKey` as stored in the session transcript — which may have been recorded before this normalization. When the stored key has different case, the event handler's comparison fails:

```typescript
// tui-event-handlers.ts line 155 (before fix)
if (evt.sessionKey !== state.currentSessionKey) {
  return; // silently drops the event
}
```

| Value | Example |
|---|---|
| `state.currentSessionKey` | `"agent:main:mysession"` (lowercased by TUI) |
| `evt.sessionKey` | `"agent:main:MySESSION"` (original case from transcript) |
| Comparison result | `!== → event dropped` |

**Why other TUI instances see it:** Other connected TUIs have their own `state.currentSessionKey` derived from their own session selection — if they also selected the same session, they normalized the same way, so their comparison passes.

**Why manual refresh works:** `loadHistory` fetches history via a request (not via push events), so it doesn't go through this comparison.

## Fix

```typescript
if (evt.sessionKey?.toLowerCase() !== state.currentSessionKey) {
```

Case-insensitive comparison on the incoming event key. `state.currentSessionKey` is always lowercase after the PR #34013 fix, so this correctly matches regardless of the case in the stored transcript.

## Testing

Added a regression test: fires `delta` and `final` chat events with an **uppercased** `sessionKey` against a lowercase `state.currentSessionKey` — asserts both `updateAssistant` and `finalizeAssistant` are called (14/14 pass).