### PR TITLE
feat(pack): Agent Pack — shareable workspace templates

### DIFF
--- a/src/agents/pack/frontmatter.test.ts
+++ b/src/agents/pack/frontmatter.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractPackDescription,
+  parsePackFrontmatter,
+  resolvePackMetadata,
+} from "./frontmatter.js";
+
+describe("parsePackFrontmatter", () => {
+  it("parses valid PACK.md frontmatter", () => {
+    const content = `---
+name: news-curator
+description: AI news curator agent
+author: garysng
+version: 1.0.0
+skills:
+  - summarize
+  - web-search
+tags:
+  - news
+  - research
+---
+
+# News Curator`;
+
+    const fm = parsePackFrontmatter(content);
+    expect(fm.name).toBe("news-curator");
+    expect(fm.description).toBe("AI news curator agent");
+    expect(fm.author).toBe("garysng");
+    expect(fm.version).toBe("1.0.0");
+  });
+
+  it("returns empty object for missing frontmatter", () => {
+    const content = "# Just a heading\n\nSome text.";
+    const fm = parsePackFrontmatter(content);
+    expect(fm).toEqual({});
+  });
+
+  it("returns empty object for empty content", () => {
+    const fm = parsePackFrontmatter("");
+    expect(fm).toEqual({});
+  });
+});
+
+describe("resolvePackMetadata", () => {
+  it("extracts all metadata fields", () => {
+    const fm: Record<string, string> = {
+      name: "my-pack",
+      description: "A test pack",
+      author: "test-author",
+      version: "2.0.0",
+      skills: '["summarize","web-search"]',
+      tags: '["news","ai"]',
+    };
+
+    const meta = resolvePackMetadata(fm);
+    expect(meta.name).toBe("my-pack");
+    expect(meta.description).toBe("A test pack");
+    expect(meta.author).toBe("test-author");
+    expect(meta.version).toBe("2.0.0");
+    expect(meta.skills).toEqual(["summarize", "web-search"]);
+    expect(meta.tags).toEqual(["news", "ai"]);
+  });
+
+  it("handles missing optional fields", () => {
+    const meta = resolvePackMetadata({ name: "minimal" });
+    expect(meta.name).toBe("minimal");
+    expect(meta.description).toBeUndefined();
+    expect(meta.author).toBeUndefined();
+    expect(meta.version).toBeUndefined();
+    expect(meta.skills).toBeUndefined();
+    expect(meta.tags).toBeUndefined();
+  });
+
+  it("returns empty name for empty frontmatter", () => {
+    const meta = resolvePackMetadata({});
+    expect(meta.name).toBe("");
+  });
+
+  it("parses comma-separated skills", () => {
+    const meta = resolvePackMetadata({ name: "test", skills: "a, b, c" });
+    expect(meta.skills).toEqual(["a", "b", "c"]);
+  });
+
+  it("trims whitespace from values", () => {
+    const meta = resolvePackMetadata({
+      name: "  spaced  ",
+      description: "  desc  ",
+      author: "  author  ",
+    });
+    expect(meta.name).toBe("spaced");
+    expect(meta.description).toBe("desc");
+    expect(meta.author).toBe("author");
+  });
+});
+
+describe("extractPackDescription", () => {
+  it("extracts body after frontmatter", () => {
+    const content = `---
+name: test
+---
+
+# My Pack
+
+This is the description.`;
+
+    const desc = extractPackDescription(content);
+    expect(desc).toBe("# My Pack\n\nThis is the description.");
+  });
+
+  it("returns full content when no frontmatter", () => {
+    const content = "# No frontmatter\n\nJust content.";
+    const desc = extractPackDescription(content);
+    expect(desc).toBe("# No frontmatter\n\nJust content.");
+  });
+
+  it("handles empty content", () => {
+    expect(extractPackDescription("")).toBe("");
+  });
+
+  it("handles frontmatter-only content", () => {
+    const content = `---
+name: test
+---`;
+    const desc = extractPackDescription(content);
+    expect(desc).toBe("");
+  });
+});

--- a/src/agents/pack/frontmatter.ts
+++ b/src/agents/pack/frontmatter.ts
@@ -1,0 +1,77 @@
+/**
+ * PACK.md frontmatter parsing — extracts PackMetadata from YAML frontmatter.
+ */
+import { parseFrontmatterBlock } from "../../markdown/frontmatter.js";
+import type { PackMetadata } from "./types.js";
+
+export type ParsedPackFrontmatter = Record<string, string>;
+
+export function parsePackFrontmatter(content: string): ParsedPackFrontmatter {
+  return parseFrontmatterBlock(content);
+}
+
+function parseStringList(raw: string | undefined): string[] {
+  if (!raw) {
+    return [];
+  }
+  // Handle JSON array format from YAML parser: ["a","b"]
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((v): v is string => typeof v === "string").map((s) => s.trim());
+    }
+  } catch {
+    // Not JSON — fall through to comma-split
+  }
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Extract PackMetadata from parsed frontmatter fields.
+ */
+export function resolvePackMetadata(frontmatter: ParsedPackFrontmatter): PackMetadata {
+  const name = frontmatter.name?.trim() ?? "";
+  const metadata: PackMetadata = { name };
+
+  if (frontmatter.description) {
+    metadata.description = frontmatter.description.trim();
+  }
+  if (frontmatter.author) {
+    metadata.author = frontmatter.author.trim();
+  }
+  if (frontmatter.version) {
+    metadata.version = frontmatter.version.trim();
+  }
+
+  const skills = parseStringList(frontmatter.skills);
+  if (skills.length > 0) {
+    metadata.skills = skills;
+  }
+
+  const tags = parseStringList(frontmatter.tags);
+  if (tags.length > 0) {
+    metadata.tags = tags;
+  }
+
+  return metadata;
+}
+
+/**
+ * Extract the body content (after frontmatter) from PACK.md.
+ */
+export function extractPackDescription(content: string): string {
+  const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  if (!normalized.startsWith("---")) {
+    return normalized.trim();
+  }
+  const endIndex = normalized.indexOf("\n---", 3);
+  if (endIndex === -1) {
+    return normalized.trim();
+  }
+  // Skip the closing `---` line
+  const afterFrontmatter = normalized.slice(endIndex + 4);
+  return afterFrontmatter.trim();
+}

--- a/src/agents/pack/index.ts
+++ b/src/agents/pack/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Agent Pack — shareable workspace templates for OpenClaw.
+ */
+export type {
+  PackMetadata,
+  PackEntry,
+  PackInstallResult,
+  PackInstallOptions,
+  PackInitOptions,
+  PackInitResult,
+} from "./types.js";
+
+export {
+  parsePackFrontmatter,
+  resolvePackMetadata,
+  extractPackDescription,
+} from "./frontmatter.js";
+export { resolvePack, scanPacksDir } from "./resolve.js";
+export { installPack } from "./install.js";
+export { initPack } from "./init.js";

--- a/src/agents/pack/init.test.ts
+++ b/src/agents/pack/init.test.ts
@@ -1,0 +1,145 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { initPack } from "./init.js";
+
+const fsp = fs.promises;
+
+let tmpDir: string;
+let workspaceDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pack-init-test-"));
+  workspaceDir = path.join(tmpDir, "my-workspace");
+  await fsp.mkdir(workspaceDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("initPack", () => {
+  it("creates a pack with PACK.md", async () => {
+    const outputDir = path.join(tmpDir, "output-pack");
+    const result = await initPack(workspaceDir, {
+      name: "test-pack",
+      outputDir,
+      description: "A test pack",
+      author: "tester",
+      version: "1.0.0",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.packDir).toBe(outputDir);
+    expect(result.files).toContain("PACK.md");
+
+    const packMd = await fsp.readFile(path.join(outputDir, "PACK.md"), "utf-8");
+    expect(packMd).toContain("name: test-pack");
+    expect(packMd).toContain("description: A test pack");
+    expect(packMd).toContain("author: tester");
+    expect(packMd).toContain("version: 1.0.0");
+  });
+
+  it("copies workspace files", async () => {
+    await fsp.writeFile(path.join(workspaceDir, "SOUL.md"), "# My Soul", "utf-8");
+    await fsp.writeFile(path.join(workspaceDir, "AGENTS.md"), "# My Agents", "utf-8");
+
+    const outputDir = path.join(tmpDir, "output-pack");
+    const result = await initPack(workspaceDir, { name: "ws-pack", outputDir });
+
+    expect(result.ok).toBe(true);
+    expect(result.files).toContain("SOUL.md");
+    expect(result.files).toContain("AGENTS.md");
+
+    const soul = await fsp.readFile(path.join(outputDir, "SOUL.md"), "utf-8");
+    expect(soul).toBe("# My Soul");
+  });
+
+  it("creates .template versions of user-specific files", async () => {
+    await fsp.writeFile(path.join(workspaceDir, "USER.md"), "# My User", "utf-8");
+    await fsp.writeFile(path.join(workspaceDir, "TOOLS.md"), "# My Tools", "utf-8");
+
+    const outputDir = path.join(tmpDir, "output-pack");
+    const result = await initPack(workspaceDir, { name: "tpl-pack", outputDir });
+
+    expect(result.ok).toBe(true);
+    expect(result.files).toContain("USER.md.template");
+    expect(result.files).toContain("TOOLS.md.template");
+
+    const userTpl = await fsp.readFile(path.join(outputDir, "USER.md.template"), "utf-8");
+    expect(userTpl).toBe("# My User");
+  });
+
+  it("includes skills when --include-skills", async () => {
+    const skillDir = path.join(workspaceDir, "skills", "my-skill");
+    await fsp.mkdir(skillDir, { recursive: true });
+    await fsp.writeFile(path.join(skillDir, "SKILL.md"), "---\nname: my-skill\n---", "utf-8");
+
+    const outputDir = path.join(tmpDir, "output-pack");
+    const result = await initPack(workspaceDir, {
+      name: "skill-pack",
+      outputDir,
+      includeSkills: true,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.files).toContain("skills/my-skill");
+
+    const skillMd = await fsp.readFile(
+      path.join(outputDir, "skills", "my-skill", "SKILL.md"),
+      "utf-8",
+    );
+    expect(skillMd).toContain("my-skill");
+  });
+
+  it("does not include skills without --include-skills", async () => {
+    const skillDir = path.join(workspaceDir, "skills", "my-skill");
+    await fsp.mkdir(skillDir, { recursive: true });
+    await fsp.writeFile(path.join(skillDir, "SKILL.md"), "---\nname: my-skill\n---", "utf-8");
+
+    const outputDir = path.join(tmpDir, "output-pack");
+    const result = await initPack(workspaceDir, {
+      name: "no-skill-pack",
+      outputDir,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.files).not.toContain("skills/my-skill");
+  });
+
+  it("uses default output dir based on pack name", async () => {
+    const result = await initPack(workspaceDir, { name: "auto-dir" });
+    expect(result.ok).toBe(true);
+    expect(result.packDir).toContain("auto-dir-pack");
+    // Cleanup
+    await fsp.rm(result.packDir, { recursive: true, force: true });
+  });
+
+  it("skips non-existent workspace files gracefully", async () => {
+    const outputDir = path.join(tmpDir, "output-pack");
+    const result = await initPack(workspaceDir, { name: "empty-pack", outputDir });
+
+    expect(result.ok).toBe(true);
+    expect(result.files).toContain("PACK.md");
+    // No SOUL.md, AGENTS.md, etc. in the empty workspace
+    expect(result.files).not.toContain("SOUL.md");
+  });
+
+  it("generates correct PACK.md frontmatter", async () => {
+    const outputDir = path.join(tmpDir, "output-pack");
+    await initPack(workspaceDir, {
+      name: "frontmatter-test",
+      outputDir,
+      description: "Testing frontmatter generation",
+      author: "xiaoc",
+      version: "2.5.0",
+    });
+
+    const content = await fsp.readFile(path.join(outputDir, "PACK.md"), "utf-8");
+    expect(content).toMatch(/^---\n/);
+    expect(content).toContain("name: frontmatter-test");
+    expect(content).toContain("version: 2.5.0");
+    expect(content).toContain("# frontmatter-test");
+  });
+});

--- a/src/agents/pack/init.ts
+++ b/src/agents/pack/init.ts
@@ -1,0 +1,158 @@
+/**
+ * Export a workspace as an Agent Pack.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import type { PackInitOptions, PackInitResult } from "./types.js";
+
+const fsp = fs.promises;
+const packLogger = createSubsystemLogger("pack");
+
+/** Workspace files to include in a pack. */
+const INCLUDABLE_FILES = ["SOUL.md", "AGENTS.md", "IDENTITY.md", "HEARTBEAT.md", "BOOTSTRAP.md"];
+
+/** Files that should become .template (user-specific). */
+const TEMPLATE_FILES = ["USER.md", "TOOLS.md"];
+
+/**
+ * Generate PACK.md content with frontmatter.
+ */
+function generatePackMd(options: PackInitOptions): string {
+  const lines: string[] = ["---"];
+  lines.push(`name: ${options.name}`);
+  if (options.description) {
+    lines.push(`description: ${options.description}`);
+  }
+  if (options.author) {
+    lines.push(`author: ${options.author}`);
+  }
+  lines.push(`version: ${options.version ?? "1.0.0"}`);
+  lines.push("---");
+  lines.push("");
+  lines.push(`# ${options.name}`);
+  lines.push("");
+  if (options.description) {
+    lines.push(options.description);
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Export the current workspace as an Agent Pack.
+ *
+ * @param workspaceDir - Source workspace directory
+ * @param options - Pack init options (name, output, etc.)
+ */
+export async function initPack(
+  workspaceDir: string,
+  options: PackInitOptions,
+): Promise<PackInitResult> {
+  const result: PackInitResult = {
+    ok: false,
+    packDir: "",
+    files: [],
+    errors: [],
+  };
+
+  const absWorkspace = path.resolve(workspaceDir);
+  const outputDir = path.resolve(
+    options.outputDir ?? path.join(absWorkspace, "..", options.name + "-pack"),
+  );
+  result.packDir = outputDir;
+
+  try {
+    await fsp.mkdir(outputDir, { recursive: true });
+  } catch (err) {
+    result.errors.push(`Failed to create output directory: ${String(err)}`);
+    return result;
+  }
+
+  // Generate PACK.md
+  try {
+    const packContent = generatePackMd(options);
+    await fsp.writeFile(path.join(outputDir, "PACK.md"), packContent, "utf-8");
+    result.files.push("PACK.md");
+  } catch (err) {
+    result.errors.push(`Failed to write PACK.md: ${String(err)}`);
+  }
+
+  // Copy includable workspace files
+  for (const file of INCLUDABLE_FILES) {
+    const srcPath = path.join(absWorkspace, file);
+    try {
+      await fsp.access(srcPath);
+      await fsp.copyFile(srcPath, path.join(outputDir, file));
+      result.files.push(file);
+    } catch {
+      // File doesn't exist in workspace — skip
+    }
+  }
+
+  // Create .template versions of user-specific files
+  for (const file of TEMPLATE_FILES) {
+    const srcPath = path.join(absWorkspace, file);
+    const templateName = file + ".template";
+    try {
+      await fsp.access(srcPath);
+      await fsp.copyFile(srcPath, path.join(outputDir, templateName));
+      result.files.push(templateName);
+    } catch {
+      // File doesn't exist — skip
+    }
+  }
+
+  // Optionally include skills directory
+  if (options.includeSkills) {
+    const srcSkillsDir = path.join(absWorkspace, "skills");
+    const destSkillsDir = path.join(outputDir, "skills");
+    try {
+      const entries = await fsp.readdir(srcSkillsDir, { withFileTypes: true });
+      await fsp.mkdir(destSkillsDir, { recursive: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) {
+          continue;
+        }
+        const skillMdPath = path.join(srcSkillsDir, entry.name, "SKILL.md");
+        try {
+          await fsp.access(skillMdPath);
+          await copyDirRecursive(
+            path.join(srcSkillsDir, entry.name),
+            path.join(destSkillsDir, entry.name),
+          );
+          result.files.push(`skills/${entry.name}`);
+        } catch {
+          // Not a valid skill directory — skip
+        }
+      }
+    } catch {
+      // No skills/ directory — that's fine
+    }
+  }
+
+  result.ok = result.errors.length === 0;
+  packLogger.info(`Pack "${options.name}" created at ${outputDir}`, {
+    files: result.files.length,
+    errors: result.errors.length,
+  });
+
+  return result;
+}
+
+/**
+ * Recursively copy a directory.
+ */
+async function copyDirRecursive(src: string, dest: string): Promise<void> {
+  await fsp.mkdir(dest, { recursive: true });
+  const entries = await fsp.readdir(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      await copyDirRecursive(srcPath, destPath);
+    } else {
+      await fsp.copyFile(srcPath, destPath);
+    }
+  }
+}

--- a/src/agents/pack/install.test.ts
+++ b/src/agents/pack/install.test.ts
@@ -1,0 +1,131 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { installPack } from "./install.js";
+
+const fsp = fs.promises;
+
+let tmpDir: string;
+let packDir: string;
+let targetDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pack-install-test-"));
+  packDir = path.join(tmpDir, "source-pack");
+  targetDir = path.join(tmpDir, "target-workspace");
+  await fsp.mkdir(packDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+});
+
+function writePack(dir: string, frontmatter: string, body = "") {
+  return fsp.writeFile(path.join(dir, "PACK.md"), `---\n${frontmatter}\n---\n\n${body}`, "utf-8");
+}
+
+describe("installPack", () => {
+  it("installs a basic pack with workspace files", async () => {
+    await writePack(packDir, "name: basic-pack\nversion: 1.0.0");
+    await fsp.writeFile(path.join(packDir, "SOUL.md"), "# My Soul", "utf-8");
+    await fsp.writeFile(path.join(packDir, "AGENTS.md"), "# My Agents", "utf-8");
+
+    const result = await installPack(packDir, { workdir: targetDir });
+    expect(result.ok).toBe(true);
+    expect(result.workspaceDir).toBe(targetDir);
+    expect(result.copiedFiles).toContain("SOUL.md");
+    expect(result.copiedFiles).toContain("AGENTS.md");
+    expect(result.copiedFiles).toContain("PACK.md");
+
+    const soul = await fsp.readFile(path.join(targetDir, "SOUL.md"), "utf-8");
+    expect(soul).toBe("# My Soul");
+  });
+
+  it("processes template files by stripping .template extension", async () => {
+    await writePack(packDir, "name: tpl-pack");
+    await fsp.writeFile(path.join(packDir, "USER.md.template"), "# Customize me", "utf-8");
+
+    const result = await installPack(packDir, { workdir: targetDir });
+    expect(result.ok).toBe(true);
+    expect(result.copiedFiles).toContain("USER.md");
+
+    const user = await fsp.readFile(path.join(targetDir, "USER.md"), "utf-8");
+    expect(user).toBe("# Customize me");
+  });
+
+  it("skips existing files without --force", async () => {
+    await writePack(packDir, "name: skip-pack");
+    await fsp.writeFile(path.join(packDir, "SOUL.md"), "# New Soul", "utf-8");
+
+    // Pre-create target with existing file
+    await fsp.mkdir(targetDir, { recursive: true });
+    await fsp.writeFile(path.join(targetDir, "SOUL.md"), "# Old Soul", "utf-8");
+
+    const result = await installPack(packDir, { workdir: targetDir });
+    expect(result.ok).toBe(true);
+    expect(result.skippedFiles).toContain("SOUL.md");
+
+    const soul = await fsp.readFile(path.join(targetDir, "SOUL.md"), "utf-8");
+    expect(soul).toBe("# Old Soul");
+  });
+
+  it("overwrites existing files with --force", async () => {
+    await writePack(packDir, "name: force-pack");
+    await fsp.writeFile(path.join(packDir, "SOUL.md"), "# New Soul", "utf-8");
+
+    await fsp.mkdir(targetDir, { recursive: true });
+    await fsp.writeFile(path.join(targetDir, "SOUL.md"), "# Old Soul", "utf-8");
+
+    const result = await installPack(packDir, { workdir: targetDir, force: true });
+    expect(result.ok).toBe(true);
+    expect(result.copiedFiles).toContain("SOUL.md");
+
+    const soul = await fsp.readFile(path.join(targetDir, "SOUL.md"), "utf-8");
+    expect(soul).toBe("# New Soul");
+  });
+
+  it("installs bundled skills", async () => {
+    await writePack(packDir, "name: skill-pack");
+    const skillDir = path.join(packDir, "skills", "my-skill");
+    await fsp.mkdir(skillDir, { recursive: true });
+    await fsp.writeFile(path.join(skillDir, "SKILL.md"), "---\nname: my-skill\n---", "utf-8");
+    await fsp.writeFile(path.join(skillDir, "script.sh"), "#!/bin/bash\necho hi", "utf-8");
+
+    const result = await installPack(packDir, { workdir: targetDir });
+    expect(result.ok).toBe(true);
+    expect(result.installedSkills).toContain("my-skill");
+
+    const skillMd = await fsp.readFile(
+      path.join(targetDir, "skills", "my-skill", "SKILL.md"),
+      "utf-8",
+    );
+    expect(skillMd).toContain("my-skill");
+  });
+
+  it("skips skills with --skip-skills", async () => {
+    await writePack(packDir, "name: no-skill-pack");
+    const skillDir = path.join(packDir, "skills", "my-skill");
+    await fsp.mkdir(skillDir, { recursive: true });
+    await fsp.writeFile(path.join(skillDir, "SKILL.md"), "---\nname: my-skill\n---", "utf-8");
+
+    const result = await installPack(packDir, { workdir: targetDir, skipSkills: true });
+    expect(result.ok).toBe(true);
+    expect(result.installedSkills).toEqual([]);
+  });
+
+  it("returns error for invalid pack directory", async () => {
+    const result = await installPack(path.join(tmpDir, "nonexistent"), { workdir: targetDir });
+    expect(result.ok).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it("uses pack name as default workspace dir", async () => {
+    await writePack(packDir, "name: auto-dir-pack");
+    const result = await installPack(packDir);
+    expect(result.ok).toBe(true);
+    expect(result.workspaceDir).toContain("auto-dir-pack");
+    // Cleanup
+    await fsp.rm(result.workspaceDir, { recursive: true, force: true });
+  });
+});

--- a/src/agents/pack/install.ts
+++ b/src/agents/pack/install.ts
@@ -1,0 +1,172 @@
+/**
+ * Install a pack into a target workspace directory.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { resolvePack } from "./resolve.js";
+import type { PackInstallOptions, PackInstallResult } from "./types.js";
+
+const fsp = fs.promises;
+const packLogger = createSubsystemLogger("pack");
+
+/**
+ * Recursively copy a directory.
+ */
+async function copyDir(src: string, dest: string): Promise<string[]> {
+  const copied: string[] = [];
+  await fsp.mkdir(dest, { recursive: true });
+  const entries = await fsp.readdir(src, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      const subCopied = await copyDir(srcPath, destPath);
+      copied.push(...subCopied);
+    } else {
+      await fsp.copyFile(srcPath, destPath);
+      copied.push(destPath);
+    }
+  }
+  return copied;
+}
+
+/**
+ * Install a pack from `packDir` into a target workspace.
+ */
+export async function installPack(
+  packDir: string,
+  options?: PackInstallOptions,
+): Promise<PackInstallResult> {
+  const result: PackInstallResult = {
+    ok: false,
+    workspaceDir: "",
+    copiedFiles: [],
+    skippedFiles: [],
+    installedSkills: [],
+    errors: [],
+  };
+
+  const pack = await resolvePack(packDir);
+  if (!pack) {
+    result.errors.push(`No valid pack found in ${packDir}`);
+    return result;
+  }
+
+  const force = options?.force ?? false;
+  const skipSkills = options?.skipSkills ?? false;
+
+  // Determine target workspace directory
+  const workspaceDir = path.resolve(options?.workdir ?? pack.metadata.name);
+  result.workspaceDir = workspaceDir;
+
+  try {
+    await fsp.mkdir(workspaceDir, { recursive: true });
+  } catch (err) {
+    result.errors.push(`Failed to create workspace directory: ${String(err)}`);
+    return result;
+  }
+
+  // Copy workspace files
+  for (const file of pack.workspaceFiles) {
+    const srcPath = path.join(pack.dir, file);
+    const destPath = path.join(workspaceDir, file);
+    try {
+      if (!force) {
+        try {
+          await fsp.access(destPath);
+          result.skippedFiles.push(file);
+          packLogger.debug(`Skipped existing file: ${file}`);
+          continue;
+        } catch {
+          // File doesn't exist — proceed to copy
+        }
+      }
+      await fsp.copyFile(srcPath, destPath);
+      result.copiedFiles.push(file);
+    } catch (err) {
+      result.errors.push(`Failed to copy ${file}: ${String(err)}`);
+    }
+  }
+
+  // Process template files — strip .template extension
+  for (const templateFile of pack.templateFiles) {
+    const targetName = templateFile.replace(/\.template$/, "");
+    const srcPath = path.join(pack.dir, templateFile);
+    const destPath = path.join(workspaceDir, targetName);
+    try {
+      if (!force) {
+        try {
+          await fsp.access(destPath);
+          result.skippedFiles.push(targetName);
+          packLogger.debug(`Skipped existing template target: ${targetName}`);
+          continue;
+        } catch {
+          // File doesn't exist — proceed
+        }
+      }
+      await fsp.copyFile(srcPath, destPath);
+      result.copiedFiles.push(targetName);
+    } catch (err) {
+      result.errors.push(`Failed to copy template ${templateFile} → ${targetName}: ${String(err)}`);
+    }
+  }
+
+  // Copy bundled skills
+  if (!skipSkills && pack.bundledSkillDirs.length > 0) {
+    const targetSkillsDir = path.join(workspaceDir, "skills");
+    try {
+      await fsp.mkdir(targetSkillsDir, { recursive: true });
+    } catch (err) {
+      result.errors.push(`Failed to create skills directory: ${String(err)}`);
+    }
+
+    for (const skillName of pack.bundledSkillDirs) {
+      const srcSkillDir = path.join(pack.dir, "skills", skillName);
+      const destSkillDir = path.join(targetSkillsDir, skillName);
+      try {
+        if (!force) {
+          try {
+            await fsp.access(destSkillDir);
+            result.skippedFiles.push(`skills/${skillName}`);
+            packLogger.debug(`Skipped existing skill: ${skillName}`);
+            continue;
+          } catch {
+            // Skill dir doesn't exist — proceed
+          }
+        }
+        await copyDir(srcSkillDir, destSkillDir);
+        result.installedSkills.push(skillName);
+      } catch (err) {
+        result.errors.push(`Failed to install skill ${skillName}: ${String(err)}`);
+      }
+    }
+  }
+
+  // Copy PACK.md to workspace for reference
+  const packMdDest = path.join(workspaceDir, "PACK.md");
+  try {
+    if (
+      force ||
+      !(await fsp
+        .access(packMdDest)
+        .then(() => true)
+        .catch(() => false))
+    ) {
+      await fsp.copyFile(pack.packFilePath, packMdDest);
+      result.copiedFiles.push("PACK.md");
+    }
+  } catch (err) {
+    result.errors.push(`Failed to copy PACK.md: ${String(err)}`);
+  }
+
+  result.ok = result.errors.length === 0;
+  packLogger.info(`Pack "${pack.metadata.name}" installed to ${workspaceDir}`, {
+    copied: result.copiedFiles.length,
+    skipped: result.skippedFiles.length,
+    skills: result.installedSkills.length,
+    errors: result.errors.length,
+  });
+
+  return result;
+}

--- a/src/agents/pack/resolve.test.ts
+++ b/src/agents/pack/resolve.test.ts
@@ -1,0 +1,128 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolvePack, scanPacksDir } from "./resolve.js";
+
+const fsp = fs.promises;
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), "pack-resolve-test-"));
+});
+
+afterEach(async () => {
+  await fsp.rm(tmpDir, { recursive: true, force: true });
+});
+
+function writePack(dir: string, frontmatter: string, body = "") {
+  return fsp.writeFile(path.join(dir, "PACK.md"), `---\n${frontmatter}\n---\n\n${body}`, "utf-8");
+}
+
+describe("resolvePack", () => {
+  it("resolves a valid pack with workspace files", async () => {
+    await writePack(tmpDir, "name: test-pack\nversion: 1.0.0", "# Test Pack");
+    await fsp.writeFile(path.join(tmpDir, "SOUL.md"), "# Soul", "utf-8");
+    await fsp.writeFile(path.join(tmpDir, "AGENTS.md"), "# Agents", "utf-8");
+
+    const pack = await resolvePack(tmpDir);
+    expect(pack).toBeDefined();
+    expect(pack!.metadata.name).toBe("test-pack");
+    expect(pack!.metadata.version).toBe("1.0.0");
+    expect(pack!.workspaceFiles).toContain("SOUL.md");
+    expect(pack!.workspaceFiles).toContain("AGENTS.md");
+    expect(pack!.description).toBe("# Test Pack");
+  });
+
+  it("detects template files", async () => {
+    await writePack(tmpDir, "name: tpl-pack");
+    await fsp.writeFile(path.join(tmpDir, "USER.md.template"), "# User", "utf-8");
+    await fsp.writeFile(path.join(tmpDir, "TOOLS.md.template"), "# Tools", "utf-8");
+
+    const pack = await resolvePack(tmpDir);
+    expect(pack).toBeDefined();
+    expect(pack!.templateFiles).toContain("USER.md.template");
+    expect(pack!.templateFiles).toContain("TOOLS.md.template");
+  });
+
+  it("detects bundled skills", async () => {
+    await writePack(tmpDir, "name: skill-pack");
+    const skillDir = path.join(tmpDir, "skills", "my-skill");
+    await fsp.mkdir(skillDir, { recursive: true });
+    await fsp.writeFile(path.join(skillDir, "SKILL.md"), "---\nname: my-skill\n---", "utf-8");
+
+    const pack = await resolvePack(tmpDir);
+    expect(pack).toBeDefined();
+    expect(pack!.bundledSkillDirs).toContain("my-skill");
+  });
+
+  it("skips skills dirs without SKILL.md", async () => {
+    await writePack(tmpDir, "name: no-skill-pack");
+    const badSkillDir = path.join(tmpDir, "skills", "not-a-skill");
+    await fsp.mkdir(badSkillDir, { recursive: true });
+    await fsp.writeFile(path.join(badSkillDir, "readme.txt"), "hi", "utf-8");
+
+    const pack = await resolvePack(tmpDir);
+    expect(pack).toBeDefined();
+    expect(pack!.bundledSkillDirs).toEqual([]);
+  });
+
+  it("returns undefined for missing PACK.md", async () => {
+    const pack = await resolvePack(tmpDir);
+    expect(pack).toBeUndefined();
+  });
+
+  it("returns undefined for PACK.md without name", async () => {
+    await writePack(tmpDir, "description: no name here");
+    const pack = await resolvePack(tmpDir);
+    expect(pack).toBeUndefined();
+  });
+
+  it("returns undefined for non-existent directory", async () => {
+    const pack = await resolvePack(path.join(tmpDir, "nope"));
+    expect(pack).toBeUndefined();
+  });
+
+  it("does not include PACK.md as workspace file", async () => {
+    await writePack(tmpDir, "name: meta-pack");
+    const pack = await resolvePack(tmpDir);
+    expect(pack).toBeDefined();
+    expect(pack!.workspaceFiles).not.toContain("PACK.md");
+  });
+});
+
+describe("scanPacksDir", () => {
+  it("scans a directory for packs", async () => {
+    const packA = path.join(tmpDir, "pack-a");
+    const packB = path.join(tmpDir, "pack-b");
+    await fsp.mkdir(packA, { recursive: true });
+    await fsp.mkdir(packB, { recursive: true });
+    await writePack(packA, "name: pack-a\nversion: 1.0.0");
+    await writePack(packB, "name: pack-b\nversion: 2.0.0");
+
+    const packs = await scanPacksDir(tmpDir);
+    expect(packs).toHaveLength(2);
+    const names = packs.map((p) => p.metadata.name).toSorted();
+    expect(names).toEqual(["pack-a", "pack-b"]);
+  });
+
+  it("returns empty array for empty directory", async () => {
+    const packs = await scanPacksDir(tmpDir);
+    expect(packs).toEqual([]);
+  });
+
+  it("skips directories without PACK.md", async () => {
+    const noPackDir = path.join(tmpDir, "not-a-pack");
+    await fsp.mkdir(noPackDir, { recursive: true });
+    await fsp.writeFile(path.join(noPackDir, "README.md"), "hi", "utf-8");
+
+    const packs = await scanPacksDir(tmpDir);
+    expect(packs).toEqual([]);
+  });
+
+  it("returns empty array for non-existent directory", async () => {
+    const packs = await scanPacksDir(path.join(tmpDir, "nope"));
+    expect(packs).toEqual([]);
+  });
+});

--- a/src/agents/pack/resolve.ts
+++ b/src/agents/pack/resolve.ts
@@ -1,0 +1,153 @@
+/**
+ * Resolve a pack from a directory by reading PACK.md and scanning workspace files.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import {
+  extractPackDescription,
+  parsePackFrontmatter,
+  resolvePackMetadata,
+} from "./frontmatter.js";
+import type { PackEntry } from "./types.js";
+
+const fsp = fs.promises;
+const packLogger = createSubsystemLogger("pack");
+
+const PACK_FILE = "PACK.md";
+
+/** Known workspace files that a pack can include. */
+const WORKSPACE_FILES = new Set([
+  "SOUL.md",
+  "AGENTS.md",
+  "IDENTITY.md",
+  "HEARTBEAT.md",
+  "TOOLS.md",
+  "USER.md",
+  "BOOTSTRAP.md",
+  "config.json",
+]);
+
+/**
+ * Resolve a PackEntry from a directory containing a PACK.md file.
+ * Returns undefined if the directory doesn't contain a valid PACK.md.
+ */
+export async function resolvePack(dir: string): Promise<PackEntry | undefined> {
+  const absDir = path.resolve(dir);
+  const packFilePath = path.join(absDir, PACK_FILE);
+
+  let packContent: string;
+  try {
+    packContent = await fsp.readFile(packFilePath, "utf-8");
+  } catch {
+    packLogger.debug(`No ${PACK_FILE} found in ${absDir}`);
+    return undefined;
+  }
+
+  const frontmatter = parsePackFrontmatter(packContent);
+  const metadata = resolvePackMetadata(frontmatter);
+
+  if (!metadata.name) {
+    packLogger.warn(`${PACK_FILE} in ${absDir} is missing required 'name' field`);
+    return undefined;
+  }
+
+  const description = extractPackDescription(packContent);
+
+  // Scan for workspace files
+  const workspaceFiles: string[] = [];
+  const templateFiles: string[] = [];
+
+  let dirEntries: fs.Dirent[];
+  try {
+    dirEntries = await fsp.readdir(absDir, { withFileTypes: true });
+  } catch {
+    packLogger.warn(`Failed to read directory ${absDir}`);
+    return undefined;
+  }
+
+  for (const entry of dirEntries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+    const name = entry.name;
+
+    if (name === PACK_FILE) {
+      continue;
+    }
+
+    if (name.endsWith(".template")) {
+      templateFiles.push(name);
+      continue;
+    }
+
+    if (WORKSPACE_FILES.has(name)) {
+      workspaceFiles.push(name);
+    }
+  }
+
+  // Detect bundled skills
+  const bundledSkillDirs: string[] = [];
+  const skillsDir = path.join(absDir, "skills");
+  try {
+    const skillEntries = await fsp.readdir(skillsDir, { withFileTypes: true });
+    for (const entry of skillEntries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const skillMdPath = path.join(skillsDir, entry.name, "SKILL.md");
+      try {
+        await fsp.access(skillMdPath);
+        bundledSkillDirs.push(entry.name);
+      } catch {
+        // Not a valid skill directory — skip
+      }
+    }
+  } catch {
+    // No skills/ directory — that's fine
+  }
+
+  packLogger.debug(`Resolved pack "${metadata.name}" from ${absDir}`, {
+    workspaceFiles: workspaceFiles.length,
+    templateFiles: templateFiles.length,
+    bundledSkills: bundledSkillDirs.length,
+  });
+
+  return {
+    dir: absDir,
+    packFilePath,
+    metadata,
+    description,
+    templateFiles,
+    workspaceFiles,
+    bundledSkillDirs,
+  };
+}
+
+/**
+ * Scan a parent directory for pack directories (each containing PACK.md).
+ */
+export async function scanPacksDir(parentDir: string): Promise<PackEntry[]> {
+  const absParent = path.resolve(parentDir);
+  const packs: PackEntry[] = [];
+
+  let entries: fs.Dirent[];
+  try {
+    entries = await fsp.readdir(absParent, { withFileTypes: true });
+  } catch {
+    return packs;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const packDir = path.join(absParent, entry.name);
+    const pack = await resolvePack(packDir);
+    if (pack) {
+      packs.push(pack);
+    }
+  }
+
+  return packs;
+}

--- a/src/agents/pack/types.ts
+++ b/src/agents/pack/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Agent Pack types — shareable workspace templates for OpenClaw.
+ *
+ * An Agent Pack bundles personality (SOUL.md), workspace config (AGENTS.md),
+ * skills, and configuration into a versioned, installable template.
+ */
+
+/** Metadata parsed from PACK.md frontmatter */
+export type PackMetadata = {
+  /** Human-readable pack name */
+  name: string;
+  /** Short summary (one line) */
+  description?: string;
+  /** Author name or handle */
+  author?: string;
+  /** Semver version string */
+  version?: string;
+  /** Skill slugs this pack depends on (auto-install from ClawHub) */
+  skills?: string[];
+  /** Tags for discovery */
+  tags?: string[];
+};
+
+/** A resolved pack on disk */
+export type PackEntry = {
+  /** Absolute path to the pack root directory */
+  dir: string;
+  /** Absolute path to PACK.md */
+  packFilePath: string;
+  /** Parsed frontmatter metadata */
+  metadata: PackMetadata;
+  /** Raw PACK.md content (after frontmatter) */
+  description: string;
+  /** List of template files (*.template) found in the pack */
+  templateFiles: string[];
+  /** List of regular (non-template) workspace files found */
+  workspaceFiles: string[];
+  /** Skill directories bundled in the pack */
+  bundledSkillDirs: string[];
+};
+
+/** Result of a pack install operation */
+export type PackInstallResult = {
+  ok: boolean;
+  /** Target workspace directory */
+  workspaceDir: string;
+  /** Files that were copied */
+  copiedFiles: string[];
+  /** Files that were skipped (already exist and no --force) */
+  skippedFiles: string[];
+  /** Skills that were installed */
+  installedSkills: string[];
+  /** Errors encountered */
+  errors: string[];
+};
+
+/** Options for pack install */
+export type PackInstallOptions = {
+  /** Target workspace directory (default: new dir based on pack name) */
+  workdir?: string;
+  /** Overwrite existing files */
+  force?: boolean;
+  /** Skip skill dependency installation */
+  skipSkills?: boolean;
+};
+
+/** Options for pack init (export current workspace as pack) */
+export type PackInitOptions = {
+  /** Pack name */
+  name: string;
+  /** Output directory for the pack */
+  outputDir?: string;
+  /** Pack description */
+  description?: string;
+  /** Pack author */
+  author?: string;
+  /** Pack version */
+  version?: string;
+  /** Include skills directory */
+  includeSkills?: boolean;
+};
+
+/** Result of pack init */
+export type PackInitResult = {
+  ok: boolean;
+  /** Directory where the pack was created */
+  packDir: string;
+  /** Files included in the pack */
+  files: string[];
+  /** Errors encountered */
+  errors: string[];
+};

--- a/src/cli/pack-cli.ts
+++ b/src/cli/pack-cli.ts
@@ -35,7 +35,7 @@ export function registerPackCli(program: Command) {
           return;
         }
         const lines: string[] = [];
-        lines.push(`${theme.bold("Pack:")} ${entry.metadata.name}`);
+        lines.push(`${theme.heading("Pack:")} ${entry.metadata.name}`);
         if (entry.metadata.description) {
           lines.push(`${theme.muted("Description:")} ${entry.metadata.description}`);
         }
@@ -199,7 +199,7 @@ export function registerPackCli(program: Command) {
         for (const pack of packs) {
           const desc = pack.metadata.description ? ` — ${pack.metadata.description}` : "";
           const ver = pack.metadata.version ? ` (${pack.metadata.version})` : "";
-          lines.push(`  ${theme.bold(pack.metadata.name)}${ver}${theme.muted(desc)}`);
+          lines.push(`  ${theme.heading(pack.metadata.name)}${ver}${theme.muted(desc)}`);
         }
         defaultRuntime.log(lines.join("\n"));
       } catch (err) {

--- a/src/cli/pack-cli.ts
+++ b/src/cli/pack-cli.ts
@@ -1,0 +1,215 @@
+import type { Command } from "commander";
+import { defaultRuntime } from "../runtime.js";
+import { formatDocsLink } from "../terminal/links.js";
+import { theme } from "../terminal/theme.js";
+
+/**
+ * Register the pack CLI commands.
+ */
+export function registerPackCli(program: Command) {
+  const pack = program
+    .command("pack")
+    .description("Manage Agent Packs — shareable workspace templates")
+    .addHelpText(
+      "after",
+      () =>
+        `\n${theme.muted("Docs:")} ${formatDocsLink("/cli/pack", "docs.openclaw.ai/cli/pack")}\n`,
+    );
+
+  pack
+    .command("info")
+    .description("Show pack details from a directory")
+    .argument("<path>", "Path to pack directory")
+    .option("--json", "Output as JSON", false)
+    .action(async (packPath: string, opts: { json: boolean }) => {
+      try {
+        const { resolvePack } = await import("../agents/pack/resolve.js");
+        const entry = await resolvePack(packPath);
+        if (!entry) {
+          defaultRuntime.error(`No valid pack found at ${packPath}`);
+          defaultRuntime.exit(1);
+          return;
+        }
+        if (opts.json) {
+          defaultRuntime.log(JSON.stringify(entry.metadata, null, 2));
+          return;
+        }
+        const lines: string[] = [];
+        lines.push(`${theme.bold("Pack:")} ${entry.metadata.name}`);
+        if (entry.metadata.description) {
+          lines.push(`${theme.muted("Description:")} ${entry.metadata.description}`);
+        }
+        if (entry.metadata.author) {
+          lines.push(`${theme.muted("Author:")} ${entry.metadata.author}`);
+        }
+        if (entry.metadata.version) {
+          lines.push(`${theme.muted("Version:")} ${entry.metadata.version}`);
+        }
+        if (entry.metadata.skills?.length) {
+          lines.push(`${theme.muted("Skills:")} ${entry.metadata.skills.join(", ")}`);
+        }
+        if (entry.metadata.tags?.length) {
+          lines.push(`${theme.muted("Tags:")} ${entry.metadata.tags.join(", ")}`);
+        }
+        lines.push("");
+        lines.push(
+          `${theme.muted("Workspace files:")} ${entry.workspaceFiles.join(", ") || "(none)"}`,
+        );
+        lines.push(
+          `${theme.muted("Template files:")} ${entry.templateFiles.join(", ") || "(none)"}`,
+        );
+        lines.push(
+          `${theme.muted("Bundled skills:")} ${entry.bundledSkillDirs.join(", ") || "(none)"}`,
+        );
+        lines.push("");
+        lines.push(`${theme.muted("Path:")} ${entry.dir}`);
+        defaultRuntime.log(lines.join("\n"));
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
+    });
+
+  pack
+    .command("install")
+    .description("Install a pack into a workspace")
+    .argument("<path>", "Path to pack directory")
+    .option("-w, --workdir <dir>", "Target workspace directory")
+    .option("-f, --force", "Overwrite existing files", false)
+    .option("--skip-skills", "Skip skill dependency installation", false)
+    .action(
+      async (packPath: string, opts: { workdir?: string; force: boolean; skipSkills: boolean }) => {
+        try {
+          const { installPack } = await import("../agents/pack/install.js");
+          const result = await installPack(packPath, {
+            workdir: opts.workdir,
+            force: opts.force,
+            skipSkills: opts.skipSkills,
+          });
+
+          if (!result.ok) {
+            for (const err of result.errors) {
+              defaultRuntime.error(err);
+            }
+            defaultRuntime.exit(1);
+            return;
+          }
+
+          const lines: string[] = [];
+          lines.push(`${theme.success("✔")} Pack installed to ${result.workspaceDir}`);
+          if (result.copiedFiles.length > 0) {
+            lines.push(`  ${theme.muted("Copied:")} ${result.copiedFiles.join(", ")}`);
+          }
+          if (result.skippedFiles.length > 0) {
+            lines.push(`  ${theme.muted("Skipped (exists):")} ${result.skippedFiles.join(", ")}`);
+          }
+          if (result.installedSkills.length > 0) {
+            lines.push(`  ${theme.muted("Skills:")} ${result.installedSkills.join(", ")}`);
+          }
+          defaultRuntime.log(lines.join("\n"));
+        } catch (err) {
+          defaultRuntime.error(String(err));
+          defaultRuntime.exit(1);
+        }
+      },
+    );
+
+  pack
+    .command("init")
+    .description("Export current workspace as a pack")
+    .option("-n, --name <name>", "Pack name (required)")
+    .option("-o, --output <dir>", "Output directory for the pack")
+    .option("-a, --author <author>", "Pack author")
+    .option("--description <desc>", "Pack description")
+    .option("-v, --version <version>", "Pack version", "1.0.0")
+    .option("--include-skills", "Include skills directory", false)
+    .action(
+      async (opts: {
+        name?: string;
+        output?: string;
+        author?: string;
+        description?: string;
+        version: string;
+        includeSkills: boolean;
+      }) => {
+        if (!opts.name) {
+          defaultRuntime.error("Pack name is required. Use --name <name>");
+          defaultRuntime.exit(1);
+          return;
+        }
+        try {
+          const { initPack } = await import("../agents/pack/init.js");
+          const result = await initPack(process.cwd(), {
+            name: opts.name,
+            outputDir: opts.output,
+            description: opts.description,
+            author: opts.author,
+            version: opts.version,
+            includeSkills: opts.includeSkills,
+          });
+
+          if (!result.ok) {
+            for (const err of result.errors) {
+              defaultRuntime.error(err);
+            }
+            defaultRuntime.exit(1);
+            return;
+          }
+
+          const lines: string[] = [];
+          lines.push(`${theme.success("✔")} Pack "${opts.name}" created at ${result.packDir}`);
+          if (result.files.length > 0) {
+            lines.push(`  ${theme.muted("Files:")} ${result.files.join(", ")}`);
+          }
+          defaultRuntime.log(lines.join("\n"));
+        } catch (err) {
+          defaultRuntime.error(String(err));
+          defaultRuntime.exit(1);
+        }
+      },
+    );
+
+  pack
+    .command("list")
+    .description("List available packs from a directory")
+    .argument("[dir]", "Directory to scan for packs", ".")
+    .option("--json", "Output as JSON", false)
+    .action(async (dir: string, opts: { json: boolean }) => {
+      try {
+        const { scanPacksDir } = await import("../agents/pack/resolve.js");
+        const packs = await scanPacksDir(dir);
+
+        if (opts.json) {
+          defaultRuntime.log(
+            JSON.stringify(
+              packs.map((p) => p.metadata),
+              null,
+              2,
+            ),
+          );
+          return;
+        }
+
+        if (packs.length === 0) {
+          defaultRuntime.log(theme.muted("No packs found."));
+          return;
+        }
+
+        const lines: string[] = [];
+        for (const pack of packs) {
+          const desc = pack.metadata.description ? ` — ${pack.metadata.description}` : "";
+          const ver = pack.metadata.version ? ` (${pack.metadata.version})` : "";
+          lines.push(`  ${theme.bold(pack.metadata.name)}${ver}${theme.muted(desc)}`);
+        }
+        defaultRuntime.log(lines.join("\n"));
+      } catch (err) {
+        defaultRuntime.error(String(err));
+        defaultRuntime.exit(1);
+      }
+    });
+
+  // Default action (no subcommand) — show help
+  pack.action(() => {
+    pack.outputHelp();
+  });
+}

--- a/src/cli/program/register.subclis.ts
+++ b/src/cli/program/register.subclis.ts
@@ -270,6 +270,15 @@ const entries: SubCliEntry[] = [
     },
   },
   {
+    name: "pack",
+    description: "Create, install, and manage Agent Packs (shareable workspace templates)",
+    hasSubcommands: true,
+    register: async (program) => {
+      const mod = await import("../pack-cli.js");
+      mod.registerPackCli(program);
+    },
+  },
+  {
     name: "skills",
     description: "List and inspect available skills",
     hasSubcommands: true,


### PR DESCRIPTION
## Summary

Implements the **Agent Pack** feature — shareable, versioned workspace templates for OpenClaw.

An Agent Pack bundles personality (SOUL.md), workspace config (AGENTS.md), skills, and configuration into an installable template that others can use to bootstrap a complete agent setup.

## What's included

### Core modules (`src/agents/pack/`)
- **frontmatter.ts** — PACK.md YAML frontmatter parsing (name, description, author, version, skills, tags)
- **resolve.ts** — Resolve a pack from directory, scan parent dirs for packs
- **install.ts** — Install a pack into a target workspace (copy files, process templates, install bundled skills)
- **init.ts** — Export current workspace as a pack (generate PACK.md, create .template files for user-specific content)
- **types.ts** — TypeScript type definitions (PackMetadata, PackEntry, PackInstallResult, etc.)
- **index.ts** — Public API re-exports

### CLI commands (`openclaw pack`)
- `openclaw pack info <path>` — Show pack details from a directory
- `openclaw pack install <path>` — Install a pack into workspace (`--workdir`, `--force`, `--skip-skills`)
- `openclaw pack init` — Export current workspace as a pack (`--name`, `--output`, `--author`, `--version`, `--include-skills`)
- `openclaw pack list [dir]` — List available packs

### PACK.md format
```markdown
---
name: news-curator
description: AI news curator agent with search and summary skills
author: garysng
version: 1.0.0
skills:
  - summarize
  - web-search
tags:
  - news
  - research
---

# News Curator Agent Pack
A pre-configured agent setup for curating and summarizing news...
```

### Pack directory structure
```
my-agent-pack/
├── PACK.md              # Pack metadata + description
├── SOUL.md              # Agent personality
├── AGENTS.md            # Workspace conventions
├── USER.md.template     # User-specific (placeholder)
├── TOOLS.md.template    # Environment-specific (placeholder)
├── HEARTBEAT.md         # Heartbeat config
└── skills/              # Bundled skills
    └── my-skill/
        └── SKILL.md
```

## Tests

**40 tests** across 4 test files, all passing:
- `frontmatter.test.ts` — Frontmatter parsing, metadata extraction, description extraction
- `resolve.test.ts` — Pack resolution, directory scanning, edge cases
- `install.test.ts` — File copying, template processing, skill installation, force/skip behavior
- `init.test.ts` — Pack creation, workspace export, template generation

## Design decisions

1. **Templates, not overrides** — `.template` files are starting points; user customizes them
2. **Extends existing patterns** — Follows `agents/skills/` code style (logging, frontmatter parsing, types)
3. **No external dependencies** — Uses only what's already in the project
4. **Safe defaults** — Skips existing files unless `--force` is used

Closes #38038