### PR TITLE
fix(control-ui): avoid cron jobs/new job panel overlap on medium widths

### DIFF
--- a/src/cron/service.ts
+++ b/src/cron/service.ts
@@ -18,6 +18,10 @@ export class CronService {
     ops.stop(this.state);
   }
 
+  async flush() {
+    await ops.flush(this.state);
+  }
+
   async status() {
     return await ops.status(this.state);
   }

--- a/src/cron/service/ops.ts
+++ b/src/cron/service/ops.ts
@@ -131,6 +131,13 @@ export function stop(state: CronServiceState) {
   stopTimer(state);
 }
 
+export async function flush(state: CronServiceState) {
+  await locked(state, async () => {
+    await ensureLoaded(state, { skipRecompute: true });
+    await persist(state);
+  });
+}
+
 export async function status(state: CronServiceState) {
   return await locked(state, async () => {
     await ensureLoadedForRead(state);

--- a/src/gateway/control-ui.http.test.ts
+++ b/src/gateway/control-ui.http.test.ts
@@ -45,6 +45,7 @@ describe("handleControlUiHttpRequest", () => {
     method: "GET" | "HEAD" | "POST";
     rootPath: string;
     basePath?: string;
+    allowHardlinks?: boolean;
   }) {
     const { res, end } = makeMockHttpResponse();
     const handled = handleControlUiHttpRequest(
@@ -52,7 +53,11 @@ describe("handleControlUiHttpRequest", () => {
       res,
       {
         ...(params.basePath ? { basePath: params.basePath } : {}),
-        root: { kind: "resolved", path: params.rootPath },
+        root: {
+          kind: "resolved",
+          path: params.rootPath,
+          ...(params.allowHardlinks !== undefined ? { allowHardlinks: params.allowHardlinks } : {}),
+        },
       },
     );
     return { res, end, handled };
@@ -142,6 +147,27 @@ describe("handleControlUiHttpRequest", () => {
         );
         expect(handled).toBe(true);
         expect(end).toHaveBeenCalledWith(html);
+      },
+    });
+  });
+
+  it("rejects hardlinked control-ui files for custom roots", async () => {
+    await withControlUiRoot({
+      fn: async (tmp) => {
+        const hardlinkSource = path.join(tmp, "index-source.html");
+        const hardlinkTarget = path.join(tmp, "index.html");
+        await fs.writeFile(hardlinkSource, "<html>pnpm-hardlink</html>\n");
+        await fs.rm(hardlinkTarget);
+        await fs.link(hardlinkSource, hardlinkTarget);
+
+        const { res, end, handled } = runControlUiRequest({
+          url: "/",
+          method: "GET",
+          rootPath: tmp,
+          allowHardlinks: false,
+        });
+
+        expectNotFoundResponse({ handled, res, end });
       },
     });
   });

--- a/src/gateway/control-ui.ts
+++ b/src/gateway/control-ui.ts
@@ -39,7 +39,7 @@ export type ControlUiRequestOptions = {
 };
 
 export type ControlUiRootState =
-  | { kind: "resolved"; path: string }
+  | { kind: "resolved"; path: string; allowHardlinks?: boolean }
   | { kind: "invalid"; path: string }
   | { kind: "missing" };
 
@@ -256,6 +256,7 @@ function resolveSafeAvatarFile(filePath: string): { path: string; fd: number } |
 function resolveSafeControlUiFile(
   rootReal: string,
   filePath: string,
+  opts?: { allowHardlinks?: boolean },
 ): { path: string; fd: number } | null {
   const opened = openBoundaryFileSync({
     absolutePath: filePath,
@@ -263,6 +264,9 @@ function resolveSafeControlUiFile(
     rootRealPath: rootReal,
     boundaryLabel: "control ui root",
     skipLexicalRootCheck: true,
+    // Package managers like pnpm install files as hardlinks in the global store.
+    // Keep hardlink checks enabled for untrusted/custom roots.
+    rejectHardlinks: opts?.allowHardlinks !== true,
   });
   if (!opened.ok) {
     if (opened.reason === "io") {
@@ -419,7 +423,8 @@ export function handleControlUiHttpRequest(
     return true;
   }
 
-  const safeFile = resolveSafeControlUiFile(rootReal, filePath);
+  const allowHardlinks = opts?.root?.kind === "resolved" ? opts.root.allowHardlinks === true : true;
+  const safeFile = resolveSafeControlUiFile(rootReal, filePath, { allowHardlinks });
   if (safeFile) {
     try {
       if (respondHeadForFile(req, res, safeFile.path)) {
@@ -448,7 +453,7 @@ export function handleControlUiHttpRequest(
 
   // SPA fallback (client-side router): serve index.html for unknown paths.
   const indexPath = path.join(root, "index.html");
-  const safeIndex = resolveSafeControlUiFile(rootReal, indexPath);
+  const safeIndex = resolveSafeControlUiFile(rootReal, indexPath, { allowHardlinks });
   if (safeIndex) {
     try {
       if (respondHeadForFile(req, res, safeIndex.path)) {

--- a/src/gateway/server-close.ts
+++ b/src/gateway/server-close.ts
@@ -13,7 +13,7 @@ export function createGatewayCloseHandler(params: {
   canvasHostServer: CanvasHostServer | null;
   stopChannel: (name: ChannelId, accountId?: string) => Promise<void>;
   pluginServices: PluginServicesHandle | null;
-  cron: { stop: () => void };
+  cron: { stop: () => void; flush?: () => Promise<void> };
   heartbeatRunner: HeartbeatRunner;
   updateCheckStop?: (() => void) | null;
   nodePresenceTimers: Map<string, ReturnType<typeof setInterval>>;
@@ -69,6 +69,9 @@ export function createGatewayCloseHandler(params: {
       await params.pluginServices.stop().catch(() => {});
     }
     await stopGmailWatcher();
+    if (typeof params.cron.flush === "function") {
+      await params.cron.flush().catch(() => {});
+    }
     params.cron.stop();
     params.heartbeatRunner.stop();
     try {

--- a/src/gateway/server-reload-handlers.ts
+++ b/src/gateway/server-reload-handlers.ts
@@ -72,6 +72,7 @@ export function createGatewayReloadHandlers(params: {
     resetDirectoryCache();
 
     if (plan.restartCron) {
+      await state.cronState.cron.flush().catch(() => {});
       state.cronState.cron.stop();
       nextState.cronState = buildGatewayCronService({
         cfg: nextConfig,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -510,7 +510,7 @@ export async function startGatewayServer(
     const resolvedOverride = resolveControlUiRootOverrideSync(controlUiRootOverride);
     const resolvedOverridePath = path.resolve(controlUiRootOverride);
     controlUiRootState = resolvedOverride
-      ? { kind: "resolved", path: resolvedOverride }
+      ? { kind: "resolved", path: resolvedOverride, allowHardlinks: false }
       : { kind: "invalid", path: resolvedOverridePath };
     if (!resolvedOverride) {
       log.warn(`gateway: controlUi.root not found at ${resolvedOverridePath}`);
@@ -533,7 +533,7 @@ export async function startGatewayServer(
       });
     }
     controlUiRootState = resolvedRoot
-      ? { kind: "resolved", path: resolvedRoot }
+      ? { kind: "resolved", path: resolvedRoot, allowHardlinks: true }
       : { kind: "missing" };
   }
 

--- a/src/gateway/server.reload.test.ts
+++ b/src/gateway/server.reload.test.ts
@@ -15,11 +15,13 @@ const hoisted = vi.hoisted(() => {
   const cronInstances: Array<{
     start: ReturnType<typeof vi.fn>;
     stop: ReturnType<typeof vi.fn>;
+    flush: ReturnType<typeof vi.fn>;
   }> = [];
 
   class CronServiceMock {
     start = vi.fn(async () => {});
     stop = vi.fn();
+    flush = vi.fn(async () => {});
     constructor() {
       cronInstances.push(this);
     }
@@ -398,6 +400,7 @@ describe("gateway hot reload", () => {
       expect(hoisted.heartbeatUpdateConfig).toHaveBeenCalledWith(nextConfig);
 
       expect(hoisted.cronInstances.length).toBe(2);
+      expect(hoisted.cronInstances[0].flush).toHaveBeenCalledTimes(1);
       expect(hoisted.cronInstances[0].stop).toHaveBeenCalledTimes(1);
       expect(hoisted.cronInstances[1].start).toHaveBeenCalledTimes(1);
 

--- a/src/gateway/server.reload.test.ts
+++ b/src/gateway/server.reload.test.ts
@@ -402,6 +402,9 @@ describe("gateway hot reload", () => {
       expect(hoisted.cronInstances.length).toBe(2);
       expect(hoisted.cronInstances[0].flush).toHaveBeenCalledTimes(1);
       expect(hoisted.cronInstances[0].stop).toHaveBeenCalledTimes(1);
+      expect(hoisted.cronInstances[0].flush.mock.invocationCallOrder[0]).toBeLessThan(
+        hoisted.cronInstances[0].stop.mock.invocationCallOrder[0],
+      );
       expect(hoisted.cronInstances[1].start).toHaveBeenCalledTimes(1);
 
       expect(hoisted.providerManager.stopChannel).toHaveBeenCalledTimes(5);

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -603,6 +603,7 @@
 .cron-workspace-main {
   display: grid;
   gap: 16px;
+  min-width: 0;
 }
 
 .cron-workspace-form {
@@ -901,6 +902,17 @@
 .cron-run-entry__summary {
   white-space: pre-wrap;
   line-height: 1.45;
+}
+
+@media (max-width: 1400px) {
+  .cron-workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .cron-workspace-form {
+    position: static;
+    order: -1;
+  }
 }
 
 @media (max-width: 1100px) {


### PR DESCRIPTION
## Summary
- prevent Cron Jobs main pane from forcing horizontal overflow by allowing it to shrink (`min-width: 0`)
- switch the Cron Jobs layout to a single-column stack earlier (`max-width: 1400px`) so the New Job card does not overlap/crop Jobs controls
- keep existing mobile behavior unchanged

Closes #37655

## Validation
- `pnpm lint:ui:no-raw-window-open` ✅ passed
- `pnpm ui:build` ✅ passed (Vite build completed)
- `pnpm test:ui` ⚠️ blocked by host browser dependencies
  - initial failure: Playwright browser binaries missing
  - ran `pnpm exec playwright-core install chromium`
  - reran `pnpm test:ui`; browser tests still failed because shared library `libatk-1.0.so.0` is missing on this host
