### PR TITLE
fix(synology-chat): preserve 0 rate limit and fallback invalid env to default

### DIFF
--- a/extensions/synology-chat/src/accounts.test.ts
+++ b/extensions/synology-chat/src/accounts.test.ts
@@ -138,6 +138,19 @@ describe("resolveAccount", () => {
     expect(account.rateLimitPerMinute).toBe(0);
   });
 
+  it("respects SYNOLOGY_RATE_LIMIT from env var", () => {
+    process.env.SYNOLOGY_RATE_LIMIT = "100";
+    const cfg = { channels: { "synology-chat": {} } };
+    const account = resolveAccount(cfg);
+    expect(account.rateLimitPerMinute).toBe(100);
+  });
+
+  it("defaults rateLimitPerMinute to 30 when env var not set", () => {
+    const cfg = { channels: { "synology-chat": {} } };
+    const account = resolveAccount(cfg);
+    expect(account.rateLimitPerMinute).toBe(30);
+  });
+
   it("falls back to 30 for malformed SYNOLOGY_RATE_LIMIT values", () => {
     process.env.SYNOLOGY_RATE_LIMIT = "0abc";
     const cfg = { channels: { "synology-chat": {} } };


### PR DESCRIPTION
## Summary
- fix `SYNOLOGY_RATE_LIMIT` parsing so `0` is preserved instead of falling back to `30`
- fallback to default `30` when env value is invalid (e.g. non-numeric)
- add tests covering `0`, numeric env value, missing env value, and invalid env value

## Testing
- `pnpm -C openclaw exec vitest run extensions/synology-chat/src/accounts.test.ts`