### PR TITLE
fix: strip consecutive assistant error entries to prevent session poi…

### DIFF
--- a/docs/reference/transcript-hygiene.md
+++ b/docs/reference/transcript-hygiene.md
@@ -21,6 +21,7 @@ Scope includes:
 - Tool call id sanitization
 - Tool call input validation
 - Tool result pairing repair
+- Consecutive assistant-error collapsing
 - Turn validation / ordering
 - Thought signature cleanup
 - Image payload sanitization
@@ -77,6 +78,20 @@ Implementation:
 
 ---
 
+## Global rule: consecutive assistant errors
+
+Consecutive assistant messages with `stopReason: "error"` are collapsed to the
+last entry in each run before model context is built. This prevents retry storms
+and transient provider outages from poisoning the stored session history with
+same-role error turns that later violate provider alternation rules.
+
+Implementation:
+
+- `stripConsecutiveAssistantErrors` in `src/agents/pi-embedded-runner/google.ts`
+- Applied in `sanitizeSessionHistory` in `src/agents/pi-embedded-runner/google.ts`
+
+---
+
 ## Global rule: inter-session input provenance
 
 When an agent sends a prompt into another session via `sessions_send` (including
@@ -96,9 +111,12 @@ external end-user instructions.
 
 ## Provider matrix (current behavior)
 
+All providers also receive the global rules above. The matrix below lists the
+additional provider-specific behavior layered on top of those global rules.
+
 **OpenAI / OpenAI Codex**
 
-- Image sanitization only.
+- Apply the global rules above.
 - Drop orphaned reasoning signatures (standalone reasoning items without a following content block) for OpenAI Responses/Codex transcripts.
 - No tool call id sanitization.
 - No tool result pairing repair.
@@ -129,7 +147,7 @@ external end-user instructions.
 
 **Everything else**
 
-- Image sanitization only.
+- No additional provider-specific hygiene beyond the global rules above.
 
 ---
 

--- a/src/agents/pi-embedded-runner.strip-consecutive-assistant-errors.test.ts
+++ b/src/agents/pi-embedded-runner.strip-consecutive-assistant-errors.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { stripConsecutiveAssistantErrors } from "./pi-embedded-runner/google.js";
+import {
+  castAgentMessages,
+  makeAgentAssistantMessage,
+  makeAgentUserMessage,
+} from "./test-helpers/agent-message-fixtures.js";
+
+describe("stripConsecutiveAssistantErrors", () => {
+  const makeErrorAssistant = (errorMessage = "Connection error.") =>
+    makeAgentAssistantMessage({
+      content: [],
+      stopReason: "error",
+      errorMessage,
+    });
+
+  const makeOkAssistant = (text = "Hello") =>
+    makeAgentAssistantMessage({
+      content: [{ type: "text", text }],
+      stopReason: "stop",
+    });
+
+  const makeUser = (content = "hi") => makeAgentUserMessage({ content });
+
+  it("returns empty array unchanged", () => {
+    expect(stripConsecutiveAssistantErrors([])).toEqual([]);
+  });
+
+  it("returns single message unchanged", () => {
+    const msgs = castAgentMessages([makeUser()]);
+    expect(stripConsecutiveAssistantErrors(msgs)).toEqual(msgs);
+  });
+
+  it("does not touch messages without errors", () => {
+    const msgs = castAgentMessages([makeUser(), makeOkAssistant(), makeUser("bye")]);
+    expect(stripConsecutiveAssistantErrors(msgs)).toEqual(msgs);
+  });
+
+  it("keeps a single error entry untouched", () => {
+    const msgs = castAgentMessages([makeUser(), makeErrorAssistant()]);
+    expect(stripConsecutiveAssistantErrors(msgs)).toEqual(msgs);
+  });
+
+  it("collapses two consecutive error entries into the last one", () => {
+    const err1 = makeErrorAssistant("first error");
+    const err2 = makeErrorAssistant("second error");
+    const msgs = castAgentMessages([makeUser(), err1, err2]);
+    const result = stripConsecutiveAssistantErrors(msgs);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(msgs[0]); // user message preserved
+    expect(result[1]).toBe(msgs[2]); // last error kept
+  });
+
+  it("collapses three consecutive error entries into the last one", () => {
+    const err1 = makeErrorAssistant("error 1");
+    const err2 = makeErrorAssistant("error 2");
+    const err3 = makeErrorAssistant("error 3");
+    const msgs = castAgentMessages([makeUser(), err1, err2, err3]);
+    const result = stripConsecutiveAssistantErrors(msgs);
+    expect(result).toHaveLength(2);
+    expect(result[1]).toBe(msgs[3]); // last error kept
+  });
+
+  it("preserves non-error assistant between error runs", () => {
+    const err1 = makeErrorAssistant("err A");
+    const err2 = makeErrorAssistant("err B");
+    const ok = makeOkAssistant("success");
+    const err3 = makeErrorAssistant("err C");
+    const err4 = makeErrorAssistant("err D");
+    const msgs = castAgentMessages([makeUser(), err1, err2, ok, err3, err4]);
+    const result = stripConsecutiveAssistantErrors(msgs);
+    // user, err2 (collapsed from err1+err2), ok, err4 (collapsed from err3+err4)
+    expect(result).toHaveLength(4);
+    expect(result[0]).toBe(msgs[0]); // user
+    expect(result[1]).toBe(msgs[2]); // err2 (last of first run)
+    expect(result[2]).toBe(msgs[3]); // ok assistant
+    expect(result[3]).toBe(msgs[5]); // err4 (last of second run)
+  });
+
+  it("preserves user messages between error entries", () => {
+    const err1 = makeErrorAssistant("err 1");
+    const user2 = makeUser("retry");
+    const err2 = makeErrorAssistant("err 2");
+    const msgs = castAgentMessages([makeUser(), err1, user2, err2]);
+    const result = stripConsecutiveAssistantErrors(msgs);
+    // No consecutive errors — all messages preserved
+    expect(result).toEqual(msgs);
+  });
+
+  it("handles session with only error entries", () => {
+    const msgs = castAgentMessages([
+      makeErrorAssistant("e1"),
+      makeErrorAssistant("e2"),
+      makeErrorAssistant("e3"),
+    ]);
+    const result = stripConsecutiveAssistantErrors(msgs);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(msgs[2]); // last one kept
+  });
+
+  it("handles realistic session poisoning scenario", () => {
+    // Simulate: user sends message, 5 consecutive connection errors during retries,
+    // then user sends another message
+    const user1 = makeUser("what is 2+2?");
+    const errors = Array.from({ length: 5 }, (_, i) =>
+      makeErrorAssistant(`Connection error. (attempt ${i + 1})`),
+    );
+    const user2 = makeUser("please try again");
+    const ok = makeOkAssistant("2+2 = 4");
+    const msgs = castAgentMessages([user1, ...errors, user2, ok]);
+    const result = stripConsecutiveAssistantErrors(msgs);
+    // user1, last error, user2, ok
+    expect(result).toHaveLength(4);
+    expect(result[0]).toBe(msgs[0]); // user1
+    expect((result[1] as { errorMessage?: string }).errorMessage).toBe(
+      "Connection error. (attempt 5)",
+    ); // last error
+    expect(result[2]).toBe(msgs[6]); // user2
+    expect(result[3]).toBe(msgs[7]); // ok
+  });
+});

--- a/src/agents/pi-embedded-runner.strip-consecutive-assistant-errors.test.ts
+++ b/src/agents/pi-embedded-runner.strip-consecutive-assistant-errors.test.ts
@@ -1,5 +1,16 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./pi-embedded-runner/logger.js", () => ({
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 import { stripConsecutiveAssistantErrors } from "./pi-embedded-runner/google.js";
+import { log } from "./pi-embedded-runner/logger.js";
 import {
   castAgentMessages,
   makeAgentAssistantMessage,
@@ -7,6 +18,10 @@ import {
 } from "./test-helpers/agent-message-fixtures.js";
 
 describe("stripConsecutiveAssistantErrors", () => {
+  beforeEach(() => {
+    vi.mocked(log.warn).mockReset();
+  });
+
   const makeErrorAssistant = (errorMessage = "Connection error.") =>
     makeAgentAssistantMessage({
       content: [],
@@ -49,6 +64,9 @@ describe("stripConsecutiveAssistantErrors", () => {
     expect(result).toHaveLength(2);
     expect(result[0]).toBe(msgs[0]); // user message preserved
     expect(result[1]).toBe(msgs[2]); // last error kept
+    expect(log.warn).toHaveBeenCalledWith(
+      "stripped 1 consecutive assistant error entry from session history",
+    );
   });
 
   it("collapses three consecutive error entries into the last one", () => {
@@ -59,6 +77,9 @@ describe("stripConsecutiveAssistantErrors", () => {
     const result = stripConsecutiveAssistantErrors(msgs);
     expect(result).toHaveLength(2);
     expect(result[1]).toBe(msgs[3]); // last error kept
+    expect(log.warn).toHaveBeenCalledWith(
+      "stripped 2 consecutive assistant error entries from session history",
+    );
   });
 
   it("preserves non-error assistant between error runs", () => {

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -517,6 +517,59 @@ export function applyGoogleTurnOrderingFix(params: {
   return { messages: sanitized, didPrepend };
 }
 
+/**
+ * Remove consecutive assistant error messages from the session transcript,
+ * keeping only the last error entry in each consecutive run.
+ *
+ * During LLM outages or transient failures, each retry within a single
+ * request can persist a new assistant message with `stopReason: "error"`
+ * to the session JSONL.  When three or more accumulate in a row, the
+ * resulting conversation violates role-alternation rules expected by most
+ * model APIs.  Even providers that tolerate consecutive same-role turns
+ * can choke on the sheer number of error entries or misinterpret them as
+ * part of the useful context.
+ *
+ * The function scans the message array and collapses any run of ≥2
+ * consecutive assistant-error entries into a single entry (the last one
+ * in the run, which carries the most recent error detail).  Non-error
+ * assistant messages and messages with other roles are never touched.
+ *
+ * Complexity: O(n) single pass.
+ */
+export function stripConsecutiveAssistantErrors(messages: AgentMessage[]): AgentMessage[] {
+  if (messages.length < 2) {
+    return messages;
+  }
+  const out: AgentMessage[] = [];
+  let i = 0;
+  while (i < messages.length) {
+    const msg = messages[i] as { role?: string; stopReason?: string };
+    if (msg.role !== "assistant" || msg.stopReason !== "error") {
+      out.push(messages[i]);
+      i += 1;
+      continue;
+    }
+    // Found an assistant error entry — scan for consecutive ones.
+    let runEnd = i + 1;
+    while (runEnd < messages.length) {
+      const next = messages[runEnd] as { role?: string; stopReason?: string };
+      if (next.role !== "assistant" || next.stopReason !== "error") {
+        break;
+      }
+      runEnd += 1;
+    }
+    // Keep only the last entry of the run (most recent error detail).
+    out.push(messages[runEnd - 1]);
+    if (runEnd - i > 1) {
+      log.warn(
+        `stripped ${runEnd - i - 1} consecutive assistant error entries from session history`,
+      );
+    }
+    i = runEnd;
+  }
+  return out;
+}
+
 export async function sanitizeSessionHistory(params: {
   messages: AgentMessage[];
   modelApi?: string | null;
@@ -559,8 +612,18 @@ export async function sanitizeSessionHistory(params: {
     ? sanitizeToolUseResultPairing(sanitizedToolCalls)
     : sanitizedToolCalls;
   const sanitizedToolResults = stripToolResultDetails(repairedTools);
+  // Strip consecutive assistant error entries to prevent session poisoning.
+  // During LLM outages, retry loops can accumulate multiple assistant messages
+  // with stopReason: "error" in the session JSONL. These consecutive error
+  // entries violate role alternation rules and cause the API to reject all
+  // subsequent requests with 400 errors, creating a death spiral where the
+  // session becomes permanently stuck even after connectivity recovers.
+  // Keep at most one trailing error entry per consecutive run so that
+  // context about the failure is preserved without poisoning the session.
+  // See: https://github.com/openclaw/openclaw/issues/11475
+  const withoutConsecutiveErrors = stripConsecutiveAssistantErrors(sanitizedToolResults);
   const sanitizedCompactionUsage = ensureAssistantUsageSnapshots(
-    stripStaleAssistantUsageBeforeLatestCompaction(sanitizedToolResults),
+    stripStaleAssistantUsageBeforeLatestCompaction(withoutConsecutiveErrors),
   );
 
   const isOpenAIResponsesApi =

--- a/src/agents/pi-embedded-runner/google.ts
+++ b/src/agents/pi-embedded-runner/google.ts
@@ -560,9 +560,11 @@ export function stripConsecutiveAssistantErrors(messages: AgentMessage[]): Agent
     }
     // Keep only the last entry of the run (most recent error detail).
     out.push(messages[runEnd - 1]);
-    if (runEnd - i > 1) {
+    const strippedCount = runEnd - i - 1;
+    if (strippedCount > 0) {
+      const entryLabel = strippedCount === 1 ? "entry" : "entries";
       log.warn(
-        `stripped ${runEnd - i - 1} consecutive assistant error entries from session history`,
+        `stripped ${strippedCount} consecutive assistant error ${entryLabel} from session history`,
       );
     }
     i = runEnd;

--- a/src/agents/provider-capabilities.test.ts
+++ b/src/agents/provider-capabilities.test.ts
@@ -64,6 +64,9 @@ describe("resolveProviderCapabilities", () => {
       }),
     ).toBe(true);
     expect(resolveTranscriptToolCallIdMode("mistral", "mistral-large-latest")).toBe("strict9");
+    expect(resolveTranscriptToolCallIdMode("openrouter", "mistralai/devstral-2512:free")).toBe(
+      "strict9",
+    );
   });
 
   it("treats kimi aliases as anthropic tool payload compatibility providers", () => {

--- a/src/agents/provider-capabilities.ts
+++ b/src/agents/provider-capabilities.ts
@@ -75,6 +75,16 @@ const PROVIDER_CAPABILITIES: Record<string, Partial<ProviderCapabilities>> = {
   },
 };
 
+const STRICT9_TRANSCRIPT_TOOL_CALL_MODEL_HINTS = [
+  ...new Set(
+    Object.values(PROVIDER_CAPABILITIES).flatMap((capabilities) =>
+      capabilities.transcriptToolCallIdMode === "strict9"
+        ? (capabilities.transcriptToolCallIdModelHints ?? [])
+        : [],
+    ),
+  ),
+];
+
 export function resolveProviderCapabilities(provider?: string | null): ProviderCapabilities {
   const normalized = normalizeProviderId(provider ?? "");
   return {
@@ -154,7 +164,10 @@ export function resolveTranscriptToolCallIdMode(
   if (mode === "strict9") {
     return mode;
   }
-  if (modelIncludesAnyHint(modelId, capabilities.transcriptToolCallIdModelHints)) {
+  if (
+    modelIncludesAnyHint(modelId, capabilities.transcriptToolCallIdModelHints) ||
+    modelIncludesAnyHint(modelId, STRICT9_TRANSCRIPT_TOOL_CALL_MODEL_HINTS)
+  ) {
     return "strict9";
   }
   return undefined;


### PR DESCRIPTION
…soning

During LLM outages or transient API failures, each retry within a single request persists a new assistant message with stopReason: "error" to the session JSONL.  When multiple error entries accumulate consecutively, they violate role-alternation rules expected by most model APIs (e.g. Anthropic Messages, OpenAI).  The API then rejects the entire conversation with a 400 error, which causes openclaw to append yet another error entry — creating a death spiral where the session becomes permanently stuck even after connectivity recovers.

Add `stripConsecutiveAssistantErrors()` to the transcript sanitization pipeline in `sanitizeSessionHistory()`.  The function collapses any run of consecutive assistant-error messages into a single entry (the last one, which carries the most recent error detail), preserving failure context without poisoning the session history.

Closes #11475

## Summary

Describe the problem and fix in 2–5 bullets:

- Problem:
- Why it matters:
- What changed:
- What did NOT change (scope boundary):

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

List user-visible changes (including defaults/config).  
If none, write `None`.

## Security Impact (required)

- New permissions/capabilities? (`Yes/No`)
- Secrets/tokens handling changed? (`Yes/No`)
- New/changed network calls? (`Yes/No`)
- Command/tool execution surface changed? (`Yes/No`)
- Data access scope changed? (`Yes/No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS:
- Runtime/container:
- Model/provider:
- Integration/channel (if any):
- Relevant config (redacted):

### Steps

1.
2.
3.

### Expected

-

### Actual

-

## Evidence

Attach at least one:

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
- Edge cases checked:
- What you did **not** verify:

## Review Conversations

- [ ] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

If a bot review conversation is addressed by this PR, resolve that conversation yourself. Do not leave bot review conversation cleanup for maintainers.

## Compatibility / Migration

- Backward compatible? (`Yes/No`)
- Config/env changes? (`Yes/No`)
- Migration needed? (`Yes/No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly:
- Files/config to restore:
- Known bad symptoms reviewers should watch for:

## Risks and Mitigations

List only real risks for this PR. Add/remove entries as needed. If none, write `None`.

- Risk:
  - Mitigation:
