### PR TITLE
android: align MediaProjection recording with service and capture lifecycle

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeForegroundService.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeForegroundService.kt
@@ -17,47 +17,68 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 
 class NodeForegroundService : Service() {
   private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
   private var notificationJob: Job? = null
-  private var lastRequiresMic = false
-  private var didStartForeground = false
+  @Volatile private var lastRequiresMic = false
+  @Volatile private var lastRequiresMediaProjection = false
+  @Volatile private var didStartForeground = false
+  private var lastNotificationTitle = "OpenClaw Node"
+  private var lastNotificationText = "Starting…"
 
   override fun onCreate() {
     super.onCreate()
+    currentInstance = this
     ensureChannel()
-    val initial = buildNotification(title = "OpenClaw Node", text = "Starting…")
-    startForegroundWithTypes(notification = initial, requiresMic = false)
+    val initial = buildNotification(title = lastNotificationTitle, text = lastNotificationText)
+    startForegroundWithTypes(notification = initial, requiresMic = false, requiresMediaProjection = false)
 
     val runtime = (application as NodeApp).runtime
+    val connectionStateFlow =
+      combine(
+        runtime.statusText,
+        runtime.serverName,
+        runtime.isConnected,
+      ) { status: String, server: String?, connected: Boolean ->
+        ConnectionState(status = status, server = server, connected = connected)
+      }
+    val captureStateFlow =
+      combine(
+        runtime.micEnabled,
+        runtime.micIsListening,
+        runtime.screenRecordActive,
+      ) { micEnabled: Boolean, micListening: Boolean, screenRecordActive: Boolean ->
+        CaptureState(
+          micEnabled = micEnabled,
+          micListening = micListening,
+          screenRecordActive = screenRecordActive,
+        )
+      }
     notificationJob =
       scope.launch {
-        combine(
-          runtime.statusText,
-          runtime.serverName,
-          runtime.isConnected,
-          runtime.micEnabled,
-          runtime.micIsListening,
-        ) { status, server, connected, micEnabled, micListening ->
-          Quint(status, server, connected, micEnabled, micListening)
-        }.collect { (status, server, connected, micEnabled, micListening) ->
-          val title = if (connected) "OpenClaw Node · Connected" else "OpenClaw Node"
+        combine(connectionStateFlow, captureStateFlow) { connection, capture ->
+          ServiceNotificationState(connection = connection, capture = capture)
+        }.collect { state ->
+          val title = if (state.connection.connected) "OpenClaw Node · Connected" else "OpenClaw Node"
           val micSuffix =
-            if (micEnabled) {
-              if (micListening) " · Mic: Listening" else " · Mic: Pending"
+            if (state.capture.micEnabled) {
+              if (state.capture.micListening) " · Mic: Listening" else " · Mic: Pending"
             } else {
               ""
             }
-          val text = (server?.let { "$status · $it" } ?: status) + micSuffix
+          val screenSuffix = if (state.capture.screenRecordActive) " · Screen: Recording" else ""
+          val text = (state.connection.server?.let { "${state.connection.status} · $it" } ?: state.connection.status) + micSuffix + screenSuffix
 
-          val requiresMic =
-            micEnabled && hasRecordAudioPermission()
+          val requiresMic = state.capture.micEnabled && hasRecordAudioPermission()
           startForegroundWithTypes(
             notification = buildNotification(title = title, text = text),
             requiresMic = requiresMic,
+            requiresMediaProjection = state.capture.screenRecordActive,
           )
         }
       }
@@ -70,6 +91,12 @@ class NodeForegroundService : Service() {
         stopSelf()
         return START_NOT_STICKY
       }
+      ACTION_UPDATE_CAPTURE_TYPES -> {
+        applyCaptureTypes(
+          requiresMic = intent.getBooleanExtra(EXTRA_REQUIRES_MIC, false),
+          requiresMediaProjection = intent.getBooleanExtra(EXTRA_REQUIRES_MEDIA_PROJECTION, false),
+        )
+      }
     }
     // Keep running; connection is managed by NodeRuntime (auto-reconnect + manual).
     return START_STICKY
@@ -78,6 +105,9 @@ class NodeForegroundService : Service() {
   override fun onDestroy() {
     notificationJob?.cancel()
     scope.cancel()
+    if (currentInstance === this) {
+      currentInstance = null
+    }
     super.onDestroy()
   }
 
@@ -98,6 +128,9 @@ class NodeForegroundService : Service() {
   }
 
   private fun buildNotification(title: String, text: String): Notification {
+    lastNotificationTitle = title
+    lastNotificationText = text
+
     val launchIntent = Intent(this, MainActivity::class.java).apply {
       flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
     }
@@ -135,22 +168,51 @@ class NodeForegroundService : Service() {
     mgr.notify(NOTIFICATION_ID, notification)
   }
 
-  private fun startForegroundWithTypes(notification: Notification, requiresMic: Boolean) {
-    if (didStartForeground && requiresMic == lastRequiresMic) {
+  private fun startForegroundWithTypes(
+    notification: Notification,
+    requiresMic: Boolean,
+    requiresMediaProjection: Boolean,
+  ) {
+    if (
+      didStartForeground &&
+        requiresMic == lastRequiresMic &&
+        requiresMediaProjection == lastRequiresMediaProjection
+    ) {
       updateNotification(notification)
       return
     }
 
     lastRequiresMic = requiresMic
-    val types =
-      if (requiresMic) {
-        ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
-      } else {
-        ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
-      }
+    lastRequiresMediaProjection = requiresMediaProjection
+    var types = ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+    if (requiresMic) {
+      types = types or ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+    }
+    if (requiresMediaProjection) {
+      types = types or ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
+    }
     startForeground(NOTIFICATION_ID, notification, types)
     didStartForeground = true
   }
+
+  private fun applyCaptureTypes(
+    requiresMic: Boolean,
+    requiresMediaProjection: Boolean,
+  ) {
+    startForegroundWithTypes(
+      notification = buildNotification(title = lastNotificationTitle, text = lastNotificationText),
+      requiresMic = requiresMic,
+      requiresMediaProjection = requiresMediaProjection,
+    )
+  }
+
+  private fun hasForegroundTypes(
+    requiresMic: Boolean,
+    requiresMediaProjection: Boolean,
+  ): Boolean =
+    didStartForeground &&
+      lastRequiresMic == requiresMic &&
+      lastRequiresMediaProjection == requiresMediaProjection
 
   private fun hasRecordAudioPermission(): Boolean {
     return (
@@ -164,6 +226,11 @@ class NodeForegroundService : Service() {
     private const val NOTIFICATION_ID = 1
 
     private const val ACTION_STOP = "ai.openclaw.android.action.STOP"
+    private const val ACTION_UPDATE_CAPTURE_TYPES = "ai.openclaw.android.action.UPDATE_CAPTURE_TYPES"
+    private const val EXTRA_REQUIRES_MIC = "requiresMic"
+    private const val EXTRA_REQUIRES_MEDIA_PROJECTION = "requiresMediaProjection"
+
+    @Volatile private var currentInstance: NodeForegroundService? = null
 
     fun start(context: Context) {
       val intent = Intent(context, NodeForegroundService::class.java)
@@ -174,7 +241,63 @@ class NodeForegroundService : Service() {
       val intent = Intent(context, NodeForegroundService::class.java).setAction(ACTION_STOP)
       context.startService(intent)
     }
+
+    private fun requestCaptureTypes(
+      context: Context,
+      requiresMic: Boolean,
+      requiresMediaProjection: Boolean,
+    ) {
+      val intent =
+        Intent(context, NodeForegroundService::class.java)
+          .setAction(ACTION_UPDATE_CAPTURE_TYPES)
+          .putExtra(EXTRA_REQUIRES_MIC, requiresMic)
+          .putExtra(EXTRA_REQUIRES_MEDIA_PROJECTION, requiresMediaProjection)
+
+      if (currentInstance == null) {
+        context.startForegroundService(intent)
+      } else {
+        context.startService(intent)
+      }
+    }
+
+    suspend fun ensureCaptureTypes(
+      context: Context,
+      requiresMic: Boolean,
+      requiresMediaProjection: Boolean,
+      timeoutMs: Long = 2_000,
+    ) {
+      requestCaptureTypes(
+        context = context,
+        requiresMic = requiresMic,
+        requiresMediaProjection = requiresMediaProjection,
+      )
+
+      withTimeout(timeoutMs) {
+        while (true) {
+          val service = currentInstance
+          if (service != null && service.hasForegroundTypes(requiresMic, requiresMediaProjection)) {
+            return@withTimeout
+          }
+          delay(25)
+        }
+      }
+    }
   }
 }
 
-private data class Quint<A, B, C, D, E>(val first: A, val second: B, val third: C, val fourth: D, val fifth: E)
+private data class ConnectionState(
+  val status: String,
+  val server: String?,
+  val connected: Boolean,
+)
+
+private data class CaptureState(
+  val micEnabled: Boolean,
+  val micListening: Boolean,
+  val screenRecordActive: Boolean,
+)
+
+private data class ServiceNotificationState(
+  val connection: ConnectionState,
+  val capture: CaptureState,
+)

--- a/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt
@@ -121,7 +121,6 @@ class NodeRuntime(context: Context) {
 
   private val screenHandler: ScreenHandler = ScreenHandler(
     screenRecorder = screenRecorder,
-    setScreenRecordActive = { _screenRecordActive.value = it },
     invokeErrorFromThrowable = { invokeErrorFromThrowable(it) },
   )
 
@@ -310,6 +309,7 @@ class NodeRuntime(context: Context) {
     )
 
   init {
+    screenRecorder.attachScreenRecordActiveSetter { _screenRecordActive.value = it }
     DeviceNotificationListenerService.setNodeEventSink { event, payloadJson ->
       scope.launch {
         nodeSession.sendNodeEvent(event = event, payloadJson = payloadJson)

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/ScreenHandler.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/ScreenHandler.kt
@@ -4,22 +4,16 @@ import ai.openclaw.android.gateway.GatewaySession
 
 class ScreenHandler(
   private val screenRecorder: ScreenRecordManager,
-  private val setScreenRecordActive: (Boolean) -> Unit,
   private val invokeErrorFromThrowable: (Throwable) -> Pair<String, String>,
 ) {
   suspend fun handleScreenRecord(paramsJson: String?): GatewaySession.InvokeResult {
-    setScreenRecordActive(true)
-    try {
-      val res =
-        try {
-          screenRecorder.record(paramsJson)
-        } catch (err: Throwable) {
-          val (code, message) = invokeErrorFromThrowable(err)
-          return GatewaySession.InvokeResult.error(code = code, message = message)
-        }
-      return GatewaySession.InvokeResult.ok(res.payloadJson)
-    } finally {
-      setScreenRecordActive(false)
-    }
+    val res =
+      try {
+        screenRecorder.record(paramsJson)
+      } catch (err: Throwable) {
+        val (code, message) = invokeErrorFromThrowable(err)
+        return GatewaySession.InvokeResult.error(code = code, message = message)
+      }
+    return GatewaySession.InvokeResult.ok(res.payloadJson)
   }
 }

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/ScreenRecordManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/ScreenRecordManager.kt
@@ -3,9 +3,12 @@ package ai.openclaw.android.node
 import android.content.Context
 import android.hardware.display.DisplayManager
 import android.media.MediaRecorder
+import android.media.projection.MediaProjection
 import android.media.projection.MediaProjectionManager
-import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.util.Base64
+import ai.openclaw.android.NodeForegroundService
 import ai.openclaw.android.ScreenCaptureRequester
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -19,6 +22,7 @@ class ScreenRecordManager(private val context: Context) {
 
   @Volatile private var screenCaptureRequester: ScreenCaptureRequester? = null
   @Volatile private var permissionRequester: ai.openclaw.android.PermissionRequester? = null
+  @Volatile private var screenRecordActiveSetter: ((Boolean) -> Unit)? = null
 
   fun attachScreenCaptureRequester(requester: ScreenCaptureRequester) {
     screenCaptureRequester = requester
@@ -26,6 +30,10 @@ class ScreenRecordManager(private val context: Context) {
 
   fun attachPermissionRequester(requester: ai.openclaw.android.PermissionRequester) {
     permissionRequester = requester
+  }
+
+  fun attachScreenRecordActiveSetter(setter: (Boolean) -> Unit) {
+    screenRecordActiveSetter = setter
   }
 
   suspend fun record(paramsJson: String?): Payload =
@@ -50,15 +58,33 @@ class ScreenRecordManager(private val context: Context) {
         throw IllegalArgumentException("INVALID_REQUEST: screenIndex must be 0 on Android")
       }
 
-      val capture = requester.requestCapture()
-        ?: throw IllegalStateException(
-          "SCREEN_PERMISSION_REQUIRED: grant Screen Recording permission",
-        )
+      if (includeAudio) ensureMicPermission()
+
+      NodeForegroundService.ensureCaptureTypes(
+        context = context,
+        requiresMic = includeAudio,
+        requiresMediaProjection = true,
+      )
+
+      val capture =
+        requester.requestCapture()
+          ?: throw IllegalStateException(
+            "SCREEN_PERMISSION_REQUIRED: grant Screen Recording permission",
+          )
+      screenRecordActiveSetter?.invoke(true)
 
       val mgr =
         context.getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
-      val projection = mgr.getMediaProjection(capture.resultCode, capture.data)
-        ?: throw IllegalStateException("UNAVAILABLE: screen capture unavailable")
+      val projection =
+        mgr.getMediaProjection(capture.resultCode, capture.data)
+          ?: throw IllegalStateException("UNAVAILABLE: screen capture unavailable")
+      val projectionCallback =
+        object : MediaProjection.Callback() {
+          override fun onStop() {
+            screenRecordActiveSetter?.invoke(false)
+          }
+        }
+      projection.registerCallback(projectionCallback, Handler(Looper.getMainLooper()))
 
       val metrics = context.resources.displayMetrics
       val width = metrics.widthPixels
@@ -66,8 +92,6 @@ class ScreenRecordManager(private val context: Context) {
       val densityDpi = metrics.densityDpi
 
       val file = File.createTempFile("openclaw-screen-", ".mp4")
-      if (includeAudio) ensureMicPermission()
-
       val recorder = createMediaRecorder()
       var virtualDisplay: android.hardware.display.VirtualDisplay? = null
       try {
@@ -113,7 +137,9 @@ class ScreenRecordManager(private val context: Context) {
         recorder.reset()
         recorder.release()
         virtualDisplay?.release()
+        projection.unregisterCallback(projectionCallback)
         projection.stop()
+        screenRecordActiveSetter?.invoke(false)
       }
 
       val bytes = withContext(Dispatchers.IO) { file.readBytes() }

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/ScreenRecordManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/ScreenRecordManager.kt
@@ -60,17 +60,17 @@ class ScreenRecordManager(private val context: Context) {
 
       if (includeAudio) ensureMicPermission()
 
-      NodeForegroundService.ensureCaptureTypes(
-        context = context,
-        requiresMic = includeAudio,
-        requiresMediaProjection = true,
-      )
-
       val capture =
         requester.requestCapture()
           ?: throw IllegalStateException(
             "SCREEN_PERMISSION_REQUIRED: grant Screen Recording permission",
           )
+
+      NodeForegroundService.ensureCaptureTypes(
+        context = context,
+        requiresMic = includeAudio,
+        requiresMediaProjection = true,
+      )
 
       val mgr =
         context.getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/ScreenRecordManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/ScreenRecordManager.kt
@@ -85,15 +85,17 @@ class ScreenRecordManager(private val context: Context) {
         }
       projection.registerCallback(projectionCallback, Handler(Looper.getMainLooper()))
 
-      val metrics = context.resources.displayMetrics
-      val width = metrics.widthPixels
-      val height = metrics.heightPixels
-      val densityDpi = metrics.densityDpi
-
-      val file = File.createTempFile("openclaw-screen-", ".mp4")
-      val recorder = createMediaRecorder()
+      var recorder: MediaRecorder? = null
       var virtualDisplay: android.hardware.display.VirtualDisplay? = null
+      var file: File? = null
       try {
+        val metrics = context.resources.displayMetrics
+        val width = metrics.widthPixels
+        val height = metrics.heightPixels
+        val densityDpi = metrics.densityDpi
+
+        file = File.createTempFile("openclaw-screen-", ".mp4")
+        recorder = createMediaRecorder()
         if (includeAudio) {
           recorder.setAudioSource(MediaRecorder.AudioSource.MIC)
         }
@@ -130,20 +132,20 @@ class ScreenRecordManager(private val context: Context) {
         delay(durationMs.toLong())
       } finally {
         try {
-          recorder.stop()
+          recorder?.stop()
         } catch (_: Throwable) {
           // ignore
         }
-        recorder.reset()
-        recorder.release()
+        recorder?.reset()
+        recorder?.release()
         virtualDisplay?.release()
         projection.unregisterCallback(projectionCallback)
         projection.stop()
         screenRecordActiveSetter?.invoke(false)
       }
 
-      val bytes = withContext(Dispatchers.IO) { file.readBytes() }
-      file.delete()
+      val bytes = withContext(Dispatchers.IO) { file?.readBytes() ?: ByteArray(0) }
+      file?.delete()
       val base64 = Base64.encodeToString(bytes, Base64.NO_WRAP)
       Payload(
         """{"format":"mp4","base64":"$base64","durationMs":$durationMs,"fps":$fpsInt,"screenIndex":0,"hasAudio":$includeAudio}""",

--- a/apps/android/app/src/main/java/ai/openclaw/android/node/ScreenRecordManager.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/android/node/ScreenRecordManager.kt
@@ -71,7 +71,6 @@ class ScreenRecordManager(private val context: Context) {
           ?: throw IllegalStateException(
             "SCREEN_PERMISSION_REQUIRED: grant Screen Recording permission",
           )
-      screenRecordActiveSetter?.invoke(true)
 
       val mgr =
         context.getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
@@ -126,6 +125,7 @@ class ScreenRecordManager(private val context: Context) {
             null,
           )
 
+        screenRecordActiveSetter?.invoke(true)
         recorder.start()
         delay(durationMs.toLong())
       } finally {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `screen.record` could fail on newer Android versions even after screen-capture consent, due to stricter MediaProjection foreground-service and callback requirements.
- Why it matters: this breaks remote screen recording on supported Android nodes and can also cause recording state to drift from the real capture lifecycle.
- What changed: this PR aligns screen recording with Android's service/capture lifecycle by explicitly ensuring required foreground-service types before capture, moving recording-active state ownership into `ScreenRecordManager`, and registering/unregistering `MediaProjection.Callback` around the actual capture lifecycle.
- What did NOT change (scope boundary): this PR does not introduce consent-result caching/reuse; it keeps the fix focused on correctness and lifecycle alignment rather than UX optimization.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #38328

## User-visible / Behavior Changes

- `screen.record` now succeeds on the tested Android device where it previously failed.
- Recording state is now aligned with the actual capture lifecycle instead of being toggled too early in the request path.
- Audio-enabled screen recording was also verified on the tested device.
- No change to consent UX/caching behavior in this PR.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation:

None.

## Repro + Verification

### Environment

- OS: Android 15 (tested device: Xiaomi Pad 5 Pro)
- Runtime/container: Android node app
- Model/provider: N/A
- Integration/channel (if any): OpenClaw node `screen.record`
- Relevant config (redacted): default Android node setup with screen recording permission granted

### Steps

1. Install the Android node app build before this fix.
2. Trigger `screen.record` from OpenClaw against the Android node.
3. Observe failure related to MediaProjection foreground service / callback requirements.
4. Install the patched build from this PR.
5. Trigger `screen.record` again without audio.
6. Trigger `screen.record` again with audio enabled.

### Expected

- Screen recording should succeed on newer Android versions once user/system requirements are satisfied.
- Recording state should reflect the real capture lifecycle.

### Actual

- Before this fix, recording failed with MediaProjection-related errors.
- After this fix, both silent and audio-enabled recordings completed successfully and returned playable MP4 output.

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [x] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- `screen.record` failed before the fix with MediaProjection foreground-service type errors.
- After the fix, short screen recordings without audio succeeded.
- After the fix, short screen recordings with audio succeeded.
- Returned MP4 output was manually played back and verified.

- Edge cases checked:
- Verified both no-audio and audio-enabled capture paths.
- Verified that recording-active state is no longer toggled early in `ScreenHandler`.
- What you did not verify:
- Broader multi-device Android matrix.
- Long-duration recordings.
- Behavior of consent reuse/caching across repeated app/session lifecycle transitions.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

None.

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Revert this commit or restore the previous versions of the touched Android files.
- Files/config to restore:
- `apps/android/app/src/main/java/ai/openclaw/android/NodeForegroundService.kt`
- `apps/android/app/src/main/java/ai/openclaw/android/NodeRuntime.kt`
- `apps/android/app/src/main/java/ai/openclaw/android/node/ScreenHandler.kt`
- `apps/android/app/src/main/java/ai/openclaw/android/node/ScreenRecordManager.kt`
- Known bad symptoms reviewers should watch for:
- `screen.record` failing again with MediaProjection foreground-service type errors
- `screen.record` failing with callback-registration errors
- recording state showing active before capture is actually established

## Risks and Mitigations

- Risk: lifecycle handling around screen recording is more explicit and touches multiple Android-side files.
- Mitigation: changes are intentionally limited to the screen-recording path and were manually verified on-device for both silent and audio-enabled recording.

- Risk: reviewers may prefer consent-result caching as part of the Android 14+ fix.
- Mitigation: this PR intentionally keeps scope focused on correctness and lifecycle alignment; consent caching can be evaluated separately as a UX optimization with its own invalidation strategy.

## Notes on difference from #38328

Compared with approaches that only update foreground-service flags and callback registration, this PR also aligns recording state ownership and transition timing with the actual capture lifecycle.


In particular, it:
- explicitly ensures the required foreground-service types before capture starts
- moves screen-recording active-state ownership into `ScreenRecordManager`
- aligns state transitions with the real capture lifecycle instead of the early request path
- registers and unregisters `MediaProjection.Callback`
- intentionally avoids bundling consent-result caching into the correctness fix

The goal is to keep the fix focused on correctness, state ownership, and safer lifecycle behavior on newer Android versions.


