### PR TITLE
feat(feishu): add feishu_sheet tool for reading spreadsheet data

### DIFF
--- a/extensions/feishu/index.ts
+++ b/extensions/feishu/index.ts
@@ -7,6 +7,7 @@ import { registerFeishuDocTools } from "./src/docx.js";
 import { registerFeishuDriveTools } from "./src/drive.js";
 import { registerFeishuPermTools } from "./src/perm.js";
 import { setFeishuRuntime } from "./src/runtime.js";
+import { registerFeishuSheetTools } from "./src/sheet.js";
 import { registerFeishuWikiTools } from "./src/wiki.js";
 
 export { monitorFeishuProvider } from "./src/monitor.js";
@@ -59,6 +60,7 @@ const plugin = {
     registerFeishuDriveTools(api);
     registerFeishuPermTools(api);
     registerFeishuBitableTools(api);
+    registerFeishuSheetTools(api);
   },
 };
 

--- a/extensions/feishu/src/config-schema.ts
+++ b/extensions/feishu/src/config-schema.ts
@@ -92,6 +92,7 @@ const FeishuToolsConfigSchema = z
     drive: z.boolean().optional(), // Cloud storage operations (default: true)
     perm: z.boolean().optional(), // Permission management (default: false, sensitive)
     scopes: z.boolean().optional(), // App scopes diagnostic (default: true)
+    sheet: z.boolean().optional(), // Spreadsheet read operations (default: true)
   })
   .strict()
   .optional();

--- a/extensions/feishu/src/sheet-schema.ts
+++ b/extensions/feishu/src/sheet-schema.ts
@@ -1,0 +1,22 @@
+import { Type, type Static } from "@sinclair/typebox";
+
+const SHEET_ACTION_VALUES = ["read_range", "get_sheets", "get_meta"] as const;
+
+export const FeishuSheetSchema = Type.Object({
+  action: Type.Unsafe<(typeof SHEET_ACTION_VALUES)[number]>({
+    type: "string",
+    enum: [...SHEET_ACTION_VALUES],
+    description: "Action to run: read_range | get_sheets | get_meta",
+  }),
+  spreadsheet_token: Type.String({
+    description: "Spreadsheet token (extract from URL /sheets/XXX or /wiki/XXX)",
+  }),
+  sheet_id: Type.Optional(
+    Type.String({ description: "Sheet/tab ID (required for read_range)" }),
+  ),
+  range: Type.Optional(
+    Type.String({ description: "Cell range to read, e.g. 'A1:C10' (required for read_range)" }),
+  ),
+});
+
+export type FeishuSheetParams = Static<typeof FeishuSheetSchema>;

--- a/extensions/feishu/src/sheet.ts
+++ b/extensions/feishu/src/sheet.ts
@@ -1,0 +1,192 @@
+import type * as Lark from "@larksuiteoapi/node-sdk";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+import { listEnabledFeishuAccounts } from "./accounts.js";
+import { FeishuSheetSchema, type FeishuSheetParams } from "./sheet-schema.js";
+import { createFeishuToolClient } from "./tool-account.js";
+import { resolveToolsConfig } from "./tools-config.js";
+
+// ============ Helpers ============
+
+function json(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+    details: data,
+  };
+}
+
+// ============ Core Functions ============
+
+/** Read cell values from a range */
+async function readRange(
+  client: Lark.Client,
+  spreadsheetToken: string,
+  sheetId: string,
+  range: string,
+) {
+  const fullRange = `${sheetId}!${range}`;
+  const res = (await client.request({
+    method: "GET",
+    url: `/open-apis/sheets/v2/spreadsheets/${spreadsheetToken}/values/${fullRange}`,
+  })) as {
+    code?: number;
+    msg?: string;
+    data?: {
+      revision?: number;
+      spreadsheetToken?: string;
+      valueRange?: {
+        majorDimension?: string;
+        range?: string;
+        revision?: number;
+        values?: unknown[][];
+      };
+    };
+  };
+
+  if (res.code !== 0) {
+    throw new Error(res.msg ?? `Failed to read range: code=${res.code}`);
+  }
+
+  return {
+    range: fullRange,
+    values: res.data?.valueRange?.values ?? [],
+    revision: res.data?.valueRange?.revision,
+  };
+}
+
+/** List all sheets/tabs in a spreadsheet */
+async function getSheets(client: Lark.Client, spreadsheetToken: string) {
+  const res = (await client.request({
+    method: "GET",
+    url: `/open-apis/sheets/v3/spreadsheets/${spreadsheetToken}/sheets/query`,
+  })) as {
+    code?: number;
+    msg?: string;
+    data?: {
+      sheets?: Array<{
+        sheet_id?: string;
+        title?: string;
+        index?: number;
+        hidden?: boolean;
+        grid_properties?: {
+          frozen_row_count?: number;
+          frozen_column_count?: number;
+          row_count?: number;
+          column_count?: number;
+        };
+      }>;
+    };
+  };
+
+  if (res.code !== 0) {
+    throw new Error(res.msg ?? `Failed to list sheets: code=${res.code}`);
+  }
+
+  return {
+    sheets:
+      res.data?.sheets?.map((s) => ({
+        sheet_id: s.sheet_id,
+        title: s.title,
+        index: s.index,
+        hidden: s.hidden,
+        row_count: s.grid_properties?.row_count,
+        column_count: s.grid_properties?.column_count,
+      })) ?? [],
+  };
+}
+
+/** Get spreadsheet metadata */
+async function getMeta(client: Lark.Client, spreadsheetToken: string) {
+  const res = (await client.request({
+    method: "GET",
+    url: `/open-apis/sheets/v3/spreadsheets/${spreadsheetToken}`,
+  })) as {
+    code?: number;
+    msg?: string;
+    data?: {
+      spreadsheet?: {
+        title?: string;
+        owner_id?: string;
+        token?: string;
+        url?: string;
+      };
+    };
+  };
+
+  if (res.code !== 0) {
+    throw new Error(res.msg ?? `Failed to get metadata: code=${res.code}`);
+  }
+
+  return {
+    title: res.data?.spreadsheet?.title,
+    owner_id: res.data?.spreadsheet?.owner_id,
+    token: res.data?.spreadsheet?.token,
+    url: res.data?.spreadsheet?.url,
+  };
+}
+
+// ============ Tool Registration ============
+
+export function registerFeishuSheetTools(api: OpenClawPluginApi) {
+  if (!api.config) {
+    api.logger.debug?.("feishu_sheet: No config available, skipping sheet tools");
+    return;
+  }
+
+  const accounts = listEnabledFeishuAccounts(api.config);
+  if (accounts.length === 0) {
+    api.logger.debug?.("feishu_sheet: No Feishu accounts configured, skipping sheet tools");
+    return;
+  }
+
+  const firstAccount = accounts[0];
+  const toolsCfg = resolveToolsConfig(firstAccount.config.tools);
+  if (!toolsCfg.sheet) {
+    api.logger.debug?.("feishu_sheet: sheet tool disabled in config");
+    return;
+  }
+
+  type AccountAwareParams = { accountId?: string };
+
+  const getClient = (params: AccountAwareParams | undefined, defaultAccountId?: string) =>
+    createFeishuToolClient({ api, executeParams: params, defaultAccountId });
+
+  api.registerTool(
+    (ctx) => ({
+      name: "feishu_sheet",
+      label: "Feishu Sheet",
+      description:
+        "Feishu spreadsheet operations. Actions: read_range (read cells), get_sheets (list tabs), get_meta (spreadsheet info)",
+      parameters: FeishuSheetSchema,
+      async execute(_toolCallId, params) {
+        const p = params as FeishuSheetParams & AccountAwareParams;
+        try {
+          const client = getClient(p, ctx.agentAccountId);
+          switch (p.action) {
+            case "read_range": {
+              if (!p.sheet_id) {
+                return json({ error: "sheet_id is required for read_range action" });
+              }
+              if (!p.range) {
+                return json({ error: "range is required for read_range action" });
+              }
+              return json(
+                await readRange(client, p.spreadsheet_token, p.sheet_id, p.range),
+              );
+            }
+            case "get_sheets":
+              return json(await getSheets(client, p.spreadsheet_token));
+            case "get_meta":
+              return json(await getMeta(client, p.spreadsheet_token));
+            default:
+              return json({ error: `Unknown action: ${String(p.action)}` });
+          }
+        } catch (err) {
+          return json({ error: err instanceof Error ? err.message : String(err) });
+        }
+      },
+    }),
+    { name: "feishu_sheet" },
+  );
+
+  api.logger.info?.("feishu_sheet: Registered feishu_sheet tool");
+}

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -56,6 +56,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     drive: false,
     perm: false,
     scopes: false,
+    sheet: false,
   };
   for (const account of accounts) {
     const cfg = resolveToolsConfig(account.config.tools);
@@ -65,6 +66,7 @@ export function resolveAnyEnabledFeishuToolsConfig(
     merged.drive = merged.drive || cfg.drive;
     merged.perm = merged.perm || cfg.perm;
     merged.scopes = merged.scopes || cfg.scopes;
+    merged.sheet = merged.sheet || cfg.sheet;
   }
   return merged;
 }

--- a/extensions/feishu/src/tools-config.ts
+++ b/extensions/feishu/src/tools-config.ts
@@ -12,6 +12,7 @@ export const DEFAULT_TOOLS_CONFIG: Required<FeishuToolsConfig> = {
   drive: true,
   perm: false,
   scopes: true,
+  sheet: true,
 };
 
 /**

--- a/extensions/feishu/src/types.ts
+++ b/extensions/feishu/src/types.ts
@@ -79,6 +79,7 @@ export type FeishuToolsConfig = {
   drive?: boolean;
   perm?: boolean;
   scopes?: boolean;
+  sheet?: boolean;
 };
 
 export type DynamicAgentCreationConfig = {


### PR DESCRIPTION
## Summary

Add native Feishu Sheets read capability so agents can access spreadsheet cell data directly. This closes the gap where `feishu_wiki` could identify sheet nodes (`obj_type=sheet`) but agents had no way to actually read cell content.

## Motivation

Feishu Sheets and Bitable are separate products with separate APIs. The plugin already supports Bitable (`feishu_bitable_*`), but Sheets had zero read support — blocking data workflows where spreadsheets are the source of truth.

## Changes

**New files:**
- `sheet-schema.ts` — Typebox parameter schema (3 actions)
- `sheet.ts` — Full tool implementation using Feishu Sheets API v2/v3

**Modified files:**
- `index.ts` — Register `feishu_sheet` tool
- `types.ts` — Add `sheet?: boolean` to `FeishuToolsConfig`
- `config-schema.ts` — Add `sheet` to Zod validation schema
- `tools-config.ts` — Enable by default (`sheet: true`)
- `tool-account.ts` — Add `sheet` to merged multi-account config

## Tool API

| Action | Description | Params |
|--------|-------------|--------|
| `read_range` | Read cell values from a range | `spreadsheet_token`, `sheet_id`, `range` (e.g. `A1:C10`) |
| `get_sheets` | List all sheets/tabs | `spreadsheet_token` |
| `get_meta` | Get spreadsheet metadata | `spreadsheet_token` |

## Design decisions

- Uses `client.request()` for raw HTTP calls since the Lark SDK has no typed sheets methods
- Follows the `createFeishuToolClient` pattern (same as bitable.ts) for multi-account support
- Returns structured JSON with 2D value arrays for `read_range`
- Enabled by default since it's a read-only operation

Fixes #29595