### PR TITLE
fix(message-tool): ignore empty/default tool bridge fields for send

### DIFF
--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -170,17 +170,28 @@ async function executeSend(params: {
   action: Record<string, unknown>;
   toolOptions?: Partial<Parameters<typeof createMessageTool>[0]>;
 }) {
+  return executeAction({
+    toolOptions: params.toolOptions,
+    action: {
+      action: "send",
+      ...params.action,
+    },
+  });
+}
+
+async function executeAction(params: {
+  action: Record<string, unknown>;
+  toolOptions?: Partial<Parameters<typeof createMessageTool>[0]>;
+}) {
   const tool = createMessageTool({
     config: {} as never,
     runMessageAction: mocks.runMessageAction as never,
     ...params.toolOptions,
   });
-  await tool.execute("1", {
-    action: "send",
-    ...params.action,
-  });
+  await tool.execute("1", params.action);
   return mocks.runMessageAction.mock.calls[0]?.[0] as
     | {
+        action?: string;
         params?: Record<string, unknown>;
         sandboxRoot?: string;
         requesterSenderId?: string;
@@ -321,7 +332,107 @@ describe("message tool path passthrough", () => {
     });
 
     expect(call?.params?.[field]).toBe(value);
+    expect(call?.params?.message).toBe("");
     expect(call?.params?.media).toBeUndefined();
+  });
+
+  it("preserves empty emoji values for react cleanup semantics", async () => {
+    mockSendResult({ to: "telegram:123" });
+
+    const call = await executeAction({
+      action: {
+        action: "react",
+        target: "telegram:123",
+        emoji: "",
+      },
+    });
+
+    expect(call?.action).toBe("react");
+    expect(call?.params?.emoji).toBe("");
+  });
+
+  it("preserves empty button arrays for edit semantics", async () => {
+    mockSendResult({ to: "telegram:123" });
+
+    const call = await executeAction({
+      action: {
+        action: "edit",
+        target: "telegram:123",
+        buttons: [],
+      },
+    });
+
+    expect(call?.action).toBe("edit");
+    expect(call?.params?.buttons).toEqual([]);
+  });
+
+  it("strips empty legacy target placeholders before send normalization", async () => {
+    mockSendResult({ to: "channel:C123" });
+
+    const call = await executeSend({
+      action: {
+        channel: "slack",
+        target: "channel:C123",
+        to: "",
+        channelId: "",
+        targets: [],
+        message: "hi",
+      },
+    });
+
+    expect(call?.params?.target).toBe("channel:C123");
+    expect(call?.params?.to).toBeUndefined();
+    expect(call?.params?.channelId).toBeUndefined();
+    expect(call?.params?.targets).toBeUndefined();
+  });
+
+  it("keeps explicit zero-valued poll durations while stripping inert poll defaults", async () => {
+    mockSendResult({ to: "channel:C123" });
+
+    const call = await executeSend({
+      action: {
+        channel: "slack",
+        target: "channel:C123",
+        message: "hi",
+        pollDurationHours: 0,
+        poll_duration_seconds: "0 ",
+        pollAnonymous: false,
+        poll_public: " false ",
+        pollMulti: false,
+        pollOption: [],
+        poll_option: ["", "   "],
+        poll_question: "",
+      },
+    });
+
+    expect(call?.params?.pollDurationHours).toBe(0);
+    expect(call?.params?.poll_duration_seconds).toBe("0 ");
+    expect(call?.params?.pollAnonymous).toBeUndefined();
+    expect(call?.params?.poll_public).toBeUndefined();
+    expect(call?.params?.pollMulti).toBeUndefined();
+    expect(call?.params?.pollOption).toBeUndefined();
+    expect(call?.params?.poll_option).toBeUndefined();
+    expect(call?.params?.poll_question).toBeUndefined();
+  });
+
+  it("keeps poll params when action trims to poll", async () => {
+    mockSendResult({ to: "channel:C123" });
+
+    const call = await executeAction({
+      action: {
+        action: "poll ",
+        channel: "slack",
+        target: "channel:C123",
+        pollDurationSeconds: 60,
+        poll_public: "false",
+        pollOption: ["Yes", "No"],
+      },
+    });
+
+    expect(call?.action).toBe("poll");
+    expect(call?.params?.pollDurationSeconds).toBe(60);
+    expect(call?.params?.poll_public).toBe("false");
+    expect(call?.params?.pollOption).toEqual(["Yes", "No"]);
   });
 });
 

--- a/src/agents/tools/message-tool.ts
+++ b/src/agents/tools/message-tool.ts
@@ -18,7 +18,12 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { loadConfig } from "../../config/config.js";
 import { GATEWAY_CLIENT_IDS, GATEWAY_CLIENT_MODES } from "../../gateway/protocol/client-info.js";
 import { getToolResult, runMessageAction } from "../../infra/outbound/message-action-runner.js";
-import { POLL_CREATION_PARAM_DEFS, SHARED_POLL_CREATION_PARAM_NAMES } from "../../poll-params.js";
+import {
+  POLL_CREATION_PARAM_DEFS,
+  SHARED_POLL_CREATION_PARAM_NAMES,
+  toSnakeCaseKey,
+  POLL_CREATION_PARAM_NAMES,
+} from "../../poll-params.js";
 import { normalizeAccountId } from "../../routing/session-key.js";
 import { stripReasoningTagsFromText } from "../../shared/text/reasoning-tags.js";
 import { normalizeMessageChannel } from "../../utils/message-channel.js";
@@ -43,6 +48,80 @@ const EXPLICIT_TARGET_ACTIONS = new Set<ChannelMessageActionName>([
 function actionNeedsExplicitTarget(action: ChannelMessageActionName): boolean {
   return EXPLICIT_TARGET_ACTIONS.has(action);
 }
+
+const LEGACY_TARGET_PLACEHOLDER_FIELDS = ["to", "channelId", "targets"] as const;
+
+function isBlankString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length === 0;
+}
+
+function isEmptyArray(value: unknown): value is unknown[] {
+  return Array.isArray(value) && value.length === 0;
+}
+
+function stripLegacyTargetPlaceholders(params: Record<string, unknown>): void {
+  for (const key of LEGACY_TARGET_PLACEHOLDER_FIELDS) {
+    const value = params[key];
+    if (isBlankString(value) || isEmptyArray(value)) {
+      delete params[key];
+    }
+  }
+}
+
+function isInertPollParamValue(key: string, value: unknown): boolean {
+  const def = POLL_CREATION_PARAM_DEFS[key];
+  if (!def) {
+    return false;
+  }
+  switch (def.kind) {
+    case "string":
+      return isBlankString(value);
+    case "stringArray":
+      if (typeof value === "string") {
+        return value.trim().length === 0;
+      }
+      return Array.isArray(value)
+        ? !value.some((entry) => typeof entry === "string" && entry.trim().length > 0)
+        : false;
+    case "number":
+      if (typeof value === "string") {
+        const trimmed = value.trim();
+        return trimmed.length === 0;
+      }
+      return false;
+    case "boolean":
+      if (typeof value === "boolean") {
+        return !value;
+      }
+      if (typeof value === "string") {
+        const trimmed = value.trim().toLowerCase();
+        return trimmed.length === 0 || trimmed === "false";
+      }
+      return false;
+  }
+}
+
+function stripInertPollDefaults(
+  params: Record<string, unknown>,
+  normalizedAction: string | undefined,
+): void {
+  if (!normalizedAction || normalizedAction === "poll") {
+    return;
+  }
+  for (const key of POLL_CREATION_PARAM_NAMES) {
+    const value = params[key];
+    const snakeKey = toSnakeCaseKey(key);
+    const snakeValue = params[snakeKey];
+
+    if (isInertPollParamValue(key, value)) {
+      delete params[key];
+    }
+    if (snakeKey !== key && isInertPollParamValue(key, snakeValue)) {
+      delete params[snakeKey];
+    }
+  }
+}
+
 function buildRoutingSchema() {
   return {
     channel: Type.Optional(Type.String()),
@@ -684,6 +763,19 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
       }
       // Shallow-copy so we don't mutate the original event args (used for logging/dedup).
       const params = { ...(args as Record<string, unknown>) };
+
+      // Some tool bridges populate legacy target placeholders with empty defaults.
+      // That breaks target normalization because fields like `to` or `channelId`
+      // appear present even when effectively unset, triggering:
+      // "Use `target` instead of `to`/`channelId`."
+      stripLegacyTargetPlaceholders(params);
+
+      // Poll fields are exposed in the shared schema, and some tool bridges fill
+      // them with default zero/false values even for plain sends. Strip those
+      // inert defaults for non-poll actions so send/edit/etc. are not rejected as
+      // accidental poll creation.
+      const normalizedAction = typeof params.action === "string" ? params.action.trim() : undefined;
+      stripInertPollDefaults(params, normalizedAction);
 
       // Strip reasoning tags from text fields — models may include <think>…</think>
       // in tool arguments, and the messaging tool send path has no other tag filtering.

--- a/src/poll-params.ts
+++ b/src/poll-params.ts
@@ -36,6 +36,13 @@ export const TELEGRAM_POLL_CREATION_PARAM_NAMES = Object.keys(
   TELEGRAM_POLL_CREATION_PARAM_DEFS,
 ) as TelegramPollCreationParamName[];
 
+export function toSnakeCaseKey(key: string): string {
+  return key
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase();
+}
+
 function readPollParamRaw(params: Record<string, unknown>, key: string): unknown {
   return readSnakeCaseParamRaw(params, key);
 }


### PR DESCRIPTION
## Summary

- Problem: `message(action="send")` could fail even with a valid `target` when tool bridges populated shared-schema fields with inert defaults such as `""`, `[]`, `0`, or `false`.
- Why it matters: This broke normal outbound sends (observed with Slack channel sends) with misleading validation errors like `Use target instead of to/channelId` and `Poll fields require action "poll"`.
- What changed: In `src/agents/tools/message-tool.ts`, the tool now strips empty string/array fields before validation, and strips inert poll defaults for non-`poll` actions before passing params to `runMessageAction()`.
- What did NOT change (scope boundary): This PR does not change outbound delivery logic, channel plugins, cron behavior, or message action semantics; it only sanitizes tool-call params before existing normalization runs.

## Change Type (select all)

- [x] Bug fix

## Scope (select all touched areas)

- [x] Skills / tool execution
- [x] Integrations

## User-visible / Behavior Changes

- `message(action="send")` is now more tolerant of tool-bridge placeholder/default fields.
- Valid sends that previously failed due to empty/default legacy target or poll fields should now succeed.
- No config or default behavior changes for successful existing callers.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

Before the fix, we can have the following entries under `gateway.err.log`:

```log
[tools] message failed: Use `target` instead of `to`/`channelId`.
[tools] message failed: Poll fields require action "poll"; use action "poll" instead of "send".
```

After this fix, the message send works fine without any error/warning.

### Environment

- OS: macOS
- Runtime/container: local OpenClaw runtime
- Model/provider: gpt-5.4
- Integration/channel (if any): Slack
- Relevant config (redacted): Slack enabled; sending to `channel:xxx`


### Expected

- The tool should treat inert placeholder/default fields as unset and allow the send to proceed.

### Actual

- Before the patch, the tool rejected valid sends with:
- `Use target instead of to/channelId`
- `Poll fields require action "poll"; use action "poll" instead of "send"`

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets

## Human Verification (required)

What you personally verified (not just CI), and how:

Verified scenarios:
- Reproduced the broken Slack send path through the `message` tool.
- Confirmed the first failure mode (`target` vs legacy fields).
- Applied the empty/default field sanitization patch.
- Confirmed the second failure mode (poll defaults contaminating `send`).
- Applied the non-poll poll-default sanitization patch.
- Restarted OpenClaw and manually verified that Slack channel sends now succeed.

Edge cases checked:
- Existing message-tool tests still pass.
- Message action normalization tests still pass.
- Poll param detection tests still pass.

What you did **not** verify:
- I did not verify every channel plugin/provider.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Revert this commit and it can be done cleanly.

Files/config to restore:
- `src/agents/tools/message-tool.ts`

Known bad symptoms reviewers should watch for:
None

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Over-sanitizing fields that were intentionally provided by a caller.
- Mitigation: The extra stripping is limited to obviously inert values (`""`, `[]`) and to poll defaults only when `action !== "poll"`.

- Risk: Behavior difference between direct callers and tool-bridge callers could hide caller-side serialization issues.
- Mitigation: The patch is intentionally scoped to the message-tool boundary, where the placeholder/default pollution actually occurs, and leaves lower-level message action semantics unchanged.