### PR TITLE
docs(feishu): stop recommending separate install on current releases

### DIFF
--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -15,7 +15,7 @@ Text is supported everywhere; media and reactions vary by channel.
 
 - [BlueBubbles](/channels/bluebubbles) — **Recommended for iMessage**; uses the BlueBubbles macOS server REST API with full feature support (edit, unsend, effects, reactions, group management — edit currently broken on macOS 26 Tahoe).
 - [Discord](/channels/discord) — Discord Bot API + Gateway; supports servers, channels, and DMs.
-- [Feishu](/channels/feishu) — Feishu/Lark bot via WebSocket (plugin, installed separately).
+- [Feishu](/channels/feishu) — Feishu/Lark bot via WebSocket (bundled in current OpenClaw releases).
 - [Google Chat](/channels/googlechat) — Google Chat API app via HTTP webhook.
 - [iMessage (legacy)](/channels/imessage) — Legacy macOS integration via imsg CLI (deprecated, use BlueBubbles for new setups).
 - [IRC](/channels/irc) — Classic IRC servers; channels + DMs with pairing/allowlist controls.


### PR DESCRIPTION
## Summary\n- update Feishu channel docs to reflect that current OpenClaw releases bundle Feishu by default\n- keep explicit fallback instructions for local git checkouts and older releases\n- update the channel index wording to remove outdated \'installed separately\' guidance for Feishu\n\n## Why\nIssue #39986 reports that users following docs can end up with a broken path where separate install guidance conflicts with bundled plugin behavior. This PR addresses the docs acceptance part by making the default path explicit for current releases.\n\n## Scope\n- docs/channels/index.md\n- docs/channels/feishu.md\n- docs/zh-CN/channels/feishu.md\n\n## Validation\n- pnpm exec oxfmt --check docs/channels/index.md docs/channels/feishu.md docs/zh-CN/channels/feishu.md\n- powershell -ExecutionPolicy Bypass -File ../scripts/validate-pr-scope.ps1 -RepoPath . -MaxFiles 5 -MaxLines 300 -MaxLocDelta 200\n- powershell -ExecutionPolicy Bypass -File ../scripts/detect-sensitive-files.ps1 -RepoPath .\n