### PR TITLE
docs(usage): clarify which usage surface to use

### DIFF
--- a/docs/concepts/usage-tracking.md
+++ b/docs/concepts/usage-tracking.md
@@ -13,6 +13,16 @@ title: "Usage Tracking"
 - Pulls provider usage/quota directly from their usage endpoints.
 - No estimated costs; only the provider-reported windows.
 
+## Which surface should I use?
+
+- Use `/status` when you want the current session model, context usage, and the last reply's tokens.
+- Use `/usage tokens` or `/usage full` when you want a usage footer on every reply.
+- Use `/usage cost` when you want a local cost summary from OpenClaw session logs.
+- Use `openclaw status --usage` when you want a quick CLI view of provider quota windows and reset times.
+- Use `openclaw channels list` when you also want broader provider/channel diagnostics alongside the same usage snapshot.
+
+If you only need CLI quota usage, prefer `openclaw status --usage`. `openclaw channels list` is broader and can be slower because it includes additional config/health context.
+
 ## Where it shows up
 
 - `/status` in chats: emoji‑rich status card with session tokens + estimated cost (API key only). Provider usage shows for the **current model provider** when available.

--- a/docs/reference/api-usage-costs.md
+++ b/docs/reference/api-usage-costs.md
@@ -29,6 +29,9 @@ OpenClaw features that can generate provider usage or paid API calls.
 - `openclaw status --usage` and `openclaw channels list` show provider **usage windows**
   (quota snapshots, not per-message costs).
 
+For a quick CLI quota check, prefer `openclaw status --usage`. Use `openclaw channels list`
+when you also want broader provider/channel diagnostics in the same output.
+
 See [Token use & costs](/reference/token-use) for details and examples.
 
 ## How keys are discovered

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -61,6 +61,16 @@ Other surfaces:
 - **CLI:** `openclaw status --usage` and `openclaw channels list` show
   provider quota windows (not per-response costs).
 
+### Which surface should I use?
+
+- Use `/status` for the current session: model, context usage, and the last reply's tokens.
+- Use `/usage off|tokens|full` when you want per-reply token or cost footers in chat.
+- Use `/usage cost` when you want a local rollup from session logs.
+- Use `openclaw status --usage` when you want a focused CLI snapshot of provider quota windows.
+- Use `openclaw channels list` when you need the same quota snapshot plus broader provider/channel diagnostics.
+
+If you only need provider quota windows in CLI, prefer `openclaw status --usage`.
+
 ## Cost estimation (when shown)
 
 Costs are estimated from your model pricing config:

--- a/docs/zh-CN/concepts/usage-tracking.md
+++ b/docs/zh-CN/concepts/usage-tracking.md
@@ -20,6 +20,16 @@ x-i18n:
 - 直接从提供商的使用量端点拉取使用量/配额数据。
 - 不提供估算费用；仅展示提供商报告的时间窗口数据。
 
+## 我该用哪个界面？
+
+- 想看当前会话的模型、上下文占用和上一条回复的 token：用 `/status`。
+- 想让每条回复都自动带上 token/费用页脚：用 `/usage tokens` 或 `/usage full`。
+- 想看基于 OpenClaw 会话日志汇总的本地费用：用 `/usage cost`。
+- 想在 CLI 里快速看提供商配额窗口和重置时间：用 `openclaw status --usage`。
+- 想把同一份 usage 快照和更完整的 provider/channel 诊断一起看：用 `openclaw channels list`。
+
+如果你在 CLI 里只是想快速看配额，优先用 `openclaw status --usage`。openclaw channels list 更宽，也通常更慢，因为它会同时输出额外的配置和健康信息。
+
 ## 展示位置
 
 - 聊天中的 `/status`：包含会话 token 数和估算费用的表情符号丰富的状态卡片（仅限 API 密钥）。当可用时，会显示**当前模型提供商**的使用量。

--- a/docs/zh-CN/reference/api-usage-costs.md
+++ b/docs/zh-CN/reference/api-usage-costs.md
@@ -34,6 +34,8 @@ x-i18n:
 
 - `openclaw status --usage` 和 `openclaw channels list` 显示提供商**用量窗口**（配额快照，非每条消息的费用）。
 
+如果你只是想在 CLI 中快速查看配额，优先用 `openclaw status --usage`。如果你还想同时查看更完整的 provider/channel 诊断，再使用 `openclaw channels list`。
+
 详情和示例请参阅 [Token 用量与费用](/reference/token-use)。
 
 ## 密钥的发现方式

--- a/docs/zh-CN/reference/token-use.md
+++ b/docs/zh-CN/reference/token-use.md
@@ -62,6 +62,16 @@ OpenClaw 在每次运行时组装自己的系统提示词。它包括：
 - **CLI：** `openclaw status --usage` 和 `openclaw channels list` 显示
   提供商配额窗口（不是每响应成本）。
 
+### 我该用哪个界面？
+
+- 想看当前会话：模型、上下文占用、上一条回复 token，用 `/status`。
+- 想在聊天里给每条回复都附带 token 或费用页脚，用 `/usage off|tokens|full`。
+- 想看基于会话日志的本地汇总，用 `/usage cost`。
+- 想在 CLI 中看聚焦的提供商配额窗口，用 `openclaw status --usage`。
+- 想在同一个输出里同时看配额快照和更完整的 provider/channel 诊断，用 `openclaw channels list`。
+
+如果你在 CLI 中只想看提供商配额窗口，优先用 `openclaw status --usage`。
+
 ## 成本估算（显示时）
 
 成本从你的模型定价配置估算：


### PR DESCRIPTION
## Summary

- Problem: usage information exists in several places (`/status`, `/usage`, `openclaw status --usage`, token docs), but the current docs do not clearly tell users which surface to use for which question.
- Why it matters: users who just want a quick usage answer often end up guessing, invoking the wrong command, or asking the model instead of using the built-in non-LLM surfaces.
- What changed: adds concise guidance in both English and Chinese docs that maps common questions to the right usage surface.
- What did NOT change: no runtime behavior, no command changes, no new config, no auth/channel changes.

## Change Type

- [x] Docs

## Scope

- [x] UI / DX

## Linked Issue/PR

- Closes: None
- Related: None

## User-visible / Behavior Changes

- Docs now explicitly explain when to use `/status`, `/usage`, `openclaw status --usage`, and the usage/cost reference pages.
- Chinese docs receive the same clarification.
- No product behavior change.

## Security Impact

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`
- If any `Yes`, explain risk + mitigation: `N/A`

## Repro + Verification

### Environment

- OS: Windows 11
- Runtime/container: native Node/OpenClaw CLI
- Model/provider: OpenAI Codex OAuth
- Integration/channel (if any): Feishu and Telegram available locally, but not required for this docs change
- Relevant config (redacted): existing local OpenClaw setup with usage surfaces available

### Steps

1. Read the existing usage docs and compare them against the actual CLI and slash-command surfaces.
2. Update the docs so they answer the question: "which usage surface should I use for this need?"
3. Verify both English and Chinese pages remain consistent.

### Expected

- A user can quickly tell which built-in usage surface answers a given question.
- The docs steer users toward non-LLM usage checks instead of guesswork.

### Actual

- The updated docs now map common usage questions to the correct surface in both languages.

## Evidence

- [x] Trace/log snippets

Verification commands used during authoring:

- `openclaw status --usage`
- `openclaw usage --help` (where available in local experiments)
- `openclaw /status` and `/usage` doc surface comparison
- `git diff --check`

## Human Verification

- Verified scenarios:
  - reading the updated English docs as a new user flow
  - reading the updated Chinese docs for the same flow
  - checking that the referenced surfaces match real OpenClaw usage entry points
- Edge cases checked:
  - users who want current quota vs. users who want cost/token reference docs
  - users coming from chat commands vs. local CLI
- What I did **not** verify:
  - every wording variant across every downstream channel integration
  - any runtime behavior, since this is docs-only

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery

- How to disable/revert this change quickly: revert the six docs files in this PR.
- Files/config to restore: the touched docs files only.
- Known bad symptoms reviewers should watch for:
  - wording that implies a new command exists when it does not
  - wording that conflates cost docs with live usage/quota status

## Risks and Mitigations

- Risk: docs wording could accidentally overstate what a given usage surface returns.
  - Mitigation: the copy is framed around existing built-in surfaces only and was checked against the current local CLI/docs behavior.

## AI-assisted transparency

- AI-assisted: `Yes`
- Testing level: `Human-verified on a working local OpenClaw setup`