### PR TITLE
fix: drop thinking blocks for kimi provider to prevent crashes

### DIFF
--- a/src/agents/transcript-policy.ts
+++ b/src/agents/transcript-policy.ts
@@ -99,7 +99,9 @@ export function resolveTranscriptPolicy(params: {
   // GitHub Copilot's Claude endpoints can reject persisted `thinking` blocks with
   // non-binary/non-base64 signatures (e.g. thinkingSignature: "reasoning_text").
   // Drop these blocks at send-time to keep sessions usable.
-  const dropThinkingBlocks = isCopilotClaude;
+  // Also drop for kimi-coding which uses anthropic-messages API but cannot handle
+  // the returned thinking signatures (causes JSON parse errors in SDK).
+  const dropThinkingBlocks = isCopilotClaude || provider === "kimi" || provider === "kimi-api";
 
   const needsNonImageSanitize = isGoogle || isAnthropic || isMistral || isOpenRouterGemini;
 


### PR DESCRIPTION
## Summary

Fixes #39798 - kimi-coding/k2p5 crashes on turn 2+

### Problem

kimi-coding uses `modelApi: "anthropic-messages"` but cannot handle the returned thinking signatures.

### Fix

Add kimi provider to `dropThinkingBlocks` check.

---
*AI-assisted PR*