### PR TITLE
config: accept legacy array for commands.allowFrom

### DIFF
--- a/src/config/config.commands-allowfrom.legacy-array.test.ts
+++ b/src/config/config.commands-allowfrom.legacy-array.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { validateConfigObject } from "./config.js";
+
+describe("commands.allowFrom legacy array", () => {
+  it("accepts legacy array form and coerces to global '*' allowlist record", () => {
+    const res = validateConfigObject({
+      commands: {
+        allowFrom: ["discordid"],
+      },
+    });
+
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.config.commands?.allowFrom).toEqual({ "*": ["discordid"] });
+    }
+  });
+
+  it("rejects legacy array form when entries are not strings/numbers", () => {
+    const res = validateConfigObject({
+      commands: {
+        // @ts-expect-error test invalid shape
+        allowFrom: [{ bad: true }],
+      },
+    });
+
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.issues.some((i) => i.path === "commands.allowFrom.*.0")).toBe(true);
+    }
+  });
+});

--- a/src/config/config.commands-allowfrom.legacy-array.test.ts
+++ b/src/config/config.commands-allowfrom.legacy-array.test.ts
@@ -18,8 +18,8 @@ describe("commands.allowFrom legacy array", () => {
   it("rejects legacy array form when entries are not strings/numbers", () => {
     const res = validateConfigObject({
       commands: {
-        // @ts-expect-error test invalid shape
-        allowFrom: [{ bad: true }],
+        // Intentionally invalid at runtime (object), but asserted to satisfy TS.
+        allowFrom: [{ bad: true } as unknown as string],
       },
     });
 

--- a/src/config/zod-schema.session.ts
+++ b/src/config/zod-schema.session.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { parseByteSize } from "../cli/parse-bytes.js";
 import { parseDurationMs } from "../cli/parse-duration.js";
-import { ElevatedAllowFromSchema } from "./zod-schema.agent-runtime.js";
 import { createAllowDenyChannelRulesSchema } from "./zod-schema.allowdeny.js";
 import {
   GroupChatSchema,
@@ -191,6 +190,13 @@ export const MessagesSchema = z
   .strict()
   .optional();
 
+const CommandsAllowFromSchema = z
+  .preprocess(
+    (value) => (Array.isArray(value) ? { "*": value } : value),
+    z.record(z.string(), z.array(z.union([z.string(), z.number()]))),
+  )
+  .optional();
+
 export const CommandsSchema = z
   .object({
     native: NativeCommandsSettingSchema.optional().default("auto"),
@@ -205,7 +211,8 @@ export const CommandsSchema = z
     ownerAllowFrom: z.array(z.union([z.string(), z.number()])).optional(),
     ownerDisplay: z.enum(["raw", "hash"]).optional().default("raw"),
     ownerDisplaySecret: z.string().optional().register(sensitive),
-    allowFrom: ElevatedAllowFromSchema.optional(),
+    // Back-compat: accept legacy array form and treat it as the global ("*") allowlist.
+    allowFrom: CommandsAllowFromSchema,
   })
   .strict()
   .optional()


### PR DESCRIPTION
Fixes #39500\n\n- Accept legacy array form for commands.allowFrom and normalize it to {"*": [...]}\n- Add regression tests\n\nThis keeps the documented map form working unchanged.