### PR TITLE
feat(feishu): configurable group and DM display-name resolution

### DIFF
--- a/extensions/feishu/src/bot-sender-name.test.ts
+++ b/extensions/feishu/src/bot-sender-name.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  resolveFeishuDirectNameFromChatMember,
+  resolveFeishuSenderName,
+} from "./bot-sender-name.js";
+
+const mockCreateFeishuClient = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: mockCreateFeishuClient,
+}));
+
+function createAccount(accountId: string) {
+  return {
+    accountId,
+    configured: true,
+    enabled: true,
+    selectionSource: "explicit",
+    domain: "feishu",
+    config: {},
+  } as any;
+}
+
+describe("bot-sender-name cache scoping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("scopes sender name cache by account id", async () => {
+    const getUser = vi
+      .fn()
+      .mockResolvedValueOnce({ code: 0, data: { user: { name: "Account A Sender" } } })
+      .mockResolvedValueOnce({ code: 0, data: { user: { name: "Account B Sender" } } });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: getUser } },
+    });
+
+    await expect(
+      resolveFeishuSenderName({
+        account: createAccount("account-A"),
+        senderId: "ou-shared-sender",
+        log: vi.fn(),
+      }),
+    ).resolves.toEqual({ name: "Account A Sender" });
+
+    await expect(
+      resolveFeishuSenderName({
+        account: createAccount("account-B"),
+        senderId: "ou-shared-sender",
+        log: vi.fn(),
+      }),
+    ).resolves.toEqual({ name: "Account B Sender" });
+
+    expect(getUser).toHaveBeenCalledTimes(2);
+  });
+
+  it("scopes direct member display cache by account id", async () => {
+    const getMembers = vi
+      .fn()
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { items: [{ member_id: "ou-shared-direct", name: "Direct A" }] },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        data: { items: [{ member_id: "ou-shared-direct", name: "Direct B" }] },
+      });
+    mockCreateFeishuClient.mockReturnValue({
+      im: { chatMembers: { get: getMembers } },
+    });
+
+    await expect(
+      resolveFeishuDirectNameFromChatMember({
+        account: createAccount("account-A"),
+        chatId: "oc-dm-a",
+        senderOpenId: "ou-shared-direct",
+        log: vi.fn(),
+      }),
+    ).resolves.toBe("Direct A");
+
+    await expect(
+      resolveFeishuDirectNameFromChatMember({
+        account: createAccount("account-B"),
+        chatId: "oc-dm-b",
+        senderOpenId: "ou-shared-direct",
+        log: vi.fn(),
+      }),
+    ).resolves.toBe("Direct B");
+
+    expect(getMembers).toHaveBeenCalledTimes(2);
+  });
+});

--- a/extensions/feishu/src/bot-sender-name.test.ts
+++ b/extensions/feishu/src/bot-sender-name.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  clearFeishuSenderNameCachesForTests,
   resolveFeishuDirectNameFromChatMember,
   resolveFeishuSenderName,
 } from "./bot-sender-name.js";
@@ -24,6 +25,7 @@ function createAccount(accountId: string) {
 describe("bot-sender-name cache scoping", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearFeishuSenderNameCachesForTests();
   });
 
   it("scopes sender name cache by account id", async () => {
@@ -88,5 +90,84 @@ describe("bot-sender-name cache scoping", () => {
     ).resolves.toBe("Direct B");
 
     expect(getMembers).toHaveBeenCalledTimes(2);
+  });
+  it("uses a separate direct-member cache from sender profile lookups", async () => {
+    const getUser = vi.fn().mockResolvedValue({
+      code: 0,
+      data: { user: { name: "Profile Sender" } },
+    });
+    const getMembers = vi.fn().mockResolvedValue({
+      code: 0,
+      data: { items: [{ member_id: "ou-direct-cache-split", name: "Direct Member" }] },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: getUser } },
+      im: { chatMembers: { get: getMembers } },
+    });
+
+    await expect(
+      resolveFeishuSenderName({
+        account: createAccount("account-cache-split"),
+        senderId: "ou-direct-cache-split",
+        log: vi.fn(),
+      }),
+    ).resolves.toEqual({ name: "Profile Sender" });
+
+    await expect(
+      resolveFeishuDirectNameFromChatMember({
+        account: createAccount("account-cache-split"),
+        chatId: "oc-dm-cache-split",
+        senderOpenId: "ou-direct-cache-split",
+        log: vi.fn(),
+      }),
+    ).resolves.toBe("Direct Member");
+
+    expect(getMembers).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the sender id type for direct member lookups when open_id is unavailable", async () => {
+    const getMembers = vi.fn().mockResolvedValue({
+      code: 0,
+      data: { items: [{ member_id: "fouser_direct_lookup", name: "Direct By UserId" }] },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      im: { chatMembers: { get: getMembers } },
+    });
+
+    await expect(
+      resolveFeishuDirectNameFromChatMember({
+        account: createAccount("account-user-id"),
+        chatId: "oc-dm-user-id",
+        senderOpenId: "fouser_direct_lookup",
+        log: vi.fn(),
+      }),
+    ).resolves.toBe("Direct By UserId");
+
+    expect(getMembers).toHaveBeenCalledWith({
+      path: { chat_id: "oc-dm-user-id" },
+      params: { member_id_type: "user_id", page_size: 50 },
+    });
+  });
+
+  it("negative-caches failed direct member lookups for a TTL window", async () => {
+    const getMembers = vi.fn().mockResolvedValue({
+      code: 999,
+      msg: "missing scope",
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      im: { chatMembers: { get: getMembers } },
+    });
+
+    const params = {
+      account: createAccount("account-negative-cache"),
+      chatId: "oc-dm-negative-cache",
+      senderOpenId: "ou-direct-negative-cache",
+      log: vi.fn(),
+    };
+
+    await expect(resolveFeishuDirectNameFromChatMember(params)).resolves.toBeUndefined();
+    await expect(resolveFeishuDirectNameFromChatMember(params)).resolves.toBeUndefined();
+
+    expect(getMembers).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/feishu/src/bot-sender-name.ts
+++ b/extensions/feishu/src/bot-sender-name.ts
@@ -12,20 +12,18 @@ type SenderNameResult = {
   permissionError?: FeishuPermissionError;
 };
 
-type FeishuContactUserGetResponse = Awaited<
-  ReturnType<ReturnType<typeof createFeishuClient>["contact"]["user"]["get"]>
->;
-
-type FeishuLogger = {
-  (...args: unknown[]): void;
-};
-
 const IGNORED_PERMISSION_SCOPE_TOKENS = ["contact:contact.base:readonly"];
 const FEISHU_SCOPE_CORRECTIONS: Record<string, string> = {
   "contact:contact.base:readonly": "contact:user.base:readonly",
 };
 const SENDER_NAME_TTL_MS = 10 * 60 * 1000;
+const GROUP_NAME_TTL_MS = 10 * 60 * 1000;
 const senderNameCache = new Map<string, { name: string; expireAt: number }>();
+const groupNameCache = new Map<string, { name?: string; expireAt: number }>();
+
+function buildSenderCacheKey(accountId: string, senderId: string): string {
+  return `${accountId}:${senderId}`;
+}
 
 function correctFeishuScopeInUrl(url: string): string {
   let corrected = url;
@@ -45,8 +43,8 @@ function extractPermissionError(err: unknown): FeishuPermissionError | null {
   if (!err || typeof err !== "object") {
     return null;
   }
-  const axiosErr = err as { response?: { data?: unknown } };
-  const data = axiosErr.response?.data;
+  const maybeAxios = err as { response?: { data?: unknown } };
+  const data = maybeAxios.response?.data ?? err;
   if (!data || typeof data !== "object") {
     return null;
   }
@@ -78,7 +76,7 @@ export async function resolveFeishuSenderName(params: {
   account: ResolvedFeishuAccount;
   senderId: string;
   senderUserId?: string;
-  log: FeishuLogger;
+  log: (...args: any[]) => void;
 }): Promise<SenderNameResult> {
   const { account, senderId, senderUserId, log } = params;
   if (!account.configured) {
@@ -94,7 +92,7 @@ export async function resolveFeishuSenderName(params: {
 
   const now = Date.now();
   for (const candidateId of candidateIds) {
-    const cached = senderNameCache.get(candidateId);
+    const cached = senderNameCache.get(buildSenderCacheKey(account.accountId, candidateId));
     if (cached && cached.expireAt > now) {
       return { name: cached.name };
     }
@@ -124,14 +122,19 @@ export async function resolveFeishuSenderName(params: {
         continue;
       }
 
-      const user = res?.data?.user;
-      const name = user?.name ?? user?.display_name ?? user?.nickname ?? user?.en_name;
-      if (typeof name === "string" && name.trim().length > 0) {
-        const normalizedName = name.trim();
+      const name: string | undefined =
+        res?.data?.user?.name ||
+        res?.data?.user?.display_name ||
+        res?.data?.user?.nickname ||
+        res?.data?.user?.en_name;
+      if (name && typeof name === "string") {
         for (const idForCache of candidateIds) {
-          senderNameCache.set(idForCache, { name: normalizedName, expireAt: now + SENDER_NAME_TTL_MS });
+          senderNameCache.set(buildSenderCacheKey(account.accountId, idForCache), {
+            name,
+            expireAt: now + SENDER_NAME_TTL_MS,
+          });
         }
-        return { name: normalizedName };
+        return { name };
       }
     }
     return {};
@@ -148,4 +151,124 @@ export async function resolveFeishuSenderName(params: {
     log(`feishu: failed to resolve sender name for ${candidateIds.join(",")}: ${String(err)}`);
     return {};
   }
+}
+
+export async function resolveFeishuGroupName(params: {
+  account: ResolvedFeishuAccount;
+  chatId: string;
+  log: (...args: any[]) => void;
+}): Promise<string | undefined> {
+  const { account, chatId, log } = params;
+  if (!account.configured) {
+    return undefined;
+  }
+
+  const normalizedChatId = chatId.trim();
+  if (!normalizedChatId) {
+    return undefined;
+  }
+
+  const cacheKey = `${account.accountId}:${normalizedChatId}`;
+  const cached = groupNameCache.get(cacheKey);
+  const now = Date.now();
+  if (cached && cached.expireAt > now) {
+    return cached.name;
+  }
+
+  const cacheMiss = () => {
+    groupNameCache.set(cacheKey, { name: undefined, expireAt: now + GROUP_NAME_TTL_MS });
+    return undefined;
+  };
+
+  try {
+    const client = createFeishuClient(account) as any;
+    const getChat = client?.im?.chat?.get;
+    if (typeof getChat !== "function") {
+      return undefined;
+    }
+
+    const res: any = await getChat({ path: { chat_id: normalizedChatId } });
+    if (res?.code !== 0) {
+      log(
+        `feishu: failed to resolve group name for ${normalizedChatId}: code=${String(res?.code)} msg=${String(res?.msg ?? "")}`,
+      );
+      return cacheMiss();
+    }
+
+    const name =
+      typeof res?.data?.name === "string" && res.data.name.trim().length > 0
+        ? res.data.name.trim()
+        : undefined;
+    groupNameCache.set(cacheKey, { name, expireAt: now + GROUP_NAME_TTL_MS });
+    return name;
+  } catch (err) {
+    log(`feishu: failed to resolve group name for ${normalizedChatId}: ${String(err)}`);
+    return cacheMiss();
+  }
+}
+
+export async function resolveFeishuDirectNameFromChatMember(params: {
+  account: ResolvedFeishuAccount;
+  chatId: string;
+  senderOpenId: string;
+  log: (...args: any[]) => void;
+}): Promise<string | undefined> {
+  const { account, chatId, senderOpenId, log } = params;
+  if (!account.configured) {
+    return undefined;
+  }
+
+  const normalizedSenderOpenId = senderOpenId.trim();
+  const normalizedChatId = chatId.trim();
+  if (!normalizedSenderOpenId || !normalizedChatId) {
+    return undefined;
+  }
+
+  const cached = senderNameCache.get(
+    buildSenderCacheKey(account.accountId, normalizedSenderOpenId),
+  );
+  const now = Date.now();
+  if (cached && cached.expireAt > now) {
+    return cached.name;
+  }
+
+  try {
+    const client = createFeishuClient(account) as any;
+    const getChatMembers = client?.im?.chatMembers?.get ?? client?.im?.chat?.members?.get;
+    if (typeof getChatMembers !== "function") {
+      return undefined;
+    }
+
+    const res: any = await getChatMembers({
+      path: { chat_id: normalizedChatId },
+      params: { member_id_type: "open_id", page_size: 50 },
+    });
+    if (res?.code !== 0) {
+      log(
+        `feishu: failed to resolve direct member name for ${normalizedSenderOpenId} in ${normalizedChatId}: code=${String(res?.code)} msg=${String(res?.msg ?? "")}`,
+      );
+      return undefined;
+    }
+
+    const item = Array.isArray(res?.data?.items)
+      ? res.data.items.find(
+          (entry: any) =>
+            typeof entry?.member_id === "string" && entry.member_id === normalizedSenderOpenId,
+        )
+      : undefined;
+    const name = typeof item?.name === "string" ? item.name.trim() : "";
+    if (name) {
+      senderNameCache.set(buildSenderCacheKey(account.accountId, normalizedSenderOpenId), {
+        name,
+        expireAt: now + SENDER_NAME_TTL_MS,
+      });
+      return name;
+    }
+  } catch (err) {
+    log(
+      `feishu: failed to resolve direct member name for ${normalizedSenderOpenId} in ${normalizedChatId}: ${String(err)}`,
+    );
+  }
+
+  return undefined;
 }

--- a/extensions/feishu/src/bot-sender-name.ts
+++ b/extensions/feishu/src/bot-sender-name.ts
@@ -77,37 +77,62 @@ function resolveSenderLookupIdType(senderId: string): "open_id" | "user_id" | "u
 export async function resolveFeishuSenderName(params: {
   account: ResolvedFeishuAccount;
   senderId: string;
+  senderUserId?: string;
   log: FeishuLogger;
 }): Promise<SenderNameResult> {
-  const { account, senderId, log } = params;
+  const { account, senderId, senderUserId, log } = params;
   if (!account.configured) {
     return {};
   }
 
-  const normalizedSenderId = senderId.trim();
-  if (!normalizedSenderId) {
+  const candidateIds = [senderUserId?.trim(), senderId.trim()].filter(
+    (value): value is string => typeof value === "string" && value.length > 0,
+  );
+  if (candidateIds.length === 0) {
     return {};
   }
 
-  const cached = senderNameCache.get(normalizedSenderId);
   const now = Date.now();
-  if (cached && cached.expireAt > now) {
-    return { name: cached.name };
+  for (const candidateId of candidateIds) {
+    const cached = senderNameCache.get(candidateId);
+    if (cached && cached.expireAt > now) {
+      return { name: cached.name };
+    }
   }
 
   try {
     const client = createFeishuClient(account);
-    const userIdType = resolveSenderLookupIdType(normalizedSenderId);
-    const res: FeishuContactUserGetResponse = await client.contact.user.get({
-      path: { user_id: normalizedSenderId },
-      params: { user_id_type: userIdType },
-    });
-    const user = res.data?.user;
-    const name = user?.name ?? user?.nickname ?? user?.en_name;
+    for (const candidateId of candidateIds) {
+      const userIdType = resolveSenderLookupIdType(candidateId);
+      const res: any = await client.contact.user.get({
+        path: { user_id: candidateId },
+        params: { user_id_type: userIdType },
+      });
+      if (res?.code != null && res.code !== 0) {
+        const permErr = extractPermissionError(res);
+        if (permErr) {
+          if (shouldSuppressPermissionErrorNotice(permErr)) {
+            log(`feishu: ignoring stale permission scope error: ${permErr.message}`);
+            return {};
+          }
+          log(`feishu: permission error resolving sender name: code=${permErr.code}`);
+          return { permissionError: permErr };
+        }
+        log(
+          `feishu: sender name lookup failed for ${candidateId}: code=${String(res.code)} msg=${String(res?.msg ?? "")}`,
+        );
+        continue;
+      }
 
-    if (name) {
-      senderNameCache.set(normalizedSenderId, { name, expireAt: now + SENDER_NAME_TTL_MS });
-      return { name };
+      const user = res?.data?.user;
+      const name = user?.name ?? user?.display_name ?? user?.nickname ?? user?.en_name;
+      if (typeof name === "string" && name.trim().length > 0) {
+        const normalizedName = name.trim();
+        for (const idForCache of candidateIds) {
+          senderNameCache.set(idForCache, { name: normalizedName, expireAt: now + SENDER_NAME_TTL_MS });
+        }
+        return { name: normalizedName };
+      }
     }
     return {};
   } catch (err) {
@@ -120,7 +145,7 @@ export async function resolveFeishuSenderName(params: {
       log(`feishu: permission error resolving sender name: code=${permErr.code}`);
       return { permissionError: permErr };
     }
-    log(`feishu: failed to resolve sender name for ${normalizedSenderId}: ${String(err)}`);
+    log(`feishu: failed to resolve sender name for ${candidateIds.join(",")}: ${String(err)}`);
     return {};
   }
 }

--- a/extensions/feishu/src/bot-sender-name.ts
+++ b/extensions/feishu/src/bot-sender-name.ts
@@ -20,9 +20,14 @@ const SENDER_NAME_TTL_MS = 10 * 60 * 1000;
 const GROUP_NAME_TTL_MS = 10 * 60 * 1000;
 const senderNameCache = new Map<string, { name: string; expireAt: number }>();
 const groupNameCache = new Map<string, { name?: string; expireAt: number }>();
+const directMemberNameCache = new Map<string, { name?: string; expireAt: number }>();
 
 function buildSenderCacheKey(accountId: string, senderId: string): string {
   return `${accountId}:${senderId}`;
+}
+
+function buildDirectMemberCacheKey(accountId: string, chatId: string, senderId: string): string {
+  return `${accountId}:${chatId}:${senderId}`;
 }
 
 function correctFeishuScopeInUrl(url: string): string {
@@ -63,13 +68,19 @@ function extractPermissionError(err: unknown): FeishuPermissionError | null {
 
 function resolveSenderLookupIdType(senderId: string): "open_id" | "user_id" | "union_id" {
   const trimmed = senderId.trim();
-  if (trimmed.startsWith("ou_")) {
+  if (trimmed.startsWith("ou_") || trimmed.startsWith("ou-")) {
     return "open_id";
   }
-  if (trimmed.startsWith("on_")) {
+  if (trimmed.startsWith("on_") || trimmed.startsWith("on-")) {
     return "union_id";
   }
   return "user_id";
+}
+
+export function clearFeishuSenderNameCachesForTests() {
+  senderNameCache.clear();
+  groupNameCache.clear();
+  directMemberNameCache.clear();
 }
 
 export async function resolveFeishuSenderName(params: {
@@ -218,19 +229,27 @@ export async function resolveFeishuDirectNameFromChatMember(params: {
     return undefined;
   }
 
-  const normalizedSenderOpenId = senderOpenId.trim();
+  const normalizedSenderId = senderOpenId.trim();
   const normalizedChatId = chatId.trim();
-  if (!normalizedSenderOpenId || !normalizedChatId) {
+  if (!normalizedSenderId || !normalizedChatId) {
     return undefined;
   }
 
-  const cached = senderNameCache.get(
-    buildSenderCacheKey(account.accountId, normalizedSenderOpenId),
+  const cacheKey = buildDirectMemberCacheKey(
+    account.accountId,
+    normalizedChatId,
+    normalizedSenderId,
   );
+  const cached = directMemberNameCache.get(cacheKey);
   const now = Date.now();
   if (cached && cached.expireAt > now) {
     return cached.name;
   }
+
+  const cacheMiss = () => {
+    directMemberNameCache.set(cacheKey, { name: undefined, expireAt: now + SENDER_NAME_TTL_MS });
+    return undefined;
+  };
 
   try {
     const client = createFeishuClient(account) as any;
@@ -239,36 +258,35 @@ export async function resolveFeishuDirectNameFromChatMember(params: {
       return undefined;
     }
 
+    const memberIdType = resolveSenderLookupIdType(normalizedSenderId);
     const res: any = await getChatMembers({
       path: { chat_id: normalizedChatId },
-      params: { member_id_type: "open_id", page_size: 50 },
+      params: { member_id_type: memberIdType, page_size: 50 },
     });
     if (res?.code !== 0) {
       log(
-        `feishu: failed to resolve direct member name for ${normalizedSenderOpenId} in ${normalizedChatId}: code=${String(res?.code)} msg=${String(res?.msg ?? "")}`,
+        `feishu: failed to resolve direct member name for ${normalizedSenderId} in ${normalizedChatId}: code=${String(res?.code)} msg=${String(res?.msg ?? "")}`,
       );
-      return undefined;
+      return cacheMiss();
     }
 
     const item = Array.isArray(res?.data?.items)
       ? res.data.items.find(
           (entry: any) =>
-            typeof entry?.member_id === "string" && entry.member_id === normalizedSenderOpenId,
+            typeof entry?.member_id === "string" && entry.member_id === normalizedSenderId,
         )
       : undefined;
     const name = typeof item?.name === "string" ? item.name.trim() : "";
     if (name) {
-      senderNameCache.set(buildSenderCacheKey(account.accountId, normalizedSenderOpenId), {
-        name,
-        expireAt: now + SENDER_NAME_TTL_MS,
-      });
+      directMemberNameCache.set(cacheKey, { name, expireAt: now + SENDER_NAME_TTL_MS });
       return name;
     }
   } catch (err) {
     log(
-      `feishu: failed to resolve direct member name for ${normalizedSenderOpenId} in ${normalizedChatId}: ${String(err)}`,
+      `feishu: failed to resolve direct member name for ${normalizedSenderId} in ${normalizedChatId}: ${String(err)}`,
     );
+    return cacheMiss();
   }
 
-  return undefined;
+  return cacheMiss();
 }

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -691,6 +691,175 @@ describe("handleFeishuMessage command authorization", () => {
     expect(mockCreateFeishuClient).not.toHaveBeenCalled();
   });
 
+  it("uses chatMembers API for direct display names", async () => {
+    const getUser = vi
+      .fn()
+      .mockResolvedValue({ code: 0, data: { user: { name: "ShouldNotUse" } } });
+    const getMembers = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [
+          {
+            member_id: "ou-direct-review-user-members-only",
+            name: "SenderFromMembersOnly",
+          },
+        ],
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: getUser } },
+      im: { chatMembers: { get: getMembers } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-direct-review-user-members-only",
+          user_id: "fouser_12345",
+        },
+      },
+      message: {
+        message_id: "msg-direct-display-enabled",
+        chat_id: "oc-dm-direct-display",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello dm display" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(getMembers).toHaveBeenCalledWith({
+      path: { chat_id: "oc-dm-direct-display" },
+      params: { member_id_type: "open_id", page_size: 50 },
+    });
+    expect(getUser).not.toHaveBeenCalled();
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderName: "SenderFromMembersOnly (ou-direct-review-user-members-only)",
+      }),
+    );
+  });
+
+  it("keeps open_id when direct member lookup has no matching name", async () => {
+    const getMembers = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [
+          {
+            member_id: "ou-someone-else",
+            name: "SomeoneElse",
+          },
+        ],
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: vi.fn() } },
+      im: { chatMembers: { get: getMembers } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-direct-no-member-name",
+        },
+      },
+      message: {
+        message_id: "msg-direct-no-member-name",
+        chat_id: "oc-dm-direct-no-member-name",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello dm no member name" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(getMembers).toHaveBeenCalledWith({
+      path: { chat_id: "oc-dm-direct-no-member-name" },
+      params: { member_id_type: "open_id", page_size: 50 },
+    });
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderName: "ou-direct-no-member-name",
+      }),
+    );
+  });
+
+  it("prefers sender user_id lookup for group sender resolution when available", async () => {
+    const getUser = vi
+      .fn()
+      .mockResolvedValue({ code: 0, data: { user: { name: "SenderByUserId" } } });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: getUser } },
+      im: { chat: { get: vi.fn().mockResolvedValue({ code: 0, data: { name: "GroupName" } }) } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["oc-group"],
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-group-user",
+          user_id: "fouser_group_user",
+        },
+      },
+      message: {
+        message_id: "msg-group-user-id-name",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello group user id" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(getUser).toHaveBeenCalledWith({
+      path: { user_id: "fouser_group_user" },
+      params: { user_id_type: "user_id" },
+    });
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderName: "SenderByUserId",
+      }),
+    );
+  });
+
   it("propagates parent/root message ids into inbound context for reply reconstruction", async () => {
     mockGetMessageFeishu.mockResolvedValueOnce({
       messageId: "om_parent_001",
@@ -1639,6 +1808,83 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("preserves resolveSenderNames opt-out for DM and group display lookups", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    const contactGet = vi.fn().mockResolvedValue({ data: { user: { name: "Sender Name" } } });
+    const chatGet = vi.fn().mockResolvedValue({ code: 0, data: { name: "Ops Group" } });
+    const chatMembersGet = vi.fn().mockResolvedValue({
+      code: 0,
+      data: { items: [{ member_id: "ou-dm-user", name: "DM Display" }] },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: contactGet } },
+      im: {
+        chat: { get: chatGet },
+        chatMembers: { get: chatMembersGet },
+      },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          dmPolicy: "open",
+          resolveSenderNames: false,
+          groups: {
+            "oc-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    await dispatchMessage({
+      cfg,
+      event: {
+        sender: { sender_id: { open_id: "ou-dm-user" } },
+        message: {
+          message_id: "msg-dm-opt-out",
+          chat_id: "oc-dm",
+          chat_type: "p2p",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello dm" }),
+        },
+      },
+    });
+
+    expect(chatMembersGet).not.toHaveBeenCalled();
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining("ou-dm-user: hello dm"),
+      }),
+    );
+
+    mockFinalizeInboundContext.mockClear();
+    mockDispatchReplyFromConfig.mockClear();
+
+    await dispatchMessage({
+      cfg,
+      event: {
+        sender: { sender_id: { open_id: "ou-group-user" } },
+        message: {
+          message_id: "msg-group-opt-out",
+          chat_id: "oc-group",
+          chat_type: "group",
+          message_type: "text",
+          content: JSON.stringify({ text: "hello group" }),
+        },
+      },
+    });
+
+    expect(contactGet).not.toHaveBeenCalled();
+    expect(chatGet).not.toHaveBeenCalled();
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining("ou-group-user: hello group"),
+      }),
+    );
+  });
+
   it("dispatches once and appends permission notice to the main agent body", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockCreateFeishuClient.mockReturnValue({
@@ -1802,6 +2048,12 @@ describe("handleFeishuMessage command authorization", () => {
 
   it("routes topic sessions and parentPeer when groupSessionScope=group_topic_sender", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockGetMessageFeishu.mockResolvedValueOnce({
+      messageId: "om_root_topic",
+      chatId: "oc-group",
+      content: "Role-Task-Routing",
+      contentType: "text",
+    });
 
     const cfg: ClawdbotConfig = {
       channels: {
@@ -1834,6 +2086,12 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         peer: { kind: "group", id: "oc-group:topic:om_root_topic:sender:ou-topic-user" },
         parentPeer: { kind: "group", id: "oc-group" },
+      }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        MessageThreadId: "om_root_topic",
+        ThreadLabel: expect.stringContaining("Role-Task-Routing"),
       }),
     );
   });
@@ -2028,6 +2286,11 @@ describe("handleFeishuMessage command authorization", () => {
         parentPeer: { kind: "group", id: "oc-group" },
       }),
     );
+    const lastContext = mockFinalizeInboundContext.mock.calls.at(-1)?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(lastContext?.ThreadLabel).toBeUndefined();
+    expect(lastContext?.MessageThreadId).toBeUndefined();
   });
 
   it("keeps topic session key stable after first turn creates a thread", async () => {
@@ -2346,7 +2609,7 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         ThreadStarterBody: "root starter",
         ThreadHistoryBody: "assistant reply\n\nfollow-up question",
-        ThreadLabel: "Feishu thread in oc-group",
+        ThreadLabel: expect.stringContaining("root starter"),
         MessageThreadId: "om_topic_root",
       }),
     );
@@ -2389,7 +2652,7 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         ThreadStarterBody: undefined,
         ThreadHistoryBody: undefined,
-        ThreadLabel: "Feishu thread in oc-group",
+        ThreadLabel: expect.stringContaining("root starter"),
         MessageThreadId: "om_topic_root",
       }),
     );
@@ -2459,7 +2722,7 @@ describe("handleFeishuMessage command authorization", () => {
       expect.objectContaining({
         ThreadStarterBody: "root starter",
         ThreadHistoryBody: "assistant reply\n\nfollow-up question",
-        ThreadLabel: "Feishu thread in oc-group",
+        ThreadLabel: expect.stringContaining("root starter"),
         MessageThreadId: "om_topic_root",
       }),
     );

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -8,6 +8,7 @@ import type { FeishuMessageEvent } from "./bot.js";
 import {
   buildBroadcastSessionKey,
   buildFeishuAgentBody,
+  clearFeishuBotCachesForTests,
   handleFeishuMessage,
   resolveBroadcastAgents,
   toMessageResourceType,
@@ -279,6 +280,7 @@ async function dispatchMessage(params: { cfg: ClawdbotConfig; event: FeishuMessa
 describe("handleFeishuMessage ACP routing", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearFeishuBotCachesForTests();
     mockResolveConfiguredBindingRoute.mockReset().mockImplementation(
       ({
         route,
@@ -479,6 +481,7 @@ describe("handleFeishuMessage command authorization", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    clearFeishuBotCachesForTests();
     mockShouldComputeCommandAuthorized.mockReset().mockReturnValue(true);
     mockGetMessageFeishu.mockReset().mockResolvedValue(null);
     mockListFeishuThreadMessages.mockReset().mockResolvedValue([]);
@@ -2623,6 +2626,12 @@ describe("handleFeishuMessage command authorization", () => {
   it("skips topic thread bootstrap when the thread session already exists", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockReadSessionUpdatedAt.mockReturnValue(1710000000000);
+    mockGetMessageFeishu.mockResolvedValueOnce({
+      messageId: "om_topic_root",
+      chatId: "oc-group",
+      content: "root starter",
+      contentType: "text",
+    });
 
     const cfg: ClawdbotConfig = {
       channels: {
@@ -2651,7 +2660,7 @@ describe("handleFeishuMessage command authorization", () => {
 
     await dispatchMessage({ cfg, event });
 
-    expect(mockGetMessageFeishu).not.toHaveBeenCalled();
+    expect(mockGetMessageFeishu).toHaveBeenCalledTimes(1);
     expect(mockListFeishuThreadMessages).not.toHaveBeenCalled();
     expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -2763,5 +2772,227 @@ describe("handleFeishuMessage command authorization", () => {
 
     await Promise.all([dispatchMessage({ cfg, event }), dispatchMessage({ cfg, event })]);
     expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+  });
+  it("uses user_id member lookups for direct messages when open_id is unavailable", async () => {
+    const getUser = vi
+      .fn()
+      .mockResolvedValue({ code: 0, data: { user: { name: "ShouldNotUse" } } });
+    const getMembers = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [
+          {
+            member_id: "fouser_dm_only",
+            name: "SenderFromUserIdMembers",
+          },
+        ],
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: getUser } },
+      im: { chatMembers: { get: getMembers } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          user_id: "fouser_dm_only",
+        },
+      },
+      message: {
+        message_id: "msg-direct-user-id-only",
+        chat_id: "oc-dm-user-id-only",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello dm user id" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(getMembers).toHaveBeenCalledWith({
+      path: { chat_id: "oc-dm-user-id-only" },
+      params: { member_id_type: "user_id", page_size: 50 },
+    });
+    expect(getUser).not.toHaveBeenCalled();
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderName: "SenderFromUserIdMembers (fouser_dm_only)",
+      }),
+    );
+  });
+
+  it("falls back to contact lookup when direct member lookup has no matching name", async () => {
+    const getUser = vi.fn().mockResolvedValue({
+      code: 0,
+      data: { user: { name: "SenderFromContacts" } },
+    });
+    const getMembers = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [
+          {
+            member_id: "ou-someone-else",
+            name: "SomeoneElse",
+          },
+        ],
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: getUser } },
+      im: { chatMembers: { get: getMembers } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_test",
+          appSecret: "secret_test",
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-dm-contact-fallback",
+          user_id: "fouser_dm_contact_fallback",
+        },
+      },
+      message: {
+        message_id: "msg-direct-contact-fallback",
+        chat_id: "oc-dm-contact-fallback",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello dm fallback" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(getMembers).toHaveBeenCalledWith({
+      path: { chat_id: "oc-dm-contact-fallback" },
+      params: { member_id_type: "open_id", page_size: 50 },
+    });
+    expect(getUser).toHaveBeenCalledWith({
+      path: { user_id: "fouser_dm_contact_fallback" },
+      params: { user_id_type: "user_id" },
+    });
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SenderName: "SenderFromContacts (ou-dm-contact-fallback)",
+      }),
+    );
+  });
+
+  it("does not resolve group names for groups rejected by groupAllowFrom", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    const contactGet = vi
+      .fn()
+      .mockResolvedValue({ code: 0, data: { user: { name: "Sender Name" } } });
+    const chatGet = vi.fn().mockResolvedValue({ code: 0, data: { name: "Denied Group" } });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: contactGet } },
+      im: { chat: { get: chatGet } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groupPolicy: "allowlist",
+          groupAllowFrom: ["oc-allowed-group"],
+          groups: {
+            "oc-denied-group": {
+              requireMention: false,
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-denied-group-user",
+        },
+      },
+      message: {
+        message_id: "msg-denied-group-name-lookup",
+        chat_id: "oc-denied-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello denied group" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(chatGet).not.toHaveBeenCalled();
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
+  it("negative-caches missing topic labels to avoid repeated root fetches", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+    mockReadSessionUpdatedAt.mockReturnValue(123);
+    mockGetMessageFeishu.mockResolvedValue(null);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group-negative-topic": {
+              requireMention: false,
+              groupSessionScope: "group_topic_sender",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    await dispatchMessage({
+      cfg,
+      event: {
+        sender: { sender_id: { open_id: "ou-topic-negative-cache" } },
+        message: {
+          message_id: "msg-topic-negative-cache-1",
+          chat_id: "oc-group-negative-topic",
+          chat_type: "group",
+          root_id: "om_root_negative_cache",
+          message_type: "text",
+          content: JSON.stringify({ text: "first topic label miss" }),
+        },
+      },
+    });
+
+    await dispatchMessage({
+      cfg,
+      event: {
+        sender: { sender_id: { open_id: "ou-topic-negative-cache" } },
+        message: {
+          message_id: "msg-topic-negative-cache-2",
+          chat_id: "oc-group-negative-topic",
+          chat_type: "group",
+          root_id: "om_root_negative_cache",
+          message_type: "text",
+          content: JSON.stringify({ text: "second topic label miss" }),
+        },
+      },
+    });
+
+    const topicRootFetches = mockGetMessageFeishu.mock.calls.filter(
+      (call) => call[0]?.messageId === "om_root_negative_cache",
+    );
+    expect(topicRootFetches).toHaveLength(1);
   });
 });

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2896,6 +2896,76 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("propagates DM contact fallback permission errors to the agent body", async () => {
+    const getUser = vi.fn().mockRejectedValue({
+      response: {
+        data: {
+          code: 99991672,
+          msg: "permission denied: contact:user.base:readonly https://open.feishu.cn/app/cli_dm_scope",
+        },
+      },
+    });
+    const getMembers = vi.fn().mockResolvedValue({
+      code: 0,
+      data: {
+        items: [
+          {
+            member_id: "ou-someone-else",
+            name: "SomeoneElse",
+          },
+        ],
+      },
+    });
+    mockCreateFeishuClient.mockReturnValue({
+      contact: { user: { get: getUser } },
+      im: { chatMembers: { get: getMembers } },
+    });
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          appId: "cli_dm_scope",
+          appSecret: "secret_test",
+          dmPolicy: "open",
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: {
+        sender_id: {
+          open_id: "ou-dm-permission-fallback",
+          user_id: "fouser_dm_permission_fallback",
+        },
+      },
+      message: {
+        message_id: "msg-direct-permission-fallback",
+        chat_id: "oc-dm-permission-fallback",
+        chat_type: "p2p",
+        message_type: "text",
+        content: JSON.stringify({ text: "hello dm permission fallback" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockDispatchReplyFromConfig).toHaveBeenCalledTimes(1);
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining(
+          "Permission grant URL: https://open.feishu.cn/app/cli_dm_scope",
+        ),
+      }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        BodyForAgent: expect.stringContaining(
+          "ou-dm-permission-fallback: hello dm permission fallback",
+        ),
+      }),
+    );
+  });
+
   it("does not resolve group names for groups rejected by groupAllowFrom", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     const contactGet = vi

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -2094,6 +2094,11 @@ describe("handleFeishuMessage command authorization", () => {
         ThreadLabel: expect.stringContaining("Role-Task-Routing"),
       }),
     );
+    const lastContext = mockFinalizeInboundContext.mock.calls.at(-1)?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(lastContext?.ThreadLabel).toBe("oc-group / Role-Task-Routing");
+    expect(lastContext?.ThreadLabel).not.toContain("?");
   });
 
   it("keeps root_id as topic key when root_id and thread_id both exist", async () => {

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -61,7 +61,12 @@ const permissionErrorNotifiedAt = new Map<string, number>();
 const PERMISSION_ERROR_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
 const TOPIC_LABEL_TTL_MS = 10 * 60 * 1000;
 const TOPIC_LABEL_MAX_CHARS = 48;
-const topicLabelCache = new Map<string, { label: string; expireAt: number }>();
+const topicLabelCache = new Map<string, { label?: string; expireAt: number }>();
+
+export function clearFeishuBotCachesForTests() {
+  permissionErrorNotifiedAt.clear();
+  topicLabelCache.clear();
+}
 
 function buildFeishuGroupDisplayName(params: { chatId: string; groupName?: string }): string {
   const normalizedChatId = params.chatId.trim();
@@ -110,6 +115,11 @@ async function resolveFeishuTopicLabel(params: {
     return cached.label;
   }
 
+  const cacheMiss = () => {
+    topicLabelCache.set(cacheKey, { label: undefined, expireAt: now + TOPIC_LABEL_TTL_MS });
+    return undefined;
+  };
+
   try {
     const rootMessage = await getMessageFeishu({
       cfg,
@@ -118,13 +128,13 @@ async function resolveFeishuTopicLabel(params: {
     });
     const label = truncateFeishuTopicLabel(rootMessage?.content ?? "");
     if (!label) {
-      return undefined;
+      return cacheMiss();
     }
     topicLabelCache.set(cacheKey, { label, expireAt: now + TOPIC_LABEL_TTL_MS });
     return label;
   } catch (err) {
     log(`feishu: failed to resolve topic label for ${normalizedTopicRootId}: ${String(err)}`);
-    return undefined;
+    return cacheMiss();
   }
 }
 
@@ -403,12 +413,23 @@ export async function handleFeishuMessage(params: {
       senderOpenId: ctx.senderOpenId,
       log,
     });
-    if (directName) {
+    const fallbackSenderName = directName
+      ? undefined
+      : (
+          await resolveFeishuSenderName({
+            account,
+            senderId: ctx.senderOpenId,
+            senderUserId,
+            log,
+          })
+        ).name;
+    const resolvedDirectName = directName ?? fallbackSenderName;
+    if (resolvedDirectName) {
       ctx = {
         ...ctx,
         senderName: buildFeishuDirectDisplayName({
           senderOpenId: ctx.senderOpenId,
-          senderName: directName,
+          senderName: resolvedDirectName,
         }),
       };
     }
@@ -454,18 +475,7 @@ export async function handleFeishuMessage(params: {
       })
     : null;
   const groupHistoryKey = isGroup ? (groupSession?.peerId ?? ctx.chatId) : undefined;
-  const groupDisplayName = isGroup
-    ? buildFeishuGroupDisplayName({
-        chatId: ctx.chatId,
-        groupName: resolveSenderNamesEnabled
-          ? await resolveFeishuGroupName({
-              account,
-              chatId: ctx.chatId,
-              log,
-            })
-          : undefined,
-      })
-    : undefined;
+  let groupDisplayName: string | undefined;
   const dmPolicy = feishuCfg?.dmPolicy ?? "pairing";
   const configAllowFrom = feishuCfg?.allowFrom ?? [];
   const useAccessGroups = cfg.commands?.useAccessGroups !== false;
@@ -567,6 +577,19 @@ export async function handleFeishuMessage(params: {
       return;
     }
   } else {
+  }
+
+  if (isGroup) {
+    groupDisplayName = buildFeishuGroupDisplayName({
+      chatId: ctx.chatId,
+      groupName: resolveSenderNamesEnabled
+        ? await resolveFeishuGroupName({
+            account,
+            chatId: ctx.chatId,
+            log,
+          })
+        : undefined,
+    });
   }
 
   log(

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -405,6 +405,20 @@ export async function handleFeishuMessage(params: {
   // - direct chat: members-only lookup for stable peer naming
   // - group chat: contact user lookup (with user_id/open_id fallback)
   let permissionErrorForAgent: FeishuPermissionError | undefined;
+  const notePermissionErrorForAgent = (permissionError?: FeishuPermissionError) => {
+    if (!permissionError) {
+      return;
+    }
+
+    const appKey = account.appId ?? "default";
+    const now = Date.now();
+    const lastNotified = permissionErrorNotifiedAt.get(appKey) ?? 0;
+
+    if (now - lastNotified > PERMISSION_ERROR_COOLDOWN_MS) {
+      permissionErrorNotifiedAt.set(appKey, now);
+      permissionErrorForAgent = permissionError;
+    }
+  };
   const resolveSenderNamesEnabled = feishuCfg?.resolveSenderNames ?? true;
   if (isDirect && resolveSenderNamesEnabled) {
     const directName = await resolveFeishuDirectNameFromChatMember({
@@ -413,16 +427,16 @@ export async function handleFeishuMessage(params: {
       senderOpenId: ctx.senderOpenId,
       log,
     });
-    const fallbackSenderName = directName
+    const fallbackSenderResult = directName
       ? undefined
-      : (
-          await resolveFeishuSenderName({
-            account,
-            senderId: ctx.senderOpenId,
-            senderUserId,
-            log,
-          })
-        ).name;
+      : await resolveFeishuSenderName({
+          account,
+          senderId: ctx.senderOpenId,
+          senderUserId,
+          log,
+        });
+    notePermissionErrorForAgent(fallbackSenderResult?.permissionError);
+    const fallbackSenderName = fallbackSenderResult?.name;
     const resolvedDirectName = directName ?? fallbackSenderName;
     if (resolvedDirectName) {
       ctx = {
@@ -444,16 +458,7 @@ export async function handleFeishuMessage(params: {
     });
     if (senderResult.name) ctx = { ...ctx, senderName: senderResult.name };
 
-    if (senderResult.permissionError) {
-      const appKey = account.appId ?? "default";
-      const now = Date.now();
-      const lastNotified = permissionErrorNotifiedAt.get(appKey) ?? 0;
-
-      if (now - lastNotified > PERMISSION_ERROR_COOLDOWN_MS) {
-        permissionErrorNotifiedAt.set(appKey, now);
-        permissionErrorForAgent = senderResult.permissionError;
-      }
-    }
+    notePermissionErrorForAgent(senderResult.permissionError);
   }
 
   const historyLimit = Math.max(

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -31,7 +31,12 @@ import {
   resolveFeishuMediaList,
   toMessageResourceType,
 } from "./bot-content.js";
-import { type FeishuPermissionError, resolveFeishuSenderName } from "./bot-sender-name.js";
+import {
+  type FeishuPermissionError,
+  resolveFeishuDirectNameFromChatMember,
+  resolveFeishuGroupName,
+  resolveFeishuSenderName,
+} from "./bot-sender-name.js";
 import { createFeishuClient } from "./client.js";
 import { finalizeFeishuMessageProcessing, tryRecordMessagePersistent } from "./dedup.js";
 import { maybeCreateDynamicAgent } from "./dynamic-agent.js";
@@ -45,7 +50,7 @@ import {
 import { createFeishuReplyDispatcher } from "./reply-dispatcher.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { getMessageFeishu, listFeishuThreadMessages, sendMessageFeishu } from "./send.js";
-import type { FeishuMessageContext } from "./types.js";
+import type { FeishuMessageContext, ResolvedFeishuAccount } from "./types.js";
 import type { DynamicAgentCreationConfig } from "./types.js";
 
 export { toMessageResourceType } from "./bot-content.js";
@@ -54,6 +59,96 @@ export { toMessageResourceType } from "./bot-content.js";
 // Key: appId or "default", Value: timestamp of last notification
 const permissionErrorNotifiedAt = new Map<string, number>();
 const PERMISSION_ERROR_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+const TOPIC_LABEL_TTL_MS = 10 * 60 * 1000;
+const TOPIC_LABEL_MAX_CHARS = 48;
+const topicLabelCache = new Map<string, { label: string; expireAt: number }>();
+
+function buildFeishuGroupDisplayName(params: { chatId: string; groupName?: string }): string {
+  const normalizedChatId = params.chatId.trim();
+  const name = params.groupName?.trim();
+
+  if (!name) return normalizedChatId;
+  if (!normalizedChatId) return name;
+  if (name.includes(normalizedChatId)) return name;
+  return `${name} (${normalizedChatId})`;
+}
+
+function buildFeishuDirectDisplayName(params: {
+  senderOpenId: string;
+  senderName?: string;
+}): string {
+  const senderId = params.senderOpenId.trim();
+  const senderName = params.senderName?.trim();
+
+  if (!senderName) return senderId;
+  if (!senderId) return senderName;
+  if (senderName.includes(senderId)) return senderName;
+  return `${senderName} (${senderId})`;
+}
+
+function truncateFeishuTopicLabel(raw: string): string {
+  const normalized = raw.replace(/\s+/g, " ").trim();
+  if (!normalized) return "";
+  if (normalized.length <= TOPIC_LABEL_MAX_CHARS) return normalized;
+  return `${normalized.slice(0, TOPIC_LABEL_MAX_CHARS - 1).trimEnd()}?`;
+}
+
+async function resolveFeishuTopicLabel(params: {
+  cfg: ClawdbotConfig;
+  account: ResolvedFeishuAccount;
+  topicRootId: string;
+  log: (...args: any[]) => void;
+}): Promise<string | undefined> {
+  const { cfg, account, topicRootId, log } = params;
+  const normalizedTopicRootId = topicRootId.trim();
+  if (!normalizedTopicRootId) return undefined;
+
+  const cacheKey = `${account.accountId}:${normalizedTopicRootId}`;
+  const cached = topicLabelCache.get(cacheKey);
+  const now = Date.now();
+  if (cached && cached.expireAt > now) {
+    return cached.label;
+  }
+
+  try {
+    const rootMessage = await getMessageFeishu({
+      cfg,
+      messageId: normalizedTopicRootId,
+      accountId: account.accountId,
+    });
+    const label = truncateFeishuTopicLabel(rootMessage?.content ?? "");
+    if (!label) {
+      return undefined;
+    }
+    topicLabelCache.set(cacheKey, { label, expireAt: now + TOPIC_LABEL_TTL_MS });
+    return label;
+  } catch (err) {
+    log(`feishu: failed to resolve topic label for ${normalizedTopicRootId}: ${String(err)}`);
+    return undefined;
+  }
+}
+
+function shortFeishuTopicId(raw: string): string {
+  const normalized = raw.trim();
+  if (normalized.length <= 16) return normalized;
+  return `${normalized.slice(0, 8)}?${normalized.slice(-6)}`;
+}
+
+function buildFeishuTopicThreadLabel(params: {
+  groupDisplayName?: string;
+  chatId: string;
+  topicLabel?: string;
+  topicThreadId: string;
+}): string {
+  const groupLabel =
+    params.groupDisplayName?.trim() || buildFeishuGroupDisplayName({ chatId: params.chatId });
+  const topic = params.topicLabel?.trim();
+  if (topic) {
+    return `${groupLabel} ? ${topic}`;
+  }
+  return `${groupLabel} ? topic:${shortFeishuTopicId(params.topicThreadId)}`;
+}
+
 export type FeishuMessageEvent = {
   sender: {
     sender_id: {
@@ -296,18 +391,38 @@ export async function handleFeishuMessage(params: {
     }
   }
 
-  // Resolve sender display name (best-effort) so the agent can attribute messages correctly.
-  // Optimization: skip if disabled to save API quota (Feishu free tier limit).
+  // Resolve sender display name with channel-specific strategy:
+  // - direct chat: members-only lookup for stable peer naming
+  // - group chat: contact user lookup (with user_id/open_id fallback)
   let permissionErrorForAgent: FeishuPermissionError | undefined;
-  if (feishuCfg?.resolveSenderNames ?? true) {
+  const resolveSenderNamesEnabled = feishuCfg?.resolveSenderNames ?? true;
+  if (isDirect && resolveSenderNamesEnabled) {
+    const directName = await resolveFeishuDirectNameFromChatMember({
+      account,
+      chatId: ctx.chatId,
+      senderOpenId: ctx.senderOpenId,
+      log,
+    });
+    if (directName) {
+      ctx = {
+        ...ctx,
+        senderName: buildFeishuDirectDisplayName({
+          senderOpenId: ctx.senderOpenId,
+          senderName: directName,
+        }),
+      };
+    }
+  }
+
+  if (isGroup && resolveSenderNamesEnabled) {
     const senderResult = await resolveFeishuSenderName({
       account,
       senderId: ctx.senderOpenId,
+      senderUserId,
       log,
     });
     if (senderResult.name) ctx = { ...ctx, senderName: senderResult.name };
 
-    // Track permission error to inform agent later (with cooldown to avoid repetition)
     if (senderResult.permissionError) {
       const appKey = account.appId ?? "default";
       const now = Date.now();
@@ -318,16 +433,6 @@ export async function handleFeishuMessage(params: {
         permissionErrorForAgent = senderResult.permissionError;
       }
     }
-  }
-
-  log(
-    `feishu[${account.accountId}]: received message from ${ctx.senderOpenId} in ${ctx.chatId} (${ctx.chatType})`,
-  );
-
-  // Log mention targets if detected
-  if (ctx.mentionTargets && ctx.mentionTargets.length > 0) {
-    const names = ctx.mentionTargets.map((t) => t.name).join(", ");
-    log(`feishu[${account.accountId}]: detected @ forward request, targets: [${names}]`);
   }
 
   const historyLimit = Math.max(
@@ -349,6 +454,18 @@ export async function handleFeishuMessage(params: {
       })
     : null;
   const groupHistoryKey = isGroup ? (groupSession?.peerId ?? ctx.chatId) : undefined;
+  const groupDisplayName = isGroup
+    ? buildFeishuGroupDisplayName({
+        chatId: ctx.chatId,
+        groupName: resolveSenderNamesEnabled
+          ? await resolveFeishuGroupName({
+              account,
+              chatId: ctx.chatId,
+              log,
+            })
+          : undefined,
+      })
+    : undefined;
   const dmPolicy = feishuCfg?.dmPolicy ?? "pairing";
   const configAllowFrom = feishuCfg?.allowFrom ?? [];
   const useAccessGroups = cfg.commands?.useAccessGroups !== false;
@@ -450,6 +567,16 @@ export async function handleFeishuMessage(params: {
       return;
     }
   } else {
+  }
+
+  log(
+    `feishu[${account.accountId}]: received message from ${ctx.senderOpenId} in ${groupDisplayName ?? ctx.chatId} (${ctx.chatType})`,
+  );
+
+  // Log mention targets if detected
+  if (ctx.mentionTargets && ctx.mentionTargets.length > 0) {
+    const names = ctx.mentionTargets.map((t) => t.name).join(", ");
+    log(`feishu[${account.accountId}]: detected @ forward request, targets: [${names}]`);
   }
 
   try {
@@ -660,7 +787,7 @@ export async function handleFeishuMessage(params: {
 
     const preview = ctx.content.replace(/\s+/g, " ").slice(0, 160);
     const inboundLabel = isGroup
-      ? `Feishu[${account.accountId}] message in group ${ctx.chatId}`
+      ? `Feishu[${account.accountId}] message in group ${groupDisplayName ?? ctx.chatId}`
       : `Feishu[${account.accountId}] DM from ${ctx.senderOpenId}`;
 
     // Do not enqueue inbound user previews as system events.
@@ -758,6 +885,32 @@ export async function handleFeishuMessage(params: {
           }))
         : undefined;
 
+    const topicThreadId = isGroup
+      ? ctx.rootId?.trim() || ctx.threadId?.trim() || undefined
+      : undefined;
+    const isTopicScopedSession =
+      isGroup &&
+      (groupSession?.groupSessionScope === "group_topic" ||
+        groupSession?.groupSessionScope === "group_topic_sender");
+    const topicLabel =
+      isTopicScopedSession && ctx.rootId
+        ? await resolveFeishuTopicLabel({
+            cfg,
+            account,
+            topicRootId: ctx.rootId,
+            log,
+          })
+        : undefined;
+    const topicThreadLabel =
+      isTopicScopedSession && topicThreadId
+        ? buildFeishuTopicThreadLabel({
+            groupDisplayName,
+            chatId: ctx.chatId,
+            topicLabel,
+            topicThreadId,
+          })
+        : undefined;
+
     const threadContextBySessionKey = new Map<
       string,
       {
@@ -802,10 +955,7 @@ export async function handleFeishuMessage(params: {
         threadHistoryBody?: string;
         threadLabel?: string;
       } = {
-        threadLabel:
-          (ctx.rootId || ctx.threadId) && isTopicSessionForThread
-            ? `Feishu thread in ${ctx.chatId}`
-            : undefined,
+        threadLabel: topicThreadLabel,
       };
 
       if (!(ctx.rootId || ctx.threadId) || !isTopicSessionForThread) {
@@ -914,7 +1064,7 @@ export async function handleFeishuMessage(params: {
         SessionKey: agentSessionKey,
         AccountId: agentAccountId,
         ChatType: isGroup ? "group" : "direct",
-        GroupSubject: isGroup ? ctx.chatId : undefined,
+        GroupSubject: isGroup ? groupDisplayName : undefined,
         SenderName: ctx.senderName ?? ctx.senderOpenId,
         SenderId: ctx.senderOpenId,
         Provider: "feishu" as const,

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -90,7 +90,7 @@ function truncateFeishuTopicLabel(raw: string): string {
   const normalized = raw.replace(/\s+/g, " ").trim();
   if (!normalized) return "";
   if (normalized.length <= TOPIC_LABEL_MAX_CHARS) return normalized;
-  return `${normalized.slice(0, TOPIC_LABEL_MAX_CHARS - 1).trimEnd()}?`;
+  return `${normalized.slice(0, TOPIC_LABEL_MAX_CHARS - 3).trimEnd()}...`;
 }
 
 async function resolveFeishuTopicLabel(params: {
@@ -131,7 +131,7 @@ async function resolveFeishuTopicLabel(params: {
 function shortFeishuTopicId(raw: string): string {
   const normalized = raw.trim();
   if (normalized.length <= 16) return normalized;
-  return `${normalized.slice(0, 8)}?${normalized.slice(-6)}`;
+  return `${normalized.slice(0, 8)}...${normalized.slice(-6)}`;
 }
 
 function buildFeishuTopicThreadLabel(params: {
@@ -144,9 +144,9 @@ function buildFeishuTopicThreadLabel(params: {
     params.groupDisplayName?.trim() || buildFeishuGroupDisplayName({ chatId: params.chatId });
   const topic = params.topicLabel?.trim();
   if (topic) {
-    return `${groupLabel} ? ${topic}`;
+    return `${groupLabel} / ${topic}`;
   }
-  return `${groupLabel} ? topic:${shortFeishuTopicId(params.topicThreadId)}`;
+  return `${groupLabel} / topic:${shortFeishuTopicId(params.topicThreadId)}`;
 }
 
 export type FeishuMessageEvent = {

--- a/src/config/sessions.test.ts
+++ b/src/config/sessions.test.ts
@@ -154,6 +154,17 @@ describe("sessions", () => {
     ).toBe("discord:friends-of-openclaw#general");
   });
 
+  it("keeps Feishu unicode group names and appends chat id", () => {
+    expect(
+      buildGroupDisplayName({
+        provider: "feishu",
+        subject: "私-openclaw 进化",
+        id: "oc_aa28b4a19f8b78b10167a989682cfe5f",
+        key: "feishu:group:oc_aa28b4a19f8b78b10167a989682cfe5f",
+      }),
+    ).toBe("feishu:私-openclaw 进化 (oc_aa28b4a19f8b78b10167a989682cfe5f)");
+  });
+
   const resolveSessionKeyCases = [
     {
       name: "keeps explicit provider when provided in group key",

--- a/src/config/sessions/group.ts
+++ b/src/config/sessions/group.ts
@@ -38,6 +38,20 @@ export function buildGroupDisplayName(params: {
       : groupChannel || subject || space || "") || "";
   const fallbackId = params.id?.trim() || params.key;
   const rawLabel = detail || fallbackId;
+
+  if (providerKey === "feishu") {
+    if (!rawLabel) {
+      return providerKey;
+    }
+    if (!fallbackId || rawLabel === fallbackId || rawLabel.includes(fallbackId)) {
+      return `${providerKey}:${rawLabel}`;
+    }
+    if (rawLabel.toLowerCase().includes(" id:")) {
+      return `${providerKey}:${rawLabel}`;
+    }
+    return `${providerKey}:${rawLabel} (${fallbackId})`;
+  }
+
   let token = normalizeGroupLabel(rawLabel);
   if (!token) {
     token = normalizeGroupLabel(shortenGroupId(rawLabel));


### PR DESCRIPTION
## Summary

- restore Feishu group display names in session labels
- restore topic/root-message labels for topic-scoped Feishu sessions
- restore DM peer-name fallback through `chatMembers`
- prefer `user_id` before `open_id` when resolving group sender display names

## Current Scope

This PR was refreshed on top of current `main`.

Older config-schema/type changes from the original branch were intentionally dropped because current upstream `main` already covers that layer. The refreshed PR now only carries the remaining behavior changes that are still missing on `main`:

- `extensions/feishu/src/bot.ts`
- `extensions/feishu/src/bot.test.ts`
- `src/config/sessions/group.ts`
- `src/config/sessions.test.ts`

## Behavior

- keep Feishu group labels human-readable instead of collapsing to slug-like fallbacks
- append chat id only when it is not already visible
- surface topic/root labels in thread-scoped context labels
- use `chatMembers` for DM display-name fallback
- prefer `user_id` for group sender-name lookup when available

## Validation

Local refresh validation:

- branch was rebuilt directly on current `main`
- note: temporary local test-worktree environment on my side could not give a reliable fresh root-`vitest` run after the refresh, so authoritative verification should come from GitHub Actions on this refreshed branch

## Notes

- duplicate combined draft PR `#48898` was closed; this PR remains the canonical upstream Feishu thread for this change set
- current upstream `main` already includes the older config-schema/type layer, so this PR is now intentionally much smaller than the original version
