### PR TITLE
fix(skills): expand tilde in workspace path before skill root validation

### DIFF
--- a/src/agents/skills/workspace-tilde.test.ts
+++ b/src/agents/skills/workspace-tilde.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Spy on resolveUserPath before importing the module under test.
+// The replacement expands ~ to a fake home so the rest of the function
+// can proceed without hitting the real filesystem.
+const resolveUserPathSpy = vi.hoisted(() =>
+  vi.fn((p: string) => p.replace(/^~/, "/tmp/fake-home")),
+);
+
+vi.mock("../../utils.js", async (importOriginal) => {
+  const orig = await importOriginal<typeof import("../../utils.js")>();
+  return { ...orig, resolveUserPath: resolveUserPathSpy };
+});
+
+import { loadWorkspaceSkillEntries } from "./workspace.js";
+
+describe("loadWorkspaceSkillEntries", () => {
+  it("expands tilde in workspace path via resolveUserPath (regression for #40518)", () => {
+    // Before the fix, loadSkillEntries used the raw workspaceDir without
+    // calling resolveUserPath, so ~ was treated as a literal directory name.
+    loadWorkspaceSkillEntries("~/my-project");
+    expect(resolveUserPathSpy).toHaveBeenCalledWith("~/my-project");
+  });
+});

--- a/src/agents/skills/workspace.ts
+++ b/src/agents/skills/workspace.ts
@@ -443,14 +443,15 @@ function loadSkillEntries(
   };
 
   const managedSkillsDir = opts?.managedSkillsDir ?? path.join(CONFIG_DIR, "skills");
-  const workspaceSkillsDir = path.resolve(workspaceDir, "skills");
+  const resolvedWorkspaceDir = resolveUserPath(workspaceDir);
+  const workspaceSkillsDir = path.resolve(resolvedWorkspaceDir, "skills");
   const bundledSkillsDir = opts?.bundledSkillsDir ?? resolveBundledSkillsDir();
   const extraDirsRaw = opts?.config?.skills?.load?.extraDirs ?? [];
   const extraDirs = extraDirsRaw
     .map((d) => (typeof d === "string" ? d.trim() : ""))
     .filter(Boolean);
   const pluginSkillDirs = resolvePluginSkillDirs({
-    workspaceDir,
+    workspaceDir: resolvedWorkspaceDir,
     config: opts?.config,
   });
   const mergedExtraDirs = [...extraDirs, ...pluginSkillDirs];
@@ -477,7 +478,7 @@ function loadSkillEntries(
     dir: personalAgentsSkillsDir,
     source: "agents-skills-personal",
   });
-  const projectAgentsSkillsDir = path.resolve(workspaceDir, ".agents", "skills");
+  const projectAgentsSkillsDir = path.resolve(resolvedWorkspaceDir, ".agents", "skills");
   const projectAgentsSkills = loadSkills({
     dir: projectAgentsSkillsDir,
     source: "agents-skills-project",


### PR DESCRIPTION
## Summary

- Fix tilde path (`~`) in `workspaceDir` not being expanded before skill root validation
- `path.resolve()` treats `~` as a literal directory component, causing workspace skills to be incorrectly rejected as "outside configured root"
- Apply `resolveUserPath()` to `workspaceDir` before deriving skill directories (`skills/`, `.agents/skills/`, and plugin skill dirs), matching the existing behavior for `extraDirs`

## Change Type
Bug fix

## Scope
`src/agents/skills/workspace.ts`

## Security Impact
No security impact. The change uses the existing `resolveUserPath()` utility which already handles tilde expansion safely.

Closes #40154

🤖 Generated with [Claude Code](https://claude.com/claude-code)