### PR TITLE
config/memory: allow string providers with plugin slot validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,16 +320,25 @@ jobs:
           python -m pip install pre-commit
 
       - name: Detect secrets
+        env:
+          OPENCLAW_GITHUB_REF: ${{ github.ref }}
+          OPENCLAW_GITHUB_EVENT_NAME: ${{ github.event_name }}
+          OPENCLAW_PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
         run: |
           set -euo pipefail
 
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "$OPENCLAW_GITHUB_REF" = "refs/heads/main" ]; then
+            echo "Skipping detect-secrets on main until the allowlist cleanup lands."
+            exit 0
+          fi
+
+          if [ "$OPENCLAW_GITHUB_EVENT_NAME" = "push" ]; then
             echo "Running full detect-secrets scan on push."
             pre-commit run --all-files detect-secrets
             exit 0
           fi
 
-          BASE="${{ github.event.pull_request.base.sha }}"
+          BASE="$OPENCLAW_PR_BASE_SHA"
           changed_files=()
           if git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1; then
             while IFS= read -r path; do
@@ -351,13 +360,17 @@ jobs:
         run: pre-commit run --all-files detect-private-key
 
       - name: Audit changed GitHub workflows with zizmor
+        env:
+          OPENCLAW_GITHUB_EVENT_NAME: ${{ github.event_name }}
+          OPENCLAW_GITHUB_BEFORE: ${{ github.event.before || '' }}
+          OPENCLAW_PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
         run: |
           set -euo pipefail
 
-          if [ "${{ github.event_name }}" = "push" ]; then
-            BASE="${{ github.event.before }}"
+          if [ "$OPENCLAW_GITHUB_EVENT_NAME" = "push" ]; then
+            BASE="$OPENCLAW_GITHUB_BEFORE"
           else
-            BASE="${{ github.event.pull_request.base.sha }}"
+            BASE="$OPENCLAW_PR_BASE_SHA"
           fi
 
           mapfile -t workflow_files < <(git diff --name-only "$BASE" HEAD -- '.github/workflows/*.yml' '.github/workflows/*.yaml')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,13 @@ jobs:
         with:
           submodules: false
 
+      - name: Ensure secrets base commit (PR fast path)
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,13 +295,6 @@ jobs:
         with:
           submodules: false
 
-      - name: Ensure secrets base commit (PR fast path)
-        if: github.event_name == 'pull_request'
-        uses: ./.github/actions/ensure-base-commit
-        with:
-          base-sha: ${{ github.event.pull_request.base.sha }}
-          fetch-ref: ${{ github.event.pull_request.base.ref }}
-
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,25 +320,21 @@ jobs:
           python -m pip install pre-commit
 
       - name: Detect secrets
-        env:
-          OPENCLAW_GITHUB_REF: ${{ github.ref }}
-          OPENCLAW_GITHUB_EVENT_NAME: ${{ github.event_name }}
-          OPENCLAW_PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
         run: |
           set -euo pipefail
 
-          if [ "$OPENCLAW_GITHUB_REF" = "refs/heads/main" ]; then
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
             echo "Skipping detect-secrets on main until the allowlist cleanup lands."
             exit 0
           fi
 
-          if [ "$OPENCLAW_GITHUB_EVENT_NAME" = "push" ]; then
+          if [ "${{ github.event_name }}" = "push" ]; then
             echo "Running full detect-secrets scan on push."
             pre-commit run --all-files detect-secrets
             exit 0
           fi
 
-          BASE="$OPENCLAW_PR_BASE_SHA"
+          BASE="${{ github.event.pull_request.base.sha }}"
           changed_files=()
           if git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1; then
             while IFS= read -r path; do
@@ -360,17 +356,13 @@ jobs:
         run: pre-commit run --all-files detect-private-key
 
       - name: Audit changed GitHub workflows with zizmor
-        env:
-          OPENCLAW_GITHUB_EVENT_NAME: ${{ github.event_name }}
-          OPENCLAW_GITHUB_BEFORE: ${{ github.event.before || '' }}
-          OPENCLAW_PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
         run: |
           set -euo pipefail
 
-          if [ "$OPENCLAW_GITHUB_EVENT_NAME" = "push" ]; then
-            BASE="$OPENCLAW_GITHUB_BEFORE"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            BASE="${{ github.event.before }}"
           else
-            BASE="$OPENCLAW_PR_BASE_SHA"
+            BASE="${{ github.event.pull_request.base.sha }}"
           fi
 
           mapfile -t workflow_files < <(git diff --name-only "$BASE" HEAD -- '.github/workflows/*.yml' '.github/workflows/*.yaml')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,13 @@ jobs:
         with:
           submodules: false
 
+      - name: Ensure secrets base commit (PR fast path)
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
@@ -313,21 +320,25 @@ jobs:
           python -m pip install pre-commit
 
       - name: Detect secrets
+        env:
+          OPENCLAW_GITHUB_REF: ${{ github.ref }}
+          OPENCLAW_GITHUB_EVENT_NAME: ${{ github.event_name }}
+          OPENCLAW_PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
         run: |
           set -euo pipefail
 
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "$OPENCLAW_GITHUB_REF" = "refs/heads/main" ]; then
             echo "Skipping detect-secrets on main until the allowlist cleanup lands."
             exit 0
           fi
 
-          if [ "${{ github.event_name }}" = "push" ]; then
+          if [ "$OPENCLAW_GITHUB_EVENT_NAME" = "push" ]; then
             echo "Running full detect-secrets scan on push."
             pre-commit run --all-files detect-secrets
             exit 0
           fi
 
-          BASE="${{ github.event.pull_request.base.sha }}"
+          BASE="$OPENCLAW_PR_BASE_SHA"
           changed_files=()
           if git rev-parse --verify "$BASE^{commit}" >/dev/null 2>&1; then
             while IFS= read -r path; do
@@ -349,13 +360,17 @@ jobs:
         run: pre-commit run --all-files detect-private-key
 
       - name: Audit changed GitHub workflows with zizmor
+        env:
+          OPENCLAW_GITHUB_EVENT_NAME: ${{ github.event_name }}
+          OPENCLAW_GITHUB_BEFORE: ${{ github.event.before || '' }}
+          OPENCLAW_PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
         run: |
           set -euo pipefail
 
-          if [ "${{ github.event_name }}" = "push" ]; then
-            BASE="${{ github.event.before }}"
+          if [ "$OPENCLAW_GITHUB_EVENT_NAME" = "push" ]; then
+            BASE="$OPENCLAW_GITHUB_BEFORE"
           else
-            BASE="${{ github.event.pull_request.base.sha }}"
+            BASE="$OPENCLAW_PR_BASE_SHA"
           fi
 
           mapfile -t workflow_files < <(git diff --name-only "$BASE" HEAD -- '.github/workflows/*.yml' '.github/workflows/*.yaml')

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12956,7 +12956,7 @@
         "filename": "src/commands/doctor-memory-search.test.ts",
         "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
         "is_verified": false,
-        "line_number": 47
+        "line_number": 59
       }
     ],
     "src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts": [
@@ -14718,5 +14718,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-07T12:55:32Z"
+  "generated_at": "2026-03-07T14:08:13Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -11971,15 +11971,6 @@
         "line_number": 57
       }
     ],
-    "src/agents/memory-search.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/memory-search.test.ts",
-        "hashed_secret": "a1b49d68a91fdf9c9217773f3fac988d77fa0f50",
-        "is_verified": false,
-        "line_number": 191
-      }
-    ],
     "src/agents/minimax-vlm.normalizes-api-key.test.ts": [
       {
         "type": "Secret Keyword",
@@ -12965,23 +12956,7 @@
         "filename": "src/commands/doctor-memory-search.test.ts",
         "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
         "is_verified": false,
-        "line_number": 43
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/doctor-memory-search.test.ts",
-        "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
-        "is_verified": false,
-        "line_number": 278
-      }
-    ],
-    "src/commands/model-picker.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/doctor-memory-search.test.ts",
-        "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
-        "is_verified": false,
-        "line_number": 278
+        "line_number": 47
       }
     ],
     "src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts": [
@@ -13018,6 +12993,15 @@
         "hashed_secret": "3bb1ec510d35ab2af7d05d8bbd5f0820333f1a0d",
         "is_verified": false,
         "line_number": 194
+      }
+    ],
+    "src/commands/model-picker.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/doctor-memory-search.test.ts",
+        "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
+        "is_verified": false,
+        "line_number": 278
       }
     ],
     "src/commands/model-picker.test.ts": [
@@ -14734,5 +14718,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-07T11:12:54Z"
+  "generated_at": "2026-03-07T12:55:32Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12975,6 +12975,15 @@
         "line_number": 278
       }
     ],
+    "src/commands/model-picker.e2e.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/commands/doctor-memory-search.test.ts",
+        "hashed_secret": "e774aaeac31c6272107ba89080295e277050fa7c",
+        "is_verified": false,
+        "line_number": 278
+      }
+    ],
     "src/commands/doctor.warns-state-directory-is-missing.e2e.test.ts": [
       {
         "type": "Secret Keyword",

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -63,6 +63,20 @@ describe("memory search config", () => {
     expect(resolved?.fallback).toBe("none");
   });
 
+  it("returns null for plugin-managed provider ids", () => {
+    const cfg = asConfig({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "memory-openviking",
+          },
+        },
+      },
+    });
+    const resolved = resolveMemorySearchConfig(cfg, "main");
+    expect(resolved).toBeNull();
+  });
+
   it("merges defaults and overrides", () => {
     const cfg = asConfig({
       agents: {

--- a/src/agents/memory-search.test.ts
+++ b/src/agents/memory-search.test.ts
@@ -202,7 +202,7 @@ describe("memory search config", () => {
             provider: "openai",
             remote: {
               baseUrl: "https://default.example/v1",
-              apiKey: "default-key",
+              apiKey: "default-key", // pragma: allowlist secret
               headers: { "X-Default": "on" },
             },
           },
@@ -223,7 +223,7 @@ describe("memory search config", () => {
     const resolved = resolveMemorySearchConfig(cfg, "main");
     expect(resolved?.remote).toEqual({
       baseUrl: "https://agent.example/v1",
-      apiKey: "default-key",
+      apiKey: "default-key", // pragma: allowlist secret
       headers: { "X-Default": "on" },
       batch: {
         enabled: false,

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -387,8 +387,9 @@ export function resolveMemorySearchConfig(
   if (!resolved.enabled) {
     return null;
   }
-  if (!isBuiltinMemorySearchProvider(resolved.provider)) {
+  const provider = resolved.provider;
+  if (!isBuiltinMemorySearchProvider(provider)) {
     return null;
   }
-  return resolved;
+  return { ...resolved, provider };
 }

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -98,6 +98,20 @@ export type BuiltinMemorySearchProvider =
   | "ollama"
   | "auto";
 
+export function normalizeMemorySearchProvider(provider: unknown): string {
+  if (typeof provider !== "string") {
+    return "";
+  }
+  return provider.trim();
+}
+
+export function resolveBuiltinMemorySearchProvider(
+  provider: unknown,
+): BuiltinMemorySearchProvider | null {
+  const normalized = normalizeMemorySearchProvider(provider).toLowerCase();
+  return isBuiltinMemorySearchProvider(normalized) ? normalized : null;
+}
+
 export function isBuiltinMemorySearchProvider(
   provider: string,
 ): provider is BuiltinMemorySearchProvider {
@@ -165,7 +179,10 @@ function mergeConfig(
   const enabled = overrides?.enabled ?? defaults?.enabled ?? true;
   const sessionMemory =
     overrides?.experimental?.sessionMemory ?? defaults?.experimental?.sessionMemory ?? false;
-  const provider = overrides?.provider ?? defaults?.provider ?? "auto";
+  const rawProvider = overrides?.provider ?? defaults?.provider;
+  const builtinProvider = resolveBuiltinMemorySearchProvider(rawProvider);
+  const pluginProvider = normalizeMemorySearchProvider(rawProvider);
+  const provider = builtinProvider ?? (pluginProvider || "auto");
   const defaultRemote = defaults?.remote;
   const overrideRemote = overrides?.remote;
   const hasRemoteConfig = Boolean(

--- a/src/agents/memory-search.ts
+++ b/src/agents/memory-search.ts
@@ -79,6 +79,31 @@ export type ResolvedMemorySearchConfig = {
   };
 };
 
+export const BUILTIN_MEMORY_SEARCH_PROVIDERS = new Set([
+  "openai",
+  "local",
+  "gemini",
+  "voyage",
+  "mistral",
+  "ollama",
+  "auto",
+] as const);
+
+export type BuiltinMemorySearchProvider =
+  | "openai"
+  | "local"
+  | "gemini"
+  | "voyage"
+  | "mistral"
+  | "ollama"
+  | "auto";
+
+export function isBuiltinMemorySearchProvider(
+  provider: string,
+): provider is BuiltinMemorySearchProvider {
+  return BUILTIN_MEMORY_SEARCH_PROVIDERS.has(provider as BuiltinMemorySearchProvider);
+}
+
 const DEFAULT_OPENAI_MODEL = "text-embedding-3-small";
 const DEFAULT_GEMINI_MODEL = "gemini-embedding-001";
 const DEFAULT_VOYAGE_MODEL = "voyage-4-large";
@@ -136,7 +161,7 @@ function mergeConfig(
   defaults: MemorySearchConfig | undefined,
   overrides: MemorySearchConfig | undefined,
   agentId: string,
-): ResolvedMemorySearchConfig {
+): Omit<ResolvedMemorySearchConfig, "provider"> & { provider: string } {
   const enabled = overrides?.enabled ?? defaults?.enabled ?? true;
   const sessionMemory =
     overrides?.experimental?.sessionMemory ?? defaults?.experimental?.sessionMemory ?? false;
@@ -360,6 +385,9 @@ export function resolveMemorySearchConfig(
   const overrides = resolveAgentConfig(cfg, agentId)?.memorySearch;
   const resolved = mergeConfig(defaults, overrides, agentId);
   if (!resolved.enabled) {
+    return null;
+  }
+  if (!isBuiltinMemorySearchProvider(resolved.provider)) {
     return null;
   }
   return resolved;

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -6,7 +6,17 @@ const note = vi.hoisted(() => vi.fn());
 const resolveDefaultAgentId = vi.hoisted(() => vi.fn(() => "agent-default"));
 const resolveAgentDir = vi.hoisted(() => vi.fn(() => "/tmp/agent-default"));
 const resolveAgentConfig = vi.hoisted(() =>
-  vi.fn<() => { memorySearch?: { provider?: string } } | undefined>(() => undefined),
+  vi.fn<() => { memorySearch?: { provider?: string; enabled?: boolean } } | undefined>(
+    () => undefined,
+  ),
+);
+const normalizeMemorySearchProvider = vi.hoisted(() =>
+  vi.fn((provider: unknown) => (typeof provider === "string" ? provider.trim() : "")),
+);
+const isBuiltinMemorySearchProvider = vi.hoisted(() =>
+  vi.fn((provider: string) =>
+    new Set(["openai", "local", "gemini", "voyage", "mistral", "ollama", "auto"]).has(provider),
+  ),
 );
 const resolveMemorySearchConfig = vi.hoisted(() => vi.fn());
 const resolveApiKeyForProvider = vi.hoisted(() => vi.fn());
@@ -23,6 +33,8 @@ vi.mock("../agents/agent-scope.js", () => ({
 }));
 
 vi.mock("../agents/memory-search.js", () => ({
+  normalizeMemorySearchProvider,
+  isBuiltinMemorySearchProvider,
   resolveMemorySearchConfig,
 }));
 
@@ -311,6 +323,23 @@ describe("noteMemorySearchHealth", () => {
     const message = String(note.mock.calls[0]?.[0] ?? "");
     expect(message).toContain('provider "memory-openviking" is delegated');
     expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
+  });
+
+  it("prefers disabled note over plugin-provider note when memory search is disabled", async () => {
+    resolveMemorySearchConfig.mockReturnValue(null);
+    resolveAgentConfig.mockReturnValue({
+      memorySearch: {
+        enabled: false,
+        provider: "memory-openviking",
+      },
+    });
+
+    await noteMemorySearchHealth(cfg);
+
+    expect(note).toHaveBeenCalledTimes(1);
+    const message = String(note.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain("explicitly disabled");
+    expect(message).not.toContain("delegated to the memory plugin slot");
   });
 });
 

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -5,7 +5,9 @@ import type { OpenClawConfig } from "../config/config.js";
 const note = vi.hoisted(() => vi.fn());
 const resolveDefaultAgentId = vi.hoisted(() => vi.fn(() => "agent-default"));
 const resolveAgentDir = vi.hoisted(() => vi.fn(() => "/tmp/agent-default"));
-const resolveAgentConfig = vi.hoisted(() => vi.fn(() => undefined));
+const resolveAgentConfig = vi.hoisted(() =>
+  vi.fn<() => { memorySearch?: { provider?: string } } | undefined>(() => undefined),
+);
 const resolveMemorySearchConfig = vi.hoisted(() => vi.fn());
 const resolveApiKeyForProvider = vi.hoisted(() => vi.fn());
 const resolveMemoryBackendConfig = vi.hoisted(() => vi.fn());

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -5,6 +5,7 @@ import type { OpenClawConfig } from "../config/config.js";
 const note = vi.hoisted(() => vi.fn());
 const resolveDefaultAgentId = vi.hoisted(() => vi.fn(() => "agent-default"));
 const resolveAgentDir = vi.hoisted(() => vi.fn(() => "/tmp/agent-default"));
+const resolveAgentConfig = vi.hoisted(() => vi.fn(() => undefined));
 const resolveMemorySearchConfig = vi.hoisted(() => vi.fn());
 const resolveApiKeyForProvider = vi.hoisted(() => vi.fn());
 const resolveMemoryBackendConfig = vi.hoisted(() => vi.fn());
@@ -14,6 +15,7 @@ vi.mock("../terminal/note.js", () => ({
 }));
 
 vi.mock("../agents/agent-scope.js", () => ({
+  resolveAgentConfig,
   resolveDefaultAgentId,
   resolveAgentDir,
 }));
@@ -53,6 +55,8 @@ describe("noteMemorySearchHealth", () => {
     note.mockClear();
     resolveDefaultAgentId.mockClear();
     resolveAgentDir.mockClear();
+    resolveAgentConfig.mockReset();
+    resolveAgentConfig.mockReturnValue(undefined);
     resolveMemorySearchConfig.mockReset();
     resolveApiKeyForProvider.mockReset();
     resolveApiKeyForProvider.mockRejectedValue(new Error("missing key"));
@@ -289,6 +293,22 @@ describe("noteMemorySearchHealth", () => {
     const providerCalls = resolveApiKeyForProvider.mock.calls as Array<[{ provider: string }]>;
     const providersChecked = providerCalls.map(([arg]) => arg.provider);
     expect(providersChecked).toEqual(["openai", "google", "voyage", "mistral"]);
+  });
+
+  it("notes plugin-managed providers and skips built-in checks", async () => {
+    resolveMemorySearchConfig.mockReturnValue(null);
+    resolveAgentConfig.mockReturnValue({
+      memorySearch: {
+        provider: "memory-openviking",
+      },
+    });
+
+    await noteMemorySearchHealth(cfg);
+
+    expect(note).toHaveBeenCalledTimes(1);
+    const message = String(note.mock.calls[0]?.[0] ?? "");
+    expect(message).toContain('provider "memory-openviking" is delegated');
+    expect(resolveApiKeyForProvider).not.toHaveBeenCalled();
   });
 });
 

--- a/src/commands/doctor-memory-search.test.ts
+++ b/src/commands/doctor-memory-search.test.ts
@@ -281,7 +281,7 @@ describe("noteMemorySearchHealth", () => {
     resolveApiKeyForProvider.mockImplementation(async ({ provider }: { provider: string }) => {
       if (provider === "ollama") {
         return {
-          apiKey: "ollama-local",
+          apiKey: "ollama-local", // pragma: allowlist secret
           source: "env: OLLAMA_API_KEY",
           mode: "api-key",
         };

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -4,7 +4,11 @@ import {
   resolveAgentDir,
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
-import { resolveMemorySearchConfig } from "../agents/memory-search.js";
+import {
+  isBuiltinMemorySearchProvider,
+  normalizeMemorySearchProvider,
+  resolveMemorySearchConfig,
+} from "../agents/memory-search.js";
 import { resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -13,16 +17,6 @@ import { DEFAULT_LOCAL_MODEL } from "../memory/embeddings.js";
 import { hasConfiguredMemorySecretInput } from "../memory/secret-input.js";
 import { note } from "../terminal/note.js";
 import { resolveUserPath } from "../utils.js";
-
-const BUILTIN_MEMORY_SEARCH_PROVIDERS = new Set([
-  "openai",
-  "local",
-  "gemini",
-  "voyage",
-  "mistral",
-  "ollama",
-  "auto",
-]);
 
 /**
  * Check whether memory search has a usable embedding provider.
@@ -40,19 +34,24 @@ export async function noteMemorySearchHealth(
 ): Promise<void> {
   const agentId = resolveDefaultAgentId(cfg);
   const agentDir = resolveAgentDir(cfg, agentId);
+  const enabledOverride = resolveAgentConfig(cfg, agentId)?.memorySearch?.enabled;
+  const enabledDefault = cfg.agents?.defaults?.memorySearch?.enabled;
+  const memorySearchEnabled = enabledOverride ?? enabledDefault ?? true;
   const rawProvider =
-    (
+    normalizeMemorySearchProvider(
       resolveAgentConfig(cfg, agentId)?.memorySearch?.provider ??
-      cfg.agents?.defaults?.memorySearch?.provider ??
-      "auto"
-    )
-      ?.trim()
-      .toLowerCase() ?? "auto";
+        cfg.agents?.defaults?.memorySearch?.provider ??
+        "auto",
+    ).toLowerCase() || "auto";
   const resolved = resolveMemorySearchConfig(cfg, agentId);
   const hasRemoteApiKey = hasConfiguredMemorySecretInput(resolved?.remote?.apiKey);
 
   if (!resolved) {
-    if (rawProvider && !BUILTIN_MEMORY_SEARCH_PROVIDERS.has(rawProvider)) {
+    if (!memorySearchEnabled) {
+      note("Memory search is explicitly disabled (enabled: false).", "Memory search");
+      return;
+    }
+    if (rawProvider && !isBuiltinMemorySearchProvider(rawProvider)) {
       note(
         [
           `Memory search provider "${rawProvider}" is delegated to the memory plugin slot (plugins.slots.memory).`,
@@ -62,7 +61,7 @@ export async function noteMemorySearchHealth(
       );
       return;
     }
-    note("Memory search is explicitly disabled (enabled: false).", "Memory search");
+    note("Memory search is unavailable for the configured provider.", "Memory search");
     return;
   }
 

--- a/src/commands/doctor-memory-search.ts
+++ b/src/commands/doctor-memory-search.ts
@@ -1,5 +1,9 @@
 import fsSync from "node:fs";
-import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  resolveAgentConfig,
+  resolveAgentDir,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
 import { resolveMemorySearchConfig } from "../agents/memory-search.js";
 import { resolveApiKeyForProvider } from "../agents/model-auth.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -9,6 +13,16 @@ import { DEFAULT_LOCAL_MODEL } from "../memory/embeddings.js";
 import { hasConfiguredMemorySecretInput } from "../memory/secret-input.js";
 import { note } from "../terminal/note.js";
 import { resolveUserPath } from "../utils.js";
+
+const BUILTIN_MEMORY_SEARCH_PROVIDERS = new Set([
+  "openai",
+  "local",
+  "gemini",
+  "voyage",
+  "mistral",
+  "ollama",
+  "auto",
+]);
 
 /**
  * Check whether memory search has a usable embedding provider.
@@ -26,10 +40,28 @@ export async function noteMemorySearchHealth(
 ): Promise<void> {
   const agentId = resolveDefaultAgentId(cfg);
   const agentDir = resolveAgentDir(cfg, agentId);
+  const rawProvider =
+    (
+      resolveAgentConfig(cfg, agentId)?.memorySearch?.provider ??
+      cfg.agents?.defaults?.memorySearch?.provider ??
+      "auto"
+    )
+      ?.trim()
+      .toLowerCase() ?? "auto";
   const resolved = resolveMemorySearchConfig(cfg, agentId);
   const hasRemoteApiKey = hasConfiguredMemorySecretInput(resolved?.remote?.apiKey);
 
   if (!resolved) {
+    if (rawProvider && !BUILTIN_MEMORY_SEARCH_PROVIDERS.has(rawProvider)) {
+      note(
+        [
+          `Memory search provider "${rawProvider}" is delegated to the memory plugin slot (plugins.slots.memory).`,
+          "Built-in memory embeddings health checks are skipped for plugin providers.",
+        ].join("\n"),
+        "Memory search",
+      );
+      return;
+    }
     note("Memory search is explicitly disabled (enabled: false).", "Memory search");
     return;
   }

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -372,4 +372,30 @@ describe("config plugin validation", () => {
       ).toBe(true);
     }
   });
+
+  it('rejects memorySearch provider "memory-core" as reserved bundled slot id', async () => {
+    const res = validateInSuite({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "memory-core",
+          },
+        },
+      },
+      plugins: {
+        slots: { memory: "memory-core" },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(
+        res.issues.some(
+          (issue) =>
+            issue.path === "agents.defaults.memorySearch.provider" &&
+            issue.message.includes('provider "memory-core" is reserved'),
+        ),
+      ).toBe(true);
+    }
+  });
 });

--- a/src/config/config.plugin-validation.test.ts
+++ b/src/config/config.plugin-validation.test.ts
@@ -285,4 +285,91 @@ describe("config plugin validation", () => {
       ).toBe(true);
     }
   });
+
+  it("accepts memorySearch provider when it matches memory slot plugin", async () => {
+    const memoryPluginDir = path.join(suiteHome, "memory-openviking-plugin");
+    await writePluginFixture({
+      dir: memoryPluginDir,
+      id: "memory-openviking",
+      schema: { type: "object" },
+    });
+    await fs.writeFile(
+      path.join(memoryPluginDir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "memory-openviking",
+          kind: "memory",
+          configSchema: { type: "object" },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    clearPluginManifestRegistryCache();
+
+    const res = validateInSuite({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "memory-openviking",
+          },
+        },
+      },
+      plugins: {
+        load: { paths: [memoryPluginDir] },
+        slots: { memory: "memory-openviking" },
+      },
+    });
+
+    expect(res.ok).toBe(true);
+  });
+
+  it("rejects memorySearch plugin provider when memory slot differs", async () => {
+    const memoryPluginDir = path.join(suiteHome, "memory-custom-plugin");
+    await writePluginFixture({
+      dir: memoryPluginDir,
+      id: "memory-custom",
+      schema: { type: "object" },
+    });
+    await fs.writeFile(
+      path.join(memoryPluginDir, "openclaw.plugin.json"),
+      JSON.stringify(
+        {
+          id: "memory-custom",
+          kind: "memory",
+          configSchema: { type: "object" },
+        },
+        null,
+        2,
+      ),
+      "utf-8",
+    );
+    clearPluginManifestRegistryCache();
+
+    const res = validateInSuite({
+      agents: {
+        defaults: {
+          memorySearch: {
+            provider: "memory-custom",
+          },
+        },
+      },
+      plugins: {
+        load: { paths: [memoryPluginDir] },
+        slots: { memory: "memory-core" },
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(
+        res.issues.some(
+          (issue) =>
+            issue.path === "agents.defaults.memorySearch.provider" &&
+            issue.message.includes("must match plugins.slots.memory"),
+        ),
+      ).toBe(true);
+    }
+  });
 });

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -776,7 +776,7 @@ export const FIELD_HELP: Record<string, string> = {
   "agents.defaults.memorySearch.experimental.sessionMemory":
     "Indexes session transcripts into memory search so responses can reference prior chat turns. Keep this off unless transcript recall is needed, because indexing cost and storage usage both increase.",
   "agents.defaults.memorySearch.provider":
-    'Selects the embedding backend used to build/query memory vectors: "openai", "gemini", "voyage", "mistral", "ollama", or "local". Keep your most reliable provider here and configure fallback for resilience.',
+    'Selects the embedding backend used to build/query memory vectors. Use a built-in provider ("openai", "gemini", "voyage", "mistral", "ollama", "local", "auto") or a memory plugin id that matches plugins.slots.memory.',
   "agents.defaults.memorySearch.model":
     "Embedding model override used by the selected memory provider when a non-default model is required. Set this only when you need explicit recall quality/cost tuning beyond provider defaults.",
   "agents.defaults.memorySearch.remote.baseUrl":

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -324,8 +324,8 @@ export type MemorySearchConfig = {
     /** Enable session transcript indexing (experimental, default: false). */
     sessionMemory?: boolean;
   };
-  /** Embedding provider mode. */
-  provider?: "openai" | "gemini" | "local" | "voyage" | "mistral" | "ollama";
+  /** Embedding provider mode (built-in provider or memory plugin id). */
+  provider?: string;
   remote?: {
     baseUrl?: string;
     apiKey?: SecretInput;

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -1,5 +1,9 @@
 import path from "node:path";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  isBuiltinMemorySearchProvider,
+  normalizeMemorySearchProvider,
+} from "../agents/memory-search.js";
 import { CHANNEL_IDS, normalizeChatChannelId } from "../channels/registry.js";
 import {
   normalizePluginsConfig,
@@ -25,16 +29,6 @@ import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
 import { OpenClawSchema } from "./zod-schema.js";
 
 const LEGACY_REMOVED_PLUGIN_IDS = new Set(["google-antigravity-auth"]);
-const BUILTIN_MEMORY_SEARCH_PROVIDER_IDS = new Set([
-  "openai",
-  "local",
-  "gemini",
-  "voyage",
-  "mistral",
-  "ollama",
-  "auto",
-]);
-
 type UnknownIssueRecord = Record<string, unknown>;
 type AllowedValuesCollection = {
   values: unknown[];
@@ -394,8 +388,21 @@ function validateConfigObjectWithPluginsBase(
     if (typeof provider !== "string") {
       return;
     }
-    const normalizedProvider = provider.trim();
-    if (!normalizedProvider || BUILTIN_MEMORY_SEARCH_PROVIDER_IDS.has(normalizedProvider)) {
+    const normalizedProvider = normalizeMemorySearchProvider(provider);
+    if (!normalizedProvider) {
+      return;
+    }
+    const normalizedBuiltinProvider = normalizedProvider.toLowerCase();
+    if (isBuiltinMemorySearchProvider(normalizedBuiltinProvider)) {
+      return;
+    }
+
+    if (normalizedProvider === "memory-core") {
+      issues.push({
+        path: providerPath,
+        message:
+          'memory search provider "memory-core" is reserved for the bundled memory plugin; use a built-in provider (for example "auto") and keep plugins.slots.memory="memory-core"',
+      });
       return;
     }
 

--- a/src/config/validation.ts
+++ b/src/config/validation.ts
@@ -25,6 +25,15 @@ import type { OpenClawConfig, ConfigValidationIssue } from "./types.js";
 import { OpenClawSchema } from "./zod-schema.js";
 
 const LEGACY_REMOVED_PLUGIN_IDS = new Set(["google-antigravity-auth"]);
+const BUILTIN_MEMORY_SEARCH_PROVIDER_IDS = new Set([
+  "openai",
+  "local",
+  "gemini",
+  "voyage",
+  "mistral",
+  "ollama",
+  "auto",
+]);
 
 type UnknownIssueRecord = Record<string, unknown>;
 type AllowedValuesCollection = {
@@ -380,6 +389,78 @@ function validateConfigObjectWithPluginsBase(
     }
     return info.normalizedPlugins;
   };
+
+  const validateMemorySearchProvider = (provider: string | undefined, providerPath: string) => {
+    if (typeof provider !== "string") {
+      return;
+    }
+    const normalizedProvider = provider.trim();
+    if (!normalizedProvider || BUILTIN_MEMORY_SEARCH_PROVIDER_IDS.has(normalizedProvider)) {
+      return;
+    }
+
+    const normalizedPlugins = ensureNormalizedPlugins();
+    const memorySlot = normalizedPlugins.slots.memory;
+    if (memorySlot === null) {
+      issues.push({
+        path: providerPath,
+        message: `memory search provider plugin "${normalizedProvider}" requires a memory slot plugin, but plugins.slots.memory is "none"`,
+      });
+      return;
+    }
+    if (memorySlot !== normalizedProvider) {
+      issues.push({
+        path: providerPath,
+        message: `memory search provider plugin "${normalizedProvider}" must match plugins.slots.memory (current: "${memorySlot ?? "unset"}")`,
+      });
+      return;
+    }
+
+    const knownIds = ensureKnownIds();
+    if (!knownIds.has(normalizedProvider)) {
+      issues.push({
+        path: providerPath,
+        message: `unknown memory search provider plugin: ${normalizedProvider}`,
+      });
+      return;
+    }
+
+    const { registry } = ensureRegistry();
+    const record = registry.plugins.find((plugin) => plugin.id === normalizedProvider);
+    if (record?.kind !== "memory") {
+      issues.push({
+        path: providerPath,
+        message: `memory search provider plugin must be kind "memory": ${normalizedProvider}`,
+      });
+      return;
+    }
+
+    const enableState = resolveEffectiveEnableState({
+      id: normalizedProvider,
+      origin: record.origin,
+      config: normalizedPlugins,
+      rootConfig: config,
+    });
+    if (!enableState.enabled) {
+      issues.push({
+        path: providerPath,
+        message: `memory search provider plugin is disabled: ${normalizedProvider} (${enableState.reason ?? "disabled"})`,
+      });
+    }
+  };
+
+  validateMemorySearchProvider(
+    config.agents?.defaults?.memorySearch?.provider,
+    "agents.defaults.memorySearch.provider",
+  );
+  if (Array.isArray(config.agents?.list)) {
+    for (const [index, entry] of config.agents.list.entries()) {
+      validateMemorySearchProvider(
+        entry?.memorySearch?.provider,
+        `agents.list.${index}.memorySearch.provider`,
+      );
+    }
+  }
 
   const allowedChannels = new Set<string>(["defaults", "modelByChannel", ...CHANNEL_IDS]);
 

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -553,16 +553,7 @@ export const MemorySearchSchema = z
       })
       .strict()
       .optional(),
-    provider: z
-      .union([
-        z.literal("openai"),
-        z.literal("local"),
-        z.literal("gemini"),
-        z.literal("voyage"),
-        z.literal("mistral"),
-        z.literal("ollama"),
-      ])
-      .optional(),
+    provider: z.string().min(1).optional(),
     remote: z
       .object({
         baseUrl: z.string().optional(),

--- a/src/memory/embeddings.test.ts
+++ b/src/memory/embeddings.test.ts
@@ -369,6 +369,19 @@ describe("embedding provider auto selection", () => {
   });
 });
 
+describe("embedding provider validation", () => {
+  it("throws for unknown provider ids", async () => {
+    await expect(
+      createEmbeddingProvider({
+        config: {} as never,
+        provider: "openviking" as never,
+        model: "text-embedding-3-small",
+        fallback: "none",
+      }),
+    ).rejects.toThrow("Unknown memory embedding provider: openviking");
+  });
+});
+
 describe("embedding provider local fallback", () => {
   it("falls back to openai when node-llama-cpp is missing", async () => {
     mockMissingLocalEmbeddingDependency();

--- a/src/memory/embeddings.ts
+++ b/src/memory/embeddings.ts
@@ -194,6 +194,20 @@ export async function createEmbeddingProvider(
     return { provider, openAi: client };
   };
 
+  const assertEmbeddingProviderId = (provider: string): EmbeddingProviderId => {
+    if (
+      provider === "openai" ||
+      provider === "local" ||
+      provider === "gemini" ||
+      provider === "voyage" ||
+      provider === "mistral" ||
+      provider === "ollama"
+    ) {
+      return provider;
+    }
+    throw new Error(`Unknown memory embedding provider: ${provider}`);
+  };
+
   const formatPrimaryError = (err: unknown, provider: EmbeddingProviderId) =>
     provider === "local" ? formatLocalSetupError(err) : formatErrorMessage(err);
 
@@ -238,7 +252,7 @@ export async function createEmbeddingProvider(
   }
 
   try {
-    const primary = await createProvider(requestedProvider);
+    const primary = await createProvider(assertEmbeddingProviderId(requestedProvider));
     return { ...primary, requestedProvider };
   } catch (primaryErr) {
     const reason = formatPrimaryError(primaryErr, requestedProvider);


### PR DESCRIPTION
## Summary
- Problem: `agents.defaults.memorySearch.provider` was hard-limited by enum, so plugin ids (e.g. `memory-openviking`) failed schema validation and could break startup/misroute behavior.
- Why it matters: users configuring memory via plugin slot could not express provider intent cleanly; unknown providers could also silently fall through built-in embedding routing.
- What changed:
  - `memorySearch.provider` now accepts `string` (schema + type), not only built-in enum values.
  - Added startup validation: non-built-in provider must be a discovered `memory` plugin, must be enabled, and must match `plugins.slots.memory`.
  - Built-in memory index path is skipped for plugin-managed providers (scope boundary between built-in memory and plugin memory).
  - Unknown built-in embedding provider ids now fail explicitly instead of implicitly defaulting to OpenAI.
  - Updated doctor/help messaging and tests for plugin-provider scenarios.
- What did NOT change (scope boundary):
  - No change to plugin runtime protocol/tool contracts.
  - No change to default provider behavior for existing built-in values.
  - No new memory plugin execution path added; only validation/routing safety around existing paths.
## Change Type (select all)
- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra
## Scope (select all touched areas)
- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra
## Linked Issue/PR
- Closes #
- Related #
## User-visible / Behavior Changes
- `agents.*.memorySearch.provider` now supports built-in provider ids **or** memory plugin ids.
- If provider is a plugin id, config validation now enforces:
  - plugin exists,
  - plugin `kind === "memory"`,
  - plugin is enabled,
  - plugin id matches `plugins.slots.memory`.
- For plugin-managed providers, built-in memory embeddings checks are skipped with explicit doctor note.
- Unknown embedding provider ids now error explicitly instead of silently routing to OpenAI.
## Security Impact (required)
- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:
  - N/A
## Repro + Verification
### Environment
- OS: macOS (darwin)
- Runtime/container: Node.js workspace / pnpm monorepo
- Model/provider: memory provider config (built-in + plugin id paths)
- Integration/channel (if any): N/A
- Relevant config (redacted):
  - `agents.defaults.memorySearch.provider: "memory-openviking"`
  - `plugins.slots.memory: "memory-openviking"`
### Steps
1. Set `memorySearch.provider` to a memory plugin id and set matching `plugins.slots.memory`.
2. Run config validation / startup checks.
3. Run targeted tests.
### Expected
- Config validates successfully when provider is valid plugin id and slot matches.
- Config fails with clear error when slot mismatch / plugin invalid.
- Built-in memory path is skipped for plugin-managed provider.
- Unknown embedding provider id errors explicitly.
### Actual
- Matches expected behavior.
## Evidence
- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)
Targeted verification run:
`corepack pnpm exec vitest run src/agents/memory-search.test.ts src/commands/doctor-memory-search.test.ts src/config/config.plugin-validation.test.ts src/memory/embeddings.test.ts`
Result:
- Test Files: 4 passed
- Tests: 66 passed
## Human Verification (required)
- Verified scenarios:
  - plugin provider id accepted when slot matches and plugin is memory-kind/enabled.
  - plugin provider id rejected when slot mismatched.
  - doctor output for plugin-managed provider skips built-in checks.
  - unknown embedding provider id throws explicit error.
- Edge cases checked:
  - defaults + agent override provider resolution path.
  - built-in providers continue passing existing tests.
- What you did **not** verify:
  - full end-to-end gateway runtime with real OpenViking backend traffic in this PR context.
  - GitHub Actions full matrix (only targeted local tests run).
## Compatibility / Migration
- Backward compatible? (`Yes`)
- Config/env changes? (`No`)  <!-- optional new capability only -->
- Migration needed? (`No`)
- If yes, exact upgrade steps:
  - N/A
## Failure Recovery (if this breaks)
- How to disable/revert this change quickly:
  - Set `agents.*.memorySearch.provider` back to a built-in provider (`auto` / `openai` / `local` etc.), or revert this PR commit.
- Files/config to restore:
  - `agents.defaults.memorySearch.provider`
  - `plugins.slots.memory` (ensure consistent with provider intent)
- Known bad symptoms reviewers should watch for:
  - validation error on `agents.*.memorySearch.provider` with slot mismatch.
  - doctor showing plugin delegation message unexpectedly due to provider typo.
## Risks and Mitigations
- Risk: stricter startup validation may reject previously tolerated but inconsistent configs.
  - Mitigation: explicit, actionable validation messages; backward-compatible built-in provider paths unchanged.
- Risk: plugin-provider path disables built-in index manager, surprising users who expected mixed behavior.
  - Mitigation: clear doctor/help messaging and enforced slot/provider consistency to avoid ambiguous routing.