### PR TITLE
fix: refresh lastEventAt on heartbeat to prevent false stale-socket restarts

### DIFF
--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -268,7 +268,16 @@ export async function monitorWebChannel(
     };
 
     if (keepAlive) {
-      heartbeat = setInterval(() => {
+      heartbeat = setInterval(async () => {
+        // Verify socket is alive via round-trip presence update.
+        try {
+          await listener.pingPresence();
+          status.lastEventAt = Date.now();
+          emitStatus();
+        } catch {
+          // Socket didn't respond — let health monitor detect stale-socket.
+        }
+
         const authAgeMs = getWebAuthAgeMs(account.authDir);
         const minutesSinceLastMessage = lastMessageAt
           ? Math.floor((Date.now() - lastMessageAt) / 60000)

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -269,6 +269,10 @@ export async function monitorWebChannel(
 
     if (keepAlive) {
       heartbeat = setInterval(() => {
+        // Refresh staleness tracker — a running heartbeat proves the socket is alive.
+        status.lastEventAt = Date.now();
+        emitStatus();
+
         const authAgeMs = getWebAuthAgeMs(account.authDir);
         const minutesSinceLastMessage = lastMessageAt
           ? Math.floor((Date.now() - lastMessageAt) / 60000)

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -269,10 +269,6 @@ export async function monitorWebChannel(
 
     if (keepAlive) {
       heartbeat = setInterval(() => {
-        // Refresh staleness tracker — a running heartbeat proves the socket is alive.
-        status.lastEventAt = Date.now();
-        emitStatus();
-
         const authAgeMs = getWebAuthAgeMs(account.authDir);
         const minutesSinceLastMessage = lastMessageAt
           ? Math.floor((Date.now() - lastMessageAt) / 60000)

--- a/src/web/auto-reply/monitor.ts
+++ b/src/web/auto-reply/monitor.ts
@@ -273,10 +273,10 @@ export async function monitorWebChannel(
         try {
           await listener.pingPresence();
           status.lastEventAt = Date.now();
-          emitStatus();
         } catch {
           // Socket didn't respond — let health monitor detect stale-socket.
         }
+        emitStatus();
 
         const authAgeMs = getWebAuthAgeMs(account.authDir);
         const minutesSinceLastMessage = lastMessageAt

--- a/src/web/inbound/monitor.ts
+++ b/src/web/inbound/monitor.ts
@@ -482,6 +482,10 @@ export async function monitorWebInbox(options: {
     signalClose: (reason?: WebListenerCloseReason) => {
       resolveClose(reason ?? { status: undefined, isLoggedOut: false, error: "closed" });
     },
+    // Round-trip presence ping to verify the WhatsApp socket is alive.
+    pingPresence: async () => {
+      await sock.sendPresenceUpdate("available");
+    },
     // IPC surface (sendMessage/sendPoll/sendReaction/sendComposingTo)
     ...sendApi,
   } as const;


### PR DESCRIPTION
## Summary

- The health monitor marks a WhatsApp channel as `stale-socket` when `lastEventAt` exceeds 30 minutes, triggering unnecessary restarts
- `lastEventAt` was only updated on inbound messages — during quiet periods with no incoming traffic, the socket appears stale even though it's alive
- Instead of refreshing `lastEventAt` from the local heartbeat timer (which only proves the Node event loop is running), this fix sends a **round-trip presence update** through the actual WhatsApp socket
- `lastEventAt` is only refreshed when the presence ping succeeds, proving the socket is genuinely alive and delivering events

## Observed behavior (before fix)

```
09:11:01 [health-monitor] restarting (reason: stale-socket)
09:46:01 [health-monitor] restarting (reason: stale-socket)
10:21:01 [health-monitor] restarting (reason: stale-socket)
10:56:01 [health-monitor] restarting (reason: stale-socket)
```

Every ~35 minutes (30 min threshold + next 5 min health check), the channel restarts despite being connected and functional.

## Changes

- **`src/web/inbound/monitor.ts`**: Expose `pingPresence()` on the listener object, which calls `sock.sendPresenceUpdate("available")` — a real WhatsApp protocol round-trip
- **`src/web/auto-reply/monitor.ts`**: Call `listener.pingPresence()` in the heartbeat interval; only refresh `lastEventAt` on success. If the ping throws (half-dead socket), `lastEventAt` is not refreshed and the health monitor will still detect stale-socket

## Why this is safe

- `sendPresenceUpdate("available")` is already used on connect (line 60 of `inbound/monitor.ts`)
- It requires an active WebSocket, valid auth, and working Signal encryption — a true liveness proof
- If the socket is half-dead, the call will throw and `lastEventAt` won't update, preserving stale-socket detection
- No visible effect to contacts — just an availability presence update

## Test plan

- [ ] Deploy with a WhatsApp channel that receives infrequent inbound messages
- [ ] Verify no `stale-socket` restarts occur during quiet periods
- [ ] Verify stale-socket detection still works when the socket is genuinely dead (e.g. network partition)
- [ ] Unit test: mock `pingPresence()` to throw and assert `lastEventAt` is NOT refreshed
- [ ] Unit test: mock `pingPresence()` to succeed and assert `lastEventAt` IS refreshed