### PR TITLE
feat(models): improve gpt-5.4 codex defaults and add chatgpt provider alias

### DIFF
--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -363,8 +363,23 @@ describe("resolveForwardCompatModel", () => {
     expectResolvedForwardCompat(model, { provider: "openai-codex", id: "gpt-5.4" });
     expect(model?.api).toBe("openai-codex-responses");
     expect(model?.baseUrl).toBe("https://chatgpt.com/backend-api");
-    expect(model?.contextWindow).toBe(272_000);
+    expect(model?.contextWindow).toBe(1_050_000);
     expect(model?.maxTokens).toBe(128_000);
+  });
+
+  it("resolves openai-codex gpt-5.4 without templates using gpt-5.4 defaults", () => {
+    const registry = createRegistry({});
+
+    const model = resolveForwardCompatModel("openai-codex", "gpt-5.4", registry);
+
+    expectResolvedForwardCompat(model, { provider: "openai-codex", id: "gpt-5.4" });
+    expect(model?.api).toBe("openai-codex-responses");
+    expect(model?.baseUrl).toBe("https://chatgpt.com/backend-api");
+    expect(model?.input).toEqual(["text", "image"]);
+    expect(model?.reasoning).toBe(true);
+    expect(model?.contextWindow).toBe(1_050_000);
+    expect(model?.maxTokens).toBe(128_000);
+    expect(model?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
   });
 
   it("resolves anthropic opus 4.6 via 4.5 template", () => {

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -12,6 +12,8 @@ const OPENAI_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.2"] as const;
 const OPENAI_GPT_54_PRO_TEMPLATE_MODEL_IDS = ["gpt-5.2-pro", "gpt-5.2"] as const;
 
 const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
+const OPENAI_CODEX_GPT_54_CONTEXT_TOKENS = 1_050_000;
+const OPENAI_CODEX_GPT_54_MAX_TOKENS = 128_000;
 const OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex", "gpt-5.2-codex"] as const;
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
@@ -146,9 +148,16 @@ function resolveOpenAICodexForwardCompatModel(
       ...template,
       id: trimmedModelId,
       name: trimmedModelId,
+      ...(lower === OPENAI_CODEX_GPT_54_MODEL_ID
+        ? {
+            contextWindow: OPENAI_CODEX_GPT_54_CONTEXT_TOKENS,
+            maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
+          }
+        : {}),
     } as Model<Api>);
   }
 
+  const usesGpt54Defaults = lower === OPENAI_CODEX_GPT_54_MODEL_ID;
   return normalizeModelCompat({
     id: trimmedModelId,
     name: trimmedModelId,
@@ -158,8 +167,8 @@ function resolveOpenAICodexForwardCompatModel(
     reasoning: true,
     input: ["text", "image"],
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_TOKENS,
-    maxTokens: DEFAULT_CONTEXT_TOKENS,
+    contextWindow: usesGpt54Defaults ? OPENAI_CODEX_GPT_54_CONTEXT_TOKENS : DEFAULT_CONTEXT_TOKENS,
+    maxTokens: usesGpt54Defaults ? OPENAI_CODEX_GPT_54_MAX_TOKENS : DEFAULT_CONTEXT_TOKENS,
   } as Model<Api>);
 }
 

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -58,6 +58,7 @@ describe("model-selection", () => {
       expect(normalizeProviderId("z-ai")).toBe("zai");
       expect(normalizeProviderId("OpenCode-Zen")).toBe("opencode");
       expect(normalizeProviderId("qwen")).toBe("qwen-portal");
+      expect(normalizeProviderId("chatgpt")).toBe("openai-codex");
       expect(normalizeProviderId("kimi-code")).toBe("kimi-coding");
       expect(normalizeProviderId("bedrock")).toBe("amazon-bedrock");
       expect(normalizeProviderId("aws-bedrock")).toBe("amazon-bedrock");

--- a/src/agents/model-selection.ts
+++ b/src/agents/model-selection.ts
@@ -48,6 +48,9 @@ export function normalizeProviderId(provider: string): string {
   if (normalized === "qwen") {
     return "qwen-portal";
   }
+  if (normalized === "chatgpt") {
+    return "openai-codex";
+  }
   if (normalized === "kimi-code") {
     return "kimi-coding";
   }


### PR DESCRIPTION
## Summary
- add forward-compat defaults for `openai-codex/gpt-5.4` to use **1,050,000** context and **128,000** max tokens
- ensure fallback path (when no template model is present) also uses gpt-5.4 defaults
- add provider alias normalization: `chatgpt` -> `openai-codex`
- extend tests for both behaviors

## Why
`openai-codex/gpt-5.4` could be configured but runtime characteristics and alias handling were incomplete in some flows.
This aligns behavior with current model expectations and improves UX for users who type `chatgpt/...` style provider refs.

## Validation
- `npx vitest run src/agents/model-compat.test.ts src/agents/model-selection.test.ts`
- both test files pass locally (73 tests)
