### PR TITLE
fix: suppress intermediate tool failure notifications from chat surfaces

### DIFF
--- a/src/agents/pi-embedded-runner/run/payloads.test.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.test.ts
@@ -127,6 +127,7 @@ describe("buildEmbeddedRunPayloads", () => {
 
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.isError).toBe(true);
+    expect(payloads[0]?.internalOnly).toBe(true);
     expect(payloads[0]?.text).toContain("Browser");
     expect(payloads[0]?.text).toContain("tab not found");
   });
@@ -173,6 +174,7 @@ describe("buildEmbeddedRunPayloads", () => {
 
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.isError).toBe(true);
+    expect(payloads[0]?.internalOnly).toBe(true);
     expect(payloads[0]?.text).toContain("Exec");
     expect(payloads[0]?.text).toContain("code 1");
   });
@@ -242,6 +244,7 @@ describe("buildEmbeddedRunPayloads", () => {
     // Non-recoverable errors should still be shown
     expect(payloads).toHaveLength(1);
     expect(payloads[0]?.isError).toBe(true);
+    expect(payloads[0]?.internalOnly).toBe(true);
     expect(payloads[0]?.text).toContain("connection timeout");
   });
 });

--- a/src/agents/pi-embedded-runner/run/payloads.ts
+++ b/src/agents/pi-embedded-runner/run/payloads.ts
@@ -37,6 +37,7 @@ export function buildEmbeddedRunPayloads(params: {
   mediaUrls?: string[];
   replyToId?: string;
   isError?: boolean;
+  internalOnly?: boolean;
   audioAsVoice?: boolean;
   replyToTag?: boolean;
   replyToCurrent?: boolean;
@@ -45,6 +46,7 @@ export function buildEmbeddedRunPayloads(params: {
     text: string;
     media?: string[];
     isError?: boolean;
+    internalOnly?: boolean;
     audioAsVoice?: boolean;
     replyToId?: string;
     replyToTag?: boolean;
@@ -227,6 +229,8 @@ export function buildEmbeddedRunPayloads(params: {
       replyItems.push({
         text: `⚠️ ${toolSummary} failed${errorSuffix}`,
         isError: true,
+        // Preserve the fallback for internal consumers while preventing delivery to chat surfaces.
+        internalOnly: true,
       });
     }
   }
@@ -238,6 +242,7 @@ export function buildEmbeddedRunPayloads(params: {
       mediaUrls: item.media?.length ? item.media : undefined,
       mediaUrl: item.media?.[0],
       isError: item.isError,
+      internalOnly: item.internalOnly,
       replyToId: item.replyToId,
       replyToTag: item.replyToTag,
       replyToCurrent: item.replyToCurrent,

--- a/src/agents/pi-embedded-runner/types.ts
+++ b/src/agents/pi-embedded-runner/types.ts
@@ -41,6 +41,7 @@ export type EmbeddedPiRunResult = {
     mediaUrls?: string[];
     replyToId?: string;
     isError?: boolean;
+    internalOnly?: boolean;
   }>;
   meta: EmbeddedPiRunMeta;
   // True if a messaging tool (telegram, whatsapp, discord, slack, sessions_send)

--- a/src/auto-reply/reply/agent-runner-payloads.test.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { buildReplyPayloads } from "./agent-runner-payloads.js";
+
+describe("buildReplyPayloads", () => {
+  it("drops internal-only payloads before delivery", () => {
+    const result = buildReplyPayloads({
+      payloads: [
+        { text: "⚠️ 📝 Edit failed", isError: true, internalOnly: true },
+        { text: "Final answer" },
+      ],
+      isHeartbeat: false,
+      didLogHeartbeatStrip: false,
+      blockStreamingEnabled: false,
+      blockReplyPipeline: null,
+      replyToMode: "off",
+    });
+
+    expect(result.replyPayloads).toEqual([{ text: "Final answer" }]);
+  });
+
+  it("returns no reply payloads when only internal-only payloads remain", () => {
+    const result = buildReplyPayloads({
+      payloads: [{ text: "⚠️ 📝 Edit failed", isError: true, internalOnly: true }],
+      isHeartbeat: false,
+      didLogHeartbeatStrip: false,
+      blockStreamingEnabled: false,
+      blockReplyPipeline: null,
+      replyToMode: "off",
+    });
+
+    expect(result.replyPayloads).toEqual([]);
+  });
+});

--- a/src/auto-reply/reply/agent-runner-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-payloads.ts
@@ -35,8 +35,11 @@ export function buildReplyPayloads(params: {
 }): { replyPayloads: ReplyPayload[]; didLogHeartbeatStrip: boolean } {
   let didLogHeartbeatStrip = params.didLogHeartbeatStrip;
   const sanitizedPayloads = params.isHeartbeat
-    ? params.payloads
+    ? params.payloads.filter((payload) => !payload.internalOnly)
     : params.payloads.flatMap((payload) => {
+        if (payload.internalOnly) {
+          return [];
+        }
         let text = payload.text;
 
         if (payload.isError && text && isBunFetchSocketError(text)) {

--- a/src/auto-reply/reply/normalize-reply.ts
+++ b/src/auto-reply/reply/normalize-reply.ts
@@ -24,6 +24,10 @@ export function normalizeReplyPayload(
   payload: ReplyPayload,
   opts: NormalizeReplyOptions = {},
 ): ReplyPayload | null {
+  if (payload.internalOnly) {
+    opts.onSkip?.("empty");
+    return null;
+  }
   const hasMedia = Boolean(payload.mediaUrl || (payload.mediaUrls?.length ?? 0) > 0);
   const hasChannelData = Boolean(
     payload.channelData && Object.keys(payload.channelData).length > 0,

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -56,6 +56,8 @@ export type ReplyPayload = {
   /** Send audio as voice message (bubble) instead of audio file. Defaults to false. */
   audioAsVoice?: boolean;
   isError?: boolean;
+  /** Internal payloads are for local bookkeeping and must not be delivered to user chat surfaces. */
+  internalOnly?: boolean;
   /** Channel-specific payload data (per-channel envelope). */
   channelData?: Record<string, unknown>;
 };

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -427,7 +427,7 @@ export async function runCronIsolatedAgentTurn(params: {
     return withRunSession({ status: "error", error: String(err) });
   }
 
-  const payloads = runResult.payloads ?? [];
+  const payloads = (runResult.payloads ?? []).filter((payload) => !payload.internalOnly);
 
   // Update token+model fields in the session store.
   {

--- a/src/infra/outbound/payloads.test.ts
+++ b/src/infra/outbound/payloads.test.ts
@@ -46,6 +46,15 @@ describe("normalizeOutboundPayloadsForJson", () => {
       },
     ]);
   });
+
+  it("drops internal-only payloads", () => {
+    expect(
+      normalizeOutboundPayloadsForJson([
+        { text: "⚠️ 📝 Edit failed", internalOnly: true },
+        { text: "visible" },
+      ]),
+    ).toEqual([{ text: "visible", mediaUrl: null, mediaUrls: undefined, channelData: undefined }]);
+  });
 });
 
 describe("normalizeOutboundPayloads", () => {
@@ -53,6 +62,14 @@ describe("normalizeOutboundPayloads", () => {
     const channelData = { line: { flexMessage: { altText: "Card", contents: {} } } };
     const normalized = normalizeOutboundPayloads([{ channelData }]);
     expect(normalized).toEqual([{ text: "", mediaUrls: [], channelData }]);
+  });
+
+  it("drops internal-only payloads", () => {
+    const normalized = normalizeOutboundPayloads([
+      { text: "⚠️ 📝 Edit failed", internalOnly: true },
+      { text: "visible" },
+    ]);
+    expect(normalized).toEqual([{ text: "visible", mediaUrls: [] }]);
   });
 });
 

--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -39,6 +39,9 @@ function mergeMediaUrls(...lists: Array<Array<string | undefined> | undefined>):
 
 export function normalizeReplyPayloadsForDelivery(payloads: ReplyPayload[]): ReplyPayload[] {
   return payloads.flatMap((payload) => {
+    if (payload.internalOnly) {
+      return [];
+    }
     const parsed = parseReplyDirectives(payload.text ?? "");
     const explicitMediaUrls = payload.mediaUrls ?? parsed.mediaUrls;
     const explicitMediaUrl = payload.mediaUrl ?? parsed.mediaUrl;


### PR DESCRIPTION
## Summary

Fixes #39916

When an agent's tool call fails (e.g., `edit` fails due to text mismatch) and the agent retries successfully, the intermediate failure message (`⚠️ 📝 Edit: ... failed`) was being pushed to the user's chat surface (Telegram, Discord, etc.). Users should not see internal tool retry failures.

## Changes

Added an `internalOnly` flag to `ReplyPayload` that marks synthetic tool-failure fallback payloads as internal bookkeeping. These payloads are then filtered out at every delivery path:

### Source (payload generation)
- **`src/agents/pi-embedded-runner/run/payloads.ts`** — Mark `⚠️ ... failed` fallback payloads with `internalOnly: true`

### Sinks (delivery filtering)
- **`src/auto-reply/reply/agent-runner-payloads.ts`** — Filter `internalOnly` payloads in both heartbeat and normal paths
- **`src/auto-reply/reply/normalize-reply.ts`** — Return `null` for `internalOnly` payloads (early exit)
- **`src/infra/outbound/payloads.ts`** — Filter `internalOnly` in `normalizeReplyPayloadsForDelivery`
- **`src/cron/isolated-agent/run.ts`** — Filter `internalOnly` payloads before cron delivery

### Types
- **`src/auto-reply/types.ts`** — Added `internalOnly?: boolean` to `ReplyPayload`
- **`src/agents/pi-embedded-runner/types.ts`** — Added `internalOnly?: boolean` to run result payload type

### Tests
- **`src/auto-reply/reply/agent-runner-payloads.test.ts`** — New test file: verifies internal-only payloads are dropped
- **`src/agents/pi-embedded-runner/run/payloads.test.ts`** — Updated existing tests to assert `internalOnly: true` on tool failure payloads
- **`src/infra/outbound/payloads.test.ts`** — Added tests for both `normalizeOutboundPayloadsForJson` and `normalizeOutboundPayloads`

## Behavior

- Normal assistant text replies are unaffected
- Tool failure payloads are still generated internally (for logging/debugging) but never reach user chat surfaces
- If the agent explicitly mentions a tool failure in its final text response, that text still gets delivered normally