### PR TITLE
fix(secrets): allow allowInsecurePath for file providers

### DIFF
--- a/src/config/config.secrets-schema.test.ts
+++ b/src/config/config.secrets-schema.test.ts
@@ -26,6 +26,7 @@ describe("config secret refs schema", () => {
             path: "~/.openclaw/secrets.json",
             mode: "json",
             timeoutMs: 10_000,
+            allowInsecurePath: true,
           },
           vault: {
             source: "exec",

--- a/src/config/types.secrets.ts
+++ b/src/config/types.secrets.ts
@@ -187,6 +187,7 @@ export type FileSecretProviderConfig = {
   mode?: FileSecretProviderMode;
   timeoutMs?: number;
   maxBytes?: number;
+  allowInsecurePath?: boolean;
 };
 
 export type ExecSecretProviderConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -101,6 +101,7 @@ const SecretsFileProviderSchema = z
       .positive()
       .max(20 * 1024 * 1024)
       .optional(),
+    allowInsecurePath: z.boolean().optional(),
   })
   .strict();
 

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -289,6 +289,7 @@ async function readFileProviderPayload(params: {
     const secureFilePath = await assertSecurePath({
       targetPath: filePath,
       label: `secrets.providers.${params.providerName}.path`,
+      allowInsecurePath: params.providerConfig.allowInsecurePath,
     });
     const timeoutMs = normalizePositiveInt(
       params.providerConfig.timeoutMs,

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -567,7 +567,12 @@ describe("secrets runtime snapshot", () => {
         config: asConfig({
           secrets: {
             providers: {
-              default: { source: "file", path: secretFile, mode: "json" },
+              default: {
+                source: "file",
+                path: secretFile,
+                mode: "json",
+                ...(process.platform === "win32" ? { allowInsecurePath: true } : {}),
+              },
             },
           },
           models: {
@@ -658,7 +663,12 @@ describe("secrets runtime snapshot", () => {
         config: asConfig({
           secrets: {
             providers: {
-              default: { source: "file", path: secretFile, mode: "json" },
+              default: {
+                source: "file",
+                path: secretFile,
+                mode: "json",
+                ...(process.platform === "win32" ? { allowInsecurePath: true } : {}),
+              },
             },
           },
           models: {


### PR DESCRIPTION
## **Summary**

- Problem: Windows CI test shard fails in `src/secrets/runtime.test.ts` with `ACL verification unavailable on Windows` for temp-file secret providers, because file secret providers cannot opt out of strict path ACL verification.
- Why it matters: This breaks CI on `main` and causes unrelated PRs to fail and block merges.
- What changed: File secret providers now accept `allowInsecurePath?: boolean` (schema + types); the resolver passes it through to the secure-path audit; the secrets runtime tests enable it on Windows for temp-home secret files.
- What did NOT change (scope boundary): Default behavior remains strict; symlink restrictions and other path validation remain unchanged; no runtime behavior changes unless users explicitly set `allowInsecurePath: true`.

## **Change Type (select all)**

- [x]  Bug fix
- [ ]  Feature
- [ ]  Refactor
- [ ]  Docs
- [ ]  Security hardening
- [x]  Chore/infra

## **Scope (select all touched areas)**

- [ ]  Gateway / orchestration
- [ ]  Skills / tool execution
- [ ]  Auth / tokens
- [ ]  Memory / storage
- [ ]  Integrations
- [ ]  API / contracts
- [ ]  UI / DX
- [x]  CI/CD / infra

## **Linked Issue/PR**

- Related: Windows CI failures from `SecretProviderResolutionError: ... ACL verification unavailable on Windows` (example `main` run: https://github.com/openclaw/openclaw/actions/runs/22834544630)
- Note: This PR’s checks currently also include an upstream formatting failure in `src/cli/daemon-cli/lifecycle.test.ts`, which is addressed separately in #40450.

## **User-visible / Behavior Changes**

- File secret providers may now set `allowInsecurePath: true` to bypass path permission/ACL verification when the path is trusted (notably when Windows ACL verification is unavailable).

## **Security Impact (required)**

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation: N/A

## **Repro + Verification**

### **Environment**

- OS: macOS (local)
- Runtime/container: Node 22 + pnpm
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### **Steps**

1. On Windows CI, run `pnpm test` (sharded).
2. Observe `src/secrets/runtime.test.ts` failing with `ACL verification unavailable on Windows ... Set allowInsecurePath=true ...`.

### **Expected**

- Windows test shards should not fail due to ACL-audit unavailability when the secrets file path is trusted and explicitly opted out.

### **Actual**

- Before fix: file secret providers cannot set `allowInsecurePath`, so the secure-path audit fails when ACL verification is unavailable.

## **Evidence**

- [x]  Failing CI log before (Windows shard): https://github.com/openclaw/openclaw/actions/runs/22834544630

## **Human Verification (required)**

What you personally verified (not just CI), and how:

Verified scenarios:
- `pnpm tsgo`
- `pnpm exec vitest run src/secrets/runtime.test.ts`

What you did not verify:
- Running the Windows CI matrix locally.

## **Compatibility / Migration**

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps: N/A

## **Failure Recovery (if this breaks)**

- Revert this commit to remove the new `allowInsecurePath` option for file secret providers.

## **Risks and Mitigations**

Risk:
- Users could opt out of path permission checks for file secret providers.

Mitigation:
- The bypass is explicit (`allowInsecurePath: true`) and defaults to strict behavior.
