### PR TITLE
fix(webchat): extract text from array-shaped tool result content

### DIFF
--- a/ui/src/ui/chat/tool-cards.ts
+++ b/ui/src/ui/chat/tool-cards.ts
@@ -152,5 +152,14 @@ function extractToolText(item: Record<string, unknown>): string | undefined {
   if (typeof item.content === "string") {
     return item.content;
   }
+  // Handle array content (e.g. [{type: "text", text: "..."}] from Anthropic-style tool results)
+  if (Array.isArray(item.content)) {
+    const parts = (item.content as Array<Record<string, unknown>>)
+      .filter((p) => p.type === "text" && typeof p.text === "string")
+      .map((p) => p.text as string);
+    if (parts.length > 0) {
+      return parts.join("\n");
+    }
+  }
   return undefined;
 }


### PR DESCRIPTION
## Problem

The WebUI displays "No output — tool completed successfully" for all tool results, even when the tool actually returned stdout data (fixes #38223).

## Root Cause

`extractToolText()` in `ui/src/ui/chat/tool-cards.ts` only handled `content` as a string. However, many providers (Anthropic-style) return tool results with `content` as an array of `{type: 'text', text: '...'}` objects. This array case was silently ignored, causing all such results to appear empty.

## Fix

Added array content extraction to `extractToolText()`, mirroring the same pattern already used in `extractRawText()` in `message-extract.ts`.

## Testing

- Tool results with string `content` → unchanged behavior
- Tool results with array `content` (e.g. `[{type:'text', text:'hello'}]`) → now correctly displayed
- Tool results with no output → still shows "Completed" as before