### PR TITLE
fix(feishu): prioritize root_id before replyInThread when replying

### DIFF
--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -1670,7 +1670,7 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
-  it("forces thread replies when inbound message contains thread_id", async () => {
+  it("does not force thread replies when only thread_id exists and replyInThread is disabled", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
     const cfg: ClawdbotConfig = {
@@ -1703,8 +1703,85 @@ describe("handleFeishuMessage command authorization", () => {
 
     expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
       expect.objectContaining({
+        replyInThread: false,
+        threadReply: true,
+      }),
+    );
+  });
+
+  it("always replies in thread when root_id exists, even if replyInThread is disabled", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group",
+              replyInThread: "disabled",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-root-force" } },
+      message: {
+        message_id: "msg-with-root",
+        chat_id: "oc-group",
+        chat_type: "group",
+        root_id: "om_root_force",
+        message_type: "text",
+        content: JSON.stringify({ text: "thread content with root_id" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenLastCalledWith(
+      expect.objectContaining({
         replyInThread: true,
         threadReply: true,
+      }),
+    );
+  });
+
+  it("falls back to replyInThread config when no root_id", async () => {
+    mockShouldComputeCommandAuthorized.mockReturnValue(false);
+
+    const cfg: ClawdbotConfig = {
+      channels: {
+        feishu: {
+          groups: {
+            "oc-group": {
+              requireMention: false,
+              groupSessionScope: "group",
+              replyInThread: "enabled",
+            },
+          },
+        },
+      },
+    } as ClawdbotConfig;
+
+    const event: FeishuMessageEvent = {
+      sender: { sender_id: { open_id: "ou-no-root-fallback" } },
+      message: {
+        message_id: "msg-no-root-fallback",
+        chat_id: "oc-group",
+        chat_type: "group",
+        message_type: "text",
+        content: JSON.stringify({ text: "top-level message" }),
+      },
+    };
+
+    await dispatchMessage({ cfg, event });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        replyInThread: true,
+        threadReply: false,
       }),
     );
   });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -250,9 +250,13 @@ function resolveFeishuGroupSession(params: {
   const normalizedThreadId = threadId?.trim();
   const normalizedRootId = rootId?.trim();
   const threadReply = Boolean(normalizedThreadId || normalizedRootId);
-  const replyInThread =
-    (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled" ||
-    threadReply;
+  const replyInThreadConfigured =
+    (groupConfig?.replyInThread ?? feishuCfg?.replyInThread ?? "disabled") === "enabled";
+  // Reply routing rule:
+  // 1) If inbound has root_id, always reply in thread.
+  // 2) If no root_id, fall back to replyInThread config (enabled/disabled).
+  // Note: thread_id alone does not force thread replies.
+  const replyInThread = Boolean(normalizedRootId) || replyInThreadConfigured;
 
   const legacyTopicSessionMode =
     groupConfig?.topicSessionMode ?? feishuCfg?.topicSessionMode ?? "disabled";

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -268,7 +268,7 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     expect(streamingInstances[0].start).toHaveBeenCalledTimes(1);
     expect(streamingInstances[0].start).toHaveBeenCalledWith("oc_chat", "chat_id", {
       replyToMessageId: undefined,
-      replyInThread: undefined,
+      replyInThread: true,
       rootId: "om_root_topic",
     });
     expect(streamingInstances[0].close).toHaveBeenCalledTimes(1);
@@ -564,6 +564,29 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
       expect.objectContaining({
         replyToMessageId: "om_msg",
         replyInThread: true,
+      }),
+    );
+  });
+
+  it("honors replyInThread=false when only threadReply is true but rootId is absent", async () => {
+    createFeishuReplyDispatcher({
+      cfg: {} as never,
+      agentId: "agent",
+      runtime: { log: vi.fn(), error: vi.fn() } as never,
+      chatId: "oc_chat",
+      replyToMessageId: "om_msg",
+      replyInThread: false,
+      threadReply: true,
+    });
+
+    const options = createReplyDispatcherWithTypingMock.mock.calls[0]?.[0];
+    await options.deliver({ text: "```ts\nconst x = 1\n```" }, { kind: "final" });
+
+    expect(streamingInstances).toHaveLength(0);
+    expect(sendMarkdownCardFeishuMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMessageId: "om_msg",
+        replyInThread: false,
       }),
     );
   });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -71,7 +71,10 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
   } = params;
   const sendReplyToMessageId = skipReplyToInMessages ? undefined : replyToMessageId;
   const threadReplyMode = threadReply === true;
-  const effectiveReplyInThread = threadReplyMode ? true : replyInThread;
+  const normalizedRootId = rootId?.trim();
+  // root_id is authoritative for "must reply in thread".
+  // thread_id-only contexts should still honor explicit replyInThread config.
+  const effectiveReplyInThread = Boolean(normalizedRootId) || replyInThread === true;
   const account = resolveFeishuAccount({ cfg, accountId });
   const prefixContext = createReplyPrefixContext({ cfg, agentId });
 
@@ -197,7 +200,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
         await streaming.start(chatId, resolveReceiveIdType(chatId), {
           replyToMessageId,
           replyInThread: effectiveReplyInThread,
-          rootId,
+          rootId: normalizedRootId,
         });
       } catch (error) {
         params.runtime.error?.(`feishu: streaming start failed: ${String(error)}`);


### PR DESCRIPTION
## Summary
Adjust Feishu group reply routing precedence:

- If inbound message contains `root_id`, always reply with `reply_in_thread=true`
- If inbound message has no `root_id`, fall back to `replyInThread` config
- `thread_id` alone no longer forces topic replies

This keeps existing topic threads stable while avoiding accidental thread replies for top-level messages when `replyInThread` is disabled.

## Tests
- `pnpm exec vitest extensions/feishu/src/bot.test.ts --run`
- `pnpm exec vitest extensions/feishu/src/config-schema.test.ts --run`
