### PR TITLE
fix(gateway): do not crash on Playwright dialog race unhandled rejection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- Browser: ignore Playwright dialog-race unhandled rejections through the browser plugin lifecycle so the Gateway does not exit when a dialog closes before Playwright finishes handling it. Carries forward #40067. Thanks @randyjtw.
+- Browser: ignore Playwright dialog-race unhandled rejections through the browser plugin lifecycle so the Gateway does not exit when a dialog closes before Playwright finishes handling it. Carries forward #40067 from @randyjtw; related #60576 remains separate. Thanks @randyjtw.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Browser: ignore Playwright dialog-race unhandled rejections through the browser plugin lifecycle so the Gateway does not exit when a dialog closes before Playwright finishes handling it. Carries forward #40067. Thanks @randyjtw.
 - Control UI/WebChat: keep large attachment payloads out of Lit state and optimistic chat messages, using object URL previews plus send-time payload serialization so PDF/image uploads no longer trigger `RangeError: Maximum call stack size exceeded`. Fixes #73360; refs #54378 and #63432. Thanks @hejunhui-73, @Ansub, and @christianhernandez3-afk.
 - Agents/models: keep per-agent primary models strict when `fallbacks` is omitted, so probe-only custom providers are not tried as hidden fallback candidates unless the agent explicitly opts in. Fixes #73332. Thanks @haumanto.
 - Gateway/models: add `models.pricing.enabled` so offline or restricted-network installs can skip startup OpenRouter and LiteLLM pricing-catalog fetches while keeping explicit model costs working. Fixes #53639. Thanks @callebtc, @palewire, and @rjdjohnston.

--- a/extensions/browser/src/browser/runtime-lifecycle.ts
+++ b/extensions/browser/src/browser/runtime-lifecycle.ts
@@ -4,6 +4,7 @@ import { isPwAiLoaded } from "./pw-ai-state.js";
 import type { BrowserServerState } from "./server-context.js";
 import { ensureExtensionRelayForProfiles, stopKnownBrowserProfiles } from "./server-lifecycle.js";
 import { startTrackedBrowserTabCleanupTimer } from "./session-tab-cleanup.js";
+import { registerBrowserUnhandledRejectionHandler } from "./unhandled-rejections.js";
 
 export async function createBrowserRuntimeState(params: {
   resolved: BrowserServerState["resolved"];
@@ -25,6 +26,7 @@ export async function createBrowserRuntimeState(params: {
     resolved: params.resolved,
     onWarn: params.onWarn,
   });
+  state.stopUnhandledRejectionHandler = registerBrowserUnhandledRejectionHandler();
 
   return state;
 }
@@ -39,6 +41,8 @@ export async function stopBrowserRuntime(params: {
   if (!params.current) {
     return;
   }
+  params.current.stopUnhandledRejectionHandler?.();
+  params.current.stopUnhandledRejectionHandler = undefined;
   params.current.stopTrackedTabCleanup?.();
 
   await stopKnownBrowserProfiles({

--- a/extensions/browser/src/browser/runtime-lifecycle.unhandled-rejections.test.ts
+++ b/extensions/browser/src/browser/runtime-lifecycle.unhandled-rejections.test.ts
@@ -62,20 +62,29 @@ describe("browser runtime unhandled-rejection handling", () => {
     const handler = runtimeEnvMocks.registerUnhandledRejectionHandler.mock.calls[0]?.[0];
     expect(typeof handler).toBe("function");
 
-    expect(
-      handler?.(new Error("Protocol error (Page.handleJavaScriptDialog): No dialog is showing")),
-    ).toBe(true);
-    expect(
-      handler?.({
-        cause: new Error("Protocol error (Page.handleJavaScriptDialog): No dialog is showing"),
-      }),
-    ).toBe(true);
-    expect(
-      handler?.({
-        errors: [new Error("Protocol error (Page.handleJavaScriptDialog): No dialog is showing")],
-      }),
-    ).toBe(true);
+    const handlesUnhandledRejection = handler as ((reason: unknown) => boolean) | undefined;
+    const dialogRaceError = new Error(
+      "Protocol error (Page.handleJavaScriptDialog): No dialog is showing",
+    );
+
+    for (const reason of [
+      dialogRaceError,
+      { cause: dialogRaceError },
+      { reason: dialogRaceError },
+      { original: dialogRaceError },
+      { error: dialogRaceError },
+      { data: dialogRaceError },
+      { errors: [dialogRaceError] },
+    ]) {
+      expect(handlesUnhandledRejection?.(reason)).toBe(true);
+    }
+
     expect(handler?.(new Error("No dialog is showing"))).toBe(false);
+    expect(
+      handlesUnhandledRejection?.(
+        new Error("Page.handleJavaScriptDialog rejected because no dialog is showing"),
+      ),
+    ).toBe(false);
 
     const clearState = vi.fn();
     await stopBrowserRuntime({

--- a/extensions/browser/src/browser/runtime-lifecycle.unhandled-rejections.test.ts
+++ b/extensions/browser/src/browser/runtime-lifecycle.unhandled-rejections.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const runtimeEnvMocks = vi.hoisted(() => ({
+  registerUnhandledRejectionHandler: vi.fn(),
+  unregisterUnhandledRejectionHandler: vi.fn(),
+}));
+
+const lifecycleMocks = vi.hoisted(() => ({
+  ensureExtensionRelayForProfiles: vi.fn(async () => {}),
+  stopKnownBrowserProfiles: vi.fn(async () => {}),
+  stopTrackedTabCleanup: vi.fn(),
+  startTrackedBrowserTabCleanupTimer: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/runtime-env", () => ({
+  registerUnhandledRejectionHandler: runtimeEnvMocks.registerUnhandledRejectionHandler,
+}));
+
+vi.mock("./server-lifecycle.js", () => ({
+  ensureExtensionRelayForProfiles: lifecycleMocks.ensureExtensionRelayForProfiles,
+  stopKnownBrowserProfiles: lifecycleMocks.stopKnownBrowserProfiles,
+}));
+
+vi.mock("./session-tab-cleanup.js", () => ({
+  startTrackedBrowserTabCleanupTimer: lifecycleMocks.startTrackedBrowserTabCleanupTimer,
+}));
+
+vi.mock("./pw-ai-state.js", () => ({
+  isPwAiLoaded: () => false,
+}));
+
+vi.mock("./pw-ai-module.js", () => ({
+  getPwAiModule: vi.fn(),
+}));
+
+const { createBrowserRuntimeState, stopBrowserRuntime } = await import("./runtime-lifecycle.js");
+
+beforeEach(() => {
+  runtimeEnvMocks.registerUnhandledRejectionHandler.mockReset();
+  runtimeEnvMocks.unregisterUnhandledRejectionHandler.mockReset();
+  runtimeEnvMocks.registerUnhandledRejectionHandler.mockReturnValue(
+    runtimeEnvMocks.unregisterUnhandledRejectionHandler,
+  );
+  lifecycleMocks.ensureExtensionRelayForProfiles.mockClear();
+  lifecycleMocks.stopKnownBrowserProfiles.mockClear();
+  lifecycleMocks.stopTrackedTabCleanup.mockClear();
+  lifecycleMocks.startTrackedBrowserTabCleanupTimer.mockReset();
+  lifecycleMocks.startTrackedBrowserTabCleanupTimer.mockReturnValue(
+    lifecycleMocks.stopTrackedTabCleanup,
+  );
+});
+
+describe("browser runtime unhandled-rejection handling", () => {
+  it("registers a browser-owned Playwright dialog race handler and unregisters on stop", async () => {
+    const state = await createBrowserRuntimeState({
+      resolved: { profiles: {} } as never,
+      port: 18791,
+      onWarn: vi.fn(),
+    });
+
+    expect(runtimeEnvMocks.registerUnhandledRejectionHandler).toHaveBeenCalledTimes(1);
+    const handler = runtimeEnvMocks.registerUnhandledRejectionHandler.mock.calls[0]?.[0];
+    expect(typeof handler).toBe("function");
+
+    expect(
+      handler?.(new Error("Protocol error (Page.handleJavaScriptDialog): No dialog is showing")),
+    ).toBe(true);
+    expect(
+      handler?.({
+        cause: new Error("Protocol error (Page.handleJavaScriptDialog): No dialog is showing"),
+      }),
+    ).toBe(true);
+    expect(
+      handler?.({
+        errors: [new Error("Protocol error (Page.handleJavaScriptDialog): No dialog is showing")],
+      }),
+    ).toBe(true);
+    expect(handler?.(new Error("No dialog is showing"))).toBe(false);
+
+    const clearState = vi.fn();
+    await stopBrowserRuntime({
+      current: state,
+      getState: () => state,
+      clearState,
+      onWarn: vi.fn(),
+    });
+
+    expect(runtimeEnvMocks.unregisterUnhandledRejectionHandler).toHaveBeenCalledTimes(1);
+    expect(lifecycleMocks.stopTrackedTabCleanup).toHaveBeenCalledTimes(1);
+    expect(clearState).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/browser/src/browser/server-context.types.ts
+++ b/extensions/browser/src/browser/server-context.types.ts
@@ -37,6 +37,7 @@ export type BrowserServerState = {
   resolved: ResolvedBrowserConfig;
   profiles: Map<string, ProfileRuntimeState>;
   stopTrackedTabCleanup?: () => void;
+  stopUnhandledRejectionHandler?: () => void;
 };
 
 type BrowserProfileActions = {

--- a/extensions/browser/src/browser/unhandled-rejections.ts
+++ b/extensions/browser/src/browser/unhandled-rejections.ts
@@ -1,6 +1,7 @@
 import { registerUnhandledRejectionHandler } from "openclaw/plugin-sdk/runtime-env";
 
 const PLAYWRIGHT_DIALOG_RACE_MESSAGE_SNIPPETS = [
+  "protocol error",
   "page.handlejavascriptdialog",
   "no dialog is showing",
 ];

--- a/extensions/browser/src/browser/unhandled-rejections.ts
+++ b/extensions/browser/src/browser/unhandled-rejections.ts
@@ -1,0 +1,62 @@
+import { registerUnhandledRejectionHandler } from "openclaw/plugin-sdk/runtime-env";
+
+const PLAYWRIGHT_DIALOG_RACE_MESSAGE_SNIPPETS = [
+  "page.handlejavascriptdialog",
+  "no dialog is showing",
+];
+
+function collectNestedErrorCandidates(reason: unknown): unknown[] {
+  const candidates: unknown[] = [];
+  const queue: unknown[] = [reason];
+  const seen = new WeakSet<object>();
+
+  while (queue.length > 0 && candidates.length < 64) {
+    const current = queue.shift();
+    candidates.push(current);
+
+    if (!current || typeof current !== "object") {
+      continue;
+    }
+    if (seen.has(current)) {
+      continue;
+    }
+    seen.add(current);
+
+    const record = current as {
+      cause?: unknown;
+      reason?: unknown;
+      original?: unknown;
+      error?: unknown;
+      data?: unknown;
+      errors?: unknown;
+    };
+    queue.push(record.cause, record.reason, record.original, record.error, record.data);
+    if (Array.isArray(record.errors)) {
+      queue.push(...record.errors);
+    }
+  }
+
+  return candidates;
+}
+
+export function isPlaywrightDialogRaceUnhandledRejection(reason: unknown): boolean {
+  for (const candidate of collectNestedErrorCandidates(reason)) {
+    if (!candidate || typeof candidate !== "object") {
+      continue;
+    }
+    const rawMessage = (candidate as { message?: unknown }).message;
+    const message = typeof rawMessage === "string" ? rawMessage.toLowerCase() : "";
+    if (
+      message &&
+      PLAYWRIGHT_DIALOG_RACE_MESSAGE_SNIPPETS.every((snippet) => message.includes(snippet))
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function registerBrowserUnhandledRejectionHandler(): () => void {
+  return registerUnhandledRejectionHandler(isPlaywrightDialogRaceUnhandledRejection);
+}


### PR DESCRIPTION
## Summary
- treat `Protocol error (Page.handleJavaScriptDialog): No dialog is showing` as a non-fatal unhandled rejection
- keep gateway running when this Playwright dialog race condition appears
- add a unit test to lock behavior

## Why
In rare browser race conditions, Playwright can emit an unhandled rejection for a missing dialog. Today this falls into the generic fatal path and exits the gateway process.

## Scope
- `src/infra/unhandled-rejections.ts`
- `src/infra/unhandled-rejections.fatal-detection.test.ts`

## Validation
- added a test case: `does not exit on Playwright dialog race errors`
- local test execution not available in this environment (`pnpm`/`corepack` missing)
