### PR TITLE
feat: Add LLM retry mechanism with exponential backoff

### DIFF
--- a/src/agents/pi-embedded-runner/llm-retry.test.ts
+++ b/src/agents/pi-embedded-runner/llm-retry.test.ts
@@ -212,4 +212,19 @@ describe("extractRetryAfterMs", () => {
     expect(extractRetryAfterMs({ message: "retry in  5  seconds" })).toBe(5000);
     expect(extractRetryAfterMs({ message: "reset after  10  ms" })).toBe(10);
   });
+
+  it("handles messages without explicit unit (defaults to seconds)", () => {
+    expect(extractRetryAfterMs({ message: "retry in 5" })).toBe(5000);
+    expect(extractRetryAfterMs({ message: "reset after 10" })).toBe(10000);
+    expect(extractRetryAfterMs({ message: "retry in 2.5" })).toBe(2500);
+  });
+
+  it("handles optional unit in regex correctly", () => {
+    // When unit is omitted, default to seconds (multiply by 1000)
+    expect(extractRetryAfterMs({ message: "retry in 3" })).toBe(3000);
+    // When unit is "ms", don't multiply
+    expect(extractRetryAfterMs({ message: "retry in 3ms" })).toBe(3);
+    // When unit is "s", multiply by 1000
+    expect(extractRetryAfterMs({ message: "retry in 3s" })).toBe(3000);
+  });
 });

--- a/src/agents/pi-embedded-runner/llm-retry.test.ts
+++ b/src/agents/pi-embedded-runner/llm-retry.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import { extractRetryAfterMs, isRetryableLlmError } from "./llm-retry.js";
+
+describe("isRetryableLlmError", () => {
+  it("returns true for HTTP 429 rate limit errors", () => {
+    expect(isRetryableLlmError({ status: 429 })).toBe(true);
+    expect(isRetryableLlmError({ statusCode: 429 })).toBe(true);
+  });
+
+  it("returns true for HTTP 500 server error", () => {
+    expect(isRetryableLlmError({ status: 500 })).toBe(true);
+    expect(isRetryableLlmError({ statusCode: 500 })).toBe(true);
+  });
+
+  it("returns true for HTTP 502 bad gateway", () => {
+    expect(isRetryableLlmError({ status: 502 })).toBe(true);
+    expect(isRetryableLlmError({ statusCode: 502 })).toBe(true);
+  });
+
+  it("returns true for HTTP 503 service unavailable", () => {
+    expect(isRetryableLlmError({ status: 503 })).toBe(true);
+    expect(isRetryableLlmError({ statusCode: 503 })).toBe(true);
+  });
+
+  it("returns true for HTTP 504 gateway timeout", () => {
+    expect(isRetryableLlmError({ status: 504 })).toBe(true);
+    expect(isRetryableLlmError({ statusCode: 504 })).toBe(true);
+  });
+
+  it("returns false for HTTP 400 bad request", () => {
+    expect(isRetryableLlmError({ status: 400 })).toBe(false);
+    expect(isRetryableLlmError({ statusCode: 400 })).toBe(false);
+  });
+
+  it("returns false for HTTP 401 unauthorized", () => {
+    expect(isRetryableLlmError({ status: 401 })).toBe(false);
+    expect(isRetryableLlmError({ statusCode: 401 })).toBe(false);
+  });
+
+  it("returns false for HTTP 403 forbidden", () => {
+    expect(isRetryableLlmError({ status: 403 })).toBe(false);
+    expect(isRetryableLlmError({ statusCode: 403 })).toBe(false);
+  });
+
+  it("returns false for HTTP 404 not found", () => {
+    expect(isRetryableLlmError({ status: 404 })).toBe(false);
+    expect(isRetryableLlmError({ statusCode: 404 })).toBe(false);
+  });
+
+  it("returns false for HTTP 402 payment required", () => {
+    expect(isRetryableLlmError({ status: 402 })).toBe(false);
+    expect(isRetryableLlmError({ statusCode: 402 })).toBe(false);
+  });
+
+  it("returns true for network error codes", () => {
+    expect(isRetryableLlmError({ code: "ETIMEDOUT" })).toBe(true);
+    expect(isRetryableLlmError({ code: "esockettimedout" })).toBe(true);
+    expect(isRetryableLlmError({ code: "ECONNRESET" })).toBe(true);
+    expect(isRetryableLlmError({ code: "ECONNABORTED" })).toBe(true);
+  });
+
+  it("returns true for timeout errors in message", () => {
+    expect(isRetryableLlmError({ message: "Request timeout" })).toBe(true);
+    expect(isRetryableLlmError({ message: "Operation timed out" })).toBe(true);
+    expect(isRetryableLlmError({ message: "DEADLINE_EXCEEDED" })).toBe(true);
+    expect(isRetryableLlmError({ message: "Connection timed out" })).toBe(true);
+  });
+
+  it("returns false for non-timeout errors in message", () => {
+    expect(isRetryableLlmError({ message: "Invalid input" })).toBe(false);
+    expect(isRetryableLlmError({ message: "Access denied" })).toBe(false);
+  });
+
+  it("returns false for null or undefined", () => {
+    expect(isRetryableLlmError(null)).toBe(false);
+    expect(isRetryableLlmError(undefined)).toBe(false);
+  });
+
+  it("returns false for unknown error codes", () => {
+    expect(isRetryableLlmError({ status: 418 })).toBe(false); // I'm a teapot
+    expect(isRetryableLlmError({ code: "EUNKNOWN" })).toBe(false);
+  });
+
+  it("returns false for other client errors", () => {
+    expect(isRetryableLlmError({ status: 408 })).toBe(false); // Request Timeout (client error)
+    expect(isRetryableLlmError({ status: 413 })).toBe(false); // Payload Too Large
+    expect(isRetryableLlmError({ status: 415 })).toBe(false); // Unsupported Media Type
+  });
+});
+
+describe("extractRetryAfterMs", () => {
+  it("extracts delay from Retry-After header in seconds", () => {
+    const headers = {
+      get: (name: string) => {
+        if (name.toLowerCase() === "retry-after") {
+          return "5";
+        }
+        return null;
+      },
+    };
+    expect(extractRetryAfterMs({ headers })).toBe(5000);
+  });
+
+  it("extracts delay from Retry-After header with decimal seconds", () => {
+    const headers = {
+      get: (name: string) => {
+        if (name.toLowerCase() === "retry-after") {
+          return "2.5";
+        }
+        return null;
+      },
+    };
+    expect(extractRetryAfterMs({ headers })).toBe(2500);
+  });
+
+  it("extracts delay from x-ratelimit-reset header", () => {
+    const futureTimestamp = Math.floor(Date.now() / 1000) + 10;
+    const headers = {
+      get: (name: string) => {
+        if (name.toLowerCase() === "x-ratelimit-reset") {
+          return String(futureTimestamp);
+        }
+        return null;
+      },
+    };
+    const result = extractRetryAfterMs({ headers });
+    expect(result).toBeGreaterThan(0);
+    expect(result).toBeLessThanOrEqual(11000);
+  });
+
+  it("extracts delay from x-ratelimit-reset-after header", () => {
+    const headers = {
+      get: (name: string) => {
+        if (name.toLowerCase() === "x-ratelimit-reset-after") {
+          return "3";
+        }
+        return null;
+      },
+    };
+    expect(extractRetryAfterMs({ headers })).toBe(3000);
+  });
+
+  it("extracts delay from error message with 'retry in' and seconds", () => {
+    expect(extractRetryAfterMs({ message: "retry in 5 seconds" })).toBe(5000);
+    expect(extractRetryAfterMs({ message: "retry in 5 s" })).toBe(5000);
+    expect(extractRetryAfterMs({ message: "retry in 10 sec" })).toBe(10000);
+    expect(extractRetryAfterMs({ message: "retry in 2.5 seconds" })).toBe(2500);
+  });
+
+  it("extracts delay from error message with 'retry in' and milliseconds", () => {
+    expect(extractRetryAfterMs({ message: "retry in 500 ms" })).toBe(500);
+    expect(extractRetryAfterMs({ message: "retry in 500 milliseconds" })).toBe(500);
+    expect(extractRetryAfterMs({ message: "retry in 1.5 ms" })).toBe(1.5);
+  });
+
+  it("extracts delay from error message with 'reset after' and seconds", () => {
+    expect(extractRetryAfterMs({ message: "reset after 3 seconds" })).toBe(3000);
+    expect(extractRetryAfterMs({ message: "reset after 3 s" })).toBe(3000);
+  });
+
+  it("extracts delay from error message with 'reset after' and milliseconds", () => {
+    expect(extractRetryAfterMs({ message: "reset after 1000 ms" })).toBe(1000);
+    expect(extractRetryAfterMs({ message: "reset after 1000 milliseconds" })).toBe(1000);
+  });
+
+  it("returns undefined for null or undefined error", () => {
+    expect(extractRetryAfterMs(null)).toBeUndefined();
+    expect(extractRetryAfterMs(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for error with no headers or message", () => {
+    expect(extractRetryAfterMs({})).toBeUndefined();
+    expect(extractRetryAfterMs({ status: 429 })).toBeUndefined();
+  });
+
+  it("returns undefined for invalid Retry-After value", () => {
+    const headers = {
+      get: (name: string) => {
+        if (name.toLowerCase() === "retry-after") {
+          return "invalid";
+        }
+        return null;
+      },
+    };
+    expect(extractRetryAfterMs({ headers })).toBeUndefined();
+  });
+
+  it("returns undefined for negative Retry-After value", () => {
+    const headers = {
+      get: (name: string) => {
+        if (name.toLowerCase() === "retry-after") {
+          return "-5";
+        }
+        return null;
+      },
+    };
+    expect(extractRetryAfterMs({ headers })).toBeUndefined();
+  });
+
+  it("returns undefined for error message without retry hints", () => {
+    expect(extractRetryAfterMs({ message: "something went wrong" })).toBeUndefined();
+    expect(extractRetryAfterMs({ message: "rate limit exceeded" })).toBeUndefined();
+  });
+
+  it("handles case-insensitive unit matching in error messages", () => {
+    expect(extractRetryAfterMs({ message: "retry in 5 SECONDS" })).toBe(5000);
+    expect(extractRetryAfterMs({ message: "retry in 5 Seconds" })).toBe(5000);
+    expect(extractRetryAfterMs({ message: "retry in 5 MS" })).toBe(5);
+  });
+
+  it("handles whitespace in error message patterns", () => {
+    expect(extractRetryAfterMs({ message: "retry in  5  seconds" })).toBe(5000);
+    expect(extractRetryAfterMs({ message: "reset after  10  ms" })).toBe(10);
+  });
+});

--- a/src/agents/pi-embedded-runner/llm-retry.ts
+++ b/src/agents/pi-embedded-runner/llm-retry.ts
@@ -37,6 +37,19 @@ const DEFAULT_RETRY_CONFIG = {
 
 /**
  * Check if an error is retryable for LLM calls.
+ *
+ * @remarks
+ * This function checks the error's HTTP status code, error code, and message to determine
+ * whether it should be retried. The logic is:
+ * - Do not retry on client errors (4xx) except 429 (rate limit)
+ * - Do not retry on billing errors (402)
+ * - Retry on rate limit (429)
+ * - Retry on server errors (5xx)
+ * - Retry on network errors (ETIMEDOUT, ESOCKETTIMEDOUT, ECONNRESET, ECONNABORTED)
+ * - Retry on timeout errors (only when not a 4xx status code)
+ *
+ * @param err - The error to check, which may be an object with status, statusCode, code, or message properties.
+ * @returns `true` if the error is retryable, `false` otherwise.
  */
 export function isRetryableLlmError(err: unknown): boolean {
   if (!err) {
@@ -46,6 +59,17 @@ export function isRetryableLlmError(err: unknown): boolean {
   const errorObj = err as { status?: number; statusCode?: number; code?: string; message?: string };
   const status = errorObj.status ?? errorObj.statusCode;
   const message = errorObj.message ?? "";
+
+  // Check status codes first (more reliable than message parsing)
+  // Do not retry on client errors (400, 401, 403, 404, 408)
+  if (status === 400 || status === 401 || status === 403 || status === 404 || status === 408) {
+    return false;
+  }
+
+  // Do not retry on billing errors (402)
+  if (status === 402) {
+    return false;
+  }
 
   // Retry on rate limit (429)
   if (status === 429) {
@@ -57,25 +81,20 @@ export function isRetryableLlmError(err: unknown): boolean {
     return true;
   }
 
-  // Retry on network errors
-  const code = (errorObj.code ?? "").toUpperCase();
-  if (["ETIMEDOUT", "ESOCKETTIMEDOUT", "ECONNRESET", "ECONNABORTED"].includes(code)) {
-    return true;
-  }
+  // Only check timeout message if there's no 4xx status code
+  // (timeout messages in 4xx responses indicate client-side timeouts that shouldn't be retried)
+  const is4xx = status !== undefined && status >= 400 && status < 500;
+  if (!is4xx) {
+    // Retry on timeout errors (only for non-4xx status codes)
+    if (/timeout|timed out|deadline exceeded|deadline_exceeded/i.test(message)) {
+      return true;
+    }
 
-  // Retry on timeout errors
-  if (/timeout|timed out|deadline exceeded|deadline_exceeded/i.test(message)) {
-    return true;
-  }
-
-  // Do not retry on client errors (400, 401, 403, 404)
-  if (status === 400 || status === 401 || status === 403 || status === 404) {
-    return false;
-  }
-
-  // Do not retry on billing errors (402)
-  if (status === 402) {
-    return false;
+    // Retry on network errors
+    const code = (errorObj.code ?? "").toUpperCase();
+    if (["ETIMEDOUT", "ESOCKETTIMEDOUT", "ECONNRESET", "ECONNABORTED"].includes(code)) {
+      return true;
+    }
   }
 
   // Default: do not retry unknown errors
@@ -84,6 +103,16 @@ export function isRetryableLlmError(err: unknown): boolean {
 
 /**
  * Extract retry-after delay from error response headers or body.
+ *
+ * @remarks
+ * This function checks the error's headers and message for retry delay hints:
+ * - `Retry-After` header (RFC 7231, in seconds)
+ * - `x-ratelimit-reset` header (Unix timestamp, converted to relative ms)
+ * - `x-ratelimit-reset-after` header (seconds)
+ * - Message patterns like "retry in 5s" or "reset after 100ms"
+ *
+ * @param err - The error to check, which may have headers and/or message properties.
+ * @returns The retry delay in milliseconds, or `undefined` if no delay is found.
  */
 export function extractRetryAfterMs(err: unknown): number | undefined {
   if (!err || typeof err !== "object") {
@@ -127,7 +156,7 @@ export function extractRetryAfterMs(err: unknown): number | undefined {
   // Check error message for retry delay hints
   const message = errorObj.message ?? "";
   const retryInMatch = message.match(
-    /retry\s+in\s+([0-9.]+)\s*(ms|milliseconds?|seconds?|secs?|s)/i,
+    /retry\s+in\s+([0-9.]+)\s*(ms|milliseconds?|seconds?|secs?|s)?/i,
   );
   if (retryInMatch?.[1]) {
     const value = parseFloat(retryInMatch[1]);
@@ -138,7 +167,7 @@ export function extractRetryAfterMs(err: unknown): number | undefined {
   }
 
   const resetAfterMatch = message.match(
-    /reset\s+after\s+([0-9.]+)\s*(ms|milliseconds?|seconds?|secs?|s)/i,
+    /reset\s+after\s+([0-9.]+)\s*(ms|milliseconds?|seconds?|secs?|s)?/i,
   );
   if (resetAfterMatch?.[1]) {
     const value = parseFloat(resetAfterMatch[1]);

--- a/src/agents/pi-embedded-runner/llm-retry.ts
+++ b/src/agents/pi-embedded-runner/llm-retry.ts
@@ -2,7 +2,8 @@ import { retryAsync } from "../../infra/retry.js";
 
 export interface LlmRetryConfig {
   /**
-   * Max retry attempts for LLM calls (default: 7).
+   * Maximum total attempts for LLM calls, including the initial call.
+   * For example, 7 means 1 initial attempt plus up to 6 retries (default: 7).
    */
   attempts?: number;
 
@@ -20,6 +21,11 @@ export interface LlmRetryConfig {
    * Jitter factor (0-1) to randomize retry delays (default: 0.1).
    */
   jitter?: number;
+
+  /**
+   * Optional AbortSignal to cancel retry attempts.
+   */
+  signal?: AbortSignal;
 }
 
 const DEFAULT_RETRY_CONFIG = {
@@ -37,8 +43,8 @@ export function isRetryableLlmError(err: unknown): boolean {
     return false;
   }
 
-  const errorObj = err as { status?: number; code?: string; message?: string };
-  const status = errorObj.status;
+  const errorObj = err as { status?: number; statusCode?: number; code?: string; message?: string };
+  const status = errorObj.status ?? errorObj.statusCode;
   const message = errorObj.message ?? "";
 
   // Retry on rate limit (429)
@@ -58,7 +64,7 @@ export function isRetryableLlmError(err: unknown): boolean {
   }
 
   // Retry on timeout errors
-  if (/timeout|timed out|deadline exceeded/i.test(message)) {
+  if (/timeout|timed out|deadline exceeded|deadline_exceeded/i.test(message)) {
     return true;
   }
 
@@ -120,19 +126,25 @@ export function extractRetryAfterMs(err: unknown): number | undefined {
 
   // Check error message for retry delay hints
   const message = errorObj.message ?? "";
-  const retryInMatch = message.match(/retry in ([0-9.]+)(?:ms|seconds?|secs?|s)/i);
+  const retryInMatch = message.match(
+    /retry\s+in\s+([0-9.]+)\s*(ms|milliseconds?|seconds?|secs?|s)/i,
+  );
   if (retryInMatch?.[1]) {
     const value = parseFloat(retryInMatch[1]);
+    const unit = (retryInMatch[2] ?? "s").toLowerCase();
     if (Number.isFinite(value) && value > 0) {
-      return value * 1000;
+      return unit === "ms" || unit.startsWith("millisec") ? value : value * 1000;
     }
   }
 
-  const resetAfterMatch = message.match(/reset after ([0-9.]+)(?:ms|seconds?|secs?|s)/i);
+  const resetAfterMatch = message.match(
+    /reset\s+after\s+([0-9.]+)\s*(ms|milliseconds?|seconds?|secs?|s)/i,
+  );
   if (resetAfterMatch?.[1]) {
     const value = parseFloat(resetAfterMatch[1]);
+    const unit = (resetAfterMatch[2] ?? "s").toLowerCase();
     if (Number.isFinite(value) && value > 0) {
-      return value * 1000;
+      return unit === "ms" || unit.startsWith("millisec") ? value : value * 1000;
     }
   }
 

--- a/src/agents/pi-embedded-runner/llm-retry.ts
+++ b/src/agents/pi-embedded-runner/llm-retry.ts
@@ -1,0 +1,162 @@
+import { retryAsync } from "../../infra/retry.js";
+
+export interface LlmRetryConfig {
+  /**
+   * Max retry attempts for LLM calls (default: 7).
+   */
+  attempts?: number;
+
+  /**
+   * Minimum retry delay in ms (default: 1000).
+   */
+  minDelayMs?: number;
+
+  /**
+   * Maximum retry delay cap in ms (default: 32000).
+   */
+  maxDelayMs?: number;
+
+  /**
+   * Jitter factor (0-1) to randomize retry delays (default: 0.1).
+   */
+  jitter?: number;
+}
+
+const DEFAULT_RETRY_CONFIG = {
+  attempts: 7,
+  minDelayMs: 1000,
+  maxDelayMs: 32000,
+  jitter: 0.1,
+};
+
+/**
+ * Check if an error is retryable for LLM calls.
+ */
+export function isRetryableLlmError(err: unknown): boolean {
+  if (!err) {
+    return false;
+  }
+
+  const errorObj = err as { status?: number; code?: string; message?: string };
+  const status = errorObj.status;
+  const message = errorObj.message ?? "";
+
+  // Retry on rate limit (429)
+  if (status === 429) {
+    return true;
+  }
+
+  // Retry on server errors (500, 502, 503, 504)
+  if (status === 500 || status === 502 || status === 503 || status === 504) {
+    return true;
+  }
+
+  // Retry on network errors
+  const code = (errorObj.code ?? "").toUpperCase();
+  if (["ETIMEDOUT", "ESOCKETTIMEDOUT", "ECONNRESET", "ECONNABORTED"].includes(code)) {
+    return true;
+  }
+
+  // Retry on timeout errors
+  if (/timeout|timed out|deadline exceeded/i.test(message)) {
+    return true;
+  }
+
+  // Do not retry on client errors (400, 401, 403, 404)
+  if (status === 400 || status === 401 || status === 403 || status === 404) {
+    return false;
+  }
+
+  // Do not retry on billing errors (402)
+  if (status === 402) {
+    return false;
+  }
+
+  // Default: do not retry unknown errors
+  return false;
+}
+
+/**
+ * Extract retry-after delay from error response headers or body.
+ */
+export function extractRetryAfterMs(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+
+  const errorObj = err as {
+    status?: number;
+    headers?: { get?: (name: string) => string | null };
+    message?: string;
+  };
+
+  // Check headers for Retry-After
+  if (errorObj.headers && typeof errorObj.headers.get === "function") {
+    const retryAfter = errorObj.headers.get("Retry-After");
+    if (retryAfter) {
+      const seconds = Number(retryAfter);
+      if (Number.isFinite(seconds) && seconds > 0) {
+        return seconds * 1000;
+      }
+    }
+
+    // Check for rate limit reset headers
+    const rateLimitReset = errorObj.headers.get("x-ratelimit-reset");
+    if (rateLimitReset) {
+      const resetSeconds = Number.parseInt(rateLimitReset, 10);
+      if (!Number.isNaN(resetSeconds)) {
+        return Math.max(0, resetSeconds * 1000 - Date.now());
+      }
+    }
+
+    const rateLimitResetAfter = errorObj.headers.get("x-ratelimit-reset-after");
+    if (rateLimitResetAfter) {
+      const resetAfterSeconds = Number(rateLimitResetAfter);
+      if (Number.isFinite(resetAfterSeconds)) {
+        return resetAfterSeconds * 1000;
+      }
+    }
+  }
+
+  // Check error message for retry delay hints
+  const message = errorObj.message ?? "";
+  const retryInMatch = message.match(/retry in ([0-9.]+)(?:ms|seconds?|secs?|s)/i);
+  if (retryInMatch?.[1]) {
+    const value = parseFloat(retryInMatch[1]);
+    if (Number.isFinite(value) && value > 0) {
+      return value * 1000;
+    }
+  }
+
+  const resetAfterMatch = message.match(/reset after ([0-9.]+)(?:ms|seconds?|secs?|s)/i);
+  if (resetAfterMatch?.[1]) {
+    const value = parseFloat(resetAfterMatch[1]);
+    if (Number.isFinite(value) && value > 0) {
+      return value * 1000;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Wrap a prompt call with LLM retry logic.
+ */
+export function withLlmRetry<T>(fn: () => Promise<T>, config?: LlmRetryConfig): Promise<T> {
+  const cfg = { ...DEFAULT_RETRY_CONFIG, ...config };
+
+  return retryAsync(fn, {
+    attempts: cfg.attempts,
+    minDelayMs: cfg.minDelayMs,
+    maxDelayMs: cfg.maxDelayMs,
+    jitter: cfg.jitter,
+    shouldRetry: (err: unknown) => isRetryableLlmError(err),
+    retryAfterMs: (err: unknown) => extractRetryAfterMs(err),
+    onRetry: (info) => {
+      console.warn(
+        `[LLM Retry] Attempt ${info.attempt}/${info.maxAttempts}, ` +
+          `waiting ${info.delayMs}ms before retry. Error: ${String(info.err)}`,
+      );
+    },
+  });
+}

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1382,18 +1382,16 @@ export async function runEmbeddedAttempt(
       }
 
       // Wrap prompt method with LLM retry logic
-      // Use type-safe wrapper to preserve the original signature
       const originalPrompt = activeSession.prompt.bind(activeSession);
-      const promptWrapper: typeof activeSession.prompt = (prompt, options) => {
-        return withLlmRetry(() => originalPrompt(prompt, options), {
+      activeSession.prompt = (async (...args: Parameters<typeof originalPrompt>) => {
+        return withLlmRetry(() => originalPrompt(...args), {
           attempts: 8,
           minDelayMs: 1000,
           maxDelayMs: 32000,
           jitter: 0.1,
           signal: runAbortController.signal,
         });
-      };
-      activeSession.prompt = promptWrapper;
+      }) as typeof originalPrompt;
 
       try {
         const prior = await sanitizeSessionHistory({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1382,15 +1382,18 @@ export async function runEmbeddedAttempt(
       }
 
       // Wrap prompt method with LLM retry logic
+      // Use type-safe wrapper to preserve the original signature
       const originalPrompt = activeSession.prompt.bind(activeSession);
-      activeSession.prompt = async (prompt: string, options?: { images?: unknown[] }) => {
+      const promptWrapper: typeof activeSession.prompt = (prompt, options) => {
         return withLlmRetry(() => originalPrompt(prompt, options), {
-          attempts: 7,
+          attempts: 8,
           minDelayMs: 1000,
           maxDelayMs: 32000,
           jitter: 0.1,
+          signal: runAbortController.signal,
         });
       };
+      activeSession.prompt = promptWrapper;
 
       try {
         const prior = await sanitizeSessionHistory({

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -101,6 +101,7 @@ import {
   sanitizeToolsForGoogle,
 } from "../google.js";
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
+import { withLlmRetry } from "../llm-retry.js";
 import { log } from "../logger.js";
 import { buildModelAliasLines } from "../model.js";
 import {
@@ -1379,6 +1380,17 @@ export async function runEmbeddedAttempt(
           activeSession.agent.streamFn,
         );
       }
+
+      // Wrap prompt method with LLM retry logic
+      const originalPrompt = activeSession.prompt.bind(activeSession);
+      activeSession.prompt = async (prompt: string, options?: { images?: unknown[] }) => {
+        return withLlmRetry(() => originalPrompt(prompt, options), {
+          attempts: 7,
+          minDelayMs: 1000,
+          maxDelayMs: 32000,
+          jitter: 0.1,
+        });
+      };
 
       try {
         const prior = await sanitizeSessionHistory({


### PR DESCRIPTION
## Changes
- Add `llm-retry.ts` implementing exponential backoff retry logic
- Wrap `prompt()` method in `attempt.ts` with retry handler
- Support HTTP 429, 500, 502, 503, 504 auto-retry
- Max 7 retries with delays: 0s, 1s, 2s, 4s, 8s, 16s, 32s

## Motivation
The API quota limit (HTTP 429) is triggered when the Subagent concurrently calls LLM. OpenClaw's pi-ai provider has no built-in retry and needs to be implemented at the framework layer.
