### PR TITLE
fix(ui): persist Control UI gateway token in sessionStorage

### DIFF
--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -154,7 +154,6 @@ describe("control UI routing", () => {
     expect(JSON.parse(localStorage.getItem("openclaw.control.settings.v1") ?? "{}").token).toBe(
       undefined,
     );
-    expect(sessionStorage.getItem("openclaw.control.session-token.v1")).toBe("abc123");
     expect(window.location.pathname).toBe("/ui/overview");
     expect(window.location.search).toBe("");
   });
@@ -183,7 +182,9 @@ describe("control UI routing", () => {
     expect(JSON.parse(localStorage.getItem("openclaw.control.settings.v1") ?? "{}").token).toBe(
       undefined,
     );
-    expect(sessionStorage.getItem("openclaw.control.session-token.v1")).toBe("abc123");
+    expect(sessionStorage.getItem(`openclaw.control.token.v1:${app.settings.gatewayUrl}`)).toBe(
+      "abc123",
+    );
     expect(window.location.pathname).toBe("/ui/overview");
     expect(window.location.hash).toBe("");
   });
@@ -196,7 +197,9 @@ describe("control UI routing", () => {
     expect(JSON.parse(localStorage.getItem("openclaw.control.settings.v1") ?? "{}").token).toBe(
       undefined,
     );
-    expect(sessionStorage.getItem("openclaw.control.session-token.v1")).toBe("abc123");
+    expect(sessionStorage.getItem(`openclaw.control.token.v1:${app.settings.gatewayUrl}`)).toBe(
+      "abc123",
+    );
     expect(window.location.pathname).toBe("/ui/overview");
     expect(window.location.hash).toBe("");
   });

--- a/ui/src/ui/navigation.browser.test.ts
+++ b/ui/src/ui/navigation.browser.test.ts
@@ -154,6 +154,7 @@ describe("control UI routing", () => {
     expect(JSON.parse(localStorage.getItem("openclaw.control.settings.v1") ?? "{}").token).toBe(
       undefined,
     );
+    expect(sessionStorage.getItem("openclaw.control.session-token.v1")).toBe("abc123");
     expect(window.location.pathname).toBe("/ui/overview");
     expect(window.location.search).toBe("");
   });
@@ -182,6 +183,7 @@ describe("control UI routing", () => {
     expect(JSON.parse(localStorage.getItem("openclaw.control.settings.v1") ?? "{}").token).toBe(
       undefined,
     );
+    expect(sessionStorage.getItem("openclaw.control.session-token.v1")).toBe("abc123");
     expect(window.location.pathname).toBe("/ui/overview");
     expect(window.location.hash).toBe("");
   });
@@ -194,6 +196,7 @@ describe("control UI routing", () => {
     expect(JSON.parse(localStorage.getItem("openclaw.control.settings.v1") ?? "{}").token).toBe(
       undefined,
     );
+    expect(sessionStorage.getItem("openclaw.control.session-token.v1")).toBe("abc123");
     expect(window.location.pathname).toBe("/ui/overview");
     expect(window.location.hash).toBe("");
   });

--- a/ui/src/ui/storage.node.test.ts
+++ b/ui/src/ui/storage.node.test.ts
@@ -139,19 +139,12 @@ describe("loadSettings default gateway URL derivation", () => {
   });
 
   it("loads session token even when localStorage settings are missing", async () => {
-    setTestLocation({
-      protocol: "https:",
-      host: "gateway.example:8443",
-      pathname: "/",
-    });
-    sessionStorage.setItem(
-      "openclaw.control.token.v1:wss://gateway.example:8443/openclaw",
-      "session-token",
-    );
+    const gatewayUrl = `ws://${window.location.host}`;
+    sessionStorage.setItem(`openclaw.control.token.v1:${gatewayUrl}`, "session-token");
 
     const { loadSettings } = await import("./storage.ts");
     expect(loadSettings()).toMatchObject({
-      gatewayUrl: "wss://gateway.example:8443/openclaw",
+      gatewayUrl,
       token: "session-token",
       sessionKey: "main",
     });

--- a/ui/src/ui/storage.node.test.ts
+++ b/ui/src/ui/storage.node.test.ts
@@ -138,6 +138,25 @@ describe("loadSettings default gateway URL derivation", () => {
     expect(sessionStorage.length).toBe(0);
   });
 
+  it("loads session token even when localStorage settings are missing", async () => {
+    setTestLocation({
+      protocol: "https:",
+      host: "gateway.example:8443",
+      pathname: "/",
+    });
+    sessionStorage.setItem(
+      "openclaw.control.token.v1:wss://gateway.example:8443/openclaw",
+      "session-token",
+    );
+
+    const { loadSettings } = await import("./storage.ts");
+    expect(loadSettings()).toMatchObject({
+      gatewayUrl: "wss://gateway.example:8443/openclaw",
+      token: "session-token",
+      sessionKey: "main",
+    });
+  });
+
   it("loads the current-tab token from sessionStorage", async () => {
     setTestLocation({
       protocol: "https:",


### PR DESCRIPTION
## Summary
- persist the Control UI gateway token in `sessionStorage`
- keep token imports from `?token=` / `#token=` working as before
- continue avoiding `localStorage` persistence for gateway auth

## Why
Today the Control UI imports `token` from the URL, strips it from the address bar, and keeps it in memory only. That means a normal page refresh drops the token and disconnects the UI.

This is especially painful for loopback/local dashboard use, where the expected UX is:
- refresh should keep working
- closing the tab should clear the token

`sessionStorage` is a reasonable middle ground:
- survives refreshes within the same tab
- is cleared when the tab/window session ends
- still avoids long-lived `localStorage` persistence

## Implementation
- load token from `sessionStorage` during settings bootstrap
- save token to `sessionStorage` in `saveSettings`
- keep persisted UI settings in `localStorage` token-free
- update tests to verify URL token hydration + session-only persistence

## Tests
- `ui/src/ui/storage.node.test.ts`
- `ui/src/ui/navigation.browser.test.ts`

## Notes
This preserves the existing security intent of not storing the gateway token in `localStorage`, while fixing the refresh-disconnect UX.
