### PR TITLE
docs(web): mention web_fetch/browser fallback when web_search key missing

### DIFF
--- a/docs/tools/web.md
+++ b/docs/tools/web.md
@@ -330,4 +330,4 @@ Notes:
 - See [Firecrawl](/tools/firecrawl) for key setup and service details.
 - Responses are cached (default 15 minutes) to reduce repeated fetches.
 - If you use tool profiles/allowlists, add `web_search`/`web_fetch` or `group:web`.
-- If the API key is missing, `web_search` returns a short setup hint with a docs link.
+- If the API key is missing, `web_search` returns a short setup hint with a docs link. If you don't want to configure a search API key, you can often use `web_fetch` (URL fetch) or the `browser` tool instead.

--- a/docs/zh-CN/tools/web.md
+++ b/docs/zh-CN/tools/web.md
@@ -254,4 +254,4 @@ await web_search({
 - 参见 [Firecrawl](/tools/firecrawl) 了解密钥设置和服务详情。
 - 响应会被缓存（默认 15 分钟）以减少重复获取。
 - 如果你使用工具配置文件/允许列表，添加 `web_search`/`web_fetch` 或 `group:web`。
-- 如果缺少 Brave 密钥，`web_search` 返回一个简短的设置提示和文档链接。
+- 如果缺少 Brave 密钥，`web_search` 返回一个简短的设置提示和文档链接。如果你不想配置搜索 API key，很多场景下可以直接用 `web_fetch`（抓取指定 URL）或 `browser` 工具替代。


### PR DESCRIPTION
## Summary
When `web_search` is unavailable due to a missing API key, many workflows can still proceed by using `web_fetch` (URL fetch) or the `browser` tool.

## Changes
- Add this fallback hint to the Web tools docs in both English and zh-CN.

## Behavior impact
Docs-only. No runtime changes.
