### PR TITLE
fix(browser): use local chrome relay defaults in gateway.mode=remote

### DIFF
--- a/src/browser/config.test.ts
+++ b/src/browser/config.test.ts
@@ -59,6 +59,19 @@ describe("browser config", () => {
     });
   });
 
+  it("keeps local browser relay defaults when gateway.mode=remote", () => {
+    withEnv({ OPENCLAW_GATEWAY_PORT: undefined }, () => {
+      const resolved = resolveBrowserConfig(undefined, {
+        gateway: { mode: "remote", port: 443 },
+      });
+      expect(resolved.controlPort).toBe(18791);
+      const chrome = resolveProfile(resolved, "chrome");
+      expect(chrome?.driver).toBe("extension");
+      expect(chrome?.cdpPort).toBe(18792);
+      expect(chrome?.cdpUrl).toBe("http://127.0.0.1:18792");
+    });
+  });
+
   it("supports overriding the local CDP auto-allocation range start", () => {
     const resolved = resolveBrowserConfig({
       cdpPortRangeStart: 19000,

--- a/src/browser/config.ts
+++ b/src/browser/config.ts
@@ -1,5 +1,5 @@
 import type { BrowserConfig, BrowserProfileConfig, OpenClawConfig } from "../config/config.js";
-import { resolveGatewayPort } from "../config/paths.js";
+import { DEFAULT_GATEWAY_PORT, resolveGatewayPort } from "../config/paths.js";
 import {
   deriveDefaultBrowserCdpPortRange,
   deriveDefaultBrowserControlPort,
@@ -208,7 +208,17 @@ export function resolveBrowserConfig(
   const enabled = cfg?.enabled ?? DEFAULT_OPENCLAW_BROWSER_ENABLED;
   const evaluateEnabled = cfg?.evaluateEnabled ?? DEFAULT_BROWSER_EVALUATE_ENABLED;
   const gatewayPort = resolveGatewayPort(rootConfig);
-  const controlPort = deriveDefaultBrowserControlPort(gatewayPort ?? DEFAULT_BROWSER_CONTROL_PORT);
+  // In gateway.mode=remote, gateway.port often points to a remote ingress port (e.g. 443).
+  // Browser relay/control ports remain local on the current host, so derive defaults from
+  // the local gateway default unless browser ports are explicitly configured.
+  const gatewayMode =
+    typeof rootConfig?.gateway?.mode === "string"
+      ? rootConfig.gateway.mode.trim().toLowerCase()
+      : undefined;
+  const browserPortBase = gatewayMode === "remote" ? DEFAULT_GATEWAY_PORT : gatewayPort;
+  const controlPort = deriveDefaultBrowserControlPort(
+    browserPortBase ?? DEFAULT_BROWSER_CONTROL_PORT,
+  );
   const defaultColor = normalizeHexColor(cfg?.color);
   const remoteCdpTimeoutMs = normalizeTimeoutMs(cfg?.remoteCdpTimeoutMs, 1500);
   const remoteCdpHandshakeTimeoutMs = normalizeTimeoutMs(


### PR DESCRIPTION
## Summary
- keep browser relay/control default ports local when `gateway.mode=remote`
- avoid deriving chrome extension profile relay URL from remote gateway ingress port (e.g. 443)
- add coverage for remote gateway mode to ensure chrome profile still resolves to loopback relay defaults

## Why
Issue #37913 reports `profile=chrome` tabs/snapshot returning `tab not found` in node browser.proxy setups where gateway is remote and node host is local. In remote mode, `gateway.port` usually reflects remote ingress, not local relay/control ports.

## Validation
- pnpm -s test src/browser/config.test.ts
- pnpm -s check

Fixes #37913
