### PR TITLE
fix(cron): auto-fill agentId from session when not explicitly provided

### DIFF
--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -201,6 +201,43 @@ describe("cron tool", () => {
     expect(call?.params?.agentId).toBeNull();
   });
 
+  it("auto-fills agentId from session when not provided", async () => {
+    const tool = createCronTool({ agentSessionKey: "agent:xiaomeng:feishu:direct:abc" });
+    await tool.execute("call-auto-fill", {
+      action: "add",
+      job: {
+        name: "wake-up",
+        schedule: { at: new Date(123).toISOString() },
+        payload: { kind: "systemEvent", text: "hello" },
+      },
+    });
+
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      params?: { agentId?: unknown };
+    };
+    // resolveSessionAgentId mock returns "agent-123"
+    expect(call?.params?.agentId).toBe("agent-123");
+  });
+
+  it("auto-fills agentId when job.agentId is undefined", async () => {
+    const tool = createCronTool({ agentSessionKey: "agent:xiaomeng:feishu:direct:abc" });
+    await tool.execute("call-undefined", {
+      action: "add",
+      job: {
+        name: "wake-up",
+        schedule: { at: new Date(123).toISOString() },
+        agentId: undefined,
+        payload: { kind: "systemEvent", text: "hello" },
+      },
+    });
+
+    const call = callGatewayMock.mock.calls[0]?.[0] as {
+      params?: { agentId?: unknown };
+    };
+    // resolveSessionAgentId mock returns "agent-123"
+    expect(call?.params?.agentId).toBe("agent-123");
+  });
+
   it("stamps cron.add with caller sessionKey when missing", async () => {
     callGatewayMock.mockResolvedValueOnce({ ok: true });
 

--- a/src/agents/tools/cron-tool.ts
+++ b/src/agents/tools/cron-tool.ts
@@ -353,7 +353,16 @@ Use jobId as the canonical identifier; id is accepted for compatibility. Use con
             const resolvedSessionKey = opts?.agentSessionKey
               ? resolveInternalSessionKey({ key: opts.agentSessionKey, alias, mainKey })
               : undefined;
-            if (!("agentId" in job)) {
+            // Auto-fill agentId from the current session if not explicitly provided.
+            // We distinguish between:
+            // - agentId: null → user explicitly wants no agent (preserve)
+            // - agentId: "valid-string" → user specified an agent (preserve)
+            // - agentId: undefined/""/missing → auto-fill from session
+            const jobRecord = job as Record<string, unknown>;
+            const agentIdValue = jobRecord.agentId;
+            const shouldAutoFillAgentId =
+              agentIdValue !== null && (typeof agentIdValue !== "string" || !agentIdValue.trim());
+            if (shouldAutoFillAgentId) {
               const agentId = opts?.agentSessionKey
                 ? resolveSessionAgentId({ sessionKey: opts.agentSessionKey, config: cfg })
                 : undefined;


### PR DESCRIPTION
## Summary

- Fix: When a sub-agent creates a cron job without specifying `--agent`, the system now correctly auto-fills the `agentId` from the current session.
- Previously, the condition `!("agentId" in job)` would fail when `agentId: undefined` was passed (e.g., from CLI), because the key existed but the value was undefined.
- The fix changes the condition to check for a valid string value, while preserving the special case of `agentId: null` (user explicitly wants no agent).

## Background

This fix addresses a design issue reported by the community:

> Sub-agents should have their `agentId` automatically set when creating scheduled tasks (cron jobs), rather than leaving it empty or requiring explicit specification.

## Test plan

- [x] Added 2 new test cases for auto-fill scenarios
- [x] All 35 tests pass
- [x] Existing tests for `agentId: null` preservation still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)