### PR TITLE
feat: send channel notice when auto-compaction starts

### DIFF
--- a/src/agents/pi-embedded-runner/run/params.ts
+++ b/src/agents/pi-embedded-runner/run/params.ts
@@ -105,7 +105,7 @@ export type RunEmbeddedPiAgentParams = {
   onReasoningStream?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
   onReasoningEnd?: () => void | Promise<void>;
   onToolResult?: (payload: { text?: string; mediaUrls?: string[] }) => void | Promise<void>;
-  onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void;
+  onAgentEvent?: (evt: { stream: string; data: Record<string, unknown> }) => void | Promise<void>;
   lane?: string;
   enqueue?: typeof enqueueCommand;
   extraSystemPrompt?: string;

--- a/src/agents/pi-embedded-subscribe.handlers.compaction.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.compaction.ts
@@ -4,7 +4,7 @@ import { getGlobalHookRunner } from "../plugins/hook-runner-global.js";
 import type { EmbeddedPiSubscribeContext } from "./pi-embedded-subscribe.handlers.types.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
 
-export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
+export async function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
   ctx.state.compactionInFlight = true;
   ctx.ensureCompactionPromise();
   ctx.log.debug(`embedded run compaction start: runId=${ctx.params.runId}`);
@@ -13,7 +13,9 @@ export function handleAutoCompactionStart(ctx: EmbeddedPiSubscribeContext) {
     stream: "compaction",
     data: { phase: "start" },
   });
-  void ctx.params.onAgentEvent?.({
+  // Await the callback so pre-compaction notices (e.g. channel notifications)
+  // are delivered before the compaction summarization model call proceeds.
+  await ctx.params.onAgentEvent?.({
     stream: "compaction",
     data: { phase: "start" },
   });

--- a/src/agents/pi-embedded-subscribe.handlers.ts
+++ b/src/agents/pi-embedded-subscribe.handlers.ts
@@ -51,7 +51,11 @@ export function createEmbeddedPiSessionEventHandler(ctx: EmbeddedPiSubscribeCont
         handleAgentStart(ctx);
         return;
       case "auto_compaction_start":
-        handleAutoCompactionStart(ctx);
+        // Async: await so pre-compaction channel notices are delivered
+        // before the compaction summarization model call proceeds.
+        handleAutoCompactionStart(ctx).catch((err) => {
+          ctx.log.debug(`auto_compaction_start handler failed: ${String(err)}`);
+        });
         return;
       case "auto_compaction_end":
         handleAutoCompactionEnd(ctx, evt as never);

--- a/src/auto-reply/dispatch.ts
+++ b/src/auto-reply/dispatch.ts
@@ -36,7 +36,7 @@ export async function dispatchInboundMessage(params: {
   ctx: MsgContext | FinalizedMsgContext;
   cfg: OpenClawConfig;
   dispatcher: ReplyDispatcher;
-  replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
+  replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply" | "onCompactionNotice">;
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
   const finalized = finalizeInboundContext(params.ctx);
@@ -57,7 +57,7 @@ export async function dispatchInboundMessageWithBufferedDispatcher(params: {
   ctx: MsgContext | FinalizedMsgContext;
   cfg: OpenClawConfig;
   dispatcherOptions: ReplyDispatcherWithTypingOptions;
-  replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
+  replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply" | "onCompactionNotice">;
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
   const { dispatcher, replyOptions, markDispatchIdle } = createReplyDispatcherWithTyping(
@@ -83,7 +83,7 @@ export async function dispatchInboundMessageWithDispatcher(params: {
   ctx: MsgContext | FinalizedMsgContext;
   cfg: OpenClawConfig;
   dispatcherOptions: ReplyDispatcherOptions;
-  replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
+  replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply" | "onCompactionNotice">;
   replyResolver?: typeof import("./reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
   const dispatcher = createReplyDispatcher(params.dispatcherOptions);

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -394,6 +394,9 @@ export async function runAgentTurnWithFallback(params: {
                 if (evt.stream === "compaction") {
                   const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
                   if (phase === "start") {
+                    // Signal channel dispatchers to finalize in-flight previews
+                    // before compaction rewrites the context.
+                    await params.opts?.onCompactionBoundary?.();
                     const compactionNotify =
                       params.followupRun.run.config?.agents?.defaults?.compaction?.notify;
                     // Default to true when not explicitly set

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -390,9 +390,19 @@ export async function runAgentTurnWithFallback(params: {
                     await params.opts?.onToolStart?.({ name, phase });
                   }
                 }
-                // Track auto-compaction completion
+                // Track auto-compaction completion and fire notices
                 if (evt.stream === "compaction") {
                   const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
+                  if (phase === "start") {
+                    const compactionNotify =
+                      params.followupRun.run.config?.agents?.defaults?.compaction?.notify;
+                    // Default to true when not explicitly set
+                    if (compactionNotify !== false) {
+                      await params.opts?.onCompactionNotice?.({
+                        text: "⏳ Compacting context…",
+                      });
+                    }
+                  }
                   if (phase === "end") {
                     autoCompactionCompleted = true;
                   }

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -443,6 +443,12 @@ export async function dispatchReplyFromConfig(params: {
           };
           return run();
         },
+        onCompactionNotice: (payload: ReplyPayload) => {
+          if (shouldRouteToOriginating) {
+            return sendPayloadAsync(payload, undefined, false);
+          }
+          dispatcher.sendBlockReply(payload);
+        },
       },
       cfg,
     );

--- a/src/auto-reply/reply/followup-runner.ts
+++ b/src/auto-reply/reply/followup-runner.ts
@@ -215,11 +215,22 @@ export function createFollowupRunner(params: {
                 bootstrapPromptWarningSignaturesSeen[
                   bootstrapPromptWarningSignaturesSeen.length - 1
                 ],
-              onAgentEvent: (evt) => {
+              onAgentEvent: async (evt) => {
                 if (evt.stream !== "compaction") {
                   return;
                 }
                 const phase = typeof evt.data.phase === "string" ? evt.data.phase : "";
+                if (phase === "start") {
+                  const compactionNotify =
+                    queued.run.config?.agents?.defaults?.compaction?.notify;
+                  // Default to true when not explicitly set
+                  if (compactionNotify !== false) {
+                    await sendFollowupPayloads(
+                      [{ text: "⏳ Compacting context…" }],
+                      queued,
+                    );
+                  }
+                }
                 if (phase === "end") {
                   autoCompactionCompleted = true;
                 }

--- a/src/auto-reply/reply/provider-dispatcher.ts
+++ b/src/auto-reply/reply/provider-dispatcher.ts
@@ -15,7 +15,7 @@ export async function dispatchReplyWithBufferedBlockDispatcher(params: {
   ctx: MsgContext | FinalizedMsgContext;
   cfg: OpenClawConfig;
   dispatcherOptions: ReplyDispatcherWithTypingOptions;
-  replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
+  replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply" | "onCompactionNotice">;
   replyResolver?: typeof import("../reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
   return await dispatchInboundMessageWithBufferedDispatcher({
@@ -31,7 +31,7 @@ export async function dispatchReplyWithDispatcher(params: {
   ctx: MsgContext | FinalizedMsgContext;
   cfg: OpenClawConfig;
   dispatcherOptions: ReplyDispatcherOptions;
-  replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply">;
+  replyOptions?: Omit<GetReplyOptions, "onToolResult" | "onBlockReply" | "onCompactionNotice">;
   replyResolver?: typeof import("../reply.js").getReplyFromConfig;
 }): Promise<DispatchInboundResult> {
   return await dispatchInboundMessageWithDispatcher({

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -54,6 +54,8 @@ export type GetReplyOptions = {
   onToolResult?: (payload: ReplyPayload) => Promise<void> | void;
   /** Called when a tool phase starts/updates, before summary payloads are emitted. */
   onToolStart?: (payload: { name?: string; phase?: string }) => Promise<void> | void;
+  /** Called when auto-compaction starts, to deliver a user-visible notice immediately. */
+  onCompactionNotice?: (payload: ReplyPayload) => Promise<void> | void;
   /** Called when the actual model is selected (including after fallback).
    * Use this to get model/provider/thinkLevel for responsePrefix template interpolation. */
   onModelSelected?: (ctx: ModelSelectedContext) => void;

--- a/src/auto-reply/types.ts
+++ b/src/auto-reply/types.ts
@@ -56,6 +56,9 @@ export type GetReplyOptions = {
   onToolStart?: (payload: { name?: string; phase?: string }) => Promise<void> | void;
   /** Called when auto-compaction starts, to deliver a user-visible notice immediately. */
   onCompactionNotice?: (payload: ReplyPayload) => Promise<void> | void;
+  /** Called when auto-compaction starts, before the notice, so channel dispatchers
+   *  can finalize in-flight preview messages and prepare for post-compaction content. */
+  onCompactionBoundary?: () => Promise<void> | void;
   /** Called when the actual model is selected (including after fallback).
    * Use this to get model/provider/thinkLevel for responsePrefix template interpolation. */
   onModelSelected?: (ctx: ModelSelectedContext) => void;

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1017,6 +1017,8 @@ export const FIELD_HELP: Record<string, string> = {
     'AGENTS.md H2/H3 section names re-injected after compaction so the agent reruns critical startup guidance. Leave unset to use "Session Startup"/"Red Lines" with legacy fallback to "Every Session"/"Safety"; set to [] to disable reinjection entirely.',
   "agents.defaults.compaction.model":
     "Optional provider/model override used only for compaction summarization. Set this when you want compaction to run on a different model than the session default, and leave it unset to keep using the primary agent model.",
+  "agents.defaults.compaction.notify":
+    "Send a notice to the active channel when auto-compaction starts. Helps users understand why the agent goes quiet during the summarization step. Defaults to true. Set to false to suppress the notice.",
   "agents.defaults.compaction.memoryFlush":
     "Pre-compaction memory flush settings that run an agentic memory write before heavy compaction. Keep enabled for long sessions so salient context is persisted before aggressive trimming.",
   "agents.defaults.compaction.memoryFlush.enabled":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -460,6 +460,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "agents.defaults.compaction.qualityGuard.maxRetries": "Compaction Quality Guard Max Retries",
   "agents.defaults.compaction.postCompactionSections": "Post-Compaction Context Sections",
   "agents.defaults.compaction.model": "Compaction Model Override",
+  "agents.defaults.compaction.notify": "Compaction Notify",
   "agents.defaults.compaction.memoryFlush": "Compaction Memory Flush",
   "agents.defaults.compaction.memoryFlush.enabled": "Compaction Memory Flush Enabled",
   "agents.defaults.compaction.memoryFlush.softThresholdTokens":

--- a/src/config/types.agent-defaults.ts
+++ b/src/config/types.agent-defaults.ts
@@ -314,6 +314,12 @@ export type AgentCompactionConfig = {
   identifierInstructions?: string;
   /** Optional quality-audit retries for safeguard compaction summaries. */
   qualityGuard?: AgentCompactionQualityGuardConfig;
+  /**
+   * Send a notice to the active channel when auto-compaction starts.
+   * Helps users understand why the agent goes quiet for a moment.
+   * Default: true.
+   */
+  notify?: boolean;
   /** Pre-compaction memory flush (agentic turn). Default: enabled. */
   memoryFlush?: AgentCompactionMemoryFlushConfig;
   /**

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -630,6 +630,13 @@ export const dispatchTelegramMessage = async ({
       replyOptions: {
         skillFilter,
         disableBlockStreaming,
+        onCompactionBoundary: () =>
+          enqueueDraftLaneEvent(async () => {
+            // Auto-compaction is about to rewrite the context.  Finalize
+            // any in-flight preview message so it survives the cleanup
+            // phase, then force a new message for post-compaction content.
+            await rotateAnswerLaneForNewAssistantMessage();
+          }),
         onPartialReply:
           answerLane.stream || reasoningLane.stream
             ? (payload) =>


### PR DESCRIPTION
Users on messaging channels (Telegram, Discord, etc.) have no visibility
into why the agent goes quiet for 30–90 seconds during auto-compaction.
This adds a short notice ("⏳ Compacting context…") delivered **before**
the summarization LLM call begins, so users know what's happening.

## Changes
- Add `compaction.notify` boolean config option (default: `true`)
- Add `onCompactionNotice` callback to `GetReplyOptions`
- Fire notice in `agent-runner-execution.ts` on compaction `phase: start`
- Fire notice in `followup-runner.ts` on compaction `phase: start`
- Wire `onCompactionNotice` → dispatcher in `dispatch-from-config.ts`
- Add label, help text, and type docs for the new config key

The notice fires from `handleAutoCompactionStart` before the
summarization model call. Set `agents.defaults.compaction.notify: false`
to opt out.

Closes #2730