### PR TITLE
routing: keep per-channel DM last-route scoped to session

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -11780,7 +11780,7 @@
         "filename": "src/browser/cdp.test.ts",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 243
+        "line_number": 318
       }
     ],
     "src/channels/plugins/plugins-channel.test.ts": [
@@ -13034,5 +13034,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-08T18:30:57Z"
+  "generated_at": "2026-03-08T20:21:05Z"
 }

--- a/extensions/matrix/src/matrix/monitor/handler.ts
+++ b/extensions/matrix/src/matrix/monitor/handler.ts
@@ -552,7 +552,10 @@ export function createMatrixRoomMessageHandler(params: MatrixMonitorHandlerParam
         ctx: ctxPayload,
         updateLastRoute: isDirectMessage
           ? {
-              sessionKey: route.mainSessionKey,
+              sessionKey:
+                route.lastRoutePolicy === "main"
+                  ? route.mainSessionKey
+                  : (ctxPayload.SessionKey ?? route.sessionKey),
               channel: "matrix",
               to: `room:${roomId}`,
               accountId: route.accountId,

--- a/extensions/mattermost/src/mattermost/monitor.ts
+++ b/extensions/mattermost/src/mattermost/monitor.ts
@@ -1593,9 +1593,13 @@ export async function monitorMattermostProvider(opts: MonitorMattermostOpts = {}
       const storePath = core.channel.session.resolveStorePath(sessionCfg?.store, {
         agentId: route.agentId,
       });
+      const updateLastRouteSessionKey =
+        route.lastRoutePolicy === "main"
+          ? route.mainSessionKey
+          : (ctxPayload.SessionKey ?? route.sessionKey);
       await core.channel.session.updateLastRoute({
         storePath,
-        sessionKey: route.mainSessionKey,
+        sessionKey: updateLastRouteSessionKey,
         deliveryContext: {
           channel: "mattermost",
           to,

--- a/src/discord/monitor/agent-components.ts
+++ b/src/discord/monitor/agent-components.ts
@@ -37,7 +37,10 @@ import { logDebug, logError } from "../../logger.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
 import { issuePairingChallenge } from "../../pairing/pairing-challenge.js";
 import { upsertChannelPairingRequest } from "../../pairing/pairing-store.js";
-import { resolveAgentRoute } from "../../routing/resolve-route.js";
+import {
+  resolveAgentRoute,
+  resolveInboundLastRouteSessionKey,
+} from "../../routing/resolve-route.js";
 import { createNonExitingRuntime, type RuntimeEnv } from "../../runtime.js";
 import {
   readStoreAllowFromForDmPolicy,
@@ -944,6 +947,10 @@ async function dispatchDiscordComponentEvent(params: {
     OriginatingChannel: "discord" as const,
     OriginatingTo: `channel:${interactionCtx.channelId}`,
   });
+  const updateLastRouteSessionKey = resolveInboundLastRouteSessionKey({
+    route,
+    sessionKey: ctxPayload.SessionKey ?? sessionKey,
+  });
 
   await recordInboundSession({
     storePath,
@@ -951,21 +958,22 @@ async function dispatchDiscordComponentEvent(params: {
     ctx: ctxPayload,
     updateLastRoute: interactionCtx.isDirectMessage
       ? {
-          sessionKey: route.mainSessionKey,
+          sessionKey: updateLastRouteSessionKey,
           channel: "discord",
           to: `user:${interactionCtx.userId}`,
           accountId,
-          mainDmOwnerPin: pinnedMainDmOwner
-            ? {
-                ownerRecipient: pinnedMainDmOwner,
-                senderRecipient: interactionCtx.userId,
-                onSkip: ({ ownerRecipient, senderRecipient }) => {
-                  logVerbose(
-                    `discord: skip main-session last route for ${senderRecipient} (pinned owner ${ownerRecipient})`,
-                  );
-                },
-              }
-            : undefined,
+          mainDmOwnerPin:
+            pinnedMainDmOwner && updateLastRouteSessionKey === route.mainSessionKey
+              ? {
+                  ownerRecipient: pinnedMainDmOwner,
+                  senderRecipient: interactionCtx.userId,
+                  onSkip: ({ ownerRecipient, senderRecipient }) => {
+                    logVerbose(
+                      `discord: skip main-session last route for ${senderRecipient} (pinned owner ${ownerRecipient})`,
+                    );
+                  },
+                }
+              : undefined,
         }
       : undefined,
     onRecordError: (err) => {

--- a/src/imessage/monitor/monitor-provider.ts
+++ b/src/imessage/monitor/monitor-provider.ts
@@ -35,6 +35,7 @@ import {
   readChannelAllowFromStore,
   upsertChannelPairingRequest,
 } from "../../pairing/pairing-store.js";
+import { resolveInboundLastRouteSessionKey } from "../../routing/resolve-route.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../../security/dm-policy-shared.js";
 import { truncateUtf16Safe } from "../../utils.js";
 import { resolveIMessageAccount } from "../accounts.js";
@@ -350,6 +351,10 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       allowFrom,
       normalizeEntry: normalizeIMessageHandle,
     });
+    const updateLastRouteSessionKey = resolveInboundLastRouteSessionKey({
+      route: decision.route,
+      sessionKey: ctxPayload.SessionKey ?? decision.route.sessionKey,
+    });
     await recordInboundSession({
       storePath,
       sessionKey: ctxPayload.SessionKey ?? decision.route.sessionKey,
@@ -357,12 +362,14 @@ export async function monitorIMessageProvider(opts: MonitorIMessageOpts = {}): P
       updateLastRoute:
         !decision.isGroup && updateTarget
           ? {
-              sessionKey: decision.route.mainSessionKey,
+              sessionKey: updateLastRouteSessionKey,
               channel: "imessage",
               to: updateTarget,
               accountId: decision.route.accountId,
               mainDmOwnerPin:
-                pinnedMainDmOwner && decision.senderNormalized
+                updateLastRouteSessionKey === decision.route.mainSessionKey &&
+                pinnedMainDmOwner &&
+                decision.senderNormalized
                   ? {
                       ownerRecipient: pinnedMainDmOwner,
                       senderRecipient: decision.senderNormalized,

--- a/src/line/bot-message-context.ts
+++ b/src/line/bot-message-context.ts
@@ -8,7 +8,7 @@ import { recordInboundSession } from "../channels/session.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { logVerbose, shouldLogVerbose } from "../globals.js";
 import { recordChannelActivity } from "../infra/channel-activity.js";
-import { resolveAgentRoute } from "../routing/resolve-route.js";
+import { resolveAgentRoute, resolveInboundLastRouteSessionKey } from "../routing/resolve-route.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../security/dm-policy-shared.js";
 import { normalizeAllowFrom } from "./bot-access.js";
 import { resolveLineGroupConfigEntry, resolveLineGroupHistoryKey } from "./group-keys.js";
@@ -321,18 +321,24 @@ async function finalizeLineInboundContext(params: {
         normalizeEntry: (entry) => normalizeAllowFrom([entry]).entries[0],
       })
     : null;
+  const updateLastRouteSessionKey = resolveInboundLastRouteSessionKey({
+    route: params.route,
+    sessionKey: ctxPayload.SessionKey ?? params.route.sessionKey,
+  });
   await recordInboundSession({
     storePath,
     sessionKey: ctxPayload.SessionKey ?? params.route.sessionKey,
     ctx: ctxPayload,
     updateLastRoute: !params.source.isGroup
       ? {
-          sessionKey: params.route.mainSessionKey,
+          sessionKey: updateLastRouteSessionKey,
           channel: "line",
           to: params.source.userId ?? params.source.peerId,
           accountId: params.route.accountId,
           mainDmOwnerPin:
-            pinnedMainDmOwner && params.source.userId
+            updateLastRouteSessionKey === params.route.mainSessionKey &&
+            pinnedMainDmOwner &&
+            params.source.userId
               ? {
                   ownerRecipient: pinnedMainDmOwner,
                   senderRecipient: params.source.userId,

--- a/src/signal/monitor/event-handler.ts
+++ b/src/signal/monitor/event-handler.ts
@@ -30,7 +30,10 @@ import { readSessionUpdatedAt, resolveStorePath } from "../../config/sessions.js
 import { danger, logVerbose, shouldLogVerbose } from "../../globals.js";
 import { enqueueSystemEvent } from "../../infra/system-events.js";
 import { kindFromMime } from "../../media/mime.js";
-import { resolveAgentRoute } from "../../routing/resolve-route.js";
+import {
+  resolveAgentRoute,
+  resolveInboundLastRouteSessionKey,
+} from "../../routing/resolve-route.js";
 import {
   DM_GROUP_ACCESS_REASON,
   resolvePinnedMainDmOwnerFromAllowlist,
@@ -200,6 +203,10 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       OriginatingChannel: "signal" as const,
       OriginatingTo: signalTo,
     });
+    const updateLastRouteSessionKey = resolveInboundLastRouteSessionKey({
+      route,
+      sessionKey: ctxPayload.SessionKey ?? route.sessionKey,
+    });
 
     await recordInboundSession({
       storePath,
@@ -207,7 +214,7 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
       ctx: ctxPayload,
       updateLastRoute: !entry.isGroup
         ? {
-            sessionKey: route.mainSessionKey,
+            sessionKey: updateLastRouteSessionKey,
             channel: "signal",
             to: entry.senderRecipient,
             accountId: route.accountId,
@@ -218,6 +225,9 @@ export function createSignalEventHandler(deps: SignalEventHandlerDeps) {
                 normalizeEntry: normalizeSignalAllowRecipient,
               });
               if (!pinnedOwner) {
+                return undefined;
+              }
+              if (updateLastRouteSessionKey !== route.mainSessionKey) {
                 return undefined;
               }
               return {

--- a/src/slack/monitor/message-handler/dispatch.test.ts
+++ b/src/slack/monitor/message-handler/dispatch.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { shouldSkipPinnedMainLastRouteUpdate } from "./dispatch.js";
+
+describe("shouldSkipPinnedMainLastRouteUpdate", () => {
+  it("skips only mismatched writes to the main session", () => {
+    expect(
+      shouldSkipPinnedMainLastRouteUpdate({
+        pinnedMainDmOwner: "owner-1",
+        senderRecipient: "sender-2",
+        targetSessionKey: "agent:main:main",
+        mainSessionKey: "agent:main:main",
+      }),
+    ).toBe(true);
+  });
+
+  it("allows session-scoped writes even when sender differs from pinned owner", () => {
+    expect(
+      shouldSkipPinnedMainLastRouteUpdate({
+        pinnedMainDmOwner: "owner-1",
+        senderRecipient: "sender-2",
+        targetSessionKey: "agent:main:slack:direct:sender-2",
+        mainSessionKey: "agent:main:main",
+      }),
+    ).toBe(false);
+  });
+});

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -10,6 +10,7 @@ import { createTypingCallbacks } from "../../../channels/typing.js";
 import { resolveStorePath, updateLastRoute } from "../../../config/sessions.js";
 import { danger, logVerbose, shouldLogVerbose } from "../../../globals.js";
 import { resolveAgentOutboundIdentity } from "../../../infra/outbound/identity.js";
+import { resolveInboundLastRouteSessionKey } from "../../../routing/resolve-route.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../../../security/dm-policy-shared.js";
 import { reactSlackMessage, removeSlackReaction } from "../../actions.js";
 import { createSlackDraftStream } from "../../draft-stream.js";
@@ -105,16 +106,20 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
         `slack: skip main-session last route for ${senderRecipient} (pinned owner ${pinnedMainDmOwner})`,
       );
     } else {
+      const updateLastRouteSessionKey = resolveInboundLastRouteSessionKey({
+        route,
+        sessionKey: prepared.ctxPayload.SessionKey ?? route.sessionKey,
+      });
       await updateLastRoute({
         storePath,
-        sessionKey: route.mainSessionKey,
+        sessionKey: updateLastRouteSessionKey,
         deliveryContext: {
           channel: "slack",
           to: `user:${message.user}`,
           accountId: route.accountId,
           threadId: prepared.ctxPayload.MessageThreadId,
         },
-        ctx: prepared.ctxPayload,
+        ctx: updateLastRouteSessionKey === route.mainSessionKey ? prepared.ctxPayload : undefined,
       });
     }
   }

--- a/src/slack/monitor/message-handler/dispatch.ts
+++ b/src/slack/monitor/message-handler/dispatch.ts
@@ -71,6 +71,23 @@ function shouldUseStreaming(params: {
   return true;
 }
 
+export function shouldSkipPinnedMainLastRouteUpdate(params: {
+  pinnedMainDmOwner: string | null;
+  senderRecipient: string | undefined;
+  targetSessionKey: string;
+  mainSessionKey: string;
+}): boolean {
+  if (params.targetSessionKey !== params.mainSessionKey) {
+    return false;
+  }
+  const ownerRecipient = params.pinnedMainDmOwner?.trim().toLowerCase();
+  const senderRecipient = params.senderRecipient?.trim().toLowerCase();
+  if (!ownerRecipient || !senderRecipient) {
+    return false;
+  }
+  return ownerRecipient !== senderRecipient;
+}
+
 export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessage) {
   const { ctx, account, message, route } = prepared;
   const cfg = ctx.cfg;
@@ -96,20 +113,22 @@ export async function dispatchPreparedSlackMessage(prepared: PreparedSlackMessag
       allowFrom: ctx.allowFrom,
       normalizeEntry: normalizeSlackAllowOwnerEntry,
     });
+    const updateLastRouteSessionKey = resolveInboundLastRouteSessionKey({
+      route,
+      sessionKey: prepared.ctxPayload.SessionKey ?? route.sessionKey,
+    });
     const senderRecipient = message.user?.trim().toLowerCase();
-    const skipMainUpdate =
-      pinnedMainDmOwner &&
-      senderRecipient &&
-      pinnedMainDmOwner.trim().toLowerCase() !== senderRecipient;
+    const skipMainUpdate = shouldSkipPinnedMainLastRouteUpdate({
+      pinnedMainDmOwner,
+      senderRecipient,
+      targetSessionKey: updateLastRouteSessionKey,
+      mainSessionKey: route.mainSessionKey,
+    });
     if (skipMainUpdate) {
       logVerbose(
         `slack: skip main-session last route for ${senderRecipient} (pinned owner ${pinnedMainDmOwner})`,
       );
     } else {
-      const updateLastRouteSessionKey = resolveInboundLastRouteSessionKey({
-        route,
-        sessionKey: prepared.ctxPayload.SessionKey ?? route.sessionKey,
-      });
       await updateLastRoute({
         storePath,
         sessionKey: updateLastRouteSessionKey,

--- a/src/slack/monitor/message-handler/prepare.ts
+++ b/src/slack/monitor/message-handler/prepare.ts
@@ -27,7 +27,10 @@ import { recordInboundSession } from "../../../channels/session.js";
 import { readSessionUpdatedAt, resolveStorePath } from "../../../config/sessions.js";
 import { logVerbose, shouldLogVerbose } from "../../../globals.js";
 import { enqueueSystemEvent } from "../../../infra/system-events.js";
-import { resolveAgentRoute } from "../../../routing/resolve-route.js";
+import {
+  resolveAgentRoute,
+  resolveInboundLastRouteSessionKey,
+} from "../../../routing/resolve-route.js";
 import { resolveThreadSessionKeys } from "../../../routing/session-key.js";
 import { resolvePinnedMainDmOwnerFromAllowlist } from "../../../security/dm-policy-shared.js";
 import { resolveSlackReplyToMode, type ResolvedSlackAccount } from "../../accounts.js";
@@ -736,6 +739,10 @@ export async function prepareSlackMessage(params: {
         normalizeEntry: normalizeSlackAllowOwnerEntry,
       })
     : null;
+  const updateLastRouteSessionKey = resolveInboundLastRouteSessionKey({
+    route,
+    sessionKey,
+  });
 
   await recordInboundSession({
     storePath,
@@ -743,13 +750,13 @@ export async function prepareSlackMessage(params: {
     ctx: ctxPayload,
     updateLastRoute: isDirectMessage
       ? {
-          sessionKey: route.mainSessionKey,
+          sessionKey: updateLastRouteSessionKey,
           channel: "slack",
           to: `user:${message.user}`,
           accountId: route.accountId,
           threadId: threadContext.messageThreadId,
           mainDmOwnerPin:
-            pinnedMainDmOwner && message.user
+            updateLastRouteSessionKey === route.mainSessionKey && pinnedMainDmOwner && message.user
               ? {
                   ownerRecipient: pinnedMainDmOwner,
                   senderRecipient: message.user.toLowerCase(),


### PR DESCRIPTION
## Summary
- keep inbound DM last-route updates on the isolated session when route policy is `session`
- preserve main-session last-route writes only for DM routes that explicitly collapse to `main`
- apply the fix across the affected inbound surfaces: iMessage, Slack, Signal, LINE, Discord components, Matrix, and Mattermost

## Testing
- `pnpm build`
- `pnpm test -- src/routing/resolve-route.test.ts src/channels/session.test.ts src/discord/monitor/route-resolution.test.ts src/discord/monitor/message-handler.process.test.ts`

Closes #36614
