### PR TITLE
feat(hooks): expose rate limit headers in llm_output hook

### DIFF
--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -1541,6 +1541,7 @@ export async function runEmbeddedAttempt(
         getLastToolError,
         getUsageTotals,
         getCompactionCount,
+        getLastAssistantRateLimits,
       } = subscription;
 
       const queueHandle: EmbeddedPiQueueHandle = {
@@ -2008,6 +2009,8 @@ export async function runEmbeddedAttempt(
               assistantTexts,
               lastAssistant,
               usage: getUsageTotals(),
+              // TODO(pi-ai): This is a placeholder. Rate limit headers need to be exposed
+              rateLimits: getLastAssistantRateLimits(),
             },
             {
               agentId: hookAgentId,

--- a/src/agents/pi-embedded-subscribe.ts
+++ b/src/agents/pi-embedded-subscribe.ts
@@ -691,6 +691,8 @@ export function subscribeEmbeddedPiSession(params: SubscribeEmbeddedPiSessionPar
     getLastToolError: () => (state.lastToolError ? { ...state.lastToolError } : undefined),
     getUsageTotals,
     getCompactionCount: () => compactionCount,
+    getLastAssistantRateLimits: (): Record<string, string> | undefined =>
+      (state.lastAssistant as { rateLimits?: Record<string, string> } | undefined)?.rateLimits,
     waitForCompactionRetry: () => {
       // Reject after unsubscribe so callers treat it as cancellation, not success
       if (state.unsubscribed) {

--- a/src/plugins/types.ts
+++ b/src/plugins/types.ts
@@ -508,6 +508,8 @@ export type PluginHookLlmOutputEvent = {
     cacheWrite?: number;
     total?: number;
   };
+  /** Raw rate limit headers from the LLM provider, if available. */
+  rateLimits?: Record<string, string>;
 };
 
 // agent_end hook


### PR DESCRIPTION
## Summary

Adds a `rateLimits` field to the `PluginHookLlmOutputEvent` type and wires it through in `attempt.ts`, so plugins can read provider rate limit headers (e.g. `anthropic-ratelimit-tokens-remaining`) from the `llm_output` hook.

## Motivation

Plugins that want to dynamically throttle model usage (e.g. auto-switching from Opus to Sonnet when approaching rate limits) currently have no way to access the rate limit headers that Anthropic (and other providers) return on every API response. These headers include:
- `anthropic-ratelimit-tokens-limit`
- `anthropic-ratelimit-tokens-remaining`
- `anthropic-ratelimit-tokens-reset`
- (and similar for input/output tokens separately)

This change prepares the plugin hook interface to receive this data.

## Changes

- `src/plugins/types.ts`: Added optional `rateLimits?: Record<string, string>` to `PluginHookLlmOutputEvent`
- `src/agents/pi-embedded-runner/run/attempt.ts`: Passes `lastAssistant.rateLimits` (if present) through to the hook

## Upstream dependency

The `rateLimits` field will be `undefined` until `@mariozechner/pi-ai` is updated to capture and attach the raw rate limit response headers to the assistant message output object. The Anthropic SDK (`@anthropic-ai/sdk`) already exposes these headers on `MessageStream.response.headers` — pi-ai just needs to read them.

This PR is intentionally minimal so it can land independently; the pi-ai change can follow.