### PR TITLE
fix(feishu): warn users when dmPolicy default changed from open to pa…

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -981,15 +981,13 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
       if (!warnedDmPolicyMigration.has(ctx.accountId)) {
         const rawFeishu = ctx.cfg.channels?.feishu as FeishuConfig | undefined;
         const accountsMap = rawFeishu?.accounts;
-        const isMultiAccount =
-          accountsMap != null && Object.keys(accountsMap).length > 0;
+        const isMultiAccount = accountsMap != null && Object.keys(accountsMap).length > 0;
         // In multi-account mode, account-level dmPolicy is undefined when not explicitly set.
         // Root-level "open" means the user deliberately opted in, so skip the warning.
         // In single-account mode, Zod applies the schema default ("pairing"), so warn when
         // the resolved value is "pairing" as the best available signal.
         const dmPolicyImplicit = isMultiAccount
-          ? accountsMap[ctx.accountId]?.dmPolicy === undefined &&
-            rawFeishu?.dmPolicy !== "open"
+          ? accountsMap[ctx.accountId]?.dmPolicy === undefined && rawFeishu?.dmPolicy !== "open"
           : rawFeishu?.dmPolicy === "pairing";
         if (dmPolicyImplicit) {
           warnedDmPolicyMigration.add(ctx.accountId);

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -47,6 +47,9 @@ import { feishuSetupWizard } from "./setup-surface.js";
 import { normalizeFeishuTarget, looksLikeFeishuId, formatFeishuTarget } from "./targets.js";
 import type { ResolvedFeishuAccount, FeishuConfig } from "./types.js";
 
+// Track which accounts have already received the dmPolicy migration warning this session.
+const warnedDmPolicyMigration = new Set<string>();
+
 const meta: ChannelMeta = {
   id: "feishu",
   label: "Feishu",
@@ -972,6 +975,31 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
       ctx.log?.info(
         `starting feishu[${ctx.accountId}] (mode: ${account.config?.connectionMode ?? "websocket"})`,
       );
+
+      // Migration warning: dmPolicy default changed from 'open' to 'pairing' in v2026.2.14.
+      // Warn once per account per session when dmPolicy was not explicitly set by the user.
+      if (!warnedDmPolicyMigration.has(ctx.accountId)) {
+        warnedDmPolicyMigration.add(ctx.accountId);
+        const rawFeishu = ctx.cfg.channels?.feishu as FeishuConfig | undefined;
+        const accountsMap = rawFeishu?.accounts;
+        const isMultiAccount =
+          accountsMap != null && Object.keys(accountsMap).length > 0;
+        // In multi-account mode, account-level dmPolicy is undefined when not explicitly set
+        // (FeishuAccountConfigSchema uses .optional() without .default()).
+        // In single-account mode, Zod applies the schema default ("pairing"), so we check
+        // whether the resolved value is "pairing" as the best available signal.
+        const dmPolicyImplicit = isMultiAccount
+          ? accountsMap[ctx.accountId]?.dmPolicy === undefined
+          : rawFeishu?.dmPolicy === "pairing";
+        if (dmPolicyImplicit) {
+          ctx.log?.warn(
+            `[feishu] Feishu dmPolicy default changed from 'open' to 'pairing' in v2026.2.14. ` +
+              `If your bot stopped responding to DMs, add \`dmPolicy: 'open'\` to your Feishu config. ` +
+              `See https://github.com/openclaw/openclaw/issues/17741`,
+          );
+        }
+      }
+
       return monitorFeishuProvider({
         config: ctx.cfg,
         runtime: ctx.runtime,

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -979,7 +979,6 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
       // Migration warning: dmPolicy default changed from 'open' to 'pairing' in v2026.2.14.
       // Warn once per account per session when dmPolicy was not explicitly set by the user.
       if (!warnedDmPolicyMigration.has(ctx.accountId)) {
-        warnedDmPolicyMigration.add(ctx.accountId);
         const rawFeishu = ctx.cfg.channels?.feishu as FeishuConfig | undefined;
         const accountsMap = rawFeishu?.accounts;
         const isMultiAccount =
@@ -993,6 +992,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
             rawFeishu?.dmPolicy !== "open"
           : rawFeishu?.dmPolicy === "pairing";
         if (dmPolicyImplicit) {
+          warnedDmPolicyMigration.add(ctx.accountId);
           ctx.log?.warn(
             `[feishu] Feishu dmPolicy default changed from 'open' to 'pairing' in v2026.2.14. ` +
               `If your bot stopped responding to DMs, add \`dmPolicy: 'open'\` to your Feishu config. ` +

--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -984,12 +984,13 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
         const accountsMap = rawFeishu?.accounts;
         const isMultiAccount =
           accountsMap != null && Object.keys(accountsMap).length > 0;
-        // In multi-account mode, account-level dmPolicy is undefined when not explicitly set
-        // (FeishuAccountConfigSchema uses .optional() without .default()).
-        // In single-account mode, Zod applies the schema default ("pairing"), so we check
-        // whether the resolved value is "pairing" as the best available signal.
+        // In multi-account mode, account-level dmPolicy is undefined when not explicitly set.
+        // Root-level "open" means the user deliberately opted in, so skip the warning.
+        // In single-account mode, Zod applies the schema default ("pairing"), so warn when
+        // the resolved value is "pairing" as the best available signal.
         const dmPolicyImplicit = isMultiAccount
-          ? accountsMap[ctx.accountId]?.dmPolicy === undefined
+          ? accountsMap[ctx.accountId]?.dmPolicy === undefined &&
+            rawFeishu?.dmPolicy !== "open"
           : rawFeishu?.dmPolicy === "pairing";
         if (dmPolicyImplicit) {
           ctx.log?.warn(


### PR DESCRIPTION
## Summary

- **Problem:** In v2026.2.14, the Feishu `dmPolicy` default was silently changed from `"open"` to `"pairing"`. Users who hadn't explicitly set `dmPolicy` suddenly found their bots sending a pairing-code prompt instead of responding to DMs.
- **Why it matters:** This is a breaking behavioral change with no warning. Many users reported their bots stopped working overnight with no obvious cause (see #17741).
- **Fix:** On channel startup, if `dmPolicy` was not explicitly set in the user's config, emit a one-time `warn()` log pointing users to the fix and the tracking issue.
- **Scope:** Warning fires once per account per session; no functional behavior is changed.
- **Tested:** Reproduced the bug locally (bot sends pairing code), added `dmPolicy: 'open'`, confirmed warning fires correctly in single-account mode.

## Change Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope

- [x] Integrations (Feishu channel)

## Linked Issue/PR

Closes #17741

## User-visible / Behavior Changes

On Feishu channel startup, if `dmPolicy` is not explicitly set in the user's config, a one-time warning log is emitted:

