### PR TITLE
fix: patch missing long dep in baileys rc.9 via pnpm.packageExtensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -413,6 +413,13 @@
   "packageManager": "pnpm@10.23.0",
   "pnpm": {
     "minimumReleaseAge": 2880,
+    "packageExtensions": {
+      "@whiskeysockets/baileys@7.0.0-rc.9": {
+        "dependencies": {
+          "long": "^5"
+        }
+      }
+    },
     "overrides": {
       "hono": "4.12.5",
       "@hono/node-server": "1.19.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,8 @@ overrides:
   tar: 7.5.10
   tough-cookie: 4.1.3
 
+packageExtensionsChecksum: sha256-BaIvqFskqR+Pgp6brYYCQ8Gx3EEsaUME5LyWfJmaRPA=
+
 importers:
 
   .:
@@ -3491,9 +3493,6 @@ packages:
     resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
     engines: {node: 18 || 20 || >=22}
 
-  browser-or-node@1.3.0:
-    resolution: {integrity: sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==}
-
   browser-or-node@3.0.0:
     resolution: {integrity: sha512-iczIdVJzGEYhP5DqQxYM9Hh7Ztpqqi+CXZpSmX8ALFs9ecXkQIeqRyM6TfxEfMVpwhl3dSuDvxdzzo9sUOIVBQ==}
 
@@ -3672,9 +3671,6 @@ packages:
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
-
-  core-js@3.48.0:
-    resolution: {integrity: sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==}
 
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
@@ -9333,6 +9329,7 @@ snapshots:
       '@hapi/boom': 9.1.4
       async-mutex: 0.5.0
       libsignal: '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
+      long: 5.3.2
       lru-cache: 11.2.6
       music-metadata: 11.12.1
       p-queue: 9.1.0
@@ -9591,8 +9588,6 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  browser-or-node@1.3.0: {}
-
   browser-or-node@3.0.0: {}
 
   buffer-crc32@0.2.13: {}
@@ -9763,8 +9758,6 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
-
-  core-js@3.48.0: {}
 
   core-util-is@1.0.2: {}
 


### PR DESCRIPTION
## Summary

- **Problem:** `@whiskeysockets/baileys@7.0.0-rc.9` imports `long` at the top level (`lib/Socket/messages-recv.js:4`) without declaring it as a dependency. Under pnpm's isolated nodeLinker, packages can only resolve their declared deps — so `long` is invisible to baileys and the gateway crashes with `ERR_MODULE_NOT_FOUND` on startup.
- **Why it matters:** PR #22481 removed `long` from the root `package.json` after a deadcode scan flagged it as unused. This exposed the undeclared dep in baileys. Any clean install after that commit crashes.
- **What changed:** Added `pnpm.packageExtensions` entry to patch `long ^5` directly into baileys' virtual store dep list. No root-level dep change.
- **Why not a root dep:** The previous approach (adding `long` to root `dependencies`) works, but a deadcode scanner will remove it again — as already happened once. `pnpm.packageExtensions` is the idiomatic pnpm workaround for upstream missing deps and is immune to this because it's clearly annotated as an upstream patch.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [x] CI/CD / infra

## Linked Issue/PR

- Related #22481 (the removal that exposed this)
- Supersedes #38711 (previous root-dep approach, now closed)

## User-visible / Behavior Changes

None.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Ubuntu 24.04 ARM64
- Runtime: Node.js v22.22.0, pnpm 10.23.0 (project-pinned via `packageManager`)
- Integration/channel: WhatsApp (Baileys)

### Why the previous PR (#38711) showed as non-reproducible

The reviewer tested on a version of pnpm that left a stale `long` symlink in baileys' virtual store from a prior install (when `long` was still declared). A clean `node_modules` delete + reinstall reproduces the crash deterministically on pnpm 10.23.0.

### Steps to reproduce crash (without this fix)

1. `rm -rf node_modules`
2. `pnpm install --frozen-lockfile` on current `main` (after #22481)
3. Start the gateway → `ERR_MODULE_NOT_FOUND: Cannot find package 'long'`

### With this fix

`long` is symlinked directly into baileys' virtual store by pnpm via `packageExtensions`. Verify:
```
ls node_modules/.pnpm/@whiskeysockets+baileys@7.0.0-rc.9*/node_modules/long
```

## Evidence

- `baileys/lib/Socket/messages-recv.js` line 4: `import Long from 'long';` — top-level ESM import, crashes at startup
- `baileys/package.json` — `long` absent from all dep fields
- Gateway starts and WhatsApp connects healthy after this fix

## Human Verification (required)

- Verified `long` is present in baileys' virtual store after `pnpm install` with this fix
- Verified gateway starts and channels connect cleanly

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- Remove the `packageExtensions` entry and run `pnpm install`
- This should be removed entirely once baileys properly declares `long` as a dependency

## Risks and Mitigations

- Risk: None — `packageExtensions` is a pnpm-native mechanism designed exactly for this case
  - Mitigation: The entry is version-pinned to `7.0.0-rc.9` so it won't silently persist after a baileys upgrade