### PR TITLE
fix(tools): preserve required aliases in Claude schema patching

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -101,7 +101,7 @@ describe("createOpenClawCodingTools", () => {
 
       expect(props.file_path).toEqual(props.path);
       expect(params.required ?? []).not.toContain("path");
-      expect(params.required ?? []).not.toContain("file_path");
+      expect(params.required ?? []).toContain("file_path");
     });
 
     it("normalizes file_path to path and enforces required groups at runtime", async () => {

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -146,7 +146,7 @@ export function patchToolSchemaForClaudeCompatibility(tool: AnyAgentTool): AnyAg
     }
     const idx = required.indexOf(original);
     if (idx !== -1) {
-      required.splice(idx, 1);
+      required.splice(idx, 1, alias);
       changed = true;
     }
   }


### PR DESCRIPTION
## Summary
- Fix schema patching to replace required keys with Claude-compatible aliases instead of removing them.
- Preserve required semantics for OpenAI-compatible tool callers while supporting Claude-style argument names.
- Add a regression test to ensure required aliases remain required after patching.

## Why
The previous logic could drop required keys without adding replacement alias keys. That could leave strict tool-calling models with incomplete required arguments.

## Testing
- `pnpm vitest src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts`
- Result: 1 test file passed, 25 tests passed.

Closes #37645