### PR TITLE
fix(cron): fsync store writes across rename/copy durability windows

### DIFF
--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -1,3 +1,4 @@
+import fsNode from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -122,6 +123,29 @@ describe("saveCronStore", () => {
     await saveCronStore(storePath, dummyStore);
     const loaded = await loadCronStore(storePath);
     expect(loaded).toEqual(dummyStore);
+  });
+
+  it("attempts to fsync tmp/final files and parent directory", async () => {
+    const { storePath } = await makeStorePath();
+    const openedPaths: string[] = [];
+    const origOpen = fsNode.promises.open.bind(fsNode.promises);
+    const openSpy = vi
+      .spyOn(fsNode.promises, "open")
+      .mockImplementation(async (...args: Parameters<typeof fsNode.promises.open>) => {
+        openedPaths.push(String(args[0]));
+        return await origOpen(...args);
+      });
+
+    try {
+      await saveCronStore(storePath, dummyStore);
+      expect(openedPaths.some((p) => p.startsWith(`${storePath}.`) && p.endsWith(".tmp"))).toBe(
+        true,
+      );
+      expect(openedPaths).toContain(storePath);
+      expect(openedPaths).toContain(path.dirname(storePath));
+    } finally {
+      openSpy.mockRestore();
+    }
   });
 
   it("retries rename on EBUSY then succeeds", async () => {

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -60,6 +60,30 @@ async function setSecureFileMode(filePath: string): Promise<void> {
   await fs.promises.chmod(filePath, 0o600).catch(() => undefined);
 }
 
+async function fsyncPathBestEffort(filePath: string): Promise<void> {
+  let handle: fs.promises.FileHandle | undefined;
+  try {
+    handle = await fs.promises.open(filePath, "r");
+    await handle.sync();
+  } catch {
+    // best-effort
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
+async function fsyncDirBestEffort(dirPath: string): Promise<void> {
+  let handle: fs.promises.FileHandle | undefined;
+  try {
+    handle = await fs.promises.open(dirPath, "r");
+    await handle.sync();
+  } catch {
+    // best-effort (some platforms/filesystems disallow directory fsync)
+  } finally {
+    await handle?.close().catch(() => undefined);
+  }
+}
+
 export async function saveCronStore(
   storePath: string,
   store: CronStoreFile,
@@ -91,6 +115,9 @@ export async function saveCronStore(
   const tmp = `${storePath}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`;
   await fs.promises.writeFile(tmp, json, { encoding: "utf-8", mode: 0o600 });
   await setSecureFileMode(tmp);
+  // Durability guard: flush tmp file before rename so a restart after write/rename
+  // doesn't lose a just-added job on filesystems with delayed write-back.
+  await fsyncPathBestEffort(tmp);
   if (previous !== null && !opts?.skipBackup) {
     try {
       const backupPath = `${storePath}.bak`;
@@ -101,6 +128,10 @@ export async function saveCronStore(
     }
   }
   await renameWithRetry(tmp, storePath);
+  // Keep this even though tmp was fsynced above: on Windows EPERM/EEXIST fallback,
+  // renameWithRetry copies tmp -> dest, creating a fresh dest inode that needs sync.
+  await fsyncPathBestEffort(storePath);
+  await fsyncDirBestEffort(storeDir);
   await setSecureFileMode(storePath);
   serializedStoreCache.set(storePath, json);
 }


### PR DESCRIPTION
## Summary
- fsync temp cron store file before rename/copy promotion
- fsync final store path after promotion (critical for Windows copy fallback path)
- best-effort fsync parent cron directory after store update
- add regression test asserting tmp/final/dir fsync attempts

## Why
Issue #37605 reports jobs created shortly before restart being lost. This hardens cron persistence durability against delayed write-back and restart windows.

## Validation
- pnpm -s test src/cron/store.test.ts
- pnpm -s check

Fixes #37605
