### PR TITLE
🤖 fix(session): clear model override on /new to restore agent default

### DIFF
--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -388,8 +388,11 @@ export async function initSessionState(params: {
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
-      persistedModelOverride = entry.modelOverride;
-      persistedProviderOverride = entry.providerOverride;
+      // Do not carry over model/provider overrides on reset.
+      // /new should restore the agent's configured default model,
+      // not persist a prior /model switch into the new session.
+      persistedModelOverride = undefined;
+      persistedProviderOverride = undefined;
       persistedLabel = entry.label;
     }
   }


### PR DESCRIPTION
## Problem

When a user switches models via `/model` during a session and later runs `/new` or `/reset`, the model override was carried over into the new session. This caused the new session to display and use the manually selected model instead of the agent's configured default.

For example, an agent configured with `openai-codex/gpt-5.4` would show `anthropic/claude-opus-4-6` after `/new` if the user had previously run `/model opus` in that session.

## Root Cause

In `session.ts`, the reset handler intentionally preserves session-level overrides (thinking, verbose, reasoning, ttsAuto) across `/new`/`/reset` for UX continuity. However, `modelOverride` and `providerOverride` were also being carried over, which conflicts with the expectation that `/new` restores the agent's default model.

## Fix

Clear `modelOverride` and `providerOverride` on session reset instead of carrying them over. Other UX preferences (thinking level, verbose mode, reasoning, ttsAuto) are still preserved as intended.

If a user wants a specific model in the new session, they can use `/new <model>` which is handled separately by `applyResetModelOverride`.

## Testing

- Configured agent with `openai-codex/gpt-5.4` as default model
- Ran `/model opus` to switch model mid-session
- Ran `/new` — previously showed `anthropic/claude-opus-4-6`, now correctly shows `openai-codex/gpt-5.4`
- `/new opus` still works to explicitly set a model on reset

---
🤖 AI-assisted: bug identified and fix authored with AI assistance. Tested manually on a live instance.