### PR TITLE
fix(doctor): protect running gateway from ExecStart rewrites; skip inactive companion services

### DIFF
--- a/src/commands/doctor-gateway-services.test.ts
+++ b/src/commands/doctor-gateway-services.test.ts
@@ -13,6 +13,8 @@ const mocks = vi.hoisted(() => ({
   findExtraGatewayServices: vi.fn().mockResolvedValue([]),
   renderGatewayServiceCleanupHints: vi.fn().mockReturnValue([]),
   uninstallLegacySystemdUnits: vi.fn().mockResolvedValue([]),
+  // Default: gateway service not running, companion services not active
+  isSystemdUnitActive: vi.fn().mockResolvedValue(false),
   note: vi.fn(),
 }));
 
@@ -35,6 +37,7 @@ vi.mock("../daemon/service-audit.js", () => ({
   auditGatewayServiceConfig: mocks.auditGatewayServiceConfig,
   needsNodeRuntimeMigration: vi.fn(() => false),
   SERVICE_AUDIT_CODES: {
+    gatewayCommandMissing: "gateway-command-missing",
     gatewayEntrypointMismatch: "gateway-entrypoint-mismatch",
   },
 }));
@@ -48,6 +51,7 @@ vi.mock("../daemon/service.js", () => ({
 
 vi.mock("../daemon/systemd.js", () => ({
   uninstallLegacySystemdUnits: mocks.uninstallLegacySystemdUnits,
+  isSystemdUnitActive: (...args: unknown[]) => mocks.isSystemdUnitActive(...args),
 }));
 
 vi.mock("../terminal/note.js", () => ({
@@ -286,6 +290,154 @@ describe("maybeScanExtraGatewayServices", () => {
     );
     expect(runtime.log).toHaveBeenCalledWith(
       "Legacy gateway services removed. Installing OpenClaw gateway next.",
+    );
+  });
+});
+
+describe("maybeRepairGatewayServiceConfig — running gateway protection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips ExecStart-level issues when the gateway service is currently running", async () => {
+    // Simulate a custom wrapper script as ExecStart: doctor flags gateway-command-missing
+    // because the shell script doesn't pass "gateway" as a subcommand argument.
+    mocks.readCommand.mockResolvedValue({
+      programArguments: ["/home/user/.local/bin/openclaw-gateway-start"],
+      sourcePath: "/home/user/.config/systemd/user/openclaw-gateway.service",
+      environment: { OPENCLAW_GATEWAY_TOKEN: "token" },
+    });
+    mocks.auditGatewayServiceConfig.mockResolvedValue({
+      ok: false,
+      issues: [
+        {
+          code: "gateway-command-missing",
+          message: "Service command does not include the gateway subcommand",
+          level: "aggressive",
+        },
+      ],
+    });
+    mocks.resolveGatewayInstallToken.mockResolvedValue({
+      token: "token",
+      tokenRefConfigured: false,
+      warnings: [],
+    });
+    mocks.buildGatewayInstallPlan.mockResolvedValue({
+      programArguments: ["/usr/bin/node", "/path/to/openclaw", "gateway"],
+      workingDirectory: "/tmp",
+      environment: {},
+    });
+
+    // Gateway is running — ExecStart repair must be skipped
+    mocks.isSystemdUnitActive.mockResolvedValue(true);
+
+    await runRepair({});
+
+    // install should NOT have been called — no remaining issues after filtering
+    expect(mocks.install).not.toHaveBeenCalled();
+  });
+
+  it("proceeds with ExecStart repair when the gateway service is not running", async () => {
+    mocks.readCommand.mockResolvedValue({
+      programArguments: ["/home/user/.local/bin/openclaw-gateway-start"],
+      sourcePath: "/home/user/.config/systemd/user/openclaw-gateway.service",
+      environment: { OPENCLAW_GATEWAY_TOKEN: "token" },
+    });
+    mocks.auditGatewayServiceConfig.mockResolvedValue({
+      ok: false,
+      issues: [
+        {
+          code: "gateway-command-missing",
+          message: "Service command does not include the gateway subcommand",
+          level: "aggressive",
+        },
+      ],
+    });
+    mocks.resolveGatewayInstallToken.mockResolvedValue({
+      token: "token",
+      tokenRefConfigured: false,
+      warnings: [],
+    });
+    mocks.buildGatewayInstallPlan.mockResolvedValue({
+      programArguments: ["/usr/bin/node", "/path/to/openclaw", "gateway"],
+      workingDirectory: "/tmp",
+      environment: {},
+    });
+    mocks.install.mockResolvedValue(undefined);
+
+    // Gateway is NOT running — repair is allowed to proceed
+    mocks.isSystemdUnitActive.mockResolvedValue(false);
+
+    await runRepair({});
+
+    expect(mocks.install).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("maybeScanExtraGatewayServices — active-only filtering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findExtraGatewayServices.mockResolvedValue([]);
+    mocks.renderGatewayServiceCleanupHints.mockReturnValue([]);
+    mocks.uninstallLegacySystemdUnits.mockResolvedValue([]);
+    mocks.isSystemdUnitActive.mockResolvedValue(false);
+  });
+
+  function makePrompts() {
+    return {
+      confirm: vi.fn(),
+      confirmRepair: vi.fn(),
+      confirmAggressive: vi.fn(),
+      confirmSkipInNonInteractive: vi.fn().mockResolvedValue(false),
+      select: vi.fn(),
+      shouldRepair: false,
+      shouldForce: false,
+    };
+  }
+
+  it("does not warn about inactive extra services (e.g. a stopped companion)", async () => {
+    mocks.findExtraGatewayServices.mockResolvedValue([
+      {
+        platform: "linux",
+        label: "openclaw-voice.service",
+        detail: "unit: /home/user/.config/systemd/user/openclaw-voice.service",
+        scope: "user",
+        marker: "openclaw",
+        legacy: false,
+      },
+    ]);
+    // Service is not active
+    mocks.isSystemdUnitActive.mockResolvedValue(false);
+
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    await maybeScanExtraGatewayServices({ deep: false }, runtime, makePrompts());
+
+    expect(mocks.note).not.toHaveBeenCalledWith(
+      expect.any(String),
+      "Other gateway-like services detected",
+    );
+  });
+
+  it("warns about an extra service that is actively running", async () => {
+    mocks.findExtraGatewayServices.mockResolvedValue([
+      {
+        platform: "linux",
+        label: "openclaw-gateway-second.service",
+        detail: "unit: /home/user/.config/systemd/user/openclaw-gateway-second.service",
+        scope: "user",
+        marker: "openclaw",
+        legacy: false,
+      },
+    ]);
+    // Service IS active
+    mocks.isSystemdUnitActive.mockResolvedValue(true);
+
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    await maybeScanExtraGatewayServices({ deep: false }, runtime, makePrompts());
+
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("openclaw-gateway-second.service"),
+      "Other gateway-like services detected",
     );
   });
 });

--- a/src/commands/doctor-gateway-services.ts
+++ b/src/commands/doctor-gateway-services.ts
@@ -18,7 +18,7 @@ import {
   SERVICE_AUDIT_CODES,
 } from "../daemon/service-audit.js";
 import { resolveGatewayService } from "../daemon/service.js";
-import { uninstallLegacySystemdUnits } from "../daemon/systemd.js";
+import { isSystemdUnitActive, uninstallLegacySystemdUnits } from "../daemon/systemd.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { note } from "../terminal/note.js";
 import { buildGatewayInstallPlan } from "./daemon-install-helpers.js";
@@ -241,6 +241,37 @@ export async function maybeRepairGatewayServiceConfig(
       level: "recommended",
     });
   }
+
+  // If the gateway service is currently running, skip any issues that would rewrite the
+  // ExecStart or launcher command. The current ExecStart is clearly working — overwriting
+  // it (e.g. replacing a custom wrapper script with the default node invocation) would
+  // silently break custom launchers without providing any real benefit.
+  if (
+    audit.issues.some(
+      (issue) =>
+        issue.code === SERVICE_AUDIT_CODES.gatewayCommandMissing ||
+        issue.code === SERVICE_AUDIT_CODES.gatewayEntrypointMismatch,
+    )
+  ) {
+    const gatewayServiceName = command.sourcePath
+      ? path.basename(command.sourcePath)
+      : "openclaw-gateway.service";
+    const isRunning = await isSystemdUnitActive(
+      process.env as Record<string, string | undefined>,
+      gatewayServiceName,
+    );
+    if (isRunning) {
+      note(
+        "Gateway is currently running; skipping ExecStart audit to preserve the active launcher.",
+        "Gateway service config",
+      );
+      audit.issues = audit.issues.filter(
+        (issue) =>
+          issue.code !== SERVICE_AUDIT_CODES.gatewayCommandMissing &&
+          issue.code !== SERVICE_AUDIT_CODES.gatewayEntrypointMismatch,
+      );
+    }
+  }
   const needsNodeRuntime = needsNodeRuntimeMigration(audit.issues);
   const systemNodeInfo = needsNodeRuntime
     ? await resolveSystemNodeInfo({ env: process.env })
@@ -345,14 +376,43 @@ export async function maybeRepairGatewayServiceConfig(
   }
 }
 
+async function filterToActiveServices(
+  services: ExtraGatewayService[],
+  env: NodeJS.ProcessEnv,
+): Promise<ExtraGatewayService[]> {
+  // On non-Linux platforms systemctl is not available; return all services unfiltered.
+  if (process.platform !== "linux") {
+    return services;
+  }
+  const checks = await Promise.all(
+    services.map(async (svc) => ({
+      svc,
+      // Always include legacy services (clawdbot/moltbot) — they should be offered
+      // for cleanup whether running or not. Only filter non-legacy services by active state.
+      active:
+        svc.legacy === true ||
+        (await isSystemdUnitActive(env as Record<string, string | undefined>, svc.label)),
+    })),
+  );
+  return checks.filter((c) => c.active).map((c) => c.svc);
+}
+
 export async function maybeScanExtraGatewayServices(
   options: DoctorOptions,
   runtime: RuntimeEnv,
   prompter: DoctorPrompter,
 ) {
-  const extraServices = await findExtraGatewayServices(process.env, {
+  const allExtraServices = await findExtraGatewayServices(process.env, {
     deep: options.deep,
   });
+  if (allExtraServices.length === 0) {
+    return;
+  }
+
+  // Only warn about services that are actually running. An inactive companion service
+  // (e.g. openclaw-voice, openclaw-update) that merely references the gateway in its
+  // unit dependencies should not generate a conflict warning.
+  const extraServices = await filterToActiveServices(allExtraServices, process.env);
   if (extraServices.length === 0) {
     return;
   }

--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { findExtraGatewayServices } from "./inspect.js";
 
@@ -83,5 +86,163 @@ describe("findExtraGatewayServices (win32)", () => {
         legacy: true,
       },
     ]);
+  });
+});
+
+// Helper: build a minimal gateway service file with OPENCLAW_SERVICE_MARKER declared
+function gatewayServiceContent(extras: string[] = []): string {
+  return [
+    "[Unit]",
+    "Description=OpenClaw Gateway",
+    "After=network-online.target",
+    "Wants=network-online.target",
+    "",
+    "[Service]",
+    "ExecStart=/usr/bin/node /home/user/workspace/openclaw/dist/index.js gateway --port 18790",
+    "Environment=OPENCLAW_SERVICE_MARKER=openclaw",
+    "Environment=OPENCLAW_SERVICE_KIND=gateway",
+    ...extras,
+    "",
+    "[Install]",
+    "WantedBy=default.target",
+  ].join("\n");
+}
+
+// Helper: build a companion service that references the gateway via After=/Requires=
+function companionServiceContent(name: string): string {
+  return [
+    "[Unit]",
+    `Description=OpenClaw ${name}`,
+    "After=openclaw-gateway.service",
+    "Requires=openclaw-gateway.service",
+    "",
+    "[Service]",
+    `ExecStart=/usr/local/bin/${name.toLowerCase()}`,
+    "Restart=on-failure",
+    "",
+    "[Install]",
+    "WantedBy=default.target",
+  ].join("\n");
+}
+
+describe("findExtraGatewayServices (linux)", () => {
+  const originalPlatform = process.platform;
+  let tempHome: string;
+
+  beforeEach(async () => {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: "linux",
+    });
+    tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-inspect-test-"));
+    await fs.mkdir(path.join(tempHome, ".config", "systemd", "user"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: originalPlatform,
+    });
+    await fs.rm(tempHome, { recursive: true, force: true });
+  });
+
+  it("does not flag companion services that reference openclaw via After= or Requires=", async () => {
+    const unitDir = path.join(tempHome, ".config", "systemd", "user");
+    // voice service depends on the gateway but is not itself a gateway
+    await fs.writeFile(
+      path.join(unitDir, "openclaw-voice.service"),
+      companionServiceContent("Voice Assistant"),
+    );
+    // update service mentions openclaw in its name and description
+    await fs.writeFile(
+      path.join(unitDir, "openclaw-update.service"),
+      companionServiceContent("Auto-Update"),
+    );
+
+    const result = await findExtraGatewayServices({ HOME: tempHome });
+    expect(result).toEqual([]);
+  });
+
+  it("does not flag profiled or secondary openclaw gateways (openclaw-gateway-* naming or OPENCLAW_SERVICE_MARKER)", async () => {
+    // A gateway installed by openclaw for a named profile (or a second install on the same
+    // host) is either named openclaw-gateway-* or carries OPENCLAW_SERVICE_MARKER.
+    // Neither should show up as an "extra" service — they are covered by isOpenClawGatewaySystemdService.
+    const unitDir = path.join(tempHome, ".config", "systemd", "user");
+    await fs.writeFile(path.join(unitDir, "openclaw-gateway-dev.service"), gatewayServiceContent());
+
+    const result = await findExtraGatewayServices({ HOME: tempHome });
+    expect(result).toEqual([]);
+  });
+
+  it("still flags legacy clawdbot/moltbot services", async () => {
+    const unitDir = path.join(tempHome, ".config", "systemd", "user");
+    await fs.writeFile(
+      path.join(unitDir, "clawdbot-gateway.service"),
+      [
+        "[Unit]",
+        "Description=Clawdbot Legacy Gateway",
+        "[Service]",
+        "ExecStart=/usr/local/bin/clawdbot gateway",
+      ].join("\n"),
+    );
+
+    const result = await findExtraGatewayServices({ HOME: tempHome });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      platform: "linux",
+      label: "clawdbot-gateway.service",
+      scope: "user",
+      legacy: true,
+    });
+  });
+});
+
+describe("findExtraGatewayServices (darwin)", () => {
+  const originalPlatform = process.platform;
+  let tempHome: string;
+
+  beforeEach(async () => {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: "darwin",
+    });
+    tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-inspect-darwin-test-"));
+    await fs.mkdir(path.join(tempHome, "Library", "LaunchAgents"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    Object.defineProperty(process, "platform", {
+      configurable: true,
+      value: originalPlatform,
+    });
+    await fs.rm(tempHome, { recursive: true, force: true });
+  });
+
+  it("does not flag plists that reference openclaw only in string values (e.g. a dependency label)", async () => {
+    const agentsDir = path.join(tempHome, "Library", "LaunchAgents");
+    // A LaunchAgent that mentions "openclaw" only in a comment or string value —
+    // not as OPENCLAW_SERVICE_MARKER — should not be flagged.
+    await fs.writeFile(
+      path.join(agentsDir, "com.example.openclaw-companion.plist"),
+      [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+        '<plist version="1.0">',
+        "<dict>",
+        "  <key>Label</key>",
+        "  <string>com.example.openclaw-companion</string>",
+        "  <key>ProgramArguments</key>",
+        "  <array>",
+        "    <string>/usr/local/bin/companion</string>",
+        "  </array>",
+        "  <key>RunAtLoad</key>",
+        "  <true/>",
+        "</dict>",
+        "</plist>",
+      ].join("\n"),
+    );
+
+    const result = await findExtraGatewayServices({ HOME: tempHome });
+    expect(result).toEqual([]);
   });
 });

--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -99,8 +99,8 @@ function gatewayServiceContent(extras: string[] = []): string {
     "",
     "[Service]",
     "ExecStart=/usr/bin/node /home/user/workspace/openclaw/dist/index.js gateway --port 18790",
-    "Environment=OPENCLAW_SERVICE_MARKER=openclaw",
-    "Environment=OPENCLAW_SERVICE_KIND=gateway",
+    "Environment=OPENCLAW_SERVICE_MARKER=openclaw", // pragma: allowlist secret
+    "Environment=OPENCLAW_SERVICE_KIND=gateway", // pragma: allowlist secret
     ...extras,
     "",
     "[Install]",

--- a/src/daemon/inspect.ts
+++ b/src/daemon/inspect.ts
@@ -216,6 +216,16 @@ async function scanLaunchdDir(params: {
     if (isIgnoredLaunchdLabel(label)) {
       continue;
     }
+    // Skip plists that merely reference openclaw (e.g. in a <string> value) but
+    // don't declare themselves as an openclaw gateway via OPENCLAW_SERVICE_MARKER and
+    // don't use the canonical ai.openclaw.* label scheme.
+    if (
+      marker === "openclaw" &&
+      !hasGatewayServiceMarker(contents) &&
+      !label.startsWith("ai.openclaw.")
+    ) {
+      continue;
+    }
     if (marker === "openclaw" && isOpenClawGatewayLaunchdService(label, contents)) {
       continue;
     }
@@ -246,6 +256,22 @@ async function scanSystemdDir(params: {
   for (const { entry, name, fullPath, contents } of candidates) {
     const marker = detectMarker(contents);
     if (!marker) {
+      continue;
+    }
+    // Skip services that merely reference openclaw (e.g. via After=/Requires= dependency
+    // lines) but don't declare themselves as an openclaw gateway. Without this guard,
+    // companion services like openclaw-voice or openclaw-update are incorrectly reported
+    // as "gateway-like services" just because they depend on openclaw-gateway.service.
+    //
+    // A service is considered an openclaw gateway if it either:
+    //   (a) carries explicit OPENCLAW_SERVICE_MARKER + OPENCLAW_SERVICE_KIND=gateway env vars, or
+    //   (b) is named openclaw-gateway* (covers old installs without markers).
+    // Everything else that merely mentions "openclaw" is a companion service and ignored.
+    if (
+      marker === "openclaw" &&
+      !hasGatewayServiceMarker(contents) &&
+      !name.startsWith("openclaw-gateway")
+    ) {
       continue;
     }
     if (marker === "openclaw" && isOpenClawGatewaySystemdService(name, contents)) {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -445,6 +445,22 @@ export async function isSystemdServiceEnabled(args: GatewayServiceEnvArgs): Prom
   throw new Error(`systemctl is-enabled unavailable: ${detail || "unknown error"}`.trim());
 }
 
+/**
+ * Returns true if the given systemd user-scope unit is currently active (running).
+ * Returns false for any error, missing unit, or inactive state.
+ */
+export async function isSystemdUnitActive(
+  env: GatewayServiceEnv,
+  unitName: string,
+): Promise<boolean> {
+  try {
+    const res = await execSystemctlUser(env, ["is-active", "--quiet", unitName]);
+    return res.code === 0;
+  } catch {
+    return false;
+  }
+}
+
 export async function readSystemdServiceRuntime(
   env: GatewayServiceEnv = process.env as GatewayServiceEnv,
 ): Promise<GatewayServiceRuntime> {


### PR DESCRIPTION
## Problem

`openclaw doctor --non-interactive` caused two distinct issues:

### 1. Companion services falsely flagged as "gateway-like"

Services like `openclaw-voice.service` or `openclaw-update.service` that declare a systemd dependency on `openclaw-gateway.service` were reported as **"Other gateway-like services detected"**:

```ini
[Unit]
After=openclaw-gateway.service
Requires=openclaw-gateway.service
```

Because `detectMarker()` scans the full file text for the string `openclaw`, the dependency lines triggered the marker and the services were added to the conflict list.

### 2. Running gateway's ExecStart silently overwritten

When the gateway's `ExecStart` points to a custom wrapper script (e.g. a shell script that decrypts secrets before starting the process), doctor flags `gateway-command-missing` (level: aggressive) because the wrapper does not pass `gateway` as a CLI subcommand. In non-interactive mode this warning can mislead users into reinstalling the gateway, which overwrites the custom launcher with the default node invocation and breaks secrets loading on restart.

---

## Fix

### Static analysis guard (inspect.ts)

After detecting `marker="openclaw"`, skip the candidate unless it either declares itself as a gateway via `OPENCLAW_SERVICE_MARKER` + `OPENCLAW_SERVICE_KIND=gateway` env vars, or is named `openclaw-gateway*`. Services that merely reference the gateway in dependency directives are excluded.

Same guard applied to `scanLaunchdDir` on Darwin.

### Runtime guard 1 — protect the running gateway (doctor-gateway-services.ts)

Before applying audit issues that would rewrite `ExecStart` (`gatewayCommandMissing`, `gatewayEntrypointMismatch`), check whether the gateway service is currently active via `systemctl --user is-active`. If it is running, suppress those issues with an explanatory note. A running gateway proves the current launcher works — rewriting it serves no benefit and risks breaking custom configurations.

### Runtime guard 2 — skip inactive extra services (doctor-gateway-services.ts)

After `findExtraGatewayServices` returns candidates, filter to those that are actually active before emitting the conflict warning. An inactive companion service is not a real conflict. Legacy services (clawdbot/moltbot) bypass this filter so the cleanup prompt is always offered.

### New export: `isSystemdUnitActive(env, unitName)` (systemd.ts)

Thin wrapper around `systemctl --user is-active --quiet <unit>`; returns `false` on any error or missing unit.

---

## Tests

- Companion services (`openclaw-voice`, `openclaw-update`) with `After=/Requires=` not flagged on Linux
- Profiled gateways with canonical naming not double-counted
- Legacy clawdbot/moltbot still flagged
- Companion plists not flagged on Darwin
- ExecStart issues suppressed when gateway is actively running
- ExecStart repair proceeds normally when gateway is stopped
- Inactive extra services do not trigger the conflict warning
- Active extra services do trigger the conflict warning
- Legacy services offered for cleanup regardless of active state