### PR TITLE
fix(media): trim structured MEDIA tails

### DIFF
--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -86,6 +86,12 @@ describe("splitMediaFromOutput", () => {
     expect(result.text).toBe("");
   });
 
+  it("keeps valid local filenames containing quoted brace segments", () => {
+    const result = splitMediaFromOutput('MEDIA:/tmp/clip{"stereo"}.wav');
+    expect(result.mediaUrls).toEqual(['/tmp/clip{"stereo"}.wav']);
+    expect(result.text).toBe("");
+  });
+
   it("keeps quoted local filenames containing apostrophes", () => {
     const result = splitMediaFromOutput("MEDIA:'/tmp/it's good.mp3'");
     expect(result.mediaUrls).toEqual(["/tmp/it's good.mp3"]);

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -50,4 +50,45 @@ describe("splitMediaFromOutput", () => {
     const result = splitMediaFromOutput("MEDIA:screenshot");
     expect(result.mediaUrls).toBeUndefined();
   });
+
+  it("extracts a clean leading path from echoed structured tails", () => {
+    const cases = [
+      ['MEDIA:/tmp/tts/output.mp3{"results":[{"source":"MEMORY.md"}]}', ["/tmp/tts/output.mp3"]],
+      ['MEDIA:/tmp/output.mp3,"source":"MEMORY.md"', ["/tmp/output.mp3"]],
+      ['MEDIA:/tmp/output.mp3["MEMORY.md"]', ["/tmp/output.mp3"]],
+      ['MEDIA:/tmp/output.mp3{"provider":"gemini","usage":{"tokens":5000}}', ["/tmp/output.mp3"]],
+    ] as const;
+
+    for (const [input, expectedMedia] of cases) {
+      const result = splitMediaFromOutput(input);
+      expect(result.mediaUrls).toEqual(expectedMedia);
+      expect(result.text).toBe("");
+    }
+  });
+
+  it("drops invalid local-looking structured tails without inventing a media path", () => {
+    const result = splitMediaFromOutput(
+      'MEDIA:/data/openclaw/context-{"query":"test","results":[]}',
+    );
+    expect(result.mediaUrls).toBeUndefined();
+    expect(result.text).toBe("");
+  });
+
+  it("preserves prose after a valid media path without treating it as part of the path", () => {
+    const result = splitMediaFromOutput('MEDIA:/tmp/output.mp3") markdown tail');
+    expect(result.mediaUrls).toEqual(["/tmp/output.mp3"]);
+    expect(result.text).toBe("markdown tail");
+  });
+
+  it("keeps valid local filenames containing braces", () => {
+    const result = splitMediaFromOutput("MEDIA:/tmp/clip{ok}.mp3");
+    expect(result.mediaUrls).toEqual(["/tmp/clip{ok}.mp3"]);
+    expect(result.text).toBe("");
+  });
+
+  it("supports multiple media tokens on one MEDIA line", () => {
+    const result = splitMediaFromOutput("MEDIA:a.png b.png");
+    expect(result.mediaUrls).toEqual(["a.png", "b.png"]);
+    expect(result.text).toBe("");
+  });
 });

--- a/src/media/parse.test.ts
+++ b/src/media/parse.test.ts
@@ -86,9 +86,21 @@ describe("splitMediaFromOutput", () => {
     expect(result.text).toBe("");
   });
 
+  it("keeps quoted local filenames containing apostrophes", () => {
+    const result = splitMediaFromOutput("MEDIA:'/tmp/it's good.mp3'");
+    expect(result.mediaUrls).toEqual(["/tmp/it's good.mp3"]);
+    expect(result.text).toBe("");
+  });
+
   it("supports multiple media tokens on one MEDIA line", () => {
     const result = splitMediaFromOutput("MEDIA:a.png b.png");
     expect(result.mediaUrls).toEqual(["a.png", "b.png"]);
+    expect(result.text).toBe("");
+  });
+
+  it("supports multiple quoted media tokens when the first contains apostrophes", () => {
+    const result = splitMediaFromOutput("MEDIA:'/tmp/it's good.mp3' '/tmp/next clip.mp3'");
+    expect(result.mediaUrls).toEqual(["/tmp/it's good.mp3", "/tmp/next clip.mp3"]);
     expect(result.text).toBe("");
   });
 });

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -71,7 +71,9 @@ type ExtractedMediaCandidate = {
 
 function looksLikeStructuredTail(value: string): boolean {
   return (
-    /^\{["']/.test(value) || /^\[(?:\{|"|')/.test(value) || /^,\s*["'][^"'\\]+["']\s*:/.test(value)
+    /^\{\s*["'][^"'\\]+["']\s*:/.test(value) ||
+    /^\[(?:\{|"|')/.test(value) ||
+    /^,\s*["'][^"'\\]+["']\s*:/.test(value)
   );
 }
 
@@ -310,10 +312,6 @@ export function splitMediaFromOutput(raw: string): {
         foundMediaToken = true;
         if (!extracted.remainder.trim() || extracted.dropRemainder) {
           visibleTail = "";
-          break;
-        }
-        if (!extractLeadingMediaCandidate(extracted.remainder)) {
-          visibleTail = extracted.remainder;
           break;
         }
         remainingPayload = extracted.remainder;

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -63,20 +63,150 @@ function isValidMedia(
   return false;
 }
 
-function unwrapQuoted(value: string): string | undefined {
-  const trimmed = value.trim();
-  if (trimmed.length < 2) {
+type ExtractedMediaCandidate = {
+  candidate: string;
+  remainder: string;
+  dropRemainder: boolean;
+};
+
+function looksLikeStructuredTail(value: string): boolean {
+  return (
+    /^\{["']/.test(value) || /^\[(?:\{|"|')/.test(value) || /^,\s*["'][^"'\\]+["']\s*:/.test(value)
+  );
+}
+
+function findStructuredTailStart(token: string): number | undefined {
+  for (let index = 1; index < token.length; index++) {
+    if (looksLikeStructuredTail(token.slice(index))) {
+      return index;
+    }
+  }
+  return undefined;
+}
+
+function hasStrongMediaTerminator(candidate: string): boolean {
+  return /^https?:\/\//i.test(candidate) || HAS_FILE_EXT.test(candidate);
+}
+
+function looksCompleteCandidate(candidate: string): boolean {
+  const trimmed = candidate.trim();
+  if (!trimmed) {
+    return false;
+  }
+  if (hasStrongMediaTerminator(trimmed)) {
+    return true;
+  }
+  const lastChar = trimmed[trimmed.length - 1];
+  return /[A-Za-z0-9~]/.test(lastChar);
+}
+
+function isStandaloneMediaToken(token: string): boolean {
+  const candidate = normalizeMediaSource(cleanCandidate(token));
+  return isValidMedia(candidate, { allowBareFilename: true });
+}
+
+function looksLikePathContinuationToken(token: string): boolean {
+  const candidate = normalizeMediaSource(cleanCandidate(token));
+  if (!candidate) {
+    return false;
+  }
+  return (
+    candidate.includes("/") ||
+    candidate.includes("\\") ||
+    candidate.startsWith("~") ||
+    candidate.startsWith(".") ||
+    WINDOWS_DRIVE_RE.test(candidate) ||
+    HAS_FILE_EXT.test(candidate)
+  );
+}
+
+function shouldStopBeforeNextToken(candidate: string, nextToken: string): boolean {
+  if (looksLikeStructuredTail(nextToken)) {
+    return true;
+  }
+  if (!hasStrongMediaTerminator(candidate)) {
+    return false;
+  }
+  if (isStandaloneMediaToken(nextToken)) {
+    return true;
+  }
+  return !looksLikePathContinuationToken(nextToken);
+}
+
+function extractLeadingMediaCandidate(payload: string): ExtractedMediaCandidate | undefined {
+  const trimmed = payload.trimStart();
+  if (!trimmed) {
     return undefined;
   }
-  const first = trimmed[0];
-  const last = trimmed[trimmed.length - 1];
-  if (first !== last) {
+
+  const firstChar = trimmed[0];
+  if (firstChar === `"` || firstChar === "'" || firstChar === "`") {
+    const closingIndex = trimmed.indexOf(firstChar, 1);
+    if (closingIndex > 0) {
+      const candidate = normalizeMediaSource(trimmed.slice(1, closingIndex).trim());
+      if (isValidMedia(candidate, { allowSpaces: true, allowBareFilename: true })) {
+        const remainder = trimmed.slice(closingIndex + 1);
+        return {
+          candidate,
+          remainder,
+          dropRemainder: looksLikeStructuredTail(remainder.trimStart()),
+        };
+      }
+    }
+  }
+
+  const tokens = Array.from(trimmed.matchAll(/\S+/g));
+  if (tokens.length === 0) {
     return undefined;
   }
-  if (first !== `"` && first !== "'" && first !== "`") {
+
+  let best: { candidate: string; end: number } | undefined;
+  for (let index = 0; index < tokens.length; index++) {
+    const tokenMatch = tokens[index];
+    const token = tokenMatch[0];
+    const tokenStart = tokenMatch.index ?? 0;
+    const structuredTailStart = findStructuredTailStart(token);
+    const tokenHead =
+      structuredTailStart === undefined ? token : token.slice(0, structuredTailStart);
+    const tokenEnd = tokenStart + tokenHead.length;
+    if (!tokenHead) {
+      break;
+    }
+
+    const candidate = normalizeMediaSource(cleanCandidate(trimmed.slice(0, tokenEnd)));
+    if (isValidMedia(candidate, { allowSpaces: true, allowBareFilename: true })) {
+      best = { candidate, end: tokenStart + token.length };
+    }
+
+    if (structuredTailStart !== undefined) {
+      if (best && looksCompleteCandidate(best.candidate)) {
+        return {
+          candidate: best.candidate,
+          remainder: trimmed.slice(best.end),
+          dropRemainder: true,
+        };
+      }
+      return undefined;
+    }
+
+    const nextToken = tokens[index + 1]?.[0];
+    if (best && nextToken && shouldStopBeforeNextToken(best.candidate, nextToken)) {
+      return {
+        candidate: best.candidate,
+        remainder: trimmed.slice(best.end),
+        dropRemainder: false,
+      };
+    }
+  }
+
+  if (!best) {
     return undefined;
   }
-  return trimmed.slice(1, -1).trim();
+  return {
+    candidate: best.candidate,
+    remainder: trimmed.slice(best.end),
+    dropRemainder: false,
+  };
 }
 
 function mayContainFenceMarkers(input: string): boolean {
@@ -148,58 +278,37 @@ export function splitMediaFromOutput(raw: string): {
       pieces.push(line.slice(cursor, start));
 
       const payload = match[1];
-      const unwrapped = unwrapQuoted(payload);
-      const payloadValue = unwrapped ?? payload;
-      const parts = unwrapped ? [unwrapped] : payload.split(/\s+/).filter(Boolean);
-      const mediaStartIndex = media.length;
-      let validCount = 0;
-      const invalidParts: string[] = [];
       let hasValidMedia = false;
-      for (const part of parts) {
-        const candidate = normalizeMediaSource(cleanCandidate(part));
-        if (isValidMedia(candidate, unwrapped ? { allowSpaces: true } : undefined)) {
-          media.push(candidate);
-          hasValidMedia = true;
-          foundMediaToken = true;
-          validCount += 1;
-        } else {
-          invalidParts.push(part);
+      let visibleTail = "";
+      let remainingPayload = payload;
+      while (remainingPayload.trim()) {
+        const extracted = extractLeadingMediaCandidate(remainingPayload);
+        if (!extracted) {
+          visibleTail = remainingPayload;
+          break;
         }
+        media.push(extracted.candidate);
+        hasValidMedia = true;
+        foundMediaToken = true;
+        if (!extracted.remainder.trim() || extracted.dropRemainder) {
+          visibleTail = "";
+          break;
+        }
+        if (!extractLeadingMediaCandidate(extracted.remainder)) {
+          visibleTail = extracted.remainder;
+          break;
+        }
+        remainingPayload = extracted.remainder;
       }
 
-      const trimmedPayload = payloadValue.trim();
+      const trimmedPayload = payload.trim();
       const looksLikeLocalPath =
         isLikelyLocalPath(trimmedPayload) || trimmedPayload.startsWith("file://");
-      if (
-        !unwrapped &&
-        validCount === 1 &&
-        invalidParts.length > 0 &&
-        /\s/.test(payloadValue) &&
-        looksLikeLocalPath
-      ) {
-        const fallback = normalizeMediaSource(cleanCandidate(payloadValue));
-        if (isValidMedia(fallback, { allowSpaces: true })) {
-          media.splice(mediaStartIndex, media.length - mediaStartIndex, fallback);
-          hasValidMedia = true;
-          foundMediaToken = true;
-          validCount = 1;
-          invalidParts.length = 0;
-        }
-      }
-
-      if (!hasValidMedia) {
-        const fallback = normalizeMediaSource(cleanCandidate(payloadValue));
-        if (isValidMedia(fallback, { allowSpaces: true, allowBareFilename: true })) {
-          media.push(fallback);
-          hasValidMedia = true;
-          foundMediaToken = true;
-          invalidParts.length = 0;
-        }
-      }
 
       if (hasValidMedia) {
-        if (invalidParts.length > 0) {
-          pieces.push(invalidParts.join(" "));
+        const cleanedTail = visibleTail.trim();
+        if (cleanedTail) {
+          pieces.push(cleanedTail);
         }
       } else if (looksLikeLocalPath) {
         // Strip MEDIA: lines with local paths even when invalid (e.g. absolute paths

--- a/src/media/parse.ts
+++ b/src/media/parse.ts
@@ -133,6 +133,20 @@ function shouldStopBeforeNextToken(candidate: string, nextToken: string): boolea
   return !looksLikePathContinuationToken(nextToken);
 }
 
+function isQuotedRemainderBoundary(remainder: string): boolean {
+  if (!remainder) {
+    return true;
+  }
+  if (/^\s/.test(remainder)) {
+    return true;
+  }
+  const trimmed = remainder.trimStart();
+  if (!trimmed) {
+    return true;
+  }
+  return looksLikeStructuredTail(trimmed) || /^[`"'})\],.:;!?-]/.test(trimmed);
+}
+
 function extractLeadingMediaCandidate(payload: string): ExtractedMediaCandidate | undefined {
   const trimmed = payload.trimStart();
   if (!trimmed) {
@@ -141,17 +155,21 @@ function extractLeadingMediaCandidate(payload: string): ExtractedMediaCandidate 
 
   const firstChar = trimmed[0];
   if (firstChar === `"` || firstChar === "'" || firstChar === "`") {
-    const closingIndex = trimmed.indexOf(firstChar, 1);
-    if (closingIndex > 0) {
+    for (let closingIndex = trimmed.indexOf(firstChar, 1); closingIndex > 0; ) {
+      const remainder = trimmed.slice(closingIndex + 1);
+      if (!isQuotedRemainderBoundary(remainder)) {
+        closingIndex = trimmed.indexOf(firstChar, closingIndex + 1);
+        continue;
+      }
       const candidate = normalizeMediaSource(trimmed.slice(1, closingIndex).trim());
       if (isValidMedia(candidate, { allowSpaces: true, allowBareFilename: true })) {
-        const remainder = trimmed.slice(closingIndex + 1);
         return {
           candidate,
           remainder,
           dropRemainder: looksLikeStructuredTail(remainder.trimStart()),
         };
       }
+      closingIndex = trimmed.indexOf(firstChar, closingIndex + 1);
     }
   }
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: `splitMediaFromOutput` treats the whole unquoted `MEDIA:` remainder as a path, so echoed structured tails like `{"results":[...]}`, `,"source":"..."`, or `[...]` get folded into malformed local paths.
- Why it matters: outbound replies can try to load corrupted media paths instead of the real file path, which leads to filesystem errors and dropped media delivery.
- What changed: replaced the whole-payload fallback with a delimiter-aware leading candidate extractor that trims structured tails, preserves prose after a valid path, keeps valid brace-containing POSIX filenames, and still supports multiple media refs on one `MEDIA:` line.
- What did NOT change (scope boundary): no provider/content-block plumbing changed; `extractToolResultMediaPaths`, HTTP URL handling, and downstream sandbox/load validation are unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #21526
- Related N/A

## User-visible / Behavior Changes

Malformed `MEDIA:` lines that contain echoed structured tails no longer become filesystem paths. Valid `MEDIA:` paths still work, including quoted paths, multi-path lines, unquoted local paths with spaces, and brace-containing POSIX filenames.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: N/A

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: Node 24 local dev environment
- Model/provider: reproduced with issue-shaped assistant text that includes echoed structured tool-result tails
- Integration/channel (if any): outbound reply parsing via `splitMediaFromOutput`
- Relevant config (redacted): default parser behavior

### Steps

1. Produce assistant text with a `MEDIA:` line whose path is followed by echoed structured data, for example `MEDIA:/tmp/output.mp3{"results":[{"source":"MEMORY.md"}]}`.
2. Let `splitMediaFromOutput` parse the outbound reply.
3. Observe whether the parser emits a corrupted media path or a clean leading candidate.

### Expected

- Structured tails after a valid media path are not treated as part of the path.
- Invalid local-looking structured prefixes are dropped instead of inventing a media path.
- Prose after a valid media path is preserved as text instead of being appended to the path.

### Actual

- Before this change, the parser could accept the entire remainder of the line as a path once it looked local-path-like.
- After this change, the parser trims the tail and emits either a clean leading candidate or no media path.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: JSON object tails, brace-free structured tails, prose after a valid path, valid brace-containing POSIX filenames, multiple media refs on one line, and unquoted local paths with spaces.
- Edge cases checked: invalid local-looking structured prefixes are dropped without inventing a path; HTTP URLs remain accepted; quoted paths still pass through unchanged.
- What you did **not** verify: live end-to-end channel delivery against a real Gemini session, Windows-specific odd filename characters, or the broader full test suite.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this single commit.
- Files/config to restore: `src/media/parse.ts` and `src/media/parse.test.ts`.
- Known bad symptoms reviewers should watch for: false positives in the new delimiter heuristics for unusual unquoted local paths.

## Risks and Mitigations

- Risk:
  - Unquoted local paths with unusual trailing syntax could still hit an edge case in the delimiter heuristics.
  - Mitigation: focused regression coverage now exercises structured tails, prose tails, brace-containing filenames, multi-media lines, and legacy unquoted-space paths.
