### PR TITLE
fix(discord): persist component registry to disk for cross-process survival

### DIFF
--- a/src/discord/components-registry.ts
+++ b/src/discord/components-registry.ts
@@ -1,9 +1,82 @@
+import fs from "node:fs";
+import path from "node:path";
+import { STATE_DIR } from "../config/paths.js";
 import type { DiscordComponentEntry, DiscordModalEntry } from "./components.js";
 
-const DEFAULT_COMPONENT_TTL_MS = 30 * 60 * 1000;
+const DEFAULT_COMPONENT_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
-const componentEntries = new Map<string, DiscordComponentEntry>();
-const modalEntries = new Map<string, DiscordModalEntry>();
+// In-memory cache mirrors the file to avoid reading on every resolve.
+let componentEntries = new Map<string, DiscordComponentEntry>();
+let modalEntries = new Map<string, DiscordModalEntry>();
+let cacheLoaded = false;
+
+const REGISTRY_DIR = path.join(STATE_DIR, "discord");
+const REGISTRY_PATH = path.join(REGISTRY_DIR, "component-registry.json");
+
+// ---------------------------------------------------------------------------
+// File I/O
+// ---------------------------------------------------------------------------
+
+type RegistryFile = {
+  components: Record<string, DiscordComponentEntry>;
+  modals: Record<string, DiscordModalEntry>;
+};
+
+function loadFromFile(): {
+  components: Map<string, DiscordComponentEntry>;
+  modals: Map<string, DiscordModalEntry>;
+} {
+  try {
+    const raw = fs.readFileSync(REGISTRY_PATH, "utf-8");
+    const parsed: RegistryFile = JSON.parse(raw);
+    const components = new Map(Object.entries(parsed.components ?? {}));
+    const modals = new Map(Object.entries(parsed.modals ?? {}));
+    return { components, modals };
+  } catch {
+    // ENOENT or corrupt file — start fresh.
+    return { components: new Map(), modals: new Map() };
+  }
+}
+
+function saveToFile(): void {
+  try {
+    fs.mkdirSync(REGISTRY_DIR, { recursive: true });
+    const data: RegistryFile = {
+      components: Object.fromEntries(componentEntries),
+      modals: Object.fromEntries(modalEntries),
+    };
+    const json = JSON.stringify(data, null, 2);
+    const tmp = `${REGISTRY_PATH}.${process.pid}.tmp`;
+    fs.writeFileSync(tmp, json, "utf-8");
+    fs.renameSync(tmp, REGISTRY_PATH);
+  } catch {
+    // Best-effort — don't crash the bot if disk write fails.
+  }
+}
+
+function ensureLoaded(): void {
+  if (cacheLoaded) {
+    return;
+  }
+  const loaded = loadFromFile();
+  // Merge file entries into any in-memory entries (in case register was
+  // called before the first resolve in this process).
+  for (const [id, entry] of loaded.components) {
+    if (!componentEntries.has(id)) {
+      componentEntries.set(id, entry);
+    }
+  }
+  for (const [id, entry] of loaded.modals) {
+    if (!modalEntries.has(id)) {
+      modalEntries.set(id, entry);
+    }
+  }
+  cacheLoaded = true;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function isExpired(entry: { expiresAt?: number }, now: number) {
   return typeof entry.expiresAt === "number" && entry.expiresAt <= now;
@@ -19,12 +92,17 @@ function normalizeEntryTimestamps<T extends { createdAt?: number; expiresAt?: nu
   return { ...entry, createdAt, expiresAt };
 }
 
+// ---------------------------------------------------------------------------
+// Public API (unchanged signatures)
+// ---------------------------------------------------------------------------
+
 export function registerDiscordComponentEntries(params: {
   entries: DiscordComponentEntry[];
   modals: DiscordModalEntry[];
   ttlMs?: number;
   messageId?: string;
 }): void {
+  ensureLoaded();
   const now = Date.now();
   const ttlMs = params.ttlMs ?? DEFAULT_COMPONENT_TTL_MS;
   for (const entry of params.entries) {
@@ -43,12 +121,14 @@ export function registerDiscordComponentEntries(params: {
     );
     modalEntries.set(modal.id, normalized);
   }
+  saveToFile();
 }
 
 export function resolveDiscordComponentEntry(params: {
   id: string;
   consume?: boolean;
 }): DiscordComponentEntry | null {
+  ensureLoaded();
   const entry = componentEntries.get(params.id);
   if (!entry) {
     return null;
@@ -56,10 +136,12 @@ export function resolveDiscordComponentEntry(params: {
   const now = Date.now();
   if (isExpired(entry, now)) {
     componentEntries.delete(params.id);
+    saveToFile();
     return null;
   }
   if (params.consume !== false) {
     componentEntries.delete(params.id);
+    saveToFile();
   }
   return entry;
 }
@@ -68,6 +150,7 @@ export function resolveDiscordModalEntry(params: {
   id: string;
   consume?: boolean;
 }): DiscordModalEntry | null {
+  ensureLoaded();
   const entry = modalEntries.get(params.id);
   if (!entry) {
     return null;
@@ -75,10 +158,12 @@ export function resolveDiscordModalEntry(params: {
   const now = Date.now();
   if (isExpired(entry, now)) {
     modalEntries.delete(params.id);
+    saveToFile();
     return null;
   }
   if (params.consume !== false) {
     modalEntries.delete(params.id);
+    saveToFile();
   }
   return entry;
 }
@@ -86,4 +171,10 @@ export function resolveDiscordModalEntry(params: {
 export function clearDiscordComponentEntries(): void {
   componentEntries.clear();
   modalEntries.clear();
+  cacheLoaded = false;
+  try {
+    fs.unlinkSync(REGISTRY_PATH);
+  } catch {
+    // File may not exist.
+  }
 }

--- a/src/discord/components-registry.ts
+++ b/src/discord/components-registry.ts
@@ -29,8 +29,13 @@ function loadFromFile(): {
   try {
     const raw = fs.readFileSync(REGISTRY_PATH, "utf-8");
     const parsed: RegistryFile = JSON.parse(raw);
-    const components = new Map(Object.entries(parsed.components ?? {}));
-    const modals = new Map(Object.entries(parsed.modals ?? {}));
+    const now = Date.now();
+    const components = new Map(
+      Object.entries(parsed.components ?? {}).filter(([, entry]) => !isExpired(entry, now)),
+    );
+    const modals = new Map(
+      Object.entries(parsed.modals ?? {}).filter(([, entry]) => !isExpired(entry, now)),
+    );
     return { components, modals };
   } catch {
     // ENOENT or corrupt file — start fresh.
@@ -38,17 +43,17 @@ function loadFromFile(): {
   }
 }
 
-function saveToFile(): void {
+async function saveToFile(): Promise<void> {
   try {
-    fs.mkdirSync(REGISTRY_DIR, { recursive: true });
+    await fs.promises.mkdir(REGISTRY_DIR, { recursive: true });
     const data: RegistryFile = {
       components: Object.fromEntries(componentEntries),
       modals: Object.fromEntries(modalEntries),
     };
     const json = JSON.stringify(data, null, 2);
     const tmp = `${REGISTRY_PATH}.${process.pid}.tmp`;
-    fs.writeFileSync(tmp, json, "utf-8");
-    fs.renameSync(tmp, REGISTRY_PATH);
+    await fs.promises.writeFile(tmp, json, "utf-8");
+    await fs.promises.rename(tmp, REGISTRY_PATH);
   } catch {
     // Best-effort — don't crash the bot if disk write fails.
   }
@@ -121,7 +126,7 @@ export function registerDiscordComponentEntries(params: {
     );
     modalEntries.set(modal.id, normalized);
   }
-  saveToFile();
+  saveToFile().catch(() => {});
 }
 
 export function resolveDiscordComponentEntry(params: {
@@ -136,12 +141,12 @@ export function resolveDiscordComponentEntry(params: {
   const now = Date.now();
   if (isExpired(entry, now)) {
     componentEntries.delete(params.id);
-    saveToFile();
+    saveToFile().catch(() => {});
     return null;
   }
   if (params.consume !== false) {
     componentEntries.delete(params.id);
-    saveToFile();
+    saveToFile().catch(() => {});
   }
   return entry;
 }
@@ -158,12 +163,12 @@ export function resolveDiscordModalEntry(params: {
   const now = Date.now();
   if (isExpired(entry, now)) {
     modalEntries.delete(params.id);
-    saveToFile();
+    saveToFile().catch(() => {});
     return null;
   }
   if (params.consume !== false) {
     modalEntries.delete(params.id);
-    saveToFile();
+    saveToFile().catch(() => {});
   }
   return entry;
 }
@@ -171,10 +176,6 @@ export function resolveDiscordModalEntry(params: {
 export function clearDiscordComponentEntries(): void {
   componentEntries.clear();
   modalEntries.clear();
-  cacheLoaded = false;
-  try {
-    fs.unlinkSync(REGISTRY_PATH);
-  } catch {
-    // File may not exist.
-  }
+  cacheLoaded = true;
+  saveToFile().catch(() => {});
 }


### PR DESCRIPTION
## Summary

- Persist the Discord component registry to disk so it survives process restarts
- Previously, button/component handlers would be lost on restart, causing interactions to silently fail

## Test plan

- [ ] Register a Discord button interaction, restart OpenClaw, click the button and verify it still works

---
🤖 AI-assisted (Claude) | Lightly tested on local OpenClaw instance