### PR TITLE
feat(telegram): embed file_id in media placeholders and add download-file action

### DIFF
--- a/src/agents/tools/telegram-actions.ts
+++ b/src/agents/tools/telegram-actions.ts
@@ -467,5 +467,46 @@ export async function handleTelegramAction(
     });
   }
 
+  if (action === "downloadFile") {
+    const fileId = readStringParam(params, "fileId", { required: true });
+    const token = resolveTelegramToken(cfg, { accountId }).token;
+    if (!token) {
+      throw new Error(
+        "Telegram bot token missing. Set TELEGRAM_BOT_TOKEN or channels.telegram.botToken.",
+      );
+    }
+    const fileInfo = await fetch(
+      `https://api.telegram.org/bot${token}/getFile?file_id=${encodeURIComponent(fileId)}`,
+    );
+    if (!fileInfo.ok) {
+      throw new Error(`Telegram getFile failed: ${fileInfo.status}`);
+    }
+    const fileJson = (await fileInfo.json()) as {
+      ok: boolean;
+      result?: { file_path?: string; file_size?: number };
+    };
+    if (!fileJson.ok || !fileJson.result?.file_path) {
+      throw new Error("Telegram getFile returned no file_path");
+    }
+    const filePath = fileJson.result.file_path;
+    const fileUrl = `https://api.telegram.org/file/bot${token}/${filePath}`;
+    const fileRes = await fetch(fileUrl);
+    if (!fileRes.ok) {
+      throw new Error(`Telegram file download failed: ${fileRes.status}`);
+    }
+    const buffer = Buffer.from(await fileRes.arrayBuffer());
+    const ext = filePath.includes(".") ? filePath.slice(filePath.lastIndexOf(".")) : ".bin";
+    const outDir = "/tmp";
+    const outPath = `${outDir}/tg_${fileId.slice(0, 16)}${ext}`;
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(outPath, buffer);
+    return jsonResult({
+      ok: true,
+      path: outPath,
+      fileSize: fileJson.result.file_size,
+      filePath,
+    });
+  }
+
   throw new Error(`Unsupported Telegram action: ${action}`);
 }

--- a/src/channels/plugins/actions/telegram.ts
+++ b/src/channels/plugins/actions/telegram.ts
@@ -107,6 +107,8 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     if (isEnabled("createForumTopic")) {
       actions.add("topic-create");
     }
+    // download-file is always available when the bot has a token
+    actions.add("download-file");
     return Array.from(actions);
   },
   supportsButtons: ({ cfg }) => {
@@ -275,6 +277,19 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           name,
           iconColor: iconColor ?? undefined,
           iconCustomEmojiId: iconCustomEmojiId ?? undefined,
+          accountId: accountId ?? undefined,
+        },
+        cfg,
+        { mediaLocalRoots },
+      );
+    }
+
+    if (action === "download-file") {
+      const fileId = readStringParam(params, "fileId", { required: true });
+      return await handleTelegramAction(
+        {
+          action: "downloadFile",
+          fileId,
           accountId: accountId ?? undefined,
         },
         cfg,

--- a/src/telegram/bot-handlers.ts
+++ b/src/telegram/bot-handlers.ts
@@ -46,6 +46,7 @@ import { resolveMedia } from "./bot/delivery.js";
 import {
   buildTelegramGroupPeerId,
   buildTelegramParentPeer,
+  resolveInboundMediaFileId,
   resolveTelegramForumThreadId,
   resolveTelegramGroupAllowFromContext,
 } from "./bot/helpers.js";
@@ -90,18 +91,6 @@ function hasReplyTargetMedia(msg: Message): boolean {
   const externalReply = (msg as Message & { external_reply?: Message }).external_reply;
   const replyTarget = msg.reply_to_message ?? externalReply;
   return Boolean(replyTarget && hasInboundMedia(replyTarget));
-}
-
-function resolveInboundMediaFileId(msg: Message): string | undefined {
-  return (
-    msg.sticker?.file_id ??
-    msg.photo?.[msg.photo.length - 1]?.file_id ??
-    msg.video?.file_id ??
-    msg.video_note?.file_id ??
-    msg.document?.file_id ??
-    msg.audio?.file_id ??
-    msg.voice?.file_id
-  );
 }
 
 export const registerTelegramHandlers = ({

--- a/src/telegram/bot-message-context.audio-transcript.test.ts
+++ b/src/telegram/bot-message-context.audio-transcript.test.ts
@@ -65,12 +65,12 @@ function expectTranscriptRendered(
   expect(ctx).not.toBeNull();
   expect(ctx?.ctxPayload?.BodyForAgent).toBe(transcript);
   expect(ctx?.ctxPayload?.Body).toContain(transcript);
-  expect(ctx?.ctxPayload?.Body).not.toContain("<media:audio>");
+  expect(ctx?.ctxPayload?.Body).not.toContain("<media:audio");
 }
 
 function expectAudioPlaceholderRendered(ctx: Awaited<ReturnType<typeof buildGroupVoiceContext>>) {
   expect(ctx).not.toBeNull();
-  expect(ctx?.ctxPayload?.Body).toContain("<media:audio>");
+  expect(ctx?.ctxPayload?.Body).toContain("<media:audio");
 }
 
 describe("buildTelegramMessageContext audio transcript body", () => {

--- a/src/telegram/bot-message-context.ts
+++ b/src/telegram/bot-message-context.ts
@@ -470,7 +470,7 @@ export const buildTelegramMessageContext = async ({
   const commandAuthorized = commandGate.commandAuthorized;
   const historyKey = isGroup ? buildTelegramGroupPeerId(chatId, resolvedThreadId) : undefined;
 
-  let placeholder = resolveTelegramMediaPlaceholder(msg) ?? "";
+  let placeholder = resolveTelegramMediaPlaceholder(msg, { includeFileId: true }) ?? "";
 
   // Check if sticker has a cached description - if so, use it instead of sending the image
   const cachedStickerDescription = allMedia[0]?.stickerMetadata?.cachedDescription;
@@ -541,14 +541,14 @@ export const buildTelegramMessageContext = async ({
   }
 
   // Replace audio placeholder with transcript when preflight succeeds.
-  if (hasAudio && bodyText === "<media:audio>" && preflightTranscript) {
+  if (hasAudio && bodyText.startsWith("<media:audio") && preflightTranscript) {
     bodyText = preflightTranscript;
   }
 
   // Build bodyText fallback for messages that still have no text.
   if (!bodyText && allMedia.length > 0) {
     if (hasAudio) {
-      bodyText = preflightTranscript || "<media:audio>";
+      bodyText = preflightTranscript || placeholder || "<media:audio>";
     } else {
       bodyText = `<media:image>${allMedia.length > 1 ? ` (${allMedia.length} images)` : ""}`;
     }

--- a/src/telegram/bot/helpers.ts
+++ b/src/telegram/bot/helpers.ts
@@ -222,7 +222,11 @@ export function buildSenderName(msg: Message) {
   return name || undefined;
 }
 
-export function resolveTelegramMediaPlaceholder(
+/**
+ * Extract the primary file_id from an inbound Telegram message.
+ * Returns the largest photo size, or the file_id for video/audio/document/sticker.
+ */
+export function resolveInboundMediaFileId(
   msg:
     | Pick<Message, "photo" | "video" | "video_note" | "audio" | "voice" | "document" | "sticker">
     | undefined
@@ -231,20 +235,43 @@ export function resolveTelegramMediaPlaceholder(
   if (!msg) {
     return undefined;
   }
+  return (
+    msg.sticker?.file_id ??
+    msg.photo?.[msg.photo.length - 1]?.file_id ??
+    msg.video?.file_id ??
+    msg.video_note?.file_id ??
+    msg.document?.file_id ??
+    msg.audio?.file_id ??
+    msg.voice?.file_id
+  );
+}
+
+export function resolveTelegramMediaPlaceholder(
+  msg:
+    | Pick<Message, "photo" | "video" | "video_note" | "audio" | "voice" | "document" | "sticker">
+    | undefined
+    | null,
+  options?: { includeFileId?: boolean },
+): string | undefined {
+  if (!msg) {
+    return undefined;
+  }
+  const fileId = options?.includeFileId ? resolveInboundMediaFileId(msg) : undefined;
+  const suffix = fileId ? ` file_id="${fileId}"` : "";
   if (msg.photo) {
-    return "<media:image>";
+    return `<media:image${suffix}>`;
   }
   if (msg.video || msg.video_note) {
-    return "<media:video>";
+    return `<media:video${suffix}>`;
   }
   if (msg.audio || msg.voice) {
-    return "<media:audio>";
+    return `<media:audio${suffix}>`;
   }
   if (msg.document) {
-    return "<media:document>";
+    return `<media:document${suffix}>`;
   }
   if (msg.sticker) {
-    return "<media:sticker>";
+    return `<media:sticker${suffix}>`;
   }
   return undefined;
 }


### PR DESCRIPTION
## Summary

Resolves #8843.

- Telegram media placeholders now include the `file_id` attribute: `<media:image file_id="AgACAgIAA...">` instead of bare `<media:image>`
- This allows agents to retroactively download media from group chat history entries without needing the forward-message workaround used by external skills (e.g. `tg-media-resolve`)
- Adds a `download-file` action for Telegram that accepts a `fileId` param, calls `getFile` + downloads the file, and returns the local path
- Extracts `resolveInboundMediaFileId` into `bot/helpers.ts` as a shared utility (previously duplicated in `bot-handlers.ts`)

## How it works

1. When an inbound message has media, `resolveTelegramMediaPlaceholder(msg, { includeFileId: true })` embeds the file_id in the placeholder tag
2. The enriched placeholder flows into group history entries (which already store the message body)
3. The agent sees `<media:image file_id="...">` in inbound history and can extract the file_id
4. The agent calls `message(action="download-file", fileId="...")` to download the file to `/tmp` and gets back the local path for vision/analysis

## Test plan

- [x] Existing `resolveTelegramMediaPlaceholder` tests pass (no `includeFileId` = old behavior preserved)
- [x] Audio preflight transcript tests updated and passing (placeholder comparison changed from `===` to `startsWith`)
- [x] 718/719 telegram tests pass (1 pre-existing unrelated failure)
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)