### PR TITLE
fix: prefer sessionKey over label in sessions_send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Docs: https://docs.openclaw.ai
 
 - NVIDIA/NIM: persist the `NVIDIA_API_KEY` provider marker and mark bundled NVIDIA Chat Completions models as string-content compatible, so NIM models load from `models.json` and OpenAI-compatible subagent calls send plain text content. Fixes #73013 and #50107; refs #73014. Thanks @bautrey, @iot2edge, @ifearghal, and @futhgar.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.
-- Agents/sessions_send: prefer explicit `sessionKey` targets over redundant `label` and `agentId` fields so exact-key sends no longer fail or resolve through the label path. (#39551) Thanks @1034378361.
+- Agents/sessions_send: prefer explicit `sessionKey`/`sessionId` targets over redundant `label` and `agentId` fields so exact-key sends no longer fail or resolve through the label path. (#39551) Thanks @1034378361.
 - fix(plugins): restrict bundled plugin dir resolution to trusted package roots. (#73275) Thanks @pgondhi987.
 - fix(security): prevent workspace PATH injection via service env and trash helpers. (#73264) Thanks @pgondhi987.
 - Active Memory: allow `allowedChatTypes` to include explicit portal/webchat sessions and classify `agent:...:explicit:...` session keys before opaque session ids can shadow the chat type. Fixes #65775. (#66285) Thanks @Lidang-Jiang.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Docs: https://docs.openclaw.ai
 
 - NVIDIA/NIM: persist the `NVIDIA_API_KEY` provider marker and mark bundled NVIDIA Chat Completions models as string-content compatible, so NIM models load from `models.json` and OpenAI-compatible subagent calls send plain text content. Fixes #73013 and #50107; refs #73014. Thanks @bautrey, @iot2edge, @ifearghal, and @futhgar.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.
+- Agents/sessions_send: prefer explicit `sessionKey` targets over redundant `label` and `agentId` fields so exact-key sends no longer fail or resolve through the label path. (#39551) Thanks @1034378361.
 - fix(plugins): restrict bundled plugin dir resolution to trusted package roots. (#73275) Thanks @pgondhi987.
 - fix(security): prevent workspace PATH injection via service env and trash helpers. (#73264) Thanks @pgondhi987.
 - Active Memory: allow `allowedChatTypes` to include explicit portal/webchat sessions and classify `agent:...:explicit:...` session keys before opaque session ids can shadow the chat type. Fixes #65775. (#66285) Thanks @Lidang-Jiang.

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -27,7 +27,7 @@ export function describeSessionsHistoryTool(): string {
 
 export function describeSessionsSendTool(): string {
   return [
-    "Send a message into another visible session by sessionKey or label.",
+    "Send a message into another visible session by sessionKey, sessionId, or label.",
     "Use this to delegate follow-up work to an existing session; waits for the target run and returns the updated assistant reply when available.",
   ].join(" ");
 }

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -103,15 +103,12 @@ export function createSessionsSendTool(opts?: {
       });
 
       const sessionKeyParam = readStringParam(params, "sessionKey");
-      const labelParam = normalizeOptionalString(readStringParam(params, "label"));
-      const labelAgentIdParam = normalizeOptionalString(readStringParam(params, "agentId"));
-      if (sessionKeyParam && labelParam) {
-        return jsonResult({
-          runId: crypto.randomUUID(),
-          status: "error",
-          error: "Provide either sessionKey or label (not both).",
-        });
-      }
+      const labelParam = sessionKeyParam
+        ? undefined
+        : normalizeOptionalString(readStringParam(params, "label"));
+      const labelAgentIdParam = sessionKeyParam
+        ? undefined
+        : normalizeOptionalString(readStringParam(params, "agentId"));
 
       let sessionKey = sessionKeyParam;
       if (!sessionKey && labelParam) {

--- a/src/agents/tools/sessions-send-tool.ts
+++ b/src/agents/tools/sessions-send-tool.ts
@@ -36,6 +36,7 @@ import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
 
 const SessionsSendToolSchema = Type.Object({
   sessionKey: Type.Optional(Type.String()),
+  sessionId: Type.Optional(Type.String()),
   label: Type.Optional(Type.String({ minLength: 1, maxLength: SESSION_LABEL_MAX_LENGTH })),
   agentId: Type.Optional(Type.String({ minLength: 1, maxLength: 64 })),
   message: Type.String(),
@@ -102,7 +103,8 @@ export function createSessionsSendTool(opts?: {
         sandboxed: opts?.sandboxed === true,
       });
 
-      const sessionKeyParam = readStringParam(params, "sessionKey");
+      const sessionKeyParam =
+        readStringParam(params, "sessionKey") ?? readStringParam(params, "sessionId");
       const labelParam = sessionKeyParam
         ? undefined
         : normalizeOptionalString(readStringParam(params, "label"));
@@ -193,7 +195,7 @@ export function createSessionsSendTool(opts?: {
         return jsonResult({
           runId: crypto.randomUUID(),
           status: "error",
-          error: "Either sessionKey or label is required",
+          error: "Either sessionKey/sessionId or label is required",
         });
       }
       const resolvedSession = await resolveSessionReference({

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -609,7 +609,7 @@ describe("sessions_send gating", () => {
     callGatewayMock.mockClear();
   });
 
-  it("returns an error when neither sessionKey nor label is provided", async () => {
+  it("returns an error when no sessionKey, sessionId, or label is provided", async () => {
     const tool = createMainSessionsSendTool();
 
     const result = await tool.execute("call-missing-target", {
@@ -619,7 +619,7 @@ describe("sessions_send gating", () => {
 
     expect(result.details).toMatchObject({
       status: "error",
-      error: "Either sessionKey or label is required",
+      error: "Either sessionKey/sessionId or label is required",
     });
     expect(callGatewayMock).not.toHaveBeenCalled();
   });
@@ -698,6 +698,74 @@ describe("sessions_send gating", () => {
             params: expect.objectContaining({
               sessionKey: "agent:worker:main",
               message: "hello",
+            }),
+          }),
+        ],
+      ]),
+    );
+  });
+
+  it("prefers sessionId when sessionId, label, and agentId are all provided", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: {
+        agentToAgent: { enabled: true },
+        sessions: { visibility: "all" },
+      },
+    });
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      if (request.method === "sessions.resolve") {
+        if (request.params?.sessionId === "sess-worker") {
+          return { key: "agent:worker:main" };
+        }
+        return {};
+      }
+      if (request.method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [
+            {
+              key: "agent:worker:main",
+              kind: "direct",
+              sessionId: "sess-worker",
+            },
+          ],
+        };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-mixed-session-id", acceptedAt: 123 };
+      }
+      return {};
+    });
+
+    const tool = createMainSessionsSendTool();
+    const result = await tool.execute("call-mixed-session-id-target", {
+      sessionId: "sess-worker",
+      label: "wrong-label",
+      agentId: "wrong-agent",
+      message: "hello from session id",
+      timeoutSeconds: 0,
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      sessionKey: "agent:worker:main",
+    });
+    expect(
+      callGatewayMock.mock.calls.some((call) => {
+        const params = (call[0] as { params?: Record<string, unknown> }).params;
+        return params?.label === "wrong-label" || params?.agentId === "wrong-agent";
+      }),
+    ).toBe(false);
+    expect(callGatewayMock.mock.calls).toEqual(
+      expect.arrayContaining([
+        [
+          expect.objectContaining({
+            method: "agent",
+            params: expect.objectContaining({
+              sessionKey: "agent:worker:main",
+              message: "hello from session id",
             }),
           }),
         ],

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -644,6 +644,67 @@ describe("sessions_send gating", () => {
     expect(callGatewayMock.mock.calls[0]?.[0]).toMatchObject({ method: "sessions.resolve" });
   });
 
+  it("prefers sessionKey when sessionKey, label, and agentId are all provided", async () => {
+    loadConfigMock.mockReturnValue({
+      session: { scope: "per-sender", mainKey: "main" },
+      tools: {
+        agentToAgent: { enabled: true },
+        sessions: { visibility: "all" },
+      },
+    });
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: Record<string, unknown> };
+      if (request.method === "sessions.list") {
+        return {
+          path: "/tmp/sessions.json",
+          sessions: [
+            {
+              key: "agent:worker:main",
+              kind: "direct",
+              sessionId: "sess-worker",
+            },
+          ],
+        };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-mixed", acceptedAt: 123 };
+      }
+      return {};
+    });
+
+    const tool = createMainSessionsSendTool();
+    const result = await tool.execute("call-mixed-target", {
+      sessionKey: "agent:worker:main",
+      label: "worker",
+      agentId: "worker",
+      message: "hello",
+      timeoutSeconds: 0,
+    });
+
+    expect(result.details).toMatchObject({
+      status: "accepted",
+      sessionKey: "agent:worker:main",
+    });
+    expect(
+      callGatewayMock.mock.calls.some(
+        (call) => (call[0] as { method?: string }).method === "sessions.resolve",
+      ),
+    ).toBe(false);
+    expect(callGatewayMock.mock.calls).toEqual(
+      expect.arrayContaining([
+        [
+          expect.objectContaining({
+            method: "agent",
+            params: expect.objectContaining({
+              sessionKey: "agent:worker:main",
+              message: "hello",
+            }),
+          }),
+        ],
+      ]),
+    );
+  });
+
   it("blocks cross-agent sends when tools.agentToAgent.enabled is false", async () => {
     const tool = createMainSessionsSendTool();
 


### PR DESCRIPTION
## Summary

- Problem: `sessions_send` rejected calls when `sessionKey` and `label` were both present, even if `sessionKey` already identified the target unambiguously.
- Why it matters: LLM-generated tool calls can include redundant target fields (`sessionKey`, `label`, and `agentId`) from the same schema, which caused avoidable runtime failures.
- What changed: `sessions_send` now treats `sessionKey` as authoritative and ignores `label` / `agentId` when `sessionKey` is present. Added a regression test for the mixed-parameter case.
- What did NOT change (scope boundary): This does not change label-only resolution behavior, cross-agent permission checks, or the missing-target error path.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- `sessions_send` no longer fails with `Provide either sessionKey or label (not both).` when `sessionKey` is present alongside `label` / `agentId`.
- When `sessionKey` is provided, it is now used as the source of truth for target selection.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local source checkout
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): default test config with mocked gateway calls

### Steps

1. Call `sessions_send` with `sessionKey`, `label`, and `agentId` together.
2. Observe current behavior before the fix: the tool rejects the call with `Provide either sessionKey or label (not both).`
3. Apply the fix and rerun the sessions tool tests.

### Expected

- If `sessionKey` is present, `sessions_send` should use it directly.
- Redundant `label` / `agentId` should not cause the call to fail.
- `label`-only resolution should still work as before.
- Missing target should still return `Either sessionKey or label is required`.

### Actual

- After this change, mixed-input calls succeed by resolving through `sessionKey`.
- Existing label-only and missing-target behavior remains intact.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `corepack pnpm exec vitest run src/agents/tools/sessions.test.ts`
  - `corepack pnpm exec vitest run src/agents/openclaw-tools.sessions.test.ts`
  - Confirmed the new regression test passes:
    - `prefers sessionKey when sessionKey, label, and agentId are all provided`
- Edge cases checked:
  - `label`-only behavior remains covered
  - missing-target error remains `Either sessionKey or label is required`
  - higher-level sessions tools tests still pass
- What you did **not** verify:
  - Full end-to-end behavior through a live GitHub CI run
  - Additional gateway-specific test files beyond the focused sessions tool coverage

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert this commit.
- Files/config to restore:
  - `src/agents/tools/sessions-send-tool.ts`
  - `src/agents/tools/sessions.test.ts`
- Known bad symptoms reviewers should watch for:
  - Unexpected target selection changes when `sessionKey` is present
  - Regressions in label-only resolution

## Risks and Mitigations

- Risk: A caller may accidentally pass mismatched `sessionKey` and `label`, and the tool will now prefer `sessionKey`.
  - Mitigation: This is intentional and aligns behavior with the most specific target identifier; the regression test documents the precedence rule.