### PR TITLE
fix(feishu): report liveness status to prevent false health-monitor restarts

### DIFF
--- a/extensions/feishu/src/channel.ts
+++ b/extensions/feishu/src/channel.ts
@@ -363,6 +363,7 @@ export const feishuPlugin: ChannelPlugin<ResolvedFeishuAccount> = {
         runtime: ctx.runtime,
         abortSignal: ctx.abortSignal,
         accountId: ctx.accountId,
+        statusSink: (patch) => ctx.setStatus({ accountId: ctx.accountId, ...patch }),
       });
     },
   },

--- a/extensions/feishu/src/monitor.account.ts
+++ b/extensions/feishu/src/monitor.account.ts
@@ -126,12 +126,25 @@ export async function resolveReactionSyntheticEvent(
   };
 }
 
+export type FeishuMonitorStatusPatch = {
+  connected?: boolean;
+  lastEventAt?: number;
+  lastConnectedAt?: number;
+  lastError?: string | null;
+  lastDisconnect?: {
+    at: number;
+    status?: number | string;
+    error?: string;
+  };
+};
+
 type RegisterEventHandlersContext = {
   cfg: ClawdbotConfig;
   accountId: string;
   runtime?: RuntimeEnv;
   chatHistories: Map<string, HistoryEntry[]>;
   fireAndForget?: boolean;
+  statusSink?: (patch: FeishuMonitorStatusPatch) => void;
 };
 
 /**
@@ -231,7 +244,7 @@ function registerEventHandlers(
   eventDispatcher: Lark.EventDispatcher,
   context: RegisterEventHandlersContext,
 ): void {
-  const { cfg, accountId, runtime, chatHistories, fireAndForget } = context;
+  const { cfg, accountId, runtime, chatHistories, fireAndForget, statusSink } = context;
   const core = getFeishuRuntime();
   const inboundDebounceMs = core.channel.debounce.resolveInboundDebounceMs({
     cfg,
@@ -239,6 +252,9 @@ function registerEventHandlers(
   });
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
+  const markInboundEvent = () => {
+    statusSink?.({ lastEventAt: Date.now(), connected: true, lastError: null });
+  };
   const enqueue = createChatQueue();
   const dispatchFeishuMessage = async (event: FeishuMessageEvent) => {
     const chatId = event.message.chat_id?.trim() || "unknown";
@@ -380,6 +396,7 @@ function registerEventHandlers(
     "im.message.receive_v1": async (data) => {
       const processMessage = async () => {
         const event = data as unknown as FeishuMessageEvent;
+        markInboundEvent();
         await inboundDebouncer.enqueue(event);
       };
       if (fireAndForget) {
@@ -400,6 +417,7 @@ function registerEventHandlers(
     "im.chat.member.bot.added_v1": async (data) => {
       try {
         const event = data as unknown as FeishuBotAddedEvent;
+        markInboundEvent();
         log(`feishu[${accountId}]: bot added to chat ${event.chat_id}`);
       } catch (err) {
         error(`feishu[${accountId}]: error handling bot added event: ${String(err)}`);
@@ -408,6 +426,7 @@ function registerEventHandlers(
     "im.chat.member.bot.deleted_v1": async (data) => {
       try {
         const event = data as unknown as { chat_id: string };
+        markInboundEvent();
         log(`feishu[${accountId}]: bot removed from chat ${event.chat_id}`);
       } catch (err) {
         error(`feishu[${accountId}]: error handling bot removed event: ${String(err)}`);
@@ -416,6 +435,7 @@ function registerEventHandlers(
     "im.message.reaction.created_v1": async (data) => {
       const processReaction = async () => {
         const event = data as FeishuReactionCreatedEvent;
+        markInboundEvent();
         const myBotId = botOpenIds.get(accountId);
         const syntheticEvent = await resolveReactionSyntheticEvent({
           cfg,
@@ -464,6 +484,7 @@ function registerEventHandlers(
     "card.action.trigger": async (data: unknown) => {
       try {
         const event = data as unknown as FeishuCardActionEvent;
+        markInboundEvent();
         const promise = handleFeishuCardAction({
           cfg,
           event,
@@ -495,10 +516,11 @@ export type MonitorSingleAccountParams = {
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   botOpenIdSource?: BotOpenIdSource;
+  statusSink?: (patch: FeishuMonitorStatusPatch) => void;
 };
 
 export async function monitorSingleAccount(params: MonitorSingleAccountParams): Promise<void> {
-  const { cfg, account, runtime, abortSignal } = params;
+  const { cfg, account, runtime, abortSignal, statusSink } = params;
   const { accountId } = account;
   const log = runtime?.log ?? console.log;
 
@@ -516,6 +538,7 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
     botNames.delete(accountId);
   }
   log(`feishu[${accountId}]: bot open_id resolved: ${botOpenId ?? "unknown"}`);
+  statusSink?.({ connected: true, lastConnectedAt: Date.now(), lastError: null });
 
   const connectionMode = account.config.connectionMode ?? "websocket";
   if (connectionMode === "webhook" && !account.verificationToken?.trim()) {
@@ -536,10 +559,11 @@ export async function monitorSingleAccount(params: MonitorSingleAccountParams): 
     runtime,
     chatHistories,
     fireAndForget: true,
+    statusSink,
   });
 
   if (connectionMode === "webhook") {
-    return monitorWebhook({ account, accountId, runtime, abortSignal, eventDispatcher });
+    return monitorWebhook({ account, accountId, runtime, abortSignal, eventDispatcher, statusSink });
   }
-  return monitorWebSocket({ account, accountId, runtime, abortSignal, eventDispatcher });
+  return monitorWebSocket({ account, accountId, runtime, abortSignal, eventDispatcher, statusSink });
 }

--- a/extensions/feishu/src/monitor.reaction.test.ts
+++ b/extensions/feishu/src/monitor.reaction.test.ts
@@ -136,6 +136,7 @@ function createTextEvent(params: {
 async function setupDebounceMonitor(params?: {
   botOpenId?: string;
   botName?: string;
+  statusSink?: (patch: Record<string, unknown>) => void;
 }): Promise<(data: unknown) => Promise<void>> {
   const register = vi.fn((registered: Record<string, (data: unknown) => Promise<void>>) => {
     handlers = registered;
@@ -155,6 +156,7 @@ async function setupDebounceMonitor(params?: {
       botOpenId: params?.botOpenId ?? "ou_bot",
       botName: params?.botName,
     },
+    statusSink: params?.statusSink,
   });
 
   const onMessage = handlers["im.message.receive_v1"];
@@ -406,6 +408,24 @@ describe("Feishu inbound debounce regressions", () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  it("updates statusSink with lastEventAt when inbound message events arrive", async () => {
+    setDedupPassThroughMocks();
+    const statusSink = vi.fn();
+    const onMessage = await setupDebounceMonitor({ statusSink });
+
+    await onMessage(createTextEvent({ messageId: "om_status_1", text: "hello" }));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(statusSink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connected: true,
+        lastError: null,
+        lastEventAt: expect.any(Number),
+      }),
+    );
   });
 
   it("keeps bot mention when per-message mention keys collide across non-forward messages", async () => {

--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -16,6 +16,7 @@ import {
   recordWebhookStatus,
   wsClients,
 } from "./monitor.state.js";
+import type { FeishuMonitorStatusPatch } from "./monitor.account.js";
 import type { ResolvedFeishuAccount } from "./types.js";
 
 export type MonitorTransportParams = {
@@ -24,6 +25,7 @@ export type MonitorTransportParams = {
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   eventDispatcher: Lark.EventDispatcher;
+  statusSink?: (patch: FeishuMonitorStatusPatch) => void;
 };
 
 export async function monitorWebSocket({
@@ -32,6 +34,7 @@ export async function monitorWebSocket({
   runtime,
   abortSignal,
   eventDispatcher,
+  statusSink,
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
   log(`feishu[${accountId}]: starting WebSocket connection...`);
@@ -48,6 +51,10 @@ export async function monitorWebSocket({
 
     const handleAbort = () => {
       log(`feishu[${accountId}]: abort signal received, stopping`);
+      statusSink?.({
+        connected: false,
+        lastDisconnect: { at: Date.now(), error: "aborted" },
+      });
       cleanup();
       resolve();
     };
@@ -62,8 +69,14 @@ export async function monitorWebSocket({
 
     try {
       wsClient.start({ eventDispatcher });
+      statusSink?.({ connected: true, lastConnectedAt: Date.now(), lastError: null });
       log(`feishu[${accountId}]: WebSocket client started`);
     } catch (err) {
+      statusSink?.({
+        connected: false,
+        lastError: String(err),
+        lastDisconnect: { at: Date.now(), error: String(err) },
+      });
       cleanup();
       abortSignal?.removeEventListener("abort", handleAbort);
       reject(err);
@@ -77,6 +90,7 @@ export async function monitorWebhook({
   runtime,
   abortSignal,
   eventDispatcher,
+  statusSink,
 }: MonitorTransportParams): Promise<void> {
   const log = runtime?.log ?? console.log;
   const error = runtime?.error ?? console.error;
@@ -141,6 +155,10 @@ export async function monitorWebhook({
 
     const handleAbort = () => {
       log(`feishu[${accountId}]: abort signal received, stopping Webhook server`);
+      statusSink?.({
+        connected: false,
+        lastDisconnect: { at: Date.now(), error: "aborted" },
+      });
       cleanup();
       resolve();
     };
@@ -154,11 +172,17 @@ export async function monitorWebhook({
     abortSignal?.addEventListener("abort", handleAbort, { once: true });
 
     server.listen(port, host, () => {
+      statusSink?.({ connected: true, lastConnectedAt: Date.now(), lastError: null });
       log(`feishu[${accountId}]: Webhook server listening on ${host}:${port}`);
     });
 
     server.on("error", (err) => {
       error(`feishu[${accountId}]: Webhook server error: ${err}`);
+      statusSink?.({
+        connected: false,
+        lastError: String(err),
+        lastDisconnect: { at: Date.now(), error: String(err) },
+      });
       abortSignal?.removeEventListener("abort", handleAbort);
       reject(err);
     });

--- a/extensions/feishu/src/monitor.ts
+++ b/extensions/feishu/src/monitor.ts
@@ -3,6 +3,7 @@ import { listEnabledFeishuAccounts, resolveFeishuAccount } from "./accounts.js";
 import {
   monitorSingleAccount,
   resolveReactionSyntheticEvent,
+  type FeishuMonitorStatusPatch,
   type FeishuReactionCreatedEvent,
 } from "./monitor.account.js";
 import { fetchBotIdentityForMonitor } from "./monitor.startup.js";
@@ -18,6 +19,7 @@ export type MonitorFeishuOpts = {
   runtime?: RuntimeEnv;
   abortSignal?: AbortSignal;
   accountId?: string;
+  statusSink?: (patch: FeishuMonitorStatusPatch) => void;
 };
 
 export {
@@ -46,6 +48,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
       account,
       runtime: opts.runtime,
       abortSignal: opts.abortSignal,
+      statusSink: opts.statusSink,
     });
   }
 
@@ -83,6 +86,7 @@ export async function monitorFeishuProvider(opts: MonitorFeishuOpts = {}): Promi
         runtime: opts.runtime,
         abortSignal: opts.abortSignal,
         botOpenIdSource: { kind: "prefetched", botOpenId, botName },
+        statusSink: opts.statusSink,
       }),
     );
   }


### PR DESCRIPTION
## Summary

Implements channel-layer fix for Feishu (方案1 only): continuously report runtime liveness so gateway health monitor has valid signals.

### What changed

- Wire a `statusSink` from Feishu channel start path into monitor pipeline.
- Update Feishu runtime status on transport lifecycle:
  - `connected=true`, `lastConnectedAt` on websocket start / webhook listen
  - `connected=false`, `lastDisconnect`, `lastError` on abort/error
- Update liveness on inbound events:
  - on message / reaction / card action / bot-added / bot-deleted, set
    - `lastEventAt=Date.now()`
    - `connected=true`
    - `lastError=null`
- Add regression test coverage for status sink `lastEventAt` updates on inbound message events.

## Why

In mention-gated group flows, pending pre-mention history is memory-backed. False health-monitor restarts can clear it and cause partial context injection. This PR improves Feishu liveness reporting so monitor decisions are based on actual channel activity.

## Scope

- Only channel-layer implementation (no health policy logic change; no persistence refactor).

## Related

- Fixes #39486

## Testing

- Added test in `extensions/feishu/src/monitor.reaction.test.ts` for `statusSink` `lastEventAt` updates.
- Local full test run was not completed in this environment because `pnpm/corepack` is unavailable; please rely on CI for full validation.
