### PR TITLE
CLI: sync inherited session model state after default model changes

### DIFF
--- a/src/commands/models.set.e2e.test.ts
+++ b/src/commands/models.set.e2e.test.ts
@@ -3,6 +3,25 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 const readConfigFileSnapshot = vi.fn();
 const writeConfigFile = vi.fn().mockResolvedValue(undefined);
 const loadConfig = vi.fn().mockReturnValue({});
+const resolveStorePath = vi.hoisted(() => vi.fn(() => "/tmp/main.sessions.json"));
+const updateSessionStore = vi.hoisted(() =>
+  vi.fn(
+    async (
+      _storePath: string,
+      updater: (store: Record<string, Record<string, unknown>>) => unknown,
+    ) => {
+      const store = {
+        "agent:main:main": {
+          sessionId: "s1",
+          updatedAt: 1,
+          modelProvider: "anthropic",
+          model: "claude-opus-4-5",
+        },
+      };
+      return await updater(store);
+    },
+  ),
+);
 
 vi.mock("../config/config.js", () => ({
   CONFIG_PATH: "/tmp/openclaw.json",
@@ -10,6 +29,15 @@ vi.mock("../config/config.js", () => ({
   writeConfigFile,
   loadConfig,
 }));
+
+vi.mock("../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/sessions.js")>();
+  return {
+    ...actual,
+    resolveStorePath,
+    updateSessionStore,
+  };
+});
 
 function mockConfigSnapshot(config: Record<string, unknown> = {}) {
   readConfigFileSnapshot.mockResolvedValue({
@@ -55,6 +83,8 @@ describe("models set + fallbacks", () => {
   beforeEach(() => {
     readConfigFileSnapshot.mockClear();
     writeConfigFile.mockClear();
+    resolveStorePath.mockClear();
+    updateSessionStore.mockClear();
   });
 
   it("normalizes z.ai provider in models set", async () => {
@@ -124,5 +154,17 @@ describe("models set + fallbacks", () => {
         models: { "anthropic/claude-opus-4-6": {} },
       },
     });
+  });
+
+  it("clears stale runtime model snapshots for sessions inheriting the old default", async () => {
+    mockConfigSnapshot({ agents: { defaults: { model: "anthropic/claude-opus-4-5" } } });
+    const runtime = makeRuntime();
+
+    await modelsSetCommand("openai/gpt-5.4", runtime);
+
+    expect(updateSessionStore).toHaveBeenCalledWith(
+      "/tmp/main.sessions.json",
+      expect.any(Function),
+    );
   });
 });

--- a/src/commands/models/set.ts
+++ b/src/commands/models/set.ts
@@ -1,12 +1,26 @@
 import { logConfigUpdated } from "../../config/logging.js";
 import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import type { RuntimeEnv } from "../../runtime.js";
-import { applyDefaultModelPrimaryUpdate, updateConfig } from "./shared.js";
+import {
+  applyDefaultModelPrimaryUpdate,
+  syncSessionStoresForDefaultModelChange,
+  updateConfig,
+} from "./shared.js";
 
 export async function modelsSetCommand(modelRaw: string, runtime: RuntimeEnv) {
+  let previousConfig = null as
+    | Parameters<typeof syncSessionStoresForDefaultModelChange>[0]["previousConfig"]
+    | null;
   const updated = await updateConfig((cfg) => {
+    previousConfig = cfg;
     return applyDefaultModelPrimaryUpdate({ cfg, modelRaw, field: "model" });
   });
+  if (previousConfig) {
+    await syncSessionStoresForDefaultModelChange({
+      previousConfig,
+      nextConfig: updated,
+    });
+  }
 
   logConfigUpdated(runtime);
   runtime.log(

--- a/src/commands/models/shared.test.ts
+++ b/src/commands/models/shared.test.ts
@@ -4,19 +4,104 @@ import type { OpenClawConfig } from "../../config/config.js";
 const mocks = vi.hoisted(() => ({
   readConfigFileSnapshot: vi.fn(),
   writeConfigFile: vi.fn(),
+  listAgentIds: vi.fn(() => ["main"]),
+  resolveDefaultModelForAgent: vi.fn(
+    ({ cfg, agentId }: { cfg: OpenClawConfig; agentId: string }) => {
+      const raw =
+        agentId === "main"
+          ? cfg.agents?.defaults?.model
+          : (cfg.agents?.list?.find((entry) => entry.id === agentId)?.model ??
+            cfg.agents?.defaults?.model);
+      const primary =
+        typeof raw === "string"
+          ? raw
+          : raw && typeof raw === "object" && typeof raw.primary === "string"
+            ? raw.primary
+            : "anthropic/claude-opus-4-5";
+      const slash = primary.indexOf("/");
+      return slash > 0
+        ? {
+            provider: primary.slice(0, slash),
+            model: primary.slice(slash + 1),
+          }
+        : { provider: "anthropic", model: primary };
+    },
+  ),
+  resolveStorePath: vi.fn((_: unknown, { agentId }: { agentId: string }) => `/tmp/${agentId}.json`),
+  updateSessionStore: vi.fn(
+    async (
+      _storePath: string,
+      updater: (store: Record<string, Record<string, unknown>>) => unknown,
+    ) => {
+      const store = {
+        "agent:main:main": {
+          sessionId: "s1",
+          updatedAt: 1,
+          modelProvider: "openai-codex",
+          model: "gpt-5.3-codex",
+          fallbackNoticeSelectedModel: "openai-codex/gpt-5.3-codex",
+          fallbackNoticeActiveModel: "openai-codex/gpt-5.3-codex",
+          fallbackNoticeReason: "provider fallback",
+        },
+        "agent:main:kept": {
+          sessionId: "s2",
+          updatedAt: 1,
+          providerOverride: "openai",
+          modelOverride: "gpt-5.2",
+          modelProvider: "openai",
+          model: "gpt-5.2",
+        },
+      };
+      return await updater(store);
+    },
+  ),
 }));
 
 vi.mock("../../config/config.js", () => ({
-  readConfigFileSnapshot: (...args: unknown[]) => mocks.readConfigFileSnapshot(...args),
-  writeConfigFile: (...args: unknown[]) => mocks.writeConfigFile(...args),
+  readConfigFileSnapshot: mocks.readConfigFileSnapshot,
+  writeConfigFile: mocks.writeConfigFile,
 }));
 
-import { loadValidConfigOrThrow, updateConfig } from "./shared.js";
+vi.mock("../../agents/agent-scope.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/agent-scope.js")>();
+  return {
+    ...actual,
+    listAgentIds: mocks.listAgentIds,
+  };
+});
+
+vi.mock("../../agents/model-selection.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../agents/model-selection.js")>();
+  return {
+    ...actual,
+    resolveDefaultModelForAgent: mocks.resolveDefaultModelForAgent,
+  };
+});
+
+vi.mock("../../config/sessions.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../config/sessions.js")>();
+  return {
+    ...actual,
+    resolveStorePath: mocks.resolveStorePath,
+    updateSessionStore: mocks.updateSessionStore,
+  };
+});
+
+import {
+  loadValidConfigOrThrow,
+  syncSessionStoresForDefaultModelChange,
+  updateConfig,
+} from "./shared.js";
 
 describe("models/shared", () => {
   beforeEach(() => {
     mocks.readConfigFileSnapshot.mockClear();
     mocks.writeConfigFile.mockClear();
+    mocks.listAgentIds.mockReset();
+    mocks.listAgentIds.mockReturnValue(["main"]);
+    mocks.resolveDefaultModelForAgent.mockClear();
+    mocks.resolveStorePath.mockClear();
+    mocks.updateSessionStore.mockClear();
   });
 
   it("returns config when snapshot is valid", async () => {
@@ -59,5 +144,90 @@ describe("models/shared", () => {
         update: { channel: "beta" },
       }),
     );
+  });
+
+  it("syncs session runtime snapshots when an agent default model changes", async () => {
+    const previousConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "openai-codex/gpt-5.3-codex" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const nextConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "openai-codex/gpt-5.4" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await syncSessionStoresForDefaultModelChange({
+      previousConfig,
+      nextConfig,
+    });
+
+    expect(mocks.updateSessionStore).toHaveBeenCalledWith("/tmp/main.json", expect.any(Function));
+    const updater = mocks.updateSessionStore.mock.calls[0]?.[1];
+    const store = {
+      "agent:main:main": {
+        sessionId: "s1",
+        updatedAt: 1,
+        modelProvider: "openai-codex",
+        model: "gpt-5.3-codex",
+        fallbackNoticeSelectedModel: "openai-codex/gpt-5.3-codex",
+        fallbackNoticeActiveModel: "openai-codex/gpt-5.3-codex",
+        fallbackNoticeReason: "provider fallback",
+      },
+      "agent:main:kept": {
+        sessionId: "s2",
+        updatedAt: 1,
+        providerOverride: "openai",
+        modelOverride: "gpt-5.2",
+        modelProvider: "openai",
+        model: "gpt-5.2",
+      },
+    };
+
+    updater(store);
+
+    expect(store["agent:main:main"]).toMatchObject({
+      sessionId: "s1",
+    });
+    expect(store["agent:main:main"].modelProvider).toBeUndefined();
+    expect(store["agent:main:main"].model).toBeUndefined();
+    expect(store["agent:main:main"].fallbackNoticeSelectedModel).toBeUndefined();
+    expect(store["agent:main:main"].fallbackNoticeActiveModel).toBeUndefined();
+    expect(store["agent:main:main"].fallbackNoticeReason).toBeUndefined();
+    expect(store["agent:main:kept"]).toMatchObject({
+      providerOverride: "openai",
+      modelOverride: "gpt-5.2",
+      modelProvider: "openai",
+      model: "gpt-5.2",
+    });
+  });
+
+  it("skips session sync when the effective defaults do not change", async () => {
+    const previousConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "openai-codex/gpt-5.4" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const nextConfig = {
+      agents: {
+        defaults: {
+          model: { primary: "openai-codex/gpt-5.4" },
+        },
+      },
+    } as unknown as OpenClawConfig;
+
+    await syncSessionStoresForDefaultModelChange({
+      previousConfig,
+      nextConfig,
+    });
+
+    expect(mocks.updateSessionStore).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -4,6 +4,7 @@ import {
   buildModelAliasIndex,
   modelKey,
   parseModelRef,
+  resolveDefaultModelForAgent,
   resolveModelRefFromString,
 } from "../../agents/model-selection.js";
 import { formatCliCommand } from "../../cli/command-format.js";
@@ -14,6 +15,7 @@ import {
 } from "../../config/config.js";
 import { formatConfigIssueLines } from "../../config/issue-format.js";
 import { toAgentModelListLike } from "../../config/model-input.js";
+import { resolveStorePath, updateSessionStore, type SessionEntry } from "../../config/sessions.js";
 import type { AgentModelConfig } from "../../config/types.agents-shared.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 
@@ -163,6 +165,35 @@ export function resolveKnownAgentId(params: {
 
 export type PrimaryFallbackConfig = { primary?: string; fallbacks?: string[] };
 
+function hasSessionModelOverride(entry: SessionEntry): boolean {
+  return Boolean(entry.modelOverride?.trim() || entry.providerOverride?.trim());
+}
+
+function clearSessionRuntimeModelSnapshot(entry: SessionEntry): boolean {
+  let changed = false;
+  if (entry.model !== undefined) {
+    delete entry.model;
+    changed = true;
+  }
+  if (entry.modelProvider !== undefined) {
+    delete entry.modelProvider;
+    changed = true;
+  }
+  if (entry.fallbackNoticeSelectedModel !== undefined) {
+    delete entry.fallbackNoticeSelectedModel;
+    changed = true;
+  }
+  if (entry.fallbackNoticeActiveModel !== undefined) {
+    delete entry.fallbackNoticeActiveModel;
+    changed = true;
+  }
+  if (entry.fallbackNoticeReason !== undefined) {
+    delete entry.fallbackNoticeReason;
+    changed = true;
+  }
+  return changed;
+}
+
 export function mergePrimaryFallbackConfig(
   existing: PrimaryFallbackConfig | undefined,
   patch: { primary?: string; fallbacks?: string[] },
@@ -207,6 +238,53 @@ export function applyDefaultModelPrimaryUpdate(params: {
       },
     },
   };
+}
+
+export async function syncSessionStoresForDefaultModelChange(params: {
+  previousConfig: OpenClawConfig;
+  nextConfig: OpenClawConfig;
+}): Promise<void> {
+  const agentIds = new Set([
+    ...listAgentIds(params.previousConfig),
+    ...listAgentIds(params.nextConfig),
+  ]);
+
+  await Promise.all(
+    [...agentIds].map(async (agentId) => {
+      const previousDefault = resolveDefaultModelForAgent({
+        cfg: params.previousConfig,
+        agentId,
+      });
+      const nextDefault = resolveDefaultModelForAgent({
+        cfg: params.nextConfig,
+        agentId,
+      });
+      if (
+        previousDefault.provider === nextDefault.provider &&
+        previousDefault.model === nextDefault.model
+      ) {
+        return;
+      }
+
+      const storePath = resolveStorePath(params.nextConfig.session?.store, { agentId });
+      await updateSessionStore(storePath, (store) => {
+        let changed = false;
+        const updatedAt = Date.now();
+        for (const entry of Object.values(store)) {
+          // Preserve explicit per-session model choices; only reset inherited runtime snapshots.
+          if (!entry || hasSessionModelOverride(entry)) {
+            continue;
+          }
+          if (!clearSessionRuntimeModelSnapshot(entry)) {
+            continue;
+          }
+          entry.updatedAt = updatedAt;
+          changed = true;
+        }
+        return changed;
+      });
+    }),
+  );
 }
 
 export { modelKey };


### PR DESCRIPTION
## Summary

- Problem: `openclaw models set ...` updates the agent default model in config, but existing sessions that inherit defaults can keep stale runtime `model` / `modelProvider` snapshots and fallback notice fields.
- Why it matters: status output and subsequent session behavior can continue to reflect the old model even though the configured default changed.
- What changed: when an agent's effective default model changes, sessions without explicit per-session model overrides now have their inherited runtime model snapshot fields cleared.
- What did NOT change (scope boundary): sessions with explicit `modelOverride` / `providerOverride` are preserved as-is; this does not change provider fallback rules or add automatic overrides.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #38485

## User-visible / Behavior Changes

- After `openclaw models set ...`, sessions inheriting the agent default stop reporting stale runtime model snapshots from the previous default.
- Explicit per-session model selections remain unchanged.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev checkout
- Model/provider: config-driven model defaults via `models set`
- Integration/channel (if any): n/a
- Relevant config (redacted): `agents.defaults.model` changed from one provider/model ref to another

### Steps

1. Start with a session store entry that has runtime `model` / `modelProvider` fields from an old inherited default.
2. Run `openclaw models set <new-model>`.
3. Inspect the session store / status behavior for sessions that do not have explicit overrides.

### Expected

- Sessions inheriting defaults should stop carrying the stale runtime snapshot and re-resolve from the new default.

### Actual

- Before this change, those sessions could continue to show the old runtime model snapshot.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm exec vitest run src/commands/models/shared.test.ts`
  - `pnpm exec vitest run src/commands/models.set.e2e.test.ts --config vitest.e2e.config.ts`
  - `pnpm build`
  - `pnpm check`
- Edge cases checked:
  - default unchanged: session stores are not touched
  - explicit per-session overrides: runtime snapshot is preserved
- What you did **not** verify:
  - live gateway/session migration against a real persisted session store outside tests

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR / commit
- Files/config to restore: `src/commands/models/shared.ts`, `src/commands/models/set.ts`
- Known bad symptoms reviewers should watch for: sessions with explicit overrides being cleared unintentionally

## Risks and Mitigations

- Risk: clearing runtime snapshot fields could touch sessions that should keep explicit model selections
  - Mitigation: only sessions without `modelOverride` / `providerOverride` are modified, and tests cover both inherited and explicit-override cases
