### PR TITLE
feat(nano-banana-pro): Default to Nano Banana 2 (Flash), add --model flag

### DIFF
--- a/skills/nano-banana-pro/SKILL.md
+++ b/skills/nano-banana-pro/SKILL.md
@@ -65,6 +65,7 @@ uv run {baseDir}/scripts/generate_image.py --prompt "portrait photo" --filename 
 Notes
 
 - Models: `flash` (default, Nano Banana 2 — fast & cheap), `pro` (Nano Banana Pro — max quality).
+- Both Flash and Pro models support all resolution options (512px, 1K, 2K, 4K) and aspect ratios. Flash offers comparable quality at approximately half the cost.
 - Resolutions: `1K` (default), `2K`, `4K`.
 - Aspect ratios: `1:1`, `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`. Without `--aspect-ratio` / `-a`, the model picks freely - use this flag for avatars, profile pics, or consistent batch generation.
 - Use timestamps in filenames: `yyyy-mm-dd-hh-mm-ss-name.png`.

--- a/skills/nano-banana-pro/SKILL.md
+++ b/skills/nano-banana-pro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nano-banana-pro
-description: Generate or edit images via Gemini 3 Pro Image (Nano Banana Pro).
+description: Generate or edit images via Gemini Nano Banana (defaults to Flash for speed/cost; supports Pro for max quality).
 homepage: https://ai.google.dev/
 metadata:
   {
@@ -23,14 +23,20 @@ metadata:
   }
 ---
 
-# Nano Banana Pro (Gemini 3 Pro Image)
+# Nano Banana Pro (Gemini Image Generation)
 
-Use the bundled script to generate or edit images.
+Use the bundled script to generate or edit images. Defaults to **Nano Banana 2** (Gemini 3.1 Flash Image) for speed and cost efficiency. Use `--model pro` for maximum quality via Gemini 3 Pro Image.
 
 Generate
 
 ```bash
 uv run {baseDir}/scripts/generate_image.py --prompt "your image description" --filename "output.png" --resolution 1K
+```
+
+Generate with Pro model (max quality)
+
+```bash
+uv run {baseDir}/scripts/generate_image.py --prompt "your image description" --filename "output.png" --model pro
 ```
 
 Edit (single image)
@@ -58,6 +64,7 @@ uv run {baseDir}/scripts/generate_image.py --prompt "portrait photo" --filename 
 
 Notes
 
+- Models: `flash` (default, Nano Banana 2 — fast & cheap), `pro` (Nano Banana Pro — max quality).
 - Resolutions: `1K` (default), `2K`, `4K`.
 - Aspect ratios: `1:1`, `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`. Without `--aspect-ratio` / `-a`, the model picks freely - use this flag for avatars, profile pics, or consistent batch generation.
 - Use timestamps in filenames: `yyyy-mm-dd-hh-mm-ss-name.png`.

--- a/skills/nano-banana-pro/scripts/generate_image.py
+++ b/skills/nano-banana-pro/scripts/generate_image.py
@@ -194,6 +194,9 @@ def main():
             image_cfg_kwargs["aspect_ratio"] = args.aspect_ratio
 
         model_id = MODEL_MAP[args.model]
+        # Flash (Nano Banana 2) supports all Pro resolutions (1K/2K/4K) plus
+        # 0.5K, and all Pro aspect ratios plus 1:4, 4:1, 1:8, 8:1 — full
+        # feature parity confirmed per Google docs.
         print(f"Using model: {model_id}")
 
         response = client.models.generate_content(

--- a/skills/nano-banana-pro/scripts/generate_image.py
+++ b/skills/nano-banana-pro/scripts/generate_image.py
@@ -7,10 +7,14 @@
 # ]
 # ///
 """
-Generate images using Google's Nano Banana Pro (Gemini 3 Pro Image) API.
+Generate images using Google's Nano Banana (Gemini Image) API.
+
+Defaults to Nano Banana 2 (Gemini 3.1 Flash Image) for speed and cost.
+Use --model pro for Nano Banana Pro (Gemini 3 Pro Image) for max quality.
 
 Usage:
     uv run generate_image.py --prompt "your image description" --filename "output.png" [--resolution 1K|2K|4K] [--api-key KEY]
+    uv run generate_image.py --prompt "your image description" --filename "output.png" --model pro
 
 Multi-image editing (up to 14 images):
     uv run generate_image.py --prompt "combine these images" --filename "output.png" -i img1.png -i img2.png -i img3.png
@@ -20,6 +24,11 @@ import argparse
 import os
 import sys
 from pathlib import Path
+
+MODEL_MAP = {
+    "flash": "gemini-3.1-flash-image-preview",
+    "pro": "gemini-3-pro-image-preview",
+}
 
 SUPPORTED_ASPECT_RATIOS = [
     "1:1",
@@ -71,7 +80,7 @@ def choose_output_resolution(
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Generate images using Nano Banana Pro (Gemini 3 Pro Image)"
+        description="Generate images using Nano Banana (Gemini Image Generation)"
     )
     parser.add_argument(
         "--prompt", "-p",
@@ -101,6 +110,12 @@ def main():
         choices=SUPPORTED_ASPECT_RATIOS,
         default=None,
         help=f"Output aspect ratio (default: model decides). Options: {', '.join(SUPPORTED_ASPECT_RATIOS)}"
+    )
+    parser.add_argument(
+        "--model", "-m",
+        choices=list(MODEL_MAP.keys()),
+        default="flash",
+        help="Model variant: flash (default, Nano Banana 2 — fast & cheap) or pro (Nano Banana Pro — max quality)"
     )
     parser.add_argument(
         "--api-key", "-k",
@@ -178,8 +193,11 @@ def main():
         if args.aspect_ratio:
             image_cfg_kwargs["aspect_ratio"] = args.aspect_ratio
 
+        model_id = MODEL_MAP[args.model]
+        print(f"Using model: {model_id}")
+
         response = client.models.generate_content(
-            model="gemini-3-pro-image-preview",
+            model=model_id,
             contents=contents,
             config=types.GenerateContentConfig(
                 response_modalities=["TEXT", "IMAGE"],


### PR DESCRIPTION
## What

Switches the default model in the `nano-banana-pro` skill from **Gemini 3 Pro Image** (`gemini-3-pro-image-preview`) to **Nano Banana 2 / Gemini 3.1 Flash Image** (`gemini-3.1-flash-image-preview`), and adds a `--model` flag so users can still opt into Pro when needed.

## Why

Google released Nano Banana 2 (Gemini 3.1 Flash Image), which offers **comparable or better image quality** at roughly **half the cost** and significantly faster inference. For most use cases — quick generation, iteration, high-volume work — Flash is the better default. Pro remains available via `--model pro` for professional asset production that benefits from advanced reasoning.

## Changes

- **`SKILL.md`**: Updated description, added `--model pro` usage example, documented both model variants in the notes.
- **`generate_image.py`**: Added a `MODEL_MAP` (`flash` → `gemini-3.1-flash-image-preview`, `pro` → `gemini-3-pro-image-preview`), new `--model / -m` CLI flag defaulting to `flash`, swapped hardcoded model string for map lookup.
- **No test changes needed** — resolution detection logic is model-independent.

## Breaking change?

The default model changes from Pro to Flash. Existing users will get faster, cheaper results out of the box. Anyone who specifically needs Pro quality can add `--model pro` to their commands.

## AI-assisted

This PR was prepared with AI assistance (OpenClaw/Claude). Changes have been reviewed and are understood.