### PR TITLE
fix(ui): reduce browser password-save prompts in config form

### DIFF
--- a/ui/src/ui/config-form.browser.test.ts
+++ b/ui/src/ui/config-form.browser.test.ts
@@ -304,6 +304,52 @@ describe("config form renderer", () => {
     expect(noMatchContainer.textContent).toContain('No settings match "mode tag:security"');
   });
 
+  it("renders sensitive inputs with password-manager-resistant attributes", () => {
+    const onPatch = vi.fn();
+    const container = document.createElement("div");
+    const analysis = analyzeConfigSchema(rootSchema);
+    render(
+      renderConfigForm({
+        schema: analysis.schema,
+        uiHints: {
+          "gateway.auth.token": { label: "Gateway Token", sensitive: true },
+        },
+        unsupportedPaths: analysis.unsupportedPaths,
+        value: {},
+        onPatch,
+      }),
+      container,
+    );
+
+    const tokenInput: HTMLInputElement | null = container.querySelector("input[type='password']");
+    expect(tokenInput).not.toBeNull();
+    expect(tokenInput?.getAttribute("autocomplete")).toBe("new-password");
+    expect(tokenInput?.getAttribute("autocapitalize")).toBe("off");
+    expect(tokenInput?.getAttribute("autocorrect")).toBe("off");
+    expect(tokenInput?.getAttribute("spellcheck")).toBe("false");
+    expect(tokenInput?.getAttribute("data-form-type")).toBe("other");
+  });
+
+  it("renders non-sensitive text inputs with autocomplete off", () => {
+    const onPatch = vi.fn();
+    const container = document.createElement("div");
+    const analysis = analyzeConfigSchema(rootSchema);
+    render(
+      renderConfigForm({
+        schema: analysis.schema,
+        uiHints: {},
+        unsupportedPaths: analysis.unsupportedPaths,
+        value: {},
+        onPatch,
+      }),
+      container,
+    );
+
+    const textInput: HTMLInputElement | null = container.querySelector("input[type='text']");
+    expect(textInput).not.toBeNull();
+    expect(textInput?.getAttribute("autocomplete")).toBe("off");
+  });
+
   it("supports SecretInput unions in additionalProperties maps", () => {
     const onPatch = vi.fn();
     const container = document.createElement("div");

--- a/ui/src/ui/config-form.browser.test.ts
+++ b/ui/src/ui/config-form.browser.test.ts
@@ -350,6 +350,26 @@ describe("config form renderer", () => {
     expect(textInput?.getAttribute("autocomplete")).toBe("off");
   });
 
+  it("omits password-manager data attribute for non-sensitive text inputs", () => {
+    const onPatch = vi.fn();
+    const container = document.createElement("div");
+    const analysis = analyzeConfigSchema(rootSchema);
+    render(
+      renderConfigForm({
+        schema: analysis.schema,
+        uiHints: {},
+        unsupportedPaths: analysis.unsupportedPaths,
+        value: {},
+        onPatch,
+      }),
+      container,
+    );
+
+    const textInput: HTMLInputElement | null = container.querySelector("input[type='text']");
+    expect(textInput).not.toBeNull();
+    expect(textInput?.hasAttribute("data-form-type")).toBe(false);
+  });
+
   it("supports SecretInput unions in additionalProperties maps", () => {
     const onPatch = vi.fn();
     const container = document.createElement("div");

--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -568,6 +568,11 @@ function renderTextInput(params: {
           placeholder=${placeholder}
           .value=${displayValue == null ? "" : String(displayValue)}
           ?disabled=${disabled}
+          autocomplete=${isSensitive ? "new-password" : "off"}
+          autocapitalize="off"
+          autocorrect="off"
+          spellcheck="false"
+          data-form-type=${isSensitive ? "other" : ""}
           @input=${(e: Event) => {
             const raw = (e.target as HTMLInputElement).value;
             if (inputType === "number") {

--- a/ui/src/ui/views/config-form.node.ts
+++ b/ui/src/ui/views/config-form.node.ts
@@ -572,7 +572,7 @@ function renderTextInput(params: {
           autocapitalize="off"
           autocorrect="off"
           spellcheck="false"
-          data-form-type=${isSensitive ? "other" : ""}
+          data-form-type=${isSensitive ? "other" : nothing}
           @input=${(e: Event) => {
             const raw = (e.target as HTMLInputElement).value;
             if (inputType === "number") {


### PR DESCRIPTION
## Summary

Reduce browser password-manager prompts in the Control UI config form.

When sensitive config fields are rendered as password inputs, some browsers may mistake nearby settings as part of a login form and prompt users to save a password when navigating away.

## Changes

- add `autocomplete="new-password"` for sensitive config inputs
- add `autocomplete="off"` for non-sensitive text inputs
- disable autocapitalize/autocorrect/spellcheck on config text inputs
- add `data-form-type="other"` for sensitive inputs to further discourage password-manager heuristics
- add browser tests covering the new attributes

## Notes

This is a narrow UI-only mitigation intended to preserve masked secret input behavior while reducing false password-save prompts.

Fixes #24801