### PR TITLE
fix: treat undefined/null rejection reasons as non-fatal

### DIFF
--- a/src/infra/unhandled-rejections.fatal-detection.test.ts
+++ b/src/infra/unhandled-rejections.fatal-detection.test.ts
@@ -152,5 +152,21 @@ describe("installUnhandledRejectionHandler - fatal detection", () => {
         expect.stringContaining("This operation was aborted"),
       );
     });
+
+    it("does not exit on undefined rejection reason", () => {
+      expectExitCodeFromUnhandled(undefined, []);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[openclaw] Non-fatal unhandled rejection (undefined reason, continuing):",
+        undefined,
+      );
+    });
+
+    it("does not exit on null rejection reason", () => {
+      expectExitCodeFromUnhandled(null, []);
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[openclaw] Non-fatal unhandled rejection (undefined reason, continuing):",
+        "null",
+      );
+    });
   });
 });

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -236,6 +236,20 @@ export function installUnhandledRejectionHandler(): void {
       return;
     }
 
+    // Rejections with undefined/null/empty reasons are unclassifiable — they typically
+    // originate from third-party libraries (e.g. @slack/socket-mode) calling reject()
+    // without an error argument. Crashing on these is disproportionate since we can't
+    // determine severity. Log and continue; the originating subsystem's own retry logic
+    // (e.g. Slack socket reconnect) will handle recovery.
+    // See: https://github.com/openclaw/openclaw/issues/21082
+    if (reason === undefined || reason === null) {
+      console.warn(
+        "[openclaw] Non-fatal unhandled rejection (undefined reason, continuing):",
+        formatUncaughtError(reason),
+      );
+      return;
+    }
+
     console.error("[openclaw] Unhandled promise rejection:", formatUncaughtError(reason));
     process.exit(1);
   });


### PR DESCRIPTION
## Summary

- Treat `undefined`/`null` rejection reasons as non-fatal warnings instead of crashing the gateway with `process.exit(1)`
- Add test coverage for both `undefined` and `null` rejection cases

## Problem

When `@slack/socket-mode`'s internal WebSocket handling encounters a TLS disconnect, it can emit a promise rejection with `undefined` as the reason (i.e., `reject()` called without an argument). The current `installUnhandledRejectionHandler` cannot classify these rejections — they aren't AbortErrors, fatal errors, config errors, or transient network errors — so they fall through to the catch-all `process.exit(1)`.

This crashes the **entire gateway**, taking down all channels, agents, cron jobs, and plugins — not just Slack.

In Docker environments with `restart: unless-stopped`, this creates a tight crash-restart loop that can saturate all CPUs and make the host unreachable via SSH.

### Crash log

```
[ERROR]  socket-mode:SlackWebSocket:29 WebSocket error occurred: Client network socket disconnected before secure TLS connection was established
[ERROR]  socket-mode:SocketModeClient:18 WebSocket error! Error: Client network socket disconnected before secure TLS connection was established
[slack]  socket disconnected (error). retry 1/12 in 2s (...)
[openclaw] Unhandled promise rejection: undefined
```

Note: the Slack monitor's own reconnect logic (`waitForSlackSocketDisconnect`) correctly catches the error event and would retry — but the global handler kills the process before that can happen.

## Fix

When `reason` is `undefined` or `null`, we can't determine severity, so the safest behavior is to log a warning and continue. The originating subsystem's retry logic (Slack's 12-attempt backoff) handles recovery.

This is consistent with the existing philosophy — the handler already has a non-fatal path for transient network errors and AbortErrors.

## Test plan

- [x] Added tests for `undefined` rejection reason → does not exit, logs warning
- [x] Added tests for `null` rejection reason → does not exit, logs warning  
- [x] All 37 existing tests in `unhandled-rejections*.test.ts` continue to pass
- [x] Fatal errors (OOM, config) still correctly trigger `process.exit(1)`

Fixes #21082