### PR TITLE
docs: fix message send flag and claude-max-api-proxy links (#10458, #…

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ openclaw onboard --install-daemon
 openclaw gateway --port 18789 --verbose
 
 # Send a message
-openclaw message send --to +1234567890 --message "Hello from OpenClaw"
+openclaw message send --target +1234567890 --message "Hello from OpenClaw"
 
 # Talk to the assistant (optionally deliver back to any connected channel: WhatsApp/Telegram/Slack/Discord/Google Chat/Signal/iMessage/BlueBubbles/IRC/Microsoft Teams/Matrix/Feishu/LINE/Mattermost/Nextcloud Talk/Nostr/Synology Chat/Tlon/Twitch/Zalo/Zalo Personal/WebChat)
 openclaw agent --message "Ship checklist" --thinking high

--- a/docs/providers/claude-max-api-proxy.md
+++ b/docs/providers/claude-max-api-proxy.md
@@ -138,8 +138,8 @@ launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.claude-max-api.plist
 ## Links
 
 - **npm:** [https://www.npmjs.com/package/claude-max-api-proxy](https://www.npmjs.com/package/claude-max-api-proxy)
-- **GitHub:** [https://github.com/atalovesyou/claude-max-api-proxy](https://github.com/atalovesyou/claude-max-api-proxy)
-- **Issues:** [https://github.com/atalovesyou/claude-max-api-proxy/issues](https://github.com/atalovesyou/claude-max-api-proxy/issues)
+- **GitHub:** [https://github.com/wende/claude-max-api-proxy](https://github.com/wende/claude-max-api-proxy)
+- **Issues:** [https://github.com/wende/claude-max-api-proxy/issues](https://github.com/wende/claude-max-api-proxy/issues)
 
 ## Notes
 


### PR DESCRIPTION
 ## Summary

  Describe the problem and fix in 2–5 bullets:

  - Problem: README quick-start used deprecated `openclaw message send --to ...`, and the `claude-max-api-proxy` provider doc linked to an abandoned GitHub repo/issues page.
  - Why it matters: users copy-pasting README commands can hit CLI errors, and users following provider docs may report issues to the wrong/unmaintained project.
  - What changed: updated README example to `--target`; updated provider doc links from `atalovesyou/claude-max-api-proxy` to `wende/claude-max-api-proxy` (GitHub + Issues).
  - What did NOT change (scope boundary): no code/runtime behavior, no config/schema changes, no i18n regeneration, no zh-CN doc edits.

  ## Change Type (select all)

  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [x] Docs
  - [ ] Security hardening
  - [ ] Chore/infra

  ## Scope (select all touched areas)

  - [ ] Gateway / orchestration
  - [ ] Skills / tool execution
  - [ ] Auth / tokens
  - [ ] Memory / storage
  - [x] Integrations
  - [x] UI / DX
  - [ ] API / contracts
  - [ ] CI/CD / infra

  ## Linked Issue/PR

  - Closes #10458
  - Closes #20260

  ## User-visible / Behavior Changes

  - README command example now uses `--target` for `openclaw message send`.
  - Provider doc now points to maintained `claude-max-api-proxy` repository and issue tracker.

  ## Security Impact (required)

  - New permissions/capabilities? (`No`)
  - Secrets/tokens handling changed? (`No`)
  - New/changed network calls? (`No`)
  - Command/tool execution surface changed? (`No`)
  - Data access scope changed? (`No`)
  - If any `Yes`, explain risk + mitigation: `N/A`

  ## Repro + Verification

  ### Environment

  - OS: macOS
  - Runtime/ainer: Node 22+ docs context only
  - Model/provider: N/A
  - Integration/channel (if any): N/A
  - Relevant config (redacted): N/A

  ### Steps

  1. Open `README.md` quick-start section and check `openclaw message send` example.
  2. Open `docs/providers/claude-max-api-proxy.md` links section and check GitHub/Issues URLs.
  3. Compare against current CLI/docs expectations and linked issue reports.

  ### Expected

  - README uses current `--target` flag.
  - Provider docs reference maintained upstream repo/issues page.

  ### Actual

  - Before: README used `--to`; provider docs linked abandoned repo.
  - After: both are corrected.

  ## Evidence

  Attach at least one:

  - [x] Trace/log snippets
  - [ ] Failing test/log before + passing after
  - [ ] Screenshot/recording
  - [ ] Perf numbers (if relevant)

  Evidence:
  - File diff shows:
    - `README.md`: `--to` -> `--target`
    - `docs/providers/claude-max-api-proxy.md`: `atalovesyou/...` -> `wende/...`

  ## Human Verification (required)

  What you personally verified (not just CI), and how:

  - Verified scenarios:
    - Manually checked edited lines in both files after commit.
    - Confirmed change scope is limited to docs/README only.
  - Edge cases checked:
    - Searched for remaining `message send --to` usage in README/docs (non-zh-CN scope).
  - What you did **not** verify:
    - Did not run full CI/test suite (docs-only PR).
    - Did not run i18n generation (out of scope per repo guidance unless requested).

  ## Review Conversations

  - [x] I replied to or resolved every bot review conversation I addressed in this PR.
  - [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

  If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

  ## Compatibility / Migration

  - Backward compatible? (`Yes`)
  - Config/env changes? (`No`)
  - Migration needed? (`No`)
  - If yes, exact upgrade steps: `N/A`

  - How to disable/revert this change quickly:
    - Revert this PR/commit.
  - Files/config to restore:
    - `README.md`
    - `docs/providers/claude-max-api-proxy.md`
  - Known bad symptoms reviewers should watch for:
    - None expected beyond documentation mismatch.

  ## Risks and Mitigations

  - Risk: external maintained fork URL could change again in future.
    - Mitigation: keep provider links aligned with active maintainer repo and update via follow-up docs PR if upstream changes.