### PR TITLE
fix(models): default openai-codex/gpt-5.4 to 272k context, make native 1M opt-in

### DIFF
--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -158,13 +158,11 @@ describe("loadModelCatalog", () => {
         name: "gpt-5.4-pro",
       }),
     );
-    expect(result).toContainEqual(
-      expect.objectContaining({
-        provider: "openai-codex",
-        id: "gpt-5.4",
-        name: "gpt-5.4",
-      }),
+    const codexGpt54 = result.find(
+      (entry) => entry.provider === "openai-codex" && entry.id === "gpt-5.4",
     );
+    expect(codexGpt54).toBeDefined();
+    expect(codexGpt54?.contextWindow).toBe(1_050_000);
   });
 
   it("merges configured models for opted-in non-pi-native providers", async () => {

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -39,12 +39,14 @@ const OPENAI_GPT54_PRO_MODEL_ID = "gpt-5.4-pro";
 const OPENAI_CODEX_GPT53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_GPT53_SPARK_MODEL_ID = "gpt-5.3-codex-spark";
 const OPENAI_CODEX_GPT54_MODEL_ID = "gpt-5.4";
+const OPENAI_CODEX_GPT54_CONTEXT_WINDOW = 1_050_000;
 const NON_PI_NATIVE_MODEL_PROVIDERS = new Set(["kilocode"]);
 
 type SyntheticCatalogFallback = {
   provider: string;
   id: string;
   templateIds: readonly string[];
+  patch?: Partial<ModelCatalogEntry>;
 };
 
 const SYNTHETIC_CATALOG_FALLBACKS: readonly SyntheticCatalogFallback[] = [
@@ -62,6 +64,8 @@ const SYNTHETIC_CATALOG_FALLBACKS: readonly SyntheticCatalogFallback[] = [
     provider: CODEX_PROVIDER,
     id: OPENAI_CODEX_GPT54_MODEL_ID,
     templateIds: ["gpt-5.3-codex", "gpt-5.2-codex"],
+    // GPT-5.4 supports a larger native context window than its template models.
+    patch: { contextWindow: OPENAI_CODEX_GPT54_CONTEXT_WINDOW },
   },
   {
     provider: CODEX_PROVIDER,
@@ -92,6 +96,7 @@ function applySyntheticCatalogFallbacks(models: ModelCatalogEntry[]): void {
       ...template,
       id: fallback.id,
       name: fallback.id,
+      ...fallback.patch,
     });
   }
 }

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -363,7 +363,7 @@ describe("resolveForwardCompatModel", () => {
     expectResolvedForwardCompat(model, { provider: "openai-codex", id: "gpt-5.4" });
     expect(model?.api).toBe("openai-codex-responses");
     expect(model?.baseUrl).toBe("https://chatgpt.com/backend-api");
-    expect(model?.contextWindow).toBe(272_000);
+    expect(model?.contextWindow).toBe(1_050_000);
     expect(model?.maxTokens).toBe(128_000);
   });
 

--- a/src/agents/model-compat.test.ts
+++ b/src/agents/model-compat.test.ts
@@ -363,7 +363,8 @@ describe("resolveForwardCompatModel", () => {
     expectResolvedForwardCompat(model, { provider: "openai-codex", id: "gpt-5.4" });
     expect(model?.api).toBe("openai-codex-responses");
     expect(model?.baseUrl).toBe("https://chatgpt.com/backend-api");
-    expect(model?.contextWindow).toBe(1_050_000);
+    // Defaults to template context (272k); users opt into native 1,050,000 via contextTokens config.
+    expect(model?.contextWindow).toBe(272_000);
     expect(model?.maxTokens).toBe(128_000);
   });
 

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -12,8 +12,11 @@ const OPENAI_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.2"] as const;
 const OPENAI_GPT_54_PRO_TEMPLATE_MODEL_IDS = ["gpt-5.2-pro", "gpt-5.2"] as const;
 
 const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
-const OPENAI_CODEX_GPT_54_CONTEXT_TOKENS = OPENAI_GPT_54_CONTEXT_TOKENS;
-const OPENAI_CODEX_GPT_54_MAX_TOKENS = OPENAI_GPT_54_MAX_TOKENS;
+// Default to the codex template ceiling (272k) rather than the native 1,050,000. Cost doubles
+// above 272k on the Codex path and there is real performance degradation at higher context.
+// Users can opt into the full native window via contextTokens in their agent config.
+const OPENAI_CODEX_DEFAULT_CONTEXT_TOKENS = 272_000;
+const OPENAI_CODEX_DEFAULT_MAX_TOKENS = 128_000;
 const OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex", "gpt-5.2-codex"] as const;
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
@@ -125,15 +128,9 @@ function resolveOpenAICodexForwardCompatModel(
 
   let templateIds: readonly string[];
   let eligibleProviders: Set<string>;
-  let patch: Partial<Model<Api>> | undefined;
   if (lower === OPENAI_CODEX_GPT_54_MODEL_ID) {
     templateIds = OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS;
     eligibleProviders = CODEX_GPT54_ELIGIBLE_PROVIDERS;
-    // GPT-5.4 supports a larger native context window than its template models.
-    patch = {
-      contextWindow: OPENAI_CODEX_GPT_54_CONTEXT_TOKENS,
-      maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
-    };
   } else if (lower === OPENAI_CODEX_GPT_53_MODEL_ID) {
     templateIds = OPENAI_CODEX_TEMPLATE_MODEL_IDS;
     eligibleProviders = CODEX_GPT53_ELIGIBLE_PROVIDERS;
@@ -145,13 +142,14 @@ function resolveOpenAICodexForwardCompatModel(
     return undefined;
   }
 
+  // Default to template context (272k for codex models). Users can opt into
+  // the full native 1,050,000 window via contextTokens in their agent config.
   return (
     cloneFirstTemplateModel({
       normalizedProvider,
       trimmedModelId,
       templateIds: [...templateIds],
       modelRegistry,
-      patch,
     }) ??
     normalizeModelCompat({
       id: trimmedModelId,
@@ -164,11 +162,11 @@ function resolveOpenAICodexForwardCompatModel(
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow:
         lower === OPENAI_CODEX_GPT_54_MODEL_ID
-          ? OPENAI_CODEX_GPT_54_CONTEXT_TOKENS
+          ? OPENAI_CODEX_DEFAULT_CONTEXT_TOKENS
           : DEFAULT_CONTEXT_TOKENS,
       maxTokens:
         lower === OPENAI_CODEX_GPT_54_MODEL_ID
-          ? OPENAI_CODEX_GPT_54_MAX_TOKENS
+          ? OPENAI_CODEX_DEFAULT_MAX_TOKENS
           : DEFAULT_CONTEXT_TOKENS,
     } as Model<Api>)
   );

--- a/src/agents/model-forward-compat.ts
+++ b/src/agents/model-forward-compat.ts
@@ -12,6 +12,8 @@ const OPENAI_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.2"] as const;
 const OPENAI_GPT_54_PRO_TEMPLATE_MODEL_IDS = ["gpt-5.2-pro", "gpt-5.2"] as const;
 
 const OPENAI_CODEX_GPT_54_MODEL_ID = "gpt-5.4";
+const OPENAI_CODEX_GPT_54_CONTEXT_TOKENS = OPENAI_GPT_54_CONTEXT_TOKENS;
+const OPENAI_CODEX_GPT_54_MAX_TOKENS = OPENAI_GPT_54_MAX_TOKENS;
 const OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS = ["gpt-5.3-codex", "gpt-5.2-codex"] as const;
 const OPENAI_CODEX_GPT_53_MODEL_ID = "gpt-5.3-codex";
 const OPENAI_CODEX_TEMPLATE_MODEL_IDS = ["gpt-5.2-codex"] as const;
@@ -123,9 +125,15 @@ function resolveOpenAICodexForwardCompatModel(
 
   let templateIds: readonly string[];
   let eligibleProviders: Set<string>;
+  let patch: Partial<Model<Api>> | undefined;
   if (lower === OPENAI_CODEX_GPT_54_MODEL_ID) {
     templateIds = OPENAI_CODEX_GPT_54_TEMPLATE_MODEL_IDS;
     eligibleProviders = CODEX_GPT54_ELIGIBLE_PROVIDERS;
+    // GPT-5.4 supports a larger native context window than its template models.
+    patch = {
+      contextWindow: OPENAI_CODEX_GPT_54_CONTEXT_TOKENS,
+      maxTokens: OPENAI_CODEX_GPT_54_MAX_TOKENS,
+    };
   } else if (lower === OPENAI_CODEX_GPT_53_MODEL_ID) {
     templateIds = OPENAI_CODEX_TEMPLATE_MODEL_IDS;
     eligibleProviders = CODEX_GPT53_ELIGIBLE_PROVIDERS;
@@ -137,30 +145,33 @@ function resolveOpenAICodexForwardCompatModel(
     return undefined;
   }
 
-  for (const templateId of templateIds) {
-    const template = modelRegistry.find(normalizedProvider, templateId) as Model<Api> | null;
-    if (!template) {
-      continue;
-    }
-    return normalizeModelCompat({
-      ...template,
+  return (
+    cloneFirstTemplateModel({
+      normalizedProvider,
+      trimmedModelId,
+      templateIds: [...templateIds],
+      modelRegistry,
+      patch,
+    }) ??
+    normalizeModelCompat({
       id: trimmedModelId,
       name: trimmedModelId,
-    } as Model<Api>);
-  }
-
-  return normalizeModelCompat({
-    id: trimmedModelId,
-    name: trimmedModelId,
-    api: "openai-codex-responses",
-    provider: normalizedProvider,
-    baseUrl: "https://chatgpt.com/backend-api",
-    reasoning: true,
-    input: ["text", "image"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: DEFAULT_CONTEXT_TOKENS,
-    maxTokens: DEFAULT_CONTEXT_TOKENS,
-  } as Model<Api>);
+      api: "openai-codex-responses",
+      provider: normalizedProvider,
+      baseUrl: "https://chatgpt.com/backend-api",
+      reasoning: true,
+      input: ["text", "image"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow:
+        lower === OPENAI_CODEX_GPT_54_MODEL_ID
+          ? OPENAI_CODEX_GPT_54_CONTEXT_TOKENS
+          : DEFAULT_CONTEXT_TOKENS,
+      maxTokens:
+        lower === OPENAI_CODEX_GPT_54_MODEL_ID
+          ? OPENAI_CODEX_GPT_54_MAX_TOKENS
+          : DEFAULT_CONTEXT_TOKENS,
+    } as Model<Api>)
+  );
 }
 
 function resolveAnthropic46ForwardCompatModel(params: {

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -66,12 +66,12 @@ describe("pi embedded model e2e smoke", () => {
     expect(result.model?.contextWindow).toBe(272_000);
   });
 
-  it("uses native context in openai-codex/gpt-5.4 fallback when no template is discovered", () => {
+  it("uses default context in openai-codex/gpt-5.4 fallback when no template is discovered", () => {
     // No template models mocked — exercises the final fallback path.
+    // Even without a template, defaults to the safe 272k ceiling (not native 1,050,000).
     const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent");
     expect(result.error).toBeUndefined();
-    expect(result.model?.contextWindow).toBe(1_050_000);
-    expect(result.model?.maxTokens).toBe(128_000);
+    expect(result.model?.contextWindow).toBe(272_000);
   });
 
   it("keeps unknown-model errors for non-forward-compat IDs", () => {

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -58,15 +58,6 @@ describe("pi embedded model e2e smoke", () => {
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
   });
 
-  it("exposes native 1,050,000 context window for openai-codex/gpt-5.4", () => {
-    mockOpenAICodexTemplateModel();
-
-    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent");
-    expect(result.error).toBeUndefined();
-    expect(result.model?.contextWindow).toBe(1_050_000);
-    expect(result.model?.maxTokens).toBe(128_000);
-  });
-
   it("preserves template context window for openai-codex/gpt-5.3-codex", () => {
     mockOpenAICodexTemplateModel();
 

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -58,6 +58,31 @@ describe("pi embedded model e2e smoke", () => {
     expect(result.model).toMatchObject(buildOpenAICodexForwardCompatExpectation("gpt-5.4"));
   });
 
+  it("exposes native 1,050,000 context window for openai-codex/gpt-5.4", () => {
+    mockOpenAICodexTemplateModel();
+
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model?.contextWindow).toBe(1_050_000);
+    expect(result.model?.maxTokens).toBe(128_000);
+  });
+
+  it("preserves template context window for openai-codex/gpt-5.3-codex", () => {
+    mockOpenAICodexTemplateModel();
+
+    const result = resolveModel("openai-codex", "gpt-5.3-codex", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model?.contextWindow).toBe(272_000);
+  });
+
+  it("uses native context in openai-codex/gpt-5.4 fallback when no template is discovered", () => {
+    // No template models mocked — exercises the final fallback path.
+    const result = resolveModel("openai-codex", "gpt-5.4", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model?.contextWindow).toBe(1_050_000);
+    expect(result.model?.maxTokens).toBe(128_000);
+  });
+
   it("keeps unknown-model errors for non-forward-compat IDs", () => {
     const result = resolveModel("openai-codex", "gpt-4.1-mini", "/tmp/agent");
     expect(result.model).toBeUndefined();

--- a/src/agents/pi-embedded-runner/model.test-harness.ts
+++ b/src/agents/pi-embedded-runner/model.test-harness.ts
@@ -36,13 +36,15 @@ export function mockOpenAICodexTemplateModel(): void {
 export function buildOpenAICodexForwardCompatExpectation(
   id: string = "gpt-5.3-codex",
 ): Partial<typeof OPENAI_CODEX_TEMPLATE_MODEL> & { provider: string; id: string } {
+  // GPT-5.4 exposes its native 1,050,000 context window through the codex path.
+  const isGpt54 = id.toLowerCase() === "gpt-5.4";
   return {
     provider: "openai-codex",
     id,
     api: "openai-codex-responses",
     baseUrl: "https://chatgpt.com/backend-api",
     reasoning: true,
-    contextWindow: 272000,
+    contextWindow: isGpt54 ? 1_050_000 : 272000,
     maxTokens: 128000,
   };
 }

--- a/src/agents/pi-embedded-runner/model.test-harness.ts
+++ b/src/agents/pi-embedded-runner/model.test-harness.ts
@@ -36,15 +36,15 @@ export function mockOpenAICodexTemplateModel(): void {
 export function buildOpenAICodexForwardCompatExpectation(
   id: string = "gpt-5.3-codex",
 ): Partial<typeof OPENAI_CODEX_TEMPLATE_MODEL> & { provider: string; id: string } {
-  // GPT-5.4 exposes its native 1,050,000 context window through the codex path.
-  const isGpt54 = id.toLowerCase() === "gpt-5.4";
   return {
     provider: "openai-codex",
     id,
     api: "openai-codex-responses",
     baseUrl: "https://chatgpt.com/backend-api",
     reasoning: true,
-    contextWindow: isGpt54 ? 1_050_000 : 272000,
+    // All codex forward-compat models default to the template's 272k context.
+    // Users can opt into higher context via contextTokens in their agent config.
+    contextWindow: 272000,
     maxTokens: 128000,
   };
 }


### PR DESCRIPTION
## Summary

- Default `openai-codex/gpt-5.4` to the safe 272k context window (matching the `gpt-5.3-codex` template), rather than exposing the native 1,050,000 by default
- Cost doubles above 272k on the Codex path and there is real performance degradation at higher context windows — this aligns with how Codex itself gates extended context behind configuration
- Users can opt into the full native 1,050,000 window via `contextTokens: 1050000` in their `openclaw.json` agent config
- Model catalog metadata still reports the native 1,050,000 capability for informational purposes

## Changes

**`src/agents/model-forward-compat.ts`**
- Remove context window override patch for `openai-codex/gpt-5.4` — model now inherits the template's 272k context instead of being patched to 1,050,000
- Add `OPENAI_CODEX_DEFAULT_CONTEXT_TOKENS` (272k) and `OPENAI_CODEX_DEFAULT_MAX_TOKENS` (128k) constants for the no-template fallback path
- The no-template fallback also uses 272k (not the native 1,050,000) for consistency

**`src/agents/model-catalog.ts`**
- Keep the `contextWindow: 1_050_000` patch in the synthetic catalog — this is metadata that reports the model's native capability, distinct from the effective session context

**Tests**
- Update forward-compat tests: `openai-codex/gpt-5.4` now expects 272k context by default (both template and fallback paths)
- Catalog test still expects 1,050,000 (metadata reporting)
- Verify `gpt-5.3-codex` template context is preserved at 272k

## Test plan

- [x] `pnpm vitest run src/agents/model-compat.test.ts` — all pass
- [x] `pnpm vitest run src/agents/model-catalog.test.ts` — all pass
- [x] `pnpm vitest run src/agents/pi-embedded-runner/model.forward-compat.test.ts` — all pass

Closes #39791