### PR TITLE
fix(openresponses): normalize tool definitions to accept Anthropic and flat formats

### DIFF
--- a/src/gateway/openresponses-http.ts
+++ b/src/gateway/openresponses-http.ts
@@ -97,6 +97,56 @@ function resolveResponsesLimits(
   };
 }
 
+/**
+ * Normalize tool definitions to OpenAI function-tool format.
+ *
+ * Clients (including Anthropic SDK users and OpenClaw cron isolated sessions)
+ * sometimes pass tools in the Anthropic/flat format:
+ *   { name, description, input_schema }
+ *
+ * The OpenResponses schema expects the OpenAI format:
+ *   { type: "function", function: { name, description, parameters } }
+ *
+ * This function converts flat-format tool definitions before schema validation
+ * so both formats are accepted transparently.
+ *
+ * @see https://github.com/openclaw/openclaw/issues/39359
+ */
+export function normalizeToolDefinitions(
+  tools: unknown[] | undefined,
+): unknown[] | undefined {
+  if (!tools || !Array.isArray(tools)) {
+    return tools;
+  }
+  return tools.map((tool) => {
+    if (typeof tool !== "object" || tool === null) {
+      return tool;
+    }
+    const t = tool as Record<string, unknown>;
+    // Already in OpenAI format — pass through
+    if (t.type === "function" && t.function) {
+      return tool;
+    }
+    // Detect Anthropic/flat format: has `name` at top level but no `function` wrapper
+    if (typeof t.name === "string" && !t.function) {
+      return {
+        type: "function",
+        function: {
+          name: t.name,
+          ...(t.description !== undefined && { description: t.description }),
+          // Anthropic uses `input_schema`, OpenAI uses `parameters`
+          ...(t.input_schema !== undefined
+            ? { parameters: t.input_schema }
+            : t.parameters !== undefined
+              ? { parameters: t.parameters }
+              : {}),
+        },
+      };
+    }
+    return tool;
+  });
+}
+
 function extractClientTools(body: CreateResponseBody): ClientToolDefinition[] {
   return (body.tools ?? []) as ClientToolDefinition[];
 }
@@ -286,6 +336,13 @@ export async function handleOpenResponsesHttpRequest(
   }
   if (!handled) {
     return true;
+  }
+
+  // Normalize tool definitions before validation (accept both OpenAI and Anthropic formats)
+  if (handled.body && typeof handled.body === "object" && Array.isArray((handled.body as Record<string, unknown>).tools)) {
+    (handled.body as Record<string, unknown>).tools = normalizeToolDefinitions(
+      (handled.body as Record<string, unknown>).tools as unknown[],
+    );
   }
 
   // Validate request body with Zod

--- a/src/gateway/openresponses-parity.test.ts
+++ b/src/gateway/openresponses-parity.test.ts
@@ -316,4 +316,115 @@ describe("OpenResponses Feature Parity", () => {
       expect(result.message).toContain("Thanks");
     });
   });
+
+  describe("Tool Definition Normalization", () => {
+    let normalizeToolDefinitions: typeof import("./openresponses-http.js").normalizeToolDefinitions;
+
+    beforeAll(async () => {
+      ({ normalizeToolDefinitions } = await import("./openresponses-http.js"));
+    });
+
+    it("should pass through OpenAI-format tools unchanged", () => {
+      const tools = [
+        {
+          type: "function",
+          function: {
+            name: "read",
+            description: "Read a file",
+            parameters: { type: "object", properties: { path: { type: "string" } } },
+          },
+        },
+      ];
+      const result = normalizeToolDefinitions(tools);
+      expect(result).toEqual(tools);
+    });
+
+    it("should normalize Anthropic-format tools (name + input_schema) to OpenAI format", () => {
+      const tools = [
+        {
+          name: "read",
+          description: "Read the contents of a file",
+          input_schema: {
+            type: "object",
+            properties: { path: { type: "string" } },
+            required: ["path"],
+          },
+        },
+      ];
+      const result = normalizeToolDefinitions(tools);
+      expect(result).toEqual([
+        {
+          type: "function",
+          function: {
+            name: "read",
+            description: "Read the contents of a file",
+            parameters: {
+              type: "object",
+              properties: { path: { type: "string" } },
+              required: ["path"],
+            },
+          },
+        },
+      ]);
+    });
+
+    it("should normalize flat tools with parameters field", () => {
+      const tools = [
+        {
+          name: "write",
+          description: "Write a file",
+          parameters: { type: "object", properties: { content: { type: "string" } } },
+        },
+      ];
+      const result = normalizeToolDefinitions(tools);
+      expect(result).toEqual([
+        {
+          type: "function",
+          function: {
+            name: "write",
+            description: "Write a file",
+            parameters: { type: "object", properties: { content: { type: "string" } } },
+          },
+        },
+      ]);
+    });
+
+    it("should handle mixed OpenAI and Anthropic format tools", () => {
+      const tools = [
+        { type: "function", function: { name: "tool_a" } },
+        { name: "tool_b", description: "B", input_schema: { type: "object" } },
+      ];
+      const result = normalizeToolDefinitions(tools);
+      expect(result![0]).toEqual({ type: "function", function: { name: "tool_a" } });
+      expect(result![1]).toEqual({
+        type: "function",
+        function: { name: "tool_b", description: "B", parameters: { type: "object" } },
+      });
+    });
+
+    it("should return undefined for undefined input", () => {
+      expect(normalizeToolDefinitions(undefined)).toBeUndefined();
+    });
+
+    it("should return empty array for empty input", () => {
+      expect(normalizeToolDefinitions([])).toEqual([]);
+    });
+
+    it("should produce tools that pass ToolDefinitionSchema validation after normalization", () => {
+      const anthropicTools = [
+        {
+          name: "web_search",
+          description: "Search the web",
+          input_schema: {
+            type: "object",
+            properties: { query: { type: "string" } },
+            required: ["query"],
+          },
+        },
+      ];
+      const normalized = normalizeToolDefinitions(anthropicTools)!;
+      const result = ToolDefinitionSchema.safeParse(normalized[0]);
+      expect(result.success).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

The OpenResponses `/v1/responses` endpoint strictly validates tool definitions against the OpenAI function-tool schema:

```json
{ "type": "function", "function": { "name": "...", "description": "...", "parameters": {...} } }
```

However, clients using the Anthropic SDK format (and OpenClaw cron isolated sessions) pass tools in the flat format:

```json
{ "name": "read", "description": "Read the contents of a file", "input_schema": { "type": "object", ... } }
```

This causes a schema validation error:
```
Field required: tools.0.function
```

Fixes #39359

## Fix

Added a `normalizeToolDefinitions()` function in `openresponses-http.ts` that runs **before** Zod schema validation. It detects flat-format tool definitions (having `name` at the top level without a `function` wrapper) and converts them to the expected OpenAI format:

- `name` → `function.name`
- `description` → `function.description`
- `input_schema` (Anthropic) or `parameters` (flat) → `function.parameters`
- Adds `type: "function"` wrapper

Tools already in OpenAI format pass through unchanged.

## Testing

- Added 7 unit tests in `openresponses-parity.test.ts`:
  - OpenAI-format passthrough
  - Anthropic-format normalization (`input_schema`)
  - Flat-format with `parameters` field
  - Mixed format handling
  - Undefined/empty array edge cases
  - Validates normalized output passes `ToolDefinitionSchema`

## Scope

- `src/gateway/openresponses-http.ts` — normalization function + pre-validation hook
- `src/gateway/openresponses-parity.test.ts` — test cases
