### PR TITLE
fix(browser): screenshot returns file path instead of embedding base64 in context

### DIFF
--- a/src/agents/tools/browser-tool.schema.ts
+++ b/src/agents/tools/browser-tool.schema.ts
@@ -105,6 +105,7 @@ export const BrowserToolSchema = Type.Object({
   frame: Type.Optional(Type.String()),
   labels: Type.Optional(Type.Boolean()),
   fullPage: Type.Optional(Type.Boolean()),
+  embed: Type.Optional(Type.Boolean()),
   ref: Type.Optional(Type.String()),
   element: Type.Optional(Type.String()),
   type: optionalStringEnum(BROWSER_IMAGE_TYPES),

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -31,7 +31,7 @@ import {
   executeTabsAction,
 } from "./browser-tool.actions.js";
 import { BrowserToolSchema } from "./browser-tool.schema.js";
-import { type AnyAgentTool, imageResultFromFile, jsonResult, readStringParam } from "./common.js";
+import { type AnyAgentTool, jsonResult, readStringParam } from "./common.js";
 import { callGatewayTool } from "./gateway.js";
 import {
   listNodes,
@@ -512,11 +512,7 @@ export function createBrowserTool(opts?: {
                 type,
                 profile,
               });
-          return await imageResultFromFile({
-            label: "browser:screenshot",
-            path: result.path,
-            details: result,
-          });
+          return jsonResult(result);
         }
         case "navigate": {
           const targetUrl = readTargetUrlParam(params);

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -296,6 +296,7 @@ export function createBrowserTool(opts?: {
       "When using refs from snapshot (e.g. e12), keep the same tab: prefer passing targetId from the snapshot response into subsequent actions (act/click/type/etc).",
       'For stable, self-resolving refs across calls, use snapshot with refs="aria" (Playwright aria-ref ids). Default refs="role" are role+name-based.',
       "Use snapshot+act for UI automation. Avoid act:wait by default; use only in exceptional cases when no reliable UI state exists.",
+      "screenshot action: by default returns { path, ok } (file path only) to avoid embedding large base64 images (~10k-50k tokens) into context. Pass embed=true only when the LLM needs to visually inspect the image content.",
       `target selects browser location (sandbox|host|node). Default: ${targetDefault}.`,
       hostHint,
     ].join(" "),

--- a/src/agents/tools/browser-tool.ts
+++ b/src/agents/tools/browser-tool.ts
@@ -31,7 +31,7 @@ import {
   executeTabsAction,
 } from "./browser-tool.actions.js";
 import { BrowserToolSchema } from "./browser-tool.schema.js";
-import { type AnyAgentTool, jsonResult, readStringParam } from "./common.js";
+import { type AnyAgentTool, imageResultFromFile, jsonResult, readStringParam } from "./common.js";
 import { callGatewayTool } from "./gateway.js";
 import {
   listNodes,
@@ -488,6 +488,7 @@ export function createBrowserTool(opts?: {
         case "screenshot": {
           const targetId = readStringParam(params, "targetId");
           const fullPage = Boolean(params.fullPage);
+          const embed = Boolean(params.embed);
           const ref = readStringParam(params, "ref");
           const element = readStringParam(params, "element");
           const type = params.type === "jpeg" ? "jpeg" : "png";
@@ -512,6 +513,13 @@ export function createBrowserTool(opts?: {
                 type,
                 profile,
               });
+          if (embed) {
+            return await imageResultFromFile({
+              label: "browser:screenshot",
+              path: result.path,
+              details: result,
+            });
+          }
           return jsonResult(result);
         }
         case "navigate": {


### PR DESCRIPTION
## Problem

When `browser screenshot` is called, the tool currently returns the image via `imageResultFromFile()`, which reads the screenshot file and embeds the full base64-encoded image data directly into the LLM context window.

A single screenshot can consume **tens of thousands of tokens**, easily causing context overflow errors — especially in multi-step agentic workflows where screenshots are used for UI verification.

## Root Cause

In `src/agents/tools/browser-tool.ts`, the `screenshot` case:

```typescript
// Before (problematic)
return await imageResultFromFile({
  label: "browser:screenshot",
  path: result.path,
  details: result,
});
```

The browser server already saves the screenshot to disk and returns a local `path`. There is no need to re-read the file and embed it in the context.

## Fix

Return `jsonResult(result)` instead, which passes the file path through to the agent:

```typescript
// After (fixed)
return jsonResult(result);
```

The agent receives: `{ "path": "/path/to/screenshot.jpg", "ok": true, ... }`

If the agent needs to display the screenshot to a user, it can then explicitly send the file via a channel tool (e.g. `message media=<path>`), which is the correct separation of concerns.

## Verification

Tested in production on macOS (arm64). After the fix:
- `browser screenshot` returns `{ "path": "...", "ok": true }` with no image data in the tool result
- Context window usage drops dramatically in workflows that previously used screenshots for verification steps
- No regressions observed in normal browser automation workflows