### PR TITLE
feat(write): add append mode to prevent silent data loss

### DIFF
--- a/src/agents/pi-tools.read.ts
+++ b/src/agents/pi-tools.read.ts
@@ -634,11 +634,212 @@ export function createSandboxedReadTool(params: SandboxToolParams) {
   });
 }
 
+/**
+ * Wraps a write tool to reject `append: true` in sandboxed sessions.
+ * The sandbox write path doesn't support append; returning an explicit error
+ * prevents the silent-overwrite footgun that byungsker flagged in PR #40574.
+ */
+function wrapWriteToolAppendGuard(tool: AnyAgentTool): AnyAgentTool {
+  const schema =
+    tool.parameters && typeof tool.parameters === "object"
+      ? {
+          ...tool.parameters,
+          properties: {
+            ...((tool.parameters as Record<string, unknown>).properties as Record<string, unknown>),
+            append: {
+              type: "boolean",
+              description:
+                "When true, request append mode instead of overwrite mode. " +
+                "Sandboxed sessions reject append with an explicit error.",
+            },
+          },
+        }
+      : tool.parameters;
+  return {
+    ...tool,
+    parameters: schema,
+    execute: async (toolCallId, args, signal, onUpdate) => {
+      const record = getToolParamsRecord(args);
+      if (record?.append === undefined || record.append === false) {
+        return tool.execute(toolCallId, args, signal, onUpdate);
+      }
+      if (record.append !== true) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Error: `append` must be a boolean when provided.",
+            },
+          ],
+          details: {
+            status: "error",
+            error: "append must be a boolean when provided",
+          },
+        } as AgentToolResult<unknown>;
+      }
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: "Error: append mode is not supported in sandboxed sessions. Use the default overwrite mode, or break content into separate writes.",
+          },
+        ],
+        details: {
+          status: "error",
+          error: "append mode is not supported in sandboxed sessions",
+        },
+      } as AgentToolResult<unknown>;
+    },
+  };
+}
+
+/**
+ * Wraps a host write tool to support `append: true`.
+ * When append is true, content is appended via `fs.appendFile` instead of
+ * overwriting. This reduces the window for silent data loss when multiple
+ * sessions write to the same file.
+ *
+ * Note: `fs.appendFile` reduces contention but is not fully atomic — two
+ * concurrent appenders may interleave on some filesystems. Callers should
+ * not rely on strict ordering guarantees.
+ */
+function wrapWriteToolWithAppendMode(
+  tool: AnyAgentTool,
+  root: string,
+  options?: { workspaceOnly?: boolean },
+): AnyAgentTool {
+  const schema =
+    tool.parameters && typeof tool.parameters === "object"
+      ? {
+          ...tool.parameters,
+          properties: {
+            ...((tool.parameters as Record<string, unknown>).properties as Record<string, unknown>),
+            append: {
+              type: "boolean",
+              description:
+                "When true, content is appended to the file instead of overwriting it. " +
+                "Useful for log files, memory files, and other append-only content.",
+            },
+          },
+        }
+      : tool.parameters;
+
+  return {
+    ...tool,
+    parameters: schema,
+    execute: async (toolCallId, args, signal, onUpdate) => {
+      const record = getToolParamsRecord(args);
+
+      if (record?.append === undefined || record.append === false) {
+        return tool.execute(toolCallId, args, signal, onUpdate);
+      }
+
+      if (record.append !== true) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Error: `append` must be a boolean when provided.",
+            },
+          ],
+          details: {
+            status: "error",
+            error: "append must be a boolean when provided",
+          },
+        } as AgentToolResult<unknown>;
+      }
+
+      // Extract path and content
+      const filePath =
+        typeof record.path === "string"
+          ? record.path
+          : typeof record.file_path === "string"
+            ? record.file_path
+            : typeof record.filePath === "string"
+              ? record.filePath
+              : typeof record.file === "string"
+                ? record.file
+                : undefined;
+      const content = typeof record.content === "string" ? record.content : undefined;
+
+      if (!filePath || content === undefined) {
+        return tool.execute(toolCallId, args, signal, onUpdate);
+      }
+
+      const workspaceOnly = options?.workspaceOnly ?? false;
+      const safePath = workspaceOnly
+        ? toRelativeWorkspacePath(root, filePath)
+        : path.basename(filePath);
+      const resolvedPath = workspaceOnly
+        ? path.resolve(root, safePath)
+        : resolveToolPathAgainstWorkspaceRoot({ filePath, root });
+
+      try {
+        if (workspaceOnly) {
+          const relativePath = safePath;
+          await appendFileWithinRoot({
+            rootDir: root,
+            relativePath,
+            data: content,
+            mkdir: true,
+            prependNewlineIfNeeded: true,
+          });
+        } else {
+          await fs.mkdir(path.dirname(resolvedPath), { recursive: true });
+          // Use a single file descriptor for the stat check + append to avoid
+          // TOCTOU races and symlink-following between separate operations.
+          const handle = await fs.open(resolvedPath, "a+");
+          try {
+            let prefix = "";
+            const stat = await handle.stat();
+            if (stat.size > 0 && !content.startsWith("\n")) {
+              const lastByte = Buffer.alloc(1);
+              const { bytesRead } = await handle.read(lastByte, 0, 1, stat.size - 1);
+              if (bytesRead === 1 && lastByte[0] !== 0x0a) {
+                prefix = "\n";
+              }
+            }
+            await handle.appendFile(`${prefix}${content}`, "utf8");
+          } finally {
+            await handle.close();
+          }
+        }
+      } catch (error) {
+        sanitizeWriteToolAppendModeError(error, resolvedPath, safePath);
+        throw error;
+      }
+
+      // Use relative path in response to avoid leaking host filesystem layout
+      return {
+        content: [{ type: "text" as const, text: `Appended content to ${safePath}.` }],
+        details: undefined,
+      } as AgentToolResult<unknown>;
+    },
+  };
+}
+
+function sanitizeWriteToolAppendModeError(error: unknown, resolvedPath: string, safePath: string) {
+  if (!(error instanceof Error) || typeof error.message !== "string") {
+    return;
+  }
+  const replacements = [
+    [resolvedPath, safePath],
+    [path.dirname(resolvedPath), path.dirname(safePath)],
+  ] as const;
+  for (const [absoluteValue, safeValue] of replacements) {
+    if (!absoluteValue || !error.message.includes(absoluteValue)) {
+      continue;
+    }
+    error.message = error.message.split(absoluteValue).join(safeValue || ".");
+  }
+}
+
 export function createSandboxedWriteTool(params: SandboxToolParams) {
   const base = createWriteTool(params.root, {
     operations: createSandboxWriteOperations(params),
   }) as unknown as AnyAgentTool;
-  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
+  const validated = wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
+  return wrapWriteToolAppendGuard(validated);
 }
 
 export function createSandboxedEditTool(params: SandboxToolParams) {
@@ -657,7 +858,8 @@ export function createHostWorkspaceWriteTool(root: string, options?: { workspace
   const base = createWriteTool(root, {
     operations: createHostWriteOperations(root, options),
   }) as unknown as AnyAgentTool;
-  return wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
+  const validated = wrapToolParamValidation(base, REQUIRED_PARAM_GROUPS.write);
+  return wrapWriteToolWithAppendMode(validated, root, options);
 }
 
 export function createHostWorkspaceEditTool(root: string, options?: { workspaceOnly?: boolean }) {

--- a/src/agents/pi-tools.write-append-mode.test.ts
+++ b/src/agents/pi-tools.write-append-mode.test.ts
@@ -1,0 +1,149 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createHostWorkspaceWriteTool, createSandboxedWriteTool } from "./pi-tools.read.js";
+
+describe("write tool append mode", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "write-append-test-"));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("host workspace write tool", () => {
+    it("overwrites by default", async () => {
+      const tool = createHostWorkspaceWriteTool(tmpDir);
+      const filePath = path.join(tmpDir, "test.txt");
+
+      await tool.execute("call-1", { path: "test.txt", content: "first" }, undefined as never);
+      await tool.execute("call-2", { path: "test.txt", content: "second" }, undefined as never);
+
+      const content = await fs.readFile(filePath, "utf-8");
+      expect(content).toBe("second");
+    });
+
+    it("appends when append=true", async () => {
+      const tool = createHostWorkspaceWriteTool(tmpDir);
+      const filePath = path.join(tmpDir, "test.txt");
+
+      await tool.execute(
+        "call-1",
+        { path: "test.txt", content: "first", append: true },
+        undefined as never,
+      );
+      await tool.execute(
+        "call-2",
+        { path: "test.txt", content: "second", append: true },
+        undefined as never,
+      );
+
+      const content = await fs.readFile(filePath, "utf-8");
+      expect(content).toBe("first\nsecond");
+    });
+
+    it("creates parent directories when appending", async () => {
+      const tool = createHostWorkspaceWriteTool(tmpDir);
+
+      await tool.execute(
+        "call-1",
+        { path: "sub/dir/test.txt", content: "hello", append: true },
+        undefined as never,
+      );
+
+      const content = await fs.readFile(path.join(tmpDir, "sub/dir/test.txt"), "utf-8");
+      expect(content).toBe("hello");
+    });
+
+    it("redacts absolute host paths from append failures", async () => {
+      const tool = createHostWorkspaceWriteTool(tmpDir);
+      const relativePath = "nested/test.txt";
+      const absolutePath = path.join(tmpDir, relativePath);
+
+      vi.spyOn(fs, "open").mockRejectedValueOnce(
+        new Error(`EACCES: permission denied, open '${absolutePath}'`),
+      );
+
+      let thrown: unknown;
+      try {
+        await tool.execute(
+          "call-1",
+          { path: relativePath, content: "hello", append: true },
+          undefined as never,
+        );
+      } catch (error) {
+        thrown = error;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect((thrown as Error).message).toContain(path.basename(relativePath));
+      expect((thrown as Error).message).not.toContain(absolutePath);
+      expect((thrown as Error).message).not.toContain(tmpDir);
+    });
+
+    it("includes append in schema", () => {
+      const tool = createHostWorkspaceWriteTool(tmpDir);
+      const schema = tool.parameters as Record<string, unknown>;
+      const props = schema.properties as Record<string, unknown>;
+      expect(props.append).toBeDefined();
+      expect((props.append as Record<string, unknown>).type).toBe("boolean");
+    });
+  });
+
+  describe("sandboxed write tool", () => {
+    it("returns error when append=true is used", async () => {
+      // Create a minimal mock sandbox bridge
+      const mockBridge = {
+        readFile: async () => Buffer.from(""),
+        writeFile: async () => {},
+        mkdirp: async () => {},
+        stat: async () => ({ size: 0, isFile: true, isDirectory: false }),
+      } as unknown as Parameters<typeof createSandboxedWriteTool>[0]["bridge"];
+
+      const tool = createSandboxedWriteTool({
+        root: tmpDir,
+        bridge: mockBridge,
+      });
+
+      const result = await tool.execute(
+        "call-1",
+        { path: "test.txt", content: "hello", append: true },
+        undefined as never,
+      );
+
+      const textContent = result.content.find((c: { type: string }) => c.type === "text") as
+        | { type: "text"; text: string }
+        | undefined;
+      expect(textContent?.text).toContain("not supported in sandboxed sessions");
+    });
+
+    it("works normally without append", async () => {
+      let writtenPath = "";
+      let writtenData = "";
+      const mockBridge = {
+        readFile: async () => Buffer.from(""),
+        writeFile: async ({ filePath, data }: { filePath: string; data: string }) => {
+          writtenPath = filePath;
+          writtenData = data;
+        },
+        mkdirp: async () => {},
+        stat: async () => null,
+      } as unknown as Parameters<typeof createSandboxedWriteTool>[0]["bridge"];
+
+      const tool = createSandboxedWriteTool({
+        root: tmpDir,
+        bridge: mockBridge,
+      });
+
+      await tool.execute("call-1", { path: "test.txt", content: "hello" }, undefined as never);
+
+      // Should have written normally through the bridge
+      expect(writtenPath || writtenData).toBeTruthy();
+    });
+  });
+});

--- a/src/agents/pi-tools.write-append-mode.test.ts
+++ b/src/agents/pi-tools.write-append-mode.test.ts
@@ -93,6 +93,24 @@ describe("write tool append mode", () => {
       expect(props.append).toBeDefined();
       expect((props.append as Record<string, unknown>).type).toBe("boolean");
     });
+
+    it("normalizes the file alias before appending", async () => {
+      const tool = createHostWorkspaceWriteTool(tmpDir);
+
+      await tool.execute(
+        "call-1",
+        { file: "alias.txt", content: "first", append: true },
+        undefined as never,
+      );
+      await tool.execute(
+        "call-2",
+        { file: "alias.txt", content: "second", append: true },
+        undefined as never,
+      );
+
+      const content = await fs.readFile(path.join(tmpDir, "alias.txt"), "utf-8");
+      expect(content).toBe("first\nsecond");
+    });
   });
 
   describe("sandboxed write tool", () => {
@@ -120,6 +138,56 @@ describe("write tool append mode", () => {
         | { type: "text"; text: string }
         | undefined;
       expect(textContent?.text).toContain("not supported in sandboxed sessions");
+      expect((result.details as { status?: string } | undefined)?.status).toBe("error");
+    });
+
+    it("includes append in the sandbox schema before rejecting it", () => {
+      const mockBridge = {
+        readFile: async () => Buffer.from(""),
+        writeFile: async () => {},
+        mkdirp: async () => {},
+        stat: async () => ({ size: 0, isFile: true, isDirectory: false }),
+      } as unknown as Parameters<typeof createSandboxedWriteTool>[0]["bridge"];
+
+      const tool = createSandboxedWriteTool({
+        root: tmpDir,
+        bridge: mockBridge,
+      });
+
+      const schema = tool.parameters as Record<string, unknown>;
+      const props = schema.properties as Record<string, unknown>;
+      expect(props.append).toBeDefined();
+      expect((props.append as Record<string, unknown>).type).toBe("boolean");
+    });
+
+    it("rejects malformed append flags instead of overwriting", async () => {
+      let writes = 0;
+      const mockBridge = {
+        readFile: async () => Buffer.from(""),
+        writeFile: async () => {
+          writes += 1;
+        },
+        mkdirp: async () => {},
+        stat: async () => ({ size: 0, isFile: true, isDirectory: false }),
+      } as unknown as Parameters<typeof createSandboxedWriteTool>[0]["bridge"];
+
+      const tool = createSandboxedWriteTool({
+        root: tmpDir,
+        bridge: mockBridge,
+      });
+
+      const result = await tool.execute(
+        "call-1",
+        { path: "test.txt", content: "hello", append: "true" },
+        undefined as never,
+      );
+
+      const textContent = result.content.find((c: { type: string }) => c.type === "text") as
+        | { type: "text"; text: string }
+        | undefined;
+      expect(textContent?.text).toContain("must be a boolean");
+      expect((result.details as { status?: string } | undefined)?.status).toBe("error");
+      expect(writes).toBe(0);
     });
 
     it("works normally without append", async () => {


### PR DESCRIPTION
## Problem

The Write tool only supports full overwrite. When multiple isolated sessions (for example cron jobs) write to the same file concurrently, the last write wins and earlier content can be lost.

## Solution

Add an optional `append: boolean` parameter to the Write tool. When `append=true`, content is appended via `fs.appendFile` instead of overwriting.

### Implementation

- **`wrapWriteToolWithAppendMode`**: Wraps host write tools to intercept `append=true`, extending the tool schema and routing to `appendFileWithinRoot` (workspace-only mode) or `fs.appendFile` (unrestricted mode). Prepends a newline separator when the existing file does not end with one.

- **`wrapWriteToolAppendGuard`**: Wraps sandboxed write tools to return an explicit error when `append=true` is used, preventing the silent-overwrite footgun where the parameter would be silently ignored.

### Review feedback addressed

1. **Sandboxed sessions no longer silently swallow `append: true`** (byungsker): The sandbox write path now returns a clear error message when `append=true` is detected, so the model knows the parameter is unsupported rather than having the file silently overwritten.

2. **Atomicity clarification** (byungsker): `fs.appendFile` *reduces* the contention window but is not fully atomic — two concurrent appenders may interleave bytes on some filesystems (particularly on Linux without `O_APPEND` mutual exclusion). Callers should not build hard ordering dependencies on it. This is documented in the code comments.

## Tests

- Host append mode: verifies overwrite by default, append when `append=true`, parent directory creation, and schema extension.
- Sandbox guard: verifies `append=true` returns an error, normal writes work unchanged.