### PR TITLE
feat(ui): improve raw JSON5 editor readability

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,6 +536,15 @@ importers:
 
   ui:
     dependencies:
+      '@codemirror/commands':
+        specifier: ^6.10.0
+        version: 6.10.2
+      '@codemirror/state':
+        specifier: ^6.5.2
+        version: 6.5.4
+      '@codemirror/view':
+        specifier: ^6.38.6
+        version: 6.39.16
       '@lit-labs/signals':
         specifier: ^0.2.0
         version: 0.2.0
@@ -545,6 +554,9 @@ importers:
       '@noble/ed25519':
         specifier: 3.0.0
         version: 3.0.0
+      codemirror:
+        specifier: ^6.0.2
+        version: 6.0.2
       dompurify:
         specifier: ^3.3.2
         version: 3.3.2
@@ -994,6 +1006,27 @@ packages:
 
   '@cloudflare/workers-types@4.20260120.0':
     resolution: {integrity: sha512-B8pueG+a5S+mdK3z8oKu1ShcxloZ7qWb68IEyLLaepvdryIbNC7JVPcY0bWsjS56UQVKc5fnyRge3yZIwc9bxw==}
+
+  '@codemirror/autocomplete@6.20.1':
+    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
+
+  '@codemirror/commands@6.10.2':
+    resolution: {integrity: sha512-vvX1fsih9HledO1c9zdotZYUZnE4xV0m6i3m25s5DIfXofuprk6cRcLUZvSk3CASUbwjQX21tOGbkY2BH8TpnQ==}
+
+  '@codemirror/language@6.12.2':
+    resolution: {integrity: sha512-jEPmz2nGGDxhRTg3lTpzmIyGKxz3Gp3SJES4b0nAuE5SWQoKdT5GoQ69cwMmFd+wvFUhYirtDTr0/DRHpQAyWg==}
+
+  '@codemirror/lint@6.9.5':
+    resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
+
+  '@codemirror/search@6.6.0':
+    resolution: {integrity: sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==}
+
+  '@codemirror/state@6.5.4':
+    resolution: {integrity: sha512-8y7xqG/hpB53l25CIoit9/ngxdfoG+fx+V3SHBrinnhOtLvKHRyAJJuHzkWrR4YXXLX8eXBsejgAAxHUOdW1yw==}
+
+  '@codemirror/view@6.39.16':
+    resolution: {integrity: sha512-m6S22fFpKtOWhq8HuhzsI1WzUP/hB9THbDj0Tl5KX4gbO6Y91hwBl7Yky33NdvB6IffuRFiBxf1R8kJMyXmA4Q==}
 
   '@colors/colors@1.5.0':
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
@@ -1528,6 +1561,15 @@ packages:
   '@larksuiteoapi/node-sdk@1.59.0':
     resolution: {integrity: sha512-sBpkruTvZDOxnVtoTbepWKRX0j1Y1ZElQYu0x7+v088sI9pcpbVp6ZzCGn62dhrKPatzNyCJyzYCPXPYQWccrA==}
 
+  '@lezer/common@1.5.1':
+    resolution: {integrity: sha512-6YRVG9vBkaY7p1IVxL4s44n5nUnaNnGM2/AckNgYOnxTG2kWh1vR8BMxPseWPjRNpb5VtXnMpeYAEAADoRV1Iw==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/lr@1.4.8':
+    resolution: {integrity: sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==}
+
   '@line/bot-sdk@10.6.0':
     resolution: {integrity: sha512-4hSpglL/G/cW2JCcohaYz/BS0uOSJNV9IEYdMm0EiPEvDLayoI2hGq2D86uYPQFD2gvgkyhmzdShpWLG3P5r3w==}
     engines: {node: '>=20'}
@@ -1576,6 +1618,9 @@ packages:
 
   '@lydell/node-pty@1.2.0-beta.3':
     resolution: {integrity: sha512-ngGAItlRhmJXrhspxt8kX13n1dVFqzETOq0m/+gqSkO8NJBvNMwP7FZckMwps2UFySdr4yxCXNGu/bumg5at6A==}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@mariozechner/clipboard-darwin-arm64@0.3.2':
     resolution: {integrity: sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==}
@@ -4025,6 +4070,9 @@ packages:
   codec-parser@2.5.0:
     resolution: {integrity: sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ==}
 
+  codemirror@6.0.2:
+    resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -4105,6 +4153,9 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   croner@10.0.1:
     resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
@@ -6281,6 +6332,9 @@ packages:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
 
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -6636,6 +6690,9 @@ packages:
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -7885,6 +7942,52 @@ snapshots:
   '@cloudflare/workers-types@4.20260120.0':
     optional: true
 
+  '@codemirror/autocomplete@6.20.1':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.16
+      '@lezer/common': 1.5.1
+
+  '@codemirror/commands@6.10.2':
+    dependencies:
+      '@codemirror/language': 6.12.2
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.16
+      '@lezer/common': 1.5.1
+
+  '@codemirror/language@6.12.2':
+    dependencies:
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.16
+      '@lezer/common': 1.5.1
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.8
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.5':
+    dependencies:
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.16
+      crelt: 1.0.6
+
+  '@codemirror/search@6.6.0':
+    dependencies:
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.16
+      crelt: 1.0.6
+
+  '@codemirror/state@6.5.4':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/view@6.39.16':
+    dependencies:
+      '@codemirror/state': 6.5.4
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
   '@colors/colors@1.5.0':
     optional: true
 
@@ -8406,6 +8509,16 @@ snapshots:
       - debug
       - utf-8-validate
 
+  '@lezer/common@1.5.1': {}
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.1
+
+  '@lezer/lr@1.4.8':
+    dependencies:
+      '@lezer/common': 1.5.1
+
   '@line/bot-sdk@10.6.0':
     dependencies:
       '@types/node': 24.11.0
@@ -8455,6 +8568,8 @@ snapshots:
       '@lydell/node-pty-linux-x64': 1.2.0-beta.3
       '@lydell/node-pty-win32-arm64': 1.2.0-beta.3
       '@lydell/node-pty-win32-x64': 1.2.0-beta.3
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@mariozechner/clipboard-darwin-arm64@0.3.2':
     optional: true
@@ -11228,6 +11343,16 @@ snapshots:
   codec-parser@2.5.0:
     optional: true
 
+  codemirror@6.0.2:
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/commands': 6.10.2
+      '@codemirror/language': 6.12.2
+      '@codemirror/lint': 6.9.5
+      '@codemirror/search': 6.6.0
+      '@codemirror/state': 6.5.4
+      '@codemirror/view': 6.39.16
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -11292,6 +11417,8 @@ snapshots:
   core-util-is@1.0.2: {}
 
   core-util-is@1.0.3: {}
+
+  crelt@1.0.6: {}
 
   croner@10.0.1: {}
 
@@ -13890,6 +14017,8 @@ snapshots:
     dependencies:
       '@tokenizer/token': 0.3.0
 
+  style-mod@4.1.3: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -14202,6 +14331,8 @@ snapshots:
       - yaml
 
   void-elements@3.1.0: {}
+
+  w3c-keyname@2.2.8: {}
 
   web-streams-polyfill@3.3.3: {}
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,9 +9,13 @@
     "test": "vitest run --config vitest.config.ts"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.10.0",
+    "@codemirror/state": "^6.5.2",
+    "@codemirror/view": "^6.38.6",
     "@lit-labs/signals": "^0.2.0",
     "@lit/context": "^1.1.6",
     "@noble/ed25519": "3.0.0",
+    "codemirror": "^6.0.2",
     "dompurify": "^3.3.2",
     "lit": "^3.3.2",
     "marked": "^17.0.4",

--- a/ui/src/i18n/locales/de.ts
+++ b/ui/src/i18n/locales/de.ts
@@ -127,4 +127,13 @@ export const de: TranslationMap = {
     de: "Deutsch",
     es: "Spanisch (Español)",
   },
+  config: {
+    rawEditor: {
+      lineCol: "Zeile {line} Spalte {col}",
+      path: "Pfad",
+      root: "Wurzel",
+      noSelection: "Keine Auswahl",
+      selected: "{count} ausgewählt",
+    },
+  },
 };

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -124,6 +124,15 @@ export const en: TranslationMap = {
     de: "Deutsch (German)",
     es: "Español (Spanish)",
   },
+  config: {
+    rawEditor: {
+      lineCol: "Line {line} Col {col}",
+      path: "Path",
+      root: "Root",
+      noSelection: "No selection",
+      selected: "{count} selected",
+    },
+  },
   cron: {
     summary: {
       enabled: "Enabled",

--- a/ui/src/i18n/locales/es.ts
+++ b/ui/src/i18n/locales/es.ts
@@ -126,6 +126,15 @@ export const es: TranslationMap = {
     de: "Deutsch (Alemán)",
     es: "Español",
   },
+  config: {
+    rawEditor: {
+      lineCol: "Línea {line} Col {col}",
+      path: "Ruta",
+      root: "Raíz",
+      noSelection: "Sin selección",
+      selected: "{count} seleccionados",
+    },
+  },
   cron: {
     summary: {
       enabled: "Habilitado",

--- a/ui/src/i18n/locales/pt-BR.ts
+++ b/ui/src/i18n/locales/pt-BR.ts
@@ -126,4 +126,13 @@ export const pt_BR: TranslationMap = {
     de: "Deutsch (Alemão)",
     es: "Español (Espanhol)",
   },
+  config: {
+    rawEditor: {
+      lineCol: "Linha {line} Col {col}",
+      path: "Caminho",
+      root: "Raiz",
+      noSelection: "Sem seleção",
+      selected: "{count} selecionados",
+    },
+  },
 };

--- a/ui/src/i18n/locales/zh-CN.ts
+++ b/ui/src/i18n/locales/zh-CN.ts
@@ -123,6 +123,15 @@ export const zh_CN: TranslationMap = {
     de: "Deutsch (德语)",
     es: "Español (西班牙语)",
   },
+  config: {
+    rawEditor: {
+      lineCol: "第 {line} 行 第 {col} 列",
+      path: "路径",
+      root: "根",
+      noSelection: "未选择",
+      selected: "已选择 {count} 个字符",
+    },
+  },
   cron: {
     summary: {
       enabled: "已启用",

--- a/ui/src/i18n/locales/zh-TW.ts
+++ b/ui/src/i18n/locales/zh-TW.ts
@@ -123,4 +123,13 @@ export const zh_TW: TranslationMap = {
     de: "Deutsch (德語)",
     es: "Español (西班牙語)",
   },
+  config: {
+    rawEditor: {
+      lineCol: "第 {line} 行 第 {col} 列",
+      path: "路徑",
+      root: "根",
+      noSelection: "未選取",
+      selected: "已選取 {count} 個字元",
+    },
+  },
 };

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -626,11 +626,24 @@
   padding: 22px;
 }
 
-.config-raw-field textarea {
-  min-height: 500px;
-  font-family: var(--mono);
-  font-size: 13px;
-  line-height: 1.55;
+.config-raw-field config-raw-editor {
+  display: block;
+}
+
+.config-raw-shell {
+  border: 1px solid var(--input);
+  background: var(--card);
+  border-radius: var(--radius-md);
+  box-shadow: inset 0 1px 0 var(--card-highlight);
+  overflow: hidden;
+  transition:
+    border-color var(--duration-fast) ease,
+    box-shadow var(--duration-fast) ease;
+}
+
+.config-raw-shell:focus-within {
+  border-color: var(--input);
+  box-shadow: var(--focus-ring);
 }
 
 /* Loading State */

--- a/ui/src/ui/components/config-raw-editor-path.ts
+++ b/ui/src/ui/components/config-raw-editor-path.ts
@@ -1,0 +1,347 @@
+export type JsonPathSegment = string | number;
+export type JsonPathBreadcrumb = {
+  segment: JsonPathSegment;
+  from: number;
+};
+
+type RootFrame = {
+  kind: "root";
+  path: JsonPathBreadcrumb[];
+};
+
+type ObjectFrame = {
+  kind: "object";
+  path: JsonPathBreadcrumb[];
+  pendingKey: JsonPathBreadcrumb | null;
+  expectingValue: boolean;
+  lastPath: JsonPathBreadcrumb[];
+};
+
+type ArrayFrame = {
+  kind: "array";
+  path: JsonPathBreadcrumb[];
+  index: number;
+  expectingValue: boolean;
+  lastPath: JsonPathBreadcrumb[];
+  pendingFrom: number;
+};
+
+type Frame = RootFrame | ObjectFrame | ArrayFrame;
+
+function isWhitespace(char: string): boolean {
+  return char === " " || char === "\n" || char === "\r" || char === "\t" || char === "\f";
+}
+
+function isIdentifierStart(char: string): boolean {
+  return /[$_\p{ID_Start}]/u.test(char);
+}
+
+function isValueTokenStart(char: string): boolean {
+  return isIdentifierStart(char) || /[-0-9.]/.test(char);
+}
+
+function isDelimiter(char: string): boolean {
+  return (
+    char === "" ||
+    isWhitespace(char) ||
+    char === "{" ||
+    char === "}" ||
+    char === "[" ||
+    char === "]" ||
+    char === ":" ||
+    char === "," ||
+    char === "'" ||
+    char === '"' ||
+    char === "/"
+  );
+}
+
+function readQuotedString(source: string, start: number): { value: string; next: number } {
+  const quote = source[start] ?? '"';
+  let value = "";
+  let index = start + 1;
+  while (index < source.length) {
+    const char = source[index] ?? "";
+    if (char === "\\") {
+      value += source[index + 1] ?? "";
+      index += 2;
+      continue;
+    }
+    if (char === quote) {
+      return { value, next: index + 1 };
+    }
+    value += char;
+    index += 1;
+  }
+  return { value, next: source.length };
+}
+
+function readBareToken(source: string, start: number): { value: string; next: number } {
+  let index = start;
+  while (index < source.length && !isDelimiter(source[index] ?? "")) {
+    index += 1;
+  }
+  return { value: source.slice(start, index), next: index };
+}
+
+function skipTrivia(source: string, start: number): number {
+  let index = start;
+  while (index < source.length) {
+    const char = source[index] ?? "";
+    if (isWhitespace(char)) {
+      index += 1;
+      continue;
+    }
+
+    if (char === "/" && source[index + 1] === "/") {
+      index += 2;
+      while (index < source.length && source[index] !== "\n") {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (char === "/" && source[index + 1] === "*") {
+      index += 2;
+      while (index < source.length && !(source[index] === "*" && source[index + 1] === "/")) {
+        index += 1;
+      }
+      index = Math.min(source.length, index + 2);
+      continue;
+    }
+
+    return index;
+  }
+  return source.length;
+}
+
+function peekNextNonWhitespace(source: string, start: number): string {
+  const index = skipTrivia(source, start);
+  return source[index] ?? "";
+}
+
+function isObjectKeyToken(source: string, token: string, next: number): boolean {
+  return token.length > 0 && peekNextNonWhitespace(source, next) === ":";
+}
+
+function createArrayIndexBreadcrumb(index: number, from: number): JsonPathBreadcrumb {
+  return { segment: index, from };
+}
+
+function consumeValuePath(frame: Frame, from?: number): JsonPathBreadcrumb[] {
+  if (frame.kind === "object") {
+    if (frame.pendingKey === null) {
+      return frame.path;
+    }
+    const path = [...frame.path, frame.pendingKey];
+    frame.pendingKey = null;
+    frame.expectingValue = false;
+    frame.lastPath = path;
+    return path;
+  }
+  if (frame.kind === "array") {
+    const path = [
+      ...frame.path,
+      createArrayIndexBreadcrumb(frame.index, from ?? frame.pendingFrom),
+    ];
+    frame.index += 1;
+    frame.expectingValue = false;
+    frame.lastPath = path;
+    return path;
+  }
+  return frame.path;
+}
+
+function currentFramePath(frame: Frame): JsonPathBreadcrumb[] {
+  if (frame.kind === "object") {
+    if (frame.pendingKey !== null) {
+      return [...frame.path, frame.pendingKey];
+    }
+    return frame.lastPath.length > 0 ? frame.lastPath : frame.path;
+  }
+  if (frame.kind === "array") {
+    if (frame.expectingValue) {
+      return [...frame.path, createArrayIndexBreadcrumb(frame.index, frame.pendingFrom)];
+    }
+    return frame.lastPath.length > 0 ? frame.lastPath : frame.path;
+  }
+  return frame.path;
+}
+
+function readKeyTokenAtCursor(
+  source: string,
+  cursor: number,
+): { value: string; next: number; from: number } | null {
+  const char = source[cursor] ?? "";
+  if (char === '"' || char === "'") {
+    return { ...readQuotedString(source, cursor), from: cursor };
+  }
+  if (isValueTokenStart(char)) {
+    return { ...readBareToken(source, cursor), from: cursor };
+  }
+  return null;
+}
+
+export function resolveJson5BreadcrumbsAt(source: string, offset: number): JsonPathBreadcrumb[] {
+  const cursor = Math.max(0, Math.min(offset, source.length));
+  const stack: Frame[] = [{ kind: "root", path: [] }];
+  let activePath: JsonPathBreadcrumb[] = [];
+  let index = 0;
+
+  while (index < cursor) {
+    const char = source[index] ?? "";
+
+    if (isWhitespace(char)) {
+      index += 1;
+      continue;
+    }
+
+    if (char === "/" && source[index + 1] === "/") {
+      index += 2;
+      while (index < cursor && source[index] !== "\n") {
+        index += 1;
+      }
+      continue;
+    }
+
+    if (char === "/" && source[index + 1] === "*") {
+      index += 2;
+      while (index < cursor && !(source[index] === "*" && source[index + 1] === "/")) {
+        index += 1;
+      }
+      index = Math.min(cursor, index + 2);
+      continue;
+    }
+
+    if (char === '"' || char === "'") {
+      const token = readQuotedString(source, index);
+      const frame = stack.at(-1);
+      if (
+        frame?.kind === "object" &&
+        !frame.expectingValue &&
+        isObjectKeyToken(source, token.value, token.next)
+      ) {
+        const key = { segment: token.value, from: index };
+        frame.pendingKey = key;
+        activePath = [...frame.path, key];
+      } else if (frame && frame.kind !== "root") {
+        activePath = consumeValuePath(frame, index);
+      }
+      index = token.next;
+      continue;
+    }
+
+    if (char === "{") {
+      const parent = stack.at(-1) ?? { kind: "root", path: [] };
+      const path = consumeValuePath(parent, index);
+      stack.push({
+        kind: "object",
+        path,
+        pendingKey: null,
+        expectingValue: false,
+        lastPath: path,
+      });
+      activePath = path;
+      index += 1;
+      continue;
+    }
+
+    if (char === "[") {
+      const parent = stack.at(-1) ?? { kind: "root", path: [] };
+      const path = consumeValuePath(parent, index);
+      stack.push({
+        kind: "array",
+        path,
+        index: 0,
+        expectingValue: true,
+        lastPath: path,
+        pendingFrom: index + 1,
+      });
+      activePath = path;
+      index += 1;
+      continue;
+    }
+
+    if (char === "}") {
+      stack.pop();
+      activePath = currentFramePath(stack.at(-1) ?? { kind: "root", path: [] });
+      index += 1;
+      continue;
+    }
+
+    if (char === "]") {
+      stack.pop();
+      activePath = currentFramePath(stack.at(-1) ?? { kind: "root", path: [] });
+      index += 1;
+      continue;
+    }
+
+    if (char === ":") {
+      const frame = stack.at(-1);
+      if (frame?.kind === "object" && frame.pendingKey !== null) {
+        frame.expectingValue = true;
+        activePath = [...frame.path, frame.pendingKey];
+      }
+      index += 1;
+      continue;
+    }
+
+    if (char === ",") {
+      const frame = stack.at(-1);
+      if (frame?.kind === "object") {
+        frame.pendingKey = null;
+        frame.expectingValue = false;
+        activePath = frame.path;
+      } else if (frame?.kind === "array") {
+        frame.expectingValue = true;
+        frame.pendingFrom = index + 1;
+        activePath = [...frame.path, createArrayIndexBreadcrumb(frame.index, frame.pendingFrom)];
+      }
+      index += 1;
+      continue;
+    }
+
+    if (isValueTokenStart(char)) {
+      const token = readBareToken(source, index);
+      const frame = stack.at(-1);
+      if (
+        frame?.kind === "object" &&
+        !frame.expectingValue &&
+        isObjectKeyToken(source, token.value, token.next)
+      ) {
+        const key = { segment: token.value, from: index };
+        frame.pendingKey = key;
+        activePath = [...frame.path, key];
+      } else if (frame && frame.kind !== "root") {
+        activePath = consumeValuePath(frame, index);
+      }
+      index = token.next;
+      continue;
+    }
+
+    index += 1;
+  }
+
+  const frame = stack.at(-1) ?? { kind: "root", path: [] };
+  if (frame.kind === "object" && !frame.expectingValue && frame.pendingKey === null) {
+    const keyAtCursor = readKeyTokenAtCursor(source, cursor);
+    if (keyAtCursor && isObjectKeyToken(source, keyAtCursor.value, keyAtCursor.next)) {
+      return [...frame.path, { segment: keyAtCursor.value, from: keyAtCursor.from }];
+    }
+  }
+
+  return activePath.length > 0 ? activePath : currentFramePath(frame);
+}
+
+export function resolveJson5PathAt(source: string, offset: number): JsonPathSegment[] {
+  return resolveJson5BreadcrumbsAt(source, offset).map((entry) => entry.segment);
+}
+
+export function formatJsonPath(path: JsonPathSegment[]): string {
+  if (path.length === 0) {
+    return "Root";
+  }
+  return path
+    .map((segment) => (typeof segment === "number" ? `[${segment}]` : segment))
+    .join(" > ");
+}

--- a/ui/src/ui/components/config-raw-editor.browser.test.ts
+++ b/ui/src/ui/components/config-raw-editor.browser.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatJsonPath,
+  resolveJson5BreadcrumbsAt,
+  resolveJson5PathAt,
+} from "./config-raw-editor-path.ts";
+import "./config-raw-editor.ts";
+
+describe("config raw editor", () => {
+  it("tracks cursor position in the raw editor status bar", async () => {
+    const editor = document.createElement("config-raw-editor");
+    editor.value = '{\n  gateway: {\n    mode: "local"\n  }\n}\n';
+    document.body.append(editor);
+
+    await editor.updateComplete;
+
+    const status = editor.shadowRoot?.querySelector(".status");
+    expect(status?.textContent).toContain("Line 1 Col 1");
+    expect(status?.textContent).toContain("|");
+    expect(status?.textContent).toContain("Path");
+    expect(status?.textContent).toContain("Root");
+
+    editor.setSelection(5);
+    await editor.updateComplete;
+
+    expect(status?.textContent).toContain("Line 2 Col 4");
+    expect(status?.textContent).toContain("Path");
+    expect(status?.textContent).toContain("gateway");
+
+    editor.remove();
+  });
+
+  it("resolves nested JSON5 paths at the cursor", () => {
+    const raw = `{
+  // comment
+  secrets: {
+    providers: {
+      openai: {
+        apiKey: '<redacted>'
+      }
+    }
+  }
+}
+`;
+    const offset = raw.indexOf("apiKey");
+    expect(formatJsonPath(resolveJson5PathAt(raw, offset))).toBe(
+      "secrets > providers > openai > apiKey",
+    );
+  });
+
+  it("resolves object keys and values when a JSON5 comment appears before the colon", () => {
+    const raw = `{
+  foo /* note */: 1
+}
+`;
+    const keyOffset = raw.indexOf("foo");
+    const valueOffset = raw.indexOf("1");
+    expect(formatJsonPath(resolveJson5PathAt(raw, keyOffset))).toBe("foo");
+    expect(formatJsonPath(resolveJson5PathAt(raw, valueOffset))).toBe("foo");
+  });
+
+  it("resolves non-ascii unquoted JSON5 keys", () => {
+    const raw = `{
+  名称: 1
+}
+`;
+    const keyOffset = raw.indexOf("名");
+    const valueOffset = raw.indexOf("1");
+    expect(formatJsonPath(resolveJson5PathAt(raw, keyOffset))).toBe("名称");
+    expect(formatJsonPath(resolveJson5PathAt(raw, valueOffset))).toBe("名称");
+  });
+
+  it("tracks array indexes in JSON5 paths", () => {
+    const raw = `{
+  tools: [
+    { name: "a" },
+    { name: "b" }
+  ]
+}
+`;
+    const offset = raw.lastIndexOf('name: "b"');
+    expect(formatJsonPath(resolveJson5PathAt(raw, offset))).toBe("tools > [1] > name");
+  });
+
+  it("keeps array breadcrumbs structured between values", () => {
+    const raw = `[
+  1,
+  2
+]
+`;
+    const offset = raw.indexOf("2") - 1;
+    const breadcrumbs = resolveJson5BreadcrumbsAt(raw, offset);
+    expect(breadcrumbs).toHaveLength(1);
+    expect(breadcrumbs[0]).toEqual({
+      segment: 1,
+      from: raw.indexOf(",") + 1,
+    });
+    expect(formatJsonPath(resolveJson5PathAt(raw, offset))).toBe("[1]");
+  });
+
+  it("returns breadcrumb positions for nested keys", () => {
+    const raw = `{
+  plugins: {
+    entries: {
+      "feishu-greeting": {
+        config: {
+          message: "hi"
+        }
+      }
+    }
+  }
+}
+`;
+    const offset = raw.indexOf("message");
+    const breadcrumbs = resolveJson5BreadcrumbsAt(raw, offset);
+    expect(breadcrumbs.map((entry) => entry.segment)).toEqual([
+      "plugins",
+      "entries",
+      "feishu-greeting",
+      "config",
+      "message",
+    ]);
+    expect(raw.slice(breadcrumbs[1]?.from ?? 0, (breadcrumbs[1]?.from ?? 0) + 7)).toBe("entries");
+  });
+
+  it("renders array index breadcrumbs between values without blank labels", async () => {
+    const editor = document.createElement("config-raw-editor");
+    editor.value = `[
+  1,
+  2
+]
+`;
+    document.body.append(editor);
+    await editor.updateComplete;
+
+    editor.setSelection(editor.value.indexOf("2") - 1);
+    await editor.updateComplete;
+
+    const buttons = Array.from(
+      editor.shadowRoot?.querySelectorAll<HTMLButtonElement>(".status__path-btn") ?? [],
+    );
+    expect(buttons.map((button) => button.textContent?.trim())).toEqual(["[1]"]);
+
+    buttons[0]?.click();
+    await editor.updateComplete;
+
+    const status = editor.shadowRoot?.querySelector(".status");
+    expect(status?.textContent).toContain("Path");
+    expect(status?.textContent).toContain("[1]");
+
+    editor.remove();
+  });
+
+  it("jumps to the clicked path segment", async () => {
+    const editor = document.createElement("config-raw-editor");
+    editor.value = `{
+  plugins: {
+    entries: {
+      "feishu-greeting": {
+        config: {
+          message: "hi"
+        }
+      }
+    }
+  }
+}
+`;
+    document.body.append(editor);
+    await editor.updateComplete;
+
+    editor.setSelection(editor.value.indexOf("message"));
+    await editor.updateComplete;
+
+    const buttons = Array.from(
+      editor.shadowRoot?.querySelectorAll<HTMLButtonElement>(".status__path-btn") ?? [],
+    );
+    const target = buttons.find((button) => button.textContent?.trim() === "entries");
+    target?.click();
+    await editor.updateComplete;
+
+    const status = editor.shadowRoot?.querySelector(".status");
+    expect(status?.textContent).toContain("Path");
+    expect(status?.textContent).toContain("plugins");
+    expect(status?.textContent).toContain("entries");
+    expect(status?.textContent).not.toContain("message");
+
+    editor.remove();
+  });
+});

--- a/ui/src/ui/components/config-raw-editor.ts
+++ b/ui/src/ui/components/config-raw-editor.ts
@@ -1,0 +1,327 @@
+import { indentWithTab } from "@codemirror/commands";
+import { EditorState, type Extension, Compartment } from "@codemirror/state";
+import { EditorView, keymap } from "@codemirror/view";
+import { basicSetup } from "codemirror";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, property, query, state } from "lit/decorators.js";
+import { I18nController } from "../../i18n/lib/lit-controller.ts";
+import { t } from "../../i18n/lib/translate.ts";
+import { resolveJson5BreadcrumbsAt, type JsonPathBreadcrumb } from "./config-raw-editor-path.ts";
+
+const rawEditorTheme = EditorView.theme({
+  "&": {
+    height: "100%",
+    minHeight: "520px",
+    color: "var(--text)",
+    backgroundColor: "transparent",
+  },
+  ".cm-scroller": {
+    fontFamily: "var(--mono)",
+    fontSize: "13px",
+    lineHeight: "1.55",
+    overflow: "auto",
+    scrollbarWidth: "thin",
+    scrollbarColor: "var(--border) transparent",
+  },
+  ".cm-content": {
+    padding: "14px 0",
+    minWidth: "fit-content",
+  },
+  ".cm-line": {
+    padding: "0 16px",
+  },
+  ".cm-gutters": {
+    minWidth: "52px",
+    color: "var(--muted)",
+    backgroundColor: "transparent",
+    borderRight: "1px solid var(--border)",
+  },
+  ".cm-activeLine": {
+    backgroundColor: "color-mix(in srgb, var(--accent-subtle) 55%, transparent)",
+  },
+  ".cm-activeLineGutter": {
+    color: "var(--text)",
+    backgroundColor: "color-mix(in srgb, var(--accent-subtle) 45%, transparent)",
+  },
+  ".cm-selectionBackground, ::selection": {
+    backgroundColor: "color-mix(in srgb, var(--accent) 24%, transparent)",
+  },
+  ".cm-cursor, .cm-dropCursor": {
+    borderLeftColor: "var(--accent)",
+  },
+  ".cm-focused": {
+    outline: "none",
+  },
+  ".cm-matchingBracket": {
+    color: "var(--text)",
+    backgroundColor: "color-mix(in srgb, var(--accent-subtle) 70%, transparent)",
+    outline: "1px solid color-mix(in srgb, var(--accent) 45%, transparent)",
+    borderRadius: "3px",
+  },
+  ".cm-nonmatchingBracket": {
+    color: "var(--danger, #ff6b6b)",
+    outline: "1px solid color-mix(in srgb, var(--danger, #ff6b6b) 40%, transparent)",
+    borderRadius: "3px",
+  },
+});
+
+@customElement("config-raw-editor")
+export class ConfigRawEditor extends LitElement {
+  @property() value = "";
+  @property({ type: Boolean, reflect: true }) disabled = false;
+
+  @state() private cursorLine = 1;
+  @state() private cursorColumn = 1;
+  @state() private cursorBreadcrumbs: JsonPathBreadcrumb[] = [];
+  @state() private selectionChars = 0;
+
+  @query("[data-editor-root]") private editorRoot!: HTMLDivElement;
+
+  private readonly i18n = new I18nController(this);
+  private editorView: EditorView | null = null;
+  private syncingFromEditor = false;
+  private editableCompartment = new Compartment();
+  private readOnlyCompartment = new Compartment();
+
+  static styles = css`
+    :host {
+      display: block;
+      height: min(72vh, 720px);
+      min-height: 520px;
+    }
+
+    .frame {
+      display: grid;
+      grid-template-rows: minmax(0, 1fr) auto;
+      height: 100%;
+      min-height: 0;
+      overflow: hidden;
+    }
+
+    .status {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 10px 14px;
+      border-top: 1px solid var(--border);
+      background: transparent;
+      color: var(--muted);
+      font-family: var(--mono);
+      font-size: 12px;
+      letter-spacing: 0.01em;
+    }
+
+    .status__meta {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .status__sep {
+      color: var(--muted-strong);
+    }
+
+    .status__path {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+
+    .status__path-btn {
+      padding: 0;
+      border: 0;
+      background: transparent;
+      color: inherit;
+      font: inherit;
+      cursor: pointer;
+      text-decoration: none;
+    }
+
+    .status__path-btn:hover {
+      color: var(--text);
+      text-decoration: underline;
+    }
+
+    :host([disabled]) .frame {
+      opacity: 0.72;
+    }
+
+    .editor-root {
+      min-height: 0;
+      min-width: 0;
+    }
+
+    .frame ::-webkit-scrollbar {
+      width: 8px;
+      height: 8px;
+    }
+
+    .frame ::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    .frame ::-webkit-scrollbar-thumb {
+      background: var(--border);
+      border-radius: var(--radius-full);
+    }
+
+    .frame ::-webkit-scrollbar-thumb:hover {
+      background: var(--border-strong);
+    }
+  `;
+
+  render() {
+    const lineColLabel = t("config.rawEditor.lineCol", {
+      line: String(this.cursorLine),
+      col: String(this.cursorColumn),
+    });
+    const selectionLabel =
+      this.selectionChars > 0
+        ? t("config.rawEditor.selected", { count: String(this.selectionChars) })
+        : t("config.rawEditor.noSelection");
+
+    return html`
+      <div class="frame">
+        <div class="editor-root" data-editor-root></div>
+        <div class="status" aria-live="polite">
+          <div class="status__meta">
+            <span>${lineColLabel}</span>
+            <span class="status__sep">|</span>
+            <span class="status__path">
+              <span>${t("config.rawEditor.path")}</span>
+              ${
+                this.cursorBreadcrumbs.length === 0
+                  ? html`<span>${t("config.rawEditor.root")}</span>`
+                  : this.cursorBreadcrumbs.map(
+                      (entry, index) => html`
+                        <button
+                          class="status__path-btn"
+                          type="button"
+                          @click=${() => this.setSelection(entry.from)}
+                        >
+                          ${
+                            typeof entry.segment === "number" ? `[${entry.segment}]` : entry.segment
+                          }
+                        </button>
+                        ${
+                          index < this.cursorBreadcrumbs.length - 1
+                            ? html`
+                                <span>&gt;</span>
+                              `
+                            : nothing
+                        }
+                      `,
+                    )
+              }
+            </span>
+            <span class="status__sep">|</span>
+            <span>${selectionLabel}</span>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  protected firstUpdated() {
+    this.editorView = new EditorView({
+      state: this.createState(this.value),
+      parent: this.editorRoot,
+    });
+    this.syncCursorSummary();
+  }
+
+  protected updated(changed: Map<PropertyKey, unknown>) {
+    if (!this.editorView) {
+      return;
+    }
+
+    if (changed.has("disabled")) {
+      this.editorView.dispatch({
+        effects: [
+          this.editableCompartment.reconfigure(EditorView.editable.of(!this.disabled)),
+          this.readOnlyCompartment.reconfigure(EditorState.readOnly.of(this.disabled)),
+        ],
+      });
+    }
+
+    if (changed.has("value") && !this.syncingFromEditor) {
+      const current = this.editorView.state.doc.toString();
+      if (current !== this.value) {
+        this.editorView.dispatch({
+          changes: { from: 0, to: current.length, insert: this.value },
+        });
+      }
+    }
+  }
+
+  disconnectedCallback() {
+    this.editorView?.destroy();
+    this.editorView = null;
+    super.disconnectedCallback();
+  }
+
+  setSelection(from: number, to = from) {
+    if (!this.editorView) {
+      return;
+    }
+    const docLength = this.editorView.state.doc.length;
+    const anchor = Math.max(0, Math.min(from, docLength));
+    const head = Math.max(0, Math.min(to, docLength));
+    this.editorView.dispatch({
+      selection: { anchor, head },
+      scrollIntoView: true,
+    });
+    this.editorView.focus();
+  }
+
+  private createState(doc: string): EditorState {
+    const extensions: Extension[] = [
+      basicSetup,
+      keymap.of([indentWithTab]),
+      rawEditorTheme,
+      this.editableCompartment.of(EditorView.editable.of(!this.disabled)),
+      this.readOnlyCompartment.of(EditorState.readOnly.of(this.disabled)),
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged) {
+          const next = update.state.doc.toString();
+          if (next !== this.value) {
+            this.syncingFromEditor = true;
+            this.value = next;
+            this.dispatchEvent(
+              new CustomEvent("raw-change", {
+                detail: { value: next },
+                bubbles: true,
+                composed: true,
+              }),
+            );
+            this.syncingFromEditor = false;
+          }
+        }
+        if (update.docChanged || update.selectionSet) {
+          this.syncCursorSummary(update.state);
+        }
+      }),
+    ];
+    return EditorState.create({ doc, extensions });
+  }
+
+  private syncCursorSummary(state = this.editorView?.state) {
+    if (!state) {
+      return;
+    }
+    const selection = state.selection.main;
+    const line = state.doc.lineAt(selection.head);
+    this.cursorLine = line.number;
+    this.cursorColumn = selection.head - line.from + 1;
+    this.cursorBreadcrumbs = resolveJson5BreadcrumbsAt(state.doc.toString(), selection.head);
+    this.selectionChars = Math.abs(selection.to - selection.from);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "config-raw-editor": ConfigRawEditor;
+  }
+}

--- a/ui/src/ui/views/config.browser.test.ts
+++ b/ui/src/ui/views/config.browser.test.ts
@@ -134,6 +134,20 @@ describe("config view", () => {
     expect(applyButton?.disabled).toBe(false);
   });
 
+  it("renders the enhanced raw editor in raw mode", () => {
+    const container = document.createElement("div");
+    render(
+      renderConfig({
+        ...baseProps(),
+        formMode: "raw",
+      }),
+      container,
+    );
+
+    expect(container.querySelector("config-raw-editor")).not.toBeNull();
+    expect(container.querySelector("textarea")).toBeNull();
+  });
+
   it("switches mode via the sidebar toggle", () => {
     const container = document.createElement("div");
     const onFormModeChange = vi.fn();

--- a/ui/src/ui/views/config.ts
+++ b/ui/src/ui/views/config.ts
@@ -1,5 +1,6 @@
 import { html, nothing } from "lit";
 import type { ConfigUiHints } from "../types.ts";
+import "../components/config-raw-editor.ts";
 import { hintForPath, humanize, schemaType, type JsonSchema } from "./config-form.shared.ts";
 import { analyzeConfigSchema, renderConfigForm, SECTION_META } from "./config-form.ts";
 import { getTagFilters, replaceTagFilters } from "./config-search.ts";
@@ -795,11 +796,13 @@ export function renderConfig(props: ConfigProps) {
               : html`
                 <label class="field config-raw-field">
                   <span>Raw JSON5</span>
-                  <textarea
-                    .value=${props.raw}
-                    @input=${(e: Event) =>
-                      props.onRawChange((e.target as HTMLTextAreaElement).value)}
-                  ></textarea>
+                  <div class="config-raw-shell">
+                    <config-raw-editor
+                      .value=${props.raw}
+                      @raw-change=${(e: Event) =>
+                        props.onRawChange((e as CustomEvent<{ value: string }>).detail.value)}
+                    ></config-raw-editor>
+                  </div>
                 </label>
               `
           }


### PR DESCRIPTION
## Summary

- Problem: the raw JSON5 config editor was hard to scan and navigate when editing nested config.
- Why it matters: manual config editing is slower and more error-prone when users cannot quickly see where they are in the document.
- What changed: added a status bar with line/column, current path, and selection info; added path-aware breadcrumb navigation for nested keys and array items; improved raw editor readability and localized status labels; added browser tests for the new behavior.
- What did NOT change (scope boundary): no backend config format, save semantics, or runtime config behavior changed.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [x] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- None

## User-visible / Behavior Changes

- The raw JSON5 editor now shows the current line/column, active config path, and selection length in a status bar.
- Users can inspect nested object and array paths from the cursor position and click breadcrumb segments to jump back to parent keys.
- The raw editor styling is easier to scan, with improved spacing, gutter treatment, active-line highlighting, and localized status labels.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev
- Model/provider: N/A
- Integration/channel (if any): N/A
- Relevant config (redacted): N/A

### Steps

1. Open the config UI.
2. Switch to the raw JSON5 editor.
3. Move the cursor through nested keys and arrays, and click breadcrumb segments in the status bar.

### Expected

- The editor exposes cursor position and config path context, and breadcrumb clicks jump to the selected parent segment.

### Actual

- The status bar updates with line/column, path, and selection info, and breadcrumb navigation works for nested JSON5 structures.

## Evidence

Attach at least one:

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: ran `pnpm --dir ui test --run src/ui/components/config-raw-editor.browser.test.ts src/ui/views/config.browser.test.ts`.
- Edge cases checked: nested object keys, array indices, breadcrumb jumping, and localized status text wiring.
- What you did **not** verify: manual cross-browser checking outside the Chromium browser-test run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this PR.
- Files/config to restore: the raw config editor files touched by this PR under `ui/src/ui/components`, `ui/src/ui/views`, `ui/src/styles`, and related locale entries.
- Known bad symptoms reviewers should watch for: incorrect breadcrumb paths, cursor metadata not updating, or raw editor rendering regressions.

## Risks and Mitigations

- Risk: path parsing could show the wrong breadcrumb for some JSON5 edge cases.
  - Mitigation: added browser tests covering nested keys, arrays, and breadcrumb jumping.
