### PR TITLE
fix: force HTTPS libsignal override for npm installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -413,6 +413,9 @@
     "@napi-rs/canvas": "^0.1.89",
     "node-llama-cpp": "3.16.2"
   },
+  "overrides": {
+    "libsignal": "https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67"
+  },
   "engines": {
     "node": ">=22.12.0"
   },

--- a/src/plugins/windows-install-overrides.test.ts
+++ b/src/plugins/windows-install-overrides.test.ts
@@ -1,0 +1,25 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+type PackageManifest = {
+  overrides?: Record<string, string>;
+};
+
+function readJson<T>(relativePath: string): T {
+  const absolutePath = path.resolve(process.cwd(), relativePath);
+  return JSON.parse(fs.readFileSync(absolutePath, "utf8")) as T;
+}
+
+describe("npm install overrides", () => {
+  it("pins libsignal to an HTTPS tarball for npm installs", () => {
+    const rootManifest = readJson<PackageManifest>("package.json");
+    const libsignalOverride = rootManifest.overrides?.libsignal;
+
+    expect(libsignalOverride).toBe(
+      "https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
+    );
+    expect(libsignalOverride).not.toContain("git@github.com");
+    expect(libsignalOverride).not.toContain("ssh://git@github.com");
+  });
+});


### PR DESCRIPTION
## Summary
- add a top-level npm `overrides.libsignal` pin to the HTTPS codeload tarball
- keep Windows and global `npm install -g openclaw` off the `git@github.com` SSH path
- add a regression test that guards the published manifest override

## Testing
- `./node_modules/.bin/vitest run src/plugins/bundled-runtime-deps.test.ts src/plugins/windows-install-overrides.test.ts`
- verified with `npm install --package-lock-only --ignore-scripts --no-audit --no-fund` in a temp dir that `node_modules/libsignal` resolves to the HTTPS codeload tarball with no `git@github.com` / `ssh://git@github.com` URL

Closes #40684.
