### PR TITLE
fix(ui): reset config dirty on reload

### DIFF
--- a/test/ui-config-reload-clears-dirty.test.ts
+++ b/test/ui-config-reload-clears-dirty.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadConfig, type ConfigState } from "../ui/src/ui/controllers/config.ts";
+
+function createState(): ConfigState {
+  return {
+    applySessionKey: "main",
+    client: null,
+    configActiveSection: null,
+    configActiveSubsection: null,
+    configApplying: false,
+    configForm: null,
+    configFormDirty: false,
+    configFormMode: "form",
+    configFormOriginal: null,
+    configIssues: [],
+    configLoading: false,
+    configRaw: "",
+    configRawOriginal: "",
+    configSaving: false,
+    configSchema: null,
+    configSchemaLoading: false,
+    configSchemaVersion: null,
+    configSearchQuery: "",
+    configSnapshot: null,
+    configUiHints: {},
+    configValid: null,
+    connected: false,
+    lastError: null,
+    updateRunning: false,
+  };
+}
+
+describe("Control UI config reload", () => {
+  it("clears dirty state so config form refreshes on reload", async () => {
+    const request = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "config.get") {
+        return {
+          config: { gateway: { mode: "remote" } },
+          valid: true,
+          issues: [],
+          raw: '{\n  "gateway": { "mode": "remote" }\n}\n',
+        };
+      }
+      return {};
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+
+    state.configFormMode = "form";
+    state.configFormDirty = true;
+    state.configForm = { gateway: { mode: "local" } };
+    state.configRaw = '{\n  "gateway": {\n    "mode": "local"\n  }\n}\n';
+
+    await loadConfig(state);
+
+    expect(state.configFormDirty).toBe(false);
+    expect(state.configForm).toEqual({ gateway: { mode: "remote" } });
+    expect(state.configRaw).toBe('{\n  "gateway": { "mode": "remote" }\n}\n');
+  });
+});

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -40,6 +40,7 @@ export async function loadConfig(state: ConfigState) {
   if (!state.client || !state.connected) {
     return;
   }
+  state.configFormDirty = false;
   state.configLoading = true;
   state.lastError = null;
   try {


### PR DESCRIPTION
## **Summary**

- Problem: Control UI "Reload Config" can leave `configFormDirty` set, so `applyConfigSnapshot` refuses to refresh `configForm`, causing the Model Selection dropdown to show stale values.
- Why it matters: Operators can’t trust the Control UI model selection state after reloading config; this creates confusion and can lead to incorrect model changes.
- What changed: `loadConfig()` now resets `configFormDirty` before fetching/applying the fresh snapshot so the form state reflects the server config on explicit reload.
- What did NOT change (scope boundary): No server-side config logic; no changes to how dirty state is set during edits or how autosave/apply works.

## **Change Type (select all)**

- [x]  Bug fix
- [ ]  Feature
- [ ]  Refactor
- [ ]  Docs
- [ ]  Security hardening
- [ ]  Chore/infra

## **Scope (select all touched areas)**

- [ ]  Gateway / orchestration
- [ ]  Skills / tool execution
- [ ]  Auth / tokens
- [ ]  Memory / storage
- [ ]  Integrations
- [ ]  API / contracts
- [x]  UI / DX
- [ ]  CI/CD / infra

## **Linked Issue/PR**

Closes #40352

## **User-visible / Behavior Changes**

Clicking "Reload Config" now refreshes the Control UI form state from the latest config snapshot, so the Model Selection dropdown no longer remains stuck on stale values.

## **Security Impact (required)**

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## **Repro + Verification**

### **Environment**

- OS: N/A (unit-test coverage)
- Runtime/container: Node + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### **Steps**

1. Run `pnpm test test/ui-config-reload-clears-dirty.test.ts`.

### **Expected**

- When config is explicitly reloaded, the form state updates from the latest snapshot even if it was previously marked dirty.

### **Actual**

- Before fix: reload could keep dirty state and skip form refresh.
- After fix: dirty state is cleared for explicit reload, and form refreshes.

## **Evidence**

- [x]  Failing behavior before + passing after (unit test)

## **Human Verification (required)**

- Verified scenarios: `pnpm test test/ui-config-reload-clears-dirty.test.ts`
- Edge cases checked: N/A
- What you did **not** verify: Full Control UI manual flow in a running gateway

## **Compatibility / Migration**

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## **Failure Recovery (if this breaks)**

Revert this commit.

## **Risks and Mitigations**

- Risk: Reload discards unsaved form edits.
  - Mitigation: This only affects explicit "Reload Config"; save/apply flows are unchanged.
