### PR TITLE
Plugins: parse version spec in update command

### DIFF
--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -735,7 +735,23 @@ export function registerPluginsCli(program: Command) {
     .action(async (id: string | undefined, opts: PluginUpdateOptions) => {
       const cfg = loadConfig();
       const installs = cfg.plugins?.installs ?? {};
-      const targets = opts.all ? Object.keys(installs) : id ? [id] : [];
+
+      let pluginId = id;
+      let specOverrides: Record<string, string> | undefined;
+      if (id) {
+        // Parse name@version — last '@' at pos > 0 is the version separator
+        // (handles scoped packages like @openclaw/foo@1.0.0)
+        const lastAt = id.lastIndexOf("@");
+        if (lastAt > 0) {
+          const maybeName = id.slice(0, lastAt);
+          if (maybeName in installs) {
+            pluginId = maybeName;
+            specOverrides = { [maybeName]: id };
+          }
+        }
+      }
+
+      const targets = opts.all ? Object.keys(installs) : pluginId ? [pluginId] : [];
 
       if (targets.length === 0) {
         if (opts.all) {
@@ -749,6 +765,7 @@ export function registerPluginsCli(program: Command) {
       const result = await updateNpmInstalledPlugins({
         config: cfg,
         pluginIds: targets,
+        specOverrides,
         dryRun: opts.dryRun,
         logger: {
           info: (msg) => defaultRuntime.log(msg),

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -744,9 +744,17 @@ export function registerPluginsCli(program: Command) {
         const lastAt = id.lastIndexOf("@");
         if (lastAt > 0) {
           const maybeName = id.slice(0, lastAt);
+          const version = id.slice(lastAt + 1);
           if (maybeName in installs) {
             pluginId = maybeName;
-            specOverrides = { [maybeName]: id };
+            const record = installs[maybeName];
+            // Build override from the recorded spec base + user-specified version
+            // so scoped packages like @openclaw/matrix resolve correctly.
+            const base = record?.spec ?? maybeName;
+            // Strip any existing version from the base spec
+            const baseLastAt = base.lastIndexOf("@");
+            const baseName = baseLastAt > 0 ? base.slice(0, baseLastAt) : base;
+            specOverrides = { [maybeName]: `${baseName}@${version}` };
           }
         }
       }

--- a/src/cli/plugins-cli.ts
+++ b/src/cli/plugins-cli.ts
@@ -745,16 +745,21 @@ export function registerPluginsCli(program: Command) {
         if (lastAt > 0) {
           const maybeName = id.slice(0, lastAt);
           const version = id.slice(lastAt + 1);
-          if (maybeName in installs) {
-            pluginId = maybeName;
-            const record = installs[maybeName];
+          // installs keys are unscoped (e.g. "matrix" not "@openclaw/matrix"),
+          // so try both the raw name and the unscoped variant.
+          const unscoped = maybeName.includes("/") ? maybeName.split("/").pop()! : maybeName;
+          const key =
+            maybeName in installs ? maybeName : unscoped in installs ? unscoped : undefined;
+          if (key) {
+            pluginId = key;
+            const record = installs[key];
             // Build override from the recorded spec base + user-specified version
             // so scoped packages like @openclaw/matrix resolve correctly.
             const base = record?.spec ?? maybeName;
             // Strip any existing version from the base spec
             const baseLastAt = base.lastIndexOf("@");
             const baseName = baseLastAt > 0 ? base.slice(0, baseLastAt) : base;
-            specOverrides = { [maybeName]: `${baseName}@${version}` };
+            specOverrides = { [key]: `${baseName}@${version}` };
           }
         }
       }

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -150,4 +150,41 @@ describe("updateNpmInstalledPlugins", () => {
       },
     ]);
   });
+
+  it("uses specOverrides for the install call but preserves original spec in config", async () => {
+    installPluginFromNpmSpecMock.mockResolvedValue({
+      ok: true,
+      pluginId: "timbot",
+      targetDir: "/tmp/timbot",
+      version: "2026.3.6-beta.5",
+      extensions: ["index.ts"],
+    });
+
+    const { updateNpmInstalledPlugins } = await import("./update.js");
+    const result = await updateNpmInstalledPlugins({
+      config: {
+        plugins: {
+          installs: {
+            timbot: {
+              source: "npm",
+              spec: "timbot",
+              installPath: "/tmp/timbot",
+            },
+          },
+        },
+      },
+      pluginIds: ["timbot"],
+      specOverrides: { timbot: "timbot@2026.3.6-beta.5" },
+    });
+
+    // Install call should use the override spec
+    expect(installPluginFromNpmSpecMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spec: "timbot@2026.3.6-beta.5",
+      }),
+    );
+
+    // Config should preserve the original spec, not the override
+    expect(result.config.plugins?.installs?.timbot?.spec).toBe("timbot");
+  });
 });

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -373,7 +373,9 @@ export async function updateNpmInstalledPlugins(params: {
       spec: record.spec,
       installPath: result.targetDir,
       version: nextVersion,
-      ...buildNpmResolutionInstallFields(result.npmResolution),
+      // When using a one-time spec override, keep the existing resolution/integrity
+      // metadata so it stays consistent with record.spec for future updates.
+      ...(hasSpecOverride ? {} : buildNpmResolutionInstallFields(result.npmResolution)),
     });
     changed = true;
 

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -199,6 +199,7 @@ export async function updateNpmInstalledPlugins(params: {
   logger?: PluginUpdateLogger;
   pluginIds?: string[];
   skipIds?: Set<string>;
+  specOverrides?: Record<string, string>;
   dryRun?: boolean;
   onIntegrityDrift?: (params: PluginUpdateIntegrityDriftParams) => boolean | Promise<boolean>;
 }): Promise<PluginUpdateSummary> {
@@ -247,6 +248,8 @@ export async function updateNpmInstalledPlugins(params: {
       continue;
     }
 
+    const spec = params.specOverrides?.[pluginId] ?? record.spec;
+
     let installPath: string;
     try {
       installPath = record.installPath ?? resolvePluginInstallDir(pluginId);
@@ -264,7 +267,7 @@ export async function updateNpmInstalledPlugins(params: {
       let probe: Awaited<ReturnType<typeof installPluginFromNpmSpec>>;
       try {
         probe = await installPluginFromNpmSpec({
-          spec: record.spec,
+          spec,
           mode: "update",
           dryRun: true,
           expectedPluginId: pluginId,
@@ -291,7 +294,7 @@ export async function updateNpmInstalledPlugins(params: {
           status: "error",
           message: formatNpmInstallFailure({
             pluginId,
-            spec: record.spec,
+            spec,
             phase: "check",
             result: probe,
           }),
@@ -324,7 +327,7 @@ export async function updateNpmInstalledPlugins(params: {
     let result: Awaited<ReturnType<typeof installPluginFromNpmSpec>>;
     try {
       result = await installPluginFromNpmSpec({
-        spec: record.spec,
+        spec,
         mode: "update",
         expectedPluginId: pluginId,
         expectedIntegrity: expectedIntegrityForUpdate(record.spec, record.integrity),
@@ -350,7 +353,7 @@ export async function updateNpmInstalledPlugins(params: {
         status: "error",
         message: formatNpmInstallFailure({
           pluginId,
-          spec: record.spec,
+          spec,
           phase: "update",
           result: result,
         }),
@@ -362,7 +365,7 @@ export async function updateNpmInstalledPlugins(params: {
     next = recordPluginInstall(next, {
       pluginId,
       source: "npm",
-      spec: record.spec,
+      spec,
       installPath: result.targetDir,
       version: nextVersion,
       ...buildNpmResolutionInstallFields(result.npmResolution),

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -373,9 +373,12 @@ export async function updateNpmInstalledPlugins(params: {
       spec: record.spec,
       installPath: result.targetDir,
       version: nextVersion,
-      // When using a one-time spec override, keep the existing resolution/integrity
-      // metadata so it stays consistent with record.spec for future updates.
-      ...(hasSpecOverride ? {} : buildNpmResolutionInstallFields(result.npmResolution)),
+      // When using a one-time spec override, clear resolution/integrity metadata
+      // so it stays consistent with record.spec and avoids false version-drift
+      // audits (resolvedVersion would otherwise be stale).
+      ...(hasSpecOverride
+        ? buildNpmResolutionInstallFields(undefined)
+        : buildNpmResolutionInstallFields(result.npmResolution)),
     });
     changed = true;
 

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -365,7 +365,7 @@ export async function updateNpmInstalledPlugins(params: {
     next = recordPluginInstall(next, {
       pluginId,
       source: "npm",
-      spec,
+      spec: record.spec,
       installPath: result.targetDir,
       version: nextVersion,
       ...buildNpmResolutionInstallFields(result.npmResolution),

--- a/src/plugins/update.ts
+++ b/src/plugins/update.ts
@@ -249,6 +249,7 @@ export async function updateNpmInstalledPlugins(params: {
     }
 
     const spec = params.specOverrides?.[pluginId] ?? record.spec;
+    const hasSpecOverride = spec !== record.spec;
 
     let installPath: string;
     try {
@@ -271,7 +272,9 @@ export async function updateNpmInstalledPlugins(params: {
           mode: "update",
           dryRun: true,
           expectedPluginId: pluginId,
-          expectedIntegrity: expectedIntegrityForUpdate(record.spec, record.integrity),
+          expectedIntegrity: hasSpecOverride
+            ? undefined
+            : expectedIntegrityForUpdate(record.spec, record.integrity),
           onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
             pluginId,
             dryRun: true,
@@ -330,7 +333,9 @@ export async function updateNpmInstalledPlugins(params: {
         spec,
         mode: "update",
         expectedPluginId: pluginId,
-        expectedIntegrity: expectedIntegrityForUpdate(record.spec, record.integrity),
+        expectedIntegrity: hasSpecOverride
+          ? undefined
+          : expectedIntegrityForUpdate(record.spec, record.integrity),
         onIntegrityDrift: createPluginUpdateIntegrityDriftHandler({
           pluginId,
           dryRun: false,


### PR DESCRIPTION
## Summary

- `openclaw plugins update timbot@2026.3.6-beta.5` incorrectly used the full `name@version` string as the plugin ID lookup key, causing `No install record` errors.
- Parse the version spec from the argument (using last `@` position to handle scoped packages like `@openclaw/foo@1.0.0`), resolve the bare plugin ID for lookup, and pass the full spec as a one-time override for the npm install.
- Added `specOverrides` parameter to `updateNpmInstalledPlugins` so the caller can supply an explicit spec per plugin without permanently pinning it.

### Key design decisions

- **One-time override**: the versioned spec is only used for the install call; `recordPluginInstall` preserves the original `record.spec` so future `openclaw plugins update timbot` (without version) still resolves to the original unpinned spec.
- **Scoped package safety**: the override spec is built from `record.spec` (e.g. `@openclaw/matrix`) + user-specified version, not from the raw CLI argument, so scoped packages resolve correctly.

## Test plan

- [x] `pnpm tsgo` passes
- [x] `pnpm vitest run src/plugins/update.test.ts` — all 5 tests pass (including new `specOverrides` test)
- [x] Manual: `openclaw plugins update <plugin>@<version>` resolves install record and updates to specified version
- [x] Manual: `openclaw plugins update <plugin>` (without version) still works as before
- [x] Manual: scoped package `@openclaw/foo@1.0.0` correctly splits at the last `@`