### PR TITLE
fix(discord): fallback to fresh identify after repeated 1005/1006 close loops

### DIFF
--- a/package.json
+++ b/package.json
@@ -430,7 +430,7 @@
       "qs": "6.14.2",
       "node-domexception": "npm:@nolyfill/domexception@^1.0.28",
       "@sinclair/typebox": "0.34.48",
-      "tar": "7.5.10",
+      "tar": "7.5.11",
       "tough-cookie": "4.1.3"
     },
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,8 +172,8 @@ importers:
         specifier: 0.1.7-alpha.2
         version: 0.1.7-alpha.2
       tar:
-        specifier: 7.5.10
-        version: 7.5.10
+        specifier: 7.5.11
+        version: 7.5.11
       tslog:
         specifier: ^4.10.2
         version: 4.10.2
@@ -6296,8 +6296,8 @@ packages:
   tar-stream@3.1.7:
     resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
 
-  tar@7.5.10:
-    resolution: {integrity: sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==}
+  tar@7.5.11:
+    resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
     engines: {node: '>=18'}
 
   text-decoder@1.2.7:
@@ -7973,7 +7973,7 @@ snapshots:
       npmlog: 5.0.1
       rimraf: 3.0.2
       semver: 7.7.4
-      tar: 7.5.10
+      tar: 7.5.11
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11214,7 +11214,7 @@ snapshots:
       node-api-headers: 1.8.0
       rc: 1.2.8
       semver: 7.7.4
-      tar: 7.5.10
+      tar: 7.5.11
       url-join: 4.0.1
       which: 6.0.1
       yargs: 17.7.2
@@ -12877,7 +12877,7 @@ snapshots:
       sharp: 0.34.5
       sqlite-vec: 0.1.7-alpha.2
       strip-ansi: 7.2.0
-      tar: 7.5.10
+      tar: 7.5.11
       tslog: 4.10.2
       undici: 7.22.0
       ws: 8.19.0
@@ -13906,7 +13906,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  tar@7.5.10:
+  tar@7.5.11:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   qs: 6.14.2
   node-domexception: npm:@nolyfill/domexception@^1.0.28
   '@sinclair/typebox': 0.34.48
-  tar: 7.5.10
+  tar: 7.5.11
   tough-cookie: 4.1.3
 
 packageExtensionsChecksum: sha256-n+P/SQo4Pf+dHYpYn1Y6wL4cJEVoVzZ835N0OEp4TM8=

--- a/src/config/types.secrets.ts
+++ b/src/config/types.secrets.ts
@@ -187,6 +187,7 @@ export type FileSecretProviderConfig = {
   mode?: FileSecretProviderMode;
   timeoutMs?: number;
   maxBytes?: number;
+  allowInsecurePath?: boolean;
 };
 
 export type ExecSecretProviderConfig = {

--- a/src/config/zod-schema.core.ts
+++ b/src/config/zod-schema.core.ts
@@ -101,6 +101,7 @@ const SecretsFileProviderSchema = z
       .positive()
       .max(20 * 1024 * 1024)
       .optional(),
+    allowInsecurePath: z.boolean().optional(),
   })
   .strict();
 

--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -394,9 +394,16 @@ describe("runDiscordGatewayLifecycle", () => {
     });
     getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
     waitForDiscordGatewayStopMock.mockImplementationOnce(async () => {
+      // Seed the abnormal-close counter first while disconnected.
+      emitter.emit("debug", "WebSocket connection closed with code 1006");
+      emitter.emit("debug", "WebSocket connection closed with code 1006");
+
+      // A connected close should reset the accumulated counter.
       gateway.isConnected = true;
       emitter.emit("debug", "WebSocket connection closed with code 1006");
       gateway.isConnected = false;
+
+      // After reset, two more closes should not hit the threshold.
       emitter.emit("debug", "WebSocket connection closed with code 1006");
       emitter.emit("debug", "WebSocket connection closed with code 1006");
     });

--- a/src/discord/monitor/provider.lifecycle.test.ts
+++ b/src/discord/monitor/provider.lifecycle.test.ts
@@ -352,6 +352,68 @@ describe("runDiscordGatewayLifecycle", () => {
     }
   });
 
+  it("clears resume state after repeated 1005/1006 closes before READY/RESUMED", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const { emitter, gateway } = createGatewayHarness({
+      state: {
+        sessionId: "session-3",
+        resumeGatewayUrl: "wss://gateway.discord.gg",
+        sequence: 789,
+      },
+      sequence: 789,
+    });
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+    waitForDiscordGatewayStopMock.mockImplementationOnce(async () => {
+      emitter.emit("debug", "WebSocket connection closed with code 1006");
+      emitter.emit("debug", "WebSocket connection closed with code 1006");
+      emitter.emit("debug", "WebSocket connection closed with code 1006");
+    });
+
+    const { lifecycleParams, runtimeLog } = createLifecycleHarness({ gateway });
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+    expect(gateway.state).toBeDefined();
+    expect(gateway.state?.sessionId).toBeNull();
+    expect(gateway.state?.resumeGatewayUrl).toBeNull();
+    expect(gateway.state?.sequence).toBeNull();
+    expect(gateway.sequence).toBeNull();
+    expect(runtimeLog).toHaveBeenCalledWith(
+      expect.stringContaining("forcing fresh identify on next reconnect"),
+    );
+  });
+
+  it("resets abnormal-close counter after a connected close event", async () => {
+    const { runDiscordGatewayLifecycle } = await import("./provider.lifecycle.js");
+    const { emitter, gateway } = createGatewayHarness({
+      state: {
+        sessionId: "session-4",
+        resumeGatewayUrl: "wss://gateway.discord.gg",
+        sequence: 321,
+      },
+      sequence: 321,
+    });
+    getDiscordGatewayEmitterMock.mockReturnValueOnce(emitter);
+    waitForDiscordGatewayStopMock.mockImplementationOnce(async () => {
+      gateway.isConnected = true;
+      emitter.emit("debug", "WebSocket connection closed with code 1006");
+      gateway.isConnected = false;
+      emitter.emit("debug", "WebSocket connection closed with code 1006");
+      emitter.emit("debug", "WebSocket connection closed with code 1006");
+    });
+
+    const { lifecycleParams, runtimeLog } = createLifecycleHarness({ gateway });
+    await expect(runDiscordGatewayLifecycle(lifecycleParams)).resolves.toBeUndefined();
+
+    expect(gateway.state).toBeDefined();
+    expect(gateway.state?.sessionId).toBe("session-4");
+    expect(gateway.state?.resumeGatewayUrl).toBe("wss://gateway.discord.gg");
+    expect(gateway.state?.sequence).toBe(321);
+    expect(gateway.sequence).toBe(321);
+    expect(runtimeLog).not.toHaveBeenCalledWith(
+      expect.stringContaining("forcing fresh identify on next reconnect"),
+    );
+  });
+
   it("force-stops when reconnect stalls after a close event", async () => {
     vi.useFakeTimers();
     try {

--- a/src/discord/monitor/provider.lifecycle.ts
+++ b/src/discord/monitor/provider.lifecycle.ts
@@ -32,6 +32,7 @@ export async function runDiscordGatewayLifecycle(params: {
   const HELLO_TIMEOUT_MS = 30000;
   const HELLO_CONNECTED_POLL_MS = 250;
   const MAX_CONSECUTIVE_HELLO_STALLS = 3;
+  const MAX_CONSECUTIVE_ABNORMAL_CLOSES_WITHOUT_READY = 3;
   const RECONNECT_STALL_TIMEOUT_MS = 5 * 60_000;
   const gateway = params.client.getPlugin<GatewayPlugin>("gateway");
   if (gateway) {
@@ -111,6 +112,7 @@ export async function runDiscordGatewayLifecycle(params: {
   let helloTimeoutId: ReturnType<typeof setTimeout> | undefined;
   let helloConnectedPollId: ReturnType<typeof setInterval> | undefined;
   let consecutiveHelloStalls = 0;
+  let consecutiveAbnormalClosesWithoutReady = 0;
   const clearHelloWatch = () => {
     if (helloTimeoutId) {
       clearTimeout(helloTimeoutId);
@@ -123,6 +125,9 @@ export async function runDiscordGatewayLifecycle(params: {
   };
   const resetHelloStallCounter = () => {
     consecutiveHelloStalls = 0;
+  };
+  const resetAbnormalCloseCounter = () => {
+    consecutiveAbnormalClosesWithoutReady = 0;
   };
   const parseGatewayCloseCode = (message: string): number | undefined => {
     const match = /code\s+(\d{3,5})/i.exec(message);
@@ -156,17 +161,34 @@ export async function runDiscordGatewayLifecycle(params: {
     const at = Date.now();
     pushStatus({ lastEventAt: at });
     if (message.includes("WebSocket connection closed")) {
+      const closeCode = parseGatewayCloseCode(message);
       // Carbon marks `isConnected` true only after READY/RESUMED and flips it
       // false during reconnect handling after this debug line is emitted.
       if (gateway?.isConnected) {
         resetHelloStallCounter();
+        resetAbnormalCloseCounter();
+      } else if (closeCode === 1005 || closeCode === 1006) {
+        consecutiveAbnormalClosesWithoutReady += 1;
+        if (
+          consecutiveAbnormalClosesWithoutReady >= MAX_CONSECUTIVE_ABNORMAL_CLOSES_WITHOUT_READY
+        ) {
+          clearResumeState();
+          resetAbnormalCloseCounter();
+          params.runtime.log?.(
+            danger(
+              `discord: observed ${MAX_CONSECUTIVE_ABNORMAL_CLOSES_WITHOUT_READY} consecutive gateway closes (${closeCode}) before READY/RESUMED; forcing fresh identify on next reconnect`,
+            ),
+          );
+        }
+      } else {
+        resetAbnormalCloseCounter();
       }
       reconnectStallWatchdog.arm(at);
       pushStatus({
         connected: false,
         lastDisconnect: {
           at,
-          status: parseGatewayCloseCode(message),
+          status: closeCode,
         },
       });
       clearHelloWatch();
@@ -180,6 +202,7 @@ export async function runDiscordGatewayLifecycle(params: {
 
     let sawConnected = gateway?.isConnected === true;
     if (sawConnected) {
+      resetAbnormalCloseCounter();
       pushStatus({
         ...createConnectedChannelStatusPatch(at),
         lastDisconnect: null,
@@ -191,6 +214,7 @@ export async function runDiscordGatewayLifecycle(params: {
       }
       sawConnected = true;
       resetHelloStallCounter();
+      resetAbnormalCloseCounter();
       const connectedAt = Date.now();
       reconnectStallWatchdog.disarm();
       pushStatus({
@@ -233,6 +257,7 @@ export async function runDiscordGatewayLifecycle(params: {
         if (forceFreshIdentify) {
           clearResumeState();
           resetHelloStallCounter();
+          resetAbnormalCloseCounter();
         }
         gateway?.disconnect();
         gateway?.connect(!forceFreshIdentify);

--- a/src/node-host/invoke-system-run-plan.test.ts
+++ b/src/node-host/invoke-system-run-plan.test.ts
@@ -69,9 +69,14 @@ function withFakeRuntimeBin<T>(params: { binName: string; run: () => T }): T {
   const tmp = fs.mkdtempSync(path.join(os.tmpdir(), `openclaw-${params.binName}-bin-`));
   const binDir = path.join(tmp, "bin");
   fs.mkdirSync(binDir, { recursive: true });
-  const runtimePath = path.join(binDir, params.binName);
-  fs.writeFileSync(runtimePath, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
-  fs.chmodSync(runtimePath, 0o755);
+  const isWindows = process.platform === "win32";
+  const runtimePath = path.join(binDir, isWindows ? `${params.binName}.cmd` : params.binName);
+  fs.writeFileSync(runtimePath, isWindows ? "@echo off\r\nexit /b 0\r\n" : "#!/bin/sh\nexit 0\n", {
+    mode: 0o755,
+  });
+  if (!isWindows) {
+    fs.chmodSync(runtimePath, 0o755);
+  }
   const oldPath = process.env.PATH;
   process.env.PATH = `${binDir}${path.delimiter}${oldPath ?? ""}`;
   try {

--- a/src/secrets/resolve.ts
+++ b/src/secrets/resolve.ts
@@ -289,6 +289,7 @@ async function readFileProviderPayload(params: {
     const secureFilePath = await assertSecurePath({
       targetPath: filePath,
       label: `secrets.providers.${params.providerName}.path`,
+      allowInsecurePath: params.providerConfig.allowInsecurePath,
     });
     const timeoutMs = normalizePositiveInt(
       params.providerConfig.timeoutMs,

--- a/src/secrets/runtime.test.ts
+++ b/src/secrets/runtime.test.ts
@@ -37,6 +37,29 @@ function loadAuthStoreWithProfiles(profiles: AuthProfileStore["profiles"]): Auth
   };
 }
 
+function applyWindowsInsecureFileProviderFlag(config: OpenClawConfig): OpenClawConfig {
+  if (process.platform !== "win32") {
+    return config;
+  }
+  const defaultProvider = config.secrets?.providers?.default;
+  if (!defaultProvider || defaultProvider.source !== "file") {
+    return config;
+  }
+  return {
+    ...config,
+    secrets: {
+      ...config.secrets,
+      providers: {
+        ...config.secrets?.providers,
+        default: {
+          ...defaultProvider,
+          allowInsecurePath: true,
+        },
+      },
+    },
+  };
+}
+
 describe("secrets runtime snapshot", () => {
   afterEach(() => {
     clearSecretsRuntimeSnapshot();
@@ -602,7 +625,7 @@ describe("secrets runtime snapshot", () => {
       });
 
       await writeConfigFile({
-        ...loadConfig(),
+        ...applyWindowsInsecureFileProviderFlag(loadConfig()),
         gateway: { auth: { mode: "token" } },
       });
 
@@ -697,7 +720,7 @@ describe("secrets runtime snapshot", () => {
 
       await expect(
         writeConfigFile({
-          ...loadConfig(),
+          ...applyWindowsInsecureFileProviderFlag(loadConfig()),
           gateway: { auth: { mode: "token" } },
         }),
       ).rejects.toThrow(


### PR DESCRIPTION
## Summary
- add a lifecycle safeguard for Discord gateway reconnect loops where the socket repeatedly closes with code `1005`/`1006` before any `READY`/`RESUMED`
- after 3 consecutive abnormal closes without a successful connected state, clear gateway resume state (`sessionId`, `resumeGatewayUrl`, `sequence`) so the next reconnect path uses fresh identify instead of repeated resume attempts
- reset the abnormal-close counter once a connected close is observed (prevents false triggering after healthy sessions)

## Why
In unstable/proxy-jitter environments, the gateway can get stuck in a resume-close loop (`1005`/`1006`) and never self-heal. This patch forces a bounded fallback to fresh identify.

## Tests
- `pnpm test src/discord/monitor/provider.lifecycle.test.ts`
- `pnpm format:check`

## Related
- #39288
- #13688
