### PR TITLE
fix(image-tool): handle aws-sdk auth mode for Amazon Bedrock

### DIFF
--- a/src/agents/tools/media-tool-shared.ts
+++ b/src/agents/tools/media-tool-shared.ts
@@ -107,6 +107,14 @@ export async function resolveModelRuntimeApiKey(params: {
     cfg: params.cfg,
     agentDir: params.agentDir,
   });
+  // Amazon Bedrock (and other AWS-SDK-based providers) resolve credentials via the
+  // AWS SDK credential chain rather than an explicit API key.  Skip requireApiKey
+  // and setRuntimeApiKey — the underlying pi-ai `complete` call handles auth
+  // internally through the SDK.  This mirrors the behaviour of the main agent
+  // model execution path (see agents/agent-step.ts).
+  if (apiKeyInfo.mode === "aws-sdk") {
+    return "";
+  }
   const apiKey = requireApiKey(apiKeyInfo, params.model.provider);
   params.authStorage.setRuntimeApiKey(params.model.provider, apiKey);
   return apiKey;


### PR DESCRIPTION
## Problem

The `image` (and `pdf`) tools fail with the following error when `agents.defaults.imageModel` is configured to use an Amazon Bedrock model:

```
No API key resolved for provider "amazon-bedrock" (auth mode: aws-sdk).
```

This happens even when AWS credentials are correctly configured (e.g. `aws sts get-caller-identity` succeeds) and the main agent model is working fine on the same Bedrock endpoint.

## Root cause

`resolveModelRuntimeApiKey()` in `media-tool-shared.ts` unconditionally calls `requireApiKey()`:

```typescript
const apiKey = requireApiKey(apiKeyInfo, params.model.provider);
```

`requireApiKey()` always throws when `auth.apiKey` is absent — but Amazon Bedrock uses `auth mode: aws-sdk`, where credentials are resolved by the AWS SDK credential chain (IAM role, `~/.aws/credentials`, environment variables, etc.) and there is no explicit API key.

The **main agent execution path** already handles this correctly (e.g. `agent-step.ts`):

```typescript
if (!apiKeyInfo.apiKey) {
  if (apiKeyInfo.mode !== 'aws-sdk') throw new Error(...)
  // aws-sdk: AWS SDK resolves credentials internally — no explicit key needed
}
```

The media tools are missing this guard.

## Fix

Skip `requireApiKey` and `setRuntimeApiKey` when `auth.mode === 'aws-sdk'`, mirroring the main agent execution path. The underlying `pi-ai` `complete()` call receives an empty string for `apiKey`, which Bedrock models ignore in favour of SDK credential resolution.

## Testing

Reproduce:
1. Configure OpenClaw with an AWS Bedrock model as primary (`amazon-bedrock/*`)
2. Set `agents.defaults.imageModel.primary` to the same Bedrock model
3. Call the `image` tool → previously threw `No API key resolved`; now succeeds

Existing unit tests for `image-tool` and `media-tool-shared` continue to pass.