### PR TITLE
fix: resolve Control UI token field mismatch between client and server

### DIFF
--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -174,6 +174,7 @@ function resolveDeviceSignaturePayloadVersion(params: {
   signedAtMs: number;
   nonce: string;
 }): "v3" | "v2" | null {
+  const authToken = params.connectParams.auth?.deviceToken ?? params.connectParams.auth?.token ?? null;
   const payloadV3 = buildDeviceAuthPayloadV3({
     deviceId: params.device.id,
     clientId: params.connectParams.client.id,
@@ -181,7 +182,7 @@ function resolveDeviceSignaturePayloadVersion(params: {
     role: params.role,
     scopes: params.scopes,
     signedAtMs: params.signedAtMs,
-    token: params.connectParams.auth?.token ?? params.connectParams.auth?.deviceToken ?? null,
+    token: authToken,
     nonce: params.nonce,
     platform: params.connectParams.client.platform,
     deviceFamily: params.connectParams.client.deviceFamily,
@@ -197,7 +198,7 @@ function resolveDeviceSignaturePayloadVersion(params: {
     role: params.role,
     scopes: params.scopes,
     signedAtMs: params.signedAtMs,
-    token: params.connectParams.auth?.token ?? params.connectParams.auth?.deviceToken ?? null,
+    token: authToken,
     nonce: params.nonce,
   });
   if (verifyDeviceSignature(params.device.publicKey, payloadV2, params.device.signature)) {

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -222,7 +222,7 @@ export class GatewayBrowserClient {
     }
     authToken = explicitGatewayToken ?? deviceToken;
     const auth =
-      authToken || this.opts.password || deviceToken
+      authToken || this.opts.password
         ? {
             token: authToken,
             deviceToken: deviceToken,

--- a/ui/src/ui/gateway.ts
+++ b/ui/src/ui/gateway.ts
@@ -222,9 +222,10 @@ export class GatewayBrowserClient {
     }
     authToken = explicitGatewayToken ?? deviceToken;
     const auth =
-      authToken || this.opts.password
+      authToken || this.opts.password || deviceToken
         ? {
             token: authToken,
+            deviceToken: deviceToken,
             password: this.opts.password,
           }
         : undefined;
@@ -242,6 +243,7 @@ export class GatewayBrowserClient {
     if (isSecureContext && deviceIdentity) {
       const signedAtMs = Date.now();
       const nonce = this.connectNonce ?? "";
+      const tokenForPayload = deviceToken ?? authToken ?? null;
       const payload = buildDeviceAuthPayload({
         deviceId: deviceIdentity.deviceId,
         clientId: this.opts.clientName ?? GATEWAY_CLIENT_NAMES.CONTROL_UI,
@@ -249,7 +251,7 @@ export class GatewayBrowserClient {
         role,
         scopes,
         signedAtMs,
-        token: authToken ?? null,
+        token: tokenForPayload,
         nonce,
       });
       const signature = await signDevicePayload(deviceIdentity.privateKey, payload);


### PR DESCRIPTION
## Summary

Fixes #39667 - Control UI token field mismatch

The client was signing with deviceToken but sending auth.token (shared token) to the server.

## Changes
- Client sends both token and deviceToken in auth object
- Client signs with deviceToken if available
- Server prefers deviceToken over shared token when reconstructing payload

---
*AI-assisted PR*