### PR TITLE
feat(telegram): add interactive menu for /approve command

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -187,6 +187,25 @@ function buildChatCommands(): ChatCommandDefinition[] {
       textAlias: "/approve",
       acceptsArgs: true,
       category: "management",
+      args: [
+        {
+          name: "id",
+          description: "Approval request ID",
+          type: "string",
+          required: true,
+        },
+        {
+          name: "decision",
+          description: "Decision",
+          type: "string",
+          choices: [
+            { value: "allow-once", label: "✅ Allow once" },
+            { value: "allow-always", label: "✅✅ Allow always" },
+            { value: "deny", label: "❌ Deny" },
+          ],
+        },
+      ],
+      argsMenu: "auto",
     }),
     defineChatCommand({
       key: "context",

--- a/src/auto-reply/reply/commands-approve.ts
+++ b/src/auto-reply/reply/commands-approve.ts
@@ -60,6 +60,10 @@ function parseApproveCommand(raw: string): ParsedApproveCommand | null {
   return { ok: false, error: "Usage: /approve <id> allow-once|allow-always|deny" };
 }
 
+function isApproveCommand(raw: string): boolean {
+  return raw.trim().toLowerCase().startsWith(COMMAND);
+}
+
 function buildResolvedByLabel(params: Parameters<CommandHandler>[0]): string {
   const channel = params.command.channel;
   const sender = params.command.senderId ?? "unknown";
@@ -71,6 +75,14 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
     return null;
   }
 
+  const normalized = params.command.commandBodyNormalized;
+
+  // First gate: check if this is actually an /approve command
+  if (!isApproveCommand(normalized)) {
+    return null;
+  }
+
+  // Now check authorization - only after confirming it's an approve command
   if (!params.command.isAuthorizedSender) {
     logVerbose(
       `Ignoring /approve from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
@@ -92,18 +104,21 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
     }
   }
 
-  // Fall back to legacy positional parsing if needed
+  // Fall back to legacy positional parsing only if needed
   if (!id || !decision) {
-    const normalized = params.command.commandBodyNormalized;
     const parsed = parseApproveCommand(normalized);
-    if (!parsed) {
-      return null;
+    if (parsed) {
+      // Only use legacy values if they provide missing data
+      if (!id && parsed.ok) {
+        id = parsed.id;
+      }
+      if (!decision && parsed.ok) {
+        decision = parsed.decision;
+      }
+      if (!parsed.ok) {
+        return { shouldContinue: false, reply: { text: parsed.error } };
+      }
     }
-    if (!parsed.ok) {
-      return { shouldContinue: false, reply: { text: parsed.error } };
-    }
-    id = parsed.id;
-    decision = parsed.decision;
   }
 
   if (!id || !decision) {

--- a/src/auto-reply/reply/commands-approve.ts
+++ b/src/auto-reply/reply/commands-approve.ts
@@ -70,11 +70,7 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
   if (!allowTextCommands) {
     return null;
   }
-  const normalized = params.command.commandBodyNormalized;
-  const parsed = parseApproveCommand(normalized);
-  if (!parsed) {
-    return null;
-  }
+
   if (!params.command.isAuthorizedSender) {
     logVerbose(
       `Ignoring /approve from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
@@ -82,8 +78,39 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
     return { shouldContinue: false };
   }
 
-  if (!parsed.ok) {
-    return { shouldContinue: false, reply: { text: parsed.error } };
+  // Try to parse from CommandArgs first (new format with named args)
+  const commandArgs = params.ctx.CommandArgs;
+  let id: string | undefined;
+  let decision: "allow-once" | "allow-always" | "deny" | undefined;
+
+  if (commandArgs?.values) {
+    // New format: /approve <id> <decision> with named args
+    id = commandArgs.values.id?.trim();
+    const rawDecision = commandArgs.values.decision?.trim().toLowerCase();
+    if (rawDecision) {
+      decision = DECISION_ALIASES[rawDecision];
+    }
+  }
+
+  // Fall back to legacy positional parsing if needed
+  if (!id || !decision) {
+    const normalized = params.command.commandBodyNormalized;
+    const parsed = parseApproveCommand(normalized);
+    if (!parsed) {
+      return null;
+    }
+    if (!parsed.ok) {
+      return { shouldContinue: false, reply: { text: parsed.error } };
+    }
+    id = parsed.id;
+    decision = parsed.decision;
+  }
+
+  if (!id || !decision) {
+    return {
+      shouldContinue: false,
+      reply: { text: "Usage: /approve <id> allow-once|allow-always|deny" },
+    };
   }
 
   if (isInternalMessageChannel(params.command.channel)) {
@@ -104,7 +131,7 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
   try {
     await callGateway({
       method: "exec.approval.resolve",
-      params: { id: parsed.id, decision: parsed.decision },
+      params: { id, decision },
       clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
       clientDisplayName: `Chat approval (${resolvedBy})`,
       mode: GATEWAY_CLIENT_MODES.BACKEND,
@@ -120,6 +147,6 @@ export const handleApproveCommand: CommandHandler = async (params, allowTextComm
 
   return {
     shouldContinue: false,
-    reply: { text: `✅ Exec approval ${parsed.decision} submitted for ${parsed.id}.` },
+    reply: { text: `✅ Exec approval ${decision} submitted for ${id}.` },
   };
 };

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -357,6 +357,29 @@ describe("/approve command", () => {
       );
     }
   });
+
+  it("submits approval with named args (new format)", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildParams("/approve", cfg, {
+      SenderId: "123",
+      CommandArgs: { values: { id: "xyz", decision: "deny" } },
+    });
+
+    callGatewayMock.mockResolvedValue({ ok: true });
+
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Exec approval deny submitted");
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "exec.approval.resolve",
+        params: { id: "xyz", decision: "deny" },
+      }),
+    );
+  });
 });
 
 describe("/compact command", () => {


### PR DESCRIPTION
## Summary

This PR adds interactive menu support for the `/approve` command in Telegram, making it easier for users to approve or deny exec requests without manually typing the decision.

## Changes

### commands-registry.data.ts
- Added `args` definition for `/approve` command with:
  - `id`: Approval request ID (required)
  - `decision`: Decision choice with options:
    - ✅ Allow once (`allow-once`)
    - ✅✅ Allow always (`allow-always`)
    - ❌ Deny (`deny`)
- Added `argsMenu: "auto"` to enable interactive selection

### commands-approve.ts
- Updated handler to support both named args (from interactive menus) and legacy positional format
- Maintains backward compatibility with existing `/approve <id> <decision>` usage

### commands.test.ts
- Added test case for the new named args format

## How it works

When a user types `/approve <id>` without specifying a decision, Telegram will display an inline keyboard with the three options. Users can simply tap the desired option instead of typing it manually.

The traditional format `/approve <id> allow-once` continues to work as before.
