### PR TITLE
fix: allow empty write content in Claude param shim

### DIFF
--- a/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
+++ b/src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts
@@ -8,6 +8,7 @@ import "./test-helpers/fast-coding-tools.js";
 import { createOpenClawTools } from "./openclaw-tools.js";
 import { findUnsupportedSchemaKeywords } from "./pi-embedded-runner/google.js";
 import { __testing, createOpenClawCodingTools } from "./pi-tools.js";
+import { CLAUDE_PARAM_GROUPS } from "./pi-tools.params.js";
 import { createOpenClawReadTool, createSandboxedReadTool } from "./pi-tools.read.js";
 import { createHostSandboxFsBridge } from "./test-helpers/host-sandbox-fs-bridge.js";
 import { createBrowserTool } from "./tools/browser-tool.js";
@@ -147,6 +148,34 @@ describe("createOpenClawCodingTools", () => {
       );
       await expect(wrapped.execute("tool-4", {})).rejects.toThrow(
         /Supply correct parameters before retrying\./,
+      );
+    });
+
+    it("allows empty content for write tools so zero-byte files can be created", async () => {
+      const execute = vi.fn(async (_id, args) => args);
+      const tool: AgentTool = {
+        name: "write",
+        label: "write",
+        description: "test",
+        parameters: Type.Object({
+          path: Type.String(),
+          content: Type.String(),
+        }),
+        execute,
+      };
+
+      const wrapped = __testing.wrapToolParamNormalization(tool, CLAUDE_PARAM_GROUPS.write);
+
+      await wrapped.execute("tool-empty", {
+        file_path: ".gitkeep",
+        content: "",
+      });
+
+      expect(execute).toHaveBeenCalledWith(
+        "tool-empty",
+        { path: ".gitkeep", content: "" },
+        undefined,
+        undefined,
       );
     });
   });

--- a/src/agents/pi-tools.params.ts
+++ b/src/agents/pi-tools.params.ts
@@ -16,7 +16,7 @@ export const CLAUDE_PARAM_GROUPS = {
   read: [{ keys: ["path", "file_path"], label: "path (path or file_path)" }],
   write: [
     { keys: ["path", "file_path"], label: "path (path or file_path)" },
-    { keys: ["content"], label: "content" },
+    { keys: ["content"], label: "content", allowEmpty: true },
   ],
   edit: [
     { keys: ["path", "file_path"], label: "path (path or file_path)" },


### PR DESCRIPTION
## Summary
- allow empty `content` values in the Claude-compatible required-param groups for `write`
- add a regression test covering zero-byte file creation via `file_path` + empty content

## Why
The Claude compatibility wrapper treated `write.content` as a non-empty string requirement. That breaks valid zero-byte file writes such as creating `.gitkeep`, causing the agent to get stuck retrying a write call that should have been accepted.

## Testing
- `corepack pnpm exec vitest run src/agents/pi-tools.create-openclaw-coding-tools.adds-claude-style-aliases-schemas-without-dropping.test.ts`
