### PR TITLE
feat(feishu): add feishu_reaction tool for message emoji reactions

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -6,6 +6,7 @@ import { registerFeishuChatTools } from "./src/chat.js";
 import { registerFeishuDocTools } from "./src/docx.js";
 import { registerFeishuDriveTools } from "./src/drive.js";
 import { registerFeishuPermTools } from "./src/perm.js";
+import { registerFeishuReactionTools } from "./src/reaction-tool.js";
 import { setFeishuRuntime } from "./src/runtime.js";
 import { registerFeishuWikiTools } from "./src/wiki.js";
 
@@ -59,6 +60,7 @@ const plugin = {
     registerFeishuDriveTools(api);
     registerFeishuPermTools(api);
     registerFeishuBitableTools(api);
+    registerFeishuReactionTools(api);
   },
 };
 

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -92,6 +92,7 @@ const FeishuToolsConfigSchema = z
     drive: z.boolean().optional(), // Cloud storage operations (default: true)
     perm: z.boolean().optional(), // Permission management (default: false, sensitive)
     scopes: z.boolean().optional(), // App scopes diagnostic (default: true)
+    reaction: z.boolean().optional(), // Message reaction operations (default: true)
   })
   .strict()
   .optional();

--- a/extensions/feishu/src/reaction-schema.ts
+++ b/extensions/feishu/src/reaction-schema.ts
@@ -1,0 +1,24 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+export const FeishuReactionSchema = Type.Union([
+  Type.Object({
+    action: Type.Literal("add"),
+    message_id: Type.String({ description: "Message ID to add reaction to" }),
+    emoji_type: Type.String({
+      description:
+        'Feishu emoji type, e.g. "THUMBSUP", "HEART", "SMILE", "LAUGH", "CLAP", "FIRE", "PARTY", "CHECK"',
+    }),
+  }),
+  Type.Object({
+    action: Type.Literal("remove"),
+    message_id: Type.String({ description: "Message ID to remove reaction from" }),
+    reaction_id: Type.String({ description: "Reaction ID to remove (from list action)" }),
+  }),
+  Type.Object({
+    action: Type.Literal("list"),
+    message_id: Type.String({ description: "Message ID to list reactions for" }),
+    emoji_type: Type.Optional(Type.String({ description: "Filter by emoji type (optional)" })),
+  }),
+]);
+
+export type FeishuReactionParams = Static<typeof FeishuReactionSchema>;

--- a/extensions/feishu/src/reaction-tool.ts
+++ b/extensions/feishu/src/reaction-tool.ts
@@ -1,0 +1,84 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+import { listEnabledFeishuAccounts } from "./accounts.js";
+import { FeishuReactionSchema, type FeishuReactionParams } from "./reaction-schema.js";
+import {
+  addReactionFeishu,
+  removeReactionFeishu,
+  listReactionsFeishu,
+} from "./reactions.js";
+import { resolveToolsConfig } from "./tools-config.js";
+
+function json(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    details: data,
+  };
+}
+
+export function registerFeishuReactionTools(api: OpenClawPluginApi) {
+  if (!api.config) {
+    api.logger.debug?.("feishu_reaction: No config available, skipping reaction tools");
+    return;
+  }
+
+  const accounts = listEnabledFeishuAccounts(api.config);
+  if (accounts.length === 0) {
+    api.logger.debug?.("feishu_reaction: No Feishu accounts configured, skipping reaction tools");
+    return;
+  }
+
+  const toolsCfg = resolveToolsConfig(accounts[0].config.tools);
+  if (!toolsCfg.reaction) {
+    api.logger.debug?.("feishu_reaction: reaction tool disabled in config");
+    return;
+  }
+
+  api.registerTool(
+    {
+      name: "feishu_reaction",
+      label: "Feishu Reaction",
+      description:
+        "Feishu message reaction operations. Actions: add (add emoji reaction to a message), remove (remove a reaction), list (list reactions on a message)",
+      parameters: FeishuReactionSchema,
+      async execute(_toolCallId, params) {
+        const p = params as FeishuReactionParams;
+        const cfg = api.config!;
+        try {
+          switch (p.action) {
+            case "add": {
+              const result = await addReactionFeishu({
+                cfg,
+                messageId: p.message_id,
+                emojiType: p.emoji_type,
+              });
+              return json({ success: true, ...result });
+            }
+            case "remove": {
+              await removeReactionFeishu({
+                cfg,
+                messageId: p.message_id,
+                reactionId: p.reaction_id,
+              });
+              return json({ success: true });
+            }
+            case "list": {
+              const reactions = await listReactionsFeishu({
+                cfg,
+                messageId: p.message_id,
+                emojiType: p.emoji_type,
+              });
+              return json({ reactions });
+            }
+            default:
+              return json({ error: `Unknown action: ${String((p as { action: string }).action)}` });
+          }
+        } catch (err) {
+          return json({ error: err instanceof Error ? err.message : String(err) });
+        }
+      },
+    },
+    { name: "feishu_reaction" },
+  );
+
+  api.logger.info?.("feishu_reaction: Registered feishu_reaction tool");
+}

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -12,6 +12,7 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   drive: true,
   perm: false,
   scopes: true,
+  reaction: true,
 };
 
 /**

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -79,6 +79,7 @@ export type FeishuToolsConfig = {
   drive?: boolean;
   perm?: boolean;
   scopes?: boolean;
+  reaction?: boolean;
 };
 
 export type DynamicAgentCreationConfig = {


### PR DESCRIPTION
## Summary

Expose the existing Feishu reaction API functions as an agent-callable tool, enabling bots to add, remove, and list emoji reactions on messages.

## Motivation

The Feishu plugin already has `im:message.reactions:write_only` permission and full reaction API implementation (`reactions.ts`), but no tool surface for agents to use them. This makes the bot feel more human — it can react with 👍, ❤️, 😂 etc. to user messages.

## Changes

**New files:**
- `reaction-schema.ts` — Typebox parameter schema (3 actions: add/remove/list)
- `reaction-tool.ts` — Tool registration and handler

**Modified files:**
- `index.ts` — Register `feishu_reaction` tool
- `types.ts` — Add `reaction?: boolean` to `FeishuToolsConfig`
- `config-schema.ts` — Add `reaction` to Zod schema
- `tools-config.ts` — Enable by default (`reaction: true`)

## Tool API

```
feishu_reaction(action: 'add', message_id: string, emoji_type: string)
feishu_reaction(action: 'remove', message_id: string, reaction_id: string)
feishu_reaction(action: 'list', message_id: string, emoji_type?: string)
```

Supported emoji types: THUMBSUP, HEART, SMILE, LAUGH, CLAP, FIRE, PARTY, CHECK, etc.

## Design decisions

- Follows the exact same pattern as `feishu_chat` (schema + tool + registration)
- Enabled by default since it's a non-destructive operation
- Uses existing `reactions.ts` functions — no new API integration needed

Fixes #32923