### PR TITLE
fix(feishu): fix card action context fields and chat_type detection

### DIFF
--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -39,6 +39,63 @@ describe("Feishu Card Action Handler", () => {
     );
   });
 
+  it("handles card action with form_value (form submit)", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok3",
+      action: {
+        value: { command: "submit-form" },
+        form_value: { field1: "hello", field2: "world" },
+        tag: "button",
+      },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(handleFeishuMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          message: expect.objectContaining({
+            content: expect.stringContaining('"field1":"hello"'),
+            chat_id: "chat1",
+          }),
+        }),
+      }),
+    );
+
+    // Verify the merged object includes both value and form_value fields
+    const call = vi.mocked(handleFeishuMessage).mock.calls.at(-1)![0];
+    const parsed = JSON.parse(JSON.parse(call.event.message.content).text);
+    expect(parsed).toEqual({ command: "submit-form", field1: "hello", field2: "world" });
+  });
+
+  it("handles card action with empty form_value (fallback to value logic)", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok4",
+      action: {
+        value: { command: "simple-click" },
+        form_value: {},
+        tag: "button",
+      },
+      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    expect(handleFeishuMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({
+          message: expect.objectContaining({
+            content: '{"text":"simple-click"}',
+            chat_id: "chat1",
+          }),
+        }),
+      }),
+    );
+  });
+
   it("handles card action with JSON object payload", async () => {
     const event: FeishuCardActionEvent = {
       operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },

--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { handleFeishuCardAction, type FeishuCardActionEvent } from "./card-action.js";
 
 // Mock resolveFeishuAccount
@@ -16,6 +16,10 @@ import { handleFeishuMessage } from "./bot.js";
 describe("Feishu Card Action Handler", () => {
   const cfg = {} as any; // Minimal mock
   const runtime = { log: vi.fn(), error: vi.fn() } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   it("handles card action with text payload", async () => {
     const event: FeishuCardActionEvent = {
@@ -53,19 +57,9 @@ describe("Feishu Card Action Handler", () => {
 
     await handleFeishuCardAction({ cfg, event, runtime });
 
-    expect(handleFeishuMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event: expect.objectContaining({
-          message: expect.objectContaining({
-            content: expect.stringContaining('"field1":"hello"'),
-            chat_id: "chat1",
-          }),
-        }),
-      }),
-    );
-
     // Verify the merged object includes both value and form_value fields
     const call = vi.mocked(handleFeishuMessage).mock.calls.at(-1)![0];
+    expect(call.event.message.chat_id).toBe("chat1");
     const parsed = JSON.parse(JSON.parse(call.event.message.content).text);
     expect(parsed).toEqual({ command: "submit-form", field1: "hello", field2: "world" });
   });
@@ -106,15 +100,9 @@ describe("Feishu Card Action Handler", () => {
 
     await handleFeishuCardAction({ cfg, event, runtime });
 
-    expect(handleFeishuMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event: expect.objectContaining({
-          message: expect.objectContaining({
-            content: '{"text":"{\\"key\\":\\"val\\"}"}',
-            chat_id: "u123", // Fallback to open_id
-          }),
-        }),
-      }),
-    );
+    const call = vi.mocked(handleFeishuMessage).mock.calls.at(-1)![0];
+    expect(call.event.message.chat_id).toBe("u123"); // Fallback to open_id
+    const parsed = JSON.parse(call.event.message.content);
+    expect(parsed).toEqual({ text: JSON.stringify({ key: "val" }) });
   });
 });

--- a/extensions/feishu/src/bot.card-action.test.ts
+++ b/extensions/feishu/src/bot.card-action.test.ts
@@ -11,6 +11,14 @@ vi.mock("./bot.js", () => ({
   handleFeishuMessage: vi.fn(),
 }));
 
+// Mock client.js for chat_type resolution
+const mockChatGet = vi.fn();
+vi.mock("./client.js", () => ({
+  createFeishuClient: vi.fn().mockReturnValue({
+    im: { chat: { get: (...args: unknown[]) => mockChatGet(...args) } },
+  }),
+}));
+
 import { handleFeishuMessage } from "./bot.js";
 
 describe("Feishu Card Action Handler", () => {
@@ -19,6 +27,8 @@ describe("Feishu Card Action Handler", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: API returns group chat_mode
+    mockChatGet.mockResolvedValue({ code: 0, data: { chat_mode: "group" } });
   });
 
   it("handles card action with text payload", async () => {
@@ -26,7 +36,7 @@ describe("Feishu Card Action Handler", () => {
       operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
       token: "tok1",
       action: { value: { text: "/ping" }, tag: "button" },
-      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+      context: { open_id: "u123", user_id: "uid1", open_chat_id: "oc_chat1" },
     };
 
     await handleFeishuCardAction({ cfg, event, runtime });
@@ -36,7 +46,7 @@ describe("Feishu Card Action Handler", () => {
         event: expect.objectContaining({
           message: expect.objectContaining({
             content: '{"text":"/ping"}',
-            chat_id: "chat1",
+            chat_id: "oc_chat1",
           }),
         }),
       }),
@@ -52,14 +62,14 @@ describe("Feishu Card Action Handler", () => {
         form_value: { field1: "hello", field2: "world" },
         tag: "button",
       },
-      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+      context: { open_id: "u123", user_id: "uid1", open_chat_id: "oc_chat1" },
     };
 
     await handleFeishuCardAction({ cfg, event, runtime });
 
     // Verify the merged object includes both value and form_value fields
     const call = vi.mocked(handleFeishuMessage).mock.calls.at(-1)![0];
-    expect(call.event.message.chat_id).toBe("chat1");
+    expect(call.event.message.chat_id).toBe("oc_chat1");
     const parsed = JSON.parse(JSON.parse(call.event.message.content).text);
     expect(parsed).toEqual({ command: "submit-form", field1: "hello", field2: "world" });
   });
@@ -73,7 +83,7 @@ describe("Feishu Card Action Handler", () => {
         form_value: {},
         tag: "button",
       },
-      context: { open_id: "u123", user_id: "uid1", chat_id: "chat1" },
+      context: { open_id: "u123", user_id: "uid1", open_chat_id: "oc_chat1" },
     };
 
     await handleFeishuCardAction({ cfg, event, runtime });
@@ -83,7 +93,7 @@ describe("Feishu Card Action Handler", () => {
         event: expect.objectContaining({
           message: expect.objectContaining({
             content: '{"text":"simple-click"}',
-            chat_id: "chat1",
+            chat_id: "oc_chat1",
           }),
         }),
       }),
@@ -95,7 +105,7 @@ describe("Feishu Card Action Handler", () => {
       operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
       token: "tok2",
       action: { value: { key: "val" }, tag: "button" },
-      context: { open_id: "u123", user_id: "uid1", chat_id: "" },
+      context: { open_id: "u123", user_id: "uid1" },
     };
 
     await handleFeishuCardAction({ cfg, event, runtime });
@@ -104,5 +114,151 @@ describe("Feishu Card Action Handler", () => {
     expect(call.event.message.chat_id).toBe("u123"); // Fallback to open_id
     const parsed = JSON.parse(call.event.message.content);
     expect(parsed).toEqual({ text: JSON.stringify({ key: "val" }) });
+  });
+
+  it("uses open_message_id as message_id when available", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok5",
+      action: { value: { text: "hello" }, tag: "button" },
+      context: {
+        open_id: "u123",
+        user_id: "uid1",
+        open_chat_id: "oc_chat1",
+        open_message_id: "om_real123",
+      },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    const call = vi.mocked(handleFeishuMessage).mock.calls.at(-1)![0];
+    expect(call.event.message.message_id).toBe("om_real123");
+  });
+
+  it("falls back to card-action-token when no open_message_id", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok6",
+      action: { value: { text: "hello" }, tag: "button" },
+      context: { open_id: "u123", user_id: "uid1", open_chat_id: "oc_chat1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    const call = vi.mocked(handleFeishuMessage).mock.calls.at(-1)![0];
+    expect(call.event.message.message_id).toBe("card-action-tok6");
+  });
+
+  it("injects _card_message_id into content when form_value and open_message_id present", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok7",
+      action: {
+        value: { command: "confirm" },
+        form_value: { answer: "yes" },
+        tag: "button",
+      },
+      context: {
+        open_id: "u123",
+        user_id: "uid1",
+        open_chat_id: "oc_chat1",
+        open_message_id: "om_card456",
+      },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    const call = vi.mocked(handleFeishuMessage).mock.calls.at(-1)![0];
+    const parsed = JSON.parse(JSON.parse(call.event.message.content).text);
+    expect(parsed).toEqual({
+      command: "confirm",
+      answer: "yes",
+      _card_message_id: "om_card456",
+    });
+  });
+
+  it("does not inject _card_message_id when no open_message_id", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok8",
+      action: {
+        value: { command: "confirm" },
+        form_value: { answer: "yes" },
+        tag: "button",
+      },
+      context: { open_id: "u123", user_id: "uid1", open_chat_id: "oc_chat1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    const call = vi.mocked(handleFeishuMessage).mock.calls.at(-1)![0];
+    const parsed = JSON.parse(JSON.parse(call.event.message.content).text);
+    expect(parsed).toEqual({ command: "confirm", answer: "yes" });
+    expect(parsed._card_message_id).toBeUndefined();
+  });
+
+  it("resolves chat_type as group via API when chat_mode is group", async () => {
+    mockChatGet.mockResolvedValue({ code: 0, data: { chat_mode: "group" } });
+
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok9",
+      action: { value: { text: "test" }, tag: "button" },
+      context: { open_id: "u123", user_id: "uid1", open_chat_id: "oc_group1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    const call = vi.mocked(handleFeishuMessage).mock.calls.at(-1)![0];
+    expect(call.event.message.chat_type).toBe("group");
+    expect(mockChatGet).toHaveBeenCalledWith({ path: { chat_id: "oc_group1" } });
+  });
+
+  it("resolves chat_type as p2p via API when chat_mode is not group", async () => {
+    mockChatGet.mockResolvedValue({ code: 0, data: { chat_mode: "p2p" } });
+
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok10",
+      action: { value: { text: "test" }, tag: "button" },
+      context: { open_id: "u123", user_id: "uid1", open_chat_id: "oc_p2p1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    const call = vi.mocked(handleFeishuMessage).mock.calls.at(-1)![0];
+    expect(call.event.message.chat_type).toBe("p2p");
+  });
+
+  it("defaults to p2p when chat API call fails", async () => {
+    mockChatGet.mockRejectedValue(new Error("API timeout"));
+
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok11",
+      action: { value: { text: "test" }, tag: "button" },
+      context: { open_id: "u123", user_id: "uid1", open_chat_id: "oc_fail1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    const call = vi.mocked(handleFeishuMessage).mock.calls.at(-1)![0];
+    expect(call.event.message.chat_type).toBe("p2p");
+  });
+
+  it("defaults to p2p when no open_chat_id (skips API call)", async () => {
+    const event: FeishuCardActionEvent = {
+      operator: { open_id: "u123", user_id: "uid1", union_id: "un1" },
+      token: "tok12",
+      action: { value: { text: "test" }, tag: "button" },
+      context: { open_id: "u123", user_id: "uid1" },
+    };
+
+    await handleFeishuCardAction({ cfg, event, runtime });
+
+    const call = vi.mocked(handleFeishuMessage).mock.calls.at(-1)![0];
+    expect(call.event.message.chat_type).toBe("p2p");
+    expect(call.event.message.chat_id).toBe("u123"); // Fallback to open_id
+    expect(mockChatGet).not.toHaveBeenCalled();
   });
 });

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -11,6 +11,7 @@ export type FeishuCardActionEvent = {
   token: string;
   action: {
     value: Record<string, unknown>;
+    form_value?: Record<string, unknown>;
     tag: string;
   };
   context: {
@@ -31,19 +32,26 @@ export async function handleFeishuCardAction(params: {
   const account = resolveFeishuAccount({ cfg, accountId });
   const log = runtime?.log ?? console.log;
 
-  // Extract action value
+  // Extract action value; merge form_value when present (form submit)
   const actionValue = event.action.value;
+  const formValue = event.action.form_value;
+  const hasFormValue = formValue != null && Object.keys(formValue).length > 0;
+  const mergedValue = hasFormValue ? { ...actionValue, ...formValue } : actionValue;
+
   let content = "";
-  if (typeof actionValue === "object" && actionValue !== null) {
-    if ("text" in actionValue && typeof actionValue.text === "string") {
-      content = actionValue.text;
-    } else if ("command" in actionValue && typeof actionValue.command === "string") {
-      content = actionValue.command;
+  if (typeof mergedValue === "object" && mergedValue !== null) {
+    if (hasFormValue) {
+      // Form submit: serialize the full merged object so the agent receives all fields
+      content = JSON.stringify(mergedValue);
+    } else if ("text" in mergedValue && typeof mergedValue.text === "string") {
+      content = mergedValue.text;
+    } else if ("command" in mergedValue && typeof mergedValue.command === "string") {
+      content = mergedValue.command;
     } else {
-      content = JSON.stringify(actionValue);
+      content = JSON.stringify(mergedValue);
     }
   } else {
-    content = String(actionValue);
+    content = String(mergedValue);
   }
 
   // Construct a synthetic message event

--- a/extensions/feishu/src/card-action.ts
+++ b/extensions/feishu/src/card-action.ts
@@ -1,6 +1,7 @@
 import type { ClawdbotConfig, RuntimeEnv } from "openclaw/plugin-sdk/feishu";
 import { resolveFeishuAccount } from "./accounts.js";
 import { handleFeishuMessage, type FeishuMessageEvent } from "./bot.js";
+import { createFeishuClient } from "./client.js";
 
 export type FeishuCardActionEvent = {
   operator: {
@@ -17,7 +18,8 @@ export type FeishuCardActionEvent = {
   context: {
     open_id: string;
     user_id: string;
-    chat_id: string;
+    open_chat_id?: string;
+    open_message_id?: string;
   };
 };
 
@@ -41,8 +43,12 @@ export async function handleFeishuCardAction(params: {
   let content = "";
   if (typeof mergedValue === "object" && mergedValue !== null) {
     if (hasFormValue) {
-      // Form submit: serialize the full merged object so the agent receives all fields
-      content = JSON.stringify(mergedValue);
+      // Form submit: serialize the full merged object so the agent receives all fields;
+      // inject _card_message_id so downstream skills can update the original card
+      const withCardId = event.context.open_message_id
+        ? { ...mergedValue, _card_message_id: event.context.open_message_id }
+        : mergedValue;
+      content = JSON.stringify(withCardId);
     } else if ("text" in mergedValue && typeof mergedValue.text === "string") {
       content = mergedValue.text;
     } else if ("command" in mergedValue && typeof mergedValue.command === "string") {
@@ -52,6 +58,26 @@ export async function handleFeishuCardAction(params: {
     }
   } else {
     content = String(mergedValue);
+  }
+
+  // Resolve chat_type via Feishu API — card.action.trigger events do not include
+  // chat_type, and open_chat_id uses the oc_ prefix for both group and p2p chats
+  const chatId = event.context.open_chat_id || event.operator.open_id;
+  let chatType: "p2p" | "group" = "p2p"; // safe default
+
+  if (event.context.open_chat_id) {
+    try {
+      const client = createFeishuClient(account);
+      const res = await client.im.chat.get({
+        path: { chat_id: event.context.open_chat_id },
+      });
+      // chat_type = visibility (public/private), chat_mode = session type (group/p2p/topic)
+      if (res.code === 0 && res.data?.chat_mode === "group") {
+        chatType = "group";
+      }
+    } catch {
+      // API failure → safe fallback to p2p
+    }
   }
 
   // Construct a synthetic message event
@@ -64,9 +90,9 @@ export async function handleFeishuCardAction(params: {
       },
     },
     message: {
-      message_id: `card-action-${event.token}`,
-      chat_id: event.context.chat_id || event.operator.open_id,
-      chat_type: event.context.chat_id ? "group" : "p2p",
+      message_id: event.context.open_message_id ?? `card-action-${event.token}`,
+      chat_id: chatId,
+      chat_type: chatType,
       message_type: "text",
       content: JSON.stringify({ text: content }),
     },


### PR DESCRIPTION
## Summary

Fixes several bugs in the Feishu card action handler (`card-action.ts`) related to context field names and chat type detection.

Depends on #35973 (form_value support).

### Bug Fixes

1. **Fix context field names** — Feishu `card.action.trigger` events use `open_chat_id` and `open_message_id`, not `chat_id`. The original code reads `event.context.chat_id` which is always `undefined`, causing all card action callbacks to fall back to p2p routing regardless of actual chat type.

2. **Fix synthetic message_id** — Use real `open_message_id` from event context instead of synthetic `card-action-{token}`. The synthetic ID causes Feishu API error 99992354 (Invalid message_id) when the agent tries to reply to the message.

3. **Fix chat_type detection** — Feishu `card.action.trigger` events do NOT include a `chat_type` field, and `open_chat_id` uses `oc_` prefix for BOTH group and p2p conversations. The only reliable way to determine chat type is to query `GET /im/v1/chats/{chat_id}` and check the `chat_mode` field (`"group"` vs other values). On API failure, safely defaults to `"p2p"` to avoid dropping messages.

### Enhancement

4. **Inject `_card_message_id`** — When `form_value` is present and `open_message_id` is available, inject `_card_message_id` into the content JSON. This allows downstream skills to update the original card (e.g., disable submit button after processing).

### Backward Compatibility
- No `open_message_id` → falls back to `card-action-{token}` (unchanged)
- API failure → safe fallback to p2p (messages won't be dropped)
- No `form_value` → `_card_message_id` is not injected (unchanged)

## Test Plan
- [x] Existing tests updated and pass (12/12)
- [x] New: open_message_id as message_id / fallback to token
- [x] New: _card_message_id injection with form_value
- [x] New: chat_type resolution via API (group, p2p, API failure, no open_chat_id)
- [ ] Manual: click card in group chat → dispatches to group session
- [ ] Manual: click card in p2p chat → dispatches to direct session

Ref: https://open.larkoffice.com/document/feishu-cards/card-callback-communication

🤖 Generated with [Claude Code](https://claude.com/claude-code)
