### PR TITLE
fix(gateway): require operator.admin for /allowlist add|remove via gateway

### DIFF
--- a/src/auto-reply/reply/commands-allowlist.ts
+++ b/src/auto-reply/reply/commands-allowlist.ts
@@ -29,7 +29,11 @@ import { resolveSlackAccount } from "../../slack/accounts.js";
 import { resolveSlackUserAllowlist } from "../../slack/resolve-users.js";
 import { resolveTelegramAccount } from "../../telegram/accounts.js";
 import { resolveWhatsAppAccount } from "../../web/accounts.js";
-import { rejectUnauthorizedCommand, requireCommandFlagEnabled } from "./command-gates.js";
+import {
+  rejectUnauthorizedCommand,
+  requireCommandFlagEnabled,
+  requireGatewayClientScopeForInternalChannel,
+} from "./command-gates.js";
 import type { CommandHandler } from "./commands-types.js";
 
 type AllowlistScope = "dm" | "group" | "all";
@@ -389,6 +393,17 @@ export const handleAllowlistCommand: CommandHandler = async (params, allowTextCo
   const unauthorized = rejectUnauthorizedCommand(params, "/allowlist");
   if (unauthorized) {
     return unauthorized;
+  }
+
+  if (parsed.action === "add" || parsed.action === "remove") {
+    const missingAdminScope = requireGatewayClientScopeForInternalChannel(params, {
+      label: "/allowlist write",
+      allowedScopes: ["operator.admin"],
+      missingText: "❌ /allowlist add|remove requires operator.admin for gateway clients.",
+    });
+    if (missingAdminScope) {
+      return missingAdminScope;
+    }
   }
 
   const channelId =

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -8,6 +8,7 @@ import {
   listSubagentRunsForRequester,
   resetSubagentRegistryForTests,
 } from "../../agents/subagent-registry.js";
+import type { ChannelId } from "../../channels/plugins/types.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { updateSessionStore, type SessionEntry } from "../../config/sessions.js";
 import * as internalHooks from "../../hooks/internal-hooks.js";
@@ -877,10 +878,13 @@ describe("handleCommands /allowlist", () => {
       GatewayClientScopes: ["operator.write"],
     });
     params.command.channel = INTERNAL_MESSAGE_CHANNEL;
+    // Set channelId so channel resolution succeeds after the scope guard passes
+    params.command.channelId = "telegram" as ChannelId;
     const result = await handleCommands(params);
     expect(result.shouldContinue).toBe(false);
-    // list should succeed (no admin required for reads)
+    // list should succeed and show channel info (no admin required for reads)
     expect(result.reply?.text).not.toContain("requires operator.admin");
+    expect(result.reply?.text).toContain("Channel: telegram");
   });
 
   it("removes DM allowlist entries from canonical allowFrom and deletes legacy dm.allowFrom", async () => {

--- a/src/auto-reply/reply/commands.test.ts
+++ b/src/auto-reply/reply/commands.test.ts
@@ -847,6 +847,42 @@ describe("handleCommands /allowlist", () => {
     expect(writeConfigFileMock).not.toHaveBeenCalled();
   });
 
+  it("blocks /allowlist add from gateway clients without operator.admin", async () => {
+    const cfg = {
+      commands: { text: true, config: true },
+      channels: { telegram: { allowFrom: ["123"] } },
+    } as OpenClawConfig;
+    const params = buildPolicyParams("/allowlist add dm 789", cfg, {
+      Provider: INTERNAL_MESSAGE_CHANNEL,
+      Surface: INTERNAL_MESSAGE_CHANNEL,
+      GatewayClientScopes: ["operator.write"],
+    });
+    params.command.channel = INTERNAL_MESSAGE_CHANNEL;
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    expect(result.reply?.text).toContain("requires operator.admin");
+    expect(writeConfigFileMock).not.toHaveBeenCalled();
+    expect(addChannelAllowFromStoreEntryMock).not.toHaveBeenCalled();
+  });
+
+  it("allows /allowlist list from gateway clients without operator.admin", async () => {
+    readChannelAllowFromStoreMock.mockResolvedValueOnce([]);
+    const cfg = {
+      commands: { text: true },
+      channels: { telegram: { allowFrom: ["123"] } },
+    } as OpenClawConfig;
+    const params = buildPolicyParams("/allowlist list dm", cfg, {
+      Provider: INTERNAL_MESSAGE_CHANNEL,
+      Surface: INTERNAL_MESSAGE_CHANNEL,
+      GatewayClientScopes: ["operator.write"],
+    });
+    params.command.channel = INTERNAL_MESSAGE_CHANNEL;
+    const result = await handleCommands(params);
+    expect(result.shouldContinue).toBe(false);
+    // list should succeed (no admin required for reads)
+    expect(result.reply?.text).not.toContain("requires operator.admin");
+  });
+
   it("removes DM allowlist entries from canonical allowFrom and deletes legacy dm.allowFrom", async () => {
     const cases = [
       {


### PR DESCRIPTION
## Summary
- Commit 5f8f58ae2 added `requireGatewayClientScopeForInternalChannel` to `/config set|unset` and `/approve`, but `/allowlist add|remove` was missed
- A gateway client without `operator.admin` scope could still mutate allowlist config through internal channels
- Apply the same guard so `add`/`remove` require `operator.admin` while `/allowlist list` stays available to any authorized client

## Test plan
- [x] Added test: `/allowlist add` from gateway client with `operator.write` (no admin) → blocked with "requires operator.admin"
- [x] Added test: `/allowlist list` from gateway client with `operator.write` → succeeds (reads don't need admin)
- [x] All existing commands tests pass (61/61)

🤖 Generated with [Claude Code](https://claude.com/claude-code)