### PR TITLE
fix(dispatcher): add beforeDeliver hook, wire message_sending for Discord

### DIFF
--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -30,7 +30,7 @@ import {
 } from "openclaw/plugin-sdk/config-runtime";
 import { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
-import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-hooks";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import { resolveChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -30,6 +30,7 @@ import {
 } from "openclaw/plugin-sdk/config-runtime";
 import { recordInboundSession } from "openclaw/plugin-sdk/conversation-runtime";
 import { getAgentScopedMediaLocalRoots } from "openclaw/plugin-sdk/media-runtime";
+import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-hooks";
 import { resolveChunkMode } from "openclaw/plugin-sdk/reply-chunking";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-dispatch-runtime";
 import { finalizeInboundContext } from "openclaw/plugin-sdk/reply-dispatch-runtime";
@@ -762,6 +763,48 @@ export async function processDiscordMessage(
     createReplyDispatcherWithTyping({
       ...replyPipeline,
       humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
+      typingCallbacks,
+      beforeDeliver: async (payload) => {
+        if (payload.isReasoning) {
+          return payload;
+        }
+        if (isProcessAborted(abortSignal)) {
+          return payload;
+        }
+        const hookRunner = getGlobalHookRunner();
+        if (!hookRunner?.hasHooks("message_sending")) {
+          return payload;
+        }
+        try {
+          const result = await hookRunner.runMessageSending(
+            {
+              to: deliverTarget,
+              content: payload.text ?? "",
+              metadata: {
+                channel: "discord",
+                accountId,
+                mediaUrls: payload.mediaUrls ?? (payload.mediaUrl ? [payload.mediaUrl] : []),
+              },
+            },
+            { channelId: "discord", accountId },
+          );
+          if (result?.cancel) {
+            return null;
+          }
+          if (result?.content != null) {
+            const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
+            if (result.content.trim() === "") {
+              if (hasMedia) {
+                return { ...payload, text: "" };
+              }
+              return null;
+            }
+            return { ...payload, text: result.content };
+          }
+        } catch {
+        }
+        return payload;
+      },
       deliver: async (payload: ReplyPayload, info) => {
         if (isProcessAborted(abortSignal)) {
           return;

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -763,7 +763,7 @@ export async function processDiscordMessage(
     createReplyDispatcherWithTyping({
       ...replyPipeline,
       humanDelay: resolveHumanDelayConfig(cfg, route.agentId),
-      typingCallbacks,
+      typingCallbacks: replyPipeline.typingCallbacks,
       beforeDeliver: async (payload) => {
         if (payload.isReasoning) {
           return payload;

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -237,7 +237,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
         let deliverPayload: ReplyPayload | null = normalized;
         if (options.beforeDeliver) {
           deliverPayload = await options.beforeDeliver(normalized, { kind });
-          if (!deliverPayload) {
+          if (deliverPayload === null) {
             return; // Hook cancelled delivery.
           }
         }

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -32,7 +32,7 @@ type ReplyDispatchDeliverer = (
  * Optional hook called just before `deliver()`.  Returning a modified payload
  * replaces the original; returning `null` cancels delivery for this payload.
  */
-type ReplyDispatchBeforeDeliver = (
+export type ReplyDispatchBeforeDeliver = (
   payload: ReplyPayload,
   info: { kind: ReplyDispatchKind },
 ) => Promise<ReplyPayload | null> | ReplyPayload | null;

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -28,6 +28,15 @@ type ReplyDispatchDeliverer = (
   info: { kind: ReplyDispatchKind },
 ) => Promise<void>;
 
+/**
+ * Optional hook called just before `deliver()`.  Returning a modified payload
+ * replaces the original; returning `null` cancels delivery for this payload.
+ */
+type ReplyDispatchBeforeDeliver = (
+  payload: ReplyPayload,
+  info: { kind: ReplyDispatchKind },
+) => Promise<ReplyPayload | null> | ReplyPayload | null;
+
 const DEFAULT_HUMAN_DELAY_MIN_MS = 800;
 const DEFAULT_HUMAN_DELAY_MAX_MS = 2500;
 const silentReplyLogger = createSubsystemLogger("silent-reply/dispatcher");
@@ -56,6 +65,8 @@ export type ReplyDispatcherOptions = {
     surface?: string;
     conversationType?: SilentReplyConversationType;
   };
+  /** Called before `deliver()`.  May modify or cancel (return `null`) the payload. */
+  beforeDeliver?: ReplyDispatchBeforeDeliver;
   responsePrefix?: string;
   transformReplyPayload?: (payload: ReplyPayload) => ReplyPayload | null;
   /** Static context for response prefix template interpolation. */
@@ -222,9 +233,17 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
             await sleep(delayMs);
           }
         }
+        // Run optional beforeDeliver hook (e.g. message_sending plugin hooks).
+        let deliverPayload: ReplyPayload | null = normalized;
+        if (options.beforeDeliver) {
+          deliverPayload = await options.beforeDeliver(normalized, { kind });
+          if (!deliverPayload) {
+            return; // Hook cancelled delivery.
+          }
+        }
         // Safe: deliver is called inside an async .then() callback, so even a synchronous
         // throw becomes a rejection that flows through .catch()/.finally(), ensuring cleanup.
-        await options.deliver(normalized, { kind });
+        await options.deliver(deliverPayload, { kind });
       })
       .catch((err) => {
         failedCounts[kind] += 1;

--- a/src/plugin-sdk/reply-runtime.ts
+++ b/src/plugin-sdk/reply-runtime.ts
@@ -49,6 +49,7 @@ export type {
   ReplyDispatcher,
 } from "../auto-reply/reply/reply-dispatcher.types.js";
 export type {
+  ReplyDispatchBeforeDeliver,
   ReplyDispatcherOptions,
   ReplyDispatcherWithTypingOptions,
 } from "../auto-reply/reply/reply-dispatcher.js";


### PR DESCRIPTION
## Problem

Discord same-surface replies bypass `deliverOutboundPayloads` entirely, which means `message_sending` plugin hooks never fire. Plugins that rely on this hook to strip or transform outbound text (e.g. removing metadata blocks injected by the LLM) have no way to intercept Discord replies.

The `message_sending` hook works correctly for cross-surface routing (e.g. web chat → Discord), but not for Discord → Discord (same-surface) because the Discord message handler uses its own `deliver` callback that calls `deliverDiscordReply` directly.

## Solution

1. **Adds an optional `beforeDeliver` callback to `ReplyDispatcherOptions`** — runs just before `deliver()` and may return a modified payload or `null` to cancel delivery. This is a general-purpose mechanism that any channel can opt into.

2. **Wires `beforeDeliver` in the Discord message handler** to call `runMessageSending` from the plugin hook runner, matching the behavior that `deliverOutboundPayloads` already provides for cross-surface routing.

## Changes

- `src/auto-reply/reply/reply-dispatcher.ts` — New `beforeDeliver` option + call site in `enqueue()`
- `src/discord/monitor/message-handler.process.ts` — `beforeDeliver` implementation calling `message_sending` hooks

## Follow-up

Other channel handlers (Signal, Slack, iMessage, web chat) have similar deliver callbacks that bypass the hook pipeline. They could adopt the same `beforeDeliver` pattern in follow-up PRs.