### PR TITLE
fix(auto-reply): extend typing TTL and clarify timeouts [AI]

### DIFF
--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import { resolveBootstrapWarningSignaturesSeen } from "../../agents/bootstrap-budget.js";
 import { runCliAgent } from "../../agents/cli-runner.js";
 import { getCliSessionId } from "../../agents/cli-session.js";
+import { resolveFailoverReasonFromError } from "../../agents/failover-error.js";
 import { runWithModelFallback } from "../../agents/model-fallback.js";
 import { isCliProvider } from "../../agents/model-selection.js";
 import {
@@ -609,11 +610,16 @@ export async function runAgentTurnWithFallback(params: {
         ? sanitizeUserFacingText(message, { errorContext: true })
         : message;
       const trimmedMessage = safeMessage.replace(/\.\s*$/, "");
+      const isTimeoutFailure =
+        resolveFailoverReasonFromError(err) === "timeout" ||
+        /\b(?:timed?\s*out|timeout)\b/i.test(safeMessage);
       const fallbackText = isContextOverflow
         ? "⚠️ Context overflow — prompt too large for this model. Try a shorter message or a larger-context model."
         : isRoleOrderingError
           ? "⚠️ Message ordering conflict - please try again. If this persists, use /new to start a fresh session."
-          : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
+          : isTimeoutFailure
+            ? "⚠️ Model run timed out before reply. This run has ended and will not continue in the background.\nSend a new message (or /retry) to start a fresh run.\nLogs: openclaw logs --follow"
+            : `⚠️ Agent failed before reply: ${trimmedMessage}.\nLogs: openclaw logs --follow`;
 
       return {
         kind: "final",

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -1387,6 +1387,40 @@ describe("runReplyAgent typing (heartbeat)", () => {
     });
   });
 
+  it("surfaces explicit timeout guidance when the run times out", async () => {
+    await withTempStateDir(async (stateDir) => {
+      const sessionId = "session-timeout";
+      const storePath = path.join(stateDir, "sessions", "sessions.json");
+      const sessionEntry: SessionEntry = {
+        sessionId,
+        updatedAt: Date.now(),
+      };
+      const sessionStore = { main: sessionEntry };
+
+      await fs.mkdir(path.dirname(storePath), { recursive: true });
+      await fs.writeFile(storePath, JSON.stringify(sessionStore), "utf-8");
+
+      state.runEmbeddedPiAgentMock.mockImplementationOnce(async () => {
+        throw new Error("Request timed out");
+      });
+
+      const { run } = createMinimalRun({
+        sessionEntry,
+        sessionStore,
+        sessionKey: "main",
+        storePath,
+      });
+      const res = await run();
+
+      expect(res).toMatchObject({
+        text: expect.stringContaining("timed out before reply"),
+      });
+      expect(res).toMatchObject({
+        text: expect.stringContaining("run has ended"),
+      });
+    });
+  });
+
   it("still replies even if session reset fails to persist", async () => {
     await withTempStateDir(async (stateDir) => {
       const saveSpy = vi

--- a/src/auto-reply/reply/get-reply.test-mocks.ts
+++ b/src/auto-reply/reply/get-reply.test-mocks.ts
@@ -4,6 +4,7 @@ export function registerGetReplyCommonMocks(): void {
   vi.mock("../../agents/agent-scope.js", () => ({
     resolveAgentDir: vi.fn(() => "/tmp/agent"),
     resolveAgentWorkspaceDir: vi.fn(() => "/tmp/workspace"),
+    resolveRunModelFallbacksOverride: vi.fn(() => undefined),
     resolveSessionAgentId: vi.fn(() => "main"),
     resolveAgentSkillsFilter: vi.fn(() => undefined),
   }));
@@ -20,9 +21,14 @@ export function registerGetReplyCommonMocks(): void {
   vi.mock("../../channels/model-overrides.js", () => ({
     resolveChannelModelOverride: vi.fn(() => undefined),
   }));
-  vi.mock("../../config/config.js", () => ({
-    loadConfig: vi.fn(() => ({})),
-  }));
+  vi.mock("../../config/config.js", async (importOriginal) => {
+    const actual = await importOriginal<typeof import("../../config/config.js")>();
+    return {
+      ...actual,
+      loadConfig: vi.fn(() => ({})),
+      STATE_DIR: "/tmp/openclaw-state",
+    };
+  });
   vi.mock("../../runtime.js", () => ({
     defaultRuntime: { log: vi.fn() },
   }));

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -1,6 +1,7 @@
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
+  resolveRunModelFallbacksOverride,
   resolveSessionAgentId,
   resolveAgentSkillsFilter,
 } from "../../agents/agent-scope.js";
@@ -9,6 +10,7 @@ import { resolveAgentTimeoutMs } from "../../agents/timeout.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../../agents/workspace.js";
 import { resolveChannelModelOverride } from "../../channels/model-overrides.js";
 import { type OpenClawConfig, loadConfig } from "../../config/config.js";
+import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
 import { applyLinkUnderstanding } from "../../link-understanding/apply.js";
 import { applyMediaUnderstanding } from "../../media-understanding/apply.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -52,6 +54,34 @@ function mergeSkillFilters(channelFilter?: string[], agentFilter?: string[]): st
   }
   const agentSet = new Set(agent);
   return channel.filter((name) => agentSet.has(name));
+}
+
+// Keep typing alive long enough for multi-attempt runs, but cap it to avoid
+// indefinite typing loops when timeouts are very large or disabled.
+const MIN_TYPING_TTL_MS = 2 * 60_000;
+const MAX_TYPING_TTL_MS = 120 * 60_000;
+const TRANSIENT_RETRY_CYCLES = 2;
+const TYPING_TTL_BUFFER_MS = 15_000;
+
+function resolveTypingTtlMs(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  sessionKey?: string;
+  timeoutMs: number;
+}): number {
+  const fallbackOverrides = resolveRunModelFallbacksOverride({
+    cfg: params.cfg,
+    agentId: params.agentId,
+    sessionKey: params.sessionKey,
+  });
+  const configuredFallbacks = resolveAgentModelFallbackValues(params.cfg.agents?.defaults?.model);
+  const fallbackCount = Math.max(0, (fallbackOverrides ?? configuredFallbacks).length);
+  const projectedAttemptCount = Math.max(1, 1 + fallbackCount);
+  // One transient HTTP retry can replay the full model chain; keep typing alive
+  // long enough to cover both cycles so users do not see false "dead" runs.
+  const projectedTtlMs =
+    params.timeoutMs * projectedAttemptCount * TRANSIENT_RETRY_CYCLES + TYPING_TTL_BUFFER_MS;
+  return Math.max(MIN_TYPING_TTL_MS, Math.min(projectedTtlMs, MAX_TYPING_TTL_MS));
 }
 
 export async function getReplyFromConfig(
@@ -114,10 +144,17 @@ export async function getReplyFromConfig(
     agentCfg?.typingIntervalSeconds ?? sessionCfg?.typingIntervalSeconds;
   const typingIntervalSeconds =
     typeof configuredTypingSeconds === "number" ? configuredTypingSeconds : 6;
+  const typingTtlMs = resolveTypingTtlMs({
+    cfg,
+    agentId,
+    sessionKey: agentSessionKey,
+    timeoutMs,
+  });
   const typing = createTypingController({
     onReplyStart: opts?.onReplyStart,
     onCleanup: opts?.onTypingCleanup,
     typingIntervalSeconds,
+    typingTtlMs,
     silentToken: SILENT_REPLY_TOKEN,
     log: defaultRuntime.log,
   });

--- a/src/auto-reply/reply/get-reply.typing-timeout-budget.test.ts
+++ b/src/auto-reply/reply/get-reply.typing-timeout-budget.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MsgContext } from "../templating.js";
+import { registerGetReplyCommonMocks } from "./get-reply.test-mocks.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveReplyDirectives: vi.fn(),
+  initSessionState: vi.fn(),
+}));
+
+registerGetReplyCommonMocks();
+
+vi.mock("../../link-understanding/apply.js", () => ({
+  applyLinkUnderstanding: vi.fn(async () => undefined),
+}));
+vi.mock("../../media-understanding/apply.js", () => ({
+  applyMediaUnderstanding: vi.fn(async () => undefined),
+}));
+vi.mock("./commands-core.js", () => ({
+  emitResetCommandHooks: vi.fn(async () => undefined),
+}));
+vi.mock("./get-reply-directives.js", () => ({
+  resolveReplyDirectives: (...args: unknown[]) => mocks.resolveReplyDirectives(...args),
+}));
+vi.mock("./session.js", () => ({
+  initSessionState: (...args: unknown[]) => mocks.initSessionState(...args),
+}));
+
+const { getReplyFromConfig } = await import("./get-reply.js");
+const { createTypingController } = await import("./typing.js");
+const { resolveAgentTimeoutMs } = await import("../../agents/timeout.js");
+const { resolveRunModelFallbacksOverride } = await import("../../agents/agent-scope.js");
+
+function buildCtx(overrides: Partial<MsgContext> = {}): MsgContext {
+  return {
+    Provider: "telegram",
+    Surface: "telegram",
+    OriginatingChannel: "telegram",
+    OriginatingTo: "telegram:-100123",
+    ChatType: "group",
+    Body: "hello",
+    BodyForAgent: "hello",
+    RawBody: "hello",
+    CommandBody: "hello",
+    SessionKey: "agent:main:telegram:-100123",
+    From: "telegram:user:42",
+    To: "telegram:-100123",
+    GroupChannel: "ops",
+    Timestamp: 1710000000000,
+    ...overrides,
+  };
+}
+
+describe("getReply typing timeout budget", () => {
+  beforeEach(() => {
+    mocks.resolveReplyDirectives.mockReset();
+    mocks.initSessionState.mockReset();
+    vi.mocked(createTypingController).mockClear();
+    vi.mocked(resolveAgentTimeoutMs).mockReset();
+    vi.mocked(resolveRunModelFallbacksOverride).mockReset();
+
+    mocks.resolveReplyDirectives.mockResolvedValue({ kind: "reply", reply: { text: "ok" } });
+    mocks.initSessionState.mockResolvedValue({
+      sessionCtx: {},
+      sessionEntry: {},
+      previousSessionEntry: {},
+      sessionStore: {},
+      sessionKey: "agent:main:telegram:-100123",
+      sessionId: "session-1",
+      isNewSession: false,
+      resetTriggered: false,
+      systemSent: false,
+      abortedLastRun: false,
+      storePath: "/tmp/sessions.json",
+      sessionScope: "per-chat",
+      groupResolution: undefined,
+      isGroup: true,
+      triggerBodyNormalized: "",
+      bodyStripped: "",
+    });
+  });
+
+  it("extends typing TTL based on timeout and fallback chain budget", async () => {
+    vi.mocked(resolveAgentTimeoutMs).mockReturnValue(90_000);
+    vi.mocked(resolveRunModelFallbacksOverride).mockReturnValue([
+      "openai/gpt-5.2",
+      "openai/gpt-5.1",
+    ]);
+
+    await getReplyFromConfig(buildCtx(), undefined, {});
+
+    expect(createTypingController).toHaveBeenCalledWith(
+      expect.objectContaining({
+        typingTtlMs: 555_000,
+      }),
+    );
+  });
+
+  it("keeps a minimum typing TTL for short timeout chains", async () => {
+    vi.mocked(resolveAgentTimeoutMs).mockReturnValue(30_000);
+    vi.mocked(resolveRunModelFallbacksOverride).mockReturnValue([]);
+
+    await getReplyFromConfig(buildCtx(), undefined, {});
+
+    expect(createTypingController).toHaveBeenCalledWith(
+      expect.objectContaining({
+        typingTtlMs: 120_000,
+      }),
+    );
+  });
+
+  it("caps typing TTL to avoid unbounded typing loops", async () => {
+    vi.mocked(resolveAgentTimeoutMs).mockReturnValue(4_000_000);
+    vi.mocked(resolveRunModelFallbacksOverride).mockReturnValue([
+      "openai/gpt-5.2",
+      "openai/gpt-5.1",
+      "openai/gpt-5.0",
+    ]);
+
+    await getReplyFromConfig(buildCtx(), undefined, {});
+
+    expect(createTypingController).toHaveBeenCalledWith(
+      expect.objectContaining({
+        typingTtlMs: 7_200_000,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Describe the problem and fix in 2–5 bullets:

- Problem: typing indicators stop early and timeout errors look like silent failures on multi-attempt model runs.
- Why it matters: users interpret the bot as dead and do not know the run has ended.
- What changed: typing TTL now budgets for timeout + fallback cycles; timeout failures return an explicit final message; added tests.
- What did NOT change (scope boundary): no channel-specific logic, no change to fallback selection or timeout durations.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [x] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #

## User-visible / Behavior Changes

- Typing indicators stay active for the full timeout + fallback budget (bounded).
- Timeout failures now say the run ended and prompt the user to retry.

## Security Impact (required)

- New permissions/capabilities? (No)
- Secrets/tokens handling changed? (No)
- New/changed network calls? (No)
- Command/tool execution surface changed? (No)
- Data access scope changed? (No)
- If any Yes, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS (local)
- Runtime/container: local node
- Model/provider: mixed (fallback chain)
- Integration/channel (if any): n/a
- Relevant config (redacted): agents.defaults.model.fallbacks set

### Steps

1. Configure model fallbacks and a timeout.
2. Run a message that hits the timeout across fallbacks.
3. Observe typing indicator duration and final timeout message.

### Expected

- Typing stays active for the full attempt budget.
- Timeout reply clarifies the run ended and suggests retrying.

### Actual

- Previously typing stopped early and the timeout looked like a silent failure.

## Evidence

- [ ] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios:
  - `pnpm test -- src/auto-reply/reply/get-reply.typing-timeout-budget.test.ts` (pass)
- Edge cases checked:
  - `pnpm test:e2e -- src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts` ran the e2e suite and failed in unrelated tests (`test/gateway.multi.e2e.test.ts`, `test/cli-json-stdout.e2e.test.ts`) due to missing `dist` build artifacts.
- What you did **not** verify:
  - `pnpm build` / `pnpm check`

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [ ] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (Yes)
- Config/env changes? (No)
- Migration needed? (No)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert commit f45b2f8b1
- Files/config to restore: n/a
- Known bad symptoms reviewers should watch for: typing indicators stuck for long durations.

## Risks and Mitigations

- Risk: longer typing windows on slow models could feel too long.
  - Mitigation: TTL is bounded (max 120 minutes) and still ends on run completion.

## AI-Assisted

- This PR was AI-assisted.
- Testing: partial (unit + e2e subset; full suite not run).
