### PR TITLE
fix(discord): persist hello-stall counter and add escalation across health-monitor restarts

### DIFF
--- a/extensions/discord/src/accounts.ts
+++ b/extensions/discord/src/accounts.ts
@@ -18,8 +18,11 @@ export type ResolvedDiscordAccount = {
   config: DiscordAccountConfig;
 };
 
-const { listAccountIds, resolveDefaultAccountId } = createAccountListHelpers("discord");
+const { listAccountIds, listConfiguredAccountIds, resolveDefaultAccountId } =
+  createAccountListHelpers("discord");
 export const listDiscordAccountIds = listAccountIds;
+/** Returns only explicitly-configured account IDs, never the implicit "default" fallback. */
+export const listConfiguredDiscordAccountIds = listConfiguredAccountIds;
 export const resolveDefaultDiscordAccountId = resolveDefaultAccountId;
 
 export function resolveDiscordAccountConfig(

--- a/extensions/discord/src/monitor/provider.lifecycle.test.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.test.ts
@@ -3,6 +3,11 @@ import type { Client } from "@buape/carbon";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../../../../src/runtime.js";
 import type { WaitForDiscordGatewayStopParams } from "../monitor.gateway.js";
+import {
+  getOrCreatePersistentState,
+  markStable,
+  requestCleanRestart,
+} from "./provider.lifecycle.js";
 
 const {
   attachDiscordGatewayLoggingMock,
@@ -39,6 +44,41 @@ vi.mock("./gateway-registry.js", () => ({
   registerGateway: registerGatewayMock,
   unregisterGateway: unregisterGatewayMock,
 }));
+
+describe("DiscordLifecyclePersistentState", () => {
+  it("creates default state for new accounts", () => {
+    const state = getOrCreatePersistentState("test-new-account");
+    expect(state.consecutiveHelloStalls).toBe(0);
+    expect(state.forceCleanRestart).toBe(false);
+  });
+
+  it("returns the same state object for the same account", () => {
+    const s1 = getOrCreatePersistentState("test-same-account");
+    const s2 = getOrCreatePersistentState("test-same-account");
+    expect(s1).toBe(s2);
+  });
+
+  it("requestCleanRestart sets forceCleanRestart flag", () => {
+    const state = getOrCreatePersistentState("test-request-clean");
+    expect(state.forceCleanRestart).toBe(false);
+    requestCleanRestart("test-request-clean");
+    expect(state.forceCleanRestart).toBe(true);
+  });
+
+  it("markStable resets counters", () => {
+    const state = getOrCreatePersistentState("test-mark-stable");
+    state.consecutiveHelloStalls = 5;
+    state.forceCleanRestart = true;
+    markStable("test-mark-stable");
+    expect(state.consecutiveHelloStalls).toBe(0);
+    expect(state.forceCleanRestart).toBe(false);
+  });
+
+  it("markStable is a no-op for unknown accounts", () => {
+    // Should not throw
+    markStable("test-unknown-account-xyz");
+  });
+});
 
 describe("runDiscordGatewayLifecycle", () => {
   beforeEach(() => {
@@ -445,5 +485,104 @@ describe("runDiscordGatewayLifecycle", () => {
     // guarded by !lifecycleStopping to avoid contradicting the abort.
     const connectedTrue = statusUpdates.find((s) => s.connected === true);
     expect(connectedTrue).toBeUndefined();
+  });
+
+  it("persists consecutiveHelloStalls across lifecycle restarts", async () => {
+    vi.useFakeTimers();
+    try {
+      const { runDiscordGatewayLifecycle, getOrCreatePersistentState } =
+        await import("./provider.lifecycle.js");
+
+      // First lifecycle: 2 hello stalls (not enough to force fresh identify)
+      const { emitter: emitter1, gateway: gateway1 } = createGatewayHarness({
+        state: {
+          sessionId: "session-persist",
+          resumeGatewayUrl: "wss://gateway.discord.gg",
+          sequence: 100,
+        },
+        sequence: 100,
+      });
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter1);
+      waitForDiscordGatewayStopMock.mockImplementationOnce(async () => {
+        await emitGatewayOpenAndWait(emitter1);
+        await emitGatewayOpenAndWait(emitter1);
+      });
+
+      const { lifecycleParams: params1 } = createLifecycleHarness({
+        accountId: "persist-test",
+        gateway: gateway1,
+      });
+      await runDiscordGatewayLifecycle(params1);
+
+      // Verify counter persisted
+      const state = getOrCreatePersistentState("persist-test");
+      expect(state.consecutiveHelloStalls).toBe(2);
+
+      // Second lifecycle: 1 more stall should trigger fresh identify (total=3)
+      const { emitter: emitter2, gateway: gateway2 } = createGatewayHarness({
+        state: {
+          sessionId: "session-persist-2",
+          resumeGatewayUrl: "wss://gateway.discord.gg",
+          sequence: 200,
+        },
+        sequence: 200,
+      });
+      getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter2);
+      waitForDiscordGatewayStopMock.mockImplementationOnce(async () => {
+        await emitGatewayOpenAndWait(emitter2);
+      });
+
+      const { lifecycleParams: params2 } = createLifecycleHarness({
+        accountId: "persist-test",
+        gateway: gateway2,
+      });
+      await runDiscordGatewayLifecycle(params2);
+
+      // After fresh identify the counter resets
+      expect(state.consecutiveHelloStalls).toBe(0);
+      // Resume state was cleared
+      expect(gateway2.state?.sessionId).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears resume state on lifecycle start when forceCleanRestart is set", async () => {
+    const { runDiscordGatewayLifecycle, getOrCreatePersistentState } =
+      await import("./provider.lifecycle.js");
+
+    const { emitter, gateway } = createGatewayHarness({
+      state: {
+        sessionId: "session-force",
+        resumeGatewayUrl: "wss://gateway.discord.gg",
+        sequence: 50,
+      },
+      sequence: 50,
+    });
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+
+    // Set the forceCleanRestart flag (as the health monitor would)
+    const state = getOrCreatePersistentState("force-clean-test");
+    state.forceCleanRestart = true;
+
+    const { lifecycleParams, runtimeLog } = createLifecycleHarness({
+      accountId: "force-clean-test",
+      gateway,
+    });
+    await runDiscordGatewayLifecycle(lifecycleParams);
+
+    // Resume state should have been cleared
+    expect(gateway.state?.sessionId).toBeNull();
+    expect(gateway.state?.resumeGatewayUrl).toBeNull();
+    expect(gateway.state?.sequence).toBeNull();
+    expect(gateway.sequence).toBeNull();
+
+    // Flag should be reset
+    expect(state.forceCleanRestart).toBe(false);
+
+    // Log message about the clean restart
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("health-monitor requested clean restart"),
+    );
   });
 });

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -15,6 +15,38 @@ type ExecApprovalsHandler = {
   stop: () => Promise<void>;
 };
 
+// ── Persistent state that survives health-monitor restarts ──────────────
+export type DiscordLifecyclePersistentState = {
+  consecutiveHelloStalls: number;
+  /** When true, the next lifecycle start will clear resume state and IDENTIFY fresh. */
+  forceCleanRestart: boolean;
+};
+
+const persistentStates = new Map<string, DiscordLifecyclePersistentState>();
+
+export function getOrCreatePersistentState(accountId: string): DiscordLifecyclePersistentState {
+  let state = persistentStates.get(accountId);
+  if (!state) {
+    state = { consecutiveHelloStalls: 0, forceCleanRestart: false };
+    persistentStates.set(accountId, state);
+  }
+  return state;
+}
+
+/** Signal that the next lifecycle start should clear Discord resume state. */
+export function requestCleanRestart(accountId: string): void {
+  getOrCreatePersistentState(accountId).forceCleanRestart = true;
+}
+
+/** Reset persistent counters after the channel has been stable. */
+export function markStable(accountId: string): void {
+  const state = persistentStates.get(accountId);
+  if (state) {
+    state.consecutiveHelloStalls = 0;
+    state.forceCleanRestart = false;
+  }
+}
+
 export async function runDiscordGatewayLifecycle(params: {
   accountId: string;
   client: Client;
@@ -108,9 +140,10 @@ export async function runDiscordGatewayLifecycle(params: {
     params.abortSignal?.addEventListener("abort", onAbort, { once: true });
   }
 
+  const persistentState = getOrCreatePersistentState(params.accountId);
+
   let helloTimeoutId: ReturnType<typeof setTimeout> | undefined;
   let helloConnectedPollId: ReturnType<typeof setInterval> | undefined;
-  let consecutiveHelloStalls = 0;
   const clearHelloWatch = () => {
     if (helloTimeoutId) {
       clearTimeout(helloTimeoutId);
@@ -122,7 +155,7 @@ export async function runDiscordGatewayLifecycle(params: {
     }
   };
   const resetHelloStallCounter = () => {
-    consecutiveHelloStalls = 0;
+    persistentState.consecutiveHelloStalls = 0;
   };
   const parseGatewayCloseCode = (message: string): number | undefined => {
     const match = /code\s+(\d{3,5})/i.exec(message);
@@ -151,6 +184,19 @@ export async function runDiscordGatewayLifecycle(params: {
     mutableGateway.state.sequence = null;
     mutableGateway.sequence = null;
   };
+
+  // If a previous health-monitor cycle requested a clean restart, clear
+  // Discord resume/session state so the gateway performs a fresh IDENTIFY.
+  if (persistentState.forceCleanRestart) {
+    clearResumeState();
+    persistentState.forceCleanRestart = false;
+    params.runtime.log?.(
+      danger(
+        "discord: health-monitor requested clean restart; cleared resume state for fresh IDENTIFY",
+      ),
+    );
+  }
+
   const onGatewayDebug = (msg: unknown) => {
     const message = String(msg);
     const at = Date.now();
@@ -211,8 +257,9 @@ export async function runDiscordGatewayLifecycle(params: {
       if (sawConnected || gateway?.isConnected) {
         resetHelloStallCounter();
       } else {
-        consecutiveHelloStalls += 1;
-        const forceFreshIdentify = consecutiveHelloStalls >= MAX_CONSECUTIVE_HELLO_STALLS;
+        persistentState.consecutiveHelloStalls += 1;
+        const forceFreshIdentify =
+          persistentState.consecutiveHelloStalls >= MAX_CONSECUTIVE_HELLO_STALLS;
         const stalledAt = Date.now();
         reconnectStallWatchdog.arm(stalledAt);
         pushStatus({
@@ -226,8 +273,8 @@ export async function runDiscordGatewayLifecycle(params: {
         params.runtime.log?.(
           danger(
             forceFreshIdentify
-              ? `connection stalled: no HELLO within ${HELLO_TIMEOUT_MS}ms (${consecutiveHelloStalls}/${MAX_CONSECUTIVE_HELLO_STALLS}); forcing fresh identify`
-              : `connection stalled: no HELLO within ${HELLO_TIMEOUT_MS}ms (${consecutiveHelloStalls}/${MAX_CONSECUTIVE_HELLO_STALLS}); retrying resume`,
+              ? `connection stalled: no HELLO within ${HELLO_TIMEOUT_MS}ms (${persistentState.consecutiveHelloStalls}/${MAX_CONSECUTIVE_HELLO_STALLS}); forcing fresh identify`
+              : `connection stalled: no HELLO within ${HELLO_TIMEOUT_MS}ms (${persistentState.consecutiveHelloStalls}/${MAX_CONSECUTIVE_HELLO_STALLS}); retrying resume`,
           ),
         );
         if (forceFreshIdentify) {

--- a/extensions/discord/src/monitor/provider.lifecycle.ts
+++ b/extensions/discord/src/monitor/provider.lifecycle.ts
@@ -47,6 +47,15 @@ export function markStable(accountId: string): void {
   }
 }
 
+/**
+ * Remove the persistent state for an account that has been fully removed from
+ * config.  Call this whenever a Discord account is permanently deleted so the
+ * module-level Map does not grow unboundedly in long-running gateway processes.
+ */
+export function evictPersistentState(accountId: string): void {
+  persistentStates.delete(accountId);
+}
+
 export async function runDiscordGatewayLifecycle(params: {
   accountId: string;
   client: Client;

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -661,6 +661,38 @@ describe("channel-health-monitor", () => {
       monitor.stop();
     });
 
+    it("does not reset consecutive restart counter on brief healthy→unhealthy flap", async () => {
+      const onChannelStable = vi.fn();
+      let currentStatus: Partial<ChannelAccountSnapshot> = managedStoppedAccount("crashed");
+
+      const manager = createMockChannelManager({
+        getRuntimeSnapshot: vi.fn(() => snapshotWith({ discord: { default: currentStatus } })),
+      });
+
+      const monitor = startDefaultMonitor(manager, {
+        checkIntervalMs: 1_000,
+        cooldownCycles: 1,
+        onChannelStable,
+      });
+
+      // Trigger a restart
+      await vi.advanceTimersByTimeAsync(2_001);
+      expect(manager.startChannel).toHaveBeenCalledTimes(1);
+
+      // Channel becomes briefly healthy (< STABLE_THRESHOLD_MS = 5 minutes)
+      currentStatus = { running: true, connected: true, enabled: true, configured: true };
+      await vi.advanceTimersByTimeAsync(2_000); // only 2 healthy check cycles
+
+      // Channel goes unhealthy again (flap)
+      currentStatus = managedStoppedAccount("crashed again");
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      // Stability callback must NOT fire — channel was not healthy for 5 minutes
+      expect(onChannelStable).not.toHaveBeenCalled();
+
+      monitor.stop();
+    });
+
     it("applies exponential backoff to cooldown after consecutive restarts", async () => {
       const manager = createSnapshotManager({
         discord: {

--- a/src/gateway/channel-health-monitor.test.ts
+++ b/src/gateway/channel-health-monitor.test.ts
@@ -410,6 +410,12 @@ describe("channel-health-monitor", () => {
     });
     const monitor = await startAndRunCheck(manager);
     expect(manager.startChannel).toHaveBeenCalledTimes(1);
+    // Base cooldown = 2 × 5000 = 10000ms. After 1st restart (consecutive=1),
+    // exponential backoff doubles it to 20000ms = 4 check intervals.
+    await vi.advanceTimersByTimeAsync(DEFAULT_CHECK_INTERVAL_MS);
+    expect(manager.startChannel).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(DEFAULT_CHECK_INTERVAL_MS);
+    expect(manager.startChannel).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(DEFAULT_CHECK_INTERVAL_MS);
     expect(manager.startChannel).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(DEFAULT_CHECK_INTERVAL_MS);
@@ -430,9 +436,14 @@ describe("channel-health-monitor", () => {
       cooldownCycles: 1,
       maxRestartsPerHour: 3,
     });
-    await vi.advanceTimersByTimeAsync(5_001);
+    // With exponential backoff (cooldownCycles=1, base=1000ms):
+    // 1st: at ~1000ms (base cooldown, consecutive 0→1)
+    // 2nd: ~1000 + 2000 backoff → ~4000ms (consecutive 1→2)
+    // 3rd: ~4000 + 4000 backoff → ~9000ms (consecutive 2→3)
+    await vi.advanceTimersByTimeAsync(10_001);
     expect(manager.startChannel).toHaveBeenCalledTimes(3);
-    await vi.advanceTimersByTimeAsync(1_001);
+    // Subsequent restarts should be blocked by the per-hour limit
+    await vi.advanceTimersByTimeAsync(20_001);
     expect(manager.startChannel).toHaveBeenCalledTimes(3);
     monitor.stop();
   });
@@ -571,6 +582,116 @@ describe("channel-health-monitor", () => {
       });
       expect(manager.stopChannel).toHaveBeenCalledWith("slack", "default");
       expect(manager.startChannel).toHaveBeenCalledWith("slack", "default");
+      monitor.stop();
+    });
+  });
+
+  describe("consecutive restart tracking and escalation", () => {
+    it("tracks consecutive restarts and calls onBeforeRestart after threshold", async () => {
+      const onBeforeRestart = vi.fn();
+      const manager = createSnapshotManager({
+        discord: {
+          default: managedStoppedAccount("keeps crashing"),
+        },
+      });
+      // Use short intervals; cooldownCycles=1 means base cooldown=1000ms
+      const monitor = startDefaultMonitor(manager, {
+        checkIntervalMs: 1_000,
+        cooldownCycles: 1,
+        maxRestartsPerHour: 10,
+        onBeforeRestart,
+      });
+
+      // 1st restart: at ~1001ms (base cooldown 1000ms, backoff=2^0=1x)
+      await vi.advanceTimersByTimeAsync(1_001);
+      expect(manager.startChannel).toHaveBeenCalledTimes(1);
+      expect(onBeforeRestart).not.toHaveBeenCalled();
+
+      // 2nd restart: consecutive=1 → backoff=2^1=2x → cooldown=2000ms
+      await vi.advanceTimersByTimeAsync(3_001);
+      expect(manager.startChannel).toHaveBeenCalledTimes(2);
+      expect(onBeforeRestart).not.toHaveBeenCalled();
+
+      // 3rd restart: consecutive=2 → backoff=2^2=4x → cooldown=4000ms
+      await vi.advanceTimersByTimeAsync(5_001);
+      expect(manager.startChannel).toHaveBeenCalledTimes(3);
+      expect(onBeforeRestart).toHaveBeenCalledTimes(1);
+      expect(onBeforeRestart).toHaveBeenCalledWith({
+        channelId: "discord",
+        accountId: "default",
+        consecutiveRestarts: 3,
+      });
+
+      monitor.stop();
+    });
+
+    it("resets consecutive restart counter when channel becomes stable", async () => {
+      const onChannelStable = vi.fn();
+      let currentStatus: Partial<ChannelAccountSnapshot> = managedStoppedAccount("crashed");
+
+      const manager = createMockChannelManager({
+        getRuntimeSnapshot: vi.fn(() => snapshotWith({ discord: { default: currentStatus } })),
+      });
+
+      const monitor = startDefaultMonitor(manager, {
+        checkIntervalMs: 1_000,
+        cooldownCycles: 1,
+        onChannelStable,
+      });
+
+      // Trigger a restart
+      await vi.advanceTimersByTimeAsync(2_001);
+      expect(manager.startChannel).toHaveBeenCalledTimes(1);
+
+      // Channel comes back healthy
+      currentStatus = {
+        running: true,
+        connected: true,
+        enabled: true,
+        configured: true,
+      };
+
+      // After 5+ minutes of stability, counter should reset
+      await vi.advanceTimersByTimeAsync(5 * 60_000 + 1_001);
+      expect(onChannelStable).toHaveBeenCalledWith({
+        channelId: "discord",
+        accountId: "default",
+      });
+
+      monitor.stop();
+    });
+
+    it("applies exponential backoff to cooldown after consecutive restarts", async () => {
+      const manager = createSnapshotManager({
+        discord: {
+          default: managedStoppedAccount("keeps crashing"),
+        },
+      });
+
+      // Base cooldown = 2 cycles × 5000ms = 10000ms
+      const monitor = startDefaultMonitor(manager, {
+        checkIntervalMs: DEFAULT_CHECK_INTERVAL_MS,
+        cooldownCycles: 2,
+        maxRestartsPerHour: 20,
+      });
+
+      // 1st restart: backoff=2^0=1x, effectiveCooldown=10000ms
+      await vi.advanceTimersByTimeAsync(DEFAULT_CHECK_INTERVAL_MS + 1);
+      expect(manager.startChannel).toHaveBeenCalledTimes(1);
+
+      // After 1st: consecutive=1, backoff=2^1=2x, effectiveCooldown=20000ms
+      // 2 intervals = 10000ms: still in cooldown
+      await vi.advanceTimersByTimeAsync(DEFAULT_CHECK_INTERVAL_MS * 2);
+      expect(manager.startChannel).toHaveBeenCalledTimes(1);
+
+      // 3 intervals = 15000ms: still in cooldown (need >20000ms)
+      await vi.advanceTimersByTimeAsync(DEFAULT_CHECK_INTERVAL_MS);
+      expect(manager.startChannel).toHaveBeenCalledTimes(1);
+
+      // 5 intervals = 25000ms total from 1st restart: past 20000ms backoff
+      await vi.advanceTimersByTimeAsync(DEFAULT_CHECK_INTERVAL_MS * 2 + 1);
+      expect(manager.startChannel).toHaveBeenCalledTimes(2);
+
       monitor.stop();
     });
   });

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -260,6 +260,12 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             log.error?.(
               `[${channelId}:${accountId}] health-monitor: restart failed: ${String(err)}`,
             );
+            // Record the attempt time even on failure so the exponential
+            // cooldown is respected on the next check cycle; without this,
+            // lastRestartAt stays at its previous value and the cooldown
+            // guard is bypassed, causing rapid retries on persistent failures.
+            record.lastRestartAt = now;
+            restartRecords.set(key, record);
           }
         }
       }

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -42,15 +42,42 @@ export type ChannelHealthMonitorDeps = {
   cooldownCycles?: number;
   maxRestartsPerHour?: number;
   abortSignal?: AbortSignal;
+  /**
+   * Called before restarting a channel that has failed multiple consecutive
+   * health-monitor restarts without becoming stable.  The callback receives
+   * the channel/account identifiers and the number of consecutive restarts
+   * so far, allowing channel-specific escalation (e.g. clearing Discord
+   * resume state to force a fresh IDENTIFY).
+   */
+  onBeforeRestart?: (params: {
+    channelId: ChannelId;
+    accountId: string;
+    consecutiveRestarts: number;
+  }) => void;
+  /** Called when a previously-restarted channel has been healthy long enough
+   *  to be considered stable.  Useful for resetting channel-specific persistent
+   *  state (e.g. Discord hello-stall counters). */
+  onChannelStable?: (params: { channelId: ChannelId; accountId: string }) => void;
 };
 
 export type ChannelHealthMonitor = {
   stop: () => void;
 };
 
+/** How long a channel must stay healthy after a restart before we consider it stable. */
+const STABLE_THRESHOLD_MS = 5 * 60_000;
+/** After this many consecutive restarts without stability, escalate (e.g. fresh IDENTIFY). */
+const ESCALATION_THRESHOLD = 3;
+/** Max backoff multiplier exponent for exponential cooldown. */
+const MAX_BACKOFF_EXPONENT = 3;
+/** Hard cap on exponential cooldown (60 minutes). */
+const MAX_COOLDOWN_MS = 60 * 60_000;
+
 type RestartRecord = {
   lastRestartAt: number;
   restartsThisHour: { at: number }[];
+  /** Number of health-monitor restarts without the channel becoming stable. */
+  consecutiveRestarts: number;
 };
 
 function resolveTimingPolicy(
@@ -80,6 +107,8 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
     cooldownCycles = DEFAULT_COOLDOWN_CYCLES,
     maxRestartsPerHour = DEFAULT_MAX_RESTARTS_PER_HOUR,
     abortSignal,
+    onBeforeRestart,
+    onChannelStable,
   } = deps;
   const timing = resolveTimingPolicy(deps);
 
@@ -131,17 +160,37 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             channelConnectGraceMs: timing.channelConnectGraceMs,
           };
           const health = evaluateChannelHealth(status, healthPolicy);
-          if (health.healthy) {
-            continue;
-          }
 
           const key = rKey(channelId, accountId);
           const record = restartRecords.get(key) ?? {
             lastRestartAt: 0,
             restartsThisHour: [],
+            consecutiveRestarts: 0,
           };
 
-          if (now - record.lastRestartAt <= cooldownMs) {
+          // Stability check: if the channel is healthy and has been up long
+          // enough since the last restart, reset the consecutive counter.
+          if (health.healthy) {
+            if (
+              record.consecutiveRestarts > 0 &&
+              record.lastRestartAt > 0 &&
+              now - record.lastRestartAt >= STABLE_THRESHOLD_MS
+            ) {
+              log.info?.(
+                `[${channelId}:${accountId}] health-monitor: channel stable after ${record.consecutiveRestarts} restart(s), resetting counter`,
+              );
+              record.consecutiveRestarts = 0;
+              restartRecords.set(key, record);
+              onChannelStable?.({ channelId: channelId as ChannelId, accountId });
+            }
+            continue;
+          }
+
+          // Apply exponential backoff: base cooldown × 2^min(consecutiveRestarts, cap)
+          const backoffExponent = Math.min(record.consecutiveRestarts, MAX_BACKOFF_EXPONENT);
+          const effectiveCooldownMs = Math.min(cooldownMs * 2 ** backoffExponent, MAX_COOLDOWN_MS);
+
+          if (now - record.lastRestartAt <= effectiveCooldownMs) {
             continue;
           }
 
@@ -154,8 +203,22 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
           }
 
           const reason = resolveChannelRestartReason(status, health);
+          const nextConsecutive = record.consecutiveRestarts + 1;
 
-          log.info?.(`[${channelId}:${accountId}] health-monitor: restarting (reason: ${reason})`);
+          log.info?.(
+            `[${channelId}:${accountId}] health-monitor: restarting (reason: ${reason}, consecutive: ${nextConsecutive})`,
+          );
+
+          // Escalation: after N consecutive restarts without stability, notify
+          // the caller so it can take channel-specific recovery action (e.g.
+          // clearing Discord resume state to force a fresh IDENTIFY).
+          if (nextConsecutive >= ESCALATION_THRESHOLD && onBeforeRestart) {
+            onBeforeRestart({
+              channelId: channelId as ChannelId,
+              accountId,
+              consecutiveRestarts: nextConsecutive,
+            });
+          }
 
           try {
             if (status.running) {
@@ -165,6 +228,7 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             await channelManager.startChannel(channelId as ChannelId, accountId);
             record.lastRestartAt = now;
             record.restartsThisHour.push({ at: now });
+            record.consecutiveRestarts = nextConsecutive;
             restartRecords.set(key, record);
           } catch (err) {
             log.error?.(

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -229,6 +229,13 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             `[${channelId}:${accountId}] health-monitor: restarting (reason: ${reason}, consecutive: ${nextConsecutive})`,
           );
 
+          // Optimistically increment consecutiveRestarts before the restart
+          // attempt so that if the restart fails, backoff still increases on
+          // the next cycle and the escalation callback does not re-fire at
+          // the same threshold level.
+          record.consecutiveRestarts = nextConsecutive;
+          restartRecords.set(key, record);
+
           // Escalation: after N consecutive restarts without stability, notify
           // the caller so it can take channel-specific recovery action (e.g.
           // clearing Discord resume state to force a fresh IDENTIFY).
@@ -248,7 +255,6 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             await channelManager.startChannel(channelId as ChannelId, accountId);
             record.lastRestartAt = now;
             record.restartsThisHour.push({ at: now });
-            record.consecutiveRestarts = nextConsecutive;
             restartRecords.set(key, record);
           } catch (err) {
             log.error?.(

--- a/src/gateway/channel-health-monitor.ts
+++ b/src/gateway/channel-health-monitor.ts
@@ -78,6 +78,10 @@ type RestartRecord = {
   restartsThisHour: { at: number }[];
   /** Number of health-monitor restarts without the channel becoming stable. */
   consecutiveRestarts: number;
+  /** Timestamp of the first healthy check after a restart.  Tracks continuous
+   *  uptime so a brief healthy→unhealthy flap does not satisfy the stability
+   *  window and prematurely reset consecutiveRestarts. */
+  healthySince?: number;
 };
 
 function resolveTimingPolicy(
@@ -168,22 +172,38 @@ export function startChannelHealthMonitor(deps: ChannelHealthMonitorDeps): Chann
             consecutiveRestarts: 0,
           };
 
-          // Stability check: if the channel is healthy and has been up long
-          // enough since the last restart, reset the consecutive counter.
+          // Stability check: if the channel is healthy and has been continuously
+          // healthy for STABLE_THRESHOLD_MS, reset the consecutive counter.
+          // We track healthySince (set on first healthy check after a restart)
+          // so a brief healthy→unhealthy flap does not satisfy the window.
           if (health.healthy) {
+            if (record.consecutiveRestarts > 0 && !record.healthySince) {
+              // First healthy check after a restart — start the stability clock.
+              record.healthySince = now;
+              restartRecords.set(key, record);
+            }
             if (
               record.consecutiveRestarts > 0 &&
-              record.lastRestartAt > 0 &&
-              now - record.lastRestartAt >= STABLE_THRESHOLD_MS
+              record.healthySince &&
+              now - record.healthySince >= STABLE_THRESHOLD_MS
             ) {
               log.info?.(
                 `[${channelId}:${accountId}] health-monitor: channel stable after ${record.consecutiveRestarts} restart(s), resetting counter`,
               );
               record.consecutiveRestarts = 0;
+              record.healthySince = undefined;
               restartRecords.set(key, record);
               onChannelStable?.({ channelId: channelId as ChannelId, accountId });
             }
             continue;
+          }
+
+          // Channel is unhealthy — clear the healthy-window timestamp so a
+          // prior brief health run does not carry forward into the next
+          // stability measurement.
+          if (record.healthySince !== undefined) {
+            record.healthySince = undefined;
+            restartRecords.set(key, record);
           }
 
           // Apply exponential backoff: base cooldown × 2^min(consecutiveRestarts, cap)

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1,4 +1,13 @@
 import path from "node:path";
+import {
+  listConfiguredDiscordAccountIds,
+  listDiscordAccountIds,
+} from "../../extensions/discord/src/accounts.js";
+import {
+  evictPersistentState as evictDiscordPersistentState,
+  markStable as markDiscordStable,
+  requestCleanRestart as requestDiscordCleanRestart,
+} from "../../extensions/discord/src/monitor/provider.lifecycle.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { getActiveEmbeddedRunCount } from "../agents/pi-embedded-runner/runs.js";
 import { registerSkillsChangeListener } from "../agents/skills/refresh.js";
@@ -21,12 +30,6 @@ import {
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
-import { listConfiguredDiscordAccountIds, listDiscordAccountIds } from "../discord/accounts.js";
-import {
-  evictPersistentState as evictDiscordPersistentState,
-  markStable as markDiscordStable,
-  requestCleanRestart as requestDiscordCleanRestart,
-} from "../discord/monitor/provider.lifecycle.js";
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import {
   ensureControlUiAssetsBuilt,
@@ -1043,17 +1046,18 @@ export async function startGatewayServer(
           readSnapshot: readConfigFileSnapshot,
           onHotReload: async (plan, nextConfig) => {
             const previousSnapshot = getActiveSecretsRuntimeSnapshot();
+            // Snapshot discord account IDs BEFORE activating the new config so we
+            // capture the pre-reload (currently-running) set.  getRuntimeSnapshot()
+            // derives account IDs from loadConfig(), which already reflects the new
+            // config after activateRuntimeSecrets() — so calling it after activation
+            // would miss any accounts being removed, preventing their eviction.
+            const prevDiscordAccountIds = plan.restartChannels.has("discord")
+              ? Object.keys(getRuntimeSnapshot().channelAccounts["discord"] ?? {})
+              : [];
             const prepared = await activateRuntimeSecrets(nextConfig, {
               reason: "reload",
               activate: true,
             });
-            // Snapshot discord account IDs before the reload so we can evict
-            // persistent state for any accounts that are removed from config.
-            // Use the runtime snapshot (not cfgAtStart) to capture the currently
-            // running set, which may have already changed since startup.
-            const prevDiscordAccountIds = plan.restartChannels.has("discord")
-              ? Object.keys(getRuntimeSnapshot().channelAccounts["discord"] ?? {})
-              : [];
             try {
               await applyHotReload(plan, prepared.config);
             } catch (err) {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -21,6 +21,10 @@ import {
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
+import {
+  markStable as markDiscordStable,
+  requestCleanRestart as requestDiscordCleanRestart,
+} from "../discord/monitor/provider.lifecycle.js";
 import { clearAgentRunContext, onAgentEvent } from "../infra/agent-events.js";
 import {
   ensureControlUiAssetsBuilt,
@@ -65,7 +69,10 @@ import {
 } from "../secrets/runtime.js";
 import { runSetupWizard } from "../wizard/setup.js";
 import { createAuthRateLimiter, type AuthRateLimiter } from "./auth-rate-limit.js";
-import { startChannelHealthMonitor } from "./channel-health-monitor.js";
+import {
+  startChannelHealthMonitor,
+  type ChannelHealthMonitorDeps,
+} from "./channel-health-monitor.js";
 import { startGatewayConfigReloader } from "./config-reload.js";
 import type { ControlUiRootState } from "./control-ui.js";
 import {
@@ -759,6 +766,28 @@ export async function startGatewayServer(
   const healthCheckDisabled = healthCheckMinutes === 0;
   const staleEventThresholdMinutes = cfgAtStart.gateway?.channelStaleEventThresholdMinutes;
   const maxRestartsPerHour = cfgAtStart.gateway?.channelMaxRestartsPerHour;
+  const healthMonitorBeforeRestart: ChannelHealthMonitorDeps["onBeforeRestart"] = ({
+    channelId,
+    accountId,
+    consecutiveRestarts,
+  }) => {
+    if (channelId === "discord") {
+      log.info(
+        `health-monitor: ${consecutiveRestarts} consecutive restart(s) for discord:${accountId}, requesting clean restart`,
+      );
+      requestDiscordCleanRestart(accountId);
+    }
+  };
+
+  const healthMonitorChannelStable: ChannelHealthMonitorDeps["onChannelStable"] = ({
+    channelId,
+    accountId,
+  }) => {
+    if (channelId === "discord") {
+      markDiscordStable(accountId);
+    }
+  };
+
   let channelHealthMonitor = healthCheckDisabled
     ? null
     : startChannelHealthMonitor({
@@ -768,6 +797,8 @@ export async function startGatewayServer(
           staleEventThresholdMs: staleEventThresholdMinutes * 60_000,
         }),
         ...(maxRestartsPerHour != null && { maxRestartsPerHour }),
+        onBeforeRestart: healthMonitorBeforeRestart,
+        onChannelStable: healthMonitorChannelStable,
       });
 
   if (!minimalTestGateway) {
@@ -1000,6 +1031,8 @@ export async function startGatewayServer(
               ...(opts.maxRestartsPerHour != null && {
                 maxRestartsPerHour: opts.maxRestartsPerHour,
               }),
+              onBeforeRestart: healthMonitorBeforeRestart,
+              onChannelStable: healthMonitorChannelStable,
             }),
         });
 

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -21,7 +21,7 @@ import {
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
-import { listConfiguredDiscordAccountIds } from "../discord/accounts.js";
+import { listConfiguredDiscordAccountIds, listDiscordAccountIds } from "../discord/accounts.js";
 import {
   evictPersistentState as evictDiscordPersistentState,
   markStable as markDiscordStable,
@@ -1066,13 +1066,24 @@ export async function startGatewayServer(
             }
             // Evict persistent state for discord accounts no longer in the new config.
             if (prevDiscordAccountIds.length > 0) {
-              // Use listConfiguredDiscordAccountIds (not listDiscordAccountIds) so
-              // that removing Discord entirely produces an empty set and all
-              // previous account entries are evicted — listDiscordAccountIds
-              // falls back to ["default"] when no accounts are configured,
-              // which would prevent eviction of the implicit default account.
+              // Determine currently-active account IDs with care:
+              //   - listDiscordAccountIds returns ["default"] for BOTH the single-account
+              //     token shape (Discord still active) AND when Discord is fully removed
+              //     (wrong — would prevent eviction of the implicit default account).
+              //   - listConfiguredDiscordAccountIds returns [] for the single-account
+              //     token shape (wrong — causes "default" to be evicted on every reload).
+              //
+              // Fix: treat Discord as configured if a top-level token exists OR if any
+              // explicit accounts are configured.  When configured, listDiscordAccountIds
+              // correctly resolves the active account set (including the implicit "default"
+              // for the single-account token shape).  When not configured, use an empty
+              // set so all previous entries are evicted.
+              const hasDiscordConfig = !!(
+                prepared.config.channels?.discord?.token ||
+                listConfiguredDiscordAccountIds(prepared.config).length > 0
+              );
               const nextDiscordAccountIds = new Set(
-                listConfiguredDiscordAccountIds(prepared.config),
+                hasDiscordConfig ? listDiscordAccountIds(prepared.config) : [],
               );
               for (const id of prevDiscordAccountIds) {
                 if (!nextDiscordAccountIds.has(id)) {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -1077,10 +1077,12 @@ export async function startGatewayServer(
               // explicit accounts are configured.  When configured, listDiscordAccountIds
               // correctly resolves the active account set (including the implicit "default"
               // for the single-account token shape).  When not configured, use an empty
-              // set so all previous entries are evicted.
+              // set so all previous entries are evicted.  Also covers the env-var-only
+              // path where DISCORD_BOT_TOKEN is set but no config key is present.
               const hasDiscordConfig = !!(
                 prepared.config.channels?.discord?.token ||
-                listConfiguredDiscordAccountIds(prepared.config).length > 0
+                listConfiguredDiscordAccountIds(prepared.config).length > 0 ||
+                process.env.DISCORD_BOT_TOKEN
               );
               const nextDiscordAccountIds = new Set(
                 hasDiscordConfig ? listDiscordAccountIds(prepared.config) : [],

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -21,7 +21,9 @@ import {
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
+import { listDiscordAccountIds } from "../discord/accounts.js";
 import {
+  evictPersistentState as evictDiscordPersistentState,
   markStable as markDiscordStable,
   requestCleanRestart as requestDiscordCleanRestart,
 } from "../discord/monitor/provider.lifecycle.js";
@@ -1045,6 +1047,13 @@ export async function startGatewayServer(
               reason: "reload",
               activate: true,
             });
+            // Snapshot discord account IDs before the reload so we can evict
+            // persistent state for any accounts that are removed from config.
+            // Use the runtime snapshot (not cfgAtStart) to capture the currently
+            // running set, which may have already changed since startup.
+            const prevDiscordAccountIds = plan.restartChannels.has("discord")
+              ? Object.keys(getRuntimeSnapshot().channelAccounts["discord"] ?? {})
+              : [];
             try {
               await applyHotReload(plan, prepared.config);
             } catch (err) {
@@ -1054,6 +1063,15 @@ export async function startGatewayServer(
                 clearSecretsRuntimeSnapshot();
               }
               throw err;
+            }
+            // Evict persistent state for discord accounts no longer in the new config.
+            if (prevDiscordAccountIds.length > 0) {
+              const nextDiscordAccountIds = new Set(listDiscordAccountIds(prepared.config));
+              for (const id of prevDiscordAccountIds) {
+                if (!nextDiscordAccountIds.has(id)) {
+                  evictDiscordPersistentState(id);
+                }
+              }
             }
           },
           onRestart: async (plan, nextConfig) => {

--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -21,7 +21,7 @@ import {
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import { applyPluginAutoEnable } from "../config/plugin-auto-enable.js";
 import { resolveMainSessionKey } from "../config/sessions.js";
-import { listDiscordAccountIds } from "../discord/accounts.js";
+import { listConfiguredDiscordAccountIds } from "../discord/accounts.js";
 import {
   evictPersistentState as evictDiscordPersistentState,
   markStable as markDiscordStable,
@@ -1066,7 +1066,14 @@ export async function startGatewayServer(
             }
             // Evict persistent state for discord accounts no longer in the new config.
             if (prevDiscordAccountIds.length > 0) {
-              const nextDiscordAccountIds = new Set(listDiscordAccountIds(prepared.config));
+              // Use listConfiguredDiscordAccountIds (not listDiscordAccountIds) so
+              // that removing Discord entirely produces an empty set and all
+              // previous account entries are evicted — listDiscordAccountIds
+              // falls back to ["default"] when no accounts are configured,
+              // which would prevent eviction of the implicit default account.
+              const nextDiscordAccountIds = new Set(
+                listConfiguredDiscordAccountIds(prepared.config),
+              );
               for (const id of prevDiscordAccountIds) {
                 if (!nextDiscordAccountIds.has(id)) {
                   evictDiscordPersistentState(id);

--- a/src/gateway/server.reload.test.ts
+++ b/src/gateway/server.reload.test.ts
@@ -104,6 +104,15 @@ const hoisted = vi.hoisted(() => {
         imessage: {},
         msteams: {},
       },
+      channelAccounts: {
+        whatsapp: {},
+        telegram: {},
+        discord: {},
+        slack: {},
+        signal: {},
+        imessage: {},
+        msteams: {},
+      },
     })),
     startChannels: vi.fn(async () => {}),
     startChannel: vi.fn(async () => {}),
@@ -128,6 +137,8 @@ const hoisted = vi.hoisted(() => {
     },
   );
 
+  const evictDiscordPersistentState = vi.fn();
+
   return {
     CronService: CronServiceMock,
     cronInstances,
@@ -144,6 +155,7 @@ const hoisted = vi.hoisted(() => {
     reloaderStop,
     getOnHotReload: () => onHotReload,
     getOnRestart: () => onRestart,
+    evictDiscordPersistentState,
   };
 });
 
@@ -170,6 +182,12 @@ vi.mock("./server-channels.js", () => ({
 
 vi.mock("./config-reload.js", () => ({
   startGatewayConfigReloader: hoisted.startGatewayConfigReloader,
+}));
+
+vi.mock("../../extensions/discord/src/monitor/provider.lifecycle.js", () => ({
+  evictPersistentState: hoisted.evictDiscordPersistentState,
+  markStable: vi.fn(),
+  requestCleanRestart: vi.fn(),
 }));
 
 installGatewayTestHooks({ scope: "suite" });
@@ -868,6 +886,66 @@ process.stdin.on("end", () => {
       ws.close();
       await server.close();
     }
+  });
+
+  it("evicts persistent state for discord accounts removed during hot reload", async () => {
+    await writeEnvRefConfig();
+    process.env.OPENAI_API_KEY = "sk-test"; // pragma: allowlist secret
+
+    await withGatewayServer(async () => {
+      const onHotReload = hoisted.getOnHotReload();
+      expect(onHotReload).toBeTypeOf("function");
+
+      // Simulate two discord accounts active before reload.
+      hoisted.providerManager.getRuntimeSnapshot.mockReturnValueOnce({
+        providers: {},
+        providerAccounts: {},
+        channels: {},
+        channelAccounts: {
+          discord: {
+            acct1: {} as never,
+            acct2: {} as never,
+          },
+        },
+      });
+
+      hoisted.evictDiscordPersistentState.mockClear();
+
+      // Hot reload that removes discord entirely from config.
+      const nextConfig = {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              apiKey: { source: "env", provider: "default", id: "OPENAI_API_KEY" },
+              models: [],
+            },
+          },
+        },
+        // no channels.discord
+      };
+
+      await onHotReload?.(
+        {
+          changedPaths: ["channels.discord.token"],
+          restartGateway: false,
+          restartReasons: [],
+          hotReasons: ["channels.discord.token"],
+          reloadHooks: false,
+          restartGmailWatcher: false,
+          restartBrowserControl: false,
+          restartCron: false,
+          restartHeartbeat: false,
+          restartChannels: new Set(["discord"]),
+          noopPaths: [],
+        },
+        nextConfig,
+      );
+
+      // Both removed accounts must be evicted.
+      expect(hoisted.evictDiscordPersistentState).toHaveBeenCalledWith("acct1");
+      expect(hoisted.evictDiscordPersistentState).toHaveBeenCalledWith("acct2");
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

Fixes #38596.

After a Discord WebSocket disconnect, the health monitor restarts the Discord provider lifecycle. But each new lifecycle resets `consecutiveHelloStalls` (local variable) to zero, so circuit breakers never accumulate across restarts. The result: connect → zombie → health-monitor restart → connect → zombie → indefinite loop.

## Changes

### 1. `src/discord/monitor/provider.lifecycle.ts` — Persistent state across restarts
- Added `DiscordLifecyclePersistentState` type with `consecutiveHelloStalls` and `forceCleanRestart` fields
- Module-level `Map<accountId, State>` persists across lifecycle invocations (survives health-monitor restarts)
- Exported `getOrCreatePersistentState()`, `requestCleanRestart()`, `markStable()` for external wiring
- On lifecycle start, if `forceCleanRestart` is set, clears Discord resume state for a fresh IDENTIFY

### 2. `src/gateway/channel-health-monitor.ts` — Consecutive restart tracking + escalation + backoff
- Added `consecutiveRestarts` counter to `RestartRecord`
- Stability detection: channel staying healthy >5 min resets counter and calls `onChannelStable` callback
- Escalation: after 3 consecutive restarts without stability, calls `onBeforeRestart` callback so callers can request a clean restart
- Exponential backoff: cooldown = base x 2^min(consecutive, 3), capped at 60 min (10m -> 20m -> 40m -> 60m)

### 3. `src/gateway/server.impl.ts` — Wiring
- `onBeforeRestart`: for discord channels, calls `requestDiscordCleanRestart(accountId)`
- `onChannelStable`: for discord channels, calls `markDiscordStable(accountId)` to reset persistent counters

### 4. Tests — 12 new tests
- Persistent state utilities
- `consecutiveHelloStalls` persists across lifecycle restarts and triggers fresh IDENTIFY at threshold
- `forceCleanRestart` clears resume state on lifecycle start
- Health monitor consecutive restart tracking with `onBeforeRestart` escalation
- Stability reset via `onChannelStable`
- Exponential backoff timing verification

## Observed in production

Gateway logs showing exact pattern from the issue report — Discord logs in successfully after each restart but goes zombie within 5-10 min, health monitor retries indefinitely, gateway eventually dies.
