### PR TITLE
build: update pnpm packageManager to 10.30.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -415,7 +415,7 @@
   "engines": {
     "node": ">=22.12.0"
   },
-  "packageManager": "pnpm@10.23.0",
+  "packageManager": "pnpm@10.30.3",
   "pnpm": {
     "minimumReleaseAge": 2880,
     "overrides": {


### PR DESCRIPTION
## Summary

Update the repository `packageManager` field from `pnpm@10.23.0` to `pnpm@10.30.3` so Corepack uses the newer pnpm release during installs/builds.

## Changes

- bump root `package.json` `packageManager` from `pnpm@10.23.0` to `pnpm@10.30.3`

## Testing

- validated `package.json` parses successfully with Node after the change

Fixes openclaw/openclaw#38372