### PR TITLE
nextcloud-talk: add allowPrivateNetwork for SSRF-safe private host access

### DIFF
--- a/extensions/nextcloud-talk/src/accounts.ts
+++ b/extensions/nextcloud-talk/src/accounts.ts
@@ -26,6 +26,7 @@ export type ResolvedNextcloudTalkAccount = {
   accountId: string;
   enabled: boolean;
   name?: string;
+  allowPrivateNetwork: boolean | null;
   baseUrl: string;
   secret: string;
   secretSource: "env" | "secretFile" | "config" | "none";
@@ -155,6 +156,7 @@ export function resolveNextcloudTalkAccount(params: {
       accountId,
       enabled,
       name: merged.name?.trim() || undefined,
+      allowPrivateNetwork: merged.allowPrivateNetwork ?? null,
       baseUrl,
       secret: secretResolution.secret,
       secretSource: secretResolution.source,

--- a/extensions/nextcloud-talk/src/channel.startup.test.ts
+++ b/extensions/nextcloud-talk/src/channel.startup.test.ts
@@ -20,6 +20,7 @@ function buildAccount(): ResolvedNextcloudTalkAccount {
   return {
     accountId: "default",
     enabled: true,
+    allowPrivateNetwork: null,
     baseUrl: "https://nextcloud.example.com",
     secret: "secret",
     secretSource: "config",

--- a/extensions/nextcloud-talk/src/config-schema.ts
+++ b/extensions/nextcloud-talk/src/config-schema.ts
@@ -27,6 +27,7 @@ export const NextcloudTalkAccountSchemaBase = z
     name: z.string().optional(),
     enabled: z.boolean().optional(),
     markdown: MarkdownConfigSchema,
+    allowPrivateNetwork: z.boolean().optional(),
     baseUrl: z.string().optional(),
     botSecret: buildSecretInputSchema().optional(),
     botSecretFile: z.string().optional(),

--- a/extensions/nextcloud-talk/src/inbound.authz.test.ts
+++ b/extensions/nextcloud-talk/src/inbound.authz.test.ts
@@ -43,6 +43,7 @@ describe("nextcloud-talk inbound authz", () => {
     const account: ResolvedNextcloudTalkAccount = {
       accountId: "default",
       enabled: true,
+      allowPrivateNetwork: null,
       baseUrl: "",
       secret: "",
       secretSource: "none",

--- a/extensions/nextcloud-talk/src/onboarding.ts
+++ b/extensions/nextcloud-talk/src/onboarding.ts
@@ -2,6 +2,7 @@ import {
   addWildcardAllowFrom,
   formatDocsLink,
   hasConfiguredSecretInput,
+  isBlockedHostnameOrIp,
   mergeAllowFromEntries,
   promptSingleChannelSecretInput,
   promptAccountId,
@@ -242,6 +243,26 @@ export const nextcloudTalkOnboardingAdapter: ChannelOnboardingAdapter = {
       ).trim();
     }
 
+    // Detect private/internal hostnames and require explicit approval.
+    let allowPrivateNetwork = resolvedAccount.config.allowPrivateNetwork ?? false;
+    try {
+      const { hostname } = new URL(baseUrl);
+      if (isBlockedHostnameOrIp(hostname)) {
+        allowPrivateNetwork = await prompter.confirm({
+          message:
+            "Nextcloud URL looks like a private/internal host. Allow private network access? (SSRF risk)",
+          initialValue: allowPrivateNetwork,
+        });
+        if (!allowPrivateNetwork) {
+          throw new Error("Refusing private/internal Nextcloud URL without explicit approval");
+        }
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith("Refusing")) {
+        throw err;
+      }
+    }
+
     let secret: SecretInput | null = null;
     if (!accountConfigured) {
       await noteNextcloudTalkSecretHelp(prompter);
@@ -264,7 +285,14 @@ export const nextcloudTalkOnboardingAdapter: ChannelOnboardingAdapter = {
       secret = secretResult.value;
     }
 
-    if (secretResult.action === "use-env" || secret || baseUrl !== resolvedAccount.baseUrl) {
+    const allowPrivateNetworkChanged =
+      allowPrivateNetwork !== (resolvedAccount.config.allowPrivateNetwork ?? false);
+    if (
+      secretResult.action === "use-env" ||
+      secret ||
+      baseUrl !== resolvedAccount.baseUrl ||
+      allowPrivateNetworkChanged
+    ) {
       if (accountId === DEFAULT_ACCOUNT_ID) {
         next = {
           ...next,
@@ -274,6 +302,7 @@ export const nextcloudTalkOnboardingAdapter: ChannelOnboardingAdapter = {
               ...next.channels?.["nextcloud-talk"],
               enabled: true,
               baseUrl,
+              ...(allowPrivateNetwork ? { allowPrivateNetwork: true } : {}),
               ...(secret ? { botSecret: secret } : {}),
             },
           },
@@ -293,6 +322,7 @@ export const nextcloudTalkOnboardingAdapter: ChannelOnboardingAdapter = {
                   enabled:
                     next.channels?.["nextcloud-talk"]?.accounts?.[accountId]?.enabled ?? true,
                   baseUrl,
+                  ...(allowPrivateNetwork ? { allowPrivateNetwork: true } : {}),
                   ...(secret ? { botSecret: secret } : {}),
                 },
               },

--- a/extensions/nextcloud-talk/src/onboarding.ts
+++ b/extensions/nextcloud-talk/src/onboarding.ts
@@ -245,22 +245,25 @@ export const nextcloudTalkOnboardingAdapter: ChannelOnboardingAdapter = {
 
     // Detect private/internal hostnames and require explicit approval.
     let allowPrivateNetwork = resolvedAccount.config.allowPrivateNetwork ?? false;
+    let isPrivateHost = false;
     try {
       const { hostname } = new URL(baseUrl);
-      if (isBlockedHostnameOrIp(hostname)) {
-        allowPrivateNetwork = await prompter.confirm({
-          message:
-            "Nextcloud URL looks like a private/internal host. Allow private network access? (SSRF risk)",
-          initialValue: allowPrivateNetwork,
-        });
-        if (!allowPrivateNetwork) {
-          throw new Error("Refusing private/internal Nextcloud URL without explicit approval");
-        }
+      isPrivateHost = isBlockedHostnameOrIp(hostname);
+    } catch {
+      // Malformed URL — leave isPrivateHost false; validation elsewhere will catch it.
+    }
+    if (isPrivateHost) {
+      allowPrivateNetwork = await prompter.confirm({
+        message:
+          "Nextcloud URL looks like a private/internal host. Allow private network access? (SSRF risk)",
+        initialValue: allowPrivateNetwork,
+      });
+      if (!allowPrivateNetwork) {
+        throw new Error("Refusing private/internal Nextcloud URL without explicit approval");
       }
-    } catch (err) {
-      if (err instanceof Error && err.message.startsWith("Refusing")) {
-        throw err;
-      }
+    } else {
+      // Clear stale allowPrivateNetwork when URL changes to a public host.
+      allowPrivateNetwork = false;
     }
 
     let secret: SecretInput | null = null;
@@ -302,7 +305,7 @@ export const nextcloudTalkOnboardingAdapter: ChannelOnboardingAdapter = {
               ...next.channels?.["nextcloud-talk"],
               enabled: true,
               baseUrl,
-              ...(allowPrivateNetwork ? { allowPrivateNetwork: true } : {}),
+              allowPrivateNetwork,
               ...(secret ? { botSecret: secret } : {}),
             },
           },
@@ -322,7 +325,7 @@ export const nextcloudTalkOnboardingAdapter: ChannelOnboardingAdapter = {
                   enabled:
                     next.channels?.["nextcloud-talk"]?.accounts?.[accountId]?.enabled ?? true,
                   baseUrl,
-                  ...(allowPrivateNetwork ? { allowPrivateNetwork: true } : {}),
+                  allowPrivateNetwork,
                   ...(secret ? { botSecret: secret } : {}),
                 },
               },

--- a/extensions/nextcloud-talk/src/room-info.ts
+++ b/extensions/nextcloud-talk/src/room-info.ts
@@ -105,6 +105,7 @@ export async function resolveNextcloudTalkRoomKind(params: {
           Accept: "application/json",
         },
       },
+      policy: account.allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined,
       auditContext: "nextcloud-talk.room-info",
     });
     try {

--- a/extensions/nextcloud-talk/src/send.test.ts
+++ b/extensions/nextcloud-talk/src/send.test.ts
@@ -9,11 +9,13 @@ const hoisted = vi.hoisted(() => ({
     accountId: "default",
     baseUrl: "https://nextcloud.example.com",
     secret: "secret-value",
+    allowPrivateNetwork: null,
   })),
   generateNextcloudTalkSignature: vi.fn(() => ({
     random: "r",
     signature: "s",
   })),
+  fetchWithSsrFGuard: vi.fn(),
 }));
 
 vi.mock("./runtime.js", () => ({
@@ -41,15 +43,16 @@ vi.mock("./signature.js", () => ({
   generateNextcloudTalkSignature: hoisted.generateNextcloudTalkSignature,
 }));
 
+vi.mock("openclaw/plugin-sdk/nextcloud-talk", () => ({
+  fetchWithSsrFGuard: hoisted.fetchWithSsrFGuard,
+}));
+
 import { sendMessageNextcloudTalk, sendReactionNextcloudTalk } from "./send.js";
 
 describe("nextcloud-talk send cfg threading", () => {
-  const fetchMock = vi.fn<typeof fetch>();
-
   beforeEach(() => {
     vi.clearAllMocks();
-    fetchMock.mockReset();
-    vi.stubGlobal("fetch", fetchMock);
+    hoisted.fetchWithSsrFGuard.mockReset();
   });
 
   afterEach(() => {
@@ -58,14 +61,16 @@ describe("nextcloud-talk send cfg threading", () => {
 
   it("uses provided cfg for sendMessage and skips runtime loadConfig", async () => {
     const cfg = { source: "provided" } as const;
-    fetchMock.mockResolvedValueOnce(
-      new Response(
+    hoisted.fetchWithSsrFGuard.mockResolvedValueOnce({
+      response: new Response(
         JSON.stringify({
           ocs: { data: { id: 12345, timestamp: 1_706_000_000 } },
         }),
         { status: 200, headers: { "content-type": "application/json" } },
       ),
-    );
+      finalUrl: "https://nextcloud.example.com/ocs/v2.php/apps/spreed/api/v1/bot/abc123/message",
+      release: vi.fn(),
+    });
 
     const result = await sendMessageNextcloudTalk("room:abc123", "hello", {
       cfg,
@@ -77,7 +82,7 @@ describe("nextcloud-talk send cfg threading", () => {
       cfg,
       accountId: "work",
     });
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(hoisted.fetchWithSsrFGuard).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
       messageId: "12345",
       roomToken: "abc123",
@@ -88,7 +93,12 @@ describe("nextcloud-talk send cfg threading", () => {
   it("falls back to runtime cfg for sendReaction when cfg is omitted", async () => {
     const runtimeCfg = { source: "runtime" } as const;
     hoisted.loadConfig.mockReturnValueOnce(runtimeCfg);
-    fetchMock.mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    hoisted.fetchWithSsrFGuard.mockResolvedValueOnce({
+      response: new Response("{}", { status: 200 }),
+      finalUrl:
+        "https://nextcloud.example.com/ocs/v2.php/apps/spreed/api/v1/bot/ops/reaction/m-1",
+      release: vi.fn(),
+    });
 
     const result = await sendReactionNextcloudTalk("room:ops", "m-1", "👍", {
       accountId: "default",

--- a/extensions/nextcloud-talk/src/send.test.ts
+++ b/extensions/nextcloud-talk/src/send.test.ts
@@ -95,8 +95,7 @@ describe("nextcloud-talk send cfg threading", () => {
     hoisted.loadConfig.mockReturnValueOnce(runtimeCfg);
     hoisted.fetchWithSsrFGuard.mockResolvedValueOnce({
       response: new Response("{}", { status: 200 }),
-      finalUrl:
-        "https://nextcloud.example.com/ocs/v2.php/apps/spreed/api/v1/bot/ops/reaction/m-1",
+      finalUrl: "https://nextcloud.example.com/ocs/v2.php/apps/spreed/api/v1/bot/ops/reaction/m-1",
       release: vi.fn(),
     });
 

--- a/extensions/nextcloud-talk/src/send.ts
+++ b/extensions/nextcloud-talk/src/send.ts
@@ -1,7 +1,14 @@
+import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/nextcloud-talk";
 import { resolveNextcloudTalkAccount } from "./accounts.js";
 import { getNextcloudTalkRuntime } from "./runtime.js";
 import { generateNextcloudTalkSignature } from "./signature.js";
 import type { CoreConfig, NextcloudTalkSendResult } from "./types.js";
+
+function ssrfPolicyFromAllowPrivateNetwork(
+  allowPrivateNetwork: boolean | null | undefined,
+): { allowPrivateNetwork: true } | undefined {
+  return allowPrivateNetwork ? { allowPrivateNetwork: true } : undefined;
+}
 
 type NextcloudTalkSendOpts = {
   baseUrl?: string;
@@ -105,69 +112,78 @@ export async function sendMessageNextcloudTalk(
 
   const url = `${baseUrl}/ocs/v2.php/apps/spreed/api/v1/bot/${roomToken}/message`;
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "OCS-APIRequest": "true",
-      "X-Nextcloud-Talk-Bot-Random": random,
-      "X-Nextcloud-Talk-Bot-Signature": signature,
+  const { response, release } = await fetchWithSsrFGuard({
+    url,
+    init: {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "OCS-APIRequest": "true",
+        "X-Nextcloud-Talk-Bot-Random": random,
+        "X-Nextcloud-Talk-Bot-Signature": signature,
+      },
+      body: bodyStr,
     },
-    body: bodyStr,
+    policy: ssrfPolicyFromAllowPrivateNetwork(account.allowPrivateNetwork),
+    auditContext: "nextcloud-talk.send",
   });
 
-  if (!response.ok) {
-    const errorBody = await response.text().catch(() => "");
-    const status = response.status;
-    let errorMsg = `Nextcloud Talk send failed (${status})`;
+  try {
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      const status = response.status;
+      let errorMsg = `Nextcloud Talk send failed (${status})`;
 
-    if (status === 400) {
-      errorMsg = `Nextcloud Talk: bad request - ${errorBody || "invalid message format"}`;
-    } else if (status === 401) {
-      errorMsg = "Nextcloud Talk: authentication failed - check bot secret";
-    } else if (status === 403) {
-      errorMsg = "Nextcloud Talk: forbidden - bot may not have permission in this room";
-    } else if (status === 404) {
-      errorMsg = `Nextcloud Talk: room not found (token=${roomToken})`;
-    } else if (errorBody) {
-      errorMsg = `Nextcloud Talk send failed: ${errorBody}`;
+      if (status === 400) {
+        errorMsg = `Nextcloud Talk: bad request - ${errorBody || "invalid message format"}`;
+      } else if (status === 401) {
+        errorMsg = "Nextcloud Talk: authentication failed - check bot secret";
+      } else if (status === 403) {
+        errorMsg = "Nextcloud Talk: forbidden - bot may not have permission in this room";
+      } else if (status === 404) {
+        errorMsg = `Nextcloud Talk: room not found (token=${roomToken})`;
+      } else if (errorBody) {
+        errorMsg = `Nextcloud Talk send failed: ${errorBody}`;
+      }
+
+      throw new Error(errorMsg);
     }
 
-    throw new Error(errorMsg);
-  }
-
-  let messageId = "unknown";
-  let timestamp: number | undefined;
-  try {
-    const data = (await response.json()) as {
-      ocs?: {
-        data?: {
-          id?: number | string;
-          timestamp?: number;
+    let messageId = "unknown";
+    let timestamp: number | undefined;
+    try {
+      const data = (await response.json()) as {
+        ocs?: {
+          data?: {
+            id?: number | string;
+            timestamp?: number;
+          };
         };
       };
-    };
-    if (data.ocs?.data?.id != null) {
-      messageId = String(data.ocs.data.id);
+      if (data.ocs?.data?.id != null) {
+        messageId = String(data.ocs.data.id);
+      }
+      if (typeof data.ocs?.data?.timestamp === "number") {
+        timestamp = data.ocs.data.timestamp;
+      }
+    } catch {
+      // Response parsing failed, but message was sent.
     }
-    if (typeof data.ocs?.data?.timestamp === "number") {
-      timestamp = data.ocs.data.timestamp;
+
+    if (opts.verbose) {
+      console.log(`[nextcloud-talk] Sent message ${messageId} to room ${roomToken}`);
     }
-  } catch {
-    // Response parsing failed, but message was sent.
+
+    getNextcloudTalkRuntime().channel.activity.record({
+      channel: "nextcloud-talk",
+      accountId: account.accountId,
+      direction: "outbound",
+    });
+
+    return { messageId, roomToken, timestamp };
+  } finally {
+    await release();
   }
-
-  if (opts.verbose) {
-    console.log(`[nextcloud-talk] Sent message ${messageId} to room ${roomToken}`);
-  }
-
-  getNextcloudTalkRuntime().channel.activity.record({
-    channel: "nextcloud-talk",
-    accountId: account.accountId,
-    direction: "outbound",
-  });
-
-  return { messageId, roomToken, timestamp };
 }
 
 export async function sendReactionNextcloudTalk(
@@ -196,21 +212,30 @@ export async function sendReactionNextcloudTalk(
 
   const url = `${baseUrl}/ocs/v2.php/apps/spreed/api/v1/bot/${normalizedToken}/reaction/${messageId}`;
 
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "OCS-APIRequest": "true",
-      "X-Nextcloud-Talk-Bot-Random": random,
-      "X-Nextcloud-Talk-Bot-Signature": signature,
+  const { response, release } = await fetchWithSsrFGuard({
+    url,
+    init: {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "OCS-APIRequest": "true",
+        "X-Nextcloud-Talk-Bot-Random": random,
+        "X-Nextcloud-Talk-Bot-Signature": signature,
+      },
+      body,
     },
-    body,
+    policy: ssrfPolicyFromAllowPrivateNetwork(account.allowPrivateNetwork),
+    auditContext: "nextcloud-talk.reaction",
   });
 
-  if (!response.ok) {
-    const errorBody = await response.text().catch(() => "");
-    throw new Error(`Nextcloud Talk reaction failed: ${response.status} ${errorBody}`.trim());
-  }
+  try {
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "");
+      throw new Error(`Nextcloud Talk reaction failed: ${response.status} ${errorBody}`.trim());
+    }
 
-  return { ok: true };
+    return { ok: true };
+  } finally {
+    await release();
+  }
 }

--- a/extensions/nextcloud-talk/src/types.ts
+++ b/extensions/nextcloud-talk/src/types.ts
@@ -27,6 +27,8 @@ export type NextcloudTalkAccountConfig = {
   name?: string;
   /** If false, do not start this Nextcloud Talk account. Default: true. */
   enabled?: boolean;
+  /** Allow connections to private/internal network hosts. Default: false (blocked for SSRF safety). */
+  allowPrivateNetwork?: boolean;
   /** Base URL of the Nextcloud instance (e.g., "https://cloud.example.com"). */
   baseUrl?: string;
   /** Bot shared secret from occ talk:bot:install output. */

--- a/src/plugin-sdk/nextcloud-talk.ts
+++ b/src/plugin-sdk/nextcloud-talk.ts
@@ -66,6 +66,8 @@ export {
   requestBodyErrorToText,
 } from "../infra/http-body.js";
 export { fetchWithSsrFGuard } from "../infra/net/fetch-guard.js";
+export type { SsrFPolicy } from "../infra/net/ssrf.js";
+export { isBlockedHostnameOrIp, SsrFBlockedError } from "../infra/net/ssrf.js";
 export { emptyPluginConfigSchema } from "../plugins/config-schema.js";
 export type { PluginRuntime } from "../plugins/runtime/types.js";
 export type { OpenClawPluginApi } from "../plugins/types.js";


### PR DESCRIPTION
## Summary

- Problem: Nextcloud Talk plugin has no `allowPrivateNetwork` option, so self-hosted instances on private/internal IPs (localhost, 192.168.x.x, 10.x.x.x) are blocked by the SSRF guard.
- Why it matters: many Nextcloud deployments run on private networks; without this flag the bot cannot reach them.
- What changed: added `allowPrivateNetwork` config flag (schema, types, resolved account), switched outbound HTTP calls (`send`, `reaction`, `room-info`) from raw `fetch` to `fetchWithSsrFGuard` with SSRF policy, added private-host detection + confirmation prompt during onboarding — all mirroring the existing Tlon plugin pattern.
- What did NOT change: inbound webhook server, signature verification, pairing/policy logic, default behavior (private networks still blocked unless explicitly opted in).

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: Tlon plugin `allowPrivateNetwork` implementation

## User-visible / Behavior Changes

- New optional config key `channels.nextcloud-talk.allowPrivateNetwork` (boolean, default `false`).
- Onboarding now detects private/internal Nextcloud URLs and prompts for explicit approval.
- Outbound sends/reactions/room-info lookups now go through `fetchWithSsrFGuard` (SSRF-safe) instead of raw `fetch`.

## Security Impact (required)

- New permissions/capabilities? `Yes` — opt-in `allowPrivateNetwork` lets the bot reach RFC1918/loopback hosts.
- Secrets/tokens handling changed? `No`
- New/changed network calls? `Yes` — all outbound HTTP now uses `fetchWithSsrFGuard` with DNS-pinned SSRF guard (stricter default than before).
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- Risk + mitigation: enabling `allowPrivateNetwork` relaxes SSRF protection for that account's Nextcloud URL. Mitigated by requiring explicit opt-in during onboarding with a clear SSRF-risk warning; default remains blocked.

## Repro + Verification

### Environment

- Integration/channel: Nextcloud Talk

### Steps

1. Configure Nextcloud Talk with a private-network baseUrl (e.g. `http://192.168.1.100`)
2. Run `openclaw setup nextcloud-talk`
3. Observe private-network detection prompt
4. Set `allowPrivateNetwork: true` and verify sends succeed

### Expected

- Bot connects and sends messages to private-network Nextcloud instance when flag is enabled.

### Actual

- Confirmed via unit tests (17/17 passing).

## Evidence

- [x] Failing test/log before + passing after — `send.test.ts` updated to mock `fetchWithSsrFGuard`; all 17 tests pass.

## Human Verification (required)

- Verified scenarios: all nextcloud-talk tests pass (`pnpm test extensions/nextcloud-talk`), TypeScript compiles clean (`pnpm tsgo`), build succeeds (`pnpm build`).
- Edge cases checked: non-private URLs skip the prompt; `allowPrivateNetwork` defaults to `null`/`false`; multi-account config propagation.
- What you did **not** verify: live Nextcloud Talk instance on a private network (no test environment available).

## Compatibility / Migration

- Backward compatible? `Yes` — new optional field; existing configs work unchanged.
- Config/env changes? `Yes` — new optional `allowPrivateNetwork` boolean in `channels.nextcloud-talk`.
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: remove `allowPrivateNetwork` from config; behavior reverts to default (private networks blocked).
- Known bad symptoms: `SsrFBlockedError` when sending to private-network Nextcloud without the flag enabled.

## Risks and Mitigations

- Risk: users enable `allowPrivateNetwork` without understanding SSRF implications.
  - Mitigation: onboarding prompt explicitly warns about SSRF risk; flag name is self-documenting; matches established Tlon plugin pattern.
