### PR TITLE
fix(googlechat): synchronous space events and chunked message thread continuity

### DIFF
--- a/extensions/googlechat/src/monitor-webhook.ts
+++ b/extensions/googlechat/src/monitor-webhook.ts
@@ -183,6 +183,19 @@ export function createGoogleChatWebhookRequestHandler(params: {
 
         const dispatchTarget = selectedTarget;
         dispatchTarget.statusSink?.({ lastInboundAt: Date.now() });
+
+        // For synchronous responses in spaces, we need to return a proper message
+        const evtType = (parsedEvent.type ?? (parsedEvent as { eventType?: string }).eventType)?.toUpperCase();
+        const isGroup = parsedEvent.space?.type?.toUpperCase() !== "DM";
+
+        // For ADDED_TO_SPACE events in groups, return an acknowledgment
+        if (isGroup && evtType === "ADDED_TO_SPACE") {
+          res.statusCode = 200;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ text: "Hello!" }));
+          return true;
+        }
+
         params.processEvent(parsedEvent, dispatchTarget).catch((err) => {
           dispatchTarget.runtime.error?.(
             `[${dispatchTarget.account.accountId}] Google Chat webhook failed: ${String(err)}`,

--- a/extensions/googlechat/src/monitor.ts
+++ b/extensions/googlechat/src/monitor.ts
@@ -317,7 +317,7 @@ async function processMessageWithPipeline(params: {
       ...prefixOptions,
       deliver: async (payload) => {
         await deliverGoogleChatReply({
-          payload,
+          payload: { ...payload, replyToId: payload.replyToId ?? ctxPayload.ReplyToId },
           account,
           spaceId,
           runtime,


### PR DESCRIPTION
## Summary

This PR fixes two Google Chat integration issues:

### 1. Synchronous Response for Space Events

Google Chat requires a proper JSON response body for space events (like ADDED_TO_SPACE), not just empty {}. Without this, users see error messages when adding the bot to spaces.

Fix: Return { text: Hello message } synchronously for non-MESSAGE events in group spaces.

### 2. Chunked Message Thread Continuity

When messages exceed 4000 characters, OpenClaw splits them into chunks. Previously, chunk 1 would go to the correct thread, but chunks 2+ would be sent as top-level messages.

Fix: Added fallback to use ctxPayload.ReplyToId when payload.replyToId is undefined.

## Changes

- extensions/googlechat/src/monitor-webhook.ts: Add synchronous space event response
- extensions/googlechat/src/monitor.ts: Fix chunked message thread continuity

## Testing

- Space event: Bot can be added to Google Chat spaces without error
- Chunked messages: Long messages (>4000 chars) stay in the same thread