### PR TITLE
docs(telegram): document DM topic config and missing channel options

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,8 +345,8 @@ Details: [Security guide](https://docs.openclaw.ai/gateway/security) · [Docker 
 
 ### [Telegram](https://docs.openclaw.ai/channels/telegram)
 
-- Set `TELEGRAM_BOT_TOKEN` or `channels.telegram.botToken` (env wins).
-- Optional: set `channels.telegram.groups` (with `channels.telegram.groups."*".requireMention`); when set, it is a group allowlist (include `"*"` to allow all). Also `channels.telegram.allowFrom` or `channels.telegram.webhookUrl` + `channels.telegram.webhookSecret` as needed.
+- Set `channels.telegram.botToken` (or `channels.telegram.tokenFile`); `TELEGRAM_BOT_TOKEN` is only a fallback for the default account.
+- Optional: set `channels.telegram.groups` (with `channels.telegram.groups."*".requireMention`); when set, it is a group allowlist (include `"*"` to allow all). For DM overrides, use `channels.telegram.direct.<chatId>` (or `channels.telegram.direct."*"`); for DM topic overrides (`allowFrom`, `skills`, `systemPrompt`, `enabled`, `agentId`), use `channels.telegram.direct.<chatId>.topics.<threadId>` (or `channels.telegram.direct."*".topics.<threadId>`). Also `channels.telegram.allowFrom` or `channels.telegram.webhookUrl` + `channels.telegram.webhookSecret` as needed.
 
 ```json5
 {

--- a/docs/channels/index.md
+++ b/docs/channels/index.md
@@ -28,7 +28,7 @@ Text is supported everywhere; media and reactions vary by channel.
 - [Signal](/channels/signal) — signal-cli; privacy-focused.
 - [Synology Chat](/channels/synology-chat) — Synology NAS Chat via outgoing+incoming webhooks (plugin, installed separately).
 - [Slack](/channels/slack) — Bolt SDK; workspace apps.
-- [Telegram](/channels/telegram) — Bot API via grammY; supports groups.
+- [Telegram](/channels/telegram) — Bot API via grammY; supports groups plus forum/DM topics.
 - [Tlon](/channels/tlon) — Urbit-based messenger (plugin, installed separately).
 - [Twitch](/channels/twitch) — Twitch chat via IRC connection (plugin, installed separately).
 - [WebChat](/web/webchat) — Gateway WebChat UI over WebSocket.

--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -431,7 +431,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
   </Accordion>
 
-  <Accordion title="Forum topics and thread behavior">
+  <Accordion title="Forum topics, DM topics, and thread behavior">
     Forum supergroups:
 
     - topic session keys append `:topic:<threadId>`
@@ -444,7 +444,7 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     - message sends omit `message_thread_id` (Telegram rejects `sendMessage(...thread_id=1)`)
     - typing actions still include `message_thread_id`
 
-    Topic inheritance: topic entries inherit group settings unless overridden (`requireMention`, `allowFrom`, `skills`, `systemPrompt`, `enabled`, `groupPolicy`).
+    Topic inheritance: topic entries inherit group settings unless overridden (`requireMention`, `allowFrom`, `skills`, `systemPrompt`, `enabled`, `groupPolicy`, `disableAudioPreflight`).
     `agentId` is topic-only and does not inherit from group defaults.
 
     **Per-topic agent routing**: Each topic can route to a different agent by setting `agentId` in the topic config. This gives each topic its own isolated workspace, memory, and session. Example:
@@ -520,23 +520,35 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
     }
     ```
 
-    This is currently scoped to forum topics in groups and supergroups.
+    This top-level `bindings[]` path is currently scoped to forum topics in groups and supergroups.
 
     **Thread-bound ACP spawn from chat**:
 
-    - `/acp spawn <agent> --thread here|auto` can bind the current Telegram topic to a new ACP session.
-    - Follow-up topic messages route to the bound ACP session directly (no `/acp steer` required).
-    - OpenClaw pins the spawn confirmation message in-topic after a successful bind.
-    - Requires `channels.telegram.threadBindings.spawnAcpSessions=true`.
+    - `/acp spawn <agent> --thread here|auto` binds the current Telegram conversation when one is available:
+      - forum topics in groups/supergroups
+      - DM topics
+      - plain DMs
+    - Follow-up messages from that conversation route to the bound ACP session directly (no `/acp steer` required).
+    - OpenClaw pins the spawn confirmation only for topic conversations (`<chatId>:topic:<topicId>`), not for plain DM binds.
+    - Plain non-topic groups are not bindable with `--thread here|auto`.
+    - Enabled by default for Telegram; set `channels.telegram.threadBindings.spawnAcpSessions=false` to disable it.
+
+    DM topics (`chat.type="private"` with `message_thread_id`):
+
+    - per-DM config path: `channels.telegram.direct.<chatId>` (or `channels.telegram.direct."*"`)
+    - per-DM topic config path: `channels.telegram.direct.<chatId>.topics.<threadId>` (or `channels.telegram.direct."*".topics.<threadId>`)
+    - per-DM overrides: `dmPolicy`, `allowFrom`, `skills`, `systemPrompt`, `tools`, `toolsBySender`, `enabled`, `requireTopic`
+    - per-DM-topic overrides: `allowFrom`, `skills`, `systemPrompt`, `enabled`, `agentId`
+    - DM topic sessions keep DM routing and append a thread suffix (`:thread:<chatId>:<threadId>`) to the base session key
+
+    `requireTopic: true` blocks non-topic DM messages, callback queries, and native commands.
+    Telegram reaction updates do not carry DM `message_thread_id`, so reactions are blocked for that DM when `requireTopic: true` is enabled.
+    DM topic entries reuse the shared Telegram topic schema, so config validation also accepts `requireMention`, `groupPolicy`, and `disableAudioPreflight`; those keys are group/topic-only code paths and are currently ignored in private chats.
 
     Template context includes:
 
     - `MessageThreadId`
     - `IsForum`
-
-    DM thread behavior:
-
-    - private chats with `message_thread_id` keep DM routing but use thread-aware session keys/reply targets.
 
   </Accordion>
 
@@ -853,16 +865,26 @@ Primary reference:
 - `channels.telegram.groups`: per-group defaults + allowlist (use `"*"` for global defaults).
   - `channels.telegram.groups.<id>.groupPolicy`: per-group override for groupPolicy (`open | allowlist | disabled`).
   - `channels.telegram.groups.<id>.requireMention`: mention gating default.
+  - `channels.telegram.groups.<id>.tools` / `toolsBySender`: per-group tool policy overrides.
   - `channels.telegram.groups.<id>.skills`: skill filter (omit = all skills, empty = none).
   - `channels.telegram.groups.<id>.allowFrom`: per-group sender allowlist override.
   - `channels.telegram.groups.<id>.systemPrompt`: extra system prompt for the group.
   - `channels.telegram.groups.<id>.enabled`: disable the group when `false`.
-  - `channels.telegram.groups.<id>.topics.<threadId>.*`: per-topic overrides (group fields + topic-only `agentId`).
-  - `channels.telegram.groups.<id>.topics.<threadId>.agentId`: route this topic to a specific agent (overrides group-level and binding routing).
-  - `channels.telegram.groups.<id>.topics.<threadId>.groupPolicy`: per-topic override for groupPolicy (`open | allowlist | disabled`).
-  - `channels.telegram.groups.<id>.topics.<threadId>.requireMention`: per-topic mention gating override.
-  - top-level `bindings[]` with `type: "acp"` and canonical topic id `chatId:topic:topicId` in `match.peer.id`: persistent ACP topic binding fields (see [ACP Agents](/tools/acp-agents#channel-specific-settings)).
-  - `channels.telegram.direct.<id>.topics.<threadId>.agentId`: route DM topics to a specific agent (same behavior as forum topics).
+  - `channels.telegram.groups.<id>.disableAudioPreflight`: skip mention-detection audio preflight for this group.
+  - `channels.telegram.groups.<id>.topics.<threadId>.*`: per-topic overrides (`requireMention`, `groupPolicy`, `allowFrom`, `skills`, `systemPrompt`, `enabled`, `agentId`, `disableAudioPreflight`).
+  - `channels.telegram.groups.<id>.topics.<threadId>.agentId`: route this topic to a specific agent for normal Telegram routing. Configured ACP bindings and active conversation bindings still take precedence.
+  - `channels.telegram.groups.<id>.topics.<threadId>.disableAudioPreflight`: per-topic audio preflight override.
+- `channels.telegram.direct`: per-DM config map keyed by private chat ID (or `"*"`).
+  - `channels.telegram.direct.<id>.dmPolicy`: per-DM DM policy override.
+  - `channels.telegram.direct.<id>.tools` / `toolsBySender`: per-DM tool policy overrides.
+  - `channels.telegram.direct.<id>.skills`: per-DM skill filter (omit = all skills, empty = none).
+  - `channels.telegram.direct.<id>.allowFrom`: per-DM sender allowlist override.
+  - `channels.telegram.direct.<id>.systemPrompt`: extra system prompt for this DM.
+  - `channels.telegram.direct.<id>.enabled`: disable this DM route when `false`.
+  - `channels.telegram.direct.<id>.requireTopic`: require DM messages to come from a DM topic (`message_thread_id`).
+  - `channels.telegram.direct.<id>.topics.<threadId>.*`: per-DM-topic overrides (`allowFrom`, `skills`, `systemPrompt`, `enabled`, `agentId`). The shared topic schema also accepts `requireMention`, `groupPolicy`, and `disableAudioPreflight`, but private-chat handlers currently ignore those group-only keys.
+  - `channels.telegram.direct.<id>.topics.<threadId>.agentId`: route this DM topic to a specific agent for normal Telegram routing. Configured ACP bindings and active conversation bindings still take precedence.
+- top-level `bindings[]` with `type: "acp"` and canonical topic id `chatId:topic:topicId` in `match.peer.id`: persistent ACP topic binding fields (see [ACP Agents](/tools/acp-agents#channel-specific-settings)).
 - `channels.telegram.capabilities.inlineButtons`: `off | dm | group | all | allowlist` (default: allowlist).
 - `channels.telegram.accounts.<account>.capabilities.inlineButtons`: per-account override.
 - `channels.telegram.commands.nativeSkills`: enable/disable Telegram native skills commands.
@@ -870,8 +892,11 @@ Primary reference:
 - `channels.telegram.textChunkLimit`: outbound chunk size (chars).
 - `channels.telegram.chunkMode`: `length` (default) or `newline` to split on blank lines (paragraph boundaries) before length chunking.
 - `channels.telegram.linkPreview`: toggle link previews for outbound messages (default: true).
-- `channels.telegram.streaming`: `off | partial | block | progress` (live stream preview; default: `partial`; `progress` maps to `partial`; `block` is legacy preview mode compatibility). Telegram preview streaming uses a single preview message that is edited in place.
+- `channels.telegram.streaming`: `off | partial | block | progress` (live stream preview; default: `partial`; `progress` maps to `partial`; `block` is legacy preview mode compatibility). In DMs, OpenClaw uses native `sendMessageDraft` when available and falls back to `sendMessage`/`editMessageText`; in groups and topics, it sends a single preview message and edits it in place.
+- `channels.telegram.blockStreaming`: toggle block-streaming behavior for this account.
+- `channels.telegram.blockStreamingCoalesce`: merge streamed block replies before final send.
 - `channels.telegram.mediaMaxMb`: inbound/outbound Telegram media cap (MB, default: 100).
+- `channels.telegram.timeoutSeconds`: Telegram API client timeout in seconds.
 - `channels.telegram.retry`: retry policy for Telegram send helpers (CLI/tools/actions) on recoverable outbound API errors (attempts, minDelayMs, maxDelayMs, jitter).
 - `channels.telegram.network.autoSelectFamily`: override Node autoSelectFamily (true=enable, false=disable). Defaults to enabled on Node 22+, with WSL2 defaulting to disabled.
 - `channels.telegram.network.dnsResultOrder`: override DNS result order (`ipv4first` or `verbatim`). Defaults to `ipv4first` on Node 22+.
@@ -880,29 +905,39 @@ Primary reference:
 - `channels.telegram.webhookSecret`: webhook secret (required when webhookUrl is set).
 - `channels.telegram.webhookPath`: local webhook path (default `/telegram-webhook`).
 - `channels.telegram.webhookHost`: local webhook bind host (default `127.0.0.1`).
-- `channels.telegram.webhookPort`: local webhook bind port (default `8787`).
+- `channels.telegram.webhookPort`: local webhook bind port (default `8787`; set `0` for ephemeral).
+- `channels.telegram.webhookCertPath`: self-signed cert (PEM) upload path for webhook registration.
+- `channels.telegram.threadBindings`: Telegram conversation/thread binding controls.
+  - `channels.telegram.threadBindings.enabled`: enable Telegram conversation binding logic.
+  - `channels.telegram.threadBindings.idleHours` / `maxAgeHours`: idle/age expiry for bindings.
+  - `channels.telegram.threadBindings.spawnAcpSessions`: allow `/acp spawn ... --thread` bindings.
+  - `channels.telegram.threadBindings.spawnSubagentSessions`: reserved for adapter parity; built-in thread-bound `sessions_spawn({ thread: true })` support is not currently implemented for Telegram.
 - `channels.telegram.actions.reactions`: gate Telegram tool reactions.
 - `channels.telegram.actions.sendMessage`: gate Telegram tool message sends.
+- `channels.telegram.actions.poll`: gate Telegram poll creation (requires `sendMessage`).
 - `channels.telegram.actions.deleteMessage`: gate Telegram tool message deletes.
 - `channels.telegram.actions.sticker`: gate Telegram sticker actions — send and search (default: false).
 - `channels.telegram.reactionNotifications`: `off | own | all` — control which reactions trigger system events (default: `own` when not set).
 - `channels.telegram.reactionLevel`: `off | ack | minimal | extensive` — control agent's reaction capability (default: `minimal` when not set).
+- `channels.telegram.heartbeat`: per-channel heartbeat visibility override.
+- `channels.telegram.responsePrefix`: per-channel response-prefix override.
+- `channels.telegram.ackReaction`: per-channel ack reaction override.
 
 - [Configuration reference - Telegram](/gateway/configuration-reference#telegram)
 
 Telegram-specific high-signal fields:
 
-- startup/auth: `enabled`, `botToken`, `tokenFile`, `accounts.*`
-- access control: `dmPolicy`, `allowFrom`, `groupPolicy`, `groupAllowFrom`, `groups`, `groups.*.topics.*`, top-level `bindings[]` (`type: "acp"`)
+- startup/auth: `enabled`, `botToken`, `tokenFile`, `accounts.*`, `defaultAccount`
+- access control: `dmPolicy`, `allowFrom`, `groupPolicy`, `groupAllowFrom`, `groups`, `groups.*.topics.*`, `direct`, `direct.*.topics.*`, top-level `bindings[]` (`type: "acp"`)
 - command/menu: `commands.native`, `commands.nativeSkills`, `customCommands`
-- threading/replies: `replyToMode`
-- streaming: `streaming` (preview), `blockStreaming`
+- threading/replies: `replyToMode`, `threadBindings`
+- streaming: `streaming` (preview), `blockStreaming`, `blockStreamingCoalesce`
 - formatting/delivery: `textChunkLimit`, `chunkMode`, `linkPreview`, `responsePrefix`
-- media/network: `mediaMaxMb`, `timeoutSeconds`, `retry`, `network.autoSelectFamily`, `proxy`
-- webhook: `webhookUrl`, `webhookSecret`, `webhookPath`, `webhookHost`
-- actions/capabilities: `capabilities.inlineButtons`, `actions.sendMessage|editMessage|deleteMessage|reactions|sticker`
-- reactions: `reactionNotifications`, `reactionLevel`
-- writes/history: `configWrites`, `historyLimit`, `dmHistoryLimit`, `dms.*.historyLimit`
+- media/network: `mediaMaxMb`, `timeoutSeconds`, `retry`, `network.autoSelectFamily`, `network.dnsResultOrder`, `proxy`
+- webhook: `webhookUrl`, `webhookSecret`, `webhookPath`, `webhookHost`, `webhookPort`, `webhookCertPath`
+- actions/capabilities: `capabilities.inlineButtons`, `actions.sendMessage|editMessage|deleteMessage|reactions|poll|sticker`
+- reactions: `reactionNotifications`, `reactionLevel`, `ackReaction`
+- writes/history: `configWrites`, `historyLimit`, `dmHistoryLimit`, `dms.*.historyLimit`, `heartbeat`
 
 ## Related
 

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -158,17 +158,28 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
       enabled: true,
       botToken: "your-bot-token",
       dmPolicy: "pairing",
-      allowFrom: ["tg:123456789"],
+      allowFrom: [123456789],
       groups: {
         "*": { requireMention: true },
         "-1001234567890": {
-          allowFrom: ["@admin"],
+          allowFrom: [123456789],
           systemPrompt: "Keep answers brief.",
           topics: {
             "99": {
               requireMention: false,
               skills: ["search"],
               systemPrompt: "Stay on topic.",
+            },
+          },
+        },
+      },
+      direct: {
+        "123456789": {
+          requireTopic: true,
+          topics: {
+            "7": {
+              agentId: "support",
+              systemPrompt: "Support-only DM topic",
             },
           },
         },
@@ -180,8 +191,8 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
       historyLimit: 50,
       replyToMode: "first", // off | first | all
       linkPreview: true,
-      streaming: "partial", // off | partial | block | progress (default: off)
-      actions: { reactions: true, sendMessage: true },
+      streaming: "partial", // off | partial | block | progress (default: partial)
+      actions: { reactions: true, sendMessage: true, poll: true },
       reactionNotifications: "own", // off | own | all
       mediaMaxMb: 100,
       retry: {
@@ -198,6 +209,9 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
       webhookUrl: "https://example.com/telegram-webhook",
       webhookSecret: "secret",
       webhookPath: "/telegram-webhook",
+      webhookHost: "127.0.0.1",
+      webhookPort: 8787,
+      webhookCertPath: "/path/to/cert.pem",
     },
   },
 }
@@ -207,8 +221,11 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - Optional `channels.telegram.defaultAccount` overrides default account selection when it matches a configured account id.
 - In multi-account setups (2+ account ids), set an explicit default (`channels.telegram.defaultAccount` or `channels.telegram.accounts.default`) to avoid fallback routing; `openclaw doctor` warns when this is missing or invalid.
 - `configWrites: false` blocks Telegram-initiated config writes (supergroup ID migrations, `/config set|unset`).
+- `allowFrom` / `groupAllowFrom` should use numeric Telegram user IDs. Numeric strings are accepted, and `telegram:` / `tg:` prefixes are normalized. `@username` entries are not authorized at runtime.
+- `channels.telegram.direct.<chatId>` (or `direct."*"`) configures DM-specific overrides, including DM topic routing via `channels.telegram.direct.<chatId>.topics.<threadId>.agentId` and DM topic enforcement via `requireTopic`.
 - Top-level `bindings[]` entries with `type: "acp"` configure persistent ACP bindings for forum topics (use canonical `chatId:topic:topicId` in `match.peer.id`). Field semantics are shared in [ACP Agents](/tools/acp-agents#channel-specific-settings).
-- Telegram stream previews use `sendMessage` + `editMessageText` (works in direct and group chats).
+- Telegram stream previews: in DMs, OpenClaw uses native `sendMessageDraft` when available and falls back to `sendMessage`/`editMessageText` otherwise; in groups and topics, it sends a preview message and edits it in place.
+- Webhook TLS note: set `webhookCertPath` when registering a self-signed certificate.
 - Retry policy: see [Retry policy](/concepts/retry).
 
 ### Discord

--- a/docs/tools/acp-agents.md
+++ b/docs/tools/acp-agents.md
@@ -77,16 +77,19 @@ Required feature flags for thread-bound ACP:
 
 - `acp.enabled=true`
 - `acp.dispatch.enabled` is on by default (set `false` to pause ACP dispatch)
-- Channel-adapter ACP thread-spawn flag enabled (adapter-specific)
+- Channel-adapter ACP thread-spawn support enabled (adapter-specific)
   - Discord: `channels.discord.threadBindings.spawnAcpSessions=true`
-  - Telegram: `channels.telegram.threadBindings.spawnAcpSessions=true`
+  - Telegram: enabled by default; set `channels.telegram.threadBindings.spawnAcpSessions=false` to disable
 
 ### Thread supporting channels
 
 - Any channel adapter that exposes session/thread binding capability.
 - Current built-in support:
   - Discord threads/channels
-  - Telegram topics (forum topics in groups/supergroups and DM topics)
+  - Telegram current-conversation binds for `/acp spawn --thread here|auto`:
+    - forum topics in groups/supergroups
+    - DM topics
+    - plain DMs
 - Plugin channels can add support through the same binding interface.
 
 ## Channel specific settings
@@ -99,6 +102,7 @@ For non-ephemeral workflows, configure persistent ACP bindings in top-level `bin
 - `bindings[].match` identifies the target conversation:
   - Discord channel or thread: `match.channel="discord"` + `match.peer.id="<channelOrThreadId>"`
   - Telegram forum topic: `match.channel="telegram"` + `match.peer.id="<chatId>:topic:<topicId>"`
+    - Top-level persistent `bindings[]` currently support Telegram forum topics only (not plain DMs / DM topics).
 - `bindings[].agentId` is the owning OpenClaw agent id.
 - Optional ACP overrides live under `bindings[].acp`:
   - `mode` (`persistent` or `oneshot`)
@@ -308,7 +312,7 @@ Notes:
 - On non-thread binding surfaces, default behavior is effectively `off`.
 - Thread-bound spawn requires channel policy support:
   - Discord: `channels.discord.threadBindings.spawnAcpSessions=true`
-  - Telegram: `channels.telegram.threadBindings.spawnAcpSessions=true`
+  - Telegram: enabled by default; set `channels.telegram.threadBindings.spawnAcpSessions=false` to disable
 
 ## ACP controls
 


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: Several Telegram docs described behavior that does not match the current implementation, in particular PR https://github.com/openclaw/openclaw/pull/30579 didn't include any docs.
- Why it matters: These mismatches can cause users to configure Telegram incorrectly, not know that certain features exist or how to configure them, or assume features/precedence rules that do not actually exist at runtime.
- What changed: Updated Telegram-facing docs in `README.md`, `docs/channels/telegram.md`, `docs/gateway/configuration-reference.md`, `docs/tools/acp-agents.md`, and `docs/channels/index.md` to match the current implementation.
- What did NOT change (scope boundary): No runtime/behavior code changes; no non-Telegram doc corrections were intentionally kept in this branch.

This PR aligns the Telegram docs with the current implementation. In several
places, the previous docs described behavior that does not match what the code
currently does.

I’m not fully sure whether some of the previous wording was simply stale
documentation or whether it reflected intended behavior that was never
implemented. If the previous wording was actually the intended behavior, then
those cases would require implementation changes, not just doc changes.
 * Bot token precedence
   * Previous docs: said you can set TELEGRAM_BOT_TOKEN or
     channels.telegram.botToken, and implied the env var wins.
   * Current implementation: channels.telegram.botToken or
     channels.telegram.tokenFile takes precedence, and TELEGRAM_BOT_TOKEN is
     only a fallback for the default account.
 * ACP thread spawning default
   * Previous docs: implied Telegram ACP thread spawning is opt-in via
     channels.telegram.threadBindings.spawnAcpSessions=true.
   * Current implementation: Telegram ACP thread spawning is enabled by default
     unless explicitly disabled.
 * Telegram ACP --thread here|auto scope
   * Previous docs: described Telegram ACP thread binding too narrowly.
   * Current implementation: /acp spawn --thread here|auto binds the current
     Telegram conversation when available, including forum topics, DM topics,
     and plain DMs.
   * Additional current behavior: top-level persistent bindings[] remain
     forum-topic-only; pinning applies only to topic conversations; plain
     non-topic groups are not bindable with --thread here|auto.
 * Built-in thread-bound subagent spawning
   * Previous docs: implied
     channels.telegram.threadBindings.spawnSubagentSessions enables built-in
     Telegram support for thread-bound sessions_spawn({ thread: true }).
   * Current implementation: that built-in Telegram behavior is not currently
     implemented.
 * agentId precedence
   * Previous docs: overstated the precedence of topic / DM-topic agentId.
   * Current implementation: topic / DM-topic agentId affects normal Telegram
     routing, but configured ACP bindings and active conversation bindings still
     win.
 * Streaming behavior in Telegram DMs
   * Previous docs: described Telegram DM streaming as ordinary send/edit
     message behavior.
   * Current implementation: Telegram DMs use native draft streaming when
     available, and fall back to message edits otherwise.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [x] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [x] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes # N/A
- Related #30579

## User-visible / Behavior Changes

No runtime behavior changes in this PR.

Docs are now aligned with the current Telegram implementation, including:

- Telegram bot token precedence
- Telegram DM override / DM topic config paths
- Telegram ACP thread-binding behavior and defaults
- Telegram `agentId` precedence wording
- Telegram DM streaming behavior
- Telegram topic-level `disableAudioPreflight` inheritance/override behavior

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`) No
- Secrets/tokens handling changed? (`Yes/No`) No
- New/changed network calls? (`Yes/No`) No
- Command/tool execution surface changed? (`Yes/No`) No
- Data access scope changed? (`Yes/No`) No
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: Linux
- Runtime/container: local repo checkout
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): `channels.telegram.*`, `channels.telegram.direct.*`, `channels.telegram.threadBindings.*`

### Steps

1. Read the previous Telegram docs in `README.md`, `docs/channels/telegram.md`, `docs/gateway/configuration-reference.md`, and `docs/tools/acp-agents.md`.
2. Compare those claims against the current Telegram implementation in:
   - `src/telegram/token.ts`
   - `src/telegram/draft-stream.ts`
   - `src/telegram/bot.ts`
   - `src/telegram/conversation-route.ts`
   - `src/telegram/bot-message-context.body.ts`
   - `src/auto-reply/reply/commands-acp/lifecycle.ts`
   - `src/auto-reply/reply/commands-acp/context.ts`
   - `src/auto-reply/reply/telegram-context.ts`
   - `src/acp/persistent-bindings.resolve.ts`
3. Update the docs so the documented Telegram behavior matches the code.

### Expected

- Telegram docs accurately describe the current implementation.
- Telegram-only scope is preserved.
- No unrelated channel docs drift remains in the branch.

### Actual

- Previous docs had multiple Telegram mismatches, including:
  - `TELEGRAM_BOT_TOKEN` precedence described as env-first, while code uses configured `botToken` / `tokenFile` first and env only as fallback for the default account
  - Telegram ACP thread spawning described as opt-in, while code enables it by default unless disabled
  - `spawnSubagentSessions` described like an active Telegram capability, while built-in Telegram thread-bound subagent spawning is not currently implemented
  - Telegram DM streaming described as normal send/edit behavior, while code uses native drafts when available and falls back to edits
  - Telegram ACP `--thread here|auto` scope and `agentId` precedence were documented inaccurately
  - Telegram docs omitted or mis-described some Telegram-specific topic/DM routing semantics

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

Docs only, not relevant.

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - Confirmed Telegram bot token precedence in `src/telegram/token.ts`
  - Confirmed Telegram DM streaming behavior in `src/telegram/draft-stream.ts`
  - Confirmed Telegram DM / conversation routing semantics in `src/telegram/bot.ts` and `src/telegram/conversation-route.ts`
  - Confirmed ACP thread-binding behavior for Telegram in `src/auto-reply/reply/commands-acp/lifecycle.ts`, `src/auto-reply/reply/commands-acp/context.ts`, and `src/auto-reply/reply/telegram-context.ts`
  - Confirmed persistent binding scope in `src/acp/persistent-bindings.resolve.ts`
  - Confirmed topic-level behavior in `src/telegram/bot-message-context.body.ts`
- Edge cases checked:
  - DM topics vs forum topics vs plain DMs
  - Top-level persistent bindings vs active conversation bindings
  - `agentId` routing vs ACP binding precedence
  - Telegram-only scope of the docs branch
- What you did **not** verify:
  - Live Telegram runtime behavior against a real bot account in this PR
  - Any non-Telegram channel behavior beyond ensuring unrelated cross-channel drift was removed

## Compatibility / Migration

- Backward compatible? (`Yes/No`) Yes
- Config/env changes? (`Yes/No`) No
- Migration needed? (`Yes/No`) No
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: Revert the PR / restore previous docs content.
- Files/config to restore:
  - `README.md`
  - `docs/channels/index.md`
  - `docs/channels/telegram.md`
  - `docs/gateway/configuration-reference.md`
  - `docs/tools/acp-agents.md`
- Known bad symptoms reviewers should watch for:
  - Any remaining Telegram doc claims that contradict current code
  - Any non-Telegram wording drift in the branch
  - Cross-page inconsistency between `README`, Telegram channel docs, gateway config reference, and ACP docs

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk: A Telegram doc claim may still lag behind a less obvious implementation detail.
  - Mitigation: This PR was re-reviewed against the relevant Telegram code paths and targeted Telegram ACP / routing tests.
- Risk: Scope drift could accidentally include non-Telegram docs changes.
  - Mitigation: Final review explicitly checked for Telegram-only scope.
