### PR TITLE
fix(auto-reply): embed Session Startup section in reset prompt to prevent hallucination

### DIFF
--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -290,7 +290,9 @@ export async function runPreparedReply(
   const isBareSessionReset =
     isNewSession &&
     ((baseBodyTrimmedRaw.length === 0 && rawBodyTrimmed.length > 0) || isBareNewOrReset);
-  const baseBodyFinal = isBareSessionReset ? buildBareSessionResetPrompt(cfg, undefined, workspaceDir) : baseBody;
+  const baseBodyFinal = isBareSessionReset
+    ? buildBareSessionResetPrompt(cfg, undefined, workspaceDir)
+    : baseBody;
   const inboundUserContext = buildInboundUserContextPrefix(
     isNewSession
       ? {

--- a/src/auto-reply/reply/get-reply-run.ts
+++ b/src/auto-reply/reply/get-reply-run.ts
@@ -290,7 +290,7 @@ export async function runPreparedReply(
   const isBareSessionReset =
     isNewSession &&
     ((baseBodyTrimmedRaw.length === 0 && rawBodyTrimmed.length > 0) || isBareNewOrReset);
-  const baseBodyFinal = isBareSessionReset ? buildBareSessionResetPrompt(cfg) : baseBody;
+  const baseBodyFinal = isBareSessionReset ? buildBareSessionResetPrompt(cfg, undefined, workspaceDir) : baseBody;
   const inboundUserContext = buildInboundUserContextPrefix(
     isNewSession
       ? {

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { appendCronStyleCurrentTimeLine } from "../../agents/current-time.js";
+import { resolveUserTimezone } from "../../agents/date-time.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { extractSections } from "./post-compaction-context.js";
 
@@ -9,11 +10,33 @@ const BARE_SESSION_RESET_PROMPT_BASE =
 
 const MAX_STARTUP_SECTION_CHARS = 2000;
 
+function formatDateStamp(nowMs: number, timezone: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(nowMs));
+  const year = parts.find((p) => p.type === "year")?.value;
+  const month = parts.find((p) => p.type === "month")?.value;
+  const day = parts.find((p) => p.type === "day")?.value;
+  if (year && month && day) {
+    return `${year}-${month}-${day}`;
+  }
+  return new Date(nowMs).toISOString().slice(0, 10);
+}
+
 /**
  * Try to read the ## Session Startup section from AGENTS.md in the given workspace.
+ * Substitutes YYYY-MM-DD placeholders with the real date so agents read the correct
+ * daily memory files instead of guessing based on training cutoff.
  * Returns the section content or null if not found.
  */
-function readStartupSection(workspaceDir: string): string | null {
+function readStartupSection(
+  workspaceDir: string,
+  cfg?: OpenClawConfig,
+  nowMs?: number,
+): string | null {
   const agentsPath = path.join(workspaceDir, "AGENTS.md");
   try {
     const content = fs.readFileSync(agentsPath, "utf-8");
@@ -21,7 +44,10 @@ function readStartupSection(workspaceDir: string): string | null {
     if (sections.length === 0) {
       return null;
     }
-    const combined = sections.join("\n\n");
+    const resolvedNowMs = nowMs ?? Date.now();
+    const timezone = resolveUserTimezone(cfg?.agents?.defaults?.userTimezone);
+    const dateStamp = formatDateStamp(resolvedNowMs, timezone);
+    const combined = sections.join("\n\n").replaceAll("YYYY-MM-DD", dateStamp);
     return combined.length > MAX_STARTUP_SECTION_CHARS
       ? combined.slice(0, MAX_STARTUP_SECTION_CHARS) + "\n...[truncated]..."
       : combined;
@@ -43,18 +69,18 @@ export function buildBareSessionResetPrompt(
   nowMs?: number,
   workspaceDir?: string,
 ): string {
+  const resolvedNowMs = nowMs ?? Date.now();
   let prompt = BARE_SESSION_RESET_PROMPT_BASE;
 
   if (workspaceDir) {
-    const startupSection = readStartupSection(workspaceDir);
+    const startupSection = readStartupSection(workspaceDir, cfg, resolvedNowMs);
     if (startupSection) {
       prompt +=
-        "\n\nYour Session Startup sequence (follow these steps exactly):\n\n" +
-        startupSection;
+        "\n\nYour Session Startup sequence (follow these steps exactly):\n\n" + startupSection;
     }
   }
 
-  return appendCronStyleCurrentTimeLine(prompt, cfg ?? {}, nowMs ?? Date.now());
+  return appendCronStyleCurrentTimeLine(prompt, cfg ?? {}, resolvedNowMs);
 }
 
 /** @deprecated Use buildBareSessionResetPrompt(cfg) instead */

--- a/src/auto-reply/reply/session-reset-prompt.ts
+++ b/src/auto-reply/reply/session-reset-prompt.ts
@@ -1,20 +1,60 @@
+import fs from "node:fs";
+import path from "node:path";
 import { appendCronStyleCurrentTimeLine } from "../../agents/current-time.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { extractSections } from "./post-compaction-context.js";
 
 const BARE_SESSION_RESET_PROMPT_BASE =
   "A new session was started via /new or /reset. Execute your Session Startup sequence now - read the required files before responding to the user. Then greet the user in your configured persona, if one is provided. Be yourself - use your defined voice, mannerisms, and mood. Keep it to 1-3 sentences and ask what they want to do. If the runtime model differs from default_model in the system prompt, mention the default model. Do not mention internal steps, files, tools, or reasoning.";
 
+const MAX_STARTUP_SECTION_CHARS = 2000;
+
+/**
+ * Try to read the ## Session Startup section from AGENTS.md in the given workspace.
+ * Returns the section content or null if not found.
+ */
+function readStartupSection(workspaceDir: string): string | null {
+  const agentsPath = path.join(workspaceDir, "AGENTS.md");
+  try {
+    const content = fs.readFileSync(agentsPath, "utf-8");
+    const sections = extractSections(content, ["Session Startup"]);
+    if (sections.length === 0) {
+      return null;
+    }
+    const combined = sections.join("\n\n");
+    return combined.length > MAX_STARTUP_SECTION_CHARS
+      ? combined.slice(0, MAX_STARTUP_SECTION_CHARS) + "\n...[truncated]..."
+      : combined;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Build the bare session reset prompt, appending the current date/time so agents
  * know which daily memory files to read during their Session Startup sequence.
- * Without this, agents on /new or /reset guess the date from their training cutoff.
+ *
+ * When workspaceDir is provided, the ## Session Startup section from AGENTS.md is
+ * read and inlined directly into the prompt. This prevents models from hallucinating
+ * file paths instead of following the actual configured startup instructions.
  */
-export function buildBareSessionResetPrompt(cfg?: OpenClawConfig, nowMs?: number): string {
-  return appendCronStyleCurrentTimeLine(
-    BARE_SESSION_RESET_PROMPT_BASE,
-    cfg ?? {},
-    nowMs ?? Date.now(),
-  );
+export function buildBareSessionResetPrompt(
+  cfg?: OpenClawConfig,
+  nowMs?: number,
+  workspaceDir?: string,
+): string {
+  let prompt = BARE_SESSION_RESET_PROMPT_BASE;
+
+  if (workspaceDir) {
+    const startupSection = readStartupSection(workspaceDir);
+    if (startupSection) {
+      prompt +=
+        "\n\nYour Session Startup sequence (follow these steps exactly):\n\n" +
+        startupSection;
+    }
+  }
+
+  return appendCronStyleCurrentTimeLine(prompt, cfg ?? {}, nowMs ?? Date.now());
 }
 
 /** @deprecated Use buildBareSessionResetPrompt(cfg) instead */


### PR DESCRIPTION
## Summary

When a session is reset via `/new` or `/reset`, `buildBareSessionResetPrompt()` generates a vague instruction: "Execute your Session Startup sequence now - read the required files". This relies on the model finding the `## Session Startup` section in the system prompt.

Smaller models (Haiku) follow this correctly, but larger models (Sonnet-class) hallucinate file paths like `/app/config/persona.md` from training data, ignoring the actual configured startup instructions.

## Changes

- **`src/auto-reply/reply/session-reset-prompt.ts`**: Add optional `workspaceDir` parameter to `buildBareSessionResetPrompt()`. When provided, reads `AGENTS.md` from the workspace, extracts the `## Session Startup` section using the existing `extractSections()` utility, and inlines it directly into the prompt.

- **`src/auto-reply/reply/get-reply-run.ts`**: Pass `workspaceDir` (already available in scope) to `buildBareSessionResetPrompt()`.

## Design decisions

- **Backward compatible**: `workspaceDir` is optional; when omitted (e.g. gateway RPC path), the function behaves exactly as before
- **Reuses existing infrastructure**: `extractSections()` from `post-compaction-context.ts` already handles heading parsing, code block tracking, and section extraction
- **Capped at 2000 chars**: Prevents oversized startup sections from bloating the prompt
- **Graceful failure**: If AGENTS.md doesn't exist or has no Session Startup section, falls back to the original generic prompt

## Test plan

- [ ] Configure an agent with `## Session Startup` in AGENTS.md, run `/new` with Sonnet — verify it follows the actual startup instructions instead of hallucinating paths
- [ ] Run `/new` without AGENTS.md — verify original behavior is preserved
- [ ] Run `/new` with Haiku — verify no regression (still works correctly)
- [ ] Verify gateway RPC path (no workspaceDir) still works

Closes #37889