### PR TITLE
fix(sessions): preserve idle reset timestamp in updateLastRoute

### DIFF
--- a/src/config/sessions/store.session-key-normalization.test.ts
+++ b/src/config/sessions/store.session-key-normalization.test.ts
@@ -145,4 +145,37 @@ describe("session store key normalization", () => {
     expect(store[CANONICAL_KEY]?.updatedAt).toBe(1111);
     expect(store[CANONICAL_KEY]?.origin?.provider).toBe("webchat");
   });
+
+  it("preserves updatedAt when updateLastRoute writes route metadata for an existing session", async () => {
+    await fs.writeFile(
+      storePath,
+      JSON.stringify(
+        {
+          [CANONICAL_KEY]: {
+            sessionId: "existing-session",
+            updatedAt: 1111,
+            chatType: "direct",
+            lastChannel: "whatsapp",
+            lastTo: "+1234567890",
+          },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    clearSessionStoreCacheForTest();
+
+    await updateLastRoute({
+      storePath,
+      sessionKey: CANONICAL_KEY,
+      channel: "whatsapp",
+      to: "+0987654321",
+    });
+
+    const store = loadSessionStore(storePath, { skipCache: true });
+    expect(store[CANONICAL_KEY]?.sessionId).toBe("existing-session");
+    expect(store[CANONICAL_KEY]?.updatedAt).toBe(1111);
+    expect(store[CANONICAL_KEY]?.lastTo).toBe("+0987654321");
+  });
 });

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -795,7 +795,6 @@ export async function updateLastRoute(params: {
     const store = loadSessionStore(storePath);
     const resolved = resolveStoreSessionEntry({ store, sessionKey });
     const existing = resolved.existing;
-    const now = Date.now();
     const explicitContext = normalizeDeliveryContext(params.deliveryContext);
     const inlineContext = normalizeDeliveryContext({
       channel,
@@ -841,17 +840,18 @@ export async function updateLastRoute(params: {
         })
       : null;
     const basePatch: Partial<SessionEntry> = {
-      updatedAt: Math.max(existing?.updatedAt ?? 0, now),
       deliveryContext: normalized.deliveryContext,
       lastChannel: normalized.lastChannel,
       lastTo: normalized.lastTo,
       lastAccountId: normalized.lastAccountId,
       lastThreadId: normalized.lastThreadId,
     };
-    const next = mergeSessionEntry(
-      existing,
-      metaPatch ? { ...basePatch, ...metaPatch } : basePatch,
-    );
+    const fullPatch = metaPatch ? { ...basePatch, ...metaPatch } : basePatch;
+    // Route metadata updates must not refresh activity timestamps;
+    // idle reset evaluation relies on updatedAt from actual session turns.
+    const next = existing
+      ? mergeSessionEntryPreserveActivity(existing, fullPatch)
+      : mergeSessionEntry(existing, fullPatch);
     return await persistResolvedSessionEntry({
       storePath,
       store,


### PR DESCRIPTION
## Summary

`updateLastRoute()` refreshes `updatedAt` to `Date.now()` via `Math.max(existing?.updatedAt ?? 0, now)` on every inbound message's route metadata write. This runs as a fire-and-forget background task before `initSessionState()` reads the session store, so the idle expiry check always sees a fresh timestamp and never triggers session reset.

This is the same class of bug fixed for `recordSessionMetaFromInbound` in #32379. The fix applies the same pattern: use `mergeSessionEntryPreserveActivity` for existing entries so route metadata writes preserve the original `updatedAt` from actual session turns.

### Changes

- **`src/config/sessions/store.ts`**: Replace `mergeSessionEntry` with `mergeSessionEntryPreserveActivity` for existing entries in `updateLastRoute()`, remove now-unused `now` variable
- **`src/config/sessions/store.session-key-normalization.test.ts`**: Add test verifying `updateLastRoute` preserves `updatedAt` for existing sessions

### How to reproduce

1. Configure any DM scope (e.g. `session.dmScope: "per-channel-peer"`)
2. Set `session.idleMinutes: 60` (default)
3. Send messages, then wait >60 minutes
4. Send a new message -- session does NOT reset because `updateLastRoute` refreshed `updatedAt` before `initSessionState` checked it

### Test plan

- [x] Existing test suite passes
- [x] New test verifies `updatedAt` is preserved when `updateLastRoute` writes route metadata for an existing session
- [x] Follows exact pattern of #32379 fix for `recordSessionMetaFromInbound`
