### PR TITLE
fix(gateway): filter delivery-mirror entries from chat.history

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -217,6 +217,14 @@ function sanitizeChatHistoryMessage(message: unknown): { message: unknown; chang
  * When `entry.text` is present it takes precedence over `entry.content` to avoid
  * dropping messages that carry real text alongside a stale `content: "NO_REPLY"`.
  */
+function isDeliveryMirrorMessage(message: unknown): boolean {
+  if (!message || typeof message !== "object") {
+    return false;
+  }
+  const entry = message as Record<string, unknown>;
+  return entry.role === "assistant" && entry.model === "delivery-mirror";
+}
+
 function extractAssistantTextForSilentCheck(message: unknown): string | undefined {
   if (!message || typeof message !== "object") {
     return undefined;
@@ -258,6 +266,12 @@ function sanitizeChatHistoryMessages(messages: unknown[]): unknown[] {
   for (const message of messages) {
     const res = sanitizeChatHistoryMessage(message);
     changed ||= res.changed;
+    // Drop internal delivery-mirror transcript entries so webchat doesn't
+    // show duplicate assistant messages (the real reply + the mirror copy).
+    if (isDeliveryMirrorMessage(res.message)) {
+      changed = true;
+      continue;
+    }
     // Drop assistant messages whose entire visible text is the silent reply token.
     const text = extractAssistantTextForSilentCheck(res.message);
     if (text !== undefined && isSilentReplyText(text, SILENT_REPLY_TOKEN)) {


### PR DESCRIPTION
## Summary

- Filter out internal `delivery-mirror` transcript entries from `chat.history` responses so webchat no longer displays duplicate assistant messages.
- When a delivery channel (e.g. Telegram) is configured, each assistant reply is mirrored into the session transcript with `model: "delivery-mirror"`. The `chat.history` endpoint was returning these alongside real provider messages, causing webchat to render the same reply twice.
- Adds a guard in `sanitizeChatHistoryMessages()` that drops messages with `model === "delivery-mirror"`, consistent with the existing pattern for filtering silent-reply messages.

## Test plan

- [ ] Configure a Telegram (or other) delivery channel alongside webchat
- [ ] Send a prompt and receive a normal assistant reply
- [ ] Verify webchat shows the reply only once (not duplicated)
- [ ] Verify Telegram still receives the message normally
- [ ] Verify `chat.history` API response no longer contains `delivery-mirror` entries

Fixes #38061