### PR TITLE
fix(gateway): propagate agent error payloads to webchat UI

### DIFF
--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1025,6 +1025,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         channel: INTERNAL_MESSAGE_CHANNEL,
       });
       const finalReplyParts: string[] = [];
+      const errorReplyParts: string[] = [];
       let hasErrorPayload = false;
       const dispatcher = createReplyDispatcher({
         ...prefixOptions,
@@ -1035,14 +1036,18 @@ export const chatHandlers: GatewayRequestHandlers = {
           if (info.kind !== "final") {
             return;
           }
+          if (payload.isError) {
+            hasErrorPayload = true;
+          }
           const text = payload.text?.trim() ?? "";
           if (!text) {
             return;
           }
           if (payload.isError) {
-            hasErrorPayload = true;
+            errorReplyParts.push(text);
+          } else {
+            finalReplyParts.push(text);
           }
-          finalReplyParts.push(text);
         },
       });
 
@@ -1121,11 +1126,15 @@ export const chatHandlers: GatewayRequestHandlers = {
               sessionKey: rawSessionKey,
               message,
             });
-          } else if (hasErrorPayload && finalReplyParts.length > 0) {
+          } else if (
+            hasErrorPayload &&
+            finalReplyParts.length === 0 &&
+            errorReplyParts.length > 0
+          ) {
             // When the agent run started but produced only error payloads
             // (e.g. auth failure, CLI crash), the lifecycle events carry no
             // assistant text.  Surface the error to the UI/TUI explicitly.
-            const combinedError = finalReplyParts
+            const combinedError = errorReplyParts
               .map((part) => part.trim())
               .filter(Boolean)
               .join("\n\n")

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1025,6 +1025,7 @@ export const chatHandlers: GatewayRequestHandlers = {
         channel: INTERNAL_MESSAGE_CHANNEL,
       });
       const finalReplyParts: string[] = [];
+      let hasErrorPayload = false;
       const dispatcher = createReplyDispatcher({
         ...prefixOptions,
         onError: (err) => {
@@ -1037,6 +1038,9 @@ export const chatHandlers: GatewayRequestHandlers = {
           const text = payload.text?.trim() ?? "";
           if (!text) {
             return;
+          }
+          if (payload.isError) {
+            hasErrorPayload = true;
           }
           finalReplyParts.push(text);
         },
@@ -1117,6 +1121,23 @@ export const chatHandlers: GatewayRequestHandlers = {
               sessionKey: rawSessionKey,
               message,
             });
+          } else if (hasErrorPayload && finalReplyParts.length > 0) {
+            // When the agent run started but produced only error payloads
+            // (e.g. auth failure, CLI crash), the lifecycle events carry no
+            // assistant text.  Surface the error to the UI/TUI explicitly.
+            const combinedError = finalReplyParts
+              .map((part) => part.trim())
+              .filter(Boolean)
+              .join("\n\n")
+              .trim();
+            if (combinedError) {
+              broadcastChatError({
+                context,
+                runId: clientRunId,
+                sessionKey: rawSessionKey,
+                errorMessage: combinedError,
+              });
+            }
           }
           setGatewayDedupeEntry({
             dedupe: context.dedupe,


### PR DESCRIPTION
## Summary

When the agent run starts but produces only error payloads (e.g. auth failure, CLI crash), the webchat `.then()` handler skips `broadcastChatFinal` (since `agentRunStarted` is `true`) but has no fallback — errors are silently swallowed. The `broadcastChatError` call only exists in the `.catch()` path (for when `dispatchInboundMessage` rejects), not for runs that start successfully but yield only error payloads.

This PR:
- Tracks a `hasErrorPayload` flag set when `payload.isError` is true in the deliver callback
- Surfaces errors through `broadcastChatError` when the run completes with error payloads but no assistant text

## Test plan

- [ ] Trigger an agent auth failure → verify error appears in webchat UI instead of being silently swallowed
- [ ] Normal agent runs (no errors) still work as before
- [ ] Agent runs that produce both errors and assistant text still deliver the assistant text via `broadcastChatFinal`