### PR TITLE
fix: use LRU eviction for cron schedule cache instead of FIFO

### DIFF
--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -144,6 +144,32 @@ describe("cron schedule", () => {
     expect(getCronScheduleCacheSizeForTest()).toBe(2);
   });
 
+  it("promotes accessed entries to avoid premature LRU eviction", () => {
+    const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
+
+    // Fill cache to capacity with unique expressions
+    for (let i = 0; i < 512; i++) {
+      computeNextRunAtMs(
+        { kind: "cron", expr: `${i % 60} ${Math.floor(i / 60)} * * *`, tz: "UTC" },
+        nowMs,
+      );
+    }
+    expect(getCronScheduleCacheSizeForTest()).toBe(512);
+
+    // Access the very first entry so it gets promoted (LRU touch)
+    computeNextRunAtMs({ kind: "cron", expr: "0 0 * * *", tz: "UTC" }, nowMs);
+
+    // Insert a new entry — this should evict the second-oldest, not the first
+    computeNextRunAtMs({ kind: "cron", expr: "0 0 1 1 *", tz: "UTC" }, nowMs);
+    expect(getCronScheduleCacheSizeForTest()).toBe(512);
+
+    // The first entry should still be cached (was promoted).
+    // Insert another new entry — if FIFO, the first entry would now be evicted.
+    // With LRU, the third-oldest entry is evicted instead.
+    computeNextRunAtMs({ kind: "cron", expr: "0 0 2 1 *", tz: "UTC" }, nowMs);
+    expect(getCronScheduleCacheSizeForTest()).toBe(512);
+  });
+
   describe("cron with specific seconds (6-field pattern)", () => {
     // Pattern: fire at exactly second 0 of minute 0 of hour 12 every day
     const dailyNoon = { kind: "cron" as const, expr: "0 0 12 * * *", tz: "UTC" };

--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -5,6 +5,7 @@ import {
   computeNextRunAtMs,
   computePreviousRunAtMs,
   getCronScheduleCacheSizeForTest,
+  hasCronInCacheForTest,
 } from "./schedule.js";
 
 describe("cron schedule", () => {
@@ -147,7 +148,8 @@ describe("cron schedule", () => {
   it("promotes accessed entries to avoid premature LRU eviction", () => {
     const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
 
-    // Fill cache to capacity with unique expressions
+    // Fill cache to capacity with unique expressions.
+    // i=0 → "0 0 * * *", i=1 → "1 0 * * *", ..., i=511 → "31 8 * * *"
     for (let i = 0; i < 512; i++) {
       computeNextRunAtMs(
         { kind: "cron", expr: `${i % 60} ${Math.floor(i / 60)} * * *`, tz: "UTC" },
@@ -156,18 +158,23 @@ describe("cron schedule", () => {
     }
     expect(getCronScheduleCacheSizeForTest()).toBe(512);
 
-    // Access the very first entry so it gets promoted (LRU touch)
+    // Entry #0 ("0 0 * * *") is the oldest by insertion order.
+    // Access it so LRU promotes it (delete + re-insert at end of Map).
     computeNextRunAtMs({ kind: "cron", expr: "0 0 * * *", tz: "UTC" }, nowMs);
 
-    // Insert a new entry — this should evict the second-oldest, not the first
+    // Entry #1 ("1 0 * * *") is now the least-recently-used.
+    // Insert a new entry to trigger one eviction.
     computeNextRunAtMs({ kind: "cron", expr: "0 0 1 1 *", tz: "UTC" }, nowMs);
     expect(getCronScheduleCacheSizeForTest()).toBe(512);
 
-    // The first entry should still be cached (was promoted).
-    // Insert another new entry — if FIFO, the first entry would now be evicted.
-    // With LRU, the third-oldest entry is evicted instead.
-    computeNextRunAtMs({ kind: "cron", expr: "0 0 2 1 *", tz: "UTC" }, nowMs);
-    expect(getCronScheduleCacheSizeForTest()).toBe(512);
+    // Under LRU: entry #0 survived (was promoted), entry #1 was evicted.
+    // Under FIFO: entry #0 would be evicted instead — this assertion would fail.
+    expect(hasCronInCacheForTest("0 0 * * *", "UTC")).toBe(true);
+    expect(hasCronInCacheForTest("1 0 * * *", "UTC")).toBe(false);
+
+    // The new entry and a non-evicted middle entry should both be present.
+    expect(hasCronInCacheForTest("0 0 1 1 *", "UTC")).toBe(true);
+    expect(hasCronInCacheForTest("2 0 * * *", "UTC")).toBe(true);
   });
 
   describe("cron with specific seconds (6-field pattern)", () => {

--- a/src/cron/schedule.test.ts
+++ b/src/cron/schedule.test.ts
@@ -4,6 +4,7 @@ import {
   clearCronScheduleCacheForTest,
   computeNextRunAtMs,
   computePreviousRunAtMs,
+  getCronScheduleCacheMaxForTest,
   getCronScheduleCacheSizeForTest,
   hasCronInCacheForTest,
 } from "./schedule.js";
@@ -147,16 +148,17 @@ describe("cron schedule", () => {
 
   it("promotes accessed entries to avoid premature LRU eviction", () => {
     const nowMs = Date.parse("2026-03-01T00:00:00.000Z");
+    const cacheMax = getCronScheduleCacheMaxForTest();
 
     // Fill cache to capacity with unique expressions.
     // i=0 → "0 0 * * *", i=1 → "1 0 * * *", ..., i=511 → "31 8 * * *"
-    for (let i = 0; i < 512; i++) {
+    for (let i = 0; i < cacheMax; i++) {
       computeNextRunAtMs(
         { kind: "cron", expr: `${i % 60} ${Math.floor(i / 60)} * * *`, tz: "UTC" },
         nowMs,
       );
     }
-    expect(getCronScheduleCacheSizeForTest()).toBe(512);
+    expect(getCronScheduleCacheSizeForTest()).toBe(cacheMax);
 
     // Entry #0 ("0 0 * * *") is the oldest by insertion order.
     // Access it so LRU promotes it (delete + re-insert at end of Map).
@@ -165,7 +167,7 @@ describe("cron schedule", () => {
     // Entry #1 ("1 0 * * *") is now the least-recently-used.
     // Insert a new entry to trigger one eviction.
     computeNextRunAtMs({ kind: "cron", expr: "0 0 1 1 *", tz: "UTC" }, nowMs);
-    expect(getCronScheduleCacheSizeForTest()).toBe(512);
+    expect(getCronScheduleCacheSizeForTest()).toBe(cacheMax);
 
     // Under LRU: entry #0 survived (was promoted), entry #1 was evicted.
     // Under FIFO: entry #0 would be evicted instead — this assertion would fail.

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -172,3 +172,7 @@ export function clearCronScheduleCacheForTest(): void {
 export function getCronScheduleCacheSizeForTest(): number {
   return cronEvalCache.size;
 }
+
+export function hasCronInCacheForTest(expr: string, tz: string): boolean {
+  return cronEvalCache.has(`${tz}\u0000${expr}`);
+}

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -18,6 +18,9 @@ function resolveCachedCron(expr: string, timezone: string): Cron {
   const key = `${timezone}\u0000${expr}`;
   const cached = cronEvalCache.get(key);
   if (cached) {
+    // Move to end of Map iteration order for LRU eviction
+    cronEvalCache.delete(key);
+    cronEvalCache.set(key, cached);
     return cached;
   }
   if (cronEvalCache.size >= CRON_EVAL_CACHE_MAX) {

--- a/src/cron/schedule.ts
+++ b/src/cron/schedule.ts
@@ -173,6 +173,10 @@ export function getCronScheduleCacheSizeForTest(): number {
   return cronEvalCache.size;
 }
 
+export function getCronScheduleCacheMaxForTest(): number {
+  return CRON_EVAL_CACHE_MAX;
+}
+
 export function hasCronInCacheForTest(expr: string, tz: string): boolean {
   return cronEvalCache.has(`${tz}\u0000${expr}`);
 }


### PR DESCRIPTION
## Summary
- On cache hit in `resolveCachedCron()`, delete and re-set the entry to move it to the end of Map iteration order
- This gives true LRU eviction instead of FIFO, preventing frequently-accessed cron expressions (e.g. `*/5 * * * *` heartbeats) from being evicted prematurely
- Added test verifying that accessed entries survive eviction after cache fills

## Test plan
- [x] Existing 22 tests pass
- [x] New LRU promotion test added and passing
- [x] `pnpm build && pnpm check && pnpm test` all green

Fixes #39679

🤖 Generated with [Claude Code](https://claude.com/claude-code)