### PR TITLE
test(daemon): add regression tests for USERPROFILE-only state dir on Windows

### DIFF
--- a/src/daemon/service-env.test.ts
+++ b/src/daemon/service-env.test.ts
@@ -493,4 +493,28 @@ describe("resolveGatewayStateDir", () => {
     const env = { OPENCLAW_STATE_DIR: "C:\\State\\openclaw" };
     expect(resolveGatewayStateDir(env)).toBe("C:\\State\\openclaw");
   });
+
+  it("uses USERPROFILE when HOME is absent (Windows-style env)", () => {
+    // Regression test for #40563: on Windows, HOME is often unset while USERPROFILE
+    // holds the user home dir. Ensure the state dir is resolved via path.join so a
+    // backslash separator appears between the home and .openclaw (not direct concat).
+    const env = { USERPROFILE: "C:\\Users\\alice" };
+    const resolved = resolveGatewayStateDir(env);
+    // path.join on Windows: C:\Users\alice\.openclaw
+    // path.join on macOS/Linux (CI): C:\Users\alice/.openclaw (still no concat bug)
+    expect(resolved).toBe(path.join("C:\\Users\\alice", ".openclaw"));
+    // Safety check: never regress to string concatenation without separator.
+    expect(resolved).not.toBe("C:\\Users\\alice.openclaw");
+    expect(resolved).not.toContain("alice.openclaw");
+  });
+
+  it("uses USERPROFILE with a numeric username (Windows edge case)", () => {
+    // Numeric/short usernames on Windows hit the same path but are worth testing
+    // explicitly because path.join must not collapse the separator.
+    const env = { USERPROFILE: "C:\\Users\\42" };
+    const resolved = resolveGatewayStateDir(env);
+    expect(resolved).toBe(path.join("C:\\Users\\42", ".openclaw"));
+    expect(resolved).not.toBe("C:\\Users\\42.openclaw");
+    expect(resolved).not.toContain("42.openclaw");
+  });
 });


### PR DESCRIPTION
Adds two regression tests for `resolveGatewayStateDir` for the scenario reported in #40563, where on Windows the state dir resolves to `C:\Users\alice.openclaw` (missing backslash) instead of `C:\Users\alice\.openclaw`.

The tests cover:
1. Normal alphabetic username with only `USERPROFILE` set (no `HOME`)
2. Short/numeric username (`42`) — the specific trigger mentioned in the issue

Both tests assert the resolved path does not contain the concatenated form (e.g. `alice.openclaw`) that would indicate a missing separator.

I traced through `resolveGatewayStateDir` → `resolveHomeDir` → `path.join(home, '.openclaw')` and all uses of `path.join` are correct. These tests pin the expected behavior so any future refactor that accidentally introduces string concatenation here will fail loudly on CI.

---
AI-assisted (Claude). Fully tested and reviewed.