### PR TITLE
fix(dotenv): expand env references in loaded env files

### DIFF
--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -164,4 +164,25 @@ describe("loadDotEnv", () => {
       });
     });
   });
+
+  it("does not treat dollar-prefixed literals as env references", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ cwdDir, stateDir }) => {
+        await writeEnvFile(
+          path.join(stateDir, ".env"),
+          "PRICE=cost-$5\nPASSWORD=abc$5word\nBRACED=keep-${5}\n",
+        );
+        process.chdir(cwdDir);
+        delete process.env.PRICE;
+        delete process.env.PASSWORD;
+        delete process.env.BRACED;
+
+        loadDotEnv({ quiet: true });
+
+        expect(process.env.PRICE).toBe("cost-$5");
+        expect(process.env.PASSWORD).toBe("abc$5word");
+        expect(process.env.BRACED).toBe("keep-${5}");
+      });
+    });
+  });
 });

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import dotenv from "dotenv";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { loadDotEnv } from "./dotenv.js";
 
 async function writeEnvFile(filePath: string, contents: string) {
@@ -48,6 +49,10 @@ async function withDotEnvFixture(run: (fixture: DotEnvFixture) => Promise<void>)
 }
 
 describe("loadDotEnv", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("loads ~/.openclaw/.env as fallback without overriding CWD .env", async () => {
     await withIsolatedEnvAndCwd(async () => {
       await withDotEnvFixture(async ({ cwdDir, stateDir }) => {
@@ -134,6 +139,28 @@ describe("loadDotEnv", () => {
 
         expect(process.env.BASE).toBe("from-global");
         expect(process.env.COMBINED).toBe("from-global-suffix");
+      });
+    });
+  });
+
+  it("keeps loading fallback env files when a prior env file fails to parse", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ cwdDir, stateDir }) => {
+        await writeEnvFile(path.join(cwdDir, ".env"), "BROKEN=1\n");
+        await writeEnvFile(path.join(stateDir, ".env"), "FALLBACK_OK=from-global\n");
+        process.chdir(cwdDir);
+        delete process.env.FALLBACK_OK;
+
+        const configSpy = vi.spyOn(dotenv, "configDotenv");
+        configSpy.mockImplementation((options) => {
+          if (typeof options?.path === "string" && options.path === path.join(cwdDir, ".env")) {
+            return { parsed: {}, error: new Error("boom") };
+          }
+          return { parsed: { FALLBACK_OK: "from-global" } };
+        });
+
+        expect(() => loadDotEnv({ quiet: true })).not.toThrow();
+        expect(process.env.FALLBACK_OK).toBe("from-global");
       });
     });
   });

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -152,9 +152,12 @@ describe("loadDotEnv", () => {
         delete process.env.FALLBACK_OK;
 
         const configSpy = vi.spyOn(dotenv, "configDotenv");
-        configSpy.mockImplementation((options) => {
+        configSpy.mockImplementation((options): ReturnType<typeof dotenv.configDotenv> => {
           if (typeof options?.path === "string" && options.path === path.join(cwdDir, ".env")) {
-            return { parsed: {}, error: new Error("boom") };
+            return {
+              parsed: {},
+              error: Object.assign(new Error("boom"), { code: "MISSING_DATA" as const }),
+            };
           }
           return { parsed: { FALLBACK_OK: "from-global" } };
         });

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -96,4 +96,45 @@ describe("loadDotEnv", () => {
       });
     });
   });
+
+  it("expands references from the shell and CWD env files", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ cwdDir, stateDir }) => {
+        process.env.OPENAI_API_KEY = "from-shell";
+        await writeEnvFile(path.join(cwdDir, ".env"), "LOCAL_BASE=from-cwd\n");
+        await writeEnvFile(
+          path.join(stateDir, ".env"),
+          "OPENAI_TRANSCRIPTION_API_KEY=${OPENAI_API_KEY}\nCHAINED_VALUE=${LOCAL_BASE}\n",
+        );
+
+        process.chdir(cwdDir);
+        delete process.env.OPENAI_TRANSCRIPTION_API_KEY;
+        delete process.env.CHAINED_VALUE;
+
+        loadDotEnv({ quiet: true });
+
+        expect(process.env.OPENAI_TRANSCRIPTION_API_KEY).toBe("from-shell");
+        expect(process.env.CHAINED_VALUE).toBe("from-cwd");
+      });
+    });
+  });
+
+  it("expands references defined earlier in the same env file", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ cwdDir, stateDir }) => {
+        await writeEnvFile(
+          path.join(stateDir, ".env"),
+          "BASE=from-global\nCOMBINED=${BASE}-suffix\n",
+        );
+        process.chdir(cwdDir);
+        delete process.env.BASE;
+        delete process.env.COMBINED;
+
+        loadDotEnv({ quiet: true });
+
+        expect(process.env.BASE).toBe("from-global");
+        expect(process.env.COMBINED).toBe("from-global-suffix");
+      });
+    });
+  });
 });

--- a/src/infra/dotenv.test.ts
+++ b/src/infra/dotenv.test.ts
@@ -188,4 +188,26 @@ describe("loadDotEnv", () => {
       });
     });
   });
+
+  it("preserves escaped dollar literals without expanding them", async () => {
+    await withIsolatedEnvAndCwd(async () => {
+      await withDotEnvFixture(async ({ cwdDir, stateDir }) => {
+        await writeEnvFile(
+          path.join(stateDir, ".env"),
+          "ESCAPED_BARE=abc\\$TOKEN\nESCAPED_BRACED=abc\\${TOKEN}\nDOUBLE=abc\\\\$TOKEN\n",
+        );
+        process.chdir(cwdDir);
+        delete process.env.ESCAPED_BARE;
+        delete process.env.ESCAPED_BRACED;
+        delete process.env.DOUBLE;
+        delete process.env.TOKEN;
+
+        loadDotEnv({ quiet: true });
+
+        expect(process.env.ESCAPED_BARE).toBe("abc$TOKEN");
+        expect(process.env.ESCAPED_BRACED).toBe("abc${TOKEN}");
+        expect(process.env.DOUBLE).toBe("abc\\$TOKEN");
+      });
+    });
+  });
 });

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import dotenv from "dotenv";
 import { resolveConfigDir } from "../utils.js";
 
-const ENV_REFERENCE_PATTERN = /\$\{([A-Za-z0-9_]+)\}|\$([A-Za-z0-9_]+)/g;
+const ENV_REFERENCE_PATTERN = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
 
 function expandEnvReferences(
   parsed: Record<string, string>,

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -3,7 +3,8 @@ import path from "node:path";
 import dotenv from "dotenv";
 import { resolveConfigDir } from "../utils.js";
 
-const ENV_REFERENCE_PATTERN = /\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g;
+const ENV_REFERENCE_PATTERN =
+  /(?<!\\)\$\{([A-Za-z_][A-Za-z0-9_]*)\}|(?<!\\)\$([A-Za-z_][A-Za-z0-9_]*)/g;
 
 function expandEnvReferences(
   parsed: Record<string, string>,
@@ -29,10 +30,12 @@ function expandEnvReferences(
     }
 
     resolving.add(key);
-    const expanded = raw.replace(ENV_REFERENCE_PATTERN, (_, braced, bare) => {
-      const name = typeof braced === "string" && braced.length > 0 ? braced : bare;
-      return resolveValue(name) ?? "";
-    });
+    const expanded = raw
+      .replace(ENV_REFERENCE_PATTERN, (_, braced, bare) => {
+        const name = typeof braced === "string" && braced.length > 0 ? braced : bare;
+        return resolveValue(name) ?? "";
+      })
+      .replace(/\\(?=\$)/g, "");
     resolving.delete(key);
     resolved[key] = expanded;
     return expanded;

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -3,18 +3,62 @@ import path from "node:path";
 import dotenv from "dotenv";
 import { resolveConfigDir } from "../utils.js";
 
-export function loadDotEnv(opts?: { quiet?: boolean }) {
-  const quiet = opts?.quiet ?? true;
+const ENV_REFERENCE_PATTERN = /\$\{([A-Za-z0-9_]+)\}|\$([A-Za-z0-9_]+)/g;
 
-  // Load from process CWD first (dotenv default).
-  dotenv.config({ quiet });
+function expandEnvReferences(
+  parsed: Record<string, string>,
+  baseEnv: NodeJS.ProcessEnv,
+): Record<string, string> {
+  const resolved: Record<string, string> = {};
+  const resolving = new Set<string>();
+
+  const resolveValue = (key: string): string | undefined => {
+    const existing = baseEnv[key];
+    if (existing !== undefined) {
+      return existing;
+    }
+    if (Object.hasOwn(resolved, key)) {
+      return resolved[key];
+    }
+    const raw = parsed[key];
+    if (raw === undefined) {
+      return undefined;
+    }
+    if (resolving.has(key)) {
+      return "";
+    }
+
+    resolving.add(key);
+    const expanded = raw.replace(ENV_REFERENCE_PATTERN, (_, braced, bare) => {
+      const name = typeof braced === "string" && braced.length > 0 ? braced : bare;
+      return resolveValue(name) ?? "";
+    });
+    resolving.delete(key);
+    resolved[key] = expanded;
+    return expanded;
+  };
+
+  for (const key of Object.keys(parsed)) {
+    resolveValue(key);
+  }
+  return resolved;
+}
+
+function loadEnvFile(filePath: string, opts?: { override?: boolean }) {
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+  const parsed = dotenv.parse(fs.readFileSync(filePath, "utf8"));
+  const expanded = expandEnvReferences(parsed, process.env);
+  dotenv.populate(process.env, expanded, { override: opts?.override ?? false });
+}
+
+export function loadDotEnv(_opts?: { quiet?: boolean }) {
+  // Load from process CWD first so fallback expansion can reference it.
+  loadEnvFile(path.join(process.cwd(), ".env"));
 
   // Then load global fallback: ~/.openclaw/.env (or OPENCLAW_STATE_DIR/.env),
   // without overriding any env vars already present.
   const globalEnvPath = path.join(resolveConfigDir(process.env), ".env");
-  if (!fs.existsSync(globalEnvPath)) {
-    return;
-  }
-
-  dotenv.config({ quiet, path: globalEnvPath, override: false });
+  loadEnvFile(globalEnvPath, { override: false });
 }

--- a/src/infra/dotenv.ts
+++ b/src/infra/dotenv.ts
@@ -44,21 +44,31 @@ function expandEnvReferences(
   return resolved;
 }
 
-function loadEnvFile(filePath: string, opts?: { override?: boolean }) {
+function loadEnvFile(filePath: string, opts?: { override?: boolean; quiet?: boolean }) {
   if (!fs.existsSync(filePath)) {
     return;
   }
-  const parsed = dotenv.parse(fs.readFileSync(filePath, "utf8"));
+  const result = dotenv.configDotenv({
+    path: filePath,
+    processEnv: {},
+    quiet: opts?.quiet ?? true,
+  });
+  if (result.error || !result.parsed) {
+    return;
+  }
+  const parsed = result.parsed;
   const expanded = expandEnvReferences(parsed, process.env);
   dotenv.populate(process.env, expanded, { override: opts?.override ?? false });
 }
 
-export function loadDotEnv(_opts?: { quiet?: boolean }) {
+export function loadDotEnv(opts?: { quiet?: boolean }) {
+  const quiet = opts?.quiet ?? true;
+
   // Load from process CWD first so fallback expansion can reference it.
-  loadEnvFile(path.join(process.cwd(), ".env"));
+  loadEnvFile(path.join(process.cwd(), ".env"), { quiet });
 
   // Then load global fallback: ~/.openclaw/.env (or OPENCLAW_STATE_DIR/.env),
   // without overriding any env vars already present.
   const globalEnvPath = path.join(resolveConfigDir(process.env), ".env");
-  loadEnvFile(globalEnvPath, { override: false });
+  loadEnvFile(globalEnvPath, { override: false, quiet });
 }


### PR DESCRIPTION
## Summary / What changed
- expand `${VAR}` and `$VAR` references when loading CWD and global `.env` files
- preserve shell and already-loaded env precedence so existing exported values still win
- add tests for shell-backed, chained, and same-file expansion

## Why
OpenClaw auto-loads `.env` files, but values like `OPENAI_TRANSCRIPTION_API_KEY=${OPENAI_API_KEY}` were kept literal instead of being resolved. That breaks a common env aliasing pattern and can cause provider auth/config failures after restart.

AI-assisted, manually reviewed and tested.

## Tests
- `pnpm exec vitest run src/infra/dotenv.test.ts`
- `pnpm exec oxfmt --check src/infra/dotenv.ts src/infra/dotenv.test.ts`
- `pnpm check` currently fails on unrelated `extensions/feishu/src/media.ts` `timeout` typing errors on this repo head

## Real-world validation
- reproduced on live local OpenClaw deployments on March 6, 2026 where `.env` aliases were loaded literally from loaded env files
- validated that the patched loader resolves aliases from loaded `.env` files while keeping shell env precedence unchanged

## Issue
Fixes #38259
