### PR TITLE
fix(telegram): avoid deleted-message replies after native /new

### DIFF
--- a/src/telegram/bot-native-commands.test.ts
+++ b/src/telegram/bot-native-commands.test.ts
@@ -270,4 +270,47 @@ describe("registerTelegramNativeCommands", () => {
     );
     expect(sendMessage).not.toHaveBeenCalledWith(123, "Command not found.");
   });
+
+  it("sends native /new in direct chats without reply threading even when replies are normally threaded", async () => {
+    const commandHandlers = new Map<string, (ctx: unknown) => Promise<void>>();
+
+    registerTelegramNativeCommands({
+      ...buildParams(
+        {
+          channels: { telegram: { allowFrom: ["*"] } },
+        },
+        "default",
+      ),
+      allowFrom: ["*"],
+      replyToMode: "first",
+      bot: {
+        api: {
+          setMyCommands: vi.fn().mockResolvedValue(undefined),
+          sendMessage: vi.fn().mockResolvedValue(undefined),
+        },
+        command: vi.fn((name: string, cb: (ctx: unknown) => Promise<void>) => {
+          commandHandlers.set(name, cb);
+        }),
+      } as unknown as Parameters<typeof registerTelegramNativeCommands>[0]["bot"],
+    });
+
+    const handler = commandHandlers.get("new");
+    expect(handler).toBeTruthy();
+
+    await handler?.({
+      match: "",
+      message: {
+        message_id: 42,
+        date: Math.floor(Date.now() / 1000),
+        chat: { id: 123, type: "private" },
+        from: { id: 456, username: "alice" },
+      },
+    });
+
+    expect(deliveryMocks.deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replyToMode: "off",
+      }),
+    );
+  });
 });

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -520,6 +520,7 @@ export const registerTelegramNativeCommands = ({
     threadSpec: ReturnType<typeof resolveTelegramThreadSpec>;
     tableMode: ReturnType<typeof resolveMarkdownTableMode>;
     chunkMode: ReturnType<typeof resolveChunkMode>;
+    replyToModeOverride?: ReplyToMode;
   }) => ({
     chatId: String(params.chatId),
     accountId: params.accountId,
@@ -527,7 +528,7 @@ export const registerTelegramNativeCommands = ({
     runtime,
     bot,
     mediaLocalRoots: params.mediaLocalRoots,
-    replyToMode,
+    replyToMode: params.replyToModeOverride ?? replyToMode,
     textLimit,
     thread: params.threadSpec,
     tableMode: params.tableMode,
@@ -589,6 +590,11 @@ export const registerTelegramNativeCommands = ({
             return;
           }
           const { threadSpec, route, mediaLocalRoots, tableMode, chunkMode } = runtimeContext;
+          // Telegram can render the first assistant reply after native /new or /reset in DMs
+          // as replying to a command placeholder that disappears, which shows up as
+          // “Deleted message”. Prefer a plain message for those direct-chat resets.
+          const suppressDirectChatReplyTarget =
+            !isGroup && (normalizedCommandName === "new" || normalizedCommandName === "reset");
           const deliveryBaseOptions = buildCommandDeliveryBaseOptions({
             chatId,
             accountId: route.accountId,
@@ -596,6 +602,7 @@ export const registerTelegramNativeCommands = ({
             threadSpec,
             tableMode,
             chunkMode,
+            replyToModeOverride: suppressDirectChatReplyTarget ? "off" : undefined,
           });
           const threadParams = buildTelegramThreadParams(threadSpec) ?? {};
 


### PR DESCRIPTION
## Summary
- disable reply threading for native `/new` and `/reset` replies in Telegram direct chats
- keep existing reply threading behavior for other native commands and for group or topic contexts
- add a regression test covering `/new` when global Telegram reply mode is still threaded

## Why
Telegram can render the first assistant reply after a native direct-chat `/new` or `/reset` as replying to a transient command placeholder that later disappears, which shows up as replying to **Deleted message**.

This keeps the fix narrow: only direct-chat native reset commands switch to a plain non-reply send.

## Testing
- `corepack pnpm vitest run src/telegram/bot-native-commands.test.ts`
- `corepack pnpm vitest run src/telegram/bot-native-commands.group-auth.test.ts`

Closes #40442.
