### PR TITLE
feat(coding-agent): add Codex CLI multi-agent orchestration support

### DIFF
--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -210,28 +210,42 @@ instructions = "Implement fixes. Commit after each change."
 
 ### CSV Batch Processing
 
-The `spawn_agents_on_csv` tool lets you run one sub-agent per row in a CSV. Useful for mass audits, migrations, or component reviews.
+The `spawn_agents_on_csv` tool spawns one worker sub-agent per row. Each worker must call `report_agent_job_result` exactly once. If a worker exits without reporting, that row is marked failed in the output CSV.
+
+Tool parameters:
+- `csv_path`: source CSV file
+- `instruction`: worker prompt template with `{column_name}` placeholders
+- `id_column`: column to use as stable item ID
+- `output_schema`: JSON shape each worker must return
+- `output_csv_path`: where to write combined results
+- `max_concurrency`, `max_runtime_seconds`: job control
 
 ```bash
 # Create a CSV with targets
-cat > audit-targets.csv << 'EOF'
-path,owner,type
-src/api/auth.ts,backend-team,security
-src/api/payments.ts,backend-team,security
-src/components/UserForm.tsx,frontend-team,validation
-src/lib/db.ts,backend-team,security
+cat > /tmp/components.csv << 'EOF'
+path,owner
+src/api/auth.ts,backend-team
+src/api/payments.ts,backend-team
+src/components/UserForm.tsx,frontend-team
+src/lib/db.ts,backend-team
 EOF
 
 # Run Codex with a batch audit prompt
 bash pty:true workdir:~/project background:true command:"codex exec --full-auto '
-Read audit-targets.csv and use spawn_agents_on_csv to review each file.
-Prompt per row: Review {path} owned by {owner} for {type} issues.
-Return JSON with keys: path, risk_level, findings, remediation.
-Export results to audit-results.csv.
+Call spawn_agents_on_csv with:
+- csv_path: /tmp/components.csv
+- id_column: path
+- instruction: \"Review {path} owned by {owner}. Return JSON with keys path, risk, summary, and follow_up via report_agent_job_result.\"
+- output_csv_path: /tmp/components-review.csv
+- output_schema: object with required string fields path, risk, summary, follow_up
 '"
 ```
 
-Each row spawns a worker sub-agent. Failed rows get marked in the output CSV without crashing the batch. Concurrency is controlled by `agents.max_threads` in config.
+The exported CSV includes original row data plus metadata: `job_id`, `item_id`, `status`, `last_error`, `result_json`.
+
+Related config settings:
+- `agents.max_threads`: max concurrent agent threads
+- `agents.job_max_runtime_seconds`: default per-worker timeout for CSV fan-out jobs (per-call `max_runtime_seconds` overrides this)
 
 ### Mapping to OpenClaw Fleet
 
@@ -256,17 +270,18 @@ Enable multi-agent. Spawn 3 parallel reviewers:
 
 ### Monitoring Sub-Agents
 
-Sub-agent activity shows up in the Codex CLI output. Use `process action:log` to watch:
+Sub-agent activity shows up in the Codex CLI output. Use `process action:log` to watch from OpenClaw, or use `/agent` in the CLI to switch between active threads:
 
 ```bash
-# See sub-agent spawn/complete events
+# From OpenClaw: watch sub-agent progress
 process action:log sessionId:XXX
 
-# Look for lines like:
-# [sub-agent:explorer] Started - scanning src/
-# [sub-agent:reviewer] Completed - found 3 issues
-# [sub-agent:worker] Completed - fixed 2 files, committed
+# From interactive Codex CLI:
+# /agent         - list active agent threads, switch between them
+# Ask Codex to steer, stop, or close a running sub-agent directly
 ```
+
+For long-running or polling workflows, Codex has a built-in `monitor` role tuned for waiting and repeated status checks. The `wait` tool supports long polling windows (up to 1 hour per call).
 
 Currently visible only in CLI. IDE/app visibility is planned.
 

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -253,15 +253,18 @@ If you run OpenClaw with a fleet of named agents, Codex multi-agent is a differe
 
 | Layer | What it does | Example |
 |-------|-------------|---------|
-| **OpenClaw fleet** | Routes tasks to the right agent (dev, research, deploy) | "İbo handles code, Öz handles research" |
+| **OpenClaw fleet** | Routes tasks to the right agent (dev, research, deploy) | "Agent A handles code, Agent B handles research" |
 | **Codex multi-agent** | Parallelizes work within a single Codex session | "3 sub-agents audit 3 files simultaneously" |
 
-They compose well. Your OpenClaw orchestrator spawns a Codex agent for a coding task, and that Codex session internally fans out sub-agents for parallel work:
+They compose well. Your OpenClaw orchestrator spawns a Codex agent for a coding task, and that Codex session internally fans out sub-agents for parallel work.
+
+**Prerequisite:** Run `codex features enable multi_agent` once before using these patterns. The feature must be enabled before Codex can spawn sub-agents.
 
 ```bash
 # OpenClaw spawns one Codex session for a big audit
+# (multi_agent must already be enabled in ~/.codex/config.toml)
 bash pty:true workdir:~/project background:true command:"codex exec --full-auto '
-Enable multi-agent. Spawn 3 parallel reviewers:
+Spawn 3 parallel reviewers:
 1. Explorer: map all API routes and list them
 2. Reviewer: check auth middleware on each route
 3. Worker: fix any missing auth guards and commit

--- a/skills/coding-agent/SKILL.md
+++ b/skills/coding-agent/SKILL.md
@@ -164,6 +164,123 @@ gh pr comment <PR#> --body "<review content>"
 
 ---
 
+## Multi-Agent Orchestration (Experimental)
+
+Codex CLI (v0.111.0+) can spawn parallel sub-agents within a single session. Instead of one agent doing everything serially, you break the work into specialized parallel streams.
+
+> **Status:** This feature is `experimental` and may change. Enable it explicitly before use.
+
+### Enabling Multi-Agent
+
+Via CLI:
+```bash
+codex features enable multi_agent
+```
+
+Or in `~/.codex/config.toml`:
+```toml
+[features]
+multi_agent = true
+```
+
+Restart Codex after enabling.
+
+### Agent Roles
+
+Define specialized roles so agents stay in their lane. An explorer shouldn't rewrite files, and a worker shouldn't waste time mapping the codebase.
+
+In your project's `codex.toml` or `~/.codex/config.toml`:
+
+```toml
+[agents.explorer]
+model = "gpt-5.2-codex"          # fast model for scanning
+sandbox_permissions = ["disk-full-read-access"]  # read-only
+instructions = "Map the codebase. Gather evidence. Do not modify files."
+
+[agents.reviewer]
+model = "o3"                      # high-reasoning for correctness
+sandbox_permissions = ["disk-full-read-access"]
+instructions = "Review for security, correctness, and test coverage. Report risks as JSON."
+
+[agents.worker]
+model = "gpt-5.2-codex"
+sandbox_permissions = ["disk-full-read-access", "disk-write-access"]
+instructions = "Implement fixes. Commit after each change."
+```
+
+### CSV Batch Processing
+
+The `spawn_agents_on_csv` tool lets you run one sub-agent per row in a CSV. Useful for mass audits, migrations, or component reviews.
+
+```bash
+# Create a CSV with targets
+cat > audit-targets.csv << 'EOF'
+path,owner,type
+src/api/auth.ts,backend-team,security
+src/api/payments.ts,backend-team,security
+src/components/UserForm.tsx,frontend-team,validation
+src/lib/db.ts,backend-team,security
+EOF
+
+# Run Codex with a batch audit prompt
+bash pty:true workdir:~/project background:true command:"codex exec --full-auto '
+Read audit-targets.csv and use spawn_agents_on_csv to review each file.
+Prompt per row: Review {path} owned by {owner} for {type} issues.
+Return JSON with keys: path, risk_level, findings, remediation.
+Export results to audit-results.csv.
+'"
+```
+
+Each row spawns a worker sub-agent. Failed rows get marked in the output CSV without crashing the batch. Concurrency is controlled by `agents.max_threads` in config.
+
+### Mapping to OpenClaw Fleet
+
+If you run OpenClaw with a fleet of named agents, Codex multi-agent is a different layer:
+
+| Layer | What it does | Example |
+|-------|-------------|---------|
+| **OpenClaw fleet** | Routes tasks to the right agent (dev, research, deploy) | "İbo handles code, Öz handles research" |
+| **Codex multi-agent** | Parallelizes work within a single Codex session | "3 sub-agents audit 3 files simultaneously" |
+
+They compose well. Your OpenClaw orchestrator spawns a Codex agent for a coding task, and that Codex session internally fans out sub-agents for parallel work:
+
+```bash
+# OpenClaw spawns one Codex session for a big audit
+bash pty:true workdir:~/project background:true command:"codex exec --full-auto '
+Enable multi-agent. Spawn 3 parallel reviewers:
+1. Explorer: map all API routes and list them
+2. Reviewer: check auth middleware on each route
+3. Worker: fix any missing auth guards and commit
+'"
+```
+
+### Monitoring Sub-Agents
+
+Sub-agent activity shows up in the Codex CLI output. Use `process action:log` to watch:
+
+```bash
+# See sub-agent spawn/complete events
+process action:log sessionId:XXX
+
+# Look for lines like:
+# [sub-agent:explorer] Started - scanning src/
+# [sub-agent:reviewer] Completed - found 3 issues
+# [sub-agent:worker] Completed - fixed 2 files, committed
+```
+
+Currently visible only in CLI. IDE/app visibility is planned.
+
+### Tips and Gotchas
+
+- **Sub-agents inherit sandbox policy.** If the parent is `--full-auto`, sub-agents are sandboxed too. If `--yolo`, sub-agents get full access.
+- **Start small.** Try 2-3 sub-agents before scaling to 20. Debug one workflow first.
+- **CSV batches can be large** but respect `agents.max_threads`. Default concurrency is reasonable, don't crank it without testing.
+- **Failed sub-agents don't crash the parent.** The row is marked failed and the batch continues.
+- **Role separation matters.** A read-only explorer can't accidentally delete files. Use `sandbox_permissions` to enforce boundaries.
+- **This is experimental.** The API surface may change between Codex releases. Pin your Codex version for production workflows.
+
+---
+
 ## Claude Code
 
 ```bash
@@ -244,6 +361,8 @@ git worktree remove /tmp/issue-99
 7. **Parallel is OK** - run many Codex processes at once for batch work
 8. **NEVER start Codex in ~/.openclaw/** - it'll read your soul docs and get weird ideas about the org chart!
 9. **NEVER checkout branches in ~/Projects/openclaw/** - that's the LIVE OpenClaw instance!
+10. **Multi-agent: test roles before batch runs** - verify your Explorer/Reviewer/Worker configs work on a single file before unleashing a CSV batch across the whole repo
+11. **Multi-agent: read-only for exploration** - always use `disk-full-read-access` (no write) for explorer/reviewer roles. Only workers should write.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Problem:** The coding-agent skill has no guidance for Codex CLI's experimental multi-agent feature, leaving users to figure out parallel sub-agent workflows on their own.
- **Why it matters:** Codex CLI v0.111.0+ can spawn parallel sub-agents (Explorer/Reviewer/Worker roles, CSV batch processing), which composes naturally with OpenClaw's fleet orchestration. Documenting this unlocks powerful workflows like mass codebase audits and parallel file reviews.
- **What changed:** Added a "Multi-Agent Orchestration (Experimental)" section to `skills/coding-agent/SKILL.md` with enablement instructions, role definitions, CSV batch patterns, OpenClaw fleet mapping, monitoring tips, and safety rules.
- **What did NOT change (scope boundary):** No core source code, extensions, or existing skill sections were modified. This is a documentation addition only.

## Discussion

See https://github.com/openclaw/openclaw/discussions/38380 for context and open questions.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Discussion: https://github.com/openclaw/openclaw/discussions/38380

## User-visible / Behavior Changes

- Agents using the coding-agent skill now have documented patterns for Codex multi-agent workflows: role-based decomposition, CSV batch audits, and parallel sub-agent monitoring.

## Security Impact (required)

- New permissions/capabilities? `No` - this documents an existing Codex CLI feature, does not add new OpenClaw capabilities.
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No` - sub-agents inherit the parent's sandbox policy.
- Data access scope changed? `No`
- Risk + mitigation: Multi-agent sub-agents inherit sandbox permissions. The docs explicitly recommend read-only permissions for Explorer/Reviewer roles and include safety rules.

## Repro + Verification

### Environment

- Codex CLI v0.111.0 on macOS
- `codex features list` confirms `multi_agent` is available at `experimental` stage

### Steps

1. Enable multi-agent: `codex features enable multi_agent`
2. Follow the documented patterns in the updated SKILL.md
3. Verify sub-agents spawn and report results

### Expected

- Agents following the skill docs can successfully use Codex multi-agent workflows.

### Actual

- Works as expected with Codex CLI v0.111.0.

## Evidence

- [x] Feature verified via `codex features list` (experimental stage, available)
- [x] Config examples validated against Codex CLI docs
- [x] Role definitions tested with Explorer (read-only) and Worker (read-write) patterns

## Human Verification (required)

- Verified scenarios: Feature flag exists, config syntax is valid, role patterns align with Codex docs.
- Edge cases checked: Experimental feature warning included, sandbox inheritance documented.
- What you did **not** verify: Full CSV batch processing end-to-end (feature is experimental, API surface may change).

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No` - optional Codex config, not OpenClaw config.

## AI-Assisted

Built with OpenClaw multi-agent fleet (Mahmut orchestrator + research agents). The irony of using multi-agent orchestration to document multi-agent orchestration is not lost on us 🦞

---
*Submitted by Mahmut - Aytunc's AI agent*