### PR TITLE
fix(agents): follow symlinks when loading workspace bootstrap files

### DIFF
--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_USER_FILENAME,
   ensureAgentWorkspace,
   filterBootstrapFilesForSession,
+  loadExtraBootstrapFilesWithDiagnostics,
   loadWorkspaceBootstrapFiles,
   resolveDefaultAgentWorkspaceDir,
   type WorkspaceBootstrapFile,
@@ -273,6 +274,36 @@ describe("loadWorkspaceBootstrapFiles", () => {
       const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
       expect(agents?.missing).toBe(true);
       expect(agents?.content).toBeUndefined();
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("loadExtraBootstrapFilesWithDiagnostics", () => {
+  it("rejects symlinked extra bootstrap files", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-extra-symlink-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const outsideDir = path.join(rootDir, "outside");
+      const subDir = path.join(workspaceDir, "sub");
+      await fs.mkdir(subDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      const outsideFile = path.join(outsideDir, DEFAULT_AGENTS_FILENAME);
+      await fs.writeFile(outsideFile, "extra symlinked content", "utf-8");
+      await fs.symlink(outsideFile, path.join(subDir, DEFAULT_AGENTS_FILENAME));
+
+      const { files, diagnostics } = await loadExtraBootstrapFilesWithDiagnostics(workspaceDir, [
+        `sub/${DEFAULT_AGENTS_FILENAME}`,
+      ]);
+      // The symlink fallback is NOT enabled for extra bootstrap files,
+      // so the file should be rejected with a security diagnostic.
+      expect(files).toHaveLength(0);
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.reason).toBe("security");
     } finally {
       await fs.rm(rootDir, { recursive: true, force: true });
     }

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -244,6 +244,39 @@ describe("loadWorkspaceBootstrapFiles", () => {
       await fs.rm(rootDir, { recursive: true, force: true });
     }
   });
+
+  it("rejects symlinks whose target is hardlinked", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-sym-hard-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const outsideDir = path.join(rootDir, "outside");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      const outsideFile = path.join(outsideDir, "original.md");
+      const hardlinkFile = path.join(outsideDir, DEFAULT_AGENTS_FILENAME);
+      await fs.writeFile(outsideFile, "hardlinked-symlink content", "utf-8");
+      try {
+        await fs.link(outsideFile, hardlinkFile);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "EXDEV") {
+          return;
+        }
+        throw err;
+      }
+      // Symlink in workspace → hardlinked file outside workspace
+      await fs.symlink(hardlinkFile, path.join(workspaceDir, DEFAULT_AGENTS_FILENAME));
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir);
+      const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
+      expect(agents?.missing).toBe(true);
+      expect(agents?.content).toBeUndefined();
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("filterBootstrapFilesForSession", () => {

--- a/src/agents/workspace.test.ts
+++ b/src/agents/workspace.test.ts
@@ -191,6 +191,29 @@ describe("loadWorkspaceBootstrapFiles", () => {
     expect(getMemoryEntries(files)).toHaveLength(0);
   });
 
+  it("loads symlinked bootstrap files that point outside the workspace", async () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    const rootDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-symlink-"));
+    try {
+      const workspaceDir = path.join(rootDir, "workspace");
+      const outsideDir = path.join(rootDir, "outside");
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.mkdir(outsideDir, { recursive: true });
+      const outsideFile = path.join(outsideDir, DEFAULT_AGENTS_FILENAME);
+      await fs.writeFile(outsideFile, "symlinked content", "utf-8");
+      await fs.symlink(outsideFile, path.join(workspaceDir, DEFAULT_AGENTS_FILENAME));
+
+      const files = await loadWorkspaceBootstrapFiles(workspaceDir);
+      const agents = files.find((file) => file.name === DEFAULT_AGENTS_FILENAME);
+      expect(agents?.missing).toBe(false);
+      expect(agents?.content).toBe("symlinked content");
+    } finally {
+      await fs.rm(rootDir, { recursive: true, force: true });
+    }
+  });
+
   it("treats hardlinked bootstrap aliases as missing", async () => {
     if (process.platform === "win32") {
       return;

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -53,6 +53,42 @@ function workspaceFileIdentity(stat: syncFs.Stats, canonicalPath: string): strin
   return `${canonicalPath}|${stat.dev}:${stat.ino}:${stat.size}:${stat.mtimeMs}`;
 }
 
+/**
+ * Fallback reader for workspace bootstrap files that are symlinks pointing
+ * outside the workspace boundary.  Resolves the real path, enforces the same
+ * size cap, and caches by inode identity just like the primary reader.
+ */
+async function readSymlinkedWorkspaceFile(filePath: string): Promise<WorkspaceGuardedReadResult> {
+  try {
+    const realPath = await fs.realpath(filePath);
+    const stat = await fs.stat(realPath);
+    if (!stat.isFile()) {
+      return { ok: false, reason: "validation" };
+    }
+    if (stat.size > MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES) {
+      return { ok: false, reason: "validation" };
+    }
+
+    const identity = workspaceFileIdentity(stat, realPath);
+    const cached = workspaceFileCache.get(filePath);
+    if (cached && cached.identity === identity) {
+      return { ok: true, content: cached.content };
+    }
+
+    const content = await fs.readFile(realPath, "utf-8");
+    workspaceFileCache.set(filePath, { content, identity });
+    return { ok: true, content };
+  } catch (error) {
+    workspaceFileCache.delete(filePath);
+    const code =
+      typeof error === "object" && error !== null && "code" in error ? String(error.code) : "";
+    if (code === "ENOENT" || code === "ENOTDIR" || code === "ELOOP") {
+      return { ok: false, reason: "path", error };
+    }
+    return { ok: false, reason: "io", error };
+  }
+}
+
 async function readWorkspaceFileWithGuards(params: {
   filePath: string;
   workspaceDir: string;
@@ -64,6 +100,22 @@ async function readWorkspaceFileWithGuards(params: {
     maxBytes: MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
   });
   if (!opened.ok) {
+    // If the boundary check rejected the file (e.g. symlink pointing outside
+    // the workspace), fall back to reading via realpath + readFile which
+    // naturally follow symlinks.  This is safe for workspace bootstrap files
+    // because the filenames are hardcoded constants placed by the user.
+    // Only attempt the fallback when the path is actually a symlink so that
+    // hardlink rejections and other validation failures are preserved.
+    if (opened.reason === "validation") {
+      try {
+        const lstat = await fs.lstat(params.filePath);
+        if (lstat.isSymbolicLink()) {
+          return readSymlinkedWorkspaceFile(params.filePath);
+        }
+      } catch {
+        // lstat failed — fall through to the original failure
+      }
+    }
     workspaceFileCache.delete(params.filePath);
     return opened;
   }

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -55,13 +55,16 @@ function workspaceFileIdentity(stat: syncFs.Stats, canonicalPath: string): strin
 
 /**
  * Fallback reader for workspace bootstrap files that are symlinks pointing
- * outside the workspace boundary.  Resolves the real path, enforces the same
- * size cap, and caches by inode identity just like the primary reader.
+ * outside the workspace boundary.  Resolves the real path, opens a file
+ * descriptor, then validates via fstat and reads from the same fd to
+ * eliminate TOCTOU races (the target cannot be swapped between stat and read).
  */
 async function readSymlinkedWorkspaceFile(filePath: string): Promise<WorkspaceGuardedReadResult> {
+  let handle: fs.FileHandle | undefined;
   try {
     const realPath = await fs.realpath(filePath);
-    const stat = await fs.stat(realPath);
+    handle = await fs.open(realPath, "r");
+    const stat = await handle.stat();
     if (!stat.isFile()) {
       return { ok: false, reason: "validation" };
     }
@@ -80,7 +83,7 @@ async function readSymlinkedWorkspaceFile(filePath: string): Promise<WorkspaceGu
       return { ok: true, content: cached.content };
     }
 
-    const content = await fs.readFile(realPath, "utf-8");
+    const content = await handle.readFile("utf-8");
     workspaceFileCache.set(filePath, { content, identity });
     return { ok: true, content };
   } catch (error) {
@@ -91,12 +94,18 @@ async function readSymlinkedWorkspaceFile(filePath: string): Promise<WorkspaceGu
       return { ok: false, reason: "path", error };
     }
     return { ok: false, reason: "io", error };
+  } finally {
+    await handle?.close();
   }
 }
 
 async function readWorkspaceFileWithGuards(params: {
   filePath: string;
   workspaceDir: string;
+  /** When true, symlinks pointing outside the workspace boundary are followed
+   *  via the symlink fallback reader.  Should only be enabled for the fixed
+   *  set of top-level bootstrap files, not for extra/glob-resolved patterns. */
+  allowSymlinks?: boolean;
 }): Promise<WorkspaceGuardedReadResult> {
   const opened = await openBoundaryFile({
     absolutePath: params.filePath,
@@ -106,12 +115,12 @@ async function readWorkspaceFileWithGuards(params: {
   });
   if (!opened.ok) {
     // If the boundary check rejected the file (e.g. symlink pointing outside
-    // the workspace), fall back to reading via realpath + readFile which
-    // naturally follow symlinks.  This is safe for workspace bootstrap files
-    // because the filenames are hardcoded constants placed by the user.
+    // the workspace), fall back to reading via the fd-based symlink reader.
+    // This is only allowed for top-level bootstrap files (allowSymlinks=true)
+    // so that extra bootstrap file patterns cannot abuse the fallback.
     // Only attempt the fallback when the path is actually a symlink so that
     // hardlink rejections and other validation failures are preserved.
-    if (opened.reason === "validation") {
+    if (params.allowSymlinks && opened.reason === "validation") {
       try {
         const lstat = await fs.lstat(params.filePath);
         if (lstat.isSymbolicLink()) {
@@ -596,6 +605,7 @@ export async function loadWorkspaceBootstrapFiles(dir: string): Promise<Workspac
     const loaded = await readWorkspaceFileWithGuards({
       filePath: entry.filePath,
       workspaceDir: resolvedDir,
+      allowSymlinks: true,
     });
     if (loaded.ok) {
       result.push({

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -68,6 +68,11 @@ async function readSymlinkedWorkspaceFile(filePath: string): Promise<WorkspaceGu
     if (stat.size > MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES) {
       return { ok: false, reason: "validation" };
     }
+    // Reject hardlinked targets so that the symlink fallback cannot bypass
+    // the hardlink rejection enforced by the primary boundary reader.
+    if (stat.nlink > 1) {
+      return { ok: false, reason: "validation" };
+    }
 
     const identity = workspaceFileIdentity(stat, realPath);
     const cached = workspaceFileCache.get(filePath);


### PR DESCRIPTION
## What
Fix workspace bootstrap files (AGENTS.md, SOUL.md, USER.md, MEMORY.md) being reported as [MISSING] when they are symlinks pointing outside the workspace directory.

## Why
Users with multi-agent setups often symlink workspace files to a shared vault (e.g. Obsidian) so configuration stays in sync across agents. The boundary-path security layer rejects these symlinks because their targets resolve outside the workspace root, causing agents to start without their operating instructions.

## How
- Added a targeted symlink fallback in `readWorkspaceFileWithGuards`: when `openBoundaryFile` rejects with "validation" and the path is confirmed to be a symlink, resolve via `fs.realpath()` and read the target directly
- Max file size check is still enforced
- Non-symlink validation failures and hardlink rejections are preserved
- Does not modify the boundary-path security infrastructure used by other code paths

## Testing
Added test that creates a symlink in the workspace pointing to a file outside the workspace directory, verifying it loads successfully with `missing: false` and correct content.

All 16 tests passing (15 existing + 1 new).

Closes #40210