### PR TITLE
fix(agents): prevent limitHistoryTurns from orphaning toolResult messages

### DIFF
--- a/src/agents/pi-embedded-runner.limithistoryturns.test.ts
+++ b/src/agents/pi-embedded-runner.limithistoryturns.test.ts
@@ -124,4 +124,93 @@ describe("limitHistoryTurns", () => {
     expect(firstText(limited[0])).toBe("second");
     expect(firstText(limited[1])).toBe("response");
   });
+
+  it("extends cut to include assistant tool_use when toolResult would be orphaned", () => {
+    const toolResultMessage = (toolCallId: string): AgentMessage =>
+      ({
+        role: "toolResult",
+        toolCallId,
+        content: [{ type: "text", text: "result" }],
+        timestamp: Date.now(),
+      }) as AgentMessage;
+
+    // user → assistant [tool_use] → user (interrupt) → toolResult → assistant → user → assistant
+    // With limit=2, the naive cut is at index 2 (user "interrupt"), which
+    // orphans the toolResult at index 3 because its tool_use at index 1 is removed.
+    const messages: AgentMessage[] = [
+      userMessage("hello"),
+      assistantToolCallMessage("t1"),
+      userMessage("interrupt"),
+      toolResultMessage("t1"),
+      assistantTextMessage("based on tool"),
+      userMessage("thanks"),
+      assistantTextMessage("done"),
+    ];
+
+    const limited = limitHistoryTurns(messages, 2);
+    // Cut point should move back to include the assistant tool_use at index 1
+    // so that the toolResult at index 3 is not orphaned.
+    expect(limited.length).toBe(6);
+    expect(limited[0].role).toBe("assistant");
+    expect(limited[1].role).toBe("user");
+    expect(limited[2].role).toBe("toolResult");
+    expect(limited[3].role).toBe("assistant");
+    expect(firstText(limited[4])).toBe("thanks");
+    expect(firstText(limited[5])).toBe("done");
+  });
+
+  it("does not extend cut when tool pairs are complete within kept portion", () => {
+    const toolResultMessage = (toolCallId: string): AgentMessage =>
+      ({
+        role: "toolResult",
+        toolCallId,
+        content: [{ type: "text", text: "result" }],
+        timestamp: Date.now(),
+      }) as AgentMessage;
+
+    // Standard flow: tool pairs are within a single turn, no orphaning
+    const messages: AgentMessage[] = [
+      userMessage("first"),
+      assistantTextMessage("reply1"),
+      userMessage("do something"),
+      assistantToolCallMessage("t1"),
+      toolResultMessage("t1"),
+      assistantTextMessage("here is the result"),
+      userMessage("last"),
+      assistantTextMessage("bye"),
+    ];
+
+    const limited = limitHistoryTurns(messages, 1);
+    // Cut at user "last" — no toolResult before the first assistant, so no extension needed.
+    expect(limited.length).toBe(2);
+    expect(firstText(limited[0])).toBe("last");
+    expect(firstText(limited[1])).toBe("bye");
+  });
+
+  it("does not extend cut when complete tool pairs are before the cut", () => {
+    const toolResultMessage = (toolCallId: string): AgentMessage =>
+      ({
+        role: "toolResult",
+        toolCallId,
+        content: [{ type: "text", text: "result" }],
+        timestamp: Date.now(),
+      }) as AgentMessage;
+
+    const messages: AgentMessage[] = [
+      userMessage("start"),
+      assistantToolCallMessage("t1"),
+      toolResultMessage("t1"),
+      assistantToolCallMessage("t2"),
+      toolResultMessage("t2"),
+      assistantTextMessage("summary"),
+      userMessage("next"),
+      assistantTextMessage("done"),
+    ];
+
+    const limited = limitHistoryTurns(messages, 1);
+    // Cut at user "next" — no toolResult in kept portion before first assistant.
+    expect(limited.length).toBe(2);
+    expect(firstText(limited[0])).toBe("next");
+    expect(firstText(limited[1])).toBe("done");
+  });
 });

--- a/src/agents/pi-embedded-runner.limithistoryturns.test.ts
+++ b/src/agents/pi-embedded-runner.limithistoryturns.test.ts
@@ -213,4 +213,39 @@ describe("limitHistoryTurns", () => {
     expect(firstText(limited[0])).toBe("next");
     expect(firstText(limited[1])).toBe("done");
   });
+
+  it("walks back past multiple user interruptions to reach assistant tool_use", () => {
+    const toolResultMessage = (toolCallId: string): AgentMessage =>
+      ({
+        role: "toolResult",
+        toolCallId,
+        content: [{ type: "text", text: "result" }],
+        timestamp: Date.now(),
+      }) as AgentMessage;
+
+    // assistant [tool_use] → user → user → toolResult → assistant
+    // Multiple user messages between tool_use and toolResult.
+    const messages: AgentMessage[] = [
+      userMessage("start"),
+      assistantToolCallMessage("t1"),
+      userMessage("interrupt1"),
+      userMessage("interrupt2"),
+      toolResultMessage("t1"),
+      assistantTextMessage("based on tool"),
+      userMessage("last"),
+      assistantTextMessage("done"),
+    ];
+
+    const limited = limitHistoryTurns(messages, 2);
+    // Naive cut would be at index 2 (user "interrupt1"), orphaning toolResult
+    // at index 4. Walk-back must continue past user "interrupt1" to reach
+    // the assistant at index 1.
+    expect(limited.length).toBe(7);
+    expect(limited[0].role).toBe("assistant");
+    expect(firstText(limited[1])).toBe("interrupt1");
+    expect(firstText(limited[2])).toBe("interrupt2");
+    expect(limited[3].role).toBe("toolResult");
+    expect(firstText(limited[5])).toBe("last");
+    expect(firstText(limited[6])).toBe("done");
+  });
 });

--- a/src/agents/pi-embedded-runner/history.ts
+++ b/src/agents/pi-embedded-runner/history.ts
@@ -49,8 +49,16 @@ export function limitHistoryTurns(
           }
         }
         if (hasOrphanedToolResult) {
-          while (cutIndex > 0 && messages[cutIndex - 1].role !== "user") {
+          // Walk back past user and toolResult messages until we reach an
+          // assistant message (the one containing the matching tool_use).
+          // Multiple user interruptions can appear between tool_use and
+          // toolResult, so we must not stop at intermediate user messages.
+          while (cutIndex > 0) {
+            const prevRole = messages[cutIndex - 1].role;
             cutIndex--;
+            if (prevRole === "assistant") {
+              break;
+            }
           }
         }
         return messages.slice(cutIndex);

--- a/src/agents/pi-embedded-runner/history.ts
+++ b/src/agents/pi-embedded-runner/history.ts
@@ -11,6 +11,11 @@ function stripThreadSuffix(value: string): string {
 /**
  * Limits conversation history to the last N user turns (and their associated
  * assistant responses). This reduces token usage for long-running DM sessions.
+ *
+ * The cut point is adjusted to avoid splitting tool_use/toolResult pairs: if a
+ * toolResult message would appear in the kept portion without a preceding
+ * assistant message (its tool_use was sliced off), the cut point is moved back
+ * to include the assistant that originated the tool call.
  */
 export function limitHistoryTurns(
   messages: AgentMessage[],
@@ -27,7 +32,28 @@ export function limitHistoryTurns(
     if (messages[i].role === "user") {
       userCount++;
       if (userCount > limit) {
-        return messages.slice(lastUserIndex);
+        let cutIndex = lastUserIndex;
+        // Check if any toolResult message appears in the kept portion
+        // before the first assistant message. That indicates the user
+        // interrupted a tool call and the matching tool_use is before the
+        // cut — extend the cut backward to include it.
+        let hasOrphanedToolResult = false;
+        for (let k = cutIndex; k < messages.length; k++) {
+          const role = messages[k].role;
+          if (role === "assistant") {
+            break;
+          }
+          if (role === "toolResult") {
+            hasOrphanedToolResult = true;
+            break;
+          }
+        }
+        if (hasOrphanedToolResult) {
+          while (cutIndex > 0 && messages[cutIndex - 1].role !== "user") {
+            cutIndex--;
+          }
+        }
+        return messages.slice(cutIndex);
       }
       lastUserIndex = i;
     }


### PR DESCRIPTION
## Summary
- **Problem:** `limitHistoryTurns` cuts history at user message boundaries without considering tool call sequences. When a user interrupts a tool call (sends a message while a tool is running), the cut can separate a `toolResult` from its matching `tool_use`, causing API rejection: `"unexpected tool_use_id found in tool_result blocks"`.
- **Why it matters:** Breaks all long-running sessions (170K+ tokens) that have `dmHistoryLimit` configured. The session becomes unusable.
- **What changed:** `limitHistoryTurns` now detects when the cut point would orphan a `toolResult` and extends the cut backward to include the preceding assistant message that originated the tool call.
- **What did NOT change:** The post-truncation `sanitizeToolUseResultPairing` call in `compact.ts` and `attempt.ts` remains as a safety net.

## Change Type
- [x] Bug fix

## Scope
- [x] Gateway / orchestration

## User-visible Changes
Sessions with `dmHistoryLimit` configured no longer crash with `400` errors when the history contains interrupted tool call sequences.

## Security Impact
None. No new permissions, secrets handling, network calls, or execution surface changes.

## Verification
- Reproduction: configure `dmHistoryLimit`, run a session past the limit with tool calls, send a message while a tool is executing.
- 3 new test cases added covering the fix and verifying no false positives.
- All 12 `limitHistoryTurns` tests pass.
- All 23 `session-transcript-repair` tests pass.
- Lint passes (0 errors).

## Backward Compatibility
Fully backward compatible. No config or migration changes.

## Failure Recovery
Revert the single commit. The existing post-truncation `sanitizeToolUseResultPairing` call provides fallback handling.

## Risks and Mitigations
The cut extension includes slightly more history than the configured limit in the edge case where a user interrupted a tool call at the boundary. This is preferable to crashing.

Fixes #38370