### PR TITLE
fix: node service install/uninstall uses wrong systemd unit name

### DIFF
--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -481,7 +481,7 @@ export async function installSystemdService({
   });
   await fs.writeFile(unitPath, unit, "utf8");
 
-  const serviceName = resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
+  const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
   const reload = await execSystemctlUser(env, ["daemon-reload"]);
   if (reload.code !== 0) {
@@ -525,7 +525,7 @@ export async function uninstallSystemdService({
   stdout,
 }: GatewayServiceManageArgs): Promise<void> {
   await assertSystemdAvailable(env);
-  const serviceName = resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE);
+  const serviceName = resolveSystemdServiceName(env);
   const unitName = `${serviceName}.service`;
   await execSystemctlUser(env, ["disable", "--now", unitName]);
 


### PR DESCRIPTION
## Problem

`openclaw node install` fails on Linux with:

```
systemctl enable failed: Unit file openclaw-gateway.service does not exist.
```

## Cause

`installSystemdService` and `uninstallSystemdService` in `src/daemon/systemd.ts` use `resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE)` to derive the unit name for `systemctl enable`/`disable`. This ignores the `OPENCLAW_SYSTEMD_UNIT` env override that `node-service.ts` sets via `withNodeServiceEnv`.

The unit file itself is written to the correct path (`openclaw-node.service`) because `resolveSystemdUnitPath` calls `resolveSystemdServiceName(env)`, which does respect the override. Only the subsequent `systemctl` commands used the hardcoded gateway name.

## Fix

Replace `resolveGatewaySystemdServiceName(env.OPENCLAW_PROFILE)` with `resolveSystemdServiceName(env)` on the two affected lines. `resolveSystemdServiceName` already exists in the same file and correctly reads `OPENCLAW_SYSTEMD_UNIT` before falling back to the gateway default.

Two-line change, no new code, no behavior change for gateway installs (the env override is unset, so it falls through to the same function).

## Prompt used

Discovered the bug while running `openclaw node install` on WSL2/Ubuntu. Traced the issue by reading `node-service.ts` → `withNodeServiceEnv` → `resolveSystemdServiceName` and noticing the mismatch with the hardcoded calls in `installSystemdService`/`uninstallSystemdService`.