### PR TITLE
Honor account-scoped Synology Chat bindings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,13 @@ jobs:
         with:
           submodules: false
 
+      - name: Ensure secrets base commit (PR fast path)
+        if: github.event_name == 'pull_request'
+        uses: ./.github/actions/ensure-base-commit
+        with:
+          base-sha: ${{ github.event.pull_request.base.sha }}
+          fetch-ref: ${{ github.event.pull_request.base.ref }}
+
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
         with:
@@ -297,6 +304,9 @@ jobs:
           python -m pip install pre-commit
 
       - name: Detect secrets
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
@@ -314,6 +324,11 @@ jobs:
               [ -f "$path" ] || continue
               changed_files+=("$path")
             done < <(git diff --name-only --diff-filter=ACMR "$BASE" HEAD)
+          fi
+
+          if [ "${#changed_files[@]}" -eq 0 ] && [ -n "${PR_NUMBER:-}" ]; then
+            echo "Git diff returned no changed files; loading PR file list from GitHub API."
+            mapfile -t changed_files < <(node scripts/ci-list-pr-files.mjs "$PR_NUMBER")
           fi
 
           if [ "${#changed_files[@]}" -gt 0 ]; then

--- a/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
@@ -22,7 +22,7 @@ enum HostEnvSecurityPolicy {
         "PS4",
         "GCONV_PATH",
         "IFS",
-        "SSLKEYLOGFILE"
+        "SSLKEYLOGFILE",
     ]
 
     static let blockedOverrideKeys: Set<String> = [
@@ -50,17 +50,17 @@ enum HostEnvSecurityPolicy {
         "OPENSSL_ENGINES",
         "PYTHONSTARTUP",
         "WGETRC",
-        "CURL_HOME"
+        "CURL_HOME",
     ]
 
     static let blockedOverridePrefixes: [String] = [
         "GIT_CONFIG_",
-        "NPM_CONFIG_"
+        "NPM_CONFIG_",
     ]
 
     static let blockedPrefixes: [String] = [
         "DYLD_",
         "LD_",
-        "BASH_FUNC_"
+        "BASH_FUNC_",
     ]
 }

--- a/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
+++ b/apps/macos/Sources/OpenClaw/HostEnvSecurityPolicy.generated.swift
@@ -22,7 +22,7 @@ enum HostEnvSecurityPolicy {
         "PS4",
         "GCONV_PATH",
         "IFS",
-        "SSLKEYLOGFILE",
+        "SSLKEYLOGFILE"
     ]
 
     static let blockedOverrideKeys: Set<String> = [
@@ -50,17 +50,17 @@ enum HostEnvSecurityPolicy {
         "OPENSSL_ENGINES",
         "PYTHONSTARTUP",
         "WGETRC",
-        "CURL_HOME",
+        "CURL_HOME"
     ]
 
     static let blockedOverridePrefixes: [String] = [
         "GIT_CONFIG_",
-        "NPM_CONFIG_",
+        "NPM_CONFIG_"
     ]
 
     static let blockedPrefixes: [String] = [
         "DYLD_",
         "LD_",
-        "BASH_FUNC_",
+        "BASH_FUNC_"
     ]
 }

--- a/extensions/synology-chat/src/channel.integration.test.ts
+++ b/extensions/synology-chat/src/channel.integration.test.ts
@@ -132,7 +132,9 @@ describe("Synology channel wiring integration", () => {
     const plugin = createSynologyChatPlugin();
     const abortController = new AbortController();
     const cfg = {
-      bindings: [{ agentId: "nas-code", match: { channel: "synology-chat", accountId: "code-developer" } }],
+      bindings: [
+        { agentId: "nas-code", match: { channel: "synology-chat", accountId: "code-developer" } },
+      ],
       channels: {
         "synology-chat": {
           enabled: true,
@@ -213,10 +215,7 @@ describe("Synology channel wiring integration", () => {
         dmScope: "per-account-channel-peer",
       },
       agents: {
-        list: [
-          { id: "main", default: true },
-          { id: "nas-code" },
-        ],
+        list: [{ id: "main", default: true }, { id: "nas-code" }],
       },
       bindings: [
         {

--- a/extensions/synology-chat/src/channel.integration.test.ts
+++ b/extensions/synology-chat/src/channel.integration.test.ts
@@ -1,5 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../../src/config/config.js";
+import { resolveAgentRoute as resolveAgentRouteForTest } from "../../../src/routing/resolve-route.js";
 import { makeFormBody, makeReq, makeRes } from "./test-http-utils.js";
 
 type RegisteredRoute = {
@@ -10,6 +12,18 @@ type RegisteredRoute = {
 
 const registerPluginHttpRouteMock = vi.fn<(params: RegisteredRoute) => () => void>(() => vi.fn());
 const dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockResolvedValue({ counts: {} });
+const finalizeInboundContext = vi.fn((ctx: unknown) => ctx);
+const loadConfigMock = vi.fn().mockResolvedValue({});
+const defaultResolvedRoute = {
+  agentId: "nas-code",
+  channel: "synology-chat",
+  accountId: "code-developer",
+  sessionKey: "agent:nas-code:synology-chat:direct:123",
+  mainSessionKey: "agent:nas-code:main",
+  lastRoutePolicy: "session",
+  matchedBy: "binding.account",
+} as const;
+const resolveAgentRoute = vi.fn(() => ({ ...defaultResolvedRoute }));
 
 vi.mock("openclaw/plugin-sdk/synology-chat", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/synology-chat")>();
@@ -29,10 +43,14 @@ vi.mock("openclaw/plugin-sdk/synology-chat", async (importOriginal) => {
 
 vi.mock("./runtime.js", () => ({
   getSynologyRuntime: vi.fn(() => ({
-    config: { loadConfig: vi.fn().mockResolvedValue({}) },
+    config: { loadConfig: loadConfigMock },
     channel: {
       reply: {
         dispatchReplyWithBufferedBlockDispatcher,
+        finalizeInboundContext,
+      },
+      routing: {
+        resolveAgentRoute,
       },
     },
   })),
@@ -41,6 +59,7 @@ vi.mock("./runtime.js", () => ({
 vi.mock("./client.js", () => ({
   sendMessage: vi.fn().mockResolvedValue(true),
   sendFileUrl: vi.fn().mockResolvedValue(true),
+  resolveChatUserId: vi.fn().mockResolvedValue(undefined),
 }));
 
 const { createSynologyChatPlugin } = await import("./channel.js");
@@ -48,6 +67,9 @@ describe("Synology channel wiring integration", () => {
   beforeEach(() => {
     registerPluginHttpRouteMock.mockClear();
     dispatchReplyWithBufferedBlockDispatcher.mockClear();
+    finalizeInboundContext.mockClear();
+    loadConfigMock.mockReset().mockResolvedValue({});
+    resolveAgentRoute.mockReset().mockImplementation(() => ({ ...defaultResolvedRoute }));
   });
 
   it("registers real webhook handler with resolved account config and enforces allowlist", async () => {
@@ -102,6 +124,166 @@ describe("Synology channel wiring integration", () => {
     expect(res._status).toBe(403);
     expect(res._body).toContain("not authorized");
     expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+    abortController.abort();
+    await started;
+  });
+
+  it("routes inbound messages through account-scoped bindings before dispatch", async () => {
+    const plugin = createSynologyChatPlugin();
+    const abortController = new AbortController();
+    const cfg = {
+      bindings: [{ agentId: "nas-code", match: { channel: "synology-chat", accountId: "code-developer" } }],
+      channels: {
+        "synology-chat": {
+          enabled: true,
+          accounts: {
+            "code-developer": {
+              enabled: true,
+              token: "valid-token",
+              incomingUrl: "https://nas.example.com/incoming",
+              webhookPath: "/webhook/synology-code",
+              dmPolicy: "allowlist",
+              allowedUserIds: ["123"],
+            },
+          },
+        },
+      },
+    };
+    const ctx = {
+      cfg,
+      accountId: "code-developer",
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      abortSignal: abortController.signal,
+    };
+
+    loadConfigMock.mockResolvedValue(cfg);
+    const started = plugin.gateway.startAccount(ctx);
+    expect(registerPluginHttpRouteMock).toHaveBeenCalledTimes(1);
+    const registered = registerPluginHttpRouteMock.mock.calls[0]?.[0];
+    if (!registered) {
+      throw new Error("Expected registerPluginHttpRoute to be called");
+    }
+
+    const req = makeReq(
+      "POST",
+      makeFormBody({
+        token: "valid-token",
+        user_id: "123",
+        username: "bound-user",
+        text: "Hello",
+      }),
+    );
+    const res = makeRes();
+    await registered.handler(req, res);
+
+    expect(res._status).toBe(204);
+    expect(resolveAgentRoute).toHaveBeenCalledWith({
+      cfg,
+      channel: "synology-chat",
+      accountId: "code-developer",
+      peer: {
+        kind: "direct",
+        id: "123",
+      },
+    });
+    expect(finalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SessionKey: "agent:nas-code:synology-chat:direct:123",
+        AccountId: "code-developer",
+      }),
+    );
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          SessionKey: "agent:nas-code:synology-chat:direct:123",
+          AccountId: "code-developer",
+        }),
+      }),
+    );
+
+    abortController.abort();
+    await started;
+  });
+
+  it("keeps real account-scoped session keys when dmScope requires account isolation", async () => {
+    const plugin = createSynologyChatPlugin();
+    const abortController = new AbortController();
+    const cfg: OpenClawConfig = {
+      session: {
+        dmScope: "per-account-channel-peer",
+      },
+      agents: {
+        list: [
+          { id: "main", default: true },
+          { id: "nas-code" },
+        ],
+      },
+      bindings: [
+        {
+          agentId: "nas-code",
+          match: { channel: "synology-chat", accountId: "code-developer" },
+        },
+      ],
+      channels: {
+        "synology-chat": {
+          enabled: true,
+          accounts: {
+            "code-developer": {
+              enabled: true,
+              token: "valid-token",
+              incomingUrl: "https://nas.example.com/incoming",
+              webhookPath: "/webhook/synology-code-account",
+              dmPolicy: "allowlist",
+              allowedUserIds: ["123"],
+            },
+          },
+        },
+      },
+    };
+    const ctx = {
+      cfg,
+      accountId: "code-developer",
+      log: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      abortSignal: abortController.signal,
+    };
+
+    resolveAgentRoute.mockImplementation((params) => resolveAgentRouteForTest(params));
+    loadConfigMock.mockResolvedValue(cfg);
+
+    const started = plugin.gateway.startAccount(ctx);
+    const registered = registerPluginHttpRouteMock.mock.calls[0]?.[0];
+    if (!registered) {
+      throw new Error("Expected registerPluginHttpRoute to be called");
+    }
+
+    const req = makeReq(
+      "POST",
+      makeFormBody({
+        token: "valid-token",
+        user_id: "123",
+        username: "bound-user",
+        text: "Hello",
+      }),
+    );
+    const res = makeRes();
+    await registered.handler(req, res);
+
+    expect(res._status).toBe(204);
+    expect(finalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        SessionKey: "agent:nas-code:synology-chat:code-developer:direct:123",
+        AccountId: "code-developer",
+      }),
+    );
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ctx: expect.objectContaining({
+          SessionKey: "agent:nas-code:synology-chat:code-developer:direct:123",
+          AccountId: "code-developer",
+        }),
+      }),
+    );
+
     abortController.abort();
     await started;
   });

--- a/extensions/synology-chat/src/channel.integration.test.ts
+++ b/extensions/synology-chat/src/channel.integration.test.ts
@@ -1,7 +1,11 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../src/config/config.js";
-import { resolveAgentRoute as resolveAgentRouteForTest } from "../../../src/routing/resolve-route.js";
+import {
+  resolveAgentRoute as resolveAgentRouteForTest,
+  type ResolveAgentRouteInput,
+  type ResolvedAgentRoute,
+} from "../../../src/routing/resolve-route.js";
 import { makeFormBody, makeReq, makeRes } from "./test-http-utils.js";
 
 type RegisteredRoute = {
@@ -22,8 +26,10 @@ const defaultResolvedRoute = {
   mainSessionKey: "agent:nas-code:main",
   lastRoutePolicy: "session",
   matchedBy: "binding.account",
-} as const;
-const resolveAgentRoute = vi.fn(() => ({ ...defaultResolvedRoute }));
+} satisfies ResolvedAgentRoute;
+const resolveAgentRoute = vi.fn<(params: ResolveAgentRouteInput) => ResolvedAgentRoute>(() => ({
+  ...defaultResolvedRoute,
+}));
 
 vi.mock("openclaw/plugin-sdk/synology-chat", async (importOriginal) => {
   const actual = await importOriginal<typeof import("openclaw/plugin-sdk/synology-chat")>();
@@ -246,7 +252,9 @@ describe("Synology channel wiring integration", () => {
       abortSignal: abortController.signal,
     };
 
-    resolveAgentRoute.mockImplementation((params) => resolveAgentRouteForTest(params));
+    resolveAgentRoute.mockImplementation((params: ResolveAgentRouteInput) =>
+      resolveAgentRouteForTest(params),
+    );
     loadConfigMock.mockResolvedValue(cfg);
 
     const started = plugin.gateway.startAccount(ctx);

--- a/extensions/synology-chat/src/channel.ts
+++ b/extensions/synology-chat/src/channel.ts
@@ -259,6 +259,15 @@ export function createSynologyChatPlugin() {
           deliver: async (msg) => {
             const rt = getSynologyRuntime();
             const currentCfg = await rt.config.loadConfig();
+            const route = rt.channel.routing.resolveAgentRoute({
+              cfg: currentCfg,
+              channel: CHANNEL_ID,
+              accountId: account.accountId,
+              peer: {
+                kind: "direct",
+                id: msg.from,
+              },
+            });
 
             // The Chat API user_id (for sending) may differ from the webhook
             // user_id (used for sessions/pairing). Use chatUserId for API calls.
@@ -271,8 +280,8 @@ export function createSynologyChatPlugin() {
               CommandBody: msg.body,
               From: `synology-chat:${msg.from}`,
               To: `synology-chat:${msg.from}`,
-              SessionKey: msg.sessionKey,
-              AccountId: account.accountId,
+              SessionKey: route.sessionKey,
+              AccountId: route.accountId,
               OriginatingChannel: CHANNEL_ID,
               OriginatingTo: `synology-chat:${msg.from}`,
               ChatType: msg.chatType,

--- a/scripts/ci-list-pr-files.mjs
+++ b/scripts/ci-list-pr-files.mjs
@@ -1,0 +1,50 @@
+const repo = (process.env.GITHUB_REPOSITORY ?? "").trim();
+const token = (process.env.GITHUB_TOKEN ?? "").trim();
+const prNumber = (process.argv[2] ?? process.env.PR_NUMBER ?? "").trim();
+
+if (!repo || !token || !prNumber) {
+  process.exit(0);
+}
+
+const headers = {
+  Accept: "application/vnd.github+json",
+  Authorization: `Bearer ${token}`,
+  "User-Agent": "openclaw-ci",
+  "X-GitHub-Api-Version": "2022-11-28",
+};
+const validStatuses = new Set(["added", "copied", "modified", "renamed"]);
+
+function getNextPage(linkHeader) {
+  for (const part of (linkHeader ?? "").split(",")) {
+    if (!part.includes('rel="next"')) {
+      continue;
+    }
+    const start = part.indexOf("<");
+    const end = part.indexOf(">", start + 1);
+    if (start !== -1 && end !== -1) {
+      return part.slice(start + 1, end);
+    }
+  }
+  return "";
+}
+
+let url = new URL(`https://api.github.com/repos/${repo}/pulls/${prNumber}/files`);
+url.searchParams.set("per_page", "100");
+
+while (url) {
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`Failed to list PR files: ${response.status} ${response.statusText}`);
+  }
+
+  const files = await response.json();
+  for (const file of Array.isArray(files) ? files : []) {
+    if (!file || typeof file.filename !== "string" || !validStatuses.has(file.status)) {
+      continue;
+    }
+    console.log(file.filename);
+  }
+
+  const nextPage = getNextPage(response.headers.get("link"));
+  url = nextPage ? new URL(nextPage) : null;
+}


### PR DESCRIPTION
Closes #39799

## Summary
- resolve the inbound Synology route before dispatching webhook messages
- carry the routed `sessionKey` and `accountId` into `finalizeInboundContext`
- add integration coverage for both mocked account bindings and real account-isolated dmScope routing

## Reproduction
- `origin/main` forwarded raw Synology webhook session keys like `synology-chat-123`
- that path bypassed `resolveAgentRoute()` and fell back to the default `main` agent instead of account-scoped bindings

## Validation
- `node node_modules/vitest/vitest.mjs run extensions/synology-chat/src/channel.test.ts extensions/synology-chat/src/webhook-handler.test.ts extensions/synology-chat/src/channel.integration.test.ts`