### PR TITLE
fix(gateway): recover deliveries only after sidecars initialize

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -10010,14 +10010,14 @@
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
         "is_verified": false,
-        "line_number": 70
+        "line_number": 69
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/providers/minimax.md",
         "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 148
       }
     ],
     "docs/providers/moonshot.md": [
@@ -13011,5 +13011,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T03:31:44Z"
+  "generated_at": "2026-03-08T05:04:26Z"
 }

--- a/appcast.xml
+++ b/appcast.xml
@@ -361,7 +361,7 @@
 </ul>
 <p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
 ]]></description>
-            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.3.7-beta.1/OpenClaw-2026.3.7.zip" length="23263836" type="application/octet-stream" sparkle:edSignature="IjhLPw9QKZukMDV0rU/06N2D0cu7WyNBPfZ+UL58KbTo7av7s3syYAGAmr+zhvfkMoqvtrQfN9prnvnNIKLNCQ=="/>
+            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.3.7-beta.1/OpenClaw-2026.3.7.zip" length="23263836" type="application/octet-stream" sparkle:edSignature="IjhLPw9QKZukMDV0rU/06N2D0cu7WyNBPfZ+UL58KbTo7av7s3syYAGAmr+zhvfkMoqvtrQfN9prnvnNIKLNCQ=="/> <!-- pragma: allowlist secret -->
         </item>
         <item>
             <title>2026.3.2</title>
@@ -580,8 +580,7 @@
 </ul>
 <p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
 ]]></description>
-            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.3.2/OpenClaw-2026.3.2.zip" length="23181513" type="application/octet-stream" sparkle:edSignature="THMgkcoMgz2vv5zse3Po3K7l3Or2RhBKurXZIi8iYVXN76yJy1YXAY6kXi6ovD+dbYn68JKYDIKA1Ya78bO7BQ=="/>
-            <!-- pragma: allowlist secret -->
+            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.3.2/OpenClaw-2026.3.2.zip" length="23181513" type="application/octet-stream" sparkle:edSignature="THMgkcoMgz2vv5zse3Po3K7l3Or2RhBKurXZIi8iYVXN76yJy1YXAY6kXi6ovD+dbYn68JKYDIKA1Ya78bO7BQ=="/> <!-- pragma: allowlist secret -->
         </item>
         <item>
             <title>2026.3.1</title>
@@ -719,8 +718,7 @@
 </ul>
 <p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
 ]]></description>
-            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.3.1/OpenClaw-2026.3.1.zip" length="12804155" type="application/octet-stream" sparkle:edSignature="TF1otD4Vk3pG0iViX7mvix5DQEgAsk4JkSFvH7opjf9aawV16f29SUa2wRmiCFU6HEgyNgnGI/078O+A27eXCA=="/>
-            <!-- pragma: allowlist secret -->
+            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.3.1/OpenClaw-2026.3.1.zip" length="12804155" type="application/octet-stream" sparkle:edSignature="TF1otD4Vk3pG0iViX7mvix5DQEgAsk4JkSFvH7opjf9aawV16f29SUa2wRmiCFU6HEgyNgnGI/078O+A27eXCA=="/> <!-- pragma: allowlist secret -->
         </item>
     </channel>
 </rss>

--- a/extensions/zalouser/src/monitor.group-gating.test.ts
+++ b/extensions/zalouser/src/monitor.group-gating.test.ts
@@ -83,7 +83,9 @@ function installRuntime(params: {
     };
   });
   const readAllowFromStore = vi.fn(async () => []);
-  const readSessionUpdatedAt = vi.fn(() => undefined);
+  const readSessionUpdatedAt = vi.fn<(input: { sessionKey: string }) => number | undefined>(
+    () => undefined,
+  );
   const buildAgentSessionKey = vi.fn(
     (input: {
       agentId: string;

--- a/src/gateway/server.delivery-recovery-order.test.ts
+++ b/src/gateway/server.delivery-recovery-order.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getFreePort, installGatewayTestHooks } from "./test-helpers.js";
+
+const mocks = vi.hoisted(() => {
+  const order: string[] = [];
+  let releaseSidecarsGate: (() => void) | undefined;
+  let sidecarsGate!: Promise<void>;
+  const resetSidecarsGate = () => {
+    sidecarsGate = new Promise<void>((resolve) => {
+      releaseSidecarsGate = resolve;
+    });
+  };
+  resetSidecarsGate();
+  return {
+    order,
+    resetSidecarsGate,
+    releaseSidecars: () => releaseSidecarsGate?.(),
+    startGatewaySidecars: vi.fn(async () => {
+      order.push("sidecars:start");
+      await sidecarsGate;
+      order.push("sidecars:done");
+      return { browserControl: null, pluginServices: null };
+    }),
+    recoverPendingDeliveries: vi.fn(async () => {
+      order.push("recovery");
+      return { recovered: 0, failed: 0, skippedMaxRetries: 0, deferredBackoff: 0 };
+    }),
+    deliverOutboundPayloads: vi.fn(async () => []),
+  };
+});
+
+vi.mock("./server-startup.js", async () => {
+  const actual = await vi.importActual<typeof import("./server-startup.js")>("./server-startup.js");
+  return {
+    ...actual,
+    startGatewaySidecars: mocks.startGatewaySidecars,
+  };
+});
+
+vi.mock("../infra/outbound/delivery-queue.js", async () => {
+  const actual = await vi.importActual<typeof import("../infra/outbound/delivery-queue.js")>(
+    "../infra/outbound/delivery-queue.js",
+  );
+  return {
+    ...actual,
+    recoverPendingDeliveries: mocks.recoverPendingDeliveries,
+  };
+});
+
+vi.mock("../infra/outbound/deliver.js", () => ({
+  deliverOutboundPayloads: mocks.deliverOutboundPayloads,
+}));
+
+await import("../infra/outbound/delivery-queue.js");
+await import("../infra/outbound/deliver.js");
+const { startGatewayServer } = await import("./server.js");
+
+installGatewayTestHooks();
+
+afterEach(() => {
+  mocks.order.length = 0;
+  mocks.resetSidecarsGate();
+  mocks.startGatewaySidecars.mockClear();
+  mocks.recoverPendingDeliveries.mockClear();
+  mocks.deliverOutboundPayloads.mockClear();
+});
+
+describe("startGatewayServer delivery recovery", () => {
+  it("starts sidecars before replaying queued deliveries", async () => {
+    delete process.env.OPENCLAW_TEST_MINIMAL_GATEWAY;
+
+    const port = await getFreePort();
+    const startup = startGatewayServer(port);
+    let server: Awaited<ReturnType<typeof startGatewayServer>> | undefined;
+
+    try {
+      await vi.waitFor(
+        () => {
+          expect(mocks.startGatewaySidecars).toHaveBeenCalledTimes(1);
+        },
+        { timeout: 15_000, interval: 25 },
+      );
+
+      expect(mocks.recoverPendingDeliveries).not.toHaveBeenCalled();
+
+      mocks.releaseSidecars();
+      server = await startup;
+
+      await vi.waitFor(
+        () => {
+          expect(mocks.recoverPendingDeliveries).toHaveBeenCalledTimes(1);
+        },
+        { timeout: 15_000, interval: 25 },
+      );
+
+      expect(mocks.order).toEqual(["sidecars:start", "sidecars:done", "recovery"]);
+      expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
+    } finally {
+      mocks.releaseSidecars();
+      if (!server) {
+        try {
+          server = await startup;
+        } catch {
+          server = undefined;
+        }
+      }
+      if (server) {
+        await server.close({ reason: "test complete" });
+      }
+    }
+  });
+});

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -755,20 +755,6 @@ export async function startGatewayServer(
     void cron.start().catch((err) => logCron.error(`failed to start: ${String(err)}`));
   }
 
-  // Recover pending outbound deliveries from previous crash/restart.
-  if (!minimalTestGateway) {
-    void (async () => {
-      const { recoverPendingDeliveries } = await import("../infra/outbound/delivery-queue.js");
-      const { deliverOutboundPayloads } = await import("../infra/outbound/deliver.js");
-      const logRecovery = log.child("delivery-recovery");
-      await recoverPendingDeliveries({
-        deliver: deliverOutboundPayloads,
-        log: logRecovery,
-        cfg: cfgAtStart,
-      });
-    })().catch((err) => log.error(`Delivery recovery failed: ${String(err)}`));
-  }
-
   const execApprovalManager = new ExecApprovalManager();
   const execApprovalForwarder = createExecApprovalForwarder();
   const execApprovalHandlers = createExecApprovalHandlers(execApprovalManager, {
@@ -924,6 +910,21 @@ export async function startGatewayServer(
       logChannels,
       logBrowser,
     }));
+  }
+
+  // Recover pending outbound deliveries from previous crash/restart.
+  // Run this only after sidecars/channels are initialized so delivery backends are ready.
+  if (!minimalTestGateway) {
+    void (async () => {
+      const { recoverPendingDeliveries } = await import("../infra/outbound/delivery-queue.js");
+      const { deliverOutboundPayloads } = await import("../infra/outbound/deliver.js");
+      const logRecovery = log.child("delivery-recovery");
+      await recoverPendingDeliveries({
+        deliver: deliverOutboundPayloads,
+        log: logRecovery,
+        cfg: cfgAtStart,
+      });
+    })().catch((err) => log.error(`Delivery recovery failed: ${String(err)}`));
   }
 
   // Run gateway_start plugin hook (fire-and-forget)


### PR DESCRIPTION
## Summary
- move queued delivery recovery startup to run after sidecars/channels initialize
- keep recovery async and non-blocking, but ensure delivery backends are ready first
- add a regression test that gates sidecar startup and verifies recovery ordering

## Problem
On startup, queued delivery replay could begin before sidecars were ready, causing recoverable deliveries to fail early.

## Testing
- npx -y pnpm vitest src/gateway/server.delivery-recovery-order.test.ts src/gateway/server-startup-log.test.ts