### PR TITLE
fix(telegram): send fallback when model produces empty output without error

### DIFF
--- a/src/telegram/bot-message-dispatch.test.ts
+++ b/src/telegram/bot-message-dispatch.test.ts
@@ -1690,6 +1690,29 @@ describe("dispatchTelegramMessage draft streaming", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
+  it("sends fallback when model produces empty output without error or skip", async () => {
+    const draftStream = createDraftStream(999);
+    createTelegramDraftStream.mockReturnValue(draftStream);
+    dispatchReplyWithBufferedBlockDispatcher.mockImplementation(async () => {
+      // Model produced nothing — no deliver, no skip, no error
+      return { queuedFinal: false };
+    });
+    deliverReplies.mockResolvedValueOnce({ delivered: true });
+
+    await dispatchWithContext({ context: createContext() });
+
+    expect(deliverReplies).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [
+          expect.objectContaining({
+            text: expect.stringContaining("No response"),
+          }),
+        ],
+      }),
+    );
+    expect(draftStream.clear).toHaveBeenCalledTimes(1);
+  });
+
   it("sends fallback and clears preview when deliver throws (dispatcher swallows error)", async () => {
     const draftStream = createDraftStream();
     createTelegramDraftStream.mockReturnValue(draftStream);

--- a/src/telegram/bot-message-dispatch.ts
+++ b/src/telegram/bot-message-dispatch.ts
@@ -752,11 +752,7 @@ export const dispatchTelegramMessage = async ({
   }
   let sentFallback = false;
   const deliverySummary = deliveryState.snapshot();
-  if (
-    dispatchError ||
-    (!deliverySummary.delivered &&
-      (deliverySummary.skippedNonSilent > 0 || deliverySummary.failedNonSilent > 0))
-  ) {
+  if (dispatchError || (!deliverySummary.delivered && !queuedFinal)) {
     const fallbackText = dispatchError
       ? "Something went wrong while processing your request. Please try again."
       : EMPTY_RESPONSE_FALLBACK;


### PR DESCRIPTION
## Summary

- Problem: When a model completes successfully but returns empty `content: []` (no text, no error, no skip event), Telegram silently drops the reply — the user gets no response at all.
- Why it matters: Any provider can occasionally return empty output (rate-limit without error, content filter silent rejection, etc.). Users see the bot "thinking" but never receiving a reply.
- What changed: Simplified the fallback condition from checking `skippedNonSilent > 0 || failedNonSilent > 0` to `!delivered && !queuedFinal`, which correctly covers all cases where the user would receive nothing.
- What did NOT change (scope boundary): Delivery tracking, skip/fail counting, error handling paths, and the `dispatchError` branch are all untouched.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #221, #37278, #22130
- Supersedes #30708, #2652

## User-visible / Behavior Changes

- Telegram users now see "No response generated. Please try again." instead of silence when a model returns empty output without an error.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local dev (bun/pnpm)
- Model/provider: any (reproducible when model returns empty content array)
- Integration/channel: Telegram
- Relevant config: n/a

### Steps

1. Configure a model/provider that returns empty `content: []` on completion (no error thrown).
2. Send a message to the Telegram bot.
3. Bot processes the message (`message processed, outcome=completed`) but never sends a reply.

### Expected

- User receives "No response generated. Please try again."

### Actual

- User receives nothing (silent failure).

## Evidence

- [x] Failing test/log before + passing after
- New test: `"sends fallback when model produces empty output without error or skip"` — verifies the fallback fires when dispatcher returns `{ queuedFinal: false }` with no deliver/skip/error calls.
- All 60 dispatch tests pass.
- Confirmed in production: a provider returning empty `content: []` caused repeated silent failures on Telegram DMs (`message processed, outcome=completed` in logs but no outbound reply). After the fix, the fallback message is delivered.

## Human Verification (required)

- Verified scenarios: Empty model output triggers fallback message; existing skip/fail/error paths still trigger correctly.
- Edge cases checked: `queuedFinal=true` with `delivered=false` does NOT trigger fallback (correct — final is buffered).
- Live verified: Observed the bug in production on Telegram DM — model completed with empty `content: []` across multiple messages, all silently dropped. After applying the fix and restarting the gateway, the fallback path activates correctly.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert: Revert single commit.
- Known bad symptoms: Unexpected "No response generated" messages when they shouldn't appear (would indicate a false positive in the condition).

## Risks and Mitigations

- Risk: False-positive fallback when `delivered=false` and `queuedFinal=false` but the silence is intentional.
  - Mitigation: Intentional silence uses `queuedFinal=true` or silent skip tokens (which set `delivered` via the delivery path). The new condition only fires when genuinely nothing was sent to the user.