### PR TITLE
fix(gateway): create transcript file on chat.inject when missing

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1211,7 +1211,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       storePath,
       sessionFile: entry?.sessionFile,
       agentId: resolveSessionAgentId({ sessionKey: rawSessionKey, config: cfg }),
-      createIfMissing: false,
+      createIfMissing: true,
     });
     if (!appended.ok || !appended.messageId || !appended.message) {
       respond(


### PR DESCRIPTION
## Summary

- Fix `chat.inject` failing with "transcript file not found" when the transcript file doesn't exist on disk
- Changed `createIfMissing: false` to `createIfMissing: true` in the chat.inject handler, matching the behavior of other transcript write paths
- This primarily affects ACP oneshot/run sessions where the transcript is not pre-created

Fixes #36170

## Test plan

- [ ] Verify `chat.inject` succeeds when transcript file doesn't exist yet
- [ ] Verify `chat.history` returns injected messages after first inject
- [ ] Verify existing sessions with transcript files still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)