### PR TITLE
fix(telegram): coalesce streaming preview across tool-call rounds in partial mode

### DIFF
--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -404,27 +404,45 @@ describe("dispatchTelegramMessage draft streaming", () => {
     );
   });
 
-  it.each(["block", "partial"] as const)(
-    "forces new message when assistant message restarts (%s mode)",
-    async (streamMode) => {
-      const draftStream = createDraftStream(999);
-      createTelegramDraftStream.mockReturnValue(draftStream);
-      dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
-        async ({ dispatcherOptions, replyOptions }) => {
-          await replyOptions?.onPartialReply?.({ text: "First response" });
-          await replyOptions?.onAssistantMessageStart?.();
-          await replyOptions?.onPartialReply?.({ text: "After tool call" });
-          await dispatcherOptions.deliver({ text: "After tool call" }, { kind: "final" });
-          return { queuedFinal: true };
-        },
-      );
-      deliverReplies.mockResolvedValue({ delivered: true });
+  it("forces new message when assistant message restarts (block mode)", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "First response" });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "After tool call" });
+        await dispatcherOptions.deliver({ text: "After tool call" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
 
-      await dispatchWithContext({ context: createContext(), streamMode });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
-      expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
-    },
-  );
+    expect(draftStream.forceNewMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not force new message in partial mode — coalesces across tool-call rounds", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "First response" });
+        await replyOptions?.onAssistantMessageStart?.();
+        await replyOptions?.onPartialReply?.({ text: "After tool call" });
+        await dispatcherOptions.deliver({ text: "After tool call" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
+    expect(draftStream.revive).toHaveBeenCalled();
+    expect(draftStream.update).toHaveBeenCalledWith("After tool call");
+  });
 
   it("materializes boundary preview and keeps it when no matching final arrives", async () => {
     const answerDraftStream = createDraftStream(999);
@@ -440,7 +458,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     const bot = createBot();
-    await dispatchWithContext({ context: createContext(), streamMode: "partial", bot });
+    await dispatchWithContext({ context: createContext(), streamMode: "block", bot });
 
     expect(answerDraftStream.materialize).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
@@ -480,7 +498,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     deliverReplies.mockResolvedValue({ delivered: true });
     editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
 
-    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(editMessageTelegram).toHaveBeenCalledTimes(2);
@@ -511,7 +529,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     });
 
     const bot = createBot();
-    await dispatchWithContext({ context: createContext(), streamMode: "partial", bot });
+    await dispatchWithContext({ context: createContext(), streamMode: "block", bot });
 
     expect(answerDraftStream.clear).toHaveBeenCalledTimes(1);
     const deleteMessageCalls = (
@@ -547,7 +565,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
       return { queuedFinal: false };
     });
 
-    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.materialize).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
@@ -579,7 +597,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     deliverReplies.mockResolvedValue({ delivered: true });
     editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
 
-    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(editMessageTelegram).toHaveBeenNthCalledWith(
@@ -641,7 +659,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     deliverReplies.mockResolvedValue({ delivered: true });
     editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
 
-    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(1);
     expect(answerDraftStream.update).toHaveBeenNthCalledWith(2, "Message B early");
@@ -688,7 +706,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
     const bot = createBot();
 
-    await dispatchWithContext({ context: createContext(), streamMode: "partial", bot });
+    await dispatchWithContext({ context: createContext(), streamMode: "block", bot });
 
     // Early pre-rotation could not force (no streamed partials yet), so the
     // real assistant message_start must still rotate once.
@@ -770,7 +788,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     deliverReplies.mockResolvedValue({ delivered: true });
     editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "1001" });
 
-    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(answerDraftStream.forceNewMessage).toHaveBeenCalledTimes(2);
     expect(editMessageTelegram).toHaveBeenNthCalledWith(

--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -329,7 +329,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
     deliverReplies.mockResolvedValue({ delivered: true });
     editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
 
-    await dispatchWithContext({ context: createContext() });
+    await dispatchWithContext({ context: createContext(), streamMode: "block" });
 
     expect(editMessageTelegram).toHaveBeenCalledTimes(1);
     expect(editMessageTelegram).toHaveBeenCalledWith(
@@ -442,6 +442,30 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
     expect(draftStream.revive).toHaveBeenCalled();
     expect(draftStream.update).toHaveBeenCalledWith("After tool call");
+  });
+
+  it("coalesces multiple final payloads into one preview edit in partial mode", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(
+      async ({ dispatcherOptions, replyOptions }) => {
+        await replyOptions?.onPartialReply?.({ text: "Streaming..." });
+        // Simulate multiple final payloads (one per tool-call round)
+        await dispatcherOptions.deliver({ text: "First final" }, { kind: "final" });
+        await dispatcherOptions.deliver({ text: "Second final" }, { kind: "final" });
+        await dispatcherOptions.deliver({ text: "Third final" }, { kind: "final" });
+        return { queuedFinal: true };
+      },
+    );
+    deliverReplies.mockResolvedValue({ delivered: true });
+    editMessageTelegram.mockResolvedValue({ ok: true, chatId: "123", messageId: "999" });
+
+    await dispatchWithContext({ context: createContext(), streamMode: "partial" });
+
+    // All three finals should edit the same preview (message 999), not send new messages.
+    expect(editMessageTelegram).toHaveBeenCalledTimes(3);
+    expect(draftStream.revive).toHaveBeenCalled();
+    expect(draftStream.forceNewMessage).not.toHaveBeenCalled();
   });
 
   it("materializes boundary preview and keeps it when no matching final arrives", async () => {
@@ -894,6 +918,7 @@ describe("dispatchTelegramMessage draft streaming", () => {
         forceNewMessage: vi.fn().mockImplementation(() => {
           answerMessageId = undefined;
         }),
+        revive: vi.fn(),
       };
       const reasoningDraftStream = createDraftStream();
       createTelegramDraftStream

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -325,14 +325,26 @@ export const dispatchTelegramMessage = async ({
     lane.lastPartialText = text;
     laneStream.update(text);
   };
+  // In partial mode, all tool-call rounds share a single preview message
+  // (edited in place). In block mode, each assistant message boundary creates
+  // a new preview message. Mirrors Discord's shouldSplitPreviewMessages.
+  const shouldSplitPreviewMessages = streamMode === "block";
+
   const ingestDraftLaneSegments = async (text: string | undefined) => {
     const split = splitTextIntoLaneSegments(text);
     const hasAnswerSegment = split.segments.some((segment) => segment.lane === "answer");
     if (hasAnswerSegment && finalizedPreviewByLane.answer) {
       // Some providers can emit the first partial of a new assistant message before
-      // onAssistantMessageStart() arrives. Rotate preemptively so we do not edit
-      // the previously finalized preview message with the next message's text.
-      skipNextAnswerMessageStartRotation = await rotateAnswerLaneForNewAssistantMessage();
+      // onAssistantMessageStart() arrives.
+      if (shouldSplitPreviewMessages) {
+        // Block mode: rotate preemptively so we do not edit the previously
+        // finalized preview message with the next message's text.
+        skipNextAnswerMessageStartRotation = await rotateAnswerLaneForNewAssistantMessage();
+      } else {
+        // Partial mode: reuse the same preview — just revive the stream.
+        answerLane.stream?.revive();
+        finalizedPreviewByLane.answer = false;
+      }
     }
     for (const segment of split.segments) {
       if (segment.lane === "reasoning") {
@@ -657,7 +669,15 @@ export const dispatchTelegramMessage = async ({
                   finalizedPreviewByLane.answer = false;
                   return;
                 }
-                await rotateAnswerLaneForNewAssistantMessage();
+                if (shouldSplitPreviewMessages) {
+                  await rotateAnswerLaneForNewAssistantMessage();
+                } else {
+                  // Partial mode: reuse the same preview message across
+                  // tool-call rounds. Revive the stream so subsequent
+                  // partials continue editing the same message.
+                  answerLane.stream?.revive();
+                  resetDraftLaneState(answerLane);
+                }
                 // Message-start is an explicit assistant-message boundary.
                 // Even when no forceNewMessage happened (e.g. prior answer had no
                 // streamed partials), the next partial belongs to a fresh lifecycle

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -531,6 +531,12 @@ export const dispatchTelegramMessage = async ({
             // Assistant callbacks are fire-and-forget; ensure queued boundary
             // rotations/partials are applied before final delivery mapping.
             await enqueueDraftLaneEvent(async () => {});
+            // In partial mode, allow subsequent finals to re-edit the same
+            // preview instead of falling through to sendPayload (new message).
+            if (!shouldSplitPreviewMessages && finalizedPreviewByLane.answer) {
+              answerLane.stream?.revive();
+              finalizedPreviewByLane.answer = false;
+            }
           }
           const previewButtons = (
             payload.channelData?.telegram as { buttons?: TelegramInlineButtons } | undefined

--- a/src/telegram/draft-stream.test-helpers.ts
+++ b/src/telegram/draft-stream.test-helpers.ts
@@ -13,6 +13,7 @@ export type TestDraftStream = {
   stop: ReturnType<typeof vi.fn<() => Promise<void>>>;
   materialize: ReturnType<typeof vi.fn<() => Promise<number | undefined>>>;
   forceNewMessage: ReturnType<typeof vi.fn<() => void>>;
+  revive: ReturnType<typeof vi.fn<() => void>>;
   setMessageId: (value: number | undefined) => void;
 };
 
@@ -47,6 +48,7 @@ export function createTestDraftStream(params?: {
         messageId = undefined;
       }
     }),
+    revive: vi.fn(),
     setMessageId: (value: number | undefined) => {
       messageId = value;
     },
@@ -77,6 +79,7 @@ export function createSequencedTestDraftStream(startMessageId = 1001): TestDraft
     forceNewMessage: vi.fn().mockImplementation(() => {
       activeMessageId = undefined;
     }),
+    revive: vi.fn(),
     setMessageId: (value: number | undefined) => {
       activeMessageId = value;
     },

--- a/src/telegram/draft-stream.test.ts
+++ b/src/telegram/draft-stream.test.ts
@@ -435,6 +435,58 @@ describe("createTelegramDraftStream", () => {
     expect(api.editMessageText).not.toHaveBeenCalledWith(123, 17, "Message B partial");
   });
 
+  it("revive re-opens stream for editing the same message after stop", async () => {
+    const api = createMockDraftApi();
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+    });
+
+    // First message
+    stream.update("Before tool call");
+    await stream.flush();
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+
+    // Finalize (simulates lane delivery stop)
+    await stream.stop();
+
+    // Revive — should keep the same message ID
+    stream.revive();
+    stream.update("After tool call");
+    await stream.flush();
+
+    // Should edit the same message, not send a new one
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(api.editMessageText).toHaveBeenCalledWith(123, 17, "After tool call");
+  });
+
+  it("revive does not resurrect an error-stopped stream", async () => {
+    const api = {
+      sendMessage: vi.fn().mockRejectedValueOnce(new Error("API down")),
+      editMessageText: vi.fn().mockResolvedValue(true),
+      deleteMessage: vi.fn().mockResolvedValue(true),
+    };
+    const stream = createTelegramDraftStream({
+      api: api as unknown as Bot["api"],
+      chatId: 123,
+      warn: () => {},
+    });
+
+    // Trigger error-stop
+    stream.update("Will fail");
+    await stream.flush();
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+
+    // Revive should be a no-op on error-stopped streams
+    stream.revive();
+    stream.update("After revive");
+    await stream.flush();
+
+    // No additional API calls — stream remains dead
+    expect(api.sendMessage).toHaveBeenCalledTimes(1);
+    expect(api.editMessageText).not.toHaveBeenCalled();
+  });
+
   it("supports rendered previews with parse_mode", async () => {
     const api = createMockDraftApi();
     const stream = createTelegramDraftStream({

--- a/src/telegram/draft-stream.ts
+++ b/src/telegram/draft-stream.ts
@@ -66,6 +66,11 @@ export type TelegramDraftStream = {
   materialize?: () => Promise<number | undefined>;
   /** Reset internal state so the next update creates a new message instead of editing. */
   forceNewMessage: () => void;
+  /**
+   * Re-open the stream lifecycle without creating a new message.
+   * Used in partial mode to continue editing the same preview across tool-call boundaries.
+   */
+  revive: () => void;
 };
 
 type TelegramDraftPreview = {
@@ -408,6 +413,18 @@ export function createTelegramDraftStream(params: {
     return undefined;
   };
 
+  const revive = () => {
+    if (streamState.stopped) {
+      // Stream was killed by an error; don't resurrect.
+      return;
+    }
+    streamState.final = false;
+    lastSentText = "";
+    lastSentParseMode = undefined;
+    loop.resetPending();
+    loop.resetThrottleWindow();
+  };
+
   params.log?.(`telegram stream preview ready (maxChars=${maxChars}, throttleMs=${throttleMs})`);
 
   return {
@@ -421,5 +438,6 @@ export function createTelegramDraftStream(params: {
     stop,
     materialize,
     forceNewMessage,
+    revive,
   };
 }


### PR DESCRIPTION
## Summary

In partial streaming mode, intermediate text blocks between tool calls were sent as separate Telegram messages instead of editing a single message in place. For example, when a model runs sequential tool calls like `web_search` → `web_fetch` → `web_search_pro`, each intermediate narration ("Let me search...", "Trying another approach...") became a permanent separate message visible to the user.

**Root cause:** `onAssistantMessageStart` unconditionally called `rotateAnswerLaneForNewAssistantMessage()`, which materialized the current preview and forced a new message via `forceNewMessage()` at every tool-call boundary — even in partial mode where the user expects a single updating preview.

**Fix:** Add `shouldSplitPreviewMessages` flag (only true in `block` mode), mirroring Discord's existing pattern. In partial mode:
- `revive()` re-opens the stream lifecycle without clearing the message ID
- `resetDraftLaneState()` clears text state for the next round
- Subsequent partials continue editing the same preview message

### Key changes

1. **`draft-stream.ts`** — New `revive()` method: resets `final` state without clearing `messageId`, allowing continued editing after `stop()`. Refuses to resurrect error-stopped streams.
2. **`bot-message-dispatch.ts`** — Gate rotation behind `shouldSplitPreviewMessages` in both `onAssistantMessageStart` and the preemptive rotation in `ingestDraftLaneSegments`.
3. **Tests** — Rotation tests now explicitly use `streamMode: "block"`. New test verifies partial mode coalesces across tool-call rounds. Two new `revive()` unit tests (happy path + error-stopped guard).

## Linked Issue

Fixes #32535

## User-visible Changes

- In partial streaming mode, multi-tool-call turns now show one progressively-edited preview message instead of separate message fragments per tool-call round. Only the final response text persists.
- Block mode behavior is unchanged.

## Test plan

- [x] All 87 `bot-message-dispatch.test.ts` tests pass
- [x] All 29 `draft-stream.test.ts` tests pass (including 2 new `revive` tests)
- [x] All 13 `lane-delivery.test.ts` tests pass
- [x] Full `src/telegram/` test suite: 732 pass, 1 pre-existing unrelated failure
- [x] Type check clean (`tsc --noEmit`)
- [x] Build clean (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)