### PR TITLE
fix(tui): strip <think> tags from text content when thinking is disabled

### DIFF
--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -202,6 +202,60 @@ describe("extractContentFromMessage", () => {
 
     expect(text).toContain("HTTP 429");
   });
+
+  it("strips <think> tags from text content when stripReasoningTags is true", () => {
+    const text = extractContentFromMessage(
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "<think>Internal reasoning</think>The actual response" }],
+      },
+      { stripReasoningTags: true },
+    );
+
+    expect(text).toBe("The actual response");
+  });
+
+  it("preserves <think> tags when stripReasoningTags is false", () => {
+    const text = extractContentFromMessage(
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "<think>Reasoning</think>Response" }],
+      },
+      { stripReasoningTags: false },
+    );
+
+    expect(text).toContain("<think>");
+    expect(text).toContain("Reasoning");
+  });
+
+  it("strips <think> tags from string content when stripReasoningTags is true", () => {
+    const text = extractContentFromMessage(
+      {
+        role: "assistant",
+        content: "<think>Secret thoughts</think>Visible text",
+      },
+      { stripReasoningTags: true },
+    );
+
+    expect(text).toBe("Visible text");
+  });
+
+  it("handles multiple <think> blocks when stripping", () => {
+    const text = extractContentFromMessage(
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "<think>First</think>Hello<think>Second</think>World",
+          },
+        ],
+      },
+      { stripReasoningTags: true },
+    );
+
+    expect(text).toBe("HelloWorld");
+  });
 });
 
 describe("isCommandMessage", () => {

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -1,5 +1,6 @@
 import { stripLeadingInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import { formatRawAssistantErrorForUi } from "../shared/assistant-error-format.js";
+import { stripReasoningTagsFromText } from "../shared/text/reasoning-tags.js";
 import { stripAnsi } from "../terminal/ansi.js";
 import { formatTokenCount } from "../utils/usage-format.js";
 
@@ -263,27 +264,38 @@ export function extractThinkingFromMessage(message: unknown): string {
 /**
  * Extract ONLY text content blocks from message (excludes thinking).
  * Model-agnostic: works for any model with text content blocks.
+ *
+ * When `stripReasoningTags` is true, removes any `<think>...</think>` tags
+ * from the extracted text. This handles models that emit reasoning as plain
+ * text tags rather than structured thinking blocks.
  */
-export function extractContentFromMessage(message: unknown): string {
+export function extractContentFromMessage(
+  message: unknown,
+  opts?: { stripReasoningTags?: boolean },
+): string {
   const resolved = resolveMessageRecord(message);
   if (!resolved) {
     return "";
   }
   const { record, content } = resolved;
 
+  let text: string;
   if (typeof content === "string") {
-    return sanitizeRenderableText(content).trim();
+    text = sanitizeRenderableText(content).trim();
+  } else {
+    const parts = collectSanitizedBlockStrings({
+      content,
+      blockType: "text",
+      valueKey: "text",
+    });
+    text = parts.length > 0 ? parts.join("\n").trim() : formatAssistantErrorFromRecord(record);
   }
 
-  const parts = collectSanitizedBlockStrings({
-    content,
-    blockType: "text",
-    valueKey: "text",
-  });
-  if (parts.length > 0) {
-    return parts.join("\n").trim();
+  if (opts?.stripReasoningTags && text) {
+    text = stripReasoningTagsFromText(text, { mode: "strict", trim: "both" });
   }
-  return formatAssistantErrorFromRecord(record);
+
+  return text;
 }
 
 function extractTextBlocks(content: unknown, opts?: { includeThinking?: boolean }): string {

--- a/src/tui/tui-stream-assembler.test.ts
+++ b/src/tui/tui-stream-assembler.test.ts
@@ -79,6 +79,31 @@ describe("TuiStreamAssembler", () => {
     expect(output).toBe("Visible");
   });
 
+  it("strips <think> tags from text content when showThinking is false", () => {
+    const assembler = new TuiStreamAssembler();
+    // Some models (e.g. minimax, ollama) emit reasoning as plain <think> tags
+    // in text content rather than structured thinking blocks.
+    const output = assembler.ingestDelta(
+      "run-think-tags",
+      messageWithContent([text("<think>Internal reasoning here</think>The actual response")]),
+      false,
+    );
+    expect(output).toBe("The actual response");
+  });
+
+  it("preserves <think> tags in text content when showThinking is true", () => {
+    const assembler = new TuiStreamAssembler();
+    const output = assembler.ingestDelta(
+      "run-think-tags-show",
+      messageWithContent([text("<think>Internal reasoning</think>Response")]),
+      true,
+    );
+    // Tags should be preserved when thinking display is enabled
+    expect(output).toContain("<think>");
+    expect(output).toContain("Internal reasoning");
+    expect(output).toContain("Response");
+  });
+
   it("falls back to streamed text on empty final payload", () => {
     const assembler = new TuiStreamAssembler();
     assembler.ingestDelta("run-3", messageWithContent([text("Streamed")]), false);

--- a/src/tui/tui-stream-assembler.ts
+++ b/src/tui/tui-stream-assembler.ts
@@ -125,7 +125,12 @@ export class TuiStreamAssembler {
     opts?: { boundaryDropMode?: BoundaryDropMode },
   ) {
     const thinkingText = extractThinkingFromMessage(message);
-    const contentText = extractContentFromMessage(message);
+    // When thinking display is disabled, strip <think>...</think> tags from text.
+    // This handles models that emit reasoning as plain text tags rather than
+    // structured thinking blocks.
+    const contentText = extractContentFromMessage(message, {
+      stripReasoningTags: !showThinking,
+    });
     const { textBlocks, sawNonTextContentBlocks } = extractTextBlocksAndSignals(message);
 
     if (thinkingText) {


### PR DESCRIPTION
## Summary

This PR fixes #40736 where thinking content (in the form of `<think>...</think>` tags) leaks to the TUI display even when thinking is disabled (`thinkingDefault: "off"`).

## Problem

Some models (e.g. minimax, ollama/qwen) emit reasoning as plain `<think>...</think>` tags in text content rather than structured thinking blocks. The TUI's existing `showThinking` flag correctly hides structured thinking blocks, but these plain-text tags were passing through unfiltered.

## Solution

- Added `stripReasoningTags` option to `extractContentFromMessage()` in `tui-formatters.ts`
- When `showThinking` is `false` in `TuiStreamAssembler`, the option is set to strip these tags
- Uses the existing `stripReasoningTagsFromText()` utility which already handles all `<think>`, `<thinking>`, `<thought>`, and `<antthinking>` tag variants

## Testing

Added tests covering:
- Stripping `<think>` tags from text blocks when `stripReasoningTags` is true
- Preserving tags when `stripReasoningTags` is false
- Stripping from string content (not just text blocks)
- Multiple `<think>` blocks in a single message
- Integration test in `TuiStreamAssembler` confirming end-to-end behavior

## Related Issues

- Fixes #40736
- Related: #26522, #28751, #24870, #29672 (prior thinking leak fixes)

## Checklist

- [x] Tests pass
- [x] TypeScript compiles
- [x] No breaking changes to existing behavior