### PR TITLE
Config: dedupe config warning logs

### DIFF
--- a/src/config/io.ts
+++ b/src/config/io.ts
@@ -84,6 +84,7 @@ const OPEN_DM_POLICY_ALLOW_FROM_RE =
 
 const CONFIG_AUDIT_LOG_FILENAME = "config-audit.jsonl";
 const loggedInvalidConfigs = new Set<string>();
+const loggedConfigWarningFingerprints = new Map<string, string>();
 
 type ConfigWriteAuditResult = "rename" | "copy-fallback" | "failed";
 
@@ -766,7 +767,14 @@ export function createConfigIO(overrides: ConfigIoDeps = {}) {
               `- ${sanitizeTerminalText(iss.path || "<root>")}: ${sanitizeTerminalText(iss.message)}`,
           )
           .join("\n");
-        deps.logger.warn(`Config warnings:\\n${details}`);
+        const rawHash = hashConfigRaw(raw);
+        const fingerprint = hashConfigRaw(`${rawHash}\n${details}`);
+        if (loggedConfigWarningFingerprints.get(configPath) !== fingerprint) {
+          loggedConfigWarningFingerprints.set(configPath, fingerprint);
+          deps.logger.warn(`Config warnings:\\n${details}`);
+        }
+      } else {
+        loggedConfigWarningFingerprints.delete(configPath);
       }
       warnIfConfigFromFuture(validated.config, deps.logger);
       const cfg = applyTalkConfigNormalization(

--- a/src/config/io.warning-dedupe.test.ts
+++ b/src/config/io.warning-dedupe.test.ts
@@ -1,0 +1,70 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { createConfigIO } from "./io.js";
+
+async function withTempDir(run: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-config-"));
+  try {
+    await run(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+describe("config io warning logging", () => {
+  it("dedupes warning logs when config is unchanged", async () => {
+    await withTempDir(async (dir) => {
+      const configPath = path.join(dir, "openclaw.json");
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ plugins: { entries: { "missing-plugin": {} } } }, null, 2),
+        "utf-8",
+      );
+
+      const logger = { warn: vi.fn(), error: vi.fn() };
+      const io = createConfigIO({
+        configPath,
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => dir,
+        logger,
+      });
+
+      io.loadConfig();
+      io.loadConfig();
+
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(String(logger.warn.mock.calls[0]?.[0] ?? "")).toContain("Config warnings:");
+    });
+  });
+
+  it("logs warning again when config changes", async () => {
+    await withTempDir(async (dir) => {
+      const configPath = path.join(dir, "openclaw.json");
+      const logger = { warn: vi.fn(), error: vi.fn() };
+      const io = createConfigIO({
+        configPath,
+        env: {} as NodeJS.ProcessEnv,
+        homedir: () => dir,
+        logger,
+      });
+
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ plugins: { entries: { "missing-plugin": {} } } }, null, 2),
+        "utf-8",
+      );
+      io.loadConfig();
+
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({ plugins: { entries: { "missing-plugin-2": {} } } }, null, 2),
+        "utf-8",
+      );
+      io.loadConfig();
+
+      expect(logger.warn).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
## **Summary**

- Problem: Config validation warnings can be logged repeatedly on each config load/validation cycle, producing log spam when a warning condition persists.
- Why it matters: This floods `gateway.log`, makes real issues harder to spot, and can materially increase log volume/cost in long-running gateways.
- What changed: `loadConfig()` now dedupes `Config warnings:` logging per config file by fingerprinting the config file content hash + formatted warning details; it re-logs when the config file changes or the warning set changes.
- What did NOT change (scope boundary): No config validation rules changed; only logging behavior for existing warnings.

## **Change Type (select all)**

- [x]  Bug fix
- [ ]  Feature
- [ ]  Refactor
- [ ]  Docs
- [ ]  Security hardening
- [ ]  Chore/infra

## **Scope (select all touched areas)**

- [x]  Gateway / orchestration
- [ ]  Skills / tool execution
- [ ]  Auth / tokens
- [ ]  Memory / storage
- [ ]  Integrations
- [ ]  API / contracts
- [ ]  UI / DX
- [ ]  CI/CD / infra

## **Linked Issue/PR**

Closes #40404

## **User-visible / Behavior Changes**

When config validation emits warnings, the gateway no longer repeats the same multi-line `Config warnings:` block on every validation cycle; it logs once until the underlying config/warnings change.

## **Security Impact (required)**

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## **Repro + Verification**

### **Environment**

- OS: macOS
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A (unit-test coverage)

### **Steps**

1. Run `pnpm test src/config/io.warning-dedupe.test.ts`.

### **Expected**

- The same warning set is logged once per unchanged config.
- Updating the config (changing the warning set) logs again.

### **Actual**

- Before fix: warnings were emitted on each `loadConfig()` call.
- After fix: warnings are deduped as expected.

## **Evidence**

- [x]  Failing behavior before + passing after (unit test)

## **Human Verification (required)**

- Verified scenarios: `pnpm test src/config/io.warning-dedupe.test.ts`
- Edge cases checked: config change triggers re-log
- What you did **not** verify: full gateway runtime on all OS runners

## **Compatibility / Migration**

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## **Failure Recovery (if this breaks)**

Revert this commit.

## **Risks and Mitigations**

None.
