### PR TITLE
fix(plugins): deduplicate plugins by origin rank instead of loading both

### DIFF
--- a/src/plugins/manifest-registry.test.ts
+++ b/src/plugins/manifest-registry.test.ts
@@ -43,7 +43,8 @@ function loadRegistry(candidates: PluginCandidate[]) {
 function countDuplicateWarnings(registry: ReturnType<typeof loadPluginManifestRegistry>): number {
   return registry.diagnostics.filter(
     (diagnostic) =>
-      diagnostic.level === "warn" && diagnostic.message?.includes("duplicate plugin id"),
+      (diagnostic.level === "warn" || diagnostic.level === "info") &&
+      diagnostic.message?.includes("duplicate plugin id"),
   ).length;
 }
 
@@ -150,7 +151,11 @@ describe("loadPluginManifestRegistry", () => {
       }),
     ];
 
-    expect(countDuplicateWarnings(loadRegistry(candidates))).toBe(1);
+    const registry = loadRegistry(candidates);
+    expect(countDuplicateWarnings(registry)).toBe(1);
+    // Should deduplicate: only one record, preferring the higher-precedence origin (global > bundled)
+    expect(registry.plugins).toHaveLength(1);
+    expect(registry.plugins[0].origin).toBe("global");
   });
 
   it("suppresses duplicate warning when candidates share the same physical directory via symlink", () => {

--- a/src/plugins/manifest-registry.ts
+++ b/src/plugins/manifest-registry.ts
@@ -229,12 +229,32 @@ export function loadPluginManifestRegistry(params: {
         }
         continue;
       }
-      diagnostics.push({
-        level: "warn",
-        pluginId: manifest.id,
-        source: candidate.source,
-        message: `duplicate plugin id detected; later plugin may be overridden (${candidate.source})`,
-      });
+      // Different directories but same plugin id – prefer higher-precedence
+      // origin (lower rank number) and silently replace, avoiding duplicates.
+      if (PLUGIN_ORIGIN_RANK[candidate.origin] < PLUGIN_ORIGIN_RANK[existing.candidate.origin]) {
+        records[existing.recordIndex] = buildRecord({
+          manifest,
+          candidate,
+          manifestPath: manifestRes.manifestPath,
+          schemaCacheKey,
+          configSchema,
+        });
+        seenIds.set(manifest.id, { candidate, recordIndex: existing.recordIndex });
+        diagnostics.push({
+          level: "info",
+          pluginId: manifest.id,
+          source: candidate.source,
+          message: `duplicate plugin id resolved: preferring ${candidate.origin} over ${existing.candidate.origin} (${existing.candidate.source})`,
+        });
+      } else {
+        diagnostics.push({
+          level: "info",
+          pluginId: manifest.id,
+          source: candidate.source,
+          message: `duplicate plugin id resolved: keeping ${existing.candidate.origin} over ${candidate.origin} (${candidate.source})`,
+        });
+      }
+      continue;
     } else {
       seenIds.set(manifest.id, { candidate, recordIndex: records.length });
     }


### PR DESCRIPTION
When the same plugin is installed both bundled and as a user extension, OpenClaw loads both and emits a confusing `duplicate plugin id detected` warning.

This applies origin-rank priority (`config > workspace > global > bundled`) to resolve duplicates from different directories, keeping only the higher-precedence origin. The diagnostic is downgraded to `info`.

Fixes #38437