### PR TITLE
fix(tts): recognize bare [[tts]] tag in parseTtsDirectives

### DIFF
--- a/src/tts/tts-core.ts
+++ b/src/tts/tts-core.ts
@@ -128,6 +128,16 @@ export function parseTtsDirectives(
     return "";
   });
 
+  // Match bare [[tts]] tag (no colon/args) as a simple TTS trigger.
+  // The system prompt tells AI to use [[tts]] to signal tagged-mode TTS,
+  // but the directive regex below requires a colon after "tts". This
+  // dedicated pass strips the bare tag and sets hasDirective = true.
+  const bareTtsRegex = /\[\[tts\]\]/gi;
+  cleanedText = cleanedText.replace(bareTtsRegex, () => {
+    hasDirective = true;
+    return "";
+  });
+
   const directiveRegex = /\[\[tts:([^\]]+)\]\]/gi;
   cleanedText = cleanedText.replace(directiveRegex, (_match, body: string) => {
     hasDirective = true;

--- a/src/tts/tts.test.ts
+++ b/src/tts/tts.test.ts
@@ -308,6 +308,43 @@ describe("tts", () => {
       expect(result.overrides.openai?.voice).toBeUndefined();
       expect(result.warnings).toContain('invalid OpenAI voice "kokoro-chinese"');
     });
+
+    it("recognizes bare [[tts]] tag as a directive trigger", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true });
+      const input = "Hello [[tts]] world";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(true);
+      expect(result.cleanedText.trim()).toBe("Hello  world");
+    });
+
+    it("recognizes bare [[tts]] alongside [[tts:text]] blocks", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true });
+      const input = "Hello [[tts]]\n[[tts:text]]Good morning[[/tts:text]]";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(true);
+      expect(result.ttsText).toBe("Good morning");
+      expect(result.cleanedText).not.toContain("[[tts]]");
+    });
+
+    it("handles case-insensitive bare [[TTS]] tag", () => {
+      const policy = resolveModelOverridePolicy({ enabled: true });
+      const input = "Hello [[TTS]] world";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(true);
+      expect(result.cleanedText.trim()).toBe("Hello  world");
+    });
+
+    it("does not match bare [[tts]] when overrides are disabled", () => {
+      const policy = resolveModelOverridePolicy({ enabled: false });
+      const input = "Hello [[tts]] world";
+      const result = parseTtsDirectives(input, policy);
+
+      expect(result.hasDirective).toBe(false);
+      expect(result.cleanedText).toBe(input);
+    });
   });
 
   describe("summarizeText", () => {


### PR DESCRIPTION
## Problem

Fixes #38700

`buildTtsSystemPromptHint()` tells the AI to use `[[tts]]` (bare, no colon) as a tagged-mode TTS trigger:

> "Only use TTS when you include **[[tts]]** or [[tts:text]] tags."

However, `parseTtsDirectives()` only recognizes:
- `[[tts:text]]...[[/tts:text]]` — text blocks
- `[[tts:KEY=VALUE]]` — key-value directives (requires colon after `tts`)

The bare `[[tts]]` tag matches **neither** regex. When the AI follows the system prompt and uses `[[tts]]`, `hasDirective` stays `false`, and tagged-mode TTS is silently skipped.

## Fix

Add a dedicated regex pass for bare `[[tts]]` tags in `parseTtsDirectives()`, placed before the existing directive regex. When matched, it:
1. Sets `hasDirective = true` (enabling tagged-mode TTS)
2. Strips the tag from `cleanedText` (so it does not appear in displayed text)
3. Uses the `gi` flag for case-insensitive matching, consistent with the other TTS regexes

## Testing

4 new test cases added to `tts.test.ts`:
- Bare `[[tts]]` sets `hasDirective = true` and is stripped from text
- Bare `[[tts]]` works alongside `[[tts:text]]` blocks
- Case-insensitive `[[TTS]]` is recognized
- Bare `[[tts]]` is ignored when overrides policy is disabled

## Note on Bug 2 (streaming cross-block tags)

Issue #38700 also reports that TTS tags spanning streaming block boundaries fail to match. This PR addresses Bug 1 only (parser/prompt mismatch), which is the simpler and more impactful fix. Bug 2 (streaming accumulation) is a separate architectural concern that would require changes to the streaming pipeline.