### PR TITLE
fix(agents): replace original param with alias in required[] during Claude compat patching

### DIFF
--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -146,7 +146,7 @@ export function patchToolSchemaForClaudeCompatibility(tool: AnyAgentTool): AnyAg
     }
     const idx = required.indexOf(original);
     if (idx !== -1) {
-      required.splice(idx, 1);
+      required.splice(idx, 1, alias);
       changed = true;
     }
   }


### PR DESCRIPTION
## Summary

`patchToolSchemaForClaudeCompatibility` adds snake_case aliases (e.g. `file_path` for `path`) to tool schemas for Claude compatibility, but the current code removes the original parameter name from the `required` array without inserting the alias:

```typescript
// Before (bug): removes original, adds nothing — required becomes []
required.splice(idx, 1);

// After (fix): replaces original with alias — required stays correct
required.splice(idx, 1, alias);
```

This causes all spec-compliant models (Kimi K2.5, Grok, Gemini) to treat tool parameters as optional and send empty `arguments: {}`, breaking tool calls entirely.

Claude works by coincidence because it sends parameters regardless of the `required` array.

## Changes

- **`src/agents/pi-tools.params.ts` line 149**: `splice(idx, 1)` → `splice(idx, 1, alias)`

One-line fix. The downstream `normalizeToolParams` already maps aliases back to internal names, so no other changes are needed.

## Test plan

- [ ] Verify `required` array contains alias names after patching (e.g. `["file_path"]` instead of `[]`)
- [ ] Test tool calling with a non-Claude model (Kimi/Grok/Gemini) — parameters should no longer be empty
- [ ] Verify Claude tool calling still works (no regression)

Closes #37645