### PR TITLE
fix: resolve version from package.json at runtime (issue #38473)

### DIFF
--- a/src/version.ts
+++ b/src/version.ts
@@ -7,12 +7,15 @@ const PACKAGE_JSON_CANDIDATES = [
   "../package.json",
   "../../package.json",
   "../../../package.json",
+  "../../../../package.json",
   "./package.json",
 ] as const;
 
 const BUILD_INFO_CANDIDATES = [
   "../build-info.json",
   "../../build-info.json",
+  "../../../build-info.json",
+  "../../../../build-info.json",
   "./build-info.json",
 ] as const;
 


### PR DESCRIPTION
## Summary
Fixes issue #38473 - Control UI displays incorrect version number (2026.2.26 instead of 2026.3.2)

## Problem
The version number was hardcoded in dist files or resolved incorrectly, causing CLI and Control UI to show wrong version.

## Root Cause
The `src/version.ts` file only checks 3 parent directory levels when looking for `package.json`. For deeply nested dist subdirectories, the version cannot be resolved correctly.

## Fix
Added additional lookup paths for `package.json` and `build-info.json`:
- `../../../../package.json`
- `../../../../build-info.json`

This ensures the version is always read from package.json at runtime instead of using a potentially stale hardcoded value.

## Testing
After this fix, the CLI command `openclaw --version` should display the correct version from package.json.

Closes #38473