### PR TITLE
fix(session): preserve modelOverride for subagent first-run sessions

### DIFF
--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1585,6 +1585,48 @@ describe("drainFormattedSystemEvents", () => {
   });
 });
 
+describe("initSessionState preserves modelOverride for subagent sessions (#40159)", () => {
+  it("preserves modelOverride when entry exists but resetTriggered is false", async () => {
+    // Subagent sessions: sessions.patch writes modelOverride to the store entry
+    // before the first run. The first message creates a new session (isNewSession=true)
+    // with resetTriggered=false. modelOverride must still be read from the entry.
+    const storePath = await createStorePath("openclaw-subagent-model-");
+    const sessionKey = "agent:main:subagent:sub-model-test";
+    await writeSessionStoreFast(storePath, {
+      [sessionKey]: {
+        sessionId: "pre-existing-subagent-session",
+        updatedAt: Date.now(),
+        modelOverride: "anthropic/claude-sonnet-4-6",
+        providerOverride: "anthropic",
+      },
+    });
+
+    const cfg = {
+      session: { store: storePath, idleMinutes: 999 },
+    } as OpenClawConfig;
+
+    const result = await initSessionState({
+      ctx: {
+        Body: "do some work",
+        RawBody: "do some work",
+        CommandBody: "do some work",
+        From: "parent-agent",
+        To: "bot",
+        ChatType: "direct",
+        SessionKey: sessionKey,
+        Provider: "internal",
+        Surface: "internal",
+      },
+      cfg,
+      commandAuthorized: true,
+    });
+
+    // Session is fresh and not reset-triggered, but model override must survive
+    expect(result.sessionEntry.modelOverride).toBe("anthropic/claude-sonnet-4-6");
+    expect(result.sessionEntry.providerOverride).toBe("anthropic");
+  });
+});
+
 describe("persistSessionUsageUpdate", () => {
   async function seedSessionStore(params: {
     storePath: string;

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -1586,16 +1586,17 @@ describe("drainFormattedSystemEvents", () => {
 });
 
 describe("initSessionState preserves modelOverride for subagent sessions (#40159)", () => {
-  it("preserves modelOverride when entry exists but resetTriggered is false", async () => {
+  it("preserves modelOverride when a stale entry triggers a non-reset new session", async () => {
     // Subagent sessions: sessions.patch writes modelOverride to the store entry
-    // before the first run. The first message creates a new session (isNewSession=true)
-    // with resetTriggered=false. modelOverride must still be read from the entry.
+    // before the first run. We must preserve it even when resetTriggered=false
+    // and the entry is stale (new-session path caused by freshness policy).
     const storePath = await createStorePath("openclaw-subagent-model-");
     const sessionKey = "agent:main:subagent:sub-model-test";
     await writeSessionStoreFast(storePath, {
       [sessionKey]: {
         sessionId: "pre-existing-subagent-session",
-        updatedAt: Date.now(),
+        // Force stale so initSessionState goes through the new-session branch.
+        updatedAt: 0,
         modelOverride: "anthropic/claude-sonnet-4-6",
         providerOverride: "anthropic",
       },
@@ -1621,7 +1622,8 @@ describe("initSessionState preserves modelOverride for subagent sessions (#40159
       commandAuthorized: true,
     });
 
-    // Session is fresh and not reset-triggered, but model override must survive
+    // Stale entry forces new session while resetTriggered stays false.
+    expect(result.sessionEntry.sessionId).not.toBe("pre-existing-subagent-session");
     expect(result.sessionEntry.modelOverride).toBe("anthropic/claude-sonnet-4-6");
     expect(result.sessionEntry.providerOverride).toBe("anthropic");
   });

--- a/src/auto-reply/reply/session.ts
+++ b/src/auto-reply/reply/session.ts
@@ -388,9 +388,16 @@ export async function initSessionState(params: {
       persistedVerbose = entry.verboseLevel;
       persistedReasoning = entry.reasoningLevel;
       persistedTtsAuto = entry.ttsAuto;
+      persistedLabel = entry.label;
+    }
+    // Model/provider overrides must be preserved for ALL new sessions with an
+    // existing entry, not just reset-triggered ones. Subagent sessions write
+    // modelOverride via sessions.patch before the first run, so the entry
+    // exists but resetTriggered is always false. Without this, the override
+    // is silently discarded and the subagent runs on the parent model. (#40159)
+    if (entry) {
       persistedModelOverride = entry.modelOverride;
       persistedProviderOverride = entry.providerOverride;
-      persistedLabel = entry.label;
     }
   }
 


### PR DESCRIPTION
## Summary

`initSessionState()` only preserved `modelOverride`/`providerOverride` from the session store entry when `resetTriggered` was true. For subagent sessions, `sessions.patch` writes the model override to the store entry *before* the first run, but that first message always has `resetTriggered=false`. The override was silently discarded and the subagent ran on the parent model.

This moves the `modelOverride`/`providerOverride` reads outside the `resetTriggered` guard so they are preserved for any new session that has an existing store entry — including subagent first-runs.

## What changed

- `src/auto-reply/reply/session.ts`: moved `persistedModelOverride = entry.modelOverride` and `persistedProviderOverride = entry.providerOverride` outside the `if (resetTriggered && entry)` block into a separate `if (entry)` block that runs unconditionally for new sessions.

## What did NOT change

The `resetTriggered` guard still preserves `thinkingLevel`, `verboseLevel`, `reasoningLevel`, `ttsAuto`, and `label` — those are user behavior preferences that should only carry over on explicit `/new` or `/reset`. Model/provider overrides are different: they are set programmatically by the spawn path and must survive the first run.

## Linked Issues

- Closes #40159
- Related #6295, #6671, #10883, #18451, #21705

## Validation

```
pnpm vitest run src/auto-reply/reply/session.test.ts  # 51/51 pass
pnpm build                                             # clean
```

## Tests

New regression test: "preserves modelOverride when entry exists but resetTriggered is false"
- Seeds a session store entry with `modelOverride: "anthropic/claude-sonnet-4-6"` and `providerOverride: "anthropic"` (simulating `sessions.patch`)
- Calls `initSessionState` with a non-reset message body
- Asserts both overrides survive in the returned session entry

## Impact

Every subagent spawn with a model override was silently running on the wrong (parent) model. For users configuring `subagents.model` or passing `model` to `sessions_spawn`, this caused unexpected cost (e.g. Opus billed instead of Sonnet) and incorrect behavior. `modelApplied: true` in the spawn response was misleading.
