### PR TITLE
fix(messages): add suppressMutatingToolErrorWarnings config option

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.errors.test.ts
@@ -282,6 +282,26 @@ describe("buildEmbeddedRunPayloads", () => {
     expect(payloads).toHaveLength(0);
   });
 
+  it("suppresses mutating tool errors when messages.suppressMutatingToolErrorWarnings is enabled", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "edit", error: "non-unique match" },
+      config: { messages: { suppressMutatingToolErrorWarnings: true } },
+    });
+
+    expect(payloads).toHaveLength(0);
+  });
+
+  it("still shows mutating tool errors when only messages.suppressToolErrors is enabled", () => {
+    const payloads = buildPayloads({
+      lastToolError: { toolName: "edit", error: "non-unique match" },
+      config: { messages: { suppressToolErrors: true } },
+    });
+
+    expect(payloads).toHaveLength(1);
+    expect(payloads[0]?.isError).toBe(true);
+    expect(payloads[0]?.text).toContain("Edit");
+  });
+
   it.each([
     {
       name: "still shows mutating tool errors when messages.suppressToolErrors is enabled",

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -57,6 +57,7 @@ function resolveToolErrorWarningPolicy(params: {
   hasUserFacingReply: boolean;
   suppressToolErrors: boolean;
   suppressToolErrorWarnings?: boolean;
+  suppressMutatingToolErrorWarnings?: boolean;
   verboseLevel?: VerboseLevel;
 }): ToolErrorWarningPolicy {
   const includeDetails = isVerboseToolDetailEnabled(params.verboseLevel);
@@ -76,6 +77,10 @@ function resolveToolErrorWarningPolicy(params: {
   const isMutatingToolError =
     params.lastToolError.mutatingAction ?? isLikelyMutatingToolName(params.lastToolError.toolName);
   if (isMutatingToolError) {
+    // Allow suppressing mutating tool error warnings via config (#39631).
+    if (params.suppressMutatingToolErrorWarnings) {
+      return { showWarning: false, includeDetails };
+    }
     return { showWarning: true, includeDetails };
   }
   if (params.suppressToolErrors) {
@@ -281,10 +286,13 @@ export function buildEmbeddedRunPayloads(params: {
       hasUserFacingReply: hasUserFacingAssistantReply,
       suppressToolErrors: Boolean(params.config?.messages?.suppressToolErrors),
       suppressToolErrorWarnings: params.suppressToolErrorWarnings,
+      suppressMutatingToolErrorWarnings: Boolean(
+        params.config?.messages?.suppressMutatingToolErrorWarnings,
+      ),
       verboseLevel: params.verboseLevel,
     });
 
-    // Always surface mutating tool failures so we do not silently confirm actions that did not happen.
+    // Surface mutating tool failures unless explicitly suppressed via config.
     // Otherwise, keep the previous behavior and only surface non-recoverable failures when no reply exists.
     if (warningPolicy.showWarning) {
       const toolSummary = formatToolAggregate(

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1429,6 +1429,8 @@ export const FIELD_HELP: Record<string, string> = {
     "Additional Telegram bot menu commands (merged with native; conflicts ignored).",
   "messages.suppressToolErrors":
     "When true, suppress ⚠️ tool-error warnings from being shown to the user. The agent already sees errors in context and can retry. Default: false.",
+  "messages.suppressMutatingToolErrorWarnings":
+    "When true, suppress ⚠️ warnings for mutating tool failures (edit, write, etc.) from being shown to the user. Use with caution — users won't see when file operations fail. Default: false.",
   "messages.ackReaction": "Emoji reaction used to acknowledge inbound messages (empty disables).",
   "messages.ackReactionScope":
     'When to send ack reactions ("group-mentions", "group-all", "direct", "all", "off", "none"). "off"/"none" disables ack reactions entirely.',

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -665,6 +665,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "messages.queue.drop": "Queue Drop Strategy",
   "messages.inbound": "Inbound Debounce",
   "messages.suppressToolErrors": "Suppress Tool Error Warnings",
+  "messages.suppressMutatingToolErrorWarnings": "Suppress Mutating Tool Error Warnings",
   "messages.ackReaction": "Ack Reaction Emoji",
   "messages.ackReactionScope": "Ack Reaction Scope",
   "messages.removeAckAfterReply": "Remove Ack Reaction After Reply",

--- a/src/config/types.messages.ts
+++ b/src/config/types.messages.ts
@@ -119,6 +119,12 @@ export type MessagesConfig = {
   statusReactions?: StatusReactionsConfig;
   /** When true, suppress ⚠️ tool-error warnings from being shown to the user. Default: false. */
   suppressToolErrors?: boolean;
+  /**
+   * When true, suppress ⚠️ warnings for mutating tool failures (edit, write, etc.)
+   * from being shown to the user. Use with caution — users won't see when file
+   * operations fail. Default: false.
+   */
+  suppressMutatingToolErrorWarnings?: boolean;
   /** Text-to-speech settings for outbound replies. */
   tts?: TtsConfig;
 };

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -186,6 +186,7 @@ export const MessagesSchema = z
       .strict()
       .optional(),
     suppressToolErrors: z.boolean().optional(),
+    suppressMutatingToolErrorWarnings: z.boolean().optional(),
     tts: TtsConfigSchema,
   })
   .strict()


### PR DESCRIPTION
## Summary

Adds `messages.suppressMutatingToolErrorWarnings` config option to suppress ⚠️ warnings for mutating tool failures (edit, write, etc.) from being shown to users.

## Problem

Previously, mutating tool errors were always surfaced to users for safety (so users know when file operations fail). This caused internal tool error messages like:

```
⚠️ 📝 Edit: in ~/path/file.md (1419 chars) failed
```

to leak into user-facing chats (Telegram groups, etc.), which can be confusing for non-technical users and expose internal implementation details.

## Solution

Add a new config option that allows deployments to suppress these warnings when appropriate. The agent already sees errors in context and can retry.

### Config

```json5
{
  messages: {
    suppressMutatingToolErrorWarnings: true, // default: false
  },
}
```

### Changes

- Add `messages.suppressMutatingToolErrorWarnings` config option (default: false)
- Update `resolveToolErrorWarningPolicy` to check the new option
- Add schema validation, labels, and help text
- Add tests for the new behavior

## Notes

- The existing `messages.suppressToolErrors` only suppresses non-mutating tool errors
- The existing `suppressToolErrorWarnings` only applies to heartbeat runs
- This new option specifically targets mutating tool errors in normal chat sessions

Fixes #39631
Related to #39406