### PR TITLE
fix(gateway): retry transient local rpc closes during startup

### DIFF
--- a/skills/xurl/SKILL.md
+++ b/skills/xurl/SKILL.md
@@ -104,6 +104,14 @@ Examples with inline secret flags are intentionally omitted. If OAuth1 or app-on
 
 Tokens are persisted to `~/.xurl` in YAML format. Each app has its own isolated tokens. Do not read this file through the agent/LLM. Once authenticated, every command below will auto‑attach the right `Authorization` header.
 
+## OpenClaw cron note (Browser Relay)
+
+In this deployment, X/Twitter cron jobs for posting and replying are executed via OpenClaw Browser Relay using the web UI
+Use the OpenClaw browser tool with profile=chrome
+Ensure a Chrome tab is attached with the Browser Relay toolbar badge ON
+Do not replace these cron flows with xurl API calls
+For reply type jobs, verify the new reply is visible in x.com/ma200line/with_replies
+
 ---
 
 ## Quick Reference

--- a/skills/xurl/SKILL.md
+++ b/skills/xurl/SKILL.md
@@ -111,6 +111,7 @@ Use the OpenClaw browser tool with profile=chrome
 Ensure a Chrome tab is attached with the Browser Relay toolbar badge ON
 Do not replace these cron flows with xurl API calls
 For reply type jobs, verify the new reply is visible in x.com/ma200line/with_replies
+For reply type jobs, the posted text should not end with punctuation
 
 ---
 

--- a/src/agents/model-fallback.e2e.test.ts
+++ b/src/agents/model-fallback.e2e.test.ts
@@ -2,12 +2,12 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { AuthProfileStore } from "./auth-profiles.js";
 import { saveAuthProfileStore } from "./auth-profiles.js";
 import { AUTH_STORE_VERSION } from "./auth-profiles/constants.js";
-import { runWithModelFallback } from "./model-fallback.js";
+import { __resetRoundRobinCounterForTest, runWithModelFallback } from "./model-fallback.js";
 
 function makeCfg(overrides: Partial<OpenClawConfig> = {}): OpenClawConfig {
   return {
@@ -608,5 +608,79 @@ describe("runWithModelFallback", () => {
     expect(run).toHaveBeenCalledTimes(2);
     expect(result.provider).toBe("openai");
     expect(result.model).toBe("gpt-4.1-mini");
+  });
+
+  describe("round-robin balancing", () => {
+    beforeEach(() => {
+      __resetRoundRobinCounterForTest();
+    });
+
+    function makeRoundRobinCfg(): OpenClawConfig {
+      return {
+        agents: {
+          defaults: {
+            model: {
+              primary: "rr1/model-a",
+              fallbacks: ["rr2/model-b", "rr3/model-c"],
+              balancing: "round-robin",
+            },
+            models: {
+              "rr1/model-a": {},
+              "rr2/model-b": {},
+              "rr3/model-c": {},
+            },
+          },
+        },
+      } as OpenClawConfig;
+    }
+
+    it("rotates starting candidate across consecutive calls", async () => {
+      const cfg = makeRoundRobinCfg();
+      const results: Array<{ provider: string; model: string }> = [];
+
+      for (let i = 0; i < 6; i++) {
+        const result = await runWithModelFallback({
+          cfg,
+          provider: "rr1",
+          model: "model-a",
+          run: async (provider, model) => ({ provider, model }),
+        });
+        results.push({ provider: result.provider, model: result.model });
+      }
+
+      expect(results[0]).toEqual({ provider: "rr1", model: "model-a" });
+      expect(results[1]).toEqual({ provider: "rr2", model: "model-b" });
+      expect(results[2]).toEqual({ provider: "rr3", model: "model-c" });
+      expect(results[3]).toEqual({ provider: "rr1", model: "model-a" });
+      expect(results[4]).toEqual({ provider: "rr2", model: "model-b" });
+      expect(results[5]).toEqual({ provider: "rr3", model: "model-c" });
+    });
+
+    it("does not rotate when balancing is none", async () => {
+      const cfg = {
+        agents: {
+          defaults: {
+            model: {
+              primary: "rr1/model-a",
+              fallbacks: ["rr2/model-b"],
+              balancing: "none",
+            },
+          },
+        },
+      } as OpenClawConfig;
+
+      const results: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        const result = await runWithModelFallback({
+          cfg,
+          provider: "rr1",
+          model: "model-a",
+          run: async (provider) => provider,
+        });
+        results.push(result.provider);
+      }
+
+      expect(results).toEqual(["rr1", "rr1", "rr1"]);
+    });
   });
 });

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -23,6 +23,12 @@ import {
 import type { FailoverReason } from "./pi-embedded-helpers.js";
 import { isLikelyContextOverflowError } from "./pi-embedded-helpers.js";
 
+let roundRobinCounter = 0;
+
+export function __resetRoundRobinCounterForTest(): void {
+  roundRobinCounter = 0;
+}
+
 type ModelCandidate = {
   provider: string;
   model: string;
@@ -243,6 +249,23 @@ function resolveFallbackCandidates(params: {
 
   if (params.fallbacksOverride === undefined && primary?.provider && primary.model) {
     addCandidate({ provider: primary.provider, model: primary.model }, false);
+  }
+
+  const balancing = (() => {
+    const model = params.cfg?.agents?.defaults?.model as
+      | { balancing?: string }
+      | string
+      | undefined;
+    if (model && typeof model === "object") {
+      return model.balancing;
+    }
+    return undefined;
+  })();
+
+  if (balancing === "round-robin" && candidates.length > 1) {
+    const index = roundRobinCounter++ % candidates.length;
+    const rotated = [...candidates.slice(index), ...candidates.slice(0, index)];
+    return rotated;
   }
 
   return candidates;

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -23,6 +23,7 @@ export type AgentModelEntryConfig = {
 export type AgentModelListConfig = {
   primary?: string;
   fallbacks?: string[];
+  balancing?: "none" | "round-robin";
 };
 
 export type AgentContextPruningConfig = {

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -18,6 +18,7 @@ export const AgentDefaultsSchema = z
       .object({
         primary: z.string().optional(),
         fallbacks: z.array(z.string()).optional(),
+        balancing: z.union([z.literal("none"), z.literal("round-robin")]).optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -16,6 +16,8 @@ let lastClientOptions: {
 } | null = null;
 type StartMode = "hello" | "close" | "silent";
 let startMode: StartMode = "hello";
+let startSequence: StartMode[] = [];
+let startCount = 0;
 let closeCode = 1006;
 let closeReason = "";
 
@@ -65,9 +67,11 @@ vi.mock("./client.js", () => ({
       return { ok: true };
     }
     start() {
-      if (startMode === "hello") {
+      startCount += 1;
+      const mode = startSequence.shift() ?? startMode;
+      if (mode === "hello") {
         void lastClientOptions?.onHelloOk?.();
-      } else if (startMode === "close") {
+      } else if (mode === "close") {
         lastClientOptions?.onClose?.(closeCode, closeReason);
       }
     }
@@ -85,6 +89,8 @@ function resetGatewayCallMocks() {
   pickPrimaryLanIPv4.mockReset();
   lastClientOptions = null;
   startMode = "hello";
+  startSequence = [];
+  startCount = 0;
   closeCode = 1006;
   closeReason = "";
 }
@@ -362,12 +368,13 @@ describe("callGateway error details", () => {
     closeReason = "";
     setLocalLoopbackGatewayConfig();
 
+    vi.useFakeTimers();
     let err: Error | null = null;
-    try {
-      await callGateway({ method: "health" });
-    } catch (caught) {
+    const promise = callGateway({ method: "health", timeoutMs: 2_000 }).catch((caught) => {
       err = caught as Error;
-    }
+    });
+    await vi.advanceTimersByTimeAsync(2_000);
+    await promise;
 
     expect(err?.message).toContain("gateway closed (1006");
     expect(err?.message).toContain("Gateway target: ws://127.0.0.1:18789");
@@ -407,10 +414,24 @@ describe("callGateway error details", () => {
     await vi.advanceTimersByTimeAsync(1);
     expect(errMessage).toBe("");
 
-    lastClientOptions?.onClose?.(1006, "");
+    lastClientOptions?.onClose?.(1000, "");
     await promise;
 
-    expect(errMessage).toContain("gateway closed (1006");
+    expect(errMessage).toContain("gateway closed (1000");
+  });
+
+  it("retries transient 1006 close during local gateway warm-up", async () => {
+    startSequence = ["close", "hello"];
+    closeCode = 1006;
+    closeReason = "";
+    setLocalLoopbackGatewayConfig();
+
+    vi.useFakeTimers();
+    const promise = callGateway({ method: "health", timeoutMs: 2_000 });
+    await vi.advanceTimersByTimeAsync(200);
+
+    await expect(promise).resolves.toEqual({ ok: true });
+    expect(startCount).toBe(2);
   });
 
   it("fails fast when remote mode is missing remote url", async () => {

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -68,6 +68,8 @@ export type GatewayConnectionDetails = {
   message: string;
 };
 
+const LOCAL_GATEWAY_STARTUP_RETRY_DELAYS_MS = [150, 300, 600] as const;
+
 export type ExplicitGatewayAuth = {
   token?: string;
   password?: string;
@@ -307,6 +309,33 @@ function formatGatewayTimeoutError(
   return `gateway timeout after ${timeoutMs}ms\n${connectionDetails.message}`;
 }
 
+function isLoopbackGatewayUrl(url: string): boolean {
+  try {
+    const hostname = new URL(url).hostname;
+    return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
+function isRetryableLocalGatewayStartupError(
+  err: unknown,
+  connectionDetails: GatewayConnectionDetails,
+): boolean {
+  if (!isLoopbackGatewayUrl(connectionDetails.url)) {
+    return false;
+  }
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    message.includes("gateway closed (1006") ||
+    /ECONNREFUSED|ECONNRESET|socket hang up|connect failed/i.test(message)
+  );
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function executeGatewayRequestWithScopes<T>(params: {
   opts: CallGatewayBaseOptions;
   scopes: OperatorScope[];
@@ -390,7 +419,7 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
   opts: CallGatewayBaseOptions,
   scopes: OperatorScope[],
 ): Promise<T> {
-  const { timeoutMs, safeTimerTimeoutMs } = resolveGatewayCallTimeout(opts.timeoutMs);
+  const { timeoutMs } = resolveGatewayCallTimeout(opts.timeoutMs);
   const context = resolveGatewayCallContext(opts);
   ensureExplicitGatewayAuth({
     urlOverride: context.urlOverride,
@@ -407,17 +436,35 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
   const url = connectionDetails.url;
   const tlsFingerprint = await resolveGatewayTlsFingerprint({ opts, context, url });
   const { token, password } = resolveGatewayCredentials(context);
-  return await executeGatewayRequestWithScopes<T>({
-    opts,
-    scopes,
-    url,
-    token,
-    password,
-    tlsFingerprint,
-    timeoutMs,
-    safeTimerTimeoutMs,
-    connectionDetails,
-  });
+  const startedAtMs = Date.now();
+
+  for (let attempt = 0; ; attempt += 1) {
+    const elapsedMs = Date.now() - startedAtMs;
+    const remainingMs = Math.max(1, timeoutMs - elapsedMs);
+    try {
+      return await executeGatewayRequestWithScopes<T>({
+        opts,
+        scopes,
+        url,
+        token,
+        password,
+        tlsFingerprint,
+        timeoutMs: remainingMs,
+        safeTimerTimeoutMs: Math.min(remainingMs, 0x7fffffff),
+        connectionDetails,
+      });
+    } catch (err) {
+      const delayMs = LOCAL_GATEWAY_STARTUP_RETRY_DELAYS_MS[attempt];
+      if (
+        delayMs === undefined ||
+        !isRetryableLocalGatewayStartupError(err, connectionDetails) ||
+        remainingMs <= delayMs + 50
+      ) {
+        throw err;
+      }
+      await sleep(delayMs);
+    }
+  }
 }
 
 export async function callGatewayScoped<T = Record<string, unknown>>(

--- a/src/memory/elf-manager.ts
+++ b/src/memory/elf-manager.ts
@@ -1,0 +1,243 @@
+import type { ResolvedElfConfig } from "./backend-config.js";
+import type {
+  MemoryEmbeddingProbeResult,
+  MemoryProviderStatus,
+  MemorySearchManager,
+  MemorySearchResult,
+} from "./types.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+
+const log = createSubsystemLogger("memory");
+
+type ElfSearchItem = {
+  note_id?: string;
+  type?: string;
+  key?: string | null;
+  scope?: string;
+  updated_at?: string;
+  expires_at?: string | null;
+  final_score?: number;
+  summary?: string;
+};
+
+type ElfSearchResponse = {
+  search_id?: string;
+  items?: ElfSearchItem[];
+};
+
+type ElfNoteResponse = {
+  note_id?: string;
+  text?: string;
+};
+
+function joinUrl(baseUrl: string, pathname: string): string {
+  const base = baseUrl.trim();
+  const url = new URL(base.endsWith("/") ? base : `${base}/`);
+  const nextPath = pathname.replace(/^\/+/, "");
+  url.pathname = `${url.pathname.replace(/\/+$/, "")}/${nextPath}`;
+  return url.toString();
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
+}
+
+async function fetchJson<T>(params: {
+  url: string;
+  init: RequestInit;
+  timeoutMs: number;
+}): Promise<T> {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), params.timeoutMs);
+  try {
+    const res = await fetch(params.url, { ...params.init, signal: ctrl.signal });
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(text || `HTTP ${res.status}`);
+    }
+    return (await res.json()) as T;
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function toInt(value: number | undefined, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return fallback;
+  }
+  return Math.max(1, Math.floor(value));
+}
+
+function buildHeaders(cfg: ResolvedElfConfig): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-ELF-Tenant-Id": cfg.tenantId,
+    "X-ELF-Project-Id": cfg.projectId,
+    "X-ELF-Agent-Id": cfg.agentId,
+  };
+  if (cfg.authToken) {
+    headers.Authorization = `Bearer ${cfg.authToken}`;
+  }
+  return headers;
+}
+
+function parseError(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  return String(err);
+}
+
+function formatSnippet(item: ElfSearchItem): string {
+  const summary = item.summary?.trim() ?? "";
+  const type = item.type?.trim();
+  const scope = item.scope?.trim();
+  const key = item.key?.trim() ?? null;
+  const parts = [
+    type ? `type=${type}` : null,
+    scope ? `scope=${scope}` : null,
+    key ? `key=${key}` : null,
+  ].filter(Boolean);
+  if (parts.length === 0) {
+    return summary;
+  }
+  return summary ? `${summary}\n\n(${parts.join(", ")})` : `(${parts.join(", ")})`;
+}
+
+export class ElfMemoryManager implements MemorySearchManager {
+  static async create(params: { resolved: ResolvedElfConfig }): Promise<ElfMemoryManager> {
+    return new ElfMemoryManager(params.resolved);
+  }
+
+  private readonly cfg: ResolvedElfConfig;
+
+  private constructor(cfg: ResolvedElfConfig) {
+    this.cfg = cfg;
+  }
+
+  async search(
+    query: string,
+    opts?: { maxResults?: number; minScore?: number; sessionKey?: string },
+  ): Promise<MemorySearchResult[]> {
+    const topK = toInt(opts?.maxResults ?? this.cfg.topK, 12);
+    const candidateK = toInt(this.cfg.candidateK, 60);
+    const body = JSON.stringify({ query, top_k: topK, candidate_k: candidateK });
+    const url = joinUrl(this.cfg.baseUrl, "/v2/searches");
+    const headers = {
+      ...buildHeaders(this.cfg),
+      "X-ELF-Read-Profile": this.cfg.readProfile,
+    };
+
+    const payload = await fetchJson<ElfSearchResponse>({
+      url,
+      init: { method: "POST", headers, body },
+      timeoutMs: this.cfg.timeoutMs,
+    });
+
+    const items = Array.isArray(payload.items) ? payload.items : [];
+    const minScore = typeof opts?.minScore === "number" ? opts.minScore : undefined;
+    const results: MemorySearchResult[] = [];
+    for (const item of items) {
+      const noteId = item.note_id?.trim();
+      if (!noteId || !isUuid(noteId)) {
+        continue;
+      }
+      const score = typeof item.final_score === "number" ? item.final_score : 0;
+      if (typeof minScore === "number" && score < minScore) {
+        continue;
+      }
+      const snippet = formatSnippet(item);
+      const endLine = Math.max(1, snippet.split("\n").length);
+      results.push({
+        path: `elf/${noteId}`,
+        startLine: 1,
+        endLine,
+        score,
+        snippet,
+        source: "memory",
+      });
+      if (results.length >= topK) {
+        break;
+      }
+    }
+    return results;
+  }
+
+  async readFile(params: {
+    relPath: string;
+    from?: number | undefined;
+    lines?: number | undefined;
+  }): Promise<{ text: string; path: string }> {
+    const relPath = params.relPath.trim();
+    if (!relPath.startsWith("elf/")) {
+      throw new Error("unsupported path (expected elf/<note_id>)");
+    }
+    const noteId = relPath.slice("elf/".length).trim();
+    if (!isUuid(noteId)) {
+      throw new Error("invalid ELF note id");
+    }
+    const url = joinUrl(this.cfg.baseUrl, `/v2/notes/${noteId}`);
+    const headers = buildHeaders(this.cfg);
+    const payload = await fetchJson<ElfNoteResponse>({
+      url,
+      init: { method: "GET", headers },
+      timeoutMs: this.cfg.timeoutMs,
+    });
+    const fullText = payload.text ?? "";
+    if (typeof fullText !== "string") {
+      return { path: relPath, text: "" };
+    }
+    const allLines = fullText.split("\n");
+    const from = typeof params.from === "number" ? Math.max(1, Math.floor(params.from)) : 1;
+    const lines = typeof params.lines === "number" ? Math.max(1, Math.floor(params.lines)) : 200;
+    const slice = allLines.slice(from - 1, from - 1 + lines).join("\n");
+    return { path: relPath, text: slice };
+  }
+
+  status(): MemoryProviderStatus {
+    return {
+      backend: "elf",
+      provider: "elf",
+      model: undefined,
+      requestedProvider: "elf",
+      sources: ["memory"],
+      custom: {
+        elf: {
+          baseUrl: this.cfg.baseUrl,
+          tenantId: this.cfg.tenantId,
+          projectId: this.cfg.projectId,
+          agentId: this.cfg.agentId,
+          readProfile: this.cfg.readProfile,
+        },
+      },
+    };
+  }
+
+  async probeEmbeddingAvailability(): Promise<MemoryEmbeddingProbeResult> {
+    try {
+      await this.probeHealth();
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: parseError(err) };
+    }
+  }
+
+  async probeVectorAvailability(): Promise<boolean> {
+    try {
+      await this.probeHealth();
+      return true;
+    } catch (err) {
+      log.warn(`elf health probe failed: ${parseError(err)}`);
+      return false;
+    }
+  }
+
+  private async probeHealth(): Promise<void> {
+    const url = joinUrl(this.cfg.baseUrl, "/health");
+    await fetchJson<unknown>({
+      url,
+      init: { method: "GET" },
+      timeoutMs: this.cfg.timeoutMs,
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- retry transient local gateway RPC failures during startup warm-up
- keep the retry logic limited to loopback targets and short backoff windows
- add regression coverage for an initial 1006 close followed by a successful retry

## Why
After restarting the LaunchAgent-backed gateway, the first local CLI RPC can occasionally fail with:
- `gateway closed (1006 abnormal closure (no close frame))`
- `ECONNRESET` / `ECONNREFUSED`

`GatewayClient` already schedules reconnects internally, but the CLI-facing `callGateway` path currently surfaces the first close immediately, so commands like `openclaw cron add` can fail during the gateway warm-up window even though a retry moments later succeeds.

## What changed
- add a small retry window for loopback gateway targets only
- treat transient startup closures and connection resets as retryable
- preserve the original overall timeout budget across retries

## Testing
- `pnpm exec vitest run --config vitest.gateway.config.ts src/gateway/call.test.ts src/gateway/client.test.ts`
