### PR TITLE
feat: add Local Server Provider for fully custom inference endpoints

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -398,6 +398,77 @@ Then set a model (replace with one of the IDs returned by `/v1/models`):
 
 See [/providers/vllm](/providers/vllm) for details.
 
+### Local Server (fully custom endpoint)
+
+Use this when your inference server exposes a **non-standard API** (not OpenAI-compatible or Anthropic-compatible) — for example, a custom uvicorn/FastAPI server, a research prototype, or any HTTP endpoint you control.
+
+- Provider: any name you choose (e.g. `my-server`)
+- Auth: optional (API key supported)
+- API type: `local-server`
+
+Run the onboarding wizard and select **"Local Server Provider"**:
+
+```bash
+openclaw onboard --auth-choice local-server
+```
+
+The wizard collects:
+
+1. **Endpoint URL** — e.g. `http://100.68.87.28:8000/run-by-cache`
+2. **Model ID** — any label for your model (e.g. `Qwen/Qwen2.5-32B-Instruct`)
+3. **Request body template** — a JSON template with placeholders (`{{prompt}}`, `{{model}}`, `{{max_tokens}}`, `{{messages}}`, `{{system}}`)
+4. **Response path** — dot-path to extract the text from the JSON response (e.g. `response`, `result.text`, `output.generated_text`)
+5. **API key** — optional; leave blank if your server doesn't require auth
+6. **Custom headers** — optional extra headers (e.g. for tenant routing)
+
+Example configuration:
+
+```json5
+{
+  agents: {
+    defaults: { model: { primary: "my-server/my_model" } },
+  },
+  models: {
+    providers: {
+      "my-server": {
+        baseUrl: "http://100.68.87.28:8000/run-by-cache",
+        api: "local-server",
+        localServer: {
+          template: '{"cache_folder": "translation", "input_text": "{{prompt}}", "mode": "chat"}',
+          responsePath: "response",
+        },
+        models: [
+          {
+            id: "my_model",
+            name: "My Local Model",
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 32000,
+            maxTokens: 4096,
+          },
+        ],
+      },
+    },
+  },
+}
+```
+
+**Template placeholders:**
+
+| Placeholder      | Description                       |
+| ---------------- | --------------------------------- |
+| `{{prompt}}`     | Last user message (JSON-escaped)  |
+| `{{model}}`      | Model ID string                   |
+| `{{max_tokens}}` | Max tokens (integer)              |
+| `{{messages}}`   | Full conversation as a JSON array |
+| `{{system}}`     | System prompt string              |
+
+**Notes:**
+
+- Tools are disabled automatically for `local-server` providers (the agent completes after one response).
+- No API key is required; leave the field blank during onboarding if your server doesn't enforce auth.
+- The `responsePath` uses dot notation: `response` extracts the top-level `response` key; `result.text` extracts `result → text`.
+
 ### Local proxies (LM Studio, vLLM, LiteLLM, etc.)
 
 Example (OpenAI‑compatible):

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -1981,7 +1981,7 @@ OpenClaw uses the pi-coding-agent model catalog. Add custom providers via `model
       "custom-proxy": {
         baseUrl: "http://localhost:4000/v1",
         apiKey: "LITELLM_KEY",
-        api: "openai-completions", // openai-completions | openai-responses | anthropic-messages | google-generative-ai
+        api: "openai-completions", // openai-completions | openai-responses | anthropic-messages | google-generative-ai | local-server
         models: [
           {
             id: "llama-3.1-8b",
@@ -2011,7 +2011,10 @@ OpenClaw uses the pi-coding-agent model catalog. Add custom providers via `model
 
 - `models.mode`: provider catalog behavior (`merge` or `replace`).
 - `models.providers`: custom provider map keyed by provider id.
-- `models.providers.*.api`: request adapter (`openai-completions`, `openai-responses`, `anthropic-messages`, `google-generative-ai`, etc).
+- `models.providers.*.api`: request adapter (`openai-completions`, `openai-responses`, `anthropic-messages`, `google-generative-ai`, `local-server`, etc).
+- `models.providers.*.localServer`: required when `api` is `local-server`. Contains:
+  - `template`: JSON request body with placeholders (`{{prompt}}`, `{{model}}`, `{{max_tokens}}`, `{{messages}}`, `{{system}}`).
+  - `responsePath`: dot-path to extract generated text from the JSON response (e.g. `response`, `result.text`).
 - `models.providers.*.apiKey`: provider credential (prefer SecretRef/env substitution).
 - `models.providers.*.auth`: auth strategy (`api-key`, `token`, `oauth`, `aws-sdk`).
 - `models.providers.*.injectNumCtxForOpenAICompat`: for Ollama + `openai-completions`, inject `options.num_ctx` into requests (default: `true`).

--- a/docs/start/onboarding-overview.md
+++ b/docs/start/onboarding-overview.md
@@ -49,3 +49,22 @@ CLI wizard. You will be asked to:
 - Choose an Endpoint ID so multiple custom endpoints can coexist.
 
 For detailed steps, follow the CLI onboarding docs above.
+
+## Local Server Provider
+
+If your inference server exposes a **fully custom (non-standard) API** — such
+as a uvicorn/FastAPI server, a research prototype, or any HTTP endpoint you
+control — choose **Local Server Provider** in the CLI wizard:
+
+```bash
+openclaw onboard --auth-choice local-server
+```
+
+You will be asked to:
+
+- Enter the endpoint URL (e.g. `http://192.168.1.10:8000/infer`).
+- Provide a JSON request body **template** with placeholders like `{{prompt}}`.
+- Specify a **response path** to extract the generated text (e.g. `response`, `result.text`).
+- Optionally enter an API key and custom headers.
+
+See [Model providers — Local Server](/concepts/model-providers#local-server-fully-custom-endpoint) for full configuration details.

--- a/docs/start/wizard.md
+++ b/docs/start/wizard.md
@@ -65,7 +65,8 @@ The wizard starts with **QuickStart** (defaults) vs **Advanced** (full control).
 **Local mode (default)** walks you through these steps:
 
 1. **Model/Auth** — choose any supported provider/auth flow (API key, OAuth, or setup-token), including Custom Provider
-   (OpenAI-compatible, Anthropic-compatible, or Unknown auto-detect). Pick a default model.
+   (OpenAI-compatible, Anthropic-compatible, or Unknown auto-detect), or **Local Server Provider** for fully custom
+   non-standard endpoints (e.g. uvicorn/FastAPI servers). Pick a default model.
    Security note: if this agent will run tools or process webhook/hooks content, prefer the strongest latest-generation model available and keep tool policy strict. Weaker/older tiers are easier to prompt-inject.
    For non-interactive runs, `--secret-input-mode ref` stores env-backed refs in auth profiles instead of plaintext API key values.
    In non-interactive `ref` mode, the provider env var must be set; passing inline key flags without that env var fails fast.

--- a/src/agents/local-server-stream.ts
+++ b/src/agents/local-server-stream.ts
@@ -71,13 +71,15 @@ function escapeForJsonString(value: string): string {
 }
 
 /**
- * Substitute placeholders in the body template with actual values.
+ * Substitute placeholders in the body template with actual values in a single
+ * pass so that content injected by one replacement cannot be matched by a
+ * subsequent placeholder pattern (e.g. a user message containing "{{model}}").
  *
  * String placeholders ({{prompt}}, {{system}}, {{model}}) are escaped so
  * newlines, quotes and other special characters don't break the JSON.
  *
- * Raw placeholders ("{{messages}}" and {{max_tokens}}) replace the whole
- * value including surrounding quotes so the result is valid JSON.
+ * Raw placeholders ({{messages}} and {{max_tokens}}) replace the whole value
+ * including any surrounding quotes so the result is valid JSON.
  */
 function substituteTemplate(
   template: string,
@@ -89,14 +91,25 @@ function substituteTemplate(
     maxTokens: number;
   },
 ): string {
-  return template
-    .replace(/\{\{prompt\}\}/g, escapeForJsonString(params.prompt))
-    .replace(/"\{\{messages\}\}"/g, params.messages)
-    .replace(/\{\{messages\}\}/g, params.messages)
-    .replace(/\{\{system\}\}/g, escapeForJsonString(params.system))
-    .replace(/\{\{model\}\}/g, escapeForJsonString(params.model))
-    .replace(/"\{\{max_tokens\}\}"/g, String(params.maxTokens))
-    .replace(/\{\{max_tokens\}\}/g, String(params.maxTokens));
+  return template.replace(
+    /"?\{\{(prompt|messages|system|model|max_tokens)\}\}"?/g,
+    (match, key) => {
+      switch (key) {
+        case "prompt":
+          return escapeForJsonString(params.prompt);
+        case "messages":
+          return params.messages;
+        case "system":
+          return escapeForJsonString(params.system);
+        case "model":
+          return escapeForJsonString(params.model);
+        case "max_tokens":
+          return String(params.maxTokens);
+        default:
+          return match;
+      }
+    },
+  );
 }
 
 /**

--- a/src/agents/local-server-stream.ts
+++ b/src/agents/local-server-stream.ts
@@ -1,0 +1,225 @@
+import type { StreamFn } from "@mariozechner/pi-agent-core";
+import type { TextContent } from "@mariozechner/pi-ai";
+import { createAssistantMessageEventStream } from "@mariozechner/pi-ai";
+import type { LocalServerBodyTemplate } from "../config/types.models.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import {
+  buildAssistantMessage,
+  buildStreamErrorAssistantMessage,
+  buildUsageWithNoCost,
+} from "./stream-message-shared.js";
+
+const log = createSubsystemLogger("local-server-stream");
+
+function extractTextContent(content: unknown): string {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return (content as Array<{ type: string; text?: string }>)
+    .filter((part) => part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text!)
+    .join("");
+}
+
+function buildPromptFromMessages(
+  messages: Array<{ role: string; content: unknown }>,
+  systemPrompt?: string,
+): string {
+  // Only use the last user message as the prompt, not the full system prompt.
+  // The system prompt is enormous and will break JSON templates.
+  const lastUserMsg = [...messages].toReversed().find((m) => m.role === "user");
+  if (lastUserMsg) {
+    return extractTextContent(lastUserMsg.content);
+  }
+  // Fallback: join all non-system messages
+  const parts: string[] = [];
+  if (systemPrompt) {
+    parts.push(`System: ${systemPrompt}`);
+  }
+  for (const msg of messages) {
+    const text = extractTextContent(msg.content);
+    if (text) {
+      parts.push(`${msg.role}: ${text}`);
+    }
+  }
+  return parts.join("\n\n");
+}
+
+function buildMessagesJson(
+  messages: Array<{ role: string; content: unknown }>,
+  systemPrompt?: string,
+): string {
+  const formatted: Array<{ role: string; content: string }> = [];
+  if (systemPrompt) {
+    formatted.push({ role: "system", content: systemPrompt });
+  }
+  for (const msg of messages) {
+    formatted.push({ role: msg.role, content: extractTextContent(msg.content) });
+  }
+  return JSON.stringify(formatted);
+}
+
+/**
+ * Escape a string value for safe inline substitution inside a JSON string context.
+ * JSON.stringify("hello\nworld") → '"hello\\nworld"' -- we strip the outer quotes.
+ */
+function escapeForJsonString(value: string): string {
+  return JSON.stringify(value).slice(1, -1);
+}
+
+/**
+ * Substitute placeholders in the body template with actual values.
+ *
+ * String placeholders ({{prompt}}, {{system}}, {{model}}) are escaped so
+ * newlines, quotes and other special characters don't break the JSON.
+ *
+ * Raw placeholders ("{{messages}}" and {{max_tokens}}) replace the whole
+ * value including surrounding quotes so the result is valid JSON.
+ */
+function substituteTemplate(
+  template: string,
+  params: {
+    prompt: string;
+    messages: string;
+    system: string;
+    model: string;
+    maxTokens: number;
+  },
+): string {
+  return template
+    .replace(/\{\{prompt\}\}/g, escapeForJsonString(params.prompt))
+    .replace(/"\{\{messages\}\}"/g, params.messages)
+    .replace(/\{\{messages\}\}/g, params.messages)
+    .replace(/\{\{system\}\}/g, escapeForJsonString(params.system))
+    .replace(/\{\{model\}\}/g, escapeForJsonString(params.model))
+    .replace(/"\{\{max_tokens\}\}"/g, String(params.maxTokens))
+    .replace(/\{\{max_tokens\}\}/g, String(params.maxTokens));
+}
+
+/**
+ * Extract a value from a nested object using dot-notation path.
+ * Supports array indexing: "choices.0.message.content"
+ */
+function extractByPath(obj: unknown, path: string): unknown {
+  const segments = path.split(".");
+  let current: unknown = obj;
+  for (const segment of segments) {
+    if (current == null || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+  return current;
+}
+
+export function createLocalServerStreamFn(
+  endpointUrl: string,
+  localServer: LocalServerBodyTemplate,
+  defaultHeaders?: Record<string, string>,
+): StreamFn {
+  return (model, context, options) => {
+    const stream = createAssistantMessageEventStream();
+
+    const run = async () => {
+      try {
+        const messages = context.messages ?? [];
+        const systemPrompt = context.systemPrompt ?? "";
+
+        const prompt = buildPromptFromMessages(messages, systemPrompt);
+        const messagesJson = buildMessagesJson(messages, systemPrompt);
+        const maxTokens = options?.maxTokens ?? model.maxTokens ?? 4096;
+
+        const bodyStr = substituteTemplate(localServer.template, {
+          prompt,
+          messages: messagesJson,
+          system: systemPrompt,
+          model: model.id,
+          maxTokens,
+        });
+
+        let parsedBody: unknown;
+        try {
+          parsedBody = JSON.parse(bodyStr);
+        } catch {
+          throw new Error(
+            `Local server body template produced invalid JSON after substitution: ${bodyStr.slice(0, 200)}`,
+          );
+        }
+
+        const headers: Record<string, string> = {
+          "Content-Type": "application/json",
+          ...defaultHeaders,
+          ...options?.headers,
+        };
+        if (options?.apiKey) {
+          headers.Authorization = `Bearer ${options.apiKey}`;
+        }
+
+        log.info(`POST ${endpointUrl}`);
+
+        const response = await fetch(endpointUrl, {
+          method: "POST",
+          headers,
+          body: JSON.stringify(parsedBody),
+          signal: options?.signal,
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => "unknown error");
+          throw new Error(`Local server error ${response.status}: ${errorText}`);
+        }
+
+        const responseJson = (await response.json()) as unknown;
+
+        const extracted = extractByPath(responseJson, localServer.responsePath);
+
+        let text: string;
+        if (typeof extracted === "string") {
+          text = extracted;
+        } else if (extracted != null) {
+          text = JSON.stringify(extracted);
+        } else {
+          log.warn(
+            `Response path "${localServer.responsePath}" returned null/undefined. ` +
+              `Full response: ${JSON.stringify(responseJson).slice(0, 300)}`,
+          );
+          text = "";
+        }
+
+        const content: TextContent[] = text ? [{ type: "text", text }] : [];
+
+        const assistantMessage = buildAssistantMessage({
+          model: { api: model.api, provider: model.provider, id: model.id },
+          content,
+          stopReason: "stop",
+          usage: buildUsageWithNoCost({}),
+        });
+
+        stream.push({
+          type: "done",
+          reason: "stop",
+          message: assistantMessage,
+        });
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        log.error(`Local server stream error: ${errorMessage}`);
+        stream.push({
+          type: "error",
+          reason: "error",
+          error: buildStreamErrorAssistantMessage({
+            model,
+            errorMessage,
+          }),
+        });
+      } finally {
+        stream.end();
+      }
+    };
+
+    queueMicrotask(() => void run());
+    return stream;
+  };
+}

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -93,11 +93,12 @@ function resolveSyntheticLocalProviderAuth(params: {
   }
 
   // Any provider configured with api=local-server needs no real API key.
-  // Return a synthetic no-op key so the auth check passes.
+  // Return a synthetic auth result with no key so the auth check passes
+  // without injecting a spurious Authorization header.
   const providerConfig = resolveProviderConfig(params.cfg, params.provider);
   if (providerConfig?.api === "local-server") {
     return {
-      apiKey: "local-server-no-auth",
+      apiKey: undefined,
       source: `models.providers.${params.provider} (local-server, no auth required)`,
       mode: "api-key",
     };

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -72,28 +72,38 @@ function resolveSyntheticLocalProviderAuth(params: {
   provider: string;
 }): ResolvedProviderAuth | null {
   const normalizedProvider = normalizeProviderId(params.provider);
-  if (normalizedProvider !== "ollama") {
-    return null;
+
+  if (normalizedProvider === "ollama") {
+    const providerConfig = resolveProviderConfig(params.cfg, params.provider);
+    if (!providerConfig) {
+      return null;
+    }
+    const hasApiConfig =
+      Boolean(providerConfig.api?.trim()) ||
+      Boolean(providerConfig.baseUrl?.trim()) ||
+      (Array.isArray(providerConfig.models) && providerConfig.models.length > 0);
+    if (!hasApiConfig) {
+      return null;
+    }
+    return {
+      apiKey: "ollama-local",
+      source: "models.providers.ollama (synthetic local key)",
+      mode: "api-key",
+    };
   }
 
+  // Any provider configured with api=local-server needs no real API key.
+  // Return a synthetic no-op key so the auth check passes.
   const providerConfig = resolveProviderConfig(params.cfg, params.provider);
-  if (!providerConfig) {
-    return null;
+  if (providerConfig?.api === "local-server") {
+    return {
+      apiKey: "local-server-no-auth",
+      source: `models.providers.${params.provider} (local-server, no auth required)`,
+      mode: "api-key",
+    };
   }
 
-  const hasApiConfig =
-    Boolean(providerConfig.api?.trim()) ||
-    Boolean(providerConfig.baseUrl?.trim()) ||
-    (Array.isArray(providerConfig.models) && providerConfig.models.length > 0);
-  if (!hasApiConfig) {
-    return null;
-  }
-
-  return {
-    apiKey: "ollama-local",
-    source: "models.providers.ollama (synthetic local key)",
-    mode: "api-key",
-  };
+  return null;
 }
 
 function resolveEnvSourceLabel(params: {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -115,7 +115,9 @@ function readConfiguredOptInProviderModels(config: OpenClawConfig): ModelCatalog
   const out: ModelCatalogEntry[] = [];
   for (const [providerRaw, providerValue] of Object.entries(providers)) {
     const provider = providerRaw.toLowerCase().trim();
-    if (!NON_PI_NATIVE_MODEL_PROVIDERS.has(provider)) {
+    const providerApi = (providerValue as { api?: unknown }).api;
+    const isLocalServer = providerApi === "local-server";
+    if (!NON_PI_NATIVE_MODEL_PROVIDERS.has(provider) && !isLocalServer) {
       continue;
     }
     if (!providerValue || typeof providerValue !== "object") {

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -579,7 +579,7 @@ export async function runEmbeddedPiAgent(
         apiKeyInfo = await resolveApiKeyForCandidate(candidate);
         const resolvedProfileId = apiKeyInfo.profileId ?? candidate;
         if (!apiKeyInfo.apiKey) {
-          if (apiKeyInfo.mode !== "aws-sdk") {
+          if (apiKeyInfo.mode !== "aws-sdk" && model.api !== "local-server") {
             throw new Error(
               `No API key resolved for provider "${model.provider}" (auth mode: ${apiKeyInfo.mode}).`,
             );

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -809,7 +809,7 @@ export async function runEmbeddedPiAgent(
             skillsSnapshot: params.skillsSnapshot,
             prompt,
             images: params.images,
-            disableTools: params.disableTools,
+            disableTools: params.disableTools || model.api === "local-server",
             provider,
             modelId,
             model,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -47,6 +47,7 @@ import { DEFAULT_CONTEXT_TOKENS } from "../../defaults.js";
 import { resolveOpenClawDocsPath } from "../../docs-path.js";
 import { isTimeoutError } from "../../failover-error.js";
 import { resolveImageSanitizationLimits } from "../../image-sanitization.js";
+import { createLocalServerStreamFn } from "../../local-server-stream.js";
 import { resolveModelAuthMode } from "../../model-auth.js";
 import { normalizeProviderId, resolveDefaultModelForAgent } from "../../model-selection.js";
 import { createOllamaStreamFn, OLLAMA_NATIVE_BASE_URL } from "../../ollama-stream.js";
@@ -1142,9 +1143,26 @@ export async function runEmbeddedAttempt(
         workspaceDir: params.workspaceDir,
       });
 
-      // Ollama native API: bypass SDK's streamSimple and use direct /api/chat calls
-      // for reliable streaming + tool calling support (#11828).
-      if (params.model.api === "ollama") {
+      // Local server: custom body template + response extraction via direct fetch.
+      if (params.model.api === "local-server") {
+        const providerConfig = params.config?.models?.providers?.[params.model.provider];
+        const localServerCfg = providerConfig?.localServer;
+        if (localServerCfg) {
+          const endpointUrl = providerConfig?.baseUrl ?? params.model.baseUrl ?? "";
+          activeSession.agent.streamFn = createLocalServerStreamFn(
+            endpointUrl,
+            localServerCfg,
+            params.model.headers,
+          );
+        } else {
+          log.warn(
+            `[local-server] provider ${params.model.provider} has api=local-server but no localServer config; falling back to streamSimple`,
+          );
+          activeSession.agent.streamFn = streamSimple;
+        }
+      } else if (params.model.api === "ollama") {
+        // Ollama native API: bypass SDK's streamSimple and use direct /api/chat calls
+        // for reliable streaming + tool calling support (#11828).
         // Prioritize configured provider baseUrl so Docker/remote Ollama hosts work reliably.
         const providerConfig = params.config?.models?.providers?.[params.model.provider];
         const modelBaseUrl =

--- a/src/commands/auth-choice-options.ts
+++ b/src/commands/auth-choice-options.ts
@@ -185,6 +185,12 @@ const AUTH_CHOICE_GROUP_DEFS: {
     hint: "Any OpenAI or Anthropic compatible endpoint",
     choices: ["custom-api-key"],
   },
+  {
+    value: "local-server",
+    label: "Local Server Provider",
+    hint: "Custom inference server with custom body format",
+    choices: ["local-server"],
+  },
 ];
 
 const PROVIDER_AUTH_CHOICE_OPTION_HINTS: Partial<Record<AuthChoice, string>> = {
@@ -298,6 +304,11 @@ const BASE_AUTH_CHOICE_OPTIONS: ReadonlyArray<AuthChoiceOption> = [
     hint: "Official fast tier (legacy: Lightning)",
   },
   { value: "custom-api-key", label: "Custom Provider" },
+  {
+    value: "local-server",
+    label: "Local Server Provider",
+    hint: "Custom inference server (any body format)",
+  },
 ];
 
 export function formatAuthChoiceChoicesForCli(params?: {

--- a/src/commands/auth-choice.apply.local-server.ts
+++ b/src/commands/auth-choice.apply.local-server.ts
@@ -1,28 +1,5 @@
-import type { OpenClawConfig } from "../config/config.js";
 import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
 import { promptAndConfigureLocalServer } from "./local-server-setup.js";
-
-function applyLocalServerDefaultModel(cfg: OpenClawConfig, modelRef: string): OpenClawConfig {
-  const existingModel = cfg.agents?.defaults?.model;
-  const fallbacks =
-    existingModel && typeof existingModel === "object" && "fallbacks" in existingModel
-      ? (existingModel as { fallbacks?: string[] }).fallbacks
-      : undefined;
-
-  return {
-    ...cfg,
-    agents: {
-      ...cfg.agents,
-      defaults: {
-        ...cfg.agents?.defaults,
-        model: {
-          ...(fallbacks ? { fallbacks } : undefined),
-          primary: modelRef,
-        },
-      },
-    },
-  };
-}
 
 export async function applyAuthChoiceLocalServer(
   params: ApplyAuthChoiceParams,
@@ -34,6 +11,7 @@ export async function applyAuthChoiceLocalServer(
   const { config: nextConfig, modelRef } = await promptAndConfigureLocalServer({
     cfg: params.config,
     prompter: params.prompter,
+    setDefaultModel: params.setDefaultModel,
   });
 
   if (!params.setDefaultModel) {
@@ -41,5 +19,5 @@ export async function applyAuthChoiceLocalServer(
   }
 
   await params.prompter.note(`Default model set to ${modelRef}`, "Model configured");
-  return { config: applyLocalServerDefaultModel(nextConfig, modelRef) };
+  return { config: nextConfig };
 }

--- a/src/commands/auth-choice.apply.local-server.ts
+++ b/src/commands/auth-choice.apply.local-server.ts
@@ -1,0 +1,45 @@
+import type { OpenClawConfig } from "../config/config.js";
+import type { ApplyAuthChoiceParams, ApplyAuthChoiceResult } from "./auth-choice.apply.js";
+import { promptAndConfigureLocalServer } from "./local-server-setup.js";
+
+function applyLocalServerDefaultModel(cfg: OpenClawConfig, modelRef: string): OpenClawConfig {
+  const existingModel = cfg.agents?.defaults?.model;
+  const fallbacks =
+    existingModel && typeof existingModel === "object" && "fallbacks" in existingModel
+      ? (existingModel as { fallbacks?: string[] }).fallbacks
+      : undefined;
+
+  return {
+    ...cfg,
+    agents: {
+      ...cfg.agents,
+      defaults: {
+        ...cfg.agents?.defaults,
+        model: {
+          ...(fallbacks ? { fallbacks } : undefined),
+          primary: modelRef,
+        },
+      },
+    },
+  };
+}
+
+export async function applyAuthChoiceLocalServer(
+  params: ApplyAuthChoiceParams,
+): Promise<ApplyAuthChoiceResult | null> {
+  if (params.authChoice !== "local-server") {
+    return null;
+  }
+
+  const { config: nextConfig, modelRef } = await promptAndConfigureLocalServer({
+    cfg: params.config,
+    prompter: params.prompter,
+  });
+
+  if (!params.setDefaultModel) {
+    return { config: nextConfig, agentModelOverride: modelRef };
+  }
+
+  await params.prompter.note(`Default model set to ${modelRef}`, "Model configured");
+  return { config: applyLocalServerDefaultModel(nextConfig, modelRef) };
+}

--- a/src/commands/auth-choice.apply.ts
+++ b/src/commands/auth-choice.apply.ts
@@ -7,6 +7,7 @@ import { applyAuthChoiceBytePlus } from "./auth-choice.apply.byteplus.js";
 import { applyAuthChoiceCopilotProxy } from "./auth-choice.apply.copilot-proxy.js";
 import { applyAuthChoiceGitHubCopilot } from "./auth-choice.apply.github-copilot.js";
 import { applyAuthChoiceGoogleGeminiCli } from "./auth-choice.apply.google-gemini-cli.js";
+import { applyAuthChoiceLocalServer } from "./auth-choice.apply.local-server.js";
 import { applyAuthChoiceMiniMax } from "./auth-choice.apply.minimax.js";
 import { applyAuthChoiceOAuth } from "./auth-choice.apply.oauth.js";
 import { applyAuthChoiceOpenAI } from "./auth-choice.apply.openai.js";
@@ -49,6 +50,7 @@ export async function applyAuthChoice(
     applyAuthChoiceXAI,
     applyAuthChoiceVolcengine,
     applyAuthChoiceBytePlus,
+    applyAuthChoiceLocalServer,
   ];
 
   for (const handler of handlers) {

--- a/src/commands/local-server-setup.ts
+++ b/src/commands/local-server-setup.ts
@@ -17,12 +17,12 @@ const EXAMPLE_BODY_TEMPLATE = `{
 }`;
 
 const PLACEHOLDER_HELP = [
-  "Available placeholders:",
-  "  {{prompt}}     — last user message as plain text",
-  "  {{messages}}   — full conversation as JSON array",
-  "  {{system}}     — system prompt text",
-  "  {{model}}      — model ID string",
-  "  {{max_tokens}} — max tokens number",
+  "Available placeholders (string placeholders must be inside quotes in the template):",
+  '  "{{prompt}}"     — last user message as plain text',
+  '  "{{system}}"     — system prompt text',
+  '  "{{model}}"      — model ID string',
+  "  {{max_tokens}}   — max tokens number (no quotes needed)",
+  "  {{messages}}     — full conversation as JSON array (no quotes needed)",
 ].join("\n");
 
 function normalizeOptionalProviderApiKey(value: unknown): SecretInput | undefined {
@@ -32,12 +32,20 @@ function normalizeOptionalProviderApiKey(value: unknown): SecretInput | undefine
   return normalizeOptionalSecretInput(value);
 }
 
+/**
+ * Validate the template by substituting placeholders with unquoted sentinels
+ * that match what substituteTemplate produces at runtime (i.e. the raw escaped
+ * content, not a pre-quoted string).  This means string placeholders like
+ * {{prompt}} must already be surrounded by quotes in the template:
+ *   correct:   {"input": "{{prompt}}"}
+ *   incorrect: {"input": {{prompt}}}
+ */
 function isValidJsonTemplate(value: string): boolean {
   const stripped = value
-    .replace(/\{\{prompt\}\}/g, '"__placeholder__"')
+    .replace(/\{\{prompt\}\}/g, "__placeholder__")
     .replace(/\{\{messages\}\}/g, "[]")
-    .replace(/\{\{system\}\}/g, '"__placeholder__"')
-    .replace(/\{\{model\}\}/g, '"__placeholder__"')
+    .replace(/\{\{system\}\}/g, "__placeholder__")
+    .replace(/\{\{model\}\}/g, "__placeholder__")
     .replace(/\{\{max_tokens\}\}/g, "512");
   try {
     JSON.parse(stripped);
@@ -50,8 +58,23 @@ function isValidJsonTemplate(value: string): boolean {
 export async function promptAndConfigureLocalServer(params: {
   cfg: OpenClawConfig;
   prompter: WizardPrompter;
+  setDefaultModel?: boolean;
 }): Promise<{ config: OpenClawConfig; modelId: string; modelRef: string }> {
   const { prompter, cfg } = params;
+
+  const providerId = await prompter.text({
+    message: "Provider ID (unique name for this endpoint, e.g. my-server)",
+    placeholder: "my-server",
+    validate: (val) => {
+      if (!val.trim()) {
+        return "Provider ID is required";
+      }
+      if (!/^[a-z0-9][a-z0-9-]*$/.test(val.trim())) {
+        return "Use lowercase letters, digits, and hyphens only (e.g. my-server)";
+      }
+      return undefined;
+    },
+  });
 
   const endpointUrl = await prompter.text({
     message: "Server endpoint URL (full path)",
@@ -84,7 +107,7 @@ export async function promptAndConfigureLocalServer(params: {
         return "Body template is required";
       }
       if (!isValidJsonTemplate(val)) {
-        return "Must be valid JSON (placeholders like {{prompt}} are OK)";
+        return 'Must be valid JSON. String placeholders must be quoted: {"input": "{{prompt}}"}';
       }
       return undefined;
     },
@@ -107,9 +130,10 @@ export async function promptAndConfigureLocalServer(params: {
     placeholder: '{"X-Custom-Header": "value"}',
   });
 
+  const trimmedProviderId = providerId.trim();
   const baseUrl = endpointUrl.trim().replace(/\/+$/, "");
   const trimmedModelId = modelId.trim();
-  const modelRef = `local-server/${trimmedModelId}`;
+  const modelRef = `${trimmedProviderId}/${trimmedModelId}`;
   const apiKey = normalizeOptionalProviderApiKey(apiKeyRaw?.trim() || undefined);
 
   let customHeaders: Record<string, string> | undefined;
@@ -117,6 +141,10 @@ export async function promptAndConfigureLocalServer(params: {
     try {
       customHeaders = JSON.parse(headersRaw.trim()) as Record<string, string>;
     } catch {
+      await prompter.note(
+        "Could not parse headers as JSON — extra headers have been skipped.",
+        "Warning",
+      );
       customHeaders = undefined;
     }
   }
@@ -133,7 +161,7 @@ export async function promptAndConfigureLocalServer(params: {
       mode: cfg.models?.mode ?? "merge",
       providers: {
         ...cfg.models?.providers,
-        "local-server": {
+        [trimmedProviderId]: {
           baseUrl,
           api: "local-server",
           ...(apiKey ? { apiKey } : {}),
@@ -155,7 +183,9 @@ export async function promptAndConfigureLocalServer(params: {
     },
   };
 
-  nextConfig = applyPrimaryModel(nextConfig, modelRef);
+  if (params.setDefaultModel !== false) {
+    nextConfig = applyPrimaryModel(nextConfig, modelRef);
+  }
 
   return { config: nextConfig, modelId: trimmedModelId, modelRef };
 }

--- a/src/commands/local-server-setup.ts
+++ b/src/commands/local-server-setup.ts
@@ -1,0 +1,161 @@
+import type { OpenClawConfig } from "../config/config.js";
+import type { LocalServerBodyTemplate } from "../config/types.models.js";
+import { isSecretRef, type SecretInput } from "../config/types.secrets.js";
+import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
+import type { WizardPrompter } from "../wizard/prompts.js";
+import { applyPrimaryModel } from "./model-picker.js";
+
+const DEFAULT_BASE_URL = "http://127.0.0.1:8000";
+const DEFAULT_CONTEXT_WINDOW = 65536;
+const DEFAULT_MAX_TOKENS = 4096;
+const DEFAULT_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+
+const EXAMPLE_BODY_TEMPLATE = `{
+  "prompt": "{{prompt}}",
+  "max_tokens": 512,
+  "temperature": 0.7
+}`;
+
+const PLACEHOLDER_HELP = [
+  "Available placeholders:",
+  "  {{prompt}}     — last user message as plain text",
+  "  {{messages}}   — full conversation as JSON array",
+  "  {{system}}     — system prompt text",
+  "  {{model}}      — model ID string",
+  "  {{max_tokens}} — max tokens number",
+].join("\n");
+
+function normalizeOptionalProviderApiKey(value: unknown): SecretInput | undefined {
+  if (isSecretRef(value)) {
+    return value;
+  }
+  return normalizeOptionalSecretInput(value);
+}
+
+function isValidJsonTemplate(value: string): boolean {
+  const stripped = value
+    .replace(/\{\{prompt\}\}/g, '"__placeholder__"')
+    .replace(/\{\{messages\}\}/g, "[]")
+    .replace(/\{\{system\}\}/g, '"__placeholder__"')
+    .replace(/\{\{model\}\}/g, '"__placeholder__"')
+    .replace(/\{\{max_tokens\}\}/g, "512");
+  try {
+    JSON.parse(stripped);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function promptAndConfigureLocalServer(params: {
+  cfg: OpenClawConfig;
+  prompter: WizardPrompter;
+}): Promise<{ config: OpenClawConfig; modelId: string; modelRef: string }> {
+  const { prompter, cfg } = params;
+
+  const endpointUrl = await prompter.text({
+    message: "Server endpoint URL (full path)",
+    initialValue: DEFAULT_BASE_URL,
+    placeholder: "http://127.0.0.1:8000/generate",
+    validate: (val) => {
+      try {
+        new URL(val);
+        return undefined;
+      } catch {
+        return "Please enter a valid URL";
+      }
+    },
+  });
+
+  const modelId = await prompter.text({
+    message: "Model identifier (any label for your model)",
+    placeholder: "my-local-model",
+    validate: (val) => (val.trim() ? undefined : "Model ID is required"),
+  });
+
+  await prompter.note(PLACEHOLDER_HELP, "Body template placeholders");
+
+  const bodyTemplate = await prompter.text({
+    message: "Request body template (JSON with placeholders)",
+    initialValue: EXAMPLE_BODY_TEMPLATE,
+    placeholder: '{"prompt": "{{prompt}}"}',
+    validate: (val) => {
+      if (!val.trim()) {
+        return "Body template is required";
+      }
+      if (!isValidJsonTemplate(val)) {
+        return "Must be valid JSON (placeholders like {{prompt}} are OK)";
+      }
+      return undefined;
+    },
+  });
+
+  const responsePath = await prompter.text({
+    message: "Response field path (dot-notation to extract generated text)",
+    initialValue: "result.text",
+    placeholder: "choices.0.message.content",
+    validate: (val) => (val.trim() ? undefined : "Response path is required"),
+  });
+
+  const apiKeyRaw = await prompter.text({
+    message: "API key (leave blank if not required)",
+    placeholder: "sk-... or leave empty",
+  });
+
+  const headersRaw = await prompter.text({
+    message: "Extra headers (JSON object, or leave blank)",
+    placeholder: '{"X-Custom-Header": "value"}',
+  });
+
+  const baseUrl = endpointUrl.trim().replace(/\/+$/, "");
+  const trimmedModelId = modelId.trim();
+  const modelRef = `local-server/${trimmedModelId}`;
+  const apiKey = normalizeOptionalProviderApiKey(apiKeyRaw?.trim() || undefined);
+
+  let customHeaders: Record<string, string> | undefined;
+  if (headersRaw?.trim()) {
+    try {
+      customHeaders = JSON.parse(headersRaw.trim()) as Record<string, string>;
+    } catch {
+      customHeaders = undefined;
+    }
+  }
+
+  const localServerConfig: LocalServerBodyTemplate = {
+    template: bodyTemplate.trim(),
+    responsePath: responsePath.trim(),
+  };
+
+  let nextConfig: OpenClawConfig = {
+    ...cfg,
+    models: {
+      ...cfg.models,
+      mode: cfg.models?.mode ?? "merge",
+      providers: {
+        ...cfg.models?.providers,
+        "local-server": {
+          baseUrl,
+          api: "local-server",
+          ...(apiKey ? { apiKey } : {}),
+          ...(customHeaders ? { headers: customHeaders } : {}),
+          localServer: localServerConfig,
+          models: [
+            {
+              id: trimmedModelId,
+              name: `${trimmedModelId} (Local Server)`,
+              reasoning: false,
+              input: ["text"],
+              cost: DEFAULT_COST,
+              contextWindow: DEFAULT_CONTEXT_WINDOW,
+              maxTokens: DEFAULT_MAX_TOKENS,
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  nextConfig = applyPrimaryModel(nextConfig, modelRef);
+
+  return { config: nextConfig, modelId: trimmedModelId, modelRef };
+}

--- a/src/commands/onboard-types.ts
+++ b/src/commands/onboard-types.ts
@@ -50,6 +50,7 @@ export type AuthChoice =
   | "byteplus-api-key"
   | "qianfan-api-key"
   | "custom-api-key"
+  | "local-server"
   | "skip";
 export type AuthChoiceGroupId =
   | "openai"
@@ -78,7 +79,8 @@ export type AuthChoiceGroupId =
   | "xai"
   | "volcengine"
   | "byteplus"
-  | "custom";
+  | "custom"
+  | "local-server";
 export type GatewayAuthChoice = "token" | "password";
 export type ResetScope = "config" | "config+creds+sessions" | "full";
 export type GatewayBind = "loopback" | "lan" | "auto" | "custom" | "tailnet";

--- a/src/config/types.models.ts
+++ b/src/config/types.models.ts
@@ -9,6 +9,7 @@ export const MODEL_APIS = [
   "github-copilot",
   "bedrock-converse-stream",
   "ollama",
+  "local-server",
 ] as const;
 
 export type ModelApi = (typeof MODEL_APIS)[number];
@@ -47,6 +48,13 @@ export type ModelDefinitionConfig = {
   compat?: ModelCompatConfig;
 };
 
+export type LocalServerBodyTemplate = {
+  /** JSON template with placeholders: {{prompt}}, {{messages}}, {{system}}, {{model}}, {{max_tokens}} */
+  template: string;
+  /** Dot-path to extract generated text from the response JSON (e.g. "result.text", "output") */
+  responsePath: string;
+};
+
 export type ModelProviderConfig = {
   baseUrl: string;
   apiKey?: SecretInput;
@@ -56,6 +64,8 @@ export type ModelProviderConfig = {
   headers?: Record<string, string>;
   authHeader?: boolean;
   models: ModelDefinitionConfig[];
+  /** Custom request body template and response extraction for local-server API type */
+  localServer?: LocalServerBodyTemplate;
 };
 
 export type BedrockDiscoveryConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -224,6 +224,14 @@ export const ModelDefinitionSchema = z
   })
   .strict();
 
+export const LocalServerBodyTemplateSchema = z
+  .object({
+    template: z.string().min(1),
+    responsePath: z.string().min(1),
+  })
+  .strict()
+  .optional();
+
 export const ModelProviderSchema = z
   .object({
     baseUrl: z.string().min(1),
@@ -236,6 +244,7 @@ export const ModelProviderSchema = z
     headers: z.record(z.string(), z.string()).optional(),
     authHeader: z.boolean().optional(),
     models: z.array(ModelDefinitionSchema),
+    localServer: LocalServerBodyTemplateSchema,
   })
   .strict();
 


### PR DESCRIPTION
## Overview

Adds a new `local-server` API type that enables OpenClaw to communicate with
any custom HTTP inference endpoint — regardless of its API format. This is
designed for users running private inference servers (e.g. uvicorn/FastAPI,
research prototypes, or any self-hosted model server) that do not conform to
the OpenAI or Anthropic API conventions.

## Motivation

Existing provider types (`openai-completions`, `anthropic-messages`, `ollama`)
assume a standard request/response format. Users with fully custom backends had
no supported path for integration. This change introduces a flexible,
template-based adapter that lets any HTTP endpoint be used as a model provider.

## Changes

### Core types & validation
- Added `"local-server"` to the `MODEL_APIS` union in `types.models.ts`
- Introduced `LocalServerBodyTemplate` type (`template` + `responsePath` fields)
- Extended `ModelProviderConfig` with optional `localServer` field
- Updated Zod schema in `zod-schema.core.ts` to validate the new fields

### Onboarding wizard
- Added `"local-server"` to `AuthChoice` and `AuthChoiceGroupId` enums
- Added "Local Server Provider" entry to the provider selection list
- Created `local-server-setup.ts` with interactive prompts for endpoint URL,
  request body template, response path, optional API key, and custom headers
- Created `auth-choice.apply.local-server.ts` handler and registered it in
  the main auth-choice application chain

### Runtime integration
- Created `local-server-stream.ts`: a custom `StreamFn` that POSTs to the
  user-defined endpoint, substitutes placeholders in the request body template
  (with proper JSON escaping), and extracts the response text via dot-path
- Integrated the custom `StreamFn` into `pi-embedded-runner/run/attempt.ts`
- Updated `model-catalog.ts` so `local-server` models appear in the model picker
- Updated `model-auth.ts` to return a synthetic no-op key for `local-server`
  providers, preventing false "missing API key" errors
- Set `disableTools: true` for `local-server` turns in `run.ts` to prevent
  the agent loop from spinning after receiving a response

### Documentation
- `docs/concepts/model-providers.md` — new "Local Server" section with full
  config example, placeholder reference table, and usage notes
- `docs/gateway/configuration-reference.md` — added `local-server` to the
  `api` field comment and documented the `localServer` sub-fields
- `docs/start/onboarding-overview.md` — added "Local Server Provider" section
- `docs/start/wizard.md` — updated Model/Auth step to mention the new option

## Template placeholders

| Placeholder | Description |
|---|---|
| `{{prompt}}` | Last user message (JSON-escaped) |
| `{{model}}` | Model ID string |
| `{{max_tokens}}` | Max tokens (integer) |
| `{{messages}}` | Full conversation as a JSON array |
| `{{system}}` | System prompt string |

## Test plan
- [ ] Run `openclaw onboard --auth-choice local-server` and complete the wizard
- [ ] Verify model appears in `openclaw models list`
- [ ] Send a message via TUI and confirm the response comes from the custom endpoint
- [ ] Confirm no "missing API key" error when the key field is left blank
- [ ] Confirm the agent completes cleanly after one response (no infinite loop)