### PR TITLE
fix(reply): suppress JSON/channelData NO_REPLY action payloads

### DIFF
--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -25,6 +25,37 @@ export type NormalizeReplyOptions = {
   onSkip?: (reason: NormalizeReplySkipReason) => void;
 };
 
+function isNoReplyActionValue(value: unknown): boolean {
+  return typeof value === "string" && value.trim().toUpperCase() === SILENT_REPLY_TOKEN;
+}
+
+function parseNoReplyActionJsonText(text: string | undefined): boolean {
+  const trimmed = text?.trim();
+  if (!trimmed || !trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+    return isNoReplyActionValue(parsed.action);
+  } catch {
+    return false;
+  }
+}
+
+function containsNoReplyAction(value: unknown): boolean {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return value.some((entry) => containsNoReplyAction(entry));
+  }
+  const record = value as Record<string, unknown>;
+  if (isNoReplyActionValue(record.action)) {
+    return true;
+  }
+  return Object.values(record).some((entry) => containsNoReplyAction(entry));
+}
+
 export function normalizeReplyPayload(
   payload: ReplyPayload,
   opts: NormalizeReplyOptions = {},
@@ -33,8 +64,21 @@ export function normalizeReplyPayload(
   const hasChannelData = Boolean(
     payload.channelData && Object.keys(payload.channelData).length > 0,
   );
+  const hasNoReplyActionChannelData = containsNoReplyAction(payload.channelData);
+  const textIsNoReplyActionJson = parseNoReplyActionJsonText(payload.text);
   const trimmed = payload.text?.trim() ?? "";
-  if (!trimmed && !hasMedia && !hasChannelData) {
+  const hasEffectiveChannelData = hasChannelData && !hasNoReplyActionChannelData;
+
+  if ((textIsNoReplyActionJson || hasNoReplyActionChannelData) && !hasMedia && !trimmed) {
+    opts.onSkip?.("silent");
+    return null;
+  }
+  if (textIsNoReplyActionJson && !hasMedia && !hasEffectiveChannelData) {
+    opts.onSkip?.("silent");
+    return null;
+  }
+
+  if (!trimmed && !hasMedia && !hasEffectiveChannelData) {
     opts.onSkip?.("empty");
     return null;
   }
@@ -42,7 +86,7 @@ export function normalizeReplyPayload(
   const silentToken = opts.silentToken ?? SILENT_REPLY_TOKEN;
   let text = payload.text ?? undefined;
   if (text && isSilentReplyText(text, silentToken)) {
-    if (!hasMedia && !hasChannelData) {
+    if (!hasMedia && !hasEffectiveChannelData) {
       opts.onSkip?.("silent");
       return null;
     }
@@ -53,7 +97,7 @@ export function normalizeReplyPayload(
   // silent just like the exact-match path above.  (#30916, #30955)
   if (text && text.includes(silentToken) && !isSilentReplyText(text, silentToken)) {
     text = stripSilentToken(text, silentToken);
-    if (!text && !hasMedia && !hasChannelData) {
+    if (!text && !hasMedia && !hasEffectiveChannelData) {
       opts.onSkip?.("silent");
       return null;
     }
@@ -69,7 +113,7 @@ export function normalizeReplyPayload(
     if (stripped.didStrip) {
       opts.onHeartbeatStrip?.();
     }
-    if (stripped.shouldSkip && !hasMedia && !hasChannelData) {
+    if (stripped.shouldSkip && !hasMedia && !hasEffectiveChannelData) {
       opts.onSkip?.("heartbeat");
       return null;
     }
@@ -79,7 +123,7 @@ export function normalizeReplyPayload(
   if (text) {
     text = sanitizeUserFacingText(text, { errorContext: Boolean(payload.isError) });
   }
-  if (!text?.trim() && !hasMedia && !hasChannelData) {
+  if (!text?.trim() && !hasMedia && !hasEffectiveChannelData) {
     opts.onSkip?.("empty");
     return null;
   }

--- a/src/auto-reply/reply/reply-utils.test.ts
+++ b/src/auto-reply/reply/reply-utils.test.ts
@@ -150,6 +150,35 @@ describe("normalizeReplyPayload", () => {
     expect(result!.text).toBe("");
     expect(result!.mediaUrl).toBe("https://example.com/img.png");
   });
+
+  it("suppresses JSON action-only NO_REPLY payload", () => {
+    const reasons: string[] = [];
+    const result = normalizeReplyPayload(
+      { text: '{"action":"NO_REPLY"}' },
+      { onSkip: (reason) => reasons.push(reason) },
+    );
+    expect(result).toBeNull();
+    expect(reasons).toEqual(["silent"]);
+  });
+
+  it("suppresses channelData action-only NO_REPLY payload", () => {
+    const reasons: string[] = [];
+    const result = normalizeReplyPayload(
+      { text: "", channelData: { action: "NO_REPLY" } },
+      { onSkip: (reason) => reasons.push(reason) },
+    );
+    expect(result).toBeNull();
+    expect(reasons).toEqual(["silent"]);
+  });
+
+  it("keeps JSON action payload when media exists", () => {
+    const result = normalizeReplyPayload({
+      text: '{"action":"NO_REPLY"}',
+      mediaUrl: "https://example.com/img.png",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.mediaUrl).toBe("https://example.com/img.png");
+  });
 });
 
 describe("typing controller", () => {


### PR DESCRIPTION
## Summary
- treat JSON action-only payload text like `{"action":"NO_REPLY"}` as silent internal control payloads
- suppress channelData-only payloads that carry `action: NO_REPLY`
- keep media behavior unchanged (media + NO_REPLY action still allowed)
- add regression tests for JSON action form and channelData action form

## Why
Issue #37727 reports occasional leakage of internal NO_REPLY action payloads into Telegram user-visible messages.

## Validation
- pnpm -s test src/auto-reply/reply/reply-utils.test.ts

Fixes #37727
