### PR TITLE
fix: strip consecutive assistant error entries to prevent session poisoning

### DIFF
--- a/src/agents/pi-embedded-runner.strip-consecutive-assistant-errors.test.ts
+++ b/src/agents/pi-embedded-runner.strip-consecutive-assistant-errors.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { stripConsecutiveAssistantErrors } from "./pi-embedded-runner/google.js";
+import {
+  castAgentMessages,
+  makeAgentAssistantMessage,
+  makeAgentUserMessage,
+} from "./test-helpers/agent-message-fixtures.js";
+
+describe("stripConsecutiveAssistantErrors", () => {
+  const makeErrorAssistant = (errorMessage = "Connection error.") =>
+    makeAgentAssistantMessage({
+      content: [],
+      stopReason: "error",
+      errorMessage,
+    });
+
+  const makeOkAssistant = (text = "Hello") =>
+    makeAgentAssistantMessage({
+      content: [{ type: "text", text }],
+      stopReason: "stop",
+    });
+
+  const makeUser = (content = "hi") => makeAgentUserMessage({ content });
+
+  it("returns empty array unchanged", () => {
+    expect(stripConsecutiveAssistantErrors([])).toEqual([]);
+  });
+
+  it("returns single message unchanged", () => {
+    const msgs = castAgentMessages([makeUser()]);
+    expect(stripConsecutiveAssistantErrors(msgs)).toEqual(msgs);
+  });
+
+  it("does not touch messages without errors", () => {
+    const msgs = castAgentMessages([makeUser(), makeOkAssistant(), makeUser("bye")]);
+    expect(stripConsecutiveAssistantErrors(msgs)).toEqual(msgs);
+  });
+
+  it("keeps a single error entry untouched", () => {
+    const msgs = castAgentMessages([makeUser(), makeErrorAssistant()]);
+    expect(stripConsecutiveAssistantErrors(msgs)).toEqual(msgs);
+  });
+
+  it("collapses two consecutive error entries into the last one", () => {
+    const err1 = makeErrorAssistant("first error");
+    const err2 = makeErrorAssistant("second error");
+    const msgs = castAgentMessages([makeUser(), err1, err2]);
+    const result = stripConsecutiveAssistantErrors(msgs);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(msgs[0]); // user message preserved
+    expect(result[1]).toBe(msgs[2]); // last error kept
+  });
+
+  it("collapses three consecutive error entries into the last one", () => {
+    const err1 = makeErrorAssistant("error 1");
+    const err2 = makeErrorAssistant("error 2");
+    const err3 = makeErrorAssistant("error 3");
+    const msgs = castAgentMessages([makeUser(), err1, err2, err3]);
+    const result = stripConsecutiveAssistantErrors(msgs);
+    expect(result).toHaveLength(2);
+    expect(result[1]).toBe(msgs[3]); // last error kept
+  });
+
+  it("preserves non-error assistant between error runs", () => {
+    const err1 = makeErrorAssistant("err A");
+    const err2 = makeErrorAssistant("err B");
+    const ok = makeOkAssistant("success");
+    const err3 = makeErrorAssistant("err C");
+    const err4 = makeErrorAssistant("err D");
+    const msgs = castAgentMessages([makeUser(), err1, err2, ok, err3, err4]);
+    const result = stripConsecutiveAssistantErrors(msgs);
+    // user, err2 (collapsed from err1+err2), ok, err4 (collapsed from err3+err4)
+    expect(result).toHaveLength(4);
+    expect(result[0]).toBe(msgs[0]); // user
+    expect(result[1]).toBe(msgs[2]); // err2 (last of first run)
+    expect(result[2]).toBe(msgs[3]); // ok assistant
+    expect(result[3]).toBe(msgs[5]); // err4 (last of second run)
+  });
+
+  it("preserves user messages between error entries", () => {
+    const err1 = makeErrorAssistant("err 1");
+    const user2 = makeUser("retry");
+    const err2 = makeErrorAssistant("err 2");
+    const msgs = castAgentMessages([makeUser(), err1, user2, err2]);
+    const result = stripConsecutiveAssistantErrors(msgs);
+    // No consecutive errors — all messages preserved
+    expect(result).toEqual(msgs);
+  });
+
+  it("handles session with only error entries", () => {
+    const msgs = castAgentMessages([
+      makeErrorAssistant("e1"),
+      makeErrorAssistant("e2"),
+      makeErrorAssistant("e3"),
+    ]);
+    const result = stripConsecutiveAssistantErrors(msgs);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(msgs[2]); // last one kept
+  });
+
+  it("handles realistic session poisoning scenario", () => {
+    // Simulate: user sends message, 5 consecutive connection errors during retries,
+    // then user sends another message
+    const user1 = makeUser("what is 2+2?");
+    const errors = Array.from({ length: 5 }, (_, i) =>
+      makeErrorAssistant(`Connection error. (attempt ${i + 1})`),
+    );
+    const user2 = makeUser("please try again");
+    const ok = makeOkAssistant("2+2 = 4");
+    const msgs = castAgentMessages([user1, ...errors, user2, ok]);
+    const result = stripConsecutiveAssistantErrors(msgs);
+    // user1, last error, user2, ok
+    expect(result).toHaveLength(4);
+    expect(result[0]).toBe(msgs[0]); // user1
+    expect((result[1] as { errorMessage?: string }).errorMessage).toBe(
+      "Connection error. (attempt 5)",
+    ); // last error
+    expect(result[2]).toBe(msgs[6]); // user2
+    expect(result[3]).toBe(msgs[7]); // ok
+  });
+});

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -517,6 +517,59 @@ export function applyGoogleTurnOrderingFix(params: {
   return { messages: sanitized, didPrepend };
 }
 
+/**
+ * Remove consecutive assistant error messages from the session transcript,
+ * keeping only the last error entry in each consecutive run.
+ *
+ * During LLM outages or transient failures, each retry within a single
+ * request can persist a new assistant message with `stopReason: "error"`
+ * to the session JSONL.  When three or more accumulate in a row, the
+ * resulting conversation violates role-alternation rules expected by most
+ * model APIs.  Even providers that tolerate consecutive same-role turns
+ * can choke on the sheer number of error entries or misinterpret them as
+ * part of the useful context.
+ *
+ * The function scans the message array and collapses any run of ≥2
+ * consecutive assistant-error entries into a single entry (the last one
+ * in the run, which carries the most recent error detail).  Non-error
+ * assistant messages and messages with other roles are never touched.
+ *
+ * Complexity: O(n) single pass.
+ */
+export function stripConsecutiveAssistantErrors(messages: AgentMessage[]): AgentMessage[] {
+  if (messages.length < 2) {
+    return messages;
+  }
+  const out: AgentMessage[] = [];
+  let i = 0;
+  while (i < messages.length) {
+    const msg = messages[i] as { role?: string; stopReason?: string };
+    if (msg.role !== "assistant" || msg.stopReason !== "error") {
+      out.push(messages[i]);
+      i += 1;
+      continue;
+    }
+    // Found an assistant error entry — scan for consecutive ones.
+    let runEnd = i + 1;
+    while (runEnd < messages.length) {
+      const next = messages[runEnd] as { role?: string; stopReason?: string };
+      if (next.role !== "assistant" || next.stopReason !== "error") {
+        break;
+      }
+      runEnd += 1;
+    }
+    // Keep only the last entry of the run (most recent error detail).
+    out.push(messages[runEnd - 1]);
+    if (runEnd - i > 1) {
+      log.warn(
+        `stripped ${runEnd - i - 1} consecutive assistant error entries from session history`,
+      );
+    }
+    i = runEnd;
+  }
+  return out;
+}
+
 export async function sanitizeSessionHistory(params: {
   messages: AgentMessage[];
   modelApi?: string | null;
@@ -559,8 +612,18 @@ export async function sanitizeSessionHistory(params: {
     ? sanitizeToolUseResultPairing(sanitizedToolCalls)
     : sanitizedToolCalls;
   const sanitizedToolResults = stripToolResultDetails(repairedTools);
+  // Strip consecutive assistant error entries to prevent session poisoning.
+  // During LLM outages, retry loops can accumulate multiple assistant messages
+  // with stopReason: "error" in the session JSONL. These consecutive error
+  // entries violate role alternation rules and cause the API to reject all
+  // subsequent requests with 400 errors, creating a death spiral where the
+  // session becomes permanently stuck even after connectivity recovers.
+  // Keep at most one trailing error entry per consecutive run so that
+  // context about the failure is preserved without poisoning the session.
+  // See: https://github.com/openclaw/openclaw/issues/11475
+  const withoutConsecutiveErrors = stripConsecutiveAssistantErrors(sanitizedToolResults);
   const sanitizedCompactionUsage = ensureAssistantUsageSnapshots(
-    stripStaleAssistantUsageBeforeLatestCompaction(sanitizedToolResults),
+    stripStaleAssistantUsageBeforeLatestCompaction(withoutConsecutiveErrors),
   );
 
   const isOpenAIResponsesApi =


### PR DESCRIPTION
## Summary

- Add `stripConsecutiveAssistantErrors()` to the transcript sanitization pipeline in `sanitizeSessionHistory()` to prevent the session poisoning death spiral described in #11475
- During LLM outages, each retry persists a new assistant message with `stopReason: "error"` to the session JSONL. When multiple accumulate consecutively, they violate role-alternation rules, causing the API to reject all subsequent requests — which in turn creates more error entries
- The fix collapses any run of consecutive assistant-error messages into a single entry (the last one), preserving failure context without poisoning the session

## Test plan

- [x] Added 10 unit tests covering: empty arrays, single messages, no-error sessions, single error entries, 2/3/5 consecutive errors, interleaved error runs, user messages between errors, and realistic session poisoning scenarios
- [x] All existing `sanitize-session-history` tests pass (28 tests)
- [x] All existing `sanitize-session-history.policy` tests pass (3 tests)
- [x] All existing `sanitize-session-history.tool-result-details` tests pass (1 test)
- [ ] Manual verification: deploy on a machine with known session poisoning issues and confirm recovery

Closes #11475

🤖 Generated with [Claude Code](https://claude.com/claude-code)