### PR TITLE
fix(gateway): recover deliveries after sidecars start

### DIFF
--- a/src/gateway/server.delivery-recovery-order.test.ts
+++ b/src/gateway/server.delivery-recovery-order.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getFreePort, installGatewayTestHooks } from "./test-helpers.js";
+
+const mocks = vi.hoisted(() => {
+  const order: string[] = [];
+  let releaseSidecarsGate: (() => void) | undefined;
+  let sidecarsGate!: Promise<void>;
+  const resetSidecarsGate = () => {
+    sidecarsGate = new Promise<void>((resolve) => {
+      releaseSidecarsGate = resolve;
+    });
+  };
+  resetSidecarsGate();
+  return {
+    order,
+    resetSidecarsGate,
+    releaseSidecars: () => releaseSidecarsGate?.(),
+    startGatewaySidecars: vi.fn(async () => {
+      order.push("sidecars:start");
+      await sidecarsGate;
+      order.push("sidecars:done");
+      return { browserControl: null, pluginServices: null };
+    }),
+    recoverPendingDeliveries: vi.fn(async () => {
+      order.push("recovery");
+      return { recovered: 0, failed: 0, skippedMaxRetries: 0, deferredBackoff: 0 };
+    }),
+    deliverOutboundPayloads: vi.fn(async () => []),
+  };
+});
+
+vi.mock("./server-startup.js", async () => {
+  const actual = await vi.importActual<typeof import("./server-startup.js")>("./server-startup.js");
+  return {
+    ...actual,
+    startGatewaySidecars: mocks.startGatewaySidecars,
+  };
+});
+
+vi.mock("../infra/outbound/delivery-queue.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/outbound/delivery-queue.js")>(
+    "../infra/outbound/delivery-queue.js",
+  );
+  return {
+    ...actual,
+    recoverPendingDeliveries: mocks.recoverPendingDeliveries,
+  };
+});
+
+vi.mock("../infra/outbound/deliver.js", () => ({
+  deliverOutboundPayloads: mocks.deliverOutboundPayloads,
+}));
+
+await import("../infra/outbound/delivery-queue.js");
+await import("../infra/outbound/deliver.js");
+const { startGatewayServer } = await import("./server.js");
+
+installGatewayTestHooks();
+
+afterEach(() => {
+  mocks.order.length = 0;
+  mocks.resetSidecarsGate();
+  mocks.startGatewaySidecars.mockClear();
+  mocks.recoverPendingDeliveries.mockClear();
+  mocks.deliverOutboundPayloads.mockClear();
+});
+
+describe("startGatewayServer delivery recovery", () => {
+  it("starts sidecars before replaying queued deliveries", async () => {
+    delete process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
+
+    const port = await getFreePort();
+    const startup = startGatewayServer(port);
+    let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
+
+    try {
+      await vi.waitFor(() => {
+        expect(mocks.startGatewaySidecars).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mocks.recoverPendingDeliveries).not.toHaveBeenCalled();
+
+      mocks.releaseSidecars();
+      server = await startup;
+
+      await vi.waitFor(() => {
+        expect(mocks.recoverPendingDeliveries).toHaveBeenCalledTimes(1);
+      });
+
+      expect(mocks.order).toEqual(["sidecars:start", "sidecars:done", "recovery"]);
+      expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+    } finally {
+      mocks.releaseSidecars();
+      if (!server) {
+        try {
+          server = await startup;
+        } catch {
+          server = undefined;
+        }
+      }
+      if (server) {
+        await server.close({ reason: "test complete" });
+      }
+    }
+  });
+});

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1,15 +1,10 @@
 import path from "node:path";
-import type { CanvasHostServer } from "../canvas-host/server.js";
-import type { PluginServicesHandle } from "../plugins/services.js";
-import type { RuntimeEnv } from "../runtime.js";
-import type { CommandSecretAssignment } from "../secrets/command-config.js";
-import type { ControlUiRootState } from "./control-ui.js";
-import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
+import type { CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { createDefaultDeps } from "../cli/deps.js";
@@ -52,7 +47,10 @@ import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js
 import { getGlobalHookRunner, runGlobalGatewayStopSafely } from "../plugins/hook-runner-global.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
+import type { PluginServicesHandle } from "../plugins/services.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { CommandSecretAssignment } from "../secrets/command-config.js";
 import {
   GATEWAY_AUTH_SURFACE_PATHS,
   evaluateGatewayAuthSurfaceStates,
@@ -68,12 +66,14 @@ import { runOnboardingWizard } from "../wizard/onboarding.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { startChannelHealthMonitor } from "./channel-health-monitor.js";
 import { startGatewayConfigReloader } from "./config-reload.js";
+import type { ControlUiRootState } from "./control-ui.js";
 import {
   GATEWAY_EVENT_UPDATE_AVAILABLE,
   type GatewayUpdateAvailableEventPayload,
 } from "./events.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { NodeRegistry } from "./node-registry.js";
+import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { createChannelManager } from "./server-channels.js";
 import { createAgentEventHandler } from "./server-chat.js";
 import { createGatewayCloseHandler } from "./server-close.js";

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1,10 +1,15 @@
 import path from "node:path";
+import type { CanvasHostServer } from "../canvas-host/server.js";
+import type { PluginServicesHandle } from "../plugins/services.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { CommandSecretAssignment } from "../secrets/command-config.js";
+import type { ControlUiRootState } from "./control-ui.js";
+import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
 import { initSubagentRegistry } from "../agents/subagent-registry.js";
 import { getTotalPendingReplies } from "../auto-reply/reply/dispatcher-registry.js";
-import type { CanvasHostServer } from "../canvas-host/server.js";
 import { type ChannelId, listChannelPlugins } from "../channels/plugins/index.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { createDefaultDeps } from "../cli/deps.js";
@@ -47,10 +52,7 @@ import { createSubsystemLogger, runtimeForLogger } from "../logging/subsystem.js
 import { getGlobalHookRunner, runGlobalGatewayStopSafely } from "../plugins/hook-runner-global.js";
 import { createEmptyPluginRegistry } from "../plugins/registry.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
-import type { PluginServicesHandle } from "../plugins/services.js";
 import { getTotalQueueSize } from "../process/command-queue.js";
-import type { RuntimeEnv } from "../runtime.js";
-import type { CommandSecretAssignment } from "../secrets/command-config.js";
 import {
   GATEWAY_AUTH_SURFACE_PATHS,
   evaluateGatewayAuthSurfaceStates,
@@ -66,14 +68,12 @@ import { runOnboardingWizard } from "../wizard/onboarding.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
 import { startChannelHealthMonitor } from "./channel-health-monitor.js";
 import { startGatewayConfigReloader } from "./config-reload.js";
-import type { ControlUiRootState } from "./control-ui.js";
 import {
   GATEWAY_EVENT_UPDATE_AVAILABLE,
   type GatewayUpdateAvailableEventPayload,
 } from "./events.js";
 import { ExecApprovalManager } from "./exec-approval-manager.js";
 import { NodeRegistry } from "./node-registry.js";
-import type { startBrowserControlServerIfEnabled } from "./server-browser.js";
 import { createChannelManager } from "./server-channels.js";
 import { createAgentEventHandler } from "./server-chat.js";
 import { createGatewayCloseHandler } from "./server-close.js";
@@ -755,20 +755,6 @@ export async function startGatewayServer(
     void cron.start().catch((err) => logCron.error(`failed to start: ${String(err)}`));
   }
 
-  // Recover pending outbound deliveries from previous crash/restart.
-  if (!minimalTestGateway) {
-    void (async () => {
-      const { recoverPendingDeliveries } = await import("../infra/outbound/delivery-queue.js");
-      const { deliverOutboundPayloads } = await import("../infra/outbound/deliver.js");
-      const logRecovery = log.child("delivery-recovery");
-      await recoverPendingDeliveries({
-        deliver: deliverOutboundPayloads,
-        log: logRecovery,
-        cfg: cfgAtStart,
-      });
-    })().catch((err) => log.error(`Delivery recovery failed: ${String(err)}`));
-  }
-
   const execApprovalManager = new ExecApprovalManager();
   const execApprovalForwarder = createExecApprovalForwarder();
   const execApprovalHandlers = createExecApprovalHandlers(execApprovalManager, {
@@ -924,6 +910,20 @@ export async function startGatewayServer(
       logChannels,
       logBrowser,
     }));
+  }
+
+  // Recover queued outbound deliveries only after sidecars/channels finish starting.
+  if (!minimalTestGateway) {
+    void (async () => {
+      const { recoverPendingDeliveries } = await import("../infra/outbound/delivery-queue.js");
+      const { deliverOutboundPayloads } = await import("../infra/outbound/deliver.js");
+      const logRecovery = log.child("delivery-recovery");
+      await recoverPendingDeliveries({
+        deliver: deliverOutboundPayloads,
+        log: logRecovery,
+        cfg: cfgAtStart,
+      });
+    })().catch((err) => log.error(`Delivery recovery failed: ${String(err)}`));
   }
 
   // Run gateway_start plugin hook (fire-and-forget)

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { createEventHandlers } from "./tui-event-handlers.js";
 import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
+import { createEventHandlers } from "./tui-event-handlers.js";
 
 type MockFn = ReturnType<typeof vi.fn>;
 type HandlerChatLog = {

--- a/src/tui/tui-event-handlers.test.ts
+++ b/src/tui/tui-event-handlers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
 import { createEventHandlers } from "./tui-event-handlers.js";
+import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
 
 type MockFn = ReturnType<typeof vi.fn>;
 type HandlerChatLog = {
@@ -483,21 +483,5 @@ describe("tui-event-handlers: handleAgentEvent", () => {
 
     expect(chatLog.dropAssistant).toHaveBeenCalledWith("run-silent");
     expect(chatLog.finalizeAssistant).not.toHaveBeenCalled();
-  });
-
-  it("reloads history when a local run ends without a displayable final message", () => {
-    const { state, loadHistory, noteLocalRunId, handleChatEvent } = createHandlersHarness({
-      state: { activeChatRunId: "run-local-silent" },
-    });
-
-    noteLocalRunId("run-local-silent");
-
-    handleChatEvent({
-      runId: "run-local-silent",
-      sessionKey: state.currentSessionKey,
-      state: "final",
-    });
-
-    expect(loadHistory).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,7 +1,7 @@
-import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
+import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
 
 type EventHandlerChatLog = {
   startTool: (toolCallId: string, toolName: string, args: unknown) => void;
@@ -136,16 +136,10 @@ export function createEventHandlers(context: EventHandlerContext) {
     return sessionRuns.has(activeRunId);
   };
 
-  const maybeRefreshHistoryForRun = (
-    runId: string,
-    opts?: { allowLocalWithoutDisplayableFinal?: boolean },
-  ) => {
-    const isLocalRun = isLocalRunId?.(runId) ?? false;
-    if (isLocalRun) {
+  const maybeRefreshHistoryForRun = (runId: string) => {
+    if (isLocalRunId?.(runId)) {
       forgetLocalRunId?.(runId);
-      if (!opts?.allowLocalWithoutDisplayableFinal) {
-        return;
-      }
+      return;
     }
     if (hasConcurrentActiveRun(runId)) {
       return;
@@ -208,9 +202,7 @@ export function createEventHandlers(context: EventHandlerContext) {
     if (evt.state === "final") {
       const wasActiveRun = state.activeChatRunId === evt.runId;
       if (!evt.message) {
-        maybeRefreshHistoryForRun(evt.runId, {
-          allowLocalWithoutDisplayableFinal: true,
-        });
+        maybeRefreshHistoryForRun(evt.runId);
         chatLog.dropAssistant(evt.runId);
         finalizeRun({ runId: evt.runId, wasActiveRun, status: "idle" });
         tui.requestRender();

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,7 +1,7 @@
 import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
+import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
-import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
 
 type EventHandlerChatLog = {
   startTool: (toolCallId: string, toolName: string, args: unknown) => void;

--- a/src/tui/tui-event-handlers.ts
+++ b/src/tui/tui-event-handlers.ts
@@ -1,5 +1,5 @@
-import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import type { AgentEvent, ChatEvent, TuiStateAccess } from "./tui-types.js";
+import { parseAgentSessionKey } from "../sessions/session-key-utils.js";
 import { asString, extractTextFromMessage, isCommandMessage } from "./tui-formatters.js";
 import { TuiStreamAssembler } from "./tui-stream-assembler.js";
 


### PR DESCRIPTION
## Summary
- defer queued delivery recovery until after gateway sidecars finish starting
- keep crash-recovery replay behind channel startup so WhatsApp listeners exist before recovery attempts fire
- add a startup-order regression test that fails if recovery runs while sidecars are still blocked

Fixes #39066.

## Root cause
`recoverPendingDeliveries()` was launched before `startGatewaySidecars()`. On startup paths where channels need a few seconds to connect, recovery could attempt delivery against an unready channel stack and burn retries on messages that would have succeeded moments later.

## Validation
- `PATH=/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin:$PATH pnpm exec vitest run src/gateway/server.delivery-recovery-order.test.ts src/infra/outbound/outbound.test.ts`
- `PATH=/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin:$PATH oxfmt --check src/gateway/server.impl.ts src/gateway/server.delivery-recovery-order.test.ts`
- `PATH=/Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin:$PATH oxlint src/gateway/server.impl.ts src/gateway/server.delivery-recovery-order.test.ts`
