### PR TITLE
chore: bump pnpm from 10.23.0 to 10.30.3

### DIFF
--- a/.github/actions/setup-node-env/action.yml
+++ b/.github/actions/setup-node-env/action.yml
@@ -10,7 +10,7 @@ inputs:
   pnpm-version:
     description: pnpm version for corepack.
     required: false
-    default: "10.23.0"
+    default: "10.30.3"
   install-bun:
     description: Whether to install Bun alongside Node.
     required: false

--- a/.github/actions/setup-pnpm-store-cache/action.yml
+++ b/.github/actions/setup-pnpm-store-cache/action.yml
@@ -4,7 +4,7 @@ inputs:
   pnpm-version:
     description: pnpm version to activate via corepack.
     required: false
-    default: "10.23.0"
+    default: "10.30.3"
   cache-key-suffix:
     description: Suffix appended to the cache key.
     required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,7 +450,7 @@ jobs:
       - name: Setup pnpm + cache store
         uses: ./.github/actions/setup-pnpm-store-cache
         with:
-          pnpm-version: "10.23.0"
+          pnpm-version: "10.30.3"
           cache-key-suffix: "node22"
           # Sticky disk mount currently retries/fails on every shard and adds ~50s
           # before install while still yielding zero pnpm store reuse.

--- a/package.json
+++ b/package.json
@@ -415,7 +415,7 @@
   "engines": {
     "node": ">=22.12.0"
   },
-  "packageManager": "pnpm@10.23.0",
+  "packageManager": "pnpm@10.30.3",
   "pnpm": {
     "minimumReleaseAge": 2880,
     "overrides": {


### PR DESCRIPTION
## Summary

- Bump pinned pnpm version from 10.23.0 to 10.30.3 across all CI and config files
- Updates `package.json` (`packageManager` field), `.github/actions/setup-node-env/action.yml`, and `.github/workflows/ci.yml`
- `.github/actions/setup-pnpm-store-cache/action.yml` was already at 10.30.3

Closes #38372

## Test plan

- [ ] CI passes with the updated pnpm version
- [ ] `pnpm install --frozen-lockfile` works locally with 10.30.3