### PR TITLE
fix(heartbeat): don't advance schedule on requests-in-flight skip

### DIFF
--- a/src/infra/heartbeat-runner.scheduler.test.ts
+++ b/src/infra/heartbeat-runner.scheduler.test.ts
@@ -158,8 +158,9 @@ describe("startHeartbeatRunner", () => {
     await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
     expect(runSpy).toHaveBeenCalledTimes(1);
 
-    // Timer should be rescheduled; next heartbeat should still fire
-    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    // Schedule was NOT advanced, so the runner retries promptly.
+    // A small tick is enough for the retry to fire.
+    await vi.advanceTimersByTimeAsync(1_000);
     expect(runSpy).toHaveBeenCalledTimes(2);
 
     runner.stop();
@@ -237,6 +238,38 @@ describe("startHeartbeatRunner", () => {
       }),
     );
     expect(runSpy.mock.calls.some((call) => call[0]?.agentId === "finance")).toBe(false);
+
+    runner.stop();
+  });
+
+  it("does not advance schedule when skipped due to requests-in-flight", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(0));
+
+    let callCount = 0;
+    const runSpy = vi.fn().mockImplementation(async () => {
+      callCount++;
+      if (callCount === 1) {
+        // First call: requests are in flight
+        return { status: "skipped", reason: "requests-in-flight" };
+      }
+      return { status: "ran", durationMs: 1 };
+    });
+
+    const runner = startDefaultRunner(runSpy);
+
+    // First heartbeat fires at 30m — returns requests-in-flight
+    await vi.advanceTimersByTimeAsync(30 * 60_000 + 1_000);
+    expect(runSpy).toHaveBeenCalledTimes(1);
+
+    // Without the fix, advanceAgentSchedule would push nextDueMs to 60m,
+    // so at 31m nothing would fire. With the fix, the schedule is NOT
+    // advanced, so the very next interval tick (at the original 30m mark
+    // which is already past) should re-fire almost immediately.
+    // Advance just 1 second — the runner should retry since nextDueMs was
+    // NOT pushed forward.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(runSpy).toHaveBeenCalledTimes(2);
 
     runner.stop();
   });

--- a/src/infra/heartbeat-runner.ts
+++ b/src/infra/heartbeat-runner.ts
@@ -1190,7 +1190,8 @@ export function startHeartbeatRunner(opts: {
         continue;
       }
       if (res.status === "skipped" && res.reason === "requests-in-flight") {
-        advanceAgentSchedule(agent, now);
+        // Do NOT advance the schedule — the in-flight request will finish
+        // and the next interval tick should retry immediately.
         scheduleNext();
         return res;
       }


### PR DESCRIPTION
## Problem

When a heartbeat run is skipped because requests are in-flight, `advanceAgentSchedule()` pushes `nextDueMs` forward by a full interval. If the in-flight request takes close to the interval duration, multiple retries each advance the schedule further, eventually leaving the runner permanently idle until gateway restart.

## Root Cause

In `startHeartbeatRunner`'s `run()` function:

```typescript
if (res.status === "skipped" && res.reason === "requests-in-flight") {
    advanceAgentSchedule(agent, now);  // ← BUG: pushes nextDueMs forward
    scheduleNext();
    return res;
}
```

Each retry on a busy queue advances the schedule by another full interval, compounding the delay.

## Fix

Remove `advanceAgentSchedule()` from the `requests-in-flight` branch. The schedule stays at its original `nextDueMs`, so the next timer tick retries immediately once the queue clears.

## Tests

- Updated existing `reschedules timer when runOnce returns requests-in-flight` test to verify prompt retry
- Added new `does not advance schedule when skipped due to requests-in-flight` regression test

Fixes #39173