### PR TITLE
fix(discord): preserve native command session keys

### DIFF
--- a/src/discord/monitor/native-command.plugin-dispatch.test.ts
+++ b/src/discord/monitor/native-command.plugin-dispatch.test.ts
@@ -301,6 +301,80 @@ describe("Discord native plugin command dispatch", () => {
     expect(persistentBindingMocks.ensureConfiguredAcpBindingSession).not.toHaveBeenCalled();
   });
 
+  it("falls back to the routed slash and channel session keys when no bound session exists", async () => {
+    const guildId = "1459246755253325866";
+    const channelId = "1478836151241412759";
+    const cfg = {
+      commands: {
+        useAccessGroups: false,
+      },
+      bindings: [
+        {
+          agentId: "qwen",
+          match: {
+            channel: "discord",
+            accountId: "default",
+            peer: { kind: "channel", id: channelId },
+            guildId,
+          },
+        },
+      ],
+      channels: {
+        discord: {
+          guilds: {
+            [guildId]: {
+              channels: {
+                [channelId]: { allow: true, requireMention: false },
+              },
+            },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const commandSpec: NativeCommandSpec = {
+      name: "status",
+      description: "Status",
+      acceptsArgs: false,
+    };
+    const command = createDiscordNativeCommand({
+      command: commandSpec,
+      cfg,
+      discordConfig: cfg.channels?.discord ?? {},
+      accountId: "default",
+      sessionPrefix: "discord:slash",
+      ephemeralDefault: true,
+      threadBindings: createNoopThreadBindingManager("default"),
+    });
+    const interaction = createInteraction({
+      channelType: ChannelType.GuildText,
+      channelId,
+      guildId,
+      guildName: "Ops",
+    });
+
+    vi.spyOn(pluginCommandsModule, "matchPluginCommand").mockReturnValue(null);
+    const dispatchSpy = vi
+      .spyOn(dispatcherModule, "dispatchReplyWithDispatcher")
+      .mockResolvedValue({
+        counts: {
+          final: 1,
+          block: 0,
+          tool: 0,
+        },
+      } as never);
+
+    await (command as { run: (interaction: unknown) => Promise<void> }).run(interaction as unknown);
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const dispatchCall = dispatchSpy.mock.calls[0]?.[0] as {
+      ctx?: { SessionKey?: string; CommandTargetSessionKey?: string };
+    };
+    expect(dispatchCall.ctx?.SessionKey).toBe("agent:qwen:discord:slash:owner");
+    expect(dispatchCall.ctx?.CommandTargetSessionKey).toBe(
+      "agent:qwen:discord:channel:1478836151241412759",
+    );
+  });
+
   it("routes Discord DM native slash commands through configured ACP bindings", async () => {
     const channelId = "dm-1";
     const boundSessionKey = "agent:codex:acp:binding:discord:default:dmfeedface";


### PR DESCRIPTION
## Summary
- fix Discord native `/status` (and other native commands) dropping `SessionKey` / `CommandTargetSessionKey` when no bound session exists
- preserve fallback to the routed slash session and routed channel session instead of passing empty strings
- add a regression test covering Discord guild native slash commands without ACP/thread bindings

## Root cause
`configuredBoundSessionKey` defaulted to an empty string:

```ts
const configuredBoundSessionKey = configuredRoute?.boundSessionKey ?? "";
```

That value flowed into:

```ts
SessionKey: boundSessionKey ?? `agent:${effectiveRoute.agentId}:${sessionPrefix}:${user.id}`,
CommandTargetSessionKey: boundSessionKey ?? effectiveRoute.sessionKey,
```

Because `??` does not treat `""` as missing, both session keys could become empty strings instead of falling back to the routed session keys.

In practice this could make native `/status` lose the bound agent/channel target and surface the wrong session (for example an old `main` channel session) on Discord.

## Fix
Change the configured bound session fallback to `undefined` after trimming:

```ts
const configuredBoundSessionKey = configuredRoute?.boundSessionKey?.trim() || undefined;
```

## Test
Added a regression test in `src/discord/monitor/native-command.plugin-dispatch.test.ts` asserting that, for a guild native slash command with a normal route binding and no ACP/thread bound session:
- `SessionKey` falls back to `agent:<agent>:discord:slash:<user>`
- `CommandTargetSessionKey` falls back to `agent:<agent>:discord:channel:<channel>`

## Validation
Ran:

```bash
pnpm test -- src/discord/monitor/native-command.plugin-dispatch.test.ts
```

Passed locally.
