### PR TITLE
Agents/Usage: estimate Ollama usage for the dashboard

### DIFF
--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -605,6 +605,45 @@ describe("createOllamaStreamFn", () => {
     );
   });
 
+  it("counts image payloads in prompt usage estimates when Ollama omits counters", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"vision answer"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true}',
+      ],
+      async () => {
+        const streamFn = createOllamaStreamFn("http://ollama-host:11434");
+        const stream = await Promise.resolve(
+          streamFn(
+            {
+              id: "llava",
+              api: "ollama",
+              provider: "custom-ollama",
+              contextWindow: 131072,
+            } as never,
+            {
+              messages: [
+                {
+                  role: "user",
+                  content: [{ type: "image", data: "a".repeat(400) }],
+                },
+              ],
+            } as never,
+            {} as never,
+          ),
+        );
+        const events = await collectStreamEvents(stream);
+
+        const doneEvent = events.at(-1);
+        if (!doneEvent || doneEvent.type !== "done") {
+          throw new Error("Expected done event");
+        }
+
+        expect(doneEvent.message.usage.input).toBeGreaterThan(50);
+      },
+    );
+  });
+
   it("prefers streamed content over earlier reasoning chunks", async () => {
     await withMockNdjsonFetch(
       [

--- a/src/agents/ollama-stream.test.ts
+++ b/src/agents/ollama-stream.test.ts
@@ -138,6 +138,40 @@ describe("buildAssistantMessage", () => {
     expect(result.content).toEqual([{ type: "text", text: "Reasoning output" }]);
   });
 
+  it("estimates usage when Ollama omits eval counters", () => {
+    const response = {
+      model: "qwen3:32b",
+      created_at: "2026-01-01T00:00:00Z",
+      message: { role: "assistant" as const, content: "Estimated output" },
+      done: true,
+    };
+    const result = buildAssistantMessage(response, modelInfo, {
+      input: 11,
+      output: 4,
+    });
+    expect(result.usage.input).toBe(11);
+    expect(result.usage.output).toBe(4);
+    expect(result.usage.totalTokens).toBe(15);
+  });
+
+  it("preserves explicit zero usage counters from Ollama", () => {
+    const response = {
+      model: "qwen3:32b",
+      created_at: "2026-01-01T00:00:00Z",
+      message: { role: "assistant" as const, content: "" },
+      done: true,
+      prompt_eval_count: 0,
+      eval_count: 0,
+    };
+    const result = buildAssistantMessage(response, modelInfo, {
+      input: 11,
+      output: 4,
+    });
+    expect(result.usage.input).toBe(0);
+    expect(result.usage.output).toBe(0);
+    expect(result.usage.totalTokens).toBe(0);
+  });
+
   it("builds response with tool calls", () => {
     const response = {
       model: "qwen3:32b",
@@ -545,6 +579,28 @@ describe("createOllamaStreamFn", () => {
         }
 
         expect(doneEvent.message.content).toEqual([{ type: "text", text: "reasoned output" }]);
+      },
+    );
+  });
+
+  it("estimates usage when the final Ollama chunk omits counters", async () => {
+    await withMockNdjsonFetch(
+      [
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":"Estimated answer"},"done":false}',
+        '{"model":"m","created_at":"t","message":{"role":"assistant","content":""},"done":true}',
+      ],
+      async () => {
+        const stream = await createOllamaTestStream({ baseUrl: "http://ollama-host:11434" });
+        const events = await collectStreamEvents(stream);
+
+        const doneEvent = events.at(-1);
+        if (!doneEvent || doneEvent.type !== "done") {
+          throw new Error("Expected done event");
+        }
+
+        expect(doneEvent.message.usage.input).toBeGreaterThan(0);
+        expect(doneEvent.message.usage.output).toBeGreaterThan(0);
+        expect(doneEvent.message.usage.totalTokens).toBeGreaterThan(0);
       },
     );
   });

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -69,6 +69,13 @@ interface OllamaToolCall {
   };
 }
 
+type OllamaUsageFallback = {
+  input?: number;
+  output?: number;
+};
+
+const CHARS_PER_TOKEN_ESTIMATE = 4;
+
 const MAX_SAFE_INTEGER_ABS_STR = String(Number.MAX_SAFE_INTEGER);
 
 function isAsciiDigit(ch: string | undefined): boolean {
@@ -215,6 +222,53 @@ interface OllamaChatResponse {
   eval_duration?: number;
 }
 
+function safeJsonLength(value: unknown): number {
+  try {
+    const serialized = JSON.stringify(value);
+    return typeof serialized === "string" ? serialized.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function estimateTokensFromChars(chars: number): number {
+  if (!Number.isFinite(chars) || chars <= 0) {
+    return 0;
+  }
+  return Math.max(1, Math.round(chars / CHARS_PER_TOKEN_ESTIMATE));
+}
+
+function estimateOllamaPromptTokens(params: {
+  messages: OllamaChatMessage[];
+  tools: OllamaTool[];
+}): number {
+  let chars = 0;
+  for (const message of params.messages) {
+    chars += message.content.length;
+    chars += safeJsonLength(message.tool_calls);
+    chars += message.tool_name?.length ?? 0;
+  }
+  chars += safeJsonLength(params.tools);
+  return estimateTokensFromChars(chars);
+}
+
+function estimateOllamaCompletionTokens(response: OllamaChatResponse): number {
+  const text =
+    response.message.content || response.message.thinking || response.message.reasoning || "";
+  const chars = text.length + safeJsonLength(response.message.tool_calls);
+  return estimateTokensFromChars(chars);
+}
+
+function resolveUsageCount(value: number | undefined, fallback: number | undefined): number {
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return value;
+  }
+  if (typeof fallback === "number" && Number.isFinite(fallback) && fallback > 0) {
+    return fallback;
+  }
+  return 0;
+}
+
 // ── Message conversion ──────────────────────────────────────────────────────
 
 type InputContentPart =
@@ -337,6 +391,7 @@ function extractOllamaTools(tools: Tool[] | undefined): OllamaTool[] {
 export function buildAssistantMessage(
   response: OllamaChatResponse,
   modelInfo: { api: string; provider: string; id: string },
+  usageFallback?: OllamaUsageFallback,
 ): AssistantMessage {
   const content: (TextContent | ToolCall)[] = [];
 
@@ -362,14 +417,16 @@ export function buildAssistantMessage(
 
   const hasToolCalls = toolCalls && toolCalls.length > 0;
   const stopReason: StopReason = hasToolCalls ? "toolUse" : "stop";
+  const inputTokens = resolveUsageCount(response.prompt_eval_count, usageFallback?.input);
+  const outputTokens = resolveUsageCount(response.eval_count, usageFallback?.output);
 
   return buildStreamAssistantMessage({
     model: modelInfo,
     content,
     stopReason,
     usage: buildUsageWithNoCost({
-      input: response.prompt_eval_count ?? 0,
-      output: response.eval_count ?? 0,
+      input: inputTokens,
+      output: outputTokens,
     }),
   });
 }
@@ -534,11 +591,23 @@ export function createOllamaStreamFn(
           finalResponse.message.tool_calls = accumulatedToolCalls;
         }
 
+        // The usage dashboard reads transcript-level assistant usage. Some
+        // Ollama builds omit prompt/eval counts, so estimate enough usage here
+        // to keep local-model runs visible in the existing dashboard. This
+        // must run after accumulated output is copied onto the final response.
+        const usageFallback = {
+          input: estimateOllamaPromptTokens({
+            messages: ollamaMessages,
+            tools: ollamaTools,
+          }),
+          output: estimateOllamaCompletionTokens(finalResponse),
+        };
+
         const assistantMessage = buildAssistantMessage(finalResponse, {
           api: model.api,
           provider: model.provider,
           id: model.id,
-        });
+        }, usageFallback);
 
         const reason: Extract<StopReason, "stop" | "length" | "toolUse"> =
           assistantMessage.stopReason === "toolUse" ? "toolUse" : "stop";

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -594,7 +594,8 @@ export function createOllamaStreamFn(
         // The usage dashboard reads transcript-level assistant usage. Some
         // Ollama builds omit prompt/eval counts, so estimate enough usage here
         // to keep local-model runs visible in the existing dashboard. This
-        // must run after accumulated output is copied onto the final response.
+        // must happen after accumulated output is copied onto the final
+        // response so reasoning-mode output is counted correctly.
         const usageFallback = {
           input: estimateOllamaPromptTokens({
             messages: ollamaMessages,

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -245,6 +245,7 @@ function estimateOllamaPromptTokens(params: {
   let chars = 0;
   for (const message of params.messages) {
     chars += message.content.length;
+    chars += safeJsonLength(message.images);
     chars += safeJsonLength(message.tool_calls);
     chars += message.tool_name?.length ?? 0;
   }

--- a/src/agents/ollama-stream.ts
+++ b/src/agents/ollama-stream.ts
@@ -604,11 +604,15 @@ export function createOllamaStreamFn(
           output: estimateOllamaCompletionTokens(finalResponse),
         };
 
-        const assistantMessage = buildAssistantMessage(finalResponse, {
-          api: model.api,
-          provider: model.provider,
-          id: model.id,
-        }, usageFallback);
+        const assistantMessage = buildAssistantMessage(
+          finalResponse,
+          {
+            api: model.api,
+            provider: model.provider,
+            id: model.id,
+          },
+          usageFallback,
+        );
 
         const reason: Extract<StopReason, "stop" | "length" | "toolUse"> =
           assistantMessage.stopReason === "toolUse" ? "toolUse" : "stop";


### PR DESCRIPTION
## Summary
- estimate native Ollama usage when the final `/api/chat` chunk omits `prompt_eval_count` / `eval_count`
- keep exact Ollama counters when they are present
- add regression coverage for both the message builder and streamed Ollama responses

## Why
The existing usage dashboard already reads assistant `message.usage` from session transcripts. Native Ollama sometimes omits its eval counters, which leaves local runs at zero usage and makes them disappear from the current dashboard.

This change keeps the existing dashboard path intact and backfills a chars-based estimate only when Ollama does not return token counts.

## Scope
- fixes native Ollama visibility in the current usage dashboard
- does not add a new JSONL usage sink, new dashboard API, or generic fallback for every OpenAI-compatible local provider

## Testing
- `pnpm test -- src/agents/ollama-stream.test.ts`

Refs #38726
