### PR TITLE
fix(openresponses): forward clientTools to embedded agent attempt

### DIFF
--- a/src/agents/pi-embedded-runner/run.ts
+++ b/src/agents/pi-embedded-runner/run.ts
@@ -869,6 +869,7 @@ export async function runEmbeddedPiAgent(
             skillsSnapshot: params.skillsSnapshot,
             prompt,
             images: params.images,
+            clientTools: params.clientTools,
             disableTools: params.disableTools,
             provider,
             modelId,


### PR DESCRIPTION
## Summary

- Fix `clientTools` (OpenResponses hosted tools) not being forwarded from `runEmbeddedPiAgent()` to `runEmbeddedAttempt()`
- The `clientTools` parameter was defined in `RunEmbeddedPiAgentParams`, accepted by `EmbeddedRunAttemptParams` (via `Omit` inheritance), and handled correctly inside `attempt.ts` — but `run.ts` explicitly listed every param when calling `runEmbeddedAttempt()` and omitted `clientTools`
- This caused custom tools passed via `/v1/responses` `tools` field to be silently dropped, so the agent never saw them

## Test plan

- [x] Verified that before the fix, sending a `/v1/responses` request with custom `tools` resulted in the agent saying "tool not in my available toolset"
- [x] After the fix, the agent correctly invokes the custom tool and returns a `function_call` output with `status: "incomplete"`
- [x] Full round-trip validated: send tool definition → get `function_call` back → send `function_call_output` → get final text response
- [ ] `pnpm test` passes
- [ ] `pnpm tsgo` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)