### PR TITLE
fix(feishu): @all/@_all group broadcast should not trigger bot mention

### DIFF
--- a/extensions/feishu/src/bot.checkBotMentioned.test.ts
+++ b/extensions/feishu/src/bot.checkBotMentioned.test.ts
@@ -120,6 +120,28 @@ describe("parseFeishuMessageEvent – mentionedBot", () => {
     expect(ctx.content).toBe("hello world");
   });
 
+  it("returns mentionedBot=false when message contains @_all only (group broadcast)", () => {
+    const event = makeEvent("group", [], "@_all hello everyone");
+    event.message.content = JSON.stringify({ text: "@_all hello everyone" });
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
+  it("returns mentionedBot=false when message contains @all only (group broadcast)", () => {
+    const event = makeEvent("group", [], "@all hello everyone");
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(false);
+  });
+
+  it("returns mentionedBot=true when message has @_all and a real bot mention", () => {
+    const event = makeEvent("group", [
+      { key: "@_user_1", name: "Bot", id: { open_id: BOT_OPEN_ID } },
+    ], "@_all @_user_1 hello");
+    event.message.content = JSON.stringify({ text: "@_all @_user_1 hello" });
+    const ctx = parseFeishuMessageEvent(event as any, BOT_OPEN_ID);
+    expect(ctx.mentionedBot).toBe(true);
+  });
+
   it("returns mentionedBot=true for post message with at (no top-level mentions)", () => {
     const BOT_OPEN_ID = "ou_bot_123";
     const event = makePostEvent({

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -456,9 +456,6 @@ function checkBotMentioned(
   botName?: string,
 ): boolean {
   if (!botOpenId) return false;
-  // Check for @all (@_all in Feishu) — treat as mentioning every bot
-  const rawContent = event.message.content ?? "";
-  if (rawContent.includes("@_all")) return true;
   const mentions = event.message.mentions ?? [];
   if (mentions.length > 0) {
     return mentions.some((m) => {


### PR DESCRIPTION
## What

Remove the `@_all` shortcut from `checkBotMentioned()` in the Feishu extension so that group-wide broadcasts no longer cause the bot to reply.

Fixes #37706

## Root Cause

```ts
// extensions/feishu/src/bot.ts — before
const rawContent = event.message.content ?? "";
if (rawContent.includes("@_all")) return true; // ← wrong: group broadcast ≠ bot mention
```

Feishu's `@all` / `@_all` is a **group broadcast** that notifies all members. It was being treated as an explicit bot mention, causing the bot to reply to every group-wide notification.

## Fix

Removed the `@_all` raw-content shortcut. `checkBotMentioned()` now only returns `true` for real bot mentions:
- A `mentions` array entry matching the bot's `open_id`, or
- A post content `at` tag targeting the bot

## Tests

Added 3 regression tests in `bot.checkBotMentioned.test.ts`:
- `@_all`-only message → `mentionedBot = false`
- `@all`-only message → `mentionedBot = false`
- `@_all` + real `@bot` mention → `mentionedBot = true` (bot still responds when directly mentioned alongside a broadcast)

All 300 feishu extension tests pass.