### PR TITLE
fix(signal): add groups config to schema for per-group requireMention

### DIFF
--- a/src/config/types.signal.ts
+++ b/src/config/types.signal.ts
@@ -1,3 +1,4 @@
+import type { ChannelGroupConfig } from "./group-policy.js";
 import type { CommonChannelMessagingConfig } from "./types.channel-messaging-common.js";
 
 export type SignalReactionNotificationMode = "off" | "own" | "all" | "allowlist";
@@ -24,6 +25,8 @@ export type SignalAccountConfig = CommonChannelMessagingConfig & {
   ignoreAttachments?: boolean;
   ignoreStories?: boolean;
   sendReadReceipts?: boolean;
+  /** Per-group config (e.g. requireMention, tools). Keys are group IDs or "*" for default. */
+  groups?: Record<string, ChannelGroupConfig>;
   /** Outbound text chunk size (chars). Default: 4000. */
   textChunkLimit?: number;
   /** Reaction notification mode (off|own|all|allowlist). Default: own. */

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -936,6 +936,14 @@ export const SlackConfigSchema = SlackAccountSchema.safeExtend({
   validateSlackSigningSecretRequirements(value, ctx);
 });
 
+export const SignalGroupSchema = z
+  .object({
+    requireMention: z.boolean().optional(),
+    tools: ToolPolicySchema,
+    toolsBySender: ToolPolicyBySenderSchema,
+  })
+  .strict();
+
 export const SignalAccountSchemaBase = z
   .object({
     name: z.string().optional(),
@@ -959,6 +967,7 @@ export const SignalAccountSchemaBase = z
     defaultTo: z.string().optional(),
     groupAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     groupPolicy: GroupPolicySchema.optional().default("allowlist"),
+    groups: z.record(z.string(), SignalGroupSchema.optional()).optional(),
     historyLimit: z.number().int().min(0).optional(),
     dmHistoryLimit: z.number().int().min(0).optional(),
     dms: z.record(z.string(), DmConfigSchema.optional()).optional(),


### PR DESCRIPTION
## Summary

- Adds `SignalGroupSchema` and `groups` field to the Signal channel Zod schema
- Adds `groups` field to the `SignalAccountConfig` TypeScript type
- Enables per-group `requireMention` override for Signal groups

## Problem

Signal group messages are silently dropped because `requireMention` defaults to `true`, but Signal does not support native @mentions. Other channels (Telegram, WhatsApp, IRC, BlueBubbles) all expose a `groups` config property that allows setting `requireMention: false` per-group or globally via `"*"`.

Signal was the only channel missing this config — users had no schema-valid way to disable `requireMention` specifically for Signal groups. The runtime code (`resolveChannelGroupRequireMention`) already reads `groups` from the channel config generically, so it works for Signal once the schema allows it.

Fixes #20397

## Test plan

- [x] Zod schema tests pass (12/12)
- [ ] Setting `channels.signal.groups."*".requireMention: false` should be accepted
- [ ] Signal group messages should no longer be silently dropped when `requireMention` is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)