### PR TITLE
fix(voice-call): use ?? instead of || for TTS speed config

### DIFF
--- a/extensions/voice-call/src/providers/tts-openai.ts
+++ b/extensions/voice-call/src/providers/tts-openai.ts
@@ -82,7 +82,7 @@ export class OpenAITTSProvider {
     this.model = config.model || "gpt-4o-mini-tts";
     // Default to coral - good balance of quality and natural tone
     this.voice = (config.voice as OpenAITTSVoice) || "coral";
-    this.speed = config.speed || 1.0;
+    this.speed = config.speed ?? 1.0;
     this.instructions = config.instructions;
 
     if (!this.apiKey) {


### PR DESCRIPTION
Fixes #39285

Use nullish coalescing (`??`) instead of logical OR (`||`) for the speed default value in the OpenAI TTS provider.

## Problem
The current code uses `||`, which treats `0` as falsy. While the OpenAI API minimum speed is `0.25`, using `??` is more correct and consistent with the fixes in #39190 and #39191.

## Solution
Changed:
```typescript
this.speed = config.speed || 1.0;
```

To:
```typescript
this.speed = config.speed ?? 1.0;
```

## Impact
Low — defensive fix for consistency and correctness.