### PR TITLE
fix(ui): discard stale config state on explicit reload

### DIFF
--- a/ui/src/ui/app-channels.test.ts
+++ b/ui/src/ui/app-channels.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { handleNostrProfileSave } from "./app-channels.ts";
+import type { OpenClawApp } from "./app.ts";
+import { createNostrProfileFormState } from "./views/channels.nostr-profile-form.ts";
+
+const loadChannels = vi.fn();
+
+vi.mock("./controllers/channels.ts", () => ({
+  loadChannels: (...args: unknown[]) => loadChannels(...args),
+  logoutWhatsApp: vi.fn(),
+  startWhatsAppLogin: vi.fn(),
+  waitWhatsAppLogin: vi.fn(),
+}));
+
+vi.mock("./controllers/config.ts", () => ({
+  loadConfig: vi.fn(),
+  saveConfig: vi.fn(),
+}));
+
+function createHost(): OpenClawApp {
+  return {
+    channelsSnapshot: null,
+    hello: null,
+    nostrProfileAccountId: "default",
+    nostrProfileFormState: createNostrProfileFormState({
+      name: "alice",
+      displayName: "Alice",
+      about: "",
+      picture: "",
+      banner: "",
+      website: "",
+      nip05: "",
+      lud16: "",
+    }),
+    password: "",
+    settings: { token: "" },
+  } as unknown as OpenClawApp;
+}
+
+describe("handleNostrProfileSave", () => {
+  beforeEach(() => {
+    loadChannels.mockReset();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("does not start a save while import is in progress", async () => {
+    const host = createHost();
+    if (!host.nostrProfileFormState) {
+      throw new Error("expected form state");
+    }
+    host.nostrProfileFormState.importing = true;
+
+    await handleNostrProfileSave(host);
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(loadChannels).not.toHaveBeenCalled();
+  });
+
+  it("aligns the saved baseline with the current form state after async success", async () => {
+    const host = createHost();
+    let resolveResponse!: (value: unknown) => void;
+    const responsePromise = new Promise<unknown>((resolve) => {
+      resolveResponse = resolve;
+    });
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(responsePromise));
+
+    const savePromise = handleNostrProfileSave(host);
+    if (!host.nostrProfileFormState) {
+      throw new Error("expected form state");
+    }
+    host.nostrProfileFormState = {
+      ...host.nostrProfileFormState,
+      values: {
+        ...host.nostrProfileFormState.values,
+        displayName: "Alice Updated",
+      },
+    };
+
+    resolveResponse({
+      ok: true,
+      json: async () => ({ ok: true, persisted: true }),
+    });
+    await savePromise;
+
+    expect(host.nostrProfileFormState?.values.displayName).toBe("Alice Updated");
+    expect(host.nostrProfileFormState?.original.displayName).toBe("Alice Updated");
+    expect(loadChannels).toHaveBeenCalledWith(host, true);
+  });
+});

--- a/ui/src/ui/app-channels.ts
+++ b/ui/src/ui/app-channels.ts
@@ -26,6 +26,7 @@ export async function handleWhatsAppLogout(host: OpenClawApp) {
 
 export async function handleChannelConfigSave(host: OpenClawApp) {
   await saveConfig(host);
+  await loadConfig(host);
   await loadChannels(host, true);
 }
 

--- a/ui/src/ui/app-channels.ts
+++ b/ui/src/ui/app-channels.ts
@@ -197,7 +197,7 @@ export async function handleNostrProfileSave(host: OpenClawApp) {
       error: null,
       success: "Profile published to relays.",
       fieldErrors: {},
-      original: { ...currentState.values },
+      original: { ...state.values },
     };
     await loadChannels(host, true);
   } catch (err) {

--- a/ui/src/ui/app-channels.ts
+++ b/ui/src/ui/app-channels.ts
@@ -26,12 +26,11 @@ export async function handleWhatsAppLogout(host: OpenClawApp) {
 
 export async function handleChannelConfigSave(host: OpenClawApp) {
   await saveConfig(host);
-  await loadConfig(host);
   await loadChannels(host, true);
 }
 
 export async function handleChannelConfigReload(host: OpenClawApp) {
-  await loadConfig(host);
+  await loadConfig(host, { discardPendingEdits: true });
   await loadChannels(host, true);
 }
 
@@ -164,11 +163,15 @@ export async function handleNostrProfileSave(host: OpenClawApp) {
       details?: unknown;
       persisted?: boolean;
     } | null;
+    const currentState = host.nostrProfileFormState;
+    if (!currentState) {
+      return;
+    }
 
     if (!response.ok || data?.ok === false || !data) {
       const errorMessage = data?.error ?? `Profile update failed (${response.status})`;
       host.nostrProfileFormState = {
-        ...state,
+        ...currentState,
         saving: false,
         error: errorMessage,
         success: null,
@@ -179,7 +182,7 @@ export async function handleNostrProfileSave(host: OpenClawApp) {
 
     if (!data.persisted) {
       host.nostrProfileFormState = {
-        ...state,
+        ...currentState,
         saving: false,
         error: "Profile publish failed on all relays.",
         success: null,
@@ -188,17 +191,21 @@ export async function handleNostrProfileSave(host: OpenClawApp) {
     }
 
     host.nostrProfileFormState = {
-      ...state,
+      ...currentState,
       saving: false,
       error: null,
       success: "Profile published to relays.",
       fieldErrors: {},
-      original: { ...state.values },
+      original: { ...currentState.values },
     };
     await loadChannels(host, true);
   } catch (err) {
+    const currentState = host.nostrProfileFormState;
+    if (!currentState) {
+      return;
+    }
     host.nostrProfileFormState = {
-      ...state,
+      ...currentState,
       saving: false,
       error: `Profile update failed: ${String(err)}`,
       success: null,
@@ -236,11 +243,15 @@ export async function handleNostrProfileImport(host: OpenClawApp) {
       merged?: NostrProfile;
       saved?: boolean;
     } | null;
+    const currentState = host.nostrProfileFormState;
+    if (!currentState) {
+      return;
+    }
 
     if (!response.ok || data?.ok === false || !data) {
       const errorMessage = data?.error ?? `Profile import failed (${response.status})`;
       host.nostrProfileFormState = {
-        ...state,
+        ...currentState,
         importing: false,
         error: errorMessage,
         success: null,
@@ -249,13 +260,13 @@ export async function handleNostrProfileImport(host: OpenClawApp) {
     }
 
     const merged = data.merged ?? data.imported ?? null;
-    const nextValues = merged ? { ...state.values, ...merged } : state.values;
+    const nextValues = merged ? { ...currentState.values, ...merged } : currentState.values;
     const showAdvanced = Boolean(
       nextValues.banner || nextValues.website || nextValues.nip05 || nextValues.lud16,
     );
 
     host.nostrProfileFormState = {
-      ...state,
+      ...currentState,
       importing: false,
       values: nextValues,
       error: null,
@@ -269,8 +280,12 @@ export async function handleNostrProfileImport(host: OpenClawApp) {
       await loadChannels(host, true);
     }
   } catch (err) {
+    const currentState = host.nostrProfileFormState;
+    if (!currentState) {
+      return;
+    }
     host.nostrProfileFormState = {
-      ...state,
+      ...currentState,
       importing: false,
       error: `Profile import failed: ${String(err)}`,
       success: null,

--- a/ui/src/ui/app-channels.ts
+++ b/ui/src/ui/app-channels.ts
@@ -136,7 +136,7 @@ export function handleNostrProfileToggleAdvanced(host: OpenClawApp) {
 
 export async function handleNostrProfileSave(host: OpenClawApp) {
   const state = host.nostrProfileFormState;
-  if (!state || state.saving) {
+  if (!state || state.saving || state.importing) {
     return;
   }
   const accountId = resolveNostrAccountId(host);
@@ -197,7 +197,7 @@ export async function handleNostrProfileSave(host: OpenClawApp) {
       error: null,
       success: "Profile published to relays.",
       fieldErrors: {},
-      original: { ...state.values },
+      original: { ...currentState.values },
     };
     await loadChannels(host, true);
   } catch (err) {

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -711,7 +711,7 @@ export function renderApp(state: AppViewState) {
                     removeConfigFormValue(state, [...basePath, "deny"]);
                   }
                 },
-                onConfigReload: () => loadConfig(state),
+                onConfigReload: () => loadConfig(state, { discardPendingEdits: true }),
                 onConfigSave: () => saveAgentsConfig(state),
                 onChannelsRefresh: () => loadChannels(state, false),
                 onCronRefresh: () => state.loadCron(),
@@ -1064,7 +1064,7 @@ export function renderApp(state: AppViewState) {
                   state.configActiveSubsection = null;
                 },
                 onSubsectionChange: (section) => (state.configActiveSubsection = section),
-                onReload: () => loadConfig(state),
+                onReload: () => loadConfig(state, { discardPendingEdits: true }),
                 onSave: () => saveConfig(state),
                 onApply: () => applyConfig(state),
                 onUpdate: () => runUpdate(state),

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1064,7 +1064,7 @@ export function renderApp(state: AppViewState) {
                   state.configActiveSubsection = null;
                 },
                 onSubsectionChange: (section) => (state.configActiveSubsection = section),
-                onReload: () => loadConfig(state, { discardPendingEdits: true }),
+                onReload: () => loadConfig(state),
                 onSave: () => saveConfig(state),
                 onApply: () => applyConfig(state),
                 onUpdate: () => runUpdate(state),

--- a/ui/src/ui/app-render.ts
+++ b/ui/src/ui/app-render.ts
@@ -1064,7 +1064,7 @@ export function renderApp(state: AppViewState) {
                   state.configActiveSubsection = null;
                 },
                 onSubsectionChange: (section) => (state.configActiveSubsection = section),
-                onReload: () => loadConfig(state),
+                onReload: () => loadConfig(state, { discardPendingEdits: true }),
                 onSave: () => saveConfig(state),
                 onApply: () => applyConfig(state),
                 onUpdate: () => runUpdate(state),

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -138,6 +138,9 @@ describe("applyConfigSnapshot", () => {
     expect(state.configRaw).toBe(
       '{ "agents": { "defaults": { "model": "ollama/qwen3-coder:30b-64k" } } }',
     );
+    expect(state.configRawOriginal).toBe(
+      '{ "agents": { "defaults": { "model": "ollama/qwen3-coder:30b-64k" } } }',
+    );
     expect(state.configFormOriginal).toEqual({
       agents: { defaults: { model: "ollama/qwen3-coder:30b-64k" } },
     });

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -459,6 +459,34 @@ describe("loadConfig", () => {
     expect(state.configRaw).toBe('{ "agents": { "defaults": { "model": "custom/raw-edit" } } }');
   });
 
+  it("updates raw mode from the snapshot when only form state is still dirty", async () => {
+    const request = vi.fn().mockResolvedValue({
+      config: { agents: { defaults: { model: "ollama/qwen3-coder:30b-64k" } } },
+      valid: true,
+      issues: [],
+      raw: '{ "agents": { "defaults": { "model": "ollama/qwen3-coder:30b-64k" } } }',
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.configFormMode = "raw";
+    state.configFormDirty = true;
+    state.configForm = { agents: { defaults: { model: "anthropic/claude-opus-4-6" } } };
+    state.configRawOriginal =
+      '{ "agents": { "defaults": { "model": "anthropic/claude-opus-4-6" } } }';
+    state.configRaw = state.configRawOriginal;
+
+    await loadConfig(state);
+
+    expect(state.configRaw).toBe(
+      '{ "agents": { "defaults": { "model": "ollama/qwen3-coder:30b-64k" } } }',
+    );
+    expect(state.configForm).toEqual({
+      agents: { defaults: { model: "anthropic/claude-opus-4-6" } },
+    });
+    expect(state.configFormDirty).toBe(true);
+  });
+
   it("discards dirty raw edits for explicit reloads", async () => {
     const request = vi.fn().mockResolvedValue({
       config: { agents: { defaults: { model: "ollama/qwen3-coder:30b-64k" } } },

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -329,6 +329,43 @@ describe("applyConfig", () => {
     expect(params.baseHash).toBe("hash-apply-1");
     expect(params.sessionKey).toBe("agent:main:web:dm:test");
   });
+
+  it("refreshes the snapshot after apply hash conflicts without discarding edits", async () => {
+    const request = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "config.apply") {
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      if (method === "config.get") {
+        return {
+          hash: "hash-apply-2",
+          config: { agents: { defaults: { model: "ollama/qwen3-coder:30b-64k" } } },
+          valid: true,
+          issues: [],
+          raw: '{ "agents": { "defaults": { "model": "ollama/qwen3-coder:30b-64k" } } }',
+        };
+      }
+      return {};
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.applySessionKey = "agent:main:web:dm:test";
+    state.configFormMode = "form";
+    state.configFormDirty = true;
+    state.configForm = { agents: { defaults: { model: "anthropic/claude-opus-4-6" } } };
+    state.configRaw = '{ "agents": { "defaults": { "model": "anthropic/claude-opus-4-6" } } }';
+    state.configSnapshot = { hash: "hash-apply-1" };
+
+    await applyConfig(state);
+
+    expect(request.mock.calls.map((call) => call[0])).toEqual(["config.apply", "config.get"]);
+    expect(state.configSnapshot?.hash).toBe("hash-apply-2");
+    expect(state.configFormDirty).toBe(true);
+    expect(state.configForm).toEqual({
+      agents: { defaults: { model: "anthropic/claude-opus-4-6" } },
+    });
+    expect(state.lastError).toContain("config changed since last load");
+  });
 });
 
 describe("saveConfig", () => {
@@ -389,6 +426,42 @@ describe("saveConfig", () => {
     };
     expect(parsed.gateway.port).toBe("18789");
     expect(params.baseHash).toBe("hash-save-2");
+  });
+
+  it("refreshes the snapshot after save hash conflicts without discarding edits", async () => {
+    const request = vi.fn().mockImplementation(async (method: string) => {
+      if (method === "config.set") {
+        throw new Error("config changed since last load; re-run config.get and retry");
+      }
+      if (method === "config.get") {
+        return {
+          hash: "hash-save-2",
+          config: { agents: { defaults: { model: "ollama/qwen3-coder:30b-64k" } } },
+          valid: true,
+          issues: [],
+          raw: '{ "agents": { "defaults": { "model": "ollama/qwen3-coder:30b-64k" } } }',
+        };
+      }
+      return {};
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.configFormMode = "form";
+    state.configFormDirty = true;
+    state.configForm = { agents: { defaults: { model: "anthropic/claude-opus-4-6" } } };
+    state.configRaw = '{ "agents": { "defaults": { "model": "anthropic/claude-opus-4-6" } } }';
+    state.configSnapshot = { hash: "hash-save-1" };
+
+    await saveConfig(state);
+
+    expect(request.mock.calls.map((call) => call[0])).toEqual(["config.set", "config.get"]);
+    expect(state.configSnapshot?.hash).toBe("hash-save-2");
+    expect(state.configFormDirty).toBe(true);
+    expect(state.configForm).toEqual({
+      agents: { defaults: { model: "anthropic/claude-opus-4-6" } },
+    });
+    expect(state.lastError).toContain("config changed since last load");
   });
 });
 

--- a/ui/src/ui/controllers/config.test.ts
+++ b/ui/src/ui/controllers/config.test.ts
@@ -4,6 +4,7 @@ import {
   applyConfig,
   ensureAgentConfigEntry,
   findAgentConfigEntryIndex,
+  loadConfig,
   runUpdate,
   saveConfig,
   updateConfigFormValue,
@@ -109,6 +110,37 @@ describe("applyConfigSnapshot", () => {
     // Original values should be preserved when dirty
     expect(state.configRawOriginal).toBe('{ "original": true }');
     expect(state.configFormOriginal).toEqual({ original: true });
+  });
+
+  it("replaces pending form state when explicitly discarding edits", () => {
+    const state = createState();
+    state.configFormDirty = true;
+    state.configForm = { agents: { defaults: { model: "anthropic/claude-opus-4-6" } } };
+    state.configRaw = '{ "agents": { "defaults": { "model": "anthropic/claude-opus-4-6" } } }';
+    state.configRawOriginal = '{ "original": true }';
+    state.configFormOriginal = { original: true };
+
+    applyConfigSnapshot(
+      state,
+      {
+        config: { agents: { defaults: { model: "ollama/qwen3-coder:30b-64k" } } },
+        valid: true,
+        issues: [],
+        raw: '{ "agents": { "defaults": { "model": "ollama/qwen3-coder:30b-64k" } } }',
+      },
+      { discardPendingEdits: true },
+    );
+
+    expect(state.configFormDirty).toBe(false);
+    expect(state.configForm).toEqual({
+      agents: { defaults: { model: "ollama/qwen3-coder:30b-64k" } },
+    });
+    expect(state.configRaw).toBe(
+      '{ "agents": { "defaults": { "model": "ollama/qwen3-coder:30b-64k" } } }',
+    );
+    expect(state.configFormOriginal).toEqual({
+      agents: { defaults: { model: "ollama/qwen3-coder:30b-64k" } },
+    });
   });
 });
 
@@ -354,6 +386,99 @@ describe("saveConfig", () => {
     };
     expect(parsed.gateway.port).toBe("18789");
     expect(params.baseHash).toBe("hash-save-2");
+  });
+});
+
+describe("loadConfig", () => {
+  it("keeps dirty form edits during passive refreshes", async () => {
+    const request = vi.fn().mockResolvedValue({
+      config: { agents: { defaults: { model: "ollama/qwen3-coder:30b-64k" } } },
+      valid: true,
+      issues: [],
+      raw: '{ "agents": { "defaults": { "model": "ollama/qwen3-coder:30b-64k" } } }',
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.configFormDirty = true;
+    state.configForm = { agents: { defaults: { model: "anthropic/claude-opus-4-6" } } };
+
+    await loadConfig(state);
+
+    expect(state.configFormDirty).toBe(true);
+    expect(state.configForm).toEqual({
+      agents: { defaults: { model: "anthropic/claude-opus-4-6" } },
+    });
+  });
+
+  it("discards dirty form edits for explicit reloads", async () => {
+    const request = vi.fn().mockResolvedValue({
+      config: { agents: { defaults: { model: "ollama/qwen3-coder:30b-64k" } } },
+      valid: true,
+      issues: [],
+      raw: '{ "agents": { "defaults": { "model": "ollama/qwen3-coder:30b-64k" } } }',
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.configFormDirty = true;
+    state.configForm = { agents: { defaults: { model: "anthropic/claude-opus-4-6" } } };
+    state.configRaw = '{ "agents": { "defaults": { "model": "anthropic/claude-opus-4-6" } } }';
+
+    await loadConfig(state, { discardPendingEdits: true });
+
+    expect(state.configFormDirty).toBe(false);
+    expect(state.configForm).toEqual({
+      agents: { defaults: { model: "ollama/qwen3-coder:30b-64k" } },
+    });
+    expect(state.configRaw).toBe(
+      '{ "agents": { "defaults": { "model": "ollama/qwen3-coder:30b-64k" } } }',
+    );
+  });
+
+  it("keeps dirty raw edits during passive refreshes", async () => {
+    const request = vi.fn().mockResolvedValue({
+      config: { agents: { defaults: { model: "ollama/qwen3-coder:30b-64k" } } },
+      valid: true,
+      issues: [],
+      raw: '{ "agents": { "defaults": { "model": "ollama/qwen3-coder:30b-64k" } } }',
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.configFormMode = "raw";
+    state.configRawOriginal =
+      '{ "agents": { "defaults": { "model": "anthropic/claude-opus-4-6" } } }';
+    state.configRaw = '{ "agents": { "defaults": { "model": "custom/raw-edit" } } }';
+
+    await loadConfig(state);
+
+    expect(state.configRaw).toBe('{ "agents": { "defaults": { "model": "custom/raw-edit" } } }');
+  });
+
+  it("discards dirty raw edits for explicit reloads", async () => {
+    const request = vi.fn().mockResolvedValue({
+      config: { agents: { defaults: { model: "ollama/qwen3-coder:30b-64k" } } },
+      valid: true,
+      issues: [],
+      raw: '{ "agents": { "defaults": { "model": "ollama/qwen3-coder:30b-64k" } } }',
+    });
+    const state = createState();
+    state.connected = true;
+    state.client = { request } as unknown as ConfigState["client"];
+    state.configFormMode = "raw";
+    state.configRawOriginal =
+      '{ "agents": { "defaults": { "model": "anthropic/claude-opus-4-6" } } }';
+    state.configRaw = '{ "agents": { "defaults": { "model": "custom/raw-edit" } } }';
+
+    await loadConfig(state, { discardPendingEdits: true });
+
+    expect(state.configRaw).toBe(
+      '{ "agents": { "defaults": { "model": "ollama/qwen3-coder:30b-64k" } } }',
+    );
+    expect(state.configRawOriginal).toBe(
+      '{ "agents": { "defaults": { "model": "ollama/qwen3-coder:30b-64k" } } }',
+    );
   });
 });
 

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -44,6 +44,10 @@ type ApplyConfigSnapshotOptions = {
   discardPendingEdits?: boolean;
 };
 
+function isConfigHashConflictError(error: unknown): boolean {
+  return String(error).includes("config changed since last load");
+}
+
 export async function loadConfig(state: ConfigState, options?: LoadConfigOptions) {
   if (!state.client || !state.connected) {
     return;
@@ -166,7 +170,11 @@ export async function saveConfig(state: ConfigState) {
     state.configFormDirty = false;
     await loadConfig(state, { discardPendingEdits: true });
   } catch (err) {
-    state.lastError = String(err);
+    const errorMessage = String(err);
+    if (isConfigHashConflictError(err)) {
+      await loadConfig(state);
+    }
+    state.lastError = errorMessage;
   } finally {
     state.configSaving = false;
   }
@@ -193,7 +201,11 @@ export async function applyConfig(state: ConfigState) {
     state.configFormDirty = false;
     await loadConfig(state, { discardPendingEdits: true });
   } catch (err) {
-    state.lastError = String(err);
+    const errorMessage = String(err);
+    if (isConfigHashConflictError(err)) {
+      await loadConfig(state);
+    }
+    state.lastError = errorMessage;
   } finally {
     state.configApplying = false;
   }

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -103,9 +103,13 @@ export function applyConfigSnapshot(
       : snapshot.config && typeof snapshot.config === "object"
         ? serializeConfigForm(snapshot.config)
         : state.configRaw;
-  if (!preservePendingRawState && !preservePendingFormState) {
+  if (state.configFormMode === "raw") {
+    if (!preservePendingRawState) {
+      state.configRaw = rawFromSnapshot;
+    }
+  } else if (!preservePendingFormState) {
     state.configRaw = rawFromSnapshot;
-  } else if (state.configFormMode === "form" && state.configForm) {
+  } else if (state.configForm) {
     state.configRaw = serializeConfigForm(state.configForm);
   }
   state.configValid = typeof snapshot.valid === "boolean" ? snapshot.valid : null;

--- a/ui/src/ui/controllers/config.ts
+++ b/ui/src/ui/controllers/config.ts
@@ -36,7 +36,15 @@ export type ConfigState = {
   lastError: string | null;
 };
 
-export async function loadConfig(state: ConfigState) {
+export type LoadConfigOptions = {
+  discardPendingEdits?: boolean;
+};
+
+type ApplyConfigSnapshotOptions = {
+  discardPendingEdits?: boolean;
+};
+
+export async function loadConfig(state: ConfigState, options?: LoadConfigOptions) {
   if (!state.client || !state.connected) {
     return;
   }
@@ -44,7 +52,7 @@ export async function loadConfig(state: ConfigState) {
   state.lastError = null;
   try {
     const res = await state.client.request<ConfigSnapshot>("config.get", {});
-    applyConfigSnapshot(state, res);
+    applyConfigSnapshot(state, res, options);
   } catch (err) {
     state.lastError = String(err);
   } finally {
@@ -76,7 +84,18 @@ export function applyConfigSchema(state: ConfigState, res: ConfigSchemaResponse)
   state.configSchemaVersion = res.version ?? null;
 }
 
-export function applyConfigSnapshot(state: ConfigState, snapshot: ConfigSnapshot) {
+export function applyConfigSnapshot(
+  state: ConfigState,
+  snapshot: ConfigSnapshot,
+  options?: ApplyConfigSnapshotOptions,
+) {
+  const discardPendingEdits = options?.discardPendingEdits === true;
+  const rawModeDirty =
+    state.configFormMode === "raw" &&
+    state.configRaw !== state.configRawOriginal &&
+    !discardPendingEdits;
+  const preservePendingFormState = state.configFormDirty && !discardPendingEdits;
+  const preservePendingRawState = rawModeDirty;
   state.configSnapshot = snapshot;
   const rawFromSnapshot =
     typeof snapshot.raw === "string"
@@ -84,20 +103,19 @@ export function applyConfigSnapshot(state: ConfigState, snapshot: ConfigSnapshot
       : snapshot.config && typeof snapshot.config === "object"
         ? serializeConfigForm(snapshot.config)
         : state.configRaw;
-  if (!state.configFormDirty || state.configFormMode === "raw") {
+  if (!preservePendingRawState && !preservePendingFormState) {
     state.configRaw = rawFromSnapshot;
-  } else if (state.configForm) {
+  } else if (state.configFormMode === "form" && state.configForm) {
     state.configRaw = serializeConfigForm(state.configForm);
-  } else {
-    state.configRaw = rawFromSnapshot;
   }
   state.configValid = typeof snapshot.valid === "boolean" ? snapshot.valid : null;
   state.configIssues = Array.isArray(snapshot.issues) ? snapshot.issues : [];
 
-  if (!state.configFormDirty) {
+  if (!preservePendingFormState) {
     state.configForm = cloneConfigObject(snapshot.config ?? {});
     state.configFormOriginal = cloneConfigObject(snapshot.config ?? {});
     state.configRawOriginal = rawFromSnapshot;
+    state.configFormDirty = false;
   }
 }
 
@@ -142,7 +160,7 @@ export async function saveConfig(state: ConfigState) {
     }
     await state.client.request("config.set", { raw, baseHash });
     state.configFormDirty = false;
-    await loadConfig(state);
+    await loadConfig(state, { discardPendingEdits: true });
   } catch (err) {
     state.lastError = String(err);
   } finally {
@@ -169,7 +187,7 @@ export async function applyConfig(state: ConfigState) {
       sessionKey: state.applySessionKey,
     });
     state.configFormDirty = false;
-    await loadConfig(state);
+    await loadConfig(state, { discardPendingEdits: true });
   } catch (err) {
     state.lastError = String(err);
   } finally {

--- a/ui/src/ui/views/agents.browser.test.ts
+++ b/ui/src/ui/views/agents.browser.test.ts
@@ -1,0 +1,118 @@
+import { render } from "lit";
+import { describe, expect, it } from "vitest";
+import { renderAgents, type AgentsProps } from "./agents.ts";
+
+function createProps(
+  configForm: Record<string, unknown>,
+  overrides: Partial<AgentsProps> = {},
+): AgentsProps {
+  return {
+    loading: false,
+    error: null,
+    agentsList: {
+      defaultId: "main",
+      mainKey: "main",
+      scope: "global",
+      agents: [{ id: "main", name: "Main" }],
+    },
+    selectedAgentId: "main",
+    activePanel: "overview",
+    configForm,
+    configLoading: false,
+    configSaving: false,
+    configDirty: false,
+    channelsLoading: false,
+    channelsError: null,
+    channelsSnapshot: null,
+    channelsLastSuccess: null,
+    cronLoading: false,
+    cronStatus: null,
+    cronJobs: [],
+    cronError: null,
+    agentFilesLoading: false,
+    agentFilesError: null,
+    agentFilesList: null,
+    agentFileActive: null,
+    agentFileContents: {},
+    agentFileDrafts: {},
+    agentFileSaving: false,
+    agentIdentityLoading: false,
+    agentIdentityError: null,
+    agentIdentityById: {},
+    agentSkillsLoading: false,
+    agentSkillsReport: null,
+    agentSkillsError: null,
+    agentSkillsAgentId: null,
+    toolsCatalogLoading: false,
+    toolsCatalogError: null,
+    toolsCatalogResult: null,
+    skillsFilter: "",
+    onRefresh: () => undefined,
+    onSelectAgent: () => undefined,
+    onSelectPanel: () => undefined,
+    onLoadFiles: () => undefined,
+    onSelectFile: () => undefined,
+    onFileDraftChange: () => undefined,
+    onFileReset: () => undefined,
+    onFileSave: () => undefined,
+    onToolsProfileChange: () => undefined,
+    onToolsOverridesChange: () => undefined,
+    onConfigReload: () => undefined,
+    onConfigSave: () => undefined,
+    onModelChange: () => undefined,
+    onModelFallbacksChange: () => undefined,
+    onChannelsRefresh: () => undefined,
+    onCronRefresh: () => undefined,
+    onSkillsFilterChange: () => undefined,
+    onSkillsRefresh: () => undefined,
+    onAgentSkillToggle: () => undefined,
+    onAgentSkillsClear: () => undefined,
+    onAgentSkillsDisableAll: () => undefined,
+    ...overrides,
+  };
+}
+
+describe("agents overview model selection (browser)", () => {
+  it("updates the selected model when config changes on rerender", async () => {
+    const container = document.createElement("div");
+    const modelCatalog = {
+      "anthropic/claude-opus-4-6": { alias: "opus" },
+      "ollama/qwen3-coder:30b-64k": { alias: "qwen3-coder:30b-64k" },
+    };
+
+    render(
+      renderAgents(
+        createProps({
+          agents: {
+            defaults: {
+              models: modelCatalog,
+              model: { primary: "anthropic/claude-opus-4-6" },
+            },
+          },
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    render(
+      renderAgents(
+        createProps({
+          agents: {
+            defaults: {
+              models: modelCatalog,
+              model: { primary: "ollama/qwen3-coder:30b-64k" },
+            },
+          },
+        }),
+      ),
+      container,
+    );
+    await Promise.resolve();
+
+    const select = container.querySelector<HTMLSelectElement>(".agent-model-select select");
+    expect(select).not.toBeNull();
+    expect(select?.value).toBe("ollama/qwen3-coder:30b-64k");
+    expect(select?.selectedOptions[0]?.textContent?.trim()).toContain("qwen3-coder:30b-64k");
+  });
+});

--- a/ui/src/ui/views/channels.nostr-profile-form.ts
+++ b/ui/src/ui/views/channels.nostr-profile-form.ts
@@ -106,7 +106,7 @@ export function renderNostrProfileForm(params: {
               const target = e.target as HTMLTextAreaElement;
               callbacks.onFieldChange(field, target.value);
             }}
-            ?disabled=${state.saving}
+            ?disabled=${state.saving || state.importing}
           ></textarea>
           ${help ? html`<div style="font-size: 12px; color: var(--text-muted); margin-top: 2px;">${help}</div>` : nothing}
           ${error ? html`<div style="font-size: 12px; color: var(--danger-color); margin-top: 2px;">${error}</div>` : nothing}
@@ -130,7 +130,7 @@ export function renderNostrProfileForm(params: {
             const target = e.target as HTMLInputElement;
             callbacks.onFieldChange(field, target.value);
           }}
-          ?disabled=${state.saving}
+          ?disabled=${state.saving || state.importing}
         />
         ${help ? html`<div style="font-size: 12px; color: var(--text-muted); margin-top: 2px;">${help}</div>` : nothing}
         ${error ? html`<div style="font-size: 12px; color: var(--danger-color); margin-top: 2px;">${error}</div>` : nothing}
@@ -245,7 +245,7 @@ export function renderNostrProfileForm(params: {
         <button
           class="btn primary"
           @click=${callbacks.onSave}
-          ?disabled=${state.saving || !isDirty}
+          ?disabled=${state.saving || state.importing || !isDirty}
         >
           ${state.saving ? "Saving..." : "Save & Publish"}
         </button>


### PR DESCRIPTION
## Summary

- Problem: Control UI config reload paths could leave stale local config state in place, so the Agents model dropdown could diverge from the actual gateway config.
- Why it matters: clicking `Reload Config` should replace stale local edits with the current gateway snapshot, while passive refreshes should still preserve unsaved work.
- What changed: split passive refresh vs explicit reload semantics in the config controller, wired explicit reload buttons to discard pending edits, preserved unsaved raw-mode edits during passive refresh, and added regression coverage plus a browser-level agent view test.
- What did NOT change (scope boundary): no runtime model resolution behavior, no gateway config schema changes, and no speculative refactor of the agent dropdown rendering.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #40352
- Related #13142

## User-visible / Behavior Changes

- `Reload Config` in Control UI now discards pending local config edits and reloads the live gateway snapshot.
- Passive refreshes continue to preserve unsaved edits.
- Raw config edits are no longer overwritten by passive refreshes.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local checkout
- Model/provider: N/A
- Integration/channel (if any): Control UI / Agents / Config / Channels views
- Relevant config (redacted): `agents.defaults.model` changed between `anthropic/claude-opus-4-6` and `ollama/qwen3-coder:30b-64k`

### Steps

1. Open `Agents -> Overview` and observe the current primary model.
2. Change the saved config so the gateway snapshot points at a different model.
3. Click `Reload Config` and verify the overview and dropdown both update.
4. Make unsaved edits in both form mode and raw mode.
5. Verify passive refreshes preserve those edits, but explicit reload discards them.

### Expected

- Explicit reload replaces stale local config state with the current gateway snapshot.
- Passive refresh does not wipe unsaved edits.

### Actual

- Before this change, stale local config state could survive reload flows and raw-mode passive refreshes could overwrite pending edits.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: targeted UI tests for config reload semantics and a browser-level rerender test for the agents model dropdown; UI and root builds succeeded.
- Edge cases checked: form-mode dirty edits, raw-mode dirty edits, explicit reload, passive refresh, Nostr profile async state handling.
- What you did **not** verify: manual click-through in a live browser session against a running gateway.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit `2a467c2`.
- Files/config to restore: `ui/src/ui/controllers/config.ts`, `ui/src/ui/app-render.ts`, `ui/src/ui/app-channels.ts`.
- Known bad symptoms reviewers should watch for: explicit reload unexpectedly preserving stale edits, or passive refresh unexpectedly overwriting unsaved edits.

## Risks and Mitigations

- Risk: reload semantics differ between passive refresh and explicit reload, and a missed call site could preserve/discard edits unexpectedly.
  - Mitigation: explicit reload call sites were updated for Agents, Config, and Channels, and regression tests cover both form and raw modes.

AI-assisted: yes. Codex was used to implement the change, run checks, and apply follow-up fixes from Gemini/Claude review.
