### PR TITLE
fix(telegram): validate replyToMessageId before sending

### DIFF
--- a/src/telegram/send.ts
+++ b/src/telegram/send.ts
@@ -277,7 +277,11 @@ function buildTelegramThreadReplyParams(params: {
   const threadIdParams = buildTelegramThreadParams(threadSpec);
   const threadParams: Record<string, unknown> = threadIdParams ? { ...threadIdParams } : {};
 
-  if (params.replyToMessageId != null) {
+  if (
+    params.replyToMessageId != null &&
+    Number.isFinite(params.replyToMessageId) &&
+    params.replyToMessageId > 0
+  ) {
     const replyToMessageId = Math.trunc(params.replyToMessageId);
     if (params.quoteText?.trim()) {
       threadParams.reply_parameters = {


### PR DESCRIPTION
## Summary

- Validate `replyToMessageId` as a finite positive integer before attaching to Telegram API request
- In cross-surface routing, non-numeric reply IDs (e.g. UUIDs from other channels) can leak into the Telegram send path as `NaN`, causing `400 Bad Request: message to be replied not found`
- Invalid values are now silently dropped, allowing the message to send normally without threading

Fixes #37222

## Test plan

- [ ] Verify Telegram sends succeed when `replyToMessageId` is `NaN`
- [ ] Verify Telegram sends succeed when `replyToMessageId` is `0` or negative
- [ ] Verify normal numeric `replyToMessageId` values still thread correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)