### PR TITLE
fix(health): catch plugin errors during account resolution in health check

### DIFF
--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -430,7 +430,11 @@ export async function getHealthSnapshot(params?: {
           : true;
       } catch (err) {
         resolutionError = formatErrorMessage(err);
-        debugHealth("resolveAccount-error", { channel: plugin.id, accountId, error: resolutionError });
+        debugHealth("resolveAccount-error", {
+          channel: plugin.id,
+          accountId,
+          error: resolutionError,
+        });
       }
 
       let probe: unknown;

--- a/src/commands/health.ts
+++ b/src/commands/health.ts
@@ -416,17 +416,29 @@ export async function getHealthSnapshot(params?: {
     const accountSummaries: Record<string, ChannelAccountHealthSummary> = {};
 
     for (const accountId of accountIdsToProbe) {
-      const account = plugin.config.resolveAccount(cfg, accountId);
-      const enabled = plugin.config.isEnabled
-        ? plugin.config.isEnabled(account, cfg)
-        : isAccountEnabled(account);
-      const configured = plugin.config.isConfigured
-        ? await plugin.config.isConfigured(account, cfg)
-        : true;
+      let account: unknown;
+      let enabled = false;
+      let configured = false;
+      let resolutionError: string | undefined;
+      try {
+        account = plugin.config.resolveAccount(cfg, accountId);
+        enabled = plugin.config.isEnabled
+          ? plugin.config.isEnabled(account, cfg)
+          : isAccountEnabled(account);
+        configured = plugin.config.isConfigured
+          ? await plugin.config.isConfigured(account, cfg)
+          : true;
+      } catch (err) {
+        resolutionError = formatErrorMessage(err);
+        debugHealth("resolveAccount-error", { channel: plugin.id, accountId, error: resolutionError });
+      }
 
       let probe: unknown;
       let lastProbeAt: number | null = null;
-      if (enabled && configured && doProbe && plugin.status?.probeAccount) {
+      if (resolutionError) {
+        probe = { ok: false, error: resolutionError };
+        lastProbeAt = Date.now();
+      } else if (enabled && configured && doProbe && plugin.status?.probeAccount) {
         try {
           probe = await plugin.status.probeAccount({
             account,


### PR DESCRIPTION
## Summary

When a channel plugin's `resolveAccount()`, `isEnabled()`, or `isConfigured()` throws during the health snapshot refresh (e.g. when credentials use SecretRef format and the plugin calls `.trim()` on an unresolved object), the **entire** health check fails with an unhandled error like:

```
post-connect health refresh failed: cfg?.appId?.trim is not a function
```

This crashes the full health snapshot, causing Control-UI WebSocket disconnects (1006) and degraded monitoring for **all** channels — not just the one with the misconfigured account.

**Fix:** Wrap account resolution in try-catch (matching the existing pattern used for `probeAccount`) so a single plugin failure reports a per-account error probe instead of crashing the full health snapshot.

**Before:** One plugin error → entire health check fails → all channels show as unhealthy
**After:** One plugin error → that account shows `{ ok: false, error: "..." }` → other channels unaffected

Closes #37718

## Test plan
- [x] Verified the fix catches errors from `resolveAccount`, `isEnabled`, and `isConfigured`
- [x] Error is reported as a per-account probe result with the original error message
- [x] Debug logging added for `resolveAccount-error` events
- [x] Existing health check tests unaffected (they test CLI output formatting, not gateway internals)