### PR TITLE
fix(logging): rotate log file on date change without requiring restart

### DIFF
--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -143,11 +143,28 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
   if (isRollingPath(settings.file)) {
     pruneOldRollingLogs(path.dirname(settings.file));
   }
+  const isRolling = isRollingPath(settings.file);
+  let currentFile = settings.file;
   let currentFileBytes = getCurrentLogFileBytes(settings.file);
   let warnedAboutSizeCap = false;
 
   logger.attachTransport((logObj: LogObj) => {
     try {
+      // Rotate to the new day's log file when the date changes.
+      if (isRolling) {
+        const todayFile = defaultRollingPathForToday();
+        if (todayFile !== currentFile) {
+          fs.mkdirSync(path.dirname(todayFile), { recursive: true });
+          pruneOldRollingLogs(path.dirname(todayFile));
+          currentFile = todayFile;
+          currentFileBytes = getCurrentLogFileBytes(todayFile);
+          warnedAboutSizeCap = false;
+          // Invalidate cached logger so future getLogger() calls rebuild with the new path.
+          loggingState.cachedLogger = null;
+          loggingState.cachedSettings = null;
+        }
+      }
+
       const time = formatLocalIsoWithOffset(logObj.date ?? new Date());
       const line = JSON.stringify({ ...logObj, time });
       const payload = `${line}\n`;
@@ -160,16 +177,16 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
             time: formatLocalIsoWithOffset(new Date()),
             level: "warn",
             subsystem: "logging",
-            message: `log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}`,
+            message: `log file size cap reached; suppressing writes file=${currentFile} maxFileBytes=${settings.maxFileBytes}`,
           });
-          appendLogLine(settings.file, `${warningLine}\n`);
+          appendLogLine(currentFile, `${warningLine}\n`);
           process.stderr.write(
-            `[openclaw] log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}\n`,
+            `[openclaw] log file size cap reached; suppressing writes file=${currentFile} maxFileBytes=${settings.maxFileBytes}\n`,
           );
         }
         return;
       }
-      if (appendLogLine(settings.file, payload)) {
+      if (appendLogLine(currentFile, payload)) {
         currentFileBytes = nextBytes;
       }
     } catch {


### PR DESCRIPTION
## Summary

Long-running gateway processes continue writing to the previous day's log file after midnight. The log transport captures `settings.file` at build time in a closure and never checks whether the date has rolled over. Users must restart the gateway to get logs written to the new day's file.

## Changes

- **`src/logging/logger.ts`**: Add date-rotation check inside the transport callback
  - Track `isRolling` (whether the current path is a date-based rolling path) and `currentFile` (mutable reference to the active log file)
  - On each write, if rolling, compare `defaultRollingPathForToday()` against `currentFile`
  - When the date differs: create the new directory, prune old logs, switch `currentFile`, reset `currentFileBytes` and `warnedAboutSizeCap`
  - Invalidate `loggingState.cachedLogger` / `cachedSettings` so future `getLogger()` calls rebuild cleanly
  - Replace all `settings.file` references inside the transport with `currentFile`

## Design decisions

- The rotation check runs on every log write but is extremely cheap (one string comparison) when the date hasn't changed
- Sub-loggers that cached the old `TsLogger` instance still work because the transport closure itself mutates `currentFile`
- Cache invalidation ensures new sub-loggers created after midnight get the correct path

## Test plan

- [ ] Run gateway across midnight boundary, verify new log file is created automatically
- [ ] Verify `pruneOldRollingLogs` is called on rotation (old logs cleaned up)
- [ ] Verify `currentFileBytes` resets correctly (size cap is per-file, not cumulative)
- [ ] Verify non-rolling log paths (custom `logging.file` config) are unaffected

Closes #37388