### PR TITLE
ACP: hide default end_turn status in interactive client

### DIFF
--- a/src/acp/client.test.ts
+++ b/src/acp/client.test.ts
@@ -4,6 +4,7 @@ import type { RequestPermissionRequest } from "@agentclientprotocol/sdk";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import {
+  formatAcpClientStopReason,
   resolveAcpClientSpawnEnv,
   resolveAcpClientSpawnInvocation,
   resolvePermissionRequest,
@@ -59,6 +60,20 @@ describe("resolveAcpClientSpawnEnv", () => {
       OPENCLAW_SHELL: "wrong",
     });
     expect(env.OPENCLAW_SHELL).toBe("acp-client");
+  });
+});
+
+describe("formatAcpClientStopReason", () => {
+  it("suppresses default end_turn stop reason output", () => {
+    expect(formatAcpClientStopReason("end_turn")).toBeNull();
+  });
+
+  it("suppresses missing stop reason output", () => {
+    expect(formatAcpClientStopReason(undefined)).toBeNull();
+  });
+
+  it("renders non-default stop reasons for visibility", () => {
+    expect(formatAcpClientStopReason("max_tokens")).toBe("\n[max_tokens]\n");
   });
 });
 

--- a/src/acp/client.ts
+++ b/src/acp/client.ts
@@ -331,6 +331,13 @@ export type AcpClientHandle = {
   sessionId: string;
 };
 
+export function formatAcpClientStopReason(stopReason: string | undefined): string | null {
+  if (!stopReason || stopReason === "end_turn") {
+    return null;
+  }
+  return `\n[${stopReason}]\n`;
+}
+
 function toArgs(value: string[] | string | undefined): string[] {
   if (!value) {
     return [];
@@ -543,7 +550,10 @@ export async function runAcpClientInteractive(opts: AcpClientOptions = {}): Prom
           sessionId,
           prompt: [{ type: "text", text }],
         });
-        console.log(`\n[${response.stopReason}]\n`);
+        const stopReasonMessage = formatAcpClientStopReason(response.stopReason);
+        if (stopReasonMessage) {
+          process.stdout.write(stopReasonMessage);
+        }
       } catch (err) {
         console.error(`\n[error] ${String(err)}\n`);
       }


### PR DESCRIPTION
## Summary
- suppress default `[end_turn]` output in ACP interactive client
- keep non-default stop reasons visible
- add regression tests for stop-reason formatting

Closes #34863