### PR TITLE
fix(agents): extend thinking blocks cleanup to all Anthropic providers

### DIFF
--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -98,8 +98,10 @@ export function resolveTranscriptPolicy(params: {
 
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").
-  // Drop these blocks at send-time to keep sessions usable.
-  const dropThinkingBlocks = isCopilotClaude;
+  // Anthropic APIs also have issues with thinking blocks when thinking configuration
+  // changes in persistent sessions (e.g., cron sessions). Drop these blocks at
+  // send-time to keep sessions usable.
+  const dropThinkingBlocks = isCopilotClaude || isAnthropic;
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 


### PR DESCRIPTION
## Problem

When thinking configuration changes in persistent sessions (e.g., cron sessions switching from `thinking='high'` to `thinking='off'`), Anthropic API rejects requests with:

```
thinking or redacted_thinking blocks in the latest assistant message cannot be modified
```

This happens because:
1. A session was created with `thinking: 'high'` enabled
2. The agent config was later changed to `thinking: 'off'`
3. Cron jobs reuse the existing session which still contains thinking blocks
4. Anthropic API rejects the request due to configuration mismatch

## Solution

Extend the existing `dropThinkingBlocks` logic in `transcript-policy.ts` to cover all Anthropic-compatible providers, not just GitHub Copilot Claude.

### Changes

```typescript
// Before: only GitHub Copilot Claude
const dropThinkingBlocks = isCopilotClaude;

// After: all Anthropic providers
const dropThinkingBlocks = isCopilotClaude || isAnthropic;
```

## Testing

- Verified that cron sessions now work correctly after thinking config changes
- Existing behavior for GitHub Copilot Claude preserved
- Non-Anthropic providers (OpenAI, OpenRouter, etc.) unaffected

## Related

- Extends the fix from PR #19459 which introduced thinking block cleanup for GitHub Copilot Claude
