### PR TITLE
fix(workspace): tolerate missing packaged templates with built-in fallback

### DIFF
--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -101,6 +101,55 @@ function stripFrontMatter(content: string): string {
   return trimmed;
 }
 
+const FALLBACK_WORKSPACE_TEMPLATES: Record<string, string> = {
+  "AGENTS.md": `# AGENTS.md
+
+This file was generated from a built-in fallback template because the packaged templates were missing.
+
+- If you're seeing this, your OpenClaw install is likely incomplete.
+- Fix: reinstall OpenClaw (or run \`openclaw update\`) so docs/reference/templates are present.
+
+## Quick start
+- Read SOUL.md + USER.md
+- Use memory/ daily logs for continuity
+`,
+  "SOUL.md": `# SOUL.md
+
+Fallback template (packaged templates were missing).
+
+- Be concise and useful.
+- Prefer evidence over guesses.
+`,
+  "TOOLS.md": `# TOOLS.md
+
+Fallback template (packaged templates were missing).
+
+Environment-specific notes go here.
+`,
+  "IDENTITY.md": `# IDENTITY.md
+
+Fallback template (packaged templates were missing).
+
+- Name: Paru
+`,
+  "USER.md": `# USER.md
+
+Fallback template (packaged templates were missing).
+
+- Preferred language: Chinese
+`,
+  "HEARTBEAT.md": `# HEARTBEAT.md
+
+# Keep this file empty (or with only comments) to skip heartbeat API calls.
+`,
+  "BOOTSTRAP.md": `# BOOTSTRAP.md
+
+Fallback template (packaged templates were missing).
+
+If this is your first run, reinstall OpenClaw so the real templates are available.
+`,
+};
+
 async function loadTemplate(name: string): Promise<string> {
   const cached = workspaceTemplateCache.get(name);
   if (cached) {
@@ -114,6 +163,10 @@ async function loadTemplate(name: string): Promise<string> {
       const content = await fs.readFile(templatePath, "utf-8");
       return stripFrontMatter(content);
     } catch {
+      const fallback = FALLBACK_WORKSPACE_TEMPLATES[name];
+      if (typeof fallback === "string") {
+        return stripFrontMatter(fallback);
+      }
       throw new Error(
         `Missing workspace template: ${name} (${templatePath}). Ensure docs/reference/templates are packaged.`,
       );


### PR DESCRIPTION
## What\nToday we hit repeated production errors like:\n\n- `Missing workspace template: AGENTS.md (.../docs/reference/templates/AGENTS.md)`\n- followed by inbound worker failures (Discord/heartbeat)\n\nThis PR changes workspace bootstrap template loading to tolerate missing packaged templates by falling back to minimal built-in templates for the standard bootstrap files (AGENTS/SOUL/TOOLS/IDENTITY/USER/HEARTBEAT/BOOTSTRAP).\n\n## Why\nMissing templates should not crash inbound workers or prevent the gateway from running. The fallback keeps the system functional while still making it obvious the install is incomplete (the fallback template text explains how to reinstall/update).\n\n## Scope\n- Only affects template reads when the file is missing on disk\n- Does not change behavior when templates are present\n\n## Follow-ups\nLong-term, templates should probably be packaged in a runtime-owned location (e.g. dist assets) and validated at install/update time. This PR is the minimal safety net.