### PR TITLE
fix: inject SSE event field for anthropic-messages proxies

### DIFF
--- a/package.json
+++ b/package.json
@@ -235,6 +235,9 @@
       "node-llama-cpp",
       "protobufjs",
       "sharp"
-    ]
+    ],
+    "patchedDependencies": {
+      "@mariozechner/pi-ai": "patches/@mariozechner__pi-ai.patch"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
       "sharp"
     ],
     "patchedDependencies": {
-      "@mariozechner/pi-ai": "patches/@mariozechner__pi-ai.patch"
+      "@mariozechner/pi-ai@0.53.0": "patches/@mariozechner__pi-ai.patch"
     }
   }
 }

--- a/patches/@mariozechner__pi-ai.patch
+++ b/patches/@mariozechner__pi-ai.patch
@@ -2,7 +2,7 @@ diff --git a/dist/providers/anthropic.js b/dist/providers/anthropic.js
 index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..2834ebd9e309872792e14cc41a526412dbf8e664 100644
 --- a/dist/providers/anthropic.js
 +++ b/dist/providers/anthropic.js
-@@ -376,11 +376,122 @@ export const streamSimpleAnthropic = (model, context, options) => {
+@@ -376,11 +376,134 @@ export const streamSimpleAnthropic = (model, context, options) => {
          thinkingBudgetTokens: adjusted.thinkingBudget,
      });
  };
@@ -22,6 +22,11 @@ index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..2834ebd9e309872792e14cc41a526412
 + *
 + * @see https://github.com/openclaw/openclaw/issues/37571
 + */
++const MAX_BUFFER_CHARS = 1000000;
++function sanitizeSseEventName(value) {
++    const stripped = value.replace(/[\x00-\x1f\x7f]/g, "");
++    return stripped.length > 0 ? stripped : null;
++}
 +function createSseEventInjectionFetch() {
 +    return async function sseEventInjectionFetch(url, init) {
 +        const response = await globalThis.fetch(url, init);
@@ -48,6 +53,12 @@ index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..2834ebd9e309872792e14cc41a526412
 +                    return;
 +                }
 +                buffer += decoder.decode(value, { stream: true });
++                // Guard against unbounded buffering (CWE-400)
++                if (buffer.length > MAX_BUFFER_CHARS) {
++                    try { await reader.cancel(); } catch {}
++                    controller.error(new Error("SSE buffer limit exceeded"));
++                    return;
++                }
 +                // Process complete lines only (keep incomplete last line in buffer)
 +                const lastNewline = buffer.lastIndexOf("\n");
 +                if (lastNewline === -1) return;
@@ -92,7 +103,8 @@ index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..2834ebd9e309872792e14cc41a526412
 +                    try {
 +                        const parsed = JSON.parse(jsonStr);
 +                        if (parsed && typeof parsed.type === "string") {
-+                            result.push("event: " + parsed.type);
++                            const safeType = sanitizeSseEventName(parsed.type);
++                            if (safeType) result.push("event: " + safeType);
 +                        }
 +                    }
 +                    catch {
@@ -125,7 +137,7 @@ index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..2834ebd9e309872792e14cc41a526412
      if (model.provider === "github-copilot") {
          const betaFeatures = [];
          if (interleavedThinking) {
-@@ -391,6 +502,7 @@ function createClient(model, apiKey, interleavedThinking, optionsHeaders, dynami
+@@ -391,6 +514,7 @@ function createClient(model, apiKey, interleavedThinking, optionsHeaders, dynami
              authToken: apiKey,
              baseURL: model.baseUrl,
              dangerouslyAllowBrowser: true,
@@ -133,7 +145,7 @@ index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..2834ebd9e309872792e14cc41a526412
              defaultHeaders: mergeHeaders({
                  accept: "application/json",
                  "anthropic-dangerous-direct-browser-access": "true",
-@@ -410,6 +522,7 @@ function createClient(model, apiKey, interleavedThinking, optionsHeaders, dynami
+@@ -410,6 +534,7 @@ function createClient(model, apiKey, interleavedThinking, optionsHeaders, dynami
              authToken: apiKey,
              baseURL: model.baseUrl,
              dangerouslyAllowBrowser: true,
@@ -141,7 +153,7 @@ index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..2834ebd9e309872792e14cc41a526412
              defaultHeaders: mergeHeaders({
                  accept: "application/json",
                  "anthropic-dangerous-direct-browser-access": "true",
-@@ -425,6 +538,7 @@ function createClient(model, apiKey, interleavedThinking, optionsHeaders, dynami
+@@ -425,6 +550,7 @@ function createClient(model, apiKey, interleavedThinking, optionsHeaders, dynami
          apiKey,
          baseURL: model.baseUrl,
          dangerouslyAllowBrowser: true,

--- a/patches/@mariozechner__pi-ai.patch
+++ b/patches/@mariozechner__pi-ai.patch
@@ -1,0 +1,130 @@
+diff --git a/dist/providers/anthropic.js b/dist/providers/anthropic.js
+index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..ad925e4169c06194acc5f492e7c89ad0a3775ca8 100644
+--- a/dist/providers/anthropic.js
++++ b/dist/providers/anthropic.js
+@@ -376,11 +376,101 @@ export const streamSimpleAnthropic = (model, context, options) => {
+         thinkingBudgetTokens: adjusted.thinkingBudget,
+     });
+ };
++/**
++ * Create a custom fetch wrapper that injects SSE `event:` lines when missing.
++ *
++ * Some third-party proxies serving the Anthropic Messages API return SSE streams
++ * without `event:` field lines. The `@anthropic-ai/sdk` SSE parser requires the
++ * `event:` field to dispatch events — without it, all events are silently dropped
++ * and the stream ends with "request ended without sending any chunks".
++ *
++ * This wrapper detects `data:` lines whose JSON payload contains a `"type"` field
++ * and injects `event: <type>\n` before each such line when the preceding line is
++ * not already an `event:` line.
++ */
++function createSseEventInjectionFetch() {
++    return async function sseEventInjectionFetch(url, init) {
++        const response = await globalThis.fetch(url, init);
++        // Only transform streaming responses (SSE)
++        const contentType = response.headers.get("content-type") || "";
++        if (!contentType.includes("text/event-stream") || !response.body) {
++            return response;
++        }
++        const reader = response.body.getReader();
++        const decoder = new TextDecoder();
++        const encoder = new TextEncoder();
++        let buffer = "";
++        const readable = new ReadableStream({
++            async pull(controller) {
++                const { done, value } = await reader.read();
++                if (done) {
++                    // Flush any remaining buffer
++                    if (buffer.length > 0) {
++                        controller.enqueue(encoder.encode(processChunk(buffer)));
++                        buffer = "";
++                    }
++                    controller.close();
++                    return;
++                }
++                buffer += decoder.decode(value, { stream: true });
++                // Process complete lines only (keep incomplete last line in buffer)
++                const lastNewline = buffer.lastIndexOf("\n");
++                if (lastNewline === -1) return;
++                const toProcess = buffer.slice(0, lastNewline + 1);
++                buffer = buffer.slice(lastNewline + 1);
++                controller.enqueue(encoder.encode(processChunk(toProcess)));
++            },
++            cancel() {
++                reader.cancel();
++            },
++        });
++        return new Response(readable, {
++            status: response.status,
++            statusText: response.statusText,
++            headers: response.headers,
++        });
++    };
++}
++/**
++ * Process a chunk of SSE text, injecting `event:` lines where missing.
++ * Handles lines separated by \n, \r\n, or \r.
++ */
++function processChunk(chunk) {
++    const lines = chunk.split(/\r?\n|\r/);
++    const result = [];
++    let prevWasEvent = false;
++    for (const line of lines) {
++        if (line.startsWith("event:")) {
++            prevWasEvent = true;
++            result.push(line);
++            continue;
++        }
++        if (line.startsWith("data:") && !prevWasEvent) {
++            const jsonStr = line.slice(5).trim();
++            if (jsonStr) {
++                try {
++                    const parsed = JSON.parse(jsonStr);
++                    if (parsed && typeof parsed.type === "string") {
++                        result.push("event: " + parsed.type);
++                    }
++                }
++                catch {
++                    // Not valid JSON — leave as-is, no event injection
++                }
++            }
++        }
++        prevWasEvent = false;
++        result.push(line);
++    }
++    return result.join("\n");
++}
+ function isOAuthToken(apiKey) {
+     return apiKey.includes("sk-ant-oat");
+ }
+ function createClient(model, apiKey, interleavedThinking, optionsHeaders, dynamicHeaders) {
+     // Copilot: Bearer auth, selective betas (no fine-grained-tool-streaming)
++    // Inject SSE event field fix for proxies that omit `event:` lines
++    const sseFixFetch = createSseEventInjectionFetch();
+     if (model.provider === "github-copilot") {
+         const betaFeatures = [];
+         if (interleavedThinking) {
+@@ -391,6 +481,7 @@ function createClient(model, apiKey, interleavedThinking, optionsHeaders, dynami
+             authToken: apiKey,
+             baseURL: model.baseUrl,
+             dangerouslyAllowBrowser: true,
++            fetch: sseFixFetch,
+             defaultHeaders: mergeHeaders({
+                 accept: "application/json",
+                 "anthropic-dangerous-direct-browser-access": "true",
+@@ -410,6 +501,7 @@ function createClient(model, apiKey, interleavedThinking, optionsHeaders, dynami
+             authToken: apiKey,
+             baseURL: model.baseUrl,
+             dangerouslyAllowBrowser: true,
++            fetch: sseFixFetch,
+             defaultHeaders: mergeHeaders({
+                 accept: "application/json",
+                 "anthropic-dangerous-direct-browser-access": "true",
+@@ -425,6 +517,7 @@ function createClient(model, apiKey, interleavedThinking, optionsHeaders, dynami
+         apiKey,
+         baseURL: model.baseUrl,
+         dangerouslyAllowBrowser: true,
++        fetch: sseFixFetch,
+         defaultHeaders: mergeHeaders({
+             accept: "application/json",
+             "anthropic-dangerous-direct-browser-access": "true",

--- a/patches/@mariozechner__pi-ai.patch
+++ b/patches/@mariozechner__pi-ai.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/providers/anthropic.js b/dist/providers/anthropic.js
-index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..ad925e4169c06194acc5f492e7c89ad0a3775ca8 100644
+index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..2834ebd9e309872792e14cc41a526412dbf8e664 100644
 --- a/dist/providers/anthropic.js
 +++ b/dist/providers/anthropic.js
-@@ -376,11 +376,101 @@ export const streamSimpleAnthropic = (model, context, options) => {
+@@ -376,11 +376,122 @@ export const streamSimpleAnthropic = (model, context, options) => {
          thinkingBudgetTokens: adjusted.thinkingBudget,
      });
  };
@@ -15,8 +15,12 @@ index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..ad925e4169c06194acc5f492e7c89ad0
 + * and the stream ends with "request ended without sending any chunks".
 + *
 + * This wrapper detects `data:` lines whose JSON payload contains a `"type"` field
-+ * and injects `event: <type>\n` before each such line when the preceding line is
-+ * not already an `event:` line.
++ * and injects `event: <type>\n` before each such line when no `event:` line
++ * precedes it. State is tracked across chunk boundaries so that an `event:` line
++ * at the end of one chunk correctly suppresses injection for the `data:` line at
++ * the start of the next chunk.
++ *
++ * @see https://github.com/openclaw/openclaw/issues/37571
 + */
 +function createSseEventInjectionFetch() {
 +    return async function sseEventInjectionFetch(url, init) {
@@ -30,13 +34,14 @@ index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..ad925e4169c06194acc5f492e7c89ad0
 +        const decoder = new TextDecoder();
 +        const encoder = new TextEncoder();
 +        let buffer = "";
++        const state = { prevWasEvent: false };
 +        const readable = new ReadableStream({
 +            async pull(controller) {
 +                const { done, value } = await reader.read();
 +                if (done) {
 +                    // Flush any remaining buffer
 +                    if (buffer.length > 0) {
-+                        controller.enqueue(encoder.encode(processChunk(buffer)));
++                        controller.enqueue(encoder.encode(processChunk(buffer, state)));
 +                        buffer = "";
 +                    }
 +                    controller.close();
@@ -48,7 +53,7 @@ index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..ad925e4169c06194acc5f492e7c89ad0
 +                if (lastNewline === -1) return;
 +                const toProcess = buffer.slice(0, lastNewline + 1);
 +                buffer = buffer.slice(lastNewline + 1);
-+                controller.enqueue(encoder.encode(processChunk(toProcess)));
++                controller.enqueue(encoder.encode(processChunk(toProcess, state)));
 +            },
 +            cancel() {
 +                reader.cancel();
@@ -63,33 +68,49 @@ index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..ad925e4169c06194acc5f492e7c89ad0
 +}
 +/**
 + * Process a chunk of SSE text, injecting `event:` lines where missing.
-+ * Handles lines separated by \n, \r\n, or \r.
++ *
++ * The `state` parameter carries `prevWasEvent` across calls so that an
++ * `event:` line flushed at the end of one chunk correctly suppresses
++ * injection for the `data:` line at the start of the next chunk.
++ * Only resets on empty lines (SSE dispatch boundaries) or `data:` lines,
++ * so intermediate fields like `id:` or `retry:` do not cause false injection.
 + */
-+function processChunk(chunk) {
++function processChunk(chunk, state) {
 +    const lines = chunk.split(/\r?\n|\r/);
 +    const result = [];
-+    let prevWasEvent = false;
-+    for (const line of lines) {
++    for (let i = 0; i < lines.length; i++) {
++        const line = lines[i];
 +        if (line.startsWith("event:")) {
-+            prevWasEvent = true;
++            state.prevWasEvent = true;
 +            result.push(line);
 +            continue;
 +        }
-+        if (line.startsWith("data:") && !prevWasEvent) {
-+            const jsonStr = line.slice(5).trim();
-+            if (jsonStr) {
-+                try {
-+                    const parsed = JSON.parse(jsonStr);
-+                    if (parsed && typeof parsed.type === "string") {
-+                        result.push("event: " + parsed.type);
++        if (line.startsWith("data:")) {
++            if (!state.prevWasEvent) {
++                const jsonStr = line.slice(5).trim();
++                if (jsonStr) {
++                    try {
++                        const parsed = JSON.parse(jsonStr);
++                        if (parsed && typeof parsed.type === "string") {
++                            result.push("event: " + parsed.type);
++                        }
++                    }
++                    catch {
++                        // Not valid JSON — leave as-is, no event injection
 +                    }
 +                }
-+                catch {
-+                    // Not valid JSON — leave as-is, no event injection
-+                }
 +            }
++            state.prevWasEvent = false;
++            result.push(line);
++            continue;
 +        }
-+        prevWasEvent = false;
++        // Empty line = SSE dispatch boundary — reset state.
++        // Skip the trailing empty string from split (artifact of chunk ending
++        // with \n) since it's not a real dispatch boundary.
++        if (line === "" && i < lines.length - 1) {
++            state.prevWasEvent = false;
++        }
++        // For other SSE fields (id:, retry:, comments) do NOT reset prevWasEvent
 +        result.push(line);
 +    }
 +    return result.join("\n");
@@ -104,7 +125,7 @@ index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..ad925e4169c06194acc5f492e7c89ad0
      if (model.provider === "github-copilot") {
          const betaFeatures = [];
          if (interleavedThinking) {
-@@ -391,6 +481,7 @@ function createClient(model, apiKey, interleavedThinking, optionsHeaders, dynami
+@@ -391,6 +502,7 @@ function createClient(model, apiKey, interleavedThinking, optionsHeaders, dynami
              authToken: apiKey,
              baseURL: model.baseUrl,
              dangerouslyAllowBrowser: true,
@@ -112,7 +133,7 @@ index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..ad925e4169c06194acc5f492e7c89ad0
              defaultHeaders: mergeHeaders({
                  accept: "application/json",
                  "anthropic-dangerous-direct-browser-access": "true",
-@@ -410,6 +501,7 @@ function createClient(model, apiKey, interleavedThinking, optionsHeaders, dynami
+@@ -410,6 +522,7 @@ function createClient(model, apiKey, interleavedThinking, optionsHeaders, dynami
              authToken: apiKey,
              baseURL: model.baseUrl,
              dangerouslyAllowBrowser: true,
@@ -120,7 +141,7 @@ index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..ad925e4169c06194acc5f492e7c89ad0
              defaultHeaders: mergeHeaders({
                  accept: "application/json",
                  "anthropic-dangerous-direct-browser-access": "true",
-@@ -425,6 +517,7 @@ function createClient(model, apiKey, interleavedThinking, optionsHeaders, dynami
+@@ -425,6 +538,7 @@ function createClient(model, apiKey, interleavedThinking, optionsHeaders, dynami
          apiKey,
          baseURL: model.baseUrl,
          dangerouslyAllowBrowser: true,

--- a/patches/@mariozechner__pi-ai.patch
+++ b/patches/@mariozechner__pi-ai.patch
@@ -26,7 +26,7 @@ index 0bf2b894799bbc9ef5fda07bc44ea4301c9f395a..2834ebd9e309872792e14cc41a526412
 +    return async function sseEventInjectionFetch(url, init) {
 +        const response = await globalThis.fetch(url, init);
 +        // Only transform streaming responses (SSE)
-+        const contentType = response.headers.get("content-type") || "";
++        const contentType = (response.headers.get("content-type") || "").toLowerCase();
 +        if (!contentType.includes("text/event-stream") || !response.body) {
 +            return response;
 +        }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
 
 patchedDependencies:
   '@mariozechner/pi-ai':
-    hash: d87463a41836d6d27147f95f98dc7a1251290cb0c34c9e996d6ce2d882bd9701
+    hash: ee8e82b7551bd5ac8cf1e5cc2c902c17b6bc70e45031e9373d5835e5d8d2bdf7
     path: patches/@mariozechner__pi-ai.patch
 
 importers:
@@ -59,7 +59,7 @@ importers:
         version: 0.53.0(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai':
         specifier: 0.53.0
-        version: 0.53.0(patch_hash=d87463a41836d6d27147f95f98dc7a1251290cb0c34c9e996d6ce2d882bd9701)(ws@8.19.0)(zod@4.3.6)
+        version: 0.53.0(patch_hash=ee8e82b7551bd5ac8cf1e5cc2c902c17b6bc70e45031e9373d5835e5d8d2bdf7)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.53.0
         version: 0.53.0(ws@8.19.0)(zod@4.3.6)
@@ -7024,7 +7024,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.53.0(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.53.0(patch_hash=d87463a41836d6d27147f95f98dc7a1251290cb0c34c9e996d6ce2d882bd9701)(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.53.0(patch_hash=ee8e82b7551bd5ac8cf1e5cc2c902c17b6bc70e45031e9373d5835e5d8d2bdf7)(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -7034,7 +7034,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.53.0(patch_hash=d87463a41836d6d27147f95f98dc7a1251290cb0c34c9e996d6ce2d882bd9701)(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.53.0(patch_hash=ee8e82b7551bd5ac8cf1e5cc2c902c17b6bc70e45031e9373d5835e5d8d2bdf7)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.992.0
@@ -7062,7 +7062,7 @@ snapshots:
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.53.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.53.0(patch_hash=d87463a41836d6d27147f95f98dc7a1251290cb0c34c9e996d6ce2d882bd9701)(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.53.0(patch_hash=ee8e82b7551bd5ac8cf1e5cc2c902c17b6bc70e45031e9373d5835e5d8d2bdf7)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.53.0
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,15 +5,20 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  fast-xml-parser: 5.3.6
   request: npm:@cypress/request@3.0.10
   request-promise: npm:@cypress/request-promise@5.0.0
-  fast-xml-parser: 5.3.6
   form-data: 2.5.4
   minimatch: 10.2.1
   qs: 6.14.2
   '@sinclair/typebox': 0.34.48
   tar: 7.5.9
   tough-cookie: 4.1.3
+
+patchedDependencies:
+  '@mariozechner/pi-ai':
+    hash: 245a1a1cd7c5e57b9b5e1bb3748144a00afcfda1126af08ef9b55b98eae8d42b
+    path: patches/@mariozechner__pi-ai.patch
 
 importers:
 
@@ -54,7 +59,7 @@ importers:
         version: 0.53.0(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai':
         specifier: 0.53.0
-        version: 0.53.0(ws@8.19.0)(zod@4.3.6)
+        version: 0.53.0(patch_hash=245a1a1cd7c5e57b9b5e1bb3748144a00afcfda1126af08ef9b55b98eae8d42b)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.53.0
         version: 0.53.0(ws@8.19.0)(zod@4.3.6)
@@ -7019,7 +7024,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.53.0(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.53.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.53.0(patch_hash=245a1a1cd7c5e57b9b5e1bb3748144a00afcfda1126af08ef9b55b98eae8d42b)(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -7029,7 +7034,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.53.0(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.53.0(patch_hash=245a1a1cd7c5e57b9b5e1bb3748144a00afcfda1126af08ef9b55b98eae8d42b)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.992.0
@@ -7057,7 +7062,7 @@ snapshots:
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.53.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.53.0(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.53.0(patch_hash=245a1a1cd7c5e57b9b5e1bb3748144a00afcfda1126af08ef9b55b98eae8d42b)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.53.0
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
 
 patchedDependencies:
   '@mariozechner/pi-ai':
-    hash: 245a1a1cd7c5e57b9b5e1bb3748144a00afcfda1126af08ef9b55b98eae8d42b
+    hash: d87463a41836d6d27147f95f98dc7a1251290cb0c34c9e996d6ce2d882bd9701
     path: patches/@mariozechner__pi-ai.patch
 
 importers:
@@ -59,7 +59,7 @@ importers:
         version: 0.53.0(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-ai':
         specifier: 0.53.0
-        version: 0.53.0(patch_hash=245a1a1cd7c5e57b9b5e1bb3748144a00afcfda1126af08ef9b55b98eae8d42b)(ws@8.19.0)(zod@4.3.6)
+        version: 0.53.0(patch_hash=d87463a41836d6d27147f95f98dc7a1251290cb0c34c9e996d6ce2d882bd9701)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
         specifier: 0.53.0
         version: 0.53.0(ws@8.19.0)(zod@4.3.6)
@@ -7024,7 +7024,7 @@ snapshots:
 
   '@mariozechner/pi-agent-core@0.53.0(ws@8.19.0)(zod@4.3.6)':
     dependencies:
-      '@mariozechner/pi-ai': 0.53.0(patch_hash=245a1a1cd7c5e57b9b5e1bb3748144a00afcfda1126af08ef9b55b98eae8d42b)(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.53.0(patch_hash=d87463a41836d6d27147f95f98dc7a1251290cb0c34c9e996d6ce2d882bd9701)(ws@8.19.0)(zod@4.3.6)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - aws-crt
@@ -7034,7 +7034,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.53.0(patch_hash=245a1a1cd7c5e57b9b5e1bb3748144a00afcfda1126af08ef9b55b98eae8d42b)(ws@8.19.0)(zod@4.3.6)':
+  '@mariozechner/pi-ai@0.53.0(patch_hash=d87463a41836d6d27147f95f98dc7a1251290cb0c34c9e996d6ce2d882bd9701)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@anthropic-ai/sdk': 0.73.0(zod@4.3.6)
       '@aws-sdk/client-bedrock-runtime': 3.992.0
@@ -7062,7 +7062,7 @@ snapshots:
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.53.0(ws@8.19.0)(zod@4.3.6)
-      '@mariozechner/pi-ai': 0.53.0(patch_hash=245a1a1cd7c5e57b9b5e1bb3748144a00afcfda1126af08ef9b55b98eae8d42b)(ws@8.19.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.53.0(patch_hash=d87463a41836d6d27147f95f98dc7a1251290cb0c34c9e996d6ce2d882bd9701)(ws@8.19.0)(zod@4.3.6)
       '@mariozechner/pi-tui': 0.53.0
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2

--- a/src/agents/sse-event-injection.test.ts
+++ b/src/agents/sse-event-injection.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { type SseInjectionState, processChunk } from "./sse-event-injection.js";
+import {
+  type SseInjectionState,
+  processChunk,
+  sanitizeSseEventName,
+} from "./sse-event-injection.js";
 
 /**
  * Tests for the SSE event field injection fix.
@@ -9,6 +13,23 @@ import { type SseInjectionState, processChunk } from "./sse-event-injection.js";
 function freshState(): SseInjectionState {
   return { prevWasEvent: false };
 }
+
+describe("sanitizeSseEventName", () => {
+  it("passes through normal event names", () => {
+    expect(sanitizeSseEventName("message_start")).toBe("message_start");
+    expect(sanitizeSseEventName("content_block_delta")).toBe("content_block_delta");
+  });
+
+  it("strips CR/LF and control characters", () => {
+    expect(sanitizeSseEventName("foo\r\nbar")).toBe("foobar");
+    expect(sanitizeSseEventName("foo\x00bar")).toBe("foobar");
+  });
+
+  it("returns null for empty or control-only strings", () => {
+    expect(sanitizeSseEventName("")).toBeNull();
+    expect(sanitizeSseEventName("\r\n")).toBeNull();
+  });
+});
 
 describe("SSE event injection (issue #37571)", () => {
   it("injects event: lines when missing from data-only SSE stream", () => {
@@ -134,6 +155,23 @@ describe("SSE event injection (issue #37571)", () => {
     const chunk2 = 'data: {"type":"content_block_start","index":0}\n\n';
     const output2 = processChunk(chunk2, state);
     expect(output2).toContain("event: content_block_start");
+  });
+
+  it("sanitizes event names with CRLF injection (CWE-93)", () => {
+    const input = 'data: {"type":"foo\\r\\nid:evil"}\n\n';
+
+    const output = processChunk(input, freshState());
+
+    // The injected event name should have control chars stripped
+    expect(output).toContain("event: fooid:evil");
+    expect(output).not.toContain("event: foo\r");
+    expect(output).not.toContain("event: foo\n");
+  });
+
+  it("drops event injection when type is only control characters", () => {
+    const input = 'data: {"type":"\\r\\n"}\n\n';
+    const output = processChunk(input, freshState());
+    expect(output).not.toContain("event:");
   });
 
   it("does not reset prevWasEvent on intermediate SSE fields (id:, retry:)", () => {

--- a/src/agents/sse-event-injection.test.ts
+++ b/src/agents/sse-event-injection.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+/**
+ * Tests for the SSE event field injection fix applied via pnpm patch to
+ * `@mariozechner/pi-ai`. The patch injects `event:` lines into SSE streams
+ * from proxies that omit them, which is required by the `@anthropic-ai/sdk`
+ * SSE parser.
+ *
+ * These tests import the patched `processChunk` logic inline to verify
+ * correctness without requiring a live HTTP server.
+ */
+
+// Inline the processChunk function from the patch for unit testing
+function processChunk(chunk: string): string {
+  const lines = chunk.split(/\r?\n|\r/);
+  const result: string[] = [];
+  let prevWasEvent = false;
+  for (const line of lines) {
+    if (line.startsWith("event:")) {
+      prevWasEvent = true;
+      result.push(line);
+      continue;
+    }
+    if (line.startsWith("data:") && !prevWasEvent) {
+      const jsonStr = line.slice(5).trim();
+      if (jsonStr) {
+        try {
+          const parsed = JSON.parse(jsonStr);
+          if (parsed && typeof parsed.type === "string") {
+            result.push("event: " + parsed.type);
+          }
+        } catch {
+          // Not valid JSON — leave as-is, no event injection
+        }
+      }
+    }
+    prevWasEvent = false;
+    result.push(line);
+  }
+  return result.join("\n");
+}
+
+describe("SSE event injection (issue #37571)", () => {
+  it("injects event: lines when missing from data-only SSE stream", () => {
+    const input = [
+      'data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant"}}',
+      "",
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+      "",
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}',
+      "",
+      'data: {"type":"content_block_stop","index":0}',
+      "",
+      'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}',
+      "",
+      'data: {"type":"message_stop"}',
+      "",
+    ].join("\n");
+
+    const output = processChunk(input);
+    const lines = output.split("\n");
+
+    // Each data: line should now be preceded by an event: line
+    expect(lines).toContain("event: message_start");
+    expect(lines).toContain("event: content_block_start");
+    expect(lines).toContain("event: content_block_delta");
+    expect(lines).toContain("event: content_block_stop");
+    expect(lines).toContain("event: message_delta");
+    expect(lines).toContain("event: message_stop");
+  });
+
+  it("does not double-inject when event: lines already present", () => {
+    const input = [
+      "event: message_start",
+      'data: {"type":"message_start","message":{"id":"msg_1"}}',
+      "",
+      "event: content_block_delta",
+      'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hi"}}',
+      "",
+    ].join("\n");
+
+    const output = processChunk(input);
+
+    // Count occurrences of "event: message_start"
+    const matches = output.match(/event: message_start/g);
+    expect(matches).toHaveLength(1);
+
+    const deltaMatches = output.match(/event: content_block_delta/g);
+    expect(deltaMatches).toHaveLength(1);
+  });
+
+  it("handles data: lines with non-JSON content gracefully", () => {
+    const input = ["data: [DONE]", "", "data: not json", ""].join("\n");
+
+    const output = processChunk(input);
+
+    // Should not crash and should not inject event lines
+    expect(output).not.toContain("event:");
+    expect(output).toContain("data: [DONE]");
+    expect(output).toContain("data: not json");
+  });
+
+  it("handles data: lines without a type field", () => {
+    const input = ['data: {"id":"msg_1","role":"assistant"}', ""].join("\n");
+
+    const output = processChunk(input);
+
+    // No type field -> no event injection
+    expect(output).not.toContain("event:");
+  });
+
+  it("handles mixed stream with some event: lines present", () => {
+    const input = [
+      "event: message_start",
+      'data: {"type":"message_start","message":{"id":"msg_1"}}',
+      "",
+      'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+      "",
+    ].join("\n");
+
+    const output = processChunk(input);
+    const lines = output.split("\n");
+
+    // message_start should appear only once (from original)
+    const msgStartMatches = output.match(/event: message_start/g);
+    expect(msgStartMatches).toHaveLength(1);
+
+    // content_block_start should be injected
+    expect(lines).toContain("event: content_block_start");
+  });
+
+  it("preserves empty lines between SSE events", () => {
+    const input = [
+      'data: {"type":"message_start","message":{"id":"msg_1"}}',
+      "",
+      'data: {"type":"message_stop"}',
+      "",
+    ].join("\n");
+
+    const output = processChunk(input);
+
+    // Should still have empty separator lines
+    expect(output).toContain("\n\n");
+  });
+});

--- a/src/agents/sse-event-injection.test.ts
+++ b/src/agents/sse-event-injection.test.ts
@@ -1,43 +1,13 @@
 import { describe, expect, it } from "vitest";
+import { type SseInjectionState, processChunk } from "./sse-event-injection.js";
 
 /**
- * Tests for the SSE event field injection fix applied via pnpm patch to
- * `@mariozechner/pi-ai`. The patch injects `event:` lines into SSE streams
- * from proxies that omit them, which is required by the `@anthropic-ai/sdk`
- * SSE parser.
- *
- * These tests import the patched `processChunk` logic inline to verify
- * correctness without requiring a live HTTP server.
+ * Tests for the SSE event field injection fix.
+ * @see https://github.com/openclaw/openclaw/issues/37571
  */
 
-// Inline the processChunk function from the patch for unit testing
-function processChunk(chunk: string): string {
-  const lines = chunk.split(/\r?\n|\r/);
-  const result: string[] = [];
-  let prevWasEvent = false;
-  for (const line of lines) {
-    if (line.startsWith("event:")) {
-      prevWasEvent = true;
-      result.push(line);
-      continue;
-    }
-    if (line.startsWith("data:") && !prevWasEvent) {
-      const jsonStr = line.slice(5).trim();
-      if (jsonStr) {
-        try {
-          const parsed = JSON.parse(jsonStr);
-          if (parsed && typeof parsed.type === "string") {
-            result.push("event: " + parsed.type);
-          }
-        } catch {
-          // Not valid JSON — leave as-is, no event injection
-        }
-      }
-    }
-    prevWasEvent = false;
-    result.push(line);
-  }
-  return result.join("\n");
+function freshState(): SseInjectionState {
+  return { prevWasEvent: false };
 }
 
 describe("SSE event injection (issue #37571)", () => {
@@ -57,10 +27,9 @@ describe("SSE event injection (issue #37571)", () => {
       "",
     ].join("\n");
 
-    const output = processChunk(input);
+    const output = processChunk(input, freshState());
     const lines = output.split("\n");
 
-    // Each data: line should now be preceded by an event: line
     expect(lines).toContain("event: message_start");
     expect(lines).toContain("event: content_block_start");
     expect(lines).toContain("event: content_block_delta");
@@ -79,22 +48,17 @@ describe("SSE event injection (issue #37571)", () => {
       "",
     ].join("\n");
 
-    const output = processChunk(input);
+    const output = processChunk(input, freshState());
 
-    // Count occurrences of "event: message_start"
-    const matches = output.match(/event: message_start/g);
-    expect(matches).toHaveLength(1);
-
-    const deltaMatches = output.match(/event: content_block_delta/g);
-    expect(deltaMatches).toHaveLength(1);
+    expect(output.match(/event: message_start/g)).toHaveLength(1);
+    expect(output.match(/event: content_block_delta/g)).toHaveLength(1);
   });
 
   it("handles data: lines with non-JSON content gracefully", () => {
     const input = ["data: [DONE]", "", "data: not json", ""].join("\n");
 
-    const output = processChunk(input);
+    const output = processChunk(input, freshState());
 
-    // Should not crash and should not inject event lines
     expect(output).not.toContain("event:");
     expect(output).toContain("data: [DONE]");
     expect(output).toContain("data: not json");
@@ -103,9 +67,8 @@ describe("SSE event injection (issue #37571)", () => {
   it("handles data: lines without a type field", () => {
     const input = ['data: {"id":"msg_1","role":"assistant"}', ""].join("\n");
 
-    const output = processChunk(input);
+    const output = processChunk(input, freshState());
 
-    // No type field -> no event injection
     expect(output).not.toContain("event:");
   });
 
@@ -118,15 +81,10 @@ describe("SSE event injection (issue #37571)", () => {
       "",
     ].join("\n");
 
-    const output = processChunk(input);
-    const lines = output.split("\n");
+    const output = processChunk(input, freshState());
 
-    // message_start should appear only once (from original)
-    const msgStartMatches = output.match(/event: message_start/g);
-    expect(msgStartMatches).toHaveLength(1);
-
-    // content_block_start should be injected
-    expect(lines).toContain("event: content_block_start");
+    expect(output.match(/event: message_start/g)).toHaveLength(1);
+    expect(output).toContain("event: content_block_start");
   });
 
   it("preserves empty lines between SSE events", () => {
@@ -137,9 +95,61 @@ describe("SSE event injection (issue #37571)", () => {
       "",
     ].join("\n");
 
-    const output = processChunk(input);
+    const output = processChunk(input, freshState());
 
-    // Should still have empty separator lines
     expect(output).toContain("\n\n");
+  });
+
+  it("carries prevWasEvent state across chunk boundaries", () => {
+    const state = freshState();
+
+    // First chunk ends with an event: line
+    const chunk1 = "event: message_start\n";
+    processChunk(chunk1, state);
+    expect(state.prevWasEvent).toBe(true);
+
+    // Second chunk starts with the corresponding data: line
+    const chunk2 = 'data: {"type":"message_start","message":{"id":"msg_1"}}\n\n';
+    const output2 = processChunk(chunk2, state);
+
+    // Should NOT inject a duplicate event: line
+    expect(output2).not.toContain("event:");
+    expect(output2).toContain("data:");
+  });
+
+  it("resets state on empty line (dispatch boundary) across chunks", () => {
+    const state = freshState();
+
+    // First chunk: event + data + empty dispatch boundary
+    const chunk1 = [
+      "event: message_start",
+      'data: {"type":"message_start","message":{"id":"msg_1"}}',
+      "",
+      "",
+    ].join("\n");
+    processChunk(chunk1, state);
+    expect(state.prevWasEvent).toBe(false);
+
+    // Second chunk: data without event (should inject)
+    const chunk2 = 'data: {"type":"content_block_start","index":0}\n\n';
+    const output2 = processChunk(chunk2, state);
+    expect(output2).toContain("event: content_block_start");
+  });
+
+  it("does not reset prevWasEvent on intermediate SSE fields (id:, retry:)", () => {
+    const state = freshState();
+
+    // event: line followed by id: field followed by data: line
+    const input = [
+      "event: message_start",
+      "id: 123",
+      'data: {"type":"message_start","message":{"id":"msg_1"}}',
+      "",
+    ].join("\n");
+
+    const output = processChunk(input, state);
+
+    // Should NOT inject a second event: line — the id: field should not reset state
+    expect(output.match(/event: message_start/g)).toHaveLength(1);
   });
 });

--- a/src/agents/sse-event-injection.ts
+++ b/src/agents/sse-event-injection.ts
@@ -14,6 +14,24 @@
  */
 
 /**
+ * Maximum number of characters to buffer before aborting the stream.
+ * Prevents memory exhaustion when an upstream proxy sends data without
+ * newline delimiters (CWE-400).
+ */
+const MAX_BUFFER_CHARS = 1_000_000;
+
+/**
+ * Sanitize an SSE event name to prevent CRLF/field injection (CWE-93).
+ * Returns `null` if the value is empty after sanitization.
+ */
+export function sanitizeSseEventName(value: string): string | null {
+  // Strip CR, LF, and other ASCII control characters
+  // eslint-disable-next-line no-control-regex
+  const stripped = value.replace(/[\x00-\x1f\x7f]/g, "");
+  return stripped.length > 0 ? stripped : null;
+}
+
+/**
  * Mutable state object for tracking whether the previous line was an `event:`
  * line across chunk boundaries in a streaming SSE response.
  */
@@ -51,7 +69,10 @@ export function processChunk(chunk: string, state: SseInjectionState): string {
           try {
             const parsed = JSON.parse(jsonStr);
             if (parsed && typeof parsed.type === "string") {
-              result.push("event: " + parsed.type);
+              const safeType = sanitizeSseEventName(parsed.type);
+              if (safeType) {
+                result.push("event: " + safeType);
+              }
             }
           } catch {
             // Not valid JSON — leave as-is, no event injection
@@ -114,6 +135,17 @@ export function createSseEventInjectionFetch(): typeof globalThis.fetch {
         }
 
         buffer += decoder.decode(value, { stream: true });
+
+        // Guard against unbounded buffering when upstream sends no newlines
+        if (buffer.length > MAX_BUFFER_CHARS) {
+          try {
+            await reader.cancel();
+          } catch {
+            /* best-effort */
+          }
+          controller.error(new Error("SSE buffer limit exceeded"));
+          return;
+        }
 
         // Process complete lines only (keep incomplete last line in buffer)
         const lastNewline = buffer.lastIndexOf("\n");

--- a/src/agents/sse-event-injection.ts
+++ b/src/agents/sse-event-injection.ts
@@ -1,0 +1,139 @@
+/**
+ * SSE event field injection for third-party Anthropic-compatible proxies.
+ *
+ * Some proxies serving the Anthropic Messages API return SSE streams without
+ * `event:` field lines. The `@anthropic-ai/sdk` SSE parser requires `event:`
+ * fields to dispatch events — without them, all events are silently dropped
+ * and the stream ends with "request ended without sending any chunks".
+ *
+ * This module provides a custom `fetch` wrapper that detects `data:` lines
+ * whose JSON payload contains a `"type"` field and injects the corresponding
+ * `event: <type>` line when no `event:` line precedes it.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/37571
+ */
+
+/**
+ * Mutable state object for tracking whether the previous line was an `event:`
+ * line across chunk boundaries in a streaming SSE response.
+ */
+export interface SseInjectionState {
+  prevWasEvent: boolean;
+}
+
+/**
+ * Process a chunk of SSE text, injecting `event:` lines where missing.
+ *
+ * The `state` parameter carries `prevWasEvent` across calls so that an
+ * `event:` line flushed at the end of one chunk correctly suppresses
+ * injection for the `data:` line at the start of the next chunk.
+ *
+ * Only resets `prevWasEvent` on empty/blank lines (SSE event dispatch
+ * boundaries) or `data:` lines, so intermediate fields like `id:` or
+ * `retry:` between `event:` and `data:` do not cause false injection.
+ */
+export function processChunk(chunk: string, state: SseInjectionState): string {
+  const lines = chunk.split(/\r?\n|\r/);
+  const result: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.startsWith("event:")) {
+      state.prevWasEvent = true;
+      result.push(line);
+      continue;
+    }
+
+    if (line.startsWith("data:")) {
+      if (!state.prevWasEvent) {
+        const jsonStr = line.slice(5).trim();
+        if (jsonStr) {
+          try {
+            const parsed = JSON.parse(jsonStr);
+            if (parsed && typeof parsed.type === "string") {
+              result.push("event: " + parsed.type);
+            }
+          } catch {
+            // Not valid JSON — leave as-is, no event injection
+          }
+        }
+      }
+      state.prevWasEvent = false;
+      result.push(line);
+      continue;
+    }
+
+    // Empty line = SSE dispatch boundary — reset state.
+    // Skip the trailing empty string from split (artifact of chunk ending with \n)
+    // since it's not a real dispatch boundary.
+    if (line === "" && i < lines.length - 1) {
+      state.prevWasEvent = false;
+    }
+    // For other SSE fields (id:, retry:, comments) do NOT reset prevWasEvent
+    // so that `event:` → `id:` → `data:` sequences are handled correctly.
+
+    result.push(line);
+  }
+
+  return result.join("\n");
+}
+
+/**
+ * Create a custom fetch wrapper that injects SSE `event:` lines when missing.
+ */
+export function createSseEventInjectionFetch(): typeof globalThis.fetch {
+  return async function sseEventInjectionFetch(
+    url: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    const response = await globalThis.fetch(url, init);
+
+    // Only transform streaming responses (SSE)
+    const contentType = response.headers.get("content-type") || "";
+    if (!contentType.includes("text/event-stream") || !response.body) {
+      return response;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    const encoder = new TextEncoder();
+    let buffer = "";
+    const state: SseInjectionState = { prevWasEvent: false };
+
+    const readable = new ReadableStream({
+      async pull(controller) {
+        const { done, value } = await reader.read();
+        if (done) {
+          // Flush any remaining buffer
+          if (buffer.length > 0) {
+            controller.enqueue(encoder.encode(processChunk(buffer, state)));
+            buffer = "";
+          }
+          controller.close();
+          return;
+        }
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // Process complete lines only (keep incomplete last line in buffer)
+        const lastNewline = buffer.lastIndexOf("\n");
+        if (lastNewline === -1) {
+          return;
+        }
+
+        const toProcess = buffer.slice(0, lastNewline + 1);
+        buffer = buffer.slice(lastNewline + 1);
+        controller.enqueue(encoder.encode(processChunk(toProcess, state)));
+      },
+      cancel() {
+        void reader.cancel();
+      },
+    });
+
+    return new Response(readable, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
+  };
+}

--- a/src/agents/sse-event-injection.ts
+++ b/src/agents/sse-event-injection.ts
@@ -89,7 +89,7 @@ export function createSseEventInjectionFetch(): typeof globalThis.fetch {
     const response = await globalThis.fetch(url, init);
 
     // Only transform streaming responses (SSE)
-    const contentType = response.headers.get("content-type") || "";
+    const contentType = (response.headers.get("content-type") || "").toLowerCase();
     if (!contentType.includes("text/event-stream") || !response.body) {
       return response;
     }


### PR DESCRIPTION
## Summary

Fixes #37571

- Third-party proxies using `api: "anthropic-messages"` may return SSE streams without `event:` field lines
- The `@anthropic-ai/sdk` SSE parser requires `event:` fields to dispatch events — without them, all events are silently dropped and the stream ends with `"request ended without sending any chunks"`
- This patch adds a custom `fetch` wrapper (via pnpm patch on `@mariozechner/pi-ai`) that injects `event: <type>` lines by parsing the `"type"` field from `data:` JSON payloads when no `event:` line precedes them
- The wrapper is a no-op when `event:` lines are already present (e.g. Anthropic's own API)

## Root Cause

1. `@anthropic-ai/sdk` SSE parser initializes `this.event = null`
2. Without `event:` lines in the stream, `sse.event` stays `null`
3. The SDK's `Stream.fromSSEResponse` only yields events matching named types (`message_start`, `content_block_delta`, etc.) — `null` events are silently dropped
4. Stream ends with no message snapshot → error thrown

## Changes

- **`patches/@mariozechner__pi-ai.patch`**: Patches `createClient` in the Anthropic provider to pass a custom `fetch` that wraps SSE response bodies with event field injection
- **`src/agents/sse-event-injection.test.ts`**: Unit tests covering injection, no-double-injection, non-JSON data lines, and mixed streams

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` (formatting + linting) passes
- [x] Unit tests pass (6 new tests for SSE event injection)
- [x] Existing unit test suite passes (747/749 files, 3 pre-existing failures unrelated to this change)