### PR TITLE
fix(agents): strip legacy <tool_call> dump blocks from assistant text

### DIFF
--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -562,6 +562,11 @@ describe("stripDowngradedToolCallText", () => {
         expected: "Intro.",
       },
       {
+        name: "multiple legacy tool_call XML blocks",
+        text: `Start\n<tool_call><function=read><parameter=path>/tmp/a</parameter></tool_call>\nMiddle\n<tool_call><function=exec><parameter=command>ls</parameter></tool_call>\nEnd`,
+        expected: "Start\nMiddle\nEnd",
+      },
+      {
         name: "no markers",
         text: "Just a normal response with no markers.",
         expected: "Just a normal response with no markers.",

--- a/src/agents/pi-embedded-utils.test.ts
+++ b/src/agents/pi-embedded-utils.test.ts
@@ -334,6 +334,30 @@ Arguments: { "command": "ls -la" }`,
     expect(result).toBe("");
   });
 
+  it("strips legacy xml-like tool call dumps from local models", () => {
+    const msg = makeAssistantMessage({
+      role: "assistant",
+      content: [
+        {
+          type: "text",
+          text: `Before
+<tool_call>
+<function=exec>
+<parameter=command>
+qmd update --reindex
+</parameter>
+</function>
+</tool_call>
+After`,
+        },
+      ],
+      timestamp: Date.now(),
+    });
+
+    const result = extractAssistantText(msg);
+    expect(result).toBe("Before\nAfter");
+  });
+
   it("strips tool results for downgraded calls", () => {
     const msg = makeAssistantMessage({
       role: "assistant",

--- a/src/agents/pi-embedded-utils.ts
+++ b/src/agents/pi-embedded-utils.ts
@@ -43,7 +43,11 @@ export function stripDowngradedToolCallText(text: string): string {
   if (!text) {
     return text;
   }
-  if (!/\[Tool (?:Call|Result)/i.test(text) && !/\[Historical context/i.test(text)) {
+  if (
+    !/\[Tool (?:Call|Result)/i.test(text) &&
+    !/\[Historical context/i.test(text) &&
+    !/<tool_call>/i.test(text)
+  ) {
     return text;
   }
 
@@ -188,6 +192,10 @@ export function stripDowngradedToolCallText(text: string): string {
 
   // Remove [Tool Call: name (ID: ...)] blocks and their Arguments.
   let cleaned = stripToolCalls(text);
+
+  // Remove legacy XML-like tool call dumps from local models, e.g.:
+  // <tool_call> <function=exec> <parameter=command>...</parameter> ... </tool_call>
+  cleaned = cleaned.replace(/<tool_call>[\s\S]*?<\/tool_call>\s*/gi, "");
 
   // Remove [Tool Result for ID ...] blocks and their content.
   cleaned = cleaned.replace(/\[Tool Result for ID[^\]]*\]\n?[\s\S]*?(?=\n*\[Tool |\n*$)/gi, "");


### PR DESCRIPTION
## Summary

- Problem: Some local models emit raw XML-like tool dumps (`<tool_call>...`) into assistant text, which then leaks to users and can trigger parse failures in follow-up runs.
- Why it matters: Heartbeat-style prompts with multiple tool calls were intermittently failing for users on local Qwen/llama.cpp setups.
- What changed: `stripDowngradedToolCallText` now detects and removes legacy `<tool_call>...</tool_call>` dump blocks; added regression test coverage in `pi-embedded-utils.test.ts`.
- What did NOT change (scope boundary): No changes to tool execution, routing, parser contracts, or provider transport.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #38899
- Related #38891

## User-visible / Behavior Changes

Assistant text rendering now strips legacy XML-like tool dump blocks when they appear as downgraded text.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (WSL2)
- Runtime/container: Node 22 / pnpm workspace
- Model/provider: N/A (unit test level)
- Integration/channel (if any): agent text sanitization path
- Relevant config (redacted): default repo test config

### Steps

1. Run `pnpm -s vitest run src/agents/pi-embedded-utils.test.ts`
2. Confirm new test `strips legacy xml-like tool call dumps from local models` passes.
3. Confirm existing sanitization tests continue passing.

### Expected

- Legacy `<tool_call>...</tool_call>` blocks are stripped from assistant text while preserving surrounding prose.

### Actual

- ✅ Test passes; suite passes (34 tests).

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted vitest run for `src/agents/pi-embedded-utils.test.ts`.
- Edge cases checked: surrounding user text before/after tool dump is preserved.
- What you did **not** verify: full end-to-end run against live local Qwen model.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `ee3ab7fae`.
- Files/config to restore: `src/agents/pi-embedded-utils.ts` and associated test file.
- Known bad symptoms reviewers should watch for: accidental stripping of legitimate literal `<tool_call>` content in normal prose.

## Risks and Mitigations

- Risk: Over-stripping user-visible text that intentionally includes `<tool_call>` examples.
  - Mitigation: Strip only closed block form `<tool_call>...</tool_call>` and preserve surrounding text.
