### PR TITLE
fix(slack): support unsigned url_verification in http mode

### DIFF
--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -21,7 +21,7 @@ import { normalizeResolvedSecretInputString } from "../../config/types.secrets.j
 import { createConnectedChannelStatusPatch } from "../../gateway/channel-status-patches.js";
 import { warn } from "../../globals.js";
 import { computeBackoff, sleepWithAbort } from "../../infra/backoff.js";
-import { installRequestBodyLimitGuard } from "../../infra/http-body.js";
+import { installRequestBodyLimitGuard, readJsonBodyWithLimit } from "../../infra/http-body.js";
 import { normalizeMainKey } from "../../routing/session-key.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../../runtime.js";
 import { normalizeStringEntries } from "../../shared/string-normalization.js";
@@ -57,6 +57,72 @@ const { App, HTTPReceiver } = slackBolt;
 
 const SLACK_WEBHOOK_MAX_BODY_BYTES = 1024 * 1024;
 const SLACK_WEBHOOK_BODY_TIMEOUT_MS = 30_000;
+
+type SlackUrlVerificationPayload = {
+  type: "url_verification";
+  challenge: string;
+};
+
+function hasAnySlackSignatureHeader(req: IncomingMessage): boolean {
+  const signature = req.headers["x-slack-signature"];
+  const timestamp = req.headers["x-slack-request-timestamp"];
+  const signatureValue = (Array.isArray(signature) ? signature[0] : signature)?.trim();
+  const timestampValue = (Array.isArray(timestamp) ? timestamp[0] : timestamp)?.trim();
+  return Boolean(signatureValue || timestampValue);
+}
+
+function isSlackUrlVerificationPayload(value: unknown): value is SlackUrlVerificationPayload {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  return record.type === "url_verification" && typeof record.challenge === "string";
+}
+
+async function maybeHandleUnsignedSlackUrlVerification(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<boolean> {
+  if (hasAnySlackSignatureHeader(req)) {
+    return false;
+  }
+
+  const parsed = await readJsonBodyWithLimit(req, {
+    maxBytes: SLACK_WEBHOOK_MAX_BODY_BYTES,
+    timeoutMs: SLACK_WEBHOOK_BODY_TIMEOUT_MS,
+    emptyObjectOnEmpty: false,
+  });
+  if (!parsed.ok) {
+    const statusCode =
+      parsed.code === "PAYLOAD_TOO_LARGE"
+        ? 413
+        : parsed.code === "REQUEST_BODY_TIMEOUT"
+          ? 408
+          : 400;
+    if (!res.headersSent) {
+      res.statusCode = statusCode;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end(parsed.error);
+    }
+    return true;
+  }
+
+  if (!isSlackUrlVerificationPayload(parsed.value)) {
+    if (!res.headersSent) {
+      res.statusCode = 401;
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end("Missing Slack signature");
+    }
+    return true;
+  }
+
+  if (!res.headersSent) {
+    res.statusCode = 200;
+    res.setHeader("Content-Type", "application/json; charset=utf-8");
+    res.end(JSON.stringify({ challenge: parsed.value.challenge }));
+  }
+  return true;
+}
 
 function parseApiAppIdFromAppToken(raw?: string) {
   const token = raw?.trim();
@@ -210,6 +276,9 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
   const slackHttpHandler =
     slackMode === "http" && receiver
       ? async (req: IncomingMessage, res: ServerResponse) => {
+          if (await maybeHandleUnsignedSlackUrlVerification(req, res)) {
+            return;
+          }
           const guard = installRequestBodyLimitGuard(req, res, {
             maxBytes: SLACK_WEBHOOK_MAX_BODY_BYTES,
             timeoutMs: SLACK_WEBHOOK_BODY_TIMEOUT_MS,
@@ -517,4 +586,5 @@ export const __testing = {
   resolveDefaultGroupPolicy,
   getSocketEmitter,
   waitForSlackSocketDisconnect,
+  maybeHandleUnsignedSlackUrlVerification,
 };

--- a/src/slack/monitor/provider.url-verification.test.ts
+++ b/src/slack/monitor/provider.url-verification.test.ts
@@ -1,0 +1,75 @@
+import { EventEmitter } from "node:events";
+import type { IncomingMessage } from "node:http";
+import { describe, expect, it } from "vitest";
+import { createMockServerResponse } from "../../test-utils/mock-http-response.js";
+import { __testing } from "./provider.js";
+
+type MockIncomingMessage = IncomingMessage & {
+  destroyed?: boolean;
+  destroy: (error?: Error) => MockIncomingMessage;
+};
+
+function createMockRequest(params: {
+  body?: string;
+  headers?: Record<string, string>;
+}): MockIncomingMessage {
+  const req = new EventEmitter() as MockIncomingMessage;
+  req.destroyed = false;
+  req.headers = params.headers ?? {};
+  req.destroy = (() => {
+    req.destroyed = true;
+    return req;
+  }) as MockIncomingMessage["destroy"];
+
+  if (typeof params.body === "string") {
+    void Promise.resolve().then(() => {
+      req.emit("data", Buffer.from(params.body, "utf-8"));
+      req.emit("end");
+    });
+  }
+
+  return req;
+}
+
+describe("slack unsigned url_verification handling", () => {
+  it("responds to unsigned url_verification challenge", async () => {
+    const req = createMockRequest({
+      body: JSON.stringify({ type: "url_verification", challenge: "abc123" }),
+    });
+    const res = createMockServerResponse();
+
+    const handled = await __testing.maybeHandleUnsignedSlackUrlVerification(req, res);
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(200);
+    expect(res.getHeader("content-type")).toContain("application/json");
+    expect(JSON.parse(res.body ?? "{}")).toEqual({ challenge: "abc123" });
+  });
+
+  it("does not intercept signed requests", async () => {
+    const req = createMockRequest({
+      headers: {
+        "x-slack-signature": "v0=test",
+      },
+    });
+    const res = createMockServerResponse();
+
+    const handled = await __testing.maybeHandleUnsignedSlackUrlVerification(req, res);
+
+    expect(handled).toBe(false);
+    expect(res.headersSent).toBe(false);
+  });
+
+  it("rejects unsigned non-verification payloads", async () => {
+    const req = createMockRequest({
+      body: JSON.stringify({ type: "event_callback", event: { type: "message" } }),
+    });
+    const res = createMockServerResponse();
+
+    const handled = await __testing.maybeHandleUnsignedSlackUrlVerification(req, res);
+
+    expect(handled).toBe(true);
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toBe("Missing Slack signature");
+  });
+});

--- a/src/slack/monitor/provider.url-verification.test.ts
+++ b/src/slack/monitor/provider.url-verification.test.ts
@@ -22,8 +22,9 @@ function createMockRequest(params: {
   }) as MockIncomingMessage["destroy"];
 
   if (typeof params.body === "string") {
+    const body = params.body;
     void Promise.resolve().then(() => {
-      req.emit("data", Buffer.from(params.body, "utf-8"));
+      req.emit("data", Buffer.from(body, "utf-8"));
       req.emit("end");
     });
   }


### PR DESCRIPTION
## Summary
- handle Slack HTTP-mode `url_verification` when Slack sends it without signature headers
- keep existing Bolt signature verification path unchanged for signed requests
- add targeted tests for unsigned challenge handling and non-challenge rejection

## Why
Slack may send the initial `url_verification` challenge without `X-Slack-Signature`/timestamp headers. Previously we passed all requests directly into Bolt's signed-request flow, so the handshake could fail and HTTP mode never became usable.

## Behavior
- **Unsigned + `type=url_verification`**: return `200` with `{ "challenge": "..." }`
- **Unsigned + non-verification payload**: reject with `401 Missing Slack signature`
- **Signed requests**: unchanged path via Bolt receiver + existing size/time guards

## Test evidence
- `pnpm vitest run --config vitest.unit.config.ts src/slack/monitor/provider.url-verification.test.ts src/slack/monitor/provider.group-policy.test.ts src/slack/monitor/provider.auth-errors.test.ts`
  - Passed: 3 files, 26 tests

Fixes #39432
