### PR TITLE
fix(daemon): Windows gateway restart - avoid double restart and EADDRINUSE

### DIFF
--- a/src/cli/daemon-cli/lifecycle-core.ts
+++ b/src/cli/daemon-cli/lifecycle-core.ts
@@ -28,6 +28,7 @@ type RestartPostCheckContext = {
   stdout: Writable;
   warnings: string[];
   fail: (message: string, hints?: string[]) => void;
+  restartPort?: number;
 };
 
 async function maybeAugmentSystemdHints(hints: string[]): Promise<string[]> {
@@ -253,6 +254,7 @@ export async function runServiceRestart(params: {
   opts?: DaemonLifecycleOptions;
   checkTokenDrift?: boolean;
   postRestartCheck?: (ctx: RestartPostCheckContext) => Promise<void>;
+  restartPort?: number;
 }): Promise<boolean> {
   const json = Boolean(params.opts?.json);
   const { stdout, emit, fail } = createActionIO({ action: "restart", json });
@@ -315,9 +317,9 @@ export async function runServiceRestart(params: {
   }
 
   try {
-    await params.service.restart({ env: process.env, stdout });
+    await params.service.restart({ env: process.env, stdout, port: params.restartPort });
     if (params.postRestartCheck) {
-      await params.postRestartCheck({ json, stdout, warnings, fail });
+      await params.postRestartCheck({ json, stdout, warnings, fail, restartPort: params.restartPort });
     }
     let restarted = true;
     try {

--- a/src/cli/daemon-cli/lifecycle.ts
+++ b/src/cli/daemon-cli/lifecycle.ts
@@ -79,10 +79,11 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
   return await runServiceRestart({
     serviceNoun: "Gateway",
     service,
+    restartPort,
     renderStartHints: renderGatewayServiceStartHints,
     opts,
     checkTokenDrift: true,
-    postRestartCheck: async ({ warnings, fail, stdout }) => {
+    postRestartCheck: async ({ warnings, fail, stdout, restartPort: postRestartPort }) => {
       let health = await waitForGatewayHealthyRestart({
         service,
         port: restartPort,
@@ -91,7 +92,13 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
         includeUnknownListenersAsStale: process.platform === "win32",
       });
 
-      if (!health.healthy && health.staleGatewayPids.length > 0) {
+      // On Windows, skip stale retry: schtasks status is delayed so the new process
+      // is often misclassified as "stale", leading to a second restart and EADDRINUSE.
+      if (
+        !health.healthy &&
+        health.staleGatewayPids.length > 0 &&
+        process.platform !== "win32"
+      ) {
         const staleMsg = `Found stale gateway process(es): ${health.staleGatewayPids.join(", ")}.`;
         warnings.push(staleMsg);
         if (!json) {
@@ -100,7 +107,7 @@ export async function runDaemonRestart(opts: DaemonLifecycleOptions = {}): Promi
         }
 
         await terminateStaleGatewayPids(health.staleGatewayPids);
-        await service.restart({ env: process.env, stdout });
+        await service.restart({ env: process.env, stdout, port: postRestartPort });
         health = await waitForGatewayHealthyRestart({
           service,
           port: restartPort,

--- a/src/daemon/schtasks-exec.ts
+++ b/src/daemon/schtasks-exec.ts
@@ -1,7 +1,24 @@
+import path from "node:path";
 import { execFileUtf8 } from "./exec-file.js";
 
 export async function execSchtasks(
   args: string[],
 ): Promise<{ stdout: string; stderr: string; code: number }> {
   return await execFileUtf8("schtasks", args, { windowsHide: true });
+}
+
+/**
+ * Wait until the gateway port is free on Windows.
+ * schtasks /End is async; the new process must not start until the port is released.
+ */
+export async function waitForGatewayPortFreeWindows(port: number): Promise<void> {
+  if (!Number.isFinite(port) || port <= 0) return;
+  const script = `while (Get-NetTCPConnection -LocalPort ${port} -ErrorAction SilentlyContinue) { Start-Sleep -Seconds 1 }`;
+  const pwsh =
+    process.env.SystemRoot != null
+      ? path.join(process.env.SystemRoot, "System32", "WindowsPowerShell", "v1.0", "powershell.exe")
+      : "powershell.exe";
+  await execFileUtf8(pwsh, ["-NoProfile", "-NonInteractive", "-Command", script], {
+    windowsHide: true,
+  });
 }

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -6,7 +6,8 @@ import { resolveGatewayServiceDescription, resolveGatewayWindowsTaskName } from 
 import { formatLine, writeFormattedLines } from "./output.js";
 import { resolveGatewayStateDir } from "./paths.js";
 import { parseKeyValueOutput } from "./runtime-parse.js";
-import { execSchtasks } from "./schtasks-exec.js";
+import { DEFAULT_GATEWAY_PORT, resolveGatewayPort } from "../../config/paths.js";
+import { execSchtasks, waitForGatewayPortFreeWindows } from "./schtasks-exec.js";
 import type { GatewayServiceRuntime } from "./service-runtime.js";
 import type {
   GatewayServiceCommandConfig,
@@ -313,10 +314,16 @@ export async function stopScheduledTask({ stdout, env }: GatewayServiceControlAr
 export async function restartScheduledTask({
   stdout,
   env,
+  port,
 }: GatewayServiceControlArgs): Promise<void> {
   await assertSchtasksAvailable();
   const taskName = resolveTaskName(env ?? (process.env as GatewayServiceEnv));
   await execSchtasks(["/End", "/TN", taskName]);
+
+  const gatewayPort =
+    port ?? resolveGatewayPort(undefined, env ?? process.env) ?? DEFAULT_GATEWAY_PORT;
+  await waitForGatewayPortFreeWindows(gatewayPort);
+
   const res = await execSchtasks(["/Run", "/TN", taskName]);
   if (res.code !== 0) {
     throw new Error(`schtasks run failed: ${res.stderr || res.stdout}`.trim());

--- a/src/daemon/service-types.ts
+++ b/src/daemon/service-types.ts
@@ -17,6 +17,7 @@ export type GatewayServiceManageArgs = {
 export type GatewayServiceControlArgs = {
   stdout: NodeJS.WritableStream;
   env?: GatewayServiceEnv;
+  port?: number;
 };
 
 export type GatewayServiceEnvArgs = {


### PR DESCRIPTION
…INUSE

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
