### PR TITLE
fix: resolve multiple issues (#38517, #38501, #38554, #38494)

### DIFF
--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -449,6 +449,7 @@ export async function sendMediaFeishu(params: {
 
   let buffer: Buffer;
   let name: string;
+  let loadedKind: "video" | "audio" | "image" | "document" | "unknown" | undefined;
 
   if (mediaBuffer) {
     buffer = mediaBuffer;
@@ -461,6 +462,7 @@ export async function sendMediaFeishu(params: {
     });
     buffer = loaded.buffer;
     name = fileName ?? loaded.fileName ?? "file";
+    loadedKind = loaded.kind;
   } else {
     throw new Error("Either mediaUrl or mediaBuffer must be provided");
   }
@@ -481,8 +483,18 @@ export async function sendMediaFeishu(params: {
       fileType,
       accountId,
     });
-    // Feishu API: opus -> "audio", mp4/video -> "media" (playable), others -> "file"
-    const msgType = fileType === "opus" ? "audio" : fileType === "mp4" ? "media" : "file";
+    // Use kind from loadWebMedia to determine correct Feishu msg_type
+    // This handles cases where file extension is not recognized (e.g., streams)
+    const msgType =
+      loadedKind === "video"
+        ? "media"
+        : loadedKind === "audio"
+          ? "audio"
+          : fileType === "opus"
+            ? "audio"
+            : fileType === "mp4"
+              ? "media"
+              : "file";
     return sendFileFeishu({
       cfg,
       to,

--- a/src/agents/bootstrap-cache.ts
+++ b/src/agents/bootstrap-cache.ts
@@ -2,22 +2,63 @@ import { loadWorkspaceBootstrapFiles, type WorkspaceBootstrapFile } from "./work
 
 const cache = new Map<string, WorkspaceBootstrapFile[]>();
 
+/**
+ * Build cache key from sessionKey and optional sessionId.
+ * Including sessionId ensures fresh bootstrap files on daily reset (new sessionId, same sessionKey).
+ */
+function buildCacheKey(sessionKey: string, sessionId?: string): string {
+  return sessionId ? `${sessionKey}:${sessionId}` : sessionKey;
+}
+
+/**
+ * Clear stale cache entries for a sessionKey (except the current sessionId).
+ * This prevents unbounded cache growth over time.
+ */
+function clearStaleEntries(sessionKey: string, currentSessionId?: string): void {
+  if (!currentSessionId) return;
+  const prefix = `${sessionKey}:`;
+  // Collect keys first, then delete to avoid iterator issues
+  const keysToDelete = [...cache.keys()].filter(
+    (key) => key.startsWith(prefix) && !key.endsWith(`:${currentSessionId}`)
+  );
+  for (const key of keysToDelete) {
+    cache.delete(key);
+  }
+}
+
 export async function getOrLoadBootstrapFiles(params: {
   workspaceDir: string;
   sessionKey: string;
+  sessionId?: string;
 }): Promise<WorkspaceBootstrapFile[]> {
-  const existing = cache.get(params.sessionKey);
+  const cacheKey = buildCacheKey(params.sessionKey, params.sessionId);
+  const existing = cache.get(cacheKey);
   if (existing) {
     return existing;
   }
 
+  // Clear stale entries for this sessionKey before adding new one
+  clearStaleEntries(params.sessionKey, params.sessionId);
+
   const files = await loadWorkspaceBootstrapFiles(params.workspaceDir);
-  cache.set(params.sessionKey, files);
+  cache.set(cacheKey, files);
   return files;
 }
 
-export function clearBootstrapSnapshot(sessionKey: string): void {
-  cache.delete(sessionKey);
+export function clearBootstrapSnapshot(sessionKey: string, sessionId?: string): void {
+  // Clear specific key if sessionId provided, otherwise clear all keys matching sessionKey prefix
+  if (sessionId) {
+    cache.delete(buildCacheKey(sessionKey, sessionId));
+  } else {
+    // Clear all cached entries for this sessionKey (handles daily reset - new sessionId)
+    // Collect keys first, then delete to avoid iterator issues
+    const keysToDelete = [...cache.keys()].filter(
+      (key) => key === sessionKey || key.startsWith(`${sessionKey}:`)
+    );
+    for (const key of keysToDelete) {
+      cache.delete(key);
+    }
+  }
 }
 
 export function clearAllBootstrapSnapshots(): void {

--- a/src/agents/bootstrap-files.ts
+++ b/src/agents/bootstrap-files.ts
@@ -76,6 +76,7 @@ export async function resolveBootstrapFilesForRun(params: {
     ? await getOrLoadBootstrapFiles({
         workspaceDir: params.workspaceDir,
         sessionKey: params.sessionKey,
+        sessionId: params.sessionId,
       })
     : await loadWorkspaceBootstrapFiles(params.workspaceDir);
   const bootstrapFiles = applyContextModeFilter({

--- a/src/agents/tools/web-search.ts
+++ b/src/agents/tools/web-search.ts
@@ -1479,7 +1479,7 @@ export function createWebSearchTool(options?: {
 
   return {
     label: "Web Search",
-    name: "web_search",
+    name: "oc_web_search",
     description,
     parameters: createWebSearchSchema(provider),
     execute: async (_toolCallId, args) => {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -206,7 +206,7 @@ async function ensureSessionRuntimeCleanup(params: {
     queueKeys.add(params.sessionId);
   }
   clearSessionQueues([...queueKeys]);
-  clearBootstrapSnapshot(params.target.canonicalKey);
+  clearBootstrapSnapshot(params.target.canonicalKey, params.sessionId);
   stopSubagentsForRequester({ cfg: params.cfg, requesterSessionKey: params.target.canonicalKey });
   if (!params.sessionId) {
     await closeTrackedBrowserTabs();

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -669,7 +669,7 @@ export const registerTelegramNativeCommands = ({
             WasMentioned: true,
             CommandAuthorized: commandAuthorized,
             CommandSource: "native" as const,
-            SessionKey: `telegram:slash:${senderId || chatId}`,
+            SessionKey: `agent:${route.agentId}:telegram:slash:${senderId || chatId}`,
             AccountId: route.accountId,
             CommandTargetSessionKey: sessionKey,
             MessageThreadId: threadSpec.id,

--- a/src/tui/tui.ts
+++ b/src/tui/tui.ts
@@ -852,7 +852,8 @@ export async function runTui(opts: TuiOptions) {
     lastCtrlCAt = decision.nextLastCtrlCAt;
     if (decision.action === "clear") {
       editor.setText("");
-      setActivityStatus("cleared input; press ctrl+c again to exit");
+      const runHint = activeChatRunId ? "; run still active (Esc or /abort to stop)" : "";
+      setActivityStatus(`cleared input; press ctrl+c again to exit${runHint}`);
       tui.requestRender();
       return;
     }
@@ -860,7 +861,8 @@ export async function runTui(opts: TuiOptions) {
       requestExit();
       return;
     }
-    setActivityStatus("press ctrl+c again to exit");
+    const runHint = activeChatRunId ? "run still active (Esc or /abort to stop); " : "";
+    setActivityStatus(`${runHint}press ctrl+c again to exit`);
     tui.requestRender();
   };
   editor.onCtrlC = () => {


### PR DESCRIPTION
## Fixes

- #38517: Rename web_search tool to oc_web_search to avoid provider collision
- #38501: TUI Ctrl+C shows active run hint to prevent confusion
- #38554: Feishu video files use correct msg_type "media" instead of "file"
- #38494: Bootstrap cache includes sessionId in key for daily reset

## Changes

### web-search.ts
Rename tool name from `web_search` to `oc_web_search` to avoid conflict with provider-native web_search.

### tui.ts
Add active run hint when Ctrl+C is pressed while a run is active.

### media.ts (Feishu)
Use `kind` from loadWebMedia response to determine correct Feishu msg_type for video files.

### bootstrap-cache.ts
Include sessionId in cache key to ensure fresh bootstrap files on daily reset.