### PR TITLE
feat(ui): add polling mechanism for real-time chat history updates

### DIFF
--- a/ui/src/ui/app-chat.ts
+++ b/ui/src/ui/app-chat.ts
@@ -22,6 +22,7 @@ export type ChatHost = {
   hello: GatewayHelloOk | null;
   chatAvatarUrl: string | null;
   refreshSessionsAfterChat: Set<string>;
+  chatPollInterval: number | null;
 };
 
 export const CHAT_SESSIONS_ACTIVE_MINUTES = 120;
@@ -106,6 +107,9 @@ async function sendChatMessageNow(
   resetToolStream(host as unknown as Parameters<typeof resetToolStream>[0]);
   const runId = await sendChatMessage(host as unknown as OpenClawApp, message, opts?.attachments);
   const ok = Boolean(runId);
+  if (ok) {
+    startChatPoll(host);
+  }
   if (!ok && opts?.previousDraft != null) {
     host.chatMessage = opts.previousDraft;
   }
@@ -263,4 +267,25 @@ export async function refreshChatAvatar(host: ChatHost) {
   } catch {
     host.chatAvatarUrl = null;
   }
+}
+
+export function startChatPoll(host: ChatHost) {
+  if (host.chatPollInterval != null) {
+    return;
+  }
+  host.chatPollInterval = window.setInterval(() => {
+    if (!host.chatRunId) {
+      stopChatPoll(host);
+      return;
+    }
+    void loadChatHistory(host as unknown as OpenClawApp);
+  }, 1500);
+}
+
+export function stopChatPoll(host: ChatHost) {
+  if (host.chatPollInterval == null) {
+    return;
+  }
+  clearInterval(host.chatPollInterval);
+  host.chatPollInterval = null;
 }

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -232,6 +232,7 @@ export function connectGateway(host: GatewayHost) {
         return;
       }
       host.connected = false;
+      stopChatPoll(host as unknown as import("./app-chat.ts").ChatHost);
       // Code 1012 = Service Restart (expected during config saves, don't show as error)
       host.lastErrorCode =
         resolveGatewayErrorDetailCode(error) ??

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -318,7 +318,7 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
   }
   const state = handleChatEvent(host as unknown as OpenClawApp, payload);
   const historyReloaded = handleTerminalChatEvent(host, payload, state);
-  if (state === "final") {
+  if (state === "final" || state === "error" || state === "aborted") {
     stopChatPoll(host as unknown as import("./app-chat.ts").ChatHost);
   }
   if (state === "final" && !historyReloaded && shouldReloadHistoryForFinalEvent(payload)) {

--- a/ui/src/ui/app-gateway.ts
+++ b/ui/src/ui/app-gateway.ts
@@ -3,7 +3,7 @@ import {
   type GatewayUpdateAvailableEventPayload,
 } from "../../../src/gateway/events.js";
 import { ConnectErrorDetailCodes } from "../../../src/gateway/protocol/connect-error-details.js";
-import { CHAT_SESSIONS_ACTIVE_MINUTES, flushChatQueueForEvent } from "./app-chat.ts";
+import { CHAT_SESSIONS_ACTIVE_MINUTES, flushChatQueueForEvent, stopChatPoll } from "./app-chat.ts";
 import type { EventLogEntry } from "./app-events.ts";
 import {
   applySettings,
@@ -92,6 +92,7 @@ type GatewayHost = {
   sessionKey: string;
   chatRunId: string | null;
   refreshSessionsAfterChat: Set<string>;
+  chatPollInterval: number | null;
   execApprovalQueue: ExecApprovalRequest[];
   execApprovalError: string | null;
   updateAvailable: UpdateAvailable | null;
@@ -316,6 +317,9 @@ function handleChatGatewayEvent(host: GatewayHost, payload: ChatEventPayload | u
   }
   const state = handleChatEvent(host as unknown as OpenClawApp, payload);
   const historyReloaded = handleTerminalChatEvent(host, payload, state);
+  if (state === "final") {
+    stopChatPoll(host as unknown as import("./app-chat.ts").ChatHost);
+  }
   if (state === "final" && !historyReloaded && shouldReloadHistoryForFinalEvent(payload)) {
     void loadChatHistory(host as unknown as OpenClawApp);
   }

--- a/ui/src/ui/app-view-state.ts
+++ b/ui/src/ui/app-view-state.ts
@@ -258,6 +258,7 @@ export type AppViewState = {
     updateAvailable: import("./types.js").UpdateAvailable | null;
     client: GatewayBrowserClient | null;
     refreshSessionsAfterChat: Set<string>;
+    chatPollInterval: number | null;
     connect: () => void;
     setTab: (tab: Tab) => void;
     setTheme: (theme: ThemeMode, context?: ThemeTransitionContext) => void;

--- a/ui/src/ui/app.ts
+++ b/ui/src/ui/app.ts
@@ -390,6 +390,7 @@ export class OpenClawApp extends LitElement {
   private toolStreamById = new Map<string, ToolStreamEntry>();
   private toolStreamOrder: string[] = [];
   refreshSessionsAfterChat = new Set<string>();
+  chatPollInterval: number | null = null;
   basePath = "";
   private popStateHandler = () =>
     onPopStateInternal(this as unknown as Parameters<typeof onPopStateInternal>[0]);


### PR DESCRIPTION
## Problem

When users stay on the chat page during long inference sessions, chat messages are not updated in real-time. Users need to manually switch pages or refresh to see new messages.

## Solution

Add a client-side polling mechanism that periodically refreshes chat history while a chat session is active. This ensures messages are displayed in real-time even when the gateway doesn't send intermediate events.

## Changes

- Add `chatPollInterval` field to `ChatHost` and `GatewayHost` types
- Implement `startChatPoll` and `stopChatPoll` functions in `app-chat.ts`
- Start polling when sending a chat message via `sendChatMessageNow`
- Stop polling when receiving the final event from gateway in `handleChatGatewayEvent`
- Initialize `chatPollInterval` in `OpenClawApp` class

## How it works

1. When a user sends a message, `startChatPoll()` is called to start a timer
2. Every 1.5 seconds, the timer calls `loadChatHistory()` to fetch the latest messages
3. When the gateway sends a "final" event (indicating the chat session is complete), `stopChatPoll()` is called to stop the timer