### PR TITLE
fix(agents): strip thinking tags from non-reasoning providers when thinking is off

### DIFF
--- a/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/pi-embedded-helpers.sanitizeuserfacingtext.test.ts
@@ -111,6 +111,35 @@ describe("sanitizeUserFacingText", () => {
   it.each(["\n\n", "  \n  "])("returns empty for whitespace-only input: %j", (input) => {
     expect(sanitizeUserFacingText(input)).toBe("");
   });
+
+  it("strips <think>...</think> tags and their content", () => {
+    expect(sanitizeUserFacingText("<think>internal reasoning</think>Hello")).toBe("Hello");
+    expect(sanitizeUserFacingText("Hi <think>some thought</think> there")).toBe("Hi  there");
+  });
+
+  it("strips <thinking>...</thinking> tags and their content", () => {
+    expect(sanitizeUserFacingText("<thinking>internal reasoning</thinking>Hello")).toBe("Hello");
+    expect(sanitizeUserFacingText("Hi <thinking>some thought</thinking> there")).toBe("Hi  there");
+  });
+
+  it("strips unclosed <think> tags in strict mode (discards trailing content)", () => {
+    expect(sanitizeUserFacingText("<think>reasoning without closing tag")).toBe("");
+  });
+
+  it("strips multiline thinking tags", () => {
+    const input = "<think>\nLine 1\nLine 2\n</think>\nActual response here";
+    expect(sanitizeUserFacingText(input)).toBe("Actual response here");
+  });
+
+  it("strips multiple thinking tag pairs", () => {
+    const input = "<think>first</think>Hello <thinking>second</thinking>World";
+    expect(sanitizeUserFacingText(input)).toBe("Hello World");
+  });
+
+  it("strips thinking tags combined with final tags", () => {
+    const input = "<think>reasoning</think><final>Hello world</final>";
+    expect(sanitizeUserFacingText(input)).toBe("Hello world");
+  });
 });
 
 describe("stripThoughtSignatures", () => {

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import type { OpenClawConfig } from "../../config/config.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { stripReasoningTagsFromText } from "../../shared/text/reasoning-tags.js";
 import { formatSandboxToolPolicyBlockedMessage } from "../sandbox.js";
 import { stableStringify } from "../stable-stringify.js";
 import {
@@ -716,7 +717,10 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
     return text;
   }
   const errorContext = opts?.errorContext ?? false;
-  const stripped = stripFinalTagsFromText(text);
+  // Strip both <final> and <think>/<thinking> tags to prevent reasoning content
+  // from leaking to channels when models emit tags in text (e.g. Ollama/Qwen, MiniMax).
+  const withoutFinal = stripFinalTagsFromText(text);
+  const stripped = stripReasoningTagsFromText(withoutFinal, { mode: "strict", trim: "both" });
   const trimmed = stripped.trim();
   if (!trimmed) {
     return "";

--- a/src/agents/pi-embedded-helpers/errors.ts
+++ b/src/agents/pi-embedded-helpers/errors.ts
@@ -720,7 +720,10 @@ export function sanitizeUserFacingText(text: string, opts?: { errorContext?: boo
   // Strip both <final> and <think>/<thinking> tags to prevent reasoning content
   // from leaking to channels when models emit tags in text (e.g. Ollama/Qwen, MiniMax).
   const withoutFinal = stripFinalTagsFromText(text);
-  const stripped = stripReasoningTagsFromText(withoutFinal, { mode: "strict", trim: "both" });
+  // Use trim:"none" to preserve leading indentation in the surviving answer text
+  // (e.g. "<think>...</think>\n    indented code" should keep the indentation).
+  // The overall .trim() below handles leading/trailing blanks for the full output.
+  const stripped = stripReasoningTagsFromText(withoutFinal, { mode: "strict", trim: "none" });
   const trimmed = stripped.trim();
   if (!trimmed) {
     return "";

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -362,15 +362,11 @@ export function createAgentEventHandler({
       mode: "strict",
       trim: "both",
     });
-    // Use trim:"none" on deltas to preserve leading whitespace/newlines that
-    // act as separators when appending to the buffer (P2 review fix).
-    const tagStrippedDelta =
-      typeof delta === "string"
-        ? stripReasoningTagsFromText(stripInlineDirectiveTagsForDisplay(delta).text, {
-            mode: "strict",
-            trim: "none",
-          })
-        : "";
+    // Strip inline directives but NOT reasoning tags from the delta — the
+    // stateful streaming filter needs to see raw <think>/<thinking> tag
+    // boundaries to correctly track cross-chunk reasoning blocks.
+    const rawDelta =
+      typeof delta === "string" ? stripInlineDirectiveTagsForDisplay(delta).text : "";
     // Apply stateful streaming filter to suppress thinking content that arrives
     // in bare delta chunks (between <think> open and </think> close tags).
     let thinkingFilter = chatRunState.thinkingFilters.get(clientRunId);
@@ -378,7 +374,7 @@ export function createAgentEventHandler({
       thinkingFilter = createStreamingThinkingFilter();
       chatRunState.thinkingFilters.set(clientRunId, thinkingFilter);
     }
-    const cleanedDelta = thinkingFilter.filter(tagStrippedDelta);
+    const cleanedDelta = thinkingFilter.filter(rawDelta);
     const previousText = chatRunState.buffers.get(clientRunId) ?? "";
     const mergedText = resolveMergedAssistantText({
       previousText,

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -360,7 +360,7 @@ export function createAgentEventHandler({
     // content from leaking to TUI/webchat when models emit tags in text output.
     const cleanedText = stripReasoningTagsFromText(stripInlineDirectiveTagsForDisplay(text).text, {
       mode: "strict",
-      trim: "both",
+      trim: "start",
     });
     // Strip inline directives but NOT reasoning tags from the delta — the
     // stateful streaming filter needs to see raw <think>/<thinking> tag

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -4,6 +4,7 @@ import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-events.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
+import { stripReasoningTagsFromText } from "../shared/text/reasoning-tags.js";
 import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
 import { loadSessionEntry } from "./session-utils.js";
 import { formatForLog } from "./ws-log.js";
@@ -346,9 +347,19 @@ export function createAgentEventHandler({
     text: string,
     delta?: unknown,
   ) => {
-    const cleanedText = stripInlineDirectiveTagsForDisplay(text).text;
+    // Strip inline directives and reasoning tags to prevent <think>/<thinking>
+    // content from leaking to TUI/webchat when models emit tags in text output.
+    const cleanedText = stripReasoningTagsFromText(stripInlineDirectiveTagsForDisplay(text).text, {
+      mode: "strict",
+      trim: "both",
+    });
     const cleanedDelta =
-      typeof delta === "string" ? stripInlineDirectiveTagsForDisplay(delta).text : "";
+      typeof delta === "string"
+        ? stripReasoningTagsFromText(stripInlineDirectiveTagsForDisplay(delta).text, {
+            mode: "strict",
+            trim: "both",
+          })
+        : "";
     const previousText = chatRunState.buffers.get(clientRunId) ?? "";
     const mergedText = resolveMergedAssistantText({
       previousText,

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -4,7 +4,11 @@ import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../auto-reply/tokens.js";
 import { loadConfig } from "../config/config.js";
 import { type AgentEventPayload, getAgentRunContext } from "../infra/agent-events.js";
 import { resolveHeartbeatVisibility } from "../infra/heartbeat-visibility.js";
-import { stripReasoningTagsFromText } from "../shared/text/reasoning-tags.js";
+import {
+  type StreamingThinkingFilter,
+  createStreamingThinkingFilter,
+  stripReasoningTagsFromText,
+} from "../shared/text/reasoning-tags.js";
 import { stripInlineDirectiveTagsForDisplay } from "../utils/directive-tags.js";
 import { loadSessionEntry } from "./session-utils.js";
 import { formatForLog } from "./ws-log.js";
@@ -204,6 +208,8 @@ export type ChatRunState = {
   /** Length of text at the time of the last broadcast, used to avoid duplicate flushes. */
   deltaLastBroadcastLen: Map<string, number>;
   abortedRuns: Map<string, number>;
+  /** Per-run stateful filter that suppresses streaming deltas inside thinking blocks. */
+  thinkingFilters: Map<string, StreamingThinkingFilter>;
   clear: () => void;
 };
 
@@ -213,6 +219,7 @@ export function createChatRunState(): ChatRunState {
   const deltaSentAt = new Map<string, number>();
   const deltaLastBroadcastLen = new Map<string, number>();
   const abortedRuns = new Map<string, number>();
+  const thinkingFilters = new Map<string, StreamingThinkingFilter>();
 
   const clear = () => {
     registry.clear();
@@ -220,6 +227,7 @@ export function createChatRunState(): ChatRunState {
     deltaSentAt.clear();
     deltaLastBroadcastLen.clear();
     abortedRuns.clear();
+    thinkingFilters.clear();
   };
 
   return {
@@ -228,6 +236,7 @@ export function createChatRunState(): ChatRunState {
     deltaSentAt,
     deltaLastBroadcastLen,
     abortedRuns,
+    thinkingFilters,
     clear,
   };
 }
@@ -353,13 +362,23 @@ export function createAgentEventHandler({
       mode: "strict",
       trim: "both",
     });
-    const cleanedDelta =
+    // Use trim:"none" on deltas to preserve leading whitespace/newlines that
+    // act as separators when appending to the buffer (P2 review fix).
+    const tagStrippedDelta =
       typeof delta === "string"
         ? stripReasoningTagsFromText(stripInlineDirectiveTagsForDisplay(delta).text, {
             mode: "strict",
-            trim: "both",
+            trim: "none",
           })
         : "";
+    // Apply stateful streaming filter to suppress thinking content that arrives
+    // in bare delta chunks (between <think> open and </think> close tags).
+    let thinkingFilter = chatRunState.thinkingFilters.get(clientRunId);
+    if (!thinkingFilter) {
+      thinkingFilter = createStreamingThinkingFilter();
+      chatRunState.thinkingFilters.set(clientRunId, thinkingFilter);
+    }
+    const cleanedDelta = thinkingFilter.filter(tagStrippedDelta);
     const previousText = chatRunState.buffers.get(clientRunId) ?? "";
     const mergedText = resolveMergedAssistantText({
       previousText,
@@ -483,6 +502,8 @@ export function createAgentEventHandler({
     chatRunState.deltaLastBroadcastLen.delete(clientRunId);
     chatRunState.buffers.delete(clientRunId);
     chatRunState.deltaSentAt.delete(clientRunId);
+    chatRunState.thinkingFilters.get(clientRunId)?.reset();
+    chatRunState.thinkingFilters.delete(clientRunId);
     if (jobState === "done") {
       const payload = {
         runId: clientRunId,
@@ -643,6 +664,8 @@ export function createAgentEventHandler({
         chatRunState.abortedRuns.delete(evt.runId);
         chatRunState.buffers.delete(clientRunId);
         chatRunState.deltaSentAt.delete(clientRunId);
+        chatRunState.thinkingFilters.get(clientRunId)?.reset();
+        chatRunState.thinkingFilters.delete(clientRunId);
         if (chatLink) {
           chatRunState.registry.remove(evt.runId, clientRunId, sessionKey);
         }

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -307,4 +307,61 @@ describe("createStreamingThinkingFilter", () => {
     // Simulates the P2 scenario: delta with leading newline + thinking tags
     expect(f.filter("\n<think>reasoning</think>After tool call")).toBe("\nAfter tool call");
   });
+
+  describe("code-fence preservation", () => {
+    it("preserves think tags inside triple-backtick code fences", () => {
+      const f = createStreamingThinkingFilter();
+      expect(f.filter("Example:\n")).toBe("Example:\n");
+      expect(f.filter("```\n")).toBe("```\n");
+      expect(f.filter("<think>literal</think>\n")).toBe("<think>literal</think>\n");
+      expect(f.filter("```\n")).toBe("```\n");
+      expect(f.filter("Done!")).toBe("Done!");
+    });
+
+    it("preserves think tags inside triple-tilde code fences", () => {
+      const f = createStreamingThinkingFilter();
+      expect(f.filter("~~~\n")).toBe("~~~\n");
+      expect(f.filter("<think>code</think>\n")).toBe("<think>code</think>\n");
+      expect(f.filter("~~~\n")).toBe("~~~\n");
+      expect(f.filter("visible")).toBe("visible");
+    });
+
+    it("preserves think tags inside fenced code with language tag", () => {
+      const f = createStreamingThinkingFilter();
+      expect(f.filter("```html\n")).toBe("```html\n");
+      expect(f.filter("<think>literal</think>\n")).toBe("<think>literal</think>\n");
+      expect(f.filter("```\n")).toBe("```\n");
+    });
+
+    it("still strips real think tags outside code fences", () => {
+      const f = createStreamingThinkingFilter();
+      // Send code fence content in separate chunks (realistic streaming)
+      expect(f.filter("```\n")).toBe("```\n");
+      expect(f.filter("<think>preserved</think>\n")).toBe("<think>preserved</think>\n");
+      expect(f.filter("```\n")).toBe("```\n");
+      // Now outside the fence, real think tags should be stripped
+      expect(f.filter("<think>")).toBe("");
+      expect(f.filter("hidden")).toBe("");
+      expect(f.filter("</think>visible")).toBe("visible");
+    });
+
+    it("handles code fence split across chunks", () => {
+      const f = createStreamingThinkingFilter();
+      expect(f.filter("text\n`")).toBe("text\n`");
+      expect(f.filter("``\n<think>inside fence</think>\n")).toBe(
+        "``\n<think>inside fence</think>\n",
+      );
+      expect(f.filter("```\n")).toBe("```\n");
+      // Now outside fence, think tags should be stripped
+      expect(f.filter("<think>hidden</think>after")).toBe("after");
+    });
+
+    it("resets code fence state on reset()", () => {
+      const f = createStreamingThinkingFilter();
+      f.filter("```\n");
+      f.reset();
+      // After reset, should not think we're in a code fence
+      expect(f.filter("<think>hidden</think>visible")).toBe("visible");
+    });
+  });
 });

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -347,13 +347,28 @@ describe("createStreamingThinkingFilter", () => {
 
     it("handles code fence split across chunks", () => {
       const f = createStreamingThinkingFilter();
-      expect(f.filter("text\n`")).toBe("text\n`");
-      expect(f.filter("``\n<think>inside fence</think>\n")).toBe(
-        "``\n<think>inside fence</think>\n",
-      );
+      // Fence opener arrives as a complete line in its own chunk
+      expect(f.filter("text\n")).toBe("text\n");
+      expect(f.filter("```\n")).toBe("```\n");
+      // Now inside fence — think tags should be preserved
+      expect(f.filter("<think>inside fence</think>\n")).toBe("<think>inside fence</think>\n");
       expect(f.filter("```\n")).toBe("```\n");
       // Now outside fence, think tags should be stripped
       expect(f.filter("<think>hidden</think>after")).toBe("after");
+    });
+
+    it("preserves think tags in single-chunk code fence", () => {
+      const f = createStreamingThinkingFilter();
+      const input = "```\n<think>literal</think>\n```\n";
+      expect(f.filter(input)).toBe(input);
+    });
+
+    it("preserves think tags in single-chunk fence then strips outside", () => {
+      const f = createStreamingThinkingFilter();
+      expect(f.filter("```\n<think>literal</think>\n```\n")).toBe(
+        "```\n<think>literal</think>\n```\n",
+      );
+      expect(f.filter("<think>hidden</think>visible")).toBe("visible");
     });
 
     it("resets code fence state on reset()", () => {

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -371,6 +371,17 @@ describe("createStreamingThinkingFilter", () => {
       expect(f.filter("<think>hidden</think>visible")).toBe("visible");
     });
 
+    it("handles fence opener split across chunks (no trailing newline)", () => {
+      const f = createStreamingThinkingFilter();
+      // Fence opener arrives WITHOUT trailing newline — stays in lineBuffer
+      expect(f.filter("```html")).toBe("```html");
+      // Newline arrives in next chunk, completing the fence opener line.
+      // Think tags inside the fence must be preserved.
+      expect(f.filter("\n<think>literal</think>\nmore code")).toBe(
+        "\n<think>literal</think>\nmore code",
+      );
+    });
+
     it("resets code fence state on reset()", () => {
       const f = createStreamingThinkingFilter();
       f.filter("```\n");

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { stripReasoningTagsFromText } from "./reasoning-tags.js";
+import { createStreamingThinkingFilter, stripReasoningTagsFromText } from "./reasoning-tags.js";
 
 describe("stripReasoningTagsFromText", () => {
   describe("basic functionality", () => {
@@ -220,5 +220,91 @@ describe("stripReasoningTagsFromText", () => {
         expect(stripReasoningTagsFromText(testCase.input, testCase.opts)).toBe(testCase.expected);
       }
     });
+  });
+});
+
+describe("createStreamingThinkingFilter", () => {
+  it("passes through text with no thinking tags", () => {
+    const f = createStreamingThinkingFilter();
+    expect(f.filter("Hello ")).toBe("Hello ");
+    expect(f.filter("world")).toBe("world");
+  });
+
+  it("suppresses content between streamed <think> and </think> tags", () => {
+    const f = createStreamingThinkingFilter();
+    expect(f.filter("<think>")).toBe("");
+    expect(f.filter("some reasoning")).toBe("");
+    expect(f.filter("more reasoning")).toBe("");
+    expect(f.filter("</think>Answer")).toBe("Answer");
+  });
+
+  it("suppresses content between <thinking> and </thinking> tags", () => {
+    const f = createStreamingThinkingFilter();
+    expect(f.filter("<thinking>")).toBe("");
+    expect(f.filter("reasoning")).toBe("");
+    expect(f.filter("</thinking>Result")).toBe("Result");
+  });
+
+  it("handles opening tag and content in a single chunk", () => {
+    const f = createStreamingThinkingFilter();
+    expect(f.filter("<think>reasoning</think>visible")).toBe("visible");
+  });
+
+  it("handles multiple thinking blocks across chunks", () => {
+    const f = createStreamingThinkingFilter();
+    expect(f.filter("A")).toBe("A");
+    expect(f.filter("<think>")).toBe("");
+    expect(f.filter("hidden")).toBe("");
+    expect(f.filter("</think>B")).toBe("B");
+    expect(f.filter("<think>")).toBe("");
+    expect(f.filter("also hidden")).toBe("");
+    expect(f.filter("</think>C")).toBe("C");
+  });
+
+  it("preserves text before an opening tag in the same chunk", () => {
+    const f = createStreamingThinkingFilter();
+    expect(f.filter("before<think>hidden")).toBe("before");
+    expect(f.filter("</think>after")).toBe("after");
+  });
+
+  it("handles tag split across two chunks", () => {
+    const f = createStreamingThinkingFilter();
+    expect(f.filter("text<thi")).toBe("text");
+    expect(f.filter("nk>reasoning")).toBe("");
+    expect(f.filter("</think>done")).toBe("done");
+  });
+
+  it("handles closing tag split across chunks", () => {
+    const f = createStreamingThinkingFilter();
+    expect(f.filter("<think>hidden")).toBe("");
+    expect(f.filter("</thi")).toBe("");
+    expect(f.filter("nk>visible")).toBe("visible");
+  });
+
+  it("resets state correctly", () => {
+    const f = createStreamingThinkingFilter();
+    f.filter("<think>hidden");
+    f.reset();
+    expect(f.filter("visible after reset")).toBe("visible after reset");
+  });
+
+  it("handles antthinking tags", () => {
+    const f = createStreamingThinkingFilter();
+    expect(f.filter("<antthinking>")).toBe("");
+    expect(f.filter("internal")).toBe("");
+    expect(f.filter("</antthinking>output")).toBe("output");
+  });
+
+  it("handles thought tags", () => {
+    const f = createStreamingThinkingFilter();
+    expect(f.filter("<thought>")).toBe("");
+    expect(f.filter("hmm")).toBe("");
+    expect(f.filter("</thought>answer")).toBe("answer");
+  });
+
+  it("handles inline thinking with leading newline preserved", () => {
+    const f = createStreamingThinkingFilter();
+    // Simulates the P2 scenario: delta with leading newline + thinking tags
+    expect(f.filter("\n<think>reasoning</think>After tool call")).toBe("\nAfter tool call");
   });
 });

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -274,14 +274,18 @@ export function createStreamingThinkingFilter(): StreamingThinkingFilter {
     const wasInFence = insideCodeFence;
     processCodeFences(input);
 
-    // If we were already inside a code fence, pass through unfiltered.
-    if (wasInFence && !insideBlock) {
+    // If we are inside a code fence (entered before or during this chunk),
+    // pass through unfiltered. This handles fence openers that are split
+    // across chunks (e.g. "```html" without trailing newline in chunk 1,
+    // then "\n<think>literal</think>" in chunk 2 — the newline completes
+    // the fence opener line in processCodeFences).
+    if ((wasInFence || insideCodeFence) && !insideBlock) {
       return input;
     }
 
     // Check if this chunk contains inline fence regions that need protection.
     // This handles the case where a fence opens and closes within a single chunk.
-    if (!wasInFence) {
+    if (!wasInFence && !insideCodeFence) {
       const protected_ = protectInlineFencedRegions(input);
       if (protected_ !== null) {
         return protected_;

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -115,16 +115,66 @@ export type StreamingThinkingFilter = {
 
 export function createStreamingThinkingFilter(): StreamingThinkingFilter {
   let insideBlock = false;
+  let insideCodeFence = false;
+  let codeFenceChar = ""; // "`" or "~"
+  let codeFenceLen = 0; // number of backticks/tildes in the opening fence
   let pendingPartial = "";
+  // Buffer for detecting code fence boundaries that may span chunks.
+  let lineBuffer = "";
+
+  /**
+   * Check accumulated text for code fence toggles. Updates insideCodeFence state.
+   * Processes complete lines only, keeping any incomplete trailing line in lineBuffer.
+   */
+  function processCodeFences(text: string): void {
+    lineBuffer += text;
+    const lines = lineBuffer.split("\n");
+    // Keep the last (potentially incomplete) line in the buffer.
+    lineBuffer = lines.pop() ?? "";
+    for (const line of lines) {
+      checkLineForFence(line);
+    }
+  }
+
+  function checkLineForFence(line: string): void {
+    const trimmed = line.trimStart();
+    if (!insideCodeFence) {
+      // Check for opening fence: line starting with ``` or ~~~
+      const m = trimmed.match(/^(`{3,}|~{3,})/);
+      if (m) {
+        insideCodeFence = true;
+        codeFenceChar = m[1][0];
+        codeFenceLen = m[1].length;
+      }
+    } else {
+      // Check for closing fence: line starting with at least as many of the same char
+      const escaped = codeFenceChar === "`" ? "`" : "~";
+      const closeRe = new RegExp(`^${escaped}{${codeFenceLen},}\\s*$`);
+      if (closeRe.test(trimmed)) {
+        insideCodeFence = false;
+        codeFenceChar = "";
+        codeFenceLen = 0;
+      }
+    }
+  }
 
   function filter(delta: string): string {
     const input = pendingPartial + delta;
     pendingPartial = "";
 
+    // Track code fence state for the incoming text.
+    processCodeFences(input);
+
+    // Inside a code fence — pass through unfiltered (preserve literal think tags).
+    if (insideCodeFence && !insideBlock) {
+      return input;
+    }
+
     if (!insideBlock) {
       // Look for an opening tag in this chunk.
       const openMatch = OPEN_TAG_RE.exec(input);
       if (openMatch) {
+        // Don't strip if the tag is inside a code fence detected in accumulated context.
         insideBlock = true;
         const before = input.slice(0, openMatch.index);
         const after = input.slice(openMatch.index + openMatch[0].length);
@@ -159,7 +209,11 @@ export function createStreamingThinkingFilter(): StreamingThinkingFilter {
 
   function reset() {
     insideBlock = false;
+    insideCodeFence = false;
+    codeFenceChar = "";
+    codeFenceLen = 0;
     pendingPartial = "";
+    lineBuffer = "";
   }
 
   return { filter, reset };

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -122,20 +122,6 @@ export function createStreamingThinkingFilter(): StreamingThinkingFilter {
   // Buffer for detecting code fence boundaries that may span chunks.
   let lineBuffer = "";
 
-  /**
-   * Check accumulated text for code fence toggles. Updates insideCodeFence state.
-   * Processes complete lines only, keeping any incomplete trailing line in lineBuffer.
-   */
-  function processCodeFences(text: string): void {
-    lineBuffer += text;
-    const lines = lineBuffer.split("\n");
-    // Keep the last (potentially incomplete) line in the buffer.
-    lineBuffer = lines.pop() ?? "";
-    for (const line of lines) {
-      checkLineForFence(line);
-    }
-  }
-
   function checkLineForFence(line: string): void {
     const trimmed = line.trimStart();
     if (!insideCodeFence) {
@@ -158,30 +144,107 @@ export function createStreamingThinkingFilter(): StreamingThinkingFilter {
     }
   }
 
-  function filter(delta: string): string {
-    const input = pendingPartial + delta;
-    pendingPartial = "";
+  /**
+   * Check accumulated text for code fence toggles. Updates insideCodeFence state.
+   * Processes complete lines only, keeping any incomplete trailing line in lineBuffer.
+   */
+  function processCodeFences(text: string): void {
+    lineBuffer += text;
+    const lines = lineBuffer.split("\n");
+    // Keep the last (potentially incomplete) line in the buffer.
+    lineBuffer = lines.pop() ?? "";
+    for (const line of lines) {
+      checkLineForFence(line);
+    }
+  }
 
-    // Track code fence state for the incoming text.
-    processCodeFences(input);
+  /**
+   * Check if the input contains a complete code fence block (opens and closes)
+   * that would need protection from think-tag filtering. Returns the input with
+   * fenced regions preserved if detected, or null to indicate normal filtering.
+   */
+  function protectInlineFencedRegions(input: string): string | null {
+    // Quick check: does this chunk contain a fence marker at all?
+    if (!/^(`{3,}|~{3,})/m.test(input)) {
+      return null;
+    }
+    // Split by lines and process, tracking which lines are fenced.
+    const lines = input.split("\n");
+    const fencedFlags: boolean[] = [];
+    // Use temporary fence state to check each line.
+    let tempInFence = insideCodeFence;
+    let tempChar = codeFenceChar;
+    let tempLen = codeFenceLen;
+    let anyFenced = false;
 
-    // Inside a code fence — pass through unfiltered (preserve literal think tags).
-    if (insideCodeFence && !insideBlock) {
-      return input;
+    for (const line of lines) {
+      const trimmed = line.trimStart();
+      if (!tempInFence) {
+        const m = trimmed.match(/^(`{3,}|~{3,})/);
+        if (m) {
+          tempInFence = true;
+          tempChar = m[1][0];
+          tempLen = m[1].length;
+          fencedFlags.push(true); // fence opener line itself is fenced
+          anyFenced = true;
+          continue;
+        }
+      } else {
+        const escaped = tempChar === "`" ? "`" : "~";
+        const closeRe = new RegExp(`^${escaped}{${tempLen},}\\s*$`);
+        if (closeRe.test(trimmed)) {
+          fencedFlags.push(true); // fence closer line itself is fenced
+          tempInFence = false;
+          tempChar = "";
+          tempLen = 0;
+          continue;
+        }
+      }
+      fencedFlags.push(tempInFence);
+      if (tempInFence) {
+        anyFenced = true;
+      }
     }
 
+    if (!anyFenced) {
+      return null;
+    }
+
+    // Build result: fenced lines pass through, non-fenced lines get think-tag filtered.
+    // We process non-fenced lines as a single block to maintain think-tag state.
+    let result = "";
+    let nonFencedBuffer = "";
+
+    for (let i = 0; i < lines.length; i++) {
+      const suffix = i < lines.length - 1 ? "\n" : "";
+      if (fencedFlags[i]) {
+        // Flush any non-fenced buffer through think-tag filtering first.
+        if (nonFencedBuffer) {
+          result += filterThinkTags(nonFencedBuffer);
+          nonFencedBuffer = "";
+        }
+        result += lines[i] + suffix;
+      } else {
+        nonFencedBuffer += lines[i] + suffix;
+      }
+    }
+    // Flush remaining non-fenced buffer.
+    if (nonFencedBuffer) {
+      result += filterThinkTags(nonFencedBuffer);
+    }
+    return result;
+  }
+
+  /** Apply think-tag filtering to a non-fenced text segment. */
+  function filterThinkTags(input: string): string {
     if (!insideBlock) {
-      // Look for an opening tag in this chunk.
       const openMatch = OPEN_TAG_RE.exec(input);
       if (openMatch) {
-        // Don't strip if the tag is inside a code fence detected in accumulated context.
         insideBlock = true;
         const before = input.slice(0, openMatch.index);
         const after = input.slice(openMatch.index + openMatch[0].length);
-        // Recurse to handle closing tag (or more opens) in the remainder.
-        return before + filter(after);
+        return before + filterThinkTags(after);
       }
-      // Check for a partial tag at the end that might complete in the next delta.
       const partialMatch = PARTIAL_OPEN_RE.exec(input);
       if (partialMatch && partialMatch[0].length > 0) {
         pendingPartial = partialMatch[0];
@@ -190,21 +253,43 @@ export function createStreamingThinkingFilter(): StreamingThinkingFilter {
       return input;
     }
 
-    // Inside a thinking block — look for closing tag.
     const closeMatch = CLOSE_TAG_RE.exec(input);
     if (closeMatch) {
       insideBlock = false;
       const after = input.slice(closeMatch.index + closeMatch[0].length);
-      // Recurse so further opens/text in the remainder are processed.
-      return filter(after);
+      return filterThinkTags(after);
     }
-    // Check for partial closing tag at the end.
     const partialClose = PARTIAL_CLOSE_RE.exec(input);
     if (partialClose && partialClose[0].length > 0) {
       pendingPartial = partialClose[0];
     }
-    // Suppress everything while inside the block.
     return "";
+  }
+
+  function filter(delta: string): string {
+    const input = pendingPartial + delta;
+    pendingPartial = "";
+
+    // Save fence state before processing this chunk.
+    const wasInFence = insideCodeFence;
+    processCodeFences(input);
+
+    // If we were already inside a code fence, pass through unfiltered.
+    if (wasInFence && !insideBlock) {
+      return input;
+    }
+
+    // Check if this chunk contains inline fence regions that need protection.
+    // This handles the case where a fence opens and closes within a single chunk.
+    if (!wasInFence) {
+      const protected_ = protectInlineFencedRegions(input);
+      if (protected_ !== null) {
+        return protected_;
+      }
+    }
+
+    // Normal think-tag filtering (no code fence involved).
+    return filterThinkTags(input);
   }
 
   function reset() {

--- a/src/shared/text/reasoning-tags.ts
+++ b/src/shared/text/reasoning-tags.ts
@@ -90,3 +90,77 @@ export function stripReasoningTagsFromText(
 
   return applyTrim(result, trimMode);
 }
+
+// --- Stateful streaming thinking-block filter ---
+// Tracks whether the stream is inside a <think>/<thinking>/<thought>/<antthinking>
+// block across incremental delta chunks, suppressing all content between the
+// opening and closing tags (inclusive).
+
+const OPEN_TAG_RE = /<\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/i;
+const CLOSE_TAG_RE = /<\s*\/\s*(?:think(?:ing)?|thought|antthinking)\b[^<>]*>/i;
+
+// Partial-tag detector: an incomplete `<...` at the end of a chunk that could
+// be the start of a thinking tag split across two deltas.
+const PARTIAL_OPEN_RE =
+  /<\s*(?:t(?:h(?:i(?:n(?:k(?:i(?:n(?:g)?)?)?)?)?)?)?|a(?:n(?:t(?:t(?:h(?:i(?:n(?:k(?:i(?:n(?:g)?)?)?)?)?)?)?)?)?)?)?$/i;
+const PARTIAL_CLOSE_RE =
+  /<\s*\/\s*(?:t(?:h(?:i(?:n(?:k(?:i(?:n(?:g)?)?)?)?)?)?)?|a(?:n(?:t(?:t(?:h(?:i(?:n(?:k(?:i(?:n(?:g)?)?)?)?)?)?)?)?)?)?)?$/i;
+
+export type StreamingThinkingFilter = {
+  /** Process a delta chunk — returns the portion safe to emit (may be empty). */
+  filter(delta: string): string;
+  /** Reset state (e.g. when a run ends). */
+  reset(): void;
+};
+
+export function createStreamingThinkingFilter(): StreamingThinkingFilter {
+  let insideBlock = false;
+  let pendingPartial = "";
+
+  function filter(delta: string): string {
+    const input = pendingPartial + delta;
+    pendingPartial = "";
+
+    if (!insideBlock) {
+      // Look for an opening tag in this chunk.
+      const openMatch = OPEN_TAG_RE.exec(input);
+      if (openMatch) {
+        insideBlock = true;
+        const before = input.slice(0, openMatch.index);
+        const after = input.slice(openMatch.index + openMatch[0].length);
+        // Recurse to handle closing tag (or more opens) in the remainder.
+        return before + filter(after);
+      }
+      // Check for a partial tag at the end that might complete in the next delta.
+      const partialMatch = PARTIAL_OPEN_RE.exec(input);
+      if (partialMatch && partialMatch[0].length > 0) {
+        pendingPartial = partialMatch[0];
+        return input.slice(0, partialMatch.index);
+      }
+      return input;
+    }
+
+    // Inside a thinking block — look for closing tag.
+    const closeMatch = CLOSE_TAG_RE.exec(input);
+    if (closeMatch) {
+      insideBlock = false;
+      const after = input.slice(closeMatch.index + closeMatch[0].length);
+      // Recurse so further opens/text in the remainder are processed.
+      return filter(after);
+    }
+    // Check for partial closing tag at the end.
+    const partialClose = PARTIAL_CLOSE_RE.exec(input);
+    if (partialClose && partialClose[0].length > 0) {
+      pendingPartial = partialClose[0];
+    }
+    // Suppress everything while inside the block.
+    return "";
+  }
+
+  function reset() {
+    insideBlock = false;
+    pendingPartial = "";
+  }
+
+  return { filter, reset };
+}


### PR DESCRIPTION
## Summary

- Adds defense-in-depth stripping of `<think>`/`<thinking>` tags in `sanitizeUserFacingText` (covers `normalizeReplyPayload`, `normalizeStreamingText`, and `extractAssistantText` paths)
- Adds thinking tag stripping in gateway `emitChatDelta` to prevent leakage to TUI/webchat streaming
- Adds test coverage for thinking tag stripping in `sanitizeUserFacingText`

Models like Ollama/Qwen and MiniMax emit `<think>...</think>` tags directly in text content blocks. When thinking is set to "off", these tags and their content were leaking through to the channel because the last-mile sanitization function only stripped `<final>` tags but not reasoning tags.

Fixes #40736

## Test plan

- [x] `sanitizeUserFacingText` strips `<think>...</think>` tags
- [x] `sanitizeUserFacingText` strips `<thinking>...</thinking>` tags
- [x] `sanitizeUserFacingText` strips unclosed `<think>` tags (strict mode)
- [x] `sanitizeUserFacingText` strips multiline thinking tags
- [x] `sanitizeUserFacingText` strips multiple thinking tag pairs
- [x] `sanitizeUserFacingText` strips combined thinking + final tags
- [x] All existing tests continue to pass
- [x] Gateway agent-events tests pass
- [x] TypeScript type check passes