### PR TITLE
fix: guard against malformed text blocks in context truncation

### DIFF
--- a/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
+++ b/src/agents/pi-embedded-runner/tool-result-char-estimator.ts
@@ -7,7 +7,12 @@ const IMAGE_CHAR_ESTIMATE = 8_000;
 export type MessageCharEstimateCache = WeakMap<AgentMessage, number>;
 
 function isTextBlock(block: unknown): block is { type: "text"; text: string } {
-  return !!block && typeof block === "object" && (block as { type?: unknown }).type === "text";
+  return (
+    !!block &&
+    typeof block === "object" &&
+    (block as { type?: unknown }).type === "text" &&
+    typeof (block as { text?: unknown }).text === "string"
+  );
 }
 
 function isImageBlock(block: unknown): boolean {

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -99,7 +99,7 @@ function hasImageBlocks(content: ReadonlyArray<TextContent | ImageContent>): boo
 function estimateTextAndImageChars(content: ReadonlyArray<TextContent | ImageContent>): number {
   let chars = 0;
   for (const block of content) {
-    if (block.type === "text") {
+    if (block.type === "text" && typeof block.text === "string") {
       chars += block.text.length;
     }
     if (block.type === "image") {

--- a/src/agents/pi-extensions/context-pruning/pruner.ts
+++ b/src/agents/pi-extensions/context-pruning/pruner.ts
@@ -16,7 +16,7 @@ function asText(text: string): TextContent {
 function collectTextSegments(content: ReadonlyArray<TextContent | ImageContent>): string[] {
   const parts: string[] = [];
   for (const block of content) {
-    if (block.type === "text") {
+    if (block.type === "text" && typeof block.text === "string") {
       parts.push(block.text);
     }
   }


### PR DESCRIPTION
## Summary

- Fix session-permanent crash loop caused by malformed tool result content blocks (`{type: "text"}` missing `text` property)
- When a plugin tool handler returns `undefined`, the framework persists `{type: "text"}` without a `text` property to the session JSONL
- `isTextBlock()` type guard only checked `type === "text"` without verifying `typeof text === "string"`, causing `block.text.length` to throw `TypeError` on every subsequent message
- Also added the same defensive check in the context pruning estimator

Fixes #34979

## Test plan

- [ ] Verify sessions with malformed `{type: "text"}` content blocks no longer crash
- [ ] Verify normal text blocks still estimate correctly
- [ ] Verify context truncation still works for valid tool results

🤖 Generated with [Claude Code](https://claude.com/claude-code)