### PR TITLE
fix(feishu): drop invalid media request timeout fields

### DIFF
--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -182,7 +182,7 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
-  it("uses image upload timeout override for image media", async () => {
+  it("uses the media client timeout override for image media", async () => {
     await sendMediaFeishu({
       cfg: {} as any,
       to: "user:ou_target",
@@ -190,9 +190,9 @@ describe("sendMediaFeishu msg_type routing", () => {
       fileName: "photo.png",
     });
 
-    expect(imageCreateMock).toHaveBeenCalledWith(
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        timeout: 120_000,
+        httpTimeoutMs: 120_000,
       }),
     );
     expect(messageCreateMock).toHaveBeenCalledWith(
@@ -320,7 +320,11 @@ describe("sendMediaFeishu msg_type routing", () => {
     expect(imageGetMock).toHaveBeenCalledWith(
       expect.objectContaining({
         path: { image_key: imageKey },
-        timeout: 120_000,
+      }),
+    );
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpTimeoutMs: 120_000,
       }),
     );
     expect(result.buffer).toEqual(Buffer.from("image-data"));
@@ -512,7 +516,11 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_audio_msg", file_key: "file_key_audio" },
         params: { type: "file" },
-        timeout: 120_000,
+      }),
+    );
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpTimeoutMs: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);
@@ -532,7 +540,11 @@ describe("downloadMessageResourceFeishu", () => {
       expect.objectContaining({
         path: { message_id: "om_img_msg", file_key: "img_key_1" },
         params: { type: "image" },
-        timeout: 120_000,
+      }),
+    );
+    expect(createFeishuClientMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        httpTimeoutMs: 120_000,
       }),
     );
     expect(result.buffer).toBeInstanceOf(Buffer);

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -106,7 +106,6 @@ export async function downloadImageFeishu(params: {
 
   const response = await client.im.image.get({
     path: { image_key: normalizedImageKey },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   const buffer = await readFeishuResponseBuffer({
@@ -146,7 +145,6 @@ export async function downloadMessageResourceFeishu(params: {
   const response = await client.im.messageResource.get({
     path: { message_id: messageId, file_key: normalizedFileKey },
     params: { type },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   const buffer = await readFeishuResponseBuffer({
@@ -202,7 +200,6 @@ export async function uploadImageFeishu(params: {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- SDK accepts Buffer or ReadStream
       image: imageData as any,
     },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   // SDK v1.30+ returns data directly without code wrapper on success
@@ -277,7 +274,6 @@ export async function uploadFileFeishu(params: {
       file: fileData as any,
       ...(duration !== undefined && { duration }),
     },
-    timeout: FEISHU_MEDIA_HTTP_TIMEOUT_MS,
   });
 
   // SDK v1.30+ returns data directly without code wrapper on success


### PR DESCRIPTION
## Summary

- Problem: `main` CI started failing in the Feishu media helpers after the SDK types stopped accepting per-request `timeout` fields on `im.image.get`, `im.messageResource.get`, `im.image.create`, and `im.file.create`.
- Why it matters: every push to `main` was leaving the `CI` workflow red even though the transport timeout is already enforced by the shared Feishu client.
- What changed: removed the invalid per-call `timeout` fields from `extensions/feishu/src/media.ts` and updated the Feishu media tests to assert the timeout override through `createFeishuClient({ httpTimeoutMs: 120_000 })` instead.
- What did NOT change (scope boundary): request behavior, timeout duration, and Feishu send/download logic remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A
- Integration/channel (if any): Feishu extension
- Relevant config (redacted): N/A

### Steps

1. Check the latest failing `main` CI run, for example [22776895079](https://github.com/openclaw/openclaw/actions/runs/22776895079).
2. Inspect the `check` job logs.
3. Run `pnpm check` locally on `main` before the patch.

### Expected

- `pnpm check` passes and `main` CI stays green.

### Actual

- TypeScript failed with `TS2353` because `timeout` is no longer a valid property on those Feishu SDK request payloads.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: `pnpm test -- extensions/feishu/src/media.test.ts`; `pnpm check`
- Edge cases checked: image upload, image download, and `messageResource.get` tests now verify the timeout override through the shared Feishu client instead of invalid per-call fields.
- What you did **not** verify: live Feishu API traffic

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or restore the prior two commits from the branch.
- Files/config to restore: `extensions/feishu/src/media.ts`, `extensions/feishu/src/media.test.ts`
- Known bad symptoms reviewers should watch for: Feishu media helpers timing out unexpectedly or tests failing to observe the client-level timeout override.

## Risks and Mitigations

- Risk: the Feishu SDK could stop honoring the shared client timeout override in a later release.
  - Mitigation: the tests now pin the timeout override at the `createFeishuClient` boundary, which is where the transport timeout is actually injected.
