### PR TITLE
fix(agents): preserve aliased params in required array

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -101,7 +101,7 @@ describe("createOpenClawCodingTools", () => {
 
       expect(props.file_path).toEqual(props.path);
       expect(params.required ?? []).not.toContain("path");
-      expect(params.required ?? []).not.toContain("file_path");
+      expect(params.required ?? []).toContain("file_path");
     });
 
     it("normalizes file_path to path and enforces required groups at runtime", async () => {

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -146,7 +146,7 @@ export function patchToolSchemaForClaudeCompatibility(tool: AnyAgentTool): AnyAg
     }
     const idx = required.indexOf(original);
     if (idx !== -1) {
-      required.splice(idx, 1);
+      required.splice(idx, 1, alias);
       changed = true;
     }
   }


### PR DESCRIPTION
## Summary

- `patchToolSchemaForClaudeCompatibility()` removes original param names from `required` without adding aliases back, leaving `required: []` for tools like read, edit, and write
- Non-Claude models (Kimi K2.5, Grok, Gemini) interpret all parameters as optional and sometimes send empty arguments
- Fix: replace `required.splice(idx, 1)` with `required.splice(idx, 1, alias)` so aliases (e.g. `file_path`) take the place of originals (e.g. `path`) in the required array

Fixes #37645

## Test plan

- [x] Updated existing test to verify alias appears in `required` after patching
- [x] All 25 tests in the alias/compatibility test suite pass
- [x] `pnpm build` succeeds
- [x] `pnpm check` succeeds