### PR TITLE
fix(exec-approvals): reject non-persistable allow-always approvals

### DIFF
--- a/src/gateway/server-methods/exec-approval.ts
+++ b/src/gateway/server-methods/exec-approval.ts
@@ -1,6 +1,8 @@
 import type { ExecApprovalForwarder } from "../../infra/exec-approval-forwarder.js";
 import {
   DEFAULT_EXEC_APPROVAL_TIMEOUT_MS,
+  evaluateShellAllowlist,
+  resolveAllowAlwaysPatterns,
   type ExecApprovalDecision,
 } from "../../infra/exec-approvals.js";
 import { buildSystemRunApprovalBinding } from "../../infra/system-run-approval-binding.js";
@@ -276,6 +278,44 @@ export function createExecApprovalHandlers(
         return;
       }
       const snapshot = manager.getSnapshot(p.id);
+      if (!snapshot) {
+        respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, "unknown approval id"));
+        return;
+      }
+      if (decision === "allow-always") {
+        const analysis = evaluateShellAllowlist({
+          command: snapshot.request.command,
+          allowlist: [],
+          safeBins: new Set<string>(),
+          cwd: snapshot.request.cwd ?? undefined,
+          platform: process.platform,
+        });
+        if (analysis.analysisOk) {
+          const persistedPatterns = resolveAllowAlwaysPatterns({
+            segments: analysis.segments,
+            cwd: snapshot.request.cwd ?? undefined,
+            platform: process.platform,
+          });
+          const recheck = evaluateShellAllowlist({
+            command: snapshot.request.command,
+            allowlist: persistedPatterns.map((pattern) => ({ pattern })),
+            safeBins: new Set<string>(),
+            cwd: snapshot.request.cwd ?? undefined,
+            platform: process.platform,
+          });
+          if (!recheck.analysisOk || !recheck.allowlistSatisfied) {
+            respond(
+              false,
+              undefined,
+              errorShape(
+                ErrorCodes.INVALID_REQUEST,
+                "cannot persist allow-always for this command; use allow-once",
+              ),
+            );
+            return;
+          }
+        }
+      }
       const resolvedBy = client?.connect?.client?.displayName ?? client?.connect?.client?.id;
       const ok = manager.resolve(p.id, decision, resolvedBy ?? null);
       if (!ok) {

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -531,6 +531,52 @@ describe("exec approval handlers", () => {
     expect(broadcasts.some((entry) => entry.event === "exec.approval.resolved")).toBe(true);
   });
 
+  it("rejects allow-always when no allowlist pattern can be persisted", async () => {
+    const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
+
+    const requestPromise = requestExecApproval({
+      handlers,
+      respond,
+      context,
+      params: {
+        command: "cd some-dir && ls",
+        commandArgv: ["cd", "some-dir", "&&", "ls"],
+        host: "gateway",
+        twoPhase: true,
+      },
+    });
+
+    const requested = broadcasts.find((entry) => entry.event === "exec.approval.requested");
+    expect(requested).toBeTruthy();
+    const id = (requested?.payload as { id?: string })?.id ?? "";
+
+    const resolveRespond = vi.fn();
+    await handlers["exec.approval.resolve"]({
+      params: { id, decision: "allow-always" } as ExecApprovalResolveArgs["params"],
+      respond: resolveRespond as unknown as ExecApprovalResolveArgs["respond"],
+      context: toExecApprovalResolveContext(context),
+      client: null,
+      req: { id: "req-allow-always", type: "req", method: "exec.approval.resolve" },
+      isWebchatConnect: execApprovalNoop,
+    });
+
+    expect(resolveRespond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        message: "cannot persist allow-always for this command; use allow-once",
+      }),
+    );
+
+    await resolveExecApproval({
+      handlers,
+      id,
+      respond: vi.fn(),
+      context,
+    });
+    await requestPromise;
+  });
+
   it("stores versioned system.run binding and sorted env keys on approval request", async () => {
     const { handlers, broadcasts, respond, context } = createExecApprovalFixture();
     await requestExecApproval({


### PR DESCRIPTION
## Summary
- reject `allow-always` when the approved command cannot be persisted into an effective allowlist pattern
- validate by re-evaluating the same command against derived patterns before accepting `allow-always`
- return a clear error telling operators to use `allow-once` instead

## Why
For commands like `cd some-dir && ls`, previous behavior could return success for `allow-always` but fail to persist a usable allowlist rule, causing repeated approval prompts. This change avoids false-positive confirmation.

Fixes #40478

## Testing
- ./node_modules/.bin/vitest run --config vitest.gateway.config.ts src/gateway/server-methods/server-methods.test.ts
- ./node_modules/.bin/vitest run --config vitest.unit.config.ts src/infra/exec-approvals-allow-always.test.ts
