### PR TITLE
fix(sessions): updateLastRoute should not bump updatedAt

### DIFF
--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -840,15 +840,19 @@ export async function updateLastRoute(params: {
           groupResolution: params.groupResolution,
         })
       : null;
+    // Route updates must not refresh activity timestamps — session freshness
+    // (daily/idle reset) is evaluated against the last actual agent turn, not
+    // the last inbound delivery route update.  Using mergeSessionEntryPreserveActivity
+    // mirrors the same policy already applied in recordSessionMetaFromInbound.
+    // See: https://github.com/openclaw/openclaw/issues/38262
     const basePatch: Partial<SessionEntry> = {
-      updatedAt: Math.max(existing?.updatedAt ?? 0, now),
       deliveryContext: normalized.deliveryContext,
       lastChannel: normalized.lastChannel,
       lastTo: normalized.lastTo,
       lastAccountId: normalized.lastAccountId,
       lastThreadId: normalized.lastThreadId,
     };
-    const next = mergeSessionEntry(
+    const next = mergeSessionEntryPreserveActivity(
       existing,
       metaPatch ? { ...basePatch, ...metaPatch } : basePatch,
     );


### PR DESCRIPTION
## Summary

Fixes #38262 — `session.resetByChannel` (and daily/idle resets) silently skipped for Discord channel sessions.

## Root Cause

The Discord inbound handler calls `recordInboundSession()` (which calls `updateLastRoute()`) **before** dispatching the agent. `updateLastRoute` writes `updatedAt: Date.now()` to the session store. When the agent runner subsequently calls `loadSessionStore({ skipCache: true })`, it reads the already-bumped `updatedAt`. `evaluateSessionFreshness` then sees the session as fresh (since `updatedAt` is now *after* the daily reset boundary) and skips the reset.

The same bug affects all channels that call `recordInboundSession` before agent dispatch.

## Fix

Route tracking is inbound metadata, not agent activity. The codebase already has the right pattern in `recordSessionMetaFromInbound` (line 769):

```typescript
// Inbound metadata updates must not refresh activity timestamps;
// idle reset evaluation relies on updatedAt from actual session turns.
mergeSessionEntryPreserveActivity(existing, patch)
```

This PR applies the same policy to `updateLastRoute`:
- Removes `updatedAt` from `basePatch`
- Switches `mergeSessionEntry` → `mergeSessionEntryPreserveActivity`

`updatedAt` is now only advanced by actual agent turns, making `daily` and `idle` resets reliable.

## Change

`src/config/sessions/store.ts` — `updateLastRoute` function only, 2-line diff.