### PR TITLE
fix: close memory managers on CLI exit to prevent FSWatcher hang

### DIFF
--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -135,6 +135,10 @@ export async function runCli(argv: string[] = process.argv) {
   }
 
   await program.parseAsync(parseArgv);
+
+  // Clean up memory managers on exit to prevent FSWatcher handles from keeping process alive
+  const { closeAllMemoryManagers } = await import("../memory/index.js");
+  await closeAllMemoryManagers();
 }
 
 export function isCliMainModule(): boolean {

--- a/src/memory/index.ts
+++ b/src/memory/index.ts
@@ -1,4 +1,4 @@
-export { MemoryIndexManager } from "./manager.js";
+export { MemoryIndexManager, closeAllMemoryManagers } from "./manager.js";
 export type {
   MemoryEmbeddingProbeResult,
   MemorySearchManager,

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -784,3 +784,10 @@ export class MemoryIndexManager extends MemoryManagerEmbeddingOps implements Mem
     INDEX_CACHE.delete(this.cacheKey);
   }
 }
+
+export async function closeAllMemoryManagers(): Promise<void> {
+  const managers = Array.from(INDEX_CACHE.values());
+  INDEX_CACHE.clear();
+  INDEX_CACHE_PENDING.clear();
+  await Promise.allSettled(managers.map((m) => m.close()));
+}


### PR DESCRIPTION
## Problem

Fixes #40365

One-shot CLI runs would hang after completion due to unclosed FSWatcher handles in cached MemoryIndexManager instances.

## Root Cause

- MemoryIndexManager uses chokidar to watch memory files
- Instances are cached globally in INDEX_CACHE
- FSWatcher keeps Node.js event loop alive
- CLI completes but process never exits

## Solution

1. Added closeAllMemoryManagers() to clean up all cached managers
2. Call cleanup at end of runCli() to ensure watchers are closed
3. Use Promise.allSettled to handle cleanup errors gracefully

## Testing

Tested with one-shot CLI commands - process now exits cleanly after completion.

## Impact

- CLI exits cleanly after completion
- No more false timeout failures in automation/CI
- Prevents orphaned processes
- Minimal code changes (12 lines added)
