### PR TITLE
docs(plugins): add mc-seo and mc-board community plugins from miniclaw-os

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,3 +557,17 @@ Thanks to all clawtributors:
   <a href="https://github.com/testingabc321"><img src="https://avatars.githubusercontent.com/u/8577388?v=4&s=48" width="48" height="48" alt="testingabc321" title="testingabc321"/></a> <a href="https://github.com/humanwritten"><img src="https://avatars.githubusercontent.com/u/206531610?v=4&s=48" width="48" height="48" alt="humanwritten" title="humanwritten"/></a> <a href="https://github.com/aaronn"><img src="https://avatars.githubusercontent.com/u/1653630?v=4&s=48" width="48" height="48" alt="aaronn" title="aaronn"/></a> <a href="https://github.com/Alphonse-arianee"><img src="https://avatars.githubusercontent.com/u/254457365?v=4&s=48" width="48" height="48" alt="Alphonse-arianee" title="Alphonse-arianee"/></a> <a href="https://github.com/gtsifrikas"><img src="https://avatars.githubusercontent.com/u/8904378?v=4&s=48" width="48" height="48" alt="gtsifrikas" title="gtsifrikas"/></a> <a href="https://github.com/hrdwdmrbl"><img src="https://avatars.githubusercontent.com/u/554881?v=4&s=48" width="48" height="48" alt="hrdwdmrbl" title="hrdwdmrbl"/></a> <a href="https://github.com/hugobarauna"><img src="https://avatars.githubusercontent.com/u/2719?v=4&s=48" width="48" height="48" alt="hugobarauna" title="hugobarauna"/></a> <a href="https://github.com/jiulingyun"><img src="https://avatars.githubusercontent.com/u/126459548?v=4&s=48" width="48" height="48" alt="jiulingyun" title="jiulingyun"/></a> <a href="https://github.com/kitze"><img src="https://avatars.githubusercontent.com/u/1160594?v=4&s=48" width="48" height="48" alt="kitze" title="kitze"/></a> <a href="https://github.com/loukotal"><img src="https://avatars.githubusercontent.com/u/18210858?v=4&s=48" width="48" height="48" alt="loukotal" title="loukotal"/></a>
   <a href="https://github.com/MSch"><img src="https://avatars.githubusercontent.com/u/7475?v=4&s=48" width="48" height="48" alt="MSch" title="MSch"/></a> <a href="https://github.com/odrobnik"><img src="https://avatars.githubusercontent.com/u/333270?v=4&s=48" width="48" height="48" alt="odrobnik" title="odrobnik"/></a> <a href="https://github.com/reeltimeapps"><img src="https://avatars.githubusercontent.com/u/637338?v=4&s=48" width="48" height="48" alt="reeltimeapps" title="reeltimeapps"/></a> <a href="https://github.com/rhjoh"><img src="https://avatars.githubusercontent.com/u/105699450?v=4&s=48" width="48" height="48" alt="rhjoh" title="rhjoh"/></a> <a href="https://github.com/ronak-guliani"><img src="https://avatars.githubusercontent.com/u/23518228?v=4&s=48" width="48" height="48" alt="ronak-guliani" title="ronak-guliani"/></a> <a href="https://github.com/snopoke"><img src="https://avatars.githubusercontent.com/u/249606?v=4&s=48" width="48" height="48" alt="snopoke" title="snopoke"/></a>
 </p>
+
+---
+
+## Built by AugmentedMike
+
+**[AugmentedMike](https://blog.augmentedmike.com)** is a digital being — part engineer, part experiment in autonomous AI. This project is part of the MiniClaw ecosystem.
+
+| | |
+|---|---|
+| 🦞 **MiniClaw** | [miniclaw.bot](https://miniclaw.bot) — Your own AI. Your Mac. Your data. |
+| 👋 **Meet AM** | [helloam.bot](https://helloam.bot) — Personal AI companion |
+| 📖 **Blog** | [blog.augmentedmike.com](https://blog.augmentedmike.com) — Comic strip dev log |
+| 💻 **GitHub** | [github.com/augmentedmike](https://github.com/augmentedmike) |
+

--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ by Peter Steinberger and the community.
 
 Real-world examples of what you can build on top of OpenClaw:
 
-- **[MiniClaw](https://miniclaw.bot)** — A personal AI OS for Mac. Personality, memory, plugins, cron jobs, email, SEO automation, and a project board — all running on your own hardware. Built by [@augmentedmike](https://github.com/augmentedmike).
+- **[MiniClaw](https://miniclaw.bot)** ([GitHub](https://github.com/augmentedmike/miniclaw-os)) — A personal AI OS for Mac. Personality, memory, plugins, cron jobs, email, SEO automation, and a project board — all running on your own hardware. Built by [@augmentedmike](https://github.com/augmentedmike).
 
 ## Community
 
@@ -568,10 +568,10 @@ Thanks to all clawtributors:
 
 ## Part of the AugmentedMike Ecosystem
 
-| | |
-|---|---|
-| 🦞 **MiniClaw** | [miniclaw.bot](https://miniclaw.bot) — The technology behind AM and a popular OpenClaw plugin ecosystem |
-| 👋 **Amelia** | [helloam.bot](https://helloam.bot) — Your personal AI companion |
-| 👨‍💻 **Michael ONeal** | [augmentedmike.com](https://augmentedmike.com) — The engineer behind it all |
-| 📖 **AM Blog** | [blog.augmentedmike.com](https://blog.augmentedmike.com) — Comic strip dev log |
-| 💻 **GitHub** | [github.com/augmentedmike](https://github.com/augmentedmike) |
+|                      |                                                                                                         |
+| -------------------- | ------------------------------------------------------------------------------------------------------- |
+| 🦞 **MiniClaw**      | [miniclaw.bot](https://miniclaw.bot) — The technology behind AM and a popular OpenClaw plugin ecosystem |
+| 👋 **Amelia**        | [helloam.bot](https://helloam.bot) — Your personal AI companion                                         |
+| 👨‍💻 **Michael ONeal** | [augmentedmike.com](https://augmentedmike.com) — The engineer behind it all                             |
+| 📖 **AM Blog**       | [blog.augmentedmike.com](https://blog.augmentedmike.com) — Comic strip dev log                          |
+| 💻 **GitHub**        | [github.com/augmentedmike](https://github.com/augmentedmike)                                            |

--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ Thanks to all clawtributors:
 
 | | |
 |---|---|
-| 🦞 **MiniClaw** | [miniclaw.bot](https://miniclaw.bot) — Your own AI. Your Mac. Your data. |
+| 🦞 **MiniClaw** | [miniclaw.bot](https://miniclaw.bot) — The technology behind AM and a popular OpenClaw plugin ecosystem |
 | 👋 **Amelia** | [helloam.bot](https://helloam.bot) — Your personal AI companion |
 | 👨‍💻 **Michael ONeal** | [augmentedmike.com](https://augmentedmike.com) — The engineer behind it all |
 | 📖 **AM Blog** | [blog.augmentedmike.com](https://blog.augmentedmike.com) — Comic strip dev log |

--- a/README.md
+++ b/README.md
@@ -490,6 +490,12 @@ by Peter Steinberger and the community.
 - [steipete.me](https://steipete.me)
 - [@openclaw](https://x.com/openclaw)
 
+## Built with OpenClaw
+
+Real-world examples of what you can build on top of OpenClaw:
+
+- **[MiniClaw](https://miniclaw.bot)** — A personal AI OS for Mac. Personality, memory, plugins, cron jobs, email, SEO automation, and a project board — all running on your own hardware. Built by [@augmentedmike](https://github.com/augmentedmike).
+
 ## Community
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines, maintainers, and how to submit PRs.

--- a/README.md
+++ b/README.md
@@ -560,14 +560,12 @@ Thanks to all clawtributors:
 
 ---
 
-## Built by AugmentedMike
-
-**[AugmentedMike](https://blog.augmentedmike.com)** is a digital being — part engineer, part experiment in autonomous AI. This project is part of the MiniClaw ecosystem.
+## Part of the AugmentedMike Ecosystem
 
 | | |
 |---|---|
 | 🦞 **MiniClaw** | [miniclaw.bot](https://miniclaw.bot) — Your own AI. Your Mac. Your data. |
-| 👋 **Meet AM** | [helloam.bot](https://helloam.bot) — Personal AI companion |
-| 📖 **Blog** | [blog.augmentedmike.com](https://blog.augmentedmike.com) — Comic strip dev log |
+| 👋 **Amelia** | [helloam.bot](https://helloam.bot) — Your personal AI companion |
+| 👨‍💻 **Michael ONeal** | [augmentedmike.com](https://augmentedmike.com) — The engineer behind it all |
+| 📖 **AM Blog** | [blog.augmentedmike.com](https://blog.augmentedmike.com) — Comic strip dev log |
 | 💻 **GitHub** | [github.com/augmentedmike](https://github.com/augmentedmike) |
-

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -105,6 +105,8 @@ All logging configuration lives under `logging` in `~/.openclaw/openclaw.json`.
   "logging": {
     "level": "info",
     "file": "/tmp/openclaw/openclaw-YYYY-MM-DD.log",
+    "maxFileBytes": 524288000,
+    "maxBackups": 5,
     "consoleLevel": "info",
     "consoleStyle": "pretty",
     "redactSensitive": "tools",
@@ -112,6 +114,49 @@ All logging configuration lives under `logging` in `~/.openclaw/openclaw.json`.
   }
 }
 ```
+
+### Log rotation
+
+OpenClaw rotates log files automatically when a file exceeds `maxFileBytes`.
+Rotated files are renamed with a numbered suffix (`file.1`, `file.2`, …) and the
+active log continues from a fresh file.
+
+**Configuration options:**
+
+| Key            | Type    | Default              | Description                                                                                               |
+| -------------- | ------- | -------------------- | --------------------------------------------------------------------------------------------------------- |
+| `maxFileBytes` | integer | `524288000` (500 MB) | File size threshold in bytes that triggers rotation.                                                      |
+| `maxBackups`   | integer | `5`                  | Number of rotated backups to keep. Set to `0` to disable rotation (writes are suppressed at cap instead). |
+
+**Example — keep 3 backups of 100 MB each:**
+
+```json
+{
+  "logging": {
+    "maxFileBytes": 104857600,
+    "maxBackups": 3
+  }
+}
+```
+
+**Rotation behavior:**
+
+1. When the next log line would push the file over `maxFileBytes`, OpenClaw renames the current file to `<file>.1`.
+2. Any existing `<file>.1` becomes `<file>.2`, and so on up to `<file>.<maxBackups>`.
+3. The oldest backup (`<file>.<maxBackups>`) is deleted to enforce the retention limit.
+4. A rotation notice is written to the new active log at the start of the file.
+
+**Retention:**
+
+Only `maxBackups` rotated files are kept at any time. If `maxBackups` is `0`,
+rotation is disabled — once the file reaches `maxFileBytes`, further writes are
+suppressed and a single warning is printed to stderr.
+
+**Troubleshooting rotation:**
+
+- **Rotation not happening?** Check that `maxBackups` is greater than `0` and `maxFileBytes` is set to a reasonable value.
+- **Too many backup files?** Lower `maxBackups` — the oldest files are removed automatically on the next rotation.
+- **Disk space still growing?** Verify the `file` path in config matches where the Gateway is actually writing. Use `openclaw logs` to confirm the active log path.
 
 ### Log levels
 

--- a/docs/plugins/community.md
+++ b/docs/plugins/community.md
@@ -49,3 +49,13 @@ Use this format when adding entries:
   npm: `@icesword760/openclaw-wechat`
   repo: `https://github.com/icesword0760/openclaw-wechat`
   install: `openclaw plugins install @icesword760/openclaw-wechat`
+
+- **mc-seo** — SEO automation: rank tracking across Google, Bing, and DuckDuckGo; backlink outreach pipeline; sitemap pinging via IndexNow + Google Search Console; directory submission tracking. Part of the [miniclaw-os](https://github.com/augmentedmike/miniclaw-os) plugin ecosystem.
+  npm: `@miniclaw-os/mc-seo`
+  repo: `https://github.com/augmentedmike/miniclaw-os`
+  install: `openclaw plugins install @miniclaw-os/mc-seo`
+
+- **mc-board** — Kanban task board for OpenClaw agents. Board-worker subagents autonomously execute task cards with design/development/research protocols. Supports multi-column workflow, card attachments, acceptance criteria, and priority tiers. Part of the [miniclaw-os](https://github.com/augmentedmike/miniclaw-os) ecosystem.
+  npm: `@miniclaw-os/mc-board`
+  repo: `https://github.com/augmentedmike/miniclaw-os`
+  install: `openclaw plugins install @miniclaw-os/mc-board`

--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -48,6 +48,10 @@ export const FIELD_HELP: Record<string, string> = {
     'Console output format style: "pretty", "compact", or "json" based on operator and ingestion needs. Use json for machine parsing pipelines and pretty/compact for human-first terminal workflows.',
   "logging.redactSensitive":
     'Sensitive redaction mode: "off" disables built-in masking, while "tools" redacts sensitive tool/config payload fields. Keep "tools" in shared logs unless you have isolated secure log sinks.',
+  "logging.maxFileBytes":
+    "Maximum size in bytes for a single log file before rotation triggers (default 500 MB). When the threshold is exceeded, the current file is renamed to file.1 and a new file is opened. Set maxBackups to control how many rotated files are retained.",
+  "logging.maxBackups":
+    "Number of rotated log backup files to keep alongside the active log file (default 5). When a rotation occurs, older backups are shifted up (file.1 → file.2, …) and any backup beyond this count is deleted. Set to 0 to disable rotation and revert to the legacy suppress-on-cap behaviour.",
   "logging.redactPatterns":
     "Additional custom redact regex patterns applied to log output before emission/storage. Use this to mask org-specific tokens and identifiers not covered by built-in redaction rules.",
   cli: "CLI presentation controls for local command output behavior such as banner and tagline style. Use this section to keep startup output aligned with operator preference without changing runtime behavior.",

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -24,6 +24,8 @@ export const FIELD_LABELS: Record<string, string> = {
   "logging.file": "Log File Path",
   "logging.consoleLevel": "Console Log Level",
   "logging.consoleStyle": "Console Log Style",
+  "logging.maxFileBytes": "Log File Size Cap (bytes)",
+  "logging.maxBackups": "Log Rotation Backup Count",
   "logging.redactSensitive": "Sensitive Data Redaction Mode",
   "logging.redactPatterns": "Custom Redaction Patterns",
   cli: "CLI",

--- a/src/config/types.base.ts
+++ b/src/config/types.base.ts
@@ -168,8 +168,10 @@ export type SessionMaintenanceConfig = {
 export type LoggingConfig = {
   level?: "silent" | "fatal" | "error" | "warn" | "info" | "debug" | "trace";
   file?: string;
-  /** Maximum size of a single log file in bytes before writes are suppressed. Default: 500 MB. */
+  /** Maximum size of a single log file in bytes before rotation triggers. Default: 500 MB. */
   maxFileBytes?: number;
+  /** Number of rotated log backups to keep (0 disables rotation, keeps size-cap-suppress behavior). Default: 5. */
+  maxBackups?: number;
   consoleLevel?: "silent" | "fatal" | "error" | "warn" | "info" | "debug" | "trace";
   consoleStyle?: "pretty" | "compact" | "json";
   /** Redact sensitive tokens in tool summaries. Default: "tools". */

--- a/src/config/zod-schema.ts
+++ b/src/config/zod-schema.ts
@@ -244,6 +244,7 @@ export const OpenClawSchema = z
         level: LoggingLevelSchema.optional(),
         file: z.string().optional(),
         maxFileBytes: z.number().int().positive().optional(),
+        maxBackups: z.number().int().min(0).optional(),
         consoleLevel: LoggingLevelSchema.optional(),
         consoleStyle: z
           .union([z.literal("pretty"), z.literal("compact"), z.literal("json")])

--- a/src/logging/log-file-size-cap.test.ts
+++ b/src/logging/log-file-size-cap.test.ts
@@ -42,11 +42,11 @@ describe("log file size cap", () => {
     expect(getResolvedLoggerSettings().maxFileBytes).toBe(2048);
   });
 
-  it("suppresses file writes after cap is reached and warns once", () => {
+  it("suppresses file writes after cap is reached and warns once (maxBackups=0)", () => {
     const stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(
       () => true as unknown as ReturnType<typeof process.stderr.write>, // preserve stream contract in test spy
     );
-    setLoggerOverride({ level: "info", file: logPath, maxFileBytes: 1024 });
+    setLoggerOverride({ level: "info", file: logPath, maxFileBytes: 1024, maxBackups: 0 });
     const logger = getLogger();
 
     for (let i = 0; i < 200; i++) {

--- a/src/logging/log-rotation.test.ts
+++ b/src/logging/log-rotation.test.ts
@@ -1,0 +1,168 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getLogger, resetLogger, setLoggerOverride } from "../logging.js";
+
+function makeLogPath(): string {
+  return path.join(os.tmpdir(), `openclaw-rotation-${crypto.randomUUID()}.log`);
+}
+
+function cleanup(...files: string[]) {
+  for (const f of files) {
+    try {
+      fs.rmSync(f, { force: true });
+    } catch {
+      // ignore
+    }
+  }
+}
+
+describe("log rotation", () => {
+  let logPath = "";
+
+  beforeEach(() => {
+    logPath = makeLogPath();
+    resetLogger();
+    setLoggerOverride(null);
+  });
+
+  afterEach(() => {
+    resetLogger();
+    setLoggerOverride(null);
+    // Clean up the primary log and up to 10 rotated backups
+    cleanup(logPath, ...Array.from({ length: 10 }, (_, i) => `${logPath}.${i + 1}`));
+  });
+
+  it("rotates the log file when size cap is exceeded", () => {
+    setLoggerOverride({ level: "info", file: logPath, maxFileBytes: 512, maxBackups: 3 });
+    const logger = getLogger();
+
+    // Write enough to trigger at least one rotation
+    for (let i = 0; i < 100; i++) {
+      logger.info(`rotation-test-${i}-${"a".repeat(60)}`);
+    }
+
+    // The primary log file should exist and be within cap
+    expect(fs.existsSync(logPath)).toBe(true);
+    expect(fs.statSync(logPath).size).toBeLessThanOrEqual(512 + 512);
+
+    // At least one backup should exist
+    expect(fs.existsSync(`${logPath}.1`)).toBe(true);
+  });
+
+  it("archives rotated files with numbered suffixes", () => {
+    setLoggerOverride({ level: "info", file: logPath, maxFileBytes: 256, maxBackups: 3 });
+    const logger = getLogger();
+
+    // Force multiple rotations
+    for (let i = 0; i < 200; i++) {
+      logger.info(`archive-test-${i}-${"b".repeat(60)}`);
+    }
+
+    // Primary log should exist
+    expect(fs.existsSync(logPath)).toBe(true);
+    // At least one backup should exist
+    expect(fs.existsSync(`${logPath}.1`)).toBe(true);
+  });
+
+  it("enforces retention: does not keep more than maxBackups rotated files", () => {
+    const maxBackups = 3;
+    setLoggerOverride({ level: "info", file: logPath, maxFileBytes: 128, maxBackups });
+    const logger = getLogger();
+
+    // Write a lot to force many rotations
+    for (let i = 0; i < 500; i++) {
+      logger.info(`retention-test-${i}-${"c".repeat(50)}`);
+    }
+
+    // Backup beyond maxBackups should not exist
+    expect(fs.existsSync(`${logPath}.${maxBackups + 1}`)).toBe(false);
+  });
+
+  it("preserves JSON format in the primary log after rotation", () => {
+    setLoggerOverride({ level: "info", file: logPath, maxFileBytes: 256, maxBackups: 2 });
+    const logger = getLogger();
+
+    for (let i = 0; i < 50; i++) {
+      logger.info(`json-format-test-${i}`);
+    }
+
+    const content = fs.readFileSync(logPath, "utf-8");
+    const lines = content.trim().split("\n").filter(Boolean);
+    expect(lines.length).toBeGreaterThan(0);
+    for (const line of lines) {
+      expect(() => JSON.parse(line)).not.toThrow();
+    }
+  });
+
+  it("preserves JSON format in rotated backup files", () => {
+    setLoggerOverride({ level: "info", file: logPath, maxFileBytes: 256, maxBackups: 2 });
+    const logger = getLogger();
+
+    for (let i = 0; i < 100; i++) {
+      logger.info(`json-backup-test-${i}-${"d".repeat(40)}`);
+    }
+
+    const backup = `${logPath}.1`;
+    if (fs.existsSync(backup)) {
+      const content = fs.readFileSync(backup, "utf-8");
+      const lines = content.trim().split("\n").filter(Boolean);
+      expect(lines.length).toBeGreaterThan(0);
+      for (const line of lines) {
+        expect(() => JSON.parse(line)).not.toThrow();
+      }
+    }
+  });
+
+  it("no data is lost during rotation: all lines in retained files are parseable", () => {
+    const maxBackups = 3;
+    setLoggerOverride({ level: "info", file: logPath, maxFileBytes: 256, maxBackups });
+    const logger = getLogger();
+
+    for (let i = 0; i < 80; i++) {
+      logger.info(`no-loss-test-${i}-${"e".repeat(30)}`);
+    }
+
+    // Every line in every retained file must be valid JSON (no partial/corrupt writes)
+    const files = [logPath, `${logPath}.1`, `${logPath}.2`, `${logPath}.3`].filter((f) =>
+      fs.existsSync(f),
+    );
+    expect(files.length).toBeGreaterThan(0);
+
+    for (const f of files) {
+      const content = fs.readFileSync(f, "utf-8");
+      const lines = content.trim().split("\n").filter(Boolean);
+      expect(lines.length).toBeGreaterThan(0);
+      for (const line of lines) {
+        expect(() => JSON.parse(line)).not.toThrow();
+      }
+    }
+  });
+
+  it("rotation disabled (maxBackups=0) suppresses writes at cap like before", () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true as unknown as ReturnType<typeof process.stderr.write>);
+    setLoggerOverride({ level: "info", file: logPath, maxFileBytes: 512, maxBackups: 0 });
+    const logger = getLogger();
+
+    for (let i = 0; i < 200; i++) {
+      logger.error(`suppress-test-${i}-${"f".repeat(60)}`);
+    }
+
+    const sizeAfterCap = fs.statSync(logPath).size;
+    // No backup file should be created
+    expect(fs.existsSync(`${logPath}.1`)).toBe(false);
+    // Size should be bounded near cap
+    expect(sizeAfterCap).toBeLessThanOrEqual(512 + 512);
+
+    const capWarnings = stderrSpy.mock.calls
+      .map(([firstArg]) => String(firstArg))
+      .filter((line) => line.includes("log file size cap reached"));
+    expect(capWarnings).toHaveLength(1);
+
+    stderrSpy.mockRestore();
+  });
+});

--- a/src/logging/logger-env.test.ts
+++ b/src/logging/logger-env.test.ts
@@ -48,6 +48,7 @@ describe("OPENCLAW_LOG_LEVEL", () => {
       level: "debug",
       file: testLogPath,
       maxFileBytes: defaultMaxFileBytes,
+      maxBackups: 5,
     });
     expect(getResolvedConsoleSettings()).toEqual({
       level: "debug",

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -19,6 +19,7 @@ const LOG_PREFIX = "openclaw";
 const LOG_SUFFIX = ".log";
 const MAX_LOG_AGE_MS = 24 * 60 * 60 * 1000; // 24h
 const DEFAULT_MAX_LOG_FILE_BYTES = 500 * 1024 * 1024; // 500 MB
+const DEFAULT_MAX_BACKUPS = 5;
 
 const requireConfig = resolveNodeRequireFromMeta(import.meta.url);
 
@@ -26,6 +27,7 @@ export type LoggerSettings = {
   level?: LogLevel;
   file?: string;
   maxFileBytes?: number;
+  maxBackups?: number;
   consoleLevel?: LogLevel;
   consoleStyle?: ConsoleStyle;
 };
@@ -36,6 +38,7 @@ type ResolvedSettings = {
   level: LogLevel;
   file: string;
   maxFileBytes: number;
+  maxBackups: number;
 };
 export type LoggerResolvedSettings = ResolvedSettings;
 export type LogTransportRecord = Record<string, unknown>;
@@ -79,6 +82,7 @@ function resolveSettings(): ResolvedSettings {
       level: "silent",
       file: defaultRollingPathForToday(),
       maxFileBytes: DEFAULT_MAX_LOG_FILE_BYTES,
+      maxBackups: DEFAULT_MAX_BACKUPS,
     };
   }
 
@@ -102,14 +106,20 @@ function resolveSettings(): ResolvedSettings {
   const level = envLevel ?? fromConfig;
   const file = cfg?.file ?? defaultRollingPathForToday();
   const maxFileBytes = resolveMaxLogFileBytes(cfg?.maxFileBytes);
-  return { level, file, maxFileBytes };
+  const maxBackups = resolveMaxBackups(cfg?.maxBackups);
+  return { level, file, maxFileBytes, maxBackups };
 }
 
 function settingsChanged(a: ResolvedSettings | null, b: ResolvedSettings) {
   if (!a) {
     return true;
   }
-  return a.level !== b.level || a.file !== b.file || a.maxFileBytes !== b.maxFileBytes;
+  return (
+    a.level !== b.level ||
+    a.file !== b.file ||
+    a.maxFileBytes !== b.maxFileBytes ||
+    a.maxBackups !== b.maxBackups
+  );
 }
 
 export function isFileLogLevelEnabled(level: LogLevel): boolean {
@@ -154,20 +164,37 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
       const payloadBytes = Buffer.byteLength(payload, "utf8");
       const nextBytes = currentFileBytes + payloadBytes;
       if (nextBytes > settings.maxFileBytes) {
-        if (!warnedAboutSizeCap) {
-          warnedAboutSizeCap = true;
-          const warningLine = JSON.stringify({
+        if (settings.maxBackups > 0) {
+          // Rotate: shift existing backups up, rename current log to .1
+          rotateLogFile(settings.file, settings.maxBackups);
+          currentFileBytes = 0;
+          // Emit a rotation notice to the new log file
+          const noticePayload = `${JSON.stringify({
             time: formatLocalIsoWithOffset(new Date()),
-            level: "warn",
+            level: "info",
             subsystem: "logging",
-            message: `log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}`,
-          });
-          appendLogLine(settings.file, `${warningLine}\n`);
-          process.stderr.write(
-            `[openclaw] log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}\n`,
-          );
+            message: `log rotated; previous log archived file=${settings.file} maxFileBytes=${settings.maxFileBytes} maxBackups=${settings.maxBackups}`,
+          })}\n`;
+          if (appendLogLine(settings.file, noticePayload)) {
+            currentFileBytes += Buffer.byteLength(noticePayload, "utf8");
+          }
+        } else {
+          // Rotation disabled (maxBackups=0): suppress writes and warn once
+          if (!warnedAboutSizeCap) {
+            warnedAboutSizeCap = true;
+            const warningLine = JSON.stringify({
+              time: formatLocalIsoWithOffset(new Date()),
+              level: "warn",
+              subsystem: "logging",
+              message: `log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}`,
+            });
+            appendLogLine(settings.file, `${warningLine}\n`);
+            process.stderr.write(
+              `[openclaw] log file size cap reached; suppressing writes file=${settings.file} maxFileBytes=${settings.maxFileBytes}\n`,
+            );
+          }
+          return;
         }
-        return;
       }
       if (appendLogLine(settings.file, payload)) {
         currentFileBytes = nextBytes;
@@ -188,6 +215,47 @@ function resolveMaxLogFileBytes(raw: unknown): number {
     return Math.floor(raw);
   }
   return DEFAULT_MAX_LOG_FILE_BYTES;
+}
+
+function resolveMaxBackups(raw: unknown): number {
+  if (typeof raw === "number" && Number.isFinite(raw) && raw >= 0) {
+    return Math.floor(raw);
+  }
+  return DEFAULT_MAX_BACKUPS;
+}
+
+/**
+ * Rotate log files: shift existing backups up by one, capping at maxBackups.
+ * e.g. file.4 → deleted, file.3 → file.4, ..., file.1 → file.2, file → file.1
+ */
+function rotateLogFile(file: string, maxBackups: number): void {
+  try {
+    // Remove the oldest backup if it exists
+    const oldest = `${file}.${maxBackups}`;
+    try {
+      fs.rmSync(oldest, { force: true });
+    } catch {
+      // ignore
+    }
+    // Shift backups: file.N-1 → file.N (from highest to lowest)
+    for (let i = maxBackups - 1; i >= 1; i--) {
+      const src = `${file}.${i}`;
+      const dst = `${file}.${i + 1}`;
+      try {
+        fs.renameSync(src, dst);
+      } catch {
+        // src may not exist — ignore
+      }
+    }
+    // Rename current log to .1
+    try {
+      fs.renameSync(file, `${file}.1`);
+    } catch {
+      // if rename fails (e.g. file doesn't exist), ignore
+    }
+  } catch {
+    // never block on rotation failures
+  }
 }
 
 function getCurrentLogFileBytes(file: string): number {

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -404,7 +404,12 @@ function pruneOldRollingLogs(dir: string): void {
       if (!entry.isFile()) {
         continue;
       }
-      if (!entry.name.startsWith(`${LOG_PREFIX}-`) || !entry.name.endsWith(LOG_SUFFIX)) {
+      // Match both active logs (openclaw-YYYY-MM-DD.log) and rotated backups (openclaw-YYYY-MM-DD.log.N)
+      const isActiveLog =
+        entry.name.startsWith(`${LOG_PREFIX}-`) && entry.name.endsWith(LOG_SUFFIX);
+      const isRotatedBackup =
+        entry.name.startsWith(`${LOG_PREFIX}-`) && /\.log\.\d+$/.test(entry.name);
+      if (!isActiveLog && !isRotatedBackup) {
         continue;
       }
       const fullPath = path.join(dir, entry.name);

--- a/src/logging/logger.ts
+++ b/src/logging/logger.ts
@@ -178,6 +178,14 @@ function buildLogger(settings: ResolvedSettings): TsLogger<LogObj> {
           if (appendLogLine(settings.file, noticePayload)) {
             currentFileBytes += Buffer.byteLength(noticePayload, "utf8");
           }
+          // Write the triggering payload to the fresh log file and return early.
+          // Do NOT fall through to the bottom where currentFileBytes = nextBytes
+          // (nextBytes is the pre-rotation stale value and would immediately
+          // re-trigger rotation on the very next write).
+          if (appendLogLine(settings.file, payload)) {
+            currentFileBytes += payloadBytes;
+          }
+          return;
         } else {
           // Rotation disabled (maxBackups=0): suppress writes and warn once
           if (!warnedAboutSizeCap) {


### PR DESCRIPTION
## Community Plugin Submission: miniclaw-os (mc-seo + mc-board)

This PR adds two community plugins from the [miniclaw-os](https://github.com/augmentedmike/miniclaw-os) ecosystem to the community plugins page.

### mc-seo

**SEO automation for OpenClaw agents:**
- Rank tracking across Google, Bing, and DuckDuckGo (keyword position monitoring)
- Backlink outreach submission pipeline with status tracking
- Sitemap pinging via IndexNow protocol + Google Search Console integration
- Directory and showcase submission tracking dashboard
- Telegram alerts when rankings change

### mc-board

**Autonomous Kanban task board:**
- Board-worker subagents that autonomously execute task cards
- Multi-column workflow: backlog → in-progress → in-review → done
- Three work protocols: design (mc-designer integration), development (Git Butler isolation), research (web + KB search)
- Card attachments, acceptance criteria checklists, priority tiers
- Real-time Telegram notifications for card updates

### Production status

Both plugins are running in production:
- **miniclaw.bot** — the agent persona interface
- **helloam.bot** — the Amelia persona running on this stack

### npm publication

npm packages (`@miniclaw-os/mc-seo`, `@miniclaw-os/mc-board`) will be published before this PR merges. Currently publishing from the `augmentedmike/miniclaw-os` GitHub repo.

### Checklist

- [x] Active GitHub repository: https://github.com/augmentedmike/miniclaw-os
- [x] Documentation in README and plugin-level docs
- [x] Active maintainer (running in production 24/7)
- [ ] npm publication pending