### PR TITLE
fix(config): coerce commands.allowFrom array to record format (#39500)

### DIFF
--- a/src/config/validation.allowed-values.test.ts
+++ b/src/config/validation.allowed-values.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { validateConfigObjectRaw } from "./validation.js";
+import { ElevatedAllowFromSchema } from "./zod-schema.agent-runtime.js";
 
 describe("config validation allowed-values metadata", () => {
   it("adds allowed values for invalid union paths", () => {
@@ -72,6 +73,43 @@ describe("config validation allowed-values metadata", () => {
       expect(issue?.allowedValues).toBeUndefined();
       expect(issue?.allowedValuesHiddenCount).toBeUndefined();
       expect(issue?.message).not.toContain("(allowed:");
+    }
+  });
+});
+
+describe("ElevatedAllowFromSchema — legacy array coercion (#39500)", () => {
+  it("accepts canonical record format", () => {
+    const result = ElevatedAllowFromSchema.safeParse({
+      discord: ["userId1", "userId2"],
+      "*": ["adminId"],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ discord: ["userId1", "userId2"], "*": ["adminId"] });
+    }
+  });
+
+  it("coerces legacy array shorthand to {'*': array}", () => {
+    const result = ElevatedAllowFromSchema.safeParse(["userId1", "userId2"]);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ "*": ["userId1", "userId2"] });
+    }
+  });
+
+  it("passes through undefined (optional field)", () => {
+    const result = ElevatedAllowFromSchema.safeParse(undefined);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toBeUndefined();
+    }
+  });
+
+  it("coerces empty array to {'*': []}", () => {
+    const result = ElevatedAllowFromSchema.safeParse([]);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ "*": [] });
     }
   });
 });

--- a/src/config/zod-schema.agent-runtime.ts
+++ b/src/config/zod-schema.agent-runtime.ts
@@ -372,9 +372,12 @@ export const ToolPolicyWithProfileSchema = z
   });
 
 // Provider docking: allowlists keyed by provider id (no schema updates when adding providers).
-export const ElevatedAllowFromSchema = z
-  .record(z.string(), z.array(z.union([z.string(), z.number()])))
-  .optional();
+// Accepts both the canonical record format {"discord": [...]} and a legacy shorthand array
+// ["userId", ...] which is coerced to {"*": ["userId", ...]} for backward-compat (#39500).
+export const ElevatedAllowFromSchema = z.preprocess(
+  (val) => (Array.isArray(val) ? { "*": val } : val),
+  z.record(z.string(), z.array(z.union([z.string(), z.number()]))).optional(),
+);
 
 const ToolExecApplyPatchSchema = z
   .object({


### PR DESCRIPTION
## Problem

When users configure `commands.allowFrom` as a flat array (e.g. `["discordId"]`) instead of the canonical record format (`{"discord": ["discordId"]}`), the Zod schema rejects it with:

```
Config validation failed: commands.allowFrom: Invalid input: expected record, received array
```

This causes the gateway to fail to start, even though the user's intent is clear: allow the listed IDs from any channel.

Fixes #39500

## Root Cause

`ElevatedAllowFromSchema` is typed as `z.record(z.string(), z.array(...))`, which rejects plain arrays. There was no coercion path for the common shorthand.

## Fix

Add a `z.preprocess` step to `ElevatedAllowFromSchema` that coerces an array value to `{"*": array}`. The wildcard key `"*"` is already handled by `resolveCommandsAllowFromList` as a global allowlist, so no downstream changes are needed.

This affects both `commands.allowFrom` and `tools.elevated.allowFrom` (both use `ElevatedAllowFromSchema`).

## Tests

Added 4 new test cases to `validation.allowed-values.test.ts` covering:
- Canonical record format accepted unchanged
- Array shorthand coerced to `{"*": array}`
- `undefined` (optional field) passes through
- Empty array coerced to `{"*": []}`