### PR TITLE
feat(subagents): config-driven prompt hook for sessions_spawn

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -183,7 +183,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
       streaming: "partial", // off | partial | block | progress (default: off)
       actions: { reactions: true, sendMessage: true },
       reactionNotifications: "own", // off | own | all
-      mediaMaxMb: 100,
+      mediaMaxMb: 5,
       retry: {
         attempts: 3,
         minDelayMs: 400,
@@ -205,9 +205,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 
 - Bot token: `channels.telegram.botToken` or `channels.telegram.tokenFile`, with `TELEGRAM_BOT_TOKEN` as fallback for the default account.
 - Optional `channels.telegram.defaultAccount` overrides default account selection when it matches a configured account id.
-- In multi-account setups (2+ account ids), set an explicit default (`channels.telegram.defaultAccount` or `channels.telegram.accounts.default`) to avoid fallback routing; `openclaw doctor` warns when this is missing or invalid.
 - `configWrites: false` blocks Telegram-initiated config writes (supergroup ID migrations, `/config set|unset`).
-- Top-level `bindings[]` entries with `type: "acp"` configure persistent ACP bindings for forum topics (use canonical `chatId:topic:topicId` in `match.peer.id`). Field semantics are shared in [ACP Agents](/tools/acp-agents#channel-specific-settings).
 - Telegram stream previews use `sendMessage` + `editMessageText` (works in direct and group chats).
 - Retry policy: see [Retry policy](/concepts/retry).
 
@@ -246,7 +244,6 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
         "123456789012345678": {
           slug: "friends-of-openclaw",
           requireMention: false,
-          ignoreOtherMentions: true,
           reactionNotifications: "own",
           users: ["987654321098765432"],
           channels: {
@@ -307,21 +304,18 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - Optional `channels.discord.defaultAccount` overrides default account selection when it matches a configured account id.
 - Use `user:<id>` (DM) or `channel:<id>` (guild channel) for delivery targets; bare numeric IDs are rejected.
 - Guild slugs are lowercase with spaces replaced by `-`; channel keys use the slugged name (no `#`). Prefer guild IDs.
-- Bot-authored messages are ignored by default. `allowBots: true` enables them; use `allowBots: "mentions"` to only accept bot messages that mention the bot (own messages still filtered).
-- `channels.discord.guilds.<id>.ignoreOtherMentions` (and channel overrides) drops messages that mention another user or role but not the bot (excluding @everyone/@here).
+- Bot-authored messages are ignored by default. `allowBots: true` enables them (own messages still filtered).
 - `maxLinesPerMessage` (default 17) splits tall messages even when under 2000 chars.
 - `channels.discord.threadBindings` controls Discord thread-bound routing:
   - `enabled`: Discord override for thread-bound session features (`/focus`, `/unfocus`, `/agents`, `/session idle`, `/session max-age`, and bound delivery/routing)
   - `idleHours`: Discord override for inactivity auto-unfocus in hours (`0` disables)
   - `maxAgeHours`: Discord override for hard max age in hours (`0` disables)
   - `spawnSubagentSessions`: opt-in switch for `sessions_spawn({ thread: true })` auto thread creation/binding
-- Top-level `bindings[]` entries with `type: "acp"` configure persistent ACP bindings for channels and threads (use channel/thread id in `match.peer.id`). Field semantics are shared in [ACP Agents](/tools/acp-agents#channel-specific-settings).
 - `channels.discord.ui.components.accentColor` sets the accent color for Discord components v2 containers.
 - `channels.discord.voice` enables Discord voice channel conversations and optional auto-join + TTS overrides.
 - `channels.discord.voice.daveEncryption` and `channels.discord.voice.decryptionFailureTolerance` pass through to `@discordjs/voice` DAVE options (`true` and `24` by default).
 - OpenClaw additionally attempts voice receive recovery by leaving/rejoining a voice session after repeated decrypt failures.
 - `channels.discord.streaming` is the canonical stream mode key. Legacy `streamMode` and boolean `streaming` values are auto-migrated.
-- `channels.discord.autoPresence` maps runtime availability to bot presence (healthy => online, degraded => idle, exhausted => dnd) and allows optional status text overrides.
 - `channels.discord.dangerouslyAllowNameMatching` re-enables mutable name/tag matching (break-glass compatibility mode).
 
 **Reaction notification modes:** `off` (none), `own` (bot's messages, default), `all` (all messages), `allowlist` (from `guilds.<id>.users` on all messages).
@@ -406,7 +400,6 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
         sessionPrefix: "slack:slash",
         ephemeral: true,
       },
-      typingReaction: "hourglass_flowing_sand",
       textChunkLimit: 4000,
       chunkMode: "length",
       streaming: "partial", // off | partial | block | progress (preview mode)
@@ -427,8 +420,6 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 **Reaction notification modes:** `off`, `own` (default), `all`, `allowlist` (from `reactionAllowlist`).
 
 **Thread session isolation:** `thread.historyScope` is per-thread (default) or shared across channel. `thread.inheritParent` copies parent channel transcript to new threads.
-
-- `typingReaction` adds a temporary reaction to the inbound Slack message while a reply is running, then removes it on completion. Use a Slack emoji shortcode such as `"hourglass_flowing_sand"`.
 
 | Action group | Default | Notes                  |
 | ------------ | ------- | ---------------------- |
@@ -452,13 +443,6 @@ Mattermost ships as a plugin: `openclaw plugins install @openclaw/mattermost`.
       dmPolicy: "pairing",
       chatmode: "oncall", // oncall | onmessage | onchar
       oncharPrefixes: [">", "!"],
-      commands: {
-        native: true, // opt-in
-        nativeSkills: true,
-        callbackPath: "/api/channels/mattermost/command",
-        // Optional explicit URL for reverse-proxy/public deployments
-        callbackUrl: "https://gateway.example.com/api/channels/mattermost/command",
-      },
       textChunkLimit: 4000,
       chunkMode: "length",
     },
@@ -468,13 +452,6 @@ Mattermost ships as a plugin: `openclaw plugins install @openclaw/mattermost`.
 
 Chat modes: `oncall` (respond on @-mention, default), `onmessage` (every message), `onchar` (messages starting with trigger prefix).
 
-When Mattermost native commands are enabled:
-
-- `commands.callbackPath` must be a path (for example `/api/channels/mattermost/command`), not a full URL.
-- `commands.callbackUrl` must resolve to the OpenClaw gateway endpoint and be reachable from the Mattermost server.
-- For private/tailnet/internal callback hosts, Mattermost may require
-  `ServiceSettings.AllowedUntrustedInternalConnections` to include the callback host/domain.
-  Use host/domain values, not full URLs.
 - `channels.mattermost.configWrites`: allow or deny Mattermost-initiated config writes.
 - `channels.mattermost.requireMention`: require `@mention` before replying in channels.
 - Optional `channels.mattermost.defaultAccount` overrides default account selection when it matches a configured account id.
@@ -745,7 +722,7 @@ Include your own number in `allowFrom` to enable self-chat mode (ignores native 
 - Override per channel: `channels.discord.commands.native` (bool or `"auto"`). `false` clears previously registered commands.
 - `channels.telegram.customCommands` adds extra Telegram bot menu entries.
 - `bash: true` enables `! <cmd>` for host shell. Requires `tools.elevated.enabled` and sender in `tools.elevated.allowFrom.<channel>`.
-- `config: true` enables `/config` (reads/writes `openclaw.json`). For gateway `chat.send` clients, persistent `/config set|unset` writes also require `operator.admin`; read-only `/config show` stays available to normal write-scoped operator clients.
+- `config: true` enables `/config` (reads/writes `openclaw.json`).
 - `channels.<provider>.configWrites` gates config mutations per channel (default: true).
 - `allowFrom` is per-provider. When set, it is the **only** authorization source (channel allowlists/pairing and `useAccessGroups` are ignored).
 - `useAccessGroups: false` allows commands to bypass access-group policies when `allowFrom` is not set.
@@ -803,21 +780,6 @@ Max total characters injected across all workspace bootstrap files. Default: `15
 ```json5
 {
   agents: { defaults: { bootstrapTotalMaxChars: 150000 } },
-}
-```
-
-### `agents.defaults.bootstrapPromptTruncationWarning`
-
-Controls agent-visible warning text when bootstrap context is truncated.
-Default: `"once"`.
-
-- `"off"`: never inject warning text into the system prompt.
-- `"once"`: inject warning once per unique truncation signature (recommended).
-- `"always"`: inject warning on every run when truncation exists.
-
-```json5
-{
-  agents: { defaults: { bootstrapPromptTruncationWarning: "once" } }, // off | once | always
 }
 ```
 
@@ -910,15 +872,14 @@ Time format in system prompt. Default: `auto` (OS preference).
 
 **Built-in alias shorthands** (only apply when the model is in `agents.defaults.models`):
 
-| Alias               | Model                                  |
-| ------------------- | -------------------------------------- |
-| `opus`              | `anthropic/claude-opus-4-6`            |
-| `sonnet`            | `anthropic/claude-sonnet-4-6`          |
-| `gpt`               | `openai/gpt-5.4`                       |
-| `gpt-mini`          | `openai/gpt-5-mini`                    |
-| `gemini`            | `google/gemini-3.1-pro-preview`        |
-| `gemini-flash`      | `google/gemini-3-flash-preview`        |
-| `gemini-flash-lite` | `google/gemini-3.1-flash-lite-preview` |
+| Alias          | Model                           |
+| -------------- | ------------------------------- |
+| `opus`         | `anthropic/claude-opus-4-6`     |
+| `sonnet`       | `anthropic/claude-sonnet-4-5`   |
+| `gpt`          | `openai/gpt-5.2`                |
+| `gpt-mini`     | `openai/gpt-5-mini`             |
+| `gemini`       | `google/gemini-3-pro-preview`   |
+| `gemini-flash` | `google/gemini-3-flash-preview` |
 
 Your configured aliases always win over defaults.
 
@@ -972,7 +933,6 @@ Periodic heartbeat runs.
         every: "30m", // 0m disables
         model: "openai/gpt-5.2-mini",
         includeReasoning: false,
-        lightContext: false, // default: false; true keeps only HEARTBEAT.md from workspace bootstrap files
         session: "main",
         to: "+15555550123",
         directPolicy: "allow", // allow (default) | block
@@ -989,7 +949,6 @@ Periodic heartbeat runs.
 - `every`: duration string (ms/s/m/h). Default: `30m`.
 - `suppressToolErrorWarnings`: when true, suppresses tool error warning payloads during heartbeat runs.
 - `directPolicy`: direct/DM delivery policy. `allow` (default) permits direct-target delivery. `block` suppresses direct-target delivery and emits `reason=dm-blocked`.
-- `lightContext`: when true, heartbeat runs use lightweight bootstrap context and keep only `HEARTBEAT.md` from workspace bootstrap files.
 - Per-agent: set `agents.list[].heartbeat`. When any agent defines `heartbeat`, **only those agents** run heartbeats.
 - Heartbeats run full agent turns — shorter intervals burn more tokens.
 
@@ -1004,8 +963,6 @@ Periodic heartbeat runs.
         reserveTokensFloor: 24000,
         identifierPolicy: "strict", // strict | off | custom
         identifierInstructions: "Preserve deployment IDs, ticket IDs, and host:port pairs exactly.", // used when identifierPolicy=custom
-        postCompactionSections: ["Session Startup", "Red Lines"], // [] disables reinjection
-        model: "openrouter/anthropic/claude-sonnet-4-5", // optional compaction-only model override
         memoryFlush: {
           enabled: true,
           softThresholdTokens: 6000,
@@ -1021,8 +978,6 @@ Periodic heartbeat runs.
 - `mode`: `default` or `safeguard` (chunked summarization for long histories). See [Compaction](/concepts/compaction).
 - `identifierPolicy`: `strict` (default), `off`, or `custom`. `strict` prepends built-in opaque identifier retention guidance during compaction summarization.
 - `identifierInstructions`: optional custom identifier-preservation text used when `identifierPolicy=custom`.
-- `postCompactionSections`: optional AGENTS.md H2/H3 section names to re-inject after compaction. Defaults to `["Session Startup", "Red Lines"]`; set `[]` to disable reinjection. When unset or explicitly set to that default pair, older `Every Session`/`Safety` headings are also accepted as a legacy fallback.
-- `model`: optional `provider/model-id` override for compaction summarization only. Use this when the main session should keep one model but compaction summaries should run on another; when unset, compaction uses the session's primary model.
 - `memoryFlush`: silent agentic turn before auto-compaction to store durable memories. Skipped when workspace is read-only.
 
 ### `agents.defaults.contextPruning`
@@ -1215,8 +1170,8 @@ Optional **Docker sandboxing** for the embedded agent. See [Sandboxing](/gateway
 
 **`docker.binds`** mounts additional host directories; global and per-agent binds are merged.
 
-**Sandboxed browser** (`sandbox.browser.enabled`): Chromium + CDP in a container. noVNC URL injected into system prompt. Does not require `browser.enabled` in `openclaw.json`.
-noVNC observer access uses VNC auth by default and OpenClaw emits a short-lived token URL (instead of exposing the password in the shared URL).
+**Sandboxed browser** (`sandbox.browser.enabled`): Chromium + CDP in a container. noVNC URL injected into system prompt. Does not require `browser.enabled` in main config.
+noVNC observer access uses VNC auth by default and OpenClaw emits a short-lived token URL that serves a local bootstrap page; noVNC password is passed via URL fragment (instead of URL query).
 
 - `allowHostControl: false` (default) blocks sandboxed sessions from targeting the host browser.
 - `network` defaults to `openclaw-sandbox-browser` (dedicated bridge network). Set to `bridge` only when you explicitly want global bridge connectivity.
@@ -1283,15 +1238,6 @@ scripts/sandbox-browser-setup.sh   # optional browser image
         },
         groupChat: { mentionPatterns: ["@openclaw"] },
         sandbox: { mode: "off" },
-        runtime: {
-          type: "acp",
-          acp: {
-            agent: "codex",
-            backend: "acpx",
-            mode: "persistent",
-            cwd: "/workspace/openclaw",
-          },
-        },
         subagents: { allowAgents: ["*"] },
         tools: {
           profile: "coding",
@@ -1309,7 +1255,6 @@ scripts/sandbox-browser-setup.sh   # optional browser image
 - `default`: when multiple are set, first wins (warning logged). If none set, first list entry is default.
 - `model`: string form overrides `primary` only; object form `{ primary, fallbacks }` overrides both (`[]` disables global fallbacks). Cron jobs that only override `primary` still inherit default fallbacks unless you set `fallbacks: []`.
 - `params`: per-agent stream params merged over the selected model entry in `agents.defaults.models`. Use this for agent-specific overrides like `cacheRetention`, `temperature`, or `maxTokens` without duplicating the whole model catalog.
-- `runtime`: optional per-agent runtime descriptor. Use `type: "acp"` with `runtime.acp` defaults (`agent`, `backend`, `mode`, `cwd`) when the agent should default to ACP harness sessions.
 - `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI.
 - `identity` derives defaults: `ackReaction` from `emoji`, `mentionPatterns` from `name`/`emoji`.
 - `subagents.allowAgents`: allowlist of agent ids for `sessions_spawn` (`["*"]` = any; default: same agent only).
@@ -1338,12 +1283,10 @@ Run multiple isolated agents inside one Gateway. See [Multi-Agent](/concepts/mul
 
 ### Binding match fields
 
-- `type` (optional): `route` for normal routing (missing type defaults to route), `acp` for persistent ACP conversation bindings.
 - `match.channel` (required)
 - `match.accountId` (optional; `*` = any account; omitted = default account)
 - `match.peer` (optional; `{ kind: direct|group|channel, id }`)
 - `match.guildId` / `match.teamId` (optional; channel-specific)
-- `acp` (optional; only for `type: "acp"`): `{ mode, label, cwd, backend }`
 
 **Deterministic match order:**
 
@@ -1355,8 +1298,6 @@ Run multiple isolated agents inside one Gateway. See [Multi-Agent](/concepts/mul
 6. Default agent
 
 Within each tier, the first matching `bindings` entry wins.
-
-For `type: "acp"` entries, OpenClaw resolves by exact conversation identity (`match.channel` + account + `match.peer.id`) and does not use the route binding tier order above.
 
 ### Per-agent access profiles
 
@@ -1628,7 +1569,6 @@ Batches rapid text-only messages from the same sender into a single agent turn. 
       },
       openai: {
         apiKey: "openai_api_key",
-        baseUrl: "https://api.openai.com/v1",
         model: "gpt-4o-mini-tts",
         voice: "alloy",
       },
@@ -1641,8 +1581,6 @@ Batches rapid text-only messages from the same sender into a single agent turn. 
 - `summaryModel` overrides `agents.defaults.model.primary` for auto-summary.
 - `modelOverrides` is enabled by default; `modelOverrides.allowProvider` defaults to `false` (opt-in).
 - API keys fall back to `ELEVENLABS_API_KEY`/`XI_API_KEY` and `OPENAI_API_KEY`.
-- `openai.baseUrl` overrides the OpenAI TTS endpoint. Resolution order is config, then `OPENAI_TTS_BASE_URL`, then `https://api.openai.com/v1`.
-- When `openai.baseUrl` points to a non-OpenAI endpoint, OpenClaw treats it as an OpenAI-compatible TTS server and relaxes model/voice validation.
 
 ---
 
@@ -1661,17 +1599,14 @@ Defaults for Talk mode (macOS/iOS/Android).
     modelId: "eleven_v3",
     outputFormat: "mp3_44100_128",
     apiKey: "elevenlabs_api_key",
-    silenceTimeoutMs: 1500,
     interruptOnSpeech: true,
   },
 }
 ```
 
 - Voice IDs fall back to `ELEVENLABS_VOICE_ID` or `SAG_VOICE_ID`.
-- `apiKey` and `providers.*.apiKey` accept plaintext strings or SecretRef objects.
-- `ELEVENLABS_API_KEY` fallback applies only when no Talk API key is configured.
+- `apiKey` falls back to `ELEVENLABS_API_KEY`.
 - `voiceAliases` lets Talk directives use friendly names.
-- `silenceTimeoutMs` controls how long Talk mode waits after user silence before it sends the transcript. Unset keeps the platform default pause window (`700 ms on macOS and Android, 900 ms on iOS`).
 
 ---
 
@@ -1681,7 +1616,7 @@ Defaults for Talk mode (macOS/iOS/Android).
 
 `tools.profile` sets a base allowlist before `tools.allow`/`tools.deny`:
 
-Local onboarding defaults new local configs to `tools.profile: "coding"` when unset (existing explicit profiles are preserved).
+Local onboarding defaults new local configs to `tools.profile: "messaging"` when unset (existing explicit profiles are preserved).
 
 | Profile     | Includes                                                                                  |
 | ----------- | ----------------------------------------------------------------------------------------- |
@@ -1869,7 +1804,7 @@ Configures inbound media understanding (image/audio/video):
 
 - `provider`: API provider id (`openai`, `anthropic`, `google`/`gemini`, `groq`, etc.)
 - `model`: model id override
-- `profile` / `preferredProfile`: `auth-profiles.json` profile selection
+- `profile` / `preferredProfile`: auth profile selection
 
 **CLI entry** (`type: "cli"`):
 
@@ -1882,7 +1817,7 @@ Configures inbound media understanding (image/audio/video):
 - `prompt`, `maxChars`, `maxBytes`, `timeoutSeconds`, `language`: per-entry overrides.
 - Failures fall back to the next entry.
 
-Provider auth follows standard order: `auth-profiles.json` → env vars → `models.providers.*.apiKey`.
+Provider auth follows standard order: auth profiles → env vars → `models.providers.*.apiKey`.
 
 </Accordion>
 
@@ -1974,6 +1909,29 @@ Notes:
 - `runTimeoutSeconds`: default timeout (seconds) for `sessions_spawn` when the tool call omits `runTimeoutSeconds`. `0` means no timeout.
 - Per-subagent tool policy: `tools.subagents.tools.allow` / `tools.subagents.tools.deny`.
 
+Prompt hook injection (subagent runtime only):
+
+```json5
+{
+  agents: {
+    subagent: {
+      promptHook: {
+        enabled: true,
+        mode: "wrap", // prepend | append | wrap
+        prefixPath: "~/.openclaw/prompts/subagent_hook_prefix.md",
+        suffixPath: "~/.openclaw/prompts/subagent_hook_suffix.md",
+        maxBytes: 65536,
+        onMissing: "warn", // warn | disable
+      },
+    },
+  },
+}
+```
+
+- `onMissing: "warn"`: continue with available segments and log a warning.
+- `onMissing: "disable"`: skip hook injection entirely if a configured file is unavailable.
+- Runtime telemetry logs include status (`applied`/`partial`/`skipped`), mode, and file hashes (not prompt body text).
+
 ---
 
 ## Custom providers and base URLs
@@ -2009,9 +1967,7 @@ OpenClaw uses the pi-coding-agent model catalog. Add custom providers via `model
 - Use `authHeader: true` + `headers` for custom auth needs.
 - Override agent config root with `OPENCLAW_AGENT_DIR` (or `PI_CODING_AGENT_DIR`).
 - Merge precedence for matching provider IDs:
-  - Non-empty agent `models.json` `baseUrl` values win.
-  - Non-empty agent `apiKey` values win only when that provider is not SecretRef-managed in current config/auth-profile context.
-  - SecretRef-managed provider `apiKey` values are refreshed from source markers (`ENV_VAR_NAME` for env refs, `secretref-managed` for file/exec refs) instead of persisting resolved secrets.
+  - Non-empty agent `models.json` `apiKey`/`baseUrl` win.
   - Empty or missing agent `apiKey`/`baseUrl` fall back to `models.providers` in config.
   - Matching model `contextWindow`/`maxTokens` use the higher value between explicit config and implicit catalog values.
   - Use `models.mode: "replace"` when you want config to fully rewrite `models.json`.
@@ -2028,7 +1984,6 @@ OpenClaw uses the pi-coding-agent model catalog. Add custom providers via `model
 - `models.providers.*.baseUrl`: upstream API base URL.
 - `models.providers.*.headers`: extra static headers for proxy/tenant routing.
 - `models.providers.*.models`: explicit provider model catalog entries.
-- `models.providers.*.models.*.compat.supportsDeveloperRole`: optional compatibility hint. For `api: "openai-completions"` with a non-empty non-native `baseUrl` (host not `api.openai.com`), OpenClaw forces this to `false` at runtime. Empty/omitted `baseUrl` keeps default OpenAI behavior.
 - `models.bedrockDiscovery`: Bedrock auto-discovery settings root.
 - `models.bedrockDiscovery.enabled`: turn discovery polling on/off.
 - `models.bedrockDiscovery.region`: AWS region for discovery.
@@ -2304,9 +2259,6 @@ See [Local Models](/gateway/local-models). TL;DR: run MiniMax M2.5 via LM Studio
     entries: {
       "voice-call": {
         enabled: true,
-        hooks: {
-          allowPromptInjection: false,
-        },
         config: { provider: "twilio" },
       },
     },
@@ -2319,10 +2271,8 @@ See [Local Models](/gateway/local-models). TL;DR: run MiniMax M2.5 via LM Studio
 - `allow`: optional allowlist (only listed plugins load). `deny` wins.
 - `plugins.entries.<id>.apiKey`: plugin-level API key convenience field (when supported by the plugin).
 - `plugins.entries.<id>.env`: plugin-scoped env var map.
-- `plugins.entries.<id>.hooks.allowPromptInjection`: when `false`, core blocks `before_prompt_build` and ignores prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride`.
 - `plugins.entries.<id>.config`: plugin-defined config object (validated by plugin schema).
 - `plugins.slots.memory`: pick the active memory plugin id, or `"none"` to disable memory plugins.
-- `plugins.slots.contextEngine`: pick the active context engine plugin id; defaults to `"legacy"` unless you install and select another engine.
 - `plugins.installs`: CLI-managed install metadata used by `openclaw plugins update`.
   - Includes `source`, `spec`, `sourcePath`, `installPath`, `version`, `resolvedName`, `resolvedVersion`, `resolvedSpec`, `integrity`, `shasum`, `resolvedAt`, `installedAt`.
   - Treat `plugins.installs.*` as managed state; prefer CLI commands over manual edits.
@@ -2354,7 +2304,6 @@ See [Plugins](/tools/plugin).
     // headless: false,
     // noSandbox: false,
     // extraArgs: [],
-    // relayBindHost: "0.0.0.0", // only when the extension relay must be reachable across namespaces (for example WSL2)
     // executablePath: "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
     // attachOnly: false,
   },
@@ -2371,7 +2320,6 @@ See [Plugins](/tools/plugin).
 - Control service: loopback only (port derived from `gateway.port`, default `18791`).
 - `extraArgs` appends extra launch flags to local Chromium startup (for example
   `--disable-gpu`, window sizing, or debug flags).
-- `relayBindHost` changes where the Chrome extension relay listens. Leave unset for loopback-only access; set an explicit non-loopback bind address such as `0.0.0.0` only when the relay must cross a namespace boundary (for example WSL2) and the host network is already trusted.
 
 ---
 
@@ -2455,7 +2403,6 @@ See [Plugins](/tools/plugin).
 - **Legacy bind aliases**: use bind mode values in `gateway.bind` (`auto`, `loopback`, `lan`, `tailnet`, `custom`), not host aliases (`0.0.0.0`, `127.0.0.1`, `localhost`, `::`, `::1`).
 - **Docker note**: the default `loopback` bind listens on `127.0.0.1` inside the container. With Docker bridge networking (`-p 18789:18789`), traffic arrives on `eth0`, so the gateway is unreachable. Use `--network host`, or set `bind: "lan"` (or `bind: "custom"` with `customBindHost: "0.0.0.0"`) to listen on all interfaces.
 - **Auth**: required by default. Non-loopback binds require a shared token/password. Onboarding wizard generates a token by default.
-- If both `gateway.auth.token` and `gateway.auth.password` are configured (including SecretRefs), set `gateway.auth.mode` explicitly to `token` or `password`. Startup and service install/repair flows fail when both are configured and mode is unset.
 - `gateway.auth.mode: "none"`: explicit no-auth mode. Use only for trusted local loopback setups; this is intentionally not offered by onboarding prompts.
 - `gateway.auth.mode: "trusted-proxy"`: delegate auth to an identity-aware reverse proxy and trust identity headers from `gateway.trustedProxies` (see [Trusted Proxy Auth](/gateway/trusted-proxy-auth)).
 - `gateway.auth.allowTailscale`: when `true`, Tailscale Serve identity headers can satisfy Control UI/WebSocket auth (verified via `tailscale whois`); HTTP API endpoints still require token/password auth. This tokenless flow assumes the gateway host is trusted. Defaults to `true` when `tailscale.mode = "serve"`.
@@ -2713,11 +2660,14 @@ Validation:
 - `source: "file"` id: absolute JSON pointer (for example `"/providers/openai/apiKey"`)
 - `source: "exec"` id pattern: `^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$`
 
-### Supported credential surface
+### Supported fields in config
 
-- Canonical matrix: [SecretRef Credential Surface](/reference/secretref-credential-surface)
-- `secrets apply` targets supported `openclaw.json` credential paths.
-- `auth-profiles.json` refs are included in runtime resolution and audit coverage.
+- `models.providers.<provider>.apiKey`
+- `skills.entries.<skillKey>.apiKey`
+- `channels.googlechat.serviceAccount`
+- `channels.googlechat.serviceAccountRef`
+- `channels.googlechat.accounts.<accountId>.serviceAccount`
+- `channels.googlechat.accounts.<accountId>.serviceAccountRef`
 
 ### Secret providers config
 
@@ -2755,7 +2705,6 @@ Notes:
 - If `trustedDirs` is configured, the trusted-dir check applies to the resolved target path.
 - `exec` child environment is minimal by default; pass required variables explicitly with `passEnv`.
 - Secret refs are resolved at activation time into an in-memory snapshot, then request paths read the snapshot only.
-- Active-surface filtering applies during activation: unresolved refs on enabled surfaces fail startup/reload, while inactive surfaces are skipped with diagnostics.
 
 ---
 
@@ -2775,8 +2724,8 @@ Notes:
 }
 ```
 
-- Per-agent profiles are stored at `<agentDir>/auth-profiles.json`.
-- `auth-profiles.json` supports value-level refs (`keyRef` for `api_key`, `tokenRef` for `token`).
+- Per-agent auth profiles stored at `<agentDir>/auth-profiles.json`.
+- Auth profiles support value-level refs (`keyRef` for `api_key`, `tokenRef` for `token`).
 - Static runtime credentials come from in-memory resolved snapshots; legacy static `auth.json` entries are scrubbed when discovered.
 - Legacy OAuth imports from `~/.openclaw/credentials/oauth.json`.
 - See [OAuth](/concepts/oauth).
@@ -2973,7 +2922,7 @@ Split config into multiple files:
 - Array of files: deep-merged in order (later overrides earlier).
 - Sibling keys: merged after includes (override included values).
 - Nested includes: up to 10 levels deep.
-- Paths: resolved relative to the including file, but must stay inside the top-level config directory (`dirname` of `openclaw.json`). Absolute/`../` forms are allowed only when they still resolve inside that boundary.
+- Paths: resolved relative to the including file, but must stay inside the top-level config directory (`dirname` of the main config file). Absolute/`../` forms are allowed only when they still resolve inside that boundary.
 - Errors: clear messages for missing files, parse errors, and circular includes.
 
 ---

--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -183,7 +183,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
       streaming: "partial", // off | partial | block | progress (default: off)
       actions: { reactions: true, sendMessage: true },
       reactionNotifications: "own", // off | own | all
-      mediaMaxMb: 5,
+      mediaMaxMb: 100,
       retry: {
         attempts: 3,
         minDelayMs: 400,
@@ -205,7 +205,9 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 
 - Bot token: `channels.telegram.botToken` or `channels.telegram.tokenFile`, with `TELEGRAM_BOT_TOKEN` as fallback for the default account.
 - Optional `channels.telegram.defaultAccount` overrides default account selection when it matches a configured account id.
+- In multi-account setups (2+ account ids), set an explicit default (`channels.telegram.defaultAccount` or `channels.telegram.accounts.default`) to avoid fallback routing; `openclaw doctor` warns when this is missing or invalid.
 - `configWrites: false` blocks Telegram-initiated config writes (supergroup ID migrations, `/config set|unset`).
+- Top-level `bindings[]` entries with `type: "acp"` configure persistent ACP bindings for forum topics (use canonical `chatId:topic:topicId` in `match.peer.id`). Field semantics are shared in [ACP Agents](/tools/acp-agents#channel-specific-settings).
 - Telegram stream previews use `sendMessage` + `editMessageText` (works in direct and group chats).
 - Retry policy: see [Retry policy](/concepts/retry).
 
@@ -244,6 +246,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
         "123456789012345678": {
           slug: "friends-of-openclaw",
           requireMention: false,
+          ignoreOtherMentions: true,
           reactionNotifications: "own",
           users: ["987654321098765432"],
           channels: {
@@ -304,18 +307,21 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 - Optional `channels.discord.defaultAccount` overrides default account selection when it matches a configured account id.
 - Use `user:<id>` (DM) or `channel:<id>` (guild channel) for delivery targets; bare numeric IDs are rejected.
 - Guild slugs are lowercase with spaces replaced by `-`; channel keys use the slugged name (no `#`). Prefer guild IDs.
-- Bot-authored messages are ignored by default. `allowBots: true` enables them (own messages still filtered).
+- Bot-authored messages are ignored by default. `allowBots: true` enables them; use `allowBots: "mentions"` to only accept bot messages that mention the bot (own messages still filtered).
+- `channels.discord.guilds.<id>.ignoreOtherMentions` (and channel overrides) drops messages that mention another user or role but not the bot (excluding @everyone/@here).
 - `maxLinesPerMessage` (default 17) splits tall messages even when under 2000 chars.
 - `channels.discord.threadBindings` controls Discord thread-bound routing:
   - `enabled`: Discord override for thread-bound session features (`/focus`, `/unfocus`, `/agents`, `/session idle`, `/session max-age`, and bound delivery/routing)
   - `idleHours`: Discord override for inactivity auto-unfocus in hours (`0` disables)
   - `maxAgeHours`: Discord override for hard max age in hours (`0` disables)
   - `spawnSubagentSessions`: opt-in switch for `sessions_spawn({ thread: true })` auto thread creation/binding
+- Top-level `bindings[]` entries with `type: "acp"` configure persistent ACP bindings for channels and threads (use channel/thread id in `match.peer.id`). Field semantics are shared in [ACP Agents](/tools/acp-agents#channel-specific-settings).
 - `channels.discord.ui.components.accentColor` sets the accent color for Discord components v2 containers.
 - `channels.discord.voice` enables Discord voice channel conversations and optional auto-join + TTS overrides.
 - `channels.discord.voice.daveEncryption` and `channels.discord.voice.decryptionFailureTolerance` pass through to `@discordjs/voice` DAVE options (`true` and `24` by default).
 - OpenClaw additionally attempts voice receive recovery by leaving/rejoining a voice session after repeated decrypt failures.
 - `channels.discord.streaming` is the canonical stream mode key. Legacy `streamMode` and boolean `streaming` values are auto-migrated.
+- `channels.discord.autoPresence` maps runtime availability to bot presence (healthy => online, degraded => idle, exhausted => dnd) and allows optional status text overrides.
 - `channels.discord.dangerouslyAllowNameMatching` re-enables mutable name/tag matching (break-glass compatibility mode).
 
 **Reaction notification modes:** `off` (none), `own` (bot's messages, default), `all` (all messages), `allowlist` (from `guilds.<id>.users` on all messages).
@@ -400,6 +406,7 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
         sessionPrefix: "slack:slash",
         ephemeral: true,
       },
+      typingReaction: "hourglass_flowing_sand",
       textChunkLimit: 4000,
       chunkMode: "length",
       streaming: "partial", // off | partial | block | progress (preview mode)
@@ -420,6 +427,8 @@ WhatsApp runs through the gateway's web channel (Baileys Web). It starts automat
 **Reaction notification modes:** `off`, `own` (default), `all`, `allowlist` (from `reactionAllowlist`).
 
 **Thread session isolation:** `thread.historyScope` is per-thread (default) or shared across channel. `thread.inheritParent` copies parent channel transcript to new threads.
+
+- `typingReaction` adds a temporary reaction to the inbound Slack message while a reply is running, then removes it on completion. Use a Slack emoji shortcode such as `"hourglass_flowing_sand"`.
 
 | Action group | Default | Notes                  |
 | ------------ | ------- | ---------------------- |
@@ -443,6 +452,13 @@ Mattermost ships as a plugin: `openclaw plugins install @openclaw/mattermost`.
       dmPolicy: "pairing",
       chatmode: "oncall", // oncall | onmessage | onchar
       oncharPrefixes: [">", "!"],
+      commands: {
+        native: true, // opt-in
+        nativeSkills: true,
+        callbackPath: "/api/channels/mattermost/command",
+        // Optional explicit URL for reverse-proxy/public deployments
+        callbackUrl: "https://gateway.example.com/api/channels/mattermost/command",
+      },
       textChunkLimit: 4000,
       chunkMode: "length",
     },
@@ -452,6 +468,13 @@ Mattermost ships as a plugin: `openclaw plugins install @openclaw/mattermost`.
 
 Chat modes: `oncall` (respond on @-mention, default), `onmessage` (every message), `onchar` (messages starting with trigger prefix).
 
+When Mattermost native commands are enabled:
+
+- `commands.callbackPath` must be a path (for example `/api/channels/mattermost/command`), not a full URL.
+- `commands.callbackUrl` must resolve to the OpenClaw gateway endpoint and be reachable from the Mattermost server.
+- For private/tailnet/internal callback hosts, Mattermost may require
+  `ServiceSettings.AllowedUntrustedInternalConnections` to include the callback host/domain.
+  Use host/domain values, not full URLs.
 - `channels.mattermost.configWrites`: allow or deny Mattermost-initiated config writes.
 - `channels.mattermost.requireMention`: require `@mention` before replying in channels.
 - Optional `channels.mattermost.defaultAccount` overrides default account selection when it matches a configured account id.
@@ -722,7 +745,7 @@ Include your own number in `allowFrom` to enable self-chat mode (ignores native 
 - Override per channel: `channels.discord.commands.native` (bool or `"auto"`). `false` clears previously registered commands.
 - `channels.telegram.customCommands` adds extra Telegram bot menu entries.
 - `bash: true` enables `! <cmd>` for host shell. Requires `tools.elevated.enabled` and sender in `tools.elevated.allowFrom.<channel>`.
-- `config: true` enables `/config` (reads/writes `openclaw.json`).
+- `config: true` enables `/config` (reads/writes `openclaw.json`). For gateway `chat.send` clients, persistent `/config set|unset` writes also require `operator.admin`; read-only `/config show` stays available to normal write-scoped operator clients.
 - `channels.<provider>.configWrites` gates config mutations per channel (default: true).
 - `allowFrom` is per-provider. When set, it is the **only** authorization source (channel allowlists/pairing and `useAccessGroups` are ignored).
 - `useAccessGroups: false` allows commands to bypass access-group policies when `allowFrom` is not set.
@@ -780,6 +803,21 @@ Max total characters injected across all workspace bootstrap files. Default: `15
 ```json5
 {
   agents: { defaults: { bootstrapTotalMaxChars: 150000 } },
+}
+```
+
+### `agents.defaults.bootstrapPromptTruncationWarning`
+
+Controls agent-visible warning text when bootstrap context is truncated.
+Default: `"once"`.
+
+- `"off"`: never inject warning text into the system prompt.
+- `"once"`: inject warning once per unique truncation signature (recommended).
+- `"always"`: inject warning on every run when truncation exists.
+
+```json5
+{
+  agents: { defaults: { bootstrapPromptTruncationWarning: "once" } }, // off | once | always
 }
 ```
 
@@ -872,14 +910,15 @@ Time format in system prompt. Default: `auto` (OS preference).
 
 **Built-in alias shorthands** (only apply when the model is in `agents.defaults.models`):
 
-| Alias          | Model                           |
-| -------------- | ------------------------------- |
-| `opus`         | `anthropic/claude-opus-4-6`     |
-| `sonnet`       | `anthropic/claude-sonnet-4-5`   |
-| `gpt`          | `openai/gpt-5.2`                |
-| `gpt-mini`     | `openai/gpt-5-mini`             |
-| `gemini`       | `google/gemini-3-pro-preview`   |
-| `gemini-flash` | `google/gemini-3-flash-preview` |
+| Alias               | Model                                  |
+| ------------------- | -------------------------------------- |
+| `opus`              | `anthropic/claude-opus-4-6`            |
+| `sonnet`            | `anthropic/claude-sonnet-4-6`          |
+| `gpt`               | `openai/gpt-5.4`                       |
+| `gpt-mini`          | `openai/gpt-5-mini`                    |
+| `gemini`            | `google/gemini-3.1-pro-preview`        |
+| `gemini-flash`      | `google/gemini-3-flash-preview`        |
+| `gemini-flash-lite` | `google/gemini-3.1-flash-lite-preview` |
 
 Your configured aliases always win over defaults.
 
@@ -933,6 +972,7 @@ Periodic heartbeat runs.
         every: "30m", // 0m disables
         model: "openai/gpt-5.2-mini",
         includeReasoning: false,
+        lightContext: false, // default: false; true keeps only HEARTBEAT.md from workspace bootstrap files
         session: "main",
         to: "+15555550123",
         directPolicy: "allow", // allow (default) | block
@@ -949,6 +989,7 @@ Periodic heartbeat runs.
 - `every`: duration string (ms/s/m/h). Default: `30m`.
 - `suppressToolErrorWarnings`: when true, suppresses tool error warning payloads during heartbeat runs.
 - `directPolicy`: direct/DM delivery policy. `allow` (default) permits direct-target delivery. `block` suppresses direct-target delivery and emits `reason=dm-blocked`.
+- `lightContext`: when true, heartbeat runs use lightweight bootstrap context and keep only `HEARTBEAT.md` from workspace bootstrap files.
 - Per-agent: set `agents.list[].heartbeat`. When any agent defines `heartbeat`, **only those agents** run heartbeats.
 - Heartbeats run full agent turns — shorter intervals burn more tokens.
 
@@ -963,6 +1004,8 @@ Periodic heartbeat runs.
         reserveTokensFloor: 24000,
         identifierPolicy: "strict", // strict | off | custom
         identifierInstructions: "Preserve deployment IDs, ticket IDs, and host:port pairs exactly.", // used when identifierPolicy=custom
+        postCompactionSections: ["Session Startup", "Red Lines"], // [] disables reinjection
+        model: "openrouter/anthropic/claude-sonnet-4-5", // optional compaction-only model override
         memoryFlush: {
           enabled: true,
           softThresholdTokens: 6000,
@@ -978,6 +1021,8 @@ Periodic heartbeat runs.
 - `mode`: `default` or `safeguard` (chunked summarization for long histories). See [Compaction](/concepts/compaction).
 - `identifierPolicy`: `strict` (default), `off`, or `custom`. `strict` prepends built-in opaque identifier retention guidance during compaction summarization.
 - `identifierInstructions`: optional custom identifier-preservation text used when `identifierPolicy=custom`.
+- `postCompactionSections`: optional AGENTS.md H2/H3 section names to re-inject after compaction. Defaults to `["Session Startup", "Red Lines"]`; set `[]` to disable reinjection. When unset or explicitly set to that default pair, older `Every Session`/`Safety` headings are also accepted as a legacy fallback.
+- `model`: optional `provider/model-id` override for compaction summarization only. Use this when the main session should keep one model but compaction summaries should run on another; when unset, compaction uses the session's primary model.
 - `memoryFlush`: silent agentic turn before auto-compaction to store durable memories. Skipped when workspace is read-only.
 
 ### `agents.defaults.contextPruning`
@@ -1170,8 +1215,8 @@ Optional **Docker sandboxing** for the embedded agent. See [Sandboxing](/gateway
 
 **`docker.binds`** mounts additional host directories; global and per-agent binds are merged.
 
-**Sandboxed browser** (`sandbox.browser.enabled`): Chromium + CDP in a container. noVNC URL injected into system prompt. Does not require `browser.enabled` in main config.
-noVNC observer access uses VNC auth by default and OpenClaw emits a short-lived token URL that serves a local bootstrap page; noVNC password is passed via URL fragment (instead of URL query).
+**Sandboxed browser** (`sandbox.browser.enabled`): Chromium + CDP in a container. noVNC URL injected into system prompt. Does not require `browser.enabled` in `openclaw.json`.
+noVNC observer access uses VNC auth by default and OpenClaw emits a short-lived token URL (instead of exposing the password in the shared URL).
 
 - `allowHostControl: false` (default) blocks sandboxed sessions from targeting the host browser.
 - `network` defaults to `openclaw-sandbox-browser` (dedicated bridge network). Set to `bridge` only when you explicitly want global bridge connectivity.
@@ -1238,6 +1283,15 @@ scripts/sandbox-browser-setup.sh   # optional browser image
         },
         groupChat: { mentionPatterns: ["@openclaw"] },
         sandbox: { mode: "off" },
+        runtime: {
+          type: "acp",
+          acp: {
+            agent: "codex",
+            backend: "acpx",
+            mode: "persistent",
+            cwd: "/workspace/openclaw",
+          },
+        },
         subagents: { allowAgents: ["*"] },
         tools: {
           profile: "coding",
@@ -1255,10 +1309,38 @@ scripts/sandbox-browser-setup.sh   # optional browser image
 - `default`: when multiple are set, first wins (warning logged). If none set, first list entry is default.
 - `model`: string form overrides `primary` only; object form `{ primary, fallbacks }` overrides both (`[]` disables global fallbacks). Cron jobs that only override `primary` still inherit default fallbacks unless you set `fallbacks: []`.
 - `params`: per-agent stream params merged over the selected model entry in `agents.defaults.models`. Use this for agent-specific overrides like `cacheRetention`, `temperature`, or `maxTokens` without duplicating the whole model catalog.
+- `runtime`: optional per-agent runtime descriptor. Use `type: "acp"` with `runtime.acp` defaults (`agent`, `backend`, `mode`, `cwd`) when the agent should default to ACP harness sessions.
 - `identity.avatar`: workspace-relative path, `http(s)` URL, or `data:` URI.
 - `identity` derives defaults: `ackReaction` from `emoji`, `mentionPatterns` from `name`/`emoji`.
 - `subagents.allowAgents`: allowlist of agent ids for `sessions_spawn` (`["*"]` = any; default: same agent only).
 - Sandbox inheritance guard: if the requester session is sandboxed, `sessions_spawn` rejects targets that would run unsandboxed.
+
+### `agents.subagent.promptHook` (optional)
+
+Global prompt-hook controls for `sessions_spawn` when `runtime: "subagent"`.
+
+```json5
+{
+  agents: {
+    subagent: {
+      promptHook: {
+        enabled: true,
+        mode: "wrap", // prepend | append | wrap
+        prefixPath: "~/.openclaw/prompts/subagent_hook_prefix.md",
+        suffixPath: "~/.openclaw/prompts/subagent_hook_suffix.md",
+        maxBytes: 65536,
+        onMissing: "warn", // warn | disable
+      },
+    },
+  },
+}
+```
+
+- `enabled`: turns hook injection on/off.
+- `mode`: placement strategy relative to the original task string.
+- `prefixPath` / `suffixPath`: UTF-8 markdown/text files read at spawn time.
+- `maxBytes`: per-file read limit for safety.
+- `onMissing`: behavior when files are missing/unreadable/oversized (`warn` keeps spawn running; `disable` skips hook injection).
 
 ---
 
@@ -1283,10 +1365,12 @@ Run multiple isolated agents inside one Gateway. See [Multi-Agent](/concepts/mul
 
 ### Binding match fields
 
+- `type` (optional): `route` for normal routing (missing type defaults to route), `acp` for persistent ACP conversation bindings.
 - `match.channel` (required)
 - `match.accountId` (optional; `*` = any account; omitted = default account)
 - `match.peer` (optional; `{ kind: direct|group|channel, id }`)
 - `match.guildId` / `match.teamId` (optional; channel-specific)
+- `acp` (optional; only for `type: "acp"`): `{ mode, label, cwd, backend }`
 
 **Deterministic match order:**
 
@@ -1298,6 +1382,8 @@ Run multiple isolated agents inside one Gateway. See [Multi-Agent](/concepts/mul
 6. Default agent
 
 Within each tier, the first matching `bindings` entry wins.
+
+For `type: "acp"` entries, OpenClaw resolves by exact conversation identity (`match.channel` + account + `match.peer.id`) and does not use the route binding tier order above.
 
 ### Per-agent access profiles
 
@@ -1569,6 +1655,7 @@ Batches rapid text-only messages from the same sender into a single agent turn. 
       },
       openai: {
         apiKey: "openai_api_key",
+        baseUrl: "https://api.openai.com/v1",
         model: "gpt-4o-mini-tts",
         voice: "alloy",
       },
@@ -1581,6 +1668,8 @@ Batches rapid text-only messages from the same sender into a single agent turn. 
 - `summaryModel` overrides `agents.defaults.model.primary` for auto-summary.
 - `modelOverrides` is enabled by default; `modelOverrides.allowProvider` defaults to `false` (opt-in).
 - API keys fall back to `ELEVENLABS_API_KEY`/`XI_API_KEY` and `OPENAI_API_KEY`.
+- `openai.baseUrl` overrides the OpenAI TTS endpoint. Resolution order is config, then `OPENAI_TTS_BASE_URL`, then `https://api.openai.com/v1`.
+- When `openai.baseUrl` points to a non-OpenAI endpoint, OpenClaw treats it as an OpenAI-compatible TTS server and relaxes model/voice validation.
 
 ---
 
@@ -1599,14 +1688,17 @@ Defaults for Talk mode (macOS/iOS/Android).
     modelId: "eleven_v3",
     outputFormat: "mp3_44100_128",
     apiKey: "elevenlabs_api_key",
+    silenceTimeoutMs: 1500,
     interruptOnSpeech: true,
   },
 }
 ```
 
 - Voice IDs fall back to `ELEVENLABS_VOICE_ID` or `SAG_VOICE_ID`.
-- `apiKey` falls back to `ELEVENLABS_API_KEY`.
+- `apiKey` and `providers.*.apiKey` accept plaintext strings or SecretRef objects.
+- `ELEVENLABS_API_KEY` fallback applies only when no Talk API key is configured.
 - `voiceAliases` lets Talk directives use friendly names.
+- `silenceTimeoutMs` controls how long Talk mode waits after user silence before it sends the transcript. Unset keeps the platform default pause window (`700 ms on macOS and Android, 900 ms on iOS`).
 
 ---
 
@@ -1616,7 +1708,7 @@ Defaults for Talk mode (macOS/iOS/Android).
 
 `tools.profile` sets a base allowlist before `tools.allow`/`tools.deny`:
 
-Local onboarding defaults new local configs to `tools.profile: "messaging"` when unset (existing explicit profiles are preserved).
+Local onboarding defaults new local configs to `tools.profile: "coding"` when unset (existing explicit profiles are preserved).
 
 | Profile     | Includes                                                                                  |
 | ----------- | ----------------------------------------------------------------------------------------- |
@@ -1804,7 +1896,7 @@ Configures inbound media understanding (image/audio/video):
 
 - `provider`: API provider id (`openai`, `anthropic`, `google`/`gemini`, `groq`, etc.)
 - `model`: model id override
-- `profile` / `preferredProfile`: auth profile selection
+- `profile` / `preferredProfile`: `auth-profiles.json` profile selection
 
 **CLI entry** (`type: "cli"`):
 
@@ -1817,7 +1909,7 @@ Configures inbound media understanding (image/audio/video):
 - `prompt`, `maxChars`, `maxBytes`, `timeoutSeconds`, `language`: per-entry overrides.
 - Failures fall back to the next entry.
 
-Provider auth follows standard order: auth profiles → env vars → `models.providers.*.apiKey`.
+Provider auth follows standard order: `auth-profiles.json` → env vars → `models.providers.*.apiKey`.
 
 </Accordion>
 
@@ -1909,29 +2001,6 @@ Notes:
 - `runTimeoutSeconds`: default timeout (seconds) for `sessions_spawn` when the tool call omits `runTimeoutSeconds`. `0` means no timeout.
 - Per-subagent tool policy: `tools.subagents.tools.allow` / `tools.subagents.tools.deny`.
 
-Prompt hook injection (subagent runtime only):
-
-```json5
-{
-  agents: {
-    subagent: {
-      promptHook: {
-        enabled: true,
-        mode: "wrap", // prepend | append | wrap
-        prefixPath: "~/.openclaw/prompts/subagent_hook_prefix.md",
-        suffixPath: "~/.openclaw/prompts/subagent_hook_suffix.md",
-        maxBytes: 65536,
-        onMissing: "warn", // warn | disable
-      },
-    },
-  },
-}
-```
-
-- `onMissing: "warn"`: continue with available segments and log a warning.
-- `onMissing: "disable"`: skip hook injection entirely if a configured file is unavailable.
-- Runtime telemetry logs include status (`applied`/`partial`/`skipped`), mode, and file hashes (not prompt body text).
-
 ---
 
 ## Custom providers and base URLs
@@ -1967,7 +2036,9 @@ OpenClaw uses the pi-coding-agent model catalog. Add custom providers via `model
 - Use `authHeader: true` + `headers` for custom auth needs.
 - Override agent config root with `OPENCLAW_AGENT_DIR` (or `PI_CODING_AGENT_DIR`).
 - Merge precedence for matching provider IDs:
-  - Non-empty agent `models.json` `apiKey`/`baseUrl` win.
+  - Non-empty agent `models.json` `baseUrl` values win.
+  - Non-empty agent `apiKey` values win only when that provider is not SecretRef-managed in current config/auth-profile context.
+  - SecretRef-managed provider `apiKey` values are refreshed from source markers (`ENV_VAR_NAME` for env refs, `secretref-managed` for file/exec refs) instead of persisting resolved secrets.
   - Empty or missing agent `apiKey`/`baseUrl` fall back to `models.providers` in config.
   - Matching model `contextWindow`/`maxTokens` use the higher value between explicit config and implicit catalog values.
   - Use `models.mode: "replace"` when you want config to fully rewrite `models.json`.
@@ -1984,6 +2055,7 @@ OpenClaw uses the pi-coding-agent model catalog. Add custom providers via `model
 - `models.providers.*.baseUrl`: upstream API base URL.
 - `models.providers.*.headers`: extra static headers for proxy/tenant routing.
 - `models.providers.*.models`: explicit provider model catalog entries.
+- `models.providers.*.models.*.compat.supportsDeveloperRole`: optional compatibility hint. For `api: "openai-completions"` with a non-empty non-native `baseUrl` (host not `api.openai.com`), OpenClaw forces this to `false` at runtime. Empty/omitted `baseUrl` keeps default OpenAI behavior.
 - `models.bedrockDiscovery`: Bedrock auto-discovery settings root.
 - `models.bedrockDiscovery.enabled`: turn discovery polling on/off.
 - `models.bedrockDiscovery.region`: AWS region for discovery.
@@ -2259,6 +2331,9 @@ See [Local Models](/gateway/local-models). TL;DR: run MiniMax M2.5 via LM Studio
     entries: {
       "voice-call": {
         enabled: true,
+        hooks: {
+          allowPromptInjection: false,
+        },
         config: { provider: "twilio" },
       },
     },
@@ -2271,8 +2346,10 @@ See [Local Models](/gateway/local-models). TL;DR: run MiniMax M2.5 via LM Studio
 - `allow`: optional allowlist (only listed plugins load). `deny` wins.
 - `plugins.entries.<id>.apiKey`: plugin-level API key convenience field (when supported by the plugin).
 - `plugins.entries.<id>.env`: plugin-scoped env var map.
+- `plugins.entries.<id>.hooks.allowPromptInjection`: when `false`, core blocks `before_prompt_build` and ignores prompt-mutating fields from legacy `before_agent_start`, while preserving legacy `modelOverride` and `providerOverride`.
 - `plugins.entries.<id>.config`: plugin-defined config object (validated by plugin schema).
 - `plugins.slots.memory`: pick the active memory plugin id, or `"none"` to disable memory plugins.
+- `plugins.slots.contextEngine`: pick the active context engine plugin id; defaults to `"legacy"` unless you install and select another engine.
 - `plugins.installs`: CLI-managed install metadata used by `openclaw plugins update`.
   - Includes `source`, `spec`, `sourcePath`, `installPath`, `version`, `resolvedName`, `resolvedVersion`, `resolvedSpec`, `integrity`, `shasum`, `resolvedAt`, `installedAt`.
   - Treat `plugins.installs.*` as managed state; prefer CLI commands over manual edits.
@@ -2304,6 +2381,7 @@ See [Plugins](/tools/plugin).
     // headless: false,
     // noSandbox: false,
     // extraArgs: [],
+    // relayBindHost: "0.0.0.0", // only when the extension relay must be reachable across namespaces (for example WSL2)
     // executablePath: "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
     // attachOnly: false,
   },
@@ -2320,6 +2398,7 @@ See [Plugins](/tools/plugin).
 - Control service: loopback only (port derived from `gateway.port`, default `18791`).
 - `extraArgs` appends extra launch flags to local Chromium startup (for example
   `--disable-gpu`, window sizing, or debug flags).
+- `relayBindHost` changes where the Chrome extension relay listens. Leave unset for loopback-only access; set an explicit non-loopback bind address such as `0.0.0.0` only when the relay must cross a namespace boundary (for example WSL2) and the host network is already trusted.
 
 ---
 
@@ -2403,6 +2482,7 @@ See [Plugins](/tools/plugin).
 - **Legacy bind aliases**: use bind mode values in `gateway.bind` (`auto`, `loopback`, `lan`, `tailnet`, `custom`), not host aliases (`0.0.0.0`, `127.0.0.1`, `localhost`, `::`, `::1`).
 - **Docker note**: the default `loopback` bind listens on `127.0.0.1` inside the container. With Docker bridge networking (`-p 18789:18789`), traffic arrives on `eth0`, so the gateway is unreachable. Use `--network host`, or set `bind: "lan"` (or `bind: "custom"` with `customBindHost: "0.0.0.0"`) to listen on all interfaces.
 - **Auth**: required by default. Non-loopback binds require a shared token/password. Onboarding wizard generates a token by default.
+- If both `gateway.auth.token` and `gateway.auth.password` are configured (including SecretRefs), set `gateway.auth.mode` explicitly to `token` or `password`. Startup and service install/repair flows fail when both are configured and mode is unset.
 - `gateway.auth.mode: "none"`: explicit no-auth mode. Use only for trusted local loopback setups; this is intentionally not offered by onboarding prompts.
 - `gateway.auth.mode: "trusted-proxy"`: delegate auth to an identity-aware reverse proxy and trust identity headers from `gateway.trustedProxies` (see [Trusted Proxy Auth](/gateway/trusted-proxy-auth)).
 - `gateway.auth.allowTailscale`: when `true`, Tailscale Serve identity headers can satisfy Control UI/WebSocket auth (verified via `tailscale whois`); HTTP API endpoints still require token/password auth. This tokenless flow assumes the gateway host is trusted. Defaults to `true` when `tailscale.mode = "serve"`.
@@ -2660,14 +2740,11 @@ Validation:
 - `source: "file"` id: absolute JSON pointer (for example `"/providers/openai/apiKey"`)
 - `source: "exec"` id pattern: `^[A-Za-z0-9][A-Za-z0-9._:/-]{0,255}$`
 
-### Supported fields in config
+### Supported credential surface
 
-- `models.providers.<provider>.apiKey`
-- `skills.entries.<skillKey>.apiKey`
-- `channels.googlechat.serviceAccount`
-- `channels.googlechat.serviceAccountRef`
-- `channels.googlechat.accounts.<accountId>.serviceAccount`
-- `channels.googlechat.accounts.<accountId>.serviceAccountRef`
+- Canonical matrix: [SecretRef Credential Surface](/reference/secretref-credential-surface)
+- `secrets apply` targets supported `openclaw.json` credential paths.
+- `auth-profiles.json` refs are included in runtime resolution and audit coverage.
 
 ### Secret providers config
 
@@ -2705,6 +2782,7 @@ Notes:
 - If `trustedDirs` is configured, the trusted-dir check applies to the resolved target path.
 - `exec` child environment is minimal by default; pass required variables explicitly with `passEnv`.
 - Secret refs are resolved at activation time into an in-memory snapshot, then request paths read the snapshot only.
+- Active-surface filtering applies during activation: unresolved refs on enabled surfaces fail startup/reload, while inactive surfaces are skipped with diagnostics.
 
 ---
 
@@ -2724,8 +2802,8 @@ Notes:
 }
 ```
 
-- Per-agent auth profiles stored at `<agentDir>/auth-profiles.json`.
-- Auth profiles support value-level refs (`keyRef` for `api_key`, `tokenRef` for `token`).
+- Per-agent profiles are stored at `<agentDir>/auth-profiles.json`.
+- `auth-profiles.json` supports value-level refs (`keyRef` for `api_key`, `tokenRef` for `token`).
 - Static runtime credentials come from in-memory resolved snapshots; legacy static `auth.json` entries are scrubbed when discovered.
 - Legacy OAuth imports from `~/.openclaw/credentials/oauth.json`.
 - See [OAuth](/concepts/oauth).
@@ -2922,7 +3000,7 @@ Split config into multiple files:
 - Array of files: deep-merged in order (later overrides earlier).
 - Sibling keys: merged after includes (override included values).
 - Nested includes: up to 10 levels deep.
-- Paths: resolved relative to the including file, but must stay inside the top-level config directory (`dirname` of the main config file). Absolute/`../` forms are allowed only when they still resolve inside that boundary.
+- Paths: resolved relative to the including file, but must stay inside the top-level config directory (`dirname` of `openclaw.json`). Absolute/`../` forms are allowed only when they still resolve inside that boundary.
 - Errors: clear messages for missing files, parse errors, and circular includes.
 
 ---

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -162,6 +162,32 @@ By default, sub-agents cannot spawn their own sub-agents (`maxSpawnDepth: 1`). Y
 }
 ```
 
+### Subagent prompt hook (runtime injection)
+
+You can enforce common protocol text on every `runtime: "subagent"` spawn with a prompt hook:
+
+```json5
+{
+  agents: {
+    subagent: {
+      promptHook: {
+        enabled: true,
+        mode: "wrap", // prepend | append | wrap
+        prefixPath: "~/.openclaw/prompts/subagent_hook_prefix.md",
+        suffixPath: "~/.openclaw/prompts/subagent_hook_suffix.md",
+        maxBytes: 65536,
+        onMissing: "warn", // warn | disable
+      },
+    },
+  },
+}
+```
+
+- Applies only to `sessions_spawn` with `runtime: "subagent"`.
+- `warn`: continue with available segments when files are missing/unreadable.
+- `disable`: skip hook injection entirely if any configured segment cannot be loaded.
+- Operational logs include metadata (`applied`/`partial`/`skipped`, mode, file hashes), not full prompt bodies.
+
 ### Depth levels
 
 | Depth | Session key shape                            | Role                                          | Can spawn?                   |
@@ -214,11 +240,7 @@ Sub-agents report back via an announce step:
 
 - The announce step runs inside the sub-agent session (not the requester session).
 - If the sub-agent replies exactly `ANNOUNCE_SKIP`, nothing is posted.
-- Otherwise delivery depends on requester depth:
-  - top-level requester sessions use a follow-up `agent` call with external delivery (`deliver=true`)
-  - nested requester subagent sessions receive an internal follow-up injection (`deliver=false`) so the orchestrator can synthesize child results in-session
-  - if a nested requester subagent session is gone, OpenClaw falls back to that session's requester when available
-- Child completion aggregation is scoped to the current requester run when building nested completion findings, preventing stale prior-run child outputs from leaking into the current announce.
+- Otherwise the announce reply is posted to the requester chat channel via a follow-up `agent` call (`deliver=true`).
 - Announce replies preserve thread/topic routing when available on channel adapters.
 - Announce context is normalized to a stable internal event block:
   - source (`subagent` or `cron`)

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -93,6 +93,31 @@ Tool params:
 - `sandbox?` (`inherit|require`, default `inherit`; `require` rejects spawn unless target child runtime is sandboxed)
 - `sessions_spawn` does **not** accept channel-delivery params (`target`, `channel`, `to`, `threadId`, `replyTo`, `transport`). For delivery, use `message`/`sessions_send` from the spawned run.
 
+### Prompt hook (optional)
+
+You can wrap every subagent task body with reusable prompt fragments before dispatch:
+
+```json5
+{
+  agents: {
+    subagent: {
+      promptHook: {
+        enabled: true,
+        mode: "wrap", // prepend | append | wrap
+        prefixPath: "~/.openclaw/prompts/subagent_hook_prefix.md",
+        suffixPath: "~/.openclaw/prompts/subagent_hook_suffix.md",
+        maxBytes: 65536,
+        onMissing: "warn", // warn | disable
+      },
+    },
+  },
+}
+```
+
+- `mode` controls placement around the original `task`.
+- `onMissing: "warn"` keeps spawning when files are missing/unreadable and logs telemetry.
+- `onMissing: "disable"` skips hook injection when any hook file is unavailable.
+
 ## Thread-bound sessions
 
 When thread bindings are enabled for a channel, a sub-agent can stay bound to a thread so follow-up user messages in that thread keep routing to the same sub-agent session.
@@ -162,32 +187,6 @@ By default, sub-agents cannot spawn their own sub-agents (`maxSpawnDepth: 1`). Y
 }
 ```
 
-### Subagent prompt hook (runtime injection)
-
-You can enforce common protocol text on every `runtime: "subagent"` spawn with a prompt hook:
-
-```json5
-{
-  agents: {
-    subagent: {
-      promptHook: {
-        enabled: true,
-        mode: "wrap", // prepend | append | wrap
-        prefixPath: "~/.openclaw/prompts/subagent_hook_prefix.md",
-        suffixPath: "~/.openclaw/prompts/subagent_hook_suffix.md",
-        maxBytes: 65536,
-        onMissing: "warn", // warn | disable
-      },
-    },
-  },
-}
-```
-
-- Applies only to `sessions_spawn` with `runtime: "subagent"`.
-- `warn`: continue with available segments when files are missing/unreadable.
-- `disable`: skip hook injection entirely if any configured segment cannot be loaded.
-- Operational logs include metadata (`applied`/`partial`/`skipped`, mode, file hashes), not full prompt bodies.
-
 ### Depth levels
 
 | Depth | Session key shape                            | Role                                          | Can spawn?                   |
@@ -240,7 +239,11 @@ Sub-agents report back via an announce step:
 
 - The announce step runs inside the sub-agent session (not the requester session).
 - If the sub-agent replies exactly `ANNOUNCE_SKIP`, nothing is posted.
-- Otherwise the announce reply is posted to the requester chat channel via a follow-up `agent` call (`deliver=true`).
+- Otherwise delivery depends on requester depth:
+  - top-level requester sessions use a follow-up `agent` call with external delivery (`deliver=true`)
+  - nested requester subagent sessions receive an internal follow-up injection (`deliver=false`) so the orchestrator can synthesize child results in-session
+  - if a nested requester subagent session is gone, OpenClaw falls back to that session's requester when available
+- Child completion aggregation is scoped to the current requester run when building nested completion findings, preventing stale prior-run child outputs from leaking into the current announce.
 - Announce replies preserve thread/topic routing when available on channel adapters.
 - Announce context is normalized to a stable internal event block:
   - source (`subagent` or `cron`)

--- a/src/agents/openclaw-tools.subagents.sessions-spawn.prompt-hook.test.ts
+++ b/src/agents/openclaw-tools.subagents.sessions-spawn.prompt-hook.test.ts
@@ -1,0 +1,75 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import "./test-helpers/fast-core-tools.js";
+import {
+  getCallGatewayMock,
+  getSessionsSpawnTool,
+  resetSessionsSpawnConfigOverride,
+  setSessionsSpawnConfigOverride,
+} from "./openclaw-tools.subagents.sessions-spawn.test-harness.js";
+import { resetSubagentRegistryForTests } from "./subagent-registry.js";
+
+const callGatewayMock = getCallGatewayMock();
+
+describe("sessions_spawn subagent prompt hook", () => {
+  beforeEach(() => {
+    resetSessionsSpawnConfigOverride();
+    resetSubagentRegistryForTests();
+    callGatewayMock.mockReset();
+  });
+
+  it("wraps subagent task with configured prefix/suffix files", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-hook-"));
+    const prefixPath = path.join(tmpDir, "prefix.md");
+    const suffixPath = path.join(tmpDir, "suffix.md");
+    await fs.writeFile(prefixPath, "[HOOK PREFIX]", "utf8");
+    await fs.writeFile(suffixPath, "[HOOK SUFFIX]", "utf8");
+
+    setSessionsSpawnConfigOverride({
+      session: { mainKey: "main", scope: "per-sender" },
+      agents: {
+        subagent: {
+          promptHook: {
+            enabled: true,
+            mode: "wrap",
+            prefixPath,
+            suffixPath,
+            maxBytes: 1024,
+            onMissing: "warn",
+          },
+        },
+      },
+    });
+
+    const calls: Array<{ method?: string; params?: unknown }> = [];
+    callGatewayMock.mockImplementation(async (opts: unknown) => {
+      const request = opts as { method?: string; params?: unknown };
+      calls.push(request);
+      if (request.method === "sessions.patch") {
+        return { ok: true };
+      }
+      if (request.method === "agent") {
+        return { runId: "run-hook", status: "accepted" };
+      }
+      return {};
+    });
+
+    const tool = await getSessionsSpawnTool({
+      agentSessionKey: "agent:main:main",
+      agentChannel: "discord",
+    });
+
+    const result = await tool.execute("call-hook-wrap", { task: "ORIGINAL TASK" });
+    expect(result.details).toMatchObject({ status: "accepted" });
+
+    const agentCall = calls.find((call) => call.method === "agent");
+    const message = (agentCall?.params as { message?: string } | undefined)?.message ?? "";
+    expect(message).toContain("[HOOK PREFIX]");
+    expect(message).toContain("ORIGINAL TASK");
+    expect(message).toContain("[HOOK SUFFIX]");
+    expect(message.indexOf("[HOOK PREFIX]")).toBeLessThan(message.indexOf("ORIGINAL TASK"));
+    expect(message.indexOf("ORIGINAL TASK")).toBeLessThan(message.indexOf("[HOOK SUFFIX]"));
+  });
+});

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
 import { promises as fs } from "node:fs";
+import path from "node:path";
 import { formatThinkingLevels, normalizeThinkLevel } from "../auto-reply/thinking.js";
 import { DEFAULT_SUBAGENT_MAX_SPAWN_DEPTH } from "../config/agent-limits.js";
 import { loadConfig } from "../config/config.js";
@@ -11,22 +12,13 @@ import {
   normalizeAgentId,
   parseAgentSessionKey,
 } from "../routing/session-key.js";
+import { resolveUserPath } from "../utils.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
-import { resolveAgentConfig } from "./agent-scope.js";
+import { resolveAgentConfig, resolveAgentWorkspaceDir } from "./agent-scope.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import { resolveSubagentSpawnModelSelection } from "./model-selection.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
-import {
-  mapToolContextToSpawnedRunMetadata,
-  normalizeSpawnedRunMetadata,
-  resolveSpawnedWorkspaceInheritance,
-} from "./spawned-context.js";
 import { buildSubagentSystemPrompt } from "./subagent-announce.js";
-import {
-  decodeStrictBase64,
-  materializeSubagentAttachments,
-  type SubagentAttachmentReceiptFile,
-} from "./subagent-attachments.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { countActiveRunsForSession, registerSubagentRun } from "./subagent-registry.js";
 import { readStringParam } from "./tools/common.js";
@@ -41,7 +33,27 @@ export type SpawnSubagentMode = (typeof SUBAGENT_SPAWN_MODES)[number];
 export const SUBAGENT_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
 export type SpawnSubagentSandboxMode = (typeof SUBAGENT_SPAWN_SANDBOX_MODES)[number];
 
-export { decodeStrictBase64 };
+export function decodeStrictBase64(value: string, maxDecodedBytes: number): Buffer | null {
+  const maxEncodedBytes = Math.ceil(maxDecodedBytes / 3) * 4;
+  if (value.length > maxEncodedBytes * 2) {
+    return null;
+  }
+  const normalized = value.replace(/\s+/g, "");
+  if (!normalized || normalized.length % 4 !== 0) {
+    return null;
+  }
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(normalized)) {
+    return null;
+  }
+  if (normalized.length > maxEncodedBytes) {
+    return null;
+  }
+  const decoded = Buffer.from(normalized, "base64");
+  if (decoded.byteLength > maxDecodedBytes) {
+    return null;
+  }
+  return decoded;
+}
 
 export type SpawnSubagentParams = {
   task: string;
@@ -74,12 +86,10 @@ export type SpawnSubagentContext = {
   agentGroupChannel?: string | null;
   agentGroupSpace?: string | null;
   requesterAgentIdOverride?: string;
-  /** Explicit workspace directory for subagent to inherit (optional). */
-  workspaceDir?: string;
 };
 
 export const SUBAGENT_SPAWN_ACCEPTED_NOTE =
-  "Auto-announce is push-based. After spawning children, do NOT call sessions_list, sessions_history, exec sleep, or any polling tool. Wait for completion events to arrive as user messages, track expected child session keys, and only send your final answer after ALL expected completions arrive. If a child completion event arrives AFTER your final answer, reply ONLY with NO_REPLY.";
+  "auto-announces on completion, do not poll/sleep. The response will be sent back as an user message.";
 export const SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE =
   "thread-bound session stays active after this task; continue in-thread for follow-ups.";
 
@@ -171,6 +181,179 @@ function summarizeError(err: unknown): string {
     return err;
   }
   return "error";
+}
+
+function sha256Hex(value: string): string {
+  return crypto.createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+type SubagentPromptHookMode = "prepend" | "append" | "wrap";
+type SubagentPromptHookOnMissing = "warn" | "disable";
+type SubagentPromptHookConfig = {
+  enabled: boolean;
+  mode: SubagentPromptHookMode;
+  prefixPath: string;
+  suffixPath: string;
+  maxBytes: number;
+  onMissing: SubagentPromptHookOnMissing;
+};
+
+type SubagentPromptHookApplyResult = {
+  task: string;
+  telemetry: {
+    prompt_hook_enabled: boolean;
+    prompt_hook_mode: SubagentPromptHookMode;
+    hook_apply_status: "applied" | "partial" | "skipped";
+    prefix_path?: string;
+    suffix_path?: string;
+    prefix_hash?: string;
+    suffix_hash?: string;
+    hook_warning?: string;
+  };
+};
+
+function resolveSubagentPromptHookConfig(
+  cfg: ReturnType<typeof loadConfig>,
+): SubagentPromptHookConfig {
+  const defaults = {
+    enabled: false,
+    mode: "wrap" as SubagentPromptHookMode,
+    prefixPath: "~/.openclaw/prompts/subagent_hook_prefix.md",
+    suffixPath: "~/.openclaw/prompts/subagent_hook_suffix.md",
+    maxBytes: 64 * 1024,
+    onMissing: "warn" as SubagentPromptHookOnMissing,
+  };
+
+  const configured =
+    (cfg as unknown as { agents?: { subagent?: { promptHook?: Record<string, unknown> } } })?.agents
+      ?.subagent?.promptHook ?? {};
+
+  const mode =
+    configured.mode === "prepend" || configured.mode === "append" || configured.mode === "wrap"
+      ? configured.mode
+      : defaults.mode;
+
+  const onMissing =
+    configured.onMissing === "warn" || configured.onMissing === "disable"
+      ? configured.onMissing
+      : defaults.onMissing;
+
+  const maxBytesRaw = configured.maxBytes;
+  const maxBytes =
+    typeof maxBytesRaw === "number" && Number.isFinite(maxBytesRaw) && maxBytesRaw > 0
+      ? Math.floor(maxBytesRaw)
+      : defaults.maxBytes;
+
+  const envPrefix = process.env.OPENCLAW_SUBAGENT_HOOK_PREFIX_PATH?.trim();
+  const envSuffix = process.env.OPENCLAW_SUBAGENT_HOOK_SUFFIX_PATH?.trim();
+
+  return {
+    enabled: configured.enabled === true,
+    mode,
+    prefixPath:
+      envPrefix || (typeof configured.prefixPath === "string" && configured.prefixPath.trim())
+        ? envPrefix || String(configured.prefixPath).trim()
+        : defaults.prefixPath,
+    suffixPath:
+      envSuffix || (typeof configured.suffixPath === "string" && configured.suffixPath.trim())
+        ? envSuffix || String(configured.suffixPath).trim()
+        : defaults.suffixPath,
+    maxBytes,
+    onMissing,
+  };
+}
+
+async function loadPromptHookSegment(params: {
+  pathHint: string;
+  maxBytes: number;
+}): Promise<{ content?: string; resolvedPath: string; hash?: string; warning?: string }> {
+  const resolvedPath = path.resolve(resolveUserPath(params.pathHint));
+  try {
+    const stat = await fs.stat(resolvedPath);
+    if (!stat.isFile()) {
+      return { resolvedPath, warning: `not a file: ${resolvedPath}` };
+    }
+    if (stat.size > params.maxBytes) {
+      return {
+        resolvedPath,
+        warning: `file exceeds maxBytes (${stat.size} > ${params.maxBytes}) at ${resolvedPath}`,
+      };
+    }
+    const content = await fs.readFile(resolvedPath, "utf8");
+    if (Buffer.byteLength(content, "utf8") > params.maxBytes) {
+      return {
+        resolvedPath,
+        warning: `file exceeds maxBytes after decode at ${resolvedPath}`,
+      };
+    }
+    return { content, resolvedPath, hash: sha256Hex(content) };
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { resolvedPath, warning: `failed to read ${resolvedPath}: ${detail}` };
+  }
+}
+
+async function applySubagentPromptHook(task: string, cfg: ReturnType<typeof loadConfig>) {
+  const hook = resolveSubagentPromptHookConfig(cfg);
+  const telemetry: SubagentPromptHookApplyResult["telemetry"] = {
+    prompt_hook_enabled: hook.enabled,
+    prompt_hook_mode: hook.mode,
+    hook_apply_status: "skipped",
+  };
+
+  if (!hook.enabled) {
+    return { task, telemetry } satisfies SubagentPromptHookApplyResult;
+  }
+
+  const [prefix, suffix] = await Promise.all([
+    loadPromptHookSegment({ pathHint: hook.prefixPath, maxBytes: hook.maxBytes }),
+    loadPromptHookSegment({ pathHint: hook.suffixPath, maxBytes: hook.maxBytes }),
+  ]);
+
+  telemetry.prefix_path = prefix.resolvedPath;
+  telemetry.suffix_path = suffix.resolvedPath;
+  telemetry.prefix_hash = prefix.hash;
+  telemetry.suffix_hash = suffix.hash;
+
+  const warnings = [prefix.warning, suffix.warning].filter((v): v is string => Boolean(v));
+  if (warnings.length > 0) {
+    telemetry.hook_warning = warnings.join("; ");
+    if (hook.onMissing === "disable") {
+      telemetry.hook_apply_status = "skipped";
+      return { task, telemetry } satisfies SubagentPromptHookApplyResult;
+    }
+  }
+
+  const prefixContent = prefix.content?.trim() ?? "";
+  const suffixContent = suffix.content?.trim() ?? "";
+  let nextTask = task;
+
+  if (hook.mode === "prepend") {
+    if (prefixContent) {
+      nextTask = `${prefixContent}
+
+${task}`;
+    }
+  } else if (hook.mode === "append") {
+    if (suffixContent) {
+      nextTask = `${task}
+
+${suffixContent}`;
+    }
+  } else {
+    const parts = [prefixContent, task, suffixContent].filter((v) => v.length > 0);
+    nextTask = parts.join("\n\n");
+  }
+
+  if (nextTask === task) {
+    telemetry.hook_apply_status = "skipped";
+  } else if (warnings.length > 0 || !prefixContent || !suffixContent) {
+    telemetry.hook_apply_status = "partial";
+  } else {
+    telemetry.hook_apply_status = "applied";
+  }
+
+  return { task: nextTask, telemetry } satisfies SubagentPromptHookApplyResult;
 }
 
 async function ensureThreadBindingForSubagentSpawn(params: {
@@ -281,6 +464,14 @@ export async function spawnSubagentDirect(
   });
   const hookRunner = getGlobalHookRunner();
   const cfg = loadConfig();
+  const hookApplied = await applySubagentPromptHook(task, cfg);
+  const effectiveTask = hookApplied.task;
+
+  if (hookApplied.telemetry.hook_warning) {
+    console.warn("[subagent.prompt_hook]", hookApplied.telemetry);
+  } else {
+    console.info("[subagent.prompt_hook]", hookApplied.telemetry);
+  }
 
   // When agent omits runTimeoutSeconds, use the config default.
   // Falls back to 0 (no timeout) if config key is also unset,
@@ -486,45 +677,195 @@ export async function spawnSubagentDirect(
     requesterOrigin,
     childSessionKey,
     label: label || undefined,
-    task,
+    task: effectiveTask,
     acpEnabled: cfg.acp?.enabled !== false && !childRuntime.sandboxed,
     childDepth,
     maxSpawnDepth,
   });
 
-  let retainOnSessionKeep = false;
+  const attachmentsCfg = (
+    cfg as unknown as {
+      tools?: { sessions_spawn?: { attachments?: Record<string, unknown> } };
+    }
+  ).tools?.sessions_spawn?.attachments;
+  const attachmentsEnabled = attachmentsCfg?.enabled === true;
+  const maxTotalBytes =
+    typeof attachmentsCfg?.maxTotalBytes === "number" &&
+    Number.isFinite(attachmentsCfg.maxTotalBytes)
+      ? Math.max(0, Math.floor(attachmentsCfg.maxTotalBytes))
+      : 5 * 1024 * 1024;
+  const maxFiles =
+    typeof attachmentsCfg?.maxFiles === "number" && Number.isFinite(attachmentsCfg.maxFiles)
+      ? Math.max(0, Math.floor(attachmentsCfg.maxFiles))
+      : 50;
+  const maxFileBytes =
+    typeof attachmentsCfg?.maxFileBytes === "number" && Number.isFinite(attachmentsCfg.maxFileBytes)
+      ? Math.max(0, Math.floor(attachmentsCfg.maxFileBytes))
+      : 1 * 1024 * 1024;
+  const retainOnSessionKeep = attachmentsCfg?.retainOnSessionKeep === true;
+
+  type AttachmentReceipt = { name: string; bytes: number; sha256: string };
   let attachmentsReceipt:
     | {
         count: number;
         totalBytes: number;
-        files: SubagentAttachmentReceiptFile[];
+        files: AttachmentReceipt[];
         relDir: string;
       }
     | undefined;
   let attachmentAbsDir: string | undefined;
   let attachmentRootDir: string | undefined;
-  const materializedAttachments = await materializeSubagentAttachments({
-    config: cfg,
-    targetAgentId,
-    attachments: params.attachments,
-    mountPathHint,
-  });
-  if (materializedAttachments && materializedAttachments.status !== "ok") {
-    await cleanupProvisionalSession(childSessionKey, {
-      emitLifecycleHooks: threadBindingReady,
-      deleteTranscript: true,
-    });
-    return {
-      status: materializedAttachments.status,
-      error: materializedAttachments.error,
+
+  const requestedAttachments = Array.isArray(params.attachments) ? params.attachments : [];
+
+  if (requestedAttachments.length > 0) {
+    if (!attachmentsEnabled) {
+      await cleanupProvisionalSession(childSessionKey, {
+        emitLifecycleHooks: threadBindingReady,
+        deleteTranscript: true,
+      });
+      return {
+        status: "forbidden",
+        error:
+          "attachments are disabled for sessions_spawn (enable tools.sessions_spawn.attachments.enabled)",
+      };
+    }
+    if (requestedAttachments.length > maxFiles) {
+      await cleanupProvisionalSession(childSessionKey, {
+        emitLifecycleHooks: threadBindingReady,
+        deleteTranscript: true,
+      });
+      return {
+        status: "error",
+        error: `attachments_file_count_exceeded (maxFiles=${maxFiles})`,
+      };
+    }
+
+    const attachmentId = crypto.randomUUID();
+    const childWorkspaceDir = resolveAgentWorkspaceDir(cfg, targetAgentId);
+    const absRootDir = path.join(childWorkspaceDir, ".openclaw", "attachments");
+    const relDir = path.posix.join(".openclaw", "attachments", attachmentId);
+    const absDir = path.join(absRootDir, attachmentId);
+    attachmentAbsDir = absDir;
+    attachmentRootDir = absRootDir;
+
+    const fail = (error: string): never => {
+      throw new Error(error);
     };
-  }
-  if (materializedAttachments?.status === "ok") {
-    retainOnSessionKeep = materializedAttachments.retainOnSessionKeep;
-    attachmentsReceipt = materializedAttachments.receipt;
-    attachmentAbsDir = materializedAttachments.absDir;
-    attachmentRootDir = materializedAttachments.rootDir;
-    childSystemPrompt = `${childSystemPrompt}\n\n${materializedAttachments.systemPromptSuffix}`;
+
+    try {
+      await fs.mkdir(absDir, { recursive: true, mode: 0o700 });
+
+      const seen = new Set<string>();
+      const files: AttachmentReceipt[] = [];
+      const writeJobs: Array<{ outPath: string; buf: Buffer }> = [];
+      let totalBytes = 0;
+
+      for (const raw of requestedAttachments) {
+        const name = typeof raw?.name === "string" ? raw.name.trim() : "";
+        const contentVal = typeof raw?.content === "string" ? raw.content : "";
+        const encodingRaw = typeof raw?.encoding === "string" ? raw.encoding.trim() : "utf8";
+        const encoding = encodingRaw === "base64" ? "base64" : "utf8";
+
+        if (!name) {
+          fail("attachments_invalid_name (empty)");
+        }
+        if (name.includes("/") || name.includes("\\") || name.includes("\u0000")) {
+          fail(`attachments_invalid_name (${name})`);
+        }
+        // eslint-disable-next-line no-control-regex
+        if (/[\r\n\t\u0000-\u001F\u007F]/.test(name)) {
+          fail(`attachments_invalid_name (${name})`);
+        }
+        if (name === "." || name === ".." || name === ".manifest.json") {
+          fail(`attachments_invalid_name (${name})`);
+        }
+        if (seen.has(name)) {
+          fail(`attachments_duplicate_name (${name})`);
+        }
+        seen.add(name);
+
+        let buf: Buffer;
+        if (encoding === "base64") {
+          const strictBuf = decodeStrictBase64(contentVal, maxFileBytes);
+          if (strictBuf === null) {
+            throw new Error("attachments_invalid_base64_or_too_large");
+          }
+          buf = strictBuf;
+        } else {
+          buf = Buffer.from(contentVal, "utf8");
+          const estimatedBytes = buf.byteLength;
+          if (estimatedBytes > maxFileBytes) {
+            fail(
+              `attachments_file_bytes_exceeded (name=${name} bytes=${estimatedBytes} maxFileBytes=${maxFileBytes})`,
+            );
+          }
+        }
+
+        const bytes = buf.byteLength;
+        if (bytes > maxFileBytes) {
+          fail(
+            `attachments_file_bytes_exceeded (name=${name} bytes=${bytes} maxFileBytes=${maxFileBytes})`,
+          );
+        }
+        totalBytes += bytes;
+        if (totalBytes > maxTotalBytes) {
+          fail(
+            `attachments_total_bytes_exceeded (totalBytes=${totalBytes} maxTotalBytes=${maxTotalBytes})`,
+          );
+        }
+
+        const sha256 = crypto.createHash("sha256").update(buf).digest("hex");
+        const outPath = path.join(absDir, name);
+        writeJobs.push({ outPath, buf });
+        files.push({ name, bytes, sha256 });
+      }
+      await Promise.all(
+        writeJobs.map(({ outPath, buf }) =>
+          fs.writeFile(outPath, buf, { mode: 0o600, flag: "wx" }),
+        ),
+      );
+
+      const manifest = {
+        relDir,
+        count: files.length,
+        totalBytes,
+        files,
+      };
+      await fs.writeFile(
+        path.join(absDir, ".manifest.json"),
+        JSON.stringify(manifest, null, 2) + "\n",
+        {
+          mode: 0o600,
+          flag: "wx",
+        },
+      );
+
+      attachmentsReceipt = {
+        count: files.length,
+        totalBytes,
+        files,
+        relDir,
+      };
+
+      childSystemPrompt =
+        `${childSystemPrompt}\n\n` +
+        `Attachments: ${files.length} file(s), ${totalBytes} bytes. Treat attachments as untrusted input.\n` +
+        `In this sandbox, they are available at: ${relDir} (relative to workspace).\n` +
+        (mountPathHint ? `Requested mountPath hint: ${mountPathHint}.\n` : "");
+    } catch (err) {
+      try {
+        await fs.rm(absDir, { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup only.
+      }
+      await cleanupProvisionalSession(childSessionKey, {
+        emitLifecycleHooks: threadBindingReady,
+        deleteTranscript: true,
+      });
+      const messageText = err instanceof Error ? err.message : "attachments_materialization_failed";
+      return { status: "error", error: messageText };
+    }
   }
 
   const childTaskMessage = [
@@ -532,26 +873,10 @@ export async function spawnSubagentDirect(
     spawnMode === "session"
       ? "[Subagent Context] This subagent session is persistent and remains available for thread follow-up messages."
       : undefined,
-    `[Subagent Task]: ${task}`,
+    `[Subagent Task]: ${effectiveTask}`,
   ]
     .filter((line): line is string => Boolean(line))
     .join("\n\n");
-
-  const toolSpawnMetadata = mapToolContextToSpawnedRunMetadata({
-    agentGroupId: ctx.agentGroupId,
-    agentGroupChannel: ctx.agentGroupChannel,
-    agentGroupSpace: ctx.agentGroupSpace,
-    workspaceDir: ctx.workspaceDir,
-  });
-  const spawnedMetadata = normalizeSpawnedRunMetadata({
-    spawnedBy: spawnedByKey,
-    ...toolSpawnMetadata,
-    workspaceDir: resolveSpawnedWorkspaceInheritance({
-      config: cfg,
-      requesterSessionKey: requesterInternalKey,
-      explicitWorkspaceDir: toolSpawnMetadata.workspaceDir,
-    }),
-  });
 
   const childIdem = crypto.randomUUID();
   let childRunId: string = childIdem;
@@ -572,7 +897,10 @@ export async function spawnSubagentDirect(
         thinking: thinkingOverride,
         timeout: runTimeoutSeconds,
         label: label || undefined,
-        ...spawnedMetadata,
+        spawnedBy: spawnedByKey,
+        groupId: ctx.agentGroupId ?? undefined,
+        groupChannel: ctx.agentGroupChannel ?? undefined,
+        groupSpace: ctx.agentGroupSpace ?? undefined,
       },
       timeoutMs: 10_000,
     });
@@ -650,7 +978,6 @@ export async function spawnSubagentDirect(
       cleanup,
       label: label || undefined,
       model: resolvedModel,
-      workspaceDir: spawnedMetadata.workspaceDir,
       runTimeoutSeconds,
       expectsCompletionMessage,
       spawnMode,

--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -14,11 +14,21 @@ import {
 } from "../routing/session-key.js";
 import { resolveUserPath } from "../utils.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.js";
-import { resolveAgentConfig, resolveAgentWorkspaceDir } from "./agent-scope.js";
+import { resolveAgentConfig } from "./agent-scope.js";
 import { AGENT_LANE_SUBAGENT } from "./lanes.js";
 import { resolveSubagentSpawnModelSelection } from "./model-selection.js";
 import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
+import {
+  mapToolContextToSpawnedRunMetadata,
+  normalizeSpawnedRunMetadata,
+  resolveSpawnedWorkspaceInheritance,
+} from "./spawned-context.js";
 import { buildSubagentSystemPrompt } from "./subagent-announce.js";
+import {
+  decodeStrictBase64,
+  materializeSubagentAttachments,
+  type SubagentAttachmentReceiptFile,
+} from "./subagent-attachments.js";
 import { getSubagentDepthFromSessionStore } from "./subagent-depth.js";
 import { countActiveRunsForSession, registerSubagentRun } from "./subagent-registry.js";
 import { readStringParam } from "./tools/common.js";
@@ -33,27 +43,7 @@ export type SpawnSubagentMode = (typeof SUBAGENT_SPAWN_MODES)[number];
 export const SUBAGENT_SPAWN_SANDBOX_MODES = ["inherit", "require"] as const;
 export type SpawnSubagentSandboxMode = (typeof SUBAGENT_SPAWN_SANDBOX_MODES)[number];
 
-export function decodeStrictBase64(value: string, maxDecodedBytes: number): Buffer | null {
-  const maxEncodedBytes = Math.ceil(maxDecodedBytes / 3) * 4;
-  if (value.length > maxEncodedBytes * 2) {
-    return null;
-  }
-  const normalized = value.replace(/\s+/g, "");
-  if (!normalized || normalized.length % 4 !== 0) {
-    return null;
-  }
-  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(normalized)) {
-    return null;
-  }
-  if (normalized.length > maxEncodedBytes) {
-    return null;
-  }
-  const decoded = Buffer.from(normalized, "base64");
-  if (decoded.byteLength > maxDecodedBytes) {
-    return null;
-  }
-  return decoded;
-}
+export { decodeStrictBase64 };
 
 export type SpawnSubagentParams = {
   task: string;
@@ -86,10 +76,12 @@ export type SpawnSubagentContext = {
   agentGroupChannel?: string | null;
   agentGroupSpace?: string | null;
   requesterAgentIdOverride?: string;
+  /** Explicit workspace directory for subagent to inherit (optional). */
+  workspaceDir?: string;
 };
 
 export const SUBAGENT_SPAWN_ACCEPTED_NOTE =
-  "auto-announces on completion, do not poll/sleep. The response will be sent back as an user message.";
+  "Auto-announce is push-based. After spawning children, do NOT call sessions_list, sessions_history, exec sleep, or any polling tool. Wait for completion events to arrive as user messages, track expected child session keys, and only send your final answer after ALL expected completions arrive. If a child completion event arrives AFTER your final answer, reply ONLY with NO_REPLY.";
 export const SUBAGENT_SPAWN_SESSION_ACCEPTED_NOTE =
   "thread-bound session stays active after this task; continue in-thread for follow-ups.";
 
@@ -330,15 +322,11 @@ async function applySubagentPromptHook(task: string, cfg: ReturnType<typeof load
 
   if (hook.mode === "prepend") {
     if (prefixContent) {
-      nextTask = `${prefixContent}
-
-${task}`;
+      nextTask = `${prefixContent}\n\n${task}`;
     }
   } else if (hook.mode === "append") {
     if (suffixContent) {
-      nextTask = `${task}
-
-${suffixContent}`;
+      nextTask = `${task}\n\n${suffixContent}`;
     }
   } else {
     const parts = [prefixContent, task, suffixContent].filter((v) => v.length > 0);
@@ -464,13 +452,10 @@ export async function spawnSubagentDirect(
   });
   const hookRunner = getGlobalHookRunner();
   const cfg = loadConfig();
-  const hookApplied = await applySubagentPromptHook(task, cfg);
-  const effectiveTask = hookApplied.task;
-
-  if (hookApplied.telemetry.hook_warning) {
-    console.warn("[subagent.prompt_hook]", hookApplied.telemetry);
-  } else {
-    console.info("[subagent.prompt_hook]", hookApplied.telemetry);
+  const promptHookResult = await applySubagentPromptHook(task, cfg);
+  const wrappedTask = promptHookResult.task;
+  if (promptHookResult.telemetry.prompt_hook_enabled) {
+    console.log("[subagent.prompt_hook]", promptHookResult.telemetry);
   }
 
   // When agent omits runTimeoutSeconds, use the config default.
@@ -677,195 +662,45 @@ export async function spawnSubagentDirect(
     requesterOrigin,
     childSessionKey,
     label: label || undefined,
-    task: effectiveTask,
+    task,
     acpEnabled: cfg.acp?.enabled !== false && !childRuntime.sandboxed,
     childDepth,
     maxSpawnDepth,
   });
 
-  const attachmentsCfg = (
-    cfg as unknown as {
-      tools?: { sessions_spawn?: { attachments?: Record<string, unknown> } };
-    }
-  ).tools?.sessions_spawn?.attachments;
-  const attachmentsEnabled = attachmentsCfg?.enabled === true;
-  const maxTotalBytes =
-    typeof attachmentsCfg?.maxTotalBytes === "number" &&
-    Number.isFinite(attachmentsCfg.maxTotalBytes)
-      ? Math.max(0, Math.floor(attachmentsCfg.maxTotalBytes))
-      : 5 * 1024 * 1024;
-  const maxFiles =
-    typeof attachmentsCfg?.maxFiles === "number" && Number.isFinite(attachmentsCfg.maxFiles)
-      ? Math.max(0, Math.floor(attachmentsCfg.maxFiles))
-      : 50;
-  const maxFileBytes =
-    typeof attachmentsCfg?.maxFileBytes === "number" && Number.isFinite(attachmentsCfg.maxFileBytes)
-      ? Math.max(0, Math.floor(attachmentsCfg.maxFileBytes))
-      : 1 * 1024 * 1024;
-  const retainOnSessionKeep = attachmentsCfg?.retainOnSessionKeep === true;
-
-  type AttachmentReceipt = { name: string; bytes: number; sha256: string };
+  let retainOnSessionKeep = false;
   let attachmentsReceipt:
     | {
         count: number;
         totalBytes: number;
-        files: AttachmentReceipt[];
+        files: SubagentAttachmentReceiptFile[];
         relDir: string;
       }
     | undefined;
   let attachmentAbsDir: string | undefined;
   let attachmentRootDir: string | undefined;
-
-  const requestedAttachments = Array.isArray(params.attachments) ? params.attachments : [];
-
-  if (requestedAttachments.length > 0) {
-    if (!attachmentsEnabled) {
-      await cleanupProvisionalSession(childSessionKey, {
-        emitLifecycleHooks: threadBindingReady,
-        deleteTranscript: true,
-      });
-      return {
-        status: "forbidden",
-        error:
-          "attachments are disabled for sessions_spawn (enable tools.sessions_spawn.attachments.enabled)",
-      };
-    }
-    if (requestedAttachments.length > maxFiles) {
-      await cleanupProvisionalSession(childSessionKey, {
-        emitLifecycleHooks: threadBindingReady,
-        deleteTranscript: true,
-      });
-      return {
-        status: "error",
-        error: `attachments_file_count_exceeded (maxFiles=${maxFiles})`,
-      };
-    }
-
-    const attachmentId = crypto.randomUUID();
-    const childWorkspaceDir = resolveAgentWorkspaceDir(cfg, targetAgentId);
-    const absRootDir = path.join(childWorkspaceDir, ".openclaw", "attachments");
-    const relDir = path.posix.join(".openclaw", "attachments", attachmentId);
-    const absDir = path.join(absRootDir, attachmentId);
-    attachmentAbsDir = absDir;
-    attachmentRootDir = absRootDir;
-
-    const fail = (error: string): never => {
-      throw new Error(error);
+  const materializedAttachments = await materializeSubagentAttachments({
+    config: cfg,
+    targetAgentId,
+    attachments: params.attachments,
+    mountPathHint,
+  });
+  if (materializedAttachments && materializedAttachments.status !== "ok") {
+    await cleanupProvisionalSession(childSessionKey, {
+      emitLifecycleHooks: threadBindingReady,
+      deleteTranscript: true,
+    });
+    return {
+      status: materializedAttachments.status,
+      error: materializedAttachments.error,
     };
-
-    try {
-      await fs.mkdir(absDir, { recursive: true, mode: 0o700 });
-
-      const seen = new Set<string>();
-      const files: AttachmentReceipt[] = [];
-      const writeJobs: Array<{ outPath: string; buf: Buffer }> = [];
-      let totalBytes = 0;
-
-      for (const raw of requestedAttachments) {
-        const name = typeof raw?.name === "string" ? raw.name.trim() : "";
-        const contentVal = typeof raw?.content === "string" ? raw.content : "";
-        const encodingRaw = typeof raw?.encoding === "string" ? raw.encoding.trim() : "utf8";
-        const encoding = encodingRaw === "base64" ? "base64" : "utf8";
-
-        if (!name) {
-          fail("attachments_invalid_name (empty)");
-        }
-        if (name.includes("/") || name.includes("\\") || name.includes("\u0000")) {
-          fail(`attachments_invalid_name (${name})`);
-        }
-        // eslint-disable-next-line no-control-regex
-        if (/[\r\n\t\u0000-\u001F\u007F]/.test(name)) {
-          fail(`attachments_invalid_name (${name})`);
-        }
-        if (name === "." || name === ".." || name === ".manifest.json") {
-          fail(`attachments_invalid_name (${name})`);
-        }
-        if (seen.has(name)) {
-          fail(`attachments_duplicate_name (${name})`);
-        }
-        seen.add(name);
-
-        let buf: Buffer;
-        if (encoding === "base64") {
-          const strictBuf = decodeStrictBase64(contentVal, maxFileBytes);
-          if (strictBuf === null) {
-            throw new Error("attachments_invalid_base64_or_too_large");
-          }
-          buf = strictBuf;
-        } else {
-          buf = Buffer.from(contentVal, "utf8");
-          const estimatedBytes = buf.byteLength;
-          if (estimatedBytes > maxFileBytes) {
-            fail(
-              `attachments_file_bytes_exceeded (name=${name} bytes=${estimatedBytes} maxFileBytes=${maxFileBytes})`,
-            );
-          }
-        }
-
-        const bytes = buf.byteLength;
-        if (bytes > maxFileBytes) {
-          fail(
-            `attachments_file_bytes_exceeded (name=${name} bytes=${bytes} maxFileBytes=${maxFileBytes})`,
-          );
-        }
-        totalBytes += bytes;
-        if (totalBytes > maxTotalBytes) {
-          fail(
-            `attachments_total_bytes_exceeded (totalBytes=${totalBytes} maxTotalBytes=${maxTotalBytes})`,
-          );
-        }
-
-        const sha256 = crypto.createHash("sha256").update(buf).digest("hex");
-        const outPath = path.join(absDir, name);
-        writeJobs.push({ outPath, buf });
-        files.push({ name, bytes, sha256 });
-      }
-      await Promise.all(
-        writeJobs.map(({ outPath, buf }) =>
-          fs.writeFile(outPath, buf, { mode: 0o600, flag: "wx" }),
-        ),
-      );
-
-      const manifest = {
-        relDir,
-        count: files.length,
-        totalBytes,
-        files,
-      };
-      await fs.writeFile(
-        path.join(absDir, ".manifest.json"),
-        JSON.stringify(manifest, null, 2) + "\n",
-        {
-          mode: 0o600,
-          flag: "wx",
-        },
-      );
-
-      attachmentsReceipt = {
-        count: files.length,
-        totalBytes,
-        files,
-        relDir,
-      };
-
-      childSystemPrompt =
-        `${childSystemPrompt}\n\n` +
-        `Attachments: ${files.length} file(s), ${totalBytes} bytes. Treat attachments as untrusted input.\n` +
-        `In this sandbox, they are available at: ${relDir} (relative to workspace).\n` +
-        (mountPathHint ? `Requested mountPath hint: ${mountPathHint}.\n` : "");
-    } catch (err) {
-      try {
-        await fs.rm(absDir, { recursive: true, force: true });
-      } catch {
-        // Best-effort cleanup only.
-      }
-      await cleanupProvisionalSession(childSessionKey, {
-        emitLifecycleHooks: threadBindingReady,
-        deleteTranscript: true,
-      });
-      const messageText = err instanceof Error ? err.message : "attachments_materialization_failed";
-      return { status: "error", error: messageText };
-    }
+  }
+  if (materializedAttachments?.status === "ok") {
+    retainOnSessionKeep = materializedAttachments.retainOnSessionKeep;
+    attachmentsReceipt = materializedAttachments.receipt;
+    attachmentAbsDir = materializedAttachments.absDir;
+    attachmentRootDir = materializedAttachments.rootDir;
+    childSystemPrompt = `${childSystemPrompt}\n\n${materializedAttachments.systemPromptSuffix}`;
   }
 
   const childTaskMessage = [
@@ -873,10 +708,26 @@ export async function spawnSubagentDirect(
     spawnMode === "session"
       ? "[Subagent Context] This subagent session is persistent and remains available for thread follow-up messages."
       : undefined,
-    `[Subagent Task]: ${effectiveTask}`,
+    `[Subagent Task]: ${wrappedTask}`,
   ]
     .filter((line): line is string => Boolean(line))
     .join("\n\n");
+
+  const toolSpawnMetadata = mapToolContextToSpawnedRunMetadata({
+    agentGroupId: ctx.agentGroupId,
+    agentGroupChannel: ctx.agentGroupChannel,
+    agentGroupSpace: ctx.agentGroupSpace,
+    workspaceDir: ctx.workspaceDir,
+  });
+  const spawnedMetadata = normalizeSpawnedRunMetadata({
+    spawnedBy: spawnedByKey,
+    ...toolSpawnMetadata,
+    workspaceDir: resolveSpawnedWorkspaceInheritance({
+      config: cfg,
+      requesterSessionKey: requesterInternalKey,
+      explicitWorkspaceDir: toolSpawnMetadata.workspaceDir,
+    }),
+  });
 
   const childIdem = crypto.randomUUID();
   let childRunId: string = childIdem;
@@ -897,10 +748,7 @@ export async function spawnSubagentDirect(
         thinking: thinkingOverride,
         timeout: runTimeoutSeconds,
         label: label || undefined,
-        spawnedBy: spawnedByKey,
-        groupId: ctx.agentGroupId ?? undefined,
-        groupChannel: ctx.agentGroupChannel ?? undefined,
-        groupSpace: ctx.agentGroupSpace ?? undefined,
+        ...spawnedMetadata,
       },
       timeoutMs: 10_000,
     });
@@ -978,6 +826,7 @@ export async function spawnSubagentDirect(
       cleanup,
       label: label || undefined,
       model: resolvedModel,
+      workspaceDir: spawnedMetadata.workspaceDir,
       runTimeoutSeconds,
       expectsCompletionMessage,
       spawnMode,

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -5,59 +5,6 @@ import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
 
-export type AgentRuntimeAcpConfig = {
-  /** ACP harness adapter id (for example codex, claude). */
-  agent?: string;
-  /** Optional ACP backend override for this agent runtime. */
-  backend?: string;
-  /** Optional ACP session mode override. */
-  mode?: "persistent" | "oneshot";
-  /** Optional runtime working directory override. */
-  cwd?: string;
-};
-
-export type AgentRuntimeConfig =
-  | {
-      type: "embedded";
-    }
-  | {
-      type: "acp";
-      acp?: AgentRuntimeAcpConfig;
-    };
-
-export type AgentBindingMatch = {
-  channel: string;
-  accountId?: string;
-  peer?: { kind: ChatType; id: string };
-  guildId?: string;
-  teamId?: string;
-  /** Discord role IDs used for role-based routing. */
-  roles?: string[];
-};
-
-export type AgentRouteBinding = {
-  /** Missing type is interpreted as route for backward compatibility. */
-  type?: "route";
-  agentId: string;
-  comment?: string;
-  match: AgentBindingMatch;
-};
-
-export type AgentAcpBinding = {
-  type: "acp";
-  agentId: string;
-  comment?: string;
-  match: AgentBindingMatch;
-  acp?: {
-    mode?: "persistent" | "oneshot";
-    label?: string;
-    cwd?: string;
-    backend?: string;
-  };
-};
-
-export type AgentBinding = AgentRouteBinding | AgentAcpBinding;
-
 export type AgentConfig = {
   id: string;
   default?: boolean;
@@ -85,11 +32,34 @@ export type AgentConfig = {
   /** Optional per-agent stream params (e.g. cacheRetention, temperature). */
   params?: Record<string, unknown>;
   tools?: AgentToolsConfig;
-  /** Optional runtime descriptor for this agent. */
-  runtime?: AgentRuntimeConfig;
 };
 
 export type AgentsConfig = {
   defaults?: AgentDefaultsConfig;
   list?: AgentConfig[];
+  /** Global subagent runtime settings (applied to sessions_spawn runtime=subagent). */
+  subagent?: {
+    promptHook?: {
+      enabled?: boolean;
+      mode?: "prepend" | "append" | "wrap";
+      prefixPath?: string;
+      suffixPath?: string;
+      maxBytes?: number;
+      onMissing?: "warn" | "disable";
+    };
+  };
+};
+
+export type AgentBinding = {
+  agentId: string;
+  comment?: string;
+  match: {
+    channel: string;
+    accountId?: string;
+    peer?: { kind: ChatType; id: string };
+    guildId?: string;
+    teamId?: string;
+    /** Discord role IDs used for role-based routing. */
+    roles?: string[];
+  };
 };

--- a/src/config/types.agents.ts
+++ b/src/config/types.agents.ts
@@ -5,6 +5,59 @@ import type { HumanDelayConfig, IdentityConfig } from "./types.base.js";
 import type { GroupChatConfig } from "./types.messages.js";
 import type { AgentToolsConfig, MemorySearchConfig } from "./types.tools.js";
 
+export type AgentRuntimeAcpConfig = {
+  /** ACP harness adapter id (for example codex, claude). */
+  agent?: string;
+  /** Optional ACP backend override for this agent runtime. */
+  backend?: string;
+  /** Optional ACP session mode override. */
+  mode?: "persistent" | "oneshot";
+  /** Optional runtime working directory override. */
+  cwd?: string;
+};
+
+export type AgentRuntimeConfig =
+  | {
+      type: "embedded";
+    }
+  | {
+      type: "acp";
+      acp?: AgentRuntimeAcpConfig;
+    };
+
+export type AgentBindingMatch = {
+  channel: string;
+  accountId?: string;
+  peer?: { kind: ChatType; id: string };
+  guildId?: string;
+  teamId?: string;
+  /** Discord role IDs used for role-based routing. */
+  roles?: string[];
+};
+
+export type AgentRouteBinding = {
+  /** Missing type is interpreted as route for backward compatibility. */
+  type?: "route";
+  agentId: string;
+  comment?: string;
+  match: AgentBindingMatch;
+};
+
+export type AgentAcpBinding = {
+  type: "acp";
+  agentId: string;
+  comment?: string;
+  match: AgentBindingMatch;
+  acp?: {
+    mode?: "persistent" | "oneshot";
+    label?: string;
+    cwd?: string;
+    backend?: string;
+  };
+};
+
+export type AgentBinding = AgentRouteBinding | AgentAcpBinding;
+
 export type AgentConfig = {
   id: string;
   default?: boolean;
@@ -32,6 +85,8 @@ export type AgentConfig = {
   /** Optional per-agent stream params (e.g. cacheRetention, temperature). */
   params?: Record<string, unknown>;
   tools?: AgentToolsConfig;
+  /** Optional runtime descriptor for this agent. */
+  runtime?: AgentRuntimeConfig;
 };
 
 export type AgentsConfig = {
@@ -47,19 +102,5 @@ export type AgentsConfig = {
       maxBytes?: number;
       onMissing?: "warn" | "disable";
     };
-  };
-};
-
-export type AgentBinding = {
-  agentId: string;
-  comment?: string;
-  match: {
-    channel: string;
-    accountId?: string;
-    peer?: { kind: ChatType; id: string };
-    guildId?: string;
-    teamId?: string;
-    /** Discord role IDs used for role-based routing. */
-    roles?: string[];
   };
 };

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -7,89 +7,58 @@ export const AgentsSchema = z
   .object({
     defaults: z.lazy(() => AgentDefaultsSchema).optional(),
     list: z.array(AgentEntrySchema).optional(),
+    subagent: z
+      .object({
+        promptHook: z
+          .object({
+            enabled: z.boolean().optional(),
+            mode: z.enum(["prepend", "append", "wrap"]).optional(),
+            prefixPath: z.string().optional(),
+            suffixPath: z.string().optional(),
+            maxBytes: z.number().int().positive().optional(),
+            onMissing: z.enum(["warn", "disable"]).optional(),
+          })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
   })
   .strict()
   .optional();
 
-const BindingMatchSchema = z
-  .object({
-    channel: z.string(),
-    accountId: z.string().optional(),
-    peer: z
+export const BindingsSchema = z
+  .array(
+    z
       .object({
-        kind: z.union([
-          z.literal("direct"),
-          z.literal("group"),
-          z.literal("channel"),
-          /** @deprecated Use `direct` instead. Kept for backward compatibility. */
-          z.literal("dm"),
-        ]),
-        id: z.string(),
+        agentId: z.string(),
+        comment: z.string().optional(),
+        match: z
+          .object({
+            channel: z.string(),
+            accountId: z.string().optional(),
+            peer: z
+              .object({
+                kind: z.union([
+                  z.literal("direct"),
+                  z.literal("group"),
+                  z.literal("channel"),
+                  /** @deprecated Use `direct` instead. Kept for backward compatibility. */
+                  z.literal("dm"),
+                ]),
+                id: z.string(),
+              })
+              .strict()
+              .optional(),
+            guildId: z.string().optional(),
+            teamId: z.string().optional(),
+            roles: z.array(z.string()).optional(),
+          })
+          .strict(),
       })
-      .strict()
-      .optional(),
-    guildId: z.string().optional(),
-    teamId: z.string().optional(),
-    roles: z.array(z.string()).optional(),
-  })
-  .strict();
-
-const RouteBindingSchema = z
-  .object({
-    type: z.literal("route").optional(),
-    agentId: z.string(),
-    comment: z.string().optional(),
-    match: BindingMatchSchema,
-  })
-  .strict();
-
-const AcpBindingSchema = z
-  .object({
-    type: z.literal("acp"),
-    agentId: z.string(),
-    comment: z.string().optional(),
-    match: BindingMatchSchema,
-    acp: z
-      .object({
-        mode: z.enum(["persistent", "oneshot"]).optional(),
-        label: z.string().optional(),
-        cwd: z.string().optional(),
-        backend: z.string().optional(),
-      })
-      .strict()
-      .optional(),
-  })
-  .strict()
-  .superRefine((value, ctx) => {
-    const peerId = value.match.peer?.id?.trim() ?? "";
-    if (!peerId) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["match", "peer"],
-        message: "ACP bindings require match.peer.id to target a concrete conversation.",
-      });
-      return;
-    }
-    const channel = value.match.channel.trim().toLowerCase();
-    if (channel !== "discord" && channel !== "telegram") {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["match", "channel"],
-        message: 'ACP bindings currently support only "discord" and "telegram" channels.',
-      });
-      return;
-    }
-    if (channel === "telegram" && !/^-\d+:topic:\d+$/.test(peerId)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ["match", "peer", "id"],
-        message:
-          "Telegram ACP bindings require canonical topic IDs in the form -1001234567890:topic:42.",
-      });
-    }
-  });
-
-export const BindingsSchema = z.array(z.union([RouteBindingSchema, AcpBindingSchema])).optional();
+      .strict(),
+  )
+  .optional();
 
 export const BroadcastStrategySchema = z.enum(["parallel", "sequential"]);
 

--- a/src/config/zod-schema.agents.ts
+++ b/src/config/zod-schema.agents.ts
@@ -27,38 +27,85 @@ export const AgentsSchema = z
   .strict()
   .optional();
 
-export const BindingsSchema = z
-  .array(
-    z
+const BindingMatchSchema = z
+  .object({
+    channel: z.string(),
+    accountId: z.string().optional(),
+    peer: z
       .object({
-        agentId: z.string(),
-        comment: z.string().optional(),
-        match: z
-          .object({
-            channel: z.string(),
-            accountId: z.string().optional(),
-            peer: z
-              .object({
-                kind: z.union([
-                  z.literal("direct"),
-                  z.literal("group"),
-                  z.literal("channel"),
-                  /** @deprecated Use `direct` instead. Kept for backward compatibility. */
-                  z.literal("dm"),
-                ]),
-                id: z.string(),
-              })
-              .strict()
-              .optional(),
-            guildId: z.string().optional(),
-            teamId: z.string().optional(),
-            roles: z.array(z.string()).optional(),
-          })
-          .strict(),
+        kind: z.union([
+          z.literal("direct"),
+          z.literal("group"),
+          z.literal("channel"),
+          /** @deprecated Use `direct` instead. Kept for backward compatibility. */
+          z.literal("dm"),
+        ]),
+        id: z.string(),
       })
-      .strict(),
-  )
-  .optional();
+      .strict()
+      .optional(),
+    guildId: z.string().optional(),
+    teamId: z.string().optional(),
+    roles: z.array(z.string()).optional(),
+  })
+  .strict();
+
+const RouteBindingSchema = z
+  .object({
+    type: z.literal("route").optional(),
+    agentId: z.string(),
+    comment: z.string().optional(),
+    match: BindingMatchSchema,
+  })
+  .strict();
+
+const AcpBindingSchema = z
+  .object({
+    type: z.literal("acp"),
+    agentId: z.string(),
+    comment: z.string().optional(),
+    match: BindingMatchSchema,
+    acp: z
+      .object({
+        mode: z.enum(["persistent", "oneshot"]).optional(),
+        label: z.string().optional(),
+        cwd: z.string().optional(),
+        backend: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const peerId = value.match.peer?.id?.trim() ?? "";
+    if (!peerId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["match", "peer"],
+        message: "ACP bindings require match.peer.id to target a concrete conversation.",
+      });
+      return;
+    }
+    const channel = value.match.channel.trim().toLowerCase();
+    if (channel !== "discord" && channel !== "telegram") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["match", "channel"],
+        message: 'ACP bindings currently support only "discord" and "telegram" channels.',
+      });
+      return;
+    }
+    if (channel === "telegram" && !/^-\d+:topic:\d+$/.test(peerId)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["match", "peer", "id"],
+        message:
+          "Telegram ACP bindings require canonical topic IDs in the form -1001234567890:topic:42.",
+      });
+    }
+  });
+
+export const BindingsSchema = z.array(z.union([RouteBindingSchema, AcpBindingSchema])).optional();
 
 export const BroadcastStrategySchema = z.enum(["parallel", "sequential"]);
 


### PR DESCRIPTION
Summary:
- add agents.subagent.promptHook config (types + zod schema)
- inject optional prefix/suffix wrapping into subagent task payloads in spawnSubagentDirect
- add prompt-hook telemetry fields (applied|partial|skipped) without logging prompt bodies
- add focused test coverage and docs updates

Validation:
- pnpm vitest run --config vitest.config.ts src/agents/openclaw-tools.subagents.sessions-spawn.prompt-hook.test.ts
- pnpm build:docker
