### PR TITLE
Fix onboarding tool-profile drift and preflight unsupported Codex Spark auth

### DIFF
--- a/src/agents/model-auth.test.ts
+++ b/src/agents/model-auth.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { AuthProfileStore } from "./auth-profiles.js";
-import { requireApiKey, resolveAwsSdkEnvVarName, resolveModelAuthMode } from "./model-auth.js";
+import {
+  requireApiKey,
+  resolveAwsSdkEnvVarName,
+  resolveModelAuthCompatibilityError,
+  resolveModelAuthMode,
+} from "./model-auth.js";
 
 describe("resolveAwsSdkEnvVarName", () => {
   it("prefers bearer token over access keys and profile", () => {
@@ -115,5 +120,53 @@ describe("requireApiKey", () => {
         "openai",
       ),
     ).toThrow('No API key resolved for provider "openai"');
+  });
+});
+
+describe("resolveModelAuthCompatibilityError", () => {
+  it("rejects codex spark when openai-codex oauth is configured", () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai-codex:default": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "oauth-access",
+          refresh: "oauth-refresh",
+          expires: Date.now() + 60_000,
+        },
+      },
+    };
+
+    expect(
+      resolveModelAuthCompatibilityError({
+        provider: "openai-codex",
+        model: "gpt-5.3-codex-spark",
+        store,
+      }),
+    ).toContain("not supported with OpenAI Codex OAuth");
+  });
+
+  it("allows non-spark codex models with openai-codex oauth", () => {
+    const store: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "openai-codex:default": {
+          type: "oauth",
+          provider: "openai-codex",
+          access: "oauth-access",
+          refresh: "oauth-refresh",
+          expires: Date.now() + 60_000,
+        },
+      },
+    };
+
+    expect(
+      resolveModelAuthCompatibilityError({
+        provider: "openai-codex",
+        model: "gpt-5.3-codex",
+        store,
+      }),
+    ).toBeUndefined();
   });
 });

--- a/src/agents/model-auth.ts
+++ b/src/agents/model-auth.ts
@@ -268,6 +268,7 @@ export async function resolveApiKeyForProvider(params: {
 
 export type EnvApiKeyResult = { apiKey: string; source: string };
 export type ModelAuthMode = "api-key" | "oauth" | "token" | "mixed" | "aws-sdk" | "unknown";
+const OPENAI_CODEX_SPARK_MODEL = "gpt-5.3-codex-spark";
 
 export function resolveEnvApiKey(provider: string): EnvApiKeyResult | null {
   const normalized = normalizeProviderId(provider);
@@ -419,6 +420,37 @@ export function resolveModelAuthMode(
   }
 
   return "unknown";
+}
+
+export function resolveModelAuthCompatibilityError(params: {
+  provider?: string;
+  model?: string;
+  cfg?: OpenClawConfig;
+  store?: AuthProfileStore;
+  agentDir?: string;
+}): string | undefined {
+  const provider = normalizeProviderId(params.provider ?? "");
+  const model = String(params.model ?? "")
+    .trim()
+    .toLowerCase();
+  if (provider !== "openai-codex" || model !== OPENAI_CODEX_SPARK_MODEL) {
+    return undefined;
+  }
+
+  const authStore =
+    params.store ??
+    ensureAuthProfileStore(params.agentDir, {
+      allowKeychainPrompt: false,
+    });
+  const authMode = resolveModelAuthMode(provider, params.cfg, authStore);
+  if (authMode !== "oauth") {
+    return undefined;
+  }
+
+  return [
+    'Model "openai-codex/gpt-5.3-codex-spark" is not supported with OpenAI Codex OAuth (ChatGPT account).',
+    "Use openai-codex/gpt-5.3-codex or openai-codex/gpt-5.4 instead.",
+  ].join(" ");
 }
 
 export async function getApiKeyForModel(params: {

--- a/src/auto-reply/reply/directive-handling.model.test.ts
+++ b/src/auto-reply/reply/directive-handling.model.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelAliasIndex } from "../../agents/model-selection.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -9,11 +9,27 @@ import {
   resolveModelSelectionFromDirective,
 } from "./directive-handling.model.js";
 
+const resolveModelAuthCompatibilityError = vi.hoisted(() =>
+  vi.fn<() => string | undefined>(() => undefined),
+);
+
 // Mock dependencies for directive handling persistence.
 vi.mock("../../agents/agent-scope.js", () => ({
   resolveAgentConfig: vi.fn(() => ({})),
   resolveAgentDir: vi.fn(() => "/tmp/agent"),
   resolveSessionAgentId: vi.fn(() => "main"),
+}));
+
+vi.mock("../../agents/auth-profiles.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/auth-profiles.js")>();
+  return {
+    ...actual,
+    ensureAuthProfileStore: vi.fn(() => ({ version: 1, profiles: {} })),
+  };
+});
+
+vi.mock("../../agents/model-auth.js", () => ({
+  resolveModelAuthCompatibilityError,
 }));
 
 vi.mock("../../agents/sandbox.js", () => ({
@@ -57,7 +73,27 @@ function resolveModelSelectionForCommand(params: {
   });
 }
 
+beforeEach(() => {
+  resolveModelAuthCompatibilityError.mockReset();
+  resolveModelAuthCompatibilityError.mockReturnValue(undefined);
+});
+
 describe("/model chat UX", () => {
+  it("rejects incompatible model/auth combinations before switching", () => {
+    resolveModelAuthCompatibilityError.mockReturnValue(
+      'Model "openai-codex/gpt-5.3-codex-spark" is not supported with OpenAI Codex OAuth (ChatGPT account).',
+    );
+
+    const resolved = resolveModelSelectionForCommand({
+      command: "/model openai-codex/gpt-5.3-codex-spark",
+      allowedModelKeys: new Set(["openai-codex/gpt-5.3-codex-spark"]),
+      allowedModelCatalog: [{ provider: "openai-codex", id: "gpt-5.3-codex-spark" }],
+    });
+
+    expect(resolved.modelSelection).toBeUndefined();
+    expect(resolved.errorText).toContain("not supported with OpenAI Codex OAuth");
+  });
+
   it("shows summary for /model with no args", async () => {
     const directives = parseInlineDirectives("/model");
     const cfg = { commands: { text: true } } as unknown as OpenClawConfig;

--- a/src/auto-reply/reply/directive-handling.model.ts
+++ b/src/auto-reply/reply/directive-handling.model.ts
@@ -1,4 +1,8 @@
-import { resolveAuthStorePathForDisplay } from "../../agents/auth-profiles.js";
+import {
+  ensureAuthProfileStore,
+  resolveAuthStorePathForDisplay,
+} from "../../agents/auth-profiles.js";
+import { resolveModelAuthCompatibilityError } from "../../agents/model-auth.js";
 import {
   type ModelAliasIndex,
   modelKey,
@@ -438,6 +442,21 @@ export function resolveModelSelectionFromDirective(params: {
       return { errorText: profileResolved.error };
     }
     profileOverride = profileResolved.profileId;
+  }
+
+  if (modelSelection) {
+    const compatibilityError = resolveModelAuthCompatibilityError({
+      provider: modelSelection.provider,
+      model: modelSelection.model,
+      cfg: params.cfg,
+      agentDir: params.agentDir,
+      store: ensureAuthProfileStore(params.agentDir, {
+        allowKeychainPrompt: false,
+      }),
+    });
+    if (compatibilityError) {
+      return { errorText: compatibilityError };
+    }
   }
 
   return { modelSelection, profileOverride };

--- a/src/commands/models.set.e2e.test.ts
+++ b/src/commands/models.set.e2e.test.ts
@@ -3,12 +3,19 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const readConfigFileSnapshot = vi.fn();
 const writeConfigFile = vi.fn().mockResolvedValue(undefined);
 const loadConfig = vi.fn().mockReturnValue({});
+const resolveModelAuthCompatibilityError = vi.hoisted(() =>
+  vi.fn<() => string | undefined>(() => undefined),
+);
 
 vi.mock("../config/config.js", () => ({
   CONFIG_PATH: "/tmp/openclaw.json",
   readConfigFileSnapshot,
   writeConfigFile,
   loadConfig,
+}));
+
+vi.mock("../agents/model-auth.js", () => ({
+  resolveModelAuthCompatibilityError,
 }));
 
 function mockConfigSnapshot(config: Record<string, unknown> = {}) {
@@ -55,6 +62,8 @@ describe("models set + fallbacks", () => {
   beforeEach(() => {
     readConfigFileSnapshot.mockClear();
     writeConfigFile.mockClear();
+    resolveModelAuthCompatibilityError.mockReset();
+    resolveModelAuthCompatibilityError.mockReturnValue(undefined);
   });
 
   it("normalizes z.ai provider in models set", async () => {
@@ -124,5 +133,18 @@ describe("models set + fallbacks", () => {
         models: { "anthropic/claude-opus-4-6": {} },
       },
     });
+  });
+
+  it("fails fast when the requested model is incompatible with configured auth", async () => {
+    mockConfigSnapshot({});
+    const runtime = makeRuntime();
+    resolveModelAuthCompatibilityError.mockReturnValue(
+      'Model "openai-codex/gpt-5.3-codex-spark" is not supported with OpenAI Codex OAuth (ChatGPT account).',
+    );
+
+    await expect(modelsSetCommand("openai-codex/gpt-5.3-codex-spark", runtime)).rejects.toThrow(
+      "not supported with OpenAI Codex OAuth",
+    );
+    expect(writeConfigFile).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -1,5 +1,6 @@
 import { listAgentIds } from "../../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
+import { resolveModelAuthCompatibilityError } from "../../agents/model-auth.js";
 import {
   buildModelAliasIndex,
   modelKey,
@@ -185,6 +186,16 @@ export function applyDefaultModelPrimaryUpdate(params: {
 }): OpenClawConfig {
   const resolved = resolveModelTarget({ raw: params.modelRaw, cfg: params.cfg });
   const key = `${resolved.provider}/${resolved.model}`;
+  if (params.field === "model") {
+    const compatibilityError = resolveModelAuthCompatibilityError({
+      provider: resolved.provider,
+      model: resolved.model,
+      cfg: params.cfg,
+    });
+    if (compatibilityError) {
+      throw new Error(compatibilityError);
+    }
+  }
 
   const nextModels = { ...params.cfg.agents?.defaults?.models };
   if (!nextModels[key]) {

--- a/src/commands/onboard-config.test.ts
+++ b/src/commands/onboard-config.test.ts
@@ -49,4 +49,20 @@ describe("applyOnboardingLocalWorkspaceConfig", () => {
 
     expect(result.tools?.profile).toBe("full");
   });
+
+  it("preserves implicit tool access when rerunning onboarding for an existing config", () => {
+    const baseConfig: OpenClawConfig = {
+      tools: {
+        allow: ["group:fs"],
+      },
+    };
+    const result = applyOnboardingLocalWorkspaceConfig(baseConfig, "/tmp/workspace", {
+      hasExistingConfig: true,
+    });
+
+    expect(result.tools).toEqual({
+      allow: ["group:fs"],
+    });
+    expect(result.tools?.profile).toBeUndefined();
+  });
 });

--- a/src/commands/onboard-config.ts
+++ b/src/commands/onboard-config.ts
@@ -8,7 +8,21 @@ export const ONBOARDING_DEFAULT_TOOLS_PROFILE: ToolProfileId = "messaging";
 export function applyOnboardingLocalWorkspaceConfig(
   baseConfig: OpenClawConfig,
   workspaceDir: string,
+  options?: { hasExistingConfig?: boolean },
 ): OpenClawConfig {
+  const nextTools =
+    baseConfig.tools?.profile !== undefined
+      ? {
+          ...baseConfig.tools,
+          profile: baseConfig.tools.profile,
+        }
+      : options?.hasExistingConfig
+        ? baseConfig.tools
+        : {
+            ...baseConfig.tools,
+            profile: ONBOARDING_DEFAULT_TOOLS_PROFILE,
+          };
+
   return {
     ...baseConfig,
     agents: {
@@ -26,9 +40,6 @@ export function applyOnboardingLocalWorkspaceConfig(
       ...baseConfig.session,
       dmScope: baseConfig.session?.dmScope ?? ONBOARDING_DEFAULT_DM_SCOPE,
     },
-    tools: {
-      ...baseConfig.tools,
-      profile: baseConfig.tools?.profile ?? ONBOARDING_DEFAULT_TOOLS_PROFILE,
-    },
+    ...(nextTools ? { tools: nextTools } : {}),
   };
 }

--- a/src/commands/onboard-non-interactive.ts
+++ b/src/commands/onboard-non-interactive.ts
@@ -33,5 +33,10 @@ export async function runNonInteractiveOnboarding(
     return;
   }
 
-  await runNonInteractiveOnboardingLocal({ opts, runtime, baseConfig });
+  await runNonInteractiveOnboardingLocal({
+    opts,
+    runtime,
+    baseConfig,
+    hasExistingConfig: snapshot.exists,
+  });
 }

--- a/src/commands/onboard-non-interactive/local.ts
+++ b/src/commands/onboard-non-interactive/local.ts
@@ -23,6 +23,7 @@ export async function runNonInteractiveOnboardingLocal(params: {
   opts: OnboardOptions;
   runtime: RuntimeEnv;
   baseConfig: OpenClawConfig;
+  hasExistingConfig: boolean;
 }) {
   const { opts, runtime, baseConfig } = params;
   const mode = "local" as const;
@@ -33,7 +34,9 @@ export async function runNonInteractiveOnboardingLocal(params: {
     defaultWorkspaceDir: DEFAULT_WORKSPACE,
   });
 
-  let nextConfig: OpenClawConfig = applyOnboardingLocalWorkspaceConfig(baseConfig, workspaceDir);
+  let nextConfig: OpenClawConfig = applyOnboardingLocalWorkspaceConfig(baseConfig, workspaceDir, {
+    hasExistingConfig: params.hasExistingConfig,
+  });
 
   const inferredAuthChoice = inferAuthChoiceFromFlags(opts);
   if (!opts.authChoice && inferredAuthChoice.matches.length > 1) {

--- a/src/wizard/onboarding.ts
+++ b/src/wizard/onboarding.ts
@@ -407,7 +407,9 @@ export async function runOnboardingWizard(
   const workspaceDir = resolveUserPath(workspaceInput.trim() || onboardHelpers.DEFAULT_WORKSPACE);
 
   const { applyOnboardingLocalWorkspaceConfig } = await import("../commands/onboard-config.js");
-  let nextConfig: OpenClawConfig = applyOnboardingLocalWorkspaceConfig(baseConfig, workspaceDir);
+  let nextConfig: OpenClawConfig = applyOnboardingLocalWorkspaceConfig(baseConfig, workspaceDir, {
+    hasExistingConfig: snapshot.exists,
+  });
 
   const { ensureAuthProfileStore } = await import("../agents/auth-profiles.js");
   const { promptAuthChoiceGrouped } = await import("../commands/auth-choice-prompt.js");


### PR DESCRIPTION
## Summary
- preserve implicit tool access when rerunning local onboarding on an existing config
- fail early when `openai-codex/gpt-5.3-codex-spark` is selected with incompatible OpenAI Codex OAuth auth
- cover both regressions in command and chat model-switch tests

## Problem
Two issues were easy to hit in local Codex-based setups:

1. Rerunning local onboarding against an existing config with no explicit `tools.profile` wrote `tools.profile: messaging`, silently stripping `exec/read/browser` access.
2. Selecting `openai-codex/gpt-5.3-codex-spark` while authenticated through OpenAI Codex OAuth only failed later at runtime with a provider error, so model switches looked like they succeeded and then the agent stopped replying.

## Changes
### Onboarding
- `applyOnboardingLocalWorkspaceConfig` now only injects the `messaging` tool-profile default for new local configs.
- Existing configs without an explicit `tools.profile` keep their current implicit tool access when onboarding is rerun.
- Interactive and non-interactive local onboarding now pass the config-exists signal through to that merge step.

### Model compatibility precheck
- Added `resolveModelAuthCompatibilityError()` in `src/agents/model-auth.ts`.
- `models set` now rejects unsupported `openai-codex/gpt-5.3-codex-spark` + Codex OAuth combinations before writing config.
- Chat `/model ...` switching now returns the same clear error before applying a session override.

## Verification
- `pnpm exec vitest run src/commands/onboard-config.test.ts src/agents/model-auth.test.ts src/auto-reply/reply/directive-handling.model.test.ts`
- `pnpm exec vitest run src/commands/models.set.e2e.test.ts --config vitest.e2e.config.ts`
- `pnpm build`
- `pnpm check`
