### PR TITLE
fix(slack): prevent auth-failure retry storm by disabling SDK auto-reconnect

### DIFF
--- a/src/slack/monitor/provider.auth-errors.test.ts
+++ b/src/slack/monitor/provider.auth-errors.test.ts
@@ -8,6 +8,7 @@ describe("isNonRecoverableSlackAuthError", () => {
     "An API error occurred: token_revoked",
     "An API error occurred: token_expired",
     "An API error occurred: not_authed",
+    "An API error occurred: not_allowed_token_type",
     "An API error occurred: org_login_required",
     "An API error occurred: team_access_not_granted",
     "An API error occurred: missing_scope",

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -185,8 +185,9 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   // at ~1.5s intervals on auth failures, flooding logs and bypassing our
   // circuit-breaker.
   if (slackMode === "socket") {
-    const smClient = (app as unknown as { receiver?: { client?: { autoReconnectEnabled?: boolean } } })
-      .receiver?.client;
+    const smClient = (
+      app as unknown as { receiver?: { client?: { autoReconnectEnabled?: boolean } } }
+    ).receiver?.client;
     if (smClient && "autoReconnectEnabled" in smClient) {
       smClient.autoReconnectEnabled = false;
     }

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -178,6 +178,20 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
           clientOptions,
         },
   );
+
+  // Disable the Slack SDK's built-in auto-reconnect so OpenClaw's own backoff
+  // loop (with exponential backoff and auth-error detection) controls all
+  // reconnection logic.  Without this, the SocketModeClient retries internally
+  // at ~1.5s intervals on auth failures, flooding logs and bypassing our
+  // circuit-breaker.
+  if (slackMode === "socket") {
+    const smClient = (app as unknown as { receiver?: { client?: { autoReconnectEnabled?: boolean } } })
+      .receiver?.client;
+    if (smClient && "autoReconnectEnabled" in smClient) {
+      smClient.autoReconnectEnabled = false;
+    }
+  }
+
   const slackHttpHandler =
     slackMode === "http" && receiver
       ? async (req: IncomingMessage, res: ServerResponse) => {

--- a/src/slack/monitor/reconnect-policy.ts
+++ b/src/slack/monitor/reconnect-policy.ts
@@ -1,5 +1,5 @@
 const SLACK_AUTH_ERROR_RE =
-  /account_inactive|invalid_auth|token_revoked|token_expired|not_authed|org_login_required|team_access_not_granted|missing_scope|cannot_find_service|invalid_token/i;
+  /account_inactive|invalid_auth|token_revoked|token_expired|not_authed|not_allowed_token_type|org_login_required|team_access_not_granted|missing_scope|cannot_find_service|invalid_token/i;
 
 export const SLACK_SOCKET_RECONNECT_POLICY = {
   initialMs: 2_000,


### PR DESCRIPTION
## Summary

When a Slack bot token expires, the gateway enters a tight retry loop (~1.5s intervals) that floods logs with thousands of identical errors and can degrade other channels. Root cause: the Slack SDK's `SocketModeClient` has built-in auto-reconnect that retries regardless of error type, bypassing OpenClaw's own backoff logic.

**Two fixes:**

1. **Disable SDK auto-reconnect** — Set `SocketModeClient.autoReconnectEnabled = false` after App creation so OpenClaw's reconnect loop (with exponential backoff + auth-error fail-fast) controls all retry logic.

2. **Add `not_allowed_token_type` to non-recoverable error regex** — This error appears when reconnecting with a wrong token type after expiry. It was previously treated as transient, causing infinite retries instead of fail-fast.

**Before:** Token expires → SDK retries at 1.5s × ∞ → 1,700+ errors in 9h → log flood + channel degradation
**After:** Token expires → `isNonRecoverableSlackAuthError` matches → immediate fail-fast → channel marked unhealthy

Closes #38083

## Test plan
- [x] `not_allowed_token_type` added to auth error test matrix
- [x] Existing reconnect tests (`provider.reconnect.test.ts`) verify disconnect event handling
- [x] Existing auth error tests verify all non-recoverable patterns are detected