### PR TITLE
fix: don't suppress WhatsApp read receipts when bot number is in allowFrom

### DIFF
--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -162,6 +162,7 @@ export async function monitorWebInbox(options: {
     groupParticipants?: string[];
     messageTimestampMs?: number;
     access: Awaited<ReturnType<typeof checkInboundAccessControl>>;
+    isFromMe: boolean;
   };
 
   const normalizeInboundMessage = async (
@@ -233,12 +234,13 @@ export async function monitorWebInbox(options: {
       groupParticipants,
       messageTimestampMs,
       access,
+      isFromMe: Boolean(msg.key?.fromMe),
     };
   };
 
   const maybeMarkInboundAsRead = async (inbound: NormalizedInboundMessage) => {
-    const { id, remoteJid, participantJid, access } = inbound;
-    if (id && !access.isSelfChat && options.sendReadReceipts !== false) {
+    const { id, remoteJid, participantJid } = inbound;
+    if (id && !inbound.isFromMe && options.sendReadReceipts !== false) {
       try {
         await sock.readMessages([{ remoteJid, id, participant: participantJid, fromMe: false }]);
         if (shouldLogVerbose()) {
@@ -248,9 +250,9 @@ export async function monitorWebInbox(options: {
       } catch (err) {
         logVerbose(`Failed to mark message ${id} read: ${String(err)}`);
       }
-    } else if (id && access.isSelfChat && shouldLogVerbose()) {
-      // Self-chat mode: never auto-send read receipts (blue ticks) on behalf of the owner.
-      logVerbose(`Self-chat mode: skipping read receipt for ${id}`);
+    } else if (id && inbound.isFromMe && shouldLogVerbose()) {
+      // Own message (fromMe): skipping read receipt.
+      logVerbose(`Skipping read receipt for own message ${id}`);
     }
   };
 


### PR DESCRIPTION
## Summary

- Problem: `maybeMarkInboundAsRead` uses `access.isSelfChat` to gate read receipts. `isSelfChatMode()` returns `true` whenever the bot's own number is in `allowFrom`, suppressing read receipts for **all** inbound messages — not just self-sent ones.
- Why it matters: Senders permanently see grey "Delivered" ticks instead of blue "Seen" ticks. The bug is intermittent — works on fresh connect (when `selfE164` is still `null`), breaks after WebSocket reconnection (when `selfE164` is cached), making it hard to diagnose.
- What changed: Added `isFromMe` (from `msg.key.fromMe`) to `NormalizedInboundMessage` and replaced `!access.isSelfChat` with `!inbound.isFromMe` in the read receipt gate.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #29674

## User-visible / Behavior Changes

WhatsApp senders will now see blue "Seen" ticks when the gateway processes their message, even when the bot's own number is in `channels.whatsapp.allowFrom`. Previously this only worked until the first WebSocket reconnection.

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No` — `sock.readMessages()` was already called; this fix ensures it's no longer incorrectly skipped.
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux 6.8.0 (x64)
- Runtime/container: Node.js v22.22.0
- Model/provider: N/A (gateway-level bug)
- Integration/channel: WhatsApp (Baileys web session)
- Relevant config (redacted):
  ```json
  {
    "channels": {
      "whatsapp": {
        "sendReadReceipts": true,
        "dmPolicy": "allowlist",
        "allowFrom": ["+44BOTNUM", "+44USER1", "+44USER2"]
      }
    }
  }
  ```

### Steps

1. Configure `channels.whatsapp.allowFrom` to include the bot's own WhatsApp number
2. Set `sendReadReceipts: true`
3. Send a message to the bot from another WhatsApp number
4. Observe message status on sender's device

### Expected

Message shows blue "Seen" ticks after gateway processes it.

### Actual

Message stays on grey "Delivered" ticks permanently. Debug logs show `Self-chat mode: skipping read receipt` for every inbound message.

## Evidence

- [x] Trace/log snippets

Before fix — verbose logs show read receipts skipped for all messages:
```
Self-chat mode: skipping read receipt for 3EB04124A63B16CA64E4B5
```

After fix — read receipts sent normally:
```
Marked message 3EB0F9A356... as read for 44XXXXXXXX@s.whatsapp.net
```

Blue ticks confirmed on sender's device after patch applied.

## Human Verification (required)

- Verified scenarios: DM from allowlisted user → blue ticks appear; bot's own outbound messages → no read receipt sent to self

Before:
![IMG_4384](https://github.com/user-attachments/assets/54c4739f-1cea-4a44-9c01-b47f6e2371cc)
After:
![IMG_4385](https://github.com/user-attachments/assets/eead99b2-ea20-4143-84ff-0230accbbec5)

- Edge cases checked: Also works in group chat
- What you did **not** verify: n/a

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert single file `src/web/inbound/monitor.ts`
- Files/config to restore: `src/web/inbound/monitor.ts`
- Known bad symptoms reviewers should watch for: Read receipts sent for bot's own outbound messages (echo). Check verbose logs for `Skipping read receipt for own message` to confirm fromMe gating works.

## Risks and Mitigations

- Risk: `msg.key.fromMe` could behave differently across Baileys versions or edge cases (e.g. multi-device relay).
  - Mitigation: `fromMe` is a standard WAProto field used throughout the codebase (access control, echo tracking). Already trusted in `checkInboundAccessControl` at line 215.