### PR TITLE
fix(agents): use nullish coalescing for context_length in kilocode model discovery

### DIFF
--- a/src/agents/kilocode-models.test.ts
+++ b/src/agents/kilocode-models.test.ts
@@ -182,6 +182,24 @@ describe("discoverKilocodeModels (fetch path)", () => {
     });
   });
 
+  it("preserves zero context_length instead of falling back to default", async () => {
+    const zeroCtxModel = makeGatewayModel({
+      id: "provider/zero-ctx-model",
+      context_length: 0,
+    });
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ data: [zeroCtxModel] }),
+    });
+    await withFetchPathTest(mockFetch, async () => {
+      const models = await discoverKilocodeModels();
+      const model = models.find((m) => m.id === "provider/zero-ctx-model");
+      expect(model).toBeDefined();
+      expect(model?.contextWindow).toBe(0);
+    });
+  });
+
   it("detects text-only models without image modality", async () => {
     const textOnlyModel = makeGatewayModel({
       id: "some/text-model",

--- a/src/agents/kilocode-models.ts
+++ b/src/agents/kilocode-models.ts
@@ -103,7 +103,7 @@ function toModelDefinition(entry: GatewayModelEntry): ModelDefinitionConfig {
       cacheRead: toPricePerMillion(entry.pricing.input_cache_read),
       cacheWrite: toPricePerMillion(entry.pricing.input_cache_write),
     },
-    contextWindow: entry.context_length || KILOCODE_DEFAULT_CONTEXT_WINDOW,
+    contextWindow: entry.context_length ?? KILOCODE_DEFAULT_CONTEXT_WINDOW,
     maxTokens: entry.top_provider?.max_completion_tokens ?? KILOCODE_DEFAULT_MAX_TOKENS,
   };
 }


### PR DESCRIPTION
## Summary
- `toModelDefinition()` used `||` for `context_length`, silently replacing an explicit `0` with `KILOCODE_DEFAULT_CONTEXT_WINDOW` (1M tokens)
- The adjacent `maxTokens` field already uses `??`, as do all other callers (`models-config.providers.ts`, `huggingface-models.ts`, `buildStaticCatalog` in the same file)
- Switch to `??` so the fallback only activates for `null`/`undefined`

## Test plan
- [x] Added regression test: gateway returns `context_length: 0` → model gets `contextWindow: 0` (not 1M)
- [x] All existing kilocode-models tests pass (9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)