### PR TITLE
System prompt: include weekday in Current Date & Time section

### DIFF
--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -387,6 +387,11 @@ describe("buildAgentSystemPrompt", () => {
       const prompt = buildAgentSystemPrompt(testCase.params);
       expect(prompt, testCase.name).toContain("## Current Date & Time");
       expect(prompt, testCase.name).toContain("Time zone: America/Chicago");
+      if (testCase.name === "timezone-only") {
+        expect(prompt, testCase.name).not.toContain("Day of week:");
+      } else {
+        expect(prompt, testCase.name).toContain("Day of week: Monday");
+      }
     }
   });
 
@@ -400,8 +405,8 @@ describe("buildAgentSystemPrompt", () => {
     expect(prompt).toContain("current date");
   });
 
-  // The system prompt intentionally does NOT include the current date/time.
-  // Only the timezone is included, to keep the prompt stable for caching.
+  // The system prompt intentionally does NOT include the full current date/time.
+  // Timezone and weekday are included; full date/time is omitted for cache stability.
   // See: https://github.com/moltbot/moltbot/commit/66eec295b894bce8333886cfbca3b960c57c4946
   // Agents should use session_status or message timestamps to determine the date/time.
   // Related: https://github.com/moltbot/moltbot/issues/1897
@@ -420,6 +425,7 @@ describe("buildAgentSystemPrompt", () => {
     // https://github.com/moltbot/moltbot/issues/3658 for the preferred approach:
     // gateway-level timestamp injection into messages, not the system prompt.
     expect(prompt).toContain("Time zone: America/Chicago");
+    expect(prompt).toContain("Day of week: Monday");
     expect(prompt).not.toContain("Monday, January 5th, 2026");
     expect(prompt).not.toContain("3:26 PM");
     expect(prompt).not.toContain("15:26");

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -94,11 +94,26 @@ function buildOwnerIdentityLine(
   return `Authorized senders: ${displayOwnerNumbers.join(", ")}. These senders are allowlisted; do not assume they are the owner.`;
 }
 
-function buildTimeSection(params: { userTimezone?: string }) {
+function extractWeekdayFromUserTime(userTime?: string): string | undefined {
+  const trimmed = userTime?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const match = /^([A-Za-z]+),/.exec(trimmed);
+  return match?.[1];
+}
+
+function buildTimeSection(params: { userTimezone?: string; userTime?: string }) {
   if (!params.userTimezone) {
     return [];
   }
-  return ["## Current Date & Time", `Time zone: ${params.userTimezone}`, ""];
+  const weekday = extractWeekdayFromUserTime(params.userTime);
+  return [
+    "## Current Date & Time",
+    `Time zone: ${params.userTimezone}`,
+    ...(weekday ? [`Day of week: ${weekday}`] : []),
+    "",
+  ];
 }
 
 function buildReplyTagsSection(isMinimal: boolean) {
@@ -561,6 +576,7 @@ export function buildAgentSystemPrompt(params: {
     ...buildUserIdentitySection(ownerLine, isMinimal),
     ...buildTimeSection({
       userTimezone,
+      userTime: params.userTime,
     }),
     "## Workspace Files (injected)",
     "These user-editable files are loaded by OpenClaw and included below in Project Context.",


### PR DESCRIPTION
## Summary
Adds a weekday line to the runtime system prompt time section when `userTime` is available.

Before:
- `## Current Date & Time`
- `Time zone: America/New_York`

After:
- `## Current Date & Time`
- `Time zone: America/New_York`
- `Day of week: Monday`

## Why
This improves schedule/calendar reliability without reintroducing full date/time churn in the system prompt.

## Scope
- `src/agents/system-prompt.ts`
  - Parse weekday from `userTime` and inject `Day of week: <weekday>`.
  - Keep full date/time out of system prompt for cache stability.
- `src/agents/system-prompt.test.ts`
  - Added/updated assertions for weekday behavior.
  - Preserved assertions that full date/time strings are not injected.

## Validation
- `npx vitest run src/agents/system-prompt.test.ts` (43 tests passed)

Relates to #9899.
