### PR TITLE
feat(control-ui): add configurable chat send shortcut

### DIFF
--- a/ui/src/ui/app-render.helpers.ts
+++ b/ui/src/ui/app-render.helpers.ts
@@ -255,6 +255,23 @@ export function renderChatControls(state: AppViewState) {
         ${icons.brain}
       </button>
       <button
+        class="btn btn--sm ${state.settings.chatEnterSends ? "" : "active"}"
+        ?disabled=${state.onboarding}
+        @click=${() => {
+          if (state.onboarding) {
+            return;
+          }
+          state.applySettings({
+            ...state.settings,
+            chatEnterSends: !state.settings.chatEnterSends,
+          });
+        }}
+        aria-pressed=${!state.settings.chatEnterSends}
+        title=${state.settings.chatEnterSends ? "Enter sends" : "Shift+Enter sends"}
+      >
+        ${state.settings.chatEnterSends ? "Enter sends" : "Shift+Enter sends"}
+      </button>
+      <button
         class="btn btn--sm btn--icon ${focusActive ? "active" : ""}"
         ?disabled=${disableFocusToggle}
         @click=${() => {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1039,6 +1039,7 @@ export function renderApp(state: AppViewState) {
                 error: state.lastError,
                 sessions: state.sessionsResult,
                 focusMode: chatFocus,
+                chatEnterSends: state.settings.chatEnterSends,
                 onRefresh: () => {
                   state.resetToolStream();
                   return Promise.all([loadChatHistory(state), refreshChatAvatar(state)]);

--- a/ui/src/ui/storage.ts
+++ b/ui/src/ui/storage.ts
@@ -12,6 +12,7 @@ export type UiSettings = {
   theme: ThemeMode;
   chatFocusMode: boolean;
   chatShowThinking: boolean;
+  chatEnterSends: boolean;
   splitRatio: number; // Sidebar split ratio (0.4 to 0.7, default 0.6)
   navCollapsed: boolean; // Collapsible sidebar state
   navGroupsCollapsed: Record<string, boolean>; // Which nav groups are collapsed
@@ -39,6 +40,7 @@ export function loadSettings(): UiSettings {
     theme: "system",
     chatFocusMode: false,
     chatShowThinking: true,
+    chatEnterSends: true,
     splitRatio: 0.6,
     navCollapsed: false,
     navGroupsCollapsed: {},
@@ -75,6 +77,10 @@ export function loadSettings(): UiSettings {
         typeof parsed.chatShowThinking === "boolean"
           ? parsed.chatShowThinking
           : defaults.chatShowThinking,
+      chatEnterSends:
+        typeof parsed.chatEnterSends === "boolean"
+          ? parsed.chatEnterSends
+          : defaults.chatEnterSends,
       splitRatio:
         typeof parsed.splitRatio === "number" &&
         parsed.splitRatio >= 0.4 &&

--- a/ui/src/ui/views/chat.test.ts
+++ b/ui/src/ui/views/chat.test.ts
@@ -181,6 +181,59 @@ describe("chat view", () => {
     nowSpy.mockRestore();
   });
 
+  it("uses Enter to send by default", () => {
+    const container = document.createElement("div");
+    const onSend = vi.fn();
+    render(
+      renderChat(
+        createProps({
+          onSend,
+          draft: "hello",
+        }),
+      ),
+      container,
+    );
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+    const event = new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true });
+    textarea?.dispatchEvent(event);
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses Shift+Enter to send when chatEnterSends is false", () => {
+    const container = document.createElement("div");
+    const onSend = vi.fn();
+    render(
+      renderChat(
+        createProps({
+          onSend,
+          draft: "hello",
+          chatEnterSends: false,
+        }),
+      ),
+      container,
+    );
+
+    const textarea = container.querySelector("textarea");
+    expect(textarea).not.toBeNull();
+
+    textarea?.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true, cancelable: true }),
+    );
+    expect(onSend).toHaveBeenCalledTimes(0);
+
+    textarea?.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        key: "Enter",
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    expect(onSend).toHaveBeenCalledTimes(1);
+  });
+
   it("shows a stop button when aborting is available", () => {
     const container = document.createElement("div");
     const onAbort = vi.fn();

--- a/ui/src/ui/views/chat.ts
+++ b/ui/src/ui/views/chat.ts
@@ -55,6 +55,7 @@ export type ChatProps = {
   sessions: SessionsListResult | null;
   // Focus mode
   focusMode: boolean;
+  chatEnterSends?: boolean;
   // Sidebar state
   sidebarOpen?: boolean;
   sidebarContent?: string | null;
@@ -250,10 +251,14 @@ export function renderChat(props: ChatProps) {
   };
 
   const hasAttachments = (props.attachments?.length ?? 0) > 0;
+  const chatEnterSends = props.chatEnterSends ?? true;
+  const sendHint = chatEnterSends
+    ? "↩ to send, Shift+↩ for line breaks"
+    : "Shift+↩ to send, ↩ for line breaks";
   const composePlaceholder = props.connected
     ? hasAttachments
       ? "Add a message or paste more images..."
-      : "Message (↩ to send, Shift+↩ for line breaks, paste images)"
+      : `Message (${sendHint}, paste images)`
     : "Connect to the gateway to start chatting…";
 
   const splitRatio = props.splitRatio ?? 0.6;
@@ -437,9 +442,10 @@ export function renderChat(props: ChatProps) {
                 if (e.isComposing || e.keyCode === 229) {
                   return;
                 }
-                if (e.shiftKey) {
+                const shouldSend = chatEnterSends ? !e.shiftKey : e.shiftKey;
+                if (!shouldSend) {
                   return;
-                } // Allow Shift+Enter for line breaks
+                }
                 if (!props.connected) {
                   return;
                 }
@@ -470,7 +476,7 @@ export function renderChat(props: ChatProps) {
               ?disabled=${!props.connected}
               @click=${props.onSend}
             >
-              ${isBusy ? "Queue" : "Send"}<kbd class="btn-kbd">↵</kbd>
+              ${isBusy ? "Queue" : "Send"}<kbd class="btn-kbd">${chatEnterSends ? "↵" : "⇧↵"}</kbd>
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Add a configurable chat input shortcut for the OpenClaw dashboard so users can choose whether Enter sends the message or inserts a line break.

## What changed
- add a persisted `chatEnterSends` UI setting (default: `true` to preserve current behavior)
- add a chat toolbar toggle to switch between:
  - `Enter sends`
  - `Shift+Enter sends`
- update the composer keydown behavior to respect the setting
- update the composer placeholder text to match the active shortcut
- update the send button shortcut hint to match the active shortcut (`↵` vs `⇧↵`)
- add tests covering both shortcut modes

## Why
This is not only a preference issue, but also a safety issue for some users.

In agent workflows, an accidental Enter press can submit a prompt before the user has finished typing. The unfinished second half of the message may materially change the meaning of the first half. Once submitted, the model may already start running, calling tools, or taking actions based on incomplete intent.

Providing a configurable send shortcut reduces unintended submissions for users who are prone to accidental Enter presses, and lowers the risk of premature or unsafe agent actions.

## Validation
- added focused chat view tests for both modes
- verified locally with:
  - `corepack pnpm exec vitest run --config ui/vitest.chat.node.config.ts` during development
