### PR TITLE
docs: add ClawdBoost to community plugins

### DIFF
--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,8 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **ClawdBoost** — Smart context injection that automatically boosts AI conversations with pattern-matched, time-aware context snippets. Supports regex triggers, time-of-day rules, priority-weighted snippet selection, and a full CLI.
+  npm: `clawdboost`
+  repo: `https://github.com/NikeGunn/clawdboost`
+  install: `openclaw plugins install clawdboost`


### PR DESCRIPTION
## Summary

Adds **ClawdBoost** to the community plugins listing in `docs/plugins/community.md`.

ClawdBoost is a smart context injection plugin that automatically boosts AI conversations with:
- **Pattern matching** — regex-based triggers inject relevant context snippets
- **Time awareness** — different context for morning/evening, weekdays/weekends
- **Rule engine** — complex trigger-action conditions with priority weighting
- **Full CLI** — manage snippets and rules via `openclaw cb ...`
- **AI tool** — the agent can manage context through the `clawdboost` tool

### Checklist (per listing requirements)

- [x] Published on npm: [`clawdboost`](https://www.npmjs.com/package/clawdboost)
- [x] Public GitHub repo: [NikeGunn/clawdboost](https://github.com/NikeGunn/clawdboost)
- [x] Setup/usage docs in README
- [x] Issue tracker enabled
- [x] Active maintenance — v2.0.0 just shipped with full OpenClaw plugin system support (`openclaw.plugin.json`, `openclaw/plugin-sdk` imports, hooks, CLI registration)

### Why a fresh PR

This replaces the stale [#3802](https://github.com/openclaw/openclaw/pull/3802) which targeted the old `docs/plugin.md` path (no longer exists on main). Per @steipete's suggestion, this targets `docs/plugins/community.md` using the current entry format.

## Test plan

- [ ] Verify `docs/plugins/community.md` renders correctly on the docs site
- [ ] Confirm the entry follows the existing format (matches WeChat listing style)
- [ ] Verify npm package `clawdboost` is installable via `openclaw plugins install clawdboost`