### PR TITLE
fix: explicitly hide the console window to avoid it appearing in edge cases

### DIFF
--- a/src/cli/update-cli/restart-helper.ts
+++ b/src/cli/update-cli/restart-helper.ts
@@ -167,6 +167,7 @@ export async function runRestartScript(scriptPath: string): Promise<void> {
   const child = spawn(file, args, {
     detached: true,
     stdio: "ignore",
+    windowsHide: isWindows,
   });
   child.unref();
 }


### PR DESCRIPTION
## Summary

A small and quick fix.

- Problem: In very rare cases, the console window may appear. This has already happened before, either as repeated pop-ups that seriously disrupt use, or as a console window showing directly with the content `netstat -ano | findstr /R /C:"...`
- What changed: set `windowsHide: true` for Windows, hide the console window explicitly.

## Linked Issue/PR

- Closes #25856

## User-visible / Behavior Changes

None`.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation: