### PR TITLE
fix(agent): mirror nested ACP output to child session transcript

### DIFF
--- a/src/agents/subagent-registry.persistence.test.ts
+++ b/src/agents/subagent-registry.persistence.test.ts
@@ -332,6 +332,35 @@ describe("subagent registry persistence", () => {
     expect(afterSecond.runs["run-3"].cleanupCompletedAt).toBeDefined();
   });
 
+  it("retries cleanup announce after announce flow rejects", async () => {
+    const persisted = createPersistedEndedRun({
+      runId: "run-reject",
+      childSessionKey: "agent:main:subagent:reject",
+      task: "reject announce",
+      cleanup: "keep",
+    });
+    const registryPath = await writePersistedRegistry(persisted);
+
+    announceSpy.mockRejectedValueOnce(new Error("announce boom"));
+    await restartRegistryAndFlush();
+
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    const afterFirst = JSON.parse(await fs.readFile(registryPath, "utf8")) as {
+      runs: Record<string, { cleanupHandled?: boolean; cleanupCompletedAt?: number }>;
+    };
+    expect(afterFirst.runs["run-reject"].cleanupHandled).toBe(false);
+    expect(afterFirst.runs["run-reject"].cleanupCompletedAt).toBeUndefined();
+
+    announceSpy.mockResolvedValueOnce(true);
+    await restartRegistryAndFlush();
+
+    expect(announceSpy).toHaveBeenCalledTimes(2);
+    const afterSecond = JSON.parse(await fs.readFile(registryPath, "utf8")) as {
+      runs: Record<string, { cleanupCompletedAt?: number }>;
+    };
+    expect(afterSecond.runs["run-reject"].cleanupCompletedAt).toBeDefined();
+  });
+
   it("keeps delete-mode runs retryable when announce is deferred", async () => {
     const persisted = createPersistedEndedRun({
       runId: "run-4",

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -382,6 +382,18 @@ function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecor
     return false;
   }
   const requesterOrigin = normalizeDeliveryContext(entry.requesterOrigin);
+  const finalizeAnnounceCleanup = (didAnnounce: boolean) => {
+    void finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce).catch((err) => {
+      defaultRuntime.log(`[warn] subagent cleanup finalize failed (${runId}): ${String(err)}`);
+      const current = subagentRuns.get(runId);
+      if (!current || current.cleanupCompletedAt) {
+        return;
+      }
+      current.cleanupHandled = false;
+      persistSubagentRuns();
+    });
+  };
+
   void runSubagentAnnounceFlow({
     childSessionKey: entry.childSessionKey,
     childRunId: entry.runId,
@@ -400,13 +412,13 @@ function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecor
     expectsCompletionMessage: entry.expectsCompletionMessage,
   })
     .then((didAnnounce) => {
-      void finalizeSubagentCleanup(runId, entry.cleanup, didAnnounce);
+      finalizeAnnounceCleanup(didAnnounce);
     })
     .catch((error) => {
       defaultRuntime.log(
         `[warn] Subagent announce flow failed during cleanup for run ${runId}: ${String(error)}`,
       );
-      void finalizeSubagentCleanup(runId, entry.cleanup, false);
+      finalizeAnnounceCleanup(false);
     });
   return true;
 }

--- a/src/agents/subagent-registry.ts
+++ b/src/agents/subagent-registry.ts
@@ -390,6 +390,7 @@ function startSubagentAnnounceCleanupFlow(runId: string, entry: SubagentRunRecor
         return;
       }
       current.cleanupHandled = false;
+      resumedRuns.delete(runId);
       persistSubagentRuns();
     });
   };

--- a/src/commands/agent/delivery.test.ts
+++ b/src/commands/agent/delivery.test.ts
@@ -179,7 +179,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
     expect(mockAppendTranscript).toHaveBeenCalledOnce();
     expect(mockAppendTranscript).toHaveBeenCalledWith({
       sessionKey: "session-media",
-      text: "pic\n\nAttached media: https://example.com/img.png",
+      text: "pic\n\nAttached media: img.png",
       mediaUrls: undefined,
       agentId: undefined,
     });
@@ -223,10 +223,64 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
     expect(mockAppendTranscript).toHaveBeenCalledOnce();
     expect(mockAppendTranscript).toHaveBeenCalledWith({
       sessionKey: "session-text-media",
-      text: "Here is the chart summary\n\nAttached media: https://example.com/chart.png, https://example.com/report.pdf",
+      text: "Here is the chart summary\n\nAttached media: chart.png, report.pdf",
       mediaUrls: undefined,
       agentId: undefined,
     });
+  });
+
+  it("does not persist querystring media tokens in mirrored transcript text", async () => {
+    mockAppendTranscript.mockClear();
+    mockAppendTranscript.mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
+    const runtime = makeRuntime();
+
+    await deliverAgentCommandResult({
+      cfg: makeCfg(),
+      deps: makeDeps(),
+      runtime,
+      opts: {
+        message: "test",
+        deliver: false,
+        lane: AGENT_LANE_NESTED,
+        sessionKey: "session-tokenized-media",
+        inputProvenance: { kind: "inter_session" },
+      },
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      result: {
+        payloads: [
+          {
+            text: "Shared files",
+            mediaUrls: [
+              "https://cdn.example.com/files/chart.png?token=secret&expires=9999",
+              "https://cdn.example.com/files/report.pdf?X-Amz-Signature=topsecret",
+            ],
+          },
+        ],
+        meta: {} as never,
+      },
+      payloads: [
+        {
+          text: "Shared files",
+          mediaUrls: [
+            "https://cdn.example.com/files/chart.png?token=secret&expires=9999",
+            "https://cdn.example.com/files/report.pdf?X-Amz-Signature=topsecret",
+          ],
+        },
+      ],
+    });
+
+    expect(mockAppendTranscript).toHaveBeenCalledOnce();
+    const appendCall = mockAppendTranscript.mock.calls[0]?.[0];
+    expect(appendCall).toMatchObject({
+      sessionKey: "session-tokenized-media",
+      text: "Shared files\n\nAttached media: chart.png, report.pdf",
+      mediaUrls: undefined,
+      agentId: undefined,
+    });
+    expect(appendCall?.text).not.toContain("token=");
+    expect(appendCall?.text).not.toContain("X-Amz-Signature=");
+    expect(appendCall?.text).not.toContain("https://");
   });
 
   it("caps mirrored text and media urls before appending transcript", async () => {
@@ -264,6 +318,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
       sessionKey: "session-capped",
       text: `${"x".repeat(MAX_NESTED_TRANSCRIPT_TEXT_CHARS - "\n\n[truncated]".length)}\n\n[truncated]\n\nAttached media: ${mediaUrls
         .slice(0, MAX_NESTED_TRANSCRIPT_MEDIA_URLS)
+        .map((url) => url.split("/").pop())
         .join(", ")}`,
       mediaUrls: undefined,
     });

--- a/src/commands/agent/delivery.test.ts
+++ b/src/commands/agent/delivery.test.ts
@@ -72,6 +72,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
         deliver: false,
         lane: AGENT_LANE_NESTED,
         sessionKey: "child-session-abc",
+        inputProvenance: { kind: "inter_session" },
       },
       outboundSession: undefined,
       sessionEntry: undefined,
@@ -84,6 +85,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
       sessionKey: "child-session-abc",
       text: "Hello from agent",
       mediaUrls: undefined,
+      agentId: undefined,
     });
   });
 
@@ -102,6 +104,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
           deliver: true,
           lane: AGENT_LANE_NESTED,
           sessionKey: "child-session-abc",
+          inputProvenance: { kind: "inter_session" },
         },
         outboundSession: undefined,
         sessionEntry: undefined,
@@ -151,6 +154,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
         deliver: false,
         lane: AGENT_LANE_NESTED,
         sessionKey: "session-media",
+        inputProvenance: { kind: "inter_session" },
       },
       outboundSession: undefined,
       sessionEntry: undefined,
@@ -166,6 +170,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
       sessionKey: "session-media",
       text: "pic",
       mediaUrls: ["https://example.com/img.png"],
+      agentId: undefined,
     });
   });
 
@@ -187,6 +192,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
         deliver: false,
         lane: AGENT_LANE_NESTED,
         sessionKey: "session-capped",
+        inputProvenance: { kind: "inter_session" },
       },
       outboundSession: undefined,
       sessionEntry: undefined,
@@ -206,6 +212,142 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
     });
   });
 
+  it("resolves mirror agentId from outbound session context before opts.agentId", async () => {
+    mockAppendTranscript.mockClear();
+    mockAppendTranscript.mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
+    const runtime = makeRuntime();
+
+    await deliverAgentCommandResult({
+      cfg: makeCfg(),
+      deps: makeDeps(),
+      runtime,
+      opts: {
+        message: "test",
+        agentId: "wrong-fallback",
+        deliver: false,
+        lane: AGENT_LANE_NESTED,
+        sessionKey: "agent:main:child-session",
+        inputProvenance: { kind: "inter_session" },
+      },
+      outboundSession: {
+        key: "agent:ops:child-session",
+        agentId: "ops",
+      },
+      sessionEntry: undefined,
+      result: { payloads: [{ text: "agent reply", mediaUrls: [] }], meta: {} as never },
+      payloads: [{ text: "agent reply", mediaUrls: [] }],
+    });
+
+    expect(mockAppendTranscript).toHaveBeenCalledWith({
+      agentId: "ops",
+      sessionKey: "agent:ops:child-session",
+      text: "agent reply",
+      mediaUrls: undefined,
+    });
+  });
+
+  it("resolves mirror agentId from session key when outbound session agentId is missing", async () => {
+    mockAppendTranscript.mockClear();
+    mockAppendTranscript.mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
+    const runtime = makeRuntime();
+
+    await deliverAgentCommandResult({
+      cfg: makeCfg(),
+      deps: makeDeps(),
+      runtime,
+      opts: {
+        message: "test",
+        deliver: false,
+        lane: AGENT_LANE_NESTED,
+        sessionKey: "agent:research:thread:123",
+        inputProvenance: { kind: "inter_session" },
+      },
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      result: { payloads: [{ text: "agent reply", mediaUrls: [] }], meta: {} as never },
+      payloads: [{ text: "agent reply", mediaUrls: [] }],
+    });
+
+    expect(mockAppendTranscript).toHaveBeenCalledWith({
+      agentId: "research",
+      sessionKey: "agent:research:thread:123",
+      text: "agent reply",
+      mediaUrls: undefined,
+    });
+  });
+
+  it("skips nested transcript mirror when provenance is missing or not inter_session", async () => {
+    mockAppendTranscript.mockClear();
+    const runtimeMissing = makeRuntime();
+    const runtimeWrong = makeRuntime();
+
+    await deliverAgentCommandResult({
+      cfg: makeCfg(),
+      deps: makeDeps(),
+      runtime: runtimeMissing,
+      opts: {
+        message: "test",
+        deliver: false,
+        lane: AGENT_LANE_NESTED,
+        sessionKey: "child-session-abc",
+      },
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      result: { payloads: [{ text: "blocked", mediaUrls: [] }], meta: {} as never },
+      payloads: [{ text: "blocked", mediaUrls: [] }],
+    });
+
+    await deliverAgentCommandResult({
+      cfg: makeCfg(),
+      deps: makeDeps(),
+      runtime: runtimeWrong,
+      opts: {
+        message: "test",
+        deliver: false,
+        lane: AGENT_LANE_NESTED,
+        sessionKey: "child-session-abc",
+        inputProvenance: { kind: "external_user" },
+      },
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      result: { payloads: [{ text: "blocked", mediaUrls: [] }], meta: {} as never },
+      payloads: [{ text: "blocked", mediaUrls: [] }],
+    });
+
+    expect(mockAppendTranscript).not.toHaveBeenCalled();
+    expect(runtimeMissing.log).toHaveBeenCalledWith(
+      expect.stringContaining("transcript mirror skipped (unauthorized nested mirror)"),
+    );
+    expect(runtimeWrong.log).toHaveBeenCalledWith(
+      expect.stringContaining("transcript mirror skipped (unauthorized nested mirror)"),
+    );
+  });
+
+  it("mirrors nested transcript when provenance is inter_session", async () => {
+    mockAppendTranscript.mockClear();
+    mockAppendTranscript.mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
+    const runtime = makeRuntime();
+
+    await deliverAgentCommandResult({
+      cfg: makeCfg(),
+      deps: makeDeps(),
+      runtime,
+      opts: {
+        message: "test",
+        deliver: false,
+        lane: AGENT_LANE_NESTED,
+        sessionKey: "child-session-abc",
+        inputProvenance: { kind: "inter_session" },
+      },
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      result: { payloads: [{ text: "allowed", mediaUrls: [] }], meta: {} as never },
+      payloads: [{ text: "allowed", mediaUrls: [] }],
+    });
+
+    expect(mockAppendTranscript).toHaveBeenCalledOnce();
+  });
+
   it("does not abort nested run when transcript append rejects", async () => {
     mockAppendTranscript.mockClear();
     mockAppendTranscript.mockRejectedValue(new Error("sensitive transcript path leaked"));
@@ -221,6 +363,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
           deliver: false,
           lane: AGENT_LANE_NESTED,
           sessionKey: "child-session-abc",
+          inputProvenance: { kind: "inter_session" },
         },
         outboundSession: undefined,
         sessionEntry: undefined,
@@ -257,6 +400,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
         json: true,
         lane: AGENT_LANE_NESTED,
         sessionKey: "json-session",
+        inputProvenance: { kind: "inter_session" },
       },
       outboundSession: undefined,
       sessionEntry: undefined,
@@ -274,7 +418,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
     expect(runtime.log).toHaveBeenCalledTimes(1);
   });
 
-  it("passes agentId to transcript append for non-default agent stores", async () => {
+  it("falls back to opts.agentId when no session context is available", async () => {
     mockAppendTranscript.mockClear();
     mockAppendTranscript.mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
     const runtime = makeRuntime();
@@ -289,6 +433,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
         deliver: false,
         lane: AGENT_LANE_NESTED,
         sessionKey: "agent-session",
+        inputProvenance: { kind: "inter_session" },
       },
       outboundSession: undefined,
       sessionEntry: undefined,
@@ -322,6 +467,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
           deliver: false,
           lane: AGENT_LANE_NESTED,
           sessionKey: "child-session-abc",
+          inputProvenance: { kind: "inter_session" },
         },
         outboundSession: undefined,
         sessionEntry: undefined,

--- a/src/commands/agent/delivery.test.ts
+++ b/src/commands/agent/delivery.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it, vi } from "vitest";
+import { AGENT_LANE_NESTED } from "../../agents/lanes.js";
+
+const mockAppendTranscript = vi
+  .fn()
+  .mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
+vi.mock("../../config/sessions.js", async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    appendAssistantMessageToSessionTranscript: (...args: unknown[]) =>
+      mockAppendTranscript(...args),
+  };
+});
+
+// Stub outbound delivery infra so we don't need real config/plugins.
+vi.mock("../../infra/outbound/agent-delivery.js", () => ({
+  resolveAgentDeliveryPlan: () => ({
+    resolvedChannel: "internal",
+    resolvedTo: null,
+    resolvedAccountId: null,
+    resolvedThreadId: null,
+    deliveryTargetMode: undefined,
+  }),
+  resolveAgentOutboundTarget: () => ({
+    resolvedTarget: null,
+    resolvedTo: null,
+    targetMode: "implicit",
+  }),
+}));
+vi.mock("../../infra/outbound/channel-selection.js", () => ({
+  resolveMessageChannelSelection: vi.fn(),
+}));
+vi.mock("../../infra/outbound/deliver.js", () => ({
+  deliverOutboundPayloads: vi.fn(),
+}));
+vi.mock("../../channels/plugins/index.js", () => ({
+  getChannelPlugin: () => undefined,
+  normalizeChannelId: (id: string) => id,
+}));
+
+import { deliverAgentCommandResult } from "./delivery.js";
+
+function makeRuntime() {
+  return {
+    log: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function makeDeps() {
+  return {} as Parameters<typeof deliverAgentCommandResult>[0]["deps"];
+}
+
+function makeCfg() {
+  return {} as Parameters<typeof deliverAgentCommandResult>[0]["cfg"];
+}
+
+describe("deliverAgentCommandResult – transcript mirror", () => {
+  it("writes to child session transcript when deliver=false and lane=nested", async () => {
+    mockAppendTranscript.mockClear();
+    const runtime = makeRuntime();
+    await deliverAgentCommandResult({
+      cfg: makeCfg(),
+      deps: makeDeps(),
+      runtime,
+      opts: {
+        message: "test",
+        deliver: false,
+        lane: AGENT_LANE_NESTED,
+        sessionKey: "child-session-abc",
+      },
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      result: { payloads: [{ text: "Hello from agent", mediaUrls: [] }], meta: {} as never },
+      payloads: [{ text: "Hello from agent", mediaUrls: [] }],
+    });
+
+    expect(mockAppendTranscript).toHaveBeenCalledOnce();
+    expect(mockAppendTranscript).toHaveBeenCalledWith({
+      sessionKey: "child-session-abc",
+      text: "Hello from agent",
+      mediaUrls: undefined,
+    });
+  });
+
+  it("does NOT call appendAssistantMessageToSessionTranscript when deliver=true", async () => {
+    mockAppendTranscript.mockClear();
+    const runtime = makeRuntime();
+    // deliver=true but with internal channel → will throw; wrap to catch.
+    try {
+      await deliverAgentCommandResult({
+        cfg: makeCfg(),
+        deps: makeDeps(),
+        runtime,
+        opts: {
+          message: "test",
+          deliver: true,
+          lane: AGENT_LANE_NESTED,
+          sessionKey: "child-session-abc",
+        },
+        outboundSession: undefined,
+        sessionEntry: undefined,
+        result: { payloads: [{ text: "response", mediaUrls: [] }], meta: {} as never },
+        payloads: [{ text: "response", mediaUrls: [] }],
+      });
+    } catch {
+      // expected – delivery channel is required error
+    }
+
+    expect(mockAppendTranscript).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call appendAssistantMessageToSessionTranscript when lane is not nested", async () => {
+    mockAppendTranscript.mockClear();
+    const runtime = makeRuntime();
+    await deliverAgentCommandResult({
+      cfg: makeCfg(),
+      deps: makeDeps(),
+      runtime,
+      opts: {
+        message: "test",
+        deliver: false,
+        lane: undefined,
+        sessionKey: "child-session-abc",
+      },
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      result: { payloads: [{ text: "response", mediaUrls: [] }], meta: {} as never },
+      payloads: [{ text: "response", mediaUrls: [] }],
+    });
+
+    expect(mockAppendTranscript).not.toHaveBeenCalled();
+  });
+
+  it("includes mediaUrls when present", async () => {
+    mockAppendTranscript.mockClear();
+    const runtime = makeRuntime();
+    await deliverAgentCommandResult({
+      cfg: makeCfg(),
+      deps: makeDeps(),
+      runtime,
+      opts: {
+        message: "test",
+        deliver: false,
+        lane: AGENT_LANE_NESTED,
+        sessionKey: "session-media",
+      },
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      result: {
+        payloads: [{ text: "pic", mediaUrls: ["https://example.com/img.png"] }],
+        meta: {} as never,
+      },
+      payloads: [{ text: "pic", mediaUrls: ["https://example.com/img.png"] }],
+    });
+
+    expect(mockAppendTranscript).toHaveBeenCalledOnce();
+    expect(mockAppendTranscript).toHaveBeenCalledWith({
+      sessionKey: "session-media",
+      text: "pic",
+      mediaUrls: ["https://example.com/img.png"],
+    });
+  });
+});

--- a/src/commands/agent/delivery.test.ts
+++ b/src/commands/agent/delivery.test.ts
@@ -369,6 +369,43 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
     );
   });
 
+  it("keeps unauthorized nested mirror warnings off json stdout", async () => {
+    mockAppendTranscript.mockClear();
+    const runtime = makeRuntime();
+
+    await expect(
+      deliverAgentCommandResult({
+        cfg: makeCfg(),
+        deps: makeDeps(),
+        runtime,
+        opts: {
+          message: "test",
+          deliver: false,
+          json: true,
+          lane: AGENT_LANE_NESTED,
+          sessionKey: "child-session-abc",
+        },
+        outboundSession: undefined,
+        sessionEntry: undefined,
+        result: { payloads: [{ text: "blocked", mediaUrls: [] }], meta: {} as never },
+        payloads: [{ text: "blocked", mediaUrls: [] }],
+      }),
+    ).resolves.toEqual({
+      payloads: [{ text: "blocked", mediaUrl: null, mediaUrls: undefined, channelData: undefined }],
+      meta: {},
+    });
+
+    expect(mockAppendTranscript).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("transcript mirror skipped (unauthorized nested mirror)"),
+    );
+    expect(runtime.log).toHaveBeenCalledTimes(1);
+    expect(runtime.log).not.toHaveBeenCalledWith(
+      expect.stringContaining("transcript mirror skipped (unauthorized nested mirror)"),
+    );
+    expect(runtime.log.mock.calls[0]?.[0]).toContain('"text": "blocked"');
+  });
+
   it("mirrors nested transcript when provenance is inter_session", async () => {
     mockAppendTranscript.mockClear();
     mockAppendTranscript.mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
@@ -531,5 +568,48 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
       expect.stringContaining("transcript mirror skipped (transcript unavailable)"),
     );
     expect(runtime.error).not.toHaveBeenCalledWith(expect.stringContaining("super-secret-session"));
+  });
+
+  it("keeps transcript append failures off json stdout", async () => {
+    mockAppendTranscript.mockClear();
+    mockAppendTranscript.mockResolvedValue({
+      ok: false,
+      reason: "unknown sessionKey: super-secret-session",
+    });
+    const runtime = makeRuntime();
+
+    await expect(
+      deliverAgentCommandResult({
+        cfg: makeCfg(),
+        deps: makeDeps(),
+        runtime,
+        opts: {
+          message: "test",
+          deliver: false,
+          json: true,
+          lane: AGENT_LANE_NESTED,
+          sessionKey: "child-session-abc",
+          inputProvenance: { kind: "inter_session" },
+        },
+        outboundSession: undefined,
+        sessionEntry: undefined,
+        result: { payloads: [{ text: "Hello from agent", mediaUrls: [] }], meta: {} as never },
+        payloads: [{ text: "Hello from agent", mediaUrls: [] }],
+      }),
+    ).resolves.toEqual({
+      payloads: [
+        { text: "Hello from agent", mediaUrl: null, mediaUrls: undefined, channelData: undefined },
+      ],
+      meta: {},
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("transcript mirror skipped (transcript unavailable)"),
+    );
+    expect(runtime.log).toHaveBeenCalledTimes(1);
+    expect(runtime.log).not.toHaveBeenCalledWith(
+      expect.stringContaining("transcript mirror skipped (transcript unavailable)"),
+    );
+    expect(runtime.log.mock.calls[0]?.[0]).toContain('"text": "Hello from agent"');
   });
 });

--- a/src/commands/agent/delivery.test.ts
+++ b/src/commands/agent/delivery.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import { AGENT_LANE_NESTED } from "../../agents/lanes.js";
 
+const MAX_NESTED_TRANSCRIPT_TEXT_CHARS = 8_000;
+const MAX_NESTED_TRANSCRIPT_MEDIA_URLS = 16;
 const mockAppendTranscript = vi
   .fn()
   .mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
@@ -59,6 +61,7 @@ function makeCfg() {
 describe("deliverAgentCommandResult – transcript mirror", () => {
   it("writes to child session transcript when deliver=false and lane=nested", async () => {
     mockAppendTranscript.mockClear();
+    mockAppendTranscript.mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
     const runtime = makeRuntime();
     await deliverAgentCommandResult({
       cfg: makeCfg(),
@@ -86,6 +89,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
 
   it("does NOT call appendAssistantMessageToSessionTranscript when deliver=true", async () => {
     mockAppendTranscript.mockClear();
+    mockAppendTranscript.mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
     const runtime = makeRuntime();
     // deliver=true but with internal channel → will throw; wrap to catch.
     try {
@@ -113,6 +117,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
 
   it("does NOT call appendAssistantMessageToSessionTranscript when lane is not nested", async () => {
     mockAppendTranscript.mockClear();
+    mockAppendTranscript.mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
     const runtime = makeRuntime();
     await deliverAgentCommandResult({
       cfg: makeCfg(),
@@ -135,6 +140,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
 
   it("includes mediaUrls when present", async () => {
     mockAppendTranscript.mockClear();
+    mockAppendTranscript.mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
     const runtime = makeRuntime();
     await deliverAgentCommandResult({
       cfg: makeCfg(),
@@ -161,5 +167,177 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
       text: "pic",
       mediaUrls: ["https://example.com/img.png"],
     });
+  });
+
+  it("caps mirrored text and media urls before appending transcript", async () => {
+    mockAppendTranscript.mockClear();
+    mockAppendTranscript.mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
+    const runtime = makeRuntime();
+    const oversizedText = "x".repeat(MAX_NESTED_TRANSCRIPT_TEXT_CHARS + 50);
+    const mediaUrls = Array.from({ length: MAX_NESTED_TRANSCRIPT_MEDIA_URLS + 5 }, (_, index) => {
+      return `https://example.com/media-${index}.png`;
+    });
+
+    await deliverAgentCommandResult({
+      cfg: makeCfg(),
+      deps: makeDeps(),
+      runtime,
+      opts: {
+        message: "test",
+        deliver: false,
+        lane: AGENT_LANE_NESTED,
+        sessionKey: "session-capped",
+      },
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      result: {
+        payloads: [{ text: oversizedText, mediaUrls }],
+        meta: {} as never,
+      },
+      payloads: [{ text: oversizedText, mediaUrls }],
+    });
+
+    expect(mockAppendTranscript).toHaveBeenCalledOnce();
+    expect(mockAppendTranscript).toHaveBeenCalledWith({
+      agentId: undefined,
+      sessionKey: "session-capped",
+      text: `${"x".repeat(MAX_NESTED_TRANSCRIPT_TEXT_CHARS - "\n\n[truncated]".length)}\n\n[truncated]`,
+      mediaUrls: mediaUrls.slice(0, MAX_NESTED_TRANSCRIPT_MEDIA_URLS),
+    });
+  });
+
+  it("does not abort nested run when transcript append rejects", async () => {
+    mockAppendTranscript.mockClear();
+    mockAppendTranscript.mockRejectedValue(new Error("sensitive transcript path leaked"));
+    const runtime = makeRuntime();
+
+    await expect(
+      deliverAgentCommandResult({
+        cfg: makeCfg(),
+        deps: makeDeps(),
+        runtime,
+        opts: {
+          message: "test",
+          deliver: false,
+          lane: AGENT_LANE_NESTED,
+          sessionKey: "child-session-abc",
+        },
+        outboundSession: undefined,
+        sessionEntry: undefined,
+        result: { payloads: [{ text: "Hello from agent", mediaUrls: [] }], meta: {} as never },
+        payloads: [{ text: "Hello from agent", mediaUrls: [] }],
+      }),
+    ).resolves.toEqual({
+      payloads: [
+        { text: "Hello from agent", mediaUrl: null, mediaUrls: undefined, channelData: undefined },
+      ],
+      meta: {},
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("transcript mirror skipped (unexpected transcript error)"),
+    );
+    expect(runtime.error).not.toHaveBeenCalledWith(
+      expect.stringContaining("sensitive transcript path leaked"),
+    );
+  });
+
+  it("mirrors nested transcript before json-mode early return", async () => {
+    mockAppendTranscript.mockClear();
+    mockAppendTranscript.mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
+    const runtime = makeRuntime();
+
+    await deliverAgentCommandResult({
+      cfg: makeCfg(),
+      deps: makeDeps(),
+      runtime,
+      opts: {
+        message: "test",
+        deliver: false,
+        json: true,
+        lane: AGENT_LANE_NESTED,
+        sessionKey: "json-session",
+      },
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      result: { payloads: [{ text: "json reply", mediaUrls: [] }], meta: {} as never },
+      payloads: [{ text: "json reply", mediaUrls: [] }],
+    });
+
+    expect(mockAppendTranscript).toHaveBeenCalledOnce();
+    expect(mockAppendTranscript).toHaveBeenCalledWith({
+      agentId: undefined,
+      sessionKey: "json-session",
+      text: "json reply",
+      mediaUrls: undefined,
+    });
+    expect(runtime.log).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes agentId to transcript append for non-default agent stores", async () => {
+    mockAppendTranscript.mockClear();
+    mockAppendTranscript.mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
+    const runtime = makeRuntime();
+
+    await deliverAgentCommandResult({
+      cfg: makeCfg(),
+      deps: makeDeps(),
+      runtime,
+      opts: {
+        message: "test",
+        agentId: "research",
+        deliver: false,
+        lane: AGENT_LANE_NESTED,
+        sessionKey: "agent-session",
+      },
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      result: { payloads: [{ text: "agent reply", mediaUrls: [] }], meta: {} as never },
+      payloads: [{ text: "agent reply", mediaUrls: [] }],
+    });
+
+    expect(mockAppendTranscript).toHaveBeenCalledWith({
+      agentId: "research",
+      sessionKey: "agent-session",
+      text: "agent reply",
+      mediaUrls: undefined,
+    });
+  });
+
+  it("logs sanitized append failures returned by transcript helper", async () => {
+    mockAppendTranscript.mockClear();
+    mockAppendTranscript.mockResolvedValue({
+      ok: false,
+      reason: "unknown sessionKey: super-secret-session",
+    });
+    const runtime = makeRuntime();
+
+    await expect(
+      deliverAgentCommandResult({
+        cfg: makeCfg(),
+        deps: makeDeps(),
+        runtime,
+        opts: {
+          message: "test",
+          deliver: false,
+          lane: AGENT_LANE_NESTED,
+          sessionKey: "child-session-abc",
+        },
+        outboundSession: undefined,
+        sessionEntry: undefined,
+        result: { payloads: [{ text: "Hello from agent", mediaUrls: [] }], meta: {} as never },
+        payloads: [{ text: "Hello from agent", mediaUrls: [] }],
+      }),
+    ).resolves.toEqual({
+      payloads: [
+        { text: "Hello from agent", mediaUrl: null, mediaUrls: undefined, channelData: undefined },
+      ],
+      meta: {},
+    });
+
+    expect(runtime.error).toHaveBeenCalledWith(
+      expect.stringContaining("transcript mirror skipped (transcript unavailable)"),
+    );
+    expect(runtime.error).not.toHaveBeenCalledWith(expect.stringContaining("super-secret-session"));
   });
 });

--- a/src/commands/agent/delivery.test.ts
+++ b/src/commands/agent/delivery.test.ts
@@ -168,8 +168,52 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
     expect(mockAppendTranscript).toHaveBeenCalledOnce();
     expect(mockAppendTranscript).toHaveBeenCalledWith({
       sessionKey: "session-media",
-      text: "pic",
+      text: "pic\n\nAttached media: https://example.com/img.png",
       mediaUrls: ["https://example.com/img.png"],
+      agentId: undefined,
+    });
+  });
+
+  it("preserves assistant text when mediaUrls are also present", async () => {
+    mockAppendTranscript.mockClear();
+    mockAppendTranscript.mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
+    const runtime = makeRuntime();
+
+    await deliverAgentCommandResult({
+      cfg: makeCfg(),
+      deps: makeDeps(),
+      runtime,
+      opts: {
+        message: "test",
+        deliver: false,
+        lane: AGENT_LANE_NESTED,
+        sessionKey: "session-text-media",
+        inputProvenance: { kind: "inter_session" },
+      },
+      outboundSession: undefined,
+      sessionEntry: undefined,
+      result: {
+        payloads: [
+          {
+            text: "Here is the chart summary",
+            mediaUrls: ["https://example.com/chart.png", "https://example.com/report.pdf"],
+          },
+        ],
+        meta: {} as never,
+      },
+      payloads: [
+        {
+          text: "Here is the chart summary",
+          mediaUrls: ["https://example.com/chart.png", "https://example.com/report.pdf"],
+        },
+      ],
+    });
+
+    expect(mockAppendTranscript).toHaveBeenCalledOnce();
+    expect(mockAppendTranscript).toHaveBeenCalledWith({
+      sessionKey: "session-text-media",
+      text: "Here is the chart summary\n\nAttached media: https://example.com/chart.png, https://example.com/report.pdf",
+      mediaUrls: ["https://example.com/chart.png", "https://example.com/report.pdf"],
       agentId: undefined,
     });
   });
@@ -207,7 +251,9 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
     expect(mockAppendTranscript).toHaveBeenCalledWith({
       agentId: undefined,
       sessionKey: "session-capped",
-      text: `${"x".repeat(MAX_NESTED_TRANSCRIPT_TEXT_CHARS - "\n\n[truncated]".length)}\n\n[truncated]`,
+      text: `${"x".repeat(MAX_NESTED_TRANSCRIPT_TEXT_CHARS - "\n\n[truncated]".length)}\n\n[truncated]\n\nAttached media: ${mediaUrls
+        .slice(0, MAX_NESTED_TRANSCRIPT_MEDIA_URLS)
+        .join(", ")}`,
       mediaUrls: mediaUrls.slice(0, MAX_NESTED_TRANSCRIPT_MEDIA_URLS),
     });
   });

--- a/src/commands/agent/delivery.test.ts
+++ b/src/commands/agent/delivery.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, type Mock } from "vitest";
 import { AGENT_LANE_NESTED } from "../../agents/lanes.js";
+import type { RuntimeEnv } from "../../runtime.js";
 
 const MAX_NESTED_TRANSCRIPT_TEXT_CHARS = 8_000;
 const MAX_NESTED_TRANSCRIPT_MEDIA_URLS = 16;
@@ -7,7 +8,7 @@ const mockAppendTranscript = vi
   .fn()
   .mockResolvedValue({ ok: true, sessionFile: "/tmp/test.jsonl" });
 vi.mock("../../config/sessions.js", async (importOriginal) => {
-  const original = await importOriginal();
+  const original = await importOriginal<typeof import("../../config/sessions.js")>();
   return {
     ...original,
     appendAssistantMessageToSessionTranscript: (...args: unknown[]) =>
@@ -43,10 +44,20 @@ vi.mock("../../channels/plugins/index.js", () => ({
 
 import { deliverAgentCommandResult } from "./delivery.js";
 
-function makeRuntime() {
+type RuntimeMock = RuntimeEnv & {
+  log: Mock<(...args: unknown[]) => void>;
+  error: Mock<(...args: unknown[]) => void>;
+  exit: Mock<(code: number) => void>;
+};
+
+function makeRuntime(): RuntimeMock {
+  const log = vi.fn<(...args: unknown[]) => void>();
+  const error = vi.fn<(...args: unknown[]) => void>();
+  const exit = vi.fn<(code: number) => void>();
   return {
-    log: vi.fn(),
-    error: vi.fn(),
+    log,
+    error,
+    exit,
   };
 }
 
@@ -169,7 +180,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
     expect(mockAppendTranscript).toHaveBeenCalledWith({
       sessionKey: "session-media",
       text: "pic\n\nAttached media: https://example.com/img.png",
-      mediaUrls: ["https://example.com/img.png"],
+      mediaUrls: undefined,
       agentId: undefined,
     });
   });
@@ -213,7 +224,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
     expect(mockAppendTranscript).toHaveBeenCalledWith({
       sessionKey: "session-text-media",
       text: "Here is the chart summary\n\nAttached media: https://example.com/chart.png, https://example.com/report.pdf",
-      mediaUrls: ["https://example.com/chart.png", "https://example.com/report.pdf"],
+      mediaUrls: undefined,
       agentId: undefined,
     });
   });
@@ -254,7 +265,7 @@ describe("deliverAgentCommandResult – transcript mirror", () => {
       text: `${"x".repeat(MAX_NESTED_TRANSCRIPT_TEXT_CHARS - "\n\n[truncated]".length)}\n\n[truncated]\n\nAttached media: ${mediaUrls
         .slice(0, MAX_NESTED_TRANSCRIPT_MEDIA_URLS)
         .join(", ")}`,
-      mediaUrls: mediaUrls.slice(0, MAX_NESTED_TRANSCRIPT_MEDIA_URLS),
+      mediaUrls: undefined,
     });
   });
 

--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -70,6 +70,33 @@ function logNestedOutput(
   }
 }
 
+function logNestedTranscriptMirrorWarning(
+  runtime: RuntimeEnv,
+  opts: AgentCommandOpts,
+  message: string,
+) {
+  if (opts.json) {
+    runtime.error(message);
+    return;
+  }
+  runtime.log(message);
+}
+
+function logNestedTranscriptMirrorError(
+  runtime: RuntimeEnv,
+  opts: AgentCommandOpts,
+  message: string,
+) {
+  if (opts.json) {
+    runtime.error(message);
+    return;
+  }
+  runtime.error?.(message);
+  if (!runtime.error) {
+    runtime.log(message);
+  }
+}
+
 function resolveNestedTranscriptAgentId(params: {
   cfg: OpenClawConfig;
   outboundSession: OutboundSessionContext | undefined;
@@ -185,7 +212,7 @@ async function mirrorNestedTranscriptToChildSession(params: {
   }
   if (!isInterSessionInputProvenance(opts.inputProvenance)) {
     const message = `${formatNestedLogPrefix(opts, sessionKey)} transcript mirror skipped (unauthorized nested mirror)`;
-    runtime.log(message);
+    logNestedTranscriptMirrorWarning(runtime, opts, message);
     return;
   }
 
@@ -215,17 +242,11 @@ async function mirrorNestedTranscriptToChildSession(params: {
     });
     if (!mirror.ok) {
       const message = `${formatNestedLogPrefix(opts, sessionKey)} transcript mirror skipped (${classifyNestedTranscriptMirrorFailure(mirror.reason)})`;
-      runtime.error?.(message);
-      if (!runtime.error) {
-        runtime.log(message);
-      }
+      logNestedTranscriptMirrorError(runtime, opts, message);
     }
   } catch {
     const message = `${formatNestedLogPrefix(opts, sessionKey)} transcript mirror skipped (unexpected transcript error)`;
-    runtime.error?.(message);
-    if (!runtime.error) {
-      runtime.log(message);
-    }
+    logNestedTranscriptMirrorError(runtime, opts, message);
   }
 }
 

--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -1,3 +1,4 @@
+import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { AGENT_LANE_NESTED } from "../../agents/lanes.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
@@ -18,7 +19,9 @@ import {
   normalizeOutboundPayloadsForJson,
 } from "../../infra/outbound/payloads.js";
 import type { OutboundSessionContext } from "../../infra/outbound/session-context.js";
+import { classifySessionKeyShape } from "../../routing/session-key.js";
 import type { RuntimeEnv } from "../../runtime.js";
+import { isInterSessionInputProvenance } from "../../sessions/input-provenance.js";
 import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import type { AgentCommandOpts } from "./types.js";
 
@@ -67,16 +70,94 @@ function logNestedOutput(
   }
 }
 
-function truncateNestedTranscriptText(text: string): string | undefined {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return undefined;
+function resolveNestedTranscriptAgentId(params: {
+  cfg: OpenClawConfig;
+  outboundSession: OutboundSessionContext | undefined;
+  sessionKey?: string;
+  opts: AgentCommandOpts;
+}): string | undefined {
+  const sessionKey = params.sessionKey?.trim();
+  if (params.outboundSession?.agentId?.trim()) {
+    return params.outboundSession.agentId;
   }
-  if (trimmed.length <= MAX_NESTED_TRANSCRIPT_TEXT_CHARS) {
-    return trimmed;
+  if (sessionKey && classifySessionKeyShape(sessionKey) !== "legacy_or_alias") {
+    return resolveSessionAgentId({ config: params.cfg, sessionKey });
   }
-  const suffix = "\n\n[truncated]";
-  return `${trimmed.slice(0, MAX_NESTED_TRANSCRIPT_TEXT_CHARS - suffix.length)}${suffix}`;
+  return params.opts.agentId;
+}
+
+function buildNestedTranscriptMirror(payloads: NormalizedOutboundPayload[]): {
+  text?: string;
+  mediaUrls?: string[];
+} {
+  const textLimit = MAX_NESTED_TRANSCRIPT_TEXT_CHARS - "\n\n[truncated]".length;
+  const textParts: string[] = [];
+  const mediaUrls: string[] = [];
+  let textChars = 0;
+  let hasMoreText = false;
+  let hasText = false;
+
+  for (const payload of payloads) {
+    if (mediaUrls.length < MAX_NESTED_TRANSCRIPT_MEDIA_URLS && payload.mediaUrls?.length) {
+      for (const url of payload.mediaUrls) {
+        if (!url) {
+          continue;
+        }
+        mediaUrls.push(url);
+        if (mediaUrls.length >= MAX_NESTED_TRANSCRIPT_MEDIA_URLS) {
+          break;
+        }
+      }
+    }
+
+    if (hasMoreText) {
+      continue;
+    }
+    const chunk = payload.text;
+    if (!chunk) {
+      continue;
+    }
+    if (hasText) {
+      if (textChars >= textLimit) {
+        hasMoreText = true;
+        continue;
+      }
+      const separator = "\n\n";
+      const separatorSlice = separator.slice(0, textLimit - textChars);
+      textParts.push(separatorSlice);
+      textChars += separatorSlice.length;
+      if (separatorSlice.length < separator.length) {
+        hasMoreText = true;
+        continue;
+      }
+    }
+    hasText = true;
+    if (textChars >= textLimit) {
+      hasMoreText = true;
+      continue;
+    }
+    const available = textLimit - textChars;
+    if (chunk.length <= available) {
+      textParts.push(chunk);
+      textChars += chunk.length;
+      continue;
+    }
+    textParts.push(chunk.slice(0, available));
+    textChars += available;
+    hasMoreText = true;
+  }
+
+  const baseText = textParts.join("");
+  const text = baseText.trim()
+    ? hasMoreText
+      ? `${baseText.trim()}\n\n[truncated]`
+      : baseText.trim()
+    : undefined;
+
+  return {
+    ...(text ? { text } : {}),
+    ...(mediaUrls.length > 0 ? { mediaUrls } : {}),
+  };
 }
 
 function classifyNestedTranscriptMirrorFailure(reason?: string): string {
@@ -91,36 +172,41 @@ function classifyNestedTranscriptMirrorFailure(reason?: string): string {
 }
 
 async function mirrorNestedTranscriptToChildSession(params: {
+  cfg: OpenClawConfig;
   runtime: RuntimeEnv;
   opts: AgentCommandOpts;
+  outboundSession: OutboundSessionContext | undefined;
   sessionKey?: string;
   payloads: NormalizedOutboundPayload[];
 }) {
-  const { runtime, opts, payloads, sessionKey } = params;
+  const { cfg, runtime, opts, outboundSession, payloads, sessionKey } = params;
   if (!sessionKey || payloads.length === 0) {
     return;
   }
+  if (!isInterSessionInputProvenance(opts.inputProvenance)) {
+    const message = `${formatNestedLogPrefix(opts, sessionKey)} transcript mirror skipped (unauthorized nested mirror)`;
+    runtime.log(message);
+    return;
+  }
 
-  const combinedText = payloads
-    .map((payload) => payload.text)
-    .filter(Boolean)
-    .join("\n\n");
-  const text = truncateNestedTranscriptText(combinedText);
-  const mediaUrls = payloads
-    .flatMap((payload) => payload.mediaUrls ?? [])
-    .filter((url): url is string => Boolean(url))
-    .slice(0, MAX_NESTED_TRANSCRIPT_MEDIA_URLS);
+  const { text, mediaUrls } = buildNestedTranscriptMirror(payloads);
+  const agentId = resolveNestedTranscriptAgentId({
+    cfg,
+    outboundSession,
+    sessionKey,
+    opts,
+  });
 
-  if (!text && mediaUrls.length === 0) {
+  if (!text && !mediaUrls) {
     return;
   }
 
   try {
     const mirror = await appendAssistantMessageToSessionTranscript({
-      agentId: opts.agentId,
+      agentId,
       sessionKey,
       text,
-      mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
+      mediaUrls,
     });
     if (!mirror.ok) {
       const message = `${formatNestedLogPrefix(opts, sessionKey)} transcript mirror skipped (${classifyNestedTranscriptMirrorFailure(mirror.reason)})`;
@@ -253,8 +339,10 @@ export async function deliverAgentCommandResult(params: {
   const deliveryPayloads = payloads?.length ? normalizeOutboundPayloads(payloads) : [];
   if (!deliver && opts.lane === AGENT_LANE_NESTED) {
     await mirrorNestedTranscriptToChildSession({
+      cfg,
       runtime,
       opts,
+      outboundSession,
       sessionKey: effectiveSessionKey,
       payloads: deliveryPayloads,
     });

--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -2,6 +2,7 @@ import { AGENT_LANE_NESTED } from "../../agents/lanes.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
+import { appendAssistantMessageToSessionTranscript } from "../../config/sessions.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   resolveAgentDeliveryPlan,
@@ -215,6 +216,26 @@ export async function deliverAgentCommandResult(params: {
   if (!deliver) {
     for (const payload of deliveryPayloads) {
       logPayload(payload);
+    }
+  }
+  // Mirror nested agent output to child session transcript so sessions_history reflects the result.
+  if (
+    !deliver &&
+    opts.lane === AGENT_LANE_NESTED &&
+    effectiveSessionKey &&
+    deliveryPayloads.length > 0
+  ) {
+    const combinedText = deliveryPayloads
+      .map((p) => p.text)
+      .filter(Boolean)
+      .join("\n\n");
+    const mediaUrls = deliveryPayloads.flatMap((p) => p.mediaUrls ?? []).filter(Boolean);
+    if (combinedText.trim() || mediaUrls.length > 0) {
+      await appendAssistantMessageToSessionTranscript({
+        sessionKey: effectiveSessionKey,
+        text: combinedText || undefined,
+        mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
+      });
     }
   }
   if (deliver && deliveryChannel && !isInternalMessageChannel(deliveryChannel)) {

--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -3,7 +3,10 @@ import { AGENT_LANE_NESTED } from "../../agents/lanes.js";
 import { getChannelPlugin, normalizeChannelId } from "../../channels/plugins/index.js";
 import { createOutboundSendDeps, type CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/config.js";
-import { appendAssistantMessageToSessionTranscript } from "../../config/sessions.js";
+import {
+  appendAssistantMessageToSessionTranscript,
+  resolveMirroredTranscriptText,
+} from "../../config/sessions.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   resolveAgentDeliveryPlan,
@@ -230,9 +233,12 @@ async function mirrorNestedTranscriptToChildSession(params: {
 
   try {
     const hasMirrorText = Boolean(text?.trim());
+    const sanitizedMediaText = mediaUrls?.length
+      ? resolveMirroredTranscriptText({ mediaUrls })
+      : null;
     const mirrorText = hasMirrorText
-      ? mediaUrls?.length
-        ? `${text}\n\nAttached media: ${mediaUrls.join(", ")}`
+      ? sanitizedMediaText
+        ? `${text}\n\nAttached media: ${sanitizedMediaText}`
         : text
       : undefined;
     const mirror = await appendAssistantMessageToSessionTranscript({

--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -229,7 +229,8 @@ async function mirrorNestedTranscriptToChildSession(params: {
   }
 
   try {
-    const mirrorText = text?.trim()
+    const hasMirrorText = Boolean(text?.trim());
+    const mirrorText = hasMirrorText
       ? mediaUrls?.length
         ? `${text}\n\nAttached media: ${mediaUrls.join(", ")}`
         : text
@@ -238,7 +239,7 @@ async function mirrorNestedTranscriptToChildSession(params: {
       agentId,
       sessionKey,
       text: mirrorText ?? text,
-      mediaUrls,
+      mediaUrls: hasMirrorText ? undefined : mediaUrls,
     });
     if (!mirror.ok) {
       const message = `${formatNestedLogPrefix(opts, sessionKey)} transcript mirror skipped (${classifyNestedTranscriptMirrorFailure(mirror.reason)})`;

--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -27,6 +27,8 @@ type RunResult = Awaited<
 >;
 
 const NESTED_LOG_PREFIX = "[agent:nested]";
+const MAX_NESTED_TRANSCRIPT_TEXT_CHARS = 8_000;
+const MAX_NESTED_TRANSCRIPT_MEDIA_URLS = 16;
 
 function formatNestedLogPrefix(opts: AgentCommandOpts, sessionKey?: string): string {
   const parts = [NESTED_LOG_PREFIX];
@@ -62,6 +64,77 @@ function logNestedOutput(
       continue;
     }
     runtime.log(`${prefix} ${line}`);
+  }
+}
+
+function truncateNestedTranscriptText(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  if (trimmed.length <= MAX_NESTED_TRANSCRIPT_TEXT_CHARS) {
+    return trimmed;
+  }
+  const suffix = "\n\n[truncated]";
+  return `${trimmed.slice(0, MAX_NESTED_TRANSCRIPT_TEXT_CHARS - suffix.length)}${suffix}`;
+}
+
+function classifyNestedTranscriptMirrorFailure(reason?: string): string {
+  switch (reason) {
+    case "missing sessionKey":
+      return "missing session";
+    case "empty text":
+      return "empty mirror";
+    default:
+      return "transcript unavailable";
+  }
+}
+
+async function mirrorNestedTranscriptToChildSession(params: {
+  runtime: RuntimeEnv;
+  opts: AgentCommandOpts;
+  sessionKey?: string;
+  payloads: NormalizedOutboundPayload[];
+}) {
+  const { runtime, opts, payloads, sessionKey } = params;
+  if (!sessionKey || payloads.length === 0) {
+    return;
+  }
+
+  const combinedText = payloads
+    .map((payload) => payload.text)
+    .filter(Boolean)
+    .join("\n\n");
+  const text = truncateNestedTranscriptText(combinedText);
+  const mediaUrls = payloads
+    .flatMap((payload) => payload.mediaUrls ?? [])
+    .filter((url): url is string => Boolean(url))
+    .slice(0, MAX_NESTED_TRANSCRIPT_MEDIA_URLS);
+
+  if (!text && mediaUrls.length === 0) {
+    return;
+  }
+
+  try {
+    const mirror = await appendAssistantMessageToSessionTranscript({
+      agentId: opts.agentId,
+      sessionKey,
+      text,
+      mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
+    });
+    if (!mirror.ok) {
+      const message = `${formatNestedLogPrefix(opts, sessionKey)} transcript mirror skipped (${classifyNestedTranscriptMirrorFailure(mirror.reason)})`;
+      runtime.error?.(message);
+      if (!runtime.error) {
+        runtime.log(message);
+      }
+    }
+  } catch {
+    const message = `${formatNestedLogPrefix(opts, sessionKey)} transcript mirror skipped (unexpected transcript error)`;
+    runtime.error?.(message);
+    if (!runtime.error) {
+      runtime.log(message);
+    }
   }
 }
 
@@ -177,6 +250,15 @@ export async function deliverAgentCommandResult(params: {
   }
 
   const normalizedPayloads = normalizeOutboundPayloadsForJson(payloads ?? []);
+  const deliveryPayloads = payloads?.length ? normalizeOutboundPayloads(payloads) : [];
+  if (!deliver && opts.lane === AGENT_LANE_NESTED) {
+    await mirrorNestedTranscriptToChildSession({
+      runtime,
+      opts,
+      sessionKey: effectiveSessionKey,
+      payloads: deliveryPayloads,
+    });
+  }
   if (opts.json) {
     runtime.log(
       JSON.stringify(
@@ -198,7 +280,6 @@ export async function deliverAgentCommandResult(params: {
     return { payloads: [], meta: result.meta };
   }
 
-  const deliveryPayloads = normalizeOutboundPayloads(payloads);
   const logPayload = (payload: NormalizedOutboundPayload) => {
     if (opts.json) {
       return;
@@ -216,26 +297,6 @@ export async function deliverAgentCommandResult(params: {
   if (!deliver) {
     for (const payload of deliveryPayloads) {
       logPayload(payload);
-    }
-  }
-  // Mirror nested agent output to child session transcript so sessions_history reflects the result.
-  if (
-    !deliver &&
-    opts.lane === AGENT_LANE_NESTED &&
-    effectiveSessionKey &&
-    deliveryPayloads.length > 0
-  ) {
-    const combinedText = deliveryPayloads
-      .map((p) => p.text)
-      .filter(Boolean)
-      .join("\n\n");
-    const mediaUrls = deliveryPayloads.flatMap((p) => p.mediaUrls ?? []).filter(Boolean);
-    if (combinedText.trim() || mediaUrls.length > 0) {
-      await appendAssistantMessageToSessionTranscript({
-        sessionKey: effectiveSessionKey,
-        text: combinedText || undefined,
-        mediaUrls: mediaUrls.length > 0 ? mediaUrls : undefined,
-      });
     }
   }
   if (deliver && deliveryChannel && !isInternalMessageChannel(deliveryChannel)) {

--- a/src/commands/agent/delivery.ts
+++ b/src/commands/agent/delivery.ts
@@ -202,10 +202,15 @@ async function mirrorNestedTranscriptToChildSession(params: {
   }
 
   try {
+    const mirrorText = text?.trim()
+      ? mediaUrls?.length
+        ? `${text}\n\nAttached media: ${mediaUrls.join(", ")}`
+        : text
+      : undefined;
     const mirror = await appendAssistantMessageToSessionTranscript({
       agentId,
       sessionKey,
-      text,
+      text: mirrorText ?? text,
       mediaUrls,
     });
     if (!mirror.ok) {


### PR DESCRIPTION
## Summary
- mirror nested ACP output into the child session transcript when nested delivery is disabled
- preserve journal-only delivery behavior while restoring oneshot ACP session history
- add regression coverage for nested ACP transcript mirroring

## Testing
- pnpm vitest src/commands/agent/delivery.test.ts
- pnpm lint src/commands/agent/delivery.ts src/commands/agent/delivery.test.ts
