### PR TITLE
fix: allow Onboard UI to overwrite existing provider apiKey/baseUrl

### DIFF
--- a/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
+++ b/src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts
@@ -207,7 +207,7 @@ describe("models-config", () => {
     });
   });
 
-  it("preserves non-empty agent apiKey/baseUrl for matching providers in merge mode", async () => {
+  it("overwrites agent apiKey/baseUrl when config provides non-empty values in merge mode", async () => {
     await withTempHome(async () => {
       const parsed = await runCustomProviderMergeTest({
         baseUrl: "https://agent.example/v1",
@@ -215,8 +215,9 @@ describe("models-config", () => {
         api: "openai-responses",
         models: [{ id: "agent-model", name: "Agent model", input: ["text"] }],
       });
-      expect(parsed.providers.custom?.apiKey).toBe("AGENT_KEY");
-      expect(parsed.providers.custom?.baseUrl).toBe("https://agent.example/v1");
+      // Config values should take precedence over agent values
+      expect(parsed.providers.custom?.apiKey).toBe("CONFIG_KEY");
+      expect(parsed.providers.custom?.baseUrl).toBe("https://config.example/v1");
     });
   });
 

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -158,11 +158,13 @@ function mergeWithExistingProviderSecrets(params: {
       mergedProviders[key] = newEntry;
       continue;
     }
+    // Fix: Only preserve existing secrets if new entry doesn't provide them.
+    // This allows users to update apiKey/baseUrl via Onboard UI.
     const preserved: Record<string, unknown> = {};
-    if (typeof existing.apiKey === "string" && existing.apiKey) {
+    if (typeof existing.apiKey === "string" && existing.apiKey && !newEntry.apiKey) {
       preserved.apiKey = existing.apiKey;
     }
-    if (typeof existing.baseUrl === "string" && existing.baseUrl) {
+    if (typeof existing.baseUrl === "string" && existing.baseUrl && !newEntry.baseUrl) {
       preserved.baseUrl = existing.baseUrl;
     }
     mergedProviders[key] = { ...newEntry, ...preserved };


### PR DESCRIPTION
Previously, `mergeWithExistingProviderSecrets()` always preserved existing `apiKey` and `baseUrl` values from `models.json`, preventing users from updating these values through the Onboard UI.

Now, the function only preserves existing secrets when the new entry doesn't provide them. This allows users to correct configuration mistakes and update provider settings via the UI.

Fixes #38657

## Summary

- **Problem:** Users cannot update existing provider configurations (apiKey/baseUrl) through the Onboard UI because the merge logic unconditionally preserves existing values.
- **Why it matters:** Users who make configuration mistakes cannot correct them without manually editing JSON files, creating poor UX.
- **What changed:** Added conditional checks (`&& !newEntry.apiKey` and `&& !newEntry.baseUrl`) to only preserve existing secrets when the new config doesn't provide them.
- **What did NOT change (scope boundary):** The overall merge mode behavior is preserved - existing values are still used as fallback when new values are not provided.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38657
- Related #

## User-visible / Behavior Changes

Users can now update provider apiKey and baseUrl values through the Onboard UI. Previously, these values were silently ignored if they already existed in models.json.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (Yes)
  - **Explanation:** The change affects how provider secrets are merged during config updates. Previously, existing secrets were always preserved. Now, explicitly provided secrets in new config entries will overwrite existing ones. This is the intended behavior for UI-based configuration updates.
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)

## Repro + Verification

### Environment

- OS: macOS 15.4 (Darwin 24.6.0 arm64)
- Runtime/container: Node.js (Homebrew installation)
- Model/provider: Moonshot (affected), all providers with configurable apiKey/baseUrl
- Integration/channel (if any): N/A
- Relevant config (redacted): ~/.openclaw/config/openclaw.json, ~/.openclaw/agents/main/agent/models.json

### Steps

1. Open Onboard UI and configure a new provider (e.g., Moonshot) with apiKey "OLD_KEY"
2. Save the configuration
3. Try to update the same provider with apiKey "NEW_KEY" via Onboard UI
4. Check if the change is persisted in models.json

### Expected

The provider configuration should be updated with the new apiKey "NEW_KEY".

### Actual

Before fix: The old apiKey "OLD_KEY" remains in models.json, ignoring the UI update.
After fix: The new apiKey "NEW_KEY" correctly overwrites the old value.

## Evidence

- [x] Failing test/log before + passing after
  - Updated test: `src/agents/models-config.fills-missing-provider-apikey-from-env-var.test.ts`
  - Changed expectation from preserving agent values to expecting config values to take precedence
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

- **Verified scenarios:**
  - Config-provided apiKey overwrites existing agent apiKey
  - Config-provided baseUrl overwrites existing agent baseUrl
  - Existing values are preserved when new config omits them (backward compatibility)
  - Test suite passes with updated expectations

- **Edge cases checked:**
  - Empty string values in new config
  - Undefined values in new config
  - Both apiKey and baseUrl updated simultaneously

- What you did **not** verify:
  - Other provider configuration fields beyond apiKey/baseUrl
  - Behavior with `models.mode` set to values other than "merge"

## Compatibility / Migration

- Backward compatible? (Yes)
  - Existing behavior is preserved when new config doesn't provide apiKey/baseUrl
- Config/env changes? (No)
- Migration needed? (No)

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert commit f70d9ff7d
- Files/config to restore: src/agents/models-config.ts
- Known bad symptoms reviewers should watch for: Users reporting that their provider secrets are being unexpectedly overwritten

## Risks and Mitigations

- **Risk:** Users might accidentally overwrite provider secrets if they have stale config entries.
  - **Mitigation:** This is the intended behavior - users should be able to update their configs. The change only affects explicit updates via Onboard UI.
- **Risk:** Merge mode semantics change for agent-local credentials.
  - **Mitigation:** The change is scoped to only affect cases where new config explicitly provides values. Fallback behavior for omitted values remains unchanged.