### PR TITLE
Fix imageModel auto-switch when primary model doesn't support vision

### DIFF
--- a/src/auto-reply/reply/get-reply.image-model-autoswitch.test.ts
+++ b/src/auto-reply/reply/get-reply.image-model-autoswitch.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
+import type { MsgContext } from "../templating.js";
 
 // Mock dependencies
 vi.mock("../../agents/model-catalog.js", () => ({
@@ -30,10 +31,10 @@ describe("resolveImageModelAutoSwitch", () => {
     vi.resetAllMocks();
   });
 
-  const baseCtx = {
+  const baseCtx: MsgContext = {
     MediaPath: undefined,
     MediaPaths: undefined,
-  } as never;
+  };
 
   const baseCfg = {} as OpenClawConfig;
   const emptyAliasIndex = { byKey: new Map(), byAlias: new Map() };
@@ -289,7 +290,12 @@ describe("resolveImageModelAutoSwitch", () => {
 
     const aliasIndex = {
       byKey: new Map([["anthropic/claude-opus-4-1", ["claude-opus"]]]),
-      byAlias: new Map([["claude-opus", { provider: "anthropic", model: "claude-opus-4-1" }]]),
+      byAlias: new Map([
+        [
+          "claude-opus",
+          { alias: "claude-opus", ref: { provider: "anthropic", model: "claude-opus-4-1" } },
+        ],
+      ]),
     };
 
     vi.mocked(loadModelCatalog).mockResolvedValue([textOnlyModel, visionModel] as never);

--- a/src/auto-reply/reply/get-reply.image-model-autoswitch.test.ts
+++ b/src/auto-reply/reply/get-reply.image-model-autoswitch.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+
+// Mock dependencies
+vi.mock("../../agents/model-catalog.js", () => ({
+  loadModelCatalog: vi.fn(),
+  findModelInCatalog: vi.fn(),
+  modelSupportsVision: vi.fn(),
+}));
+
+vi.mock("../../agents/model-selection.js", () => ({
+  resolveModelRefFromString: vi.fn(),
+}));
+
+vi.mock("../../config/model-input.js", () => ({
+  resolveAgentModelPrimaryValue: vi.fn(),
+}));
+
+import { findModelInCatalog, loadModelCatalog, modelSupportsVision } from "../../agents/model-catalog.js";
+import { resolveModelRefFromString } from "../../agents/model-selection.js";
+import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
+import { resolveImageModelAutoSwitch } from "./get-reply.js";
+
+describe("resolveImageModelAutoSwitch", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const baseCtx = {
+    MediaPath: undefined,
+    MediaPaths: undefined,
+  } as never;
+
+  const baseCfg = {} as OpenClawConfig;
+
+  it("returns original provider/model when no images are present", async () => {
+    vi.mocked(loadModelCatalog).mockResolvedValue([]);
+    vi.mocked(modelSupportsVision).mockReturnValue(false);
+
+    const result = await resolveImageModelAutoSwitch({
+      provider: "deepseek",
+      model: "deepseek-r1",
+      ctx: baseCtx,
+      cfg: baseCfg,
+      hasResolvedHeartbeatModelOverride: false,
+      hasSessionModelOverride: false,
+    });
+
+    expect(result).toEqual({ provider: "deepseek", model: "deepseek-r1" });
+  });
+
+  it("returns original provider/model when heartbeat model override is active", async () => {
+    const ctxWithImage = { ...baseCtx, MediaPath: "/tmp/image.png" };
+    vi.mocked(loadModelCatalog).mockResolvedValue([]);
+
+    const result = await resolveImageModelAutoSwitch({
+      provider: "deepseek",
+      model: "deepseek-r1",
+      ctx: ctxWithImage,
+      cfg: baseCfg,
+      hasResolvedHeartbeatModelOverride: true,
+      hasSessionModelOverride: false,
+    });
+
+    expect(result).toEqual({ provider: "deepseek", model: "deepseek-r1" });
+    expect(findModelInCatalog).not.toHaveBeenCalled();
+  });
+
+  it("returns original provider/model when session model override is active", async () => {
+    const ctxWithImage = { ...baseCtx, MediaPath: "/tmp/image.png" };
+    vi.mocked(loadModelCatalog).mockResolvedValue([]);
+
+    const result = await resolveImageModelAutoSwitch({
+      provider: "deepseek",
+      model: "deepseek-r1",
+      ctx: ctxWithImage,
+      cfg: baseCfg,
+      hasResolvedHeartbeatModelOverride: false,
+      hasSessionModelOverride: true,
+    });
+
+    expect(result).toEqual({ provider: "deepseek", model: "deepseek-r1" });
+    expect(findModelInCatalog).not.toHaveBeenCalled();
+  });
+
+  it("returns original provider/model when current model supports vision", async () => {
+    const ctxWithImage = { ...baseCtx, MediaPath: "/tmp/image.png" };
+    const textOnlyModel = { provider: "deepseek", id: "deepseek-r1", input: [] };
+    const visionModel = { provider: "anthropic", id: "claude-opus-4-1", input: ["text", "image"] };
+    vi.mocked(loadModelCatalog).mockResolvedValue([textOnlyModel, visionModel] as never);
+    vi.mocked(findModelInCatalog).mockReturnValue(visionModel as never);
+    vi.mocked(modelSupportsVision).mockReturnValue(true);
+
+    const result = await resolveImageModelAutoSwitch({
+      provider: "anthropic",
+      model: "claude-opus-4-1",
+      ctx: ctxWithImage,
+      cfg: baseCfg,
+      hasResolvedHeartbeatModelOverride: false,
+      hasSessionModelOverride: false,
+    });
+
+    expect(result).toEqual({ provider: "anthropic", model: "claude-opus-4-1" });
+  });
+
+  it("returns original provider/model when no imageModel.primary is configured", async () => {
+    const ctxWithImage = { ...baseCtx, MediaPath: "/tmp/image.png" };
+    const textOnlyModel = { provider: "deepseek", id: "deepseek-r1", input: ["text"] };
+    vi.mocked(loadModelCatalog).mockResolvedValue([textOnlyModel] as never);
+    vi.mocked(findModelInCatalog).mockReturnValue(textOnlyModel as never);
+    vi.mocked(modelSupportsVision).mockReturnValue(false);
+    vi.mocked(resolveAgentModelPrimaryValue).mockReturnValue(undefined);
+
+    const result = await resolveImageModelAutoSwitch({
+      provider: "deepseek",
+      model: "deepseek-r1",
+      ctx: ctxWithImage,
+      cfg: baseCfg,
+      hasResolvedHeartbeatModelOverride: false,
+      hasSessionModelOverride: false,
+    });
+
+    expect(result).toEqual({ provider: "deepseek", model: "deepseek-r1" });
+  });
+
+  it("switches to imageModel.primary when current model doesn't support vision", async () => {
+    const ctxWithImage = { ...baseCtx, MediaPath: "/tmp/image.png" };
+    const textOnlyModel = { provider: "deepseek", id: "deepseek-r1", input: ["text"] };
+    const visionModel = { provider: "anthropic", id: "claude-opus-4-1", input: ["text", "image"] };
+    const cfg = {
+      agents: {
+        defaults: {
+          imageModel: { primary: "anthropic/claude-opus-4-1" },
+        },
+      },
+    } as OpenClawConfig;
+
+    vi.mocked(loadModelCatalog).mockResolvedValue([textOnlyModel, visionModel] as never);
+    vi.mocked(findModelInCatalog)
+      .mockReturnValueOnce(textOnlyModel as never)
+      .mockReturnValueOnce(visionModel as never);
+    vi.mocked(modelSupportsVision)
+      .mockReturnValueOnce(false)  // current model doesn't support vision
+      .mockReturnValueOnce(true);   // imageModel does support vision
+    vi.mocked(resolveAgentModelPrimaryValue).mockReturnValue("anthropic/claude-opus-4-1");
+    vi.mocked(resolveModelRefFromString).mockReturnValue({
+      ref: { provider: "anthropic", model: "claude-opus-4-1" },
+    } as never);
+
+    const result = await resolveImageModelAutoSwitch({
+      provider: "deepseek",
+      model: "deepseek-r1",
+      ctx: ctxWithImage,
+      cfg,
+      hasResolvedHeartbeatModelOverride: false,
+      hasSessionModelOverride: false,
+    });
+
+    expect(result).toEqual({ provider: "anthropic", model: "claude-opus-4-1" });
+  });
+
+  it("returns original provider/model when imageModel.primary doesn't support vision either", async () => {
+    const ctxWithImage = { ...baseCtx, MediaPath: "/tmp/image.png" };
+    const textOnlyModel = { provider: "deepseek", id: "deepseek-r1", input: ["text"] };
+    const anotherTextOnlyModel = { provider: "openai", id: "gpt-4o-mini", input: ["text"] };
+    const cfg = {
+      agents: {
+        defaults: {
+          imageModel: { primary: "openai/gpt-4o-mini" },
+        },
+      },
+    } as OpenClawConfig;
+
+    vi.mocked(loadModelCatalog).mockResolvedValue([textOnlyModel, anotherTextOnlyModel] as never);
+    vi.mocked(findModelInCatalog)
+      .mockReturnValueOnce(textOnlyModel as never)
+      .mockReturnValueOnce(anotherTextOnlyModel as never);
+    vi.mocked(modelSupportsVision).mockReturnValue(false);
+    vi.mocked(resolveAgentModelPrimaryValue).mockReturnValue("openai/gpt-4o-mini");
+    vi.mocked(resolveModelRefFromString).mockReturnValue({
+      ref: { provider: "openai", model: "gpt-4o-mini" },
+    } as never);
+
+    const result = await resolveImageModelAutoSwitch({
+      provider: "deepseek",
+      model: "deepseek-r1",
+      ctx: ctxWithImage,
+      cfg,
+      hasResolvedHeartbeatModelOverride: false,
+      hasSessionModelOverride: false,
+    });
+
+    expect(result).toEqual({ provider: "deepseek", model: "deepseek-r1" });
+  });
+
+  it("detects images from MediaPaths array", async () => {
+    const ctxWithImages = { ...baseCtx, MediaPaths: ["/tmp/a.png", "/tmp/b.png"] };
+    const textOnlyModel = { provider: "deepseek", id: "deepseek-r1", input: ["text"] };
+    const visionModel = { provider: "anthropic", id: "claude-opus-4-1", input: ["text", "image"] };
+    const cfg = {
+      agents: {
+        defaults: {
+          imageModel: { primary: "anthropic/claude-opus-4-1" },
+        },
+      },
+    } as OpenClawConfig;
+
+    vi.mocked(loadModelCatalog).mockResolvedValue([textOnlyModel, visionModel] as never);
+    vi.mocked(findModelInCatalog)
+      .mockReturnValueOnce(textOnlyModel as never)
+      .mockReturnValueOnce(visionModel as never);
+    vi.mocked(modelSupportsVision)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    vi.mocked(resolveAgentModelPrimaryValue).mockReturnValue("anthropic/claude-opus-4-1");
+    vi.mocked(resolveModelRefFromString).mockReturnValue({
+      ref: { provider: "anthropic", model: "claude-opus-4-1" },
+    } as never);
+
+    const result = await resolveImageModelAutoSwitch({
+      provider: "deepseek",
+      model: "deepseek-r1",
+      ctx: ctxWithImages,
+      cfg,
+      hasResolvedHeartbeatModelOverride: false,
+      hasSessionModelOverride: false,
+    });
+
+    expect(result).toEqual({ provider: "anthropic", model: "claude-opus-4-1" });
+  });
+});

--- a/src/auto-reply/reply/get-reply.image-model-autoswitch.test.ts
+++ b/src/auto-reply/reply/get-reply.image-model-autoswitch.test.ts
@@ -16,7 +16,11 @@ vi.mock("../../config/model-input.js", () => ({
   resolveAgentModelPrimaryValue: vi.fn(),
 }));
 
-import { findModelInCatalog, loadModelCatalog, modelSupportsVision } from "../../agents/model-catalog.js";
+import {
+  findModelInCatalog,
+  loadModelCatalog,
+  modelSupportsVision,
+} from "../../agents/model-catalog.js";
 import { resolveModelRefFromString } from "../../agents/model-selection.js";
 import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import { resolveImageModelAutoSwitch } from "./get-reply.js";
@@ -170,8 +174,8 @@ describe("resolveImageModelAutoSwitch", () => {
       .mockReturnValueOnce(textOnlyModel as never)
       .mockReturnValueOnce(visionModel as never);
     vi.mocked(modelSupportsVision)
-      .mockReturnValueOnce(false)  // current model doesn't support vision
-      .mockReturnValueOnce(true);   // imageModel does support vision
+      .mockReturnValueOnce(false) // current model doesn't support vision
+      .mockReturnValueOnce(true); // imageModel does support vision
     vi.mocked(resolveAgentModelPrimaryValue).mockReturnValue("anthropic/claude-opus-4-1");
     vi.mocked(resolveModelRefFromString).mockReturnValue({
       ref: { provider: "anthropic", model: "claude-opus-4-1" },
@@ -243,9 +247,7 @@ describe("resolveImageModelAutoSwitch", () => {
     vi.mocked(findModelInCatalog)
       .mockReturnValueOnce(textOnlyModel as never)
       .mockReturnValueOnce(visionModel as never);
-    vi.mocked(modelSupportsVision)
-      .mockReturnValueOnce(false)
-      .mockReturnValueOnce(true);
+    vi.mocked(modelSupportsVision).mockReturnValueOnce(false).mockReturnValueOnce(true);
     vi.mocked(resolveAgentModelPrimaryValue).mockReturnValue("anthropic/claude-opus-4-1");
     vi.mocked(resolveModelRefFromString).mockReturnValue({
       ref: { provider: "anthropic", model: "claude-opus-4-1" },
@@ -268,7 +270,12 @@ describe("resolveImageModelAutoSwitch", () => {
   it("resolves bare model names using aliasIndex", async () => {
     const ctxWithImage = { ...baseCtx, MediaPath: "/tmp/image.png" };
     const textOnlyModel = { provider: "deepseek", id: "deepseek-r1", input: ["text"] };
-    const visionModel = { provider: "anthropic", id: "claude-opus-4-1", name: "Claude Opus", input: ["text", "image"] };
+    const visionModel = {
+      provider: "anthropic",
+      id: "claude-opus-4-1",
+      name: "Claude Opus",
+      input: ["text", "image"],
+    };
     const cfg = {
       agents: {
         defaults: {
@@ -289,9 +296,7 @@ describe("resolveImageModelAutoSwitch", () => {
     vi.mocked(findModelInCatalog)
       .mockReturnValueOnce(textOnlyModel as never)
       .mockReturnValueOnce(visionModel as never);
-    vi.mocked(modelSupportsVision)
-      .mockReturnValueOnce(false)
-      .mockReturnValueOnce(true);
+    vi.mocked(modelSupportsVision).mockReturnValueOnce(false).mockReturnValueOnce(true);
     vi.mocked(resolveAgentModelPrimaryValue).mockReturnValue("claude-opus");
     vi.mocked(resolveModelRefFromString).mockReturnValue({
       ref: { provider: "anthropic", model: "claude-opus-4-1" },

--- a/src/auto-reply/reply/get-reply.image-model-autoswitch.test.ts
+++ b/src/auto-reply/reply/get-reply.image-model-autoswitch.test.ts
@@ -32,6 +32,7 @@ describe("resolveImageModelAutoSwitch", () => {
   } as never;
 
   const baseCfg = {} as OpenClawConfig;
+  const emptyAliasIndex = { byKey: new Map(), byAlias: new Map() };
 
   it("returns original provider/model when no images are present", async () => {
     vi.mocked(loadModelCatalog).mockResolvedValue([]);
@@ -44,6 +45,8 @@ describe("resolveImageModelAutoSwitch", () => {
       cfg: baseCfg,
       hasResolvedHeartbeatModelOverride: false,
       hasSessionModelOverride: false,
+      hasChannelModelOverride: false,
+      aliasIndex: emptyAliasIndex,
     });
 
     expect(result).toEqual({ provider: "deepseek", model: "deepseek-r1" });
@@ -60,6 +63,8 @@ describe("resolveImageModelAutoSwitch", () => {
       cfg: baseCfg,
       hasResolvedHeartbeatModelOverride: true,
       hasSessionModelOverride: false,
+      hasChannelModelOverride: false,
+      aliasIndex: emptyAliasIndex,
     });
 
     expect(result).toEqual({ provider: "deepseek", model: "deepseek-r1" });
@@ -77,6 +82,27 @@ describe("resolveImageModelAutoSwitch", () => {
       cfg: baseCfg,
       hasResolvedHeartbeatModelOverride: false,
       hasSessionModelOverride: true,
+      hasChannelModelOverride: false,
+      aliasIndex: emptyAliasIndex,
+    });
+
+    expect(result).toEqual({ provider: "deepseek", model: "deepseek-r1" });
+    expect(findModelInCatalog).not.toHaveBeenCalled();
+  });
+
+  it("returns original provider/model when channel model override is active", async () => {
+    const ctxWithImage = { ...baseCtx, MediaPath: "/tmp/image.png" };
+    vi.mocked(loadModelCatalog).mockResolvedValue([]);
+
+    const result = await resolveImageModelAutoSwitch({
+      provider: "deepseek",
+      model: "deepseek-r1",
+      ctx: ctxWithImage,
+      cfg: baseCfg,
+      hasResolvedHeartbeatModelOverride: false,
+      hasSessionModelOverride: false,
+      hasChannelModelOverride: true,
+      aliasIndex: emptyAliasIndex,
     });
 
     expect(result).toEqual({ provider: "deepseek", model: "deepseek-r1" });
@@ -98,6 +124,8 @@ describe("resolveImageModelAutoSwitch", () => {
       cfg: baseCfg,
       hasResolvedHeartbeatModelOverride: false,
       hasSessionModelOverride: false,
+      hasChannelModelOverride: false,
+      aliasIndex: emptyAliasIndex,
     });
 
     expect(result).toEqual({ provider: "anthropic", model: "claude-opus-4-1" });
@@ -118,6 +146,8 @@ describe("resolveImageModelAutoSwitch", () => {
       cfg: baseCfg,
       hasResolvedHeartbeatModelOverride: false,
       hasSessionModelOverride: false,
+      hasChannelModelOverride: false,
+      aliasIndex: emptyAliasIndex,
     });
 
     expect(result).toEqual({ provider: "deepseek", model: "deepseek-r1" });
@@ -154,6 +184,8 @@ describe("resolveImageModelAutoSwitch", () => {
       cfg,
       hasResolvedHeartbeatModelOverride: false,
       hasSessionModelOverride: false,
+      hasChannelModelOverride: false,
+      aliasIndex: emptyAliasIndex,
     });
 
     expect(result).toEqual({ provider: "anthropic", model: "claude-opus-4-1" });
@@ -188,6 +220,8 @@ describe("resolveImageModelAutoSwitch", () => {
       cfg,
       hasResolvedHeartbeatModelOverride: false,
       hasSessionModelOverride: false,
+      hasChannelModelOverride: false,
+      aliasIndex: emptyAliasIndex,
     });
 
     expect(result).toEqual({ provider: "deepseek", model: "deepseek-r1" });
@@ -224,6 +258,55 @@ describe("resolveImageModelAutoSwitch", () => {
       cfg,
       hasResolvedHeartbeatModelOverride: false,
       hasSessionModelOverride: false,
+      hasChannelModelOverride: false,
+      aliasIndex: emptyAliasIndex,
+    });
+
+    expect(result).toEqual({ provider: "anthropic", model: "claude-opus-4-1" });
+  });
+
+  it("resolves bare model names using aliasIndex", async () => {
+    const ctxWithImage = { ...baseCtx, MediaPath: "/tmp/image.png" };
+    const textOnlyModel = { provider: "deepseek", id: "deepseek-r1", input: ["text"] };
+    const visionModel = { provider: "anthropic", id: "claude-opus-4-1", name: "Claude Opus", input: ["text", "image"] };
+    const cfg = {
+      agents: {
+        defaults: {
+          imageModel: { primary: "claude-opus" },
+          models: {
+            "anthropic/claude-opus-4-1": { alias: "claude-opus" },
+          },
+        },
+      },
+    } as OpenClawConfig;
+
+    const aliasIndex = {
+      byKey: new Map([["anthropic/claude-opus-4-1", ["claude-opus"]]]),
+      byAlias: new Map([["claude-opus", { provider: "anthropic", model: "claude-opus-4-1" }]]),
+    };
+
+    vi.mocked(loadModelCatalog).mockResolvedValue([textOnlyModel, visionModel] as never);
+    vi.mocked(findModelInCatalog)
+      .mockReturnValueOnce(textOnlyModel as never)
+      .mockReturnValueOnce(visionModel as never);
+    vi.mocked(modelSupportsVision)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true);
+    vi.mocked(resolveAgentModelPrimaryValue).mockReturnValue("claude-opus");
+    vi.mocked(resolveModelRefFromString).mockReturnValue({
+      ref: { provider: "anthropic", model: "claude-opus-4-1" },
+      alias: "claude-opus",
+    } as never);
+
+    const result = await resolveImageModelAutoSwitch({
+      provider: "deepseek",
+      model: "deepseek-r1",
+      ctx: ctxWithImage,
+      cfg,
+      hasResolvedHeartbeatModelOverride: false,
+      hasSessionModelOverride: false,
+      hasChannelModelOverride: false,
+      aliasIndex,
     });
 
     expect(result).toEqual({ provider: "anthropic", model: "claude-opus-4-1" });

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -4,13 +4,17 @@ import {
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
 } from "../../agents/agent-scope.js";
-import { findModelInCatalog, loadModelCatalog, modelSupportsVision } from "../../agents/model-catalog.js";
+import {
+  findModelInCatalog,
+  loadModelCatalog,
+  modelSupportsVision,
+} from "../../agents/model-catalog.js";
 import { resolveModelRefFromString } from "../../agents/model-selection.js";
-import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
+import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
 import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { defaultRuntime } from "../../runtime.js";

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -4,7 +4,9 @@ import {
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
 } from "../../agents/agent-scope.js";
+import { findModelInCatalog, loadModelCatalog, modelSupportsVision } from "../../agents/model-catalog.js";
 import { resolveModelRefFromString } from "../../agents/model-selection.js";
+import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
@@ -51,6 +53,73 @@ function mergeSkillFilters(channelFilter?: string[], agentFilter?: string[]): st
   }
   const agentSet = new Set(agent);
   return channel.filter((name) => agentSet.has(name));
+}
+
+/**
+ * Auto-switch to imageModel.primary when images are present and the current
+ * model doesn't support vision. Returns the updated provider/model if a switch
+ * is needed, otherwise returns the original values.
+ */
+export async function resolveImageModelAutoSwitch(params: {
+  provider: string;
+  model: string;
+  ctx: MsgContext;
+  cfg: OpenClawConfig;
+  hasResolvedHeartbeatModelOverride: boolean;
+  hasSessionModelOverride: boolean;
+}): Promise<{ provider: string; model: string }> {
+  // Skip auto-switch if model was explicitly overridden via heartbeat or session
+  if (params.hasResolvedHeartbeatModelOverride || params.hasSessionModelOverride) {
+    return { provider: params.provider, model: params.model };
+  }
+
+  // Check if images are present in the message
+  const hasImages =
+    Boolean(params.ctx.MediaPath?.trim()) ||
+    (Array.isArray(params.ctx.MediaPaths) && params.ctx.MediaPaths.length > 0);
+  if (!hasImages) {
+    return { provider: params.provider, model: params.model };
+  }
+
+  // Check if current model supports vision
+  const catalog = await loadModelCatalog({ config: params.cfg });
+  const currentModelEntry = findModelInCatalog(catalog, params.provider, params.model);
+  if (modelSupportsVision(currentModelEntry)) {
+    return { provider: params.provider, model: params.model };
+  }
+
+  // Current model doesn't support vision, check if imageModel.primary is configured
+  const imageModelPrimary = resolveAgentModelPrimaryValue(params.cfg.agents?.defaults?.imageModel);
+  if (!imageModelPrimary?.trim()) {
+    return { provider: params.provider, model: params.model };
+  }
+
+  // Resolve imageModel.primary to provider/model
+  const imageModelResolved = resolveModelRefFromString({
+    raw: imageModelPrimary.trim(),
+    defaultProvider: params.provider,
+    aliasIndex: {},
+  });
+  if (!imageModelResolved) {
+    return { provider: params.provider, model: params.model };
+  }
+
+  // Verify the imageModel actually supports vision
+  const imageModelEntry = findModelInCatalog(
+    catalog,
+    imageModelResolved.ref.provider,
+    imageModelResolved.ref.model,
+  );
+  if (!modelSupportsVision(imageModelEntry)) {
+    // Configured imageModel doesn't support vision either, don't switch
+    return { provider: params.provider, model: params.model };
+  }
+
+  // Auto-switch to the imageModel
+  return {
+    provider: imageModelResolved.ref.provider,
+    model: imageModelResolved.ref.model,
+  };
 }
 
 export async function getReplyFromConfig(
@@ -216,6 +285,19 @@ export async function getReplyFromConfig(
       model = resolved.ref.model;
     }
   }
+
+  // Auto-switch to imageModel.primary when images are present and current model
+  // doesn't support vision
+  const imageModelSwitch = await resolveImageModelAutoSwitch({
+    provider,
+    model,
+    ctx: finalized,
+    cfg,
+    hasResolvedHeartbeatModelOverride,
+    hasSessionModelOverride,
+  });
+  provider = imageModelSwitch.provider;
+  model = imageModelSwitch.model;
 
   const directiveResult = await resolveReplyDirectives({
     ctx: finalized,

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -67,9 +67,15 @@ export async function resolveImageModelAutoSwitch(params: {
   cfg: OpenClawConfig;
   hasResolvedHeartbeatModelOverride: boolean;
   hasSessionModelOverride: boolean;
+  hasChannelModelOverride: boolean;
+  aliasIndex: ReturnType<typeof import("../../agents/model-selection.js").buildModelAliasIndex>;
 }): Promise<{ provider: string; model: string }> {
-  // Skip auto-switch if model was explicitly overridden via heartbeat or session
-  if (params.hasResolvedHeartbeatModelOverride || params.hasSessionModelOverride) {
+  // Skip auto-switch if model was explicitly overridden via heartbeat, session, or channel
+  if (
+    params.hasResolvedHeartbeatModelOverride ||
+    params.hasSessionModelOverride ||
+    params.hasChannelModelOverride
+  ) {
     return { provider: params.provider, model: params.model };
   }
 
@@ -98,7 +104,7 @@ export async function resolveImageModelAutoSwitch(params: {
   const imageModelResolved = resolveModelRefFromString({
     raw: imageModelPrimary.trim(),
     defaultProvider: params.provider,
-    aliasIndex: {},
+    aliasIndex: params.aliasIndex,
   });
   if (!imageModelResolved) {
     return { provider: params.provider, model: params.model };
@@ -274,6 +280,7 @@ export async function getReplyFromConfig(
   const hasSessionModelOverride = Boolean(
     sessionEntry.modelOverride?.trim() || sessionEntry.providerOverride?.trim(),
   );
+  let hasChannelModelOverride = false;
   if (!hasResolvedHeartbeatModelOverride && !hasSessionModelOverride && channelModelOverride) {
     const resolved = resolveModelRefFromString({
       raw: channelModelOverride.model,
@@ -283,6 +290,7 @@ export async function getReplyFromConfig(
     if (resolved) {
       provider = resolved.ref.provider;
       model = resolved.ref.model;
+      hasChannelModelOverride = true;
     }
   }
 
@@ -295,6 +303,8 @@ export async function getReplyFromConfig(
     cfg,
     hasResolvedHeartbeatModelOverride,
     hasSessionModelOverride,
+    hasChannelModelOverride,
+    aliasIndex,
   });
   provider = imageModelSwitch.provider;
   model = imageModelSwitch.model;


### PR DESCRIPTION
## Summary

Fixes issue #38796

When WebChat (or any channel) receives an image and the primary model
doesn't support vision, automatically switch to the configured
`agents.defaults.imageModel.primary` model for the agent run.

## Problem

Users who configured `agents.defaults.imageModel.primary` with a
vision-capable model expected the system to automatically switch to that
model when images were present. However, the system only used the
`imageModel.primary` for separate media understanding runs, while the
main agent run continued using the text-only model.

## Solution

Added `resolveImageModelAutoSwitch()` function that:
1. Checks if images are present in the message (MediaPath/MediaPaths)
2. Checks if the current model supports vision (via model catalog)
3. If images present and current model doesn't support vision, switches
   to the configured `imageModel.primary`
4. Verifies the configured imageModel actually supports vision before
   switching

The auto-switch is skipped when:
- Heartbeat model override is active (hasResolvedHeartbeatModelOverride)
- Session model override is active (user explicitly selected a model)
- No images are present
- Current model already supports vision
- No imageModel.primary is configured
- The configured imageModel.primary doesn't support vision

## Changes

- src/auto-reply/reply/get-reply.ts: Add resolveImageModelAutoSwitch()
  function and call it after media understanding but before directive
  processing
- src/auto-reply/reply/get-reply.image-model-autoswitch.test.ts: Add
  comprehensive tests for the auto-switch logic

## Test Plan

The test file covers:
- No images present → no switch
- Heartbeat override active → no switch
- Session override active → no switch
- Current model supports vision → no switch
- No imageModel.primary configured → no switch
- imageModel.primary configured but doesn't support vision → no switch
- Images present + current model doesn't support vision + imageModel.primary
  configured → switch to imageModel.primary
- Images detected from MediaPaths array (not just MediaPath)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>