### PR TITLE
fix(config): respect explicit input modalities override in provider model merge

### DIFF
--- a/src/agents/models-config.merge.ts
+++ b/src/agents/models-config.merge.ts
@@ -74,7 +74,7 @@ export function mergeProviderModels(
 
     return {
       ...explicitModel,
-      input: implicitModel.input,
+      input: "input" in explicitModel ? explicitModel.input : implicitModel.input,
       reasoning: "reasoning" in explicitModel ? explicitModel.reasoning : implicitModel.reasoning,
       ...(contextWindow === undefined ? {} : { contextWindow }),
       ...(maxTokens === undefined ? {} : { maxTokens }),


### PR DESCRIPTION
## Summary

- **Problem:** `mergeProviderModels` unconditionally overwrites the user's explicit `input` field (e.g. `["text", "image"]`) with the implicit (auto-discovered/built-in) value, silently stripping vision capability from custom models.
- **Why it matters:** Users configuring vision-capable models (e.g. Ollama VL models, custom OpenAI-compatible proxies) lose image support with no error or warning — images are silently dropped from requests.
- **What changed:** Apply the same `"key" in obj` override pattern already used for `reasoning` to the `input` field, so user-configured values win over implicit defaults.
- **What did NOT change (scope boundary):** No changes to auto-discovery logic, Pi SDK, model catalog, or any other merge fields. Only the single `input` merge line in `mergeProviderModels`.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #39690

## User-visible / Behavior Changes

When a user explicitly configures `input: ["text", "image"]` on a model in `models.providers.<name>.models`, that setting is now preserved through the provider merge instead of being silently replaced by the built-in default (`["text"]`). If the user omits `input`, behavior is unchanged (falls back to built-in catalog value).

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: Linux (Ubuntu 22.04)
- Runtime/container: Node 22, pnpm
- Model/provider: Ollama local, `qwen3-vl:8b-instruct-q8_0`
- Relevant config:
```json
{
  "models": {
    "providers": {
      "ollama": {
        "baseUrl": "http://127.0.0.1:11434",
        "api": "ollama",
        "models": [{
          "id": "qwen3-vl:8b-instruct-q8_0",
          "name": "Qwen3 VL 8B",
          "input": ["text", "image"],
          "reasoning": false,
          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 },
          "contextWindow": 262144,
          "maxTokens": 8192
        }]
      }
    }
  }
}
```

### Steps

1. Configure a vision-capable Ollama model with `input: ["text", "image"]` in `openclaw.json`
2. Run `ensureOpenClawModelsJson` (or start gateway)
3. Check `models.json` for the model's `input` field

### Expected

- `models.json` contains `"input": ["text", "image"]` for the configured model
- `modelSupportsVision()` returns `true`

### Actual (before fix)

- `models.json` contains `"input": ["text"]` — user's vision config silently dropped
- `modelSupportsVision()` returns `false`
- All 11 VL models on local Ollama instance incorrectly marked as text-only

## Evidence

- Programmatic verification before fix: all VL models show `input: ["text"]`, `modelSupportsVision: false`
- After fix: configured model shows `input: ["text", "image"]`, `modelSupportsVision: true`
- Direct Ollama API call confirms model correctly handles image input (returns image description)
- Existing test suite: 18 related tests pass with zero regressions

## Human Verification (required)

- Verified scenarios: explicit `input: ["text", "image"]` preserved; omitted `input` falls back to built-in; existing `reasoning` override still works
- Edge cases checked: model exists only in explicit (no implicit match) — passes through unchanged; model exists only in implicit — unchanged
- What I did **not** verify: end-to-end image delivery through a messaging channel (WhatsApp/Telegram)

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert: revert the single line in `src/agents/models-config.ts:93` back to `input: implicitModel.input`
- Known bad symptoms: if a model's `input` field is unexpectedly set to user config instead of built-in, vision may be enabled for models that don't actually support it (user misconfiguration)

## Risks and Mitigations

- Risk: User misconfigures `input: ["text", "image"]` on a text-only model, causing failed image requests.
  - Mitigation: This is explicit user opt-in; the model provider will return an appropriate error. Same risk already exists for `reasoning` override.