### PR TITLE
fix(agents): inject trigger into requester session after direct completion

### DIFF
--- a/src/agents/subagent-announce-dispatch.test.ts
+++ b/src/agents/subagent-announce-dispatch.test.ts
@@ -69,7 +69,7 @@ describe("runSubagentAnnounceDispatch", () => {
     ]);
   });
 
-  it("uses direct-first ordering for completion mode", async () => {
+  it("uses direct-first ordering for completion mode and still injects trigger", async () => {
     const queue = vi.fn(async () => "queued" as const);
     const direct = vi.fn(async () => ({ delivered: true, path: "direct" as const }));
 
@@ -80,11 +80,53 @@ describe("runSubagentAnnounceDispatch", () => {
     });
 
     expect(direct).toHaveBeenCalledTimes(1);
-    expect(queue).not.toHaveBeenCalled();
+    expect(queue).toHaveBeenCalledTimes(1);
     expect(result.path).toBe("direct");
     expect(result.phases).toEqual([
       { phase: "direct-primary", delivered: true, path: "direct", error: undefined },
+      { phase: "queue-fallback", delivered: true, path: "queued", error: undefined },
     ]);
+  });
+
+  it("still returns direct success when trigger injection fails", async () => {
+    const queue = vi.fn(async () => "none" as const);
+    const direct = vi.fn(async () => ({ delivered: true, path: "direct" as const }));
+
+    const result = await runSubagentAnnounceDispatch({
+      expectsCompletionMessage: true,
+      queue,
+      direct,
+    });
+
+    expect(direct).toHaveBeenCalledTimes(1);
+    expect(queue).toHaveBeenCalledTimes(1);
+    expect(result.delivered).toBe(true);
+    expect(result.path).toBe("direct");
+    expect(result.phases).toEqual([
+      { phase: "direct-primary", delivered: true, path: "direct", error: undefined },
+      { phase: "queue-fallback", delivered: false, path: "none", error: undefined },
+    ]);
+  });
+
+  it("skips trigger injection when signal is aborted after direct delivery", async () => {
+    const controller = new AbortController();
+    const queue = vi.fn(async () => "queued" as const);
+    const direct = vi.fn(async () => {
+      controller.abort();
+      return { delivered: true, path: "direct" as const };
+    });
+
+    const result = await runSubagentAnnounceDispatch({
+      expectsCompletionMessage: true,
+      signal: controller.signal,
+      queue,
+      direct,
+    });
+
+    expect(direct).toHaveBeenCalledTimes(1);
+    expect(queue).not.toHaveBeenCalled();
+    expect(result.delivered).toBe(true);
+    expect(result.path).toBe("direct");
   });
 
   it("falls back to queue when completion direct send fails", async () => {

--- a/src/agents/subagent-announce-dispatch.ts
+++ b/src/agents/subagent-announce-dispatch.ts
@@ -84,6 +84,18 @@ export async function runSubagentAnnounceDispatch(params: {
   const primaryDirect = await params.direct();
   appendPhase("direct-primary", primaryDirect);
   if (primaryDirect.delivered) {
+    // Direct delivery succeeded, but we still need to inject the trigger
+    // message into the requester session so the main agent gets notified.
+    // This is best-effort; ignore failures since the external delivery
+    // already succeeded.
+    if (!params.signal?.aborted) {
+      try {
+        const triggerQueue = mapQueueOutcomeToDeliveryResult(await params.queue());
+        appendPhase("queue-fallback", triggerQueue);
+      } catch {
+        // Best-effort: external delivery already succeeded.
+      }
+    }
     return withPhases(primaryDirect);
   }
 


### PR DESCRIPTION
## Summary

When `expectsCompletionMessage` is `true` and direct delivery succeeds in `runSubagentAnnounceDispatch()`, the function returned early without calling the queue function. This meant the trigger message was never injected into the requester session, so the main agent was not notified of sub-agent completion in group topic sessions.

- After successful direct delivery in completion mode, now also runs the queue function (best-effort) to inject the trigger message into the requester session
- Queue failure does not affect the overall delivery result (direct already succeeded)
- Respects abort signal: skips trigger injection if signal is aborted after direct delivery

## Test plan

- [x] Updated `subagent-announce-dispatch.test.ts` with three new test cases:
  - Verifies queue is called after successful direct delivery in completion mode
  - Verifies direct success is preserved even when trigger injection returns "none"
  - Verifies trigger injection is skipped when signal is aborted after direct delivery
- [x] All 11 dispatch tests pass
- [x] Full test suite passes (869/870, 1 pre-existing failure in unrelated `delivery-dispatch.test.ts`)
- [x] `pnpm build` succeeds
- [x] `pnpm check` passes (pre-existing tlon extension TS errors only)

Fixes #40605