### PR TITLE
fix: add missing long dep for baileys via packageExtensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -441,6 +441,13 @@
       "node-llama-cpp",
       "protobufjs",
       "sharp"
-    ]
+    ],
+    "packageExtensions": {
+      "@whiskeysockets/baileys": {
+        "dependencies": {
+          "long": "^5.2.3"
+        }
+      }
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,8 @@ overrides:
   tar: 7.5.10
   tough-cookie: 4.1.3
 
+packageExtensionsChecksum: sha256-mU+kBmOSIlbVW/HRtT2LQ5LMzXiJv9d3cBEa3Pueqxw=
+
 importers:
 
   .:
@@ -10505,6 +10507,7 @@ snapshots:
       '@hapi/boom': 9.1.4
       async-mutex: 0.5.0
       libsignal: '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
+      long: 5.3.2
       lru-cache: 11.2.6
       music-metadata: 11.12.1
       p-queue: 9.1.0


### PR DESCRIPTION
## Summary

- `@whiskeysockets/baileys` imports `long` but doesn't declare it in its `dependencies`
- pnpm's strict `node_modules` layout prevents resolving undeclared transitive deps, causing `ERR_MODULE_NOT_FOUND` at runtime when the browser/WhatsApp module loads
- Adds `pnpm.packageExtensions` to inject `long@^5.2.3` into `@whiskeysockets/baileys`

## Test plan

- [x] `pnpm install` completes successfully
- [x] Browser/WhatsApp module no longer fails with missing `long` package error
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)