### PR TITLE
Fix ACP session init fallback and persist ACP child transcripts

### DIFF
--- a/extensions/acpx/src/runtime.ts
+++ b/extensions/acpx/src/runtime.ts
@@ -66,6 +66,41 @@ function formatAcpxExitMessage(params: {
   return stderr || `acpx exited with code ${params.exitCode ?? "unknown"}`;
 }
 
+function parseControlPlainTextSession(stdout: string): AcpxJsonObject[] {
+  const text = stdout.trim();
+  if (!text) {
+    return [];
+  }
+
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  if (lines.length === 0) {
+    return [];
+  }
+
+  const record: AcpxJsonObject = {};
+  let sawStructuredField = false;
+
+  for (const line of lines) {
+    const fieldMatch = line.match(/^(acpxRecordId|acpxSessionId|agentSessionId|status):\s*(.+)$/);
+    if (fieldMatch) {
+      sawStructuredField = true;
+      record[fieldMatch[1]] = fieldMatch[2].trim();
+      continue;
+    }
+
+    if (!sawStructuredField && !record.acpxRecordId && !line.startsWith("[acpx]")) {
+      record.acpxRecordId = line;
+    }
+  }
+
+  return record.acpxRecordId || record.acpxSessionId || record.agentSessionId || record.status
+    ? [record]
+    : [];
+}
+
 export function encodeAcpxRuntimeHandleState(state: AcpxHandleState): string {
   const payload = Buffer.from(JSON.stringify(state), "utf8").toString("base64url");
   return `${ACPX_RUNTIME_HANDLE_PREFIX}${payload}`;
@@ -647,7 +682,11 @@ export class AcpxRuntime implements AcpRuntime {
       throw new AcpRuntimeError(params.fallbackCode, result.error.message, { cause: result.error });
     }
 
-    const events = parseJsonLines(result.stdout);
+    let events = parseJsonLines(result.stdout);
+    if (events.length === 0) {
+      events = parseControlPlainTextSession(result.stdout);
+    }
+
     const errorEvent = events.map((event) => toAcpxErrorEvent(event)).find(Boolean) ?? null;
     if (errorEvent) {
       if (params.ignoreNoSession && errorEvent.code === "NO_SESSION") {

--- a/src/commands/agent.ts
+++ b/src/commands/agent.ts
@@ -59,6 +59,7 @@ import { getAgentRuntimeCommandSecretTargetIds } from "../cli/command-secret-tar
 import { type CliDeps, createDefaultDeps } from "../cli/deps.js";
 import { loadConfig } from "../config/config.js";
 import {
+  appendAssistantMessageToSessionTranscript,
   mergeSessionEntry,
   parseSessionThreadInfo,
   resolveAndPersistSessionFile,
@@ -649,8 +650,23 @@ async function agentCommandInternal(
         },
       });
 
+      const finalizedText = visibleTextAccumulator.finalize();
+      if (sessionKey && finalizedText) {
+        const appendResult = await appendAssistantMessageToSessionTranscript({
+          agentId: sessionAgentId,
+          sessionKey,
+          text: finalizedText,
+          storePath,
+        });
+        if (!appendResult.ok) {
+          log.warn(
+            `acp transcript mirror skipped for ${sessionKey}: ${appendResult.reason}`,
+          );
+        }
+      }
+
       const normalizedFinalPayload = normalizeReplyPayload({
-        text: visibleTextAccumulator.finalize(),
+        text: finalizedText,
       });
       const payloads = normalizedFinalPayload ? [normalizedFinalPayload] : [];
       const result = {


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Claude Code ACP session initialization could fail when `acpx sessions ensure/new` returned plain-text output instead of JSON, and successful ACP child sessions could still have empty transcript history.
- Why it matters: OpenClaw could create or dispatch Claude ACP work inconsistently, and `sessions_history` could not read back child-session output even when the task completed.
- What changed: Added a plain-text fallback for ACP session control output in `extensions/acpx/src/runtime.ts`, and persisted finalized ACP assistant output into child session transcripts in `src/commands/agent.ts`.
- What did NOT change (scope boundary): This PR does not change ACP policy defaults, channel routing policy, or non-ACP transcript behavior.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [x] Skills / tool execution
- [ ] Auth / tokens
- [x] Memory / storage
- [ ] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None

## User-visible / Behavior Changes

- Claude Code ACP sessions can initialize successfully even when `acpx` control commands emit plain-text session metadata.
- Claude ACP child sessions now persist final assistant output into the child transcript, so `sessions_history` can read back results.
- No config default changes were introduced by this PR.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS 26.0 arm64
- Runtime/container: local OpenClaw gateway + local Claude Code ACP runtime
- Model/provider: Claude Code ACP path, with returned transcript mirrored as `provider=openclaw model=delivery-mirror`
- Integration/channel (if any): local webchat / direct session flow
- Relevant config (redacted):
  - `acp.enabled=true`
  - `acp.dispatch.enabled=true`
  - `acp.backend="acpx"`
  - `acp.defaultAgent="claude"`
  - `plugins.entries.acpx.enabled=true`

### Steps

1. Configure OpenClaw to use `acpx` as the ACP backend with `claude` allowed as an ACP agent.
2. Spawn a Claude ACP session and send a one-shot task.
3. Read back the child session with `sessions_history`.

### Expected

- ACP session initialization succeeds.
- Child transcript `.jsonl` is created for the Claude ACP session.
- `sessions_history` returns the final assistant output.

### Actual

- Before fix: ACP init could fail on non-JSON `acpx sessions ensure/new` output, and successful child sessions had empty transcript history.
- After fix: Claude ACP session init succeeds and child transcript/history are populated.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Claude ACP session initialization succeeds after the plain-text fallback.
  - A real Claude ACP task completes and writes a child transcript `.jsonl`.
  - `sessions_history` returns the persisted assistant text from the child ACP session.
- Edge cases checked:
  - Plain-text control output path in `acpx sessions ensure/new`
  - Child transcript persistence on the actual `commands/agent.ts` ACP execution path
- What you did **not** verify:
  - Non-Claude ACP harnesses beyond this path
  - Full automated test suite / CI
  - Multi-channel delivery behavior beyond the direct local validation flow

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
  - Revert the two commits in this PR.
- Files/config to restore:
  - `extensions/acpx/src/runtime.ts`
  - `src/commands/agent.ts`
- Known bad symptoms reviewers should watch for:
  - Claude ACP session init still failing with `ACP_SESSION_INIT_FAILED`
  - Child ACP sessions appearing in `sessions.json` without transcript `.jsonl`
  - `sessions_history` returning empty results for completed Claude ACP sessions

## Risks and Mitigations

- Risk: The plain-text fallback could accept unexpected control-command output shapes.
 - Mitigation: The fallback only extracts a small allowlisted set of session identifier fields and leaves the JSON path unchanged when JSON output is available.
- Risk: Transcript mirroring persists only finalized assistant text, not full ACP event streams.
 - Mitigation: This matches the minimal bug-fix scope needed to restore child transcript readability without changing broader ACP event projection behavior.
