### PR TITLE
fix: ignore zero-valued poll params when detecting poll creation

### DIFF
--- a/src/poll-params.test.ts
+++ b/src/poll-params.test.ts
@@ -23,8 +23,12 @@ describe("poll params", () => {
     },
   );
 
-  it("treats finite numeric poll params as poll creation intent", () => {
-    expect(hasPollCreationParams({ pollDurationHours: 0 })).toBe(true);
+  it("treats only positive numeric poll params as poll creation intent", () => {
+    expect(hasPollCreationParams({ pollDurationHours: 0 })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationSeconds: 0 })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationSeconds: "0" })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationHours: -1 })).toBe(false);
+    expect(hasPollCreationParams({ pollDurationSeconds: "-5" })).toBe(false);
     expect(hasPollCreationParams({ pollDurationSeconds: 60 })).toBe(true);
     expect(hasPollCreationParams({ pollDurationSeconds: "60" })).toBe(true);
     expect(hasPollCreationParams({ pollDurationSeconds: "1e3" })).toBe(true);

--- a/src/poll-params.ts
+++ b/src/poll-params.ts
@@ -66,13 +66,16 @@ export function hasPollCreationParams(params: Record<string, unknown>): boolean 
       }
     }
     if (def.kind === "number") {
-      if (typeof value === "number" && Number.isFinite(value)) {
+      if (typeof value === "number" && Number.isFinite(value) && value > 0) {
         return true;
       }
       if (typeof value === "string") {
         const trimmed = value.trim();
-        if (trimmed.length > 0 && Number.isFinite(Number(trimmed))) {
-          return true;
+        if (trimmed.length > 0) {
+          const numericValue = Number(trimmed);
+          if (Number.isFinite(numericValue) && numericValue > 0) {
+            return true;
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary
Fix poll creation detection so zero-valued numeric defaults do not hijack regular `message.send` requests.

## Problem
`hasPollCreationParams(...)` treated any finite numeric poll field as active poll intent, including default values like `0`. That can cause normal sends carrying zero-valued poll defaults to be misclassified as poll creation payloads, which is especially noticeable when sending attachments/media.

## Change
- require numeric poll params to be strictly greater than zero
- require string-encoded numeric poll params to parse to a value greater than zero
- update the focused unit test to cover zero and negative values as non-poll input

## Why this is safe
`0` is not a meaningful poll-creation value, so excluding it preserves valid poll detection while avoiding accidental routing into poll handling.

## Testing
- `./node_modules/.bin/vitest run --config vitest.unit.config.ts src/poll-params.test.ts`

## AI assistance
AI-assisted patch and test verification.
