### PR TITLE
fix(telegram): coalesce DM streaming into single message in partial mode

### DIFF
--- a/extensions/telegram/src/bot-message-dispatch.ts
+++ b/extensions/telegram/src/bot-message-dispatch.ts
@@ -190,6 +190,8 @@ export const dispatchTelegramMessage = async ({
   const forceBlockStreamingForReasoning = resolvedReasoningLevel === "on";
   const streamReasoningDraft = resolvedReasoningLevel === "stream";
   const previewStreamingEnabled = streamMode !== "off";
+  const shouldSplitPreviewMessages = streamMode !== "partial";
+  const useDmMessageTransport = threadSpec?.scope === "dm";
   const canStreamAnswerDraft =
     previewStreamingEnabled && !accountBlockStreamingEnabled && !forceBlockStreamingForReasoning;
   const canStreamReasoningDraft = canStreamAnswerDraft || streamReasoningDraft;
@@ -199,11 +201,13 @@ export const dispatchTelegramMessage = async ({
   // Keep DM preview lanes on real message transport. Native draft previews still
   // require a draft->message materialize hop, and that overlap keeps reintroducing
   // a visible duplicate flash at finalize time.
-  const useMessagePreviewTransportForDm = threadSpec?.scope === "dm" && canStreamAnswerDraft;
   const mediaLocalRoots = getAgentScopedMediaLocalRoots(cfg, route.agentId);
   const archivedAnswerPreviews: ArchivedPreview[] = [];
   const archivedReasoningPreviewIds: number[] = [];
   const createDraftLane = (laneName: LaneName, enabled: boolean): DraftLaneState => {
+    const useMessagePreviewTransportForDm =
+      useDmMessageTransport ||
+      (laneName === "reasoning" && threadSpec?.scope === "dm" && canStreamAnswerDraft);
     const stream = enabled
       ? createTelegramDraftStream({
           api: bot.api,
@@ -348,10 +352,15 @@ export const dispatchTelegramMessage = async ({
     const split = splitTextIntoLaneSegments(text);
     const hasAnswerSegment = split.segments.some((segment) => segment.lane === "answer");
     if (hasAnswerSegment && activePreviewLifecycleByLane.answer !== "transient") {
-      // Some providers can emit the first partial of a new assistant message before
-      // onAssistantMessageStart() arrives. Rotate preemptively so we do not edit
-      // the previously finalized preview message with the next message's text.
-      skipNextAnswerMessageStartRotation = await rotateAnswerLaneForNewAssistantMessage();
+      if (shouldSplitPreviewMessages) {
+        // Some providers can emit the first partial of a new assistant message before
+        // onAssistantMessageStart() arrives. Rotate preemptively so we do not edit
+        // the previously finalized preview message with the next message's text.
+        skipNextAnswerMessageStartRotation = await rotateAnswerLaneForNewAssistantMessage();
+      } else {
+        // In partial (coalesced) mode, allow continued editing of the same message.
+        activePreviewLifecycleByLane.answer = "transient";
+      }
     }
     for (const segment of split.segments) {
       if (segment.lane === "reasoning") {
@@ -609,6 +618,10 @@ export const dispatchTelegramMessage = async ({
               infoKind: info.kind,
               previewButtons,
               allowPreviewUpdateForNonFinal: segment.lane === "reasoning",
+              // In partial mode, allow re-editing a finalized preview when the
+              // stream has been revived. This lets subsequent finals in a batch
+              // (from buffered block dispatcher) coalesce into the same message.
+              allowRefinalize: !shouldSplitPreviewMessages && segment.lane === "answer",
             });
             if (segment.lane === "reasoning") {
               if (result !== "skipped") {
@@ -623,6 +636,12 @@ export const dispatchTelegramMessage = async ({
                 retainPreviewOnCleanupByLane.reasoning = true;
               }
               reasoningStepState.resetForNextStep();
+              // In partial (coalesced) mode, keep the stream alive after
+              // finalization so the next tool-call turn can continue editing
+              // the same message. The finally block will stop it for good.
+              if (!shouldSplitPreviewMessages && result === "preview-finalized") {
+                answerLane.stream?.revive?.();
+              }
             }
           }
           if (segments.length > 0) {
@@ -700,9 +719,18 @@ export const dispatchTelegramMessage = async ({
               enqueueDraftLaneEvent(async () => {
                 reasoningStepState.resetForNextStep();
                 if (skipNextAnswerMessageStartRotation) {
+                  // Block-mode pre-rotation already handled this boundary — do not
+                  // reset lane state here as that would clear hasStreamedMessage
+                  // set by the partial that triggered the pre-rotation.
                   skipNextAnswerMessageStartRotation = false;
                   activePreviewLifecycleByLane.answer = "transient";
                   retainPreviewOnCleanupByLane.answer = false;
+                  return;
+                }
+                if (!shouldSplitPreviewMessages) {
+                  // In partial (coalesced) mode, reset lane tracking state but keep
+                  // the same stream message — allowing continued editing in place.
+                  resetDraftLaneState(answerLane);
                   return;
                 }
                 await rotateAnswerLaneForNewAssistantMessage();

--- a/extensions/telegram/src/draft-stream.test-helpers.ts
+++ b/extensions/telegram/src/draft-stream.test-helpers.ts
@@ -13,6 +13,7 @@ export type TestDraftStream = {
   stop: ReturnType<typeof vi.fn<() => Promise<void>>>;
   materialize: ReturnType<typeof vi.fn<() => Promise<number | undefined>>>;
   forceNewMessage: ReturnType<typeof vi.fn<() => void>>;
+  revive: ReturnType<typeof vi.fn<() => void>>;
   sendMayHaveLanded: ReturnType<typeof vi.fn<() => boolean>>;
   setMessageId: (value: number | undefined) => void;
 };
@@ -48,6 +49,7 @@ export function createTestDraftStream(params?: {
         messageId = undefined;
       }
     }),
+    revive: vi.fn(),
     sendMayHaveLanded: vi.fn().mockReturnValue(false),
     setMessageId: (value: number | undefined) => {
       messageId = value;
@@ -79,6 +81,7 @@ export function createSequencedTestDraftStream(startMessageId = 1001): TestDraft
     forceNewMessage: vi.fn().mockImplementation(() => {
       activeMessageId = undefined;
     }),
+    revive: vi.fn(),
     sendMayHaveLanded: vi.fn().mockReturnValue(false),
     setMessageId: (value: number | undefined) => {
       activeMessageId = value;

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -77,6 +77,8 @@ export type TelegramDraftStream = {
   materialize?: () => Promise<number | undefined>;
   /** Reset internal state so the next update creates a new message instead of editing. */
   forceNewMessage: () => void;
+  /** Re-open a stopped stream without clearing messageId or incrementing generation. */
+  revive?: () => void;
   /** True when a preview sendMessage was attempted but the response was lost. */
   sendMayHaveLanded?: () => boolean;
 };
@@ -366,6 +368,13 @@ export function createTelegramDraftStream(params: {
     warnPrefix: "telegram stream preview cleanup failed",
   });
 
+  const revive = () => {
+    // Re-open a stopped stream without clearing messageId or incrementing
+    // generation, so continued edits land on the same Telegram message.
+    streamState.stopped = false;
+    streamState.final = false;
+  };
+
   const forceNewMessage = () => {
     // Boundary rotation may call stop() to finalize the previous draft.
     // Re-open the stream lifecycle for the next assistant segment.
@@ -448,6 +457,7 @@ export function createTelegramDraftStream(params: {
     stop,
     materialize,
     forceNewMessage,
+    revive,
     sendMayHaveLanded: () => messageSendAttempted && typeof streamMessageId !== "number",
   };
 }

--- a/extensions/telegram/src/lane-delivery-text-deliverer.ts
+++ b/extensions/telegram/src/lane-delivery-text-deliverer.ts
@@ -91,6 +91,7 @@ type DeliverLaneTextParams = {
   infoKind: string;
   previewButtons?: TelegramInlineButtons;
   allowPreviewUpdateForNonFinal?: boolean;
+  allowRefinalize?: boolean;
 };
 
 type TryUpdatePreviewParams = {
@@ -457,6 +458,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
     infoKind,
     previewButtons,
     allowPreviewUpdateForNonFinal = false,
+    allowRefinalize = false,
   }: DeliverLaneTextParams): Promise<LaneDeliveryResult> => {
     const lane = params.lanes[laneName];
     const hasMedia = Boolean(payload.mediaUrl) || (payload.mediaUrls?.length ?? 0) > 0;
@@ -482,7 +484,7 @@ export function createLaneTextDeliverer(params: CreateLaneTextDelivererParams) {
           return archivedResult;
         }
       }
-      if (canEditViaPreview && params.activePreviewLifecycleByLane[laneName] === "transient") {
+      if (canEditViaPreview && (params.activePreviewLifecycleByLane[laneName] === "transient" || allowRefinalize)) {
         await params.flushDraftLane(lane);
         if (laneName === "answer") {
           const archivedResultAfterFlush = await consumeArchivedAnswerPreviewForFinal({

--- a/src/agents/sandbox/browser.ts
+++ b/src/agents/sandbox/browser.ts
@@ -87,6 +87,7 @@ function buildSandboxBrowserResolvedConfig(params: {
     attachOnly: true,
     defaultProfile: DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME,
     extraArgs: [],
+    gpuEnabled: false,
     profiles: {
       [DEFAULT_OPENCLAW_BROWSER_PROFILE_NAME]: {
         cdpPort: params.cdpPort,


### PR DESCRIPTION
## Summary

Rebased version of #33844 (closed as superseded by #34318, but #34318 only addressed the duplicate-send bug #33492, not the coalescing behavior).

When streaming mode is `partial`, responses with multiple tool-call round-trips now coalesce into a single progressively-edited Telegram message instead of sending separate message fragments. Aligns Telegram DM behavior with Discord's existing `shouldSplitPreviewMessages` pattern.

## What #34318 did NOT cover

PR #34318 materialized draft previews into permanent messages to prevent duplicate sends (#33492). This PR addresses the remaining issue (#32535): **inter-tool-call text blocks still leak as separate messages** in partial streaming mode.

### Changes in this PR (not covered by #34318):

1. **`draft-stream.ts` — `revive()` method**: Re-opens the stream lifecycle without clearing `messageId` or incrementing generation, allowing continued editing of the same message across tool-call boundaries.

2. **`bot-message-dispatch.ts` — partial mode coalescing**: Gates `rotateAnswerLane` behind `shouldSplitPreviewMessages` so that in partial mode, `onAssistantMessageStart` resets lane state without forcing a new message. Calls `revive()` after preview finalization to keep the stream alive. Passes `allowRefinalize` to lane delivery.

3. **`lane-delivery-text-deliverer.ts` — `allowRefinalize` parameter**: Bypasses the `finalizedPreviewByLane` guard in partial mode so subsequent finals can edit the same preview message.

## Testing
- Existing tests updated to explicitly use `streamMode: "block"` where rotation behavior is expected
- New test: `does not force new message in partial mode — coalesces across turns`
- Live-tested on Telegram DM: responses with 2-8 tool calls consistently coalesce into single message

Closes #32535

Co-authored-by: Claude <noreply@anthropic.com>