### PR TITLE
Respect skill tool policy in inline command dispatch

### DIFF
--- a/src/auto-reply/reply/get-reply-inline-actions.skill-dispatch-policy.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skill-dispatch-policy.test.ts
@@ -123,6 +123,12 @@ describe("handleInlineActions skill tool dispatch policy", () => {
     );
 
     expect(result).toEqual({ kind: "reply", reply: { text: "❌ Tool not available: exec" } });
+    expect(createOpenClawCodingToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        senderIsOwner: false,
+        config: { tools: { profile: "messaging" } },
+      }),
+    );
     expect(handleCommandsMock).not.toHaveBeenCalled();
   });
 
@@ -149,6 +155,8 @@ describe("handleInlineActions skill tool dispatch policy", () => {
     expect(result).toEqual({ kind: "reply", reply: { text: "Hello World" } });
     expect(createOpenClawCodingToolsMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        senderIsOwner: false,
+        config: { tools: { profile: "messaging" } },
         messageTo: "whatsapp:+18880001111",
         messageThreadId: "thread-42",
       }),

--- a/src/auto-reply/reply/get-reply-inline-actions.skill-dispatch-policy.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skill-dispatch-policy.test.ts
@@ -42,6 +42,8 @@ function createInput(params: {
     Body: params.commandBody,
     CommandBody: params.commandBody,
     Provider: "whatsapp",
+    OriginatingTo: "whatsapp:+18880001111",
+    MessageThreadId: "thread-42",
   });
   const cleanedBody = params.commandBody;
 
@@ -145,6 +147,12 @@ describe("handleInlineActions skill tool dispatch policy", () => {
     );
 
     expect(result).toEqual({ kind: "reply", reply: { text: "Hello World" } });
+    expect(createOpenClawCodingToolsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageTo: "whatsapp:+18880001111",
+        messageThreadId: "thread-42",
+      }),
+    );
     expect(execute).toHaveBeenCalledWith(
       expect.stringMatching(/^cmd_/),
       expect.objectContaining({

--- a/src/auto-reply/reply/get-reply-inline-actions.skill-dispatch-policy.test.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.skill-dispatch-policy.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SkillCommandSpec } from "../../agents/skills.js";
+import type { TemplateContext } from "../templating.js";
+import { clearInlineDirectives } from "./get-reply-directives-utils.js";
+import { buildTestCtx } from "./test-ctx.js";
+import type { TypingController } from "./typing.js";
+
+const handleCommandsMock = vi.fn();
+const createOpenClawCodingToolsMock = vi.fn();
+
+vi.mock("../../agents/pi-tools.js", () => ({
+  createOpenClawCodingTools: (...args: unknown[]) => createOpenClawCodingToolsMock(...args),
+}));
+
+vi.mock("./commands.js", () => ({
+  handleCommands: (...args: unknown[]) => handleCommandsMock(...args),
+  buildStatusReply: vi.fn(),
+  buildCommandContext: vi.fn(),
+}));
+
+const { handleInlineActions } = await import("./get-reply-inline-actions.js");
+type HandleInlineActionsInput = Parameters<typeof handleInlineActions>[0];
+
+function createTypingController(): TypingController {
+  return {
+    onReplyStart: async () => {},
+    startTypingLoop: async () => {},
+    startTypingOnText: async () => {},
+    refreshTypingTtl: () => {},
+    isActive: () => false,
+    markRunComplete: () => {},
+    markDispatchIdle: () => {},
+    cleanup: vi.fn(),
+  };
+}
+
+function createInput(params: {
+  commandBody: string;
+  skillCommands: SkillCommandSpec[];
+}): HandleInlineActionsInput {
+  const ctx = buildTestCtx({
+    Body: params.commandBody,
+    CommandBody: params.commandBody,
+    Provider: "whatsapp",
+  });
+  const cleanedBody = params.commandBody;
+
+  return {
+    ctx,
+    sessionCtx: ctx as unknown as TemplateContext,
+    cfg: { tools: { profile: "messaging" } },
+    agentId: "main",
+    sessionKey: "agent:main:whatsapp:+15550001",
+    workspaceDir: "/tmp",
+    isGroup: false,
+    typing: createTypingController(),
+    allowTextCommands: true,
+    inlineStatusRequested: false,
+    command: {
+      surface: "whatsapp",
+      channel: "whatsapp",
+      channelId: "whatsapp",
+      ownerList: [],
+      senderIsOwner: false,
+      isAuthorizedSender: true,
+      senderId: "user-1",
+      abortKey: "user-1",
+      rawBodyNormalized: params.commandBody,
+      commandBodyNormalized: params.commandBody,
+      from: "whatsapp:+15550001",
+      to: "whatsapp:+15550001",
+    },
+    directives: clearInlineDirectives(cleanedBody),
+    cleanedBody,
+    elevatedEnabled: false,
+    elevatedAllowed: false,
+    elevatedFailures: [],
+    defaultActivation: () => "always",
+    resolvedThinkLevel: undefined,
+    resolvedVerboseLevel: undefined,
+    resolvedReasoningLevel: "off",
+    resolvedElevatedLevel: "off",
+    resolveDefaultThinkingLevel: async () => "off",
+    provider: "openai",
+    model: "gpt-5.2",
+    contextTokens: 0,
+    abortedLastRun: false,
+    sessionScope: "per-sender",
+    skillCommands: params.skillCommands,
+  };
+}
+
+describe("handleInlineActions skill tool dispatch policy", () => {
+  beforeEach(() => {
+    handleCommandsMock.mockReset();
+    createOpenClawCodingToolsMock.mockReset();
+  });
+
+  it("rejects dispatch when requested tool is filtered out by policy", async () => {
+    createOpenClawCodingToolsMock.mockReturnValue([
+      {
+        name: "message",
+        execute: vi.fn(),
+      },
+    ]);
+
+    const skillCommands: SkillCommandSpec[] = [
+      {
+        name: "hello_world",
+        skillName: "hello-world",
+        description: "Run hello world script",
+        dispatch: { kind: "tool", toolName: "exec", argMode: "raw" },
+      },
+    ];
+
+    const result = await handleInlineActions(
+      createInput({
+        commandBody: "/hello_world echo hello",
+        skillCommands,
+      }),
+    );
+
+    expect(result).toEqual({ kind: "reply", reply: { text: "❌ Tool not available: exec" } });
+    expect(handleCommandsMock).not.toHaveBeenCalled();
+  });
+
+  it("executes dispatch when tool is available after policy filtering", async () => {
+    const execute = vi.fn(async () => ({ content: "Hello World\n" }));
+    createOpenClawCodingToolsMock.mockReturnValue([{ name: "exec", execute }]);
+
+    const skillCommands: SkillCommandSpec[] = [
+      {
+        name: "hello_world",
+        skillName: "hello-world",
+        description: "Run hello world script",
+        dispatch: { kind: "tool", toolName: "exec", argMode: "raw" },
+      },
+    ];
+
+    const result = await handleInlineActions(
+      createInput({
+        commandBody: "/hello_world python3 scripts/hello_world.py",
+        skillCommands,
+      }),
+    );
+
+    expect(result).toEqual({ kind: "reply", reply: { text: "Hello World" } });
+    expect(execute).toHaveBeenCalledWith(
+      expect.stringMatching(/^cmd_/),
+      expect.objectContaining({
+        command: "python3 scripts/hello_world.py",
+        commandName: "hello_world",
+        skillName: "hello-world",
+      }),
+    );
+  });
+});

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -203,6 +203,8 @@ export async function handleInlineActions(params: {
         agentId,
         workspaceDir,
         sessionKey,
+        messageTo: ctx.OriginatingTo ?? ctx.To,
+        messageThreadId: ctx.MessageThreadId,
         messageProvider: command.channel ?? channel,
         modelProvider: provider,
         modelId: model,

--- a/src/auto-reply/reply/get-reply-inline-actions.ts
+++ b/src/auto-reply/reply/get-reply-inline-actions.ts
@@ -1,7 +1,6 @@
 import { collectTextContentBlocks } from "../../agents/content-blocks.js";
-import { createOpenClawTools } from "../../agents/openclaw-tools.js";
+import { createOpenClawCodingTools } from "../../agents/pi-tools.js";
 import type { SkillCommandSpec } from "../../agents/skills.js";
-import { applyOwnerOnlyToolPolicy } from "../../agents/tool-policy.js";
 import { getChannelDock } from "../../channels/dock.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -199,19 +198,24 @@ export async function handleInlineActions(params: {
         resolveGatewayMessageChannel(ctx.Provider) ??
         undefined;
 
-      const tools = createOpenClawTools({
-        agentSessionKey: sessionKey,
-        agentChannel: channel,
-        agentAccountId: (ctx as { AccountId?: string }).AccountId,
-        agentTo: ctx.OriginatingTo ?? ctx.To,
-        agentThreadId: ctx.MessageThreadId ?? undefined,
-        agentDir,
-        workspaceDir,
+      const tools = createOpenClawCodingTools({
         config: cfg,
+        agentId,
+        workspaceDir,
+        sessionKey,
+        messageProvider: command.channel ?? channel,
+        modelProvider: provider,
+        modelId: model,
+        groupId: sessionEntry?.groupId ?? undefined,
+        groupChannel: sessionEntry?.groupChannel ?? undefined,
+        groupSpace: sessionEntry?.space ?? undefined,
+        spawnedBy: sessionEntry?.spawnedBy ?? undefined,
+        senderIsOwner: command.senderIsOwner,
+        senderId: command.senderId,
+        agentAccountId: (ctx as { AccountId?: string }).AccountId,
+        agentDir,
       });
-      const authorizedTools = applyOwnerOnlyToolPolicy(tools, command.senderIsOwner);
-
-      const tool = authorizedTools.find((candidate) => candidate.name === dispatch.toolName);
+      const tool = tools.find((candidate) => candidate.name === dispatch.toolName);
       if (!tool) {
         typing.cleanup();
         return { kind: "reply", reply: { text: `❌ Tool not available: ${dispatch.toolName}` } };


### PR DESCRIPTION
## Summary
- ensure inline `command-dispatch: tool` uses the same coding-tool policy filtering as normal coding sessions
- remove the owner-only fallback tool filter in inline dispatch to avoid bypassing permission profiles
- add regression coverage for non-owner users to confirm command-exec style tools are blocked when policy disallows them

## Testing
- pnpm -s vitest run src/auto-reply/reply/get-reply-inline-actions.skill-dispatch-policy.test.ts
