### PR TITLE
Skills: recover unquoted colon descriptions

### DIFF
--- a/src/agents/skills.loadworkspaceskillentries.test.ts
+++ b/src/agents/skills.loadworkspaceskillentries.test.ts
@@ -175,4 +175,29 @@ describe("loadWorkspaceSkillEntries", () => {
       expect(entries.map((entry) => entry.skill.name)).not.toContain("outside-file-skill");
     },
   );
+
+  it("loads skills when description contains an unquoted colon", async () => {
+    const workspaceDir = await createTempWorkspaceDir();
+    const skillDir = path.join(workspaceDir, "skills", "colon-desc");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(
+      path.join(skillDir, "SKILL.md"),
+      `---
+name: colon-desc
+description: Use anime style IMPORTANT: Must be kawaii
+---
+
+# Colon description
+`,
+      "utf-8",
+    );
+
+    const entries = loadWorkspaceSkillEntries(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, ".managed"),
+      bundledSkillsDir: path.join(workspaceDir, ".bundled"),
+    });
+
+    const skill = entries.find((entry) => entry.skill.name === "colon-desc");
+    expect(skill?.skill.description).toBe("Use anime style IMPORTANT: Must be kawaii");
+  });
 });

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -276,19 +276,6 @@ function resolveNestedSkillsRoot(
   return { baseDir: dir };
 }
 
-function unwrapLoadedSkills(loaded: unknown): Skill[] {
-  if (Array.isArray(loaded)) {
-    return loaded as Skill[];
-  }
-  if (loaded && typeof loaded === "object" && "skills" in loaded) {
-    const skills = (loaded as { skills?: unknown }).skills;
-    if (Array.isArray(skills)) {
-      return skills as Skill[];
-    }
-  }
-  return [];
-}
-
 function loadSkillEntries(
   workspaceDir: string,
   opts?: {
@@ -343,9 +330,13 @@ function loadSkillEntries(
         return [];
       }
 
-      const loaded = loadSkillsFromDir({ dir: baseDir, source: params.source });
+      const loaded = loadSkillsWithDiagnostics({
+        dir: baseDir,
+        source: params.source,
+        fallbackSkillFilePath: rootSkillMd,
+      });
       return filterLoadedSkillsInsideRoot({
-        skills: unwrapLoadedSkills(loaded),
+        skills: loaded,
         source: params.source,
         rootDir,
         rootRealPath: baseDirRealPath,
@@ -417,10 +408,14 @@ function loadSkillEntries(
         continue;
       }
 
-      const loaded = loadSkillsFromDir({ dir: skillDir, source: params.source });
+      const loaded = loadSkillsWithDiagnostics({
+        dir: skillDir,
+        source: params.source,
+        fallbackSkillFilePath: skillMd,
+      });
       loadedSkills.push(
         ...filterLoadedSkillsInsideRoot({
-          skills: unwrapLoadedSkills(loaded),
+          skills: loaded,
           source: params.source,
           rootDir,
           rootRealPath: baseDirRealPath,
@@ -599,6 +594,96 @@ type WorkspaceSkillBuildOptions = {
   skillFilter?: string[];
   eligibility?: SkillEligibilityContext;
 };
+
+type LoadedSkillsWithDiagnostics = {
+  skills: Skill[];
+  diagnostics: Array<{ message?: string; path?: string }>;
+};
+
+function parseFrontmatterBoolString(value: string | undefined, fallback: boolean): boolean {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) {
+    return fallback;
+  }
+  if (["true", "1", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["false", "0", "no", "off"].includes(normalized)) {
+    return false;
+  }
+  return fallback;
+}
+
+function loadSkillFromFileFallback(filePath: string, source: string): Skill | null {
+  try {
+    const rawContent = fs.readFileSync(filePath, "utf-8");
+    const frontmatter = parseFrontmatter(rawContent);
+    const description = frontmatter.description?.trim();
+    if (!description) {
+      return null;
+    }
+    const skillDir = path.dirname(filePath);
+    return {
+      name: frontmatter.name?.trim() || path.basename(skillDir),
+      description,
+      filePath,
+      baseDir: skillDir,
+      source,
+      disableModelInvocation: parseFrontmatterBoolString(
+        frontmatter["disable-model-invocation"],
+        false,
+      ),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function loadSkillsWithDiagnostics(params: {
+  dir: string;
+  source: string;
+  fallbackSkillFilePath?: string;
+}): Skill[] {
+  const loaded = loadSkillsFromDir({ dir: params.dir, source: params.source });
+  const normalized = (() => {
+    if (Array.isArray(loaded)) {
+      return { skills: loaded as Skill[], diagnostics: [] } as LoadedSkillsWithDiagnostics;
+    }
+    if (loaded && typeof loaded === "object" && "skills" in loaded) {
+      const result = loaded as { skills?: unknown; diagnostics?: unknown };
+      return {
+        skills: Array.isArray(result.skills) ? (result.skills as Skill[]) : [],
+        diagnostics: Array.isArray(result.diagnostics)
+          ? (result.diagnostics as Array<{ message?: string; path?: string }>)
+          : [],
+      } satisfies LoadedSkillsWithDiagnostics;
+    }
+    return { skills: [], diagnostics: [] } as LoadedSkillsWithDiagnostics;
+  })();
+
+  if (normalized.skills.length > 0) {
+    return normalized.skills;
+  }
+
+  const fallbackFile = params.fallbackSkillFilePath;
+  if (!fallbackFile || !fs.existsSync(fallbackFile)) {
+    return normalized.skills;
+  }
+
+  const fallback = loadSkillFromFileFallback(fallbackFile, params.source);
+  if (!fallback) {
+    return normalized.skills;
+  }
+
+  const summary = normalized.diagnostics
+    .map((diag) => diag.message?.trim())
+    .filter((message): message is string => Boolean(message))
+    .join("; ");
+  skillsLogger.warn(
+    `Skill parser fallback loaded ${path.basename(path.dirname(fallbackFile))} from ${fallbackFile}${summary ? ` (${summary})` : ""}. If your description contains ':', quote it in frontmatter to avoid YAML parser issues.`,
+  );
+  return [fallback];
+}
 
 function resolveWorkspaceSkillPromptState(
   workspaceDir: string,


### PR DESCRIPTION
### Motivation

- Some SKILL.md frontmatter descriptions that include unquoted colons (e.g. `description: ... IMPORTANT: ...`) could cause the upstream parser to return no skills, silently dropping them from the workspace snapshot.

### Description

- Add a resilient fallback loader in `src/agents/skills/workspace.ts` that normalizes `loadSkillsFromDir` results and diagnostics and attempts a direct `SKILL.md` frontmatter parse when no skills are returned.
- Implement helper utilities `parseFrontmatterBoolString`, `loadSkillFromFileFallback`, and `loadSkillsWithDiagnostics` and wire them into both root-skill and per-directory loading flows in `loadSkillEntries` so a skill can be recovered when the main loader yields nothing.
- Emit a helpful warning via `skillsLogger.warn` when the fallback is used, including parse diagnostics and guidance to quote `:` in frontmatter descriptions.
- Add a regression test `src/agents/skills.loadworkspaceskillentries.test.ts` that verifies a skill with an unquoted colon in its `description` is loaded with the expected description.

### Testing

- Ran `pnpm -s vitest src/agents/skills.loadworkspaceskillentries.test.ts src/markdown/frontmatter.test.ts` and both test files passed.
- The added test `loads skills when description contains an unquoted colon` succeeded and validates the fallback behavior.

