### PR TITLE
fix: prevent phantom toolResult from corrupting sessions

### DIFF
--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -686,6 +686,23 @@ export function normalizeProviders(params: {
       }
     }
 
+    // Reverse-lookup: if apiKey looks like a resolved secret value (not an env
+    // var name), check whether it matches the canonical env var for this provider.
+    // This prevents resolveConfigEnvVars()-resolved secrets from being persisted
+    // to models.json as plaintext. (Fixes #38757)
+    const currentApiKey = normalizedProvider.apiKey;
+    if (
+      typeof currentApiKey === "string" &&
+      currentApiKey.trim() &&
+      !ENV_VAR_NAME_RE.test(currentApiKey.trim())
+    ) {
+      const envVarName = resolveEnvApiKeyVarName(normalizedKey);
+      if (envVarName && process.env[envVarName] === currentApiKey) {
+        mutated = true;
+        normalizedProvider = { ...normalizedProvider, apiKey: envVarName };
+      }
+    }
+
     // If a provider defines models, pi's ModelRegistry requires apiKey to be set.
     // Fill it from the environment or auth profiles when possible.
     const hasModels =

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -686,23 +686,6 @@ export function normalizeProviders(params: {
       }
     }
 
-    // Reverse-lookup: if apiKey looks like a resolved secret value (not an env
-    // var name), check whether it matches the canonical env var for this provider.
-    // This prevents resolveConfigEnvVars()-resolved secrets from being persisted
-    // to models.json as plaintext. (Fixes #38757)
-    const currentApiKey = normalizedProvider.apiKey;
-    if (
-      typeof currentApiKey === "string" &&
-      currentApiKey.trim() &&
-      !ENV_VAR_NAME_RE.test(currentApiKey.trim())
-    ) {
-      const envVarName = resolveEnvApiKeyVarName(normalizedKey);
-      if (envVarName && process.env[envVarName] === currentApiKey) {
-        mutated = true;
-        normalizedProvider = { ...normalizedProvider, apiKey: envVarName };
-      }
-    }
-
     // If a provider defines models, pi's ModelRegistry requires apiKey to be set.
     // Fill it from the environment or auth profiles when possible.
     const hasModels =

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -404,7 +404,17 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
 
     const toolCalls = extractToolCallsFromAssistant(assistant);
     if (toolCalls.length === 0) {
-      out.push(msg);
+      // If stopReason claims "toolUse" but no actual toolCall blocks exist,
+      // correct the stopReason to prevent downstream code from creating
+      // phantom toolResult entries with empty toolCallId. This can happen
+      // when a fallback model returns stopReason "toolUse" with only
+      // thinking + text content. (Fixes #21985)
+      if (stopReason === "toolUse") {
+        const corrected = { ...assistant, stopReason: "stop" };
+        out.push(corrected as AgentMessage);
+      } else {
+        out.push(msg);
+      }
       continue;
     }
 

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -411,6 +411,7 @@ export function repairToolUseResultPairing(messages: AgentMessage[]): ToolUseRep
       // thinking + text content. (Fixes #21985)
       if (stopReason === "toolUse") {
         const corrected = { ...assistant, stopReason: "stop" };
+        changed = true;
         out.push(corrected as AgentMessage);
       } else {
         out.push(msg);


### PR DESCRIPTION
## Summary

- Fix session-permanent corruption caused by phantom `toolResult` entries with empty `toolCallId`
- When a fallback model returns `stopReason: "toolUse"` but the response content has NO actual `toolCall` blocks (only thinking + text), downstream repair creates phantom `toolResult` entries that permanently corrupt the session
- Detect the mismatch in `repairToolUseResultPairing` and correct `stopReason` to `"stop"` so no synthetic `toolResult` entries are generated

Fixes #21985

## Test plan

- [ ] Verify sessions with `stopReason: "toolUse"` and no toolCall blocks no longer create phantom toolResults
- [ ] Verify normal tool use flows with valid toolCall blocks still work correctly
- [ ] Verify existing session repair for valid tool use is not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)