### PR TITLE
fix(ui): clear connectTimer in GatewayBrowserClient.stop() to prevent…

### DIFF
--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -137,6 +137,10 @@ export class GatewayBrowserClient {
 
   stop() {
     this.closed = true;
+    if (this.connectTimer !== null) {
+      window.clearTimeout(this.connectTimer);
+      this.connectTimer = null;
+    }
     this.ws?.close();
     this.ws = null;
     this.pendingConnectError = undefined;
@@ -187,7 +191,7 @@ export class GatewayBrowserClient {
   }
 
   private async sendConnect() {
-    if (this.connectSent) {
+    if (this.closed || this.connectSent) {
       return;
     }
     this.connectSent = true;


### PR DESCRIPTION
# fix(ui): clear connectTimer in GatewayBrowserClient.stop()

## Summary

`GatewayBrowserClient.stop()` did not clear the pending `connectTimer` set by `queueConnect()`. If `stop()` was called within the 750ms delay window, the timer callback would still fire and execute `sendConnect()`, triggering unnecessary async crypto operations (device identity loading, payload signing) on a stopped client.

## What Changed

- **`ui/src/ui/gateway.ts`**: Clear `connectTimer` in `stop()` before closing the WebSocket, preventing stale `sendConnect()` callbacks after the client is stopped.

## Existing Functionality Check

- [x] I searched the codebase for existing functionality.
  - Verified `sendConnect()` has no `this.closed` guard, confirming the timer callback would proceed with expensive async work.
  - Confirmed `connect()` already guards with `this.closed` (unrelated `scheduleReconnect` timer), but `sendConnect()` does not.
