### PR TITLE
fix(agents): always include configured fallbacks in cross-provider model resolution

### DIFF
--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -89,24 +89,6 @@ async function expectFallsBackToHaiku(params: {
   expect(run.mock.calls[1]?.[1]).toBe("claude-haiku-3-5");
 }
 
-function createOverrideFailureRun(params: {
-  overrideProvider: string;
-  overrideModel: string;
-  fallbackProvider: string;
-  fallbackModel: string;
-  firstError: Error;
-}) {
-  return vi.fn().mockImplementation(async (provider, model) => {
-    if (provider === params.overrideProvider && model === params.overrideModel) {
-      throw params.firstError;
-    }
-    if (provider === params.fallbackProvider && model === params.fallbackModel) {
-      return "ok";
-    }
-    throw new Error(`unexpected fallback candidate: ${provider}/${model}`);
-  });
-}
-
 function makeSingleProviderStore(params: {
   provider: string;
   usageStat: NonNullable<AuthProfileStore["usageStats"]>[string];
@@ -270,7 +252,7 @@ describe("runWithModelFallback", () => {
     });
   });
 
-  it("falls back directly to configured primary when an override model fails", async () => {
+  it("falls back through configured fallbacks then to configured primary when an override model fails", async () => {
     const cfg = makeCfg({
       agents: {
         defaults: {
@@ -282,12 +264,11 @@ describe("runWithModelFallback", () => {
       },
     });
 
-    const run = createOverrideFailureRun({
-      overrideProvider: "anthropic",
-      overrideModel: "claude-opus-4-5",
-      fallbackProvider: "openai",
-      fallbackModel: "gpt-4.1-mini",
-      firstError: Object.assign(new Error("unauthorized"), { status: 401 }),
+    const run = vi.fn().mockImplementation(async (provider: string, model: string) => {
+      if (provider === "openai" && model === "gpt-4.1-mini") {
+        return "ok";
+      }
+      throw Object.assign(new Error("unauthorized"), { status: 401 });
     });
 
     const result = await runWithModelFallback({
@@ -300,8 +281,11 @@ describe("runWithModelFallback", () => {
     expect(result.result).toBe("ok");
     expect(result.provider).toBe("openai");
     expect(result.model).toBe("gpt-4.1-mini");
+    // Cross-provider requests now traverse the full configured fallback chain
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4-5"],
+      ["anthropic", "claude-haiku-3-5"],
+      ["openrouter", "openrouter/deepseek-chat"],
       ["openai", "gpt-4.1-mini"],
     ]);
   });
@@ -422,14 +406,13 @@ describe("runWithModelFallback", () => {
     expect(result.attempts[0]?.reason).toBe("billing");
   });
 
-  it("falls back to configured primary for override credential validation errors", async () => {
+  it("falls back through configured fallbacks for override credential validation errors", async () => {
     const cfg = makeCfg();
-    const run = createOverrideFailureRun({
-      overrideProvider: "anthropic",
-      overrideModel: "claude-opus-4",
-      fallbackProvider: "openai",
-      fallbackModel: "gpt-4.1-mini",
-      firstError: new Error('No credentials found for profile "anthropic:default".'),
+    const run = vi.fn().mockImplementation(async (provider: string, model: string) => {
+      if (provider === "openai" && model === "gpt-4.1-mini") {
+        return "ok";
+      }
+      throw new Error('No credentials found for profile "anthropic:default".');
     });
 
     const result = await runWithModelFallback({
@@ -440,18 +423,22 @@ describe("runWithModelFallback", () => {
     });
 
     expect(result.result).toBe("ok");
+    // Cross-provider requests now traverse the configured fallback chain
     expect(run.mock.calls).toEqual([
       ["anthropic", "claude-opus-4"],
+      ["anthropic", "claude-haiku-3-5"],
       ["openai", "gpt-4.1-mini"],
     ]);
   });
 
   it("falls back on unknown model errors", async () => {
     const cfg = makeCfg();
-    const run = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("Unknown model: anthropic/claude-opus-4-6"))
-      .mockResolvedValueOnce("ok");
+    const run = vi.fn().mockImplementation(async (provider: string, model: string) => {
+      if (provider === "openai" && model === "gpt-4.1-mini") {
+        return "ok";
+      }
+      throw new Error(`Unknown model: ${provider}/${model}`);
+    });
 
     const result = await runWithModelFallback({
       cfg,
@@ -460,12 +447,14 @@ describe("runWithModelFallback", () => {
       run,
     });
 
-    // Override model failed with model_not_found → falls back to configured primary.
-    // (Same candidate-resolution path as other override-model failures.)
+    // Override model failed with model_not_found → falls back through configured chain.
     expect(result.result).toBe("ok");
-    expect(run).toHaveBeenCalledTimes(2);
-    expect(run.mock.calls[1]?.[0]).toBe("openai");
-    expect(run.mock.calls[1]?.[1]).toBe("gpt-4.1-mini");
+    expect(run).toHaveBeenCalledTimes(3);
+    expect(run.mock.calls).toEqual([
+      ["anthropic", "claude-opus-4-6"],
+      ["anthropic", "claude-haiku-3-5"],
+      ["openai", "gpt-4.1-mini"],
+    ]);
   });
 
   it("falls back on model not found errors", async () => {
@@ -997,13 +986,13 @@ describe("runWithModelFallback", () => {
       expect(run).toHaveBeenNthCalledWith(2, "groq", "llama-3.3-70b-versatile");
     });
 
-    it("still skips fallbacks when using different provider than config", async () => {
+    it("falls back to configured primary when cross-provider with empty fallbacks", async () => {
       const cfg = makeCfg({
         agents: {
           defaults: {
             model: {
               primary: "anthropic/claude-opus-4-6",
-              fallbacks: [], // Empty fallbacks to match working pattern
+              fallbacks: [], // No configured fallbacks
             },
           },
         },
@@ -1021,11 +1010,44 @@ describe("runWithModelFallback", () => {
         run,
       });
 
-      // Cross-provider requests should skip configured fallbacks but still try configured primary
+      // Cross-provider requests with no configured fallbacks still try configured primary
       expect(result.result).toBe("config primary worked");
       expect(run).toHaveBeenCalledTimes(2);
       expect(run).toHaveBeenNthCalledWith(1, "openai", "gpt-4.1-mini"); // Original request
       expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-opus-4-6"); // Config primary as final fallback
+    });
+
+    it("includes configured fallbacks for cross-provider requests", async () => {
+      const cfg = makeCfg({
+        agents: {
+          defaults: {
+            model: {
+              primary: "anthropic/claude-opus-4-6",
+              fallbacks: ["anthropic/claude-sonnet-4-6"],
+            },
+          },
+        },
+      });
+
+      const run = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("xai failure"))
+        .mockRejectedValueOnce(new Error("sonnet failure"))
+        .mockResolvedValueOnce("opus success");
+
+      const result = await runWithModelFallback({
+        cfg,
+        provider: "xai",
+        model: "grok-4-1-fast-reasoning-latest",
+        run,
+      });
+
+      // Cross-provider requests should now include configured fallbacks
+      expect(result.result).toBe("opus success");
+      expect(run).toHaveBeenCalledTimes(3);
+      expect(run).toHaveBeenNthCalledWith(1, "xai", "grok-4-1-fast-reasoning-latest");
+      expect(run).toHaveBeenNthCalledWith(2, "anthropic", "claude-sonnet-4-6");
+      expect(run).toHaveBeenNthCalledWith(3, "anthropic", "claude-opus-4-6");
     });
 
     it("uses fallbacks when session model exactly matches config primary", async () => {

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -181,10 +181,6 @@ async function runFallbackAttempt<T>(params: {
   return { error: runResult.error };
 }
 
-function sameModelCandidate(a: ModelCandidate, b: ModelCandidate): boolean {
-  return a.provider === b.provider && a.model === b.model;
-}
-
 function throwFallbackFailureSummary(params: {
   attempts: FallbackAttempt[];
   candidates: ModelCandidate[];
@@ -276,7 +272,6 @@ function resolveFallbackCandidates(params: {
   const providerRaw = String(params.provider ?? "").trim() || defaultProvider;
   const modelRaw = String(params.model ?? "").trim() || defaultModel;
   const normalizedPrimary = normalizeModelRef(providerRaw, modelRaw);
-  const configuredPrimary = normalizeModelRef(defaultProvider, defaultModel);
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg ?? {},
     defaultProvider,
@@ -296,20 +291,9 @@ function resolveFallbackCandidates(params: {
     const configuredFallbacks = resolveAgentModelFallbackValues(
       params.cfg?.agents?.defaults?.model,
     );
-    // When user runs a different provider than config, only use configured fallbacks
-    // if the current model is already in that chain (e.g. session on first fallback).
-    if (normalizedPrimary.provider !== configuredPrimary.provider) {
-      const isConfiguredFallback = configuredFallbacks.some((raw) => {
-        const resolved = resolveModelRefFromString({
-          raw: String(raw ?? ""),
-          defaultProvider,
-          aliasIndex,
-        });
-        return resolved ? sameModelCandidate(resolved.ref, normalizedPrimary) : false;
-      });
-      return isConfiguredFallback ? configuredFallbacks : [];
-    }
-    // Same provider: always use full fallback chain (model version differences within provider).
+    // Always use configured fallbacks regardless of provider mismatch.
+    // Cross-provider requests (e.g. xai/grok when config is anthropic/claude)
+    // should still fall back through the configured chain before giving up.
     return configuredFallbacks;
   })();
 


### PR DESCRIPTION
## Summary

`resolveFallbackCandidates()` contains a cross-provider guard that empties the configured fallback chain when the requested model's provider differs from the configured primary's provider. For example, when using `xai/grok-4-1-fast-reasoning-latest` with a primary of `anthropic/claude-opus-4-6`, the guard checks if the requested model is already in the configured fallback list — and since it isn't, returns an empty fallback array.

This causes two problems:

1. **Cost escalation**: The candidate list becomes `[xai/grok-4-1-fast-reasoning-latest, anthropic/claude-opus-4-6]`, skipping the configured `anthropic/claude-sonnet-4-6` fallback entirely. If the Grok model fails, it jumps directly to the most expensive model.

2. **Tool permission bypass**: When fallback reaches the primary model, tool permissions are resolved against the primary's provider policy, not the originally-requested model's. A `deny: [gateway, cron, exec]` list configured for `xai/*` is never consulted.

## Changes

- **`src/agents/model-fallback.ts`**: Remove the cross-provider guard in `resolveFallbackCandidates()`. Configured fallbacks are now always included in the candidate list regardless of provider mismatch.

The guard was originally added to prevent fallback chain pollution when switching providers, but in practice it causes worse behavior (silent cost escalation and permission bypass) than the problem it tried to prevent.

## Test plan

- [ ] Configure fallbacks `[claude-sonnet-4-6]` with primary `claude-opus-4-6`
- [ ] Override model to `xai/grok-4-1-fast-reasoning-latest`
- [ ] Trigger a model failure — verify it falls back to Sonnet before Opus
- [ ] Verify tool permissions from the requested model's provider are preserved during fallback
- [ ] Verify same-provider fallback still works correctly (no regression)

Closes #37813