### PR TITLE
fix(doctor): skip plugins.entries for installed plugins already auto-loaded via manifest channels

### DIFF
--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -300,7 +300,7 @@ describe("applyPluginAutoEnable", () => {
       };
       const result = applyPluginAutoEnable({
         config: {
-          channels: { feishu: { appId: "cli_xxx", appSecret: "xxx" } },
+          channels: { feishu: { appId: "cli_xxx", appSecret: "xxx" } }, // pragma: allowlist secret
         },
         env: {},
         manifestRegistry: bundledRegistry,

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -246,17 +246,45 @@ describe("applyPluginAutoEnable", () => {
       expect(result.changes).toEqual([]);
     });
 
-    it("falls back to channel key as plugin id when no installed manifest declares the channel", () => {
-      // Without a matching manifest entry, behavior is unchanged (backward compat).
+    it("does not add plugins.entries for a globally-installed plugin already auto-loaded via its manifest channel (fixes #37548)", () => {
+      // When a globally-installed plugin (e.g. "feishu", origin "global") declares
+      // channels: ["feishu"] in its manifest AND channels.feishu is configured,
+      // the plugin loader auto-discovers and loads it from ~/.openclaw/extensions/.
+      // Doctor must NOT also write plugins.entries.feishu, which would create a
+      // "duplicate plugin id" warning at startup.
+      const globalRegistry: PluginManifestRegistry = {
+        plugins: [
+          {
+            id: "feishu",
+            channels: ["feishu"],
+            providers: [],
+            skills: [],
+            origin: "global" as const,
+            rootDir: "/fake/feishu",
+            source: "/fake/feishu/index.js",
+            manifestPath: "/fake/feishu/openclaw.plugin.json",
+          },
+        ],
+        diagnostics: [],
+      };
       const result = applyPluginAutoEnable({
         config: {
-          channels: { "unknown-chan": { someKey: "value" } },
+          channels: { feishu: { appId: "cli_xxx", appSecret: "xxx" } },
         },
         env: {},
-        manifestRegistry: makeRegistry([]),
+        manifestRegistry: globalRegistry,
       });
 
-      expect(result.config.plugins?.entries?.["unknown-chan"]?.enabled).toBe(true);
+      expect(result.config.plugins?.entries?.feishu).toBeUndefined();
+      expect(result.changes).toEqual([]);
+    });
+
+    it("still adds plugins.entries for a bundled plugin (not auto-loaded from extensions directory)", () => {
+      // Bundled plugins need plugins.entries to be explicitly enabled; they are NOT
+      // auto-discovered from the filesystem the same way installed plugins are.
+      const result = applyWithApnChannelConfig();
+
+      expect(result.config.plugins?.entries?.["apn-channel"]?.enabled).toBe(true);
     });
   });
 

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -279,12 +279,47 @@ describe("applyPluginAutoEnable", () => {
       expect(result.changes).toEqual([]);
     });
 
-    it("still adds plugins.entries for a bundled plugin (not auto-loaded from extensions directory)", () => {
-      // Bundled plugins need plugins.entries to be explicitly enabled; they are NOT
-      // auto-discovered from the filesystem the same way installed plugins are.
-      const result = applyWithApnChannelConfig();
+    it('still adds plugins.entries for a bundled plugin (origin "bundled", not auto-loaded from extensions directory)', () => {
+      // Bundled plugins are part of OpenClaw's own distribution. They are NOT
+      // auto-discovered from ~/.openclaw/extensions/, so they still require an
+      // explicit plugins.entries entry. The fix must NOT skip them.
+      const bundledRegistry: PluginManifestRegistry = {
+        plugins: [
+          {
+            id: "feishu",
+            channels: ["feishu"],
+            providers: [],
+            skills: [],
+            origin: "bundled" as const,
+            rootDir: "/fake/feishu",
+            source: "/fake/feishu/index.js",
+            manifestPath: "/fake/feishu/openclaw.plugin.json",
+          },
+        ],
+        diagnostics: [],
+      };
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: { feishu: { appId: "cli_xxx", appSecret: "xxx" } },
+        },
+        env: {},
+        manifestRegistry: bundledRegistry,
+      });
 
-      expect(result.config.plugins?.entries?.["apn-channel"]?.enabled).toBe(true);
+      expect(result.config.plugins?.entries?.feishu?.enabled).toBe(true);
+    });
+
+    it("falls back to channel key as plugin id when no installed manifest declares the channel", () => {
+      // Without a matching manifest entry, behavior is unchanged (backward compat).
+      const result = applyPluginAutoEnable({
+        config: {
+          channels: { "unknown-chan": { someKey: "value" } },
+        },
+        env: {},
+        manifestRegistry: makeRegistry([]),
+      });
+
+      expect(result.config.plugins?.entries?.["unknown-chan"]?.enabled).toBe(true);
     });
   });
 

--- a/src/config/plugin-auto-enable.test.ts
+++ b/src/config/plugin-auto-enable.test.ts
@@ -269,7 +269,7 @@ describe("applyPluginAutoEnable", () => {
       };
       const result = applyPluginAutoEnable({
         config: {
-          channels: { feishu: { appId: "cli_xxx", appSecret: "xxx" } },
+          channels: { feishu: { appId: "cli_xxx", appSecret: "xxx" } }, // pragma: allowlist secret
         },
         env: {},
         manifestRegistry: globalRegistry,

--- a/src/config/plugin-auto-enable.ts
+++ b/src/config/plugin-auto-enable.ts
@@ -517,7 +517,25 @@ export function applyPluginAutoEnable(params: {
             }
             return (channelConfig as { enabled?: unknown }).enabled === true;
           })()
-        : next.plugins?.entries?.[entry.pluginId]?.enabled === true;
+        : (() => {
+            if (next.plugins?.entries?.[entry.pluginId]?.enabled === true) {
+              return true;
+            }
+            // A globally- or workspace-installed plugin that declares channels in its
+            // manifest will be auto-loaded by the plugin loader whenever one of those
+            // channels is configured — adding it to plugins.entries would create a
+            // "duplicate plugin id" warning at startup.  Bundled plugins (origin
+            // "bundled") are NOT auto-loaded this way and still need plugins.entries
+            // to be explicitly enabled.
+            // See: https://github.com/openclaw/openclaw/issues/37548
+            const pluginRecord = registry.plugins.find((p) => p.id === entry.pluginId);
+            return (
+              pluginRecord != null &&
+              (pluginRecord.origin === "global" || pluginRecord.origin === "workspace") &&
+              pluginRecord.channels.length > 0 &&
+              pluginRecord.channels.some((ch) => isChannelConfigured(next, ch, env))
+            );
+          })();
     if (alreadyEnabled && !allowMissing) {
       continue;
     }


### PR DESCRIPTION
## Problem

When a globally- or workspace-installed plugin declares channels in its manifest (e.g. the 'feishu' plugin declares `channels: ["feishu"]`), OpenClaw's plugin loader already auto-discovers and loads it from `~/.openclaw/extensions/`. Running `openclaw doctor --fix` would also write `plugins.entries.feishu.enabled = true`, causing the plugin to be registered twice and producing a startup warning:

```
plugins.entries.feishu: duplicate plugin id detected
```

Fixes #37548
See also #35884

## Root cause

In `applyPluginAutoEnable`, the `alreadyEnabled` check for non-built-in plugins only looked at `plugins.entries[pluginId].enabled === true`. It did not consider that a globally/workspace-installed plugin would already be auto-loaded by the plugin loader via filesystem discovery — so doctor would redundantly add it to `plugins.entries`.

## Fix

Skip writing `plugins.entries` for a plugin when **all** of the following are true:
1. The plugin is globally or workspace-installed (`origin === 'global' || origin === 'workspace'`)
2. The plugin declares one or more channels in its manifest
3. At least one of those declared channels is configured in `channels.<id>`

Bundled plugins (`origin === 'bundled'`) are intentionally excluded from this shortcut — they are part of OpenClaw's own distribution and still require an explicit `plugins.entries` entry to be enabled for any given user.

## Testing

- Existing 20 tests still pass
- Added 2 new tests:
  - `does not add plugins.entries for a globally-installed plugin already auto-loaded via its manifest channel` — directly reproduces the feishu duplicate scenario
  - `still adds plugins.entries for a bundled plugin (not auto-loaded from extensions directory)` — ensures bundled plugins are unaffected