### PR TITLE
slack: support account-level slashCommand.nativeNames mapping

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -583,6 +583,9 @@ export async function resolvePromptBuildHookResult(params: {
       promptBuildResult?.appendSystemContext,
       legacyResult?.appendSystemContext,
     ]),
+    truncateBefore:
+      Math.max(promptBuildResult?.truncateBefore ?? 0, legacyResult?.truncateBefore ?? 0) ||
+      undefined,
   };
 }
 
@@ -1664,6 +1667,21 @@ export async function runEmbeddedAttempt(
               `hooks: applied prependSystemContext/appendSystemContext (${prependSystemLen}+${appendSystemLen} chars)`,
             );
           }
+        }
+        const truncateBefore = hookResult?.truncateBefore;
+        if (truncateBefore) {
+          const originalMessageCount = activeSession.messages.length;
+          const truncatedMessages = activeSession.messages.filter((msg) => {
+            const timestamp = (msg as { timestamp?: unknown }).timestamp;
+            return typeof timestamp !== "number" || timestamp >= truncateBefore;
+          });
+          const removedCount = originalMessageCount - truncatedMessages.length;
+          // Repair orphaned tool_result blocks left by the truncation cut.
+          const repaired = sanitizeToolUseResultPairing(truncatedMessages);
+          activeSession.messages.splice(0, activeSession.messages.length, ...repaired);
+          log.debug(
+            `hooks: truncated prompt history before ${truncateBefore} (removed ${removedCount} messages, repaired tool pairing)`,
+          );
         }
 
         log.debug(`embedded run prompt start: runId=${params.runId} sessionId=${params.sessionId}`);

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -170,49 +170,6 @@ describe("commands registry", () => {
     expect(findCommandByNativeName("status", "slack", { nativeNames: {} })).toBeUndefined();
   });
 
-  it("prefixes slack native command specs when nativePrefix is set", () => {
-    const native = listNativeCommandSpecsForConfig(
-      { commands: { native: true } },
-      { provider: "slack", nativePrefix: "acct1" },
-    );
-    expect(native.find((spec) => spec.name === "acct1-help")).toBeTruthy();
-    expect(native.find((spec) => spec.name === "acct1-agentstatus")).toBeTruthy();
-    expect(native.find((spec) => spec.name === "help")).toBeFalsy();
-    expect(native.find((spec) => spec.name === "agentstatus")).toBeFalsy();
-  });
-
-  it("normalizes mixed-case nativePrefix for slack command specs", () => {
-    const native = listNativeCommandSpecsForConfig(
-      { commands: { native: true } },
-      { provider: "slack", nativePrefix: "AcCt1" },
-    );
-    expect(native.find((spec) => spec.name === "acct1-help")).toBeTruthy();
-    expect(native.find((spec) => spec.name === "acct1-agentstatus")).toBeTruthy();
-  });
-
-  it("finds slack commands by prefixed native names", () => {
-    expect(
-      findCommandByNativeName("acct1-agentstatus", "slack", { nativePrefix: "acct1" })?.key,
-    ).toBe("status");
-    expect(findCommandByNativeName("acct1-agentstatus", "slack")?.key).toBe("status");
-    expect(findCommandByNativeName("agentstatus", "slack", { nativePrefix: "acct1" })?.key).toBe(
-      "status",
-    );
-  });
-
-  it("ignores invalid hyphenated nativePrefix values", () => {
-    const native = listNativeCommandSpecsForConfig(
-      { commands: { native: true } },
-      { provider: "slack", nativePrefix: "acct-1" },
-    );
-    expect(native.find((spec) => spec.name === "help")).toBeTruthy();
-    expect(native.find((spec) => spec.name === "agentstatus")).toBeTruthy();
-    expect(native.find((spec) => spec.name === "acct-1-help")).toBeFalsy();
-    expect(
-      findCommandByNativeName("acct-1-agentstatus", "slack", { nativePrefix: "acct-1" }),
-    ).toBeUndefined();
-  });
-
   it("keeps discord native command specs within slash-command limits", () => {
     const cfg = { commands: { native: true } };
     const native = listNativeCommandSpecsForConfig(cfg, { provider: "discord" });

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -132,6 +132,15 @@ describe("commands registry", () => {
     expect(native.find((spec) => spec.name === "agentstatus")).toBeFalsy();
   });
 
+  it("normalizes mixed-case nativePrefix for slack command specs", () => {
+    const native = listNativeCommandSpecsForConfig(
+      { commands: { native: true } },
+      { provider: "slack", nativePrefix: "AcCt1" },
+    );
+    expect(native.find((spec) => spec.name === "acct1-help")).toBeTruthy();
+    expect(native.find((spec) => spec.name === "acct1-agentstatus")).toBeTruthy();
+  });
+
   it("finds slack commands by prefixed native names", () => {
     expect(
       findCommandByNativeName("acct1-agentstatus", "slack", { nativePrefix: "acct1" })?.key,
@@ -140,6 +149,19 @@ describe("commands registry", () => {
     expect(findCommandByNativeName("agentstatus", "slack", { nativePrefix: "acct1" })?.key).toBe(
       "status",
     );
+  });
+
+  it("ignores invalid hyphenated nativePrefix values", () => {
+    const native = listNativeCommandSpecsForConfig(
+      { commands: { native: true } },
+      { provider: "slack", nativePrefix: "acct-1" },
+    );
+    expect(native.find((spec) => spec.name === "help")).toBeTruthy();
+    expect(native.find((spec) => spec.name === "agentstatus")).toBeTruthy();
+    expect(native.find((spec) => spec.name === "acct-1-help")).toBeFalsy();
+    expect(
+      findCommandByNativeName("acct-1-agentstatus", "slack", { nativePrefix: "acct-1" }),
+    ).toBeUndefined();
   });
 
   it("keeps discord native command specs within slash-command limits", () => {

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -121,6 +121,27 @@ describe("commands registry", () => {
     expect(findCommandByNativeName("status", "slack")).toBeUndefined();
   });
 
+  it("prefixes slack native command specs when nativePrefix is set", () => {
+    const native = listNativeCommandSpecsForConfig(
+      { commands: { native: true } },
+      { provider: "slack", nativePrefix: "acct1" },
+    );
+    expect(native.find((spec) => spec.name === "acct1-help")).toBeTruthy();
+    expect(native.find((spec) => spec.name === "acct1-agentstatus")).toBeTruthy();
+    expect(native.find((spec) => spec.name === "help")).toBeFalsy();
+    expect(native.find((spec) => spec.name === "agentstatus")).toBeFalsy();
+  });
+
+  it("finds slack commands by prefixed native names", () => {
+    expect(
+      findCommandByNativeName("acct1-agentstatus", "slack", { nativePrefix: "acct1" })?.key,
+    ).toBe("status");
+    expect(findCommandByNativeName("acct1-agentstatus", "slack")?.key).toBe("status");
+    expect(findCommandByNativeName("agentstatus", "slack", { nativePrefix: "acct1" })?.key).toBe(
+      "status",
+    );
+  });
+
   it("keeps discord native command specs within slash-command limits", () => {
     const cfg = { commands: { native: true } };
     const native = listNativeCommandSpecsForConfig(cfg, { provider: "discord" });

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -121,6 +121,55 @@ describe("commands registry", () => {
     expect(findCommandByNativeName("status", "slack")).toBeUndefined();
   });
 
+  it("applies custom nativeNames mapping for slack native specs", () => {
+    const native = listNativeCommandSpecsForConfig(
+      { commands: { native: true } },
+      {
+        provider: "slack",
+        nativeNames: {
+          status: "ozstatus",
+          compact: "oz-compact",
+        },
+      },
+    );
+    expect(native.find((spec) => spec.name === "ozstatus")).toBeTruthy();
+    expect(native.find((spec) => spec.name === "oz-compact")).toBeTruthy();
+    expect(native.find((spec) => spec.name === "agentstatus")).toBeFalsy();
+    expect(native.find((spec) => spec.name === "compact")).toBeFalsy();
+  });
+
+  it("keeps default native names for unmapped slack commands", () => {
+    const native = listNativeCommandSpecsForConfig(
+      { commands: { native: true } },
+      {
+        provider: "slack",
+        nativeNames: {
+          reset: "oz-reset",
+        },
+      },
+    );
+    expect(native.find((spec) => spec.name === "oz-reset")).toBeTruthy();
+    expect(native.find((spec) => spec.name === "help")).toBeTruthy();
+    expect(native.find((spec) => spec.name === "agentstatus")).toBeTruthy();
+  });
+
+  it("resolves custom nativeNames via reverse lookup", () => {
+    const nativeNames = {
+      status: "ozstatus",
+      stop: "oz-stop",
+    };
+    expect(findCommandByNativeName("ozstatus", "slack", { nativeNames })?.key).toBe("status");
+    expect(findCommandByNativeName("oz-stop", "slack", { nativeNames })?.key).toBe("stop");
+    expect(findCommandByNativeName("agentstatus", "slack", { nativeNames })).toBeUndefined();
+  });
+
+  it("keeps slack native override behavior when nativeNames is not configured", () => {
+    expect(findCommandByNativeName("agentstatus", "slack", { nativeNames: {} })?.key).toBe(
+      "status",
+    );
+    expect(findCommandByNativeName("status", "slack", { nativeNames: {} })).toBeUndefined();
+  });
+
   it("prefixes slack native command specs when nativePrefix is set", () => {
     const native = listNativeCommandSpecsForConfig(
       { commands: { native: true } },

--- a/src/auto-reply/commands-registry.test.ts
+++ b/src/auto-reply/commands-registry.test.ts
@@ -153,6 +153,20 @@ describe("commands registry", () => {
     expect(native.find((spec) => spec.name === "agentstatus")).toBeTruthy();
   });
 
+  it("rejects nativeNames mapping that collides with another default native name", () => {
+    expect(() =>
+      listNativeCommandSpecsForConfig(
+        { commands: { native: true } },
+        {
+          provider: "slack",
+          nativeNames: {
+            status: "help",
+          },
+        },
+      ),
+    ).toThrow("Duplicate native command name");
+  });
+
   it("resolves custom nativeNames via reverse lookup", () => {
     const nativeNames = {
       status: "ozstatus",

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -143,9 +143,26 @@ function resolveNativeName(command: ChatCommandDefinition, provider?: string): s
   return command.nativeName;
 }
 
-function toNativeCommandSpec(command: ChatCommandDefinition, provider?: string): NativeCommandSpec {
+function normalizeNativePrefix(nativePrefix?: string): string | undefined {
+  const trimmed = nativePrefix?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.replace(/^-+|-+$/g, "");
+}
+
+function withNativePrefix(name: string, nativePrefix?: string): string {
+  const prefix = normalizeNativePrefix(nativePrefix);
+  return prefix ? `${prefix}-${name}` : name;
+}
+
+function toNativeCommandSpec(
+  command: ChatCommandDefinition,
+  provider?: string,
+  nativePrefix?: string,
+): NativeCommandSpec {
   return {
-    name: resolveNativeName(command, provider) ?? command.key,
+    name: withNativePrefix(resolveNativeName(command, provider) ?? command.key, nativePrefix),
     description: command.description,
     acceptsArgs: Boolean(command.acceptsArgs),
     args: command.args,
@@ -155,39 +172,77 @@ function toNativeCommandSpec(command: ChatCommandDefinition, provider?: string):
 function listNativeSpecsFromCommands(
   commands: ChatCommandDefinition[],
   provider?: string,
+  nativePrefix?: string,
 ): NativeCommandSpec[] {
   return commands
     .filter((command) => command.scope !== "text" && command.nativeName)
-    .map((command) => toNativeCommandSpec(command, provider));
+    .map((command) => toNativeCommandSpec(command, provider, nativePrefix));
 }
 
 export function listNativeCommandSpecs(params?: {
   skillCommands?: SkillCommandSpec[];
   provider?: string;
+  nativePrefix?: string;
 }): NativeCommandSpec[] {
   return listNativeSpecsFromCommands(
     listChatCommands({ skillCommands: params?.skillCommands }),
     params?.provider,
+    params?.nativePrefix,
   );
 }
 
 export function listNativeCommandSpecsForConfig(
   cfg: OpenClawConfig,
-  params?: { skillCommands?: SkillCommandSpec[]; provider?: string },
+  params?: { skillCommands?: SkillCommandSpec[]; provider?: string; nativePrefix?: string },
 ): NativeCommandSpec[] {
-  return listNativeSpecsFromCommands(listChatCommandsForConfig(cfg, params), params?.provider);
+  return listNativeSpecsFromCommands(
+    listChatCommandsForConfig(cfg, params),
+    params?.provider,
+    params?.nativePrefix,
+  );
+}
+
+function stripNativePrefixCandidate(name: string, nativePrefix?: string): string | undefined {
+  const prefix = normalizeNativePrefix(nativePrefix)?.toLowerCase();
+  if (!prefix) {
+    return undefined;
+  }
+  const token = `${prefix}-`;
+  if (!name.startsWith(token)) {
+    return undefined;
+  }
+  const stripped = name.slice(token.length).trim();
+  return stripped || undefined;
 }
 
 export function findCommandByNativeName(
   name: string,
   provider?: string,
+  params?: { nativePrefix?: string; nativePrefixes?: string[] },
 ): ChatCommandDefinition | undefined {
   const normalized = name.trim().toLowerCase();
-  return getChatCommands().find(
-    (command) =>
-      command.scope !== "text" &&
-      resolveNativeName(command, provider)?.toLowerCase() === normalized,
-  );
+  const candidates = new Set<string>([normalized]);
+  const configuredPrefixes = [params?.nativePrefix, ...(params?.nativePrefixes ?? [])];
+  for (const prefix of configuredPrefixes) {
+    const stripped = stripNativePrefixCandidate(normalized, prefix);
+    if (stripped) {
+      candidates.add(stripped);
+    }
+  }
+  // Slack native commands can be account-prefixed. If account context is not available,
+  // fall back to stripping one leading "<prefix>-" segment and retrying.
+  const dynamicDashIndex = normalized.indexOf("-");
+  if (provider === "slack" && dynamicDashIndex > 0 && dynamicDashIndex < normalized.length - 1) {
+    candidates.add(normalized.slice(dynamicDashIndex + 1));
+  }
+
+  return getChatCommands().find((command) => {
+    if (command.scope === "text") {
+      return false;
+    }
+    const resolved = resolveNativeName(command, provider)?.toLowerCase();
+    return Boolean(resolved && candidates.has(resolved));
+  });
 }
 
 export function buildCommandText(commandName: string, args?: string): string {

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -148,7 +148,13 @@ function normalizeNativePrefix(nativePrefix?: string): string | undefined {
   if (!trimmed) {
     return undefined;
   }
-  return trimmed.replace(/^-+|-+$/g, "");
+  const normalized = trimmed.toLowerCase();
+  // Native slash command prefix is a single segment prepended as "<prefix>-<command>".
+  // Restrict to lowercase alphanumeric to avoid ambiguous multi-segment matching.
+  if (!/^[a-z0-9]+$/.test(normalized)) {
+    return undefined;
+  }
+  return normalized;
 }
 
 function withNativePrefix(name: string, nativePrefix?: string): string {

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -194,10 +194,28 @@ export function listNativeCommandSpecsForConfig(
     nativeNames?: Record<string, string>;
   },
 ): NativeCommandSpec[] {
-  return listNativeSpecsFromCommands(
-    listChatCommandsForConfig(cfg, params),
-    params?.provider,
-    params?.nativeNames,
+  const commands = listChatCommandsForConfig(cfg, params).filter(
+    (command) => command.scope !== "text" && command.nativeName,
+  );
+  const resolvedByName = new Map<string, string>();
+
+  for (const command of commands) {
+    const resolved = resolveNativeName(command, params?.provider, params?.nativeNames);
+    if (!resolved) {
+      continue;
+    }
+    const normalized = resolved.toLowerCase();
+    const existingCommandKey = resolvedByName.get(normalized);
+    if (existingCommandKey && existingCommandKey !== command.key) {
+      throw new Error(
+        `Duplicate native command name '${resolved}' resolved for '${command.key}' and '${existingCommandKey}'`,
+      );
+    }
+    resolvedByName.set(normalized, command.key);
+  }
+
+  return commands.map((command) =>
+    toNativeCommandSpec(command, params?.provider, params?.nativeNames),
   );
 }
 

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -151,36 +151,13 @@ function resolveNativeName(
   return command.nativeName;
 }
 
-function normalizeNativePrefix(nativePrefix?: string): string | undefined {
-  const trimmed = nativePrefix?.trim();
-  if (!trimmed) {
-    return undefined;
-  }
-  const normalized = trimmed.toLowerCase();
-  // Native slash command prefix is a single segment prepended as "<prefix>-<command>".
-  // Restrict to lowercase alphanumeric to avoid ambiguous multi-segment matching.
-  if (!/^[a-z0-9]+$/.test(normalized)) {
-    return undefined;
-  }
-  return normalized;
-}
-
-function withNativePrefix(name: string, nativePrefix?: string): string {
-  const prefix = normalizeNativePrefix(nativePrefix);
-  return prefix ? `${prefix}-${name}` : name;
-}
-
 function toNativeCommandSpec(
   command: ChatCommandDefinition,
   provider?: string,
-  nativePrefix?: string,
   nativeNames?: Record<string, string>,
 ): NativeCommandSpec {
   return {
-    name: withNativePrefix(
-      resolveNativeName(command, provider, nativeNames) ?? command.key,
-      nativePrefix,
-    ),
+    name: resolveNativeName(command, provider, nativeNames) ?? command.key,
     description: command.description,
     acceptsArgs: Boolean(command.acceptsArgs),
     args: command.args,
@@ -190,24 +167,21 @@ function toNativeCommandSpec(
 function listNativeSpecsFromCommands(
   commands: ChatCommandDefinition[],
   provider?: string,
-  nativePrefix?: string,
   nativeNames?: Record<string, string>,
 ): NativeCommandSpec[] {
   return commands
     .filter((command) => command.scope !== "text" && command.nativeName)
-    .map((command) => toNativeCommandSpec(command, provider, nativePrefix, nativeNames));
+    .map((command) => toNativeCommandSpec(command, provider, nativeNames));
 }
 
 export function listNativeCommandSpecs(params?: {
   skillCommands?: SkillCommandSpec[];
   provider?: string;
-  nativePrefix?: string;
   nativeNames?: Record<string, string>;
 }): NativeCommandSpec[] {
   return listNativeSpecsFromCommands(
     listChatCommands({ skillCommands: params?.skillCommands }),
     params?.provider,
-    params?.nativePrefix,
     params?.nativeNames,
   );
 }
@@ -217,62 +191,31 @@ export function listNativeCommandSpecsForConfig(
   params?: {
     skillCommands?: SkillCommandSpec[];
     provider?: string;
-    nativePrefix?: string;
     nativeNames?: Record<string, string>;
   },
 ): NativeCommandSpec[] {
   return listNativeSpecsFromCommands(
     listChatCommandsForConfig(cfg, params),
     params?.provider,
-    params?.nativePrefix,
     params?.nativeNames,
   );
-}
-
-function stripNativePrefixCandidate(name: string, nativePrefix?: string): string | undefined {
-  const prefix = normalizeNativePrefix(nativePrefix)?.toLowerCase();
-  if (!prefix) {
-    return undefined;
-  }
-  const token = `${prefix}-`;
-  if (!name.startsWith(token)) {
-    return undefined;
-  }
-  const stripped = name.slice(token.length).trim();
-  return stripped || undefined;
 }
 
 export function findCommandByNativeName(
   name: string,
   provider?: string,
   params?: {
-    nativePrefix?: string;
-    nativePrefixes?: string[];
     nativeNames?: Record<string, string>;
   },
 ): ChatCommandDefinition | undefined {
   const normalized = name.trim().toLowerCase();
-  const candidates = new Set<string>([normalized]);
-  const configuredPrefixes = [params?.nativePrefix, ...(params?.nativePrefixes ?? [])];
-  for (const prefix of configuredPrefixes) {
-    const stripped = stripNativePrefixCandidate(normalized, prefix);
-    if (stripped) {
-      candidates.add(stripped);
-    }
-  }
-  // Slack native commands can be account-prefixed. If account context is not available,
-  // fall back to stripping one leading "<prefix>-" segment and retrying.
-  const dynamicDashIndex = normalized.indexOf("-");
-  if (provider === "slack" && dynamicDashIndex > 0 && dynamicDashIndex < normalized.length - 1) {
-    candidates.add(normalized.slice(dynamicDashIndex + 1));
-  }
 
   return getChatCommands().find((command) => {
     if (command.scope === "text") {
       return false;
     }
     const resolved = resolveNativeName(command, provider, params?.nativeNames)?.toLowerCase();
-    return Boolean(resolved && candidates.has(resolved));
+    return Boolean(resolved && resolved === normalized);
   });
 }
 

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -130,9 +130,17 @@ const NATIVE_NAME_OVERRIDES: Record<string, Record<string, string>> = {
   },
 };
 
-function resolveNativeName(command: ChatCommandDefinition, provider?: string): string | undefined {
+function resolveNativeName(
+  command: ChatCommandDefinition,
+  provider?: string,
+  nativeNames?: Record<string, string>,
+): string | undefined {
   if (!command.nativeName) {
     return undefined;
+  }
+  const mapped = nativeNames?.[command.key]?.trim();
+  if (mapped) {
+    return mapped;
   }
   if (provider) {
     const override = NATIVE_NAME_OVERRIDES[provider]?.[command.key];
@@ -166,9 +174,13 @@ function toNativeCommandSpec(
   command: ChatCommandDefinition,
   provider?: string,
   nativePrefix?: string,
+  nativeNames?: Record<string, string>,
 ): NativeCommandSpec {
   return {
-    name: withNativePrefix(resolveNativeName(command, provider) ?? command.key, nativePrefix),
+    name: withNativePrefix(
+      resolveNativeName(command, provider, nativeNames) ?? command.key,
+      nativePrefix,
+    ),
     description: command.description,
     acceptsArgs: Boolean(command.acceptsArgs),
     args: command.args,
@@ -179,32 +191,41 @@ function listNativeSpecsFromCommands(
   commands: ChatCommandDefinition[],
   provider?: string,
   nativePrefix?: string,
+  nativeNames?: Record<string, string>,
 ): NativeCommandSpec[] {
   return commands
     .filter((command) => command.scope !== "text" && command.nativeName)
-    .map((command) => toNativeCommandSpec(command, provider, nativePrefix));
+    .map((command) => toNativeCommandSpec(command, provider, nativePrefix, nativeNames));
 }
 
 export function listNativeCommandSpecs(params?: {
   skillCommands?: SkillCommandSpec[];
   provider?: string;
   nativePrefix?: string;
+  nativeNames?: Record<string, string>;
 }): NativeCommandSpec[] {
   return listNativeSpecsFromCommands(
     listChatCommands({ skillCommands: params?.skillCommands }),
     params?.provider,
     params?.nativePrefix,
+    params?.nativeNames,
   );
 }
 
 export function listNativeCommandSpecsForConfig(
   cfg: OpenClawConfig,
-  params?: { skillCommands?: SkillCommandSpec[]; provider?: string; nativePrefix?: string },
+  params?: {
+    skillCommands?: SkillCommandSpec[];
+    provider?: string;
+    nativePrefix?: string;
+    nativeNames?: Record<string, string>;
+  },
 ): NativeCommandSpec[] {
   return listNativeSpecsFromCommands(
     listChatCommandsForConfig(cfg, params),
     params?.provider,
     params?.nativePrefix,
+    params?.nativeNames,
   );
 }
 
@@ -224,7 +245,11 @@ function stripNativePrefixCandidate(name: string, nativePrefix?: string): string
 export function findCommandByNativeName(
   name: string,
   provider?: string,
-  params?: { nativePrefix?: string; nativePrefixes?: string[] },
+  params?: {
+    nativePrefix?: string;
+    nativePrefixes?: string[];
+    nativeNames?: Record<string, string>;
+  },
 ): ChatCommandDefinition | undefined {
   const normalized = name.trim().toLowerCase();
   const candidates = new Set<string>([normalized]);
@@ -246,7 +271,7 @@ export function findCommandByNativeName(
     if (command.scope === "text") {
       return false;
     }
-    const resolved = resolveNativeName(command, provider)?.toLowerCase();
+    const resolved = resolveNativeName(command, provider, params?.nativeNames)?.toLowerCase();
     return Boolean(resolved && candidates.has(resolved));
   });
 }

--- a/src/cli/program/register.agent.test.ts
+++ b/src/cli/program/register.agent.test.ts
@@ -100,6 +100,25 @@ describe("registerAgentCommands", () => {
     );
   });
 
+  it("forwards --session-key", async () => {
+    await runCli([
+      "agent",
+      "--message",
+      "hi",
+      "--session-key",
+      "agent:demo:slack:channel:c0123456789",
+    ]);
+
+    expect(agentCliCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "hi",
+        sessionKey: "agent:demo:slack:channel:c0123456789",
+      }),
+      runtime,
+      { deps: true },
+    );
+  });
+
   it("runs agents add and computes hasFlags based on explicit options", async () => {
     await runCli(["agents", "add", "alpha"]);
     expect(agentsAddCommandMock).toHaveBeenNthCalledWith(

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -25,6 +25,7 @@ export function registerAgentCommands(program: Command, args: { agentChannelOpti
     .description("Run an agent turn via the Gateway (use --local for embedded)")
     .requiredOption("-m, --message <text>", "Message body for the agent")
     .option("-t, --to <number>", "Recipient number in E.164 used to derive the session key")
+    .option("--session-key <key>", "Use an explicit session key")
     .option("--session-id <id>", "Use an explicit session id")
     .option("--agent <id>", "Agent id (overrides routing bindings)")
     .option("--thinking <level>", "Thinking level: off | minimal | low | medium | high")
@@ -56,8 +57,12 @@ ${formatHelpExamples([
   ['openclaw agent --to +15555550123 --message "status update"', "Start a new session."],
   ['openclaw agent --agent ops --message "Summarize logs"', "Use a specific agent."],
   [
+    'openclaw agent --session-key "agent:demo:slack:channel:c0123456789" --message "Summarize inbox" --thinking medium',
+    "Target a session key with explicit thinking level.",
+  ],
+  [
     'openclaw agent --session-id 1234 --message "Summarize inbox" --thinking medium',
-    "Target a session with explicit thinking level.",
+    "Target a session by id.",
   ],
   [
     'openclaw agent --to +15555550123 --message "Trace logs" --verbose on --json',

--- a/src/commands/agent-via-gateway.test.ts
+++ b/src/commands/agent-via-gateway.test.ts
@@ -107,6 +107,27 @@ describe("agentCliCommand", () => {
     });
   });
 
+  it("accepts --session-key and forwards it to gateway", async () => {
+    await withTempStore(async () => {
+      mockGatewaySuccessReply();
+      const explicitSessionKey = "agent:demo:slack:channel:c0123456789";
+
+      await agentCliCommand(
+        {
+          message: "hi",
+          sessionKey: explicitSessionKey,
+        },
+        runtime,
+      );
+
+      expect(callGateway).toHaveBeenCalledTimes(1);
+      const request = vi.mocked(callGateway).mock.calls[0]?.[0] as {
+        params?: { sessionKey?: string };
+      };
+      expect(request.params?.sessionKey).toBe(explicitSessionKey);
+    });
+  });
+
   it("falls back to embedded agent when gateway fails", async () => {
     await withTempStore(async () => {
       vi.mocked(callGateway).mockRejectedValue(new Error("gateway not connected"));

--- a/src/commands/agent-via-gateway.ts
+++ b/src/commands/agent-via-gateway.ts
@@ -36,6 +36,7 @@ export type AgentCliOpts = {
   message: string;
   agent?: string;
   to?: string;
+  sessionKey?: string;
   sessionId?: string;
   thinking?: string;
   verbose?: string;
@@ -89,8 +90,10 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
   if (!body) {
     throw new Error("Message (--message) is required");
   }
-  if (!opts.to && !opts.sessionId && !opts.agent) {
-    throw new Error("Pass --to <E.164>, --session-id, or --agent to choose a session");
+  if (!opts.to && !opts.sessionKey && !opts.sessionId && !opts.agent) {
+    throw new Error(
+      "Pass --session-key, --session-id, --to <E.164>, or --agent to choose a session",
+    );
   }
 
   const cfg = loadConfig();
@@ -115,6 +118,7 @@ export async function agentViaGatewayCommand(opts: AgentCliOpts, runtime: Runtim
     agentId,
     to: opts.to,
     sessionId: opts.sessionId,
+    sessionKey: opts.sessionKey,
   }).sessionKey;
 
   const channel = normalizeMessageChannel(opts.channel);

--- a/src/config/slack-http-config.test.ts
+++ b/src/config/slack-http-config.test.ts
@@ -129,4 +129,94 @@ describe("Slack HTTP mode config", () => {
     });
     expect(res.ok).toBe(true);
   });
+
+  it("rejects top-level slack slashCommand nativeNames with invalid format", () => {
+    const res = validateConfigObject({
+      channels: {
+        slack: {
+          slashCommand: {
+            nativeNames: {
+              status: "oz_status",
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.map((issue) => issue.path)).toContain(
+        "channels.slack.slashCommand.nativeNames.status",
+      );
+    }
+  });
+
+  it("rejects top-level slack slashCommand nativeNames with duplicate values", () => {
+    const res = validateConfigObject({
+      channels: {
+        slack: {
+          slashCommand: {
+            nativeNames: {
+              status: "ozstatus",
+              stop: "ozstatus",
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.map((issue) => issue.path)).toContain(
+        "channels.slack.slashCommand.nativeNames.stop",
+      );
+    }
+  });
+
+  it("rejects account-level slack slashCommand nativeNames with invalid format", () => {
+    const res = validateConfigObject({
+      channels: {
+        slack: {
+          accounts: {
+            ops: {
+              slashCommand: {
+                nativeNames: {
+                  stop: "oz stop",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.map((issue) => issue.path)).toContain(
+        "channels.slack.accounts.ops.slashCommand.nativeNames.stop",
+      );
+    }
+  });
+
+  it("rejects account-level slack slashCommand nativeNames with duplicate values", () => {
+    const res = validateConfigObject({
+      channels: {
+        slack: {
+          accounts: {
+            ops: {
+              slashCommand: {
+                nativeNames: {
+                  compact: "oz-compact",
+                  stop: "oz-compact",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.map((issue) => issue.path)).toContain(
+        "channels.slack.accounts.ops.slashCommand.nativeNames.stop",
+      );
+    }
+  });
 });

--- a/src/config/slack-http-config.test.ts
+++ b/src/config/slack-http-config.test.ts
@@ -93,4 +93,40 @@ describe("Slack HTTP mode config", () => {
       expect(res.issues[0]?.path).toBe("channels.slack.accounts.ops.signingSecret");
     }
   });
+
+  it("accepts top-level slack slashCommand nativeNames", () => {
+    const res = validateConfigObject({
+      channels: {
+        slack: {
+          slashCommand: {
+            nativeNames: {
+              reset: "oz-reset",
+              status: "ozstatus",
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it("accepts account-level slack slashCommand nativeNames", () => {
+    const res = validateConfigObject({
+      channels: {
+        slack: {
+          accounts: {
+            ops: {
+              slashCommand: {
+                nativeNames: {
+                  compact: "oz-compact",
+                  stop: "oz-stop",
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(res.ok).toBe(true);
+  });
 });

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -64,7 +64,7 @@ export type SlackSlashCommandConfig = {
   enabled?: boolean;
   /** Slash command name (default: "openclaw"). */
   name?: string;
-  /** Optional per-account prefix for native slash commands (e.g. "acct-help"). */
+  /** Optional per-account prefix for native slash commands; must be one lowercase alphanumeric word (e.g. "acct1"). */
   nativePrefix?: string;
   /** Session key prefix for slash commands (default: "slack:slash"). */
   sessionPrefix?: string;

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -66,6 +66,8 @@ export type SlackSlashCommandConfig = {
   name?: string;
   /** Optional per-account prefix for native slash commands; must be one lowercase alphanumeric word (e.g. "acct1"). */
   nativePrefix?: string;
+  /** Optional per-command native slash command name overrides keyed by internal command key. */
+  nativeNames?: Record<string, string>;
   /** Session key prefix for slash commands (default: "slack:slash"). */
   sessionPrefix?: string;
   /** Reply ephemerally (default: true). */

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -64,6 +64,8 @@ export type SlackSlashCommandConfig = {
   enabled?: boolean;
   /** Slash command name (default: "openclaw"). */
   name?: string;
+  /** Optional per-account prefix for native slash commands (e.g. "acct-help"). */
+  nativePrefix?: string;
   /** Session key prefix for slash commands (default: "slack:slash"). */
   sessionPrefix?: string;
   /** Reply ephemerally (default: true). */

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -64,8 +64,6 @@ export type SlackSlashCommandConfig = {
   enabled?: boolean;
   /** Slash command name (default: "openclaw"). */
   name?: string;
-  /** Optional per-account prefix for native slash commands; must be one lowercase alphanumeric word (e.g. "acct1"). */
-  nativePrefix?: string;
   /** Optional per-command native slash command name overrides keyed by internal command key. */
   nativeNames?: Record<string, string>;
   /** Session key prefix for slash commands (default: "slack:slash"). */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -842,7 +842,6 @@ export const SlackAccountSchema = z
       .object({
         enabled: z.boolean().optional(),
         name: z.string().optional(),
-        nativePrefix: z.string().optional(),
         nativeNames: z.record(z.string(), z.string()).optional(),
         sessionPrefix: z.string().optional(),
         ephemeral: z.boolean().optional(),

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -842,6 +842,8 @@ export const SlackAccountSchema = z
       .object({
         enabled: z.boolean().optional(),
         name: z.string().optional(),
+        nativePrefix: z.string().optional(),
+        nativeNames: z.record(z.string(), z.string()).optional(),
         sessionPrefix: z.string().optional(),
         ephemeral: z.boolean().optional(),
       })

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -790,6 +790,31 @@ const SlackReplyToModeByChatTypeSchema = z
   })
   .strict();
 
+const SlackNativeCommandNamePattern = /^[a-z0-9-]+$/;
+
+const SlackSlashCommandNativeNamesSchema = z
+  .record(
+    z.string(),
+    z
+      .string()
+      .regex(SlackNativeCommandNamePattern, "Native slash command names must match /^[a-z0-9-]+$/"),
+  )
+  .superRefine((nativeNames, ctx) => {
+    const seenValues = new Map<string, string>();
+    for (const [commandKey, nativeName] of Object.entries(nativeNames)) {
+      const firstCommandKey = seenValues.get(nativeName);
+      if (firstCommandKey) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [commandKey],
+          message: `Duplicate native slash command name "${nativeName}" already used by "${firstCommandKey}"`,
+        });
+        continue;
+      }
+      seenValues.set(nativeName, commandKey);
+    }
+  });
+
 export const SlackAccountSchema = z
   .object({
     name: z.string().optional(),
@@ -842,7 +867,7 @@ export const SlackAccountSchema = z
       .object({
         enabled: z.boolean().optional(),
         name: z.string().optional(),
-        nativeNames: z.record(z.string(), z.string()).optional(),
+        nativeNames: SlackSlashCommandNativeNamesSchema.optional(),
         sessionPrefix: z.string().optional(),
         ephemeral: z.boolean().optional(),
       })

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -153,6 +153,7 @@ export function createHookRunner(registry: PluginRegistry, options: HookRunnerOp
       left: acc?.appendSystemContext,
       right: next.appendSystemContext,
     }),
+    truncateBefore: Math.max(acc?.truncateBefore ?? 0, next.truncateBefore ?? 0) || undefined,
   });
 
   const mergeSubagentSpawningResult = (

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -433,6 +433,7 @@ export type PluginHookBeforePromptBuildResult = {
    * Use for static plugin guidance instead of prependContext to avoid per-turn token cost.
    */
   appendSystemContext?: string;
+  truncateBefore?: number;
 };
 
 export const PLUGIN_PROMPT_MUTATION_RESULT_FIELDS = [
@@ -440,6 +441,7 @@ export const PLUGIN_PROMPT_MUTATION_RESULT_FIELDS = [
   "prependContext",
   "prependSystemContext",
   "appendSystemContext",
+  "truncateBefore",
 ] as const satisfies readonly (keyof PluginHookBeforePromptBuildResult)[];
 
 type MissingPluginPromptMutationResultFields = Exclude<

--- a/src/slack/monitor/commands.ts
+++ b/src/slack/monitor/commands.ts
@@ -2,9 +2,8 @@ import type { SlackSlashCommandConfig } from "../../config/config.js";
 
 export type ResolvedSlackSlashCommandConfig = Omit<
   Required<SlackSlashCommandConfig>,
-  "nativePrefix" | "nativeNames"
+  "nativeNames"
 > & {
-  nativePrefix?: string;
   nativeNames?: Record<string, string>;
 };
 
@@ -28,11 +27,9 @@ export function resolveSlackSlashCommandConfig(
 ): ResolvedSlackSlashCommandConfig {
   const normalizedName = normalizeSlackSlashCommandName(raw?.name?.trim() || "openclaw");
   const name = normalizedName || "openclaw";
-  const nativePrefix = raw?.nativePrefix?.trim();
   return {
     enabled: raw?.enabled === true,
     name,
-    nativePrefix: nativePrefix || undefined,
     nativeNames: raw?.nativeNames,
     sessionPrefix: raw?.sessionPrefix?.trim() || "slack:slash",
     ephemeral: raw?.ephemeral !== false,

--- a/src/slack/monitor/commands.ts
+++ b/src/slack/monitor/commands.ts
@@ -2,9 +2,10 @@ import type { SlackSlashCommandConfig } from "../../config/config.js";
 
 export type ResolvedSlackSlashCommandConfig = Omit<
   Required<SlackSlashCommandConfig>,
-  "nativePrefix"
+  "nativePrefix" | "nativeNames"
 > & {
   nativePrefix?: string;
+  nativeNames?: Record<string, string>;
 };
 
 /**
@@ -32,6 +33,7 @@ export function resolveSlackSlashCommandConfig(
     enabled: raw?.enabled === true,
     name,
     nativePrefix: nativePrefix || undefined,
+    nativeNames: raw?.nativeNames,
     sessionPrefix: raw?.sessionPrefix?.trim() || "slack:slash",
     ephemeral: raw?.ephemeral !== false,
   };

--- a/src/slack/monitor/commands.ts
+++ b/src/slack/monitor/commands.ts
@@ -1,5 +1,12 @@
 import type { SlackSlashCommandConfig } from "../../config/config.js";
 
+export type ResolvedSlackSlashCommandConfig = Omit<
+  Required<SlackSlashCommandConfig>,
+  "nativePrefix"
+> & {
+  nativePrefix?: string;
+};
+
 /**
  * Strip Slack mentions (<@U123>, <@U123|name>) so command detection works on
  * normalized text. Use in both prepare and debounce gate for consistency.
@@ -17,12 +24,14 @@ export function normalizeSlackSlashCommandName(raw: string) {
 
 export function resolveSlackSlashCommandConfig(
   raw?: SlackSlashCommandConfig,
-): Required<SlackSlashCommandConfig> {
+): ResolvedSlackSlashCommandConfig {
   const normalizedName = normalizeSlackSlashCommandName(raw?.name?.trim() || "openclaw");
   const name = normalizedName || "openclaw";
+  const nativePrefix = raw?.nativePrefix?.trim();
   return {
     enabled: raw?.enabled === true,
     name,
+    nativePrefix: nativePrefix || undefined,
     sessionPrefix: raw?.sessionPrefix?.trim() || "slack:slash",
     ephemeral: raw?.ephemeral !== false,
   };

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -14,6 +14,7 @@ import { normalizeAllowList, normalizeAllowListLower, normalizeSlackSlug } from 
 import type { SlackChannelConfigEntries } from "./channel-config.js";
 import { resolveSlackChannelConfig } from "./channel-config.js";
 import { normalizeSlackChannelType } from "./channel-type.js";
+import type { ResolvedSlackSlashCommandConfig } from "./commands.js";
 import { isSlackChannelAllowedByPolicy } from "./policy.js";
 
 export { inferSlackChannelType, normalizeSlackChannelType } from "./channel-type.js";
@@ -50,7 +51,7 @@ export type SlackMonitorContext = {
   replyToMode: "off" | "first" | "all";
   threadHistoryScope: "thread" | "channel";
   threadInheritParent: boolean;
-  slashCommand: Required<import("../../config/config.js").SlackSlashCommandConfig>;
+  slashCommand: ResolvedSlackSlashCommandConfig;
   textLimit: number;
   ackReactionScope: string;
   typingReaction: string;

--- a/src/slack/monitor/slash.test.ts
+++ b/src/slack/monitor/slash.test.ts
@@ -80,71 +80,91 @@ vi.mock("../../auto-reply/commands-registry.js", () => {
     findCommandByNativeName: (
       name: string,
       _provider?: string,
-      params?: { nativePrefix?: string },
+      params?: { nativePrefix?: string; nativeNames?: Record<string, string> },
     ) => {
       const normalized = stripPrefix(name.trim().toLowerCase(), params?.nativePrefix);
-      if (normalized === "usage") {
+      const reverseNativeNames = new Map<string, string>();
+      for (const [key, mapped] of Object.entries(params?.nativeNames ?? {})) {
+        const trimmed = mapped.trim().toLowerCase();
+        if (trimmed) {
+          reverseNativeNames.set(trimmed, key);
+        }
+      }
+      const resolved = reverseNativeNames.get(normalized) ?? normalized;
+      if (resolved === "usage") {
         return usageCommand;
       }
-      if (normalized === "report") {
+      if (resolved === "report") {
         return reportCommand;
       }
-      if (normalized === "reportcompact") {
+      if (resolved === "reportcompact") {
         return reportCompactCommand;
       }
-      if (normalized === "reportexternal") {
+      if (resolved === "reportexternal") {
         return reportExternalCommand;
       }
-      if (normalized === "reportlong") {
+      if (resolved === "reportlong") {
         return reportLongCommand;
       }
-      if (normalized === "unsafeconfirm") {
+      if (resolved === "unsafeconfirm") {
         return unsafeConfirmCommand;
       }
-      if (normalized === "agentstatus") {
+      if (resolved === "agentstatus" || resolved === "status") {
         return statusAliasCommand;
       }
       return undefined;
     },
-    listNativeCommandSpecsForConfig: (_cfg?: unknown, params?: { nativePrefix?: string }) => [
+    listNativeCommandSpecsForConfig: (
+      _cfg?: unknown,
+      params?: { nativePrefix?: string; nativeNames?: Record<string, string> },
+    ) => [
       {
-        name: withPrefix("usage", params?.nativePrefix),
+        name: withPrefix(params?.nativeNames?.usage ?? "usage", params?.nativePrefix),
         description: "Usage",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: withPrefix("report", params?.nativePrefix),
+        name: withPrefix(params?.nativeNames?.report ?? "report", params?.nativePrefix),
         description: "Report",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: withPrefix("reportcompact", params?.nativePrefix),
+        name: withPrefix(
+          params?.nativeNames?.reportcompact ?? "reportcompact",
+          params?.nativePrefix,
+        ),
         description: "ReportCompact",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: withPrefix("reportexternal", params?.nativePrefix),
+        name: withPrefix(
+          params?.nativeNames?.reportexternal ?? "reportexternal",
+          params?.nativePrefix,
+        ),
         description: "ReportExternal",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: withPrefix("reportlong", params?.nativePrefix),
+        name: withPrefix(params?.nativeNames?.reportlong ?? "reportlong", params?.nativePrefix),
         description: "ReportLong",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: withPrefix("unsafeconfirm", params?.nativePrefix),
+        name: withPrefix(
+          params?.nativeNames?.unsafeconfirm ?? "unsafeconfirm",
+          params?.nativePrefix,
+        ),
         description: "UnsafeConfirm",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: withPrefix("agentstatus", params?.nativePrefix),
+        name: withPrefix(params?.nativeNames?.status ?? "agentstatus", params?.nativePrefix),
         description: "Status",
         acceptsArgs: false,
         args: [],
@@ -252,6 +272,8 @@ function createDeferred<T>() {
 function createArgMenusHarness(overrides?: {
   nativePrefix?: string;
   accountNativePrefix?: string;
+  nativeNames?: Record<string, string>;
+  accountNativeNames?: Record<string, string>;
 }) {
   const commands = new Map<string, (args: unknown) => Promise<void>>();
   const actions = new Map<string, (args: unknown) => Promise<void>>();
@@ -294,6 +316,7 @@ function createArgMenusHarness(overrides?: {
       ephemeral: true,
       sessionPrefix: "slack:slash",
       nativePrefix: overrides?.nativePrefix,
+      nativeNames: overrides?.nativeNames,
     },
     textLimit: 4000,
     app,
@@ -307,9 +330,12 @@ function createArgMenusHarness(overrides?: {
     config: {
       commands: { native: true, nativeSkills: false },
       slashCommand:
-        overrides?.accountNativePrefix === undefined
+        overrides?.accountNativePrefix === undefined && overrides?.accountNativeNames === undefined
           ? undefined
-          : { nativePrefix: overrides.accountNativePrefix },
+          : {
+              nativePrefix: overrides.accountNativePrefix,
+              nativeNames: overrides.accountNativeNames,
+            },
     },
   } as unknown;
 
@@ -730,41 +756,47 @@ describe("Slack native command argument menus", () => {
   });
 });
 
-describe("Slack native command prefix wiring", () => {
-  it("registers prefixed native slash commands using account nativePrefix", async () => {
+describe("Slack native command name mapping wiring", () => {
+  it("registers custom native slash command names from account nativeNames", async () => {
     const harness = createArgMenusHarness({
-      nativePrefix: "ctxprefix",
-      accountNativePrefix: "acctprefix",
+      accountNativeNames: {
+        usage: "oz-usage",
+        status: "ozstatus",
+      },
     });
     await registerCommands(harness.ctx, harness.account);
 
-    expect(harness.commands.has("/acctprefix-usage")).toBe(true);
-    expect(harness.commands.has("/acctprefix-agentstatus")).toBe(true);
-    expect(harness.commands.has("/ctxprefix-usage")).toBe(false);
+    expect(harness.commands.has("/oz-usage")).toBe(true);
+    expect(harness.commands.has("/ozstatus")).toBe(true);
+    expect(harness.commands.has("/usage")).toBe(false);
+    expect(harness.commands.has("/agentstatus")).toBe(false);
   });
 
-  it("dispatches prefixed native slash commands to internal command keys", async () => {
-    const harness = createArgMenusHarness({ accountNativePrefix: "acctprefix" });
+  it("dispatches custom native slash command names to canonical internal commands", async () => {
+    const harness = createArgMenusHarness({
+      accountNativeNames: { status: "ozstatus" },
+    });
     await registerCommands(harness.ctx, harness.account);
 
-    const statusHandler = requireHandler(
-      harness.commands,
-      "/acctprefix-agentstatus",
-      "/acctprefix-agentstatus",
-    );
+    const statusHandler = requireHandler(harness.commands, "/ozstatus", "/ozstatus");
     await runCommandHandler(statusHandler);
     expectSingleDispatchedSlashBody("/status");
   });
 
-  it("resolves prefixed arg-menu command names during dispatch", async () => {
-    const harness = createArgMenusHarness({ accountNativePrefix: "acctprefix" });
+  it("supports partial nativeNames mapping (mapped and default names together)", async () => {
+    const harness = createArgMenusHarness({
+      accountNativeNames: { usage: "ozusage" },
+    });
     await registerCommands(harness.ctx, harness.account);
+
+    expect(harness.commands.has("/ozusage")).toBe(true);
+    expect(harness.commands.has("/agentstatus")).toBe(true);
 
     const argMenuHandler = requireHandler(harness.actions, "openclaw_cmdarg", "arg-menu action");
     await runArgMenuAction(argMenuHandler, {
       action: {
         value: encodeValue({
-          command: "acctprefix-usage",
+          command: "ozusage",
           arg: "mode",
           value: "tokens",
           userId: "U1",
@@ -774,7 +806,7 @@ describe("Slack native command prefix wiring", () => {
     expectSingleDispatchedSlashBody("/usage tokens");
   });
 
-  it("keeps no-prefix native slash behavior unchanged", async () => {
+  it("keeps default native slash behavior unchanged when nativeNames is not configured", async () => {
     const harness = createArgMenusHarness();
     await registerCommands(harness.ctx, harness.account);
 

--- a/src/slack/monitor/slash.test.ts
+++ b/src/slack/monitor/slash.test.ts
@@ -756,15 +756,19 @@ describe("Slack native command name mapping wiring", () => {
     expect(harness.commands.has("/ozusage")).toBe(true);
     expect(harness.commands.has("/agentstatus")).toBe(true);
 
+    const mappedUsageHandler = requireHandler(harness.commands, "/ozusage", "/ozusage");
     const argMenuHandler = requireHandler(harness.actions, "openclaw_cmdarg", "arg-menu action");
+    const { payload } = await runCommandAndResolveActionsBlock(mappedUsageHandler);
+    const actionValue = (
+      findFirstActionsBlock(payload as { blocks?: Array<{ type: string }> })?.elements?.[0] as
+        | { value?: string }
+        | undefined
+    )?.value;
+    expect(actionValue).toBeTruthy();
+
     await runArgMenuAction(argMenuHandler, {
       action: {
-        value: encodeValue({
-          command: "ozusage",
-          arg: "mode",
-          value: "tokens",
-          userId: "U1",
-        }),
+        value: actionValue,
       },
     });
     expectSingleDispatchedSlashBody("/usage tokens");

--- a/src/slack/monitor/slash.test.ts
+++ b/src/slack/monitor/slash.test.ts
@@ -37,6 +37,29 @@ vi.mock("../../auto-reply/commands-registry.js", () => {
     return { arg: periodArg, choices };
   };
 
+  const normalizePrefix = (prefix?: string) => {
+    const trimmed = prefix?.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    return trimmed.replace(/^-+|-+$/g, "").toLowerCase() || undefined;
+  };
+  const withPrefix = (name: string, prefix?: string) => {
+    const normalizedPrefix = normalizePrefix(prefix);
+    return normalizedPrefix ? `${normalizedPrefix}-${name}` : name;
+  };
+  const stripPrefix = (name: string, prefix?: string) => {
+    const normalizedPrefix = normalizePrefix(prefix);
+    if (!normalizedPrefix) {
+      return name;
+    }
+    const token = `${normalizedPrefix}-`;
+    if (!name.startsWith(token)) {
+      return name;
+    }
+    return name.slice(token.length) || name;
+  };
+
   return {
     buildCommandTextFromArgs: (
       cmd: { nativeName?: string; key: string },
@@ -54,8 +77,12 @@ vi.mock("../../auto-reply/commands-registry.js", () => {
             : "";
       return selected ? `/${name} ${selected}` : `/${name}`;
     },
-    findCommandByNativeName: (name: string) => {
-      const normalized = name.trim().toLowerCase();
+    findCommandByNativeName: (
+      name: string,
+      _provider?: string,
+      params?: { nativePrefix?: string },
+    ) => {
+      const normalized = stripPrefix(name.trim().toLowerCase(), params?.nativePrefix);
       if (normalized === "usage") {
         return usageCommand;
       }
@@ -79,45 +106,45 @@ vi.mock("../../auto-reply/commands-registry.js", () => {
       }
       return undefined;
     },
-    listNativeCommandSpecsForConfig: () => [
+    listNativeCommandSpecsForConfig: (_cfg?: unknown, params?: { nativePrefix?: string }) => [
       {
-        name: "usage",
+        name: withPrefix("usage", params?.nativePrefix),
         description: "Usage",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: "report",
+        name: withPrefix("report", params?.nativePrefix),
         description: "Report",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: "reportcompact",
+        name: withPrefix("reportcompact", params?.nativePrefix),
         description: "ReportCompact",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: "reportexternal",
+        name: withPrefix("reportexternal", params?.nativePrefix),
         description: "ReportExternal",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: "reportlong",
+        name: withPrefix("reportlong", params?.nativePrefix),
         description: "ReportLong",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: "unsafeconfirm",
+        name: withPrefix("unsafeconfirm", params?.nativePrefix),
         description: "UnsafeConfirm",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: "agentstatus",
+        name: withPrefix("agentstatus", params?.nativePrefix),
         description: "Status",
         acceptsArgs: false,
         args: [],
@@ -222,7 +249,10 @@ function createDeferred<T>() {
   return { promise, resolve };
 }
 
-function createArgMenusHarness() {
+function createArgMenusHarness(overrides?: {
+  nativePrefix?: string;
+  accountNativePrefix?: string;
+}) {
   const commands = new Map<string, (args: unknown) => Promise<void>>();
   const actions = new Map<string, (args: unknown) => Promise<void>>();
   const options = new Map<string, (args: unknown) => Promise<void>>();
@@ -263,6 +293,7 @@ function createArgMenusHarness() {
       name: "openclaw",
       ephemeral: true,
       sessionPrefix: "slack:slash",
+      nativePrefix: overrides?.nativePrefix,
     },
     textLimit: 4000,
     app,
@@ -273,7 +304,13 @@ function createArgMenusHarness() {
 
   const account = {
     accountId: "acct",
-    config: { commands: { native: true, nativeSkills: false } },
+    config: {
+      commands: { native: true, nativeSkills: false },
+      slashCommand:
+        overrides?.accountNativePrefix === undefined
+          ? undefined
+          : { nativePrefix: overrides.accountNativePrefix },
+    },
   } as unknown;
 
   return {
@@ -690,6 +727,59 @@ describe("Slack native command argument menus", () => {
         text: "Sorry, that button is no longer valid.",
       }),
     );
+  });
+});
+
+describe("Slack native command prefix wiring", () => {
+  it("registers prefixed native slash commands using account nativePrefix", async () => {
+    const harness = createArgMenusHarness({
+      nativePrefix: "ctxprefix",
+      accountNativePrefix: "acctprefix",
+    });
+    await registerCommands(harness.ctx, harness.account);
+
+    expect(harness.commands.has("/acctprefix-usage")).toBe(true);
+    expect(harness.commands.has("/acctprefix-agentstatus")).toBe(true);
+    expect(harness.commands.has("/ctxprefix-usage")).toBe(false);
+  });
+
+  it("dispatches prefixed native slash commands to internal command keys", async () => {
+    const harness = createArgMenusHarness({ accountNativePrefix: "acctprefix" });
+    await registerCommands(harness.ctx, harness.account);
+
+    const statusHandler = requireHandler(
+      harness.commands,
+      "/acctprefix-agentstatus",
+      "/acctprefix-agentstatus",
+    );
+    await runCommandHandler(statusHandler);
+    expectSingleDispatchedSlashBody("/status");
+  });
+
+  it("resolves prefixed arg-menu command names during dispatch", async () => {
+    const harness = createArgMenusHarness({ accountNativePrefix: "acctprefix" });
+    await registerCommands(harness.ctx, harness.account);
+
+    const argMenuHandler = requireHandler(harness.actions, "openclaw_cmdarg", "arg-menu action");
+    await runArgMenuAction(argMenuHandler, {
+      action: {
+        value: encodeValue({
+          command: "acctprefix-usage",
+          arg: "mode",
+          value: "tokens",
+          userId: "U1",
+        }),
+      },
+    });
+    expectSingleDispatchedSlashBody("/usage tokens");
+  });
+
+  it("keeps no-prefix native slash behavior unchanged", async () => {
+    const harness = createArgMenusHarness();
+    await registerCommands(harness.ctx, harness.account);
+
+    expect(harness.commands.has("/usage")).toBe(true);
+    expect(harness.commands.has("/agentstatus")).toBe(true);
   });
 });
 

--- a/src/slack/monitor/slash.test.ts
+++ b/src/slack/monitor/slash.test.ts
@@ -37,29 +37,6 @@ vi.mock("../../auto-reply/commands-registry.js", () => {
     return { arg: periodArg, choices };
   };
 
-  const normalizePrefix = (prefix?: string) => {
-    const trimmed = prefix?.trim();
-    if (!trimmed) {
-      return undefined;
-    }
-    return trimmed.replace(/^-+|-+$/g, "").toLowerCase() || undefined;
-  };
-  const withPrefix = (name: string, prefix?: string) => {
-    const normalizedPrefix = normalizePrefix(prefix);
-    return normalizedPrefix ? `${normalizedPrefix}-${name}` : name;
-  };
-  const stripPrefix = (name: string, prefix?: string) => {
-    const normalizedPrefix = normalizePrefix(prefix);
-    if (!normalizedPrefix) {
-      return name;
-    }
-    const token = `${normalizedPrefix}-`;
-    if (!name.startsWith(token)) {
-      return name;
-    }
-    return name.slice(token.length) || name;
-  };
-
   return {
     buildCommandTextFromArgs: (
       cmd: { nativeName?: string; key: string },
@@ -80,9 +57,9 @@ vi.mock("../../auto-reply/commands-registry.js", () => {
     findCommandByNativeName: (
       name: string,
       _provider?: string,
-      params?: { nativePrefix?: string; nativeNames?: Record<string, string> },
+      params?: { nativeNames?: Record<string, string> },
     ) => {
-      const normalized = stripPrefix(name.trim().toLowerCase(), params?.nativePrefix);
+      const normalized = name.trim().toLowerCase();
       const reverseNativeNames = new Map<string, string>();
       for (const [key, mapped] of Object.entries(params?.nativeNames ?? {})) {
         const trimmed = mapped.trim().toLowerCase();
@@ -116,55 +93,46 @@ vi.mock("../../auto-reply/commands-registry.js", () => {
     },
     listNativeCommandSpecsForConfig: (
       _cfg?: unknown,
-      params?: { nativePrefix?: string; nativeNames?: Record<string, string> },
+      params?: { nativeNames?: Record<string, string> },
     ) => [
       {
-        name: withPrefix(params?.nativeNames?.usage ?? "usage", params?.nativePrefix),
+        name: params?.nativeNames?.usage ?? "usage",
         description: "Usage",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: withPrefix(params?.nativeNames?.report ?? "report", params?.nativePrefix),
+        name: params?.nativeNames?.report ?? "report",
         description: "Report",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: withPrefix(
-          params?.nativeNames?.reportcompact ?? "reportcompact",
-          params?.nativePrefix,
-        ),
+        name: params?.nativeNames?.reportcompact ?? "reportcompact",
         description: "ReportCompact",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: withPrefix(
-          params?.nativeNames?.reportexternal ?? "reportexternal",
-          params?.nativePrefix,
-        ),
+        name: params?.nativeNames?.reportexternal ?? "reportexternal",
         description: "ReportExternal",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: withPrefix(params?.nativeNames?.reportlong ?? "reportlong", params?.nativePrefix),
+        name: params?.nativeNames?.reportlong ?? "reportlong",
         description: "ReportLong",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: withPrefix(
-          params?.nativeNames?.unsafeconfirm ?? "unsafeconfirm",
-          params?.nativePrefix,
-        ),
+        name: params?.nativeNames?.unsafeconfirm ?? "unsafeconfirm",
         description: "UnsafeConfirm",
         acceptsArgs: true,
         args: [],
       },
       {
-        name: withPrefix(params?.nativeNames?.status ?? "agentstatus", params?.nativePrefix),
+        name: params?.nativeNames?.status ?? "agentstatus",
         description: "Status",
         acceptsArgs: false,
         args: [],
@@ -270,8 +238,6 @@ function createDeferred<T>() {
 }
 
 function createArgMenusHarness(overrides?: {
-  nativePrefix?: string;
-  accountNativePrefix?: string;
   nativeNames?: Record<string, string>;
   accountNativeNames?: Record<string, string>;
 }) {
@@ -315,7 +281,6 @@ function createArgMenusHarness(overrides?: {
       name: "openclaw",
       ephemeral: true,
       sessionPrefix: "slack:slash",
-      nativePrefix: overrides?.nativePrefix,
       nativeNames: overrides?.nativeNames,
     },
     textLimit: 4000,
@@ -330,10 +295,9 @@ function createArgMenusHarness(overrides?: {
     config: {
       commands: { native: true, nativeSkills: false },
       slashCommand:
-        overrides?.accountNativePrefix === undefined && overrides?.accountNativeNames === undefined
+        overrides?.accountNativeNames === undefined
           ? undefined
           : {
-              nativePrefix: overrides.accountNativePrefix,
               nativeNames: overrides.accountNativeNames,
             },
     },

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -669,6 +669,7 @@ export async function registerSlackMonitorSlashCommands(params: {
     nativeCommands = slashCommandsRuntime.listNativeCommandSpecsForConfig(cfg, {
       skillCommands,
       provider: "slack",
+      nativePrefix: slashCommand.nativePrefix,
     });
   }
 
@@ -683,6 +684,7 @@ export async function registerSlackMonitorSlashCommands(params: {
           const commandDefinition = slashCommandsRuntime.findCommandByNativeName(
             command.name,
             "slack",
+            { nativePrefix: slashCommand.nativePrefix },
           );
           const rawText = cmd.text?.trim() ?? "";
           const commandArgs = commandDefinition
@@ -837,7 +839,9 @@ export async function registerSlackMonitorSlashCommands(params: {
       }
       const { buildCommandTextFromArgs, findCommandByNativeName } =
         await loadSlashCommandsRuntime();
-      const commandDefinition = findCommandByNativeName(parsed.command, "slack");
+      const commandDefinition = findCommandByNativeName(parsed.command, "slack", {
+        nativePrefix: slashCommand.nativePrefix,
+      });
       const commandArgs: CommandArgs = {
         values: { [parsed.arg]: parsed.value },
       };

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -494,7 +494,11 @@ export async function registerSlackMonitorSlashCommands(params: {
           cfg,
         });
         if (menu) {
-          const commandLabel = commandDefinition.nativeName ?? commandDefinition.key;
+          const mappedNativeName = nativeNames?.[commandDefinition.key]?.trim();
+          const commandLabel =
+            mappedNativeName && mappedNativeName.length > 0
+              ? mappedNativeName
+              : (commandDefinition.nativeName ?? commandDefinition.key);
           const title =
             menu.title ?? `Choose ${menu.arg.description || menu.arg.name} for /${commandLabel}.`;
           const blocks = buildSlackCommandArgMenuBlocks({

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -295,7 +295,6 @@ export async function registerSlackMonitorSlashCommands(params: {
   const slashCommand = resolveSlackSlashCommandConfig(
     ctx.slashCommand ?? account.config.slashCommand,
   );
-  const nativePrefix = account.config.slashCommand?.nativePrefix ?? slashCommand.nativePrefix;
   const nativeNames = account.config.slashCommand?.nativeNames ?? slashCommand.nativeNames;
 
   const handleSlashCommand = async (p: {
@@ -671,7 +670,6 @@ export async function registerSlackMonitorSlashCommands(params: {
     nativeCommands = slashCommandsRuntime.listNativeCommandSpecsForConfig(cfg, {
       skillCommands,
       provider: "slack",
-      nativePrefix,
       nativeNames,
     });
   }
@@ -687,7 +685,7 @@ export async function registerSlackMonitorSlashCommands(params: {
           const commandDefinition = slashCommandsRuntime.findCommandByNativeName(
             command.name,
             "slack",
-            { nativePrefix, nativeNames },
+            { nativeNames },
           );
           const rawText = cmd.text?.trim() ?? "";
           const commandArgs = commandDefinition
@@ -843,7 +841,6 @@ export async function registerSlackMonitorSlashCommands(params: {
       const { buildCommandTextFromArgs, findCommandByNativeName } =
         await loadSlashCommandsRuntime();
       const commandDefinition = findCommandByNativeName(parsed.command, "slack", {
-        nativePrefix,
         nativeNames,
       });
       const commandArgs: CommandArgs = {

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -295,6 +295,7 @@ export async function registerSlackMonitorSlashCommands(params: {
   const slashCommand = resolveSlackSlashCommandConfig(
     ctx.slashCommand ?? account.config.slashCommand,
   );
+  const nativePrefix = account.config.slashCommand?.nativePrefix ?? slashCommand.nativePrefix;
 
   const handleSlashCommand = async (p: {
     command: SlackCommandMiddlewareArgs["command"];
@@ -669,7 +670,7 @@ export async function registerSlackMonitorSlashCommands(params: {
     nativeCommands = slashCommandsRuntime.listNativeCommandSpecsForConfig(cfg, {
       skillCommands,
       provider: "slack",
-      nativePrefix: slashCommand.nativePrefix,
+      nativePrefix,
     });
   }
 
@@ -684,7 +685,7 @@ export async function registerSlackMonitorSlashCommands(params: {
           const commandDefinition = slashCommandsRuntime.findCommandByNativeName(
             command.name,
             "slack",
-            { nativePrefix: slashCommand.nativePrefix },
+            { nativePrefix },
           );
           const rawText = cmd.text?.trim() ?? "";
           const commandArgs = commandDefinition
@@ -840,7 +841,7 @@ export async function registerSlackMonitorSlashCommands(params: {
       const { buildCommandTextFromArgs, findCommandByNativeName } =
         await loadSlashCommandsRuntime();
       const commandDefinition = findCommandByNativeName(parsed.command, "slack", {
-        nativePrefix: slashCommand.nativePrefix,
+        nativePrefix,
       });
       const commandArgs: CommandArgs = {
         values: { [parsed.arg]: parsed.value },

--- a/src/slack/monitor/slash.ts
+++ b/src/slack/monitor/slash.ts
@@ -296,6 +296,7 @@ export async function registerSlackMonitorSlashCommands(params: {
     ctx.slashCommand ?? account.config.slashCommand,
   );
   const nativePrefix = account.config.slashCommand?.nativePrefix ?? slashCommand.nativePrefix;
+  const nativeNames = account.config.slashCommand?.nativeNames ?? slashCommand.nativeNames;
 
   const handleSlashCommand = async (p: {
     command: SlackCommandMiddlewareArgs["command"];
@@ -671,6 +672,7 @@ export async function registerSlackMonitorSlashCommands(params: {
       skillCommands,
       provider: "slack",
       nativePrefix,
+      nativeNames,
     });
   }
 
@@ -685,7 +687,7 @@ export async function registerSlackMonitorSlashCommands(params: {
           const commandDefinition = slashCommandsRuntime.findCommandByNativeName(
             command.name,
             "slack",
-            { nativePrefix },
+            { nativePrefix, nativeNames },
           );
           const rawText = cmd.text?.trim() ?? "";
           const commandArgs = commandDefinition
@@ -842,6 +844,7 @@ export async function registerSlackMonitorSlashCommands(params: {
         await loadSlashCommandsRuntime();
       const commandDefinition = findCommandByNativeName(parsed.command, "slack", {
         nativePrefix,
+        nativeNames,
       });
       const commandArgs: CommandArgs = {
         values: { [parsed.arg]: parsed.value },


### PR DESCRIPTION
## Summary
- add account-level `slashCommand.nativeNames?: Record<string, string>` for Slack config
- thread `nativeNames` through Slack slash native command registration + lookup paths
- preserve defaults for unmapped commands and keep `NATIVE_NAME_OVERRIDES` behavior unchanged
- add coverage for custom registration, custom dispatch, partial mapping, and no-mapping compatibility

## Testing
- `pnpm test src/slack/monitor/slash.test.ts`

Closes #38302
