### PR TITLE
fix: ignore ACP-only streamTo for subagent spawns

### DIFF
--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -476,7 +476,7 @@ Core parameters:
 - `sessions_list`: `kinds?`, `limit?`, `activeMinutes?`, `messageLimit?` (0 = none)
 - `sessions_history`: `sessionKey` (or `sessionId`), `limit?`, `includeTools?`
 - `sessions_send`: `sessionKey` (or `sessionId`), `message`, `timeoutSeconds?` (0 = fire-and-forget)
-- `sessions_spawn`: `task`, `label?`, `runtime?`, `agentId?`, `model?`, `thinking?`, `cwd?`, `runTimeoutSeconds?`, `thread?`, `mode?`, `cleanup?`, `sandbox?`, `streamTo?`, `attachments?`, `attachAs?`
+- `sessions_spawn`: `task`, `label?`, `runtime?`, `agentId?`, `model?`, `thinking?`, `cwd?`, `runTimeoutSeconds?`, `thread?`, `mode?`, `cleanup?`, `sandbox?`, `streamTo?` (ACP only), `attachments?`, `attachAs?`
 - `session_status`: `sessionKey?` (default current; accepts `sessionId`), `model?` (`default` clears override)
 
 Notes:
@@ -488,6 +488,7 @@ Notes:
 - Delivery/announce happens after completion and is best-effort; `status: "ok"` confirms the agent run finished, not that the announce was delivered.
 - `sessions_spawn` supports `runtime: "subagent" | "acp"` (`subagent` default). For ACP runtime behavior, see [ACP Agents](/tools/acp-agents).
 - For ACP runtime, `streamTo: "parent"` routes initial-run progress summaries back to the requester session as system events instead of direct child delivery.
+- For subagent runtime, `streamTo` is ignored for compatibility and has no effect.
 - `sessions_spawn` starts a sub-agent run and posts an announce reply back to the requester chat.
   - Supports one-shot mode (`mode: "run"`) and persistent thread-bound mode (`mode: "session"` with `thread: true`).
   - If `thread: true` and `mode` is omitted, mode defaults to `session`.

--- a/src/agents/tools/sessions-spawn-tool.test.ts
+++ b/src/agents/tools/sessions-spawn-tool.test.ts
@@ -187,7 +187,7 @@ describe("sessions_spawn tool", () => {
     expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
-  it('rejects streamTo when runtime is not "acp"', async () => {
+  it('ignores streamTo when runtime is "subagent"', async () => {
     const tool = createSessionsSpawnTool({
       agentSessionKey: "agent:main:main",
     });
@@ -199,12 +199,17 @@ describe("sessions_spawn tool", () => {
     });
 
     expect(result.details).toMatchObject({
-      status: "error",
+      status: "accepted",
+      childSessionKey: "agent:main:subagent:1",
+      runId: "run-subagent",
     });
-    const details = result.details as { error?: string };
-    expect(details.error).toContain("streamTo is only supported for runtime=acp");
+    expect(hoisted.spawnSubagentDirectMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: "analyze file",
+      }),
+      expect.any(Object),
+    );
     expect(hoisted.spawnAcpDirectMock).not.toHaveBeenCalled();
-    expect(hoisted.spawnSubagentDirectMock).not.toHaveBeenCalled();
   });
 
   it("keeps attachment content schema unconstrained for llama.cpp grammar safety", () => {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -98,7 +98,8 @@ export function createSessionsSpawnTool(
       const cleanup =
         params.cleanup === "keep" || params.cleanup === "delete" ? params.cleanup : "keep";
       const sandbox = params.sandbox === "require" ? "require" : "inherit";
-      const streamTo = params.streamTo === "parent" ? "parent" : undefined;
+      const streamToRequested = params.streamTo === "parent" ? "parent" : undefined;
+      const streamTo = runtime === "acp" ? streamToRequested : undefined;
       // Back-compat: older callers used timeoutSeconds for this tool.
       const timeoutSecondsCandidate =
         typeof params.runTimeoutSeconds === "number"
@@ -119,13 +120,6 @@ export function createSessionsSpawnTool(
             mimeType?: string;
           }>)
         : undefined;
-
-      if (streamTo && runtime !== "acp") {
-        return jsonResult({
-          status: "error",
-          error: `streamTo is only supported for runtime=acp; got runtime=${runtime}`,
-        });
-      }
 
       if (runtime === "acp") {
         if (Array.isArray(attachments) && attachments.length > 0) {


### PR DESCRIPTION
## Summary

Fix `sessions_spawn` so ACP-only `streamTo` no longer breaks normal subagent runs.

In `2026.3.7`, `streamTo` became visible on the general `sessions_spawn` surface, but runtime validation still rejects it unless `runtime="acp"`. In practice this caused subagent spawns to fail with:

```
streamTo is only supported for runtime=acp; got runtime=subagent
```

That was especially easy to hit when tool callers or model-generated calls treated `streamTo` as a generic optional field on `sessions_spawn`.

This change keeps ACP behavior intact while making subagent spawns tolerant:

- `runtime="acp"` keeps using `streamTo` normally
- `runtime="subagent"` ignores `streamTo` for compatibility instead of returning an error
- docs now mark `streamTo` as ACP-only and explicitly note that subagent runtime ignores it

## Why this approach

This is intentionally a compatibility fix, not a feature removal.

`streamTo` is still a valid ACP feature and should remain available for ACP session flows. The bug was that the shared `sessions_spawn` surface exposed the field broadly while runtime treated it as ACP-only. Ignoring it on subagent runs is the safest behavior for existing callers and avoids breaking ACP.

## Tests

Passed:

```bash
node $(find node_modules -path '*/vitest/vitest.mjs' | head -n 1) run src/agents/tools/sessions-spawn-tool.test.ts src/agents/openclaw-tools.sessions.test.ts
```

Results:

- `src/agents/tools/sessions-spawn-tool.test.ts` ✅
- `src/agents/openclaw-tools.sessions.test.ts` ✅

## Files changed

- `src/agents/tools/sessions-spawn-tool.ts`
- `src/agents/tools/sessions-spawn-tool.test.ts`
- `docs/tools/index.md`
