### PR TITLE
fix(telegram): report lastEventAt to channel health monitor

### DIFF
--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -65,6 +65,7 @@ export type TelegramBotOptions = {
   /** Pre-resolved Telegram transport to reuse across bot instances. If not provided, creates a new one. */
   telegramTransport?: TelegramTransport;
   telegramDeps?: TelegramBotDeps;
+  setStatus?: (status: Record<string, unknown>) => void;
 };
 
 export { getTelegramSequentialKey };
@@ -244,6 +245,17 @@ export function createTelegramBot(opts: TelegramBotOptions) {
   bot.catch((err) => {
     runtime.error?.(danger(`telegram bot error: ${formatUncaughtError(err)}`));
   });
+
+  // ── Health-status middleware ──
+  // Update lastEventAt on every inbound Telegram update so the channel
+  // health monitor knows the connection is alive.
+  if (opts.setStatus) {
+    const setStatus = opts.setStatus;
+    bot.use(async (_ctx, next) => {
+      setStatus({ lastEventAt: Date.now() });
+      await next();
+    });
+  }
 
   const recentUpdates = createTelegramUpdateDedupe();
   const initialUpdateId =
@@ -548,11 +560,36 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     telegramDeps,
   });
 
+  // Track lastInboundAt only for message-bearing updates (not reactions/callbacks).
+  if (opts.setStatus) {
+    const setStatus = opts.setStatus;
+    bot.on(["message", "channel_post"], async (_ctx, next) => {
+      setStatus({ lastInboundAt: Date.now() });
+      await next();
+    });
+  }
+
   const originalStop = bot.stop.bind(bot);
   bot.stop = ((...args: Parameters<typeof originalStop>) => {
     threadBindingManager?.stop();
     return originalStop(...args);
   }) as typeof bot.stop;
+
+  // ── Transport heartbeat ──
+  // Stamp lastEventAt on every successful getUpdates response so the health
+  // monitor sees transport liveness even during idle periods (no messages).
+  // If getUpdates fails/hangs, this never fires and lastEventAt goes stale,
+  // letting the health monitor detect the failure correctly.
+  if (opts.setStatus) {
+    const setStatus = opts.setStatus;
+    bot.api.config.use(async (prev, method, payload, signal) => {
+      const result = await prev(method, payload, signal);
+      if (method === "getUpdates") {
+        setStatus({ lastEventAt: Date.now() });
+      }
+      return result;
+    });
+  }
 
   return bot;
 }

--- a/extensions/telegram/src/bot.ts
+++ b/extensions/telegram/src/bot.ts
@@ -541,6 +541,17 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     telegramDeps,
   });
 
+  // Track lastInboundAt only for message-bearing updates (not reactions/callbacks).
+  // Must be registered BEFORE registerTelegramHandlers, whose terminal handlers
+  // do not call next() and would prevent this middleware from running.
+  if (opts.setStatus) {
+    const setStatus = opts.setStatus;
+    bot.on(["message", "channel_post"], async (_ctx, next) => {
+      setStatus({ lastInboundAt: Date.now() });
+      await next();
+    });
+  }
+
   registerTelegramHandlers({
     cfg,
     accountId: account.accountId,
@@ -559,15 +570,6 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     logger,
     telegramDeps,
   });
-
-  // Track lastInboundAt only for message-bearing updates (not reactions/callbacks).
-  if (opts.setStatus) {
-    const setStatus = opts.setStatus;
-    bot.on(["message", "channel_post"], async (_ctx, next) => {
-      setStatus({ lastInboundAt: Date.now() });
-      await next();
-    });
-  }
 
   const originalStop = bot.stop.bind(bot);
   bot.stop = ((...args: Parameters<typeof originalStop>) => {

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -723,6 +723,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         webhookHost: account.config.webhookHost,
         webhookPort: account.config.webhookPort,
         webhookCertPath: account.config.webhookCertPath,
+        setStatus: ctx.setStatus,
       });
     },
     logoutAccount: async ({ accountId, cfg }) => {

--- a/extensions/telegram/src/channel.ts
+++ b/extensions/telegram/src/channel.ts
@@ -723,7 +723,7 @@ export const telegramPlugin: ChannelPlugin<ResolvedTelegramAccount, TelegramProb
         webhookHost: account.config.webhookHost,
         webhookPort: account.config.webhookPort,
         webhookCertPath: account.config.webhookCertPath,
-        setStatus: ctx.setStatus,
+        setStatus: ctx.setStatus as (status: Record<string, unknown>) => void,
       });
     },
     logoutAccount: async ({ accountId, cfg }) => {

--- a/extensions/telegram/src/monitor.ts
+++ b/extensions/telegram/src/monitor.ts
@@ -33,6 +33,7 @@ export type MonitorTelegramOpts = {
   proxyFetch?: typeof fetch;
   webhookUrl?: string;
   webhookCertPath?: string;
+  setStatus?: (status: Record<string, unknown>) => void;
 };
 
 export function createTelegramRunnerOptions(cfg: OpenClawConfig): RunOptions<unknown> {
@@ -174,6 +175,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
         abortSignal: opts.abortSignal,
         publicUrl: opts.webhookUrl,
         webhookCertPath: opts.webhookCertPath,
+        setStatus: opts.setStatus,
       });
       await waitForAbortSignal(opts.abortSignal);
       return;
@@ -196,6 +198,7 @@ export async function monitorTelegramProvider(opts: MonitorTelegramOpts = {}) {
       persistUpdateId,
       log,
       telegramTransport,
+      setStatus: opts.setStatus,
     });
     await pollingSession.runUntilAbort();
   } finally {

--- a/extensions/telegram/src/polling-session.ts
+++ b/extensions/telegram/src/polling-session.ts
@@ -50,6 +50,7 @@ type TelegramPollingSessionOpts = {
   log: (line: string) => void;
   /** Pre-resolved Telegram transport to reuse across bot instances */
   telegramTransport?: TelegramTransport;
+  setStatus?: (status: Record<string, unknown>) => void;
 };
 
 export class TelegramPollingSession {
@@ -139,6 +140,7 @@ export class TelegramPollingSession {
           onUpdateId: this.opts.persistUpdateId,
         },
         telegramTransport: this.opts.telegramTransport,
+        setStatus: this.opts.setStatus,
       });
     } catch (err) {
       await this.#waitBeforeRetryOnRecoverableSetupError(err, "Telegram setup network error");

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -111,6 +111,7 @@ export async function startTelegramWebhook(opts: {
   healthPath?: string;
   publicUrl?: string;
   webhookCertPath?: string;
+  setStatus?: (status: Record<string, unknown>) => void;
 }) {
   const path = opts.path ?? "/telegram-webhook";
   const healthPath = opts.healthPath ?? "/healthz";
@@ -131,6 +132,7 @@ export async function startTelegramWebhook(opts: {
     proxyFetch: opts.fetch,
     config: opts.config,
     accountId: opts.accountId,
+    setStatus: opts.setStatus,
   });
   await initializeTelegramWebhookBot({
     bot,
@@ -285,12 +287,35 @@ export async function startTelegramWebhook(opts: {
   runtime.log?.(`webhook local listener on http://${host}:${boundPort}${path}`);
   runtime.log?.(`webhook advertised to telegram on ${publicUrl}`);
 
+  // ── Webhook transport heartbeat ──
+  // Periodically verify Telegram API reachability so the health monitor
+  // sees transport liveness even if no webhook requests arrive.
+  let webhookHeartbeat: ReturnType<typeof setInterval> | null = null;
+  if (opts.setStatus) {
+    const setStatus = opts.setStatus;
+    const ping = async () => {
+      try {
+        await bot.api.getWebhookInfo();
+        setStatus({ lastEventAt: Date.now() });
+      } catch {
+        // API unreachable — don't update, let health monitor detect staleness
+      }
+    };
+    webhookHeartbeat = setInterval(ping, 10 * 60_000);
+    if (typeof webhookHeartbeat === "object" && "unref" in webhookHeartbeat) {
+      (webhookHeartbeat as NodeJS.Timeout).unref();
+    }
+  }
+
   let shutDown = false;
   const shutdown = () => {
     if (shutDown) {
       return;
     }
     shutDown = true;
+    if (webhookHeartbeat) {
+      clearInterval(webhookHeartbeat);
+    }
     void withTelegramApiErrorLogging({
       operation: "deleteWebhook",
       runtime,

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -301,6 +301,7 @@ export async function startTelegramWebhook(opts: {
         // API unreachable — don't update, let health monitor detect staleness
       }
     };
+    void ping();
     webhookHeartbeat = setInterval(ping, 10 * 60_000);
     if (typeof webhookHeartbeat === "object" && "unref" in webhookHeartbeat) {
       (webhookHeartbeat as NodeJS.Timeout).unref();

--- a/extensions/telegram/src/webhook.ts
+++ b/extensions/telegram/src/webhook.ts
@@ -303,9 +303,7 @@ export async function startTelegramWebhook(opts: {
     };
     void ping();
     webhookHeartbeat = setInterval(ping, 10 * 60_000);
-    if (typeof webhookHeartbeat === "object" && "unref" in webhookHeartbeat) {
-      (webhookHeartbeat as NodeJS.Timeout).unref();
-    }
+    webhookHeartbeat.unref();
   }
 
   let shutDown = false;

--- a/test/fixtures/test-parallel.behavior.json
+++ b/test/fixtures/test-parallel.behavior.json
@@ -20,6 +20,10 @@
       {
         "file": "extensions/imessage/src/monitor.shutdown.unhandled-rejection.test.ts",
         "reason": "Touches process-level unhandledRejection listeners."
+      },
+      {
+        "file": "src/plugins/loader.git-path-regression.test.ts",
+        "reason": "Constructs a real Jiti boundary; vmForks on Node 24 makes require a getter-only property, so force process forks."
       }
     ],
     "singletonIsolated": [
@@ -198,10 +202,6 @@
       {
         "file": "src/infra/heartbeat-runner.model-override.test.ts",
         "reason": "Mocks jiti at file scope, so it is safer outside shared Vitest workers."
-      },
-      {
-        "file": "src/plugins/loader.git-path-regression.test.ts",
-        "reason": "Constructs a real Jiti boundary and is safer outside shared workers that may have mocked jiti earlier."
       },
       {
         "file": "src/infra/outbound/outbound-session.test.ts",


### PR DESCRIPTION
## Summary

- The Telegram provider never updated `lastEventAt` in the channel health snapshot, causing the health monitor to declare "stale-socket" and restart the bot every 30 minutes — even when the connection was healthy
- Thread `setStatus` from the channel plugin through `monitorTelegramProvider` → `createTelegramBot` → `startTelegramWebhook`
- Add grammY middleware for `lastEventAt` on all inbound updates and `lastInboundAt` only for message/channel_post
- Add transport-level heartbeat via `getUpdates` API transformer (polling) and periodic `getWebhookInfo` ping (webhook) for idle-channel liveness

## Test plan

- [ ] Verify Telegram bot responds to messages after deploy
- [ ] Check gateway logs show `lastEventAt` updates, no more "stale-socket" restarts
- [ ] Wait >30 min idle — confirm transport heartbeat keeps channel healthy
- [ ] Failure drill: block Telegram API → verify health monitor detects staleness → unblock → verify recovery
- [ ] Run `pnpm test -- --grep telegram`

🤖 Generated with [Claude Code](https://claude.com/claude-code)