### PR TITLE
fix(feishu): reply inside thread for P2P direct messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Docs: https://docs.openclaw.ai
 - Channels/Telegram: persist native command metadata on target sessions so topic, helper, and ACP-bound slash commands keep their session metadata attached to the routed conversation. (#57548) Thanks @GaosCode.
 - Channels/native commands: keep validated native slash command replies visible in group chats while preserving explicit owner allowlists for command authorization. (#73672) Thanks @obviyus.
 - Auto-reply/session: carry the tail of user/assistant turns into the freshly-rotated transcript on silent in-reply session resets (compaction failure, role-ordering conflict) so direct-chat continuity survives the rebind. Fixes #70853. (#70898) Thanks @neeravmakwana.
+- Feishu: reply inside P2P direct-message threads when Feishu provides `thread_id`, while preserving plain P2P quote replies outside thread mode. Fixes #38806; carries forward #38808; refs #66631 for topic-group follow-up. Thanks @LiaoyuanNing and @vincentkoc.
 
 ## 2026.4.27
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2959,8 +2959,8 @@ describe("handleFeishuMessage command authorization", () => {
       sender: { sender_id: { open_id: "ou-dm-thread-user" } },
       message: {
         message_id: "om_dm_thread_reply",
-        root_id: "om_dm_thread_root",
-        thread_id: "omt_dm_thread",
+        root_id: " om_dm_thread_root ",
+        thread_id: " omt_dm_thread ",
         chat_id: "oc-dm",
         chat_type: "p2p",
         message_type: "text",

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -435,6 +435,41 @@ describe("handleFeishuMessage ACP routing", () => {
     );
   });
 
+  it("keeps configured ACP initialization failures inside Feishu p2p threads", async () => {
+    mockResolveConfiguredBindingRoute.mockReturnValue(createConfiguredFeishuRoute());
+    mockEnsureConfiguredBindingRouteReady.mockResolvedValue(
+      createConfiguredBindingReadiness(false, "runtime unavailable"),
+    );
+
+    await dispatchMessage({
+      cfg: {
+        session: { mainKey: "main", scope: "per-sender" },
+        channels: { feishu: { enabled: true, allowFrom: ["ou_sender_1"], dmPolicy: "open" } },
+      },
+      event: {
+        sender: { sender_id: { open_id: "ou_sender_1" } },
+        message: {
+          message_id: "om_acp_failure_dm_thread_reply",
+          root_id: "om_dm_thread_root",
+          thread_id: "omt_dm_thread",
+          chat_id: "oc_dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello in p2p thread" }),
+        },
+      },
+    });
+
+    expect(mockSendMessageFeishu).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "chat:oc_dm",
+        replyToMessageId: "om_dm_thread_root",
+        replyInThread: true,
+        text: expect.stringContaining("runtime unavailable"),
+      }),
+    );
+  });
+
   it("routes Feishu topic messages through active bound conversations", async () => {
     mockResolveBoundConversation.mockReturnValue(createBoundConversation());
 

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2944,6 +2944,79 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("replies to topic root in p2p thread message (thread_id present)", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-dm-thread-user" } },
+      message: {
+        message_id: "om_dm_thread_reply",
+        root_id: "om_dm_thread_root",
+        thread_id: "omt_dm_thread",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello in p2p thread" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_dm_thread_root",
+        skipReplyToInMessages: false,
+        rootId: "om_dm_thread_root",
+        replyInThread: true,
+        threadReply: true,
+      }),
+    );
+  });
+
+  it("replies to triggering message in p2p plain reply (root_id only, no thread_id)", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-dm-reply-user" } },
+      message: {
+        message_id: "om_dm_plain_reply",
+        root_id: "om_dm_original_msg",
+        chat_id: "oc-dm",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "just a quote reply in p2p" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_dm_plain_reply",
+        skipReplyToInMessages: true,
+        rootId: "om_dm_original_msg",
+        replyInThread: false,
+        threadReply: false,
+      }),
+    );
+  });
+
   it("does not dispatch twice for the same image message_id (concurrent dedupe)", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -805,9 +805,10 @@ export async function handleFeishuMessage(params: {
       });
       if (!ensured.ok) {
         const replyTargetMessageId =
-          isGroup &&
-          (groupSession?.groupSessionScope === "group_topic" ||
-            groupSession?.groupSessionScope === "group_topic_sender")
+          (isGroup &&
+            (groupSession?.groupSessionScope === "group_topic" ||
+              groupSession?.groupSessionScope === "group_topic_sender")) ||
+          directThreadMessage
             ? (ctx.rootId ?? ctx.messageId)
             : ctx.messageId;
         await sendMessageFeishu({
@@ -815,7 +816,7 @@ export async function handleFeishuMessage(params: {
           to: `chat:${ctx.chatId}`,
           text: `⚠️ Failed to initialize the configured ACP session for this Feishu conversation: ${ensured.error}`,
           replyToMessageId: replyTargetMessageId,
-          replyInThread: isGroup ? (groupSession?.replyInThread ?? false) : false,
+          replyInThread: isGroup ? (groupSession?.replyInThread ?? false) : directThreadMessage,
           accountId: account.accountId,
         }).catch((err) => {
           log(`feishu[${account.accountId}]: failed to send ACP init error reply: ${String(err)}`);

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -246,9 +246,9 @@ export function parseFeishuMessageEvent(
     chatType: event.message.chat_type,
     mentionedBot,
     hasAnyMention,
-    rootId: event.message.root_id || undefined,
-    parentId: event.message.parent_id || undefined,
-    threadId: event.message.thread_id || undefined,
+    rootId: event.message.root_id?.trim() || undefined,
+    parentId: event.message.parent_id?.trim() || undefined,
+    threadId: event.message.thread_id?.trim() || undefined,
     content,
     contentType: event.message.message_type,
   };

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -701,7 +701,11 @@ export async function handleFeishuMessage(params: {
     const feishuTo = isGroup ? `chat:${ctx.chatId}` : `user:${ctx.senderOpenId}`;
     const peerId = isGroup ? (groupSession?.peerId ?? ctx.chatId) : ctx.senderOpenId;
     const parentPeer = isGroup ? (groupSession?.parentPeer ?? null) : null;
-    const replyInThread = isGroup ? (groupSession?.replyInThread ?? false) : false;
+    // P2P thread messages (thread_id present) need reply_in_thread so the
+    // response stays inside the Feishu thread container, not just as an inline
+    // reply to the root message.
+    const directThreadMessage = isDirect && Boolean(ctx.threadId);
+    const replyInThread = isGroup ? (groupSession?.replyInThread ?? false) : directThreadMessage;
     const feishuAcpConversationSupported =
       !isGroup ||
       groupSession?.groupSessionScope === "group_topic" ||
@@ -1196,11 +1200,19 @@ export async function handleFeishuMessage(params: {
       });
     };
 
-    // Determine reply target based on group session mode:
-    // - Topic-mode groups (group_topic / group_topic_sender): reply to the topic
-    //   root so the bot stays in the same thread.
-    // - Groups with explicit replyInThread config: reply to the root so the bot
-    //   stays in the thread the user expects.
+    // Determine reply target:
+    //
+    // P2P (direct) chats:
+    // - Thread messages (thread_id present): reply to the topic root so
+    //   the bot's reply stays inside the thread.
+    // - Plain reply (root_id only, no thread_id): reply to the triggering
+    //   message; root_id is just a quote reference, not a thread container.
+    //
+    // Group chats:
+    // - Topic-mode groups (group_topic / group_topic_sender): reply to the
+    //   topic root so the bot stays in the same thread.
+    // - Groups with explicit replyInThread config: reply to the root so the
+    //   bot stays in the thread the user expects.
     // - Normal groups (auto-detected threadReply from root_id): reply to the
     //   triggering message itself. Using rootId here would silently push the
     //   reply into a topic thread invisible in the main chat view (#32980).
@@ -1212,12 +1224,12 @@ export async function handleFeishuMessage(params: {
       isGroup &&
       (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
     const replyTargetMessageId =
-      isTopicSession || configReplyInThread
+      directThreadMessage || isTopicSession || configReplyInThread
         ? (ctx.rootId ??
           ctx.replyTargetMessageId ??
           (ctx.suppressReplyTarget ? undefined : ctx.messageId))
         : (ctx.replyTargetMessageId ?? (ctx.suppressReplyTarget ? undefined : ctx.messageId));
-    const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
+    const threadReply = isGroup ? (groupSession?.threadReply ?? false) : directThreadMessage;
 
     if (broadcastAgents) {
       // Cross-account dedup: in multi-account setups, Feishu delivers the same
@@ -1276,7 +1288,7 @@ export async function handleFeishuMessage(params: {
             chatId: ctx.chatId,
             allowReasoningPreview,
             replyToMessageId: replyTargetMessageId,
-            skipReplyToInMessages: !isGroup,
+            skipReplyToInMessages: !isGroup && !directThreadMessage,
             replyInThread,
             rootId: ctx.rootId,
             threadReply,
@@ -1385,7 +1397,7 @@ export async function handleFeishuMessage(params: {
         chatId: ctx.chatId,
         allowReasoningPreview,
         replyToMessageId: replyTargetMessageId,
-        skipReplyToInMessages: !isGroup,
+        skipReplyToInMessages: !isGroup && !directThreadMessage,
         replyInThread,
         rootId: ctx.rootId,
         threadReply,


### PR DESCRIPTION
## Summary

  - Fix bot replying outside thread in P2P (direct message) chats when user sends a message inside a Feishu thread
  - Distinguish between thread messages (`thread_id` present) and plain quote replies (`root_id` only) per the Feishu API contract
  - Group chat behavior is completely unchanged — the new condition requires `isDirect=true`

  Fixes #38806 

  ## Changes

  Four targeted changes in `extensions/feishu/src/bot.ts`, all gated by `directThreadMessage = isDirect && Boolean(ctx.threadId)`:

  | Parameter | Before (P2P) | After (P2P thread) | After (P2P non-thread) |
  |-----------|-------------|-------------------|----------------------|
  | `replyInThread` | `false` | `true` | `false` (unchanged) |
  | `replyTargetMessageId` | `ctx.messageId` | `ctx.rootId` | `ctx.messageId` (unchanged) |
  | `threadReply` | `false` | `true` | `false` (unchanged) |
  | `skipReplyToInMessages` | `true` | `false` | `true` (unchanged) |

  ## Test plan

  - [x] Added test: P2P thread message (thread_id present) → replies to root with `replyInThread=true`
  - [x] Added test: P2P plain reply (root_id only, no thread_id) → replies to triggering message with `replyInThread=false`
  - [x] All 54 existing feishu bot tests pass
  - [ ] Manual verification: send message in P2P thread, confirm bot replies inside thread
