### PR TITLE
docs(zh-CN): fix Lark link format in Feishu documentation

### DIFF
--- a/docs/zh-CN/channels/feishu.md
+++ b/docs/zh-CN/channels/feishu.md
@@ -71,7 +71,7 @@ openclaw channels add
 
 访问 [飞书开放平台](https://open.feishu.cn/app)，使用飞书账号登录。
 
-Lark（国际版）请使用 https://open.larksuite.com/app，并在配置中设置 `domain: "lark"`。
+Lark（国际版）请使用 [https://open.larksuite.com/app](https://open.larksuite.com/app)，并在配置中设置 `domain: "lark"`。
 
 ### 2. 创建应用
 


### PR DESCRIPTION
## Summary

- Problem: In the Chinese Feishu documentation, the Lark (international version) URL incorrectly included Chinese text "，并在配置中设置" as part of the markdown hyperlink
- Why it matters: This creates a broken/malformed link that includes configuration instruction text in the URL itself
- What changed: Fixed markdown link formatting to properly separate the URL from the configuration instruction text
- What did NOT change: No functional changes, only documentation formatting

## Change Type (select all)

- [x] Docs

## Scope (select all touched areas)

- [x] UI / DX

## Linked Issue/PR

- Fixes: N/A (documentation formatting issue discovered during review)

## User-visible / Behavior Changes

The Lark URL in the Chinese Feishu documentation now displays as a proper clickable link, with the configuration instruction text appearing after the link instead of being part of it.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: Linux (WSL2)
- Documentation: Mintlify-based docs at docs.openclaw.ai

### Steps

1. Visit https://docs.openclaw.ai/zh-CN/channels/feishu
2. Scroll to "第一步：创建飞书应用" section
3. Look at the Lark (国际版) line (line 74 in source)
4. Observe the malformed link that includes Chinese text in the URL

### Expected

The Lark URL should be a proper markdown link: `[https://open.larksuite.com/app](https://open.larksuite.com/app)`

### Actual (before fix)

The line was: `Lark（国际版）请使用 https://open.larksuite.com/app，并在配置中设置 \`domain: "lark"\`。`
This rendered as plain text with the configuration instruction appearing to be part of the URL.

## Evidence

- [x] Screenshot before fix (showing malformed link on live docs)
- [x] Screenshot after fix (showing proper link formatting)
- [x] All checks passed: `pnpm check` (format, lint, tsgo)

Screenshots attached to PR.

## Human Verification (required)

What I personally verified:
- Verified the exact line in the source file that had the formatting issue
- Verified the fix renders correctly as a proper markdown link
- Verified all project checks pass (pnpm check: format, lint, tsgo)
- Verified no other similar issues exist in the same file

Edge cases checked:
- Confirmed only this one line needed fixing in the Chinese Feishu docs
- Confirmed the English version already has correct formatting

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Simply revert the commit
- Files/config to restore: `docs/zh-CN/channels/feishu.md` line 74
- Known bad symptoms: None expected (pure documentation formatting fix)

## Risks and Mitigations

None. This is a pure documentation formatting fix with no functional changes.

---

## AI-Assisted PR Notice

- [x] This PR was created with AI assistance (Claude Code)
- [x] Testing: Fully tested (all checks passed, manual verification completed)
- [x] I understand what the code does: Yes, simple markdown link formatting fix
- [x] I will resolve bot review conversations after addressing them
