### PR TITLE
docs: add third-party package marketplaces section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,12 @@ ClawHub is a minimal skill registry. With ClawHub enabled, the agent can search 
 
 [ClawHub](https://clawhub.com)
 
+## Third-party package marketplaces
+
+Community-built marketplaces and curated package registries for OpenClaw:
+
+- [AgentStandard](https://agentstandard.ai) — Certified AI agent package marketplace. 37 curated packages for OpenClaw, Claude, and Telegram. Every package includes SKILL.md for one-command install. ✦ reviewed.
+
 ## Chat commands
 
 Send these in WhatsApp/Telegram/Slack/Google Chat/Microsoft Teams/WebChat (group commands are owner-only):


### PR DESCRIPTION
Adds a new "Third-party package marketplaces" section to the Skills registry part of the README.

First entry: [AgentStandard](https://agentstandard.ai) — a certified AI agent package marketplace with 37 curated packages for OpenClaw, Claude, and Telegram. Every package ships with a `SKILL.md` for one-command installation.

This creates a natural home for community marketplaces and curated registries that extend the ClawHub ecosystem without requiring skills to be listed on ClawHub directly.