### PR TITLE
fix(synology-chat): respect SYNOLOGY_RATE_LIMIT=0 by using ?? instead of ||

### DIFF
--- a/extensions/synology-chat/src/accounts.ts
+++ b/extensions/synology-chat/src/accounts.ts
@@ -80,7 +80,11 @@ export function resolveAccount(cfg: any, accountId?: string | null): ResolvedSyn
     rateLimitPerMinute:
       accountOverride.rateLimitPerMinute ??
       channelCfg.rateLimitPerMinute ??
-      (envRateLimit ? parseInt(envRateLimit, 10) ?? 30 : 30),
+      (envRateLimit
+        ? Number.isNaN(parseInt(envRateLimit, 10))
+          ? 30
+          : parseInt(envRateLimit, 10)
+        : 30),
     botName: accountOverride.botName ?? channelCfg.botName ?? envBotName,
     allowInsecureSsl: accountOverride.allowInsecureSsl ?? channelCfg.allowInsecureSsl ?? false,
   };

--- a/extensions/synology-chat/src/accounts.ts
+++ b/extensions/synology-chat/src/accounts.ts
@@ -80,7 +80,7 @@ export function resolveAccount(cfg: any, accountId?: string | null): ResolvedSyn
     rateLimitPerMinute:
       accountOverride.rateLimitPerMinute ??
       channelCfg.rateLimitPerMinute ??
-      (envRateLimit ? parseInt(envRateLimit, 10) || 30 : 30),
+      (envRateLimit ? parseInt(envRateLimit, 10) ?? 30 : 30),
     botName: accountOverride.botName ?? channelCfg.botName ?? envBotName,
     allowInsecureSsl: accountOverride.allowInsecureSsl ?? channelCfg.allowInsecureSsl ?? false,
   };


### PR DESCRIPTION
## Issue

Fixes #39191

## Problem

In `extensions/synology-chat/src/accounts.ts:83`, the rate limit parsing used `||` instead of `??`:

```typescript
(envRateLimit ? parseInt(envRateLimit, 10) || 30 : 30)
```

When `SYNOLOGY_RATE_LIMIT=0`, `parseInt("0", 10)` returns `0`, and `0 || 30` evaluates to `30`, silently ignoring the user′s intent.

## Solution

Changed `||` to `??` (nullish coalescing) so that `0` is respected:

```typescript
(envRateLimit ? parseInt(envRateLimit, 10) ?? 30 : 30)
```

Now `SYNOLOGY_RATE_LIMIT=0` correctly produces `rateLimitPerMinute: 0`.

## Testing

Verified the fix:
- `SYNOLOGY_RATE_LIMIT=0` → `rateLimitPerMinute: 0` ✓
- `SYNOLOGY_RATE_LIMIT=5` → `rateLimitPerMinute: 5` ✓
- `SYNOLOGY_RATE_LIMIT` unset → `rateLimitPerMinute: 30` ✓