### PR TITLE
feishu: prioritize session accountId over config defaultAccount in tools

### DIFF
--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -69,7 +69,7 @@ describe("feishu tool account routing", () => {
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");
   });
 
-  test("wiki tool prefers configured defaultAccount over inherited default account context", async () => {
+  test("wiki tool prefers session agentAccountId over configured defaultAccount", async () => {
     const { api, resolveTool } = createToolFactoryHarness(
       createConfig({
         defaultAccount: "b",
@@ -80,6 +80,22 @@ describe("feishu tool account routing", () => {
     registerFeishuWikiTools(api);
 
     const tool = resolveTool("feishu_wiki", { agentAccountId: "a" });
+    await tool.execute("call", { action: "search" });
+
+    expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-a");
+  });
+
+  test("wiki tool falls back to configured defaultAccount when no agentAccountId is set", async () => {
+    const { api, resolveTool } = createToolFactoryHarness(
+      createConfig({
+        defaultAccount: "b",
+        toolsA: { wiki: true },
+        toolsB: { wiki: true },
+      }),
+    );
+    registerFeishuWikiTools(api);
+
+    const tool = resolveTool("feishu_wiki", { agentAccountId: undefined });
     await tool.execute("call", { action: "search" });
 
     expect(createFeishuClientMock.mock.calls.at(-1)?.[0]?.appId).toBe("app-b");

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -33,8 +33,8 @@ export function resolveFeishuToolAccount(params: {
     cfg: params.api.config,
     accountId:
       normalizeOptionalAccountId(params.executeParams?.accountId) ??
-      readConfiguredDefaultAccountId(params.api.config) ??
-      normalizeOptionalAccountId(params.defaultAccountId),
+      normalizeOptionalAccountId(params.defaultAccountId) ??
+      readConfiguredDefaultAccountId(params.api.config),
   });
 }
 


### PR DESCRIPTION
Fixes #40691

## Problem
In multi-account mode, Feishu plugin tools (doc/wiki/drive/bitable) always use accounts[0] credentials instead of the current session's accountId. This happens because the account resolution priority in resolveFeishuToolAccount prioritizes the configured defaultAccount over the session's agentAccountId.

## Solution
Change the account resolution priority in resolveFeishuToolAccount to prioritize the session's agentAccountId (passed as defaultAccountId parameter) over the configured defaultAccount. This ensures tools use the current session's account in multi-account mode.

## Changes
- Modified resolveFeishuToolAccount to prioritize defaultAccountId (session's agentAccountId) over configured defaultAccount
- Priority order is now:
  1. Explicit accountId in params (highest priority)
  2. Session's agentAccountId (defaultAccountId parameter)
  3. Configured defaultAccount (fallback)

## Testing
All tools (doc/wiki/drive/bitable/perm) already pass ctx.agentAccountId as defaultAccountId. This change ensures that value is used instead of falling back to the configured default.