### PR TITLE
feat(plugins): workspace-shield — protect critical files from agent writes

### DIFF
--- a/extensions/workspace-shield/index.ts
+++ b/extensions/workspace-shield/index.ts
@@ -1,0 +1,180 @@
+/**
+ * Workspace Shield
+ *
+ * Protects critical workspace files from accidental agent writes.
+ * Uses the before_tool_call hook to intercept Write and Edit operations
+ * targeting protected files and blocks them with a clear explanation.
+ *
+ * Configuration:
+ *   protectedFiles    — explicit file paths to protect
+ *   protectedPatterns — glob patterns for protected files
+ *   allowReads        — whether Read is allowed on protected files (default: true)
+ *   logViolations     — whether to log blocked operations (default: true)
+ *   violationsPath    — path for the violations log file
+ */
+
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
+import fs from "node:fs";
+import path from "node:path";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+interface PluginConfig {
+  protectedFiles?: string[];
+  protectedPatterns?: string[];
+  allowReads?: boolean;
+  logViolations?: boolean;
+  violationsPath?: string;
+}
+
+interface ViolationRecord {
+  timestamp: string;
+  tool: string;
+  file: string;
+  action: "blocked" | "logged";
+  reason: string;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/** Convert a simple glob pattern to a regex. Supports * and ** wildcards. */
+function globToRegex(pattern: string): RegExp {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "<<<GLOBSTAR>>>")
+    .replace(/\*/g, "[^/]*")
+    .replace(/<<<GLOBSTAR>>>/g, ".*");
+  return new RegExp(`^${escaped}$`);
+}
+
+/** Extract the file path from a tool call's parameters. */
+function extractFilePath(toolName: string, params: Record<string, unknown>): string | null {
+  // The Write, Edit, and Read tools accept both `path` and `file_path`
+  const raw = params.file_path ?? params.path ?? params.filePath;
+  return typeof raw === "string" ? raw : null;
+}
+
+/** Resolve a path relative to the workspace, handling absolute paths. */
+function toRelative(filePath: string, workspaceDir: string): string {
+  const resolved = path.resolve(workspaceDir, filePath);
+  if (resolved.startsWith(workspaceDir + path.sep) || resolved === workspaceDir) {
+    return path.relative(workspaceDir, resolved);
+  }
+  // For absolute paths outside workspace, return the original
+  return filePath;
+}
+
+// ── Plugin ─────────────────────────────────────────────────────────────
+
+export default function register(api: OpenClawPluginApi) {
+  const config = (api.config ?? {}) as PluginConfig;
+  const workspaceDir = api.workspaceDir ?? process.cwd();
+
+  const protectedFiles = new Set(
+    (config.protectedFiles ?? []).map((f) => f.trim()).filter(Boolean),
+  );
+  const protectedPatterns = (config.protectedPatterns ?? [])
+    .map((p) => p.trim())
+    .filter(Boolean)
+    .map(globToRegex);
+
+  const allowReads = config.allowReads !== false;
+  const logViolations = config.logViolations !== false;
+  const violationsPath = path.resolve(
+    workspaceDir,
+    config.violationsPath ?? "shield-violations.jsonl",
+  );
+
+  // Write tools that modify files
+  const WRITE_TOOLS = new Set(["Write", "Edit"]);
+  const READ_TOOLS = new Set(["Read"]);
+
+  function isProtected(relativePath: string): boolean {
+    if (protectedFiles.has(relativePath)) {
+      return true;
+    }
+    for (const regex of protectedPatterns) {
+      if (regex.test(relativePath)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function logViolation(record: ViolationRecord): void {
+    if (!logViolations) return;
+    try {
+      const dir = path.dirname(violationsPath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      fs.appendFileSync(violationsPath, JSON.stringify(record) + "\n");
+    } catch {
+      // Non-fatal
+    }
+  }
+
+  if (protectedFiles.size === 0 && protectedPatterns.length === 0) {
+    api.logger.info(
+      "[workspace-shield] No protected files or patterns configured. " +
+        "Add protectedFiles or protectedPatterns to your plugin config.",
+    );
+    return;
+  }
+
+  api.logger.info(
+    `[workspace-shield] Protecting ${protectedFiles.size} files + ${protectedPatterns.length} patterns`,
+  );
+
+  // ── Hook: before_tool_call ──────────────────────────────────────────
+
+  api.on(
+    "before_tool_call",
+    (event: { toolName: string; params: Record<string, unknown> }) => {
+      const { toolName, params } = event;
+
+      const isWrite = WRITE_TOOLS.has(toolName);
+      const isRead = READ_TOOLS.has(toolName);
+
+      if (!isWrite && !isRead) return {};
+
+      const filePath = extractFilePath(toolName, params);
+      if (!filePath) return {};
+
+      const relativePath = toRelative(filePath, workspaceDir);
+
+      if (!isProtected(relativePath)) return {};
+
+      if (isRead && allowReads) {
+        // Log the read but allow it
+        logViolation({
+          timestamp: new Date().toISOString(),
+          tool: toolName,
+          file: relativePath,
+          action: "logged",
+          reason: "read allowed on protected file",
+        });
+        return {};
+      }
+
+      // Block the operation
+      logViolation({
+        timestamp: new Date().toISOString(),
+        tool: toolName,
+        file: relativePath,
+        action: "blocked",
+        reason: `${toolName} blocked on protected file`,
+      });
+
+      const action = isWrite ? "modify" : "read";
+      return {
+        block: true,
+        blockReason:
+          `🛡️ **Workspace Shield**: \`${relativePath}\` is a protected file. ` +
+          `${toolName} operations that ${action} this file are blocked. ` +
+          `If you need to update this file, ask the user to do it manually ` +
+          `or have them temporarily disable protection in the plugin config.`,
+      };
+    },
+  );
+}

--- a/extensions/workspace-shield/openclaw.plugin.json
+++ b/extensions/workspace-shield/openclaw.plugin.json
@@ -1,0 +1,37 @@
+{
+  "id": "workspace-shield",
+  "name": "Workspace Shield",
+  "description": "Protects critical workspace files from accidental writes by the agent. Intercepts Write and Edit tool calls targeting protected files and blocks them with a helpful explanation.",
+  "version": "1.0.0",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "protectedFiles": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "List of file paths (relative to workspace) to protect from writes. Example: [\"SOUL.md\", \"IDENTITY.md\", \"openclaw.json\"]"
+      },
+      "protectedPatterns": {
+        "type": "array",
+        "items": { "type": "string" },
+        "description": "Glob-like patterns for files to protect. Supports * and ** wildcards. Example: [\"*.env\", \"secrets/**\"]"
+      },
+      "allowReads": {
+        "type": "boolean",
+        "default": true,
+        "description": "Whether to allow Read operations on protected files (default: true). Set to false to also block reads."
+      },
+      "logViolations": {
+        "type": "boolean",
+        "default": true,
+        "description": "Whether to log blocked operations to a violations file."
+      },
+      "violationsPath": {
+        "type": "string",
+        "default": "shield-violations.jsonl",
+        "description": "Path (relative to workspace) for the violations log."
+      }
+    }
+  }
+}

--- a/extensions/workspace-shield/workspace-shield.test.ts
+++ b/extensions/workspace-shield/workspace-shield.test.ts
@@ -1,0 +1,186 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+function createMockApi(workspaceDir: string, config: Record<string, unknown> = {}) {
+  const handlers: Record<string, Function> = {};
+  return {
+    api: {
+      config,
+      workspaceDir,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      },
+      on: (event: string, handler: Function) => {
+        handlers[event] = handler;
+      },
+    },
+    handlers,
+  };
+}
+
+describe("workspace-shield plugin", () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "workspace-shield-test-"));
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("blocks Write to protected files", async () => {
+    const { api, handlers } = createMockApi(tmpDir, {
+      protectedFiles: ["SOUL.md", "IDENTITY.md"],
+    });
+    const { default: register } = await import("./index.js");
+    register(api as any);
+
+    const result = handlers.before_tool_call({
+      toolName: "Write",
+      params: { file_path: "SOUL.md", content: "overwritten" },
+    });
+
+    expect(result.block).toBe(true);
+    expect(result.blockReason).toContain("protected file");
+    expect(result.blockReason).toContain("SOUL.md");
+  });
+
+  it("blocks Edit to protected files", async () => {
+    const { api, handlers } = createMockApi(tmpDir, {
+      protectedFiles: ["SOUL.md"],
+    });
+    const { default: register } = await import("./index.js");
+    register(api as any);
+
+    const result = handlers.before_tool_call({
+      toolName: "Edit",
+      params: { file_path: "SOUL.md", old_string: "a", new_string: "b" },
+    });
+
+    expect(result.block).toBe(true);
+  });
+
+  it("allows Read on protected files by default", async () => {
+    const { api, handlers } = createMockApi(tmpDir, {
+      protectedFiles: ["SOUL.md"],
+    });
+    const { default: register } = await import("./index.js");
+    register(api as any);
+
+    const result = handlers.before_tool_call({
+      toolName: "Read",
+      params: { path: "SOUL.md" },
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it("blocks Read when allowReads is false", async () => {
+    const { api, handlers } = createMockApi(tmpDir, {
+      protectedFiles: ["secrets.env"],
+      allowReads: false,
+    });
+    const { default: register } = await import("./index.js");
+    register(api as any);
+
+    const result = handlers.before_tool_call({
+      toolName: "Read",
+      params: { path: "secrets.env" },
+    });
+
+    expect(result.block).toBe(true);
+  });
+
+  it("allows operations on non-protected files", async () => {
+    const { api, handlers } = createMockApi(tmpDir, {
+      protectedFiles: ["SOUL.md"],
+    });
+    const { default: register } = await import("./index.js");
+    register(api as any);
+
+    const result = handlers.before_tool_call({
+      toolName: "Write",
+      params: { file_path: "README.md", content: "hello" },
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it("supports glob patterns", async () => {
+    const { api, handlers } = createMockApi(tmpDir, {
+      protectedPatterns: ["*.env", "secrets/**"],
+    });
+    const { default: register } = await import("./index.js");
+    register(api as any);
+
+    const envResult = handlers.before_tool_call({
+      toolName: "Write",
+      params: { file_path: ".env", content: "SECRET=x" },
+    });
+    expect(envResult.block).toBe(true);
+
+    const secretResult = handlers.before_tool_call({
+      toolName: "Write",
+      params: { file_path: "secrets/api-key.txt", content: "sk-..." },
+    });
+    expect(secretResult.block).toBe(true);
+
+    const safeResult = handlers.before_tool_call({
+      toolName: "Write",
+      params: { file_path: "notes.md", content: "safe" },
+    });
+    expect(safeResult).toEqual({});
+  });
+
+  it("allows unrelated tools through", async () => {
+    const { api, handlers } = createMockApi(tmpDir, {
+      protectedFiles: ["SOUL.md"],
+    });
+    const { default: register } = await import("./index.js");
+    register(api as any);
+
+    const result = handlers.before_tool_call({
+      toolName: "exec",
+      params: { command: "echo hello" },
+    });
+
+    expect(result).toEqual({});
+  });
+
+  it("logs violations when logViolations is true", async () => {
+    const logPath = path.join(tmpDir, "test-violations.jsonl");
+    const { api, handlers } = createMockApi(tmpDir, {
+      protectedFiles: ["SOUL.md"],
+      violationsPath: logPath,
+    });
+    const { default: register } = await import("./index.js");
+    register(api as any);
+
+    handlers.before_tool_call({
+      toolName: "Write",
+      params: { file_path: "SOUL.md", content: "bad" },
+    });
+
+    expect(fs.existsSync(logPath)).toBe(true);
+    const log = fs.readFileSync(logPath, "utf-8").trim();
+    const record = JSON.parse(log);
+    expect(record.tool).toBe("Write");
+    expect(record.file).toBe("SOUL.md");
+    expect(record.action).toBe("blocked");
+  });
+
+  it("does nothing when no files or patterns are configured", async () => {
+    const { api, handlers } = createMockApi(tmpDir, {});
+    const { default: register } = await import("./index.js");
+    register(api as any);
+
+    // No before_tool_call handler should be registered
+    expect(handlers.before_tool_call).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new bundled plugin (`workspace-shield`) that protects critical workspace files from accidental agent writes. Uses the `before_tool_call` hook to intercept `Write` and `Edit` operations targeting protected files and blocks them with a clear, helpful explanation.

## Acknowledgment

The file protection concept was inspired by the Shield pattern from [ResonantOS](https://resonantos.substack.com/) by Manolo Remiddi — the idea that certain agent-critical files should be immutable during normal operation, with violations logged for audit. Our implementation adapts this into an OpenClaw plugin using the `before_tool_call` hook with configurable file lists, glob patterns, and violation logging.

## Problem

Every OpenClaw user with files like `SOUL.md`, `IDENTITY.md`, `.env`, or `openclaw.json` in their workspace risks the agent accidentally overwriting them during normal operation. There is currently no built-in way to mark files as read-only for the agent while keeping them readable.

## Solution

A simple plugin that intercepts tool calls and checks file paths against a configurable protection list:

```json
{
  "plugins": {
    "entries": {
      "workspace-shield": {
        "enabled": true,
        "config": {
          "protectedFiles": ["SOUL.md", "IDENTITY.md", ".env"],
          "protectedPatterns": ["secrets/**", "*.key"]
        }
      }
    }
  }
}
```

When the agent tries to write to a protected file, it receives:

> 🛡️ **Workspace Shield**: `SOUL.md` is a protected file. Write operations that modify this file are blocked. If you need to update this file, ask the user to do it manually or have them temporarily disable protection in the plugin config.

## Features

- **Explicit file protection** — list specific files by path
- **Glob pattern support** — `*.env`, `secrets/**`, etc.
- **Configurable read policy** — reads allowed by default, optionally blocked
- **Violation logging** — blocked operations logged to JSONL for audit
- **Zero overhead when unconfigured** — no hook registered if no files are protected
- **Clear block messages** — the agent knows why it was blocked and what to tell the user

## Testing

9 tests covering: write blocking, edit blocking, read passthrough, read blocking when configured, non-protected passthrough, glob patterns, unrelated tools passthrough, violation logging, and empty config handling.