### PR TITLE
feat: expose background exec processes in sessions.list

### DIFF
--- a/src/agents/tools/sessions-helpers.ts
+++ b/src/agents/tools/sessions-helpers.ts
@@ -82,6 +82,9 @@ export function classifySessionKind(params: {
   if (key === params.alias || key === params.mainKey) {
     return "main";
   }
+  if (key.startsWith("exec:")) {
+    return "other";
+  }
   if (key.startsWith("cron:")) {
     return "cron";
   }

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -21,6 +21,8 @@ export const SessionsListParamsSchema = Type.Object(
     spawnedBy: Type.Optional(NonEmptyString),
     agentId: Type.Optional(NonEmptyString),
     search: Type.Optional(Type.String()),
+    /** Include background exec processes (codex, claude, etc.) as virtual session rows. Defaults to true. */
+    includeProcesses: Type.Optional(Type.Boolean()),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import { listFinishedSessions, listRunningSessions } from "../agents/bash-process-registry.js";
 import { lookupContextTokens } from "../agents/context.js";
 import { DEFAULT_CONTEXT_TOKENS, DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import {
@@ -888,11 +889,43 @@ export function listSessionsFromStore(params: {
     return { ...rest, derivedTitle, lastMessagePreview } satisfies GatewaySessionRow;
   });
 
+  // Append background exec processes (codex, claude, etc.) as virtual session rows
+  const processRows: GatewaySessionRow[] = [];
+  const includeProcesses = opts.includeProcesses !== false;
+  if (includeProcesses) {
+    const running = listRunningSessions();
+    const finished = listFinishedSessions();
+    for (const proc of running) {
+      processRows.push({
+        key: `exec:${proc.id}`,
+        kind: "process",
+        displayName: proc.command.length > 80 ? `${proc.command.slice(0, 77)}…` : proc.command,
+        label: proc.id,
+        updatedAt: proc.startedAt,
+        sessionId: proc.id,
+      });
+    }
+    for (const proc of finished) {
+      processRows.push({
+        key: `exec:${proc.id}`,
+        kind: "process",
+        displayName: proc.command.length > 80 ? `${proc.command.slice(0, 77)}…` : proc.command,
+        label: proc.id,
+        updatedAt: proc.endedAt ?? proc.startedAt,
+        sessionId: proc.id,
+      });
+    }
+  }
+
+  const allSessions = [...finalSessions, ...processRows].toSorted(
+    (a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0),
+  );
+
   return {
     ts: now,
     path: storePath,
-    count: finalSessions.length,
+    count: allSessions.length,
     defaults: getSessionDefaults(cfg),
-    sessions: finalSessions,
+    sessions: allSessions,
   };
 }

--- a/src/gateway/session-utils.types.ts
+++ b/src/gateway/session-utils.types.ts
@@ -15,7 +15,7 @@ export type GatewaySessionsDefaults = {
 
 export type GatewaySessionRow = {
   key: string;
-  kind: "direct" | "group" | "global" | "unknown";
+  kind: "direct" | "group" | "global" | "unknown" | "process";
   label?: string;
   displayName?: string;
   derivedTitle?: string;


### PR DESCRIPTION
Background exec processes (codex CLI, claude code, etc.) are now included in sessions.list responses as virtual session rows with kind=process.

**Changes:**
- Add 'process' to GatewaySessionRow kind union
- Merge running + finished process entries from bash-process-registry into sessions.list
- Namespace IDs as exec:<slug> to avoid collision with real sessions
- Add includeProcesses param to SessionsListParams (defaults to true)
- Classify exec: keys in sessions-helpers

**Why:** Background coding agents launched via exec tool were invisible in the web UI (mcgenie.vercel.app). The data already existed in bash-process-registry but was only accessible via the process tool. This bridges the gap with ~40 lines of code.

**Convergence:** Ran Gemini + GPT convergence. Both agreed this is an API exposure problem. GPT recommended Option A (augment sessions.list) for fast delivery; Gemini preferred Option C (new endpoint). Synthesized to Option A with evolution path to C — minimal change, zero risk to existing sessions, web UI picks it up automatically.