### PR TITLE
fix: accept both sk-ant-oat01- and sk-ant-api03- setup tokens

### DIFF
--- a/src/agents/anthropic.setup-token.live.test.ts
+++ b/src/agents/anthropic.setup-token.live.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { type Api, completeSimple, type Model } from "@mariozechner/pi-ai";
 import { describe, expect, it } from "vitest";
 import {
-  ANTHROPIC_SETUP_TOKEN_PREFIX,
+  ANTHROPIC_SETUP_TOKEN_PREFIXES,
   validateAnthropicSetupToken,
 } from "../commands/auth-token.js";
 import { loadConfig } from "../config/config.js";
@@ -37,7 +37,7 @@ type TokenSource = {
 };
 
 function isSetupToken(value: string): boolean {
-  return value.startsWith(ANTHROPIC_SETUP_TOKEN_PREFIX);
+  return ANTHROPIC_SETUP_TOKEN_PREFIXES.some((prefix) => value.startsWith(prefix));
 }
 
 function listSetupTokenProfiles(store: {

--- a/src/commands/auth-choice.apply.anthropic.test.ts
+++ b/src/commands/auth-choice.apply.anthropic.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { applyAuthChoiceAnthropic } from "./auth-choice.apply.anthropic.js";
-import { ANTHROPIC_SETUP_TOKEN_PREFIX } from "./auth-token.js";
+import { ANTHROPIC_SETUP_TOKEN_PREFIXES } from "./auth-token.js";
 import {
   createAuthTestLifecycle,
   createExitThrowingRuntime,
@@ -29,7 +29,7 @@ describe("applyAuthChoiceAnthropic", () => {
 
   it("persists setup-token ref without plaintext token in auth-profiles store", async () => {
     const agentDir = await setupTempState();
-    process.env.ANTHROPIC_SETUP_TOKEN = `${ANTHROPIC_SETUP_TOKEN_PREFIX}${"x".repeat(100)}`;
+    process.env.ANTHROPIC_SETUP_TOKEN = `${ANTHROPIC_SETUP_TOKEN_PREFIXES[0]}${"x".repeat(100)}`;
 
     const prompter = createWizardPrompter({}, { defaultSelect: "ref" });
     const runtime = createExitThrowingRuntime();

--- a/src/commands/auth-token.ts
+++ b/src/commands/auth-token.ts
@@ -1,6 +1,6 @@
 import { normalizeProviderId } from "../agents/model-selection.js";
 
-export const ANTHROPIC_SETUP_TOKEN_PREFIX = "sk-ant-oat01-";
+export const ANTHROPIC_SETUP_TOKEN_PREFIXES = ["sk-ant-oat01-", "sk-ant-api03-"];
 export const ANTHROPIC_SETUP_TOKEN_MIN_LENGTH = 80;
 export const DEFAULT_TOKEN_PROFILE_NAME = "default";
 
@@ -28,8 +28,8 @@ export function validateAnthropicSetupToken(raw: string): string | undefined {
   if (!trimmed) {
     return "Required";
   }
-  if (!trimmed.startsWith(ANTHROPIC_SETUP_TOKEN_PREFIX)) {
-    return `Expected token starting with ${ANTHROPIC_SETUP_TOKEN_PREFIX}`;
+  if (!ANTHROPIC_SETUP_TOKEN_PREFIXES.some((prefix) => trimmed.startsWith(prefix))) {
+    return `Expected token starting with sk-ant-oat01- or sk-ant-api03-`;
   }
   if (trimmed.length < ANTHROPIC_SETUP_TOKEN_MIN_LENGTH) {
     return "Token looks too short; paste the full setup-token";

--- a/src/commands/auth-token.ts
+++ b/src/commands/auth-token.ts
@@ -29,7 +29,7 @@ export function validateAnthropicSetupToken(raw: string): string | undefined {
     return "Required";
   }
   if (!ANTHROPIC_SETUP_TOKEN_PREFIXES.some((prefix) => trimmed.startsWith(prefix))) {
-    return `Expected token starting with sk-ant-oat01- or sk-ant-api03-`;
+    return `Expected token starting with ${ANTHROPIC_SETUP_TOKEN_PREFIXES.join(" or ")}`;
   }
   if (trimmed.length < ANTHROPIC_SETUP_TOKEN_MIN_LENGTH) {
     return "Token looks too short; paste the full setup-token";


### PR DESCRIPTION
Update validateAnthropicSetupToken to accept tokens starting with either 'sk-ant-oat01-' or 'sk-ant-api03-' prefix.

This change:
- Renamed ANTHROPIC_SETUP_TOKEN_PREFIX to ANTHROPIC_SETUP_TOKEN_PREFIXES (array)
- Updated validation logic to check against both prefixes
- Updated test files to use the new constant