### PR TITLE
fix(gateway): prevent chat.send cross-channel leakage on configured main

### DIFF
--- a/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
@@ -22,7 +22,7 @@ enum HostEnvSecurityPolicy {
         "PS4",
         "GCONV_PATH",
         "IFS",
-        "SSLKEYLOGFILE",
+        "SSLKEYLOGFILE"
     ]
 
     static let blockedOverrideKeys: Set<String> = [
@@ -50,17 +50,17 @@ enum HostEnvSecurityPolicy {
         "OPENSSL_ENGINES",
         "PYTHONSTARTUP",
         "WGETRC",
-        "CURL_HOME",
+        "CURL_HOME"
     ]
 
     static let blockedOverridePrefixes: [String] = [
         "GIT_CONFIG_",
-        "NPM_CONFIG_",
+        "NPM_CONFIG_"
     ]
 
     static let blockedPrefixes: [String] = [
         "DYLD_",
         "LD_",
-        "BASH_FUNC_",
+        "BASH_FUNC_"
     ]
 }

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -648,7 +648,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
     );
   });
 
-  it("chat.send inherits external delivery context for CLI clients on configured main sessions", async () => {
+  it("chat.send does not inherit external delivery context for CLI clients on configured main sessions", async () => {
     createTranscriptFixture("openclaw-chat-send-config-main-cli-routes-");
     mockState.mainSessionKey = "work";
     mockState.finalText = "ok";
@@ -684,14 +684,15 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
     expect(mockState.lastDispatchCtx).toEqual(
       expect.objectContaining({
-        OriginatingChannel: "whatsapp",
-        OriginatingTo: "whatsapp:+8613800138000",
-        AccountId: "default",
+        OriginatingChannel: "webchat",
+        OriginatingTo: undefined,
+        AccountId: undefined,
+        ExplicitDeliverRoute: false,
       }),
     );
   });
 
-  it("chat.send keeps configured main delivery inheritance when connect metadata omits client details", async () => {
+  it("chat.send does not inherit external delivery context when connect metadata omits client details on configured main", async () => {
     createTranscriptFixture("openclaw-chat-send-config-main-connect-no-client-");
     mockState.mainSessionKey = "work";
     mockState.finalText = "ok";
@@ -722,9 +723,10 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
     expect(mockState.lastDispatchCtx).toEqual(
       expect.objectContaining({
-        OriginatingChannel: "whatsapp",
-        OriginatingTo: "whatsapp:+8613800138000",
-        AccountId: "default",
+        OriginatingChannel: "webchat",
+        OriginatingTo: undefined,
+        AccountId: undefined,
+        ExplicitDeliverRoute: false,
       }),
     );
   });

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -165,21 +165,15 @@ function resolveChatSendOriginatingRoute(params: {
     typeof sessionScopeParts[1] === "string" &&
     sessionChannelHint === routeChannelCandidate;
   const isFromWebchatClient = isWebchatClient(params.client);
-  const configuredMainKey = (params.mainKey ?? "main").trim().toLowerCase();
-  const isConfiguredMainSessionScope =
-    normalizedSessionScopeHead.length > 0 && normalizedSessionScopeHead === configuredMainKey;
-
-  // Webchat/Control UI clients never inherit external delivery routes, even when
-  // accessing channel-scoped sessions. External routes are only for non-webchat
-  // clients where the session key explicitly encodes an external target.
-  // Preserve the old configured-main contract: any connected non-webchat client
-  // may inherit the last external route even when client metadata is absent.
+  // Webchat/Control UI/TUI clients must not inherit external delivery routes on
+  // shared/main sessions. External route inheritance is only allowed when the
+  // session key itself is explicitly channel-scoped.
   const canInheritDeliverableRoute = Boolean(
     !isFromWebchatClient &&
     sessionChannelHint &&
     sessionChannelHint !== INTERNAL_MESSAGE_CHANNEL &&
-    ((!isChannelAgnosticSessionScope && (isChannelScopedSession || hasLegacyChannelPeerShape)) ||
-      (isConfiguredMainSessionScope && params.hasConnectedClient)),
+    !isChannelAgnosticSessionScope &&
+    (isChannelScopedSession || hasLegacyChannelPeerShape),
   );
   const hasDeliverableRoute =
     canInheritDeliverableRoute &&


### PR DESCRIPTION
## Summary
- stop inheriting external delivery routes for chat.send when the session key is configured-main/shared
- keep external route inheritance only for explicitly channel-scoped session keys
- add regression coverage for CLI and missing-client-metadata paths on configured-main sessions

## Validation
- pnpm vitest run src/gateway/server-methods/chat.directive-tags.test.ts

Closes #39855