### PR TITLE
fix(logging): share external log transports across bundled module instances

### DIFF
--- a/src/gateway/server-methods/chat.abort.test-helpers.ts
+++ b/src/gateway/server-methods/chat.abort.test-helpers.ts
@@ -2,6 +2,20 @@ import { vi } from "vitest";
 import type { Mock } from "vitest";
 import type { GatewayRequestHandler, RespondFn } from "./types.js";
 
+export type ChatAbortTestContext = Record<string, unknown> & {
+  chatAbortControllers: Map<string, ReturnType<typeof createActiveRun>>;
+  chatRunBuffers: Map<string, string>;
+  chatDeltaSentAt: Map<string, number>;
+  chatAbortedRuns: Map<string, number>;
+  removeChatRun: (...args: unknown[]) => { sessionKey: string; clientRunId: string } | undefined;
+  agentRunSeq: Map<string, number>;
+  broadcast: (...args: unknown[]) => void;
+  nodeSendToSession: (...args: unknown[]) => void;
+  logGateway: { warn: (...args: unknown[]) => void };
+};
+
+export type ChatAbortRespondMock = Mock<RespondFn>;
+
 export function createActiveRun(
   sessionKey: string,
   params: {
@@ -21,20 +35,6 @@ export function createActiveRun(
   };
 }
 
-export type ChatAbortTestContext = Record<string, unknown> & {
-  chatAbortControllers: Map<string, ReturnType<typeof createActiveRun>>;
-  chatRunBuffers: Map<string, string>;
-  chatDeltaSentAt: Map<string, number>;
-  chatAbortedRuns: Map<string, number>;
-  removeChatRun: (...args: unknown[]) => { sessionKey: string; clientRunId: string } | undefined;
-  agentRunSeq: Map<string, number>;
-  broadcast: (...args: unknown[]) => void;
-  nodeSendToSession: (...args: unknown[]) => void;
-  logGateway: { warn: (...args: unknown[]) => void };
-};
-
-export type ChatAbortRespondMock = Mock<RespondFn>;
-
 export function createChatAbortContext(
   overrides: Record<string, unknown> = {},
 ): ChatAbortTestContext {
@@ -51,7 +51,7 @@ export function createChatAbortContext(
     nodeSendToSession: vi.fn(),
     logGateway: { warn: vi.fn() },
     ...overrides,
-  };
+  } as ChatAbortTestContext;
 }
 
 export async function invokeChatAbortHandler(params: {

--- a/src/logging/logger-transports.test.ts
+++ b/src/logging/logger-transports.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerLogTransport, resetLogger, setLoggerOverride } from "./logger.js";
+
+const EXTERNAL_TRANSPORTS_KEY = Symbol.for("openclaw.logging.externalTransports");
+
+afterEach(() => {
+  resetLogger();
+  setLoggerOverride(null);
+  vi.restoreAllMocks();
+  const transports = (globalThis as Record<symbol, unknown>)[EXTERNAL_TRANSPORTS_KEY];
+  if (transports instanceof Set) {
+    transports.clear();
+  }
+});
+
+describe("registerLogTransport", () => {
+  it("stores transports in a process-global registry", () => {
+    const transport = vi.fn();
+    const unsubscribe = registerLogTransport(transport);
+
+    const transports = (globalThis as Record<symbol, unknown>)[EXTERNAL_TRANSPORTS_KEY];
+    expect(transports).toBeInstanceOf(Set);
+    expect((transports as Set<unknown>).has(transport)).toBe(true);
+
+    unsubscribe();
+    expect((transports as Set<unknown>).has(transport)).toBe(false);
+  });
+});

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -41,7 +41,23 @@ export type LoggerResolvedSettings = ResolvedSettings;
 export type LogTransportRecord = Record<string, unknown>;
 export type LogTransport = (logObj: LogTransportRecord) => void;
 
-const externalTransports = new Set<LogTransport>();
+const EXTERNAL_TRANSPORTS_KEY = Symbol.for("openclaw.logging.externalTransports");
+
+type GlobalWithExternalTransports = typeof globalThis & {
+  [EXTERNAL_TRANSPORTS_KEY]?: Set<LogTransport>;
+};
+
+function getExternalTransports(): Set<LogTransport> {
+  const target = globalThis as GlobalWithExternalTransports;
+  if (!target[EXTERNAL_TRANSPORTS_KEY]) {
+    target[EXTERNAL_TRANSPORTS_KEY] = new Set<LogTransport>();
+  }
+  return target[EXTERNAL_TRANSPORTS_KEY];
+}
+
+// Snapshot is stable: only getExternalTransports() writes this key, and it
+// never replaces an existing Set.  All bundles in the process share one Set.
+const externalTransports = getExternalTransports();
 
 function shouldSkipLoadConfigFallback(argv: string[] = process.argv): boolean {
   const [primary, secondary] = getCommandPathWithRootOptions(argv, 2);

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -49,7 +49,7 @@ type GlobalWithExternalTransports = typeof globalThis & {
 
 function getExternalTransports(): Set<LogTransport> {
   const target = globalThis as GlobalWithExternalTransports;
-  if (!target[EXTERNAL_TRANSPORTS_KEY]) {
+  if (!(target[EXTERNAL_TRANSPORTS_KEY] instanceof Set)) {
     target[EXTERNAL_TRANSPORTS_KEY] = new Set<LogTransport>();
   }
   return target[EXTERNAL_TRANSPORTS_KEY];


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: diagnostics-otel log exporting registers a transport from plugin-sdk, but bundled module isolation can create separate `externalTransports` registries, so gateway logs never reach the plugin transport.
- Why it matters: `diagnostics.otel.logs: true` appears enabled but exports no log records, creating a silent observability gap.
- What changed: moved log transport storage to a process-global registry (`globalThis` + `Symbol.for("openclaw.logging.externalTransports")`) so all bundles share the same transport set.
- What did NOT change (scope boundary): no changes to log formatting, log file behavior, OTLP payload shape, or diagnostics event pipelines.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39156
- Related #

## User-visible / Behavior Changes

When diagnostics-otel registers a log transport, it now receives gateway log records even when plugin-sdk and gateway logger code are loaded from different bundle/module instances in the same process.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Ubuntu (WSL2)
- Runtime/container: Node + Vitest
- Model/provider: N/A
- Integration/channel (if any): diagnostics-otel plugin + gateway logging
- Relevant config (redacted): N/A

### Steps

1. Register a log transport via `registerLogTransport`.
2. Inspect the process-global transport registry key (`Symbol.for("openclaw.logging.externalTransports")`).
3. Unsubscribe transport and verify removal.

### Expected

- Transport is present in shared process-global registry while subscribed.
- Transport is removed cleanly on unsubscribe.

### Actual

- Matches expected.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm vitest run src/logging/logger-transports.test.ts`; confirmed transport registration/unregistration against process-global registry.
- Edge cases checked: ensured existing per-logger attach behavior remains intact when cached logger exists.
- What you did **not** verify: full end-to-end OTLP collector export in a live diagnostics stack.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit or remove the global registry usage in `src/logging/logger.ts`.
- Files/config to restore: `src/logging/logger.ts`.
- Known bad symptoms reviewers should watch for: unexpected duplicate transport delivery (not observed in current validation).

## Risks and Mitigations

- Risk: process-global transport set could retain stale callbacks if callers never unsubscribe.
  - Mitigation: unchanged API contract continues returning unsubscribe; test covers unsubscribe removal path.
