### PR TITLE
Gateway: improve invalid-config startup recovery hints

### DIFF
--- a/src/gateway/server.impl.ts
+++ b/src/gateway/server.impl.ts
@@ -312,7 +312,7 @@ export async function startGatewayServer(
         ? formatConfigIssueLines(configSnapshot.issues, "", { normalizeRoot: true }).join("\n")
         : "Unknown validation issue.";
     throw new Error(
-      `Invalid config at ${configSnapshot.path}.\n${issues}\nRun "${formatCliCommand("openclaw doctor")}" to repair, then retry.`,
+      `Invalid config at ${configSnapshot.path}.\n${issues}\nRun "${formatCliCommand("openclaw doctor --fix")}" to repair, then retry. If recovery still fails, restore "${configSnapshot.path}.bak" over "${configSnapshot.path}" and start again.`,
     );
   }
 
@@ -405,7 +405,9 @@ export async function startGatewayServer(
         freshSnapshot.issues.length > 0
           ? formatConfigIssueLines(freshSnapshot.issues, "", { normalizeRoot: true }).join("\n")
           : "Unknown validation issue.";
-      throw new Error(`Invalid config at ${freshSnapshot.path}.\n${issues}`);
+      throw new Error(
+        `Invalid config at ${freshSnapshot.path}.\n${issues}\nRun "${formatCliCommand("openclaw doctor --fix")}" to repair, then retry. If recovery still fails, restore "${freshSnapshot.path}.bak" over "${freshSnapshot.path}" and start again.`,
+      );
     }
     const startupPreflightConfig = applyGatewayAuthOverridesForStartupPreflight(
       freshSnapshot.config,


### PR DESCRIPTION
## Summary
- Improve startup error guidance with direct doctor fix command and explicit .bak rollback hint to shorten recovery time.
- Keep scope intentionally small and single-purpose.

## Linked Issue
- Closes #40652

## Verification
- Targeted tests:
  - `pnpm vitest src/commands/doctor-config-flow.safe-bins.test.ts src/gateway/call.test.ts`
  - Passed locally before split PRs.