### PR TITLE
Improve skill descriptions with trigger phrases and NOT FOR clauses

### DIFF
--- a/skills/discord/SKILL.md
+++ b/skills/discord/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: discord
-description: "Discord ops via the message tool (channel=discord)."
+description: "Discord ops via the message tool (channel=discord). Use when sending messages, reacting, managing channels, threads, polls, roles, or events on Discord. Trigger phrases: 'post to Discord', 'send in #channel', 'react to message', 'create thread', 'pin this'. NOT for: Telegram, Slack, or other messaging platforms (use their respective skills)."
 metadata: { "openclaw": { "emoji": "🎮", "requires": { "config": ["channels.discord.token"] } } }
 allowed-tools: ["message"]
 ---

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gog
-description: Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs.
+description: "Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs. Use when reading/sending emails, checking calendar events, managing Drive files, or editing Sheets/Docs. Trigger phrases: 'check my email', 'schedule a meeting', 'add to calendar', 'open Drive', 'read my spreadsheet'. NOT for: non-Google services, or when a dedicated channel (e.g. bluebubbles) already handles messaging."
 homepage: https://gogcli.sh
 metadata:
   {

--- a/skills/gog/SKILL.md
+++ b/skills/gog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gog
-description: "Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs. Use when reading/sending emails, checking calendar events, managing Drive files, or editing Sheets/Docs. Trigger phrases: 'check my email', 'schedule a meeting', 'add to calendar', 'open Drive', 'read my spreadsheet'. NOT for: non-Google services, or when a dedicated channel (e.g. bluebubbles) already handles messaging."
+description: "Google Workspace CLI for Gmail, Calendar, Drive, Contacts, Sheets, and Docs. Use when reading/sending emails, checking calendar events, managing Drive files, or editing Sheets/Docs. Trigger phrases: 'check my email', 'schedule a meeting', 'add to calendar', 'open Drive', 'read my spreadsheet'. NOT for: non-Google services (Outlook, iCloud, etc.), or local file management."
 homepage: https://gogcli.sh
 metadata:
   {

--- a/skills/imsg/SKILL.md
+++ b/skills/imsg/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: imsg
-description: iMessage/SMS CLI for listing chats, history, and sending messages via Messages.app.
+description: "iMessage/SMS CLI for listing chats, history, and sending messages via Messages.app. Use when sending iMessages or SMS, reading chat history, or listing conversations. Trigger phrases: 'text', 'iMessage', 'send SMS', 'check messages'. NOT for: platforms with dedicated integrations (Discord, Telegram, Slack — use their skills), or when bluebubbles is configured (prefer that for iMessage)."
 homepage: https://imsg.to
 metadata:
   {

--- a/skills/obsidian/SKILL.md
+++ b/skills/obsidian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obsidian
-description: Work with Obsidian vaults (plain Markdown notes) and automate via obsidian-cli.
+description: "Work with Obsidian vaults (plain Markdown notes) and automate via obsidian-cli. Use when creating, searching, opening, or managing notes in Obsidian. Trigger phrases: 'add to Obsidian', 'create a note', 'search my vault', 'open note', 'daily note'. NOT for: Apple Notes (use apple-notes skill), Bear (use bear-notes skill), or general file management."
 homepage: https://help.obsidian.md
 metadata:
   {

--- a/skills/openai-whisper/SKILL.md
+++ b/skills/openai-whisper/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openai-whisper
-description: Local speech-to-text with the Whisper CLI (no API key).
+description: "Local offline speech-to-text with the Whisper CLI (no API key required). Use when transcribing audio or video files locally without sending data to the cloud. Trigger phrases: 'transcribe', 'convert audio to text', 'speech to text', 'transcribe this recording'. NOT for: cloud-based transcription (use openai-whisper-api), or YouTube/URL transcription (use summarize skill)."
 homepage: https://openai.com/research/whisper
 metadata:
   {

--- a/skills/openhue/SKILL.md
+++ b/skills/openhue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openhue
-description: "Control Philips Hue lights and scenes via the OpenHue CLI. Use when turning lights on/off, adjusting brightness/color, activating scenes, or managing Hue rooms and groups. Trigger phrases: 'turn on the lights', 'dim', 'set color', 'activate scene', 'turn off Hue'. NOT for: non-Hue smart lights (use Hubitat or other home automation skills)."
+description: "Control Philips Hue lights and scenes via the OpenHue CLI. Use when turning lights on/off, adjusting brightness/color, activating scenes, or managing Hue rooms and groups. Trigger phrases: 'turn on the lights', 'dim', 'set color', 'activate scene', 'turn off Hue'. NOT for: non-Hue smart home devices (Lutron, Ikea, Z-Wave, etc.) — use a general home automation MCP or skill instead."
 homepage: https://www.openhue.io/cli
 metadata:
   {

--- a/skills/openhue/SKILL.md
+++ b/skills/openhue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: openhue
-description: Control Philips Hue lights and scenes via the OpenHue CLI.
+description: "Control Philips Hue lights and scenes via the OpenHue CLI. Use when turning lights on/off, adjusting brightness/color, activating scenes, or managing Hue rooms and groups. Trigger phrases: 'turn on the lights', 'dim', 'set color', 'activate scene', 'turn off Hue'. NOT for: non-Hue smart lights (use Hubitat or other home automation skills)."
 homepage: https://www.openhue.io/cli
 metadata:
   {

--- a/skills/video-frames/SKILL.md
+++ b/skills/video-frames/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video-frames
-description: Extract frames or short clips from videos using ffmpeg.
+description: "Extract frames or short clips from videos using ffmpeg. Use when capturing screenshots from video, creating frame grids, or trimming clips. Trigger phrases: 'extract frame', 'screenshot from video', 'grab a clip', 'capture at timestamp', 'make a thumbnail from video'. NOT for: full video transcription (use summarize skill), audio extraction only, or downloading online videos."
 homepage: https://ffmpeg.org
 metadata:
   {


### PR DESCRIPTION
## Summary

Based on Anthropic's [Complete Guide to Building Skills for Claude](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf), skill descriptions need:
1. **WHAT** the skill does
2. **WHEN** to use it (trigger phrases)
3. **NOT FOR** (negative triggers to prevent over-firing)

The guide specifically calls out the description field as *"the most consequential piece to get right"* since it determines whether a skill loads at all.

## Skills improved

| Skill | Issue | Fix |
|-------|-------|-----|
| `discord` | 1-sentence, no triggers | Added trigger phrases + NOT for other platforms |
| `gog` | Lists tools but no triggers | Added trigger phrases + NOT for non-Google |
| `imsg` | No triggers, no disambiguation vs bluebubbles | Added trigger phrases + NOT for when bluebubbles configured |
| `obsidian` | No triggers | Added trigger phrases + NOT for other note apps |
| `openai-whisper` | Minimal, 1 line | Added trigger phrases + NOT for cloud/URL transcription |
| `openhue` | No triggers | Added trigger phrases + NOT for non-Hue lights |
| `video-frames` | No triggers | Added trigger phrases + NOT for transcription/download |

## Testing

Verified trigger logic against the guide's debugging tip: *"Ask Claude 'When would you use the [skill name] skill?' — it will quote the description back, revealing what's missing."*