### PR TITLE
fix(voice-call): add speed and instructions to OpenAI TTS plugin schema

### DIFF
--- a/extensions/voice-call/openclaw.plugin.json
+++ b/extensions/voice-call/openclaw.plugin.json
@@ -527,6 +527,14 @@
               },
               "voice": {
                 "type": "string"
+              },
+              "speed": {
+                "type": "number",
+                "minimum": 0.25,
+                "maximum": 4.0
+              },
+              "instructions": {
+                "type": "string"
               }
             }
           },


### PR DESCRIPTION
## Summary

- Adds `speed` and `instructions` properties to the OpenAI TTS provider schema in the voice-call plugin manifest

## Problem

The OpenAI TTS config schema in `extensions/voice-call/openclaw.plugin.json` has `additionalProperties: false` but only declares `apiKey`, `model`, and `voice`. The runtime code (`tts-openai.ts:85-86`) and TypeScript interfaces accept two additional properties:

- `speed` (number, 0.25–4.0) — speech speed multiplier
- `instructions` (string) — speech style instructions for gpt-4o-mini-tts

Users who configure these valid options get JSON schema validation errors.

Fixes #39192

## Test plan

- [ ] Configure `tts.openai.speed: 1.5` — should be accepted
- [ ] Configure `tts.openai.instructions: "Speak slowly"` — should be accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)