### PR TITLE
fix: register ACP run-mode spawns in subagent registry for completion announce

### DIFF
--- a/src/agents/acp-spawn.test.ts
+++ b/src/agents/acp-spawn.test.ts
@@ -145,6 +145,11 @@ vi.mock("./acp-spawn-parent-stream.js", () => ({
     hoisted.resolveAcpSpawnStreamLogPathMock(...args),
 }));
 
+const registerSubagentRunMock = vi.fn();
+vi.mock("./subagent-registry.js", () => ({
+  registerSubagentRun: (...args: unknown[]) => registerSubagentRunMock(...args),
+}));
+
 const { spawnAcpDirect } = await import("./acp-spawn.js");
 
 function createSessionBindingCapabilities() {
@@ -1040,5 +1045,105 @@ describe("spawnAcpDirect", () => {
     expect(result.error).toContain('streamTo="parent"');
     expect(hoisted.callGatewayMock).not.toHaveBeenCalled();
     expect(hoisted.startAcpSpawnParentStreamRelayMock).not.toHaveBeenCalled();
+  });
+
+  describe("completion announce registration", () => {
+    beforeEach(() => {
+      registerSubagentRunMock.mockReset();
+    });
+
+    it("registers run-mode ACP spawn in subagent registry for completion announce", async () => {
+      const result = await spawnAcpDirect(
+        {
+          task: "Implement the full auth module",
+          agentId: "codex",
+          mode: "run",
+          label: "auth-impl",
+        },
+        {
+          agentSessionKey: "agent:main:main",
+          agentChannel: "discord",
+          agentAccountId: "default",
+          agentTo: "channel:1234567890",
+          agentThreadId: "987654321",
+        },
+      );
+
+      expect(result.status).toBe("accepted");
+      expect(result.mode).toBe("run");
+      expect(registerSubagentRunMock).toHaveBeenCalledOnce();
+      const call = registerSubagentRunMock.mock.calls[0][0] as Record<string, unknown>;
+      expect(call.runId).toBe(result.runId);
+      expect(call.childSessionKey).toBe(result.childSessionKey);
+      expect(call.expectsCompletionMessage).toBe(true);
+      expect(call.spawnMode).toBe("run");
+      expect(call.label).toBe("auth-impl");
+      expect(call.task).toBe("Implement the full auth module");
+      // Requester origin should include the Discord channel context
+      expect((call.requesterOrigin as Record<string, unknown>)?.channel).toBe("discord");
+      expect((call.requesterOrigin as Record<string, unknown>)?.to).toBe("channel:1234567890");
+    });
+
+    it("does NOT register session-mode ACP spawn (long-lived, no natural completion)", async () => {
+      const result = await spawnAcpDirect(
+        {
+          task: "Open a persistent coding session",
+          agentId: "codex",
+          mode: "session",
+          thread: true,
+        },
+        {
+          agentSessionKey: "agent:main:discord:guild:1234:channel:5678",
+          agentChannel: "discord",
+          agentAccountId: "default",
+          agentTo: "channel:5678",
+        },
+      );
+
+      expect(result.status).toBe("accepted");
+      expect(result.mode).toBe("session");
+      expect(registerSubagentRunMock).not.toHaveBeenCalled();
+    });
+
+    it("does NOT register when there is no requester session key", async () => {
+      const result = await spawnAcpDirect(
+        {
+          task: "Standalone task with no parent",
+          agentId: "codex",
+          mode: "run",
+        },
+        {
+          // No agentSessionKey
+          agentChannel: "discord",
+          agentAccountId: "default",
+          agentTo: "channel:1234567890",
+        },
+      );
+
+      expect(result.status).toBe("accepted");
+      expect(registerSubagentRunMock).not.toHaveBeenCalled();
+    });
+
+    it("still returns accepted even if registerSubagentRun throws", async () => {
+      registerSubagentRunMock.mockImplementationOnce(() => {
+        throw new Error("registry write failed");
+      });
+
+      const result = await spawnAcpDirect(
+        {
+          task: "Implement feature X",
+          agentId: "codex",
+          mode: "run",
+        },
+        {
+          agentSessionKey: "agent:main:main",
+          agentChannel: "discord",
+          agentAccountId: "default",
+          agentTo: "channel:1234567890",
+        },
+      );
+
+      expect(result.status).toBe("accepted");
+    });
   });
 });

--- a/src/agents/acp-spawn.ts
+++ b/src/agents/acp-spawn.ts
@@ -49,6 +49,7 @@ import {
 } from "./acp-spawn-parent-stream.js";
 import { resolveAgentConfig, resolveDefaultAgentId } from "./agent-scope.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
+import { registerSubagentRun } from "./subagent-registry.js";
 import { resolveInternalSessionKey, resolveMainSessionAlias } from "./tools/sessions-helpers.js";
 
 const log = createSubsystemLogger("agents/acp-spawn");
@@ -726,6 +727,47 @@ export async function spawnAcpDirect(
       error: summarizeError(err),
       childSessionKey: sessionKey,
     };
+  }
+
+  // Register one-shot ACP runs in the subagent registry so the existing
+  // announce pipeline delivers a completion notification back to the
+  // requester channel (Discord, WhatsApp, etc.) when the run finishes.
+  // Session-mode ("persistent thread-bound") ACP sessions are long-lived and
+  // don't have a natural completion point, so we skip registration for those.
+  // Only register when there is an explicit requester session context (i.e.
+  // the spawn was triggered from within another agent turn, not standalone).
+  const explicitRequesterKey = ctx.agentSessionKey?.trim();
+  if (spawnMode === "run" && explicitRequesterKey && requesterInternalKey) {
+    try {
+      // cleanup: "keep" preserves the session during the normal lifecycle cleanup
+      // flow (announce, hooks, frozen result caching). The time-based sweep
+      // (archiveAtMs) is a separate safety net for orphaned/stale runs that never
+      // complete — it fires well after the configured archiveAfterMinutes and is
+      // intentionally terminal.
+      //
+      // Note: ACP run-mode registrations consume a child slot in
+      // countActiveRunsForSession. This is intentional — it prevents unbounded
+      // spawns from a single session and ensures ACP runs are visible in the
+      // subagent tree. The slot is released when the run ends or is swept.
+      registerSubagentRun({
+        runId: childRunId,
+        childSessionKey: sessionKey,
+        requesterSessionKey: requesterInternalKey,
+        requesterOrigin: requesterOrigin ?? undefined,
+        requesterDisplayKey: requesterInternalKey,
+        task: params.task,
+        cleanup: "keep",
+        label: params.label || undefined,
+        expectsCompletionMessage: true,
+        spawnMode: "run",
+      });
+    } catch (err) {
+      // Best-effort: registration failure should not prevent the spawn
+      // from succeeding. Log for diagnostics only.
+      log.warn?.(
+        `acp-spawn: failed to register run ${childRunId} for completion announce: ${String(err)}`,
+      );
+    }
   }
 
   if (effectiveStreamToParent && parentSessionKey) {


### PR DESCRIPTION
## Problem

Closes #40272

When `sessions_spawn` is called with `runtime="acp"` and `mode="run"`, the spawned session had no completion notification mechanism. The requester channel (Discord, WhatsApp, etc.) **never received a push notification** when the task finished — users had to manually ask for status.

## Root Cause

`spawnAcpDirect()` did not register the run in the subagent registry. The registry's `onAgentEvent` listener already monitors `lifecycle:end` events and calls `runSubagentAnnounceFlow` for all registered runs — but ACP runs were never registered, so the pipeline was never invoked.

## Fix

A one-liner conceptually: after a successful ACP run-mode dispatch, call `registerSubagentRun()` with `expectsCompletionMessage: true`. The existing announce infrastructure does the rest.

```ts
// src/agents/acp-spawn.ts
if (spawnMode === "run" && explicitRequesterKey && requesterInternalKey) {
  registerSubagentRun({
    runId: childRunId,
    childSessionKey: sessionKey,
    requesterSessionKey: requesterInternalKey,
    requesterOrigin,
    expectsCompletionMessage: true,
    spawnMode: "run",
    // ...
  });
}
```

## Scope

| Case | Registered? | Reason |
|---|---|---|
| `runtime="acp"`, `mode="run"` | ✅ Yes | One-shot task, has a natural end |
| `runtime="acp"`, `mode="session"` | ❌ No | Long-lived thread, no natural completion |
| No `agentSessionKey` (standalone/CLI) | ❌ No | No requester to notify |

## Safety

- `registerSubagentRun()` failure is caught and logged — the spawn still returns `"accepted"`
- No new code paths in the announce pipeline (reuses existing subagent announce flow)
- `cleanup: "keep"` — ACP sessions are not deleted by the registry on completion

## Tests

4 new test cases in `src/agents/acp-spawn.test.ts`:
1. ✅ run-mode spawn registers with correct fields (runId, channel, label, task, etc.)
2. ✅ session-mode spawn is **not** registered
3. ✅ spawn without `agentSessionKey` is **not** registered  
4. ✅ registration failure does not prevent `"accepted"` result

All 18 existing `acp-spawn.test.ts` tests continue to pass.