### PR TITLE
fix: filter delivery-mirror from all consumer paths (LLM context, webchat, API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- Sessions/WebChat: filter OpenClaw delivery-mirror transcript artifacts from LLM context, `chat.history`, and `sessions.get` so internal delivery audit rows do not appear as duplicate assistant messages. Carries forward #40716. Thanks @kiyoakii.
 - NVIDIA/NIM: persist the `NVIDIA_API_KEY` provider marker and mark bundled NVIDIA Chat Completions models as string-content compatible, so NIM models load from `models.json` and OpenAI-compatible subagent calls send plain text content. Fixes #73013 and #50107; refs #73014. Thanks @bautrey, @iot2edge, @ifearghal, and @futhgar.
 - Channels/Discord: let text-only configs drop the `GuildVoiceStates` gateway intent and expose a bounded `/gateway/bot` metadata timeout with rate-limited fallback logs, reducing idle CPU and warning floods. Fixes #73709 and #73585. Thanks @sanchezm86 and @trac3r00.
 - CLI/plugins: use plugin metadata snapshots for install slot selection and add opt-in plugin lifecycle timing traces, so plugin install avoids runtime-loading the plugin registry for metadata-only decisions. Thanks @shakkernerd.

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -398,8 +398,8 @@ enumeration of `src/gateway/server-methods/*.ts`.
     - `sessions.abort` aborts active work for a session.
     - `sessions.patch` updates session metadata/overrides.
     - `sessions.reset`, `sessions.delete`, and `sessions.compact` perform session maintenance.
-    - `sessions.get` returns the full stored session row.
-    - Chat execution still uses `chat.history`, `chat.send`, `chat.abort`, and `chat.inject`. `chat.history` is display-normalized for UI clients: inline directive tags are stripped from visible text, plain-text tool-call XML payloads (including `<tool_call>...</tool_call>`, `<function_call>...</function_call>`, `<tool_calls>...</tool_calls>`, `<function_calls>...</function_calls>`, and truncated tool-call blocks) and leaked ASCII/full-width model control tokens are stripped, pure silent-token assistant rows such as exact `NO_REPLY` / `no_reply` are omitted, and oversized rows can be replaced with placeholders.
+    - `sessions.get` returns the stored session messages after omitting internal OpenClaw delivery-mirror transcript artifacts.
+    - Chat execution still uses `chat.history`, `chat.send`, `chat.abort`, and `chat.inject`. `chat.history` is display-normalized for UI clients: inline directive tags are stripped from visible text, plain-text tool-call XML payloads (including `<tool_call>...</tool_call>`, `<function_call>...</function_call>`, `<tool_calls>...</tool_calls>`, `<function_calls>...</function_calls>`, and truncated tool-call blocks) and leaked ASCII/full-width model control tokens are stripped, internal OpenClaw delivery-mirror transcript artifacts and pure silent-token assistant rows such as exact `NO_REPLY` / `no_reply` are omitted, and oversized rows can be replaced with placeholders.
 
   </Accordion>
 

--- a/docs/web/webchat.md
+++ b/docs/web/webchat.md
@@ -32,9 +32,10 @@ Status: the macOS/iOS SwiftUI chat UI talks directly to the Gateway WebSocket.
   payloads (including `<tool_call>...</tool_call>`,
   `<function_call>...</function_call>`, `<tool_calls>...</tool_calls>`,
   `<function_calls>...</function_calls>`, and truncated tool-call blocks), and
-  leaked ASCII/full-width model control tokens are stripped from visible text,
-  and assistant entries whose whole visible text is only the exact silent
-  token `NO_REPLY` / `no_reply` are omitted.
+  leaked ASCII/full-width model control tokens are stripped from visible text.
+  Internal OpenClaw delivery-mirror transcript artifacts and assistant entries
+  whose whole visible text is only the exact silent token `NO_REPLY` /
+  `no_reply` are omitted.
 - Reasoning-flagged reply payloads (`isReasoning: true`) are excluded from WebChat assistant content, transcript replay text, and audio content blocks, so thinking-only payloads do not surface as visible assistant messages or playable audio.
 - `chat.inject` appends an assistant note directly to the transcript and broadcasts it to the UI (no agent run).
 - Aborted runs can keep partial assistant output visible in the UI.

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.test.ts
@@ -669,4 +669,64 @@ describe("installContextEngineLoopHook", () => {
     expect(retryResult).toBe(compactedView);
     expect(engine.assemble).toHaveBeenCalledTimes(1);
   });
+
+  it("strips delivery-mirror messages from context", async () => {
+    const agent = makeGuardableAgent();
+
+    installToolResultContextGuard({
+      agent,
+      contextWindowTokens: 100_000,
+    });
+
+    const deliveryMirror = castAgentMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "Hello from mirror" }],
+      provider: "openclaw",
+      model: "delivery-mirror",
+      timestamp: Date.now(),
+    });
+
+    const realAssistant = castAgentMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "Hello from LLM" }],
+      provider: "anthropic",
+      model: "claude-3",
+      timestamp: Date.now(),
+    });
+
+    const contextForNextCall = [makeUser("hi"), realAssistant, deliveryMirror, makeUser("thanks")];
+
+    const result = (await agent.transformContext?.(
+      contextForNextCall,
+      new AbortController().signal,
+    )) as AgentMessage[];
+
+    expect(result).toHaveLength(3);
+    expect(result.some((m) => "model" in m && m.model === "delivery-mirror")).toBe(false);
+    expect(result.some((m) => "model" in m && m.model === "claude-3")).toBe(true);
+  });
+
+  it("preserves array identity when no delivery-mirror messages present", async () => {
+    const agent = makeGuardableAgent();
+
+    installToolResultContextGuard({
+      agent,
+      contextWindowTokens: 100_000,
+    });
+
+    const contextForNextCall = [
+      makeUser("hi"),
+      castAgentMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "Hello" }],
+        provider: "anthropic",
+        model: "claude-3",
+        timestamp: Date.now(),
+      }),
+    ];
+
+    const result = await agent.transformContext?.(contextForNextCall, new AbortController().signal);
+
+    expect(result).toBe(contextForNextCall);
+  });
 });

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -1,4 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
+import { isDeliveryMirrorMessage } from "../../config/sessions/transcript.js";
 import type { ContextEngine, ContextEngineRuntimeContext } from "../../context-engine/types.js";
 import {
   CHARS_PER_TOKEN_ESTIMATE,
@@ -319,13 +320,16 @@ export function installToolResultContextGuard(params: {
       : messages;
 
     const sourceMessages = Array.isArray(transformed) ? transformed : messages;
+    const visibleMessages = sourceMessages.some(isDeliveryMirrorMessage)
+      ? sourceMessages.filter((msg) => !isDeliveryMirrorMessage(msg))
+      : sourceMessages;
     const contextMessages = toolResultsNeedTruncation({
-      messages: sourceMessages,
+      messages: visibleMessages,
       maxSingleToolResultChars,
     })
-      ? cloneMessagesForGuard(sourceMessages)
-      : sourceMessages;
-    if (contextMessages !== sourceMessages) {
+      ? cloneMessagesForGuard(visibleMessages)
+      : visibleMessages;
+    if (contextMessages !== visibleMessages) {
       enforceToolResultLimitInPlace({
         messages: contextMessages,
         maxSingleToolResultChars,

--- a/src/agents/pi-embedded-runner/tool-result-context-guard.ts
+++ b/src/agents/pi-embedded-runner/tool-result-context-guard.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage } from "@mariozechner/pi-agent-core";
-import { isDeliveryMirrorMessage } from "../../config/sessions/transcript.js";
+import { filterDeliveryMirrorMessages } from "../../config/sessions/transcript.js";
 import type { ContextEngine, ContextEngineRuntimeContext } from "../../context-engine/types.js";
 import {
   CHARS_PER_TOKEN_ESTIMATE,
@@ -320,9 +320,7 @@ export function installToolResultContextGuard(params: {
       : messages;
 
     const sourceMessages = Array.isArray(transformed) ? transformed : messages;
-    const visibleMessages = sourceMessages.some(isDeliveryMirrorMessage)
-      ? sourceMessages.filter((msg) => !isDeliveryMirrorMessage(msg))
-      : sourceMessages;
+    const visibleMessages = filterDeliveryMirrorMessages(sourceMessages);
     const contextMessages = toolResultsNeedTruncation({
       messages: visibleMessages,
       maxSingleToolResultChars,

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -18,6 +18,7 @@ import { evaluateSessionFreshness, resolveSessionResetPolicy } from "./reset.js"
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import { clearSessionStoreCacheForTest, loadSessionStore, updateSessionStore } from "./store.js";
 import { useTempSessionsFixture } from "./test-helpers.js";
+import { isDeliveryMirrorMessage } from "./transcript.js";
 import { mergeSessionEntry, mergeSessionEntryWithPolicy, type SessionEntry } from "./types.js";
 
 describe("session path safety", () => {
@@ -591,5 +592,54 @@ describe("resolveAndPersistSessionFile", () => {
 
     const saved = loadSessionStore(fixture.storePath(), { skipCache: true });
     expect(saved[sessionKey]?.sessionFile).toBe(expectedNextSessionFile);
+  });
+});
+
+describe("isDeliveryMirrorMessage", () => {
+  it("returns true for delivery-mirror messages", () => {
+    expect(
+      isDeliveryMirrorMessage({
+        role: "assistant",
+        provider: "openclaw",
+        model: "delivery-mirror",
+        content: [{ type: "text", text: "hello" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for regular assistant messages", () => {
+    expect(
+      isDeliveryMirrorMessage({
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-3",
+        content: [{ type: "text", text: "hello" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for user messages", () => {
+    expect(
+      isDeliveryMirrorMessage({
+        role: "user",
+        content: [{ type: "text", text: "hello" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for null/undefined/non-object", () => {
+    expect(isDeliveryMirrorMessage(null)).toBe(false);
+    expect(isDeliveryMirrorMessage(undefined)).toBe(false);
+    expect(isDeliveryMirrorMessage("string")).toBe(false);
+  });
+
+  it("returns false when provider matches but model does not", () => {
+    expect(
+      isDeliveryMirrorMessage({
+        role: "assistant",
+        provider: "openclaw",
+        model: "gpt-4",
+      }),
+    ).toBe(false);
   });
 });

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -18,7 +18,7 @@ import { evaluateSessionFreshness, resolveSessionResetPolicy } from "./reset.js"
 import { resolveAndPersistSessionFile } from "./session-file.js";
 import { clearSessionStoreCacheForTest, loadSessionStore, updateSessionStore } from "./store.js";
 import { useTempSessionsFixture } from "./test-helpers.js";
-import { isDeliveryMirrorMessage } from "./transcript.js";
+import { filterDeliveryMirrorMessages, isDeliveryMirrorMessage } from "./transcript.js";
 import { mergeSessionEntry, mergeSessionEntryWithPolicy, type SessionEntry } from "./types.js";
 
 describe("session path safety", () => {
@@ -651,5 +651,44 @@ describe("isDeliveryMirrorMessage", () => {
         model: "delivery-mirror",
       }),
     ).toBe(false);
+  });
+});
+
+describe("filterDeliveryMirrorMessages", () => {
+  it("removes only OpenClaw delivery-mirror assistant messages", () => {
+    const visibleAssistant = {
+      role: "assistant",
+      provider: "anthropic",
+      model: "delivery-mirror",
+      content: [{ type: "text", text: "visible" }],
+    };
+    const mirrorAssistant = {
+      role: "assistant",
+      provider: "openclaw",
+      model: "delivery-mirror",
+      content: [{ type: "text", text: "mirror" }],
+    };
+    const userMessage = {
+      role: "user",
+      content: [{ type: "text", text: "hello" }],
+    };
+
+    expect(filterDeliveryMirrorMessages([userMessage, mirrorAssistant, visibleAssistant])).toEqual([
+      userMessage,
+      visibleAssistant,
+    ]);
+  });
+
+  it("preserves array identity when there are no delivery-mirror messages", () => {
+    const messages = [
+      {
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-3",
+        content: [{ type: "text", text: "visible" }],
+      },
+    ];
+
+    expect(filterDeliveryMirrorMessages(messages)).toBe(messages);
   });
 });

--- a/src/config/sessions/sessions.test.ts
+++ b/src/config/sessions/sessions.test.ts
@@ -642,4 +642,14 @@ describe("isDeliveryMirrorMessage", () => {
       }),
     ).toBe(false);
   });
+
+  it("returns false when model matches but provider does not", () => {
+    expect(
+      isDeliveryMirrorMessage({
+        role: "assistant",
+        provider: "anthropic",
+        model: "delivery-mirror",
+      }),
+    ).toBe(false);
+  });
 });

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -154,6 +154,29 @@ export async function readLatestAssistantTextFromSessionTranscript(
   return undefined;
 }
 
+/**
+ * Returns true when a transcript message is an internal delivery-mirror entry
+ * written by {@link appendAssistantMessageToSessionTranscript} for cross-channel
+ * delivery auditing.  These must be excluded from LLM context and API responses
+ * to prevent duplicate-message artifacts.
+ *
+ * Refs: #33263, #38061, #39469
+ */
+export function isDeliveryMirrorMessage(msg: unknown): boolean {
+  if (!msg || typeof msg !== "object") {
+    return false;
+  }
+  if (!("role" in msg) || !("provider" in msg) || !("model" in msg)) {
+    return false;
+  }
+  return (
+    typeof msg.role === "string" &&
+    msg.role.toLowerCase() === "assistant" &&
+    msg.provider === "openclaw" &&
+    msg.model === "delivery-mirror"
+  );
+}
+
 export async function appendAssistantMessageToSessionTranscript(params: {
   agentId?: string;
   sessionKey: string;
@@ -325,7 +348,7 @@ async function transcriptHasIdempotencyKey(
 }
 
 function isRedundantDeliveryMirror(message: SessionTranscriptAssistantMessage): boolean {
-  return message.provider === "openclaw" && message.model === "delivery-mirror";
+  return isDeliveryMirrorMessage(message);
 }
 
 function extractAssistantMessageText(message: SessionTranscriptAssistantMessage): string | null {

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -172,6 +172,12 @@ export function isDeliveryMirrorMessage(msg: unknown): boolean {
   return msg.role === "assistant" && msg.provider === "openclaw" && msg.model === "delivery-mirror";
 }
 
+export function filterDeliveryMirrorMessages<T>(messages: T[]): T[] {
+  return messages.some(isDeliveryMirrorMessage)
+    ? messages.filter((message) => !isDeliveryMirrorMessage(message))
+    : messages;
+}
+
 export async function appendAssistantMessageToSessionTranscript(params: {
   agentId?: string;
   sessionKey: string;

--- a/src/config/sessions/transcript.ts
+++ b/src/config/sessions/transcript.ts
@@ -169,12 +169,7 @@ export function isDeliveryMirrorMessage(msg: unknown): boolean {
   if (!("role" in msg) || !("provider" in msg) || !("model" in msg)) {
     return false;
   }
-  return (
-    typeof msg.role === "string" &&
-    msg.role.toLowerCase() === "assistant" &&
-    msg.provider === "openclaw" &&
-    msg.model === "delivery-mirror"
-  );
+  return msg.role === "assistant" && msg.provider === "openclaw" && msg.model === "delivery-mirror";
 }
 
 export async function appendAssistantMessageToSessionTranscript(params: {

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -13,6 +13,7 @@ import { stageSandboxMedia } from "../../auto-reply/reply/stage-sandbox-media.js
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
 import { extractCanvasFromText } from "../../chat/canvas-render.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
+import { isDeliveryMirrorMessage } from "../../config/sessions/transcript.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
@@ -1717,10 +1718,11 @@ export const chatHandlers: GatewayRequestHandlers = {
       });
     }
     const verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
+    const visibleMessages = bounded.messages.filter((msg) => !isDeliveryMirrorMessage(msg));
     respond(true, {
       sessionKey,
       sessionId,
-      messages: bounded.messages,
+      messages: visibleMessages,
       thinkingLevel,
       fastMode: entry?.fastMode,
       verboseLevel,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -1670,13 +1670,14 @@ export const chatHandlers: GatewayRequestHandlers = {
       provider: resolvedSessionModel.provider,
       localMessages,
     });
+    const visibleMessages = rawMessages.filter((msg) => !isDeliveryMirrorMessage(msg));
     const hardMax = 1000;
     const defaultLimit = 200;
     const requested = typeof limit === "number" ? limit : defaultLimit;
     const max = Math.min(hardMax, requested);
     const effectiveMaxChars = resolveEffectiveChatHistoryMaxChars(cfg, maxChars);
     const normalized = augmentChatHistoryWithCanvasBlocks(
-      projectRecentChatDisplayMessages(rawMessages, {
+      projectRecentChatDisplayMessages(visibleMessages, {
         maxChars: effectiveMaxChars,
         maxMessages: max,
       }),
@@ -1718,11 +1719,10 @@ export const chatHandlers: GatewayRequestHandlers = {
       });
     }
     const verboseLevel = entry?.verboseLevel ?? cfg.agents?.defaults?.verboseDefault;
-    const visibleMessages = bounded.messages.filter((msg) => !isDeliveryMirrorMessage(msg));
     respond(true, {
       sessionKey,
       sessionId,
-      messages: visibleMessages,
+      messages: bounded.messages,
       thinkingLevel,
       fastMode: entry?.fastMode,
       verboseLevel,

--- a/src/gateway/server-methods/chat.ts
+++ b/src/gateway/server-methods/chat.ts
@@ -13,7 +13,7 @@ import { stageSandboxMedia } from "../../auto-reply/reply/stage-sandbox-media.js
 import type { MsgContext, TemplateContext } from "../../auto-reply/templating.js";
 import { extractCanvasFromText } from "../../chat/canvas-render.js";
 import { resolveSessionFilePath } from "../../config/sessions.js";
-import { isDeliveryMirrorMessage } from "../../config/sessions/transcript.js";
+import { filterDeliveryMirrorMessages } from "../../config/sessions/transcript.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { jsonUtf8Bytes } from "../../infra/json-utf8-bytes.js";
@@ -1670,7 +1670,7 @@ export const chatHandlers: GatewayRequestHandlers = {
       provider: resolvedSessionModel.provider,
       localMessages,
     });
-    const visibleMessages = rawMessages.filter((msg) => !isDeliveryMirrorMessage(msg));
+    const visibleMessages = filterDeliveryMirrorMessages(rawMessages);
     const hardMax = 1000;
     const defaultLimit = 200;
     const requested = typeof limit === "number" ? limit : defaultLimit;

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -19,6 +19,7 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
+import { isDeliveryMirrorMessage } from "../../config/sessions/transcript.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   hasInternalHookListeners,
@@ -1604,7 +1605,8 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
     const allMessages = readSessionMessages(entry.sessionId, storePath, entry.sessionFile);
-    const messages = limit < allMessages.length ? allMessages.slice(-limit) : allMessages;
+    const filtered = allMessages.filter((msg) => !isDeliveryMirrorMessage(msg));
+    const messages = limit < filtered.length ? filtered.slice(-limit) : filtered;
     respond(true, { messages }, undefined);
   },
   "sessions.compact": async ({ req, params, respond, context, client, isWebchatConnect }) => {

--- a/src/gateway/server-methods/sessions.ts
+++ b/src/gateway/server-methods/sessions.ts
@@ -19,7 +19,7 @@ import {
   type SessionEntry,
   updateSessionStore,
 } from "../../config/sessions.js";
-import { isDeliveryMirrorMessage } from "../../config/sessions/transcript.js";
+import { filterDeliveryMirrorMessages } from "../../config/sessions/transcript.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   hasInternalHookListeners,
@@ -1605,7 +1605,7 @@ export const sessionsHandlers: GatewayRequestHandlers = {
       return;
     }
     const allMessages = readSessionMessages(entry.sessionId, storePath, entry.sessionFile);
-    const filtered = allMessages.filter((msg) => !isDeliveryMirrorMessage(msg));
+    const filtered = filterDeliveryMirrorMessages(allMessages);
     const messages = limit < filtered.length ? filtered.slice(-limit) : filtered;
     respond(true, { messages }, undefined);
   },


### PR DESCRIPTION
## Problem

Internal `delivery-mirror` audit entries (`provider=openclaw`, `model=delivery-mirror`) leak into all three consumer paths, causing **escalating duplicate assistant messages** that degrade over the life of a session:

- **LLM context window pollution** — duplicates compound from 2x to 6-8x over a conversation, wasting tokens and confusing the model
- **Webchat UI duplication** — users see every assistant reply rendered twice (or more)
- **Thinking block API rejections** — extra assistant entries shift message indices, causing Anthropic to reject `thinking` blocks with errors visible to end users (#39469)
- **Cross-channel impact** — reported on Telegram, BlueBubbles/iMessage, and Webchat (#30316)

Fixes #33263, #38061, #39469.
Related: #30316, #39795.

> **Note:** Other open PRs (#38075 etc.) only filter `chat.history`. This PR covers all three consumer paths — including LLM context (the most impactful) and the sessions API.

## Changes

| Path | File | What |
|---|---|---|
| LLM context | `tool-result-context-guard.ts` | Filter via shared predicate in `transformContext` pipeline |
| Webchat UI | `chat.ts` | Filter **before** slice/byte-budget so audit entries don't consume the bounded window |
| API | `sessions.ts` | Filter in `sessions.get` handler |
| Predicate | `transcript.ts` | New `isDeliveryMirrorMessage()` using `in` narrowing (zero type assertions) |

The write path is intentionally unchanged — delivery-mirror entries remain in session JSONL as an audit trail. `appendCustomEntry()` was investigated but `SessionManager._persist()` defers writes until a `type:"message"` + `role:"assistant"` entry exists, making it unreliable for standalone entries. Existing session files already contain old-format entries, so consumer-side filters are needed regardless.

## Tests

7 new tests across 2 files covering the predicate (positive match, role/provider/model mismatches, non-object input) and the `transformContext` integration (strips delivery-mirror; preserves array identity when none present).

## Unrelated

Commit `f5c618eb` fixes a pre-existing oxfmt formatting issue in `src/cli/daemon-cli/lifecycle.test.ts`.