### PR TITLE
fix(tui): show configured default model instead of "unknown" for new sessions

### DIFF
--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -330,7 +330,7 @@ describe("gateway session utils", () => {
 });
 
 describe("resolveSessionModelRef", () => {
-  test("prefers runtime model/provider from session entry", () => {
+  test("prefers override over runtime model when both are present", () => {
     const cfg = createModelDefaultsConfig({
       primary: "anthropic/claude-opus-4-6",
     });
@@ -344,7 +344,8 @@ describe("resolveSessionModelRef", () => {
       providerOverride: "anthropic",
     });
 
-    expect(resolved).toEqual({ provider: "openai-codex", model: "gpt-5.3-codex" });
+    // Override reflects user intent for the *next* run and wins over last-run runtime model.
+    expect(resolved).toEqual({ provider: "anthropic", model: "claude-opus-4-6" });
   });
 
   test("preserves openrouter provider when model contains vendor prefix", () => {
@@ -412,6 +413,38 @@ describe("resolveSessionModelRef", () => {
     });
 
     expect(resolved).toEqual({ provider: "anthropic", model: "claude-sonnet-4-6" });
+  });
+
+  test("preserves providerOverride for slash-containing modelOverride (wrapper providers)", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "anthropic/claude-opus-4-6",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "s-wrapper",
+      updatedAt: Date.now(),
+      modelOverride: "anthropic/claude-sonnet-4-6",
+      providerOverride: "openrouter",
+    });
+
+    // providerOverride should be preserved as-is; re-parsing the model string
+    // would incorrectly treat "anthropic" as the provider.
+    expect(resolved).toEqual({ provider: "openrouter", model: "anthropic/claude-sonnet-4-6" });
+  });
+
+  test("uses runtime model when no override is set", () => {
+    const cfg = createModelDefaultsConfig({
+      primary: "anthropic/claude-opus-4-6",
+    });
+
+    const resolved = resolveSessionModelRef(cfg, {
+      sessionId: "s-runtime-only",
+      updatedAt: Date.now(),
+      modelProvider: "openai-codex",
+      model: "gpt-5.3-codex",
+    });
+
+    expect(resolved).toEqual({ provider: "openai-codex", model: "gpt-5.3-codex" });
   });
 });
 

--- a/src/gateway/session-utils.ts
+++ b/src/gateway/session-utils.ts
@@ -639,10 +639,33 @@ export function resolveSessionModelRef(
         defaultModel: DEFAULT_MODEL,
       });
 
-  // Prefer the last runtime model recorded on the session entry.
-  // This is the actual model used by the latest run and must win over defaults.
+  // Prefer explicit per-session override (set via /model or at spawn time).
+  // This reflects the user's intent for the next run and should take precedence
+  // over the runtime model recorded from a previous run.
   let provider = resolved.provider;
   let model = resolved.model;
+  const storedModelOverride = entry?.modelOverride?.trim();
+  if (storedModelOverride) {
+    const explicitOverrideProvider = entry?.providerOverride?.trim();
+    if (explicitOverrideProvider) {
+      // Provider is explicitly set alongside the override — use it directly.
+      // Re-parsing would incorrectly split vendor-prefixed model names
+      // (e.g. modelOverride="anthropic/claude-sonnet-4-6" with providerOverride="openrouter").
+      return { provider: explicitOverrideProvider, model: storedModelOverride };
+    }
+    const overrideProvider = provider || DEFAULT_PROVIDER;
+    const parsedOverride = parseModelRef(storedModelOverride, overrideProvider);
+    if (parsedOverride) {
+      provider = parsedOverride.provider;
+      model = parsedOverride.model;
+    } else {
+      provider = overrideProvider;
+      model = storedModelOverride;
+    }
+    return { provider, model };
+  }
+
+  // Fall back to the last runtime model recorded on the session entry.
   const runtimeModel = entry?.model?.trim();
   const runtimeProvider = entry?.modelProvider?.trim();
   if (runtimeModel) {
@@ -663,21 +686,6 @@ export function resolveSessionModelRef(
       model = runtimeModel;
     }
     return { provider, model };
-  }
-
-  // Fall back to explicit per-session override (set at spawn/model-patch time),
-  // then finally to configured defaults.
-  const storedModelOverride = entry?.modelOverride?.trim();
-  if (storedModelOverride) {
-    const overrideProvider = entry?.providerOverride?.trim() || provider || DEFAULT_PROVIDER;
-    const parsedOverride = parseModelRef(storedModelOverride, overrideProvider);
-    if (parsedOverride) {
-      provider = parsedOverride.provider;
-      model = parsedOverride.model;
-    } else {
-      provider = overrideProvider;
-      model = storedModelOverride;
-    }
   }
   return { provider, model };
 }

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -271,4 +271,64 @@ describe("tui session actions", () => {
     expect(state.sessionInfo.modelProvider).toBe("openai");
     expect(state.sessionInfo.updatedAt).toBe(50);
   });
+
+  it("falls back to defaults model when session entry is not found", async () => {
+    // When the current session key has no entry in the store (brand-new session),
+    // the TUI should show the configured default model, not "unknown".
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 0,
+      defaults: {
+        modelProvider: "my-copilot",
+        model: "claude-opus-4.6",
+        contextTokens: 200000,
+      },
+      sessions: [],
+    });
+
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: false,
+      sessionInfo: {},
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { refreshSessionInfo } = createSessionActions({
+      client: { listSessions } as unknown as GatewayChatClient,
+      chatLog: { addSystem: vi.fn() } as unknown as import("./components/chat-log.js").ChatLog,
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn(),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus: vi.fn(),
+    });
+
+    await refreshSessionInfo();
+
+    expect(state.sessionInfo.model).toBe("claude-opus-4.6");
+    expect(state.sessionInfo.modelProvider).toBe("my-copilot");
+    expect(state.sessionInfo.contextTokens).toBe(200000);
+  });
 });

--- a/src/tui/tui-session-actions.test.ts
+++ b/src/tui/tui-session-actions.test.ts
@@ -331,4 +331,69 @@ describe("tui session actions", () => {
     expect(state.sessionInfo.modelProvider).toBe("my-copilot");
     expect(state.sessionInfo.contextTokens).toBe(200000);
   });
+
+  it("prefers modelOverride over runtime model in session entry", async () => {
+    // After /model switch, the entry has both a runtime model (from last run)
+    // and a modelOverride (user's intent for next run). The override should win.
+    const listSessions = vi.fn().mockResolvedValue({
+      ts: Date.now(),
+      path: "/tmp/sessions.json",
+      count: 1,
+      defaults: {},
+      sessions: [
+        {
+          key: "agent:main:main",
+          model: "gpt-5.3-codex",
+          modelProvider: "openai-codex",
+          modelOverride: "claude-opus-4-6",
+          providerOverride: "anthropic",
+          updatedAt: 200,
+        },
+      ],
+    });
+
+    const state: TuiStateAccess = {
+      agentDefaultId: "main",
+      sessionMainKey: "agent:main:main",
+      sessionScope: "global",
+      agents: [],
+      currentAgentId: "main",
+      currentSessionKey: "agent:main:main",
+      currentSessionId: null,
+      activeChatRunId: null,
+      historyLoaded: false,
+      sessionInfo: {},
+      initialSessionApplied: true,
+      isConnected: true,
+      autoMessageSent: false,
+      toolsExpanded: false,
+      showThinking: false,
+      connectionStatus: "connected",
+      activityStatus: "idle",
+      statusTimeout: null,
+      lastCtrlCAt: 0,
+    };
+
+    const { refreshSessionInfo } = createSessionActions({
+      client: { listSessions } as unknown as GatewayChatClient,
+      chatLog: { addSystem: vi.fn() } as unknown as import("./components/chat-log.js").ChatLog,
+      tui: { requestRender: vi.fn() } as unknown as import("@mariozechner/pi-tui").TUI,
+      opts: {},
+      state,
+      agentNames: new Map(),
+      initialSessionInput: "",
+      initialSessionAgentId: null,
+      resolveSessionKey: vi.fn(),
+      updateHeader: vi.fn(),
+      updateFooter: vi.fn(),
+      updateAutocompleteProvider: vi.fn(),
+      setActivityStatus: vi.fn(),
+    });
+
+    await refreshSessionInfo();
+
+    // Override should take precedence over runtime model
+    expect(state.sessionInfo.model).toBe("claude-opus-4-6");
+    expect(state.sessionInfo.modelProvider).toBe("anthropic");
+  });
 });

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -114,7 +114,10 @@ export function createSessionActions(context: SessionActionContext) {
     }
   };
 
-  const resolveModelSelection = (entry?: SessionInfoEntry) => {
+  const resolveModelSelection = (
+    entry?: SessionInfoEntry,
+    defaults?: SessionInfoDefaults | null,
+  ) => {
     if (entry?.modelProvider || entry?.model) {
       return {
         modelProvider: entry.modelProvider ?? state.sessionInfo.modelProvider,
@@ -125,6 +128,12 @@ export function createSessionActions(context: SessionActionContext) {
     if (overrideModel) {
       const overrideProvider = entry?.providerOverride?.trim() || state.sessionInfo.modelProvider;
       return { modelProvider: overrideProvider, model: overrideModel };
+    }
+    if (defaults?.modelProvider || defaults?.model) {
+      return {
+        modelProvider: defaults.modelProvider ?? state.sessionInfo.modelProvider,
+        model: defaults.model ?? state.sessionInfo.model,
+      };
     }
     return {
       modelProvider: state.sessionInfo.modelProvider,
@@ -194,7 +203,7 @@ export function createSessionActions(context: SessionActionContext) {
       next.updatedAt = entry.updatedAt;
     }
 
-    const selection = resolveModelSelection(entry);
+    const selection = resolveModelSelection(entry, defaults);
     if (selection.modelProvider !== undefined) {
       next.modelProvider = selection.modelProvider;
     }

--- a/src/tui/tui-session-actions.ts
+++ b/src/tui/tui-session-actions.ts
@@ -118,17 +118,21 @@ export function createSessionActions(context: SessionActionContext) {
     entry?: SessionInfoEntry,
     defaults?: SessionInfoDefaults | null,
   ) => {
+    // 1. Explicit user override (set via /model) wins over last-run runtime model.
+    //    This matches the priority in resolveSessionModelRef (session-utils.ts).
+    const overrideModel = entry?.modelOverride?.trim();
+    if (overrideModel) {
+      const overrideProvider = entry?.providerOverride?.trim() || state.sessionInfo.modelProvider;
+      return { modelProvider: overrideProvider, model: overrideModel };
+    }
+    // 2. Fall back to runtime model from last run.
     if (entry?.modelProvider || entry?.model) {
       return {
         modelProvider: entry.modelProvider ?? state.sessionInfo.modelProvider,
         model: entry.model ?? state.sessionInfo.model,
       };
     }
-    const overrideModel = entry?.modelOverride?.trim();
-    if (overrideModel) {
-      const overrideProvider = entry?.providerOverride?.trim() || state.sessionInfo.modelProvider;
-      return { modelProvider: overrideProvider, model: overrideModel };
-    }
+    // 3. Configured defaults.
     if (defaults?.modelProvider || defaults?.model) {
       return {
         modelProvider: defaults.modelProvider ?? state.sessionInfo.modelProvider,


### PR DESCRIPTION
## Problem

When opening TUI with a brand-new session (no prior runs), the status bar shows `unknown` instead of the configured default model. This persists until the first message is sent.

Additionally, after using `/model` to switch models and then switching back to the default, the status bar can still show the previous runtime model instead of the current selection.

## Root cause

Two separate issues:

### 1. `resolveModelSelection` ignores `defaults`

In `tui-session-actions.ts`, `resolveModelSelection(entry)` does not accept a `defaults` parameter. When the session has no store entry yet (new session), `entry` is `undefined` and `state.sessionInfo` is `{}`, so the function returns `{ modelProvider: undefined, model: undefined }` — which the footer renders as `"unknown"`.

The `defaults` payload (containing the configured agent default model) is already available in `applySessionInfo` but was never forwarded.

### 2. `resolveSessionModelRef` priority order

In `session-utils.ts`, the function checks runtime `model/modelProvider` before `modelOverride/providerOverride`. When a user switches models via `/model`, the override is set. When switching *back* to default, the override is cleared — but the stale runtime model from the previous run still takes precedence.

## Fix

### 1. Pass `defaults` to `resolveModelSelection`

`resolveModelSelection` now accepts an optional `defaults` parameter. When `entry` has no model info and no override, it falls back to `defaults` before falling back to `state.sessionInfo`.

### 2. Reorder resolution priority

`resolveSessionModelRef` now checks in this order:
1. `modelOverride` / `providerOverride` (user's explicit selection for the next run)
2. Runtime `model` / `modelProvider` (last-run recorded model)
3. Configured defaults

When `providerOverride` is explicitly set, it is preserved without re-parsing (handles wrapper providers like OpenRouter with vendor-prefixed model names).

## Test plan

- Added unit test: new session with no entry falls back to `defaults` model
- Added unit test: override takes precedence over runtime model
- Added unit test: `providerOverride` preserved for slash-containing model IDs
- Added unit test: runtime model used when no override is set
- All 47 gateway tests + 4 TUI tests pass locally

## Supersedes

Closes the intent of #27735 (which was closed as stale/conflicted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)