### PR TITLE
fix(telegram): resolve session entry for /stop in forum topics

### DIFF
--- a/src/auto-reply/reply/abort.test.ts
+++ b/src/auto-reply/reply/abort.test.ts
@@ -356,6 +356,20 @@ describe("abort detection", () => {
     expect(resolveSessionEntryForKey(undefined, "session-1")).toEqual({});
   });
 
+  it("resolves Telegram forum topic session when lookup key has different casing than store", () => {
+    // Store normalizes keys to lowercase; caller may pass mixed-case. /stop in topic must find entry.
+    const storeKey = "agent:main:telegram:group:-1001234567890:topic:99";
+    const lookupKey = "Agent:Main:Telegram:Group:-1001234567890:Topic:99";
+    const store = {
+      [storeKey]: { sessionId: "pi-topic-99", updatedAt: 0 },
+    } as Record<string, { sessionId: string; updatedAt: number }>;
+    // Direct lookup fails (store uses lowercase keys); normalization fallback must succeed.
+    expect(store[lookupKey]).toBeUndefined();
+    const result = resolveSessionEntryForKey(store, lookupKey);
+    expect(result.entry?.sessionId).toBe("pi-topic-99");
+    expect(result.key).toBe(storeKey);
+  });
+
   it("fast-aborts even when text commands are disabled", async () => {
     const { cfg } = await createAbortConfig({ commandsTextEnabled: false });
 

--- a/src/auto-reply/reply/abort.ts
+++ b/src/auto-reply/reply/abort.ts
@@ -12,6 +12,7 @@ import {
 import type { OpenClawConfig } from "../../config/config.js";
 import {
   loadSessionStore,
+  normalizeStoreSessionKey,
   resolveStorePath,
   type SessionEntry,
   updateSessionStore,
@@ -179,6 +180,11 @@ export function resolveSessionEntryForKey(
   const direct = store[sessionKey];
   if (direct) {
     return { entry: direct, key: sessionKey };
+  }
+  const normalized = normalizeStoreSessionKey(sessionKey);
+  const entry = store[normalized];
+  if (entry) {
+    return { entry, key: normalized };
   }
   return {};
 }

--- a/src/config/sessions/store.ts
+++ b/src/config/sessions/store.ts
@@ -108,7 +108,7 @@ function removeThreadFromDeliveryContext(context?: DeliveryContext): DeliveryCon
   return next;
 }
 
-function normalizeStoreSessionKey(sessionKey: string): string {
+export function normalizeStoreSessionKey(sessionKey: string): string {
   return sessionKey.trim().toLowerCase();
 }
 


### PR DESCRIPTION
try to fix #38675

## Summary

- **Problem:** `/stop` commands are ignored when sent in Telegram forum topic channels. The agent continues generating even after the user sends `/stop`.
- **Why it matters:** Users cannot interrupt long-running responses in topic-based group conversations, unlike in DMs and non-topic groups.
- **What changed:** Session store keys are normalized (trim + lowercase). `resolveSessionEntryForKey` in the abort flow now reuses `normalizeStoreSessionKey` from `store.ts` so topic session keys are found correctly when handling `/stop`. Without this, the session entry lookup failed, `sessionId` was undefined, and `abortEmbeddedPiRun` was never called.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [x] Integrations (Telegram)
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

-  #38675

## User-visible / Behavior Changes

- `/stop` now correctly halts generation when sent in Telegram forum topic channels.
- No change to behavior in DMs or non-topic groups.

