### PR TITLE
fix(daemon): include n-managed node in service PATH

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -27,6 +27,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     expect(result).toContain("/home/testuser/.asdf/shims");
     expect(result).toContain("/home/testuser/.local/share/pnpm");
     expect(result).toContain("/home/testuser/.bun/bin");
+    expect(result).toContain("/home/testuser/.n/bin");
   });
 
   it("excludes user bin directories when HOME is undefined on Linux", () => {
@@ -83,6 +84,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
         BUN_INSTALL: "/opt/bun",
         VOLTA_HOME: "/opt/volta",
         ASDF_DATA_DIR: "/opt/asdf",
+        N_PREFIX: "/opt/n",
         NVM_DIR: "/opt/nvm",
         FNM_DIR: "/opt/fnm",
       },
@@ -93,6 +95,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     expect(result).toContain("/opt/bun/bin");
     expect(result).toContain("/opt/volta/bin");
     expect(result).toContain("/opt/asdf/shims");
+    expect(result).toContain("/opt/n/bin");
     expect(result).toContain("/opt/nvm/current/bin");
     expect(result).toContain("/opt/fnm/current/bin");
   });
@@ -117,6 +120,7 @@ describe("getMinimalServicePathParts - Linux user directories", () => {
     expect(result).toContain("/Users/testuser/Library/pnpm"); // pnpm default on macOS
     expect(result).toContain("/Users/testuser/.local/share/pnpm"); // pnpm XDG fallback
     expect(result).toContain("/Users/testuser/.bun/bin");
+    expect(result).toContain("/Users/testuser/.n/bin");
 
     // Should also include macOS system directories
     expect(result).toContain("/opt/homebrew/bin");

--- a/src/daemon/service-env.ts
+++ b/src/daemon/service-env.ts
@@ -84,6 +84,7 @@ function addCommonUserBinDirs(dirs: string[], home: string): void {
   dirs.push(`${home}/.volta/bin`);
   dirs.push(`${home}/.asdf/shims`);
   dirs.push(`${home}/.bun/bin`);
+  dirs.push(`${home}/.n/bin`);
 }
 
 function addCommonEnvConfiguredBinDirs(
@@ -95,6 +96,7 @@ function addCommonEnvConfiguredBinDirs(
   addNonEmptyDir(dirs, appendSubdir(env?.BUN_INSTALL, "bin"));
   addNonEmptyDir(dirs, appendSubdir(env?.VOLTA_HOME, "bin"));
   addNonEmptyDir(dirs, appendSubdir(env?.ASDF_DATA_DIR, "shims"));
+  addNonEmptyDir(dirs, appendSubdir(env?.N_PREFIX, "bin"));
 }
 
 function resolveSystemPathDirs(platform: NodeJS.Platform): string[] {
@@ -128,6 +130,7 @@ export function resolveDarwinUserBinDirs(
   // Env-configured bin roots (override defaults when present).
   // Note: FNM_DIR on macOS defaults to ~/Library/Application Support/fnm
   // Note: PNPM_HOME on macOS defaults to ~/Library/pnpm
+  // Note: n uses N_PREFIX/bin when configured
   addCommonEnvConfiguredBinDirs(dirs, env);
   // nvm: no stable default path, relies on env or user's shell config
   // User must set NVM_DIR and source nvm.sh for it to work


### PR DESCRIPTION
## Summary
- include `N_PREFIX/bin` when building service PATH for supervised environments
- include the default `~/.n/bin` fallback in common user bin directories
- add service-env tests covering `n` on macOS and Linux

## Problem
OpenClaw could install a launchd service using an `n`-managed Node binary in `ProgramArguments`, but the generated service `PATH` omitted `~/.n/bin`. That let the gateway start while later `exec` runs inside the supervised environment could not resolve `node`, `codex`, or `gemini`.

## Testing
- `pnpm vitest run src/daemon/service-env.test.ts`