### PR TITLE
Formalize Agent-to-Agent Learning with Policy-Governed Knowledge Transfer

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -13493,14 +13493,14 @@
         "filename": "src/config/schema.help.ts",
         "hashed_secret": "9f4cda226d3868676ac7f86f59e4190eb94bd208",
         "is_verified": false,
-        "line_number": 649
+        "line_number": 661
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/schema.help.ts",
         "hashed_secret": "01822c8bbf6a8b136944b14182cb885100ec2eae",
         "is_verified": false,
-        "line_number": 680
+        "line_number": 692
       }
     ],
     "src/config/schema.irc.ts": [
@@ -13539,14 +13539,14 @@
         "filename": "src/config/schema.labels.ts",
         "hashed_secret": "e73c9fcad85cd4eecc74181ec4bdb31064d68439",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 225
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/schema.labels.ts",
         "hashed_secret": "2eda7cd978f39eebec3bf03e4410a40e14167fff",
         "is_verified": false,
-        "line_number": 324
+        "line_number": 333
       }
     ],
     "src/config/slack-http-config.test.ts": [
@@ -14486,41 +14486,6 @@
       {
         "type": "Secret Keyword",
         "filename": "src/security/audit.test.ts",
-        "hashed_secret": "cf27add3cb4cb83efe9a48cf7289068fa869c4cd",
-        "is_verified": false,
-        "line_number": 1493
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/security/audit.test.ts",
-        "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
-        "is_verified": false,
-        "line_number": 1969
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/security/audit.test.ts",
-        "hashed_secret": "071d3673192b4b44a84aa73ac9d00c155821303b",
-        "is_verified": false,
-        "line_number": 1970
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/security/audit.test.ts",
-        "hashed_secret": "7b231a50a498ef151e291795f46f56bee569eae5",
-        "is_verified": false,
-        "line_number": 1982
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/security/audit.test.ts",
-        "hashed_secret": "5a013c49508291c6816ac388f93a2c11973086ed",
-        "is_verified": false,
-        "line_number": 2058
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/security/audit.test.ts",
         "hashed_secret": "21f688ab56f76a99e5c6ed342291422f4e57e47f",
         "is_verified": false,
         "line_number": 3473
@@ -14725,5 +14690,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-07T11:12:54Z"
+  "generated_at": "2026-03-07T11:22:31Z"
 }

--- a/docs/concepts/session-tool.md
+++ b/docs/concepts/session-tool.md
@@ -14,6 +14,7 @@ Goal: small, hard-to-misuse tool set so agents can list sessions, fetch history,
 - `sessions_list`
 - `sessions_history`
 - `sessions_send`
+- `sessions_transfer_knowledge`
 - `sessions_spawn`
 
 ## Key Model
@@ -103,6 +104,79 @@ Behavior:
   - Reply exactly `ANNOUNCE_SKIP` to stay silent.
   - Any other reply is sent to the target channel.
   - Announce step includes the original request + round‑1 reply + latest ping‑pong reply.
+
+## sessions_transfer_knowledge
+
+Request memory transfer from another session/agent with two-sided policy checks.
+
+Parameters:
+
+- `sessionKey` (or `label` + optional `agentId`)
+- `timeoutSeconds?` (optional override for approval wait timeout)
+- `question?` (reserved; accepted for compatibility)
+
+Behavior:
+
+- Resolves the target session using existing session visibility + agent-to-agent policy gates.
+- Scans the target agent workspace memory files (`MEMORY.md`, `memory/**/*.md`).
+- Evaluates each candidate item through both sides:
+  - **export** policy (what source agent allows to expose)
+  - **import** policy (what requester agent allows to accept)
+- Runs approvals per side when the matched policy decision is `ask`.
+- Computes a per-item fingerprint and imports into `memory/transfers/*.md`.
+- Deduplicates using fingerprint markers from existing transfer files:
+  - New items are imported.
+  - Existing fingerprints are counted as `skippedDuplicate`.
+- Returns transfer summary fields including policy/approval counts, `imported`, `skippedDuplicate`, and `transferFile` (when created).
+
+Rule decisions:
+
+- `hide`: blocked (never transferred)
+- `ask`: requires owner approval
+- `auto`: proceeds without prompt
+
+Policy:
+
+- `tools.agentToAgent.knowledgeTransfer.enabled` (default false)
+- `tools.agentToAgent.knowledgeTransfer.defaultMode` (legacy fallback)
+- `tools.agentToAgent.knowledgeTransfer.defaultExportMode`
+- `tools.agentToAgent.knowledgeTransfer.defaultImportMode`
+- `tools.agentToAgent.knowledgeTransfer.approvalTimeoutSeconds`
+- `/learn mode ask|auto [--pair requester,target]` applies catch-all allow mode (`path=*`) for both export+import.
+- `/learn rule add <hide|ask|auto> --side export|import --path <glob> [--pair requester,target]`
+- `/learn rule remove <id> [--pair requester,target]`
+- `/learn rule list [--pair requester,target]`
+- `/learn status [--pair requester,target]`
+
+Manual proof demo:
+
+1. Configure pair rules:
+   - `/learn rule add ask --side export --path MEMORY.md --pair requester,target`
+   - `/learn rule add ask --side import --path MEMORY.md --pair requester,target`
+   - `/learn rule add auto --side export --path memory/public/** --pair requester,target`
+   - `/learn rule add auto --side import --path memory/public/** --pair requester,target`
+   - `/learn rule add hide --side export --path memory/private/** --pair requester,target`
+2. Run transfer:
+   - `sessions_transfer_knowledge(sessionKey="agent:target:main")`
+   - capture export approval id and import approval id from result flow.
+3. Approve both:
+   - `/learn approve <export-id>`
+   - `/learn approve <import-id>`
+   - verify `status=ok`, `imported>0`, `blockedExport/blockedImport` counts.
+4. Verify file evidence:
+   - inspect `memory/transfers/*.md`
+   - confirm facts, modes, and `openclaw-transfer-fingerprint` markers.
+5. Run same transfer again and approve both:
+   - verify dedupe (`imported=0`, `skippedDuplicate>0`).
+6. Deny path:
+   - deny import approval with `/learn deny <import-id>`
+   - verify `status=declined` when no items remain importable.
+7. Auto path:
+   - `/learn mode auto --pair requester,target`
+   - run transfer and verify import succeeds with no approval creation.
+8. Retrieval proof:
+   - run `memory_search` for a transferred fact
+   - verify a hit path under `memory/transfers/...`.
 
 ## Channel Field
 

--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -75,6 +75,13 @@ Text + native (when enabled):
 - `/status` (show current status; includes provider usage/quota for the current model provider when available)
 - `/allowlist` (list/add/remove allowlist entries)
 - `/approve <id> allow-once|allow-always|deny` (resolve exec approval prompts)
+- `/learn approve <id>` (approve pending knowledge transfer)
+- `/learn deny <id>` (deny pending knowledge transfer)
+- `/learn mode ask|auto [--pair requester,target]` (set catch-all export+import mode for `path=*`; default pair is `*,*`)
+- `/learn rule add <hide|ask|auto> --side export|import --path <glob> [--pair requester,target]` (path-level policy)
+- `/learn rule remove <id> [--pair requester,target]`
+- `/learn rule list [--pair requester,target]`
+- `/learn status [--pair requester,target]` (show effective knowledge transfer mode/defaults)
 - `/context [list|detail|json]` (explain “context”; `detail` shows per-file + per-tool + per-skill + system prompt size)
 - `/export-session [path]` (alias: `/export`) (export current session to HTML with full system prompt)
 - `/whoami` (show your sender id; alias: `/id`)
@@ -123,6 +130,7 @@ Notes:
 - `/new <model>` accepts a model alias, `provider/model`, or a provider name (fuzzy match); if no match, the text is treated as the message body.
 - For full provider usage breakdown, use `openclaw status --usage`.
 - `/allowlist add|remove` requires `commands.config=true` and honors channel `configWrites`.
+- `/learn approve|deny|mode|rule add|rule remove` requires an authorized **owner** sender. For gateway clients, `operator.approvals` (or `operator.admin`) is also required.
 - `/usage` controls the per-response usage footer; `/usage cost` prints a local cost summary from OpenClaw session logs.
 - `/restart` is enabled by default; set `commands.restart: false` to disable it.
 - Discord-only native command: `/vc join|leave|status` controls voice channels (requires `channels.discord.voice` and native commands; not available as text).

--- a/extensions/feishu/src/monitor.startup.test.ts
+++ b/extensions/feishu/src/monitor.startup.test.ts
@@ -1,6 +1,5 @@
 import type { ClawdbotConfig } from "openclaw/plugin-sdk/feishu";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { monitorFeishuProvider, stopFeishuMonitor } from "./monitor.js";
 
 const probeFeishuMock = vi.hoisted(() => vi.fn());
 const feishuClientMockModule = vi.hoisted(() => ({
@@ -30,6 +29,8 @@ vi.mock("./probe.js", () => ({
 
 vi.mock("./client.js", () => feishuClientMockModule);
 vi.mock("./runtime.js", () => feishuRuntimeMockModule);
+
+import { monitorFeishuProvider, stopFeishuMonitor } from "./monitor.js";
 
 function buildMultiAccountWebsocketConfig(accountIds: string[]): ClawdbotConfig {
   return {

--- a/src/agents/openclaw-tools.sessions-transfer.test.ts
+++ b/src/agents/openclaw-tools.sessions-transfer.test.ts
@@ -1,0 +1,453 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resetMemoryToolMockState,
+  setMemorySearchImpl,
+} from "../../test/helpers/memory-tool-manager-mock.js";
+import {
+  setKnowledgeTransferPairMode,
+  upsertKnowledgeTransferRule,
+} from "../infra/knowledge-transfer-policy.js";
+import { createMemorySearchTool } from "./tools/memory-tool.js";
+
+const callGatewayMock = vi.fn();
+vi.mock("../gateway/call.js", () => ({
+  callGateway: (opts: unknown) => callGatewayMock(opts),
+}));
+
+let mockConfig: Record<string, unknown> = {};
+vi.mock("../config/config.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/config.js")>();
+  return {
+    ...actual,
+    loadConfig: () => mockConfig,
+    resolveGatewayPort: () => 18789,
+  };
+});
+
+import "./test-helpers/fast-core-tools.js";
+import { createOpenClawTools } from "./openclaw-tools.js";
+
+type PendingApproval = {
+  id: string;
+  approvalKind: "export" | "import";
+  resolve: (decision: "allow" | "deny" | null) => void;
+  promise: Promise<"allow" | "deny" | null>;
+};
+
+function computeFingerprint(text: string, sourcePath: string): string {
+  const normalized = text
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .trim();
+  return crypto.createHash("sha256").update(`${sourcePath}\n${normalized}`).digest("hex");
+}
+
+describe("sessions_transfer_knowledge proof scenario", () => {
+  let rootDir = "";
+  let requesterWorkspace = "";
+  let sourceWorkspace = "";
+  let stateDir = "";
+  let previousStateDir: string | undefined;
+  let approvalSeq = 0;
+  const pendingApprovals = new Map<string, PendingApproval>();
+  let approvalRequests = 0;
+
+  beforeEach(async () => {
+    resetMemoryToolMockState({ searchImpl: async () => [] });
+    callGatewayMock.mockReset();
+    approvalSeq = 0;
+    pendingApprovals.clear();
+    approvalRequests = 0;
+
+    rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-transfer-proof-"));
+    requesterWorkspace = path.join(rootDir, "workspace-requester");
+    sourceWorkspace = path.join(rootDir, "workspace-source");
+    stateDir = path.join(rootDir, "state");
+    await fs.mkdir(requesterWorkspace, { recursive: true });
+    await fs.mkdir(path.join(sourceWorkspace, "memory", "public"), { recursive: true });
+    await fs.mkdir(path.join(sourceWorkspace, "memory", "private"), { recursive: true });
+
+    await fs.writeFile(path.join(sourceWorkspace, "MEMORY.md"), "Fact A\nFact B\n", "utf-8");
+    await fs.writeFile(
+      path.join(sourceWorkspace, "memory", "public", "share.md"),
+      "Fact C\nFact D\n",
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(sourceWorkspace, "memory", "private", "secret.md"),
+      "Secret X\n",
+      "utf-8",
+    );
+
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+
+    mockConfig = {
+      session: { mainKey: "main", scope: "per-sender" },
+      tools: {
+        sessions: { visibility: "all" },
+        agentToAgent: {
+          enabled: true,
+          allow: ["*"],
+          knowledgeTransfer: {
+            enabled: true,
+            defaultExportMode: "ask",
+            defaultImportMode: "ask",
+            approvalTimeoutSeconds: 120,
+          },
+        },
+      },
+      agents: {
+        list: [
+          { id: "requester", workspace: requesterWorkspace },
+          { id: "source", workspace: sourceWorkspace },
+        ],
+      },
+      memory: {
+        citations: "off",
+      },
+    };
+
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as {
+        method?: string;
+        params?: Record<string, unknown>;
+      };
+
+      if (request.method === "sessions.resolve") {
+        const key = typeof request.params?.key === "string" ? request.params.key : "";
+        return { key: key || "agent:source:main" };
+      }
+
+      if (request.method === "knowledge.transfer.approval.request") {
+        approvalRequests += 1;
+        approvalSeq += 1;
+        const approvalKindRaw = request.params?.approvalKind;
+        const approvalKind = approvalKindRaw === "import" ? "import" : "export";
+        const id = `kt-approval-${approvalSeq}`;
+        let resolveDecision!: (decision: "allow" | "deny" | null) => void;
+        const promise = new Promise<"allow" | "deny" | null>((resolve) => {
+          resolveDecision = resolve;
+        });
+        pendingApprovals.set(id, { id, approvalKind, resolve: resolveDecision, promise });
+        return {
+          status: "accepted",
+          id,
+          createdAtMs: Date.now(),
+          expiresAtMs: Date.now() + 120_000,
+        };
+      }
+
+      if (request.method === "knowledge.transfer.approval.wait") {
+        const id = typeof request.params?.id === "string" ? request.params.id : "";
+        const pending = pendingApprovals.get(id);
+        if (!pending) {
+          return { decision: null };
+        }
+        const decision = await pending.promise;
+        return { id, decision };
+      }
+
+      if (request.method === "knowledge.transfer.approval.resolve") {
+        const id = typeof request.params?.id === "string" ? request.params.id : "";
+        const decision = request.params?.decision;
+        const pending = pendingApprovals.get(id);
+        if (!pending) {
+          throw new Error("unknown approval id");
+        }
+        pendingApprovals.delete(id);
+        pending.resolve(decision === "allow" ? "allow" : "deny");
+        return { ok: true };
+      }
+
+      return {};
+    });
+  });
+
+  afterEach(async () => {
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    await fs.rm(rootDir, { recursive: true, force: true });
+  });
+
+  it("proves path-level export/import policy, dual approvals, dedupe, deny, auto, and memory retrieval", async () => {
+    await upsertKnowledgeTransferRule({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "export",
+      pathPattern: "MEMORY.md",
+      decision: "ask",
+      baseDir: stateDir,
+    });
+    await upsertKnowledgeTransferRule({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "import",
+      pathPattern: "MEMORY.md",
+      decision: "ask",
+      baseDir: stateDir,
+    });
+    await upsertKnowledgeTransferRule({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "export",
+      pathPattern: "memory/public/**",
+      decision: "auto",
+      baseDir: stateDir,
+    });
+    await upsertKnowledgeTransferRule({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "import",
+      pathPattern: "memory/public/**",
+      decision: "auto",
+      baseDir: stateDir,
+    });
+    await upsertKnowledgeTransferRule({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "export",
+      pathPattern: "memory/private/**",
+      decision: "hide",
+      baseDir: stateDir,
+    });
+    await upsertKnowledgeTransferRule({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "import",
+      pathPattern: "memory/private/**",
+      decision: "hide",
+      baseDir: stateDir,
+    });
+
+    const tool = createOpenClawTools({
+      agentSessionKey: "agent:requester:main",
+    }).find((candidate) => candidate.name === "sessions_transfer_knowledge");
+    if (!tool) {
+      throw new Error("missing sessions_transfer_knowledge tool");
+    }
+
+    const runAllow = tool.execute("transfer-allow", {
+      sessionKey: "agent:source:main",
+      timeoutSeconds: 10,
+    });
+
+    await vi.waitFor(() => {
+      expect(pendingApprovals.size).toBe(1);
+    });
+    const exportApprovalId = Array.from(pendingApprovals.keys())[0];
+    const exportPending = pendingApprovals.get(exportApprovalId);
+    if (!exportPending) {
+      throw new Error("missing export approval");
+    }
+    expect(exportPending.approvalKind).toBe("export");
+    pendingApprovals.delete(exportApprovalId);
+    exportPending.resolve("allow");
+
+    await vi.waitFor(() => {
+      expect(pendingApprovals.size).toBe(1);
+    });
+    const importApprovalId = Array.from(pendingApprovals.keys())[0];
+    const importPending = pendingApprovals.get(importApprovalId);
+    if (!importPending) {
+      throw new Error("missing import approval");
+    }
+    expect(importPending.approvalKind).toBe("import");
+    pendingApprovals.delete(importApprovalId);
+    importPending.resolve("allow");
+
+    const firstResult = (await runAllow).details as {
+      status: string;
+      candidateTotal: number;
+      blockedExport: number;
+      blockedImport: number;
+      imported: number;
+      skippedDuplicate: number;
+      transferFile?: string;
+      exportApprovalId?: string;
+      importApprovalId?: string;
+    };
+
+    expect(firstResult.status).toBe("ok");
+    expect(firstResult.candidateTotal).toBe(5);
+    expect(firstResult.blockedExport).toBe(1);
+    expect(firstResult.blockedImport).toBe(0);
+    expect(firstResult.imported).toBe(4);
+    expect(firstResult.skippedDuplicate).toBe(0);
+    expect(firstResult.exportApprovalId).toBe(exportApprovalId);
+    expect(firstResult.importApprovalId).toBe(importApprovalId);
+    expect(typeof firstResult.transferFile).toBe("string");
+
+    const firstTransferRel = firstResult.transferFile ?? "";
+    expect(firstTransferRel.startsWith("memory/transfers/")).toBe(true);
+    const firstTransferAbs = path.join(requesterWorkspace, firstTransferRel);
+    const firstTransferText = await fs.readFile(firstTransferAbs, "utf-8");
+    expect(firstTransferText).toContain("Fact A");
+    expect(firstTransferText).toContain("Fact C");
+    expect(firstTransferText).not.toContain("Secret X");
+    expect(firstTransferText).toContain("openclaw-transfer-fingerprint");
+    expect(firstTransferText).toContain(computeFingerprint("Fact A", "MEMORY.md"));
+    expect(firstTransferText).toContain(computeFingerprint("Fact C", "memory/public/share.md"));
+
+    setMemorySearchImpl(async () => [
+      {
+        path: firstTransferRel,
+        startLine: 1,
+        endLine: 1,
+        score: 0.99,
+        snippet: "Fact A",
+        source: "memory" as const,
+      },
+    ]);
+    const memoryTool = createMemorySearchTool({
+      config: mockConfig as Parameters<typeof createMemorySearchTool>[0]["config"],
+      agentSessionKey: "agent:requester:main",
+    });
+    if (!memoryTool) {
+      throw new Error("missing memory_search tool");
+    }
+    const memoryResult = (
+      await memoryTool.execute("memory-proof", {
+        query: "Fact A",
+      })
+    ).details as {
+      results?: Array<{ path?: string; snippet?: string }>;
+    };
+    expect(memoryResult.results?.[0]?.path?.startsWith("memory/transfers/")).toBe(true);
+    expect(memoryResult.results?.[0]?.snippet).toContain("Fact A");
+
+    const transferDir = path.join(requesterWorkspace, "memory", "transfers");
+    const filesAfterFirst = (await fs.readdir(transferDir)).toSorted();
+
+    const runDuplicate = tool.execute("transfer-duplicate", {
+      sessionKey: "agent:source:main",
+      timeoutSeconds: 10,
+    });
+
+    await vi.waitFor(() => {
+      expect(pendingApprovals.size).toBe(1);
+    });
+    const exportApprovalId2 = Array.from(pendingApprovals.keys())[0];
+    const exportPending2 = pendingApprovals.get(exportApprovalId2);
+    if (!exportPending2) {
+      throw new Error("missing export approval 2");
+    }
+    pendingApprovals.delete(exportApprovalId2);
+    exportPending2.resolve("allow");
+
+    await vi.waitFor(() => {
+      expect(pendingApprovals.size).toBe(1);
+    });
+    const importApprovalId2 = Array.from(pendingApprovals.keys())[0];
+    const importPending2 = pendingApprovals.get(importApprovalId2);
+    if (!importPending2) {
+      throw new Error("missing import approval 2");
+    }
+    pendingApprovals.delete(importApprovalId2);
+    importPending2.resolve("allow");
+
+    const duplicateResult = (await runDuplicate).details as {
+      status: string;
+      imported: number;
+      skippedDuplicate: number;
+      transferFile?: string;
+    };
+    expect(duplicateResult.status).toBe("ok");
+    expect(duplicateResult.imported).toBe(0);
+    expect(duplicateResult.skippedDuplicate).toBe(4);
+    expect(duplicateResult.transferFile).toBeUndefined();
+
+    const filesAfterDuplicate = (await fs.readdir(transferDir)).toSorted();
+    expect(filesAfterDuplicate).toEqual(filesAfterFirst);
+
+    await upsertKnowledgeTransferRule({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "import",
+      pathPattern: "memory/public/**",
+      decision: "hide",
+      baseDir: stateDir,
+    });
+
+    const runDeny = tool.execute("transfer-deny", {
+      sessionKey: "agent:source:main",
+      timeoutSeconds: 10,
+    });
+
+    await vi.waitFor(() => {
+      expect(pendingApprovals.size).toBe(1);
+    });
+    const exportApprovalId3 = Array.from(pendingApprovals.keys())[0];
+    const exportPending3 = pendingApprovals.get(exportApprovalId3);
+    if (!exportPending3) {
+      throw new Error("missing export approval 3");
+    }
+    pendingApprovals.delete(exportApprovalId3);
+    exportPending3.resolve("allow");
+
+    await vi.waitFor(() => {
+      expect(pendingApprovals.size).toBe(1);
+    });
+    const importApprovalId3 = Array.from(pendingApprovals.keys())[0];
+    const importPending3 = pendingApprovals.get(importApprovalId3);
+    if (!importPending3) {
+      throw new Error("missing import approval 3");
+    }
+    pendingApprovals.delete(importApprovalId3);
+    importPending3.resolve("deny");
+
+    const denyResult = (await runDeny).details as {
+      status: string;
+      imported: number;
+      skippedDuplicate: number;
+    };
+    expect(denyResult.status).toBe("declined");
+    expect(denyResult.imported).toBe(0);
+    expect(denyResult.skippedDuplicate).toBe(0);
+
+    const filesAfterDeny = (await fs.readdir(transferDir)).toSorted();
+    expect(filesAfterDeny).toEqual(filesAfterFirst);
+
+    await setKnowledgeTransferPairMode({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      mode: "auto",
+      baseDir: stateDir,
+    });
+
+    const approvalsBeforeAuto = approvalRequests;
+    const autoResult = (
+      await tool.execute("transfer-auto", {
+        sessionKey: "agent:source:main",
+        timeoutSeconds: 10,
+      })
+    ).details as {
+      status: string;
+      imported: number;
+      skippedDuplicate: number;
+      transferFile?: string;
+    };
+
+    expect(autoResult.status).toBe("ok");
+    expect(autoResult.imported).toBe(1);
+    expect(autoResult.skippedDuplicate).toBe(4);
+    expect(approvalRequests).toBe(approvalsBeforeAuto);
+
+    const autoTransferRel = autoResult.transferFile ?? "";
+    expect(autoTransferRel.startsWith("memory/transfers/")).toBe(true);
+    const autoTransferText = await fs.readFile(
+      path.join(requesterWorkspace, autoTransferRel),
+      "utf-8",
+    );
+    expect(autoTransferText).toContain("Secret X");
+  });
+});

--- a/src/agents/openclaw-tools.sessions-transfer.test.ts
+++ b/src/agents/openclaw-tools.sessions-transfer.test.ts
@@ -72,6 +72,7 @@ describe("sessions_transfer_knowledge proof scenario", () => {
     await fs.mkdir(requesterWorkspace, { recursive: true });
     await fs.mkdir(path.join(sourceWorkspace, "memory", "public"), { recursive: true });
     await fs.mkdir(path.join(sourceWorkspace, "memory", "private"), { recursive: true });
+    await fs.mkdir(path.join(sourceWorkspace, "memory", "transfers"), { recursive: true });
 
     await fs.writeFile(path.join(sourceWorkspace, "MEMORY.md"), "Fact A\nFact B\n", "utf-8");
     await fs.writeFile(
@@ -82,6 +83,19 @@ describe("sessions_transfer_knowledge proof scenario", () => {
     await fs.writeFile(
       path.join(sourceWorkspace, "memory", "private", "secret.md"),
       "Secret X\n",
+      "utf-8",
+    );
+    await fs.writeFile(
+      path.join(sourceWorkspace, "memory", "transfers", "previous-transfer.md"),
+      [
+        "# Knowledge Transfer",
+        "",
+        "Requester Agent: legacy",
+        "Source: memory/public/share.md",
+        "Modes: export=auto, import=auto",
+        "Transferred metadata that should not be re-imported.",
+        "",
+      ].join("\n"),
       "utf-8",
     );
 
@@ -294,6 +308,7 @@ describe("sessions_transfer_knowledge proof scenario", () => {
     expect(firstTransferText).toContain("Fact A");
     expect(firstTransferText).toContain("Fact C");
     expect(firstTransferText).not.toContain("Secret X");
+    expect(firstTransferText).not.toContain("Transferred metadata that should not be re-imported.");
     expect(firstTransferText).toContain("openclaw-transfer-fingerprint");
     expect(firstTransferText).toContain(computeFingerprint("Fact A", "MEMORY.md"));
     expect(firstTransferText).toContain(computeFingerprint("Fact C", "memory/public/share.md"));

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -88,6 +88,7 @@ describe("sessions tools", () => {
     expect(schemaProp("sessions_list", "activeMinutes").type).toBe("number");
     expect(schemaProp("sessions_list", "messageLimit").type).toBe("number");
     expect(schemaProp("sessions_send", "timeoutSeconds").type).toBe("number");
+    expect(schemaProp("sessions_transfer_knowledge", "timeoutSeconds").type).toBe("number");
     expect(schemaProp("sessions_spawn", "thinking").type).toBe("string");
     expect(schemaProp("sessions_spawn", "runTimeoutSeconds").type).toBe("number");
     expect(schemaProp("sessions_spawn", "thread").type).toBe("boolean");

--- a/src/agents/openclaw-tools.ts
+++ b/src/agents/openclaw-tools.ts
@@ -19,6 +19,7 @@ import { createSessionsHistoryTool } from "./tools/sessions-history-tool.js";
 import { createSessionsListTool } from "./tools/sessions-list-tool.js";
 import { createSessionsSendTool } from "./tools/sessions-send-tool.js";
 import { createSessionsSpawnTool } from "./tools/sessions-spawn-tool.js";
+import { createSessionsTransferKnowledgeTool } from "./tools/sessions-transfer-knowledge-tool.js";
 import { createSubagentsTool } from "./tools/subagents-tool.js";
 import { createTtsTool } from "./tools/tts-tool.js";
 import { createWebFetchTool, createWebSearchTool } from "./tools/web-tools.js";
@@ -167,6 +168,11 @@ export function createOpenClawTools(options?: {
       sandboxed: options?.sandboxed,
     }),
     createSessionsSendTool({
+      agentSessionKey: options?.agentSessionKey,
+      agentChannel: options?.agentChannel,
+      sandboxed: options?.sandboxed,
+    }),
+    createSessionsTransferKnowledgeTool({
       agentSessionKey: options?.agentSessionKey,
       agentChannel: options?.agentChannel,
       sandboxed: options?.sandboxed,

--- a/src/agents/pi-embedded-subscribe.tools.ts
+++ b/src/agents/pi-embedded-subscribe.tools.ts
@@ -152,6 +152,7 @@ const TRUSTED_TOOL_RESULT_MEDIA = new Set([
   "sessions_history",
   "sessions_list",
   "sessions_send",
+  "sessions_transfer_knowledge",
   "sessions_spawn",
   "subagents",
   "tts",

--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -305,6 +305,7 @@ describe("createOpenClawCodingTools", () => {
       "sessions_list",
       "sessions_history",
       "sessions_send",
+      "sessions_transfer_knowledge",
       "sessions_spawn",
       "subagents",
       "session_status",
@@ -328,6 +329,7 @@ describe("createOpenClawCodingTools", () => {
     expect(names.has("sessions_list")).toBe(false);
     expect(names.has("sessions_history")).toBe(false);
     expect(names.has("sessions_send")).toBe(false);
+    expect(names.has("sessions_transfer_knowledge")).toBe(false);
     expect(names.has("sessions_spawn")).toBe(false);
     // Explicit subagent orchestration tool remains available (list/steer/kill with safeguards).
     expect(names.has("subagents")).toBe(true);
@@ -404,6 +406,7 @@ describe("createOpenClawCodingTools", () => {
     const names = new Set(tools.map((tool) => tool.name));
     expect(names.has("message")).toBe(true);
     expect(names.has("sessions_send")).toBe(true);
+    expect(names.has("sessions_transfer_knowledge")).toBe(true);
     expect(names.has("sessions_spawn")).toBe(false);
     expect(names.has("exec")).toBe(false);
     expect(names.has("browser")).toBe(false);

--- a/src/agents/pi-tools.policy.test.ts
+++ b/src/agents/pi-tools.policy.test.ts
@@ -126,6 +126,7 @@ describe("resolveSubagentToolPolicy depth awareness", () => {
     expect(isToolAllowedByPolicyName("cron", policy)).toBe(false);
     expect(isToolAllowedByPolicyName("memory_search", policy)).toBe(false);
     expect(isToolAllowedByPolicyName("memory_get", policy)).toBe(false);
+    expect(isToolAllowedByPolicyName("sessions_transfer_knowledge", policy)).toBe(false);
   });
 
   it("depth-2 leaf denies sessions_spawn", () => {

--- a/src/agents/pi-tools.policy.ts
+++ b/src/agents/pi-tools.policy.ts
@@ -57,6 +57,8 @@ const SUBAGENT_TOOL_DENY_ALWAYS = [
   "memory_get",
   // Direct session sends - subagents communicate through announce chain
   "sessions_send",
+  // Cross-agent knowledge imports must remain user-mediated at parent level
+  "sessions_transfer_knowledge",
 ];
 
 /**

--- a/src/agents/sandbox/constants.ts
+++ b/src/agents/sandbox/constants.ts
@@ -21,6 +21,7 @@ export const DEFAULT_TOOL_ALLOW = [
   "sessions_list",
   "sessions_history",
   "sessions_send",
+  "sessions_transfer_knowledge",
   "sessions_spawn",
   "subagents",
   "session_status",

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -132,6 +132,7 @@ function buildMessagingSection(params: {
     "## Messaging",
     "- Reply in current session → automatically routes to the source channel (Signal, Telegram, etc.)",
     "- Cross-session messaging → use sessions_send(sessionKey, message)",
+    "- Cross-agent memory import (user-gated) → use sessions_transfer_knowledge(sessionKey)",
     "- Sub-agent orchestration → use subagents(action=list|steer|kill)",
     `- Runtime-generated completion events may ask for a user update. Rewrite those in your normal assistant voice and send the update (do not forward raw internal metadata or default to ${SILENT_REPLY_TOKEN}).`,
     "- Never use exec/curl for provider messaging; OpenClaw handles all routing internally.",
@@ -262,6 +263,8 @@ export function buildAgentSystemPrompt(params: {
     sessions_list: "List other sessions (incl. sub-agents) with filters/last",
     sessions_history: "Fetch history for another session/sub-agent",
     sessions_send: "Send a message to another session/sub-agent",
+    sessions_transfer_knowledge:
+      "Request curated memory transfer from another session (ask or auto mode, with dedupe import)",
     sessions_spawn: acpSpawnRuntimeEnabled
       ? 'Spawn an isolated sub-agent or ACP coding session (runtime="acp" requires `agentId` unless `acp.defaultAgent` is configured; ACP harness ids follow acp.allowedAgents, not agents_list)'
       : "Spawn an isolated sub-agent session",
@@ -293,6 +296,7 @@ export function buildAgentSystemPrompt(params: {
     "sessions_list",
     "sessions_history",
     "sessions_send",
+    "sessions_transfer_knowledge",
     "subagents",
     "session_status",
     "image",
@@ -442,6 +446,7 @@ export function buildAgentSystemPrompt(params: {
           "- sessions_list: list sessions",
           "- sessions_history: fetch session history",
           "- sessions_send: send to another session",
+          "- sessions_transfer_knowledge: request user-gated curated memory transfer",
           "- subagents: list/steer/kill sub-agent runs",
           '- session_status: show usage/time/model state and answer "what model are we using?"',
         ].join("\n"),

--- a/src/agents/tool-catalog.ts
+++ b/src/agents/tool-catalog.ts
@@ -138,6 +138,14 @@ const CORE_TOOL_DEFINITIONS: CoreToolDefinition[] = [
     includeInOpenClawGroup: true,
   },
   {
+    id: "sessions_transfer_knowledge",
+    label: "sessions_transfer_knowledge",
+    description: "Transfer curated knowledge",
+    sectionId: "sessions",
+    profiles: ["coding", "messaging"],
+    includeInOpenClawGroup: true,
+  },
+  {
     id: "sessions_spawn",
     label: "sessions_spawn",
     description: "Spawn sub-agent",

--- a/src/agents/tool-display-overrides.json
+++ b/src/agents/tool-display-overrides.json
@@ -31,6 +31,11 @@
       "title": "Session Send",
       "detailKeys": ["label", "sessionKey", "agentId", "timeoutSeconds"]
     },
+    "sessions_transfer_knowledge": {
+      "emoji": "🧠",
+      "title": "Knowledge Transfer",
+      "detailKeys": ["label", "sessionKey", "agentId", "timeoutSeconds"]
+    },
     "sessions_history": {
       "emoji": "🧾",
       "title": "Session History",

--- a/src/agents/tool-mutation.test.ts
+++ b/src/agents/tool-mutation.test.ts
@@ -67,6 +67,7 @@ describe("tool mutation helpers", () => {
 
   it("keeps legacy name-only mutating heuristics for payload fallback", () => {
     expect(isLikelyMutatingToolName("sessions_send")).toBe(true);
+    expect(isLikelyMutatingToolName("sessions_transfer_knowledge")).toBe(true);
     expect(isLikelyMutatingToolName("browser_actions")).toBe(true);
     expect(isLikelyMutatingToolName("message_slack")).toBe(true);
     expect(isLikelyMutatingToolName("browser")).toBe(false);

--- a/src/agents/tool-mutation.ts
+++ b/src/agents/tool-mutation.ts
@@ -7,6 +7,7 @@ const MUTATING_TOOL_NAMES = new Set([
   "process",
   "message",
   "sessions_send",
+  "sessions_transfer_knowledge",
   "cron",
   "gateway",
   "canvas",
@@ -107,6 +108,7 @@ export function isMutatingToolCall(toolName: string, args: unknown): boolean {
     case "exec":
     case "bash":
     case "sessions_send":
+    case "sessions_transfer_knowledge":
       return true;
     case "process":
       return action != null && PROCESS_MUTATING_ACTIONS.has(action);

--- a/src/agents/tools/sessions-transfer-knowledge-tool.ts
+++ b/src/agents/tools/sessions-transfer-knowledge-tool.ts
@@ -1,0 +1,785 @@
+import crypto from "node:crypto";
+import type { Dirent } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { Type } from "@sinclair/typebox";
+import { resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
+import { loadConfig } from "../../config/config.js";
+import { callGateway } from "../../gateway/call.js";
+import {
+  createKnowledgeTransferPolicyResolver,
+  type KnowledgeTransferMode,
+} from "../../infra/knowledge-transfer-policy.js";
+import { normalizeAgentId, resolveAgentIdFromSessionKey } from "../../routing/session-key.js";
+import { SESSION_LABEL_MAX_LENGTH } from "../../sessions/session-label.js";
+import type { GatewayMessageChannel } from "../../utils/message-channel.js";
+import type { AnyAgentTool } from "./common.js";
+import { jsonResult, readStringParam } from "./common.js";
+import {
+  createAgentToAgentPolicy,
+  createSessionVisibilityGuard,
+  resolveEffectiveSessionToolsVisibility,
+  resolveSandboxedSessionToolContext,
+  resolveSessionReference,
+  resolveVisibleSessionReference,
+} from "./sessions-helpers.js";
+
+type TransferPayloadItem = {
+  text: string;
+  sourcePath: string;
+  fingerprint: string;
+};
+
+type ApprovedTransferItem = TransferPayloadItem & {
+  exportMode: KnowledgeTransferMode;
+  importMode: KnowledgeTransferMode;
+};
+
+type ApprovalKind = "export" | "import";
+
+type ApprovalResult =
+  | {
+      ok: true;
+      approved: boolean;
+      approvalId?: string;
+      decision?: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
+type TransferImportResult = {
+  imported: number;
+  skippedDuplicate: number;
+  filePath?: string;
+  importedFingerprints: string[];
+};
+
+const SessionsTransferKnowledgeToolSchema = Type.Object({
+  sessionKey: Type.Optional(Type.String()),
+  label: Type.Optional(Type.String({ minLength: 1, maxLength: SESSION_LABEL_MAX_LENGTH })),
+  agentId: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
+  timeoutSeconds: Type.Optional(Type.Number({ minimum: 0 })),
+  question: Type.Optional(Type.String({ minLength: 1 })),
+});
+
+const APPROVAL_STATUS_ACCEPTED = "accepted";
+const APPROVAL_DECISION_ALLOW = "allow";
+const TRANSFER_FINGERPRINT_MARKER = "openclaw-transfer-fingerprint";
+const MAX_TRANSFER_ITEMS = 500;
+const MAX_APPROVAL_SUMMARY_ITEMS = 50;
+
+function normalizeKnowledgeText(value: string): string {
+  return value
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n")
+    .trim();
+}
+
+function normalizeSourcePath(value: string): string {
+  return value
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^[./]+/, "");
+}
+
+function computeTransferFingerprint(params: { text: string; sourcePath: string }): string {
+  const normalizedText = normalizeKnowledgeText(params.text);
+  return crypto
+    .createHash("sha256")
+    .update(`${params.sourcePath}\n${normalizedText}`)
+    .digest("hex");
+}
+
+function fileSafeSegment(value: string): string {
+  const safe = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/-+/g, "-");
+  return safe.replace(/^-|-$/g, "") || "agent";
+}
+
+function isMarkdownMemoryFile(relPath: string): boolean {
+  const normalized = normalizeSourcePath(relPath).toLowerCase();
+  if (normalized === "memory.md") {
+    return true;
+  }
+  return normalized.startsWith("memory/") && normalized.endsWith(".md");
+}
+
+async function listMemoryFiles(
+  workspaceDir: string,
+): Promise<Array<{ absPath: string; sourcePath: string }>> {
+  const files: Array<{ absPath: string; sourcePath: string }> = [];
+
+  const memoryRootFile = path.join(workspaceDir, "MEMORY.md");
+  try {
+    const stat = await fs.stat(memoryRootFile);
+    if (stat.isFile()) {
+      files.push({
+        absPath: memoryRootFile,
+        sourcePath: "MEMORY.md",
+      });
+    }
+  } catch {
+    // Ignore missing root memory file.
+  }
+
+  const memoryDir = path.join(workspaceDir, "memory");
+  async function walk(dir: string, relDir: string): Promise<void> {
+    let entries: Dirent[] = [];
+    try {
+      entries = await fs.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      const absPath = path.join(dir, entry.name);
+      const relPath = relDir ? `${relDir}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        await walk(absPath, relPath);
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+      if (!entry.name.toLowerCase().endsWith(".md")) {
+        continue;
+      }
+      files.push({
+        absPath,
+        sourcePath: normalizeSourcePath(`memory/${relPath}`),
+      });
+    }
+  }
+
+  await walk(memoryDir, "");
+  return files;
+}
+
+function extractKnowledgeItemsFromMarkdown(text: string): string[] {
+  const lines = text.replace(/\r\n/g, "\n").split("\n");
+  const items: string[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    if (trimmed.startsWith("#")) {
+      continue;
+    }
+    if (trimmed.startsWith("```")) {
+      continue;
+    }
+    if (trimmed.startsWith("<!--") && trimmed.endsWith("-->")) {
+      continue;
+    }
+    items.push(trimmed);
+  }
+  return items;
+}
+
+async function collectTransferPayloadFromWorkspace(
+  workspaceDir: string,
+): Promise<TransferPayloadItem[]> {
+  const files = await listMemoryFiles(workspaceDir);
+  const items: TransferPayloadItem[] = [];
+
+  for (const file of files) {
+    if (!isMarkdownMemoryFile(file.sourcePath)) {
+      continue;
+    }
+    let text = "";
+    try {
+      text = await fs.readFile(file.absPath, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const extracted = extractKnowledgeItemsFromMarkdown(text);
+    for (const snippet of extracted) {
+      const normalizedText = normalizeKnowledgeText(snippet);
+      if (!normalizedText) {
+        continue;
+      }
+      const fingerprint = computeTransferFingerprint({
+        text: normalizedText,
+        sourcePath: file.sourcePath,
+      });
+      items.push({
+        text: normalizedText,
+        sourcePath: file.sourcePath,
+        fingerprint,
+      });
+      if (items.length >= MAX_TRANSFER_ITEMS) {
+        return items;
+      }
+    }
+  }
+
+  return items;
+}
+
+async function collectExistingTransferFingerprints(transferDir: string): Promise<Set<string>> {
+  const existing = new Set<string>();
+  let entries: string[] = [];
+  try {
+    entries = await fs.readdir(transferDir);
+  } catch {
+    return existing;
+  }
+
+  const marker = new RegExp(`${TRANSFER_FINGERPRINT_MARKER}:\\s*([a-f0-9]{64})`, "gi");
+  for (const entry of entries) {
+    if (!entry.toLowerCase().endsWith(".md")) {
+      continue;
+    }
+    const absPath = path.join(transferDir, entry);
+    try {
+      const stat = await fs.stat(absPath);
+      if (!stat.isFile()) {
+        continue;
+      }
+      const text = await fs.readFile(absPath, "utf-8");
+      for (const match of text.matchAll(marker)) {
+        const fingerprint = match[1]?.toLowerCase();
+        if (fingerprint) {
+          existing.add(fingerprint);
+        }
+      }
+    } catch {
+      // Ignore per-file read failures.
+    }
+  }
+
+  return existing;
+}
+
+function buildTransferFileContent(params: {
+  requesterAgentId: string;
+  targetAgentId: string;
+  targetSessionKey: string;
+  exportApprovalId?: string;
+  importApprovalId?: string;
+  importedItems: ApprovedTransferItem[];
+}): string {
+  const lines: string[] = [
+    "# Knowledge Transfer",
+    "",
+    `- Requester Agent: ${params.requesterAgentId}`,
+    `- Target Agent: ${params.targetAgentId}`,
+    `- Target Session: ${params.targetSessionKey}`,
+    `- Transferred At: ${new Date().toISOString()}`,
+  ];
+  if (params.exportApprovalId) {
+    lines.push(`- Export Approval ID: ${params.exportApprovalId}`);
+  }
+  if (params.importApprovalId) {
+    lines.push(`- Import Approval ID: ${params.importApprovalId}`);
+  }
+  lines.push("", "## Imported Items", "");
+
+  for (let i = 0; i < params.importedItems.length; i += 1) {
+    const item = params.importedItems[i];
+    lines.push(`### Item ${i + 1}`);
+    lines.push(`<!-- ${TRANSFER_FINGERPRINT_MARKER}: ${item.fingerprint} -->`);
+    lines.push(`Source: ${item.sourcePath}`);
+    lines.push(`Modes: export=${item.exportMode}, import=${item.importMode}`);
+    lines.push("");
+    lines.push(item.text);
+    lines.push("");
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function importTransferredKnowledge(params: {
+  cfg: ReturnType<typeof loadConfig>;
+  requesterAgentId: string;
+  targetAgentId: string;
+  targetSessionKey: string;
+  exportApprovalId?: string;
+  importApprovalId?: string;
+  items: ApprovedTransferItem[];
+}): Promise<TransferImportResult> {
+  const requesterWorkspace = resolveAgentWorkspaceDir(params.cfg, params.requesterAgentId);
+  const transferDir = path.join(requesterWorkspace, "memory", "transfers");
+  await fs.mkdir(transferDir, { recursive: true });
+
+  const existingFingerprints = await collectExistingTransferFingerprints(transferDir);
+  const importedItems: ApprovedTransferItem[] = [];
+  let skippedDuplicate = 0;
+
+  for (const item of params.items) {
+    const normalizedFingerprint = item.fingerprint.toLowerCase();
+    if (existingFingerprints.has(normalizedFingerprint)) {
+      skippedDuplicate += 1;
+      continue;
+    }
+    existingFingerprints.add(normalizedFingerprint);
+    importedItems.push(item);
+  }
+
+  if (importedItems.length === 0) {
+    return {
+      imported: 0,
+      skippedDuplicate,
+      importedFingerprints: [],
+    };
+  }
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const fileName = `${stamp}-${fileSafeSegment(params.targetAgentId)}-to-${fileSafeSegment(
+    params.requesterAgentId,
+  )}.md`;
+  const filePath = path.join(transferDir, fileName);
+  const content = buildTransferFileContent({
+    requesterAgentId: params.requesterAgentId,
+    targetAgentId: params.targetAgentId,
+    targetSessionKey: params.targetSessionKey,
+    exportApprovalId: params.exportApprovalId,
+    importApprovalId: params.importApprovalId,
+    importedItems,
+  });
+  await fs.writeFile(filePath, content, "utf-8");
+
+  return {
+    imported: importedItems.length,
+    skippedDuplicate,
+    filePath,
+    importedFingerprints: importedItems.map((item) => item.fingerprint),
+  };
+}
+
+function buildApprovalSummary(items: ApprovedTransferItem[]): string[] {
+  return items.slice(0, MAX_APPROVAL_SUMMARY_ITEMS).map((item, index) => {
+    const preview = item.text.split("\n")[0]?.trim() ?? "";
+    const capped = preview.length > 140 ? `${preview.slice(0, 137)}...` : preview;
+    return `${index + 1}. [${item.sourcePath}] ${capped}`;
+  });
+}
+
+async function requestKnowledgeTransferApproval(params: {
+  approvalKind: ApprovalKind;
+  requesterAgentId: string;
+  targetAgentId: string;
+  requesterSessionKey: string;
+  targetSessionKey: string;
+  requestedBySessionKey?: string;
+  requestedByChannel?: GatewayMessageChannel;
+  timeoutMs: number;
+  items: ApprovedTransferItem[];
+}): Promise<ApprovalResult> {
+  const itemFingerprints = params.items.map((item) => item.fingerprint);
+  const summary = buildApprovalSummary(params.items);
+
+  let requestResponse:
+    | {
+        status?: string;
+        id?: string;
+      }
+    | undefined;
+  try {
+    requestResponse = await callGateway<{
+      status?: string;
+      id?: string;
+    }>({
+      method: "knowledge.transfer.approval.request",
+      params: {
+        approvalKind: params.approvalKind,
+        requesterAgentId: params.requesterAgentId,
+        targetAgentId: params.targetAgentId,
+        requesterSessionKey: params.requesterSessionKey,
+        targetSessionKey: params.targetSessionKey,
+        requestedBySessionKey: params.requestedBySessionKey,
+        requestedByChannel: params.requestedByChannel,
+        mode: "ask",
+        itemCount: params.items.length,
+        itemFingerprints,
+        summary,
+        timeoutMs: params.timeoutMs,
+        twoPhase: true,
+      },
+      timeoutMs: 10_000,
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const status = typeof requestResponse?.status === "string" ? requestResponse.status : "";
+  const approvalId = typeof requestResponse?.id === "string" ? requestResponse.id.trim() : "";
+  if (status !== APPROVAL_STATUS_ACCEPTED || !approvalId) {
+    return {
+      ok: false,
+      error: `failed to create ${params.approvalKind} knowledge transfer approval request`,
+    };
+  }
+
+  let waitResponse: { decision?: string | null } | undefined;
+  try {
+    waitResponse = await callGateway<{ decision?: string | null }>({
+      method: "knowledge.transfer.approval.wait",
+      params: { id: approvalId },
+      timeoutMs: params.timeoutMs + 2000,
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const decision =
+    typeof waitResponse?.decision === "string"
+      ? waitResponse.decision.trim().toLowerCase()
+      : "timeout";
+  return {
+    ok: true,
+    approved: decision === APPROVAL_DECISION_ALLOW,
+    approvalId,
+    decision,
+  };
+}
+
+export function createSessionsTransferKnowledgeTool(opts?: {
+  agentSessionKey?: string;
+  agentChannel?: GatewayMessageChannel;
+  sandboxed?: boolean;
+}): AnyAgentTool {
+  return {
+    label: "Session Transfer Knowledge",
+    name: "sessions_transfer_knowledge",
+    description:
+      "Transfer memory knowledge from another session using per-path export/import policy with optional owner approvals.",
+    parameters: SessionsTransferKnowledgeToolSchema,
+    execute: async (_toolCallId, args) => {
+      const params = args as Record<string, unknown>;
+      const cfg = loadConfig();
+      const { mainKey, alias, effectiveRequesterKey, restrictToSpawned } =
+        resolveSandboxedSessionToolContext({
+          cfg,
+          agentSessionKey: opts?.agentSessionKey,
+          sandboxed: opts?.sandboxed,
+        });
+      const a2aPolicy = createAgentToAgentPolicy(cfg);
+      const sessionVisibility = resolveEffectiveSessionToolsVisibility({
+        cfg,
+        sandboxed: opts?.sandboxed === true,
+      });
+
+      const sessionKeyParam = readStringParam(params, "sessionKey");
+      const labelParam = readStringParam(params, "label")?.trim() || undefined;
+      const labelAgentIdParam = readStringParam(params, "agentId")?.trim() || undefined;
+      if (sessionKeyParam && labelParam) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error: "Provide either sessionKey or label (not both).",
+        });
+      }
+
+      let sessionKey = sessionKeyParam;
+      if (!sessionKey && labelParam) {
+        const requesterAgentId = resolveAgentIdFromSessionKey(effectiveRequesterKey);
+        const requestedAgentId = labelAgentIdParam
+          ? normalizeAgentId(labelAgentIdParam)
+          : undefined;
+
+        if (restrictToSpawned && requestedAgentId && requestedAgentId !== requesterAgentId) {
+          return jsonResult({
+            runId: crypto.randomUUID(),
+            status: "forbidden",
+            error: "Sandboxed sessions_transfer_knowledge label lookup is limited to this agent",
+          });
+        }
+
+        if (requesterAgentId && requestedAgentId && requestedAgentId !== requesterAgentId) {
+          if (!a2aPolicy.enabled) {
+            return jsonResult({
+              runId: crypto.randomUUID(),
+              status: "forbidden",
+              error:
+                "Agent-to-agent messaging is disabled. Set tools.agentToAgent.enabled=true to allow cross-agent sends.",
+            });
+          }
+          if (!a2aPolicy.isAllowed(requesterAgentId, requestedAgentId)) {
+            return jsonResult({
+              runId: crypto.randomUUID(),
+              status: "forbidden",
+              error: "Agent-to-agent messaging denied by tools.agentToAgent.allow.",
+            });
+          }
+        }
+
+        const resolveParams: Record<string, unknown> = {
+          label: labelParam,
+          ...(requestedAgentId ? { agentId: requestedAgentId } : {}),
+          ...(restrictToSpawned ? { spawnedBy: effectiveRequesterKey } : {}),
+        };
+
+        try {
+          const resolved = await callGateway<{ key: string }>({
+            method: "sessions.resolve",
+            params: resolveParams,
+            timeoutMs: 10_000,
+          });
+          const resolvedKey = typeof resolved?.key === "string" ? resolved.key.trim() : "";
+          if (!resolvedKey) {
+            throw new Error(`No session found with label: ${labelParam}`);
+          }
+          sessionKey = resolvedKey;
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return jsonResult({
+            runId: crypto.randomUUID(),
+            status: restrictToSpawned ? "forbidden" : "error",
+            error: restrictToSpawned
+              ? "Session not visible from this sandboxed agent session."
+              : message || `No session found with label: ${labelParam}`,
+          });
+        }
+      }
+
+      if (!sessionKey) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error: "Either sessionKey or label is required",
+        });
+      }
+
+      const resolvedSession = await resolveSessionReference({
+        sessionKey,
+        alias,
+        mainKey,
+        requesterInternalKey: effectiveRequesterKey,
+        restrictToSpawned,
+      });
+      if (!resolvedSession.ok) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: resolvedSession.status,
+          error: resolvedSession.error,
+        });
+      }
+
+      const visibleSession = await resolveVisibleSessionReference({
+        resolvedSession,
+        requesterSessionKey: effectiveRequesterKey,
+        restrictToSpawned,
+        visibilitySessionKey: sessionKey,
+      });
+      if (!visibleSession.ok) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: visibleSession.status,
+          error: visibleSession.error,
+          sessionKey: visibleSession.displayKey,
+        });
+      }
+
+      const resolvedKey = visibleSession.key;
+      const displayKey = visibleSession.displayKey;
+      const visibilityGuard = await createSessionVisibilityGuard({
+        action: "send",
+        requesterSessionKey: effectiveRequesterKey,
+        visibility: sessionVisibility,
+        a2aPolicy,
+      });
+      const access = visibilityGuard.check(resolvedKey);
+      if (!access.allowed) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: access.status,
+          error: access.error,
+          sessionKey: displayKey,
+        });
+      }
+
+      const requesterAgentId = resolveAgentIdFromSessionKey(effectiveRequesterKey);
+      const targetAgentId = resolveAgentIdFromSessionKey(resolvedKey);
+      const policyResolver = await createKnowledgeTransferPolicyResolver({
+        cfg,
+        requesterAgentId,
+        targetAgentId,
+      });
+      if (!policyResolver.defaults.enabled) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: "forbidden",
+          error:
+            "Knowledge transfer is disabled. Set tools.agentToAgent.knowledgeTransfer.enabled=true to allow sessions_transfer_knowledge.",
+          sessionKey: displayKey,
+        });
+      }
+
+      const targetWorkspace = resolveAgentWorkspaceDir(cfg, targetAgentId);
+      const payloadItems = await collectTransferPayloadFromWorkspace(targetWorkspace);
+      if (payloadItems.length === 0) {
+        return jsonResult({
+          runId: crypto.randomUUID(),
+          status: "error",
+          error: "No transferable memory content found in target agent memory files.",
+          sessionKey: displayKey,
+        });
+      }
+
+      let blockedExport = 0;
+      let blockedImport = 0;
+      const allowedByPolicy: ApprovedTransferItem[] = [];
+      for (const item of payloadItems) {
+        const exportDecision = policyResolver.resolve("export", item.sourcePath);
+        if (!exportDecision.allowed || !exportDecision.mode) {
+          blockedExport += 1;
+          continue;
+        }
+        const importDecision = policyResolver.resolve("import", item.sourcePath);
+        if (!importDecision.allowed || !importDecision.mode) {
+          blockedImport += 1;
+          continue;
+        }
+        allowedByPolicy.push({
+          ...item,
+          exportMode: exportDecision.mode,
+          importMode: importDecision.mode,
+        });
+      }
+
+      const timeoutSecondsRaw =
+        typeof params.timeoutSeconds === "number" && Number.isFinite(params.timeoutSeconds)
+          ? Math.max(0, Math.floor(params.timeoutSeconds))
+          : 0;
+      const approvalTimeoutMs =
+        timeoutSecondsRaw > 0
+          ? timeoutSecondsRaw * 1000
+          : Math.max(1000, Math.floor(policyResolver.defaults.approvalTimeoutSeconds * 1000));
+
+      const exportAuto = allowedByPolicy.filter((item) => item.exportMode === "auto");
+      const exportAsk = allowedByPolicy.filter((item) => item.exportMode === "ask");
+
+      let exportApprovedAsk: ApprovedTransferItem[] = [];
+      let exportApprovalId: string | undefined;
+      let exportApprovalDecision: string | undefined;
+      if (exportAsk.length > 0) {
+        const approval = await requestKnowledgeTransferApproval({
+          approvalKind: "export",
+          requesterAgentId,
+          targetAgentId,
+          requesterSessionKey: effectiveRequesterKey,
+          targetSessionKey: resolvedKey,
+          requestedBySessionKey: opts?.agentSessionKey,
+          requestedByChannel: opts?.agentChannel,
+          timeoutMs: approvalTimeoutMs,
+          items: exportAsk,
+        });
+        if (!approval.ok) {
+          return jsonResult({
+            runId: crypto.randomUUID(),
+            status: "error",
+            error: approval.error,
+            sessionKey: displayKey,
+          });
+        }
+        exportApprovalId = approval.approvalId;
+        exportApprovalDecision = approval.decision;
+        if (approval.approved) {
+          exportApprovedAsk = exportAsk;
+        }
+      }
+
+      const postExport = [...exportAuto, ...exportApprovedAsk];
+      const importAuto = postExport.filter((item) => item.importMode === "auto");
+      const importAsk = postExport.filter((item) => item.importMode === "ask");
+
+      let importApprovedAsk: ApprovedTransferItem[] = [];
+      let importApprovalId: string | undefined;
+      let importApprovalDecision: string | undefined;
+      if (importAsk.length > 0) {
+        const approval = await requestKnowledgeTransferApproval({
+          approvalKind: "import",
+          requesterAgentId,
+          targetAgentId,
+          requesterSessionKey: effectiveRequesterKey,
+          targetSessionKey: resolvedKey,
+          requestedBySessionKey: opts?.agentSessionKey,
+          requestedByChannel: opts?.agentChannel,
+          timeoutMs: approvalTimeoutMs,
+          items: importAsk,
+        });
+        if (!approval.ok) {
+          return jsonResult({
+            runId: crypto.randomUUID(),
+            status: "error",
+            error: approval.error,
+            sessionKey: displayKey,
+          });
+        }
+        importApprovalId = approval.approvalId;
+        importApprovalDecision = approval.decision;
+        if (approval.approved) {
+          importApprovedAsk = importAsk;
+        }
+      }
+
+      const finalApprovedItems = [...importAuto, ...importApprovedAsk];
+      const transfer = await importTransferredKnowledge({
+        cfg,
+        requesterAgentId,
+        targetAgentId,
+        targetSessionKey: displayKey,
+        exportApprovalId,
+        importApprovalId,
+        items: finalApprovedItems,
+      });
+
+      const transferFileRel =
+        typeof transfer.filePath === "string"
+          ? path
+              .relative(resolveAgentWorkspaceDir(cfg, requesterAgentId), transfer.filePath)
+              .replace(/\\/g, "/")
+          : undefined;
+
+      const exportDeclined = exportAsk.length - exportApprovedAsk.length;
+      const importDeclined = importAsk.length - importApprovedAsk.length;
+      const status =
+        transfer.imported === 0 &&
+        transfer.skippedDuplicate === 0 &&
+        (exportDeclined > 0 || importDeclined > 0)
+          ? "declined"
+          : "ok";
+
+      return jsonResult({
+        runId: crypto.randomUUID(),
+        status,
+        sessionKey: displayKey,
+        requesterAgentId,
+        targetAgentId,
+        candidateTotal: payloadItems.length,
+        allowedByPolicy: allowedByPolicy.length,
+        blockedExport,
+        blockedImport,
+        exportAskCount: exportAsk.length,
+        importAskCount: importAsk.length,
+        exportDeclined,
+        importDeclined,
+        exportApprovalId,
+        importApprovalId,
+        exportApprovalDecision,
+        importApprovalDecision,
+        imported: transfer.imported,
+        skippedDuplicate: transfer.skippedDuplicate,
+        importedFingerprints: transfer.importedFingerprints,
+        transferFile: transferFileRel,
+      });
+    },
+  };
+}

--- a/src/agents/tools/sessions-transfer-knowledge-tool.ts
+++ b/src/agents/tools/sessions-transfer-knowledge-tool.ts
@@ -108,7 +108,13 @@ function isMarkdownMemoryFile(relPath: string): boolean {
   if (normalized === "memory.md") {
     return true;
   }
-  return normalized.startsWith("memory/") && normalized.endsWith(".md");
+  if (!normalized.startsWith("memory/") || !normalized.endsWith(".md")) {
+    return false;
+  }
+  if (normalized.startsWith("memory/transfers/")) {
+    return false;
+  }
+  return true;
 }
 
 async function listMemoryFiles(

--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -189,6 +189,14 @@ function buildChatCommands(): ChatCommandDefinition[] {
       category: "management",
     }),
     defineChatCommand({
+      key: "learn",
+      nativeName: "learn",
+      description: "Manage knowledge transfer approvals and modes.",
+      textAlias: "/learn",
+      acceptsArgs: true,
+      category: "management",
+    }),
+    defineChatCommand({
       key: "context",
       nativeName: "context",
       description: "Explain how context is built and used.",

--- a/src/auto-reply/reply/commands-core.ts
+++ b/src/auto-reply/reply/commands-core.ts
@@ -21,6 +21,7 @@ import {
   handleStatusCommand,
   handleWhoamiCommand,
 } from "./commands-info.js";
+import { handleLearnCommand } from "./commands-learn.js";
 import { handleModelsCommand } from "./commands-models.js";
 import { handlePluginCommand } from "./commands-plugin.js";
 import {
@@ -184,6 +185,7 @@ export async function handleCommands(params: HandleCommandsParams): Promise<Comm
       handleStatusCommand,
       handleAllowlistCommand,
       handleApproveCommand,
+      handleLearnCommand,
       handleContextCommand,
       handleExportSessionCommand,
       handleWhoamiCommand,

--- a/src/auto-reply/reply/commands-learn.ts
+++ b/src/auto-reply/reply/commands-learn.ts
@@ -1,0 +1,439 @@
+import { loadConfig } from "../../config/config.js";
+import { callGateway } from "../../gateway/call.js";
+import { logVerbose } from "../../globals.js";
+import {
+  listKnowledgeTransferRules,
+  removeKnowledgeTransferRule,
+  resolveKnowledgeTransferDefaults,
+  setKnowledgeTransferPairMode,
+  upsertKnowledgeTransferRule,
+  type KnowledgeTransferMode,
+  type KnowledgeTransferRuleDecision,
+  type KnowledgeTransferSide,
+} from "../../infra/knowledge-transfer-policy.js";
+import {
+  GATEWAY_CLIENT_MODES,
+  GATEWAY_CLIENT_NAMES,
+  isInternalMessageChannel,
+} from "../../utils/message-channel.js";
+import type { CommandHandler } from "./commands-types.js";
+
+const COMMAND = "/learn";
+
+type PairTarget = { requesterAgentId: string; targetAgentId: string };
+
+type ParsedLearnCommand =
+  | { ok: true; action: "approve"; id: string }
+  | { ok: true; action: "deny"; id: string }
+  | { ok: true; action: "mode"; mode: KnowledgeTransferMode; pair: PairTarget }
+  | {
+      ok: true;
+      action: "rule_add";
+      pair: PairTarget;
+      side: KnowledgeTransferSide;
+      decision: KnowledgeTransferRuleDecision;
+      pathPattern: string;
+    }
+  | { ok: true; action: "rule_remove"; id: string; pair?: PairTarget }
+  | { ok: true; action: "rule_list"; pair?: PairTarget }
+  | { ok: true; action: "status"; pair?: PairTarget }
+  | { ok: false; error: string }
+  | null;
+
+function usage(): string {
+  return [
+    "Usage:",
+    "/learn approve <id>",
+    "/learn deny <id>",
+    "/learn mode ask|auto [--pair <requester,target>]",
+    "/learn rule add <hide|ask|auto> --side <export|import> --path <glob> [--pair <requester,target>]",
+    "/learn rule remove <id> [--pair <requester,target>]",
+    "/learn rule list [--pair <requester,target>]",
+    "/learn status [--pair <requester,target>]",
+  ].join("\n");
+}
+
+function parsePairValue(raw: string): PairTarget | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const parts = trimmed.split(",");
+  if (parts.length !== 2) {
+    return null;
+  }
+  const requesterAgentId = parts[0]?.trim() ?? "";
+  const targetAgentId = parts[1]?.trim() ?? "";
+  if (!requesterAgentId || !targetAgentId) {
+    return null;
+  }
+  return { requesterAgentId, targetAgentId };
+}
+
+function parseOptionalPair(tokens: string[]):
+  | {
+      ok: true;
+      pair?: PairTarget;
+    }
+  | {
+      ok: false;
+      error: string;
+    } {
+  if (tokens.length === 0) {
+    return { ok: true, pair: undefined };
+  }
+
+  let pairValue: string | undefined;
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i] ?? "";
+    const lowered = token.toLowerCase();
+    if (lowered === "--pair") {
+      pairValue = tokens[i + 1];
+      break;
+    }
+    if (lowered.startsWith("--pair=")) {
+      pairValue = token.slice("--pair=".length);
+      break;
+    }
+  }
+
+  if (pairValue == null) {
+    return { ok: true, pair: undefined };
+  }
+
+  const pair = parsePairValue(pairValue);
+  if (!pair) {
+    return { ok: false, error: `${usage()}\n\nInvalid --pair value. Use requester,target.` };
+  }
+
+  return { ok: true, pair };
+}
+
+function parseMode(value: string | undefined): KnowledgeTransferMode | null {
+  const normalized = (value ?? "").trim().toLowerCase();
+  if (normalized === "ask" || normalized === "auto") {
+    return normalized;
+  }
+  return null;
+}
+
+function parseRuleDecision(value: string | undefined): KnowledgeTransferRuleDecision | null {
+  const normalized = (value ?? "").trim().toLowerCase();
+  if (normalized === "ask" || normalized === "auto" || normalized === "hide") {
+    return normalized;
+  }
+  return null;
+}
+
+function parseRuleSide(value: string | undefined): KnowledgeTransferSide | null {
+  const normalized = (value ?? "").trim().toLowerCase();
+  if (normalized === "export" || normalized === "import") {
+    return normalized;
+  }
+  return null;
+}
+
+function readOptionValue(tokens: string[], name: string): string | undefined {
+  for (let i = 0; i < tokens.length; i += 1) {
+    const token = tokens[i] ?? "";
+    const lowered = token.toLowerCase();
+    if (lowered === `--${name}`) {
+      return tokens[i + 1];
+    }
+    if (lowered.startsWith(`--${name}=`)) {
+      return token.slice(name.length + 3);
+    }
+  }
+  return undefined;
+}
+
+function parseLearnCommand(raw: string): ParsedLearnCommand {
+  const trimmed = raw.trim();
+  if (!trimmed.toLowerCase().startsWith(COMMAND)) {
+    return null;
+  }
+
+  const rest = trimmed.slice(COMMAND.length).trim();
+  if (!rest) {
+    return { ok: false, error: usage() };
+  }
+
+  const tokens = rest.split(/\s+/).filter(Boolean);
+  const action = tokens[0]?.toLowerCase();
+  if (action === "approve" || action === "deny") {
+    const id = tokens.slice(1).join(" ").trim();
+    if (!id) {
+      return { ok: false, error: usage() };
+    }
+    return { ok: true, action, id };
+  }
+
+  if (action === "mode") {
+    const mode = parseMode(tokens[1]);
+    if (!mode) {
+      return { ok: false, error: usage() };
+    }
+    const pairResult = parseOptionalPair(tokens.slice(2));
+    if (!pairResult.ok) {
+      return pairResult;
+    }
+    return {
+      ok: true,
+      action: "mode",
+      mode,
+      pair: pairResult.pair ?? { requesterAgentId: "*", targetAgentId: "*" },
+    };
+  }
+
+  if (action === "rule") {
+    const subAction = tokens[1]?.toLowerCase();
+    if (subAction === "add") {
+      const decision =
+        parseRuleDecision(tokens[2]) ?? parseRuleDecision(readOptionValue(tokens, "decision"));
+      const side = parseRuleSide(readOptionValue(tokens, "side"));
+      const pathPattern = readOptionValue(tokens, "path")?.trim();
+      const pairResult = parseOptionalPair(tokens.slice(2));
+      if (!pairResult.ok) {
+        return pairResult;
+      }
+      if (!decision || !side || !pathPattern) {
+        return { ok: false, error: usage() };
+      }
+      return {
+        ok: true,
+        action: "rule_add",
+        pair: pairResult.pair ?? { requesterAgentId: "*", targetAgentId: "*" },
+        side,
+        decision,
+        pathPattern,
+      };
+    }
+
+    if (subAction === "remove") {
+      const id = (tokens[2] ?? "").trim();
+      if (!id) {
+        return { ok: false, error: usage() };
+      }
+      const pairResult = parseOptionalPair(tokens.slice(3));
+      if (!pairResult.ok) {
+        return pairResult;
+      }
+      return {
+        ok: true,
+        action: "rule_remove",
+        id,
+        pair: pairResult.pair,
+      };
+    }
+
+    if (subAction === "list") {
+      const pairResult = parseOptionalPair(tokens.slice(2));
+      if (!pairResult.ok) {
+        return pairResult;
+      }
+      return {
+        ok: true,
+        action: "rule_list",
+        pair: pairResult.pair,
+      };
+    }
+
+    return { ok: false, error: usage() };
+  }
+
+  if (action === "status") {
+    const pairResult = parseOptionalPair(tokens.slice(1));
+    if (!pairResult.ok) {
+      return pairResult;
+    }
+    return {
+      ok: true,
+      action: "status",
+      pair: pairResult.pair,
+    };
+  }
+
+  return { ok: false, error: usage() };
+}
+
+function pairLabel(pair: PairTarget): string {
+  return `${pair.requesterAgentId},${pair.targetAgentId}`;
+}
+
+function requiresOwner(action: ParsedLearnCommand & { ok: true }): boolean {
+  return (
+    action.action === "approve" ||
+    action.action === "deny" ||
+    action.action === "mode" ||
+    action.action === "rule_add" ||
+    action.action === "rule_remove"
+  );
+}
+
+function resolvedByLabel(params: Parameters<CommandHandler>[0]): string {
+  const channel = params.command.channel;
+  const sender = params.command.senderId ?? "unknown";
+  return `${channel}:${sender}`;
+}
+
+function hasGatewayApprovalsScope(scopes: string[]): boolean {
+  return scopes.includes("operator.admin") || scopes.includes("operator.approvals");
+}
+
+export const handleLearnCommand: CommandHandler = async (params, allowTextCommands) => {
+  if (!allowTextCommands) {
+    return null;
+  }
+
+  const parsed = parseLearnCommand(params.command.commandBodyNormalized);
+  if (!parsed) {
+    return null;
+  }
+
+  if (!params.command.isAuthorizedSender) {
+    logVerbose(
+      `Ignoring /learn from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+    );
+    return { shouldContinue: false };
+  }
+
+  if (!parsed.ok) {
+    return { shouldContinue: false, reply: { text: parsed.error } };
+  }
+
+  if (requiresOwner(parsed) && !params.command.senderIsOwner) {
+    return {
+      shouldContinue: false,
+      reply: { text: "❌ /learn approve|deny|mode|rule add|rule remove requires an owner sender." },
+    };
+  }
+
+  if (isInternalMessageChannel(params.command.channel) && requiresOwner(parsed)) {
+    const scopes = params.ctx.GatewayClientScopes ?? [];
+    if (!hasGatewayApprovalsScope(scopes)) {
+      return {
+        shouldContinue: false,
+        reply: {
+          text: "❌ /learn owner actions require operator.approvals for gateway clients.",
+        },
+      };
+    }
+  }
+
+  if (parsed.action === "approve" || parsed.action === "deny") {
+    const decision = parsed.action === "approve" ? "allow" : "deny";
+    try {
+      await callGateway({
+        method: "knowledge.transfer.approval.resolve",
+        params: { id: parsed.id, decision },
+        clientName: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+        clientDisplayName: `Knowledge transfer approval (${resolvedByLabel(params)})`,
+        mode: GATEWAY_CLIENT_MODES.BACKEND,
+      });
+    } catch (err) {
+      return {
+        shouldContinue: false,
+        reply: {
+          text: `❌ Failed to submit knowledge transfer decision: ${String(err)}`,
+        },
+      };
+    }
+
+    return {
+      shouldContinue: false,
+      reply: {
+        text: `✅ Knowledge transfer ${decision} submitted for ${parsed.id}.`,
+      },
+    };
+  }
+
+  if (parsed.action === "mode") {
+    await setKnowledgeTransferPairMode({
+      requesterAgentId: parsed.pair.requesterAgentId,
+      targetAgentId: parsed.pair.targetAgentId,
+      mode: parsed.mode,
+    });
+    return {
+      shouldContinue: false,
+      reply: {
+        text: `✅ Learn mode set to ${parsed.mode} for pair ${pairLabel(parsed.pair)} (export+import, path=*).`,
+      },
+    };
+  }
+
+  if (parsed.action === "rule_add") {
+    const result = await upsertKnowledgeTransferRule({
+      requesterAgentId: parsed.pair.requesterAgentId,
+      targetAgentId: parsed.pair.targetAgentId,
+      side: parsed.side,
+      pathPattern: parsed.pathPattern,
+      decision: parsed.decision,
+    });
+    return {
+      shouldContinue: false,
+      reply: {
+        text: `✅ Rule saved: id=${result.rule.id} pair=${pairLabel(parsed.pair)} side=${parsed.side} decision=${parsed.decision} path=${result.rule.pathPattern}`,
+      },
+    };
+  }
+
+  if (parsed.action === "rule_remove") {
+    const removed = await removeKnowledgeTransferRule({
+      id: parsed.id,
+      requesterAgentId: parsed.pair?.requesterAgentId,
+      targetAgentId: parsed.pair?.targetAgentId,
+    });
+    if (!removed.removed) {
+      return {
+        shouldContinue: false,
+        reply: { text: `❌ No rule found for id=${parsed.id}.` },
+      };
+    }
+    const pairText = removed.pair
+      ? `${removed.pair.requesterAgentId},${removed.pair.targetAgentId}`
+      : "unknown";
+    return {
+      shouldContinue: false,
+      reply: { text: `✅ Removed rule ${parsed.id} from pair ${pairText}.` },
+    };
+  }
+
+  const cfg = loadConfig();
+  const defaults = resolveKnowledgeTransferDefaults(cfg);
+
+  if (parsed.action === "rule_list" || parsed.action === "status") {
+    const rules = await listKnowledgeTransferRules({
+      requesterAgentId: parsed.pair?.requesterAgentId,
+      targetAgentId: parsed.pair?.targetAgentId,
+    });
+
+    const lines = [
+      parsed.action === "status" ? "🧠 Learn status" : "🧠 Learn rules",
+      `Enabled: ${defaults.enabled ? "yes" : "no"}`,
+      `Default Export Mode: ${defaults.defaultExportMode}`,
+      `Default Import Mode: ${defaults.defaultImportMode}`,
+      `Approval Timeout: ${defaults.approvalTimeoutSeconds}s`,
+      ...(parsed.pair ? [`Pair: ${pairLabel(parsed.pair)}`] : []),
+      `Rules: ${rules.length}`,
+    ];
+
+    for (const rule of rules.slice(0, 30)) {
+      lines.push(
+        `- ${rule.id} | ${rule.requesterAgentId},${rule.targetAgentId} | ${rule.side} | ${rule.decision} | ${rule.pathPattern}`,
+      );
+    }
+    if (rules.length > 30) {
+      lines.push(`- ... ${rules.length - 30} more`);
+    }
+
+    return {
+      shouldContinue: false,
+      reply: { text: lines.join("\n") },
+    };
+  }
+
+  return {
+    shouldContinue: false,
+    reply: { text: usage() },
+  };
+};

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { abortEmbeddedPiRun, compactEmbeddedPiSession } from "../../agents/pi-embedded.js";
 import {
   addSubagentRunForTests,
@@ -329,7 +329,7 @@ describe("/approve command", () => {
 
     const result = await handleCommands(params);
     expect(result.shouldContinue).toBe(false);
-    expect(result.reply?.text).toContain("requires operator.approvals");
+    expect(result.reply?.text).toContain("operator.approvals");
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
 
@@ -356,6 +356,185 @@ describe("/approve command", () => {
         }),
       );
     }
+  });
+});
+
+describe("/learn command", () => {
+  let stateDir: string | null = null;
+  let previousStateDir: string | undefined;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-learn-policy-"));
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+  });
+
+  afterEach(async () => {
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    if (stateDir) {
+      await fs.rm(stateDir, { recursive: true, force: true });
+      stateDir = null;
+    }
+  });
+
+  it("shows usage when missing args", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildParams("/learn", cfg);
+
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Usage:");
+    expect(result.reply?.text).toContain("/learn rule add");
+  });
+
+  it("requires owner for approve/deny/mode", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildParams("/learn mode auto", cfg, { SenderId: "123" });
+    params.command.senderIsOwner = false;
+
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("requires an owner sender");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("dispatches /learn approve to gateway resolve", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+    } as OpenClawConfig;
+    const params = buildParams("/learn approve req-1", cfg, { SenderId: "owner" });
+    params.command.senderIsOwner = true;
+    callGatewayMock.mockResolvedValue({ ok: true });
+
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("Knowledge transfer allow submitted");
+    expect(callGatewayMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "knowledge.transfer.approval.resolve",
+        params: { id: "req-1", decision: "allow" },
+      }),
+    );
+  });
+
+  it("requires operator.approvals for gateway clients on owner actions", async () => {
+    const cfg = {
+      commands: { text: true },
+    } as OpenClawConfig;
+    const params = buildParams("/learn approve req-1", cfg, {
+      Provider: "webchat",
+      Surface: "webchat",
+      GatewayClientScopes: ["operator.write"],
+    });
+    params.command.senderIsOwner = true;
+
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("operator.approvals");
+    expect(callGatewayMock).not.toHaveBeenCalled();
+  });
+
+  it("persists /learn mode ask|auto by pair", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      tools: {
+        agentToAgent: {
+          knowledgeTransfer: {
+            enabled: true,
+            defaultExportMode: "ask",
+            defaultImportMode: "ask",
+            approvalTimeoutSeconds: 120,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const modeParams = buildParams("/learn mode auto --pair worker,teacher", cfg, {
+      SenderId: "owner",
+    });
+    modeParams.command.senderIsOwner = true;
+    const modeResult = await handleCommands(modeParams);
+    expect(modeResult.shouldContinue).toBe(false);
+    expect(modeResult.reply?.text).toContain("Learn mode set to auto");
+
+    const statusParams = buildParams("/learn status --pair worker,teacher", cfg, {
+      SenderId: "owner",
+    });
+    statusParams.command.senderIsOwner = true;
+    const statusResult = await handleCommands(statusParams);
+    expect(statusResult.shouldContinue).toBe(false);
+    expect(statusResult.reply?.text).toContain("Default Export Mode");
+    expect(statusResult.reply?.text).toContain("Pair: worker,teacher");
+  });
+
+  it("supports /learn rule add/list/remove with pair and side", async () => {
+    const cfg = {
+      commands: { text: true },
+      channels: { whatsapp: { allowFrom: ["*"] } },
+      tools: {
+        agentToAgent: {
+          knowledgeTransfer: {
+            enabled: true,
+            defaultExportMode: "ask",
+            defaultImportMode: "ask",
+            approvalTimeoutSeconds: 120,
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const addParams = buildParams(
+      "/learn rule add hide --side export --path memory/private/** --pair worker,teacher",
+      cfg,
+      {
+        SenderId: "owner",
+      },
+    );
+    addParams.command.senderIsOwner = true;
+    const addResult = await handleCommands(addParams);
+    expect(addResult.shouldContinue).toBe(false);
+    expect(addResult.reply?.text).toContain("Rule saved:");
+    expect(addResult.reply?.text).toContain("side=export");
+    expect(addResult.reply?.text).toContain("decision=hide");
+
+    const listParams = buildParams("/learn rule list --pair worker,teacher", cfg, {
+      SenderId: "owner",
+    });
+    listParams.command.senderIsOwner = true;
+    const listResult = await handleCommands(listParams);
+    expect(listResult.shouldContinue).toBe(false);
+    expect(listResult.reply?.text).toContain("worker,teacher");
+    expect(listResult.reply?.text).toContain("memory/private/**");
+
+    const ruleLine = listResult.reply?.text?.split("\n").find((line) => line.startsWith("- "));
+    if (!ruleLine) {
+      throw new Error("missing rule line");
+    }
+    const id = ruleLine.slice(2).split(" | ")[0]?.trim();
+    if (!id) {
+      throw new Error("missing rule id");
+    }
+
+    const removeParams = buildParams(`/learn rule remove ${id} --pair worker,teacher`, cfg, {
+      SenderId: "owner",
+    });
+    removeParams.command.senderIsOwner = true;
+    const removeResult = await handleCommands(removeParams);
+    expect(removeResult.shouldContinue).toBe(false);
+    expect(removeResult.reply?.text).toContain("Removed rule");
   });
 });
 

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -314,6 +314,18 @@ export const FIELD_HELP: Record<string, string> = {
     "Enables the agent_to_agent tool surface so one agent can invoke another agent at runtime. Keep off in simple deployments and enable only when orchestration value outweighs complexity.",
   "tools.agentToAgent.allow":
     "Allowlist of target agent IDs permitted for agent_to_agent calls when orchestration is enabled. Use explicit allowlists to avoid uncontrolled cross-agent call graphs.",
+  "tools.agentToAgent.knowledgeTransfer":
+    "Knowledge-transfer controls for sessions_transfer_knowledge, including enablement, default approval mode, and approval timeout. Keep ask mode as default unless operators explicitly opt into auto-learning.",
+  "tools.agentToAgent.knowledgeTransfer.enabled":
+    "Enable curated memory transfer between agents via sessions_transfer_knowledge. Keep disabled by default and enable only for trusted agent-pair workflows.",
+  "tools.agentToAgent.knowledgeTransfer.defaultMode":
+    'Default learning mode when no per-pair override exists: "ask" (user approval required) or "auto" (learn immediately). Use "ask" for human-in-the-loop control.',
+  "tools.agentToAgent.knowledgeTransfer.defaultExportMode":
+    'Default export-side mode when a matching policy rule allows transfer but does not override mode. "ask" requires owner approval, "auto" approves immediately.',
+  "tools.agentToAgent.knowledgeTransfer.defaultImportMode":
+    'Default import-side mode when a matching policy rule allows transfer but does not override mode. "ask" requires owner approval, "auto" approves immediately.',
+  "tools.agentToAgent.knowledgeTransfer.approvalTimeoutSeconds":
+    "Timeout in seconds for pending ask-mode transfer approvals before automatic decline. Use a short timeout for interactive channels and longer timeout when approvals are handled asynchronously.",
   "tools.elevated":
     "Elevated tool access controls for privileged command surfaces that should only be reachable from trusted senders. Keep disabled unless operator workflows explicitly require elevated actions.",
   "tools.elevated.enabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -182,6 +182,15 @@ export const FIELD_LABELS: Record<string, string> = {
   "tools.agentToAgent": "Agent-to-Agent Tool Access",
   "tools.agentToAgent.enabled": "Enable Agent-to-Agent Tool",
   "tools.agentToAgent.allow": "Agent-to-Agent Target Allowlist",
+  "tools.agentToAgent.knowledgeTransfer": "Knowledge Transfer Policy",
+  "tools.agentToAgent.knowledgeTransfer.enabled": "Enable Knowledge Transfer",
+  "tools.agentToAgent.knowledgeTransfer.defaultMode": "Knowledge Transfer Default Mode",
+  "tools.agentToAgent.knowledgeTransfer.defaultExportMode":
+    "Knowledge Transfer Default Export Mode",
+  "tools.agentToAgent.knowledgeTransfer.defaultImportMode":
+    "Knowledge Transfer Default Import Mode",
+  "tools.agentToAgent.knowledgeTransfer.approvalTimeoutSeconds":
+    "Knowledge Transfer Approval Timeout (sec)",
   "tools.elevated": "Elevated Tool Access",
   "tools.elevated.enabled": "Enable Elevated Tool Access",
   "tools.elevated.allowFrom": "Elevated Tool Allow Rules",

--- a/src/config/types.tools.ts
+++ b/src/config/types.tools.ts
@@ -553,6 +553,19 @@ export type ToolsConfig = {
     enabled?: boolean;
     /** Allowlist of agent ids or patterns (implementation-defined). */
     allow?: string[];
+    /** User-gated knowledge transfer policy for sessions_transfer_knowledge. */
+    knowledgeTransfer?: {
+      /** Enable cross-agent curated memory transfer. Default: false. */
+      enabled?: boolean;
+      /** @deprecated Use defaultExportMode/defaultImportMode. */
+      defaultMode?: "ask" | "auto";
+      /** Default export-side approval mode when no matching rule exists. */
+      defaultExportMode?: "ask" | "auto";
+      /** Default import-side approval mode when no matching rule exists. */
+      defaultImportMode?: "ask" | "auto";
+      /** Approval wait timeout for ask mode. Default: 120 seconds. */
+      approvalTimeoutSeconds?: number;
+    };
   };
   /**
    * Session tool visibility controls which sessions can be targeted by session tools

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -788,6 +788,16 @@ export const ToolsSchema = z
       .object({
         enabled: z.boolean().optional(),
         allow: z.array(z.string()).optional(),
+        knowledgeTransfer: z
+          .object({
+            enabled: z.boolean().optional(),
+            defaultMode: z.enum(["ask", "auto"]).optional(),
+            defaultExportMode: z.enum(["ask", "auto"]).optional(),
+            defaultImportMode: z.enum(["ask", "auto"]).optional(),
+            approvalTimeoutSeconds: z.number().optional(),
+          })
+          .strict()
+          .optional(),
       })
       .strict()
       .optional(),

--- a/src/gateway/gateway-misc.test.ts
+++ b/src/gateway/gateway-misc.test.ts
@@ -198,15 +198,16 @@ describe("gateway broadcaster", () => {
     const { broadcast, broadcastToConnIds } = createGatewayBroadcaster({ clients });
 
     broadcast("exec.approval.requested", { id: "1" });
+    broadcast("knowledge.transfer.approval.pending", { id: "kt-1" });
     broadcast("device.pair.requested", { requestId: "r1" });
 
-    expect(approvalsSocket.send).toHaveBeenCalledTimes(1);
+    expect(approvalsSocket.send).toHaveBeenCalledTimes(2);
     expect(pairingSocket.send).toHaveBeenCalledTimes(1);
     expect(readSocket.send).toHaveBeenCalledTimes(0);
 
     broadcastToConnIds("tick", { ts: 1 }, new Set(["c-read"]));
     expect(readSocket.send).toHaveBeenCalledTimes(1);
-    expect(approvalsSocket.send).toHaveBeenCalledTimes(1);
+    expect(approvalsSocket.send).toHaveBeenCalledTimes(2);
     expect(pairingSocket.send).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/gateway/knowledge-transfer-approval-manager.ts
+++ b/src/gateway/knowledge-transfer-approval-manager.ts
@@ -1,0 +1,157 @@
+import { randomUUID } from "node:crypto";
+
+// Keep resolved entries briefly so waiters racing with resolve can still observe the decision.
+const RESOLVED_ENTRY_GRACE_MS = 15_000;
+
+export type KnowledgeTransferApprovalDecision = "allow" | "deny";
+export type KnowledgeTransferApprovalKind = "export" | "import";
+
+export type KnowledgeTransferApprovalRequestPayload = {
+  approvalKind: KnowledgeTransferApprovalKind;
+  requesterAgentId: string;
+  targetAgentId: string;
+  requesterSessionKey: string;
+  targetSessionKey: string;
+  requestedBySessionKey?: string | null;
+  requestedByChannel?: string | null;
+  mode: "ask";
+  itemCount: number;
+  itemFingerprints: string[];
+  summary: string[];
+};
+
+export type KnowledgeTransferApprovalRecord = {
+  id: string;
+  request: KnowledgeTransferApprovalRequestPayload;
+  createdAtMs: number;
+  expiresAtMs: number;
+  requestedByConnId?: string | null;
+  requestedByDeviceId?: string | null;
+  requestedByClientId?: string | null;
+  resolvedAtMs?: number;
+  decision?: KnowledgeTransferApprovalDecision;
+  resolvedBy?: string | null;
+};
+
+type PendingEntry = {
+  record: KnowledgeTransferApprovalRecord;
+  resolve: (decision: KnowledgeTransferApprovalDecision | null) => void;
+  timer: ReturnType<typeof setTimeout>;
+  promise: Promise<KnowledgeTransferApprovalDecision | null>;
+};
+
+export class KnowledgeTransferApprovalManager {
+  private pending = new Map<string, PendingEntry>();
+
+  create(
+    request: KnowledgeTransferApprovalRequestPayload,
+    timeoutMs: number,
+    id?: string | null,
+  ): KnowledgeTransferApprovalRecord {
+    const now = Date.now();
+    const resolvedId = id && id.trim().length > 0 ? id.trim() : randomUUID();
+    return {
+      id: resolvedId,
+      request,
+      createdAtMs: now,
+      expiresAtMs: now + timeoutMs,
+    };
+  }
+
+  register(
+    record: KnowledgeTransferApprovalRecord,
+    timeoutMs: number,
+  ): Promise<KnowledgeTransferApprovalDecision | null> {
+    const existing = this.pending.get(record.id);
+    if (existing) {
+      if (existing.record.resolvedAtMs === undefined) {
+        return existing.promise;
+      }
+      throw new Error(`approval id '${record.id}' already resolved`);
+    }
+
+    let resolvePromise!: (decision: KnowledgeTransferApprovalDecision | null) => void;
+    const promise = new Promise<KnowledgeTransferApprovalDecision | null>((resolve) => {
+      resolvePromise = resolve;
+    });
+
+    const entry: PendingEntry = {
+      record,
+      resolve: resolvePromise,
+      timer: null as unknown as ReturnType<typeof setTimeout>,
+      promise,
+    };
+    entry.timer = setTimeout(() => {
+      this.expire(record.id);
+    }, timeoutMs);
+    this.pending.set(record.id, entry);
+    return promise;
+  }
+
+  awaitDecision(recordId: string): Promise<KnowledgeTransferApprovalDecision | null> | null {
+    return this.pending.get(recordId)?.promise ?? null;
+  }
+
+  getSnapshot(recordId: string): KnowledgeTransferApprovalRecord | null {
+    return this.pending.get(recordId)?.record ?? null;
+  }
+
+  listPending(): KnowledgeTransferApprovalRecord[] {
+    const now = Date.now();
+    const records: KnowledgeTransferApprovalRecord[] = [];
+    for (const entry of this.pending.values()) {
+      if (entry.record.expiresAtMs < now && entry.record.resolvedAtMs == null) {
+        continue;
+      }
+      records.push(entry.record);
+    }
+    records.sort((a, b) => b.createdAtMs - a.createdAtMs);
+    return records;
+  }
+
+  resolve(
+    recordId: string,
+    decision: KnowledgeTransferApprovalDecision,
+    resolvedBy?: string | null,
+  ): boolean {
+    const pending = this.pending.get(recordId);
+    if (!pending) {
+      return false;
+    }
+    if (pending.record.resolvedAtMs !== undefined) {
+      return false;
+    }
+    clearTimeout(pending.timer);
+    pending.record.resolvedAtMs = Date.now();
+    pending.record.decision = decision;
+    pending.record.resolvedBy = resolvedBy ?? null;
+    pending.resolve(decision);
+    setTimeout(() => {
+      if (this.pending.get(recordId) === pending) {
+        this.pending.delete(recordId);
+      }
+    }, RESOLVED_ENTRY_GRACE_MS);
+    return true;
+  }
+
+  expire(recordId: string, resolvedBy?: string | null): boolean {
+    const pending = this.pending.get(recordId);
+    if (!pending) {
+      return false;
+    }
+    if (pending.record.resolvedAtMs !== undefined) {
+      return false;
+    }
+    clearTimeout(pending.timer);
+    pending.record.resolvedAtMs = Date.now();
+    pending.record.decision = undefined;
+    pending.record.resolvedBy = resolvedBy ?? null;
+    pending.resolve(null);
+    setTimeout(() => {
+      if (this.pending.get(recordId) === pending) {
+        this.pending.delete(recordId);
+      }
+    }, RESOLVED_ENTRY_GRACE_MS);
+    return true;
+  }
+}

--- a/src/gateway/method-scopes.test.ts
+++ b/src/gateway/method-scopes.test.ts
@@ -48,6 +48,12 @@ describe("operator scope authorization", () => {
       allowed: false,
       missingScope: "operator.approvals",
     });
+    expect(
+      authorizeOperatorScopesForMethod("knowledge.transfer.approval.resolve", ["operator.write"]),
+    ).toEqual({
+      allowed: false,
+      missingScope: "operator.approvals",
+    });
   });
 
   it("requires admin for unknown methods", () => {

--- a/src/gateway/method-scopes.ts
+++ b/src/gateway/method-scopes.ts
@@ -31,6 +31,9 @@ const METHOD_SCOPE_GROUPS: Record<OperatorScope, readonly string[]> = {
     "exec.approval.request",
     "exec.approval.waitDecision",
     "exec.approval.resolve",
+    "knowledge.transfer.approval.request",
+    "knowledge.transfer.approval.wait",
+    "knowledge.transfer.approval.resolve",
   ],
   [PAIRING_SCOPE]: [
     "node.pair.request",

--- a/src/gateway/server-broadcast.ts
+++ b/src/gateway/server-broadcast.ts
@@ -9,6 +9,8 @@ const PAIRING_SCOPE = "operator.pairing";
 const EVENT_SCOPE_GUARDS: Record<string, string[]> = {
   "exec.approval.requested": [APPROVALS_SCOPE],
   "exec.approval.resolved": [APPROVALS_SCOPE],
+  "knowledge.transfer.approval.pending": [APPROVALS_SCOPE],
+  "knowledge.transfer.approval.resolved": [APPROVALS_SCOPE],
   "device.pair.requested": [PAIRING_SCOPE],
   "device.pair.resolved": [PAIRING_SCOPE],
   "node.pair.requested": [PAIRING_SCOPE],

--- a/src/gateway/server-methods-list.ts
+++ b/src/gateway/server-methods-list.ts
@@ -29,6 +29,9 @@ const BASE_METHODS = [
   "exec.approval.request",
   "exec.approval.waitDecision",
   "exec.approval.resolve",
+  "knowledge.transfer.approval.request",
+  "knowledge.transfer.approval.wait",
+  "knowledge.transfer.approval.resolve",
   "wizard.start",
   "wizard.next",
   "wizard.cancel",
@@ -124,5 +127,7 @@ export const GATEWAY_EVENTS = [
   "voicewake.changed",
   "exec.approval.requested",
   "exec.approval.resolved",
+  "knowledge.transfer.approval.pending",
+  "knowledge.transfer.approval.resolved",
   GATEWAY_EVENT_UPDATE_AVAILABLE,
 ];

--- a/src/gateway/server-methods/knowledge-transfer-approval.test.ts
+++ b/src/gateway/server-methods/knowledge-transfer-approval.test.ts
@@ -22,7 +22,7 @@ const baseRequestParams = {
 
 function buildRequestContext(params: {
   broadcasts: Array<{ event: string; payload: unknown }>;
-  hasExecApprovalClients?: () => boolean;
+  hasExecApprovalClients?: (opts?: { excludeConnId?: string | null }) => boolean;
 }): RequestArgs["context"] {
   return {
     broadcast: (event: string, payload: unknown) => {
@@ -120,6 +120,29 @@ describe("knowledge transfer approval handlers", () => {
     expect(respond).toHaveBeenCalledWith(
       true,
       expect.objectContaining({ id: approvalId, decision: "allow" }),
+      undefined,
+    );
+  });
+
+  it("auto-expires when requester is the only approvals client connected", async () => {
+    const manager = new KnowledgeTransferApprovalManager();
+    const handlers = createKnowledgeTransferApprovalHandlers(manager);
+    const respond = vi.fn();
+    const broadcasts: Array<{ event: string; payload: unknown }> = [];
+
+    await requestApproval({
+      handlers,
+      respond,
+      context: buildRequestContext({
+        broadcasts,
+        hasExecApprovalClients: (opts) => opts?.excludeConnId !== "conn-1",
+      }),
+    });
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ decision: null }),
       undefined,
     );
   });

--- a/src/gateway/server-methods/knowledge-transfer-approval.test.ts
+++ b/src/gateway/server-methods/knowledge-transfer-approval.test.ts
@@ -51,7 +51,7 @@ function requestApproval(params: {
         client: { id: "client-1" },
         device: { id: "device-1" },
       },
-    } as RequestArgs["client"],
+    } as unknown as RequestArgs["client"],
     req: { id: "req-1", type: "req", method: "knowledge.transfer.approval.request" },
     isWebchatConnect: () => false,
   });

--- a/src/gateway/server-methods/knowledge-transfer-approval.test.ts
+++ b/src/gateway/server-methods/knowledge-transfer-approval.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { KnowledgeTransferApprovalManager } from "../knowledge-transfer-approval-manager.js";
+import { createKnowledgeTransferApprovalHandlers } from "./knowledge-transfer-approval.js";
+
+type KnowledgeTransferApprovalHandlers = ReturnType<typeof createKnowledgeTransferApprovalHandlers>;
+type RequestArgs = Parameters<
+  KnowledgeTransferApprovalHandlers["knowledge.transfer.approval.request"]
+>[0];
+
+const baseRequestParams = {
+  approvalKind: "export",
+  requesterAgentId: "requester",
+  targetAgentId: "target",
+  requesterSessionKey: "agent:requester:main",
+  targetSessionKey: "agent:target:main",
+  mode: "ask",
+  itemCount: 1,
+  itemFingerprints: ["abc123"],
+  summary: ["1. test item"],
+  timeoutMs: 10_000,
+} as const;
+
+function buildRequestContext(params: {
+  broadcasts: Array<{ event: string; payload: unknown }>;
+  hasExecApprovalClients?: () => boolean;
+}): RequestArgs["context"] {
+  return {
+    broadcast: (event: string, payload: unknown) => {
+      params.broadcasts.push({ event, payload });
+    },
+    hasExecApprovalClients: params.hasExecApprovalClients ?? (() => true),
+  } as unknown as RequestArgs["context"];
+}
+
+function requestApproval(params: {
+  handlers: KnowledgeTransferApprovalHandlers;
+  respond: ReturnType<typeof vi.fn>;
+  context: RequestArgs["context"];
+  requestParams?: Record<string, unknown>;
+}) {
+  return params.handlers["knowledge.transfer.approval.request"]({
+    params: {
+      ...baseRequestParams,
+      ...params.requestParams,
+    } as RequestArgs["params"],
+    respond: params.respond as unknown as RequestArgs["respond"],
+    context: params.context,
+    client: {
+      connId: "conn-1",
+      connect: {
+        client: { id: "client-1" },
+        device: { id: "device-1" },
+      },
+    } as RequestArgs["client"],
+    req: { id: "req-1", type: "req", method: "knowledge.transfer.approval.request" },
+    isWebchatConnect: () => false,
+  });
+}
+
+describe("knowledge transfer approval handlers", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    await vi.runOnlyPendingTimersAsync();
+    vi.useRealTimers();
+  });
+
+  it("returns immediately in two-phase mode without sending a second response", async () => {
+    const manager = new KnowledgeTransferApprovalManager();
+    const handlers = createKnowledgeTransferApprovalHandlers(manager);
+    const respond = vi.fn();
+    const broadcasts: Array<{ event: string; payload: unknown }> = [];
+    const requestPromise = requestApproval({
+      handlers,
+      respond,
+      context: buildRequestContext({ broadcasts }),
+      requestParams: { twoPhase: true },
+    });
+
+    await expect(requestPromise).resolves.toBeUndefined();
+    expect(respond).toHaveBeenCalledTimes(1);
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ status: "accepted" }),
+      undefined,
+    );
+
+    const approvalId =
+      (respond.mock.calls[0]?.[1] as { id?: string } | undefined)?.id?.toString() ?? "";
+    expect(approvalId).not.toBe("");
+    expect(manager.resolve(approvalId, "allow", "operator")).toBe(true);
+
+    await Promise.resolve();
+    expect(respond).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the final decision in single-phase mode", async () => {
+    const manager = new KnowledgeTransferApprovalManager();
+    const handlers = createKnowledgeTransferApprovalHandlers(manager);
+    const respond = vi.fn();
+    const broadcasts: Array<{ event: string; payload: unknown }> = [];
+    const requestPromise = requestApproval({
+      handlers,
+      respond,
+      context: buildRequestContext({ broadcasts }),
+    });
+
+    const pendingEvent = broadcasts.find(
+      (entry) => entry.event === "knowledge.transfer.approval.pending",
+    );
+    const approvalId = (pendingEvent?.payload as { id?: string } | undefined)?.id ?? "";
+    expect(approvalId).not.toBe("");
+
+    expect(manager.resolve(approvalId, "allow", "operator")).toBe(true);
+    await requestPromise;
+
+    expect(respond).toHaveBeenCalledTimes(1);
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ id: approvalId, decision: "allow" }),
+      undefined,
+    );
+  });
+});

--- a/src/gateway/server-methods/knowledge-transfer-approval.ts
+++ b/src/gateway/server-methods/knowledge-transfer-approval.ts
@@ -1,0 +1,265 @@
+import type {
+  KnowledgeTransferApprovalKind,
+  KnowledgeTransferApprovalDecision,
+  KnowledgeTransferApprovalManager,
+} from "../knowledge-transfer-approval-manager.js";
+import { ErrorCodes, errorShape } from "../protocol/index.js";
+import type { GatewayRequestHandlers } from "./types.js";
+
+const DEFAULT_APPROVAL_TIMEOUT_MS = 120_000;
+const MIN_APPROVAL_TIMEOUT_MS = 1_000;
+const MAX_APPROVAL_TIMEOUT_MS = 3_600_000;
+
+function parseNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function parseOptionalNonEmptyString(value: unknown): string | null {
+  if (value == null) {
+    return null;
+  }
+  return parseNonEmptyString(value);
+}
+
+function parseStringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) {
+    return null;
+  }
+  const values = value
+    .map((entry) => parseNonEmptyString(entry))
+    .filter((entry): entry is string => typeof entry === "string");
+  return values;
+}
+
+function clampTimeoutMs(value: unknown): number {
+  const numeric = typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : 0;
+  if (!numeric) {
+    return DEFAULT_APPROVAL_TIMEOUT_MS;
+  }
+  return Math.max(MIN_APPROVAL_TIMEOUT_MS, Math.min(MAX_APPROVAL_TIMEOUT_MS, numeric));
+}
+
+function hasApprovalClients(context: { hasExecApprovalClients?: () => boolean }): boolean {
+  if (typeof context.hasExecApprovalClients === "function") {
+    return context.hasExecApprovalClients();
+  }
+  return false;
+}
+
+function parseDecision(value: unknown): KnowledgeTransferApprovalDecision | null {
+  const parsed = parseNonEmptyString(value)?.toLowerCase();
+  if (parsed === "allow" || parsed === "deny") {
+    return parsed;
+  }
+  return null;
+}
+
+function parseApprovalKind(value: unknown): KnowledgeTransferApprovalKind | null {
+  const parsed = parseNonEmptyString(value)?.toLowerCase();
+  if (parsed === "export" || parsed === "import") {
+    return parsed;
+  }
+  return null;
+}
+
+export function createKnowledgeTransferApprovalHandlers(
+  manager: KnowledgeTransferApprovalManager,
+): GatewayRequestHandlers {
+  return {
+    "knowledge.transfer.approval.request": async ({ params, respond, context, client }) => {
+      const record = params;
+      const requesterAgentId = parseNonEmptyString(record.requesterAgentId);
+      const targetAgentId = parseNonEmptyString(record.targetAgentId);
+      const approvalKind = parseApprovalKind(record.approvalKind);
+      const requesterSessionKey = parseNonEmptyString(record.requesterSessionKey);
+      const targetSessionKey = parseNonEmptyString(record.targetSessionKey);
+      const mode = parseNonEmptyString(record.mode);
+      const itemCountRaw =
+        typeof record.itemCount === "number" && Number.isFinite(record.itemCount)
+          ? Math.max(0, Math.floor(record.itemCount))
+          : null;
+      const itemFingerprints = parseStringArray(record.itemFingerprints);
+      const summary = parseStringArray(record.summary);
+      const explicitId = parseOptionalNonEmptyString(record.id);
+      const timeoutMs = clampTimeoutMs(record.timeoutMs);
+      const twoPhase = record.twoPhase === true;
+
+      if (
+        !requesterAgentId ||
+        !targetAgentId ||
+        !approvalKind ||
+        !requesterSessionKey ||
+        !targetSessionKey ||
+        mode !== "ask" ||
+        itemCountRaw == null ||
+        !itemFingerprints ||
+        !summary
+      ) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "invalid knowledge.transfer.approval.request params",
+          ),
+        );
+        return;
+      }
+
+      if (explicitId && manager.getSnapshot(explicitId)) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "approval id already pending"),
+        );
+        return;
+      }
+
+      const request = {
+        approvalKind,
+        requesterAgentId,
+        targetAgentId,
+        requesterSessionKey,
+        targetSessionKey,
+        requestedBySessionKey: parseOptionalNonEmptyString(record.requestedBySessionKey),
+        requestedByChannel: parseOptionalNonEmptyString(record.requestedByChannel),
+        mode: "ask" as const,
+        itemCount: itemCountRaw,
+        itemFingerprints,
+        summary,
+      };
+
+      const approvalRecord = manager.create(request, timeoutMs, explicitId);
+      approvalRecord.requestedByConnId = client?.connId ?? null;
+      approvalRecord.requestedByDeviceId = client?.connect?.device?.id ?? null;
+      approvalRecord.requestedByClientId = client?.connect?.client?.id ?? null;
+
+      let decisionPromise: Promise<KnowledgeTransferApprovalDecision | null>;
+      try {
+        decisionPromise = manager.register(approvalRecord, timeoutMs);
+      } catch (err) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, `registration failed: ${String(err)}`),
+        );
+        return;
+      }
+
+      context.broadcast(
+        "knowledge.transfer.approval.pending",
+        {
+          id: approvalRecord.id,
+          request: approvalRecord.request,
+          createdAtMs: approvalRecord.createdAtMs,
+          expiresAtMs: approvalRecord.expiresAtMs,
+        },
+        { dropIfSlow: true },
+      );
+
+      if (!hasApprovalClients(context)) {
+        manager.expire(approvalRecord.id, "auto-expire:no-approver-clients");
+      }
+
+      if (twoPhase) {
+        respond(
+          true,
+          {
+            status: "accepted",
+            id: approvalRecord.id,
+            createdAtMs: approvalRecord.createdAtMs,
+            expiresAtMs: approvalRecord.expiresAtMs,
+          },
+          undefined,
+        );
+      }
+
+      const decision = await decisionPromise;
+      respond(
+        true,
+        {
+          id: approvalRecord.id,
+          decision,
+          createdAtMs: approvalRecord.createdAtMs,
+          expiresAtMs: approvalRecord.expiresAtMs,
+        },
+        undefined,
+      );
+    },
+
+    "knowledge.transfer.approval.wait": async ({ params, respond }) => {
+      const record = params;
+      const id = parseNonEmptyString(record.id);
+      if (!id) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "id is required"));
+        return;
+      }
+
+      const decisionPromise = manager.awaitDecision(id);
+      if (!decisionPromise) {
+        respond(
+          false,
+          undefined,
+          errorShape(ErrorCodes.INVALID_REQUEST, "approval expired or not found"),
+        );
+        return;
+      }
+
+      const snapshot = manager.getSnapshot(id);
+      const decision = await decisionPromise;
+      respond(
+        true,
+        {
+          id,
+          decision,
+          createdAtMs: snapshot?.createdAtMs,
+          expiresAtMs: snapshot?.expiresAtMs,
+        },
+        undefined,
+      );
+    },
+
+    "knowledge.transfer.approval.resolve": async ({ params, respond, client, context }) => {
+      const record = params;
+      const id = parseNonEmptyString(record.id);
+      const decision = parseDecision(record.decision);
+      if (!id || !decision) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "invalid knowledge.transfer.approval.resolve params",
+          ),
+        );
+        return;
+      }
+
+      const snapshot = manager.getSnapshot(id);
+      const resolvedBy = client?.connect?.client?.displayName ?? client?.connect?.client?.id;
+      const ok = manager.resolve(id, decision, resolvedBy ?? null);
+      if (!ok) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown approval id"));
+        return;
+      }
+
+      context.broadcast(
+        "knowledge.transfer.approval.resolved",
+        {
+          id,
+          decision,
+          resolvedBy,
+          ts: Date.now(),
+          request: snapshot?.request,
+        },
+        { dropIfSlow: true },
+      );
+
+      respond(true, { ok: true }, undefined);
+    },
+  };
+}

--- a/src/gateway/server-methods/knowledge-transfer-approval.ts
+++ b/src/gateway/server-methods/knowledge-transfer-approval.ts
@@ -43,9 +43,12 @@ function clampTimeoutMs(value: unknown): number {
   return Math.max(MIN_APPROVAL_TIMEOUT_MS, Math.min(MAX_APPROVAL_TIMEOUT_MS, numeric));
 }
 
-function hasApprovalClients(context: { hasExecApprovalClients?: () => boolean }): boolean {
+function hasApprovalClients(
+  context: { hasExecApprovalClients?: (opts?: { excludeConnId?: string | null }) => boolean },
+  requesterConnId?: string | null,
+): boolean {
   if (typeof context.hasExecApprovalClients === "function") {
-    return context.hasExecApprovalClients();
+    return context.hasExecApprovalClients({ excludeConnId: requesterConnId ?? undefined });
   }
   return false;
 }
@@ -161,7 +164,7 @@ export function createKnowledgeTransferApprovalHandlers(
         { dropIfSlow: true },
       );
 
-      if (!hasApprovalClients(context)) {
+      if (!hasApprovalClients(context, client?.connId ?? null)) {
         manager.expire(approvalRecord.id, "auto-expire:no-approver-clients");
       }
 

--- a/src/gateway/server-methods/knowledge-transfer-approval.ts
+++ b/src/gateway/server-methods/knowledge-transfer-approval.ts
@@ -176,6 +176,7 @@ export function createKnowledgeTransferApprovalHandlers(
           },
           undefined,
         );
+        return;
       }
 
       const decision = await decisionPromise;

--- a/src/gateway/server-methods/types.ts
+++ b/src/gateway/server-methods/types.ts
@@ -50,7 +50,7 @@ export type GatewayRequestContext = {
   nodeUnsubscribe: (nodeId: string, sessionKey: string) => void;
   nodeUnsubscribeAll: (nodeId: string) => void;
   hasConnectedMobileNode: () => boolean;
-  hasExecApprovalClients?: () => boolean;
+  hasExecApprovalClients?: (opts?: { excludeConnId?: string | null }) => boolean;
   nodeRegistry: NodeRegistry;
   agentRunSeq: Map<string, number>;
   chatAbortControllers: Map<string, ChatAbortControllerEntry>;

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -72,6 +72,7 @@ import {
   type GatewayUpdateAvailableEventPayload,
 } from "./events.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
+import { KnowledgeTransferApprovalManager } from "./knowledge-transfer-approval-manager.js";
 import { NodeRegistry } from "./node-registry.js";
 import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { createChannelManager } from "./server-channels.js";
@@ -84,6 +85,7 @@ import { startGatewayMaintenanceTimers } from "./server-maintenance.js";
 import { GATEWAY_EVENTS, listGatewayMethods } from "./server-methods-list.js";
 import { coreGatewayHandlers } from "./server-methods.js";
 import { createExecApprovalHandlers } from "./server-methods/exec-approval.js";
+import { createKnowledgeTransferApprovalHandlers } from "./server-methods/knowledge-transfer-approval.js";
 import { safeParseJson } from "./server-methods/nodes.helpers.js";
 import { createSecretsHandlers } from "./server-methods/secrets.js";
 import { hasConnectedMobileNode } from "./server-mobile-nodes.js";
@@ -774,6 +776,10 @@ export async function startGatewayServer(
   const execApprovalHandlers = createExecApprovalHandlers(execApprovalManager, {
     forwarder: execApprovalForwarder,
   });
+  const knowledgeTransferApprovalManager = new KnowledgeTransferApprovalManager();
+  const knowledgeTransferApprovalHandlers = createKnowledgeTransferApprovalHandlers(
+    knowledgeTransferApprovalManager,
+  );
   const secretsHandlers = createSecretsHandlers({
     reloadSecrets: async () => {
       const active = getActiveSecretsRuntimeSnapshot();
@@ -876,6 +882,7 @@ export async function startGatewayServer(
     extraHandlers: {
       ...pluginRegistry.gatewayHandlers,
       ...execApprovalHandlers,
+      ...knowledgeTransferApprovalHandlers,
       ...secretsHandlers,
     },
     broadcast,

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -827,8 +827,13 @@ export async function startGatewayServer(
     nodeUnsubscribe,
     nodeUnsubscribeAll,
     hasConnectedMobileNode: hasMobileNodeConnected,
-    hasExecApprovalClients: () => {
+    hasExecApprovalClients: (opts) => {
+      const excludedConnId =
+        typeof opts?.excludeConnId === "string" ? opts.excludeConnId : undefined;
       for (const gatewayClient of clients) {
+        if (excludedConnId && gatewayClient.connId === excludedConnId) {
+          continue;
+        }
         const scopes = Array.isArray(gatewayClient.connect.scopes)
           ? gatewayClient.connect.scopes
           : [];

--- a/src/gateway/tools-invoke-http.test.ts
+++ b/src/gateway/tools-invoke-http.test.ts
@@ -93,6 +93,11 @@ vi.mock("../agents/openclaw-tools.js", () => {
       execute: async () => ({ ok: true }),
     },
     {
+      name: "sessions_transfer_knowledge",
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ ok: true }),
+    },
+    {
       name: "gateway",
       parameters: { type: "object", properties: {} },
       execute: async () => {
@@ -463,6 +468,17 @@ describe("POST /tools/invoke", () => {
 
     const res = await invokeToolAuthed({
       tool: "sessions_send",
+      sessionKey: "main",
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("denies sessions_transfer_knowledge via HTTP gateway", async () => {
+    setMainAllowedTools({ allow: ["sessions_transfer_knowledge"] });
+
+    const res = await invokeToolAuthed({
+      tool: "sessions_transfer_knowledge",
       sessionKey: "main",
     });
 

--- a/src/infra/knowledge-transfer-policy.test.ts
+++ b/src/infra/knowledge-transfer-policy.test.ts
@@ -1,0 +1,210 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
+import {
+  listKnowledgeTransferRules,
+  removeKnowledgeTransferRule,
+  resolveKnowledgeTransferMode,
+  resolveKnowledgeTransferPathDecision,
+  setKnowledgeTransferPairMode,
+  upsertKnowledgeTransferRule,
+} from "./knowledge-transfer-policy.js";
+
+function buildConfig(): OpenClawConfig {
+  return {
+    tools: {
+      agentToAgent: {
+        knowledgeTransfer: {
+          enabled: true,
+          defaultExportMode: "ask",
+          defaultImportMode: "ask",
+          approvalTimeoutSeconds: 120,
+        },
+      },
+    },
+  } as OpenClawConfig;
+}
+
+describe("knowledge-transfer-policy", () => {
+  let stateDir = "";
+  let previousStateDir: string | undefined;
+
+  beforeEach(async () => {
+    stateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-kt-policy-"));
+    previousStateDir = process.env.OPENCLAW_STATE_DIR;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+  });
+
+  afterEach(async () => {
+    if (previousStateDir === undefined) {
+      delete process.env.OPENCLAW_STATE_DIR;
+    } else {
+      process.env.OPENCLAW_STATE_DIR = previousStateDir;
+    }
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  it("defaults to deny when no rules are configured", async () => {
+    const exportDecision = await resolveKnowledgeTransferPathDecision({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "export",
+      sourcePath: "MEMORY.md",
+      baseDir: stateDir,
+    });
+    expect(exportDecision.allowed).toBe(false);
+    expect(exportDecision.decision).toBe("hide");
+    expect(exportDecision.source).toBe("default_deny");
+
+    const importDecision = await resolveKnowledgeTransferPathDecision({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "import",
+      sourcePath: "memory/public/share.md",
+      baseDir: stateDir,
+    });
+    expect(importDecision.allowed).toBe(false);
+    expect(importDecision.decision).toBe("hide");
+    expect(importDecision.source).toBe("default_deny");
+  });
+
+  it("resolves pair rules before wildcard rules and keeps side-specific behavior", async () => {
+    await upsertKnowledgeTransferRule({
+      requesterAgentId: "*",
+      targetAgentId: "*",
+      side: "export",
+      pathPattern: "memory/**",
+      decision: "auto",
+      baseDir: stateDir,
+    });
+    await upsertKnowledgeTransferRule({
+      requesterAgentId: "*",
+      targetAgentId: "*",
+      side: "import",
+      pathPattern: "memory/**",
+      decision: "auto",
+      baseDir: stateDir,
+    });
+
+    await upsertKnowledgeTransferRule({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "export",
+      pathPattern: "memory/private/**",
+      decision: "hide",
+      baseDir: stateDir,
+    });
+    await upsertKnowledgeTransferRule({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "import",
+      pathPattern: "memory/public/**",
+      decision: "ask",
+      baseDir: stateDir,
+    });
+
+    const privateExport = await resolveKnowledgeTransferPathDecision({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "export",
+      sourcePath: "memory/private/secrets.md",
+      baseDir: stateDir,
+    });
+    expect(privateExport.allowed).toBe(false);
+    expect(privateExport.decision).toBe("hide");
+    expect(privateExport.source).toBe("pair");
+
+    const publicExport = await resolveKnowledgeTransferPathDecision({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "export",
+      sourcePath: "memory/public/share.md",
+      baseDir: stateDir,
+    });
+    expect(publicExport.allowed).toBe(true);
+    expect(publicExport.mode).toBe("auto");
+    expect(publicExport.source).toBe("global_wildcard");
+
+    const publicImport = await resolveKnowledgeTransferPathDecision({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "import",
+      sourcePath: "memory/public/share.md",
+      baseDir: stateDir,
+    });
+    expect(publicImport.allowed).toBe(true);
+    expect(publicImport.mode).toBe("ask");
+    expect(publicImport.source).toBe("pair");
+  });
+
+  it("uses last matching rule wins semantics within a pair", async () => {
+    await upsertKnowledgeTransferRule({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "export",
+      pathPattern: "memory/public/**",
+      decision: "hide",
+      baseDir: stateDir,
+    });
+    await upsertKnowledgeTransferRule({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "export",
+      pathPattern: "memory/public/**",
+      decision: "auto",
+      baseDir: stateDir,
+    });
+
+    const decision = await resolveKnowledgeTransferPathDecision({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      side: "export",
+      sourcePath: "memory/public/notes.md",
+      baseDir: stateDir,
+    });
+    expect(decision.allowed).toBe(true);
+    expect(decision.mode).toBe("auto");
+  });
+
+  it("supports mode shorthand and explicit rule removal", async () => {
+    const cfg = buildConfig();
+    await setKnowledgeTransferPairMode({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      mode: "auto",
+      baseDir: stateDir,
+    });
+
+    const mode = await resolveKnowledgeTransferMode({
+      cfg,
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      baseDir: stateDir,
+    });
+    expect(mode.mode).toBe("auto");
+
+    const rules = await listKnowledgeTransferRules({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      baseDir: stateDir,
+    });
+    expect(rules.length).toBeGreaterThanOrEqual(2);
+
+    const removed = await removeKnowledgeTransferRule({
+      id: rules[0]?.id ?? "",
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      baseDir: stateDir,
+    });
+    expect(removed.removed).toBe(true);
+
+    const rulesAfterRemove = await listKnowledgeTransferRules({
+      requesterAgentId: "requester",
+      targetAgentId: "source",
+      baseDir: stateDir,
+    });
+    expect(rulesAfterRemove.length).toBe(rules.length - 1);
+  });
+});

--- a/src/infra/knowledge-transfer-policy.ts
+++ b/src/infra/knowledge-transfer-policy.ts
@@ -1,0 +1,749 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { compileGlobPattern } from "../agents/glob-pattern.js";
+import type { OpenClawConfig } from "../config/config.js";
+import { resolveStateDir } from "../config/paths.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { createAsyncLock, readJsonFile, writeJsonAtomic } from "./json-files.js";
+
+export type KnowledgeTransferMode = "ask" | "auto";
+export type KnowledgeTransferSide = "export" | "import";
+export type KnowledgeTransferRuleDecision = "hide" | KnowledgeTransferMode;
+
+export type KnowledgeTransferRule = {
+  id: string;
+  side: KnowledgeTransferSide;
+  pathPattern: string;
+  decision: KnowledgeTransferRuleDecision;
+  updatedAtMs: number;
+};
+
+export type KnowledgeTransferPairPolicy = {
+  updatedAtMs: number;
+  rules: KnowledgeTransferRule[];
+};
+
+export type KnowledgeTransferPolicyStore = {
+  version: 2;
+  updatedAtMs: number;
+  pairs: Record<string, KnowledgeTransferPairPolicy>;
+};
+
+export type KnowledgeTransferDefaults = {
+  enabled: boolean;
+  defaultMode: KnowledgeTransferMode;
+  defaultExportMode: KnowledgeTransferMode;
+  defaultImportMode: KnowledgeTransferMode;
+  approvalTimeoutSeconds: number;
+};
+
+export type KnowledgeTransferModeResolution = {
+  mode: KnowledgeTransferMode;
+  source: "pair" | "requester_wildcard" | "target_wildcard" | "global_wildcard" | "default";
+  matchedPair?: { requesterAgentId: string; targetAgentId: string };
+  defaults: KnowledgeTransferDefaults;
+};
+
+export type KnowledgeTransferPathResolution = {
+  allowed: boolean;
+  decision: KnowledgeTransferRuleDecision;
+  mode?: KnowledgeTransferMode;
+  side: KnowledgeTransferSide;
+  source: "pair" | "requester_wildcard" | "target_wildcard" | "global_wildcard" | "default_deny";
+  matchedPair?: { requesterAgentId: string; targetAgentId: string };
+  matchedRuleId?: string;
+  matchedPathPattern?: string;
+};
+
+export type KnowledgeTransferPolicyRuleView = {
+  requesterAgentId: string;
+  targetAgentId: string;
+  id: string;
+  side: KnowledgeTransferSide;
+  pathPattern: string;
+  decision: KnowledgeTransferRuleDecision;
+  updatedAtMs: number;
+};
+
+type RuleMatch = {
+  source: Exclude<KnowledgeTransferPathResolution["source"], "default_deny">;
+  matchedPair: { requesterAgentId: string; targetAgentId: string };
+  rule: KnowledgeTransferRule;
+};
+
+const DEFAULT_APPROVAL_TIMEOUT_SECONDS = 120;
+const MIN_APPROVAL_TIMEOUT_SECONDS = 1;
+const MAX_APPROVAL_TIMEOUT_SECONDS = 60 * 60;
+const withLock = createAsyncLock();
+
+function resolvePath(baseDir?: string): string {
+  const root = baseDir ?? resolveStateDir();
+  return path.join(root, "settings", "knowledge-transfer-policy.json");
+}
+
+function normalizeMode(value: unknown): KnowledgeTransferMode | undefined {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (normalized === "ask" || normalized === "auto") {
+    return normalized;
+  }
+  return undefined;
+}
+
+function normalizeSide(value: unknown): KnowledgeTransferSide | undefined {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (normalized === "export" || normalized === "import") {
+    return normalized;
+  }
+  return undefined;
+}
+
+function normalizeDecision(value: unknown): KnowledgeTransferRuleDecision | undefined {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : "";
+  if (normalized === "ask" || normalized === "auto" || normalized === "hide") {
+    return normalized;
+  }
+  if (normalized === "deny") {
+    return "hide";
+  }
+  if (normalized === "allow") {
+    return "auto";
+  }
+  return undefined;
+}
+
+function normalizePathPattern(raw: unknown): string {
+  const normalized =
+    typeof raw === "string"
+      ? raw
+          .trim()
+          .replace(/\\/g, "/")
+          .replace(/^[./]+/, "")
+          .toLowerCase()
+      : "";
+  if (!normalized) {
+    return "*";
+  }
+  return normalized;
+}
+
+function normalizeMemoryPath(raw: string): string {
+  return raw
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^[./]+/, "")
+    .toLowerCase();
+}
+
+function clampApprovalTimeoutSeconds(value: unknown): number {
+  const numeric =
+    typeof value === "number" && Number.isFinite(value) ? Math.floor(value) : undefined;
+  if (typeof numeric !== "number") {
+    return DEFAULT_APPROVAL_TIMEOUT_SECONDS;
+  }
+  return Math.max(MIN_APPROVAL_TIMEOUT_SECONDS, Math.min(MAX_APPROVAL_TIMEOUT_SECONDS, numeric));
+}
+
+function normalizePairAgentId(raw: unknown, opts?: { allowWildcard?: boolean }): string {
+  const trimmed = typeof raw === "string" ? raw.trim() : "";
+  if (opts?.allowWildcard && trimmed === "*") {
+    return "*";
+  }
+  return normalizeAgentId(trimmed || "main");
+}
+
+export function buildKnowledgeTransferPairKey(
+  requesterAgentId: string,
+  targetAgentId: string,
+): string {
+  const requester = normalizePairAgentId(requesterAgentId, { allowWildcard: true });
+  const target = normalizePairAgentId(targetAgentId, { allowWildcard: true });
+  return `${requester}|${target}`;
+}
+
+function splitPairKey(pairKey: string): { requesterAgentId: string; targetAgentId: string } | null {
+  const [requesterAgentId, targetAgentId] = pairKey.split("|");
+  if (!requesterAgentId || !targetAgentId) {
+    return null;
+  }
+  return { requesterAgentId, targetAgentId };
+}
+
+function resolvePairCandidates(
+  requesterAgentId: string,
+  targetAgentId: string,
+): Array<{
+  key: string;
+  source: Exclude<KnowledgeTransferPathResolution["source"], "default_deny">;
+  matchedPair: { requesterAgentId: string; targetAgentId: string };
+}> {
+  return [
+    {
+      key: buildKnowledgeTransferPairKey(requesterAgentId, targetAgentId),
+      source: "pair",
+      matchedPair: { requesterAgentId, targetAgentId },
+    },
+    {
+      key: buildKnowledgeTransferPairKey(requesterAgentId, "*"),
+      source: "requester_wildcard",
+      matchedPair: { requesterAgentId, targetAgentId: "*" },
+    },
+    {
+      key: buildKnowledgeTransferPairKey("*", targetAgentId),
+      source: "target_wildcard",
+      matchedPair: { requesterAgentId: "*", targetAgentId },
+    },
+    {
+      key: buildKnowledgeTransferPairKey("*", "*"),
+      source: "global_wildcard",
+      matchedPair: { requesterAgentId: "*", targetAgentId: "*" },
+    },
+  ];
+}
+
+function buildDefaultStore(): KnowledgeTransferPolicyStore {
+  return {
+    version: 2,
+    updatedAtMs: 0,
+    pairs: {},
+  };
+}
+
+function sanitizeRule(raw: unknown): KnowledgeTransferRule | null {
+  if (!raw || typeof raw !== "object") {
+    return null;
+  }
+  const record = raw as {
+    id?: unknown;
+    side?: unknown;
+    pathPattern?: unknown;
+    decision?: unknown;
+    mode?: unknown;
+    updatedAtMs?: unknown;
+  };
+  const side = normalizeSide(record.side);
+  if (!side) {
+    return null;
+  }
+  const decision = normalizeDecision(record.decision ?? record.mode);
+  if (!decision) {
+    return null;
+  }
+  const idRaw = typeof record.id === "string" ? record.id.trim() : "";
+  const id = idRaw || randomUUID();
+  const pathPattern = normalizePathPattern(record.pathPattern ?? "*");
+  const updatedAtMs =
+    typeof record.updatedAtMs === "number" && record.updatedAtMs > 0 ? record.updatedAtMs : 0;
+  return { id, side, pathPattern, decision, updatedAtMs };
+}
+
+function buildLegacyPairRules(params: {
+  mode: KnowledgeTransferMode;
+  pairKey: string;
+  updatedAtMs: number;
+}): KnowledgeTransferRule[] {
+  return [
+    {
+      id: `${params.pairKey}:legacy:export`,
+      side: "export",
+      pathPattern: "*",
+      decision: params.mode,
+      updatedAtMs: params.updatedAtMs,
+    },
+    {
+      id: `${params.pairKey}:legacy:import`,
+      side: "import",
+      pathPattern: "*",
+      decision: params.mode,
+      updatedAtMs: params.updatedAtMs,
+    },
+  ];
+}
+
+function sanitizeStore(raw: unknown): KnowledgeTransferPolicyStore {
+  if (!raw || typeof raw !== "object") {
+    return buildDefaultStore();
+  }
+  const record = raw as {
+    version?: unknown;
+    updatedAtMs?: unknown;
+    pairs?: unknown;
+  };
+
+  const pairsRaw =
+    record.pairs && typeof record.pairs === "object"
+      ? (record.pairs as Record<string, unknown>)
+      : {};
+  const pairs: Record<string, KnowledgeTransferPairPolicy> = {};
+
+  for (const [pairKey, pairRaw] of Object.entries(pairsRaw)) {
+    const pair = splitPairKey(pairKey);
+    if (!pair) {
+      continue;
+    }
+
+    const pairRecord = pairRaw && typeof pairRaw === "object" ? pairRaw : {};
+    const pairObj = pairRecord as {
+      updatedAtMs?: unknown;
+      rules?: unknown;
+      mode?: unknown;
+    };
+    const pairUpdatedAtMs =
+      typeof pairObj.updatedAtMs === "number" && pairObj.updatedAtMs > 0 ? pairObj.updatedAtMs : 0;
+
+    if (Array.isArray(pairObj.rules)) {
+      const rules = pairObj.rules
+        .map((entry) => sanitizeRule(entry))
+        .filter((entry): entry is KnowledgeTransferRule => entry !== null);
+      pairs[pairKey] = {
+        updatedAtMs: pairUpdatedAtMs,
+        rules,
+      };
+      continue;
+    }
+
+    const legacyMode = normalizeMode(pairObj.mode);
+    if (!legacyMode) {
+      pairs[pairKey] = {
+        updatedAtMs: pairUpdatedAtMs,
+        rules: [],
+      };
+      continue;
+    }
+
+    pairs[pairKey] = {
+      updatedAtMs: pairUpdatedAtMs,
+      rules: buildLegacyPairRules({
+        mode: legacyMode,
+        pairKey,
+        updatedAtMs: pairUpdatedAtMs,
+      }),
+    };
+  }
+
+  return {
+    version: 2,
+    updatedAtMs:
+      typeof record.updatedAtMs === "number" && record.updatedAtMs > 0 ? record.updatedAtMs : 0,
+    pairs,
+  };
+}
+
+export function resolveKnowledgeTransferDefaults(cfg: OpenClawConfig): KnowledgeTransferDefaults {
+  const raw = cfg.tools?.agentToAgent?.knowledgeTransfer;
+  const legacyMode = normalizeMode(raw?.defaultMode);
+  const defaultExportMode = normalizeMode(raw?.defaultExportMode) ?? legacyMode ?? "ask";
+  const defaultImportMode = normalizeMode(raw?.defaultImportMode) ?? legacyMode ?? "ask";
+  return {
+    enabled: raw?.enabled === true,
+    defaultMode: legacyMode ?? "ask",
+    defaultExportMode,
+    defaultImportMode,
+    approvalTimeoutSeconds: clampApprovalTimeoutSeconds(raw?.approvalTimeoutSeconds),
+  };
+}
+
+export async function loadKnowledgeTransferPolicyStore(
+  baseDir?: string,
+): Promise<KnowledgeTransferPolicyStore> {
+  const filePath = resolvePath(baseDir);
+  const existing = await readJsonFile<KnowledgeTransferPolicyStore>(filePath);
+  return sanitizeStore(existing);
+}
+
+function findRuleMatch(params: {
+  store: KnowledgeTransferPolicyStore;
+  requesterAgentId: string;
+  targetAgentId: string;
+  side: KnowledgeTransferSide;
+  sourcePath: string;
+}): RuleMatch | null {
+  const sourcePath = normalizeMemoryPath(params.sourcePath);
+  const candidates = resolvePairCandidates(params.requesterAgentId, params.targetAgentId);
+
+  for (const candidate of candidates) {
+    const pair = params.store.pairs[candidate.key];
+    if (!pair || pair.rules.length === 0) {
+      continue;
+    }
+
+    let matchedRule: KnowledgeTransferRule | null = null;
+    for (const rule of pair.rules) {
+      if (rule.side !== params.side) {
+        continue;
+      }
+      const pattern = compileGlobPattern({
+        raw: rule.pathPattern,
+        normalize: (value) => normalizePathPattern(value),
+      });
+      if (pattern.kind === "all") {
+        matchedRule = rule;
+        continue;
+      }
+      if (pattern.kind === "exact" && sourcePath === pattern.value) {
+        matchedRule = rule;
+        continue;
+      }
+      if (pattern.kind === "regex" && pattern.value.test(sourcePath)) {
+        matchedRule = rule;
+      }
+    }
+
+    if (matchedRule) {
+      return {
+        source: candidate.source,
+        matchedPair: candidate.matchedPair,
+        rule: matchedRule,
+      };
+    }
+  }
+
+  return null;
+}
+
+function resolvePathDecisionFromStore(params: {
+  store: KnowledgeTransferPolicyStore;
+  requesterAgentId: string;
+  targetAgentId: string;
+  side: KnowledgeTransferSide;
+  sourcePath: string;
+}): KnowledgeTransferPathResolution {
+  const match = findRuleMatch(params);
+  if (!match) {
+    return {
+      allowed: false,
+      decision: "hide",
+      side: params.side,
+      source: "default_deny",
+    };
+  }
+
+  if (match.rule.decision === "hide") {
+    return {
+      allowed: false,
+      decision: "hide",
+      side: params.side,
+      source: match.source,
+      matchedPair: match.matchedPair,
+      matchedRuleId: match.rule.id,
+      matchedPathPattern: match.rule.pathPattern,
+    };
+  }
+
+  return {
+    allowed: true,
+    decision: match.rule.decision,
+    mode: match.rule.decision,
+    side: params.side,
+    source: match.source,
+    matchedPair: match.matchedPair,
+    matchedRuleId: match.rule.id,
+    matchedPathPattern: match.rule.pathPattern,
+  };
+}
+
+export async function resolveKnowledgeTransferPathDecision(params: {
+  requesterAgentId: string;
+  targetAgentId: string;
+  side: KnowledgeTransferSide;
+  sourcePath: string;
+  baseDir?: string;
+}): Promise<KnowledgeTransferPathResolution> {
+  const store = await loadKnowledgeTransferPolicyStore(params.baseDir);
+  return resolvePathDecisionFromStore({
+    store,
+    requesterAgentId: normalizePairAgentId(params.requesterAgentId),
+    targetAgentId: normalizePairAgentId(params.targetAgentId),
+    side: params.side,
+    sourcePath: params.sourcePath,
+  });
+}
+
+export async function createKnowledgeTransferPolicyResolver(params: {
+  cfg: OpenClawConfig;
+  requesterAgentId: string;
+  targetAgentId: string;
+  baseDir?: string;
+}): Promise<{
+  defaults: KnowledgeTransferDefaults;
+  resolve: (side: KnowledgeTransferSide, sourcePath: string) => KnowledgeTransferPathResolution;
+}> {
+  const store = await loadKnowledgeTransferPolicyStore(params.baseDir);
+  const requesterAgentId = normalizePairAgentId(params.requesterAgentId);
+  const targetAgentId = normalizePairAgentId(params.targetAgentId);
+  const defaults = resolveKnowledgeTransferDefaults(params.cfg);
+  return {
+    defaults,
+    resolve: (side, sourcePath) =>
+      resolvePathDecisionFromStore({
+        store,
+        requesterAgentId,
+        targetAgentId,
+        side,
+        sourcePath,
+      }),
+  };
+}
+
+export async function listKnowledgeTransferRules(params?: {
+  requesterAgentId?: string;
+  targetAgentId?: string;
+  baseDir?: string;
+}): Promise<KnowledgeTransferPolicyRuleView[]> {
+  const store = await loadKnowledgeTransferPolicyStore(params?.baseDir);
+  const filterPairKey =
+    params?.requesterAgentId && params?.targetAgentId
+      ? buildKnowledgeTransferPairKey(params.requesterAgentId, params.targetAgentId)
+      : null;
+
+  const views: KnowledgeTransferPolicyRuleView[] = [];
+  for (const [pairKey, pairPolicy] of Object.entries(store.pairs)) {
+    if (filterPairKey && pairKey !== filterPairKey) {
+      continue;
+    }
+    const pair = splitPairKey(pairKey);
+    if (!pair) {
+      continue;
+    }
+    for (const rule of pairPolicy.rules) {
+      views.push({
+        requesterAgentId: pair.requesterAgentId,
+        targetAgentId: pair.targetAgentId,
+        id: rule.id,
+        side: rule.side,
+        pathPattern: rule.pathPattern,
+        decision: rule.decision,
+        updatedAtMs: rule.updatedAtMs,
+      });
+    }
+  }
+
+  views.sort((a, b) => {
+    const pairA = `${a.requesterAgentId}|${a.targetAgentId}`;
+    const pairB = `${b.requesterAgentId}|${b.targetAgentId}`;
+    if (pairA !== pairB) {
+      return pairA.localeCompare(pairB);
+    }
+    if (a.side !== b.side) {
+      return a.side.localeCompare(b.side);
+    }
+    if (a.pathPattern !== b.pathPattern) {
+      return a.pathPattern.localeCompare(b.pathPattern);
+    }
+    return a.updatedAtMs - b.updatedAtMs;
+  });
+
+  return views;
+}
+
+export async function upsertKnowledgeTransferRule(params: {
+  requesterAgentId: string;
+  targetAgentId: string;
+  side: KnowledgeTransferSide;
+  pathPattern: string;
+  decision: KnowledgeTransferRuleDecision;
+  id?: string;
+  baseDir?: string;
+}): Promise<{ store: KnowledgeTransferPolicyStore; rule: KnowledgeTransferRule }> {
+  const filePath = resolvePath(params.baseDir);
+  return await withLock(async () => {
+    const store = sanitizeStore(await readJsonFile<KnowledgeTransferPolicyStore>(filePath));
+    const now = Date.now();
+    const pairKey = buildKnowledgeTransferPairKey(params.requesterAgentId, params.targetAgentId);
+    const pairPolicy = store.pairs[pairKey] ?? { updatedAtMs: 0, rules: [] };
+
+    const ruleId =
+      typeof params.id === "string" && params.id.trim() ? params.id.trim() : randomUUID();
+    const normalizedRule: KnowledgeTransferRule = {
+      id: ruleId,
+      side: params.side,
+      pathPattern: normalizePathPattern(params.pathPattern),
+      decision: params.decision,
+      updatedAtMs: now,
+    };
+
+    const existingIndex = pairPolicy.rules.findIndex((rule) => rule.id === ruleId);
+    if (existingIndex >= 0) {
+      pairPolicy.rules[existingIndex] = normalizedRule;
+    } else {
+      pairPolicy.rules.push(normalizedRule);
+    }
+
+    pairPolicy.updatedAtMs = now;
+    store.pairs[pairKey] = pairPolicy;
+    store.updatedAtMs = now;
+    await writeJsonAtomic(filePath, store, { trailingNewline: true });
+
+    return { store, rule: normalizedRule };
+  });
+}
+
+export async function removeKnowledgeTransferRule(params: {
+  id: string;
+  requesterAgentId?: string;
+  targetAgentId?: string;
+  baseDir?: string;
+}): Promise<{ removed: boolean; pair?: { requesterAgentId: string; targetAgentId: string } }> {
+  const id = params.id.trim();
+  if (!id) {
+    return { removed: false };
+  }
+
+  const filePath = resolvePath(params.baseDir);
+  return await withLock(async () => {
+    const store = sanitizeStore(await readJsonFile<KnowledgeTransferPolicyStore>(filePath));
+
+    const targetPairKey =
+      params.requesterAgentId && params.targetAgentId
+        ? buildKnowledgeTransferPairKey(params.requesterAgentId, params.targetAgentId)
+        : null;
+
+    for (const [pairKey, pairPolicy] of Object.entries(store.pairs)) {
+      if (targetPairKey && pairKey !== targetPairKey) {
+        continue;
+      }
+      const index = pairPolicy.rules.findIndex((rule) => rule.id === id);
+      if (index < 0) {
+        continue;
+      }
+
+      pairPolicy.rules.splice(index, 1);
+      const now = Date.now();
+      pairPolicy.updatedAtMs = now;
+      store.updatedAtMs = now;
+
+      if (pairPolicy.rules.length === 0) {
+        delete store.pairs[pairKey];
+      } else {
+        store.pairs[pairKey] = pairPolicy;
+      }
+
+      await writeJsonAtomic(filePath, store, { trailingNewline: true });
+      const pair = splitPairKey(pairKey);
+      return {
+        removed: true,
+        ...(pair ? { pair } : {}),
+      };
+    }
+
+    return { removed: false };
+  });
+}
+
+export async function listKnowledgeTransferPairPolicies(params?: {
+  baseDir?: string;
+}): Promise<
+  Array<{ requesterAgentId: string; targetAgentId: string; mode: KnowledgeTransferMode }>
+> {
+  const store = await loadKnowledgeTransferPolicyStore(params?.baseDir);
+  const entries: Array<{
+    requesterAgentId: string;
+    targetAgentId: string;
+    mode: KnowledgeTransferMode;
+  }> = [];
+
+  for (const pairKey of Object.keys(store.pairs)) {
+    const pair = splitPairKey(pairKey);
+    if (!pair) {
+      continue;
+    }
+    const match = findRuleMatch({
+      store,
+      requesterAgentId: pair.requesterAgentId,
+      targetAgentId: pair.targetAgentId,
+      side: "export",
+      sourcePath: "*",
+    });
+    const mode =
+      match?.rule.decision === "ask" || match?.rule.decision === "auto"
+        ? match.rule.decision
+        : "ask";
+    entries.push({
+      requesterAgentId: pair.requesterAgentId,
+      targetAgentId: pair.targetAgentId,
+      mode,
+    });
+  }
+
+  entries.sort((a, b) =>
+    `${a.requesterAgentId}|${a.targetAgentId}`.localeCompare(
+      `${b.requesterAgentId}|${b.targetAgentId}`,
+    ),
+  );
+  return entries;
+}
+
+export async function setKnowledgeTransferPairMode(params: {
+  requesterAgentId: string;
+  targetAgentId: string;
+  mode: KnowledgeTransferMode;
+  baseDir?: string;
+}): Promise<KnowledgeTransferPolicyStore> {
+  const filePath = resolvePath(params.baseDir);
+  return await withLock(async () => {
+    const store = sanitizeStore(await readJsonFile<KnowledgeTransferPolicyStore>(filePath));
+    const now = Date.now();
+    const pairKey = buildKnowledgeTransferPairKey(params.requesterAgentId, params.targetAgentId);
+    const pairPolicy = store.pairs[pairKey] ?? { updatedAtMs: 0, rules: [] };
+
+    pairPolicy.rules = pairPolicy.rules.filter(
+      (rule) => !(rule.pathPattern === "*" && (rule.side === "export" || rule.side === "import")),
+    );
+
+    pairPolicy.rules.push(
+      {
+        id: randomUUID(),
+        side: "export",
+        pathPattern: "*",
+        decision: params.mode,
+        updatedAtMs: now,
+      },
+      {
+        id: randomUUID(),
+        side: "import",
+        pathPattern: "*",
+        decision: params.mode,
+        updatedAtMs: now,
+      },
+    );
+
+    pairPolicy.updatedAtMs = now;
+    store.pairs[pairKey] = pairPolicy;
+    store.updatedAtMs = now;
+    await writeJsonAtomic(filePath, store, { trailingNewline: true });
+    return store;
+  });
+}
+
+export async function resolveKnowledgeTransferMode(params: {
+  cfg: OpenClawConfig;
+  requesterAgentId: string;
+  targetAgentId: string;
+  baseDir?: string;
+}): Promise<KnowledgeTransferModeResolution> {
+  const store = await loadKnowledgeTransferPolicyStore(params.baseDir);
+  const requesterAgentId = normalizePairAgentId(params.requesterAgentId);
+  const targetAgentId = normalizePairAgentId(params.targetAgentId);
+  const defaults = resolveKnowledgeTransferDefaults(params.cfg);
+
+  const match = findRuleMatch({
+    store,
+    requesterAgentId,
+    targetAgentId,
+    side: "export",
+    sourcePath: "*",
+  });
+  if (match && (match.rule.decision === "ask" || match.rule.decision === "auto")) {
+    return {
+      mode: match.rule.decision,
+      source: match.source,
+      matchedPair: match.matchedPair,
+      defaults,
+    };
+  }
+
+  return {
+    mode: defaults.defaultMode,
+    source: "default",
+    defaults,
+  };
+}

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1490,7 +1490,7 @@ description: test skill
       channels: {
         feishu: {
           appId: "cli_test",
-          appSecret: "secret_test",
+          appSecret: "secret_test", // pragma: allowlist secret
         },
       },
     };
@@ -1522,7 +1522,7 @@ description: test skill
       channels: {
         feishu: {
           appId: "cli_test",
-          appSecret: "secret_test",
+          appSecret: "secret_test", // pragma: allowlist secret
           tools: { doc: false },
         },
       },
@@ -1978,8 +1978,8 @@ description: test skill
             mode: "http",
             botTokenSource: "config",
             botTokenStatus: "available",
-            signingSecretSource: "config",
-            signingSecretStatus: "available",
+            signingSecretSource: "config", // pragma: allowlist secret
+            signingSecretStatus: "available", // pragma: allowlist secret
             config: channel,
           };
         },
@@ -2042,8 +2042,8 @@ description: test skill
               mode: "http",
               botTokenSource: "config",
               botTokenStatus: "configured_unavailable",
-              signingSecretSource: "config",
-              signingSecretStatus: "configured_unavailable",
+              signingSecretSource: "config", // pragma: allowlist secret
+              signingSecretStatus: "configured_unavailable", // pragma: allowlist secret
               config: channel,
             };
           }

--- a/src/security/audit.test.ts
+++ b/src/security/audit.test.ts
@@ -1966,8 +1966,8 @@ description: test skill
               mode: "http",
               botTokenSource: "config",
               botTokenStatus: "configured_unavailable",
-              signingSecretSource: "config",
-              signingSecretStatus: "configured_unavailable",
+              signingSecretSource: "config", // pragma: allowlist secret
+              signingSecretStatus: "configured_unavailable", // pragma: allowlist secret
               config: channel,
             };
           }
@@ -2054,8 +2054,8 @@ description: test skill
             mode: "http",
             botTokenSource: "config",
             botTokenStatus: "available",
-            signingSecretSource: "config",
-            signingSecretStatus: "missing",
+            signingSecretSource: "config", // pragma: allowlist secret
+            signingSecretStatus: "missing", // pragma: allowlist secret
             config: channel,
           };
         },

--- a/src/security/dangerous-tools.ts
+++ b/src/security/dangerous-tools.ts
@@ -11,6 +11,8 @@ export const DEFAULT_GATEWAY_HTTP_TOOL_DENY = [
   "sessions_spawn",
   // Cross-session injection — message injection across sessions
   "sessions_send",
+  // Cross-agent memory import flow — requires user approval workflow
+  "sessions_transfer_knowledge",
   // Persistent automation control plane — can create/update/remove scheduled runs
   "cron",
   // Gateway control plane — prevents gateway reconfiguration via HTTP
@@ -29,6 +31,7 @@ export const DANGEROUS_ACP_TOOL_NAMES = [
   "shell",
   "sessions_spawn",
   "sessions_send",
+  "sessions_transfer_knowledge",
   "gateway",
   "fs_write",
   "fs_delete",


### PR DESCRIPTION
## Summary

- This PR introduces a formal **agent-to-agent learning** mechanism in OpenClaw.
- The core objective is to let one agent learn structured knowledge from another agent, under explicit policy and approval controls.
- Learning is implemented through `sessions_transfer_knowledge`, which reads candidate memory items from a source agent and imports approved items into the requester agent's transfer memory.
- The design is intentionally governed: export and import are evaluated independently, so learning only occurs when both sides permit it.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [x] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## Agent-to-Agent Learning Design

- Added `sessions_transfer_knowledge` as the dedicated tool for cross-agent learning.
- Added path-aware policy decisions (`hide|ask|auto`) for both directions:
  - **export**: what the source agent may expose
  - **import**: what the requester agent may accept
- Added wildcard and pair-specific matching so teams can define broad defaults and strict pair overrides.
- Added approval lifecycle methods and broadcasts:
  - `knowledge.transfer.approval.request`
  - `knowledge.transfer.approval.wait`
  - `knowledge.transfer.approval.resolve`
  - `knowledge.transfer.approval.pending`
  - `knowledge.transfer.approval.resolved`
- Added `/learn` command surface for formal operator control:
  - approve/deny pending learning events
  - configure default pair learning mode
  - add/remove/list path-level learning rules
  - inspect effective learning status

## User-visible / Behavior Changes

- New agent-to-agent learning tool: `sessions_transfer_knowledge`.
- New command family: `/learn approve|deny|mode|rule add|rule remove|rule list|status`.
- New config namespace: `tools.agentToAgent.knowledgeTransfer.*`.
- New documentation for session-tool learning flow and slash-command controls.

## Security Impact (required)

- New permissions/capabilities? (`Yes`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`Yes`)
- Command/tool execution surface changed? (`Yes`)
- Data access scope changed? (`Yes`)
- If any `Yes`, explain risk + mitigation:
  - Risk: uncontrolled transfer of memory between agents.
  - Mitigation: learning is gated by default-disabled policy, dual-side rule evaluation, approval requirements for `ask`, scoped path rules, method-scope enforcement, and HTTP restrictions for dangerous tools.

## Repro + Verification

### Environment

- OS: Darwin 24.3.0
- Runtime/container: Node v22.19.0 / pnpm 10.23.0
- Model/provider: N/A (tooling + gateway + command layer)
- Integration/channel (if any): command and gateway paths

### Steps

1. Configure learning policy with `/learn mode` and `/learn rule add` for export/import paths.
2. Execute `sessions_transfer_knowledge` from requester agent to source agent.
3. Approve or deny learning prompts via `/learn approve` and `/learn deny`.
4. Re-run to validate deduplication and stable outcomes.

### Expected

- Agent-to-agent learning occurs only when export and import policy both permit it.
- `ask` requires approval; `hide` blocks; `auto` proceeds.
- Repeated transfers skip duplicates using transfer fingerprints.

### Actual

- Matches expected outcomes across approval, deny, auto, and dedupe paths in tests.

## Evidence

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Validation run:

- `pnpm check` (pass)
- `pnpm build` (pass)
- `pnpm test src/agents/openclaw-tools.sessions-transfer.test.ts src/agents/openclaw-tools.sessions.test.ts src/gateway/tools-invoke-http.test.ts src/infra/knowledge-transfer-policy.test.ts src/auto-reply/reply/commands.test.ts src/gateway/method-scopes.test.ts src/gateway/gateway-misc.test.ts` (pass, 7 files / 128 tests)

## Human Verification (required)

- Verified scenarios:
  - End-to-end tool wiring for agent-to-agent learning requests.
  - Approval manager lifecycle and gateway method routing.
  - `/learn` authorization and policy updates.
  - HTTP/method-scope protections for high-risk paths.
- Edge cases checked:
  - Pair-vs-wildcard precedence, side-specific rules, last-match rule semantics.
  - Duplicate transfer suppression by fingerprint.
  - Unknown/expired approval handling.
- What you did **not** verify:
  - Manual live-channel validation with production operator clients.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No` required; optional configuration only)
- Migration needed? (`No`)

## Failure Recovery (if this breaks)

- Disable agent-to-agent learning by setting `tools.agentToAgent.knowledgeTransfer.enabled=false`.
- Optionally hard-stop learning with `hide` rules via `/learn rule add`.

## Risks and Mitigations

- Risk: overly broad wildcard rules may permit unintended learning.
  - Mitigation: pair-level overrides, explicit path rules, and default-deny behavior when no rule matches.
- Risk: no active approver may stall ask-mode learning.
  - Mitigation: timeout and expiration handling in approval manager.
- Risk: transfer store growth over time.
  - Mitigation: fingerprint-based deduplication of imported knowledge.
