### PR TITLE
[codex] Surface google-gemini-cli provider stalls

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1401,6 +1401,8 @@ export async function runEmbeddedAttempt(
       const subscription = subscribeEmbeddedPiSession({
         session: activeSession,
         runId: params.runId,
+        provider: params.provider,
+        modelId: params.modelId,
         hookRunner: getGlobalHookRunner() ?? undefined,
         verboseLevel: params.verboseLevel,
         reasoningMode: params.reasoningLevel ?? "off",

--- a/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.lifecycle.ts
@@ -2,6 +2,10 @@ import { emitAgentEvent } from "../infra/agent-events.js";
 import { createInlineCodeState } from "../markdown/code-spans.js";
 import { formatAssistantErrorText } from "./pi-embedded-helpers.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
+import {
+  maybeWarnProviderStall,
+  noteProviderProgress,
+} from "./pi-embedded-subscribe.provider-stall.js";
 import { isAssistantMessage } from "./pi-embedded-utils.js";
 
 export {
@@ -10,6 +14,7 @@ export {
 } from "./pi-embedded-subscribe.handlers.compaction.js";
 
 export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
+  noteProviderProgress(ctx, "agent_start");
   ctx.log.debug(`embedded run agent start: runId=${ctx.params.runId}`);
   emitAgentEvent({
     runId: ctx.params.runId,
@@ -26,6 +31,7 @@ export function handleAgentStart(ctx: EmbeddedPiSubscribeContext) {
 }
 
 export function handleAgentEnd(ctx: EmbeddedPiSubscribeContext) {
+  maybeWarnProviderStall(ctx, { phase: "before_agent_end" });
   const lastAssistant = ctx.state.lastAssistant;
   const isError = isAssistantMessage(lastAssistant) && lastAssistant.stopReason === "error";
 

--- a/src/agents/pi-embedded-subscribe.handlers.tools.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.tools.ts
@@ -9,6 +9,10 @@ import type {
   ToolHandlerContext,
 } from "./pi-embedded-subscribe.handlers.types.js";
 import {
+  maybeWarnProviderStall,
+  noteProviderProgress,
+} from "./pi-embedded-subscribe.provider-stall.js";
+import {
   extractMessagingToolSend,
   extractToolErrorMessage,
   extractToolResultMediaPaths,
@@ -215,6 +219,7 @@ export async function handleToolExecutionStart(
 
   const meta = extendExecMeta(toolName, args, inferToolMetaFromArgs(toolName, args));
   ctx.state.toolMetaById.set(toolCallId, buildToolCallSummary(toolName, args, meta));
+  maybeWarnProviderStall(ctx, { phase: "before_tool", toolName, toolCallId });
   ctx.log.debug(
     `embedded run tool start: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
   );
@@ -426,6 +431,7 @@ export async function handleToolExecutionEnd(
   ctx.log.debug(
     `embedded run tool end: runId=${ctx.params.runId} tool=${toolName} toolCallId=${toolCallId}`,
   );
+  noteProviderProgress(ctx, "tool_result");
 
   emitToolResultOutput({ ctx, toolName, meta, isToolError, result, sanitizedResult });
 

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -78,7 +78,7 @@ export type EmbeddedPiSubscribeState = {
   pendingMessagingMediaUrls: Map<string, string[]>;
   lastAssistant?: AgentMessage;
   lastProviderProgressAtMs?: number;
-  lastProviderProgressPhase?: "agent_start" | "tool_result";
+  lastProviderProgressPhase?: "agent_start" | "tool_result" | "stall_warning";
 };
 
 export type EmbeddedPiSubscribeContext = {

--- a/src/agents/pi-embedded-subscribe.handlers.types.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.types.ts
@@ -77,6 +77,8 @@ export type EmbeddedPiSubscribeState = {
   successfulCronAdds: number;
   pendingMessagingMediaUrls: Map<string, string[]>;
   lastAssistant?: AgentMessage;
+  lastProviderProgressAtMs?: number;
+  lastProviderProgressPhase?: "agent_start" | "tool_result";
 };
 
 export type EmbeddedPiSubscribeContext = {
@@ -133,6 +135,8 @@ export type EmbeddedPiSubscribeContext = {
 export type ToolHandlerParams = Pick<
   SubscribeEmbeddedPiSessionParams,
   | "runId"
+  | "provider"
+  | "modelId"
   | "onBlockReplyFlush"
   | "onAgentEvent"
   | "onToolResult"
@@ -155,6 +159,8 @@ export type ToolHandlerState = Pick<
   | "messagingToolSentMediaUrls"
   | "messagingToolSentTargets"
   | "successfulCronAdds"
+  | "lastProviderProgressAtMs"
+  | "lastProviderProgressPhase"
 >;
 
 export type ToolHandlerContext = {

--- a/src/agents/pi-embedded-subscribe.provider-stall.test.ts
+++ b/src/agents/pi-embedded-subscribe.provider-stall.test.ts
@@ -4,10 +4,12 @@ import {
   noteProviderProgress,
 } from "./pi-embedded-subscribe.provider-stall.js";
 
+type ProviderStallTestContext = Parameters<typeof noteProviderProgress>[0];
+
 describe("provider stall diagnostics", () => {
   it("logs a warning for long google-gemini-cli stalls", () => {
     const warn = vi.fn();
-    const ctx = {
+    const ctx: ProviderStallTestContext = {
       params: {
         runId: "run-1",
         provider: "google-gemini-cli",
@@ -40,7 +42,7 @@ describe("provider stall diagnostics", () => {
 
   it("does not warn below the stall threshold", () => {
     const warn = vi.fn();
-    const ctx = {
+    const ctx: ProviderStallTestContext = {
       params: {
         runId: "run-2",
         provider: "google-gemini-cli",
@@ -61,7 +63,7 @@ describe("provider stall diagnostics", () => {
 
   it("advances the warning baseline so the same gap is not warned twice", () => {
     const warn = vi.fn();
-    const ctx = {
+    const ctx: ProviderStallTestContext = {
       params: {
         runId: "run-dup",
         provider: "google-gemini-cli",
@@ -90,7 +92,7 @@ describe("provider stall diagnostics", () => {
 
   it("ignores non-google providers", () => {
     const warn = vi.fn();
-    const ctx = {
+    const ctx: ProviderStallTestContext = {
       params: {
         runId: "run-3",
         provider: "openai",

--- a/src/agents/pi-embedded-subscribe.provider-stall.test.ts
+++ b/src/agents/pi-embedded-subscribe.provider-stall.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  maybeWarnProviderStall,
+  noteProviderProgress,
+} from "./pi-embedded-subscribe.provider-stall.js";
+
+describe("provider stall diagnostics", () => {
+  it("logs a warning for long google-gemini-cli stalls", () => {
+    const warn = vi.fn();
+    const ctx = {
+      params: {
+        runId: "run-1",
+        provider: "google-gemini-cli",
+        modelId: "gemini-2.5-flash",
+      },
+      state: {},
+      log: { warn },
+    };
+
+    noteProviderProgress(ctx, "tool_result", 1_000);
+    maybeWarnProviderStall(ctx, {
+      phase: "before_tool",
+      toolName: "read",
+      toolCallId: "tool-1",
+      nowMs: 47_250,
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    const message = String(warn.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("embedded run provider stall");
+    expect(message).toContain("runId=run-1");
+    expect(message).toContain("provider=google-gemini-cli");
+    expect(message).toContain("model=gemini-2.5-flash");
+    expect(message).toContain("gapMs=46250");
+    expect(message).toContain("since=tool_result");
+    expect(message).toContain("phase=before_tool");
+    expect(message).toContain("tool=read");
+    expect(message).toContain("toolCallId=tool-1");
+  });
+
+  it("does not warn below the stall threshold", () => {
+    const warn = vi.fn();
+    const ctx = {
+      params: {
+        runId: "run-2",
+        provider: "google-gemini-cli",
+        modelId: "gemini-2.5-flash",
+      },
+      state: {},
+      log: { warn },
+    };
+
+    noteProviderProgress(ctx, "agent_start", 10_000);
+    maybeWarnProviderStall(ctx, {
+      phase: "before_agent_end",
+      nowMs: 54_999,
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-google providers", () => {
+    const warn = vi.fn();
+    const ctx = {
+      params: {
+        runId: "run-3",
+        provider: "openai",
+        modelId: "gpt-5",
+      },
+      state: {},
+      log: { warn },
+    };
+
+    noteProviderProgress(ctx, "tool_result", 5_000);
+    maybeWarnProviderStall(ctx, {
+      phase: "before_tool",
+      toolName: "read",
+      toolCallId: "tool-2",
+      nowMs: 100_000,
+    });
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/src/agents/pi-embedded-subscribe.provider-stall.test.ts
+++ b/src/agents/pi-embedded-subscribe.provider-stall.test.ts
@@ -59,6 +59,35 @@ describe("provider stall diagnostics", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it("advances the warning baseline so the same gap is not warned twice", () => {
+    const warn = vi.fn();
+    const ctx = {
+      params: {
+        runId: "run-dup",
+        provider: "google-gemini-cli",
+        modelId: "gemini-2.5-flash",
+      },
+      state: {},
+      log: { warn },
+    };
+
+    noteProviderProgress(ctx, "tool_result", 1_000);
+    maybeWarnProviderStall(ctx, {
+      phase: "before_tool",
+      toolName: "read",
+      toolCallId: "tool-dup",
+      nowMs: 47_250,
+    });
+    maybeWarnProviderStall(ctx, {
+      phase: "before_agent_end",
+      nowMs: 90_000,
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(ctx.state.lastProviderProgressAtMs).toBe(47_250);
+    expect(ctx.state.lastProviderProgressPhase).toBe("stall_warning");
+  });
+
   it("ignores non-google providers", () => {
     const warn = vi.fn();
     const ctx = {

--- a/src/agents/pi-embedded-subscribe.provider-stall.ts
+++ b/src/agents/pi-embedded-subscribe.provider-stall.ts
@@ -1,0 +1,77 @@
+const PROVIDER_STALL_WARN_MS = 45_000;
+const GOOGLE_GEMINI_CLI_PROVIDER = "google-gemini-cli";
+
+type ProviderProgressState = {
+  lastProviderProgressAtMs?: number;
+  lastProviderProgressPhase?: "agent_start" | "tool_result";
+};
+
+type ProviderProgressParams = {
+  runId: string;
+  provider?: string;
+  modelId?: string;
+};
+
+type ProviderProgressLogger = {
+  warn: (message: string) => void;
+};
+
+type ProviderProgressContext = {
+  params: ProviderProgressParams;
+  state: ProviderProgressState;
+  log: ProviderProgressLogger;
+};
+
+export function noteProviderProgress(
+  ctx: ProviderProgressContext,
+  phase: "agent_start" | "tool_result",
+  nowMs = Date.now(),
+): void {
+  ctx.state.lastProviderProgressAtMs = nowMs;
+  ctx.state.lastProviderProgressPhase = phase;
+}
+
+export function maybeWarnProviderStall(
+  ctx: ProviderProgressContext,
+  params: {
+    phase: "before_tool" | "before_agent_end";
+    toolName?: string;
+    toolCallId?: string;
+    nowMs?: number;
+  },
+): void {
+  if (ctx.params.provider !== GOOGLE_GEMINI_CLI_PROVIDER) {
+    return;
+  }
+
+  const lastAt = ctx.state.lastProviderProgressAtMs;
+  if (typeof lastAt !== "number" || !Number.isFinite(lastAt)) {
+    return;
+  }
+
+  const nowMs = params.nowMs ?? Date.now();
+  const gapMs = nowMs - lastAt;
+  if (!Number.isFinite(gapMs) || gapMs < PROVIDER_STALL_WARN_MS) {
+    return;
+  }
+
+  const parts = [
+    `embedded run provider stall: runId=${ctx.params.runId}`,
+    `provider=${ctx.params.provider}`,
+    `model=${ctx.params.modelId ?? "unknown"}`,
+    `gapMs=${Math.round(gapMs)}`,
+    `since=${ctx.state.lastProviderProgressPhase ?? "unknown"}`,
+    `phase=${params.phase}`,
+  ];
+  if (params.toolName) {
+    parts.push(`tool=${params.toolName}`);
+  }
+  if (params.toolCallId) {
+    parts.push(`toolCallId=${params.toolCallId}`);
+  }
+  parts.push(
+    "hint=possible upstream google-gemini-cli retry/backoff (for example HTTP 429) before OpenClaw received the next lifecycle event",
+  );
+
+  ctx.log.warn(parts.join(" "));
+}

--- a/src/agents/pi-embedded-subscribe.provider-stall.ts
+++ b/src/agents/pi-embedded-subscribe.provider-stall.ts
@@ -3,7 +3,7 @@ const GOOGLE_GEMINI_CLI_PROVIDER = "google-gemini-cli";
 
 type ProviderProgressState = {
   lastProviderProgressAtMs?: number;
-  lastProviderProgressPhase?: "agent_start" | "tool_result";
+  lastProviderProgressPhase?: "agent_start" | "tool_result" | "stall_warning";
 };
 
 type ProviderProgressParams = {
@@ -55,12 +55,14 @@ export function maybeWarnProviderStall(
     return;
   }
 
+  const sincePhase = ctx.state.lastProviderProgressPhase ?? "unknown";
+
   const parts = [
     `embedded run provider stall: runId=${ctx.params.runId}`,
     `provider=${ctx.params.provider}`,
     `model=${ctx.params.modelId ?? "unknown"}`,
     `gapMs=${Math.round(gapMs)}`,
-    `since=${ctx.state.lastProviderProgressPhase ?? "unknown"}`,
+    `since=${sincePhase}`,
     `phase=${params.phase}`,
   ];
   if (params.toolName) {
@@ -72,6 +74,9 @@ export function maybeWarnProviderStall(
   parts.push(
     "hint=possible upstream google-gemini-cli retry/backoff (for example HTTP 429) before OpenClaw received the next lifecycle event",
   );
+
+  ctx.state.lastProviderProgressAtMs = nowMs;
+  ctx.state.lastProviderProgressPhase = "stall_warning";
 
   ctx.log.warn(parts.join(" "));
 }

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -78,6 +78,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     pendingMessagingTargets: new Map(),
     successfulCronAdds: 0,
     pendingMessagingMediaUrls: new Map(),
+    lastProviderProgressAtMs: undefined,
+    lastProviderProgressPhase: undefined,
   };
   const usageTotals = {
     input: 0,

--- a/src/agents/pi-embedded-subscribe.types.ts
+++ b/src/agents/pi-embedded-subscribe.types.ts
@@ -10,6 +10,8 @@ export type ToolResultFormat = "markdown" | "plain";
 export type SubscribeEmbeddedPiSessionParams = {
   session: AgentSession;
   runId: string;
+  provider?: string;
+  modelId?: string;
   hookRunner?: HookRunner;
   verboseLevel?: VerboseLevel;
   reasoningMode?: ReasoningLevel;


### PR DESCRIPTION
## Summary

- Problem: `google-gemini-cli` turns could appear to hang for ~60s between tool steps without any explicit lifecycle warning in OpenClaw logs.
- Why it matters: users and maintainers could see a frozen-looking agent run but have no direct signal that the stall likely happened inside the upstream OAuth/provider path before the next tool call was emitted.
- What changed: the embedded subscribe lifecycle now tracks the last confirmed provider progress point and emits an explicit warning when `google-gemini-cli` spends 45s+ without producing the next lifecycle event.
- What did NOT change (scope boundary): this does not alter upstream retry behavior, backoff timing, or tool execution semantics; it only improves diagnosability.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #36399
- Related #4011653299

## User-visible / Behavior Changes

- File logs now emit `embedded run provider stall` warnings for `google-gemini-cli` when OpenClaw observes a 45s+ silent gap before the next tool start or final agent end.
- The warning includes `provider`, `model`, `gapMs`, `since`, `phase`, and tool identifiers when applicable.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 25 locally for dev/test, repository target remains Node 22+
- Model/provider: `google-gemini-cli`
- Integration/channel (if any): embedded agent lifecycle / tool execution logging
- Relevant config (redacted): none required for unit coverage

### Steps

1. Start an embedded run with provider `google-gemini-cli`.
2. Record agent start, then a completed tool result.
3. Allow the run to remain silent for >45s before the next tool start or agent end.

### Expected

- OpenClaw should surface a clear warning that the apparent hang happened before the next lifecycle event arrived, with enough context to correlate it to the provider path.

### Actual

- Before this change, only the next `tool start` or `agent end` log line appeared after the silent gap, making the stall look like a deadlock with no provider-side clue.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Added unit coverage for warning emission after a 45s+ `google-gemini-cli` silent gap.
  - Verified no warning is emitted below threshold.
  - Verified no warning is emitted for non-Google providers.
  - Verified existing lifecycle/tool handler tests still pass.
- Edge cases checked:
  - Missing model ID falls back to `unknown` in the warning.
  - Tool metadata is included when the next lifecycle event is a tool start.
- What you did **not** verify:
  - I did not reproduce a live OAuth 429 from Google in an end-to-end environment.
  - I did not change or verify upstream retry/backoff internals.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert commit `e5e8f52a8`.
- Files/config to restore:
  - `src/agents/pi-embedded-subscribe.handlers.lifecycle.ts`
  - `src/agents/pi-embedded-subscribe.handlers.tools.ts`
  - `src/agents/pi-embedded-subscribe.provider-stall.ts`
  - related type plumbing in subscribe params/state
- Known bad symptoms reviewers should watch for:
  - Unexpected provider stall warnings for non-`google-gemini-cli` providers.
  - Duplicate warnings for a single silent gap.

## Risks and Mitigations

- Risk: legitimate long `google-gemini-cli` reasoning phases could now produce a warning even when the upstream provider eventually succeeds.
  - Mitigation: the warning is provider-specific, thresholded at 45s, and explicitly phrased as a possible upstream retry/backoff signal rather than a hard error.
