### PR TITLE
feat: enforce minRunTimeoutSeconds floor for sessions_spawn

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1815,6 +1815,7 @@ Notes:
         model: "minimax/MiniMax-M2.1",
         maxConcurrent: 1,
         runTimeoutSeconds: 900,
+        minRunTimeoutSeconds: 120,
         archiveAfterMinutes: 60,
       },
     },
@@ -1824,6 +1825,7 @@ Notes:
 
 - `model`: default model for spawned sub-agents. If omitted, sub-agents inherit the caller's model.
 - `runTimeoutSeconds`: default timeout (seconds) for `sessions_spawn` when the tool call omits `runTimeoutSeconds`. `0` means no timeout.
+- `minRunTimeoutSeconds`: floor (seconds) for positive sub-agent timeouts, including fallback from `runTimeoutSeconds`; `0` remains no timeout.
 - Per-subagent tool policy: `tools.subagents.tools.allow` / `tools.subagents.tools.deny`.
 
 ---

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -74,6 +74,7 @@ Use `sessions_spawn`:
 - Default model: inherits the caller unless you set `agents.defaults.subagents.model` (or per-agent `agents.list[].subagents.model`); an explicit `sessions_spawn.model` still wins.
 - Default thinking: inherits the caller unless you set `agents.defaults.subagents.thinking` (or per-agent `agents.list[].subagents.thinking`); an explicit `sessions_spawn.thinking` still wins.
 - Default run timeout: if `sessions_spawn.runTimeoutSeconds` is omitted, OpenClaw uses `agents.defaults.subagents.runTimeoutSeconds` when set; otherwise it falls back to `0` (no timeout).
+- Minimum run timeout floor: if `agents.defaults.subagents.minRunTimeoutSeconds` is set, positive timeouts are clamped up to that floor; `0` remains `0` (no timeout).
 
 Tool params:
 
@@ -152,6 +153,7 @@ By default, sub-agents cannot spawn their own sub-agents (`maxSpawnDepth: 1`). Y
         maxChildrenPerAgent: 5, // max active children per agent session (default: 5)
         maxConcurrent: 8, // global concurrency lane cap (default: 8)
         runTimeoutSeconds: 900, // default timeout for sessions_spawn when omitted (0 = no timeout)
+        minRunTimeoutSeconds: 120, // floor for positive run timeouts (0 keeps no-timeout behavior)
       },
     },
   },

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-min-timeout.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-min-timeout.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
+
+type SessionsSpawnConfig = ReturnType<(typeof import("../config/config.js"))["loadConfig"]>;
+type GatewayCall = { method?: string; params?: Record<string, unknown> };
+
+const callGatewayMock = vi.fn();
+let configOverride: SessionsSpawnConfig = {
+  routing: {
+    sessions: {
+      mainKey: "agent:test:main",
+    },
+  },
+};
+
+function setSubagentConfig(subagents?: Record<string, unknown>) {
+  configOverride = {
+    routing: {
+      sessions: {
+        mainKey: "agent:test:main",
+      },
+    },
+    ...(subagents
+      ? {
+          agents: {
+            defaults: {
+              subagents,
+            },
+          },
+        }
+      : {}),
+  } as SessionsSpawnConfig;
+}
+
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => configOverride,
+  };
+});
+
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+vi.mock("../plugins/hook-runner-global.js", () => ({
+  getGlobalHookRunner: () => null,
+}));
+
+function findLastCall(calls: GatewayCall[], predicate: (call: GatewayCall) => boolean) {
+  for (let i = calls.length - 1; i >= 0; i -= 1) {
+    const call = calls[i];
+    if (call && predicate(call)) {
+      return call;
+    }
+  }
+  return undefined;
+}
+
+async function runSpawnAndReadTimeout(params: {
+  callId: string;
+  runTimeoutSeconds: number;
+  subagentsConfig?: Record<string, unknown>;
+}) {
+  setSubagentConfig(params.subagentsConfig);
+
+  const tool = createSessionsSpawnTool({ agentSessionKey: "agent:test:main" });
+  const result = await tool.execute(params.callId, {
+    task: "hello",
+    runTimeoutSeconds: params.runTimeoutSeconds,
+  });
+  expect(result.details).toMatchObject({ status: "accepted" });
+
+  const calls = callGatewayMock.mock.calls.map((call) => call[0] as GatewayCall);
+  const agentCall = findLastCall(calls, (call) => call.method === "agent");
+  return agentCall?.params?.timeout;
+}
+
+describe("sessions_spawn minRunTimeoutSeconds floor", () => {
+  beforeEach(() => {
+    setSubagentConfig();
+    callGatewayMock.mockReset();
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as GatewayCall;
+      if (request.method === "agent") {
+        return { runId: "run-123" };
+      }
+      return {};
+    });
+  });
+
+  it("clamps positive timeout up when below floor", async () => {
+    const timeout = await runSpawnAndReadTimeout({
+      callId: "call-1",
+      runTimeoutSeconds: 120,
+      subagentsConfig: { minRunTimeoutSeconds: 300 },
+    });
+
+    expect(timeout).toBe(300);
+  });
+
+  it("keeps positive timeout unchanged when above floor", async () => {
+    const timeout = await runSpawnAndReadTimeout({
+      callId: "call-2",
+      runTimeoutSeconds: 600,
+      subagentsConfig: { minRunTimeoutSeconds: 300 },
+    });
+
+    expect(timeout).toBe(600);
+  });
+
+  it("keeps timeout=0 unchanged even when floor is set", async () => {
+    const timeout = await runSpawnAndReadTimeout({
+      callId: "call-3",
+      runTimeoutSeconds: 0,
+      subagentsConfig: { minRunTimeoutSeconds: 300 },
+    });
+
+    expect(timeout).toBe(0);
+  });
+
+  it("keeps timeout unchanged when floor is not configured", async () => {
+    const timeout = await runSpawnAndReadTimeout({
+      callId: "call-4",
+      runTimeoutSeconds: 120,
+    });
+
+    expect(timeout).toBe(120);
+  });
+});

--- a/src/agents/openclaw-tools.subagents.sessions-spawn-min-timeout.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn-min-timeout.test.ts
@@ -60,16 +60,19 @@ function findLastCall(calls: GatewayCall[], predicate: (call: GatewayCall) => bo
 
 async function runSpawnAndReadTimeout(params: {
   callId: string;
-  runTimeoutSeconds: number;
+  runTimeoutSeconds?: number;
   subagentsConfig?: Record<string, unknown>;
 }) {
   setSubagentConfig(params.subagentsConfig);
 
   const tool = createSessionsSpawnTool({ agentSessionKey: "agent:test:main" });
-  const result = await tool.execute(params.callId, {
+  const spawnArgs: { task: string; runTimeoutSeconds?: number } = {
     task: "hello",
-    runTimeoutSeconds: params.runTimeoutSeconds,
-  });
+  };
+  if (typeof params.runTimeoutSeconds === "number") {
+    spawnArgs.runTimeoutSeconds = params.runTimeoutSeconds;
+  }
+  const result = await tool.execute(params.callId, spawnArgs);
   expect(result.details).toMatchObject({ status: "accepted" });
 
   const calls = callGatewayMock.mock.calls.map((call) => call[0] as GatewayCall);
@@ -124,6 +127,15 @@ describe("sessions_spawn minRunTimeoutSeconds floor", () => {
     const timeout = await runSpawnAndReadTimeout({
       callId: "call-4",
       runTimeoutSeconds: 120,
+    });
+
+    expect(timeout).toBe(120);
+  });
+
+  it("floor applies to cfgSubagentTimeout fallback when agent omits runTimeoutSeconds", async () => {
+    const timeout = await runSpawnAndReadTimeout({
+      callId: "call-5",
+      subagentsConfig: { runTimeoutSeconds: 60, minRunTimeoutSeconds: 120 },
     });
 
     expect(timeout).toBe(120);

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -207,10 +207,19 @@ export async function spawnSubagentDirect(
     Number.isFinite(cfg.agents.defaults.subagents.runTimeoutSeconds)
       ? Math.max(0, Math.floor(cfg.agents.defaults.subagents.runTimeoutSeconds))
       : 0;
-  const runTimeoutSeconds =
+  const cfgMinRunTimeout =
+    typeof cfg?.agents?.defaults?.subagents?.minRunTimeoutSeconds === "number" &&
+    Number.isFinite(cfg.agents.defaults.subagents.minRunTimeoutSeconds)
+      ? Math.max(0, Math.floor(cfg.agents.defaults.subagents.minRunTimeoutSeconds))
+      : 0;
+  let runTimeoutSeconds =
     typeof params.runTimeoutSeconds === "number" && Number.isFinite(params.runTimeoutSeconds)
       ? Math.max(0, Math.floor(params.runTimeoutSeconds))
       : cfgSubagentTimeout;
+  // runTimeoutSeconds === 0 means 'no timeout' and is intentionally exempt from the floor
+  if (cfgMinRunTimeout > 0 && runTimeoutSeconds > 0) {
+    runTimeoutSeconds = Math.max(runTimeoutSeconds, cfgMinRunTimeout);
+  }
   let modelApplied = false;
   let threadBindingReady = false;
   const { mainKey, alias } = resolveMainSessionAlias(cfg);

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -259,6 +259,8 @@ export type AgentDefaultsConfig = {
     model?: AgentModelConfig;
     /** Default thinking level for spawned sub-agents (e.g. "off", "low", "medium", "high"). */
     thinking?: string;
+    /** Minimum run timeout in seconds for spawned sub-agents (0 disables the floor). */
+    minRunTimeoutSeconds?: number;
     /** Default run timeout in seconds for spawned sub-agents (0 = no timeout). */
     runTimeoutSeconds?: number;
     /** Gateway timeout in ms for sub-agent announce delivery calls (default: 60000). */

--- a/src/config/zod-schema.agent-defaults.ts
+++ b/src/config/zod-schema.agent-defaults.ts
@@ -158,6 +158,7 @@ export const AgentDefaultsSchema = z
         archiveAfterMinutes: z.number().int().positive().optional(),
         model: AgentModelSchema.optional(),
         thinking: z.string().optional(),
+        minRunTimeoutSeconds: z.number().int().min(0).optional(),
         runTimeoutSeconds: z.number().int().min(0).optional(),
         announceTimeoutMs: z.number().int().positive().optional(),
       })


### PR DESCRIPTION
## Problem

Models sometimes pass progressively decreasing `runTimeoutSeconds` values when spawning sub-agents, eventually reaching values so low the agent can't complete any work.

## Solution

Adds a `minRunTimeoutSeconds` config option under `agents.defaults.subagents` that enforces a floor on the run timeout. When both the floor and the agent-provided timeout are positive, the timeout is clamped up to the floor.

`runTimeoutSeconds: 0` (meaning 'no timeout') is intentionally exempt from the floor — this is an explicit opt-out.

### Changes
- `src/config/types.agent-defaults.ts`: Added `minRunTimeoutSeconds?: number`
- `src/config/zod-schema.agent-defaults.ts`: Added Zod validation
- `src/agents/subagent-spawn.ts`: Floor enforcement logic with clear comment
- `src/agents/openclaw-tools.subagents.sessions-spawn-min-timeout.test.ts`: 4 test cases (clamp-up, pass-through, zero-exempt, no-config) with `beforeEach` mock reset

All tests pass.