### PR TITLE
fix(session): prevent webchat route leak on channel-agnostic session keys

### DIFF
--- a/src/auto-reply/reply/session-delivery.test.ts
+++ b/src/auto-reply/reply/session-delivery.test.ts
@@ -29,13 +29,61 @@ describe("session delivery direct-session routing overrides", () => {
   });
 
   it.each([
+    "global",
+    "agent:main:main",
+    "agent:main:cron:job-1",
+    "agent:main:subagent:worker-1",
+    "custom-scope",
+  ])("lets webchat override persisted routes for channel-agnostic session key %s", (sessionKey) => {
+    expect(
+      resolveLastChannelRaw({
+        originatingChannelRaw: "webchat",
+        persistedLastChannel: "telegram",
+        sessionKey,
+      }),
+    ).toBe("webchat");
+    expect(
+      resolveLastToRaw({
+        originatingChannelRaw: "webchat",
+        originatingToRaw: "session:dashboard",
+        persistedLastChannel: "telegram",
+        persistedLastTo: "123456",
+        sessionKey,
+      }),
+    ).toBe("session:dashboard");
+  });
+
+  it.each([
     "agent:main:main:direct",
     "agent:main:cron:job-1:dm",
     "agent:main:subagent:worker:direct:user-1",
+  ])(
+    "lets webchat override persisted routes for malformed key without channel hint %s",
+    (sessionKey) => {
+      expect(
+        resolveLastChannelRaw({
+          originatingChannelRaw: "webchat",
+          persistedLastChannel: "telegram",
+          sessionKey,
+        }),
+      ).toBe("webchat");
+      expect(
+        resolveLastToRaw({
+          originatingChannelRaw: "webchat",
+          originatingToRaw: "session:dashboard",
+          persistedLastChannel: "telegram",
+          persistedLastTo: "group:12345",
+          sessionKey,
+        }),
+      ).toBe("session:dashboard");
+    },
+  );
+
+  it.each([
     "agent:main:telegram:channel:direct",
     "agent:main:telegram:account-a:direct",
     "agent:main:telegram:direct:123456:cron:job-1",
-  ])("keeps persisted external routes for malformed direct-like key %s", (sessionKey) => {
+  ])("keeps persisted external routes for channel-scoped malformed key %s", (sessionKey) => {
     expect(
       resolveLastChannelRaw({
         originatingChannelRaw: "webchat",

--- a/src/auto-reply/reply/session-delivery.ts
+++ b/src/auto-reply/reply/session-delivery.ts
@@ -90,16 +90,21 @@ export function resolveLastChannelRaw(params: {
   sessionKey?: string;
 }): string | undefined {
   const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
+  const sessionKeyChannelHint = resolveSessionKeyChannelHint(params.sessionKey);
   // WebChat should own reply routing for direct-session UI turns, even when the
   // session previously replied through an external channel like iMessage.
+  // Also covers channel-agnostic session keys (e.g. "global") that don't encode
+  // an explicit external channel target — internal clients should never inherit
+  // stale external delivery routes on those sessions.
   if (
     originatingChannel === INTERNAL_MESSAGE_CHANNEL &&
-    (isMainSessionKey(params.sessionKey) || isDirectSessionKey(params.sessionKey))
+    (isMainSessionKey(params.sessionKey) ||
+      isDirectSessionKey(params.sessionKey) ||
+      !isExternalRoutingChannel(sessionKeyChannelHint))
   ) {
     return params.originatingChannelRaw;
   }
   const persistedChannel = normalizeMessageChannel(params.persistedLastChannel);
-  const sessionKeyChannelHint = resolveSessionKeyChannelHint(params.sessionKey);
   let resolved = params.originatingChannelRaw || params.persistedLastChannel;
   // Internal/non-deliverable sources should not overwrite previously known
   // external delivery routes (or explicit channel hints from the session key).
@@ -122,14 +127,16 @@ export function resolveLastToRaw(params: {
   sessionKey?: string;
 }): string | undefined {
   const originatingChannel = normalizeMessageChannel(params.originatingChannelRaw);
+  const sessionKeyChannelHint = resolveSessionKeyChannelHint(params.sessionKey);
   if (
     originatingChannel === INTERNAL_MESSAGE_CHANNEL &&
-    (isMainSessionKey(params.sessionKey) || isDirectSessionKey(params.sessionKey))
+    (isMainSessionKey(params.sessionKey) ||
+      isDirectSessionKey(params.sessionKey) ||
+      !isExternalRoutingChannel(sessionKeyChannelHint))
   ) {
     return params.originatingToRaw || params.toRaw;
   }
   const persistedChannel = normalizeMessageChannel(params.persistedLastChannel);
-  const sessionKeyChannelHint = resolveSessionKeyChannelHint(params.sessionKey);
 
   // When the turn originates from an internal/non-deliverable source, do not
   // replace an established external destination with internal routing ids


### PR DESCRIPTION
## Summary

Fixes #39855

After upgrading to v2026.3.2, agent replies to TUI/WebChat messages are also delivered to Telegram when all channels share a unified session (e.g. `session.scope: "global"`).

**Root cause:** `resolveLastChannelRaw()` and `resolveLastToRaw()` in `session-delivery.ts` have an early-return guard that correctly prevents webchat from inheriting stale external delivery routes — but only for `"main"` and `"direct"` session keys. Channel-agnostic session keys like `"global"` or custom scopes fall through to the fallback logic, which overwrites the webchat originating channel with the previously persisted external channel (e.g. `"telegram"`). This contaminates the session entry's `lastChannel`/`lastTo` fields, causing heartbeats, cron jobs, and subagent announcements to route to the wrong channel.

**Fix:** Broaden the early-return guard to also cover session keys whose channel hint does not encode an explicit external channel target. When the originating channel is internal (webchat/TUI) and the session key is channel-agnostic, webchat now correctly owns the reply routing instead of inheriting stale Telegram/Discord/etc. routes.

Session keys that explicitly encode an external channel (e.g. `agent:main:telegram:direct:123456`) continue to preserve the external route as before.

## Test plan

- [x] Updated existing tests to reflect correct behavior for channel-agnostic session keys
- [x] Added test cases for `"global"`, `"custom-scope"`, `"agent:main:main"`, `"agent:main:cron:job-1"`, and `"agent:main:subagent:worker-1"` session keys
- [x] Verified channel-scoped malformed keys (`agent:main:telegram:*`) still preserve external routes
- [x] All 17 tests pass
- [x] TypeScript check passes