### PR TITLE
fix: recover busy sessions and improve queued handling

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -1225,6 +1225,7 @@ export async function runEmbeddedPiAgent(
           };
 
           const payloads = buildEmbeddedRunPayloads({
+            aborted: attempt.aborted,
             assistantTexts: attempt.assistantTexts,
             toolMetas: attempt.toolMetas,
             lastAssistant: attempt.lastAssistant,

--- a/src/agents/pi-embedded-runner/run/attempt.ts
+++ b/src/agents/pi-embedded-runner/run/attempt.ts
@@ -18,6 +18,7 @@ import type {
   PluginHookBeforeAgentStartResult,
   PluginHookBeforePromptBuildResult,
 } from "../../../plugins/types.js";
+import { resetCommandLane } from "../../../process/command-queue.js";
 import { isSubagentSessionKey } from "../../../routing/session-key.js";
 import { resolveSignalReactionLevel } from "../../../signal/reaction-level.js";
 import { resolveTelegramInlineButtonsScope } from "../../../telegram/inline-buttons.js";
@@ -89,10 +90,13 @@ import {
   sanitizeToolsForGoogle,
 } from "../google.js";
 import { getDmHistoryLimitFromSessionKey, limitHistoryTurns } from "../history.js";
+import { resolveSessionLane } from "../lanes.js";
 import { log } from "../logger.js";
 import { buildModelAliasLines } from "../model.js";
 import {
   clearActiveEmbeddedRun,
+  EMBEDDED_RUN_ABORT_RELEASE_GRACE_MS,
+  isActiveEmbeddedRunHandle,
   type EmbeddedPiQueueHandle,
   setActiveEmbeddedRun,
 } from "../runs.js";
@@ -1211,9 +1215,12 @@ export async function runEmbeddedAttempt(
         isCompacting: () => subscription.isCompacting(),
         abort: abortRun,
       };
+      const sessionLane = resolveSessionLane(params.sessionKey?.trim() || params.sessionId);
       setActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
 
       let abortWarnTimer: NodeJS.Timeout | undefined;
+      let abortReleaseTimer: NodeJS.Timeout | undefined;
+      let watchdogReleased = false;
       const isProbeSession = params.sessionId?.startsWith("probe-") ?? false;
       const abortTimer = setTimeout(
         () => {
@@ -1241,6 +1248,26 @@ export async function runEmbeddedAttempt(
                 log.warn(
                   `embedded run abort still streaming: runId=${params.runId} sessionId=${params.sessionId}`,
                 );
+              }
+              if (!abortReleaseTimer) {
+                abortReleaseTimer = setTimeout(() => {
+                  if (!isActiveEmbeddedRunHandle(params.sessionId, queueHandle)) {
+                    return;
+                  }
+                  watchdogReleased = true;
+                  const releasedActive = resetCommandLane(sessionLane);
+                  clearActiveEmbeddedRun(
+                    params.sessionId,
+                    queueHandle,
+                    params.sessionKey,
+                    "run_watchdog_timeout",
+                  );
+                  if (!isProbeSession) {
+                    log.error(
+                      `embedded run watchdog forced lane release: runId=${params.runId} sessionId=${params.sessionId} lane=${sessionLane} releasedActive=${releasedActive}`,
+                    );
+                  }
+                }, EMBEDDED_RUN_ABORT_RELEASE_GRACE_MS);
               }
             }, 10_000);
           }
@@ -1551,9 +1578,12 @@ export async function runEmbeddedAttempt(
         if (abortWarnTimer) {
           clearTimeout(abortWarnTimer);
         }
+        if (abortReleaseTimer) {
+          clearTimeout(abortReleaseTimer);
+        }
         if (!isProbeSession && (aborted || timedOut) && !timedOutDuringCompaction) {
           log.debug(
-            `run cleanup: runId=${params.runId} sessionId=${params.sessionId} aborted=${aborted} timedOut=${timedOut}`,
+            `run cleanup: runId=${params.runId} sessionId=${params.sessionId} aborted=${aborted} timedOut=${timedOut} watchdogReleased=${watchdogReleased}`,
           );
         }
         try {
@@ -1566,7 +1596,12 @@ export async function runEmbeddedAttempt(
             `CRITICAL: unsubscribe failed, possible resource leak: runId=${params.runId} ${String(err)}`,
           );
         }
-        clearActiveEmbeddedRun(params.sessionId, queueHandle, params.sessionKey);
+        clearActiveEmbeddedRun(
+          params.sessionId,
+          queueHandle,
+          params.sessionKey,
+          watchdogReleased ? "run_watchdog_timeout" : "run_completed",
+        );
         params.abortSignal?.removeEventListener?.("abort", onAbort);
       }
 

--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -40,6 +40,34 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads[0]?.text).toBe(OVERLOADED_FALLBACK_TEXT);
   };
 
+  it("does not mirror stale assistant text after an aborted run", () => {
+    const payloads = buildPayloads({
+      aborted: true,
+      assistantTexts: ["partial output"],
+      lastAssistant: makeAssistant({
+        stopReason: "stop",
+        errorMessage: undefined,
+        content: [{ type: "text", text: "old final reply" }],
+      }),
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
+  it("still falls back to the last assistant text when the run was not aborted", () => {
+    const payloads = buildPayloads({
+      aborted: false,
+      assistantTexts: [],
+      lastAssistant: makeAssistant({
+        stopReason: "stop",
+        errorMessage: undefined,
+        content: [{ type: "text", text: "old final reply" }],
+      }),
+    });
+
+    expectSinglePayloadText(payloads, "old final reply");
+  });
+
   it("suppresses raw API error JSON when the assistant errored", () => {
     const payloads = buildPayloads({
       assistantTexts: [errorJson],

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -33,6 +33,22 @@ type ToolErrorWarningPolicy = {
   includeDetails: boolean;
 };
 
+export function selectAssistantAnswerTexts(params: {
+  aborted?: boolean;
+  assistantTexts: string[];
+  lastAssistant: AssistantMessage | undefined;
+}): string[] {
+  if (params.aborted) {
+    return [];
+  }
+  const fallbackAnswerText = params.lastAssistant ? extractAssistantText(params.lastAssistant) : "";
+  return params.assistantTexts.length
+    ? params.assistantTexts
+    : fallbackAnswerText
+      ? [fallbackAnswerText]
+      : [];
+}
+
 const RECOVERABLE_TOOL_ERROR_KEYWORDS = [
   "required",
   "missing",
@@ -88,6 +104,7 @@ function resolveToolErrorWarningPolicy(params: {
 }
 
 export function buildEmbeddedRunPayloads(params: {
+  aborted?: boolean;
   assistantTexts: string[];
   toolMetas: ToolMetaEntry[];
   lastAssistant: AssistantMessage | undefined;
@@ -192,7 +209,6 @@ export function buildEmbeddedRunPayloads(params: {
     replyItems.push({ text: reasoningText, isReasoning: true });
   }
 
-  const fallbackAnswerText = params.lastAssistant ? extractAssistantText(params.lastAssistant) : "";
   const shouldSuppressRawErrorText = (text: string) => {
     if (!lastAssistantErrored) {
       return false;
@@ -243,13 +259,9 @@ export function buildEmbeddedRunPayloads(params: {
     }
     return isRawApiErrorPayload(trimmed);
   };
-  const answerTexts = (
-    params.assistantTexts.length
-      ? params.assistantTexts
-      : fallbackAnswerText
-        ? [fallbackAnswerText]
-        : []
-  ).filter((text) => !shouldSuppressRawErrorText(text));
+  const answerTexts = selectAssistantAnswerTexts(params).filter(
+    (text) => !shouldSuppressRawErrorText(text),
+  );
 
   let hasUserFacingAssistantReply = false;
   for (const text of answerTexts) {

--- a/src/agents/pi-embedded-runner/runs.ts
+++ b/src/agents/pi-embedded-runner/runs.ts
@@ -12,6 +12,7 @@ type EmbeddedPiQueueHandle = {
 };
 
 const ACTIVE_EMBEDDED_RUNS = new Map<string, EmbeddedPiQueueHandle>();
+export const EMBEDDED_RUN_ABORT_RELEASE_GRACE_MS = 15_000;
 type EmbeddedRunWaiter = {
   resolve: (ended: boolean) => void;
   timer: NodeJS.Timeout;
@@ -66,6 +67,13 @@ export function isEmbeddedPiRunStreaming(sessionId: string): boolean {
 
 export function getActiveEmbeddedRunCount(): number {
   return ACTIVE_EMBEDDED_RUNS.size;
+}
+
+export function isActiveEmbeddedRunHandle(
+  sessionId: string,
+  handle: EmbeddedPiQueueHandle,
+): boolean {
+  return ACTIVE_EMBEDDED_RUNS.get(sessionId) === handle;
 }
 
 export function waitForEmbeddedPiRunEnd(sessionId: string, timeoutMs = 15_000): Promise<boolean> {
@@ -137,12 +145,15 @@ export function clearActiveEmbeddedRun(
   sessionId: string,
   handle: EmbeddedPiQueueHandle,
   sessionKey?: string,
+  reason = "run_completed",
 ) {
   if (ACTIVE_EMBEDDED_RUNS.get(sessionId) === handle) {
     ACTIVE_EMBEDDED_RUNS.delete(sessionId);
-    logSessionStateChange({ sessionId, sessionKey, state: "idle", reason: "run_completed" });
+    logSessionStateChange({ sessionId, sessionKey, state: "idle", reason });
     if (!sessionId.startsWith("probe-")) {
-      diag.debug(`run cleared: sessionId=${sessionId} totalActive=${ACTIVE_EMBEDDED_RUNS.size}`);
+      diag.debug(
+        `run cleared: sessionId=${sessionId} totalActive=${ACTIVE_EMBEDDED_RUNS.size} reason=${reason}`,
+      );
     }
     notifyEmbeddedRunEnded(sessionId);
   } else {

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -63,6 +63,7 @@ vi.mock("./queue.js", async () => {
   return {
     ...actual,
     enqueueFollowupRun: vi.fn(),
+    getFollowupQueueDepth: vi.fn(() => 1),
     scheduleFollowupDrain: vi.fn(),
   };
 });

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -10,6 +10,7 @@ import type { TemplateContext } from "../templating.js";
 import type { GetReplyOptions } from "../types.js";
 import {
   enqueueFollowupRun,
+  getFollowupQueueDepth,
   scheduleFollowupDrain,
   type FollowupRun,
   type QueueSettings,
@@ -78,6 +79,7 @@ vi.mock("../../agents/cli-runner.js", () => ({
 
 vi.mock("./queue.js", () => ({
   enqueueFollowupRun: vi.fn(),
+  getFollowupQueueDepth: vi.fn(() => 1),
   scheduleFollowupDrain: vi.fn(),
 }));
 
@@ -91,7 +93,8 @@ beforeAll(async () => {
 beforeEach(() => {
   state.runEmbeddedPiAgentMock.mockClear();
   state.runCliAgentMock.mockClear();
-  vi.mocked(enqueueFollowupRun).mockClear();
+  vi.mocked(enqueueFollowupRun).mockClear().mockReturnValue(true);
+  vi.mocked(getFollowupQueueDepth).mockClear().mockReturnValue(1);
   vi.mocked(scheduleFollowupDrain).mockClear();
   vi.stubEnv("OPENCLAW_TEST_FAST", "1");
 });
@@ -313,9 +316,28 @@ describe("runReplyAgent heartbeat followup guard", () => {
 
     const result = await run();
 
-    expect(result).toBeUndefined();
+    expect(result).toEqual({
+      text: "⏳ Still finishing the previous run — this message is queued and I'll follow up shortly.",
+    });
     expect(vi.mocked(enqueueFollowupRun)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(getFollowupQueueDepth)).toHaveBeenCalledWith("main");
     expect(state.runEmbeddedPiAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("includes queued-ahead depth in the busy receipt when backlog already exists", async () => {
+    vi.mocked(getFollowupQueueDepth).mockReturnValueOnce(3);
+    const { run } = createMinimalRun({
+      opts: { isHeartbeat: false },
+      isActive: true,
+      shouldFollowup: true,
+      resolvedQueueMode: "collect",
+    });
+
+    const result = await run();
+
+    expect(result).toEqual({
+      text: "⏳ Still finishing the previous run — this message is queued (2 ahead) and I'll follow up shortly.",
+    });
   });
 
   it("drains followup queue when an unexpected exception escapes the run path", async () => {

--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -45,8 +45,13 @@ import { resolveEffectiveBlockStreamingConfig } from "./block-streaming.js";
 import { createFollowupRunner } from "./followup-runner.js";
 import { resolveOriginMessageProvider, resolveOriginMessageTo } from "./origin-routing.js";
 import { readPostCompactionContext } from "./post-compaction-context.js";
-import { resolveActiveRunQueueAction } from "./queue-policy.js";
-import { enqueueFollowupRun, type FollowupRun, type QueueSettings } from "./queue.js";
+import { buildQueuedBusyReceipt, resolveActiveRunQueueAction } from "./queue-policy.js";
+import {
+  enqueueFollowupRun,
+  getFollowupQueueDepth,
+  type FollowupRun,
+  type QueueSettings,
+} from "./queue.js";
 import { createReplyToModeFilterForChannel, resolveReplyToMode } from "./reply-threading.js";
 import { incrementRunCompactionCount, persistRunSessionUsage } from "./session-run-accounting.js";
 import { createTypingSignaler } from "./typing-mode.js";
@@ -240,9 +245,14 @@ export async function runReplyAgent(params: {
   }
 
   if (activeRunQueueAction === "enqueue-followup") {
-    enqueueFollowupRun(queueKey, followupRun, resolvedQueue);
+    const enqueued = enqueueFollowupRun(queueKey, followupRun, resolvedQueue);
     await touchActiveSessionEntry();
     typing.cleanup();
+    if (enqueued && !isHeartbeat) {
+      return buildQueuedBusyReceipt({
+        depth: getFollowupQueueDepth(queueKey),
+      });
+    }
     return undefined;
   }
 

--- a/src/auto-reply/reply/queue-policy.test.ts
+++ b/src/auto-reply/reply/queue-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveActiveRunQueueAction } from "./queue-policy.js";
+import { buildQueuedBusyReceipt, resolveActiveRunQueueAction } from "./queue-policy.js";
 
 describe("resolveActiveRunQueueAction", () => {
   it("runs immediately when there is no active run", () => {
@@ -44,5 +44,17 @@ describe("resolveActiveRunQueueAction", () => {
         queueMode: "steer",
       }),
     ).toBe("enqueue-followup");
+  });
+});
+
+describe("buildQueuedBusyReceipt", () => {
+  it("returns a short busy receipt for the first queued message", () => {
+    expect(buildQueuedBusyReceipt({ depth: 1 }).text).toContain("queued");
+    expect(buildQueuedBusyReceipt({ depth: 1 }).text).toContain("follow up shortly");
+    expect(buildQueuedBusyReceipt({ depth: 1 }).text.length).toBeLessThan(120);
+  });
+
+  it("includes queued-ahead count when backlog already exists", () => {
+    expect(buildQueuedBusyReceipt({ depth: 3 }).text).toContain("2 ahead");
   });
 });

--- a/src/auto-reply/reply/queue-policy.ts
+++ b/src/auto-reply/reply/queue-policy.ts
@@ -19,3 +19,11 @@ export function resolveActiveRunQueueAction(params: {
   }
   return "run-now";
 }
+
+export function buildQueuedBusyReceipt(params: { depth?: number }) {
+  const queuedAhead = Math.max(0, Math.floor((params.depth ?? 1) - 1));
+  const queueHint = queuedAhead > 0 ? ` (${queuedAhead} ahead)` : "";
+  return {
+    text: `⏳ Still finishing the previous run — this message is queued${queueHint} and I'll follow up shortly.`,
+  };
+}

--- a/src/config/sessions/types.ts
+++ b/src/config/sessions/types.ts
@@ -84,6 +84,12 @@ export type SessionEntry = {
   spawnDepth?: number;
   systemSent?: boolean;
   abortedLastRun?: boolean;
+  lastResetAt?: number;
+  lastResetMode?: "new" | "reset";
+  lastResetSource?: string;
+  lastResetBy?: string;
+  lastResetReason?: string;
+  lastResetRunId?: string;
   /**
    * Session-level stop cutoff captured when /stop is received.
    * Messages at/before this boundary are skipped to avoid replaying

--- a/src/gateway/protocol/schema/sessions.ts
+++ b/src/gateway/protocol/schema/sessions.ts
@@ -86,6 +86,10 @@ export const SessionsResetParamsSchema = Type.Object(
   {
     key: NonEmptyString,
     reason: Type.Optional(Type.Union([Type.Literal("new"), Type.Literal("reset")])),
+    triggerSource: Type.Optional(NonEmptyString),
+    triggeredBy: Type.Optional(NonEmptyString),
+    triggerReason: Type.Optional(NonEmptyString),
+    triggerRunId: Type.Optional(NonEmptyString),
   },
   { additionalProperties: false },
 );

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -284,6 +284,36 @@ async function closeAcpRuntimeForSession(params: {
   return undefined;
 }
 
+export function buildSessionResetAuditMetadata(params: {
+  reason?: "new" | "reset";
+  triggerSource?: string;
+  triggeredBy?: string;
+  triggerReason?: string;
+  triggerRunId?: string;
+}) {
+  const clean = (value: unknown): string | undefined => {
+    if (typeof value !== "string") {
+      return undefined;
+    }
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+  };
+  const mode = params.reason === "new" ? "new" : "reset";
+  const source = clean(params.triggerSource) ?? "gateway:sessions.reset";
+  const triggeredBy = clean(params.triggeredBy) ?? source;
+  const triggerReason =
+    clean(params.triggerReason) ?? (mode === "new" ? "new-session" : "manual-reset");
+  const triggerRunId = clean(params.triggerRunId);
+  return {
+    lastResetAt: Date.now(),
+    lastResetMode: mode,
+    lastResetSource: source,
+    lastResetBy: triggeredBy,
+    lastResetReason: triggerReason,
+    ...(triggerRunId ? { lastResetRunId: triggerRunId } : {}),
+  } as const;
+}
+
 export const sessionsHandlers: GatewayRequestHandlers = {
   "sessions.list": ({ params, respond }) => {
     if (!assertValidParams(params, validateSessionsListParams, "sessions.list", respond)) {
@@ -433,6 +463,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const { entry, legacyKey, canonicalKey } = loadSessionEntry(key);
     const hadExistingEntry = Boolean(entry);
     const commandReason = p.reason === "new" ? "new" : "reset";
+    const resetAudit = buildSessionResetAuditMetadata(p);
     const hookEvent = createInternalHookEvent(
       "command",
       commandReason,
@@ -441,6 +472,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         sessionEntry: entry,
         previousSessionEntry: entry,
         commandSource: "gateway:sessions.reset",
+        resetAudit,
         cfg,
       },
     );
@@ -477,6 +509,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         updatedAt: now,
         systemSent: false,
         abortedLastRun: false,
+        ...resetAudit,
+        lastResetAt: now,
         thinkingLevel: entry?.thinkingLevel,
         verboseLevel: entry?.verboseLevel,
         reasoningLevel: entry?.reasoningLevel,
@@ -513,7 +547,11 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         reason: "session-reset",
       });
     }
-    respond(true, { ok: true, key: target.canonicalKey, entry: next }, undefined);
+    respond(
+      true,
+      { ok: true, key: target.canonicalKey, entry: next, reset: resetAudit },
+      undefined,
+    );
   },
   "sessions.delete": async ({ params, respond, client, isWebchatConnect }) => {
     if (!assertValidParams(params, validateSessionsDeleteParams, "sessions.delete", respond)) {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -290,6 +290,7 @@ export function buildSessionResetAuditMetadata(params: {
   triggeredBy?: string;
   triggerReason?: string;
   triggerRunId?: string;
+  lastResetAt?: number;
 }) {
   const clean = (value: unknown): string | undefined => {
     if (typeof value !== "string") {
@@ -304,8 +305,12 @@ export function buildSessionResetAuditMetadata(params: {
   const triggerReason =
     clean(params.triggerReason) ?? (mode === "new" ? "new-session" : "manual-reset");
   const triggerRunId = clean(params.triggerRunId);
+  const lastResetAt =
+    typeof params.lastResetAt === "number" && Number.isFinite(params.lastResetAt)
+      ? params.lastResetAt
+      : Date.now();
   return {
-    lastResetAt: Date.now(),
+    lastResetAt,
     lastResetMode: mode,
     lastResetSource: source,
     lastResetBy: triggeredBy,
@@ -463,7 +468,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
     const { entry, legacyKey, canonicalKey } = loadSessionEntry(key);
     const hadExistingEntry = Boolean(entry);
     const commandReason = p.reason === "new" ? "new" : "reset";
-    const resetAudit = buildSessionResetAuditMetadata(p);
+    const resetAuditAt = Date.now();
+    const resetAudit = buildSessionResetAuditMetadata({ ...p, lastResetAt: resetAuditAt });
     const hookEvent = createInternalHookEvent(
       "command",
       commandReason,
@@ -510,7 +516,6 @@ export const sessionsHandlers: GatewayRequestHandlers = {
         systemSent: false,
         abortedLastRun: false,
         ...resetAudit,
-        lastResetAt: now,
         thinkingLevel: entry?.thinkingLevel,
         verboseLevel: entry?.verboseLevel,
         reasoningLevel: entry?.reasoningLevel,

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1134,6 +1134,83 @@ describe("gateway server sessions", () => {
     ws.close();
   });
 
+  test("sessions.reset stores and returns audit metadata", async () => {
+    const { storePath } = await seedActiveMainSession();
+
+    const { ws } = await openClient();
+    const reset = await rpcReq<{
+      ok: true;
+      key: string;
+      entry: {
+        lastResetMode?: string;
+        lastResetSource?: string;
+        lastResetBy?: string;
+        lastResetReason?: string;
+        lastResetRunId?: string;
+      };
+      reset?: {
+        lastResetMode?: string;
+        lastResetSource?: string;
+        lastResetBy?: string;
+        lastResetReason?: string;
+        lastResetRunId?: string;
+      };
+    }>(ws, "sessions.reset", {
+      key: "main",
+      triggerSource: "gateway:watchdog",
+      triggeredBy: "ou_test_user",
+      triggerReason: "watchdog-timeout",
+      triggerRunId: "run_123",
+    });
+
+    expect(reset.ok).toBe(true);
+    expect(reset.payload?.reset).toMatchObject({
+      lastResetMode: "reset",
+      lastResetSource: "gateway:watchdog",
+      lastResetBy: "ou_test_user",
+      lastResetReason: "watchdog-timeout",
+      lastResetRunId: "run_123",
+    });
+    expect(reset.payload?.entry).toMatchObject({
+      lastResetMode: "reset",
+      lastResetSource: "gateway:watchdog",
+      lastResetBy: "ou_test_user",
+      lastResetReason: "watchdog-timeout",
+      lastResetRunId: "run_123",
+    });
+
+    const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
+      string,
+      {
+        lastResetMode?: string;
+        lastResetSource?: string;
+        lastResetBy?: string;
+        lastResetReason?: string;
+        lastResetRunId?: string;
+      }
+    >;
+    expect(store["agent:main:main"]).toMatchObject({
+      lastResetMode: "reset",
+      lastResetSource: "gateway:watchdog",
+      lastResetBy: "ou_test_user",
+      lastResetReason: "watchdog-timeout",
+      lastResetRunId: "run_123",
+    });
+
+    const event = (
+      sessionHookMocks.triggerInternalHook.mock.calls as unknown as Array<[unknown]>
+    )[0]?.[0] as { context?: { resetAudit?: unknown } } | undefined;
+    expect(event?.context?.resetAudit).toMatchObject({
+      lastResetMode: "reset",
+      lastResetSource: "gateway:watchdog",
+      lastResetBy: "ou_test_user",
+      lastResetReason: "watchdog-timeout",
+      lastResetRunId: "run_123",
+    });
+
+    ws.close();
+  });
+
   test("sessions.reset returns unavailable when active run does not stop", async () => {
     const { dir, storePath } = await seedActiveMainSession();
 

--- a/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
+++ b/src/gateway/server.sessions.gateway-server-sessions-a.test.ts
@@ -1142,6 +1142,7 @@ describe("gateway server sessions", () => {
       ok: true;
       key: string;
       entry: {
+        lastResetAt?: number;
         lastResetMode?: string;
         lastResetSource?: string;
         lastResetBy?: string;
@@ -1149,6 +1150,7 @@ describe("gateway server sessions", () => {
         lastResetRunId?: string;
       };
       reset?: {
+        lastResetAt?: number;
         lastResetMode?: string;
         lastResetSource?: string;
         lastResetBy?: string;
@@ -1178,10 +1180,12 @@ describe("gateway server sessions", () => {
       lastResetReason: "watchdog-timeout",
       lastResetRunId: "run_123",
     });
+    expect(reset.payload?.reset?.lastResetAt).toBe(reset.payload?.entry?.lastResetAt);
 
     const store = JSON.parse(await fs.readFile(storePath, "utf-8")) as Record<
       string,
       {
+        lastResetAt?: number;
         lastResetMode?: string;
         lastResetSource?: string;
         lastResetBy?: string;
@@ -1196,10 +1200,24 @@ describe("gateway server sessions", () => {
       lastResetReason: "watchdog-timeout",
       lastResetRunId: "run_123",
     });
+    expect(store["agent:main:main"]?.lastResetAt).toBe(reset.payload?.entry?.lastResetAt);
 
     const event = (
       sessionHookMocks.triggerInternalHook.mock.calls as unknown as Array<[unknown]>
-    )[0]?.[0] as { context?: { resetAudit?: unknown } } | undefined;
+    )[0]?.[0] as
+      | {
+          context?: {
+            resetAudit?: {
+              lastResetAt?: number;
+              lastResetMode?: string;
+              lastResetSource?: string;
+              lastResetBy?: string;
+              lastResetReason?: string;
+              lastResetRunId?: string;
+            };
+          };
+        }
+      | undefined;
     expect(event?.context?.resetAudit).toMatchObject({
       lastResetMode: "reset",
       lastResetSource: "gateway:watchdog",
@@ -1207,6 +1225,7 @@ describe("gateway server sessions", () => {
       lastResetReason: "watchdog-timeout",
       lastResetRunId: "run_123",
     });
+    expect(event?.context?.resetAudit?.lastResetAt).toBe(reset.payload?.entry?.lastResetAt);
 
     ws.close();
   });

--- a/src/process/command-queue.test.ts
+++ b/src/process/command-queue.test.ts
@@ -26,6 +26,7 @@ import {
   getQueueSize,
   markGatewayDraining,
   resetAllLanes,
+  resetCommandLane,
   setCommandLaneConcurrency,
   waitForActiveTasks,
 } from "./command-queue.js";
@@ -290,6 +291,44 @@ describe("command queue", () => {
     // Let the active task finish normally.
     release();
     await expect(first).resolves.toBe("first");
+  });
+
+  it("resetCommandLane releases stuck active bookkeeping and drains queued work", async () => {
+    const lane = `reset-single-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    setCommandLaneConcurrency(lane, 1);
+
+    let resolve1!: () => void;
+    const blocker = new Promise<void>((r) => {
+      resolve1 = r;
+    });
+
+    const first = enqueueCommandInLane(lane, async () => {
+      await blocker;
+      return "first";
+    });
+
+    await vi.waitFor(() => {
+      expect(getActiveTaskCount()).toBeGreaterThanOrEqual(1);
+    });
+
+    let secondRan = false;
+    const second = enqueueCommandInLane(lane, async () => {
+      secondRan = true;
+      return "second";
+    });
+
+    await vi.waitFor(() => {
+      expect(getQueueSize(lane)).toBeGreaterThanOrEqual(2);
+    });
+    expect(secondRan).toBe(false);
+
+    const released = resetCommandLane(lane);
+    expect(released).toBe(1);
+
+    resolve1();
+    await expect(first).resolves.toBe("first");
+    await expect(second).resolves.toBe("second");
+    expect(secondRan).toBe(true);
   });
 
   it("keeps draining functional after synchronous onWait failure", async () => {

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -228,6 +228,27 @@ export function clearCommandLane(lane: string = CommandLane.Main) {
 }
 
 /**
+ * Force-reset a single lane's active runtime bookkeeping while preserving
+ * queued work. Used by embedded-run watchdogs when a timed-out run never
+ * reaches its finally block and leaves the per-session lane permanently busy.
+ */
+export function resetCommandLane(lane: string = CommandLane.Main) {
+  const cleaned = lane.trim() || CommandLane.Main;
+  const state = lanes.get(cleaned);
+  if (!state) {
+    return 0;
+  }
+  const released = state.activeTaskIds.size;
+  state.generation += 1;
+  state.activeTaskIds.clear();
+  state.draining = false;
+  if (state.queue.length > 0) {
+    drainLane(cleaned);
+  }
+  return released;
+}
+
+/**
  * Reset all lane runtime state to idle. Used after SIGUSR1 in-process
  * restarts where interrupted tasks' finally blocks may not run, leaving
  * stale active task IDs that permanently block new work from draining.


### PR DESCRIPTION
## Summary
- add watchdog recovery for stuck busy/session embedded runs
- record richer `sessions.reset` audit metadata
- prevent aborted embedded runs from mirroring stale assistant replies
- return short queued-message receipts while a previous run is still finishing

## Testing
- `corepack pnpm exec tsc -p tsconfig.json --noEmit`
- `corepack pnpm exec vitest run src/process/command-queue.test.ts src/agents/pi-embedded-runner/run/payloads.errors.test.ts src/auto-reply/reply/queue-policy.test.ts src/gateway/server.sessions.gateway-server-sessions-a.test.ts`
- `corepack pnpm exec vitest run --config vitest.e2e.config.ts src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts`
