### PR TITLE
fix(telegram): allow custom providers for sticker vision description cache

### DIFF
--- a/src/media-understanding/providers/image.ts
+++ b/src/media-understanding/providers/image.ts
@@ -2,6 +2,7 @@ import type { Api, Context, Model } from "@mariozechner/pi-ai";
 import { complete } from "@mariozechner/pi-ai";
 import { minimaxUnderstandImage } from "../../agents/minimax-vlm.js";
 import { getApiKeyForModel, requireApiKey } from "../../agents/model-auth.js";
+import { normalizeProviderId } from "../../agents/model-selection.js";
 import { ensureOpenClawModelsJson } from "../../agents/models-config.js";
 import { coerceImageAssistantText } from "../../agents/tools/image-tool.helpers.js";
 import type { ImageDescriptionRequest, ImageDescriptionResult } from "../types.js";
@@ -22,7 +23,17 @@ export async function describeImageWithModel(
   const { discoverAuthStorage, discoverModels } = await loadPiModelDiscoveryRuntime();
   const authStorage = discoverAuthStorage(params.agentDir);
   const modelRegistry = discoverModels(authStorage, params.agentDir);
-  const model = modelRegistry.find(params.provider, params.model) as Model<Api> | null;
+  // modelRegistry.find() uses strict equality on provider name, but callers
+  // may pass a normalized (lowercased) provider ID (e.g. "claudeproxy") while
+  // the registry stores the original casing from models.json (e.g. "claudeProxy").
+  // Fall back to case-insensitive matching via getAll() when strict find fails.
+  const normalizedProvider = normalizeProviderId(params.provider);
+  const model = (modelRegistry.find(params.provider, params.model) ??
+    modelRegistry
+      .getAll()
+      .find(
+        (m) => normalizeProviderId(m.provider) === normalizedProvider && m.id === params.model,
+      )) as Model<Api> | null;
   if (!model) {
     throw new Error(`Unknown model: ${params.provider}/${params.model}`);
   }

--- a/src/telegram/sticker-cache.ts
+++ b/src/telegram/sticker-cache.ts
@@ -210,15 +210,19 @@ export async function describeStickerImage(params: DescribeStickerParams): Promi
     return preferred ?? entries[0];
   };
 
+  // 1. Try the agent's default model directly (works for custom/proxy providers too)
   let resolved = null as { provider: string; model?: string } | null;
-  if (
-    activeModel &&
-    VISION_PROVIDERS.includes(activeModel.provider as (typeof VISION_PROVIDERS)[number]) &&
-    (await hasProviderKey(activeModel.provider))
-  ) {
+  if (activeModel && (await hasProviderKey(activeModel.provider))) {
     resolved = activeModel;
   }
 
+  // 2. If default model isn't in the catalog but has a key, assume vision support
+  //    (custom providers like OpenAI-compatible proxies typically support vision)
+  if (!resolved && !activeModel && (await hasProviderKey(defaultModel.provider))) {
+    resolved = { provider: defaultModel.provider, model: defaultModel.model };
+  }
+
+  // 3. Fall back to well-known vision providers
   if (!resolved) {
     for (const provider of VISION_PROVIDERS) {
       if (!(await hasProviderKey(provider))) {
@@ -232,6 +236,7 @@ export async function describeStickerImage(params: DescribeStickerParams): Promi
     }
   }
 
+  // 4. Last resort: auto-resolve from image model registry
   if (!resolved) {
     resolved = await resolveAutoImageModel({
       cfg,


### PR DESCRIPTION
## Summary

- `describeStickerImage()` hardcoded a `VISION_PROVIDERS` whitelist (`openai`, `anthropic`, `google`, `minimax`) that blocked custom/proxy providers from being used for sticker descriptions
- Stickers were never cached when using custom providers (e.g. OpenAI-compatible proxies), even though the agent could see the sticker image directly via vision

### New resolution order:
1. Agent's default model if catalog confirms vision support (any provider)
2. Default model even without catalog entry — custom providers typically support vision
3. Well-known vision providers (existing fallback)
4. Auto-resolve from image model registry (existing fallback)

Partially addresses #31486 (custom providers not recognized for vision tasks).

## Test plan

- [x] Existing `sticker-cache.test.ts` passes
- [x] Build succeeds
- [ ] Send sticker with custom provider → sticker description cached to `sticker-cache.json`
- [ ] `sticker-search` returns cached sticker descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)