### PR TITLE
Warn on high-frequency cron schedules (<30m)

### DIFF
--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -128,6 +128,11 @@ export function registerCronAddCommand(cron: Command) {
               if (!everyMs) {
                 throw new Error("Invalid --every; use e.g. 10m, 1h, 1d");
               }
+              if (everyMs < 30 * 60 * 1000) {
+                defaultRuntime.error(
+                  "Warning: High-frequency cron (< 30m) may cause session accumulation and silently exhaust the agent context window. Consider using heartbeat or longer intervals.",
+                );
+              }
               return { kind: "every" as const, everyMs };
             }
             const staggerMs = parseCronStaggerMs({ staggerRaw, useExact });

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -111,6 +111,12 @@ export const cronHandlers: GatewayRequestHandlers = {
       );
       return;
     }
+    if (jobCreate.schedule?.kind === "every" && jobCreate.schedule.everyMs < 30 * 60 * 1000) {
+      context.logGateway.warn(
+        { schedule: jobCreate.schedule, name: jobCreate.name },
+        "cron: high-frequency schedule (<30m) may cause session accumulation and silently exhaust agent context",
+      );
+    }
     const job = await context.cron.add(jobCreate);
     context.logGateway.info("cron: job created", { jobId: job.id, schedule: jobCreate.schedule });
     respond(true, job, undefined);


### PR DESCRIPTION
# Draft PR Description

Title: **Warn on high-frequency cron schedules (<30m) to reduce session accumulation risk**

## Summary
High-frequency cron jobs (e.g. every 15m/30m) can silently accumulate sessions and inflate the agent context window until the agent becomes non-responsive (“dispatch succeeds but replies=0”). This PR adds a minimal guardrail: warn when creating cron jobs with `--every` intervals under 30 minutes.

## What this PR does
- **CLI warning** during `openclaw cron add` if `--every < 30m`.
- **Gateway log warning** on `cron.add` for `schedule.kind="every"` and `everyMs < 30m`.

CLI message:
> Warning: High-frequency cron (< 30m) may cause session accumulation and silently exhaust the agent context window. Consider using heartbeat or longer intervals.

## Why this is safe
- Does **not block** cron creation (no breaking change).
- Provides immediate, actionable feedback at the moment of job creation.

## Implementation
- `src/cli/cron-cli/register.cron-add.ts`
- `src/gateway/server-methods/cron.ts`

## Tests
- `pnpm vitest src/cli/cron-cli.test.ts --run`
- `pnpm vitest src/gateway/server.cron.test.ts --run`


Closes #38730
