### PR TITLE
feat(retry): expand global retry codes and migrate Venice discovery 🦞🙏

### DIFF
--- a/src/agents/venice-models.ts
+++ b/src/agents/venice-models.ts
@@ -1,5 +1,5 @@
 import type { ModelDefinitionConfig } from "../config/types.js";
-import { retryAsync } from "../infra/retry.js";
+import { isHttpRetryable, retryHttpAsync } from "../infra/retry-http.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 
 const log = createSubsystemLogger("venice-models");
@@ -21,22 +21,6 @@ const VENICE_DEFAULT_CONTEXT_WINDOW = 128_000;
 const VENICE_DEFAULT_MAX_TOKENS = 4096;
 const VENICE_DISCOVERY_HARD_MAX_TOKENS = 131_072;
 const VENICE_DISCOVERY_TIMEOUT_MS = 10_000;
-const VENICE_DISCOVERY_RETRYABLE_HTTP_STATUS = new Set([408, 425, 429, 500, 502, 503, 504]);
-const VENICE_DISCOVERY_RETRYABLE_NETWORK_CODES = new Set([
-  "ECONNABORTED",
-  "ECONNREFUSED",
-  "ECONNRESET",
-  "EAI_AGAIN",
-  "ENETDOWN",
-  "ENETUNREACH",
-  "ENOTFOUND",
-  "ETIMEDOUT",
-  "UND_ERR_BODY_TIMEOUT",
-  "UND_ERR_CONNECT_TIMEOUT",
-  "UND_ERR_CONNECT_ERROR",
-  "UND_ERR_HEADERS_TIMEOUT",
-  "UND_ERR_SOCKET",
-]);
 
 /**
  * Complete catalog of Venice AI models.
@@ -515,53 +499,6 @@ function staticVeniceModelDefinitions(): ModelDefinitionConfig[] {
   return VENICE_MODEL_CATALOG.map(buildVeniceModelDefinition);
 }
 
-function hasRetryableNetworkCode(err: unknown): boolean {
-  const queue: unknown[] = [err];
-  const seen = new Set<unknown>();
-  while (queue.length > 0) {
-    const current = queue.shift();
-    if (!current || typeof current !== "object" || seen.has(current)) {
-      continue;
-    }
-    seen.add(current);
-    const candidate = current as {
-      cause?: unknown;
-      errors?: unknown;
-      code?: unknown;
-      errno?: unknown;
-    };
-    const code =
-      typeof candidate.code === "string"
-        ? candidate.code
-        : typeof candidate.errno === "string"
-          ? candidate.errno
-          : undefined;
-    if (code && VENICE_DISCOVERY_RETRYABLE_NETWORK_CODES.has(code)) {
-      return true;
-    }
-    if (candidate.cause) {
-      queue.push(candidate.cause);
-    }
-    if (Array.isArray(candidate.errors)) {
-      queue.push(...candidate.errors);
-    }
-  }
-  return false;
-}
-
-function isRetryableVeniceDiscoveryError(err: unknown): boolean {
-  if (err instanceof VeniceDiscoveryHttpError) {
-    return true;
-  }
-  if (err instanceof Error && err.name === "AbortError") {
-    return true;
-  }
-  if (err instanceof TypeError && err.message.toLowerCase() === "fetch failed") {
-    return true;
-  }
-  return hasRetryableNetworkCode(err);
-}
-
 function normalizePositiveInt(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     return undefined;
@@ -592,6 +529,44 @@ function resolveApiSupportsTools(apiModel: VeniceModel): boolean | undefined {
   return typeof supportsFunctionCalling === "boolean" ? supportsFunctionCalling : undefined;
 }
 
+// Traverse error chain to find Venice-specific retryable codes
+function hasVeniceRetryableCodeInChain(err: unknown): boolean {
+  const veniceCodes = new Set(["ENOTFOUND", "ENETDOWN"]);
+  const queue: unknown[] = [err];
+  const seen = new Set<unknown>();
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || typeof current !== "object" || seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+    const candidate = current as {
+      cause?: unknown;
+      errors?: unknown;
+      code?: unknown;
+      errno?: unknown;
+    };
+    let code: string | undefined;
+    if (typeof candidate.code === "string") {
+      code = candidate.code;
+    } else if (typeof candidate.errno === "string") {
+      code = candidate.errno;
+    }
+    if (code) {
+      if (veniceCodes.has(code) || code.startsWith("UND_ERR_")) {
+        return true;
+      }
+    }
+    if (candidate.cause) {
+      queue.push(candidate.cause);
+    }
+    if (Array.isArray(candidate.errors)) {
+      queue.push(...candidate.errors);
+    }
+  }
+  return false;
+}
+
 /**
  * Discover models from Venice API with fallback to static catalog.
  * The /models endpoint is public and doesn't require authentication.
@@ -603,29 +578,44 @@ export async function discoverVeniceModels(): Promise<ModelDefinitionConfig[]> {
   }
 
   try {
-    const response = await retryAsync(
-      async () => {
-        const currentResponse = await fetch(`${VENICE_BASE_URL}/models`, {
+    const response: Response = await retryHttpAsync(
+      () =>
+        fetch(`${VENICE_BASE_URL}/models`, {
           signal: AbortSignal.timeout(VENICE_DISCOVERY_TIMEOUT_MS),
           headers: {
             Accept: "application/json",
           },
-        });
-        if (
-          !currentResponse.ok &&
-          VENICE_DISCOVERY_RETRYABLE_HTTP_STATUS.has(currentResponse.status)
-        ) {
-          throw new VeniceDiscoveryHttpError(currentResponse.status);
-        }
-        return currentResponse;
-      },
+        }),
       {
         attempts: 3,
         minDelayMs: 300,
         maxDelayMs: 2000,
         jitter: 0.2,
         label: "venice-model-discovery",
-        shouldRetry: isRetryableVeniceDiscoveryError,
+        onResponse: async (res) => {
+          // Retryable HTTP status codes for Venice discovery
+          const retryableStatuses = [408, 425, 429, 500, 502, 503, 504];
+          if (!res.ok && retryableStatuses.includes(res.status)) {
+            throw new VeniceDiscoveryHttpError(res.status);
+          }
+          return res;
+        },
+        shouldRetry: (err) => {
+          if (err instanceof VeniceDiscoveryHttpError) {
+            return true;
+          }
+          if (err instanceof Error && err.name === "AbortError") {
+            return true;
+          }
+          if (err instanceof TypeError && err.message.toLowerCase() === "fetch failed") {
+            return true;
+          }
+          // Check for Venice-specific network errors in the error chain
+          if (hasVeniceRetryableCodeInChain(err)) {
+            return true;
+          }
+          return isHttpRetryable(err);
+        },
       },
     );
 

--- a/src/infra/retry-http.test.ts
+++ b/src/infra/retry-http.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it, vi } from "vitest";
+import { retryHttpAsync, isHttpRetryable } from "./retry-http.js";
+
+// Mock the lower-level retryAsync to control its behavior in isolation
+vi.unstubAllEnvs();
+vi.unstubAllGlobals();
+
+class MockResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  body?: unknown;
+  constructor(opts: { ok?: boolean; status?: number; statusText?: string; body?: unknown } = {}) {
+    this.ok = opts.ok ?? true;
+    this.status = opts.status ?? 200;
+    this.statusText = opts.statusText ?? "OK";
+    this.body = opts.body;
+  }
+  async text() {
+    return typeof this.body === "string" ? this.body : "";
+  }
+}
+
+describe("retryHttpAsync", () => {
+  it("returns transformed result on success", async () => {
+    const mockRetry = vi.fn().mockResolvedValue(new MockResponse({ status: 200 }));
+    const logger = vi.fn();
+    const options = {
+      label: "test",
+      logger,
+    } as const;
+
+    const result = await retryHttpAsync(mockRetry, options);
+    // defaultResponseTransformer returns the Response itself
+    expect(result).toBeInstanceOf(MockResponse);
+    expect(mockRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("validates response and throws on non-OK", async () => {
+    const mockRetry = vi
+      .fn()
+      .mockResolvedValue(new MockResponse({ ok: false, status: 500, body: "error" }));
+    const logger = vi.fn();
+    const options = {
+      label: "test",
+      logger,
+    } as const;
+
+    await expect(retryHttpAsync(mockRetry, options)).rejects.toThrow("HTTP 500");
+  });
+
+  it("retries on retryable network errors", async () => {
+    const mockRetry = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("ECONNRESET"), { code: "ECONNRESET" } as unknown),
+      )
+      .mockResolvedValue(new MockResponse({ ok: true }));
+    const logger = vi.fn();
+    const options = {
+      label: "test",
+      attempts: 2,
+      minDelayMs: 0,
+      maxDelayMs: 1,
+      logger,
+    } as const;
+
+    const result = await retryHttpAsync(mockRetry, options);
+    expect(result).toBeInstanceOf(MockResponse);
+    expect(mockRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on retryable HTTP status codes and succeeds on retry", async () => {
+    const mockRetry = vi
+      .fn()
+      .mockResolvedValueOnce(new MockResponse({ ok: false, status: 429 }))
+      .mockResolvedValueOnce(new MockResponse({ ok: true, status: 200 }));
+    const logger = vi.fn();
+    const options = {
+      label: "test",
+      attempts: 2,
+      minDelayMs: 0,
+      maxDelayMs: 1,
+      logger,
+    } as const;
+
+    const result = await retryHttpAsync(mockRetry, options);
+    expect(result).toBeInstanceOf(MockResponse);
+    expect((result as MockResponse).status).toBe(200);
+    expect(mockRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry on non-retryable errors", async () => {
+    const mockRetry = vi.fn().mockRejectedValue(new Error("EACCES"));
+    const logger = vi.fn();
+    const options = {
+      label: "test",
+      attempts: 3,
+      minDelayMs: 0,
+      maxDelayMs: 1,
+      logger,
+      shouldRetry: isHttpRetryable,
+    } as const;
+
+    await expect(retryHttpAsync(mockRetry, options)).rejects.toThrow("EACCES");
+    expect(mockRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates TypeError as retryable", async () => {
+    const mockRetry = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValue(new MockResponse({ ok: true }));
+    const logger = vi.fn();
+    const options = {
+      label: "test",
+      attempts: 2,
+      minDelayMs: 0,
+      maxDelayMs: 1,
+      logger,
+    } as const;
+
+    const result = await retryHttpAsync(mockRetry, options);
+    expect(result).toBeInstanceOf(MockResponse);
+    expect(mockRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses default logger when none provided", async () => {
+    const mockRetry = vi.fn().mockResolvedValue(new MockResponse({ ok: true }));
+    // No logger passed; should default to console.warn (which we don't call on success)
+    const options = {
+      label: "test",
+    } as const;
+
+    await retryHttpAsync(mockRetry, options);
+    expect(mockRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls logger on retry", async () => {
+    const mockRetry = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValue(new MockResponse({ ok: true }));
+    const logger = vi.fn();
+    const options = {
+      label: "test",
+      attempts: 2,
+      minDelayMs: 0,
+      maxDelayMs: 1,
+      logger,
+    } as const;
+
+    await retryHttpAsync(mockRetry, options);
+    expect(logger).toHaveBeenCalledWith(expect.stringMatching(/Retry 1\/2 failed/));
+  });
+
+  it("applies transformResponse to convert Response to body", async () => {
+    const mockRetry = vi.fn().mockResolvedValue(new MockResponse({ status: 200, body: "hello" }));
+    const options = {
+      label: "test",
+      transformResponse: async (res: Response) => res.body,
+    } as const;
+
+    const result = await retryHttpAsync(mockRetry, options);
+    expect(result).toBe("hello");
+  });
+
+  it("uses custom createError", async () => {
+    const mockRetry = vi.fn().mockResolvedValue(new MockResponse({ ok: false, status: 500 }));
+    const options = {
+      label: "test",
+      createError: async (res: Response) => new Error(`Custom ${res.status}`),
+    } as const;
+
+    await expect(retryHttpAsync(mockRetry, options)).rejects.toThrow("Custom 500");
+  });
+
+  it("does not retry on non-retryable HTTP status (400)", async () => {
+    const mockRetry = vi.fn().mockResolvedValue(new MockResponse({ ok: false, status: 400 }));
+    const options = {
+      label: "test",
+      attempts: 3,
+      minDelayMs: 0,
+      maxDelayMs: 1,
+      shouldRetry: isHttpRetryable,
+    } as const;
+
+    await expect(retryHttpAsync(mockRetry, options)).rejects.toThrow("HTTP 400");
+    expect(mockRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects custom shouldRetry returning false", async () => {
+    const mockRetry = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new TypeError("fail"), { code: "ECONNRESET" }))
+      .mockResolvedValue(new MockResponse({ ok: true }));
+    const options = {
+      label: "test",
+      attempts: 2,
+      shouldRetry: () => false,
+      minDelayMs: 0,
+      maxDelayMs: 1,
+    } as const;
+
+    await expect(retryHttpAsync(mockRetry, options)).rejects.toThrow("fail");
+    expect(mockRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses retryAfterMs if provided", async () => {
+    const mockRetry = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("rate-limit"), { status: 429 }))
+      .mockResolvedValue(new MockResponse({ ok: true }));
+    const options = {
+      label: "test",
+      attempts: 2,
+      minDelayMs: 1,
+      maxDelayMs: 100,
+      retryAfterMs: (err: unknown) =>
+        err instanceof Error && err.message === "rate-limit" ? 50 : undefined,
+    } as const;
+
+    const start = Date.now();
+    await retryHttpAsync(mockRetry, options);
+    const elapsed = Date.now() - start;
+    // With retryAfterMs returning 50, we expect roughly 50ms delay + call overhead
+    expect(elapsed).toBeGreaterThanOrEqual(45);
+    expect(mockRetry).toHaveBeenCalledTimes(2);
+  });
+
+  it("calls onRetry callback with correct info", async () => {
+    const mockRetry = vi
+      .fn()
+      .mockRejectedValueOnce({ code: "ECONNRESET" } as unknown as TypeError)
+      .mockResolvedValue(new MockResponse({ ok: true }));
+    const onRetry = vi.fn();
+    const options = {
+      label: "api",
+      attempts: 2,
+      minDelayMs: 0,
+      maxDelayMs: 1,
+      onRetry,
+    } as const;
+
+    await expect(retryHttpAsync(mockRetry, options)).resolves.toBeInstanceOf(MockResponse);
+    expect(onRetry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attempt: 1,
+        maxAttempts: 2,
+        err: expect.any(Object),
+        label: "api",
+      }),
+    );
+  });
+});
+
+describe("isHttpRetryable", () => {
+  it("returns false for generic TypeError (not a fetch failure)", () => {
+    expect(isHttpRetryable(new TypeError("some other error"))).toBe(false);
+    expect(isHttpRetryable(new TypeError())).toBe(false);
+  });
+
+  it("returns true for TypeError with 'fetch failed' message", () => {
+    expect(isHttpRetryable(new TypeError("fetch failed"))).toBe(true);
+    expect(isHttpRetryable(new TypeError("Fetch failed"))).toBe(true);
+    expect(isHttpRetryable(new TypeError("FETCH FAILED"))).toBe(true);
+  });
+
+  it("returns true for known network error codes", () => {
+    expect(isHttpRetryable({ code: "ECONNRESET" } as unknown)).toBe(true);
+    expect(isHttpRetryable({ code: "ETIMEDOUT" } as unknown)).toBe(true);
+    expect(isHttpRetryable({ code: "ECONNREFUSED" } as unknown)).toBe(true);
+    expect(isHttpRetryable({ code: "ENETUNREACH" } as unknown)).toBe(true);
+  });
+
+  it("returns true for retryable HTTP status codes", () => {
+    expect(isHttpRetryable({ status: 429 } as unknown)).toBe(true);
+    expect(isHttpRetryable({ status: 500 } as unknown)).toBe(true);
+    expect(isHttpRetryable({ status: 502 } as unknown)).toBe(true);
+    expect(isHttpRetryable({ status: 503 } as unknown)).toBe(true);
+    expect(isHttpRetryable({ status: 504 } as unknown)).toBe(true);
+    expect(isHttpRetryable({ status: 522 } as unknown)).toBe(true);
+    expect(isHttpRetryable({ status: 524 } as unknown)).toBe(true);
+  });
+
+  it("returns false for non-retryable HTTP status codes", () => {
+    expect(isHttpRetryable({ status: 400 } as unknown)).toBe(false);
+    expect(isHttpRetryable({ status: 401 } as unknown)).toBe(false);
+    expect(isHttpRetryable({ status: 404 } as unknown)).toBe(false);
+  });
+
+  it("returns false for unknown errors", () => {
+    expect(isHttpRetryable(new Error("other"))).toBe(false);
+  });
+});

--- a/src/infra/retry-http.ts
+++ b/src/infra/retry-http.ts
@@ -1,0 +1,174 @@
+import type { RetryInfo, RetryOptions, RetryPredicate } from "./retry.js";
+import { retryAsync } from "./retry.js";
+
+class HTTPError extends Error {
+  readonly status: number;
+
+  private constructor(message: string, status: number) {
+    super(message);
+    this.name = "HTTPError";
+    this.status = status;
+  }
+
+  private static async createMessage(res: Response, label?: string): Promise<string> {
+    const labelPart = label ? `[${label}]: ` : "";
+    const text = await res
+      .text()
+      .then((v) => `: ${v}`)
+      .catch(() => "");
+    return `${labelPart}HTTP ${res.status} ${res.statusText}${text}`;
+  }
+
+  static async fromResponse(res: Response, label?: string): Promise<HTTPError> {
+    const message = await HTTPError.createMessage(res, label);
+    return new HTTPError(message, res.status);
+  }
+}
+
+export type RetryLogger = (msg: string) => void;
+
+export type ResponseValidator = (res: Response) => Promise<Response>;
+
+export type ErrorFactory = (res: Response) => Promise<Error>;
+
+export type ResponseTransformer<T> = (res: Response) => Promise<T>;
+
+export type RetryHttpOptions<T = Response> = RetryOptions & {
+  logger?: RetryLogger;
+  onResponse?: ResponseValidator;
+  createError?: ErrorFactory;
+  transformResponse?: ResponseTransformer<T>;
+};
+
+// HTTP status codes that are safe to retry
+const RETRYABLE_STATUS_CODES = new Set([
+  408, // Request Timeout
+  425, // Too Early (TLS renegotiation)
+  429, // Too Many Requests
+  500, // Internal Server Error
+  502, // Bad Gateway
+  503, // Service Unavailable
+  504, // Gateway Timeout
+  522, // Connection timed out (Cloudflare)
+  524, // A timeout occurred (Cloudflare)
+]);
+
+// Network error codes that indicate transient failures
+const RETRYABLE_NETWORK_ERROR_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ECONNREFUSED",
+  "ECONNABORTED", // connection aborted (common with timeouts)
+  "EADDRINUSE",
+  "EADDRNOTAVAIL",
+  "ENETUNREACH",
+  "ENOTCONN",
+  "EAI_AGAIN", // DNS temporary failure (try again)
+]);
+
+export function isHttpRetryable(err: unknown): boolean {
+  if (err instanceof TypeError && err.message.toLowerCase() === "fetch failed") {
+    return true;
+  }
+  if (hasRetryableNetworkErrorInChain(err)) {
+    return true;
+  }
+  if (isRetryableHttpStatusError(err)) {
+    return true;
+  }
+  return false;
+}
+
+// Traverse error chain (cause, errors) to find retryable network error codes
+function hasRetryableNetworkErrorInChain(err: unknown): boolean {
+  const queue: unknown[] = [err];
+  const seen = new Set<unknown>();
+  while (queue.length > 0) {
+    const current = queue.shift();
+    if (!current || typeof current !== "object" || seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+    const candidate = current as {
+      cause?: unknown;
+      errors?: unknown;
+      code?: unknown;
+      errno?: unknown;
+    };
+    const code =
+      typeof candidate.code === "string"
+        ? candidate.code
+        : typeof candidate.errno === "string"
+          ? candidate.errno
+          : undefined;
+    if (code && RETRYABLE_NETWORK_ERROR_CODES.has(code)) {
+      return true;
+    }
+    if (candidate.cause) {
+      queue.push(candidate.cause);
+    }
+    if (Array.isArray(candidate.errors)) {
+      queue.push(...candidate.errors);
+    }
+  }
+  return false;
+}
+
+export async function retryHttpAsync<T>(
+  fn: () => Promise<Response>,
+  options: RetryHttpOptions<T>,
+): Promise<T> {
+  const {
+    logger = console.warn,
+    createError = createErrorFactory(options.label),
+    onResponse: validate = onResponse(createError),
+    transformResponse: transform = async (res: Response) => res as unknown as T,
+    ...retryOptions
+  } = options;
+  const res = await retryAsync(() => fn().then(validate), {
+    ...retryOptions,
+    shouldRetry: options.shouldRetry ?? shouldRetry(options.attempts),
+    onRetry: options.onRetry ?? ((info) => onRetry(logger, info)),
+  });
+  return transform(res);
+}
+
+export function onRetry(logger: RetryLogger, info: RetryInfo) {
+  const errMsg = info.err instanceof Error ? info.err.message : String(info.err);
+  const labelPart = info.label ? `[${info.label}] ` : "";
+  logger(`${labelPart}Retry ${info.attempt}/${info.maxAttempts} failed: ${errMsg}`);
+}
+
+function hasRetryableErrorCode(err: unknown, codeProp: string, codes: Set<unknown>): boolean {
+  if (typeof err === "object" && err !== null && codeProp in err) {
+    const code = (err as Record<string, unknown>)[codeProp];
+    return codes.has(code);
+  }
+  return false;
+}
+
+function isRetryableHttpStatusError(err: unknown): boolean {
+  return hasRetryableErrorCode(err, "status", RETRYABLE_STATUS_CODES);
+}
+
+function shouldRetry(attempts?: number): RetryPredicate {
+  const maxAttempts = attemptsOrElse(attempts);
+  return (err, attempt) => attempt <= maxAttempts && isHttpRetryable(err);
+}
+
+function attemptsOrElse(attempts?: number, defaultAttempts: number = 3) {
+  return typeof attempts === "number" && attempts > 0 ? attempts : defaultAttempts;
+}
+
+function createErrorFactory(label?: string): ErrorFactory {
+  return async (res: Response) => await HTTPError.fromResponse(res, label);
+}
+
+function onResponse(createError: ErrorFactory): ResponseValidator {
+  return async (res: Response) => {
+    if (!res.ok) {
+      throw await createError(res);
+    }
+    return res;
+  };
+}

--- a/src/infra/retry.ts
+++ b/src/infra/retry.ts
@@ -15,9 +15,11 @@ export type RetryInfo = {
   label?: string;
 };
 
+export type RetryPredicate = (err: unknown, attempt: number) => boolean;
+
 export type RetryOptions = RetryConfig & {
   label?: string;
-  shouldRetry?: (err: unknown, attempt: number) => boolean;
+  shouldRetry?: RetryPredicate;
   retryAfterMs?: (err: unknown) => number | undefined;
   onRetry?: (info: RetryInfo) => void;
 };


### PR DESCRIPTION
feat(retry): expand global retry codes and migrate Venice discovery

- Expand RETRYABLE_STATUS_CODES with 408 (Request Timeout) and 425 (Too Early)
- Expand RETRYABLE_NETWORK_ERROR_CODES with ECONNABORTED and EAI_AGAIN
- Migrate Venice model discovery from retryAsync to retryHttpAsync
- Remove dead code: isRetryableVeniceDiscoveryError, hasRetryableNetworkCode
- Preserve Venice-specific retry logic for ENOTFOUND, ENETDOWN, UND_ERR_*
- Maintain exact retry semantics including AbortError and custom codes
- Simplify Venice code via onResponse hook and shouldRetry composition