### PR TITLE
fix(slack): add opt-out for implicit thread mentions [AI-assisted]

### DIFF
--- a/docs/channels/slack.md
+++ b/docs/channels/slack.md
@@ -188,7 +188,7 @@ For actions/directory reads, user token can be preferred when configured. For wr
 
     - explicit app mention (`<@botId>`)
     - mention regex patterns (`agents.list[].groupChat.mentionPatterns`, fallback `messages.groupChat.mentionPatterns`)
-    - implicit reply-to-bot thread behavior
+    - implicit reply-to-bot thread behavior (disable with `channels.slack.implicitThreadMention: false`)
 
     Per-channel controls (`channels.slack.channels.<id|name>`):
 

--- a/src/config/types.slack.ts
+++ b/src/config/types.slack.ts
@@ -160,6 +160,8 @@ export type SlackAccountConfig = {
    * Example: { direct: "all", group: "first", channel: "off" }.
    */
   replyToModeByChatType?: Partial<Record<"direct" | "group" | "channel", ReplyToMode>>;
+  /** If false, Slack thread replies only count as mentions when they explicitly mention the bot. Default: true. */
+  implicitThreadMention?: boolean;
   /** Thread session behavior. */
   thread?: SlackThreadConfig;
   actions?: SlackActionConfig;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -836,6 +836,7 @@ export const SlackAccountSchema = z
     reactionAllowlist: z.array(z.union([z.string(), z.number()])).optional(),
     replyToMode: ReplyToModeSchema.optional(),
     replyToModeByChatType: SlackReplyToModeByChatTypeSchema.optional(),
+    implicitThreadMention: z.boolean().optional(),
     thread: SlackThreadSchema.optional(),
     actions: z
       .object({

--- a/src/slack/monitor/context.ts
+++ b/src/slack/monitor/context.ts
@@ -50,6 +50,7 @@ export type SlackMonitorContext = {
   replyToMode: "off" | "first" | "all";
   threadHistoryScope: "thread" | "channel";
   threadInheritParent: boolean;
+  implicitThreadMention: boolean;
   slashCommand: Required<import("../../config/config.js").SlackSlashCommandConfig>;
   textLimit: number;
   ackReactionScope: string;
@@ -114,6 +115,7 @@ export function createSlackMonitorContext(params: {
   replyToMode: SlackMonitorContext["replyToMode"];
   threadHistoryScope: SlackMonitorContext["threadHistoryScope"];
   threadInheritParent: SlackMonitorContext["threadInheritParent"];
+  implicitThreadMention?: boolean;
   slashCommand: SlackMonitorContext["slashCommand"];
   textLimit: number;
   ackReactionScope: string;
@@ -413,6 +415,7 @@ export function createSlackMonitorContext(params: {
     replyToMode: params.replyToMode,
     threadHistoryScope: params.threadHistoryScope,
     threadInheritParent: params.threadInheritParent,
+    implicitThreadMention: params.implicitThreadMention !== false,
     slashCommand: params.slashCommand,
     textLimit: params.textLimit,
     ackReactionScope: params.ackReactionScope,

--- a/src/slack/monitor/message-handler/prepare.test-helpers.ts
+++ b/src/slack/monitor/message-handler/prepare.test-helpers.ts
@@ -9,6 +9,7 @@ export function createInboundSlackTestContext(params: {
   appClient?: App["client"];
   defaultRequireMention?: boolean;
   replyToMode?: "off" | "all" | "first";
+  implicitThreadMention?: boolean;
   channelsConfig?: Record<string, { systemPrompt: string }>;
 }) {
   return createSlackMonitorContext({
@@ -38,6 +39,7 @@ export function createInboundSlackTestContext(params: {
     replyToMode: params.replyToMode ?? "off",
     threadHistoryScope: "thread",
     threadInheritParent: false,
+    implicitThreadMention: params.implicitThreadMention,
     slashCommand: {
       enabled: false,
       name: "openclaw",

--- a/src/slack/monitor/message-handler/prepare.test.ts
+++ b/src/slack/monitor/message-handler/prepare.test.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "../../../config/config.js";
 import { resolveAgentRoute } from "../../../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../../routing/session-key.js";
 import type { ResolvedSlackAccount } from "../../accounts.js";
+import { recordSlackThreadParticipation } from "../../sent-thread-cache.js";
 import type { SlackMessageEvent } from "../../types.js";
 import type { SlackMonitorContext } from "../context.js";
 import { prepareSlackMessage } from "./prepare.js";
@@ -174,6 +175,7 @@ describe("slack prepareSlackMessage inbound contract", () => {
     groupPolicy?: "open";
     defaultRequireMention?: boolean;
     asChannel?: boolean;
+    implicitThreadMention?: boolean;
   }): SlackMonitorContext {
     const slackCtx = createInboundSlackCtx({
       cfg: {
@@ -182,6 +184,9 @@ describe("slack prepareSlackMessage inbound contract", () => {
             enabled: true,
             replyToMode: "all",
             ...(params?.groupPolicy ? { groupPolicy: params.groupPolicy } : {}),
+            ...(params?.implicitThreadMention === undefined
+              ? {}
+              : { implicitThreadMention: params.implicitThreadMention }),
           },
         },
       } as OpenClawConfig,
@@ -189,6 +194,9 @@ describe("slack prepareSlackMessage inbound contract", () => {
       ...(params?.defaultRequireMention === undefined
         ? {}
         : { defaultRequireMention: params.defaultRequireMention }),
+      ...(params?.implicitThreadMention === undefined
+        ? {}
+        : { implicitThreadMention: params.implicitThreadMention }),
     });
     // oxlint-disable-next-line typescript/no-explicit-any
     slackCtx.resolveUserName = async () => ({ name: "Alice" }) as any;
@@ -212,6 +220,22 @@ describe("slack prepareSlackMessage inbound contract", () => {
     expect(prepared).toBeTruthy();
     // oxlint-disable-next-line typescript/no-explicit-any
     expectInboundContextContract(prepared!.ctxPayload as any);
+  });
+
+  it("requires an explicit mention in threads when implicitThreadMention is false", async () => {
+    recordSlackThreadParticipation("default", "C123", "100.000");
+    const ctx = createReplyToAllSlackCtx({
+      asChannel: true,
+      defaultRequireMention: true,
+      implicitThreadMention: false,
+    });
+
+    const prepared = await prepareThreadMessage(ctx, {
+      parent_user_id: "B1",
+      text: "follow-up without mention",
+    });
+
+    expect(prepared).toBeNull();
   });
 
   it("includes forwarded shared attachment text in raw body", async () => {

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -381,6 +381,7 @@ export async function prepareSlackMessage(params: {
         },
       }));
   const implicitMention = Boolean(
+    ctx.implicitThreadMention &&
     !isDirectMessage &&
     ctx.botUserId &&
     message.thread_ts &&

--- a/src/slack/monitor/provider.ts
+++ b/src/slack/monitor/provider.ts
@@ -277,6 +277,7 @@ export async function monitorSlackProvider(opts: MonitorSlackOpts = {}) {
     replyToMode,
     threadHistoryScope,
     threadInheritParent,
+    implicitThreadMention: slackCfg.implicitThreadMention,
     slashCommand,
     textLimit,
     ackReactionScope,


### PR DESCRIPTION
## Summary

- Problem: Slack `requireMention: true` still allows follow-up replies in a thread to trigger the bot after it has replied once, because Slack thread participation is treated as an implicit mention.
- Why it matters: Some users want strict explicit `@mention` behavior in Slack threads, but there is currently no config knob to disable implicit thread wakeups.
- What changed: Added `channels.slack.implicitThreadMention?: boolean`, threaded it through Slack monitor config, gated implicit thread mention behavior behind it, documented it, and added a focused regression test.
- What did NOT change (scope boundary): Default behavior remains unchanged; no other channel mention-gating logic was modified.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Added optional Slack config: `channels.slack.implicitThreadMention`
- Default remains current behavior (`true` / enabled when unset)
- When set to `false`, Slack thread replies no longer count as implicit mentions, so `requireMention: true` behaves like explicit-mention-only in threads

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux (arm64)
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): Slack
- Relevant config (redacted): `channels.slack.requireMention: true`, `channels.slack.implicitThreadMention: false`

### Steps

1. Configure Slack with `requireMention: true`
2. Have the bot participate in a Slack thread
3. Reply in the thread without an explicit `@mention`

### Expected

- With `implicitThreadMention: false`, the follow-up reply should not trigger the bot

### Actual

- Before this patch, thread participation counted as an implicit mention and the bot could still trigger

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Added and ran focused Slack tests covering the new config behavior
- Built the repo successfully after adding the typed config surface
- Edge cases checked:
- Default behavior remains unchanged when the flag is unset
- Explicit opt-out disables implicit thread mentions only for Slack
- What you did **not** verify:
- Full end-to-end Slack runtime against a live workspace
- Full `pnpm check` currently still hits an unrelated pre-existing formatting issue in `src/cli/daemon-cli/lifecycle.test.ts`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) Yes
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Remove `channels.slack.implicitThreadMention: false` from config, or revert this commit
- Files/config to restore:
- Slack config and the touched Slack monitor files in this PR
- Known bad symptoms reviewers should watch for:
- Slack thread replies stop waking the bot unexpectedly when explicit mentions are required

## Risks and Mitigations

- Risk: Users may assume the new flag changes all mention behavior
- Mitigation: Docs and PR scope make clear it only gates Slack implicit thread mentions

## AI disclosure

This PR was AI-assisted.

### Session summary

- Investigated Slack mention-gating behavior in the OpenClaw source and confirmed that thread participation was being treated as an implicit mention after the bot replied once in a thread.
- Verified there was no existing config flag to disable that behavior while preserving explicit `@mention` handling.
- Implemented a minimal patch adding `channels.slack.implicitThreadMention?: boolean`.
- Scoped the runtime change so default behavior stays the same, and setting the flag to `false` disables implicit thread-triggered wakeups in Slack threads.
- Updated Slack docs to describe the new flag.
- Added a focused regression test covering the explicit-mention-only thread behavior.
- Ran targeted Slack tests successfully and built the repo successfully.
- Full `pnpm check` did not complete cleanly due to an unrelated pre-existing formatting issue in `src/cli/daemon-cli/lifecycle.test.ts`.

### Testing level

- Targeted tests run
- Local build run
- Full repo checks partially blocked by unrelated pre-existing formatting drift