### PR TITLE
Add ClawNexus community plugin

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -38,6 +38,19 @@ Search, e-commerce sites, and more — just by asking.
 openclaw plugins install @apify/apify-openclaw-plugin
 ```
 
+### ClawNexus
+
+Discovers OpenClaw instances on your network (mDNS, UDP broadcast, HTTP
+probing) and gives them human-readable names. Runs the discovery daemon as an
+embedded Gateway service.
+
+- **npm:** `clawnexus-plugin`
+- **repo:** [github.com/Lattice9AI/ClawNexus](https://github.com/Lattice9AI/ClawNexus)
+
+```bash
+openclaw plugins install clawnexus-plugin
+```
+
 ### Codex App Server Bridge
 
 Independent OpenClaw bridge for Codex App Server conversations. Bind a chat to


### PR DESCRIPTION
Adds ClawNexus to the community plugins page.

ClawNexus is a daemon that discovers OpenClaw instances on LAN (mDNS, UDP broadcast, HTTP probing) and keeps a local registry with human-readable names. It also has a relay for connecting instances across different networks.

Install via `openclaw plugins install clawnexus-plugin`. The plugin runs the daemon as an embedded Gateway service — no separate process needed.

There's also a standalone install (`npm install -g clawnexus`) for running it outside OpenClaw, and a Skill package (`clawnexus-skill`) for agent-level access.

- npm: [clawnexus-plugin](https://www.npmjs.com/package/clawnexus-plugin)
- MIT licensed