### PR TITLE
fix(ui): reset agent overview model form on agent switch

### DIFF
--- a/ui/src/ui/views/agents.ts
+++ b/ui/src/ui/views/agents.ts
@@ -1,4 +1,5 @@
 import { html, nothing } from "lit";
+import { keyed } from "lit/directives/keyed.js";
 import type {
   AgentIdentityResult,
   AgentsFilesListResult,
@@ -169,22 +170,25 @@ export function renderAgents(props: AgentsProps) {
                 ${renderAgentTabs(props.activePanel, (panel) => props.onSelectPanel(panel))}
                 ${
                   props.activePanel === "overview"
-                    ? renderAgentOverview({
-                        agent: selectedAgent,
-                        defaultId,
-                        configForm: props.configForm,
-                        agentFilesList: props.agentFilesList,
-                        agentIdentity: props.agentIdentityById[selectedAgent.id] ?? null,
-                        agentIdentityError: props.agentIdentityError,
-                        agentIdentityLoading: props.agentIdentityLoading,
-                        configLoading: props.configLoading,
-                        configSaving: props.configSaving,
-                        configDirty: props.configDirty,
-                        onConfigReload: props.onConfigReload,
-                        onConfigSave: props.onConfigSave,
-                        onModelChange: props.onModelChange,
-                        onModelFallbacksChange: props.onModelFallbacksChange,
-                      })
+                    ? keyed(
+                        selectedAgent.id,
+                        renderAgentOverview({
+                          agent: selectedAgent,
+                          defaultId,
+                          configForm: props.configForm,
+                          agentFilesList: props.agentFilesList,
+                          agentIdentity: props.agentIdentityById[selectedAgent.id] ?? null,
+                          agentIdentityError: props.agentIdentityError,
+                          agentIdentityLoading: props.agentIdentityLoading,
+                          configLoading: props.configLoading,
+                          configSaving: props.configSaving,
+                          configDirty: props.configDirty,
+                          onConfigReload: props.onConfigReload,
+                          onConfigSave: props.onConfigSave,
+                          onModelChange: props.onModelChange,
+                          onModelFallbacksChange: props.onModelFallbacksChange,
+                        }),
+                      )
                     : nothing
                 }
                 ${


### PR DESCRIPTION
## Summary
- key the Agents overview panel by `selectedAgent.id`
- force a remount of the model/fallback form controls when switching agents

## Why
Control UI could show stale model selection after switching `main -> another agent -> main` due to reused form element state across agent switches. Backend/runtime config remained correct, but the visible model dropdown could drift.

## Behavior after fix
When switching agents, the overview form is recreated for the selected agent id, so model/fallback controls always reflect that agent's own resolved config state.

## Test evidence
- `pnpm vitest run --config vitest.unit.config.ts ui/src/ui/controllers/agents.test.ts ui/src/ui/views/agents-utils.test.ts`
  - Passed: 2 files, 14 tests

Fixes #39392
