### PR TITLE
build: inject package version via __OPENCLAW_VERSION__ define in tsdown

### DIFF
--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -153,6 +153,13 @@ describe("version resolution", () => {
     expect(resolveUsableRuntimeVersion(" 2026.3.2 ")).toBe("2026.3.2");
   });
 
+  it("VERSION matches package.json and is not the 0.0.0 fallback", async () => {
+    const raw = await fs.readFile(path.join(import.meta.dirname, "../package.json"), "utf-8");
+    const pkg = JSON.parse(raw) as { version: string };
+    expect(VERSION).toBe(pkg.version);
+    expect(VERSION).not.toBe("0.0.0");
+  });
+
   it("prefers runtime VERSION over service/package markers and ignores blank env values", () => {
     expect(
       resolveRuntimeServiceVersion({

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,14 @@
+import fs from "node:fs";
 import { defineConfig } from "tsdown";
+
+const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8")) as { version: string };
 
 const env = {
   NODE_ENV: "production",
+};
+
+const define = {
+  __OPENCLAW_VERSION__: JSON.stringify(packageJson.version),
 };
 
 const pluginSdkEntrypoints = [
@@ -51,31 +58,30 @@ const pluginSdkEntrypoints = [
   "keyed-async-queue",
 ] as const;
 
+const shared = {
+  env,
+  define,
+  fixedExtension: false,
+  platform: "node",
+} as const;
+
 export default defineConfig([
   {
     entry: "src/index.ts",
-    env,
-    fixedExtension: false,
-    platform: "node",
+    ...shared,
   },
   {
     entry: "src/entry.ts",
-    env,
-    fixedExtension: false,
-    platform: "node",
+    ...shared,
   },
   {
     // Ensure this module is bundled as an entry so legacy CLI shims can resolve its exports.
     entry: "src/cli/daemon-cli.ts",
-    env,
-    fixedExtension: false,
-    platform: "node",
+    ...shared,
   },
   {
     entry: "src/infra/warning-filter.ts",
-    env,
-    fixedExtension: false,
-    platform: "node",
+    ...shared,
   },
   {
     // Keep sync lazy-runtime channel modules as concrete dist files.
@@ -91,27 +97,19 @@ export default defineConfig([
       "line/send": "src/line/send.ts",
       "line/template-messages": "src/line/template-messages.ts",
     },
-    env,
-    fixedExtension: false,
-    platform: "node",
+    ...shared,
   },
   ...pluginSdkEntrypoints.map((entry) => ({
     entry: `src/plugin-sdk/${entry}.ts`,
     outDir: "dist/plugin-sdk",
-    env,
-    fixedExtension: false,
-    platform: "node" as const,
+    ...shared,
   })),
   {
     entry: "src/extensionAPI.ts",
-    env,
-    fixedExtension: false,
-    platform: "node",
+    ...shared,
   },
   {
     entry: ["src/hooks/bundled/*/handler.ts", "src/hooks/llm-slug-generator.ts"],
-    env,
-    fixedExtension: false,
-    platform: "node",
+    ...shared,
   },
 ]);


### PR DESCRIPTION
The build config (`tsdown.config.ts`) did not inject `__OPENCLAW_VERSION__` at compile time. The bundled `dist/` output relied entirely on runtime `package.json` / `build-info.json` resolution to determine the version, which could return a stale value if build artifacts were produced before the version bump.

Fixes #38473

## Summary

- **Problem:** Control UI and CLI display a stale version (e.g. 2026.2.26) instead of the actual installed version (2026.3.2) because `__OPENCLAW_VERSION__` was never injected during the tsdown build.
- **Why it matters:** Users see a wrong version in the Gateway handshake (`hello-ok.server.version`), Control UI dashboard, and `openclaw status` output.
- **What changed:** Read `package.json` version at build time and inject it via `define: { __OPENCLAW_VERSION__ }` in `tsdown.config.ts`. Added a test asserting `VERSION` matches `package.json`.
- **What did NOT change:** Runtime fallback chain (`import.meta.url` to `package.json` to `build-info.json`) remains intact as a safety net.

## Change Type

- [x] Bug fix
- [x] Chore/infra

## Scope

- [x] Gateway / orchestration
- [x] CI/CD / infra

## Linked Issue/PR

- Closes #38473

## User-visible / Behavior Changes

Gateway handshake, Control UI version chip, and `openclaw status` will now display the correct version matching `package.json`.

## Security Impact

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. `pnpm build` — `dist/` files now contain the correct version string
2. `pnpm test -- src/version.test.ts` — 11/11 passing (includes new assertion)

### Expected

`VERSION` equals `package.json` version at both dev-time and after build.

### Actual (before fix)

`VERSION` could resolve to a stale version from a previous build's `build-info.json` or mismatched `package.json`.
