### PR TITLE
fix(exec): prevent shell startup files from overriding daemon env

### DIFF
--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -56,28 +56,39 @@ describe("getShellConfig", () => {
   it("prefers bash when fish is default and bash is on PATH", () => {
     const binDir = createTempCommandDir(tempDirs, [{ name: "bash" }]);
     process.env.PATH = binDir;
-    const { shell } = getShellConfig();
+    const { shell, args } = getShellConfig();
     expect(shell).toBe(path.join(binDir, "bash"));
+    expect(args).toEqual(["--noprofile", "--norc", "-c"]);
   });
 
   it("falls back to sh when fish is default and bash is missing", () => {
     const binDir = createTempCommandDir(tempDirs, [{ name: "sh" }]);
     process.env.PATH = binDir;
-    const { shell } = getShellConfig();
+    const { shell, args } = getShellConfig();
     expect(shell).toBe(path.join(binDir, "sh"));
+    expect(args).toEqual(["-c"]);
   });
 
   it("falls back to env shell when fish is default and no sh is available", () => {
     process.env.PATH = "";
-    const { shell } = getShellConfig();
+    const { shell, args } = getShellConfig();
     expect(shell).toBe("/usr/bin/fish");
+    expect(args).toEqual(["-c"]);
+  });
+
+  it("uses zsh no-rc mode to avoid startup-file env overrides", () => {
+    process.env.SHELL = "/bin/zsh";
+    const { shell, args } = getShellConfig();
+    expect(shell).toBe("/bin/zsh");
+    expect(args).toEqual(["-f", "-c"]);
   });
 
   it("uses sh when SHELL is unset", () => {
     delete process.env.SHELL;
     process.env.PATH = "";
-    const { shell } = getShellConfig();
+    const { shell, args } = getShellConfig();
     expect(shell).toBe("sh");
+    expect(args).toEqual(["-c"]);
   });
 
   it("falls back to sh on PATH when SHELL is /usr/bin/false", () => {

--- a/src/agents/shell-utils.test.ts
+++ b/src/agents/shell-utils.test.ts
@@ -73,7 +73,7 @@ describe("getShellConfig", () => {
     process.env.PATH = "";
     const { shell, args } = getShellConfig();
     expect(shell).toBe("/usr/bin/fish");
-    expect(args).toEqual(["-c"]);
+    expect(args).toEqual(["--no-config", "-c"]);
   });
 
   it("uses zsh no-rc mode to avoid startup-file env overrides", () => {

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -38,17 +38,18 @@ export function resolvePowerShellPath(): string {
   return "powershell.exe";
 }
 
-// Non-interactive placeholder shells that reject "-c"-style invocations.
-// macOS LaunchDaemon service users commonly use /usr/bin/false so login sessions
-// cannot be opened; honoring SHELL in that case causes every exec to exit 1.
-// See https://github.com/openclaw/openclaw/issues/69077.
-const NON_INTERACTIVE_SHELLS = new Set(["false", "nologin"]);
+function resolvePosixShellArgs(shellPath: string): string[] {
+  const shellName = normalizeShellName(shellPath);
 
-function isNonInteractiveShell(shellPath: string): boolean {
-  if (!shellPath) {
-    return false;
+  // Keep exec commands deterministic: avoid user startup files overriding inherited
+  // daemon environment variables (for example launchd-provided secrets on macOS).
+  if (shellName === "zsh") {
+    return ["-f", "-c"];
   }
-  return NON_INTERACTIVE_SHELLS.has(path.basename(shellPath));
+  if (shellName === "bash") {
+    return ["--noprofile", "--norc", "-c"];
+  }
+  return ["-c"];
 }
 
 export function getShellConfig(): { shell: string; args: string[] } {
@@ -71,20 +72,15 @@ export function getShellConfig(): { shell: string; args: string[] } {
   if (shellName === "fish") {
     const bash = resolveShellFromPath("bash");
     if (bash) {
-      return { shell: bash, args: ["-c"] };
+      return { shell: bash, args: resolvePosixShellArgs(bash) };
     }
     const sh = resolveShellFromPath("sh");
     if (sh) {
-      return { shell: sh, args: ["-c"] };
+      return { shell: sh, args: resolvePosixShellArgs(sh) };
     }
   }
-  if (envShell) {
-    return { shell: envShell, args: ["-c"] };
-  }
-  // Placeholder SHELL (or unset): prefer a resolved sh/bash on PATH so we do not
-  // re-invoke the placeholder and get a spurious exitCode=1.
-  const sh = resolveShellFromPath("sh") ?? resolveShellFromPath("bash");
-  return { shell: sh ?? "sh", args: ["-c"] };
+  const shell = envShell && envShell.length > 0 ? envShell : "sh";
+  return { shell, args: resolvePosixShellArgs(shell) };
 }
 
 export function resolveShellFromPath(name: string): string | undefined {

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -49,6 +49,9 @@ function resolvePosixShellArgs(shellPath: string): string[] {
   if (shellName === "bash") {
     return ["--noprofile", "--norc", "-c"];
   }
+  if (shellName === "fish") {
+    return ["--no-config", "-c"];
+  }
   return ["-c"];
 }
 

--- a/src/agents/shell-utils.ts
+++ b/src/agents/shell-utils.ts
@@ -38,6 +38,19 @@ export function resolvePowerShellPath(): string {
   return "powershell.exe";
 }
 
+// Non-interactive placeholder shells that reject "-c"-style invocations.
+// macOS LaunchDaemon service users commonly use /usr/bin/false so login sessions
+// cannot be opened; honoring SHELL in that case causes every exec to exit 1.
+// See https://github.com/openclaw/openclaw/issues/69077.
+const NON_INTERACTIVE_SHELLS = new Set(["false", "nologin"]);
+
+function isNonInteractiveShell(shellPath: string): boolean {
+  if (!shellPath) {
+    return false;
+  }
+  return NON_INTERACTIVE_SHELLS.has(path.basename(shellPath));
+}
+
 function resolvePosixShellArgs(shellPath: string): string[] {
   const shellName = normalizeShellName(shellPath);
 
@@ -82,7 +95,15 @@ export function getShellConfig(): { shell: string; args: string[] } {
       return { shell: sh, args: resolvePosixShellArgs(sh) };
     }
   }
-  const shell = envShell && envShell.length > 0 ? envShell : "sh";
+
+  if (envShell) {
+    return { shell: envShell, args: resolvePosixShellArgs(envShell) };
+  }
+
+  // Placeholder SHELL (or unset): prefer a resolved sh/bash on PATH so we do not
+  // re-invoke the placeholder and get a spurious exitCode=1.
+  const sh = resolveShellFromPath("sh") ?? resolveShellFromPath("bash");
+  const shell = sh ?? "sh";
   return { shell, args: resolvePosixShellArgs(shell) };
 }
 


### PR DESCRIPTION
## Summary
- run zsh exec commands with `-f -c` so `.zshenv` does not override inherited daemon environment variables
- run bash exec commands with `--noprofile --norc -c` for the same deterministic env behavior
- keep existing shell selection logic (including fish fallback), but derive args from shell type

## Why
Issue #40179 reports exec commands seeing stale values despite launchd showing updated service env. Startup files can override inherited env values, causing this mismatch.

## Testing
- `bash skills/openclaw-autonomous-contributor/scripts/quality_gate.sh /tmp/openclaw-issue-40179-1772997941`

## AI disclosure
This PR was prepared with AI assistance.

Fixes #40179