### PR TITLE
fix(feishu): strip reaction suffix from message_id before API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Feishu: strip synthetic reaction suffixes from message IDs before message, reaction, typing, media, streaming-card, and pin API calls so reaction-triggered actions target the original message. Fixes #34528; carries forward #39558; supersedes #34565. Thanks @liuweifly and @smartchainark.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/extensions/feishu/src/media.ts
+++ b/extensions/feishu/src/media.ts
@@ -13,6 +13,7 @@ import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import { normalizeFeishuExternalKey } from "./external-keys.js";
+import { stripFeishuReactionSuffix } from "./message-id.js";
 import { getFeishuRuntime } from "./runtime.js";
 import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
@@ -316,6 +317,7 @@ export async function downloadMessageResourceFeishu(params: {
   accountId?: string;
 }): Promise<DownloadMessageResourceResult> {
   const { cfg, messageId, fileKey, type, accountId } = params;
+  const normalizedMessageId = stripFeishuReactionSuffix(messageId);
   const normalizedFileKey = normalizeFeishuExternalKey(fileKey);
   if (!normalizedFileKey) {
     throw new Error("Feishu message resource download failed: invalid file_key");
@@ -323,7 +325,7 @@ export async function downloadMessageResourceFeishu(params: {
   const { client } = createConfiguredFeishuMediaClient({ cfg, accountId });
 
   const response = await client.im.messageResource.get({
-    path: { message_id: messageId, file_key: normalizedFileKey },
+    path: { message_id: normalizedMessageId, file_key: normalizedFileKey },
     params: { type },
   });
 
@@ -446,6 +448,9 @@ export async function sendImageFeishu(params: {
   accountId?: string;
 }): Promise<SendMediaResult> {
   const { cfg, to, imageKey, replyToMessageId, replyInThread, accountId } = params;
+  const normalizedReplyToMessageId = replyToMessageId
+    ? stripFeishuReactionSuffix(replyToMessageId)
+    : undefined;
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({
     cfg,
     to,
@@ -453,9 +458,9 @@ export async function sendImageFeishu(params: {
   });
   const content = JSON.stringify({ image_key: imageKey });
 
-  if (replyToMessageId) {
+  if (normalizedReplyToMessageId) {
     const response = await client.im.message.reply({
-      path: { message_id: replyToMessageId },
+      path: { message_id: normalizedReplyToMessageId },
       data: {
         content,
         msg_type: "image",
@@ -492,6 +497,9 @@ export async function sendFileFeishu(params: {
   accountId?: string;
 }): Promise<SendMediaResult> {
   const { cfg, to, fileKey, replyToMessageId, replyInThread, accountId } = params;
+  const normalizedReplyToMessageId = replyToMessageId
+    ? stripFeishuReactionSuffix(replyToMessageId)
+    : undefined;
   const msgType = params.msgType ?? "file";
   const { client, receiveId, receiveIdType } = resolveFeishuSendTarget({
     cfg,
@@ -500,9 +508,9 @@ export async function sendFileFeishu(params: {
   });
   const content = JSON.stringify({ file_key: fileKey });
 
-  if (replyToMessageId) {
+  if (normalizedReplyToMessageId) {
     const response = await client.im.message.reply({
-      path: { message_id: replyToMessageId },
+      path: { message_id: normalizedReplyToMessageId },
       data: {
         content,
         msg_type: msgType,

--- a/extensions/feishu/src/message-id.test.ts
+++ b/extensions/feishu/src/message-id.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { stripFeishuReactionSuffix } from "./message-id.js";
+
+describe("stripFeishuReactionSuffix", () => {
+  it("strips :reaction:EMOJI:uuid suffix", () => {
+    expect(
+      stripFeishuReactionSuffix(
+        "om_x100b55b75bbd1ca4c3647ec6a73d3a3:reaction:THUMBSUP:350dd4ec-46af-41c9-affc-a68cd11a5e49",
+      ),
+    ).toBe("om_x100b55b75bbd1ca4c3647ec6a73d3a3");
+  });
+
+  it("strips other emoji types", () => {
+    expect(
+      stripFeishuReactionSuffix("om_abc123:reaction:HEART:aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"),
+    ).toBe("om_abc123");
+  });
+
+  it("preserves clean message IDs", () => {
+    expect(stripFeishuReactionSuffix("om_x100b55b75bbd1ca4c3647ec6a73d3a3")).toBe(
+      "om_x100b55b75bbd1ca4c3647ec6a73d3a3",
+    );
+  });
+
+  it("handles empty string", () => {
+    expect(stripFeishuReactionSuffix("")).toBe("");
+  });
+
+  it("handles whitespace-only string", () => {
+    expect(stripFeishuReactionSuffix("   ")).toBe("");
+  });
+
+  it("trims whitespace from message IDs", () => {
+    expect(stripFeishuReactionSuffix("  om_abc123  ")).toBe("om_abc123");
+  });
+
+  it("trims whitespace and strips suffix", () => {
+    expect(
+      stripFeishuReactionSuffix(" om_abc123:reaction:SMILE:11111111-2222-3333-4444-555555555555 "),
+    ).toBe("om_abc123");
+  });
+
+  it("does not strip partial matches", () => {
+    expect(stripFeishuReactionSuffix("om_abc123:reaction")).toBe("om_abc123:reaction");
+    expect(stripFeishuReactionSuffix("om_abc123:reaction:THUMBSUP")).toBe(
+      "om_abc123:reaction:THUMBSUP",
+    );
+  });
+});

--- a/extensions/feishu/src/message-id.test.ts
+++ b/extensions/feishu/src/message-id.test.ts
@@ -16,6 +16,12 @@ describe("stripFeishuReactionSuffix", () => {
     ).toBe("om_abc123");
   });
 
+  it("strips uppercase UUID suffixes", () => {
+    expect(
+      stripFeishuReactionSuffix("om_abc123:reaction:THUMBSUP:350DD4EC-46AF-41C9-AFFC-A68CD11A5E49"),
+    ).toBe("om_abc123");
+  });
+
   it("preserves clean message IDs", () => {
     expect(stripFeishuReactionSuffix("om_x100b55b75bbd1ca4c3647ec6a73d3a3")).toBe(
       "om_x100b55b75bbd1ca4c3647ec6a73d3a3",
@@ -44,6 +50,12 @@ describe("stripFeishuReactionSuffix", () => {
     expect(stripFeishuReactionSuffix("om_abc123:reaction")).toBe("om_abc123:reaction");
     expect(stripFeishuReactionSuffix("om_abc123:reaction:THUMBSUP")).toBe(
       "om_abc123:reaction:THUMBSUP",
+    );
+  });
+
+  it("does not strip reaction-looking suffixes without UUIDs", () => {
+    expect(stripFeishuReactionSuffix("om_abc123:reaction:THUMBSUP:not-a-uuid")).toBe(
+      "om_abc123:reaction:THUMBSUP:not-a-uuid",
     );
   });
 });

--- a/extensions/feishu/src/message-id.ts
+++ b/extensions/feishu/src/message-id.ts
@@ -1,0 +1,14 @@
+const FEISHU_REACTION_MESSAGE_ID_SUFFIX_RE = /:reaction:[^:]+:[^:]+$/;
+
+/**
+ * Synthetic reaction events use IDs like:
+ *   om_xxx:reaction:THUMBSUP:uuid
+ * Strip the reaction suffix before calling Feishu message APIs.
+ */
+export function stripFeishuReactionSuffix(messageId: string): string {
+  const trimmed = messageId.trim();
+  if (!trimmed) {
+    return trimmed;
+  }
+  return trimmed.replace(FEISHU_REACTION_MESSAGE_ID_SUFFIX_RE, "");
+}

--- a/extensions/feishu/src/message-id.ts
+++ b/extensions/feishu/src/message-id.ts
@@ -1,4 +1,5 @@
-const FEISHU_REACTION_MESSAGE_ID_SUFFIX_RE = /:reaction:[^:]+:[^:]+$/;
+const FEISHU_REACTION_MESSAGE_ID_SUFFIX_RE =
+  /:reaction:[^:]+:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Synthetic reaction events use IDs like:

--- a/extensions/feishu/src/pins.ts
+++ b/extensions/feishu/src/pins.ts
@@ -1,6 +1,7 @@
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { stripFeishuReactionSuffix } from "./message-id.js";
 
 export type FeishuPin = {
   messageId: string;
@@ -37,6 +38,7 @@ export async function createPinFeishu(params: {
   messageId: string;
   accountId?: string;
 }): Promise<FeishuPin | null> {
+  const normalizedMessageId = stripFeishuReactionSuffix(params.messageId);
   const account = resolveFeishuRuntimeAccount({ cfg: params.cfg, accountId: params.accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -45,7 +47,7 @@ export async function createPinFeishu(params: {
   const client = createFeishuClient(account);
   const response = await client.im.pin.create({
     data: {
-      message_id: params.messageId,
+      message_id: normalizedMessageId,
     },
   });
   assertFeishuPinApiSuccess(response, "pin create");
@@ -57,6 +59,7 @@ export async function removePinFeishu(params: {
   messageId: string;
   accountId?: string;
 }): Promise<void> {
+  const normalizedMessageId = stripFeishuReactionSuffix(params.messageId);
   const account = resolveFeishuRuntimeAccount({ cfg: params.cfg, accountId: params.accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -65,7 +68,7 @@ export async function removePinFeishu(params: {
   const client = createFeishuClient(account);
   const response = await client.im.pin.delete({
     path: {
-      message_id: params.messageId,
+      message_id: normalizedMessageId,
     },
   });
   assertFeishuPinApiSuccess(response, "pin delete");

--- a/extensions/feishu/src/reactions.ts
+++ b/extensions/feishu/src/reactions.ts
@@ -1,6 +1,7 @@
 import type { ClawdbotConfig } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { stripFeishuReactionSuffix } from "./message-id.js";
 
 export type FeishuReaction = {
   reactionId: string;
@@ -35,10 +36,11 @@ export async function addReactionFeishu(params: {
   accountId?: string;
 }): Promise<{ reactionId: string }> {
   const { cfg, messageId, emojiType, accountId } = params;
+  const normalizedMessageId = stripFeishuReactionSuffix(messageId);
   const client = resolveConfiguredFeishuClient({ cfg, accountId });
 
   const response = (await client.im.messageReaction.create({
-    path: { message_id: messageId },
+    path: { message_id: normalizedMessageId },
     data: {
       reaction_type: {
         emoji_type: emojiType,
@@ -70,11 +72,12 @@ export async function removeReactionFeishu(params: {
   accountId?: string;
 }): Promise<void> {
   const { cfg, messageId, reactionId, accountId } = params;
+  const normalizedMessageId = stripFeishuReactionSuffix(messageId);
   const client = resolveConfiguredFeishuClient({ cfg, accountId });
 
   const response = (await client.im.messageReaction.delete({
     path: {
-      message_id: messageId,
+      message_id: normalizedMessageId,
       reaction_id: reactionId,
     },
   })) as { code?: number; msg?: string };
@@ -92,10 +95,11 @@ export async function listReactionsFeishu(params: {
   accountId?: string;
 }): Promise<FeishuReaction[]> {
   const { cfg, messageId, emojiType, accountId } = params;
+  const normalizedMessageId = stripFeishuReactionSuffix(messageId);
   const client = resolveConfiguredFeishuClient({ cfg, accountId });
 
   const response = (await client.im.messageReaction.list({
-    path: { message_id: messageId },
+    path: { message_id: normalizedMessageId },
     params: emojiType ? { reaction_type: emojiType } : undefined,
   })) as {
     code?: number;

--- a/extensions/feishu/src/send.ts
+++ b/extensions/feishu/src/send.ts
@@ -9,6 +9,7 @@ import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
 import type { MentionTarget } from "./mention-target.types.js";
 import { buildMentionedCardContent, buildMentionedMessage } from "./mention.js";
+import { stripFeishuReactionSuffix } from "./message-id.js";
 import { parsePostContent } from "./post.js";
 import { assertFeishuMessageApiSuccess, toFeishuSendResult } from "./send-result.js";
 import { resolveFeishuSendTarget } from "./send-target.js";
@@ -149,6 +150,7 @@ async function sendReplyOrFallbackDirect(
   if (!params.replyToMessageId) {
     return sendFallbackDirect(client, params.directParams, params.directErrorPrefix);
   }
+  const normalizedReplyToMessageId = stripFeishuReactionSuffix(params.replyToMessageId);
 
   const threadReplyFallbackError = params.replyInThread
     ? new Error(
@@ -159,7 +161,7 @@ async function sendReplyOrFallbackDirect(
   let response: { code?: number; msg?: string; data?: { message_id?: string } };
   try {
     response = await client.im.message.reply({
-      path: { message_id: params.replyToMessageId },
+      path: { message_id: normalizedReplyToMessageId },
       data: {
         content: params.content,
         msg_type: params.msgType,
@@ -380,6 +382,7 @@ export async function getMessageFeishu(params: {
   accountId?: string;
 }): Promise<FeishuMessageInfo | null> {
   const { cfg, messageId, accountId } = params;
+  const normalizedMessageId = stripFeishuReactionSuffix(messageId);
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -389,7 +392,7 @@ export async function getMessageFeishu(params: {
 
   try {
     const response = (await client.im.message.get({
-      path: { message_id: messageId },
+      path: { message_id: normalizedMessageId },
     })) as FeishuGetMessageResponse;
 
     if (response.code !== 0) {
@@ -407,7 +410,7 @@ export async function getMessageFeishu(params: {
       return null;
     }
 
-    return parseFeishuMessageItem(item, messageId);
+    return parseFeishuMessageItem(item, normalizedMessageId);
   } catch {
     return null;
   }
@@ -606,6 +609,7 @@ export async function editMessageFeishu(params: {
   accountId?: string;
 }): Promise<{ messageId: string; contentType: "post" | "interactive" }> {
   const { cfg, messageId, text, card, accountId } = params;
+  const normalizedMessageId = stripFeishuReactionSuffix(messageId);
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -622,7 +626,7 @@ export async function editMessageFeishu(params: {
   if (card) {
     const content = JSON.stringify(card);
     const response = await client.im.message.patch({
-      path: { message_id: messageId },
+      path: { message_id: normalizedMessageId },
       data: { content },
     });
 
@@ -640,7 +644,7 @@ export async function editMessageFeishu(params: {
   const messageText = convertMarkdownTables(text!, tableMode);
   const payload = buildFeishuPostMessagePayload({ messageText });
   const response = await client.im.message.patch({
-    path: { message_id: messageId },
+    path: { message_id: normalizedMessageId },
     data: { content: payload.content },
   });
 
@@ -658,6 +662,7 @@ export async function updateCardFeishu(params: {
   accountId?: string;
 }): Promise<void> {
   const { cfg, messageId, card, accountId } = params;
+  const normalizedMessageId = stripFeishuReactionSuffix(messageId);
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });
   if (!account.configured) {
     throw new Error(`Feishu account "${account.accountId}" not configured`);
@@ -667,7 +672,7 @@ export async function updateCardFeishu(params: {
   const content = JSON.stringify(card);
 
   const response = await client.im.message.patch({
-    path: { message_id: messageId },
+    path: { message_id: normalizedMessageId },
     data: { content },
   });
 

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -5,6 +5,7 @@
 import type { Client } from "@larksuiteoapi/node-sdk";
 import { fetchWithSsrFGuard } from "openclaw/plugin-sdk/ssrf-runtime";
 import { getFeishuUserAgent } from "./client.js";
+import { stripFeishuReactionSuffix } from "./message-id.js";
 import { resolveFeishuCardTemplate, type CardHeaderConfig } from "./send.js";
 import type { FeishuDomain } from "./types.js";
 
@@ -270,8 +271,9 @@ export class FeishuStreamingSession {
     const sendOptions = options ?? {};
     const sendMode = resolveStreamingCardSendMode(sendOptions);
     if (sendMode === "reply") {
+      const normalizedReplyToMessageId = stripFeishuReactionSuffix(sendOptions.replyToMessageId!);
       sendRes = await this.client.im.message.reply({
-        path: { message_id: sendOptions.replyToMessageId! },
+        path: { message_id: normalizedReplyToMessageId },
         data: {
           msg_type: "interactive",
           content: cardContent,
@@ -279,12 +281,13 @@ export class FeishuStreamingSession {
         },
       });
     } else if (sendMode === "root_create") {
+      const normalizedRootId = stripFeishuReactionSuffix(sendOptions.rootId!);
       // root_id is undeclared in the SDK types but accepted at runtime
       sendRes = await this.client.im.message.create({
         params: { receive_id_type: receiveIdType },
         data: Object.assign(
           { receive_id: receiveId, msg_type: "interactive", content: cardContent },
-          { root_id: sendOptions.rootId },
+          { root_id: normalizedRootId },
         ),
       });
     } else {

--- a/extensions/feishu/src/typing.ts
+++ b/extensions/feishu/src/typing.ts
@@ -1,6 +1,7 @@
 import type { ClawdbotConfig, RuntimeEnv } from "../runtime-api.js";
 import { resolveFeishuRuntimeAccount } from "./accounts.js";
 import { createFeishuClient } from "./client.js";
+import { stripFeishuReactionSuffix } from "./message-id.js";
 import { getFeishuRuntime } from "./runtime.js";
 
 // Feishu emoji types for typing indicator
@@ -111,6 +112,7 @@ export async function addTypingIndicator(params: {
   runtime?: RuntimeEnv;
 }): Promise<TypingIndicatorState> {
   const { cfg, messageId, accountId, runtime } = params;
+  const normalizedMessageId = stripFeishuReactionSuffix(messageId);
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });
   if (!account.configured) {
     return { messageId, reactionId: null };
@@ -120,7 +122,7 @@ export async function addTypingIndicator(params: {
 
   try {
     const response = await client.im.messageReaction.create({
-      path: { message_id: messageId },
+      path: { message_id: normalizedMessageId },
       data: {
         reaction_type: { emoji_type: TYPING_EMOJI },
       },
@@ -171,6 +173,7 @@ export async function removeTypingIndicator(params: {
   if (!state.reactionId) {
     return;
   }
+  const normalizedMessageId = stripFeishuReactionSuffix(state.messageId);
 
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });
   if (!account.configured) {
@@ -182,7 +185,7 @@ export async function removeTypingIndicator(params: {
   try {
     const result = await client.im.messageReaction.delete({
       path: {
-        message_id: state.messageId,
+        message_id: normalizedMessageId,
         reaction_id: state.reactionId,
       },
     });


### PR DESCRIPTION
## Summary

When users react to messages in Feishu, OpenClaw generates synthetic message IDs with a reaction suffix:
```
om_x100b55b75bbd1ca4c3647ec6a73d3a3:reaction:THUMBSUP:350dd4ec-46af-41c9-affc-a68cd11a5e49
```

These suffixed IDs cause `400` errors (code `99992354`) when passed to Feishu message APIs, which expect clean `om_xxx` IDs.

## Changes

- **New:** `message-id.ts` — `stripFeishuReactionSuffix()` utility that strips `:reaction:EMOJI:uuid` suffixes
- **Applied** the normalizer at all Feishu API boundary points:
  - `send.ts` — `getMessageFeishu`, `sendMessageFeishu`, `sendCardFeishu`, `updateCardFeishu`, `editMessageFeishu`
  - `reactions.ts` — `addReactionFeishu`, `removeReactionFeishu`, `listReactionsFeishu`
  - `typing.ts` — `addTypingIndicator`, `removeTypingIndicator`
  - `media.ts` — `downloadMessageResourceFeishu`, `sendImageFeishu`, `sendFileFeishu`
  - `send-message.ts` — `sendFeishuMessageWithOptionalReply`
- **New:** `message-id.test.ts` — unit tests for the stripping function

## How I tested

- Unit tests cover: suffixed IDs, clean IDs, empty strings, whitespace, partial matches
- Verified regex matches the exact suffix format from production logs

Fixes #34528