### PR TITLE
feat: add onQueued callback for user-visible feedback when messages are queued

### DIFF
--- a/src/auto-reply/reply/agent-runner.ts
+++ b/src/auto-reply/reply/agent-runner.ts
@@ -218,6 +218,13 @@ export async function runReplyAgent(params: {
   if (activeRunQueueAction === "enqueue-followup") {
     enqueueFollowupRun(queueKey, followupRun, resolvedQueue);
     await touchActiveSessionEntry();
+    // Notify callers that the message was queued (not dropped) so channels
+    // can provide user-visible feedback (e.g., ⏳ reaction).
+    try {
+      await opts?.onQueued?.();
+    } catch {
+      // Non-critical — don't let notification failures block the queue path.
+    }
     typing.cleanup();
     return undefined;
   }

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -32,6 +32,9 @@ export type GetReplyOptions = {
   onReplyStart?: () => Promise<void> | void;
   /** Called when the typing controller cleans up (e.g., run ended with NO_REPLY). */
   onTypingCleanup?: () => void;
+  /** Called when the message is queued because the agent is busy with a previous run.
+   *  Channels can use this to provide immediate user-visible feedback (e.g., a ⏳ reaction). */
+  onQueued?: () => Promise<void> | void;
   onTypingController?: (typing: TypingController) => void;
   isHeartbeat?: boolean;
   /** Policy-level typing control for run classes (user/system/internal/heartbeat). */

--- a/src/discord/monitor/message-handler.process.ts
+++ b/src/discord/monitor/message-handler.process.ts
@@ -762,6 +762,9 @@ export async function processDiscordMessage(ctx: DiscordMessagePreflightContext)
           }
           await statusReactions.setTool(payload.name);
         },
+        onQueued: async () => {
+          await statusReactions.setQueued();
+        },
       },
     });
     if (isProcessAborted(abortSignal)) {

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -678,6 +678,13 @@ export const dispatchTelegramMessage = async ({
               await statusReactionController.setTool(payload.name);
             }
           : undefined,
+        onQueued: statusReactionController
+          ? async () => {
+              // When the message is queued (agent busy), show a distinct "queued"
+              // emoji so the user knows the message was received and is waiting.
+              await statusReactionController.setQueued();
+            }
+          : undefined,
         onModelSelected,
       },
     }));


### PR DESCRIPTION
## Summary

When an agent is busy processing a previous message, new incoming messages are silently queued (`queuedFinal=false`) with **zero user-visible feedback**. From the user's perspective, it looks like the message was lost.

This PR adds an `onQueued` callback to `GetReplyOptions` that channels can use to provide immediate feedback when a message is queued.

## Changes

### Core (`src/auto-reply/`)
- **`types.ts`**: Add `onQueued?: () => Promise<void> | void` to `GetReplyOptions`
- **`agent-runner.ts`**: Invoke `onQueued` in the `enqueue-followup` branch, before `typing.cleanup()`. Wrapped in try/catch to ensure queue path is never blocked by notification failures.

### Telegram (`src/telegram/`)
- **`bot-message-dispatch.ts`**: Wire `onQueued` to `statusReactionController.setQueued()` when status reactions are enabled.

### Discord (`src/discord/`)
- **`message-handler.process.ts`**: Wire `onQueued` to `statusReactions.setQueued()`.

### Generic dispatch path (`dispatch-from-config.ts`)
- No changes needed — `onQueued` is automatically inherited from `...params.replyOptions` spread. Channel extensions (Feishu, WhatsApp, Signal, etc.) can set `onQueued` in their reply dispatcher's `replyOptions`.

## How it works

```
Before:
  User sends message → Agent busy → message silently queued → NO FEEDBACK

After:
  User sends message → Agent busy → message queued → onQueued() fires
    → Telegram: 👀 reaction (via statusReactionController)
    → Discord: 👀 reaction (via statusReactions)
    → Feishu/others: can set onQueued in their replyOptions
```

## Testing

- The existing `StatusReactionController` already has `setQueued()` fully implemented with debouncing, stall timers, and promise chain serialization
- Telegram and Discord dispatch paths are wired up
- The `onQueued` callback is non-critical (try/catch wrapped) so failures never block the queue path

## Diff stats

```
4 files changed, 20 insertions(+)
```

Closes #39669