### PR TITLE
fix: classify workspace overrides by effective skill source

### DIFF
--- a/src/agents/skills-status.ts
+++ b/src/agents/skills-status.ts
@@ -171,7 +171,6 @@ function buildSkillStatus(
   config?: OpenClawConfig,
   prefs?: SkillsInstallPreferences,
   eligibility?: SkillEligibilityContext,
-  bundledNames?: Set<string>,
 ): SkillStatusEntry {
   const skillKey = resolveSkillKey(entry);
   const skillConfig = resolveSkillConfig(config, skillKey);
@@ -186,10 +185,7 @@ function buildSkillStatus(
       (skillConfig?.apiKey && entry.metadata?.primaryEnv === envName),
     );
   const isConfigSatisfied = (pathStr: string) => isConfigPathTruthy(config, pathStr);
-  const bundled =
-    bundledNames && bundledNames.size > 0
-      ? bundledNames.has(entry.skill.name)
-      : entry.skill.source === "openclaw-bundled";
+  const bundled = entry.skill.source === "openclaw-bundled";
 
   const { emoji, homepage, required, missing, requirementsSatisfied, configChecks } =
     evaluateEntryRequirementsForCurrentPlatform({
@@ -247,7 +243,7 @@ export function buildWorkspaceSkillStatus(
     workspaceDir,
     managedSkillsDir,
     skills: skillEntries.map((entry) =>
-      buildSkillStatus(entry, opts?.config, prefs, opts?.eligibility, bundledContext.names),
+      buildSkillStatus(entry, opts?.config, prefs, opts?.eligibility),
     ),
   };
 }

--- a/src/agents/skills.buildworkspaceskillstatus.test.ts
+++ b/src/agents/skills.buildworkspaceskillstatus.test.ts
@@ -3,8 +3,8 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withEnv, withEnvAsync } from "../test-utils/env.js";
-import { writeSkill } from "./skills.e2e-test-helpers.js";
 import { buildWorkspaceSkillStatus } from "./skills-status.js";
+import { writeSkill } from "./skills.e2e-test-helpers.js";
 import type { SkillEntry } from "./skills/types.js";
 
 function makeEntry(params: {

--- a/src/agents/skills.buildworkspaceskillstatus.test.ts
+++ b/src/agents/skills.buildworkspaceskillstatus.test.ts
@@ -1,5 +1,9 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { withEnv } from "../test-utils/env.js";
+import { withEnv, withEnvAsync } from "../test-utils/env.js";
+import { writeSkill } from "./skills.e2e-test-helpers.js";
 import { buildWorkspaceSkillStatus } from "./skills-status.js";
 import type { SkillEntry } from "./skills/types.js";
 
@@ -106,6 +110,30 @@ describe("buildWorkspaceSkillStatus", () => {
     expect(skill?.blockedByAllowlist).toBe(true);
     expect(skill?.eligible).toBe(false);
     expect(skill?.bundled).toBe(true);
+  });
+
+  it("keeps workspace overrides of bundled skills out of the bundled group", async () => {
+    const bundledDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-bundled-status-"));
+    await writeSkill({
+      dir: path.join(bundledDir, "peekaboo"),
+      name: "peekaboo",
+      description: "bundled override target",
+    });
+    const entry = makeEntry({
+      name: "peekaboo",
+      source: "openclaw-workspace",
+    });
+
+    const report = await withEnvAsync({ OPENCLAW_BUNDLED_SKILLS_DIR: bundledDir }, async () =>
+      buildWorkspaceSkillStatus("/tmp/ws", {
+        entries: [entry],
+      }),
+    );
+    const skill = report.skills.find((reportEntry) => reportEntry.name === "peekaboo");
+
+    expect(skill).toBeDefined();
+    expect(skill?.source).toBe("openclaw-workspace");
+    expect(skill?.bundled).toBe(false);
   });
 
   it("filters install options by OS", async () => {


### PR DESCRIPTION
## What this fixes

When a workspace skill overrides a bundled skill with the same name, OpenClaw currently reports the resulting skill as `bundled: true` if that name appears in the bundled skills set.

That is incorrect for the effective resolved skill entry, and it causes the Control UI to group the workspace override under **Built-in Skills** instead of **Workspace Skills**.

## Change

- make `bundled` depend only on the effective entry source
- remove the now-unneeded `bundledNames` parameter from `buildSkillStatus`
- add a regression test covering a workspace skill that overrides a bundled skill with the same name

## Why this is correct

The final resolved skill entry already reflects override precedence. At that point, `bundled` should describe the source of that resolved entry, not whether some same-named bundled skill exists elsewhere on disk.

## Validation

- reproduced locally against an installed OpenClaw instance with a workspace `summarize` skill overriding the bundled one
- verified the local hotfix causes the skill to appear in the expected Workspace Skills group in Control UI
- added a regression test in `src/agents/skills.buildworkspaceskillstatus.test.ts`

