### PR TITLE
fix: support mediaLocalRoots config for Feishu channel

### DIFF
--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -165,6 +165,7 @@ const FeishuSharedConfigShape = {
   chunkMode: z.enum(["length", "newline"]).optional(),
   blockStreamingCoalesce: BlockStreamingCoalesceSchema,
   mediaMaxMb: z.number().positive().optional(),
+  mediaLocalRoots: z.union([z.array(z.string()), z.literal("any")]).optional(),
   httpTimeoutMs: z.number().int().positive().max(300_000).optional(),
   heartbeat: ChannelHeartbeatVisibilitySchema,
   renderMode: RenderModeSchema,

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -428,7 +428,7 @@ export async function sendMediaFeishu(params: {
   replyInThread?: boolean;
   accountId?: string;
   /** Allowed roots for local path reads; required for local filePath to work. */
-  mediaLocalRoots?: readonly string[];
+  mediaLocalRoots?: readonly string[] | "any";
 }): Promise<SendMediaResult> {
   const {
     cfg,
@@ -446,6 +446,8 @@ export async function sendMediaFeishu(params: {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
   }
   const mediaMaxBytes = (account.config?.mediaMaxMb ?? 30) * 1024 * 1024;
+  // Use mediaLocalRoots from params if provided, otherwise fall back to config
+  const effectiveMediaLocalRoots = mediaLocalRoots ?? account.config?.mediaLocalRoots;
 
   let buffer: Buffer;
   let name: string;
@@ -457,7 +459,7 @@ export async function sendMediaFeishu(params: {
     const loaded = await getFeishuRuntime().media.loadWebMedia(mediaUrl, {
       maxBytes: mediaMaxBytes,
       optimizeImages: false,
-      localRoots: mediaLocalRoots?.length ? mediaLocalRoots : undefined,
+      localRoots: effectiveMediaLocalRoots === "any" ? "any" : effectiveMediaLocalRoots?.length ? effectiveMediaLocalRoots : undefined,
     });
     buffer = loaded.buffer;
     name = fileName ?? loaded.fileName ?? "file";


### PR DESCRIPTION
Fixes #39506

- Add mediaLocalRoots field to FeishuConfigSchema (supports array or 'any')
- Read mediaLocalRoots from account config in sendMediaFeishu
- Properly pass 'any' value to loadWebMedia to allow all local paths

This allows users to configure channels.feishu.mediaLocalRoots = 'any' to allow local media access from any path, or specify an array of allowed directories.