### PR TITLE
docs(fly): clarify gateway token setup and pairing flow

### DIFF
--- a/docs/install/fly.md
+++ b/docs/install/fly.md
@@ -96,7 +96,7 @@ Set a gateway token **and save it somewhere**. You will need this exact value in
 
 ```bash
 # Required: Gateway token (for non-loopback binding)
-# Save this toen; you'll paste it into the UI later.
+# Save this token; you'll paste it into the UI later.
 export OPENCLAW_GATEWAY_TOKEN="$(openssl rand -hex 32)"
 echo "$OPENCLAW_GATEWAY_TOKEN"
 

--- a/docs/install/fly.md
+++ b/docs/install/fly.md
@@ -92,9 +92,15 @@ primary_region = "iad"
 
 ## 3) Set secrets
 
+Set a gateway token **and save it somewhere**. You will need this exact value in the browser after deploy.
+
 ```bash
 # Required: Gateway token (for non-loopback binding)
-fly secrets set OPENCLAW_GATEWAY_TOKEN=$(openssl rand -hex 32)
+# Save this toen; you'll paste it into the UI later.
+export OPENCLAW_GATEWAY_TOKEN="$(openssl rand -hex 32)"
+echo "$OPENCLAW_GATEWAY_TOKEN"
+
+fly secrets set OPENCLAW_GATEWAY_TOKEN="$OPENCLAW_GATEWAY_TOKEN"
 
 # Model provider API keys
 fly secrets set ANTHROPIC_API_KEY=sk-ant-...
@@ -112,6 +118,7 @@ fly secrets set DISCORD_BOT_TOKEN=MTQ...
 - Non-loopback binds (`--bind lan`) require `OPENCLAW_GATEWAY_TOKEN` for security.
 - Treat these tokens like passwords.
 - **Prefer env vars over config file** for all API keys and tokens. This keeps secrets out of `openclaw.json` where they could be accidentally exposed or logged.
+- Fly will not show the plaintext secret value back later, so save it now.
 
 ## 4) Deploy
 
@@ -190,7 +197,10 @@ cat > /data/openclaw.json << 'EOF'
   },
   "gateway": {
     "mode": "local",
-    "bind": "auto"
+    "bind": "auto",
+    "controlUi": {
+      "allowedOrigins": ["https://my-openclaw.fly.dev"]
+    }
   },
   "meta": {
     "lastTouchedVersion": "2026.1.29"
@@ -199,12 +209,14 @@ cat > /data/openclaw.json << 'EOF'
 EOF
 ```
 
-**Note:** With `OPENCLAW_STATE_DIR=/data`, the config path is `/data/openclaw.json`.
+**Notes:**
 
-**Note:** The Discord token can come from either:
-
-- Environment variable: `DISCORD_BOT_TOKEN` (recommended for secrets)
-- Config file: `channels.discord.token`
+- With `OPENCLAW_STATE_DIR=/data`, the config path is `/data/openclaw.json`.
+- Set `gateway.controlUi.allowedOrigins` to your exact public origin, for example `https://my-openclaw.fly.dev`.
+- If you already have a config, edit it instead of overwriting it.
+- The Discord token can come from either:
+  - environment variable: `DISCORD_BOT_TOKEN` (recommended)
+  - config file: `channels.discord.token`
 
 If using env var, no need to add token to config. The gateway reads `DISCORD_BOT_TOKEN` automatically.
 
@@ -227,7 +239,21 @@ fly open
 
 Or visit `https://my-openclaw.fly.dev/`
 
-Paste your gateway token (the one from `OPENCLAW_GATEWAY_TOKEN`) to authenticate.
+On first open:
+
+1. Go to **Overview**.
+2. In **Gateway Access**, paste the value of `OPENCLAW_GATEWAY_TOKEN` into **Gateway Token**.
+3. Click **Connect**.
+
+If you see **pairing required**, approve this browser/device once:
+
+```bash
+fly ssh console -a my-openclaw
+openclaw devices list --url ws://127.0.0.1:3000 --token "$OPENCLAW_GATEWAY_TOKEN"
+openclaw devices approve --latest --url ws://127.0.0.1:3000 --token "$OPENCLAW_GATEWAY_TOKEN"
+```
+
+Then return to the browser and click **Refresh** or **Connect** again.
 
 ### Logs
 
@@ -249,6 +275,49 @@ fly ssh console
 The gateway is binding to `127.0.0.1` instead of `0.0.0.0`.
 
 **Fix:** Add `--bind lan` to your process command in `fly.toml`.
+
+### "non-loopback Control UI requires gateway.controlUi.allowedOrigins"
+
+The gateway is public, but the Control UI origin is not explicitly allowed.
+
+**Fix:** In `/data/openclaw.json`, set:
+
+```json
+{
+  "gateway": {
+    "controlUi": {
+      "allowedOrigins": ["https://my-openclaw.fly.dev"]
+    }
+  }
+}
+```
+
+Then restart the machine.
+
+### "unauthorized: gateway token missing"
+
+The browser UI does not have a token yet.
+
+**Fix:**
+
+1. Open the app URL.
+2. Go to **Overview**.
+3. Paste `OPENCLAW_GATEWAY_TOKEN` into **Gateway Access → Gateway Token**.
+4. Click **Connect**.
+
+### "pairing required"
+
+The browser/device is authenticated but still needs one-time approval.
+
+**Fix:**
+
+```bash
+fly ssh console -a my-openclaw
+openclaw devices list --url ws://127.0.0.1:3000 --token "$OPENCLAW_GATEWAY_TOKEN"
+openclaw devices approve --latest --url ws://127.0.0.1:3000 --token "$OPENCLAW_GATEWAY_TOKEN"
+```
+
+**Tip:** If you pass `--url`, also pass `--token` explicitly.
 
 ### Health checks failing / connection refused
 


### PR DESCRIPTION
Clarified instructions for setting the gateway token and added notes on configuration and troubleshooting steps.

## Summary

- Problem: The Fly.io install guide did not make it clear that `OPENCLAW_GATEWAY_TOKEN` must be saved at creation time, where exactly it should be pasted in the Control UI, or that a first-time remote browser connection may require device pairing.
- Why it matters: Users can complete deployment successfully but still get blocked by `unauthorized: gateway token missing` or `pairing required`, with no obvious next step from the Fly guide alone.
- What changed: Updated `docs/install/fly.md` to make the token flow more explicit, added concise guidance for `gateway.controlUi.allowedOrigins`, and added troubleshooting entries for missing token, pairing approval, and related Fly-specific startup issues.
- What did NOT change (scope boundary): No runtime behavior, config defaults, auth model, gateway logic, or CLI behavior changed. This PR only updates documentation.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- The Fly.io install docs now explicitly tell users to save the generated `OPENCLAW_GATEWAY_TOKEN` value before setting it as a Fly secret.
- The docs now explain where to enter the token in the UI: `Overview -> Gateway Access -> Gateway Token`.
- The docs now explain that `pairing required` is a separate step after token auth and document how to approve the browser/device from the Fly host.
- The docs now include clearer notes around `/data/openclaw.json`, `gateway.controlUi.allowedOrigins`, and common Fly deployment failure modes.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: macOS client + Fly.io Linux machine
- Runtime/container: Fly.io machine running OpenClaw via Docker image
- Model/provider: Anthropic (`anthropic/claude-sonnet-4-6`)
- Integration/channel (if any): None required for repro
- Relevant config (redacted):
  - `OPENCLAW_GATEWAY_TOKEN=<redacted>`
  - `OPENCLAW_STATE_DIR=/data`
  - `gateway.controlUi.allowedOrigins=["https://<app>.fly.dev"]`
  - Fly process command includes `--bind lan --port 3000`

### Steps

1. Deploy OpenClaw to Fly.io using the existing guide and open the public app URL.
2. Reach the Control UI without having a clear instruction on where to paste `OPENCLAW_GATEWAY_TOKEN`.
3. After entering the token, encounter `pairing required` without a clear Fly-specific pairing flow.
4. Approve the device/browser from the Fly host and reconnect.

### Expected

- The docs should let a user complete first-time browser access in one pass.
- It should be obvious when to save the token, where to paste it, and how to handle pairing.

### Actual

- The original guide left the token entry location and pairing flow implicit.
- A successful deployment could still leave the user blocked on auth/pairing with unclear next steps.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Verified a Fly deployment could reach a healthy running state but still require additional UI auth steps.
  - Verified that the token must be pasted in `Overview -> Gateway Access -> Gateway Token`.
  - Verified that `pairing required` is resolved by approving the pending device from the Fly host.
  - Verified that `gateway.controlUi.allowedOrigins` must be set for non-loopback/public Fly access.
- Edge cases checked:
  - Missing token in browser UI after successful deploy
  - Device pairing required after token auth succeeds
  - Config stored in `/data/openclaw.json`
  - Fly secret value not being readable back in plaintext after creation
- What you did **not** verify:
  - Private/hardened Fly deployment flow end-to-end
  - Every optional provider/channel configuration path
  - Non-Fly deployment targets

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert changes to `docs/install/fly.md`
- Files/config to restore: `docs/install/fly.md`
- Known bad symptoms reviewers should watch for:
  - Inaccurate UI labels or navigation path for token entry
  - Incorrect device pairing command examples
  - Examples that imply behavior changes instead of doc clarifications

## Risks and Mitigations

- Risk: The documented UI path or wording may drift from the actual UI over time.
  - Mitigation: Keep the instructions concise and tied to stable labels already shown in the current dashboard.
- Risk: The troubleshooting section may grow too large for a quick-start install page.
  - Mitigation: Keep only the common Fly-specific blockers inline and avoid duplicating broader docs unnecessarily.
- Risk: Command examples for pairing may be copied without replacing placeholders.
  - Mitigation: Use clear placeholders and explain when `--url` and `--token` are required.