### PR TITLE
fix(feishu): close WSClient on abort to prevent reconnect loop leaks

### DIFF
--- a/extensions/feishu/src/monitor.transport.ts
+++ b/extensions/feishu/src/monitor.transport.ts
@@ -41,6 +41,13 @@ export async function monitorWebSocket({
 
   return new Promise((resolve, reject) => {
     const cleanup = () => {
+      try {
+        wsClient.close({ force: true });
+        log(`feishu[${accountId}]: WebSocket client closed`);
+      } catch (err) {
+        const error = runtime?.error ?? console.error;
+        error(`feishu[${accountId}]: error closing WebSocket client: ${String(err)}`);
+      }
       wsClients.delete(accountId);
       botOpenIds.delete(accountId);
       botNames.delete(accountId);


### PR DESCRIPTION
## Summary

Fixes #40451

Explicitly close the Feishu WSClient when the provider is stopped to prevent reconnect loop leaks.

## Problem

When health-monitor restarts the Feishu provider (~every 35 minutes), the old WSClient's reconnect loop continues running due to a bug in `@larksuiteoapi/node-sdk` ([larksuite/node-sdk#177](https://github.com/larksuite/node-sdk/issues/177)). The SDK's `reConnect()` method only stores the latest `setTimeout` ID, so `clearTimeout` in subsequent restarts cannot cancel older timers.

**Observed impact after 3 days:**
- 62,000+ `[ws] ws connect failed` log entries
- Memory growth from 750MB RSS to 1.9GB peak
- Dozens of concurrent leaked reconnect loops (visible from simultaneous retry counters)

## Solution

Call `wsClient.close({ force: true })` in the cleanup function before removing the client reference. This terminates the reconnect loop and prevents timer leaks.

## Testing

- Verified the fix compiles
- Confirmed `WSClient.close()` API exists in `@larksuiteoapi/node-sdk` type definitions
- Logic change is minimal and safe (adds proper cleanup)

## Notes

This is a workaround until the upstream SDK bug is fixed. The actual message delivery works fine; the leaked loops are just orphaned reconnect attempts from previous restarts.