### PR TITLE
fix(feishu): reply inside P2P thread instead of as standalone message

### DIFF
--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -1157,7 +1157,10 @@ export async function handleFeishuMessage(params: {
     const feishuTo = isGroup ? `chat:${ctx.chatId}` : `user:${ctx.senderOpenId}`;
     const peerId = isGroup ? (groupSession?.peerId ?? ctx.chatId) : ctx.senderOpenId;
     const parentPeer = isGroup ? (groupSession?.parentPeer ?? null) : null;
-    const replyInThread = isGroup ? (groupSession?.replyInThread ?? false) : false;
+    // P2P threads: when a DM message carries a thread_id, the user is inside a
+    // thread and the bot should reply there — not as a standalone message.
+    const isDmThread = isDirect && Boolean(ctx.threadId);
+    const replyInThread = isGroup ? (groupSession?.replyInThread ?? false) : isDmThread;
 
     if (isGroup && groupSession) {
       log(
@@ -1355,8 +1358,10 @@ export async function handleFeishuMessage(params: {
       isGroup &&
       (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
     const replyTargetMessageId =
-      isTopicSession || configReplyInThread ? (ctx.rootId ?? ctx.messageId) : ctx.messageId;
-    const threadReply = isGroup ? (groupSession?.threadReply ?? false) : false;
+      isTopicSession || configReplyInThread || isDmThread
+        ? (ctx.rootId ?? ctx.messageId)
+        : ctx.messageId;
+    const threadReply = isGroup ? (groupSession?.threadReply ?? false) : isDmThread;
 
     if (broadcastAgents) {
       // Cross-account dedup: in multi-account setups, Feishu delivers the same
@@ -1407,7 +1412,7 @@ export async function handleFeishuMessage(params: {
             runtime: runtime as RuntimeEnv,
             chatId: ctx.chatId,
             replyToMessageId: replyTargetMessageId,
-            skipReplyToInMessages: !isGroup,
+            skipReplyToInMessages: isDirect && !isDmThread,
             replyInThread,
             rootId: ctx.rootId,
             threadReply,
@@ -1505,7 +1510,7 @@ export async function handleFeishuMessage(params: {
         runtime: runtime as RuntimeEnv,
         chatId: ctx.chatId,
         replyToMessageId: replyTargetMessageId,
-        skipReplyToInMessages: !isGroup,
+        skipReplyToInMessages: isDirect && !isDmThread,
         replyInThread,
         rootId: ctx.rootId,
         threadReply,


### PR DESCRIPTION
## Summary

- When a user sends a message inside a thread in a P2P (direct message) chat, the bot's reply was sent as a standalone message instead of replying within the thread
- This was a regression from #33789, which gated all thread-aware reply logic behind `isGroup` checks
- Now detects P2P threads via the `thread_id` field (per [Feishu API docs](https://open.feishu.cn/document/server-docs/im-v1/message/events/receive), `thread_id` indicates a thread message)

### Changes in `extensions/feishu/src/bot.ts`

1. Added `isDmThread` detection: `isDirect && Boolean(ctx.threadId)`
2. `replyInThread` now returns `true` for P2P threads (was hardcoded `false`)
3. `replyTargetMessageId` uses `root_id` for P2P threads (was always `messageId`)
4. `skipReplyToInMessages` is `false` for P2P threads so `im.message.reply` is used instead of `im.message.create`
5. `threadReply` is `true` for P2P threads

Fixes #38806

## Test plan

- [ ] Open a P2P (direct) chat with the bot in Feishu
- [ ] Create a thread on any message
- [ ] Send a message inside the thread
- [ ] Verify: bot replies inside the thread, not as a standalone message
- [ ] Verify: normal P2P messages (outside threads) still work as before
- [ ] Verify: group thread behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)