### PR TITLE
fix(telegram): suppress bare Reasoning: prefix leak during Gemini streaming

### DIFF
--- a/src/telegram/reasoning-lane-coordinator.test.ts
+++ b/src/telegram/reasoning-lane-coordinator.test.ts
@@ -26,4 +26,16 @@ describe("splitTelegramReasoningText", () => {
   it("does not emit partial reasoning tag prefixes", () => {
     expect(splitTelegramReasoningText("  <thi")).toEqual({});
   });
+
+  it("suppresses bare 'Reasoning:' without content (streaming partial)", () => {
+    expect(splitTelegramReasoningText("Reasoning:")).toEqual({});
+    expect(splitTelegramReasoningText("Reasoning:\n")).toEqual({});
+    expect(splitTelegramReasoningText("Reasoning:  \n")).toEqual({});
+  });
+
+  it("classifies raw Gemini reasoning as reasoningText", () => {
+    expect(splitTelegramReasoningText("Reasoning:\nFirst thought.\n\nSecond thought.")).toEqual({
+      reasoningText: "Reasoning:\nFirst thought.\n\nSecond thought.",
+    });
+  });
 });

--- a/src/telegram/reasoning-lane-coordinator.ts
+++ b/src/telegram/reasoning-lane-coordinator.ts
@@ -71,7 +71,7 @@ export function splitTelegramReasoningText(text?: string): TelegramReasoningSpli
   // Suppress partial "Reasoning:" arriving during streaming before any
   // actual reasoning content follows (trim() collapses "Reasoning:\n" to
   // "Reasoning:" which would otherwise fall through to answerText).
-  if (/^Reasoning:?\s*$/.test(trimmed)) {
+  if (/^Reasoning:\s*$/.test(trimmed)) {
     return {};
   }
   if (

--- a/src/telegram/reasoning-lane-coordinator.ts
+++ b/src/telegram/reasoning-lane-coordinator.ts
@@ -68,6 +68,12 @@ export function splitTelegramReasoningText(text?: string): TelegramReasoningSpli
   if (isPartialReasoningTagPrefix(trimmed)) {
     return {};
   }
+  // Suppress partial "Reasoning:" arriving during streaming before any
+  // actual reasoning content follows (trim() collapses "Reasoning:\n" to
+  // "Reasoning:" which would otherwise fall through to answerText).
+  if (/^Reasoning:?\s*$/.test(trimmed)) {
+    return {};
+  }
   if (
     trimmed.startsWith(REASONING_MESSAGE_PREFIX) &&
     trimmed.length > REASONING_MESSAGE_PREFIX.length


### PR DESCRIPTION
## Summary

Fixes #37890

- Add guard for bare `Reasoning:` / `Reasoning:\n` during streaming partials
- `trim()` collapses `"Reasoning:\n"` to `"Reasoning:"` which doesn't match `REASONING_MESSAGE_PREFIX` and falls through to `answerText`, leaking the prefix into user-visible output
- The new regex `/^Reasoning:?\s*$/` catches these partial chunks and returns `{}` (suppress) before they reach the answer path

## Test plan

- [x] Added test cases for `"Reasoning:"`, `"Reasoning:\n"`, and `"Reasoning:  \n"`
- [x] Added test confirming multi-paragraph raw Gemini reasoning stays classified as `reasoningText`
- [x] `pnpm exec vitest run src/telegram/reasoning-lane-coordinator.test.ts` — 6 tests pass
- [x] `pnpm check` passes

cc @ayaanzaidi — you recently worked on draft materialize in this area (#36746)
