### PR TITLE
fix(discord): ignore synthetic thread starter messages in text-channel threads

### DIFF
--- a/src/discord/monitor/message-handler.preflight.test.ts
+++ b/src/discord/monitor/message-handler.preflight.test.ts
@@ -822,6 +822,169 @@ describe("preflightDiscordMessage", () => {
     expect(result).not.toBeNull();
     expect(result?.wasMentioned).toBe(true);
   });
+
+  it("drops synthetic thread starter messages in text-channel threads", async () => {
+    const threadId = "thread-starter-1";
+    const parentId = "channel-parent-1";
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === threadId) {
+          return {
+            id: threadId,
+            type: ChannelType.PublicThread,
+            name: "new-thread-title",
+            parentId,
+            ownerId: "owner-1",
+          };
+        }
+        if (id === parentId) {
+          return {
+            id: parentId,
+            type: ChannelType.GuildText,
+            name: "general",
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+
+    const message = {
+      id: threadId,
+      content: "new-thread-title",
+      timestamp: new Date().toISOString(),
+      channelId: threadId,
+      attachments: [],
+      mentionedUsers: [],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "user-1",
+        bot: false,
+        username: "Alice",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: {
+        session: {
+          mainKey: "main",
+          scope: "per-sender",
+        },
+      } as import("../../config/config.js").OpenClawConfig,
+      discordConfig: {} as NonNullable<
+        import("../../config/config.js").OpenClawConfig["channels"]
+      >["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: "openclaw-bot",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "open",
+      threadBindings: createNoopThreadBindingManager("default"),
+      data: {
+        channel_id: threadId,
+        guild_id: "guild-1",
+        guild: {
+          id: "guild-1",
+          name: "Guild One",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("keeps starter messages for forum posts", async () => {
+    const threadId = "forum-thread-1";
+    const parentId = "forum-parent-1";
+    const client = {
+      fetchChannel: async (id: string) => {
+        if (id === threadId) {
+          return {
+            id: threadId,
+            type: ChannelType.PublicThread,
+            name: "forum-topic",
+            parentId,
+            ownerId: "owner-1",
+          };
+        }
+        if (id === parentId) {
+          return {
+            id: parentId,
+            type: ChannelType.GuildForum,
+            name: "help",
+          };
+        }
+        return null;
+      },
+    } as unknown as import("@buape/carbon").Client;
+
+    const message = {
+      id: threadId,
+      content: "<@openclaw-bot> How do I configure thread bindings?",
+      timestamp: new Date().toISOString(),
+      channelId: threadId,
+      attachments: [],
+      mentionedUsers: [{ id: "openclaw-bot" }],
+      mentionedRoles: [],
+      mentionedEveryone: false,
+      author: {
+        id: "user-2",
+        bot: false,
+        username: "Bob",
+      },
+    } as unknown as import("@buape/carbon").Message;
+
+    const result = await preflightDiscordMessage({
+      cfg: {
+        session: {
+          mainKey: "main",
+          scope: "per-sender",
+        },
+      } as import("../../config/config.js").OpenClawConfig,
+      discordConfig: {
+        requireMention: false,
+      } as NonNullable<import("../../config/config.js").OpenClawConfig["channels"]>["discord"],
+      accountId: "default",
+      token: "token",
+      runtime: {} as import("../../runtime.js").RuntimeEnv,
+      botUserId: "openclaw-bot",
+      guildHistories: new Map(),
+      historyLimit: 0,
+      mediaMaxBytes: 1_000_000,
+      textLimit: 2_000,
+      replyToMode: "all",
+      dmEnabled: true,
+      groupDmEnabled: true,
+      ackReactionScope: "direct",
+      groupPolicy: "open",
+      threadBindings: createNoopThreadBindingManager("default"),
+      data: {
+        channel_id: threadId,
+        guild_id: "guild-1",
+        guild: {
+          id: "guild-1",
+          name: "Guild One",
+        },
+        author: message.author,
+        message,
+      } as unknown as import("./listeners.js").DiscordMessageEvent,
+      client,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.messageText).toContain("How do I configure thread bindings?");
+  });
 });
 
 describe("shouldIgnoreBoundThreadWebhookMessage", () => {

--- a/src/discord/monitor/message-handler.preflight.ts
+++ b/src/discord/monitor/message-handler.preflight.ts
@@ -91,6 +91,29 @@ function isBoundThreadBotSystemMessage(params: {
   return DISCORD_BOUND_THREAD_SYSTEM_PREFIXES.some((prefix) => text.startsWith(prefix));
 }
 
+function isSyntheticThreadStarterMessage(params: {
+  isGuildMessage: boolean;
+  messageId: string;
+  messageChannelId: string;
+  threadParentType?: ChannelType;
+}): boolean {
+  if (!params.isGuildMessage) {
+    return false;
+  }
+
+  // In text/announcement channels, Discord emits a synthetic starter message when a
+  // thread is created, with message.id === thread channel id. Treat this as system
+  // metadata instead of user input.
+  if (
+    params.threadParentType === ChannelType.GuildForum ||
+    params.threadParentType === ChannelType.GuildMedia
+  ) {
+    return false;
+  }
+
+  return params.messageId === params.messageChannelId;
+}
+
 export function resolvePreflightMentionRequirement(params: {
   shouldRequireMention: boolean;
   isBoundThreadSession: boolean;
@@ -326,6 +349,19 @@ export async function preflightDiscordMessage(
     earlyThreadParentId = parentInfo.id;
     earlyThreadParentName = parentInfo.name;
     earlyThreadParentType = parentInfo.type;
+  }
+
+  if (
+    earlyThreadChannel &&
+    isSyntheticThreadStarterMessage({
+      isGuildMessage,
+      messageId: String(message.id),
+      messageChannelId,
+      threadParentType: earlyThreadParentType,
+    })
+  ) {
+    logVerbose(`discord: drop synthetic thread starter message ${message.id}`);
+    return null;
   }
 
   // Fresh config for bindings lookup; other routing inputs are payload-derived.


### PR DESCRIPTION
## Summary
- prevent Discord synthetic thread-starter messages from being treated as normal user input
- only apply this filter for text/announcement-thread parents (keep forum/media starter posts intact)
- add preflight tests for both the dropped and preserved paths

## Why
When users manually create a Discord thread and name it, Discord can emit a synthetic starter message (`message.id === thread channel id`). This was being forwarded into the session and could trigger an unexpected auto-reply based on the thread title.

## Validation
- `pnpm vitest src/discord/monitor/message-handler.preflight.test.ts`
