### PR TITLE
fix(discord): add agentComponents to config Zod schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -348,6 +348,7 @@ Docs: https://docs.openclaw.ai
 - Gateway/health-monitor restart reason labeling: report `disconnected` instead of `stuck` for clean channel disconnect restarts, so operator logs distinguish socket drops from genuinely stuck channels. (#36436) Thanks @Sid-Qin.
 - Control UI/agents-page overrides: auto-create minimal per-agent config entries when editing inherited agents, so model/tool/skill changes enable Save and inherited model fallbacks can be cleared by writing a primary-only override. Landed from contributor PR #39326 by @dunamismax. Thanks @dunamismax.
 - Gateway/Telegram webhook-mode recovery: add `webhookCertPath` to re-upload self-signed certificates during webhook registration and skip stale-socket detection for webhook-mode channels, so Telegram webhook setups survive health-monitor restarts. Landed from contributor PR #39313 by @fellanH. Thanks @fellanH.
+- Discord/config schema parity: add `channels.discord.agentComponents` to the strict Zod config schema so valid `agentComponents.enabled` settings (root and account-scoped) no longer fail with unrecognized-key validation errors. Landed from contributor PR #39378 by @gambletan. Thanks @gambletan and @thewilloftheshadow.
 
 ## 2026.3.2
 


### PR DESCRIPTION
## Summary

- Adds `agentComponents` field to `DiscordAccountSchema` in the Zod config schema
- Aligns schema with the TypeScript type definition `DiscordAccountConfig` at `types.discord.ts:301`

## Problem

The `agentComponents` field is defined in the TypeScript type, actively read at runtime in `discord/monitor/provider.ts:544-545`, and used in tests — but was missing from the Zod validation schema. Because the schema uses `.strict()`, users setting `channels.discord.agentComponents.enabled: true` get an `Unrecognized key` validation error.

Fixes #35564

## Test plan

- [x] Zod schema tests pass (12/12)
- [ ] Setting `channels.discord.agentComponents.enabled: true` should be accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)