### PR TITLE
fix(agents): clarify unavailable core tool warnings

### DIFF
--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -67,6 +67,28 @@ describe("tool-policy-pipeline", () => {
     ]);
   });
 
+  test("warns when an unavailable-core-only allowlist is ignored to preserve active core tools", () => {
+    const warnings: string[] = [];
+    const tools = [{ name: "exec" }, { name: "read" }] as unknown as DummyTool[];
+    applyToolPolicyPipeline({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      tools: tools as any,
+      // oxlint-disable-next-line typescript/no-explicit-any
+      toolMeta: () => undefined,
+      warn: (msg) => warnings.push(msg),
+      steps: [
+        {
+          policy: { allow: ["apply_patch", "cron"] },
+          label: "tools.profile (coding)",
+          stripPluginOnlyAllowlist: true,
+        },
+      ],
+    });
+    expect(warnings).toEqual([
+      "tools: tools.profile (coding) allowlist includes known tools unavailable in this runtime context (apply_patch, cron). Ignoring allowlist so core tools remain available. Use tools.alsoAllow for additive plugin tool enablement.",
+    ]);
+  });
+
   test("applies allowlist filtering when core tools are explicitly listed", () => {
     const tools = [{ name: "exec" }, { name: "process" }] as unknown as DummyTool[];
     const filtered = applyToolPolicyPipeline({

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -45,6 +45,28 @@ describe("tool-policy-pipeline", () => {
     expect(warnings[0]).toContain("unknown entries (wat)");
   });
 
+  test("warns when known core tools are unavailable in the active runtime context", () => {
+    const warnings: string[] = [];
+    const tools = [{ name: "exec" }, { name: "read" }] as unknown as DummyTool[];
+    applyToolPolicyPipeline({
+      // oxlint-disable-next-line typescript/no-explicit-any
+      tools: tools as any,
+      // oxlint-disable-next-line typescript/no-explicit-any
+      toolMeta: () => undefined,
+      warn: (msg) => warnings.push(msg),
+      steps: [
+        {
+          policy: { allow: ["read", "apply_patch", "cron"] },
+          label: "tools.profile (coding)",
+          stripPluginOnlyAllowlist: true,
+        },
+      ],
+    });
+    expect(warnings).toEqual([
+      "tools: tools.profile (coding) allowlist includes known tools unavailable in this runtime context (apply_patch, cron).",
+    ]);
+  });
+
   test("applies allowlist filtering when core tools are explicitly listed", () => {
     const tools = [{ name: "exec" }, { name: "process" }] as unknown as DummyTool[];
     const filtered = applyToolPolicyPipeline({

--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -91,8 +91,11 @@ export function applyToolPolicyPipeline(params: {
       const resolved = stripPluginOnlyAllowlist(policy, pluginGroups, coreToolNames);
       if (resolved.unavailableCoreAllowlist.length > 0) {
         const entries = resolved.unavailableCoreAllowlist.join(", ");
+        const suffix = resolved.strippedAllowlist
+          ? " Ignoring allowlist so core tools remain available. Use tools.alsoAllow for additive plugin tool enablement."
+          : "";
         params.warn(
-          `tools: ${step.label} allowlist includes known tools unavailable in this runtime context (${entries}).`,
+          `tools: ${step.label} allowlist includes known tools unavailable in this runtime context (${entries}).${suffix}`,
         );
       }
       if (resolved.unknownAllowlist.length > 0) {

--- a/src/agents/tool-policy-pipeline.ts
+++ b/src/agents/tool-policy-pipeline.ts
@@ -89,6 +89,12 @@ export function applyToolPolicyPipeline(params: {
     let policy: ToolPolicyLike | undefined = step.policy;
     if (step.stripPluginOnlyAllowlist) {
       const resolved = stripPluginOnlyAllowlist(policy, pluginGroups, coreToolNames);
+      if (resolved.unavailableCoreAllowlist.length > 0) {
+        const entries = resolved.unavailableCoreAllowlist.join(", ");
+        params.warn(
+          `tools: ${step.label} allowlist includes known tools unavailable in this runtime context (${entries}).`,
+        );
+      }
       if (resolved.unknownAllowlist.length > 0) {
         const entries = resolved.unknownAllowlist.join(", ");
         const suffix = resolved.strippedAllowlist

--- a/src/agents/tool-policy-shared.ts
+++ b/src/agents/tool-policy-shared.ts
@@ -1,5 +1,6 @@
 import {
   CORE_TOOL_GROUPS,
+  isKnownCoreToolId,
   resolveCoreToolProfilePolicy,
   type ToolProfileId,
 } from "./tool-catalog.js";
@@ -46,4 +47,5 @@ export function resolveToolProfilePolicy(profile?: string): ToolProfilePolicy | 
   return resolveCoreToolProfilePolicy(profile);
 }
 
+export { isKnownCoreToolId };
 export type { ToolProfileId };

--- a/src/agents/tool-policy.plugin-only-allowlist.test.ts
+++ b/src/agents/tool-policy.plugin-only-allowlist.test.ts
@@ -53,4 +53,16 @@ describe("stripPluginOnlyAllowlist", () => {
     expect(policy.policy?.allow).toEqual(["read", "lobster"]);
     expect(policy.unknownAllowlist).toEqual(["lobster"]);
   });
+
+  it("reports known core tools that are unavailable in the active runtime toolset", () => {
+    const emptyPlugins: PluginToolGroups = { all: [], byPlugin: new Map() };
+    const policy = stripPluginOnlyAllowlist(
+      { allow: ["read", "apply_patch", "cron"] },
+      emptyPlugins,
+      coreTools,
+    );
+    expect(policy.policy?.allow).toEqual(["read", "apply_patch", "cron"]);
+    expect(policy.unknownAllowlist).toEqual([]);
+    expect(policy.unavailableCoreAllowlist).toEqual(["apply_patch", "cron"]);
+  });
 });

--- a/src/agents/tool-policy.ts
+++ b/src/agents/tool-policy.ts
@@ -1,5 +1,6 @@
 import {
   expandToolGroups,
+  isKnownCoreToolId,
   normalizeToolList,
   normalizeToolName,
   resolveToolProfilePolicy,
@@ -64,6 +65,7 @@ export type PluginToolGroups = {
 export type AllowlistResolution = {
   policy: ToolPolicyLike | undefined;
   unknownAllowlist: string[];
+  unavailableCoreAllowlist: string[];
   strippedAllowlist: boolean;
 };
 
@@ -154,15 +156,16 @@ export function stripPluginOnlyAllowlist(
   coreTools: Set<string>,
 ): AllowlistResolution {
   if (!policy?.allow || policy.allow.length === 0) {
-    return { policy, unknownAllowlist: [], strippedAllowlist: false };
+    return { policy, unknownAllowlist: [], unavailableCoreAllowlist: [], strippedAllowlist: false };
   }
   const normalized = normalizeToolList(policy.allow);
   if (normalized.length === 0) {
-    return { policy, unknownAllowlist: [], strippedAllowlist: false };
+    return { policy, unknownAllowlist: [], unavailableCoreAllowlist: [], strippedAllowlist: false };
   }
   const pluginIds = new Set(groups.byPlugin.keys());
   const pluginTools = new Set(groups.all);
   const unknownAllowlist: string[] = [];
+  const unavailableCoreAllowlist: string[] = [];
   let hasCoreEntry = false;
   for (const entry of normalized) {
     if (entry === "*") {
@@ -173,8 +176,13 @@ export function stripPluginOnlyAllowlist(
       entry === "group:plugins" || pluginIds.has(entry) || pluginTools.has(entry);
     const expanded = expandToolGroups([entry]);
     const isCoreEntry = expanded.some((tool) => coreTools.has(tool));
+    const isKnownCoreEntry = expanded.some((tool) => isKnownCoreToolId(tool));
     if (isCoreEntry) {
       hasCoreEntry = true;
+    }
+    if (!isCoreEntry && isKnownCoreEntry) {
+      unavailableCoreAllowlist.push(entry);
+      continue;
     }
     if (!isCoreEntry && !isPluginEntry) {
       unknownAllowlist.push(entry);
@@ -190,6 +198,7 @@ export function stripPluginOnlyAllowlist(
   return {
     policy: strippedAllowlist ? { ...policy, allow: undefined } : policy,
     unknownAllowlist: Array.from(new Set(unknownAllowlist)),
+    unavailableCoreAllowlist: Array.from(new Set(unavailableCoreAllowlist)),
     strippedAllowlist,
   };
 }


### PR DESCRIPTION
## Summary

Improve tool-policy warnings so known core tools that are missing from the active runtime toolset are not reported as `unknown entries`.

Previously, `tools.profile (coding)` could log warnings like:

- `allowlist contains unknown entries (apply_patch, cron)`

That was misleading when `apply_patch` and `cron` were valid built-in tools in the `coding` profile but unavailable in the specific runtime context for a turn.

## What changed

- teach `stripPluginOnlyAllowlist()` to distinguish:
  - truly unknown allowlist entries
  - known core tool ids that are unavailable in the current runtime context
- keep existing filtering behavior intact
- emit a clearer warning for the second case:
  - `allowlist includes known tools unavailable in this runtime context (...)`

## Why

This warning sends operators toward the wrong root cause. The config and built-in profile can be correct even when the per-turn active toolset omits some tools.

## Testing

- `corepack pnpm exec vitest run src/agents/tool-policy.plugin-only-allowlist.test.ts src/agents/tool-policy-pipeline.test.ts`
- `corepack pnpm exec tsc -p tsconfig.json --noEmit --pretty false` *(fails in this checkout due unrelated missing extension deps: `@pierre/diffs`, `@tloncorp/api`)*
