### PR TITLE
fix: extract text from array content in tool cards

### DIFF
--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -152,5 +152,12 @@ function extractToolText(item: Record<string, unknown>): string | undefined {
   if (typeof item.content === "string") {
     return item.content;
   }
+  // Handle array content (e.g., content: [{ text: "..." }])
+  if (Array.isArray(item.content) && item.content.length > 0) {
+    const firstItem = item.content[0];
+    if (typeof firstItem === "object" && firstItem !== null && "text" in firstItem) {
+      return String(firstItem.text);
+    }
+  }
   return undefined;
 }


### PR DESCRIPTION
When tool result content is an array like [{ text: '...' }], extractToolText now properly extracts the text field from the first array element instead of returning undefined.

Fixes #38223