### PR TITLE
fix: normalize google/<model> ids for direct Google provider resolution (#40152)

### DIFF
--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -136,6 +136,17 @@ describe("model-selection", () => {
       });
     });
 
+    it("parses google/gemini-2.5-flash as google provider with correct model id", () => {
+      expect(parseModelRef("google/gemini-2.5-flash", "anthropic")).toEqual({
+        provider: "google",
+        model: "gemini-2.5-flash",
+      });
+      expect(parseModelRef("google/gemini-2.5-pro", "anthropic")).toEqual({
+        provider: "google",
+        model: "gemini-2.5-pro",
+      });
+    });
+
     it("keeps openai gpt-5.3 codex refs on the openai provider", () => {
       expect(parseModelRef("openai/gpt-5.3-codex", "anthropic")).toEqual({
         provider: "openai",

--- a/src/agents/models-config.providers.google-implicit.test.ts
+++ b/src/agents/models-config.providers.google-implicit.test.ts
@@ -1,0 +1,52 @@
+import { mkdtempSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveImplicitProvidersForTest } from "./models-config.e2e-harness.js";
+
+describe("google implicit provider via GEMINI_API_KEY", () => {
+  it("activates the google provider when GEMINI_API_KEY is set", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    await writeFile(
+      join(agentDir, "auth-profiles.json"),
+      JSON.stringify(
+        {
+          version: 1,
+          profiles: {
+            "google:default": {
+              type: "api_key",
+              provider: "google",
+              key: "test-gemini-key", // pragma: allowlist secret
+            },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const providers = await resolveImplicitProvidersForTest({ agentDir });
+    expect(providers).toHaveProperty("google");
+    expect(providers?.google).toMatchObject({
+      baseUrl: "https://generativelanguage.googleapis.com",
+      api: "google-generative-ai",
+    });
+    // The implicit loader uses models: [] to avoid overriding the built-in catalog
+    expect(providers?.google?.models ?? []).toEqual([]);
+  });
+
+  it("does not activate google provider without credentials", async () => {
+    const agentDir = mkdtempSync(join(tmpdir(), "openclaw-test-"));
+    await writeFile(
+      join(agentDir, "auth-profiles.json"),
+      JSON.stringify({ version: 1, profiles: {} }, null, 2),
+      "utf8",
+    );
+
+    const providers = await resolveImplicitProvidersForTest({ agentDir });
+    // Google should not appear when there are no credentials
+    expect(providers?.google).toBeUndefined();
+  });
+});

--- a/src/agents/models-config.providers.ts
+++ b/src/agents/models-config.providers.ts
@@ -780,6 +780,14 @@ function mergeImplicitProviderSet(
 }
 
 const SIMPLE_IMPLICIT_PROVIDER_LOADERS: ImplicitProviderLoader[] = [
+  withApiKey("google", async ({ apiKey }) => ({
+    baseUrl: "https://generativelanguage.googleapis.com",
+    api: "google-generative-ai",
+    apiKey,
+    // Models come from pi-ai built-in catalog; empty list signals that the
+    // provider is available without overriding the built-in model definitions.
+    models: [],
+  })),
   withApiKey("minimax", async ({ apiKey }) => ({ ...buildMinimaxProvider(), apiKey })),
   withApiKey("moonshot", async ({ apiKey }) => ({ ...buildMoonshotProvider(), apiKey })),
   withApiKey("kimi-coding", async ({ apiKey }) => ({ ...buildKimiCodingProvider(), apiKey })),

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -156,4 +156,57 @@ describe("pi embedded model e2e smoke", () => {
     expect(result.model).toBeUndefined();
     expect(result.error).toBe("Unknown model: google-gemini-cli/gemini-4-unknown");
   });
+
+  it("resolves google/gemini-2.5-flash via pass-through when not in registry", () => {
+    const result = resolveModel("google", "gemini-2.5-flash", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "google",
+      api: "google-generative-ai",
+      baseUrl: "https://generativelanguage.googleapis.com",
+      id: "gemini-2.5-flash",
+      name: "gemini-2.5-flash",
+    });
+  });
+
+  it("resolves google/gemini-2.5-pro via pass-through when not in registry", () => {
+    const result = resolveModel("google", "gemini-2.5-pro", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "google",
+      api: "google-generative-ai",
+      baseUrl: "https://generativelanguage.googleapis.com",
+      id: "gemini-2.5-pro",
+      name: "gemini-2.5-pro",
+    });
+  });
+
+  it("prefers registry model over google pass-through", () => {
+    mockDiscoveredModel({
+      provider: "google",
+      modelId: "gemini-2.5-flash",
+      templateModel: {
+        id: "gemini-2.5-flash",
+        name: "Gemini 2.5 Flash",
+        provider: "google",
+        api: "google-generative-ai",
+        baseUrl: "https://generativelanguage.googleapis.com",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0.15, output: 0.6, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 1000000,
+        maxTokens: 65536,
+      },
+    });
+
+    const result = resolveModel("google", "gemini-2.5-flash", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "google",
+      id: "gemini-2.5-flash",
+      name: "Gemini 2.5 Flash",
+      contextWindow: 1000000,
+      reasoning: true,
+    });
+  });
 });

--- a/src/agents/pi-embedded-runner/model.forward-compat.test.ts
+++ b/src/agents/pi-embedded-runner/model.forward-compat.test.ts
@@ -166,6 +166,7 @@ describe("pi embedded model e2e smoke", () => {
       baseUrl: "https://generativelanguage.googleapis.com",
       id: "gemini-2.5-flash",
       name: "gemini-2.5-flash",
+      reasoning: true,
     });
   });
 
@@ -178,6 +179,38 @@ describe("pi embedded model e2e smoke", () => {
       baseUrl: "https://generativelanguage.googleapis.com",
       id: "gemini-2.5-pro",
       name: "gemini-2.5-pro",
+      reasoning: true,
+    });
+  });
+
+  it("infers reasoning: false for non-flash/pro/think google models", () => {
+    const result = resolveModel("google", "gemini-nano", "/tmp/agent");
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "google",
+      id: "gemini-nano",
+      reasoning: false,
+    });
+  });
+
+  it("applies providerConfig overrides to google pass-through models", () => {
+    const result = resolveModel("google", "gemini-2.5-flash", "/tmp/agent", {
+      models: {
+        providers: {
+          google: {
+            baseUrl: "https://my-proxy.example.com/v1",
+            api: "openai-completions",
+            models: [],
+          },
+        },
+      },
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.model).toMatchObject({
+      provider: "google",
+      id: "gemini-2.5-flash",
+      baseUrl: "https://my-proxy.example.com/v1",
+      api: "openai-completions",
     });
   });
 

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -195,6 +195,25 @@ export function resolveModelWithRegistry(params: {
     } as Model<Api>);
   }
 
+  // Google's Generative AI API accepts any valid model ID. When auth is
+  // configured (GEMINI_API_KEY / auth profile) but the specific model is not
+  // pre-registered in the local catalog, create a pass-through definition so
+  // canonical google/<model> identifiers resolve without "model not found".
+  if (normalizedProvider === "google") {
+    return normalizeModelCompat({
+      id: modelId,
+      name: modelId,
+      api: "google-generative-ai",
+      provider,
+      baseUrl: "https://generativelanguage.googleapis.com",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: DEFAULT_CONTEXT_TOKENS,
+      maxTokens: 65536,
+    } as Model<Api>);
+  }
+
   const configuredModel = providerConfig?.models?.find((candidate) => candidate.id === modelId);
   const providerHeaders = sanitizeModelHeaders(providerConfig?.headers);
   const modelHeaders = sanitizeModelHeaders(configuredModel?.headers);

--- a/src/agents/pi-embedded-runner/model.ts
+++ b/src/agents/pi-embedded-runner/model.ts
@@ -200,18 +200,27 @@ export function resolveModelWithRegistry(params: {
   // pre-registered in the local catalog, create a pass-through definition so
   // canonical google/<model> identifiers resolve without "model not found".
   if (normalizedProvider === "google") {
-    return normalizeModelCompat({
+    const baseModel = {
       id: modelId,
       name: modelId,
       api: "google-generative-ai",
       provider,
       baseUrl: "https://generativelanguage.googleapis.com",
-      reasoning: false,
+      // Infer reasoning capability from model ID — Gemini 2.5 Flash/Pro and
+      // future "thinking" variants support thinking-mode output.
+      reasoning: /flash|pro|think/i.test(modelId),
       input: ["text"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       contextWindow: DEFAULT_CONTEXT_TOKENS,
       maxTokens: 65536,
-    } as Model<Api>);
+    } as Model<Api>;
+    return normalizeModelCompat(
+      applyConfiguredProviderOverrides({
+        discoveredModel: baseModel,
+        providerConfig,
+        modelId,
+      }),
+    );
   }
 
   const configuredModel = providerConfig?.models?.find((candidate) => candidate.id === modelId);


### PR DESCRIPTION
## Summary
Fixes #40152

When using `google/gemini-2.5-flash` as the model id, OpenClaw failed to
resolve it via the Google provider and silently fell back to OpenRouter.

## Root Cause
1. The `"google"` provider was not auto-discovered from `GEMINI_API_KEY`
2. Unregistered `google/*` model ids had no pass-through fallback

## Changes
- **`src/agents/pi-embedded-runner/model.ts`** — Google pass-through fallback
  (routes any `google/*` id to `google-generative-ai` API)
- **`src/agents/models-config.providers.ts`** — Auto-discover Google provider
  from `GEMINI_API_KEY`
- **`src/agents/pi-embedded-runner/model.forward-compat.test.ts`** — 3 new tests
- **`src/agents/model-selection.test.ts`** — 1 new test

## Testing
- [x] All 4 new tests pass
- [x] No regressions in existing tests

## AI Disclosure
- [x] AI-assisted (GitHub Copilot / Claude Opus 4.6)
- [x] Fully tested
- [x] I understand what the code does