### PR TITLE
chore: update .secrets.baseline for false positives

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -202,15 +202,6 @@
         "line_number": 723
       }
     ],
-    "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "apps/android/app/src/test/java/ai/openclaw/android/node/AppUpdateHandlerTest.kt",
-        "hashed_secret": "ee662f2bc691daa48d074542722d8e1b0587673c",
-        "is_verified": false,
-        "line_number": 58
-      }
-    ],
     "apps/ios/Tests/DeepLinkParserTests.swift": [
       {
         "type": "Secret Keyword",
@@ -227,22 +218,6 @@
         "hashed_secret": "7990585255d25249fb1e6eac3d2bd6c37429b2cd",
         "is_verified": false,
         "line_number": 1749
-      }
-    ],
-    "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift": [
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "e761624445731fcb8b15da94343c6b92e507d190",
-        "is_verified": false,
-        "line_number": 26
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "apps/macos/Tests/OpenClawIPCTests/AnthropicAuthResolverTests.swift",
-        "hashed_secret": "a23c8630c8a5fbaa21f095e0269c135c20d21689",
-        "is_verified": false,
-        "line_number": 42
       }
     ],
     "apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift": [
@@ -9619,14 +9594,14 @@
         "filename": "docs/channels/feishu.md",
         "hashed_secret": "b60d121b438a380c343d5ec3c2037564b82ffef3",
         "is_verified": false,
-        "line_number": 189
+        "line_number": 187
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/channels/feishu.md",
         "hashed_secret": "186154712b2d5f6791d85b9a0987b98fa231779c",
         "is_verified": false,
-        "line_number": 501
+        "line_number": 499
       }
     ],
     "docs/channels/irc.md": [
@@ -9972,7 +9947,14 @@
         "filename": "docs/perplexity.md",
         "hashed_secret": "6b26c117c66a0c030e239eef595c1e18865132a8",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/perplexity.md",
+        "hashed_secret": "96c682c88ed551f22fe76d206c2dfb7df9221ad9",
+        "is_verified": false,
+        "line_number": 60
       }
     ],
     "docs/plugins/voice-call.md": [
@@ -10198,21 +10180,28 @@
         "filename": "docs/tools/web.md",
         "hashed_secret": "6b26c117c66a0c030e239eef595c1e18865132a8",
         "is_verified": false,
-        "line_number": 129
+        "line_number": 131
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/tools/web.md",
+        "hashed_secret": "96c682c88ed551f22fe76d206c2dfb7df9221ad9",
+        "is_verified": false,
+        "line_number": 149
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/tools/web.md",
         "hashed_secret": "491d458f895b9213facb2ee9375b1b044eaea3ac",
         "is_verified": false,
-        "line_number": 202
+        "line_number": 224
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/tools/web.md",
         "hashed_secret": "674397e2c0c2faaa85961c708d2a96a7cc7af217",
         "is_verified": false,
-        "line_number": 303
+        "line_number": 328
       }
     ],
     "docs/tts.md": [
@@ -10255,14 +10244,14 @@
         "filename": "docs/zh-CN/channels/feishu.md",
         "hashed_secret": "b60d121b438a380c343d5ec3c2037564b82ffef3",
         "is_verified": false,
-        "line_number": 195
+        "line_number": 191
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/zh-CN/channels/feishu.md",
         "hashed_secret": "186154712b2d5f6791d85b9a0987b98fa231779c",
         "is_verified": false,
-        "line_number": 509
+        "line_number": 505
       }
     ],
     "docs/zh-CN/channels/line.md": [
@@ -11011,15 +11000,6 @@
         "line_number": 74
       }
     ],
-    "extensions/google-antigravity-auth/index.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "extensions/google-antigravity-auth/index.ts",
-        "hashed_secret": "709d0f232b6ac4f8d24dec3e4fabfdb14257174f",
-        "is_verified": false,
-        "line_number": 14
-      }
-    ],
     "extensions/google-gemini-cli-auth/oauth.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11388,84 +11368,6 @@
         "line_number": 22
       }
     ],
-    "src/agents/compaction.tool-result-details.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/compaction.tool-result-details.e2e.test.ts",
-        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
-        "is_verified": false,
-        "line_number": 50
-      }
-    ],
-    "src/agents/memory-search.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/memory-search.e2e.test.ts",
-        "hashed_secret": "a1b49d68a91fdf9c9217773f3fac988d77fa0f50",
-        "is_verified": false,
-        "line_number": 189
-      }
-    ],
-    "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/minimax-vlm.normalizes-api-key.e2e.test.ts",
-        "hashed_secret": "8a8461b67e3fe515f248ac2610fd7b1f4fc3b412",
-        "is_verified": false,
-        "line_number": 28
-      }
-    ],
-    "src/agents/model-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
-        "is_verified": false,
-        "line_number": 228
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "21f296583ccd80c5ab9b3330a8b0d47e4a409fb9",
-        "is_verified": false,
-        "line_number": 254
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
-        "is_verified": false,
-        "line_number": 275
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 296
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
-        "is_verified": false,
-        "line_number": 319
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "b43be360db55d89ec6afd74d6ed8f82002fe4982",
-        "is_verified": false,
-        "line_number": 374
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/model-auth.e2e.test.ts",
-        "hashed_secret": "5b850e9dc678446137ff6d905ebd78634d687fdd",
-        "is_verified": false,
-        "line_number": 395
-      }
-    ],
     "src/agents/model-auth.ts": [
       {
         "type": "Secret Keyword",
@@ -11484,29 +11386,13 @@
         "line_number": 131
       }
     ],
-    "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts": [
+    "src/agents/models-config.merge.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
+        "filename": "src/agents/models-config.merge.test.ts",
+        "hashed_secret": "565a8d87240aae631d7a901c1f697d46ee141a7b",
         "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.fills-missing-provider-apikey-from-env-var.e2e.test.ts",
-        "hashed_secret": "3a81eb091f80c845232225be5663d270e90dacb7",
-        "is_verified": false,
-        "line_number": 73
-      }
-    ],
-    "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.normalizes-gemini-3-ids-preview-google-providers.e2e.test.ts",
-        "hashed_secret": "980d02eb9335ae7c9e9984f6c8ad432352a0d2ac",
-        "is_verified": false,
-        "line_number": 20
+        "line_number": 75
       }
     ],
     "src/agents/models-config.providers.nvidia.test.ts": [
@@ -11523,40 +11409,6 @@
         "hashed_secret": "be1a7be9d4d5af417882b267f4db6dddc08507bd",
         "is_verified": false,
         "line_number": 22
-      }
-    ],
-    "src/agents/models-config.providers.ollama.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.ollama.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 37
-      }
-    ],
-    "src/agents/models-config.providers.qianfan.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.providers.qianfan.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 12
-      }
-    ],
-    "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
-        "hashed_secret": "4c7bac93427c83bcc3beeceebfa54f16f801b78f",
-        "is_verified": false,
-        "line_number": 100
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/models-config.skips-writing-models-json-no-env-token.e2e.test.ts",
-        "hashed_secret": "4f2b3ddc953da005a97d825652080fe6eff21520",
-        "is_verified": false,
-        "line_number": 113
       }
     ],
     "src/agents/openai-responses.reasoning-replay.test.ts": [
@@ -11595,15 +11447,6 @@
         "line_number": 114
       }
     ],
-    "src/agents/pi-tools.safe-bins.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/pi-tools.safe-bins.e2e.test.ts",
-        "hashed_secret": "3ea88a727641fd5571b5e126ce87032377be1e7f",
-        "is_verified": false,
-        "line_number": 126
-      }
-    ],
     "src/agents/sanitize-for-prompt.test.ts": [
       {
         "type": "Base64 High Entropy String",
@@ -11613,65 +11456,27 @@
         "line_number": 28
       }
     ],
-    "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts": [
+    "src/agents/tools/web-search.test.ts": [
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.prefers-workspace-skills-managed-skills.e2e.test.ts",
-        "hashed_secret": "7a85f4764bbd6daf1c3545efbbf0f279a6dc0beb",
+        "filename": "src/agents/tools/web-search.test.ts",
+        "hashed_secret": "d0ffd81d6d7ad1bc3c365660fe8882480c9a986e",
         "is_verified": false,
-        "line_number": 103
-      }
-    ],
-    "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.build-workspace-skills-prompt.syncs-merged-skills-into-target-workspace.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 147
-      }
-    ],
-    "src/agents/skills.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
-        "hashed_secret": "5df3a673d724e8a1eb673a8baf623e183940804d",
-        "is_verified": false,
-        "line_number": 250
+        "line_number": 45
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/skills.e2e.test.ts",
-        "hashed_secret": "8921daaa546693e52bc1f9c40bdcf15e816e0448",
+        "filename": "src/agents/tools/web-search.test.ts",
+        "hashed_secret": "6eba473e98aa0113f5b48dd101af350490c608e8",
         "is_verified": false,
-        "line_number": 277
-      }
-    ],
-    "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts": [
+        "line_number": 59
+      },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.firecrawl-api-key-normalization.e2e.test.ts",
-        "hashed_secret": "9da08ab1e27fe0ae2ba6101aea30edcec02d21a4",
+        "filename": "src/agents/tools/web-search.test.ts",
+        "hashed_secret": "e459914897021bf37e4673ae10357cd94b91f493",
         "is_verified": false,
-        "line_number": 45
-      }
-    ],
-    "src/agents/tools/web-fetch.ssrf.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-fetch.ssrf.e2e.test.ts",
-        "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
-        "is_verified": false,
-        "line_number": 73
-      }
-    ],
-    "src/agents/tools/web-search.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-search.e2e.test.ts",
-        "hashed_secret": "c8d313eac6d38274ccfc0fa7935c68bd61d5bc2f",
-        "is_verified": false,
-        "line_number": 129
+        "line_number": 87
       }
     ],
     "src/agents/tools/web-search.ts": [
@@ -11680,64 +11485,28 @@
         "filename": "src/agents/tools/web-search.ts",
         "hashed_secret": "dfba7aade0868074c2861c98e2a9a92f3178a51b",
         "is_verified": false,
-        "line_number": 266
-      }
-    ],
-    "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "47b249a75ca78fdb578d0f28c33685e27ea82684",
-        "is_verified": false,
-        "line_number": 181
+        "line_number": 292
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.enabled-defaults.e2e.test.ts",
-        "hashed_secret": "d0ffd81d6d7ad1bc3c365660fe8882480c9a986e",
+        "filename": "src/agents/tools/web-search.ts",
+        "hashed_secret": "71f8e7976e4cbc4561c9d62fb283e7f788202acb",
         "is_verified": false,
-        "line_number": 187
-      }
-    ],
-    "src/agents/tools/web-tools.fetch.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/agents/tools/web-tools.fetch.e2e.test.ts",
-        "hashed_secret": "5ce8e9d54c77266fff990194d2219a708c59b76c",
-        "is_verified": false,
-        "line_number": 246
-      }
-    ],
-    "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 56
+        "line_number": 670
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.prefers-alias-matches-fuzzy-selection-is-ambiguous.e2e.test.ts",
-        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
+        "filename": "src/agents/tools/web-search.ts",
+        "hashed_secret": "c4865ff9250aca23b0d98eb079dad70ebec1cced",
         "is_verified": false,
-        "line_number": 62
-      }
-    ],
-    "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 42
+        "line_number": 680
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/auto-reply/reply.directive.directive-behavior.supports-fuzzy-model-matches-model-directive.e2e.test.ts",
-        "hashed_secret": "16c249e04e2be318050cb883c40137361c0c7209",
+        "filename": "src/agents/tools/web-search.ts",
+        "hashed_secret": "527ee41f36386e85fa932ef09471ca017f3c95c8",
         "is_verified": false,
-        "line_number": 149
+        "line_number": 683
       }
     ],
     "src/auto-reply/status.test.ts": [
@@ -11792,15 +11561,6 @@
         "line_number": 64
       }
     ],
-    "src/cli/program.smoke.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/cli/program.smoke.e2e.test.ts",
-        "hashed_secret": "8689a958b58e4a6f7da6211e666da8e17651697c",
-        "is_verified": false,
-        "line_number": 215
-      }
-    ],
     "src/cli/update-cli.test.ts": [
       {
         "type": "Hex High Entropy String",
@@ -11808,50 +11568,6 @@
         "hashed_secret": "e4f91dd323bac5bfc4f60a6e433787671dc2421d",
         "is_verified": false,
         "line_number": 277
-      }
-    ],
-    "src/commands/auth-choice.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "2480500ff391183070fe22ba8665a8be19350833",
-        "is_verified": false,
-        "line_number": 454
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "844ae5308654406d80db6f2b3d0beb07d616f9e1",
-        "is_verified": false,
-        "line_number": 487
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 549
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
-        "is_verified": false,
-        "line_number": 584
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "1b4d8423b11d32dd0c466428ac81de84a4a9442b",
-        "is_verified": false,
-        "line_number": 726
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/auth-choice.e2e.test.ts",
-        "hashed_secret": "c24e00b94c972ed497d5961212ac96f0dffb4f7a",
-        "is_verified": false,
-        "line_number": 798
       }
     ],
     "src/commands/auth-choice.preferred-provider.ts": [
@@ -11863,31 +11579,6 @@
         "line_number": 8
       }
     ],
-    "src/commands/configure.gateway-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 21
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/configure.gateway-auth.e2e.test.ts",
-        "hashed_secret": "d5d4cd07616a542891b7ec2d0257b3a24b69856e",
-        "is_verified": false,
-        "line_number": 62
-      }
-    ],
-    "src/commands/daemon-install-helpers.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/daemon-install-helpers.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 128
-      }
-    ],
     "src/commands/doctor-memory-search.test.ts": [
       {
         "type": "Secret Keyword",
@@ -11895,52 +11586,6 @@
         "hashed_secret": "2e07956ffc9bc4fd624064c40b7495c85d5f1467",
         "is_verified": false,
         "line_number": 43
-      }
-    ],
-    "src/commands/model-picker.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/model-picker.e2e.test.ts",
-        "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
-        "is_verified": false,
-        "line_number": 127
-      }
-    ],
-    "src/commands/models/list.status.e2e.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "d6ae2508a78a232d5378ef24b85ce40cbb4d7ff0",
-        "is_verified": false,
-        "line_number": 12
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "2d8012102440ea97852b3152239218f00579bafa",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
-        "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "51848e2be4b461a549218d3167f19c01be6b98b8",
-        "is_verified": false,
-        "line_number": 51
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/models/list.status.e2e.test.ts",
-        "hashed_secret": "1c1e381bfb72d3b7bfca9437053d9875356680f0",
-        "is_verified": false,
-        "line_number": 57
       }
     ],
     "src/commands/onboard-auth.config-minimax.ts": [
@@ -11957,96 +11602,6 @@
         "hashed_secret": "ddcb713196b974770575a9bea5a4e7d46361f8e9",
         "is_verified": false,
         "line_number": 79
-      }
-    ],
-    "src/commands/onboard-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-auth.e2e.test.ts",
-        "hashed_secret": "e184b402822abc549b37689c84e8e0e33c39a1f1",
-        "is_verified": false,
-        "line_number": 272
-      }
-    ],
-    "src/commands/onboard-custom.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-custom.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 238
-      }
-    ],
-    "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "fcdd655b11f33ba4327695084a347b2ba192976c",
-        "is_verified": false,
-        "line_number": 153
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "07a6b9cec637c806195e8aa7e5c0851ab03dc35e",
-        "is_verified": false,
-        "line_number": 191
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "77e991e9f56e6fa4ed1a908208048421f1214c07",
-        "is_verified": false,
-        "line_number": 234
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "65547299f940eca3dc839f3eac85e8a78a6deb05",
-        "is_verified": false,
-        "line_number": 282
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "2833d098c110602e4c8d577fbfdb423a9ffd58e9",
-        "is_verified": false,
-        "line_number": 304
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "266e955b27b5fc2c2f532e446f2e71c3667a4cd9",
-        "is_verified": false,
-        "line_number": 338
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "995b80728ee01edb90ddfed07870bbab405df19f",
-        "is_verified": false,
-        "line_number": 366
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "b65888424ecafcc98bfd803b24817e4dadf821f8",
-        "is_verified": false,
-        "line_number": 383
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "62e6748c6bb4c4a0f785a28cdd7d41ef212c0091",
-        "is_verified": false,
-        "line_number": 402
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/onboard-non-interactive.provider-auth.e2e.test.ts",
-        "hashed_secret": "8818d3b7c102fd6775af9e1390e5ed3a128473fb",
-        "is_verified": false,
-        "line_number": 447
       }
     ],
     "src/commands/onboard-non-interactive/api-keys.ts": [
@@ -12074,15 +11629,6 @@
         "hashed_secret": "5b924ca5330ede58702a5b0e414207b90fb1aef3",
         "is_verified": false,
         "line_number": 60
-      }
-    ],
-    "src/commands/zai-endpoint-detect.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/commands/zai-endpoint-detect.e2e.test.ts",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 24
       }
     ],
     "src/config/config-misc.test.ts": [
@@ -12409,15 +11955,6 @@
         "line_number": 10
       }
     ],
-    "src/docker-setup.test.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": "src/docker-setup.test.ts",
-        "hashed_secret": "32ac33b537769e97787f70ef85576cc243fab934",
-        "is_verified": false,
-        "line_number": 131
-      }
-    ],
     "src/gateway/auth-rate-limit.ts": [
       {
         "type": "Secret Keyword",
@@ -12501,15 +12038,6 @@
         "line_number": 704
       }
     ],
-    "src/gateway/client.e2e.test.ts": [
-      {
-        "type": "Private Key",
-        "filename": "src/gateway/client.e2e.test.ts",
-        "hashed_secret": "1348b145fa1a555461c1b790a2f66614781091e9",
-        "is_verified": false,
-        "line_number": 85
-      }
-    ],
     "src/gateway/gateway-cli-backend.live.test.ts": [
       {
         "type": "Hex High Entropy String",
@@ -12544,40 +12072,6 @@
         "hashed_secret": "e478a5eeba4907d2f12a68761996b9de745d826d",
         "is_verified": false,
         "line_number": 14
-      }
-    ],
-    "src/gateway/server.auth.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 460
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.auth.e2e.test.ts",
-        "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
-        "is_verified": false,
-        "line_number": 478
-      }
-    ],
-    "src/gateway/server.skills-status.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.skills-status.e2e.test.ts",
-        "hashed_secret": "1cc6bff0f84efb2d3ff4fa1347f3b2bc173aaff0",
-        "is_verified": false,
-        "line_number": 13
-      }
-    ],
-    "src/gateway/server.talk-config.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/gateway/server.talk-config.e2e.test.ts",
-        "hashed_secret": "3c310634864babb081f0b617c14bc34823d7e369",
-        "is_verified": false,
-        "line_number": 13
       }
     ],
     "src/gateway/session-utils.test.ts": [
@@ -12621,6 +12115,22 @@
         "hashed_secret": "6d811dc1f59a55ca1a3d38b5042a062b9f79e8ec",
         "is_verified": false,
         "line_number": 14
+      }
+    ],
+    "src/infra/git-commit.test.ts": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/infra/git-commit.test.ts",
+        "hashed_secret": "01499c5ba34738d7fa47a8584568d8c33c22625e",
+        "is_verified": false,
+        "line_number": 361
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/infra/git-commit.test.ts",
+        "hashed_secret": "158b484ae1f6f64f89da22397d25fbdafad02252",
+        "is_verified": false,
+        "line_number": 394
       }
     ],
     "src/infra/outbound/message-action-runner.test.ts": [
@@ -12790,15 +12300,6 @@
         "hashed_secret": "063995ecb4fa5afe2460397d322925cd867b7d74",
         "is_verified": false,
         "line_number": 88
-      }
-    ],
-    "src/media-understanding/apply.e2e.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": "src/media-understanding/apply.e2e.test.ts",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 12
       }
     ],
     "src/media-understanding/providers/deepgram/audio.test.ts": [
@@ -13006,6 +12507,15 @@
         "line_number": 60
       }
     ],
+    "test-fixtures/talk-config-contract.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "test-fixtures/talk-config-contract.json",
+        "hashed_secret": "fa3f8556220674269a6130b0eedd21dec9c033fb",
+        "is_verified": false,
+        "line_number": 84
+      }
+    ],
     "ui/src/i18n/locales/en.ts": [
       {
         "type": "Secret Keyword",
@@ -13034,5 +12544,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T14:28:30Z"
+  "generated_at": "2026-03-08T17:12:29Z"
 }


### PR DESCRIPTION
## Summary

- Problem: `detect-secrets` CI fails on full scans because [.secrets.baseline](cci:7://file:///Users/huzhe/LLM_Learn/openclaw/.secrets.baseline:0:0-0:0) is out of date — newly added test fixtures and doc examples containing API key placeholders are not recorded in the baseline.
- Why it matters: The `secrets` CI job blocks all PRs (including docs-only PRs) when running a full scan fallback.
- What changed: Regenerated [.secrets.baseline](cci:7://file:///Users/huzhe/LLM_Learn/openclaw/.secrets.baseline:0:0-0:0) with `detect-secrets==1.5.0` using the same exclude patterns as `.pre-commit-config.yaml`, adding 7 missing false-positive entries.
- What did NOT change (scope boundary): No source code, docs, or config files were modified. Only the baseline JSON was updated.

## Change Type (select all)

- [x] Chore/infra

## Scope (select all touched areas)

- [x] CI/CD / infra

## Linked Issue/PR

- Related #(docs PR number if applicable)

## User-visible / Behavior Changes

None

## Security Impact (required)

- New permissions/capabilities? `No`
- Secrets/tokens handling changed? `No`
- New/changed network calls? `No`
- Command/tool execution surface changed? `No`
- Data access scope changed? `No`

## Repro + Verification

### Environment

- OS: macOS / Ubuntu (CI)
- Runtime/container: Node, Python 3.12
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): `.pre-commit-config.yaml` detect-secrets hook

### Steps

1. Push any commit to a branch
2. CI `secrets` job runs `pre-commit run --all-files detect-secrets`
3. Observe failures for files not in [.secrets.baseline](cci:7://file:///Users/huzhe/LLM_Learn/openclaw/.secrets.baseline:0:0-0:0)

### Expected

- `detect-secrets` passes with all known false positives in the baseline

### Actual

- Before: 7 false positives flagged across [docs/perplexity.md](cci:7://file:///Users/huzhe/LLM_Learn/openclaw/docs/perplexity.md:0:0-0:0), [docs/tools/web.md](cci:7://file:///Users/huzhe/LLM_Learn/openclaw/docs/tools/web.md:0:0-0:0), [src/agents/tools/web-search.ts](cci:7://file:///Users/huzhe/LLM_Learn/openclaw/src/agents/tools/web-search.ts:0:0-0:0), [src/agents/tools/web-search.test.ts](cci:7://file:///Users/huzhe/LLM_Learn/openclaw/src/agents/tools/web-search.test.ts:0:0-0:0), [src/infra/git-commit.test.ts](cci:7://file:///Users/huzhe/LLM_Learn/openclaw/src/infra/git-commit.test.ts:0:0-0:0), [src/agents/models-config.merge.test.ts](cci:7://file:///Users/huzhe/LLM_Learn/openclaw/src/agents/models-config.merge.test.ts:0:0-0:0), [test-fixtures/talk-config-contract.json](cci:7://file:///Users/huzhe/LLM_Learn/openclaw/test-fixtures/talk-config-contract.json:0:0-0:0)
- After: All covered in baseline

## Evidence

- [x] Failing test/log before + passing after
  - `detect-secrets scan --baseline .secrets.baseline` exits 0 after regeneration

## Human Verification (required)

- Verified scenarios: Ran `detect-secrets scan --baseline .secrets.baseline` locally — exit code 0, all 7 CI-flagged files now have entries in the baseline (219 total files covered).
- Edge cases checked: Confirmed the same `--exclude-files` and `--exclude-lines` patterns from `.pre-commit-config.yaml` were used.
- What you did **not** verify: Full CI run with pre-commit (no local pre-commit setup).

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? `Yes`
- Config/env changes? `No`
- Migration needed? `No`

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: `git revert` the commit
- Files/config to restore: [.secrets.baseline](cci:7://file:///Users/huzhe/LLM_Learn/openclaw/.secrets.baseline:0:0-0:0)
- Known bad symptoms reviewers should watch for: `detect-secrets` flagging new files not in baseline

## Risks and Mitigations

None
