### PR TITLE
docs(plugins): add @aramisfa/openclaw-a2a-outbound to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -45,6 +45,11 @@ Use this format when adding entries:
 
 ## Listed plugins
 
+- **External A2A Delegation** — Native OpenClaw outbound A2A delegation plugin that exposes one `remote_agent` tool for target discovery, remote delegation, task watch, status, and cancel.
+  npm: `@aramisfa/openclaw-a2a-outbound`
+  repo: `https://github.com/aramisfacchinetti/openclaw-a2a-plugins`
+  install: `openclaw plugins install @aramisfa/openclaw-a2a-outbound`
+
 - **WeChat** — Connect OpenClaw to WeChat personal accounts via WeChatPadPro (iPad protocol). Supports text, image, and file exchange with keyword-triggered conversations.
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`


### PR DESCRIPTION
## Summary

- Problem: `@aramisfa/openclaw-a2a-outbound` is published and documented, but it is not listed on the OpenClaw community plugins page.
- Why it matters: the OpenClaw docs explicitly accept PRs that add qualifying community plugins to this page.
- What changed: added a community plugin entry for `@aramisfa/openclaw-a2a-outbound` in `docs/plugins/community.md`.
- What did NOT change (scope boundary): no OpenClaw runtime code, plugin code, APIs, or behavior changed.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related # N/A

## User-visible / Behavior Changes

- The community plugins page will list `@aramisfa/openclaw-a2a-outbound` with its npm package, GitHub repo, description and install command.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No
- If any `Yes`, explain risk + mitigation: This PR is docs-only. It documents an external plugin that users may optionally install separately; it does not add capabilities to OpenClaw itself.

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: N/A (docs-only change)
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Confirm `@aramisfa/openclaw-a2a-outbound` is published on npm.
2. Confirm the source repo is public and includes setup/use docs and an issue tracker.
3. Add the plugin entry to `docs/plugins/community.md` using the current community plugins format.

### Expected

- The community plugins page includes a correct entry for `@aramisfa/openclaw-a2a-outbound`.

### Actual

- Added the entry to `docs/plugins/community.md` with the npm package, repo URL, description and install command.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

```text
npm view @aramisfa/openclaw-a2a-outbound version
1.0.0
```

- npm: https://www.npmjs.com/package/@aramisfa/openclaw-a2a-outbound
- repo: https://github.com/aramisfacchinetti/openclaw-a2a-plugins
- docs: https://github.com/aramisfacchinetti/openclaw-a2a-plugins/tree/master/packages/openclaw-a2a-outbound
- issues: https://github.com/aramisfacchinetti/openclaw-a2a-plugins/issues

## Human Verification (required)

- Verified scenarios: confirmed the package is published on npm, the GitHub repo is public, package docs are present and the repo has an issue tracker.
- Edge cases checked: verified the listing format matches the current page and the entry is placed in alphabetical order; verified that `@aramisfa` is the npm scope for the published package and `aramisfacchinetti/openclaw-a2a-plugins` is its source repository.
- What you did **not** verify: post-merge docs deployment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No
- If yes, exact upgrade steps: N/A

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the added entry in `docs/plugins/community.md`.
- Files/config to restore: `docs/plugins/community.md`
- Known bad symptoms reviewers should watch for: broken npm/repo links, incorrect install command, or misplaced alphabetical ordering.

## Risks and Mitigations

- Risk: reviewers may question the npm scope (`@aramisfa`) not matching the GitHub owner (`aramisfacchinetti`).
  - Mitigation: the PR includes direct links to the published npm package and its source repository and both point to the same plugin.

AI-assisted: yes