### PR TITLE
fix(googlechat): use globalThis.fetch to avoid gaxios node-fetch v3 ESM failure on Node.js 22+

### DIFF
--- a/extensions/googlechat/src/auth.ts
+++ b/extensions/googlechat/src/auth.ts
@@ -25,6 +25,30 @@ function buildAuthKey(account: ResolvedGoogleChatAccount): string {
   return "none";
 }
 
+/**
+ * Creates a GoogleAuth instance configured to use the native `globalThis.fetch` when available
+ * (Node.js 18+), bypassing gaxios's fallback to node-fetch v3 which is ESM-only and fails
+ * to load from a CJS context on Node.js 22+.
+ *
+ * See: https://github.com/openclaw/openclaw/issues/33468
+ */
+function createGoogleAuth(options: ConstructorParameters<typeof GoogleAuth>[0]): GoogleAuth {
+  const auth = new GoogleAuth(options);
+  // Inject globalThis.fetch as the fetchImplementation so gaxios does not attempt
+  // to dynamically import node-fetch v3 (ESM-only), which breaks on Node.js 22+
+  // when loaded from a CJS bundle.
+  if (typeof globalThis.fetch === "function" && auth.transporter) {
+    const transporter = auth.transporter as {
+      defaults?: Record<string, unknown>;
+    };
+    transporter.defaults = {
+      ...transporter.defaults,
+      fetchImplementation: globalThis.fetch,
+    };
+  }
+  return auth;
+}
+
 function getAuthInstance(account: ResolvedGoogleChatAccount): GoogleAuth {
   const key = buildAuthKey(account);
   const cached = authCache.get(account.accountId);
@@ -42,20 +66,20 @@ function getAuthInstance(account: ResolvedGoogleChatAccount): GoogleAuth {
   };
 
   if (account.credentialsFile) {
-    const auth = new GoogleAuth({ keyFile: account.credentialsFile, scopes: [CHAT_SCOPE] });
+    const auth = createGoogleAuth({ keyFile: account.credentialsFile, scopes: [CHAT_SCOPE] });
     authCache.set(account.accountId, { key, auth });
     evictOldest();
     return auth;
   }
 
   if (account.credentials) {
-    const auth = new GoogleAuth({ credentials: account.credentials, scopes: [CHAT_SCOPE] });
+    const auth = createGoogleAuth({ credentials: account.credentials, scopes: [CHAT_SCOPE] });
     authCache.set(account.accountId, { key, auth });
     evictOldest();
     return auth;
   }
 
-  const auth = new GoogleAuth({ scopes: [CHAT_SCOPE] });
+  const auth = createGoogleAuth({ scopes: [CHAT_SCOPE] });
   authCache.set(account.accountId, { key, auth });
   evictOldest();
   return auth;


### PR DESCRIPTION
## Problem

After upgrading to v2026.3.2+, the Google Chat plugin fails with:

```
Google Chat: failed (unknown) - Cannot convert undefined or null to object
```

Reported in: #33468, #33256

## Root Cause

`gaxios` (used by `google-auth-library`) determines which `fetch` implementation to use with this logic:

```ts
static async #getFetch() {
  const hasWindow = typeof window !== 'undefined' && !!window;
  this.#fetch ||= hasWindow
    ? window.fetch
    : (await import('node-fetch')).default;  // <-- problem
  return this.#fetch;
}
```

On Node.js (no `window`), it falls back to dynamically importing `node-fetch`. The bundled `node-fetch` version inside `gaxios`'s own `node_modules` is **v3.3.2 (ESM-only)**. When loaded from a CJS bundle context on **Node.js 22+**, this fails with:

```
TypeError: Cannot convert undefined or null to object
  at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:213:12)
```

Node.js 18+ ships with a native `globalThis.fetch`, but `gaxios` only checks for `window` (browser), not `globalThis.fetch` (Node.js).

## Fix

Inject `globalThis.fetch` as the `fetchImplementation` on the gaxios transporter when available (Node.js 18+), so `gaxios` never attempts the failing `import('node-fetch')`.

This is done in `googlechat/src/auth.ts` via a `createGoogleAuth` wrapper that sets `transporter.defaults.fetchImplementation` after construction.

## Testing

Verified locally on Node.js v22.22.0 — both `Google Chat main` and `legal` accounts now show `works` in `openclaw channels status --probe`.