### PR TITLE
docs: fix stale PR_WORKFLOW.md reference in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@
 
 ## Commit & Pull Request Guidelines
 
-**Full maintainer PR workflow (optional):** If you want the repo's end-to-end maintainer workflow (triage order, quality bar, rebase rules, commit/changelog conventions, co-contributor policy, and the `review-pr` > `prepare-pr` > `merge-pr` pipeline), see the [`openclaw/maintainers`](https://github.com/openclaw/maintainers/) repository. Maintainers may use other workflows; when a maintainer specifies a workflow, follow that.
+**Full maintainer PR workflow (optional):** If you want the repo's end-to-end maintainer workflow (triage order, quality bar, rebase rules, commit/changelog conventions, co-contributor policy, and the `review-pr` > `prepare-pr` > `merge-pr` pipeline), see the [`openclaw/maintainers`](https://github.com/openclaw/maintainers/) repository. Maintainers may use other workflows; when a maintainer specifies a workflow, follow that. If no workflow is specified, default to the PR workflow documented in that repository.
 
 - Create commits with `scripts/committer "<msg>" <file...>`; avoid manual `git add`/`git commit` so staging stays scoped.
 - Follow concise, action-oriented commit messages (e.g., `CLI: add verbose flag to send`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,7 +109,7 @@
 
 ## Commit & Pull Request Guidelines
 
-**Full maintainer PR workflow (optional):** If you want the repo's end-to-end maintainer workflow (triage order, quality bar, rebase rules, commit/changelog conventions, co-contributor policy, and the `review-pr` > `prepare-pr` > `merge-pr` pipeline), see `.agents/skills/PR_WORKFLOW.md`. Maintainers may use other workflows; when a maintainer specifies a workflow, follow that. If no workflow is specified, default to PR_WORKFLOW.
+**Full maintainer PR workflow (optional):** If you want the repo's end-to-end maintainer workflow (triage order, quality bar, rebase rules, commit/changelog conventions, co-contributor policy, and the `review-pr` > `prepare-pr` > `merge-pr` pipeline), see the [`openclaw/maintainers`](https://github.com/openclaw/maintainers/) repository. Maintainers may use other workflows; when a maintainer specifies a workflow, follow that.
 
 - Create commits with `scripts/committer "<msg>" <file...>`; avoid manual `git add`/`git commit` so staging stays scoped.
 - Follow concise, action-oriented commit messages (e.g., `CLI: add verbose flag to send`).


### PR DESCRIPTION
## Summary

- Problem: `AGENTS.md` (symlinked as `CLAUDE.md`) references `.agents/skills/PR_WORKFLOW.md`, which was moved to the `openclaw/maintainers` repository in commit 9264a8e21 (2026-02-19).
- Why it matters: The stale path is misleading for contributors and AI agents following the instructions.
- What changed: Updated the reference to point to the [`openclaw/maintainers`](https://github.com/openclaw/maintainers/) repository.
- What did NOT change: No other instructions or workflows were modified.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related: commit 9264a8e21 (`chore: move skills to maintainers repository`)

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Steps

1. Read `AGENTS.md` line 112 — references `.agents/skills/PR_WORKFLOW.md`
2. Check that file does not exist: `ls .agents/skills/PR_WORKFLOW.md` → not found
3. After this PR, reference points to `openclaw/maintainers` repo

### Expected

- Reference points to the current location of the PR workflow docs

### Actual

- Reference pointed to a file removed in Feb 2026

## Evidence

- [x] Trace/log snippets: `git log --all --oneline -- ".agents/skills/PR_WORKFLOW.md"` shows the file was deleted in 9264a8e21

## Human Verification (required)

- Verified scenarios: confirmed file does not exist locally, confirmed `.agents/maintainers.md` points to `openclaw/maintainers` repo
- Linked repo exists

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Revert this single commit

## Risks and Mitigations

None