### PR TITLE
fix(feishu): improve bitable placeholder row cleanup to handle non-empty default values

### DIFF
--- a/extensions/feishu/src/bitable.test.ts
+++ b/extensions/feishu/src/bitable.test.ts
@@ -1,0 +1,131 @@
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/feishu";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerFeishuBitableTools } from "./bitable.js";
+import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
+
+const createFeishuClientMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./client.js", () => ({
+  createFeishuClient: createFeishuClientMock,
+}));
+
+function createConfig(): OpenClawPluginApi["config"] {
+  return {
+    channels: {
+      feishu: {
+        enabled: true,
+        appId: "app_id",
+        appSecret: "app_secret", // pragma: allowlist secret
+      },
+    },
+  } as OpenClawPluginApi["config"];
+}
+
+function createBitableClient(
+  records: Array<{ record_id?: string; fields?: Record<string, unknown> }>,
+) {
+  return {
+    bitable: {
+      app: {
+        create: vi.fn().mockResolvedValue({
+          code: 0,
+          data: {
+            app: {
+              app_token: "app_token_1",
+              name: "Cleanup test",
+              url: "https://example.feishu.cn/base/app_token_1",
+            },
+          },
+        }),
+      },
+      appTable: {
+        list: vi.fn().mockResolvedValue({
+          code: 0,
+          data: { items: [{ table_id: "tbl_1", name: "Table 1" }] },
+        }),
+      },
+      appTableField: {
+        list: vi.fn().mockResolvedValue({
+          code: 0,
+          data: { items: [] },
+        }),
+        update: vi.fn().mockResolvedValue({ code: 0 }),
+        delete: vi.fn().mockResolvedValue({ code: 0 }),
+      },
+      appTableRecord: {
+        list: vi.fn().mockResolvedValue({
+          code: 0,
+          data: { items: records },
+        }),
+        batchDelete: vi.fn().mockResolvedValue({ code: 0 }),
+        delete: vi.fn().mockResolvedValue({ code: 0 }),
+      },
+    },
+  };
+}
+
+describe("feishu bitable create app cleanup", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("deletes placeholder rows with present-but-empty values without deleting meaningful rows", async () => {
+    const client = createBitableClient([
+      { record_id: "rec_empty_string", fields: { Text: "" } },
+      { record_id: "rec_null", fields: { Text: null } },
+      { record_id: "rec_empty_array", fields: { Multi: [] } },
+      {
+        record_id: "rec_empty_rich_text",
+        fields: { RichText: [{ type: "text", text: "" }] },
+      },
+      {
+        record_id: "rec_empty_nested",
+        fields: { Nested: { value: "", detail: null, segments: [{ type: "text", text: "" }] } },
+      },
+      { record_id: "rec_no_fields", fields: {} },
+      { record_id: "rec_missing_fields" },
+      { record_id: "rec_text", fields: { Text: "keep me" } },
+      { record_id: "rec_zero", fields: { Number: 0 } },
+      { record_id: "rec_false", fields: { Checkbox: false } },
+      { record_id: "rec_url", fields: { URL: { text: "", link: "https://example.com" } } },
+      {
+        record_id: "rec_attachment",
+        fields: { Attachment: [{ file_token: "boxcn_token", name: "" }] },
+      },
+      { record_id: "rec_user", fields: { User: [{ id: "ou_1", name: "" }] } },
+      {
+        record_id: "rec_location",
+        fields: { Location: { name: "", full_address: "", location: "116,39" } },
+      },
+      {
+        record_id: "rec_rich_link",
+        fields: { RichText: [{ type: "text", text: "", link: "https://example.com" }] },
+      },
+    ]);
+    createFeishuClientMock.mockReturnValue(client);
+
+    const { api, resolveTool } = createToolFactoryHarness(createConfig());
+    registerFeishuBitableTools(api);
+
+    const result = (await resolveTool("feishu_bitable_create_app").execute("call_1", {
+      name: "Cleanup test",
+    })) as { details: { cleaned_placeholder_rows: number } };
+
+    expect(result.details.cleaned_placeholder_rows).toBe(7);
+    expect(client.bitable.appTableRecord.batchDelete).toHaveBeenCalledWith({
+      path: { app_token: "app_token_1", table_id: "tbl_1" },
+      data: {
+        records: [
+          "rec_empty_string",
+          "rec_null",
+          "rec_empty_array",
+          "rec_empty_rich_text",
+          "rec_empty_nested",
+          "rec_no_fields",
+          "rec_missing_fields",
+        ],
+      },
+    });
+    expect(client.bitable.appTableRecord.delete).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -304,8 +304,29 @@ async function cleanupNewBitable(
   });
 
   if (recordsRes.code === 0 && recordsRes.data?.items) {
+    const isEmptyValue = (v: unknown): boolean => {
+      if (v === null || v === undefined || v === "") return true;
+      if (Array.isArray(v)) {
+        return v.length === 0 || v.every((item) => isEmptyValue(item));
+      }
+      if (typeof v === "object") {
+        const obj = v as Record<string, unknown>;
+        // Rich text fields: [{type:'text', text:''}]
+        if ("text" in obj && Object.keys(obj).length <= 2) {
+          return obj.text === "" || obj.text === null || obj.text === undefined;
+        }
+        return Object.values(obj).every((val) => isEmptyValue(val));
+      }
+      return false;
+    };
+
     const emptyRecordIds = recordsRes.data.items
-      .filter((r) => !r.fields || Object.keys(r.fields).length === 0)
+      .filter((r) => {
+        if (!r.fields) return true;
+        const keys = Object.keys(r.fields);
+        if (keys.length === 0) return true;
+        return Object.values(r.fields).every((v) => isEmptyValue(v));
+      })
       .map((r) => r.record_id)
       .filter((id): id is string => Boolean(id));
 
@@ -354,7 +375,7 @@ async function createApp(
     throw new Error("Failed to create Bitable: no app_token returned");
   }
 
-  const log: CleanupLogger = logger ?? { debug: () => {}, warn: () => {} };
+  const log: CleanupLogger = logger ?? { debug: () => { }, warn: () => { } };
   let tableId: string | undefined;
   let cleanedRows = 0;
   let cleanedFields = 0;

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -313,7 +313,10 @@ async function cleanupNewBitable(
         const obj = v as Record<string, unknown>;
         // Rich text fields: [{type:'text', text:''}]
         if ("text" in obj && Object.keys(obj).length <= 2) {
-          return obj.text === "" || obj.text === null || obj.text === undefined;
+          const otherKeys = Object.keys(obj).filter((k) => k !== "text");
+          if (otherKeys.length === 0 || otherKeys[0] === "type") {
+            return obj.text === "" || obj.text === null || obj.text === undefined;
+          }
         }
         return Object.values(obj).every((val) => isEmptyValue(val));
       }


### PR DESCRIPTION
## Problem

When creating a new Bitable via `feishu_bitable_create_app`, Feishu automatically generates ~10 placeholder rows. The existing `cleanupNewBitable` logic attempts to remove these, but the filter condition only matches records with **zero fields** (`Object.keys(r.fields).length === 0`).

In practice, Feishu's placeholder rows contain fields with **default empty values** (empty strings, null, empty arrays, rich-text objects with empty text). Since they have fields present, the cleanup never matches them, and the API returns `cleaned_placeholder_rows: 0`.

## Solution

Added a recursive `isEmptyValue` helper that checks whether field values are substantively empty:

- `null`, `undefined`, `````  -> empty
- Empty arrays or arrays of all-empty items -> empty
- Objects with only empty `text` property (rich-text fields) -> empty
- Objects where all values are empty -> empty

The record filter now uses this helper to detect and remove placeholder rows whose fields exist but contain only default empty values.

## Testing

Tested locally against the Feishu API:
- **Before fix**: `cleaned_placeholder_rows: 0` (placeholder rows remained)
- **After fix**: `cleaned_placeholder_rows: 10` (all placeholder rows successfully removed)