### PR TITLE
Fix Feishu websocket cleanup on stop

### DIFF
--- a/extensions/feishu/src/monitor.cleanup.test.ts
+++ b/extensions/feishu/src/monitor.cleanup.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  botNames,
+  botOpenIds,
+  stopFeishuMonitorState,
+  wsClients,
+} from "./monitor.state.js";
+import type { ResolvedFeishuAccount } from "./types.js";
+
+const createFeishuWSClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({
+  createFeishuWSClient: createFeishuWSClientMock,
+}));
+
+import { monitorWebSocket } from "./monitor.transport.js";
+
+type MockWsClient = {
+  start: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+};
+
+function createAccount(accountId: string): ResolvedFeishuAccount {
+  return {
+    accountId,
+    enabled: true,
+    configured: true,
+    appId: `cli_${accountId}`,
+    appSecret: `secret_${accountId}`, // pragma: allowlist secret
+    domain: "feishu",
+    config: {
+      enabled: true,
+      connectionMode: "websocket",
+    },
+  } as ResolvedFeishuAccount;
+}
+
+function createWsClient(): MockWsClient {
+  return {
+    start: vi.fn(),
+    close: vi.fn(),
+  };
+}
+
+afterEach(() => {
+  stopFeishuMonitorState();
+  vi.clearAllMocks();
+});
+
+describe("feishu websocket cleanup", () => {
+  it("closes the websocket client when the monitor aborts", async () => {
+    const wsClient = createWsClient();
+    createFeishuWSClientMock.mockReturnValue(wsClient);
+
+    const abortController = new AbortController();
+    const accountId = "alpha";
+
+    botOpenIds.set(accountId, "ou_alpha");
+    botNames.set(accountId, "Alpha");
+
+    const monitorPromise = monitorWebSocket({
+      account: createAccount(accountId),
+      accountId,
+      runtime: {
+        log: vi.fn(),
+        error: vi.fn(),
+        exit: vi.fn(),
+      },
+      abortSignal: abortController.signal,
+      eventDispatcher: {} as never,
+    });
+
+    expect(wsClient.start).toHaveBeenCalledTimes(1);
+    expect(wsClients.get(accountId)).toBe(wsClient);
+
+    abortController.abort();
+    await monitorPromise;
+
+    expect(wsClient.close).toHaveBeenCalledTimes(1);
+    expect(wsClients.has(accountId)).toBe(false);
+    expect(botOpenIds.has(accountId)).toBe(false);
+    expect(botNames.has(accountId)).toBe(false);
+  });
+
+  it("closes targeted websocket clients during stop cleanup", () => {
+    const alphaClient = createWsClient();
+    const betaClient = createWsClient();
+
+    wsClients.set("alpha", alphaClient as never);
+    wsClients.set("beta", betaClient as never);
+    botOpenIds.set("alpha", "ou_alpha");
+    botOpenIds.set("beta", "ou_beta");
+    botNames.set("alpha", "Alpha");
+    botNames.set("beta", "Beta");
+
+    stopFeishuMonitorState("alpha");
+
+    expect(alphaClient.close).toHaveBeenCalledTimes(1);
+    expect(betaClient.close).not.toHaveBeenCalled();
+    expect(wsClients.has("alpha")).toBe(false);
+    expect(wsClients.has("beta")).toBe(true);
+    expect(botOpenIds.has("alpha")).toBe(false);
+    expect(botOpenIds.has("beta")).toBe(true);
+    expect(botNames.has("alpha")).toBe(false);
+    expect(botNames.has("beta")).toBe(true);
+  });
+
+  it("closes all websocket clients during global stop cleanup", () => {
+    const alphaClient = createWsClient();
+    const betaClient = createWsClient();
+
+    wsClients.set("alpha", alphaClient as never);
+    wsClients.set("beta", betaClient as never);
+    botOpenIds.set("alpha", "ou_alpha");
+    botOpenIds.set("beta", "ou_beta");
+    botNames.set("alpha", "Alpha");
+    botNames.set("beta", "Beta");
+
+    stopFeishuMonitorState();
+
+    expect(alphaClient.close).toHaveBeenCalledTimes(1);
+    expect(betaClient.close).toHaveBeenCalledTimes(1);
+    expect(wsClients.size).toBe(0);
+    expect(botOpenIds.size).toBe(0);
+    expect(botNames.size).toBe(0);
+  });
+});

--- a/extensions/feishu/src/monitor.state.ts
+++ b/extensions/feishu/src/monitor.state.ts
@@ -104,6 +104,17 @@ const feishuWebhookAnomalyTracker = createWebhookAnomalyTracker({
   logEvery: feishuWebhookAnomalyDefaults.logEvery,
 });
 
+function closeWsClient(client: Lark.WSClient | undefined): void {
+  if (!client) {
+    return;
+  }
+  try {
+    client.close();
+  } catch {
+    // Best-effort cleanup during stop/reload paths.
+  }
+}
+
 export function clearFeishuWebhookRateLimitStateForTest(): void {
   feishuWebhookRateLimiter.clear();
   feishuWebhookAnomalyTracker.clear();
@@ -134,6 +145,7 @@ export function recordWebhookStatus(
 
 export function stopFeishuMonitorState(accountId?: string): void {
   if (accountId) {
+    closeWsClient(wsClients.get(accountId));
     wsClients.delete(accountId);
     const server = httpServers.get(accountId);
     if (server) {
@@ -145,6 +157,9 @@ export function stopFeishuMonitorState(accountId?: string): void {
     return;
   }
 
+  for (const client of wsClients.values()) {
+    closeWsClient(client);
+  }
   wsClients.clear();
   for (const server of httpServers.values()) {
     server.close();

--- a/extensions/feishu/src/monitor.test-mocks.ts
+++ b/extensions/feishu/src/monitor.test-mocks.ts
@@ -1,11 +1,11 @@
 import { vi } from "vitest";
 
 export function createFeishuClientMockModule(): {
-  createFeishuWSClient: () => { start: () => void };
+  createFeishuWSClient: () => { start: () => void; close: () => void };
   createEventDispatcher: () => { register: () => void };
 } {
   return {
-    createFeishuWSClient: vi.fn(() => ({ start: vi.fn() })),
+    createFeishuWSClient: vi.fn(() => ({ start: vi.fn(), close: vi.fn() })),
     createEventDispatcher: vi.fn(() => ({ register: vi.fn() })),
   };
 }

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -80,23 +80,37 @@ export async function monitorWebSocket({
   eventDispatcher,
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
+  const error = runtime?.error ?? console.error;
   log(`feishu[${accountId}]: starting WebSocket connection...`);
 
   const wsClient = createFeishuWSClient(account);
   wsClients.set(accountId, wsClient);
 
   return new Promise((resolve, reject) => {
-    const cleanup = () => {
-      wsClients.delete(accountId);
-      botOpenIds.delete(accountId);
-      botNames.delete(accountId);
-    };
+    let cleanedUp = false;
 
-    const handleAbort = () => {
+    function cleanup(): void {
+      if (cleanedUp) {
+        return;
+      }
+      cleanedUp = true;
+      abortSignal?.removeEventListener("abort", handleAbort);
+      try {
+        wsClient.close();
+      } catch (err) {
+        error(`feishu[${accountId}]: failed to close WebSocket client: ${String(err)}`);
+      } finally {
+        wsClients.delete(accountId);
+        botOpenIds.delete(accountId);
+        botNames.delete(accountId);
+      }
+    }
+
+    function handleAbort(): void {
       log(`feishu[${accountId}]: abort signal received, stopping`);
       cleanup();
       resolve();
-    };
+    }
 
     if (abortSignal?.aborted) {
       cleanup();
@@ -111,7 +125,6 @@ export async function monitorWebSocket({
       log(`feishu[${accountId}]: WebSocket client started`);
     } catch (err) {
       cleanup();
-      abortSignal?.removeEventListener("abort", handleAbort);
       reject(err);
     }
   });


### PR DESCRIPTION
## Why this matters

Stopping the Feishu monitor (abort/stop cleanup paths) should fully tear down **all** live WebSocket connections. Today we only clear in-memory state, but the underlying WS client can remain open. That leaves “ghost” connections that continue to receive events after the monitor is stopped. In practice this can cause:

- Unexpected bot activity after a stop
- Duplicate event processing when the gateway comes back up
- Resource leaks (open connections, stale bot identity caches)
- Hard-to-debug behavior across multiple Feishu accounts

This is a correctness and stability issue: operators expect stop/abort to be a clean shutdown, not a partial cleanup.

---

## What this does

- Ensures WebSocket connections are **explicitly closed** when the monitor is aborted/stopped
- Makes cleanup **idempotent** and resilient to errors
- Extends cleanup to both per-account and global shutdown paths
- Adds focused tests that lock in the new behavior

---

## Changes

**`extensions/feishu/src/monitor.transport.ts`**
- Adds an idempotent `cleanup()` that closes the WS client on abort
- Removes the abort listener during cleanup
- Logs close failures but always clears local state

**`extensions/feishu/src/monitor.state.ts`**
- Adds a `closeWsClient()` helper
- Closes WS clients during `stopFeishuMonitorState()` (both single-account and global)

**`extensions/feishu/src/monitor.test-mocks.ts`**
- Extends the WS client mock to include `close()`

**`extensions/feishu/src/monitor.cleanup.test.ts`** (new)
- Adds coverage for cleanup semantics

---

## Design decisions

- **Best-effort cleanup:** `close()` is wrapped in try/catch so shutdown never fails due to WS close errors.
- **Idempotent cleanup:** avoids double-close or double-delete during rapid stop/abort sequences.
- **Coverage across stop paths:** cleanup happens both in the transport (abort path) and in monitor state stop helpers.
- **Scope kept tight:** no changes to webhook handling or non-WS transports.

---

## Tested

Local, Feishu-focused scenarios:

- Abort the monitor while a WS client is active → client is closed and state is cleared.
- Stop cleanup for a single account → only that account’s WS client/state is cleaned.
- Global stop cleanup → all WS clients are closed and all state maps are cleared.
- Baseline Feishu monitor flows still function (startup, reaction, bot-menu, webhook/security paths).

All above scenarios passed locally.

---

## Reviewer focus

Please pay attention to cleanup ordering and idempotency in `monitor.transport.ts` and `monitor.state.ts`, as that’s where the behavioral change lives.
