### PR TITLE
fix(agents): broaden 402 temporary-limit detection and allow billing cooldown probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -361,6 +361,7 @@ Docs: https://docs.openclaw.ai
 - Discord/config schema parity: add `channels.discord.agentComponents` to the strict Zod config schema so valid `agentComponents.enabled` settings (root and account-scoped) no longer fail with unrecognized-key validation errors. Landed from contributor PR #39378 by @gambletan. Thanks @gambletan and @thewilloftheshadow.
 - ACPX/MCP session bootstrap: inject configured MCP servers into ACP `session/new` and `session/load` for acpx-backed sessions, restoring Canva and other external MCP tools. Landed from contributor PR #39337. Thanks @goodspeed-apps.
 - Control UI/Telegram sender labels: preserve inbound sender labels in sanitized chat history so dashboard user-message groups split correctly and show real group-member names instead of `You`. (#39414) Thanks @obviyus.
+- Agents/failover 402 recovery: keep temporary spend-limit `402` payloads retryable, preserve explicit insufficient-credit billing detection even in long provider payloads, and allow throttled billing-cooldown probes so single-provider setups can recover instead of staying locked out. (#38533) Thanks @xialonglee.
 
 ## 2026.3.2
 

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -241,6 +241,21 @@ describe("failover-error", () => {
     ).toBe("rate_limit");
   });
 
+  it("keeps plan-upgrade 402 wrappers aligned with status-split billing payloads", () => {
+    const message = "Your usage limit has been reached. Please upgrade your plan.";
+    expect(
+      resolveFailoverReasonFromError({
+        message: `HTTP 402 Payment Required: ${message}`,
+      }),
+    ).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message,
+      }),
+    ).toBe("billing");
+  });
+
   it("infers format errors from error messages", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -18,6 +18,8 @@ const GEMINI_RESOURCE_EXHAUSTED_MESSAGE =
   "RESOURCE_EXHAUSTED: Resource has been exhausted (e.g. check quota).";
 // OpenRouter 402 billing example: https://openrouter.ai/docs/api-reference/errors
 const OPENROUTER_CREDITS_MESSAGE = "Payment Required: insufficient credits";
+const TOGETHER_MONTHLY_SPEND_CAP_MESSAGE =
+  "The account associated with this API key has reached its maximum allowed monthly spending limit.";
 // Issue-backed Anthropic/OpenAI-compatible insufficient_quota payload under HTTP 400:
 // https://github.com/openclaw/openclaw/issues/23440
 const INSUFFICIENT_QUOTA_PAYLOAD =
@@ -201,6 +203,27 @@ describe("failover-error", () => {
         message: `${"x".repeat(520)} insufficient credits. Monthly spend limit reached.`,
       }),
     ).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message: TOGETHER_MONTHLY_SPEND_CAP_MESSAGE,
+      }),
+    ).toBe("billing");
+  });
+
+  it("keeps raw 402 wrappers aligned with status-split temporary spend limits", () => {
+    const message = "Monthly spend limit reached. Please visit your billing settings.";
+    expect(
+      resolveFailoverReasonFromError({
+        message: `402 Payment Required: ${message}`,
+      }),
+    ).toBe("rate_limit");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message,
+      }),
+    ).toBe("rate_limit");
   });
 
   it("infers format errors from error messages", () => {

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -182,6 +182,68 @@ describe("failover-error", () => {
     ).toBe("billing");
   });
 
+  it("treats 402 with periodic usage limit as rate_limit", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message: "Monthly spend limit reached. Please visit your billing settings.",
+      }),
+    ).toBe("rate_limit");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message: "Weekly usage limit exhausted for this plan.",
+      }),
+    ).toBe("rate_limit");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message: "Daily limit reached. Your limit will reset tomorrow.",
+      }),
+    ).toBe("rate_limit");
+  });
+
+  it("treats 402 with organization/workspace limit as rate_limit", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message: "Organization spending limit exceeded.",
+      }),
+    ).toBe("rate_limit");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message: "Workspace spend limit reached. Contact your admin.",
+      }),
+    ).toBe("rate_limit");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message: "Organization limit exceeded for this billing period.",
+      }),
+    ).toBe("rate_limit");
+  });
+
+  it("keeps 402 with explicit billing signals as billing even with limit language", () => {
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message: "Your credit balance is too low. Monthly limit exceeded.",
+      }),
+    ).toBe("billing");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message: "Insufficient credits. Spend limit reached.",
+      }),
+    ).toBe("billing");
+  });
+
+  it("keeps 402 without message body as billing", () => {
+    expect(resolveFailoverReasonFromError({ status: 402 })).toBe("billing");
+    expect(resolveFailoverReasonFromError({ status: 402, message: undefined })).toBe("billing");
+  });
+
   it("infers format errors from error messages", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -226,6 +226,21 @@ describe("failover-error", () => {
     ).toBe("rate_limit");
   });
 
+  it("keeps explicit 402 rate-limit wrappers aligned with status-split payloads", () => {
+    const message = "rate limit exceeded";
+    expect(
+      resolveFailoverReasonFromError({
+        message: `HTTP 402 Payment Required: ${message}`,
+      }),
+    ).toBe("rate_limit");
+    expect(
+      resolveFailoverReasonFromError({
+        status: 402,
+        message,
+      }),
+    ).toBe("rate_limit");
+  });
+
   it("infers format errors from error messages", () => {
     expect(
       resolveFailoverReasonFromError({

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -182,32 +182,11 @@ describe("failover-error", () => {
     ).toBe("billing");
   });
 
-  it("treats 402 with periodic usage limit as rate_limit", () => {
+  it("keeps temporary 402 spend limits retryable without downgrading explicit billing", () => {
     expect(
       resolveFailoverReasonFromError({
         status: 402,
         message: "Monthly spend limit reached. Please visit your billing settings.",
-      }),
-    ).toBe("rate_limit");
-    expect(
-      resolveFailoverReasonFromError({
-        status: 402,
-        message: "Weekly usage limit exhausted for this plan.",
-      }),
-    ).toBe("rate_limit");
-    expect(
-      resolveFailoverReasonFromError({
-        status: 402,
-        message: "Daily limit reached. Your limit will reset tomorrow.",
-      }),
-    ).toBe("rate_limit");
-  });
-
-  it("treats 402 with organization/workspace limit as rate_limit", () => {
-    expect(
-      resolveFailoverReasonFromError({
-        status: 402,
-        message: "Organization spending limit exceeded.",
       }),
     ).toBe("rate_limit");
     expect(
@@ -219,29 +198,9 @@ describe("failover-error", () => {
     expect(
       resolveFailoverReasonFromError({
         status: 402,
-        message: "Organization limit exceeded for this billing period.",
-      }),
-    ).toBe("rate_limit");
-  });
-
-  it("keeps 402 with explicit billing signals as billing even with limit language", () => {
-    expect(
-      resolveFailoverReasonFromError({
-        status: 402,
-        message: "Your credit balance is too low. Monthly limit exceeded.",
+        message: `${"x".repeat(520)} insufficient credits. Monthly spend limit reached.`,
       }),
     ).toBe("billing");
-    expect(
-      resolveFailoverReasonFromError({
-        status: 402,
-        message: "Insufficient credits. Spend limit reached.",
-      }),
-    ).toBe("billing");
-  });
-
-  it("keeps 402 without message body as billing", () => {
-    expect(resolveFailoverReasonFromError({ status: 402 })).toBe("billing");
-    expect(resolveFailoverReasonFromError({ status: 402, message: undefined })).toBe("billing");
   });
 
   it("infers format errors from error messages", () => {

--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -346,7 +346,7 @@ describe("runWithModelFallback – probe logic", () => {
     });
   });
 
-  it("probes billing-cooldowned primary when no fallback candidates exist", async () => {
+  it("skips billing-cooldowned primary when no fallback candidates exist", async () => {
     const cfg = makeCfg({
       agents: {
         defaults: {
@@ -363,54 +363,15 @@ describe("runWithModelFallback – probe logic", () => {
     mockedGetSoonestCooldownExpiry.mockReturnValue(expiresIn30Min);
     mockedResolveProfilesUnavailableReason.mockReturnValue("billing");
 
-    const run = vi.fn().mockResolvedValue("billing-recovered");
-
-    const result = await runWithModelFallback({
-      cfg,
-      provider: "openai",
-      model: "gpt-4.1-mini",
-      fallbacksOverride: [],
-      run,
-    });
-
-    expect(result.result).toBe("billing-recovered");
-    expect(run).toHaveBeenCalledTimes(1);
-    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini", {
-      allowTransientCooldownProbe: true,
-    });
-  });
-
-  it("throttles billing probe for single-candidate at 30s intervals", async () => {
-    const cfg = makeCfg({
-      agents: {
-        defaults: {
-          model: {
-            primary: "openai/gpt-4.1-mini",
-            fallbacks: [],
-          },
-        },
-      },
-    } as Partial<OpenClawConfig>);
-
-    mockedGetSoonestCooldownExpiry.mockReturnValue(NOW + 30 * 60 * 1000);
-    mockedResolveProfilesUnavailableReason.mockReturnValue("billing");
-
-    // Simulate a recent probe 10s ago
-    _probeThrottleInternals.lastProbeAttempt.set("openai", NOW - 10_000);
-
-    const run = vi.fn().mockResolvedValue("unreachable");
-
     await expect(
       runWithModelFallback({
         cfg,
         provider: "openai",
         model: "gpt-4.1-mini",
         fallbacksOverride: [],
-        run,
+        run: vi.fn().mockResolvedValue("billing-recovered"),
       }),
     ).rejects.toThrow("All models failed");
-
-    expect(run).not.toHaveBeenCalled();
   });
 
   it("probes billing-cooldowned primary with fallbacks when near cooldown expiry", async () => {

--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -345,4 +345,105 @@ describe("runWithModelFallback – probe logic", () => {
       allowTransientCooldownProbe: true,
     });
   });
+
+  it("probes billing-cooldowned primary when no fallback candidates exist", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: [],
+          },
+        },
+      },
+    } as Partial<OpenClawConfig>);
+
+    // Billing cooldown far from expiry — would normally be skipped
+    const expiresIn30Min = NOW + 30 * 60 * 1000;
+    mockedGetSoonestCooldownExpiry.mockReturnValue(expiresIn30Min);
+    mockedResolveProfilesUnavailableReason.mockReturnValue("billing");
+
+    const run = vi.fn().mockResolvedValue("billing-recovered");
+
+    const result = await runWithModelFallback({
+      cfg,
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      fallbacksOverride: [],
+      run,
+    });
+
+    expect(result.result).toBe("billing-recovered");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini", {
+      allowTransientCooldownProbe: true,
+    });
+  });
+
+  it("throttles billing probe for single-candidate at 30s intervals", async () => {
+    const cfg = makeCfg({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-4.1-mini",
+            fallbacks: [],
+          },
+        },
+      },
+    } as Partial<OpenClawConfig>);
+
+    mockedGetSoonestCooldownExpiry.mockReturnValue(NOW + 30 * 60 * 1000);
+    mockedResolveProfilesUnavailableReason.mockReturnValue("billing");
+
+    // Simulate a recent probe 10s ago
+    _probeThrottleInternals.lastProbeAttempt.set("openai", NOW - 10_000);
+
+    const run = vi.fn().mockResolvedValue("unreachable");
+
+    await expect(
+      runWithModelFallback({
+        cfg,
+        provider: "openai",
+        model: "gpt-4.1-mini",
+        fallbacksOverride: [],
+        run,
+      }),
+    ).rejects.toThrow("All models failed");
+
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("probes billing-cooldowned primary with fallbacks when near cooldown expiry", async () => {
+    const cfg = makeCfg();
+    // Cooldown expires in 1 minute — within 2-min probe margin
+    const expiresIn1Min = NOW + 60 * 1000;
+    mockedGetSoonestCooldownExpiry.mockReturnValue(expiresIn1Min);
+    mockedResolveProfilesUnavailableReason.mockReturnValue("billing");
+
+    const run = vi.fn().mockResolvedValue("billing-probe-ok");
+
+    const result = await runPrimaryCandidate(cfg, run);
+
+    expect(result.result).toBe("billing-probe-ok");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("openai", "gpt-4.1-mini", {
+      allowTransientCooldownProbe: true,
+    });
+  });
+
+  it("skips billing-cooldowned primary with fallbacks when far from cooldown expiry", async () => {
+    const cfg = makeCfg();
+    const expiresIn30Min = NOW + 30 * 60 * 1000;
+    mockedGetSoonestCooldownExpiry.mockReturnValue(expiresIn30Min);
+    mockedResolveProfilesUnavailableReason.mockReturnValue("billing");
+
+    const run = vi.fn().mockResolvedValue("ok");
+
+    const result = await runPrimaryCandidate(cfg, run);
+
+    expect(result.result).toBe("ok");
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("anthropic", "claude-haiku-3-5");
+    expect(result.attempts[0]?.reason).toBe("billing");
+  });
 });

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -419,11 +419,30 @@ function resolveCooldownDecision(params: {
       profileIds: params.profileIds,
       now: params.now,
     }) ?? "rate_limit";
-  const isPersistentIssue =
-    inferredReason === "auth" ||
-    inferredReason === "auth_permanent" ||
-    inferredReason === "billing";
-  if (isPersistentIssue) {
+  const isPersistentAuthIssue = inferredReason === "auth" || inferredReason === "auth_permanent";
+  if (isPersistentAuthIssue) {
+    return {
+      type: "skip",
+      reason: inferredReason,
+      error: `Provider ${params.candidate.provider} has ${inferredReason} issue (skipping all models)`,
+    };
+  }
+
+  // Billing is semi-persistent: the user may fix their balance, or a transient
+  // 402 might have been misclassified. Without fallback candidates, skipping is
+  // guaranteed failure so we attempt (throttled). With fallbacks, probe the
+  // primary when the standard probe schedule allows.
+  if (inferredReason === "billing") {
+    if (params.isPrimary) {
+      if (!params.hasFallbackCandidates) {
+        const lastProbe = lastProbeAttempt.get(params.probeThrottleKey) ?? 0;
+        if (params.now - lastProbe >= MIN_PROBE_INTERVAL_MS) {
+          return { type: "attempt", reason: inferredReason, markProbe: true };
+        }
+      } else if (shouldProbe) {
+        return { type: "attempt", reason: inferredReason, markProbe: true };
+      }
+    }
     return {
       type: "skip",
       reason: inferredReason,
@@ -518,7 +537,11 @@ export async function runWithModelFallback<T>(params: {
         if (decision.markProbe) {
           lastProbeAttempt.set(probeThrottleKey, now);
         }
-        if (decision.reason === "rate_limit" || decision.reason === "overloaded") {
+        if (
+          decision.reason === "rate_limit" ||
+          decision.reason === "overloaded" ||
+          decision.reason === "billing"
+        ) {
           runOptions = { allowTransientCooldownProbe: true };
         }
       }

--- a/src/agents/model-fallback.ts
+++ b/src/agents/model-fallback.ts
@@ -429,19 +429,12 @@ function resolveCooldownDecision(params: {
   }
 
   // Billing is semi-persistent: the user may fix their balance, or a transient
-  // 402 might have been misclassified. Without fallback candidates, skipping is
-  // guaranteed failure so we attempt (throttled). With fallbacks, probe the
-  // primary when the standard probe schedule allows.
+  // 402 might have been misclassified. Probe the primary only when fallbacks
+  // exist; otherwise repeated single-provider probes just churn the disabled
+  // auth state without opening any recovery path.
   if (inferredReason === "billing") {
-    if (params.isPrimary) {
-      if (!params.hasFallbackCandidates) {
-        const lastProbe = lastProbeAttempt.get(params.probeThrottleKey) ?? 0;
-        if (params.now - lastProbe >= MIN_PROBE_INTERVAL_MS) {
-          return { type: "attempt", reason: inferredReason, markProbe: true };
-        }
-      } else if (shouldProbe) {
-        return { type: "attempt", reason: inferredReason, markProbe: true };
-      }
+    if (params.isPrimary && params.hasFallbackCandidates && shouldProbe) {
+      return { type: "attempt", reason: inferredReason, markProbe: true };
     }
     return {
       type: "skip",

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -542,6 +542,12 @@ describe("classifyFailoverReasonFromHttpStatus – 402 temporary limits", () => 
         "Insufficient credits. Organization limit reached.",
       ),
     ).toBe("billing");
+    expect(
+      classifyFailoverReasonFromHttpStatus(
+        402,
+        "The account associated with this API key has reached its maximum allowed monthly spending limit.",
+      ),
+    ).toBe("billing");
   });
 
   it("keeps long 402 payloads with explicit billing text as billing", () => {
@@ -553,6 +559,17 @@ describe("classifyFailoverReasonFromHttpStatus – 402 temporary limits", () => 
     expect(classifyFailoverReasonFromHttpStatus(402, undefined)).toBe("billing");
     expect(classifyFailoverReasonFromHttpStatus(402, "")).toBe("billing");
     expect(classifyFailoverReasonFromHttpStatus(402, "Payment required")).toBe("billing");
+  });
+
+  it("matches raw 402 wrappers and status-split payloads for the same message", () => {
+    const transientMessage = "Monthly spend limit reached. Please visit your billing settings.";
+    expect(classifyFailoverReason(`402 Payment Required: ${transientMessage}`)).toBe("rate_limit");
+    expect(classifyFailoverReasonFromHttpStatus(402, transientMessage)).toBe("rate_limit");
+
+    const billingMessage =
+      "The account associated with this API key has reached its maximum allowed monthly spending limit.";
+    expect(classifyFailoverReason(`402 Payment Required: ${billingMessage}`)).toBe("billing");
+    expect(classifyFailoverReasonFromHttpStatus(402, billingMessage)).toBe("billing");
   });
 });
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   classifyFailoverReason,
+  classifyFailoverReasonFromHttpStatus,
   isAuthErrorMessage,
   isAuthPermanentErrorMessage,
   isBillingErrorMessage,
@@ -502,6 +503,56 @@ describe("image dimension errors", () => {
     expect(parsed?.messageIndex).toBe(84);
     expect(parsed?.contentIndex).toBe(1);
     expect(isImageDimensionErrorMessage(raw)).toBe(true);
+  });
+});
+
+describe("classifyFailoverReasonFromHttpStatus – 402 temporary limits", () => {
+  it("reclassifies 402 with periodic usage limit as rate_limit", () => {
+    expect(classifyFailoverReasonFromHttpStatus(402, "Monthly spend limit reached.")).toBe(
+      "rate_limit",
+    );
+    expect(classifyFailoverReasonFromHttpStatus(402, "Weekly usage limit exhausted.")).toBe(
+      "rate_limit",
+    );
+    expect(classifyFailoverReasonFromHttpStatus(402, "Daily limit reached, resets tomorrow.")).toBe(
+      "rate_limit",
+    );
+  });
+
+  it("reclassifies 402 with organization/workspace limit as rate_limit", () => {
+    expect(classifyFailoverReasonFromHttpStatus(402, "Organization spending limit exceeded.")).toBe(
+      "rate_limit",
+    );
+    expect(classifyFailoverReasonFromHttpStatus(402, "Workspace spend limit reached.")).toBe(
+      "rate_limit",
+    );
+    expect(
+      classifyFailoverReasonFromHttpStatus(
+        402,
+        "Organization limit exceeded for this billing period.",
+      ),
+    ).toBe("rate_limit");
+  });
+
+  it("keeps 402 as billing when explicit billing signals are present", () => {
+    expect(
+      classifyFailoverReasonFromHttpStatus(
+        402,
+        "Your credit balance is too low. Monthly limit exceeded.",
+      ),
+    ).toBe("billing");
+    expect(
+      classifyFailoverReasonFromHttpStatus(
+        402,
+        "Insufficient credits. Organization limit reached.",
+      ),
+    ).toBe("billing");
+  });
+
+  it("keeps 402 as billing without message or with generic message", () => {
+    expect(classifyFailoverReasonFromHttpStatus(402, undefined)).toBe("billing");
+    expect(classifyFailoverReasonFromHttpStatus(402, "")).toBe("billing");
+    expect(classifyFailoverReasonFromHttpStatus(402, "Payment required")).toBe("billing");
   });
 });
 

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -571,6 +571,14 @@ describe("classifyFailoverReasonFromHttpStatus – 402 temporary limits", () => 
     expect(classifyFailoverReason(`402 Payment Required: ${billingMessage}`)).toBe("billing");
     expect(classifyFailoverReasonFromHttpStatus(402, billingMessage)).toBe("billing");
   });
+
+  it("keeps explicit 402 rate-limit messages in the rate_limit lane", () => {
+    const transientMessage = "rate limit exceeded";
+    expect(classifyFailoverReason(`HTTP 402 Payment Required: ${transientMessage}`)).toBe(
+      "rate_limit",
+    );
+    expect(classifyFailoverReasonFromHttpStatus(402, transientMessage)).toBe("rate_limit");
+  });
 });
 
 describe("classifyFailoverReason", () => {

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -579,6 +579,12 @@ describe("classifyFailoverReasonFromHttpStatus – 402 temporary limits", () => 
     );
     expect(classifyFailoverReasonFromHttpStatus(402, transientMessage)).toBe("rate_limit");
   });
+
+  it("keeps plan-upgrade 402 limit messages in billing", () => {
+    const billingMessage = "Your usage limit has been reached. Please upgrade your plan.";
+    expect(classifyFailoverReason(`HTTP 402 Payment Required: ${billingMessage}`)).toBe("billing");
+    expect(classifyFailoverReasonFromHttpStatus(402, billingMessage)).toBe("billing");
+  });
 });
 
 describe("classifyFailoverReason", () => {

--- a/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
+++ b/src/agents/pi-embedded-helpers.isbillingerrormessage.test.ts
@@ -507,31 +507,26 @@ describe("image dimension errors", () => {
 });
 
 describe("classifyFailoverReasonFromHttpStatus – 402 temporary limits", () => {
-  it("reclassifies 402 with periodic usage limit as rate_limit", () => {
-    expect(classifyFailoverReasonFromHttpStatus(402, "Monthly spend limit reached.")).toBe(
-      "rate_limit",
-    );
-    expect(classifyFailoverReasonFromHttpStatus(402, "Weekly usage limit exhausted.")).toBe(
-      "rate_limit",
-    );
-    expect(classifyFailoverReasonFromHttpStatus(402, "Daily limit reached, resets tomorrow.")).toBe(
-      "rate_limit",
-    );
+  it("reclassifies periodic usage limits as rate_limit", () => {
+    const samples = [
+      "Monthly spend limit reached.",
+      "Weekly usage limit exhausted.",
+      "Daily limit reached, resets tomorrow.",
+    ];
+    for (const sample of samples) {
+      expect(classifyFailoverReasonFromHttpStatus(402, sample)).toBe("rate_limit");
+    }
   });
 
-  it("reclassifies 402 with organization/workspace limit as rate_limit", () => {
-    expect(classifyFailoverReasonFromHttpStatus(402, "Organization spending limit exceeded.")).toBe(
-      "rate_limit",
-    );
-    expect(classifyFailoverReasonFromHttpStatus(402, "Workspace spend limit reached.")).toBe(
-      "rate_limit",
-    );
-    expect(
-      classifyFailoverReasonFromHttpStatus(
-        402,
-        "Organization limit exceeded for this billing period.",
-      ),
-    ).toBe("rate_limit");
+  it("reclassifies org/workspace spend limits as rate_limit", () => {
+    const samples = [
+      "Organization spending limit exceeded.",
+      "Workspace spend limit reached.",
+      "Organization limit exceeded for this billing period.",
+    ];
+    for (const sample of samples) {
+      expect(classifyFailoverReasonFromHttpStatus(402, sample)).toBe("rate_limit");
+    }
   });
 
   it("keeps 402 as billing when explicit billing signals are present", () => {
@@ -547,6 +542,11 @@ describe("classifyFailoverReasonFromHttpStatus – 402 temporary limits", () => 
         "Insufficient credits. Organization limit reached.",
       ),
     ).toBe("billing");
+  });
+
+  it("keeps long 402 payloads with explicit billing text as billing", () => {
+    const longBillingPayload = `${"x".repeat(520)} insufficient credits. Monthly spend limit reached.`;
+    expect(classifyFailoverReasonFromHttpStatus(402, longBillingPayload)).toBe("billing");
   });
 
   it("keeps 402 as billing without message or with generic message", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -208,8 +208,9 @@ const HTTP_ERROR_HINTS = [
   "permission",
 ];
 
+type Http402Reason = "billing" | "rate_limit";
+
 const BILLING_402_HINTS = [
-  "payment required",
   "insufficient credits",
   "insufficient quota",
   "credit balance",
@@ -221,9 +222,20 @@ const BILLING_402_HINTS = [
 
 const RETRYABLE_402_RETRY_HINTS = ["try again", "retry", "temporary", "cooldown"] as const;
 const RETRYABLE_402_LIMIT_HINTS = ["usage limit", "rate limit", "organization usage"] as const;
-const RETRYABLE_402_SPEND_HINTS = ["spend limit", "spending limit"] as const;
-const RETRYABLE_402_SCOPE_HINTS = ["organization", "workspace"] as const;
-const RETRYABLE_402_SCOPE_LIMIT_HINTS = ["limit", "exceeded"] as const;
+const BILLING_402_HARD_CAP_RE =
+  /\b(?:billing hard limit|hard limit reached|maximum allowed(?:\s+(?:daily|weekly|monthly))?(?:\s+spend(?:ing)?)?\s+limit)\b/i;
+const RAW_402_MARKER_RE =
+  /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment required\b/i;
+const LEADING_402_WRAPPER_RE =
+  /^(?:error[:\s-]+)?(?:(?:http\s*)?402(?:\s+payment required)?|payment required)(?:[:\s-]+|$)/i;
+const RETRYABLE_402_PERIODIC_USAGE_OR_SPEND_RE =
+  /\b(?:daily|weekly|monthly)(?:\/(?:daily|weekly|monthly))*\s+(?:usage|spend(?:ing)?)\s+limit(?:s)?(?:\s+(?:exhausted|reached|exceeded))?\b/i;
+const RETRYABLE_402_SCOPED_SPEND_LIMIT_RE =
+  /\b(?:organization|workspace)\s+(?:spend(?:ing)?\s+)?limit(?:s)?(?:\s+(?:reached|exhausted|exceeded))?\b/i;
+const RETRYABLE_402_SCOPED_LIMIT_EXCEEDED_RE =
+  /\b(?:organization|workspace)\b[\s\S]{0,30}\blimit(?:s)?\b[\s\S]{0,30}\bexceeded\b/i;
+const RETRYABLE_402_SCOPED_BILLING_PERIOD_RE =
+  /\b(?:organization|workspace)\b[\s\S]{0,30}\blimit(?:s)?\b[\s\S]{0,30}\bbilling period\b/i;
 
 function includesAnyHint(text: string, hints: readonly string[]): boolean {
   const lower = text.toLowerCase();
@@ -231,35 +243,54 @@ function includesAnyHint(text: string, hints: readonly string[]): boolean {
 }
 
 function hasExplicit402BillingSignal(text: string): boolean {
-  return includesAnyHint(text, BILLING_402_HINTS);
+  return includesAnyHint(text, BILLING_402_HINTS) || BILLING_402_HARD_CAP_RE.test(text);
 }
 
-function hasRetryable402UsageSignal(text: string): boolean {
+function hasRetryable402TransientSignal(text: string): boolean {
+  const lower = text.toLowerCase();
   return (
-    includesAnyHint(text, RETRYABLE_402_RETRY_HINTS) &&
-    includesAnyHint(text, RETRYABLE_402_LIMIT_HINTS)
+    (includesAnyHint(text, RETRYABLE_402_RETRY_HINTS) &&
+      includesAnyHint(text, RETRYABLE_402_LIMIT_HINTS)) ||
+    RETRYABLE_402_PERIODIC_USAGE_OR_SPEND_RE.test(text) ||
+    (includesAnyHint(lower, ["daily", "weekly", "monthly"]) &&
+      lower.includes("limit") &&
+      lower.includes("reset")) ||
+    RETRYABLE_402_SCOPED_SPEND_LIMIT_RE.test(text) ||
+    RETRYABLE_402_SCOPED_LIMIT_EXCEEDED_RE.test(text) ||
+    RETRYABLE_402_SCOPED_BILLING_PERIOD_RE.test(text)
   );
 }
 
-function shouldTreat402AsRateLimit(raw: string): boolean {
-  if (hasExplicit402BillingSignal(raw)) {
-    return false;
+function normalize402Message(raw: string): string {
+  let normalized = raw.trim();
+  while (LEADING_402_WRAPPER_RE.test(normalized)) {
+    normalized = normalized.replace(LEADING_402_WRAPPER_RE, "").trim();
+  }
+  return normalized;
+}
+
+function classify402Message(message: string): Http402Reason {
+  const normalized = normalize402Message(message);
+  if (!normalized) {
+    return "billing";
   }
 
-  if (hasRetryable402UsageSignal(raw)) {
-    return true;
+  if (hasExplicit402BillingSignal(normalized)) {
+    return "billing";
   }
 
-  if (isPeriodicUsageLimitErrorMessage(raw)) {
-    return true;
+  if (hasRetryable402TransientSignal(normalized)) {
+    return "rate_limit";
   }
 
-  return (
-    includesAnyHint(raw, RETRYABLE_402_SPEND_HINTS) ||
-    includesAnyHint(raw, RETRYABLE_402_LIMIT_HINTS) ||
-    (includesAnyHint(raw, RETRYABLE_402_SCOPE_HINTS) &&
-      includesAnyHint(raw, RETRYABLE_402_SCOPE_LIMIT_HINTS))
-  );
+  return "billing";
+}
+
+function classifyFailoverReasonFromRaw402Message(raw: string): Http402Reason | null {
+  if (!RAW_402_MARKER_RE.test(raw)) {
+    return null;
+  }
+  return classify402Message(raw);
 }
 
 function extractLeadingHttpStatus(raw: string): { code: number; rest: string } | null {
@@ -315,12 +346,7 @@ export function classifyFailoverReasonFromHttpStatus(
   }
 
   if (status === 402) {
-    // Some providers surface temporary usage caps as HTTP 402. Keep those
-    // retryable, but let explicit insufficient-credit signals stay billing.
-    if (message && shouldTreat402AsRateLimit(message)) {
-      return "rate_limit";
-    }
-    return "billing";
+    return message ? classify402Message(message) : "billing";
   }
   if (status === 429) {
     return "rate_limit";
@@ -898,6 +924,10 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   }
   if (isModelNotFoundErrorMessage(raw)) {
     return "model_not_found";
+  }
+  const raw402Reason = classifyFailoverReasonFromRaw402Message(raw);
+  if (raw402Reason) {
+    return raw402Reason;
   }
   if (isPeriodicUsageLimitErrorMessage(raw)) {
     return isBillingErrorMessage(raw) ? "billing" : "rate_limit";

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -219,6 +219,12 @@ const BILLING_402_HINTS = [
   "add more credits",
   "top up",
 ] as const;
+const BILLING_402_PLAN_HINTS = [
+  "upgrade your plan",
+  "upgrade plan",
+  "current plan",
+  "subscription",
+] as const;
 
 const PERIODIC_402_HINTS = ["daily", "weekly", "monthly"] as const;
 const RETRYABLE_402_RETRY_HINTS = ["try again", "retry", "temporary", "cooldown"] as const;
@@ -242,6 +248,7 @@ function includesAnyHint(text: string, hints: readonly string[]): boolean {
 function hasExplicit402BillingSignal(text: string): boolean {
   return (
     includesAnyHint(text, BILLING_402_HINTS) ||
+    (includesAnyHint(text, BILLING_402_PLAN_HINTS) && text.includes("limit")) ||
     text.includes("billing hard limit") ||
     text.includes("hard limit reached") ||
     (text.includes("maximum allowed") && text.includes("limit"))

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -208,6 +208,51 @@ const HTTP_ERROR_HINTS = [
   "permission",
 ];
 
+function hasExplicitBillingSignalIn402Message(raw: string): boolean {
+  const lower = raw.toLowerCase();
+  return (
+    lower.includes("payment required") ||
+    lower.includes("insufficient credits") ||
+    lower.includes("insufficient quota") ||
+    lower.includes("credit balance") ||
+    lower.includes("insufficient balance") ||
+    lower.includes("plans & billing") ||
+    lower.includes("add more credits") ||
+    lower.includes("top up")
+  );
+}
+
+function isTemporary402LimitMessage(raw: string): boolean {
+  if (hasExplicitBillingSignalIn402Message(raw)) {
+    return false;
+  }
+
+  const lower = raw.toLowerCase();
+  const hasTemporaryRetrySignal =
+    (lower.includes("try again") ||
+      lower.includes("retry") ||
+      lower.includes("temporary") ||
+      lower.includes("cooldown")) &&
+    (lower.includes("usage limit") ||
+      lower.includes("rate limit") ||
+      lower.includes("organization usage"));
+  if (hasTemporaryRetrySignal) {
+    return true;
+  }
+
+  if (isPeriodicUsageLimitErrorMessage(raw)) {
+    return true;
+  }
+
+  return (
+    lower.includes("spend limit") ||
+    lower.includes("spending limit") ||
+    lower.includes("organization usage") ||
+    ((lower.includes("organization") || lower.includes("workspace")) &&
+      (lower.includes("limit") || lower.includes("exceeded")))
+  );
+}
+
 function extractLeadingHttpStatus(raw: string): { code: number; rest: string } | null {
   const match = raw.match(HTTP_STATUS_CODE_PREFIX_RE);
   if (!match) {
@@ -261,39 +306,10 @@ export function classifyFailoverReasonFromHttpStatus(
   }
 
   if (status === 402) {
-    // Some providers (e.g. Anthropic Claude Max plan) surface temporary
-    // usage/rate-limit failures as HTTP 402. Detect temporary limits to
-    // avoid misclassifying them as persistent billing failures (#30484).
-    if (message) {
-      const lower = message.toLowerCase();
-      // Explicit retry language + usage/limit terminology
-      const hasTemporaryRetrySignal =
-        (lower.includes("try again") ||
-          lower.includes("retry") ||
-          lower.includes("temporary") ||
-          lower.includes("cooldown")) &&
-        (lower.includes("usage limit") ||
-          lower.includes("rate limit") ||
-          lower.includes("organization usage"));
-      if (hasTemporaryRetrySignal) {
-        return "rate_limit";
-      }
-      // Periodic usage limits (daily/weekly/monthly) are inherently temporary
-      // and should not trigger persistent billing cooldown, unless the message
-      // also contains explicit billing signals (e.g. "insufficient credits").
-      if (isPeriodicUsageLimitErrorMessage(message) && !isBillingErrorMessage(message)) {
-        return "rate_limit";
-      }
-      // Spending/organization/workspace limits are typically resettable caps
-      // set by the organization admin, not permanent credit-balance failures.
-      const hasSpendOrOrgLimitSignal =
-        lower.includes("spend limit") ||
-        lower.includes("spending limit") ||
-        ((lower.includes("organization") || lower.includes("workspace")) &&
-          (lower.includes("limit") || lower.includes("exceeded")));
-      if (hasSpendOrOrgLimitSignal && !isBillingErrorMessage(message)) {
-        return "rate_limit";
-      }
+    // Some providers surface temporary usage caps as HTTP 402. Keep those
+    // retryable, but let explicit insufficient-credit signals stay billing.
+    if (message && isTemporary402LimitMessage(message)) {
+      return "rate_limit";
     }
     return "billing";
   }

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -262,12 +262,12 @@ export function classifyFailoverReasonFromHttpStatus(
 
   if (status === 402) {
     // Some providers (e.g. Anthropic Claude Max plan) surface temporary
-    // usage/rate-limit failures as HTTP 402. Use a narrow matcher for
-    // temporary limits to avoid misclassifying billing failures (#30484).
+    // usage/rate-limit failures as HTTP 402. Detect temporary limits to
+    // avoid misclassifying them as persistent billing failures (#30484).
     if (message) {
       const lower = message.toLowerCase();
-      // Temporary usage limit signals: retry language + usage/limit terminology
-      const hasTemporarySignal =
+      // Explicit retry language + usage/limit terminology
+      const hasTemporaryRetrySignal =
         (lower.includes("try again") ||
           lower.includes("retry") ||
           lower.includes("temporary") ||
@@ -275,7 +275,23 @@ export function classifyFailoverReasonFromHttpStatus(
         (lower.includes("usage limit") ||
           lower.includes("rate limit") ||
           lower.includes("organization usage"));
-      if (hasTemporarySignal) {
+      if (hasTemporaryRetrySignal) {
+        return "rate_limit";
+      }
+      // Periodic usage limits (daily/weekly/monthly) are inherently temporary
+      // and should not trigger persistent billing cooldown, unless the message
+      // also contains explicit billing signals (e.g. "insufficient credits").
+      if (isPeriodicUsageLimitErrorMessage(message) && !isBillingErrorMessage(message)) {
+        return "rate_limit";
+      }
+      // Spending/organization/workspace limits are typically resettable caps
+      // set by the organization admin, not permanent credit-balance failures.
+      const hasSpendOrOrgLimitSignal =
+        lower.includes("spend limit") ||
+        lower.includes("spending limit") ||
+        ((lower.includes("organization") || lower.includes("workspace")) &&
+          (lower.includes("limit") || lower.includes("exceeded")));
+      if (hasSpendOrOrgLimitSignal && !isBillingErrorMessage(message)) {
         return "rate_limit";
       }
     }

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -277,6 +277,10 @@ function classify402Message(message: string): PaymentRequiredFailoverReason {
     return "billing";
   }
 
+  if (isRateLimitErrorMessage(normalized)) {
+    return "rate_limit";
+  }
+
   if (hasRetryable402TransientSignal(normalized)) {
     return "rate_limit";
   }

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -208,7 +208,7 @@ const HTTP_ERROR_HINTS = [
   "permission",
 ];
 
-type Http402Reason = "billing" | "rate_limit";
+type PaymentRequiredFailoverReason = Extract<FailoverReason, "billing" | "rate_limit">;
 
 const BILLING_402_HINTS = [
   "insufficient credits",
@@ -220,56 +220,54 @@ const BILLING_402_HINTS = [
   "top up",
 ] as const;
 
+const PERIODIC_402_HINTS = ["daily", "weekly", "monthly"] as const;
 const RETRYABLE_402_RETRY_HINTS = ["try again", "retry", "temporary", "cooldown"] as const;
 const RETRYABLE_402_LIMIT_HINTS = ["usage limit", "rate limit", "organization usage"] as const;
-const BILLING_402_HARD_CAP_RE =
-  /\b(?:billing hard limit|hard limit reached|maximum allowed(?:\s+(?:daily|weekly|monthly))?(?:\s+spend(?:ing)?)?\s+limit)\b/i;
+const RETRYABLE_402_SCOPED_HINTS = ["organization", "workspace"] as const;
+const RETRYABLE_402_SCOPED_RESULT_HINTS = [
+  "billing period",
+  "exceeded",
+  "reached",
+  "exhausted",
+] as const;
 const RAW_402_MARKER_RE =
   /["']?(?:status|code)["']?\s*[:=]\s*402\b|\bhttp\s*402\b|\berror(?:\s+code)?\s*[:=]?\s*402\b|\b(?:got|returned|received)\s+(?:a\s+)?402\b|^\s*402\s+payment required\b/i;
 const LEADING_402_WRAPPER_RE =
   /^(?:error[:\s-]+)?(?:(?:http\s*)?402(?:\s+payment required)?|payment required)(?:[:\s-]+|$)/i;
-const RETRYABLE_402_PERIODIC_USAGE_OR_SPEND_RE =
-  /\b(?:daily|weekly|monthly)(?:\/(?:daily|weekly|monthly))*\s+(?:usage|spend(?:ing)?)\s+limit(?:s)?(?:\s+(?:exhausted|reached|exceeded))?\b/i;
-const RETRYABLE_402_SCOPED_SPEND_LIMIT_RE =
-  /\b(?:organization|workspace)\s+(?:spend(?:ing)?\s+)?limit(?:s)?(?:\s+(?:reached|exhausted|exceeded))?\b/i;
-const RETRYABLE_402_SCOPED_LIMIT_EXCEEDED_RE =
-  /\b(?:organization|workspace)\b[\s\S]{0,30}\blimit(?:s)?\b[\s\S]{0,30}\bexceeded\b/i;
-const RETRYABLE_402_SCOPED_BILLING_PERIOD_RE =
-  /\b(?:organization|workspace)\b[\s\S]{0,30}\blimit(?:s)?\b[\s\S]{0,30}\bbilling period\b/i;
 
 function includesAnyHint(text: string, hints: readonly string[]): boolean {
-  const lower = text.toLowerCase();
-  return hints.some((hint) => lower.includes(hint));
+  return hints.some((hint) => text.includes(hint));
 }
 
 function hasExplicit402BillingSignal(text: string): boolean {
-  return includesAnyHint(text, BILLING_402_HINTS) || BILLING_402_HARD_CAP_RE.test(text);
+  return (
+    includesAnyHint(text, BILLING_402_HINTS) ||
+    text.includes("billing hard limit") ||
+    text.includes("hard limit reached") ||
+    (text.includes("maximum allowed") && text.includes("limit"))
+  );
 }
 
 function hasRetryable402TransientSignal(text: string): boolean {
-  const lower = text.toLowerCase();
+  const hasPeriodicHint = includesAnyHint(text, PERIODIC_402_HINTS);
+  const hasSpendLimit = text.includes("spend limit") || text.includes("spending limit");
+  const hasScopedHint = includesAnyHint(text, RETRYABLE_402_SCOPED_HINTS);
   return (
     (includesAnyHint(text, RETRYABLE_402_RETRY_HINTS) &&
       includesAnyHint(text, RETRYABLE_402_LIMIT_HINTS)) ||
-    RETRYABLE_402_PERIODIC_USAGE_OR_SPEND_RE.test(text) ||
-    (includesAnyHint(lower, ["daily", "weekly", "monthly"]) &&
-      lower.includes("limit") &&
-      lower.includes("reset")) ||
-    RETRYABLE_402_SCOPED_SPEND_LIMIT_RE.test(text) ||
-    RETRYABLE_402_SCOPED_LIMIT_EXCEEDED_RE.test(text) ||
-    RETRYABLE_402_SCOPED_BILLING_PERIOD_RE.test(text)
+    (hasPeriodicHint && (text.includes("usage limit") || hasSpendLimit)) ||
+    (hasPeriodicHint && text.includes("limit") && text.includes("reset")) ||
+    (hasScopedHint &&
+      text.includes("limit") &&
+      (hasSpendLimit || includesAnyHint(text, RETRYABLE_402_SCOPED_RESULT_HINTS)))
   );
 }
 
 function normalize402Message(raw: string): string {
-  let normalized = raw.trim();
-  while (LEADING_402_WRAPPER_RE.test(normalized)) {
-    normalized = normalized.replace(LEADING_402_WRAPPER_RE, "").trim();
-  }
-  return normalized;
+  return raw.trim().toLowerCase().replace(LEADING_402_WRAPPER_RE, "").trim();
 }
 
-function classify402Message(message: string): Http402Reason {
+function classify402Message(message: string): PaymentRequiredFailoverReason {
   const normalized = normalize402Message(message);
   if (!normalized) {
     return "billing";
@@ -286,7 +284,7 @@ function classify402Message(message: string): Http402Reason {
   return "billing";
 }
 
-function classifyFailoverReasonFromRaw402Message(raw: string): Http402Reason | null {
+function classifyFailoverReasonFrom402Text(raw: string): PaymentRequiredFailoverReason | null {
   if (!RAW_402_MARKER_RE.test(raw)) {
     return null;
   }
@@ -925,9 +923,9 @@ export function classifyFailoverReason(raw: string): FailoverReason | null {
   if (isModelNotFoundErrorMessage(raw)) {
     return "model_not_found";
   }
-  const raw402Reason = classifyFailoverReasonFromRaw402Message(raw);
-  if (raw402Reason) {
-    return raw402Reason;
+  const reasonFrom402Text = classifyFailoverReasonFrom402Text(raw);
+  if (reasonFrom402Text) {
+    return reasonFrom402Text;
   }
   if (isPeriodicUsageLimitErrorMessage(raw)) {
     return isBillingErrorMessage(raw) ? "billing" : "rate_limit";

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -208,35 +208,45 @@ const HTTP_ERROR_HINTS = [
   "permission",
 ];
 
-function hasExplicitBillingSignalIn402Message(raw: string): boolean {
-  const lower = raw.toLowerCase();
+const BILLING_402_HINTS = [
+  "payment required",
+  "insufficient credits",
+  "insufficient quota",
+  "credit balance",
+  "insufficient balance",
+  "plans & billing",
+  "add more credits",
+  "top up",
+] as const;
+
+const RETRYABLE_402_RETRY_HINTS = ["try again", "retry", "temporary", "cooldown"] as const;
+const RETRYABLE_402_LIMIT_HINTS = ["usage limit", "rate limit", "organization usage"] as const;
+const RETRYABLE_402_SPEND_HINTS = ["spend limit", "spending limit"] as const;
+const RETRYABLE_402_SCOPE_HINTS = ["organization", "workspace"] as const;
+const RETRYABLE_402_SCOPE_LIMIT_HINTS = ["limit", "exceeded"] as const;
+
+function includesAnyHint(text: string, hints: readonly string[]): boolean {
+  const lower = text.toLowerCase();
+  return hints.some((hint) => lower.includes(hint));
+}
+
+function hasExplicit402BillingSignal(text: string): boolean {
+  return includesAnyHint(text, BILLING_402_HINTS);
+}
+
+function hasRetryable402UsageSignal(text: string): boolean {
   return (
-    lower.includes("payment required") ||
-    lower.includes("insufficient credits") ||
-    lower.includes("insufficient quota") ||
-    lower.includes("credit balance") ||
-    lower.includes("insufficient balance") ||
-    lower.includes("plans & billing") ||
-    lower.includes("add more credits") ||
-    lower.includes("top up")
+    includesAnyHint(text, RETRYABLE_402_RETRY_HINTS) &&
+    includesAnyHint(text, RETRYABLE_402_LIMIT_HINTS)
   );
 }
 
-function isTemporary402LimitMessage(raw: string): boolean {
-  if (hasExplicitBillingSignalIn402Message(raw)) {
+function shouldTreat402AsRateLimit(raw: string): boolean {
+  if (hasExplicit402BillingSignal(raw)) {
     return false;
   }
 
-  const lower = raw.toLowerCase();
-  const hasTemporaryRetrySignal =
-    (lower.includes("try again") ||
-      lower.includes("retry") ||
-      lower.includes("temporary") ||
-      lower.includes("cooldown")) &&
-    (lower.includes("usage limit") ||
-      lower.includes("rate limit") ||
-      lower.includes("organization usage"));
-  if (hasTemporaryRetrySignal) {
+  if (hasRetryable402UsageSignal(raw)) {
     return true;
   }
 
@@ -245,11 +255,10 @@ function isTemporary402LimitMessage(raw: string): boolean {
   }
 
   return (
-    lower.includes("spend limit") ||
-    lower.includes("spending limit") ||
-    lower.includes("organization usage") ||
-    ((lower.includes("organization") || lower.includes("workspace")) &&
-      (lower.includes("limit") || lower.includes("exceeded")))
+    includesAnyHint(raw, RETRYABLE_402_SPEND_HINTS) ||
+    includesAnyHint(raw, RETRYABLE_402_LIMIT_HINTS) ||
+    (includesAnyHint(raw, RETRYABLE_402_SCOPE_HINTS) &&
+      includesAnyHint(raw, RETRYABLE_402_SCOPE_LIMIT_HINTS))
   );
 }
 
@@ -308,7 +317,7 @@ export function classifyFailoverReasonFromHttpStatus(
   if (status === 402) {
     // Some providers surface temporary usage caps as HTTP 402. Keep those
     // retryable, but let explicit insufficient-credit signals stay billing.
-    if (message && isTemporary402LimitMessage(message)) {
+    if (message && shouldTreat402AsRateLimit(message)) {
       return "rate_limit";
     }
     return "billing";

--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -668,7 +668,9 @@ export async function runEmbeddedPiAgent(
         const allowTransientCooldownProbe =
           params.allowTransientCooldownProbe === true &&
           allAutoProfilesInCooldown &&
-          (unavailableReason === "rate_limit" || unavailableReason === "overloaded");
+          (unavailableReason === "rate_limit" ||
+            unavailableReason === "overloaded" ||
+            unavailableReason === "billing");
         let didTransientCooldownProbe = false;
 
         while (profileIndex < profileCandidates.length) {


### PR DESCRIPTION
fix #38465

## Summary

- **Problem**: OpenClaw misclassifies Anthropic (and other providers) HTTP 402 responses as persistent "billing" issues, even when the error is a temporary usage/spend limit (e.g. monthly spend limit, organization usage limit). Users with active credits and working direct API calls see "Provider anthropic has billing issue (skipping all models)" indefinitely.
- **Why it matters**: Misclassification leads to 5+ hour cooldowns with no recovery path. Single-provider setups are fully locked out; multi-provider setups skip the primary until manual intervention.
- **What changed**: (1) Broaden 402 classification to treat periodic usage limits and org/workspace spend limits as `rate_limit`; (2) Treat billing as semi-persistent in model-fallback, allowing probes when no fallbacks exist (30s throttle) or when fallbacks exist (near cooldown expiry).
- **What did NOT change**: Auth/auth_permanent remain persistent (no probes). Explicit billing signals (credit balance, insufficient credits) still classify as billing. Cooldown durations and auth profile storage are unchanged.

## Change Type

- [x] Bug fix

## Linked Issue/PR

- Closes #38465


## User-visible / Behavior Changes

- **Classification**: 402 responses with periodic usage limits (daily/weekly/monthly) or org/workspace spend limits are now classified as `rate_limit` instead of `billing`, enabling fallback and probe behavior.
- **Recovery**: Billing-cooldowned providers can be probed again: every 30s when no fallbacks exist, or near cooldown expiry when fallbacks exist. Previously they were skipped indefinitely.

## Repro + Verification

### Steps

1. Configure Anthropic as the only provider with active credits.
2. Trigger a 402 from Anthropic (e.g. workspace spend limit, or transient 402).
3. Observe classification and cooldown behavior.

### Expected

- Temporary 402s (periodic limits, org spend limits) → `rate_limit` → fallback/probe allowed.
- Explicit billing (credit balance, insufficient credits) → `billing` → cooldown with probe recovery.

### Actual (before fix)

- All 402s → `billing` → indefinite skip, no probes.


