### PR TITLE
fix(openai-ws): guard against malformed content entries in message conversion

### DIFF
--- a/src/agents/openai-ws-stream.test.ts
+++ b/src/agents/openai-ws-stream.test.ts
@@ -521,6 +521,37 @@ describe("convertMessagesToInputItems", () => {
   it("returns empty array for empty messages", () => {
     expect(convertMessagesToInputItems([])).toEqual([]);
   });
+
+  it("skips malformed null/undefined entries in user content", () => {
+    const msg = {
+      role: "user" as const,
+      content: [null, { type: "text", text: "hello" }, undefined],
+      timestamp: 0,
+    };
+    const items = convertMessagesToInputItems([msg] as unknown as Parameters<
+      typeof convertMessagesToInputItems
+    >[0]);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ type: "message", role: "user", content: "hello" });
+  });
+
+  it("skips malformed null/undefined entries in assistant content", () => {
+    const msg = {
+      role: "assistant" as const,
+      content: [null, { type: "text", text: "response" }, undefined],
+      stopReason: "stop",
+      api: "openai-responses",
+      provider: "openai",
+      model: "gpt-5.2",
+      usage: {},
+      timestamp: 0,
+    };
+    const items = convertMessagesToInputItems([msg] as unknown as Parameters<
+      typeof convertMessagesToInputItems
+    >[0]);
+    expect(items).toHaveLength(1);
+    expect((items[0] as { content?: unknown }).content).toBe("response");
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/agents/openai-ws-stream.ts
+++ b/src/agents/openai-ws-stream.ts
@@ -138,6 +138,9 @@ function contentToOpenAIParts(content: unknown): ContentPart[] {
     data?: string;
     mimeType?: string;
   }>) {
+    if (!part || typeof part !== "object") {
+      continue;
+    }
     if (part.type === "text" && typeof part.text === "string") {
       parts.push({ type: "input_text", text: part.text });
     } else if (part.type === "image" && typeof part.data === "string") {
@@ -205,6 +208,9 @@ export function convertMessagesToInputItems(messages: Message[]): InputItem[] {
           arguments?: Record<string, unknown>;
           thinking?: string;
         }>) {
+          if (!block || typeof block !== "object") {
+            continue;
+          }
           if (block.type === "text" && typeof block.text === "string") {
             textParts.push(block.text);
           } else if (block.type === "thinking" && typeof block.thinking === "string") {


### PR DESCRIPTION
Adds null/object guards in `contentToOpenAIParts` and assistant content iteration to skip malformed entries (`null`, `undefined`, non-objects) instead of throwing on `block.type` dereference.

### Problem
`convertMessagesToInputItems` crashes with `Cannot read properties of null (reading 'type')` when user or assistant content arrays contain malformed entries (e.g. `null`).

### Fix
Added `!block || typeof block !== "object"` guards in both loops, consistent with the pattern used in `promoteThinkingTagsToBlocks` (fixed in #35143).

### Tests
Added two test cases covering malformed `null`/`undefined` entries in both user and assistant content arrays. All 42 tests pass.

Closes #35051