### PR TITLE
fix: resolve heartbeat.target not working for plugin channels like telegram

### DIFF
--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -15,12 +15,22 @@ const bootstrapAttempts = new Set<string>();
 
 export function normalizeDeliverableOutboundChannel(
   raw?: string | null,
+  cfg?: OpenClawConfig,
 ): DeliverableMessageChannel | undefined {
   const normalized = normalizeMessageChannel(raw);
-  if (!normalized || !isDeliverableMessageChannel(normalized)) {
+  if (!normalized) {
     return undefined;
   }
-  return normalized;
+  if (isDeliverableMessageChannel(normalized)) {
+    return normalized;
+  }
+  if (cfg) {
+    maybeBootstrapChannelPlugin({ channel: normalized as DeliverableMessageChannel, cfg });
+    if (isDeliverableMessageChannel(normalized)) {
+      return normalized;
+    }
+  }
+  return undefined;
 }
 
 function maybeBootstrapChannelPlugin(params: {

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -249,17 +249,9 @@ export function resolveHeartbeatDeliveryTarget(params: {
   if (rawTarget === "none" || rawTarget === "last") {
     target = rawTarget;
   } else if (typeof rawTarget === "string") {
-    const normalized = normalizeDeliverableOutboundChannel(rawTarget);
+    const normalized = normalizeDeliverableOutboundChannel(rawTarget, cfg);
     if (normalized) {
       target = normalized;
-    } else {
-      const resolvedPlugin = resolveOutboundChannelPlugin({
-        channel: rawTarget,
-        cfg,
-      });
-      if (resolvedPlugin) {
-        target = rawTarget.toLowerCase() as HeartbeatTarget;
-      }
     }
   }
 

--- a/src/infra/outbound/targets.ts
+++ b/src/infra/outbound/targets.ts
@@ -252,6 +252,14 @@ export function resolveHeartbeatDeliveryTarget(params: {
     const normalized = normalizeDeliverableOutboundChannel(rawTarget);
     if (normalized) {
       target = normalized;
+    } else {
+      const resolvedPlugin = resolveOutboundChannelPlugin({
+        channel: rawTarget,
+        cfg,
+      });
+      if (resolvedPlugin) {
+        target = rawTarget.toLowerCase() as HeartbeatTarget;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #39674 - heartbeat.target setting has no effect

When `heartbeat.target` is set to a plugin channel (e.g., 'telegram'), the normalization fails because the plugin registry may not be loaded.

## Fix

This fix attempts to resolve the plugin before falling back to 'none'.

---
*AI-assisted PR*