### PR TITLE
feat: add Microsoft Clarity analytics

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -8,6 +8,14 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
+    <!-- Microsoft Clarity — session recordings & analytics -->
+    <script type="text/javascript">
+      (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+      })(window, document, "clarity", "script", "vspyfp4bjr");
+    </script>
   </head>
   <body>
     <openclaw-app></openclaw-app>

--- a/ui/src/ui/analytics.ts
+++ b/ui/src/ui/analytics.ts
@@ -1,0 +1,50 @@
+/**
+ * Microsoft Clarity analytics helpers.
+ *
+ * Thin wrappers around the Clarity browser API so the rest of the UI stays
+ * clean and doesn't scatter `window.clarity` checks everywhere. All calls
+ * silently no-op if Clarity isn't loaded (ad-blockers, local dev, etc.).
+ *
+ * Clarity API reference:
+ *   https://learn.microsoft.com/en-us/clarity/setup-and-installation/clarity-api
+ */
+
+declare global {
+  interface Window {
+    clarity?: (method: string, ...args: unknown[]) => void;
+  }
+}
+
+/**
+ * Fire a Clarity custom event. Appears under Filters → Custom events in the
+ * Clarity dashboard and can be used to create funnels / segments.
+ *
+ * @param name  - Stable event name (snake_case, e.g. "message_sent")
+ * @param value - Optional string value attached to the event
+ */
+export function trackEvent(name: string, value?: string): void {
+  try {
+    if (value != null) {
+      window.clarity?.("event", name, value);
+    } else {
+      window.clarity?.("event", name);
+    }
+  } catch {
+    // Analytics must never crash the UI.
+  }
+}
+
+/**
+ * Set a Clarity custom tag (key/value pair visible on session recordings).
+ * Useful for identifying the connected gateway version, session key, theme, etc.
+ *
+ * @param key   - Tag key (e.g. "theme", "session_key")
+ * @param value - Tag value
+ */
+export function setTag(key: string, value: string): void {
+  try {
+    window.clarity?.("set", key, value);
+  } catch {
+    // Silently ignore.
+  }
+}

--- a/ui/src/ui/app-channels.ts
+++ b/ui/src/ui/app-channels.ts
@@ -1,4 +1,5 @@
 import type { OpenClawApp } from "./app.ts";
+import { trackEvent } from "./analytics.ts";
 import {
   loadChannels,
   logoutWhatsApp,
@@ -26,6 +27,7 @@ export async function handleWhatsAppLogout(host: OpenClawApp) {
 
 export async function handleChannelConfigSave(host: OpenClawApp) {
   await saveConfig(host);
+  trackEvent("channel_config_saved");
   await loadConfig(host);
   await loadChannels(host, true);
 }

--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -1,4 +1,5 @@
 import { parseAgentSessionKey } from "../../../src/sessions/session-key-utils.js";
+import { trackEvent } from "./analytics.ts";
 import { scheduleChatScroll } from "./app-scroll.ts";
 import { setLastActiveSessionKey } from "./app-settings.ts";
 import { resetToolStream } from "./app-tool-stream.ts";
@@ -64,6 +65,7 @@ export async function handleAbortChat(host: ChatHost) {
   if (!host.connected) {
     return;
   }
+  trackEvent("message_aborted");
   host.chatMessage = "";
   await abortChatRun(host as unknown as OpenClawApp);
 }
@@ -113,6 +115,7 @@ async function sendChatMessageNow(
     host.chatAttachments = opts.previousAttachments;
   }
   if (ok) {
+    trackEvent("message_sent");
     setLastActiveSessionKey(
       host as unknown as Parameters<typeof setLastActiveSessionKey>[0],
       host.sessionKey,

--- a/ui/src/ui/app-lifecycle.ts
+++ b/ui/src/ui/app-lifecycle.ts
@@ -1,4 +1,5 @@
 import { connectGateway } from "./app-gateway.ts";
+import { trackEvent, setTag } from "./analytics.ts";
 import {
   startLogsPolling,
   startNodesPolling,
@@ -56,6 +57,7 @@ export function handleConnected(host: LifecycleHost) {
       return;
     }
     connectGateway(host as unknown as Parameters<typeof connectGateway>[0]);
+    trackEvent("gateway_connected");
   });
   startNodesPolling(host as unknown as Parameters<typeof startNodesPolling>[0]);
   if (host.tab === "logs") {
@@ -71,6 +73,7 @@ export function handleFirstUpdated(host: LifecycleHost) {
 }
 
 export function handleDisconnected(host: LifecycleHost) {
+  trackEvent("gateway_disconnected");
   host.connectGeneration += 1;
   window.removeEventListener("popstate", host.popStateHandler);
   stopNodesPolling(host as unknown as Parameters<typeof stopNodesPolling>[0]);

--- a/ui/src/ui/app-settings.ts
+++ b/ui/src/ui/app-settings.ts
@@ -1,4 +1,5 @@
 import { refreshChat } from "./app-chat.ts";
+import { trackEvent, setTag } from "./analytics.ts";
 import {
   startLogsPolling,
   stopLogsPolling,
@@ -149,6 +150,7 @@ export function applySettingsFromUrl(host: SettingsHost) {
 }
 
 export function setTab(host: SettingsHost, next: Tab) {
+  trackEvent("tab_changed", next);
   applyTabSelection(host, next, { refreshPolicy: "always", syncUrl: true });
 }
 


### PR DESCRIPTION
## What

Adds Microsoft Clarity for session recording and custom event analytics.

## Changes

### `ui/index.html`
Inserts the Clarity initialization snippet in `<head>` using tag ID `vspyfp4bjr`.

### `ui/src/ui/analytics.ts` (new)
A thin, safe wrapper around the Clarity browser API:
- `trackEvent(name, value?)` — fires a Clarity custom event
- `setTag(key, value)` — sets a Clarity session tag
Both silently no-op if Clarity isn't available (ad-blockers, local dev without the snippet).

### Custom events instrumented

| Event | File | Trigger |
|---|---|---|
| `gateway_connected` | `app-lifecycle.ts` | Gateway handshake completes |
| `gateway_disconnected` | `app-lifecycle.ts` | UI component disconnects |
| `message_sent` | `app-chat.ts` | Chat message successfully dispatched |
| `message_aborted` | `app-chat.ts` | User aborts an in-flight run |
| `tab_changed` (+ tab name) | `app-settings.ts` | User navigates to a different tab |
| `channel_config_saved` | `app-channels.ts` | Channel config saved successfully |

## Why these events

These cover the core user flows without over-instrumenting. Clarity already captures heatmaps and session recordings automatically — the custom events let us filter/segment sessions by meaningful moments (connected, sent a message, changed a channel config) rather than raw clicks.