### PR TITLE
feat(feishu): add localRoots configuration for media uploads and enhance media handling tests

### DIFF
--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -165,7 +165,13 @@ const FeishuSharedConfigShape = {
   chunkMode: z.enum(["length", "newline"]).optional(),
   blockStreamingCoalesce: BlockStreamingCoalesceSchema,
   mediaMaxMb: z.number().positive().optional(),
-  /** Allowed roots for local media paths, or "any" to allow any path. Used by sendMedia/local file uploads. */
+  /**
+   * Allowed roots for local media paths (sendMedia / local file uploads). Array of absolute
+   * directory paths, or "any" to allow any local path.
+   * Security: "any" bypasses path-containment checks and grants unrestricted filesystem read
+   * access to the process. Prefer explicit path arrays in production; use "any" only in
+   * trusted environments (e.g. dev or locked-down hosts).
+   */
   localRoots: z.union([z.literal("any"), z.array(z.string())]).optional(),
   httpTimeoutMs: z.number().int().positive().max(300_000).optional(),
   heartbeat: ChannelHeartbeatVisibilitySchema,

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -165,6 +165,8 @@ const FeishuSharedConfigShape = {
   chunkMode: z.enum(["length", "newline"]).optional(),
   blockStreamingCoalesce: BlockStreamingCoalesceSchema,
   mediaMaxMb: z.number().positive().optional(),
+  /** Allowed roots for local media paths, or "any" to allow any path. Used by sendMedia/local file uploads. */
+  localRoots: z.union([z.literal("any"), z.array(z.string())]).optional(),
   httpTimeoutMs: z.number().int().positive().max(300_000).optional(),
   heartbeat: ChannelHeartbeatVisibilitySchema,
   renderMode: RenderModeSchema,

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -345,6 +345,34 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
+  it("honors explicit empty localRoots (no fallback to context mediaLocalRoots)", async () => {
+    resolveFeishuAccountMock.mockReturnValueOnce({
+      configured: true,
+      accountId: "main",
+      config: { localRoots: [] },
+    });
+    loadWebMediaMock.mockRejectedValueOnce(
+      new (class extends Error {
+        code = "path-not-allowed";
+        name = "LocalMediaAccessError";
+      })(),
+    );
+
+    await expect(
+      sendMediaFeishu({
+        cfg: {} as any,
+        to: "user:ou_target",
+        mediaUrl: "/some/local/file.png",
+        mediaLocalRoots: ["/allowed/context/root"],
+      }),
+    ).rejects.toMatchObject({ code: "path-not-allowed" });
+
+    expect(loadWebMediaMock).toHaveBeenCalledWith(
+      "/some/local/file.png",
+      expect.objectContaining({ localRoots: [] }),
+    );
+  });
+
   it("fails closed when media URL fetch is blocked", async () => {
     loadWebMediaMock.mockRejectedValueOnce(
       new Error("Blocked: resolves to private/internal IP address"),

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -288,6 +288,53 @@ describe("sendMediaFeishu msg_type routing", () => {
     );
   });
 
+  it("uses channels.feishu.localRoots 'any' and passes readFile for local paths", async () => {
+    loadWebMediaMock.mockResolvedValue({
+      buffer: Buffer.from("local-file"),
+      fileName: "pic.png",
+      kind: "image",
+      contentType: "image/png",
+    });
+
+    await sendMediaFeishu({
+      cfg: { channels: { feishu: { localRoots: "any" } } } as any,
+      to: "user:ou_target",
+      mediaUrl: "/Users/zhengxing/openclaw/workspace/ask_official.png",
+    });
+
+    expect(loadWebMediaMock).toHaveBeenCalledWith(
+      "/Users/zhengxing/openclaw/workspace/ask_official.png",
+      expect.objectContaining({
+        localRoots: "any",
+        readFile: expect.any(Function),
+      }),
+    );
+  });
+
+  it("uses channels.feishu.localRoots array over context mediaLocalRoots", async () => {
+    loadWebMediaMock.mockResolvedValue({
+      buffer: Buffer.from("local-file"),
+      fileName: "doc.pdf",
+      kind: "document",
+      contentType: "application/pdf",
+    });
+
+    const channelRoots = ["/custom/feishu/root"];
+    await sendMediaFeishu({
+      cfg: { channels: { feishu: { localRoots: channelRoots } } } as any,
+      to: "user:ou_target",
+      mediaUrl: "/custom/feishu/root/file.pdf",
+      mediaLocalRoots: ["/other/context/root"],
+    });
+
+    expect(loadWebMediaMock).toHaveBeenCalledWith(
+      "/custom/feishu/root/file.pdf",
+      expect.objectContaining({
+        localRoots: channelRoots,
+      }),
+    );
+  });
+
   it("fails closed when media URL fetch is blocked", async () => {
     loadWebMediaMock.mockRejectedValueOnce(
       new Error("Blocked: resolves to private/internal IP address"),

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -295,15 +295,20 @@ describe("sendMediaFeishu msg_type routing", () => {
       kind: "image",
       contentType: "image/png",
     });
+    resolveFeishuAccountMock.mockReturnValueOnce({
+      configured: true,
+      accountId: "main",
+      config: { localRoots: "any" },
+    });
 
     await sendMediaFeishu({
       cfg: { channels: { feishu: { localRoots: "any" } } } as any,
       to: "user:ou_target",
-      mediaUrl: "/Users/zhengxing/openclaw/workspace/ask_official.png",
+      mediaUrl: "/local/feishu/workspace/ask_official.png",
     });
 
     expect(loadWebMediaMock).toHaveBeenCalledWith(
-      "/Users/zhengxing/openclaw/workspace/ask_official.png",
+      "/local/feishu/workspace/ask_official.png",
       expect.objectContaining({
         localRoots: "any",
         readFile: expect.any(Function),
@@ -320,6 +325,11 @@ describe("sendMediaFeishu msg_type routing", () => {
     });
 
     const channelRoots = ["/custom/feishu/root"];
+    resolveFeishuAccountMock.mockReturnValueOnce({
+      configured: true,
+      accountId: "main",
+      config: { localRoots: channelRoots },
+    });
     await sendMediaFeishu({
       cfg: { channels: { feishu: { localRoots: channelRoots } } } as any,
       to: "user:ou_target",

--- a/extensions/feishu/src/media.test.ts
+++ b/extensions/feishu/src/media.test.ts
@@ -343,6 +343,9 @@ describe("sendMediaFeishu msg_type routing", () => {
         localRoots: channelRoots,
       }),
     );
+    // readFile bypass must NOT be injected for a plain array of roots.
+    const callArg = loadWebMediaMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(callArg).not.toHaveProperty("readFile");
   });
 
   it("honors explicit empty localRoots (no fallback to context mediaLocalRoots)", async () => {

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -8,6 +8,7 @@ import { normalizeFeishuExternalKey } from "./external-keys.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
+import type { FeishuConfig } from "./types.js";
 
 const FEISHU_MEDIA_HTTP_TIMEOUT_MS = 120_000;
 
@@ -414,9 +415,28 @@ export function detectFileType(
 }
 
 /**
+ * Resolve effective localRoots for loadWebMedia: channel config (localRoots) overrides
+ * context mediaLocalRoots. Supports channels.feishu.localRoots = "any" or string[].
+ */
+function resolveFeishuMediaLocalRoots(params: {
+  cfg: ClawdbotConfig;
+  mediaLocalRoots?: readonly string[];
+}): readonly string[] | "any" | undefined {
+  const feishuCfg = params.cfg.channels?.feishu as FeishuConfig | undefined;
+  const channelRoots = feishuCfg?.localRoots;
+  if (channelRoots === "any") {
+    return "any";
+  }
+  if (Array.isArray(channelRoots) && channelRoots.length > 0) {
+    return channelRoots;
+  }
+  return params.mediaLocalRoots?.length ? params.mediaLocalRoots : undefined;
+}
+
+/**
  * Upload and send media (image or file) from URL, local path, or buffer.
- * When mediaUrl is a local path, mediaLocalRoots (from core outbound context)
- * must be passed so loadWebMedia allows the path (post CVE-2026-26321).
+ * When mediaUrl is a local path, allowed roots come from channels.feishu.localRoots
+ * (or "any") or from core outbound mediaLocalRoots.
  */
 export async function sendMediaFeishu(params: {
   cfg: ClawdbotConfig;
@@ -427,7 +447,7 @@ export async function sendMediaFeishu(params: {
   replyToMessageId?: string;
   replyInThread?: boolean;
   accountId?: string;
-  /** Allowed roots for local path reads; required for local filePath to work. */
+  /** Allowed roots for local path reads (from core); overridden by channels.feishu.localRoots. */
   mediaLocalRoots?: readonly string[];
 }): Promise<SendMediaResult> {
   const {
@@ -454,11 +474,22 @@ export async function sendMediaFeishu(params: {
     buffer = mediaBuffer;
     name = fileName ?? "file";
   } else if (mediaUrl) {
-    const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
+    const localRoots = resolveFeishuMediaLocalRoots({ cfg, mediaLocalRoots });
+    const loadOptions: {
+      maxBytes: number;
+      optimizeImages: boolean;
+      localRoots: readonly string[] | "any" | undefined;
+      readFile?: (filePath: string) => Promise<Buffer>;
+    } = {
       maxBytes: mediaMaxBytes,
       optimizeImages: false,
-      localRoots: mediaLocalRoots?.length ? mediaLocalRoots : undefined,
-    });
+      localRoots,
+    };
+    // Core requires readFile override when localRoots is "any" (unsafe-bypass guard).
+    if (localRoots === "any") {
+      loadOptions.readFile = (filePath: string) => fs.promises.readFile(filePath);
+    }
+    const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, loadOptions);
     buffer = loaded.buffer;
     name = fileName ?? loaded.fileName ?? "file";
   } else {

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -426,7 +426,8 @@ function resolveFeishuMediaLocalRoots(params: {
   if (channelRoots === "any") {
     return "any";
   }
-  if (Array.isArray(channelRoots) && channelRoots.length > 0) {
+  // Honor explicit array (including empty): [] means disable local-path reads for Feishu.
+  if (Array.isArray(channelRoots)) {
     return channelRoots;
   }
   return params.mediaLocalRoots?.length ? params.mediaLocalRoots : undefined;

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -415,15 +415,14 @@ export function detectFileType(
 }
 
 /**
- * Resolve effective localRoots for loadWebMedia: channel config (localRoots) overrides
- * context mediaLocalRoots. Supports channels.feishu.localRoots = "any" or string[].
+ * Resolve effective localRoots for loadWebMedia from merged account config (so
+ * channels.feishu.accounts.<id>.localRoots overrides top-level). Supports "any" or string[].
  */
 function resolveFeishuMediaLocalRoots(params: {
-  cfg: ClawdbotConfig;
+  feishuConfig: FeishuConfig | undefined;
   mediaLocalRoots?: readonly string[];
 }): readonly string[] | "any" | undefined {
-  const feishuCfg = params.cfg.channels?.feishu as FeishuConfig | undefined;
-  const channelRoots = feishuCfg?.localRoots;
+  const channelRoots = params.feishuConfig?.localRoots;
   if (channelRoots === "any") {
     return "any";
   }
@@ -435,8 +434,8 @@ function resolveFeishuMediaLocalRoots(params: {
 
 /**
  * Upload and send media (image or file) from URL, local path, or buffer.
- * When mediaUrl is a local path, allowed roots come from channels.feishu.localRoots
- * (or "any") or from core outbound mediaLocalRoots.
+ * When mediaUrl is a local path, allowed roots come from merged Feishu config
+ * (channels.feishu.localRoots or channels.feishu.accounts.<id>.localRoots) or core mediaLocalRoots.
  */
 export async function sendMediaFeishu(params: {
   cfg: ClawdbotConfig;
@@ -474,7 +473,10 @@ export async function sendMediaFeishu(params: {
     buffer = mediaBuffer;
     name = fileName ?? "file";
   } else if (mediaUrl) {
-    const localRoots = resolveFeishuMediaLocalRoots({ cfg, mediaLocalRoots });
+    const localRoots = resolveFeishuMediaLocalRoots({
+      feishuConfig: account.config,
+      mediaLocalRoots,
+    });
     const loadOptions: {
       maxBytes: number;
       optimizeImages: boolean;


### PR DESCRIPTION
Fix LocalMediaAccessError for Feishu local media: read channels.feishu.localRoots and support "any". #39506