### PR TITLE
fix(telegram): skip reasoning stream callbacks when reasoning is off

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -681,20 +681,24 @@ export const dispatchTelegramMessage = async ({
                   await ingestDraftLaneSegments(payload.text);
                 })
             : undefined,
-        onReasoningStream: reasoningLane.stream
-          ? (payload) =>
-              enqueueDraftLaneEvent(async () => {
-                // Split between reasoning blocks only when the next reasoning
-                // stream starts. Splitting at reasoning-end can orphan the active
-                // preview and cause duplicate reasoning sends on reasoning final.
-                if (splitReasoningOnNextStream) {
-                  reasoningLane.stream?.forceNewMessage();
-                  resetDraftLaneState(reasoningLane);
-                  splitReasoningOnNextStream = false;
-                }
-                await ingestDraftLaneSegments(payload.text);
-              })
-          : undefined,
+        // When reasoning display is off, skip onReasoningStream to prevent
+        // native reasoning content (no tags) from routing to the answer lane,
+        // which would create a duplicate visible message alongside the answer.
+        onReasoningStream:
+          reasoningLane.stream && resolvedReasoningLevel !== "off"
+            ? (payload) =>
+                enqueueDraftLaneEvent(async () => {
+                  // Split between reasoning blocks only when the next reasoning
+                  // stream starts. Splitting at reasoning-end can orphan the active
+                  // preview and cause duplicate reasoning sends on reasoning final.
+                  if (splitReasoningOnNextStream) {
+                    reasoningLane.stream?.forceNewMessage();
+                    resetDraftLaneState(reasoningLane);
+                    splitReasoningOnNextStream = false;
+                  }
+                  await ingestDraftLaneSegments(payload.text);
+                })
+            : undefined,
         onAssistantMessageStart: answerLane.stream
           ? () =>
               enqueueDraftLaneEvent(async () => {
@@ -714,13 +718,14 @@ export const dispatchTelegramMessage = async ({
                 retainPreviewOnCleanupByLane.answer = false;
               })
           : undefined,
-        onReasoningEnd: reasoningLane.stream
-          ? () =>
-              enqueueDraftLaneEvent(async () => {
-                // Split when/if a later reasoning block begins.
-                splitReasoningOnNextStream = reasoningLane.hasStreamedMessage;
-              })
-          : undefined,
+        onReasoningEnd:
+          reasoningLane.stream && resolvedReasoningLevel !== "off"
+            ? () =>
+                enqueueDraftLaneEvent(async () => {
+                  // Split when/if a later reasoning block begins.
+                  splitReasoningOnNextStream = reasoningLane.hasStreamedMessage;
+                })
+            : undefined,
         onToolStart: statusReactionController
           ? async (payload) => {
               await statusReactionController.setTool(payload.name);


### PR DESCRIPTION
## Summary

- Fix duplicate Telegram messages when reasoning display is disabled (`reasoningLevel: "off"`)
- Gate `onReasoningStream` and `onReasoningEnd` callbacks on `resolvedReasoningLevel !== "off"` to prevent native reasoning content (which has no `<thinking>` tags) from being routed to the answer lane via `splitTelegramReasoningText`, which would create a duplicate visible message alongside the actual answer
- Tag-based reasoning (e.g. `<thinking>...</thinking>` in `onPartialReply`) is already correctly handled by `splitTextIntoLaneSegments` which suppresses reasoning segments when level is "off"

Closes #39324

## Root cause

When streaming is enabled, `reasoningLane.stream` is always created (gated on `canStreamReasoningDraft = canStreamAnswerDraft || streamReasoningDraft`). This caused `onReasoningStream` to be set even when `resolvedReasoningLevel === "off"`.

Native reasoning content (from providers like Claude) arrives without `<thinking>` tags. When `splitTelegramReasoningText` processes this untagged text, it returns `{ answerText: text }`, routing it to the **answer** lane. This creates a visible draft message with thinking content. When the actual answer arrives, `rotateAnswerLaneForNewAssistantMessage` materializes the thinking draft into a permanent message, resulting in two messages visible to the user.

## Test plan

- [x] `pnpm vitest run src/telegram/reasoning-lane-coordinator.test.ts src/telegram/lane-delivery.test.ts` — 17/17 pass
- [ ] Manual: send message to Telegram bot with `reasoningLevel: "off"` → verify single response (no thinking content)
- [ ] Manual: send message with `reasoningLevel: "on"` or `"stream"` → verify reasoning still displays correctly