### PR TITLE
Docs: add emergency invalid-config recovery steps to debugging guide

### DIFF
--- a/docs/help/debugging.md
+++ b/docs/help/debugging.md
@@ -104,6 +104,24 @@ Tip: if a non‑dev gateway is already running (launchd/systemd), stop it first:
 openclaw gateway stop
 ```
 
+## Recover from invalid config startup failures
+
+If gateway startup fails with `Invalid config at ...`, repair with doctor first:
+
+```bash
+openclaw doctor --fix
+openclaw gateway run
+```
+
+If startup is still blocked and you need a quick rollback, restore the latest backup:
+
+```bash
+cp ~/.openclaw/openclaw.json.bak ~/.openclaw/openclaw.json
+openclaw gateway run
+```
+
+OpenClaw keeps a small backup ring (`openclaw.json.bak`, `.bak.1`, `.bak.2`, ...). If `.bak` is also broken, try an older backup file.
+
 ## Raw stream logging (OpenClaw)
 
 OpenClaw can log the **raw assistant stream** before any filtering/formatting.


### PR DESCRIPTION
## Summary
- Add copy-paste recovery steps for invalid-config startup failures, including doctor fix and backup-ring fallback guidance.
- Keep scope intentionally small and single-purpose.

## Linked Issue
- Closes #40653

## Verification
- Targeted tests:
  - `pnpm vitest src/commands/doctor-config-flow.safe-bins.test.ts src/gateway/call.test.ts`
  - Passed locally before split PRs.