### PR TITLE
fix(discord): honor threadId in extension outbound send paths

### DIFF
--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -301,9 +301,12 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
     textChunkLimit: 2000,
     pollMaxOptions: 10,
     resolveTarget: ({ to }) => normalizeDiscordOutboundTarget(to),
-    sendText: async ({ to, text, accountId, deps, replyToId, silent }) => {
+    sendText: async ({ to, text, accountId, deps, replyToId, threadId, silent }) => {
       const send = deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
-      const result = await send(to, text, {
+      // Route to the thread channel when threadId is set; Discord threads are addressed by channel ID.
+      const target =
+        threadId != null && String(threadId).trim() ? `channel:${String(threadId).trim()}` : to;
+      const result = await send(target, text, {
         verbose: false,
         replyTo: replyToId ?? undefined,
         accountId: accountId ?? undefined,
@@ -319,10 +322,14 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       accountId,
       deps,
       replyToId,
+      threadId,
       silent,
     }) => {
       const send = deps?.sendDiscord ?? getDiscordRuntime().channel.discord.sendMessageDiscord;
-      const result = await send(to, text, {
+      // Route to the thread channel when threadId is set; Discord threads are addressed by channel ID.
+      const target =
+        threadId != null && String(threadId).trim() ? `channel:${String(threadId).trim()}` : to;
+      const result = await send(target, text, {
         verbose: false,
         mediaUrl,
         mediaLocalRoots,

--- a/extensions/discord/src/channel.ts
+++ b/extensions/discord/src/channel.ts
@@ -339,11 +339,15 @@ export const discordPlugin: ChannelPlugin<ResolvedDiscordAccount> = {
       });
       return { channel: "discord", ...result };
     },
-    sendPoll: async ({ to, poll, accountId, silent }) =>
-      await getDiscordRuntime().channel.discord.sendPollDiscord(to, poll, {
+    sendPoll: async ({ to, poll, accountId, threadId, silent }) => {
+      // Route to the thread channel when threadId is set; Discord threads are addressed by channel ID.
+      const target =
+        threadId != null && String(threadId).trim() ? `channel:${String(threadId).trim()}` : to;
+      return await getDiscordRuntime().channel.discord.sendPollDiscord(target, poll, {
         accountId: accountId ?? undefined,
         silent: silent ?? undefined,
-      }),
+      });
+    },
   },
   status: {
     defaultRuntime: {


### PR DESCRIPTION
## Summary
- The Discord extension's `sendText` and `sendMedia` outbound handlers ignored the `threadId` parameter
- Thread-targeted messages were routed to the parent channel instead of the thread
- Resolve `threadId` to `channel:<id>` format so bot-token sends reach the correct Discord thread
- Per the [Discord API docs](https://docs.discord.com/developers/resources/message), threads are addressed by channel ID — the [Create Message](https://docs.discord.com/developers/resources/message#create-message) endpoint uses the thread's channel ID as the target

## Test plan
- [ ] Send a message targeting a Discord thread via the extension and verify it arrives in the thread, not the parent channel
- [ ] Verify non-threaded sends are unaffected (falls back to `to`)

🤖 Generated with [Claude Code](https://claude.ai/code)