### PR TITLE
fix(cli): guard zsh completion against missing compinit

### DIFF
--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -381,6 +381,13 @@ function generateZshCompletion(program: Command): string {
   const script = `
 #compdef ${rootCmd}
 
+# Ensure compinit is loaded so compdef is available. Without this guard,
+# sourcing the completion script before compinit causes:
+#   "command not found: compdef"  (Fixes #14289)
+if [[ -z "\${(k)functions[compdef]}" ]]; then
+  autoload -Uz compinit && compinit -i
+fi
+
 _${rootCmd}_root_completion() {
   local -a commands
   local -a options


### PR DESCRIPTION
## Summary

Fixes #14289

The generated zsh completion script calls `compdef` to register completions, but `compdef` is only available after `compinit` has been loaded. Users who source the completion script in `.zshrc` before `compinit` get:

```
command not found: compdef
```

**Fix:** Add a guard at the top of the generated script that auto-loads `compinit` if `compdef` is not yet available:

```zsh
if [[ -z "${(k)functions[compdef]}" ]]; then
  autoload -Uz compinit && compinit -i
fi
```

This is the standard zsh pattern used by tools like `kubectl`, `gh`, etc.

## Test plan

- [x] Verified generated script includes the guard
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)