### PR TITLE
fix(core): Gracefully handle malformed tool calls to prevent Silent Gateway DoS

### DIFF
--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -119,7 +119,13 @@ function resolveToolInputErrorStatus(err: unknown): number | null {
   }
   if (typeof err !== "object" || err === null || !("name" in err)) {
     return null;
-  }
+  
+    const name = (err as { name?: unknown }).name;
+    if (name === "ZodError") {
+          return 400;
+    }
+    
+    }
   const name = (err as { name?: unknown }).name;
   if (name !== "ToolInputError" && name !== "ToolAuthorizationError") {
     return null;

--- a/src/gateway/tools-invoke-http.ts
+++ b/src/gateway/tools-invoke-http.ts
@@ -119,14 +119,12 @@ function resolveToolInputErrorStatus(err: unknown): number | null {
   }
   if (typeof err !== "object" || err === null || !("name" in err)) {
     return null;
-  
-    const name = (err as { name?: unknown }).name;
-    if (name === "ZodError") {
-          return 400;
-    }
-    
-    }
+  }
+
   const name = (err as { name?: unknown }).name;
+  if (name === "ZodError") {
+    return 400;
+  }
   if (name !== "ToolInputError" && name !== "ToolAuthorizationError") {
     return null;
   }


### PR DESCRIPTION
This adds a conceptual defensive layer (Graceful Degradation) to prevent ZodError unhandled exceptions from crashing the Gateway when the LLM hallucinates malformed ToolCall objects. Resolves the second issue submitted regarding DoS.