### PR TITLE
fix(tools): replace original param name with alias in required array for Claude compat patch

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -100,8 +100,10 @@ describe("createOpenClawCodingTools", () => {
       const props = params.properties ?? {};
 
       expect(props.file_path).toEqual(props.path);
+      // The alias should replace the original in required so that non-Claude
+      // models still receive a non-empty required array.
       expect(params.required ?? []).not.toContain("path");
-      expect(params.required ?? []).not.toContain("file_path");
+      expect(params.required ?? []).toContain("file_path");
     });
 
     it("normalizes file_path to path and enforces required groups at runtime", async () => {

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -146,7 +146,7 @@ export function patchToolSchemaForClaudeCompatibility(tool: AnyAgentTool): AnyAg
     }
     const idx = required.indexOf(original);
     if (idx !== -1) {
-      required.splice(idx, 1);
+      required.splice(idx, 1, alias);
       changed = true;
     }
   }


### PR DESCRIPTION
## Summary

`patchToolSchemaForClaudeCompatibility()` adds Claude-style aliases (`path` → `file_path`, `oldText` → `old_string`, `newText` → `new_string`) to tool schemas. However, it
 spliced the original param name out of the `required` array without inserting the alias, leaving `required: []` for read/edit/write tools.

Non-Claude models (Kimi K2.5, Grok, Gemini, etc.) that strictly follow the OpenAI tool calling spec interpreted all parameters as optional and sometimes sent `arguments:
{}` or empty values.

## Root Cause

In `src/agents/pi-tools.params.ts` line 149:

```typescript
required.splice(idx, 1);  // removes "path", adds nothing back
```
Fix

One-character fix — use splice(idx, 1, alias) to atomically replace the original name with its alias:

required.splice(idx, 1, alias);  // replaces "path" with "file_path"

Test plan

- Updated test assertion: file_path is now in required after patching
- All 16 pi-tools test files pass (122 tests)
- Lint/format/type check clean

Closes #37645