### PR TITLE
fix(cron): pass messageTo and messageThreadId to embedded PI agent in announce mode

### DIFF
--- a/src/cron/isolated-agent/run.cron-announce-target.test.ts
+++ b/src/cron/isolated-agent/run.cron-announce-target.test.ts
@@ -118,11 +118,10 @@ describe("runCronIsolatedAgentTurn cron announce target passthrough", () => {
     // When delivery target resolution fails, the agent should not receive
     // a messageTo so it does not attempt to send to an invalid target.
     // The run may still proceed (bestEffort) or fail early depending on config.
-    if (runEmbeddedPiAgentMock.mock.calls.length > 0) {
-      const callArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
-      expect(callArgs?.messageTo).toBeUndefined();
-      expect(callArgs?.messageThreadId).toBeUndefined();
-    }
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const callArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
+    expect(callArgs?.messageTo).toBeUndefined();
+    expect(callArgs?.messageThreadId).toBeUndefined();
   });
 
   it("passes messageTo for non-feishu channels (telegram)", async () => {

--- a/src/cron/isolated-agent/run.cron-announce-target.test.ts
+++ b/src/cron/isolated-agent/run.cron-announce-target.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearFastTestEnv,
+  loadRunCronIsolatedAgentTurn,
+  resetRunCronIsolatedAgentTurnHarness,
+  resolveCronDeliveryPlanMock,
+  resolveDeliveryTargetMock,
+  restoreFastTestEnv,
+  runEmbeddedPiAgentMock,
+  runWithModelFallbackMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+
+function makeParams() {
+  return {
+    cfg: {},
+    deps: {} as never,
+    job: {
+      id: "announce-target",
+      name: "Announce Target",
+      schedule: { kind: "every", everyMs: 60_000 },
+      sessionTarget: "isolated",
+      payload: { kind: "agentTurn", message: "daily report" },
+      delivery: { mode: "announce", channel: "feishu", to: "ou_xxxxx" },
+    } as never,
+    message: "daily report",
+    sessionKey: "cron:announce-target",
+  };
+}
+
+describe("runCronIsolatedAgentTurn cron announce target passthrough", () => {
+  let previousFastTestEnv: string | undefined;
+
+  const mockFallbackPassthrough = () => {
+    runWithModelFallbackMock.mockImplementation(async ({ provider, model, run }) => {
+      const result = await run(provider, model);
+      return { result, provider, model, attempts: [] };
+    });
+  };
+
+  beforeEach(() => {
+    previousFastTestEnv = clearFastTestEnv();
+    resetRunCronIsolatedAgentTurnHarness();
+  });
+
+  afterEach(() => {
+    restoreFastTestEnv(previousFastTestEnv);
+  });
+
+  it("passes messageTo from resolved delivery target to embedded PI agent", async () => {
+    mockFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "feishu",
+      to: "ou_xxxxx",
+    });
+    resolveDeliveryTargetMock.mockResolvedValue({
+      ok: true,
+      channel: "feishu",
+      to: "ou_xxxxx",
+      accountId: "feishu-account-1",
+      threadId: undefined,
+    });
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const callArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
+    expect(callArgs?.messageTo).toBe("ou_xxxxx");
+    expect(callArgs?.messageChannel).toBe("feishu");
+    expect(callArgs?.agentAccountId).toBe("feishu-account-1");
+  });
+
+  it("passes messageThreadId when delivery target includes a threadId", async () => {
+    mockFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "feishu",
+      to: "ou_xxxxx",
+    });
+    resolveDeliveryTargetMock.mockResolvedValue({
+      ok: true,
+      channel: "feishu",
+      to: "ou_xxxxx",
+      accountId: undefined,
+      threadId: "thread_12345",
+    });
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const callArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
+    expect(callArgs?.messageTo).toBe("ou_xxxxx");
+    expect(callArgs?.messageThreadId).toBe("thread_12345");
+  });
+
+  it("does not pass messageTo when delivery target resolution fails", async () => {
+    mockFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "feishu",
+      to: "ou_xxxxx",
+    });
+    resolveDeliveryTargetMock.mockResolvedValue({
+      ok: false,
+      channel: "feishu",
+      to: undefined,
+      accountId: undefined,
+      error: new Error("Target resolution failed"),
+    });
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    // When delivery target resolution fails, the agent should not receive
+    // a messageTo so it does not attempt to send to an invalid target.
+    // The run may still proceed (bestEffort) or fail early depending on config.
+    if (runEmbeddedPiAgentMock.mock.calls.length > 0) {
+      const callArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
+      expect(callArgs?.messageTo).toBeUndefined();
+      expect(callArgs?.messageThreadId).toBeUndefined();
+    }
+  });
+
+  it("passes messageTo for non-feishu channels (telegram)", async () => {
+    mockFallbackPassthrough();
+    resolveCronDeliveryPlanMock.mockReturnValue({
+      requested: true,
+      mode: "announce",
+      channel: "telegram",
+      to: "12345678",
+    });
+    resolveDeliveryTargetMock.mockResolvedValue({
+      ok: true,
+      channel: "telegram",
+      to: "12345678",
+      accountId: undefined,
+      threadId: undefined,
+    });
+
+    await runCronIsolatedAgentTurn(makeParams());
+
+    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
+    const callArgs = runEmbeddedPiAgentMock.mock.calls[0]?.[0];
+    expect(callArgs?.messageTo).toBe("12345678");
+    expect(callArgs?.messageChannel).toBe("telegram");
+  });
+});

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -603,6 +603,8 @@ export async function runCronIsolatedAgentTurn(params: {
             // inherit owner-only tooling like local `openclaw agent` runs.
             senderIsOwner: true,
             messageChannel,
+            messageTo: resolvedDelivery.ok ? resolvedDelivery.to : undefined,
+            messageThreadId: resolvedDelivery.ok ? resolvedDelivery.threadId : undefined,
             agentAccountId: resolvedDelivery.accountId,
             sessionFile,
             agentDir,


### PR DESCRIPTION
### Summary

- **Problem**: When a cron job is configured with `delivery.mode: "announce"`, the resolved delivery target (`to` and `threadId`) is not passed to `runEmbeddedPiAgent()` in `src/cron/isolated-agent/run.ts`. This causes the agent's message tool to lack target information, resulting in `[tools] message failed: Action send requires a target` errors. This is particularly problematic for channels like Feishu (Lark) that strictly require explicit targets.
- **Why it matters**: Users cannot use the cron announce feature with Feishu and other channels that require explicit targets. The agent fails to deliver the announcement, breaking the core functionality of scheduled reporting.
- **What changed**: 
  - Modified `src/cron/isolated-agent/run.ts` to pass `messageTo` (from `resolvedDelivery.to`) and `messageThreadId` (from `resolvedDelivery.threadId`) to `runEmbeddedPiAgent()`.
  - Added a new test file `src/cron/isolated-agent/run.cron-announce-target.test.ts` to explicitly verify the passthrough of these parameters.
- **What did NOT change**: The delivery resolution logic itself (`resolveDeliveryTarget`) and the outbound delivery dispatch logic (`deliverOutboundPayloads`) remain unchanged. The fix purely ensures the agent context receives the already-resolved target information.

### Change Type (select all)
- [x] Bug fix

### Scope (select all touched areas)
- [x] Gateway / orchestration
- [ ] App: web-ui

### Linked Issue/PR
Fixes #40531

### AI-Assisted Contribution
- **AI Usage**: This PR was developed with AI assistance.
- **Human Review**: I have personally reviewed, designed, and fully understand all the code changes.
- **Testing**: Fully tested locally with my OpenClaw instance.
- **Prompt Context**: I used an AI agent to trace the execution path of cron jobs, identify where the `to` parameter was being dropped before reaching the message tool, and generate the minimal fix along with explicit test cases.
