### PR TITLE
fix(ollama): migrate embedding provider from deprecated /api/embeddings to /api/embed

### DIFF
--- a/src/memory/embeddings-ollama.test.ts
+++ b/src/memory/embeddings-ollama.test.ts
@@ -3,10 +3,10 @@ import type { OpenClawConfig } from "../config/config.js";
 import { createOllamaEmbeddingProvider } from "./embeddings-ollama.js";
 
 describe("embeddings-ollama", () => {
-  it("calls /api/embeddings and returns normalized vectors", async () => {
+  it("calls /api/embed and returns normalized vectors", async () => {
     const fetchMock = vi.fn(
       async () =>
-        new Response(JSON.stringify({ embedding: [3, 4] }), {
+        new Response(JSON.stringify({ embeddings: [[3, 4]] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -31,7 +31,7 @@ describe("embeddings-ollama", () => {
   it("resolves baseUrl/apiKey/headers from models.providers.ollama and strips /v1", async () => {
     const fetchMock = vi.fn(
       async () =>
-        new Response(JSON.stringify({ embedding: [1, 0] }), {
+        new Response(JSON.stringify({ embeddings: [[1, 0]] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -60,7 +60,7 @@ describe("embeddings-ollama", () => {
     await provider.embedQuery("hello");
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:11434/api/embeddings",
+      "http://127.0.0.1:11434/api/embed",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
@@ -90,7 +90,7 @@ describe("embeddings-ollama", () => {
   it("falls back to env key when models.providers.ollama.apiKey is an unresolved SecretRef", async () => {
     const fetchMock = vi.fn(
       async () =>
-        new Response(JSON.stringify({ embedding: [1, 0] }), {
+        new Response(JSON.stringify({ embeddings: [[1, 0]] }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -118,7 +118,7 @@ describe("embeddings-ollama", () => {
     await provider.embedQuery("hello");
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://127.0.0.1:11434/api/embeddings",
+      "http://127.0.0.1:11434/api/embed",
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: "Bearer ollama-env",

--- a/src/memory/embeddings-ollama.ts
+++ b/src/memory/embeddings-ollama.ts
@@ -91,7 +91,7 @@ export async function createOllamaEmbeddingProvider(
   options: EmbeddingProviderOptions,
 ): Promise<{ provider: EmbeddingProvider; client: OllamaEmbeddingClient }> {
   const client = resolveOllamaEmbeddingClient(options);
-  const embedUrl = `${client.baseUrl.replace(/\/$/, "")}/api/embeddings`;
+  const embedUrl = `${client.baseUrl.replace(/\/$/, "")}/api/embed`;
 
   const embedOne = async (text: string): Promise<number[]> => {
     const json = await withRemoteHttpResponse({
@@ -100,19 +100,20 @@ export async function createOllamaEmbeddingProvider(
       init: {
         method: "POST",
         headers: client.headers,
-        body: JSON.stringify({ model: client.model, prompt: text }),
+        body: JSON.stringify({ model: client.model, input: text }),
       },
       onResponse: async (res) => {
         if (!res.ok) {
           throw new Error(`Ollama embeddings HTTP ${res.status}: ${await res.text()}`);
         }
-        return (await res.json()) as { embedding?: number[] };
+        return (await res.json()) as { embeddings?: number[][] };
       },
     });
-    if (!Array.isArray(json.embedding)) {
-      throw new Error(`Ollama embeddings response missing embedding[]`);
+    const embedding = json.embeddings?.[0];
+    if (!Array.isArray(embedding)) {
+      throw new Error(`Ollama embed response missing embeddings[]`);
     }
-    return sanitizeAndNormalizeEmbedding(json.embedding);
+    return sanitizeAndNormalizeEmbedding(embedding);
   };
 
   const provider: EmbeddingProvider = {
@@ -120,7 +121,7 @@ export async function createOllamaEmbeddingProvider(
     model: client.model,
     embedQuery: embedOne,
     embedBatch: async (texts: string[]) => {
-      // Ollama /api/embeddings accepts one prompt per request.
+      // Ollama /api/embed supports batch input, but we embed individually
       return await Promise.all(texts.map(embedOne));
     },
   };


### PR DESCRIPTION
## What
Migrate Ollama embedding provider from the deprecated `/api/embeddings` endpoint to the current `/api/embed` endpoint.

## Why
Ollama has deprecated `/api/embeddings` in favor of `/api/embed`. The old endpoint returns empty embeddings on recent Ollama versions, causing `memory_search` to fail with timeout errors.

## How
- Changed endpoint from `/api/embeddings` to `/api/embed`
- Changed request parameter from `prompt` to `input`
- Changed response parsing from `embedding` (1D array) to `embeddings` (2D array), taking the first element
- Updated all existing tests to match the new API format

## Testing
All 4 existing tests in `embeddings-ollama.test.ts` updated and passing:
- Endpoint URL correctly uses `/api/embed`
- Response parsing handles new `embeddings[][]` format
- Normalization still produces correct vectors
- API key resolution and header forwarding unchanged

Closes #39983