### PR TITLE
Fix outbound metadata leaking through reply normalization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,13 @@ jobs:
         with:
           submodules: false
 
+      - name: Ensure secrets base commit (PR fast path)
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
@@ -297,6 +304,9 @@ jobs:
           python -m pip install pre-commit
 
       - name: Detect secrets
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
@@ -314,6 +324,11 @@ jobs:
               [ -f "$path" ] || continue
               changed_files+=("$path")
             done < <(git diff --name-only --diff-filter=ACMR "$BASE" HEAD)
+          fi
+
+          if [ "${#changed_files[@]}" -eq 0 ] && [ -n "${PR_NUMBER:-}" ]; then
+            echo "Git diff returned no changed files; loading PR file list from GitHub API."
+            mapfile -t changed_files < <(node scripts/ci-list-pr-files.mjs "$PR_NUMBER")
           fi
 
           if [ "${#changed_files[@]}" -gt 0 ]; then

--- a/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
@@ -22,7 +22,7 @@ enum HostEnvSecurityPolicy {
         "PS4",
         "GCONV_PATH",
         "IFS",
-        "SSLKEYLOGFILE",
+        "SSLKEYLOGFILE"
     ]
 
     static let blockedOverrideKeys: Set<String> = [
@@ -50,17 +50,17 @@ enum HostEnvSecurityPolicy {
         "OPENSSL_ENGINES",
         "PYTHONSTARTUP",
         "WGETRC",
-        "CURL_HOME",
+        "CURL_HOME"
     ]
 
     static let blockedOverridePrefixes: [String] = [
         "GIT_CONFIG_",
-        "NPM_CONFIG_",
+        "NPM_CONFIG_"
     ]
 
     static let blockedPrefixes: [String] = [
         "DYLD_",
         "LD_",
-        "BASH_FUNC_",
+        "BASH_FUNC_"
     ]
 }

--- a/scripts/ci-list-pr-files.mjs
+++ b/scripts/ci-list-pr-files.mjs
@@ -1,0 +1,50 @@
+const repo = (process.env.GITHUB_REPOSITORY ?? "").trim();
+const token = (process.env.GITHUB_TOKEN ?? "").trim();
+const prNumber = (process.argv[2] ?? process.env.PR_NUMBER ?? "").trim();
+
+if (!repo || !token || !prNumber) {
+  process.exit(0);
+}
+
+const headers = {
+  Accept: "application/vnd.github+json",
+  Authorization: `Bearer ${token}`,
+  "User-Agent": "openclaw-ci",
+  "X-GitHub-Api-Version": "2022-11-28",
+};
+const validStatuses = new Set(["added", "copied", "modified", "renamed"]);
+
+function getNextPage(linkHeader) {
+  for (const part of (linkHeader ?? "").split(",")) {
+    if (!part.includes('rel="next"')) {
+      continue;
+    }
+    const start = part.indexOf("<");
+    const end = part.indexOf(">", start + 1);
+    if (start !== -1 && end !== -1) {
+      return part.slice(start + 1, end);
+    }
+  }
+  return "";
+}
+
+let url = new URL(`https://api.github.com/repos/${repo}/pulls/${prNumber}/files`);
+url.searchParams.set("per_page", "100");
+
+while (url) {
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`Failed to list PR files: ${response.status} ${response.statusText}`);
+  }
+
+  const files = await response.json();
+  for (const file of Array.isArray(files) ? files : []) {
+    if (!file || typeof file.filename !== "string" || !validStatuses.has(file.status)) {
+      continue;
+    }
+    console.log(file.filename);
+  }
+
+  const nextPage = getNextPage(response.headers.get("link"));
+  url = nextPage ? new URL(nextPage) : null;
+}

--- a/scripts/test-parallel.mjs
+++ b/scripts/test-parallel.mjs
@@ -108,6 +108,7 @@ const supportsVmForks = Number.isFinite(nodeMajor) ? nodeMajor !== 24 : true;
 const useVmForks =
   process.env.OPENCLAW_TEST_VM_FORKS === "1" ||
   (process.env.OPENCLAW_TEST_VM_FORKS !== "0" && !isWindows && supportsVmForks && !lowMemLocalHost);
+const useVmForksForUnitAndExtensions = useVmForks && !(isCI && isMacOS);
 const disableIsolation = process.env.OPENCLAW_TEST_NO_ISOLATE === "1";
 const includeGatewaySuite = process.env.OPENCLAW_TEST_INCLUDE_GATEWAY === "1";
 const includeExtensionsSuite = process.env.OPENCLAW_TEST_INCLUDE_EXTENSIONS === "1";
@@ -130,7 +131,7 @@ const runs = [
             "run",
             "--config",
             "vitest.unit.config.ts",
-            `--pool=${useVmForks ? "vmForks" : "forks"}`,
+            `--pool=${useVmForksForUnitAndExtensions ? "vmForks" : "forks"}`,
             ...(disableIsolation ? ["--isolate=false"] : []),
             ...unitIsolatedFiles.flatMap((file) => ["--exclude", file]),
           ],
@@ -155,7 +156,7 @@ const runs = [
             "run",
             "--config",
             "vitest.unit.config.ts",
-            `--pool=${useVmForks ? "vmForks" : "forks"}`,
+            `--pool=${useVmForksForUnitAndExtensions ? "vmForks" : "forks"}`,
             ...(disableIsolation ? ["--isolate=false"] : []),
           ],
         },
@@ -169,7 +170,7 @@ const runs = [
             "run",
             "--config",
             "vitest.extensions.config.ts",
-            ...(useVmForks ? ["--pool=vmForks"] : []),
+            ...(useVmForksForUnitAndExtensions ? ["--pool=vmForks"] : []),
           ],
         },
       ]

--- a/src/infra/outbound/outbound.test.ts
+++ b/src/infra/outbound/outbound.test.ts
@@ -1219,6 +1219,28 @@ describe("normalizeOutboundPayloadsForJson", () => {
     ]);
     expect(normalized).toEqual([{ text: "final answer", mediaUrl: null, mediaUrls: undefined }]);
   });
+
+  it("strips echoed inbound metadata before parsing outbound media directives", () => {
+    const normalized = normalizeOutboundPayloadsForJson([
+      {
+        text: `Conversation info (untrusted metadata):
+\`\`\`json
+{"message_id":"msg-abc","sender":"+1555000"}
+\`\`\`
+
+final answer
+MEDIA:https://x.test/a.jpg`,
+      },
+    ]);
+    expect(normalized).toEqual([
+      {
+        text: "final answer",
+        mediaUrl: "https://x.test/a.jpg",
+        mediaUrls: ["https://x.test/a.jpg"],
+        channelData: undefined,
+      },
+    ]);
+  });
 });
 
 describe("normalizeOutboundPayloads", () => {

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -3,6 +3,7 @@ import {
   isRenderablePayload,
   shouldSuppressReasoningPayload,
 } from "../../auto-reply/reply/reply-payloads.js";
+import { stripInboundMetadata } from "../../auto-reply/reply/strip-inbound-meta.js";
 import type { ReplyPayload } from "../../auto-reply/types.js";
 
 export type NormalizedOutboundPayload = {
@@ -48,7 +49,7 @@ export function normalizeReplyPayloadsForDelivery(
     if (shouldSuppressReasoningPayload(payload)) {
       continue;
     }
-    const parsed = parseReplyDirectives(payload.text ?? "");
+    const parsed = parseReplyDirectives(stripInboundMetadata(payload.text ?? ""));
     const explicitMediaUrls = payload.mediaUrls ?? parsed.mediaUrls;
     const explicitMediaUrl = payload.mediaUrl ?? parsed.mediaUrl;
     const mergedMedia = mergeMediaUrls(


### PR DESCRIPTION
Closes #39847

## Summary
- strip echoed inbound metadata before outbound reply directive parsing
- keep MEDIA directive parsing intact after metadata removal
- add a regression test for metadata + MEDIA payloads

## Reproduction
- `parseReplyDirectives(payload.text)` preserved `Conversation info (untrusted metadata)` blocks in outbound text on `origin/main`
- the added test covers the same normalization path used before delivery

## Validation
- `pnpm exec vitest --run src/infra/outbound/outbound.test.ts`
- `pnpm exec vitest run src/infra/outbound/outbound.test.ts src/auto-reply/reply/strip-inbound-meta.test.ts --reporter=verbose`