### PR TITLE
fix(dashboard): prevent agents right pane from stretching horizontally

### DIFF
--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -2228,6 +2228,7 @@
 .agents-main {
   display: grid;
   gap: 16px;
+  min-width: 0; /* prevent grid blowout when detail content overflows */
 }
 
 .agent-list {


### PR DESCRIPTION
## Problem

On the Agents page of the dashboard, when the agents list grows large, the right-hand detail pane stretches horizontally beyond its intended width, breaking the two-column layout and making the UI difficult to use.

## Root Cause

CSS grid items do not implicitly apply `min-width: 0`. When detail content (long strings, code blocks, or wide tables) inside `.agents-main` exceeds the available column width, the grid column expands to accommodate it, causing horizontal overflow.

The grid is defined as:
```css
grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
```

The `minmax(0, 1fr)` column correctly sets the maximum, but without `min-width: 0` on the direct grid child (`.agents-main`), the item can still expand beyond its cell.

## Fix

Add `min-width: 0` to `.agents-main`:

```css
.agents-main {
  display: grid;
  gap: 16px;
  min-width: 0; /* prevent grid blowout when detail content overflows */
}
```

## Testing

- Load Agents page with many configured agents
- Select an agent with a long system prompt or many tools
- Right pane should remain within its column width without causing horizontal scrollbar or layout shift