### PR TITLE
Fix gateway crash loop on wrapped fetch-failed errors

### DIFF
--- a/src/infra/unhandled-rejections.test.ts
+++ b/src/infra/unhandled-rejections.test.ts
@@ -122,6 +122,13 @@ describe("isTransientNetworkError", () => {
     expect(isTransientNetworkError(error)).toBe(true);
   });
 
+  it("returns true for wrapped fetch-failed without cause chain (e.g. @buape/carbon Discord plugin)", () => {
+    // Third-party libs may wrap TypeError("fetch failed") into a new Error
+    // without preserving the cause — the substring match must still detect it.
+    const error = new Error("Failed to get gateway information from Discord: fetch failed");
+    expect(isTransientNetworkError(error)).toBe(true);
+  });
+
   it("returns false for regular errors without network codes", () => {
     expect(isTransientNetworkError(new Error("Something went wrong"))).toBe(false);
     expect(isTransientNetworkError(new TypeError("Cannot read property"))).toBe(false);

--- a/src/infra/unhandled-rejections.ts
+++ b/src/infra/unhandled-rejections.ts
@@ -58,6 +58,7 @@ const TRANSIENT_NETWORK_MESSAGE_SNIPPETS = [
   "network error",
   "network is unreachable",
   "temporary failure in name resolution",
+  "fetch failed",
 ];
 
 function getErrorCause(err: unknown): unknown {
@@ -167,9 +168,6 @@ export function isTransientNetworkError(err: unknown): boolean {
       continue;
     }
     if (TRANSIENT_NETWORK_MESSAGE_CODE_RE.test(message)) {
-      return true;
-    }
-    if (message === "fetch failed") {
       return true;
     }
     if (TRANSIENT_NETWORK_MESSAGE_SNIPPETS.some((snippet) => message.includes(snippet))) {


### PR DESCRIPTION
## What happened

My Tailscale and Clash Verge (proxy software) were conflicting with each other, which caused Discord connections to fail intermittently. This put the gateway into an infinite crash loop — it would start up, fail to connect to Discord, crash, get restarted by launchd, and crash again, over and over every few seconds. The whole gateway was completely unusable.

## Root cause

When Discord's fetch fails, `@buape/carbon` wraps the original `TypeError: fetch failed` into a new `Error("Failed to get gateway information from Discord: fetch failed")` without preserving the `cause` chain. The unhandled rejection handler only did an exact match on `message === "fetch failed"`, so it didn't recognize the wrapped version as a transient network error — and called `process.exit(1)`.

## Fix

Moved `"fetch failed"` from exact match (`===`) to the substring snippet list (`includes()`), so it catches wrapped messages too. Added a regression test for this scenario.

---

A friend of mine also ran into a similar crash loop before — seems like this can happen whenever Discord connectivity is flaky for whatever reason.