### PR TITLE
fix(secrets): prevent ByteString crashes from pasted unicode chars

### DIFF
--- a/src/config/types.secrets.test.ts
+++ b/src/config/types.secrets.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSecretInputString } from "./types.secrets.js";
+
+describe("normalizeSecretInputString", () => {
+  it("trims ordinary string input", () => {
+    expect(normalizeSecretInputString("  sk-test  ")).toBe("sk-test");
+  });
+
+  it("returns undefined for non-string or blank values", () => {
+    expect(normalizeSecretInputString(undefined)).toBeUndefined();
+    expect(normalizeSecretInputString(null)).toBeUndefined();
+    expect(normalizeSecretInputString("   \n\r  ")).toBeUndefined();
+  });
+
+  it("drops non-latin1 characters that break header ByteString conversion", () => {
+    // U+2502 (│) should be removed so malformed pasted secrets don't crash header setup.
+    expect(normalizeSecretInputString("│sk-test")).toBe("sk-test");
+    // Latin-1 characters should still be preserved.
+    expect(normalizeSecretInputString(" café-token ")).toBe("café-token");
+  });
+});

--- a/src/config/types.secrets.ts
+++ b/src/config/types.secrets.ts
@@ -1,3 +1,5 @@
+import { normalizeOptionalSecretInput } from "../utils/normalize-secret-input.js";
+
 export type SecretRefSource = "env" | "file" | "exec"; // pragma: allowlist secret
 
 /**
@@ -111,11 +113,7 @@ export function hasConfiguredSecretInput(value: unknown, defaults?: SecretDefaul
 }
 
 export function normalizeSecretInputString(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
+  return normalizeOptionalSecretInput(value);
 }
 
 function formatSecretRefLabel(ref: SecretRef): string {


### PR DESCRIPTION
## Summary
- make `normalizeSecretInputString` use the same robust secret normalization path used by other auth codepaths
- this strips non-Latin1 characters (for example U+2502 `│`) and line breaks from configured secret strings
- add tests covering ByteString-risk characters and latin1 preservation

## Why
Some pasted credentials can include rich-text / box-drawing characters. These can trigger Node/undici header construction failures like:

`Cannot convert argument to a ByteString ... value of 9474 (U+2502)`

By normalizing secret input at the shared config secret boundary, the request path fails gracefully as an auth error instead of crashing with a ByteString conversion error.

## Test evidence
- `pnpm vitest run --config vitest.unit.config.ts src/config/types.secrets.test.ts src/utils/normalize-secret-input.test.ts`
  - Passed: 2 files, 9 tests

Fixes #39426
