### PR TITLE
fix(discord): fallback DM target when To is missing

### DIFF
--- a/src/channels/dock.test.ts
+++ b/src/channels/dock.test.ts
@@ -59,6 +59,27 @@ describe("channels dock", () => {
     });
   });
 
+  it("discord threading falls back to From for direct chats", () => {
+    const hasRepliedRef = { value: false };
+    const discordDock = getChannelDock("discord");
+    const context = discordDock?.threading?.buildToolContext?.({
+      cfg: emptyConfig(),
+      context: {
+        ChatType: "direct",
+        From: "discord:1234567890",
+        To: "",
+        ReplyToId: "msg-1",
+      },
+      hasRepliedRef,
+    });
+
+    expect(context).toEqual({
+      currentChannelId: "discord:1234567890",
+      currentThreadTs: "msg-1",
+      hasRepliedRef,
+    });
+  });
+
   it("irc resolveDefaultTo matches account id case-insensitively", () => {
     const ircDock = getChannelDock("irc");
     const cfg = {

--- a/src/channels/dock.ts
+++ b/src/channels/dock.ts
@@ -351,7 +351,9 @@ const DOCKS: Record<ChatChannelId, ChannelDock> = {
     threading: {
       resolveReplyToMode: ({ cfg }) => cfg.channels?.discord?.replyToMode ?? "off",
       buildToolContext: ({ context, hasRepliedRef }) => ({
-        currentChannelId: context.To?.trim() || undefined,
+        // DMs can arrive without a stable `To` in some paths. Fall back to `From`
+        // for direct chats so message tool sends can still infer a valid target.
+        currentChannelId: resolveDirectOrGroupChannelId(context),
         currentThreadTs: context.ReplyToId,
         hasRepliedRef,
       }),


### PR DESCRIPTION
## Summary
- fix Discord threading tool context to infer `currentChannelId` via direct/group helper instead of relying only on `To`
- this allows message tool sends in DM sessions to still resolve a target when inbound context does not include `To`
- add regression test covering direct-chat fallback to `From`

## Why
In Discord DM sessions, some inbound paths can miss `To`, causing message action normalization to throw `Action send requires a target.` and the agent reply never sends.

## Test evidence
- `pnpm vitest run --config vitest.unit.config.ts src/channels/dock.test.ts`
  - Passed: 1 file, 9 tests

Fixes #39439
