### PR TITLE
feat(usage): include model call count in response usage line

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -114,6 +114,8 @@ type UsageAccumulator = {
   lastCacheRead: number;
   lastCacheWrite: number;
   lastInput: number;
+  /** Number of LLM API calls accumulated across all attempts. */
+  callCount: number;
 };
 
 const createUsageAccumulator = (): UsageAccumulator => ({
@@ -125,6 +127,7 @@ const createUsageAccumulator = (): UsageAccumulator => ({
   lastCacheRead: 0,
   lastCacheWrite: 0,
   lastInput: 0,
+  callCount: 0,
 });
 
 function createCompactionDiagId(): string {
@@ -172,6 +175,7 @@ const mergeUsageIntoAccumulator = (
   target.lastCacheRead = usage.cacheRead ?? 0;
   target.lastCacheWrite = usage.cacheWrite ?? 0;
   target.lastInput = usage.input ?? 0;
+  target.callCount += usage.callCount ?? 0;
 };
 
 const toNormalizedUsage = (usage: UsageAccumulator) => {
@@ -199,6 +203,7 @@ const toNormalizedUsage = (usage: UsageAccumulator) => {
     cacheRead: usage.lastCacheRead || undefined,
     cacheWrite: usage.lastCacheWrite || undefined,
     total: lastPromptTokens + usage.output || undefined,
+    callCount: usage.callCount > 0 ? usage.callCount : undefined,
   };
 };
 

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -13,6 +13,7 @@ export type EmbeddedPiAgentMeta = {
     cacheRead?: number;
     cacheWrite?: number;
     total?: number;
+    callCount?: number;
   };
   /**
    * Usage from the last individual API call (not accumulated across tool-use

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -85,6 +85,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     cacheRead: 0,
     cacheWrite: 0,
     total: 0,
+    callCount: 0,
   };
   let compactionCount = 0;
 
@@ -269,6 +270,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       usage.total ??
       (usage.input ?? 0) + (usage.output ?? 0) + (usage.cacheRead ?? 0) + (usage.cacheWrite ?? 0);
     usageTotals.total += usageTotal;
+    usageTotals.callCount += 1;
   };
   const getUsageTotals = () => {
     const hasUsage =
@@ -288,6 +290,7 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
       cacheRead: usageTotals.cacheRead || undefined,
       cacheWrite: usageTotals.cacheWrite || undefined,
       total: usageTotals.total || derivedTotal || undefined,
+      callCount: usageTotals.callCount > 0 ? usageTotals.callCount : undefined,
     };
   };
   const incrementCompactionCount = () => {

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -32,6 +32,8 @@ export type NormalizedUsage = {
   cacheRead?: number;
   cacheWrite?: number;
   total?: number;
+  /** Number of LLM API calls made during the turn. */
+  callCount?: number;
 };
 
 export type AssistantUsageSnapshot = {

--- a/src/auto-reply/reply/agent-runner-utils.test.ts
+++ b/src/auto-reply/reply/agent-runner-utils.test.ts
@@ -14,6 +14,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
 const {
   buildEmbeddedRunBaseParams,
   buildEmbeddedRunContexts,
+  formatResponseUsageLine,
   resolveModelFallbackOptions,
   resolveProviderScopedAuthProfile,
 } = await import("./agent-runner-utils.js");
@@ -153,6 +154,46 @@ describe("agent-runner-utils", () => {
       senderName: undefined,
       senderUsername: undefined,
       senderE164: undefined,
+    });
+  });
+
+  describe("formatResponseUsageLine", () => {
+    it("returns null when usage is undefined", () => {
+      expect(formatResponseUsageLine({ showCost: false })).toBeNull();
+    });
+
+    it("formats basic usage without call count for single call", () => {
+      const result = formatResponseUsageLine({
+        usage: { input: 1000, output: 200, callCount: 1 },
+        showCost: false,
+      });
+      expect(result).toBe("Usage: 1.0k in / 200 out");
+    });
+
+    it("includes call count when multiple calls are made", () => {
+      const result = formatResponseUsageLine({
+        usage: { input: 60000, output: 150, callCount: 3 },
+        showCost: false,
+      });
+      expect(result).toBe("Usage: 60k in / 150 out (3 calls)");
+    });
+
+    it("omits call count when callCount is undefined", () => {
+      const result = formatResponseUsageLine({
+        usage: { input: 5000, output: 100 },
+        showCost: false,
+      });
+      expect(result).toBe("Usage: 5.0k in / 100 out");
+    });
+
+    it("includes call count before cost suffix", () => {
+      const result = formatResponseUsageLine({
+        usage: { input: 10000, output: 500, callCount: 2 },
+        showCost: true,
+        costConfig: { input: 3, output: 15, cacheRead: 0, cacheWrite: 0 },
+      });
+      expect(result).toContain("(2 calls)");
+      expect(result).toContain("est $");
     });
   });
 

--- a/src/auto-reply/reply/agent-runner-utils.ts
+++ b/src/auto-reply/reply/agent-runner-utils.ts
@@ -116,8 +116,10 @@ export const formatResponseUsageLine = (params: {
         })
       : undefined;
   const costLabel = params.showCost ? formatUsd(cost) : undefined;
-  const suffix = costLabel ? ` · est ${costLabel}` : "";
-  return `Usage: ${inputLabel} in / ${outputLabel} out${suffix}`;
+  const callCount = usage.callCount;
+  const callsSuffix = typeof callCount === "number" && callCount > 1 ? ` (${callCount} calls)` : "";
+  const costSuffix = costLabel ? ` · est ${costLabel}` : "";
+  return `Usage: ${inputLabel} in / ${outputLabel} out${callsSuffix}${costSuffix}`;
 };
 
 export const appendUsageLine = (payloads: ReplyPayload[], line: string): ReplyPayload[] => {


### PR DESCRIPTION
## Summary

- Track the number of LLM API calls made during a turn via a new `callCount` field in `NormalizedUsage` and the usage accumulator pipeline
- Display the call count in the response usage footer when multiple calls occur (e.g., tool-use loops)
- Single-call turns remain unchanged; multi-call turns now show: `Usage: 60k in / 150 out (3 calls)`

Closes #34500

## Changes

- **`src/agents/usage.ts`**: Added `callCount` to `NormalizedUsage` type
- **`src/agents/pi-embedded-subscribe.ts`**: Increment `callCount` in `recordAssistantUsage` (called once per LLM response)
- **`src/agents/pi-embedded-runner/run.ts`**: Added `callCount` to `UsageAccumulator` and propagated through `mergeUsageIntoAccumulator` / `toNormalizedUsage`
- **`src/agents/pi-embedded-runner/types.ts`**: Added `callCount` to `EmbeddedPiAgentMeta.usage`
- **`src/auto-reply/reply/agent-runner-utils.ts`**: Display `(N calls)` suffix in `formatResponseUsageLine` when `callCount > 1`
- **`src/auto-reply/reply/agent-runner-utils.test.ts`**: Added tests for call count display logic

## Security Impact

- [ ] Introduces new dependencies: **No**
- [ ] Modifies authentication/authorization: **No**
- [ ] Changes data handling: **No** (adds a counter field to existing usage data)
- [ ] Affects network communication: **No**
- [ ] Impacts file system access: **No**

## Test plan

- [x] Added unit tests for `formatResponseUsageLine` covering: no usage, single call, multiple calls, undefined callCount, and interaction with cost display
- [x] Verified existing `usage-format`, `usage-reporting`, and `agent-runner-utils` tests pass
- [x] Lint/format check passes (`pnpm check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)