### PR TITLE
fix(ui): exit focus mode when hamburger menu is clicked (#26690)

### DIFF
--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -226,13 +226,16 @@ export function renderApp(state: AppViewState) {
         <div class="topbar-left">
           <button
             class="nav-collapse-toggle"
-            @click=${() =>
+            @click=${() => {
+              // If user-initiated focus mode is active (not onboarding), exit it and reveal the nav.
+              // During onboarding, focus mode is controlled by the onboarding flow, so just toggle nav normally.
+              const userFocusMode = state.settings.chatFocusMode && !state.onboarding;
               state.applySettings({
                 ...state.settings,
-                // If focus mode is active, exit it and reveal the nav instead of toggling collapse
-                chatFocusMode: chatFocus ? false : state.settings.chatFocusMode,
-                navCollapsed: chatFocus ? false : !state.settings.navCollapsed,
-              })}
+                chatFocusMode: userFocusMode ? false : state.settings.chatFocusMode,
+                navCollapsed: userFocusMode ? false : !state.settings.navCollapsed,
+              });
+            }}
             title="${state.settings.navCollapsed ? t("nav.expand") : t("nav.collapse")}"
             aria-label="${state.settings.navCollapsed ? t("nav.expand") : t("nav.collapse")}"
           >

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -229,7 +229,9 @@ export function renderApp(state: AppViewState) {
             @click=${() =>
               state.applySettings({
                 ...state.settings,
-                navCollapsed: !state.settings.navCollapsed,
+                // If focus mode is active, exit it and reveal the nav instead of toggling collapse
+                chatFocusMode: chatFocus ? false : state.settings.chatFocusMode,
+                navCollapsed: chatFocus ? false : !state.settings.navCollapsed,
               })}
             title="${state.settings.navCollapsed ? t("nav.expand") : t("nav.collapse")}"
             aria-label="${state.settings.navCollapsed ? t("nav.expand") : t("nav.collapse")}"

--- a/ui/src/ui/focus-mode.browser.test.ts
+++ b/ui/src/ui/focus-mode.browser.test.ts
@@ -36,4 +36,23 @@ describe("chat focus mode", () => {
     expect(app.tab).toBe("chat");
     expect(shell?.classList.contains("shell--chat-focus")).toBe(true);
   });
+
+  it("exits focus mode when hamburger menu is clicked", async () => {
+    const app = mountApp("/chat");
+    await app.updateComplete;
+
+    const shell = app.querySelector(".shell");
+    const toggle = app.querySelector<HTMLButtonElement>('button[title^="Toggle focus mode"]');
+    toggle?.click();
+    await app.updateComplete;
+    expect(shell?.classList.contains("shell--chat-focus")).toBe(true);
+
+    const hamburger = app.querySelector<HTMLButtonElement>("button.nav-collapse-toggle");
+    expect(hamburger).not.toBeNull();
+    hamburger?.click();
+
+    await app.updateComplete;
+    expect(shell?.classList.contains("shell--chat-focus")).toBe(false);
+    expect(shell?.classList.contains("shell--nav-collapsed")).toBe(false);
+  });
 });

--- a/ui/src/ui/focus-mode.browser.test.ts
+++ b/ui/src/ui/focus-mode.browser.test.ts
@@ -43,6 +43,7 @@ describe("chat focus mode", () => {
 
     const shell = app.querySelector(".shell");
     const toggle = app.querySelector<HTMLButtonElement>('button[title^="Toggle focus mode"]');
+    expect(toggle).not.toBeNull();
     toggle?.click();
     await app.updateComplete;
     expect(shell?.classList.contains("shell--chat-focus")).toBe(true);


### PR DESCRIPTION
## Problem

When Focus Mode (chat focus) is active in the Control UI, the hamburger menu (☰) remains visible but clicking it does nothing. The sidebar/nav is hidden by `shell--chat-focus` and there is no obvious way to exit focus mode.

Fixes #26690

## Solution

When the hamburger is clicked while **user-initiated** focus mode is active, exit focus mode and reveal the sidebar instead of toggling nav collapse. During onboarding-triggered focus mode, the hamburger behaves normally (toggle nav) since the onboarding flow controls focus state.

## Changes

- **`ui/src/ui/app-render.ts`** — Hamburger click handler distinguishes user-initiated focus mode (`chatFocusMode && !onboarding`) from onboarding focus mode. Only exits focus for user-initiated case.
- **`ui/src/ui/focus-mode.browser.test.ts`** — Added test: enters focus mode → clicks hamburger → verifies focus mode exits and nav opens. Includes null guard on toggle button to prevent false positives.

## Testing

- [x] Added browser test covering the fix
- [x] Addressed Greptile review feedback (onboarding edge case + test null guard)
- [ ] Manual local testing (will test via dev build)

## AI Disclosure

Initial fix generated by Claude Code (Sonnet) with the following prompt:

> Fix GitHub issue #26690: "UX: Focus Mode makes hamburger menu appear broken". In the Control UI, when Focus Mode is active, the hamburger menu is visible but clicking it does nothing. Fix: clicking hamburger while in focus mode should exit focus mode and open the sidebar/nav. Look in ui/src/ui/ for focus mode toggle and hamburger click handler. Keep fix minimal. Commit as: fix(ui): exit focus mode when hamburger menu is clicked (#26690). Run relevant tests.

Review improvements (onboarding edge case handling, test null guard) applied manually with Bobby (Claude Opus) based on Greptile automated review feedback.