### PR TITLE
fix(telegram): use active session model for /think command menu

### DIFF
--- a/src/auto-reply/commands-registry.data.ts
+++ b/src/auto-reply/commands-registry.data.ts
@@ -6,7 +6,7 @@ import type {
   CommandCategory,
   CommandScope,
 } from "./commands-registry.types.js";
-import { listThinkingLevels } from "./thinking.js";
+import { listThinkingLevelChoices } from "./thinking.js";
 
 type DefineChatCommandInput = {
   key: string;
@@ -574,9 +574,9 @@ function buildChatCommands(): ChatCommandDefinition[] {
       args: [
         {
           name: "level",
-          description: "off, minimal, low, medium, high, xhigh",
+          description: "off, minimal, low, medium, high, xhigh (max for Anthropic)",
           type: "string",
-          choices: ({ provider, model }) => listThinkingLevels(provider, model),
+          choices: ({ provider, model }) => listThinkingLevelChoices(provider, model),
         },
       ],
       argsMenu: "auto",

--- a/src/auto-reply/commands-registry.ts
+++ b/src/auto-reply/commands-registry.ts
@@ -2,6 +2,8 @@ import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveConfiguredModelRef } from "../agents/model-selection.js";
 import type { SkillCommandSpec } from "../agents/skills.js";
 import { isCommandFlagEnabled } from "../config/commands.js";
+import { resolveStorePath } from "../config/sessions/paths.js";
+import { loadSessionStore } from "../config/sessions/store.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { escapeRegExp } from "../utils.js";
 import { getChatCommands, getNativeCommandSurfaces } from "./commands-registry.data.js";
@@ -17,6 +19,7 @@ import type {
   NativeCommandSpec,
   ShouldHandleTextCommandsParams,
 } from "./commands-registry.types.js";
+import { resolveStoredModelOverride } from "./reply/model-selection.js";
 
 export type {
   ChatCommandDefinition,
@@ -305,6 +308,38 @@ function resolveDefaultCommandContext(cfg?: OpenClawConfig): {
   };
 }
 
+/**
+ * Resolve the active provider and model for a session route.
+ * Falls back to the configured default when no session override exists.
+ */
+export function resolveActiveModelForRoute(params: {
+  cfg?: OpenClawConfig;
+  route?: { agentId?: string; sessionKey?: string };
+}): { provider: string; model: string } {
+  const defaults = resolveDefaultCommandContext(params.cfg);
+  if (!params.route?.sessionKey) {
+    return defaults;
+  }
+  try {
+    const storePath = resolveStorePath(params.cfg?.session?.store, {
+      agentId: params.route.agentId,
+    });
+    const sessionStore = loadSessionStore(storePath);
+    const sessionEntry = sessionStore[params.route.sessionKey];
+    const override = resolveStoredModelOverride({
+      sessionEntry,
+      sessionStore,
+      sessionKey: params.route.sessionKey,
+    });
+    return {
+      provider: override?.provider?.trim() || defaults.provider,
+      model: override?.model?.trim() || defaults.model,
+    };
+  } catch {
+    return defaults;
+  }
+}
+
 export type ResolvedCommandArgChoice = { value: string; label: string };
 
 export function resolveCommandArgChoices(params: {
@@ -341,8 +376,10 @@ export function resolveCommandArgMenu(params: {
   command: ChatCommandDefinition;
   args?: CommandArgs;
   cfg?: OpenClawConfig;
+  provider?: string;
+  model?: string;
 }): { arg: CommandArgDefinition; choices: ResolvedCommandArgChoice[]; title?: string } | null {
-  const { command, args, cfg } = params;
+  const { command, args, cfg, provider, model } = params;
   if (!command.args || !command.argsMenu) {
     return null;
   }
@@ -352,7 +389,9 @@ export function resolveCommandArgMenu(params: {
   const argSpec = command.argsMenu;
   const argName =
     argSpec === "auto"
-      ? command.args.find((arg) => resolveCommandArgChoices({ command, arg, cfg }).length > 0)?.name
+      ? command.args.find(
+          (arg) => resolveCommandArgChoices({ command, arg, cfg, provider, model }).length > 0,
+        )?.name
       : argSpec.arg;
   if (!argName) {
     return null;
@@ -367,7 +406,7 @@ export function resolveCommandArgMenu(params: {
   if (!arg) {
     return null;
   }
-  const choices = resolveCommandArgChoices({ command, arg, cfg });
+  const choices = resolveCommandArgChoices({ command, arg, cfg, provider, model });
   if (choices.length === 0) {
     return null;
   }

--- a/src/auto-reply/thinking.ts
+++ b/src/auto-reply/thinking.ts
@@ -25,6 +25,8 @@ export const XHIGH_MODEL_REFS = [
   "openai/gpt-5.4",
   "openai/gpt-5.4-pro",
   "openai/gpt-5.2",
+  "anthropic/claude-opus-4-6",
+  "anthropic-vertex/claude-opus-4-6",
   "openai-codex/gpt-5.4",
   "openai-codex/gpt-5.3-codex",
   "openai-codex/gpt-5.3-codex-spark",
@@ -51,7 +53,9 @@ export function normalizeThinkLevel(raw?: string | null): ThinkLevel | undefined
   if (collapsed === "adaptive" || collapsed === "auto") {
     return "adaptive";
   }
-  if (collapsed === "xhigh" || collapsed === "extrahigh") {
+  // "max" is the Anthropic-native label for the highest thinking level;
+  // it maps to the canonical internal ThinkLevel "xhigh".
+  if (collapsed === "xhigh" || collapsed === "extrahigh" || collapsed === "max") {
     return "xhigh";
   }
   if (["off"].includes(key)) {
@@ -69,9 +73,7 @@ export function normalizeThinkLevel(raw?: string | null): ThinkLevel | undefined
   if (["mid", "med", "medium", "thinkharder", "think-harder", "harder"].includes(key)) {
     return "medium";
   }
-  if (
-    ["high", "ultra", "ultrathink", "think-hard", "thinkhardest", "highest", "max"].includes(key)
-  ) {
+  if (["high", "ultra", "ultrathink", "thinkhardest", "highest"].includes(key)) {
     return "high";
   }
   if (["think"].includes(key)) {
@@ -101,11 +103,46 @@ export function listThinkingLevels(provider?: string | null, model?: string | nu
   return levels;
 }
 
+export type ThinkLevelChoice = { value: ThinkLevel; label: string };
+
+function isAnthropicProvider(provider?: string | null): boolean {
+  const key = normalizeProviderId(provider);
+  return key === "anthropic" || key === "anthropic-vertex";
+}
+
+/**
+ * Return thinking level choices with provider-specific display labels.
+ *
+ * The internal canonical ThinkLevel value is always "xhigh" regardless of
+ * provider.  The label shown to the user varies to match each provider's
+ * native API vocabulary:
+ *   - Anthropic (`output_config.effort`): label = "max"
+ *   - OpenAI / Codex (`reasoning_effort`): label = "xhigh"
+ */
+export function listThinkingLevelChoices(
+  provider?: string | null,
+  model?: string | null,
+): ThinkLevelChoice[] {
+  const choices: ThinkLevelChoice[] = [
+    { value: "off", label: "off" },
+    { value: "minimal", label: "minimal" },
+    { value: "low", label: "low" },
+    { value: "medium", label: "medium" },
+    { value: "high", label: "high" },
+  ];
+  if (supportsXHighThinking(provider, model)) {
+    const label = isAnthropicProvider(provider) ? "max" : "xhigh";
+    choices.push({ value: "xhigh", label });
+  }
+  choices.push({ value: "adaptive", label: "adaptive" });
+  return choices;
+}
+
 export function listThinkingLevelLabels(provider?: string | null, model?: string | null): string[] {
   if (isBinaryThinkingProvider(provider)) {
     return ["off", "on"];
   }
-  return listThinkingLevels(provider, model);
+  return listThinkingLevelChoices(provider, model).map((choice) => choice.label);
 }
 
 export function formatThinkingLevels(

--- a/src/telegram/bot-native-commands.ts
+++ b/src/telegram/bot-native-commands.ts
@@ -9,6 +9,7 @@ import {
   listNativeCommandSpecs,
   listNativeCommandSpecsForConfig,
   parseCommandArgs,
+  resolveActiveModelForRoute,
   resolveCommandArgMenu,
 } from "../auto-reply/commands-registry.js";
 import { finalizeInboundContext } from "../auto-reply/reply/inbound-context.js";
@@ -611,13 +612,32 @@ export const registerTelegramNativeCommands = ({
             : rawText
               ? `/${command.name} ${rawText}`
               : `/${command.name}`;
-          const menu = commandDefinition
-            ? resolveCommandArgMenu({
-                command: commandDefinition,
-                args: commandArgs,
-                cfg,
-              })
-            : null;
+          // Only resolve the active session model when the command might
+          // show an interactive arg menu — avoids a blocking session-store
+          // read for commands that never need one.
+          let menu: ReturnType<typeof resolveCommandArgMenu> = null;
+          if (
+            commandDefinition?.argsMenu &&
+            commandDefinition.argsParsing !== "none" &&
+            !(commandArgs?.raw && !commandArgs.values)
+          ) {
+            const menuThreadId = threadSpec.scope === "dm" ? threadSpec.id : undefined;
+            const commandSessionKey =
+              menuThreadId != null
+                ? `${route.sessionKey}:thread:${chatId}:${menuThreadId}`.toLowerCase()
+                : route.sessionKey;
+            const activeModel = resolveActiveModelForRoute({
+              cfg,
+              route: { ...route, sessionKey: commandSessionKey },
+            });
+            menu = resolveCommandArgMenu({
+              command: commandDefinition,
+              args: commandArgs,
+              cfg,
+              provider: activeModel.provider,
+              model: activeModel.model,
+            });
+          }
           if (menu && commandDefinition) {
             const title =
               menu.title ??


### PR DESCRIPTION
## Problem

The Telegram `/think` command menu always shows choices based on the **configured default model**, not the model actually active in the current session. Users who override their model per-session (e.g. switching to `claude-opus-4-6`) don't see `max` (xhigh) as an option even though their active model supports it.

Related: #36590

## Changes

- **Resolve active session model** before building the `/think` arg menu, falling back to the configured default when no override exists
- **Show provider-native labels**: Anthropic users see `max`, OpenAI users see `xhigh`
- **Normalize `max` input** → canonical `xhigh` ThinkLevel so users can type either
- **Add `claude-opus-4-6`** (direct + vertex) to `XHIGH_MODEL_REFS`
- **Guard the session-store read** behind an `argsMenu` check to avoid unnecessary I/O for commands that never show a menu

## Scope

4 files, 114 insertions — no new dependencies, no test regressions.

| File | What |
|---|---|
| `src/auto-reply/thinking.ts` | `listThinkingLevelChoices()` with provider-aware labels; `normalizeThinkLevel("max")` → `xhigh` |
| `src/auto-reply/commands-registry.ts` | `resolveActiveModelForRoute()`; thread provider/model through `resolveCommandArgMenu` |
| `src/auto-reply/commands-registry.data.ts` | Wire `listThinkingLevelChoices`; update description to mention "max" |
| `src/telegram/bot-native-commands.ts` | Conditionally resolve active model only when menu needed; use thread session key |