### PR TITLE
fix(docker): install extension dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,8 @@ RUN for dir in /app/extensions /app/.agent /app/.agents; do \
         find "$dir" -type f -exec chmod 644 {} +; \
       fi; \
     done
+# Install extension dependencies after copying extensions directory
+RUN pnpm install --no-frozen-lockfile
 RUN pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ RUN for dir in /app/extensions /app/.agent /app/.agents; do \
       fi; \
     done
 # Install extension dependencies after copying extensions directory
-RUN pnpm install --no-frozen-lockfile
+RUN NODE_OPTIONS=--max-old-space-size=2048 pnpm install --frozen-lockfile
 RUN pnpm build
 # Force pnpm for UI build (Bun may fail on ARM/Synology architectures)
 ENV OPENCLAW_PREFER_PNPM=1


### PR DESCRIPTION
fix(docker): install extension dependencies in Dockerfile

## Problem

Extension plugins like feishu failed to load in Docker with module not found errors:
```
Error: Cannot find module '@larksuiteoapi/node-sdk'
Require stack:
- /app/extensions/feishu/src/client.ts
```

The Dockerfile's initial `pnpm install --frozen-lockfile` ran before copying the `extensions/` directory, so extension dependencies were never installed.

## Solution

Added `pnpm install --no-frozen-lockfile` after `COPY . .` to ensure extension dependencies are installed before building.

## Changes

- Modified Dockerfile to add extension dependency installation step after copying source code

## Testing

- ✅ Built Docker image successfully
- ✅ Verified `/app/extensions/feishu/node_modules/@larksuiteoapi` is present in container
- ✅ Confirmed feishu plugin loads without errors
- ✅ Gateway runs normally with all extensions functional

## Impact

- Fixes all extension plugins that require external dependencies
- Minimal build time impact (~few seconds for extension deps)
- No changes to runtime behavior or existing functionality

Co-Authored-By: 赵浩dong <zhd.doge@gmail.com>
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
