### PR TITLE
feat(cron): support 'default' as special model value for runtime resolution

### DIFF
--- a/src/cron/isolated-agent.subagent-model.test.ts
+++ b/src/cron/isolated-agent.subagent-model.test.ts
@@ -192,4 +192,25 @@ describe("runCronIsolatedAgentTurn: subagent model resolution (#11461)", () => {
       expect(call?.model).toBe("gpt-4o");
     });
   });
+
+  it('job model override "default" falls back to system default model', async () => {
+    await withTempHome(async (home) => {
+      const call = await runSubagentModelCase({
+        home,
+        cfgOverrides: {
+          agents: {
+            defaults: {
+              model: "anthropic/claude-sonnet-4-5",
+              workspace: path.join(home, "openclaw"),
+            },
+          },
+        },
+        jobModelOverride: "default",
+      });
+      // When model is "default", it should use the system default_model
+      // not treat it as a literal model name
+      expect(call?.provider).toBe("anthropic");
+      expect(call?.model).toBe("claude-sonnet-4-5");
+    });
+  });
 });

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -219,7 +219,10 @@ export async function runCronIsolatedAgentTurn(params: {
   const modelOverrideRaw =
     params.job.payload.kind === "agentTurn" ? params.job.payload.model : undefined;
   const modelOverride = typeof modelOverrideRaw === "string" ? modelOverrideRaw.trim() : undefined;
-  if (modelOverride !== undefined && modelOverride.length > 0) {
+  // Support "default" as a special value to use system default model at runtime
+  // This allows cron jobs to follow the system default_model configuration
+  // without being hardcoded to a specific provider/model
+  if (modelOverride !== undefined && modelOverride.length > 0 && modelOverride !== "default") {
     const resolvedOverride = resolveAllowedModelRef({
       cfg: cfgWithAgentDefaults,
       catalog: await loadCatalog(),


### PR DESCRIPTION
## Summary
This PR adds support for `'default'` as a special value in cron job `payload.model`. When set, the job will use the system's `default_model` configuration at runtime instead of being hardcoded to a specific provider/model.

## Problem
Currently, cron jobs created with `--model` have that model hardcoded in the payload. When:
- API tokens expire
- Providers discontinue models
- Users want to switch default models

...all cron jobs using that specific model fail and must be manually deleted and recreated.

## Solution
Allow `"model": "default"` to mean "use system default_model at runtime".

## Changes
- **src/cron/isolated-agent/run.ts**: Added check for `modelOverride !== "default"`
- **src/cron/isolated-agent.subagent-model.test.ts**: Added test case for `"default"` value

## Behavior
| payload.model | Result |
|--------------|--------|
| `undefined` / `""` | Use system default_model ✅ (existing) |
| `"default"` | Use system default_model ✅ (new) |
| `"provider/model"` | Use specified model ✅ (existing) |

## Testing
Added test case: `'job model override "default" falls back to system default model'`

Fixes #37843