### PR TITLE
fix(auth): canonicalize new OpenAI Codex login profile ids

### DIFF
--- a/src/agents/auth-profiles.openai-codex-profile-id.test.ts
+++ b/src/agents/auth-profiles.openai-codex-profile-id.test.ts
@@ -1,13 +1,6 @@
 import { describe, expect, it } from "vitest";
+import { expectedOpenAICodexProfileId, makeJwt } from "../test-utils/openai-codex-profile-id.js";
 import { deriveOpenAICodexCanonicalProfileId } from "./auth-profiles/openai-codex-profile-id.js";
-
-function makeJwt(payload: Record<string, unknown>): string {
-  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" }), "utf8").toString(
-    "base64url",
-  );
-  const body = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
-  return `${header}.${body}.sig`;
-}
 
 describe("deriveOpenAICodexCanonicalProfileId", () => {
   it("derives a canonical profile id from accountId, iss, and sub", () => {
@@ -22,7 +15,11 @@ describe("deriveOpenAICodexCanonicalProfileId", () => {
         accountId: "acct_456",
       }),
     ).toBe(
-      `openai-codex:acct_456:${Buffer.from("https://auth.openai.com", "utf8").toString("base64url")}:${Buffer.from("user_123", "utf8").toString("base64url")}`,
+      expectedOpenAICodexProfileId({
+        accountId: "acct_456",
+        iss: "https://auth.openai.com",
+        sub: "user_123",
+      }),
     );
   });
 
@@ -37,7 +34,27 @@ describe("deriveOpenAICodexCanonicalProfileId", () => {
         }),
       }),
     ).toBe(
-      `openai-codex:acct_payload:${Buffer.from("https://auth.openai.com", "utf8").toString("base64url")}:${Buffer.from("user_789", "utf8").toString("base64url")}`,
+      expectedOpenAICodexProfileId({
+        accountId: "acct_payload",
+        iss: "https://auth.openai.com",
+        sub: "user_789",
+      }),
+    );
+  });
+
+  it("sanitizes account ids before building the canonical profile id", () => {
+    expect(
+      deriveOpenAICodexCanonicalProfileId({
+        provider: "openai-codex",
+        access: makeJwt({
+          iss: "https://auth.openai.com",
+          sub: "user_special",
+          "https://api.openai.com/auth": { chatgpt_account_id: "acct / special?" },
+        }),
+        accountId: "acct / special?",
+      }),
+    ).toBe(
+      `openai-codex:acct-special:${Buffer.from("https://auth.openai.com", "utf8").toString("base64url")}:${Buffer.from("user_special", "utf8").toString("base64url")}`,
     );
   });
 

--- a/src/agents/auth-profiles.openai-codex-profile-id.test.ts
+++ b/src/agents/auth-profiles.openai-codex-profile-id.test.ts
@@ -42,7 +42,7 @@ describe("deriveOpenAICodexCanonicalProfileId", () => {
     );
   });
 
-  it("sanitizes account ids before building the canonical profile id", () => {
+  it("returns null when the account id contains unsafe characters", () => {
     expect(
       deriveOpenAICodexCanonicalProfileId({
         provider: "openai-codex",
@@ -53,9 +53,7 @@ describe("deriveOpenAICodexCanonicalProfileId", () => {
         }),
         accountId: "acct / special?",
       }),
-    ).toBe(
-      `openai-codex:acct-special:${Buffer.from("https://auth.openai.com", "utf8").toString("base64url")}:${Buffer.from("user_special", "utf8").toString("base64url")}`,
-    );
+    ).toBeNull();
   });
 
   it("returns null for malformed tokens or non-codex providers", () => {

--- a/src/agents/auth-profiles.openai-codex-profile-id.test.ts
+++ b/src/agents/auth-profiles.openai-codex-profile-id.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { deriveOpenAICodexCanonicalProfileId } from "./auth-profiles/openai-codex-profile-id.js";
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" }), "utf8").toString(
+    "base64url",
+  );
+  const body = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  return `${header}.${body}.sig`;
+}
+
+describe("deriveOpenAICodexCanonicalProfileId", () => {
+  it("derives a canonical profile id from accountId, iss, and sub", () => {
+    expect(
+      deriveOpenAICodexCanonicalProfileId({
+        provider: "openai-codex",
+        access: makeJwt({
+          iss: "https://auth.openai.com",
+          sub: "user_123",
+          "https://api.openai.com/auth": { chatgpt_account_id: "acct_456" },
+        }),
+        accountId: "acct_456",
+      }),
+    ).toBe(
+      `openai-codex:acct_456:${Buffer.from("https://auth.openai.com", "utf8").toString("base64url")}:${Buffer.from("user_123", "utf8").toString("base64url")}`,
+    );
+  });
+
+  it("falls back to the JWT payload account id when accountId is missing", () => {
+    expect(
+      deriveOpenAICodexCanonicalProfileId({
+        provider: "openai-codex",
+        access: makeJwt({
+          iss: "https://auth.openai.com",
+          sub: "user_789",
+          "https://api.openai.com/auth": { chatgpt_account_id: "acct_payload" },
+        }),
+      }),
+    ).toBe(
+      `openai-codex:acct_payload:${Buffer.from("https://auth.openai.com", "utf8").toString("base64url")}:${Buffer.from("user_789", "utf8").toString("base64url")}`,
+    );
+  });
+
+  it("returns null for malformed tokens or non-codex providers", () => {
+    expect(
+      deriveOpenAICodexCanonicalProfileId({
+        provider: "openai",
+        access: "header.payload.sig",
+      }),
+    ).toBeNull();
+    expect(
+      deriveOpenAICodexCanonicalProfileId({
+        provider: "openai-codex",
+        access: "not-a-jwt",
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/agents/auth-profiles/openai-codex-profile-id.ts
+++ b/src/agents/auth-profiles/openai-codex-profile-id.ts
@@ -1,0 +1,94 @@
+import { normalizeProviderId } from "../model-selection.js";
+
+const OPENAI_CODEX_PROVIDER = "openai-codex";
+const OPENAI_CODEX_AUTH_CLAIM_PATH = "https://api.openai.com/auth";
+const MAX_JWT_LENGTH = 16_384;
+const MAX_JWT_PAYLOAD_SEGMENT_LENGTH = 8_192;
+const MAX_JWT_DECODED_PAYLOAD_LENGTH = 16_384;
+
+type JwtPayload = Record<string, unknown>;
+
+function decodeJwtPayload(token: string): JwtPayload | null {
+  const trimmed = token.trim();
+  if (!trimmed || trimmed.length > MAX_JWT_LENGTH) {
+    return null;
+  }
+
+  const parts = trimmed.split(".");
+  if (parts.length !== 3) {
+    return null;
+  }
+
+  const payloadSegment = parts[1] ?? "";
+  if (!payloadSegment || payloadSegment.length > MAX_JWT_PAYLOAD_SEGMENT_LENGTH) {
+    return null;
+  }
+
+  try {
+    const decoded = Buffer.from(payloadSegment, "base64url").toString("utf8");
+    if (!decoded || decoded.length > MAX_JWT_DECODED_PAYLOAD_LENGTH) {
+      return null;
+    }
+    const parsed = JSON.parse(decoded) as unknown;
+    return parsed && typeof parsed === "object" ? (parsed as JwtPayload) : null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveAccountIdFromPayload(payload: JwtPayload): string | null {
+  const auth = payload[OPENAI_CODEX_AUTH_CLAIM_PATH];
+  if (!auth || typeof auth !== "object") {
+    return null;
+  }
+
+  const accountId = (auth as Record<string, unknown>)["chatgpt_account_id"];
+  return typeof accountId === "string" && accountId.trim() ? accountId.trim() : null;
+}
+
+function sanitizeAccountIdSegment(raw: string): string {
+  const cleaned = raw
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "");
+  return cleaned || "unknown";
+}
+
+export function deriveOpenAICodexCanonicalProfileId(credential: {
+  provider?: unknown;
+  access?: unknown;
+  accountId?: unknown;
+}): string | null {
+  const provider = typeof credential.provider === "string" ? credential.provider : "";
+  if (normalizeProviderId(provider) !== OPENAI_CODEX_PROVIDER) {
+    return null;
+  }
+  if (typeof credential.access !== "string") {
+    return null;
+  }
+
+  const payload = decodeJwtPayload(credential.access);
+  if (!payload) {
+    return null;
+  }
+
+  const iss = typeof payload.iss === "string" ? payload.iss.trim() : "";
+  const sub = typeof payload.sub === "string" ? payload.sub.trim() : "";
+  if (!iss || !sub) {
+    return null;
+  }
+
+  const accountId =
+    typeof credential.accountId === "string" && credential.accountId.trim()
+      ? credential.accountId.trim()
+      : resolveAccountIdFromPayload(payload);
+  if (!accountId) {
+    return null;
+  }
+
+  return `${OPENAI_CODEX_PROVIDER}:${sanitizeAccountIdSegment(accountId)}:${Buffer.from(
+    iss,
+    "utf8",
+  ).toString("base64url")}:${Buffer.from(sub, "utf8").toString("base64url")}`;
+}

--- a/src/agents/auth-profiles/openai-codex-profile-id.ts
+++ b/src/agents/auth-profiles/openai-codex-profile-id.ts
@@ -5,6 +5,7 @@ const OPENAI_CODEX_AUTH_CLAIM_PATH = "https://api.openai.com/auth";
 const MAX_JWT_LENGTH = 16_384;
 const MAX_JWT_PAYLOAD_SEGMENT_LENGTH = 8_192;
 const MAX_JWT_DECODED_PAYLOAD_LENGTH = 16_384;
+const SAFE_ACCOUNT_ID_SEGMENT = /^[A-Za-z0-9._-]+$/;
 
 type JwtPayload = Record<string, unknown>;
 
@@ -46,13 +47,12 @@ function resolveAccountIdFromPayload(payload: JwtPayload): string | null {
   return typeof accountId === "string" && accountId.trim() ? accountId.trim() : null;
 }
 
-function sanitizeAccountIdSegment(raw: string): string {
-  const cleaned = raw
-    .trim()
-    .replace(/[^A-Za-z0-9._-]+/g, "-")
-    .replace(/^-+/, "")
-    .replace(/-+$/, "");
-  return cleaned || "unknown";
+function resolveAccountIdSegment(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed || !SAFE_ACCOUNT_ID_SEGMENT.test(trimmed)) {
+    return null;
+  }
+  return trimmed;
 }
 
 export function deriveOpenAICodexCanonicalProfileId(credential: {
@@ -83,12 +83,12 @@ export function deriveOpenAICodexCanonicalProfileId(credential: {
     typeof credential.accountId === "string" && credential.accountId.trim()
       ? credential.accountId.trim()
       : resolveAccountIdFromPayload(payload);
-  if (!accountId) {
+  const accountIdSegment = accountId ? resolveAccountIdSegment(accountId) : null;
+  if (!accountIdSegment) {
     return null;
   }
 
-  return `${OPENAI_CODEX_PROVIDER}:${sanitizeAccountIdSegment(accountId)}:${Buffer.from(
-    iss,
-    "utf8",
-  ).toString("base64url")}:${Buffer.from(sub, "utf8").toString("base64url")}`;
+  return `${OPENAI_CODEX_PROVIDER}:${accountIdSegment}:${Buffer.from(iss, "utf8").toString(
+    "base64url",
+  )}:${Buffer.from(sub, "utf8").toString("base64url")}`;
 }

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -21,6 +21,22 @@ import {
   setupAuthTestEnv,
 } from "./test-wizard-helpers.js";
 
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" }), "utf8").toString(
+    "base64url",
+  );
+  const body = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  return `${header}.${body}.sig`;
+}
+
+function expectedOpenAICodexProfileId(params: {
+  accountId: string;
+  iss: string;
+  sub: string;
+}): string {
+  return `openai-codex:${params.accountId}:${Buffer.from(params.iss, "utf8").toString("base64url")}:${Buffer.from(params.sub, "utf8").toString("base64url")}`;
+}
+
 type DetectZaiEndpoint = typeof import("./zai-endpoint-detect.js").detectZaiEndpoint;
 
 vi.mock("../providers/github-copilot-auth.js", () => ({
@@ -154,14 +170,25 @@ describe("applyAuthChoice", () => {
     ).resolves.toEqual({ config: {} });
   });
 
-  it("stores openai-codex OAuth with email profile id", async () => {
+  it("stores openai-codex OAuth with canonical oidc profile id", async () => {
     await setupTempState();
+
+    const canonicalProfileId = expectedOpenAICodexProfileId({
+      accountId: "acct-choice",
+      iss: "https://auth.openai.com",
+      sub: "sub-choice",
+    });
 
     loginOpenAICodexOAuth.mockResolvedValueOnce({
       email: "user@example.com",
       refresh: "refresh-token",
-      access: "access-token",
+      access: makeJwt({
+        iss: "https://auth.openai.com",
+        sub: "sub-choice",
+        "https://api.openai.com/auth": { chatgpt_account_id: "acct-choice" },
+      }),
       expires: Date.now() + 60_000,
+      accountId: "acct-choice",
     });
 
     const prompter = createPrompter({});
@@ -175,17 +202,17 @@ describe("applyAuthChoice", () => {
       setDefaultModel: false,
     });
 
-    expect(result.config.auth?.profiles?.["openai-codex:user@example.com"]).toMatchObject({
+    expect(result.config.auth?.profiles?.[canonicalProfileId]).toMatchObject({
       provider: "openai-codex",
       mode: "oauth",
     });
     expect(result.config.auth?.profiles?.["openai-codex:default"]).toBeUndefined();
-    expect(await readAuthProfile("openai-codex:user@example.com")).toMatchObject({
+    expect(await readAuthProfile(canonicalProfileId)).toMatchObject({
       type: "oauth",
       provider: "openai-codex",
       refresh: "refresh-token",
-      access: "access-token",
       email: "user@example.com",
+      accountId: "acct-choice",
     });
   });
 

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -201,6 +201,53 @@ describe("applyAuthChoice", () => {
     });
   });
 
+  it("pins a fresh openai-codex re-login ahead of a legacy default profile", async () => {
+    await setupTempState();
+
+    const canonicalProfileId = expectedOpenAICodexProfileId({
+      accountId: "acct-upgrade",
+      iss: "https://auth.openai.com",
+      sub: "sub-upgrade",
+    });
+
+    loginOpenAICodexOAuth.mockResolvedValueOnce({
+      email: "user@example.com",
+      refresh: "refresh-token",
+      access: makeJwt({
+        iss: "https://auth.openai.com",
+        sub: "sub-upgrade",
+        "https://api.openai.com/auth": { chatgpt_account_id: "acct-upgrade" },
+      }),
+      expires: Date.now() + 60_000,
+      accountId: "acct-upgrade",
+    });
+
+    const prompter = createPrompter({});
+    const runtime = createExitThrowingRuntime();
+
+    const result = await applyAuthChoice({
+      authChoice: "openai-codex",
+      config: {
+        auth: {
+          profiles: {
+            "openai-codex:default": {
+              provider: "openai-codex",
+              mode: "oauth",
+            },
+          },
+        },
+      },
+      prompter,
+      runtime,
+      setDefaultModel: false,
+    });
+
+    expect(result.config.auth?.order?.["openai-codex"]).toEqual([
+      canonicalProfileId,
+      "openai-codex:default",
+    ]);
+  });
+
   it("prompts and writes provider API key for common providers", async () => {
     const scenarios: Array<{
       authChoice:

--- a/src/commands/auth-choice.test.ts
+++ b/src/commands/auth-choice.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import type { OAuthCredentials } from "@mariozechner/pi-ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
+import { expectedOpenAICodexProfileId, makeJwt } from "../test-utils/openai-codex-profile-id.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 import { applyAuthChoice, resolvePreferredProviderForAuthChoice } from "./auth-choice.js";
 import { GOOGLE_GEMINI_DEFAULT_MODEL } from "./google-gemini-model-default.js";
@@ -20,22 +21,6 @@ import {
   requireOpenClawAgentDir,
   setupAuthTestEnv,
 } from "./test-wizard-helpers.js";
-
-function makeJwt(payload: Record<string, unknown>): string {
-  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" }), "utf8").toString(
-    "base64url",
-  );
-  const body = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
-  return `${header}.${body}.sig`;
-}
-
-function expectedOpenAICodexProfileId(params: {
-  accountId: string;
-  iss: string;
-  sub: string;
-}): string {
-  return `openai-codex:${params.accountId}:${Buffer.from(params.iss, "utf8").toString("base64url")}:${Buffer.from(params.sub, "utf8").toString("base64url")}`;
-}
 
 type DetectZaiEndpoint = typeof import("./zai-endpoint-detect.js").detectZaiEndpoint;
 

--- a/src/commands/onboard-auth.config-core.ts
+++ b/src/commands/onboard-auth.config-core.ts
@@ -505,8 +505,17 @@ export function applyAuthProfileConfig(
   const hasMixedConfiguredModes = configuredProviderProfiles.some(
     ({ profileId, mode }) => profileId !== params.profileId && mode !== params.mode,
   );
+  const hasExistingConfiguredProfile = configuredProviderProfiles.some(
+    ({ profileId }) => profileId !== params.profileId,
+  );
+  const shouldPinOpenAICodexReloginFirst =
+    normalizedProvider === "openai-codex" &&
+    params.mode === "oauth" &&
+    hasExistingConfiguredProfile;
   const derivedProviderOrder =
-    existingProviderOrder === undefined && preferProfileFirst && hasMixedConfiguredModes
+    existingProviderOrder === undefined &&
+    preferProfileFirst &&
+    (hasMixedConfiguredModes || shouldPinOpenAICodexReloginFirst)
       ? [
           params.profileId,
           ...configuredProviderProfiles

--- a/src/commands/onboard-auth.credentials.ts
+++ b/src/commands/onboard-auth.credentials.ts
@@ -3,6 +3,8 @@ import path from "node:path";
 import type { OAuthCredentials } from "@mariozechner/pi-ai";
 import { resolveOpenClawAgentDir } from "../agents/agent-paths.js";
 import { upsertAuthProfile } from "../agents/auth-profiles.js";
+import { deriveOpenAICodexCanonicalProfileId } from "../agents/auth-profiles/openai-codex-profile-id.js";
+import { normalizeProviderId } from "../agents/model-selection.js";
 import { resolveStateDir } from "../config/paths.js";
 import {
   coerceSecretRef,
@@ -151,16 +153,37 @@ function resolveSiblingAgentDirs(primaryAgentDir: string): string[] {
   return result;
 }
 
+function resolveWriteOAuthProfileId(params: { provider: string; creds: OAuthCredentials }): string {
+  const providerKey = normalizeProviderId(params.provider);
+  if (providerKey === "openai-codex") {
+    const canonicalProfileId = deriveOpenAICodexCanonicalProfileId({
+      provider: params.provider,
+      access: params.creds.access,
+      accountId: params.creds.accountId,
+    });
+    if (canonicalProfileId) {
+      return canonicalProfileId;
+    }
+  }
+
+  const email =
+    typeof params.creds.email === "string" && params.creds.email.trim()
+      ? params.creds.email.trim()
+      : "default";
+  return `${params.provider}:${email}`;
+}
+
 export async function writeOAuthCredentials(
   provider: string,
   creds: OAuthCredentials,
   agentDir?: string,
   options?: WriteOAuthCredentialsOptions,
 ): Promise<string> {
-  const email =
-    typeof creds.email === "string" && creds.email.trim() ? creds.email.trim() : "default";
-  const profileId = `${provider}:${email}`;
   const resolvedAgentDir = path.resolve(resolveAuthAgentDir(agentDir));
+  const profileId = resolveWriteOAuthProfileId({
+    provider,
+    creds,
+  });
   const targetAgentDirs = options?.syncSiblingAgents
     ? resolveSiblingAgentDirs(resolvedAgentDir)
     : [resolvedAgentDir];

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -44,6 +44,22 @@ import {
   setupAuthTestEnv,
 } from "./test-wizard-helpers.js";
 
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" }), "utf8").toString(
+    "base64url",
+  );
+  const body = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  return `${header}.${body}.sig`;
+}
+
+function expectedOpenAICodexProfileId(params: {
+  accountId: string;
+  iss: string;
+  sub: string;
+}): string {
+  return `openai-codex:${params.accountId}:${Buffer.from(params.iss, "utf8").toString("base64url")}:${Buffer.from(params.sub, "utf8").toString("base64url")}`;
+}
+
 function createLegacyProviderConfig(params: {
   providerId: string;
   api: ModelApi;
@@ -137,18 +153,28 @@ describe("writeOAuthCredentials", () => {
 
     const creds = {
       refresh: "refresh-token",
-      access: "access-token",
+      access: makeJwt({
+        iss: "https://auth.openai.com",
+        sub: "sub-main",
+        "https://api.openai.com/auth": { chatgpt_account_id: "acct-main" },
+      }),
       expires: Date.now() + 60_000,
+      accountId: "acct-main",
     } satisfies OAuthCredentials;
+
+    const canonicalProfileId = expectedOpenAICodexProfileId({
+      accountId: "acct-main",
+      iss: "https://auth.openai.com",
+      sub: "sub-main",
+    });
 
     await writeOAuthCredentials("openai-codex", creds);
 
     const parsed = await readAuthProfilesForAgent<{
       profiles?: Record<string, OAuthCredentials & { type?: string }>;
     }>(env.agentDir);
-    expect(parsed.profiles?.["openai-codex:default"]).toMatchObject({
+    expect(parsed.profiles?.[canonicalProfileId]).toMatchObject({
       refresh: "refresh-token",
-      access: "access-token",
       type: "oauth",
     });
 
@@ -173,9 +199,20 @@ describe("writeOAuthCredentials", () => {
 
     const creds = {
       refresh: "refresh-sync",
-      access: "access-sync",
+      access: makeJwt({
+        iss: "https://auth.openai.com",
+        sub: "sub-sync",
+        "https://api.openai.com/auth": { chatgpt_account_id: "acct-sync" },
+      }),
       expires: Date.now() + 60_000,
+      accountId: "acct-sync",
     } satisfies OAuthCredentials;
+
+    const canonicalProfileId = expectedOpenAICodexProfileId({
+      accountId: "acct-sync",
+      iss: "https://auth.openai.com",
+      sub: "sub-sync",
+    });
 
     await writeOAuthCredentials("openai-codex", creds, undefined, {
       syncSiblingAgents: true,
@@ -186,9 +223,8 @@ describe("writeOAuthCredentials", () => {
       const parsed = JSON.parse(raw) as {
         profiles?: Record<string, OAuthCredentials & { type?: string }>;
       };
-      expect(parsed.profiles?.["openai-codex:default"]).toMatchObject({
+      expect(parsed.profiles?.[canonicalProfileId]).toMatchObject({
         refresh: "refresh-sync",
-        access: "access-sync",
         type: "oauth",
       });
     }
@@ -208,9 +244,20 @@ describe("writeOAuthCredentials", () => {
 
     const creds = {
       refresh: "refresh-kid",
-      access: "access-kid",
+      access: makeJwt({
+        iss: "https://auth.openai.com",
+        sub: "sub-kid",
+        "https://api.openai.com/auth": { chatgpt_account_id: "acct-kid" },
+      }),
       expires: Date.now() + 60_000,
+      accountId: "acct-kid",
     } satisfies OAuthCredentials;
+
+    const canonicalProfileId = expectedOpenAICodexProfileId({
+      accountId: "acct-kid",
+      iss: "https://auth.openai.com",
+      sub: "sub-kid",
+    });
 
     await writeOAuthCredentials("openai-codex", creds, kidAgentDir);
 
@@ -218,8 +265,7 @@ describe("writeOAuthCredentials", () => {
     const kidParsed = JSON.parse(kidRaw) as {
       profiles?: Record<string, OAuthCredentials & { type?: string }>;
     };
-    expect(kidParsed.profiles?.["openai-codex:default"]).toMatchObject({
-      access: "access-kid",
+    expect(kidParsed.profiles?.[canonicalProfileId]).toMatchObject({
       type: "oauth",
     });
 
@@ -241,9 +287,20 @@ describe("writeOAuthCredentials", () => {
 
     const creds = {
       refresh: "refresh-ext",
-      access: "access-ext",
+      access: makeJwt({
+        iss: "https://auth.openai.com",
+        sub: "sub-ext",
+        "https://api.openai.com/auth": { chatgpt_account_id: "acct-ext" },
+      }),
       expires: Date.now() + 60_000,
+      accountId: "acct-ext",
     } satisfies OAuthCredentials;
+
+    const canonicalProfileId = expectedOpenAICodexProfileId({
+      accountId: "acct-ext",
+      iss: "https://auth.openai.com",
+      sub: "sub-ext",
+    });
 
     await writeOAuthCredentials("openai-codex", creds, extKid, {
       syncSiblingAgents: true,
@@ -255,9 +312,8 @@ describe("writeOAuthCredentials", () => {
       const parsed = JSON.parse(raw) as {
         profiles?: Record<string, OAuthCredentials & { type?: string }>;
       };
-      expect(parsed.profiles?.["openai-codex:default"]).toMatchObject({
+      expect(parsed.profiles?.[canonicalProfileId]).toMatchObject({
         refresh: "refresh-ext",
-        access: "access-ext",
         type: "oauth",
       });
     }

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -9,6 +9,7 @@ import {
   resolveAgentModelPrimaryValue,
 } from "../config/model-input.js";
 import type { ModelApi } from "../config/types.models.js";
+import { expectedOpenAICodexProfileId, makeJwt } from "../test-utils/openai-codex-profile-id.js";
 import {
   applyAuthProfileConfig,
   applyLitellmProviderConfig,
@@ -43,22 +44,6 @@ import {
   readAuthProfilesForAgent,
   setupAuthTestEnv,
 } from "./test-wizard-helpers.js";
-
-function makeJwt(payload: Record<string, unknown>): string {
-  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" }), "utf8").toString(
-    "base64url",
-  );
-  const body = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
-  return `${header}.${body}.sig`;
-}
-
-function expectedOpenAICodexProfileId(params: {
-  accountId: string;
-  iss: string;
-  sub: string;
-}): string {
-  return `openai-codex:${params.accountId}:${Buffer.from(params.iss, "utf8").toString("base64url")}:${Buffer.from(params.sub, "utf8").toString("base64url")}`;
-}
 
 function createLegacyProviderConfig(params: {
   providerId: string;

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -168,6 +168,34 @@ describe("writeOAuthCredentials", () => {
     ).rejects.toThrow();
   });
 
+  it("falls back to the legacy profile id when codex accountId is not safe", async () => {
+    const env = await setupAuthTestEnv("openclaw-oauth-unsafe-account-");
+    lifecycle.setStateDir(env.stateDir);
+
+    const creds = {
+      email: "unsafe@example.com",
+      refresh: "refresh-token",
+      access: makeJwt({
+        iss: "https://auth.openai.com",
+        sub: "sub-unsafe",
+        "https://api.openai.com/auth": { chatgpt_account_id: "acct / unsafe" },
+      }),
+      expires: Date.now() + 60_000,
+      accountId: "acct / unsafe",
+    } satisfies OAuthCredentials;
+
+    await writeOAuthCredentials("openai-codex", creds);
+
+    const parsed = await readAuthProfilesForAgent<{
+      profiles?: Record<string, OAuthCredentials & { type?: string }>;
+    }>(env.agentDir);
+    expect(parsed.profiles?.["openai-codex:unsafe@example.com"]).toMatchObject({
+      email: "unsafe@example.com",
+      refresh: "refresh-token",
+      type: "oauth",
+    });
+  });
+
   it("writes OAuth credentials to all sibling agent dirs when syncSiblingAgents=true", async () => {
     tempStateDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-oauth-sync-"));
     process.env.OPENCLAW_STATE_DIR = tempStateDir;

--- a/src/commands/onboard-auth.test.ts
+++ b/src/commands/onboard-auth.test.ts
@@ -427,6 +427,36 @@ describe("applyAuthProfileConfig", () => {
 
     expect(next.auth?.order).toBeUndefined();
   });
+
+  it("creates provider order for openai-codex re-login without explicit order", () => {
+    const next = applyAuthProfileConfig(
+      {
+        auth: {
+          profiles: {
+            "openai-codex:default": { provider: "openai-codex", mode: "oauth" },
+          },
+        },
+      },
+      {
+        profileId: expectedOpenAICodexProfileId({
+          accountId: "acct-new",
+          iss: "https://auth.openai.com",
+          sub: "sub-new",
+        }),
+        provider: "openai-codex",
+        mode: "oauth",
+      },
+    );
+
+    expect(next.auth?.order?.["openai-codex"]).toEqual([
+      expectedOpenAICodexProfileId({
+        accountId: "acct-new",
+        iss: "https://auth.openai.com",
+        sub: "sub-new",
+      }),
+      "openai-codex:default",
+    ]);
+  });
 });
 
 describe("applyMinimaxApiConfig", () => {

--- a/src/test-utils/openai-codex-profile-id.ts
+++ b/src/test-utils/openai-codex-profile-id.ts
@@ -1,0 +1,30 @@
+import { deriveOpenAICodexCanonicalProfileId } from "../agents/auth-profiles/openai-codex-profile-id.js";
+
+export function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" }), "utf8").toString(
+    "base64url",
+  );
+  const body = Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+  return `${header}.${body}.sig`;
+}
+
+export function expectedOpenAICodexProfileId(params: {
+  accountId: string;
+  iss: string;
+  sub: string;
+}): string {
+  const access = makeJwt({
+    iss: params.iss,
+    sub: params.sub,
+    "https://api.openai.com/auth": { chatgpt_account_id: params.accountId },
+  });
+  const profileId = deriveOpenAICodexCanonicalProfileId({
+    provider: "openai-codex",
+    access,
+    accountId: params.accountId,
+  });
+  if (!profileId) {
+    throw new Error("failed to derive expected OpenAI Codex profile id");
+  }
+  return profileId;
+}


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: OpenAI Codex OAuth logins currently derive the profile id from `email ?? "default"`, but current Codex creds can omit `email`, so distinct logins collide on `openai-codex:default`.
- Why it matters: a later Codex login can overwrite an earlier one instead of creating a distinct auth profile.
- What changed: new `openai-codex` logins now derive `openai-codex:<accountId>:<base64url(iss)>:<base64url(sub)>` from the returned access token and account id, with a fallback to the existing `provider:<email|default>` behavior if derivation fails.
- What did NOT change (scope boundary): this PR does not migrate existing auth-profiles/config/session references and does not rename current installs.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #24787
- Related #24967

## User-visible / Behavior Changes

- New OpenAI Codex OAuth logins are stored under a canonical profile id derived from the returned token identity instead of `openai-codex:default` when `email` is missing.
- Existing Codex auth profile ids are left untouched.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) Yes
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:
  The write path now parses the existing Codex access token locally to derive a stable profile id. No new token is fetched, no new network call is made, and if parsing fails the code falls back to the current `provider:<email|default>` behavior.

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 22, pnpm workspace
- Model/provider: OpenAI Codex OAuth
- Integration/channel (if any): N/A
- Relevant config (redacted): clean temporary `OPENCLAW_STATE_DIR` / `OPENCLAW_AGENT_DIR`

### Steps

1. Start from `upstream/main` and call `writeOAuthCredentials("openai-codex", creds)` with a Codex access token containing `iss`, `sub`, and `chatgpt_account_id`, but no `email`.
2. Inspect the written `auth-profiles.json` entry and the auth profile id returned to onboarding.
3. Repeat via `applyAuthChoice({ authChoice: "openai-codex", ... })` and confirm config/auth store references use the same canonical id.

### Expected

- A new Codex login gets its own stable canonical profile id.
- Existing installs are not migrated or renamed.

### Actual

- Before this change, missing-email Codex logins fell back to `openai-codex:default`, which can overwrite another Codex login.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: canonical id derivation helper; `writeOAuthCredentials` writes canonical ids for new Codex logins; `applyAuthChoice` stores the canonical id in config + auth store.
- Edge cases checked: payload-derived `accountId` fallback; malformed/non-JWT access token returns `null` and preserves the old write behavior.
- What you did **not** verify: full browser OAuth flow with a live Team account outside the focused test harness.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR or restore the old `provider:<email|default>` write path in `src/commands/onboard-auth.credentials.ts`.
- Files/config to restore: `src/commands/onboard-auth.credentials.ts`, `src/agents/auth-profiles/openai-codex-profile-id.ts`
- Known bad symptoms reviewers should watch for: new Codex logins still landing on `openai-codex:default`, or valid Codex tokens unexpectedly falling back to the legacy id format.

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: Codex token claim shapes could change and make canonical derivation fail.
  - Mitigation: the code falls back to the current legacy profile-id path, and focused tests cover malformed token handling.
- Risk: canonical ids are more opaque than email-based ids.
  - Mitigation: scope is limited to new logins only; no existing profile ids are renamed or migrated.
