### PR TITLE
fix(webchat): suppress partial NO_REPLY prefix flicker in stream (#39473)

### DIFF
--- a/ui/src/ui/controllers/chat.test.ts
+++ b/ui/src/ui/controllers/chat.test.ts
@@ -70,6 +70,28 @@ describe("handleChatEvent", () => {
     expect(state.chatStream).toBe("Hello");
   });
 
+  it("ignores partial NO_REPLY prefix delta updates to prevent flash (#39473)", () => {
+    // When NO_REPLY arrives in multiple chunks (e.g. "NO" then "NO_REPLY"), the
+    // partial prefix "NO" must not briefly appear in the stream bubble.
+    for (const partial of ["N", "NO", "NO_", "NO_R", "NO_RE", "NO_REP", "NO_REPL"]) {
+      const state = createState({
+        sessionKey: "main",
+        chatRunId: "run-1",
+        chatStream: "",
+      });
+      const payload: ChatEventPayload = {
+        runId: "run-1",
+        sessionKey: "main",
+        state: "delta",
+        message: { role: "assistant", content: [{ type: "text", text: partial }] },
+      };
+      expect(handleChatEvent(state, payload), `partial "${partial}" should be suppressed`).toBe(
+        "delta",
+      );
+      expect(state.chatStream, `partial "${partial}" must not update chatStream`).toBe("");
+    }
+  });
+
   it("appends final payload from another run without clearing active stream", () => {
     const state = createState({
       sessionKey: "main",

--- a/ui/src/ui/controllers/chat.ts
+++ b/ui/src/ui/controllers/chat.ts
@@ -5,9 +5,12 @@ import type { ChatAttachment } from "../ui-types.ts";
 import { generateUUID } from "../uuid.ts";
 
 const SILENT_REPLY_PATTERN = /^\s*NO_REPLY\s*$/;
+// Partial prefixes that could grow into NO_REPLY. Suppressing them prevents the
+// token from briefly flashing as "NO" in the stream before the full chunk arrives (#39473).
+const SILENT_REPLY_PREFIX_PATTERN = /^\s*(?:N|NO|NO_|NO_R|NO_RE|NO_REP|NO_REPL)\s*$/;
 
 function isSilentReplyStream(text: string): boolean {
-  return SILENT_REPLY_PATTERN.test(text);
+  return SILENT_REPLY_PATTERN.test(text) || SILENT_REPLY_PREFIX_PATTERN.test(text);
 }
 /** Client-side defense-in-depth: detect assistant messages whose text is purely NO_REPLY. */
 function isAssistantSilentReply(message: unknown): boolean {


### PR DESCRIPTION
## Problem

Internal control tokens like `NO_REPLY` can arrive via streaming in multiple chunks. When the partial prefix `"NO"` arrives before `"_REPLY"`, `isSilentReplyStream` correctly matched the complete token but not the partial prefixes. The partial chunk `"NO"` passed the filter and briefly appeared in the user-visible stream bubble before being overwritten.

Users reported seeing:
- `NO` flashing before the actual assistant reply
- `NO_REPLY` appearing as a visible message

Fixes #39473

## Root Cause

`isSilentReplyStream` used a single pattern `/^\s*NO_REPLY\s*$/` which only matches the complete 8-character token. Streaming delivers text cumulatively (each delta replaces the previous if longer), so partial prefixes like `"NO"` (a valid prefix of `"NO_REPLY"`) would update `chatStream` and render in the UI.

## Fix

Add `SILENT_REPLY_PREFIX_PATTERN` that matches every strict prefix of `NO_REPLY`:
`N`, `NO`, `NO_`, `NO_R`, `NO_RE`, `NO_REP`, `NO_REPL`.

`isSilentReplyStream` now returns `true` for any of these partial tokens, preventing `chatStream` from being updated during delta events.

**Note on final messages**: `isAssistantSilentReply` uses `isSilentReplyStream` internally but operates on complete final messages (which always contain the full `NO_REPLY` token). The prefix pattern does not affect final message filtering.

**Legitimate short responses**: A genuine one-word `"NO"` response would be suppressed during streaming but still appear correctly in the final message (committed to `chatMessages` after the `"final"` event, which is NOT filtered by the prefix pattern).

## Tests

Added a new test case that verifies each prefix (`N`, `NO`, `NO_`, etc.) is suppressed during delta streaming without updating `chatStream`.