### PR TITLE
fix(agents): clear stale tool call history between heartbeat cycles

### DIFF
--- a/.github/instructions/copilot.instructions.md
+++ b/.github/instructions/copilot.instructions.md
@@ -1,3 +1,4 @@
+
 # OpenClaw Codebase Patterns
 
 **Always reuse existing code - no redundancy!**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Docs: https://docs.openclaw.ai
 
 - Browser/SSRF: block private-network intermediate redirect hops in strict browser navigation flows and fail closed when remote tab-open paths cannot inspect redirect chains. Thanks @zpbrent.
 - MS Teams/authz: keep `groupPolicy: "allowlist"` enforcing sender allowlists even when a team/channel route allowlist is configured, so route matches no longer widen group access to every sender in that route. Thanks @zpbrent.
+- Agents/loop-detection: clear stale tool call history between heartbeat cycles to prevent false positive loop detection. (#40656) thanks @riftzen-bit.
 
 ## 2026.3.8
 

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -4,6 +4,7 @@ import type { SessionState } from "../logging/diagnostic-session-state.js";
 import {
   CRITICAL_THRESHOLD,
   GLOBAL_CIRCUIT_BREAKER_THRESHOLD,
+  STALE_HISTORY_GAP_MS,
   TOOL_CALL_HISTORY_SIZE,
   WARNING_THRESHOLD,
   detectToolCallLoop,
@@ -589,6 +590,66 @@ describe("tool-loop-detection", () => {
       const stats = getToolCallStats(state);
       expect(stats.mostFrequent?.toolName).toBe("read");
       expect(stats.mostFrequent?.count).toBe(7);
+    });
+  });
+
+  describe("stale history cleanup (regression #40144)", () => {
+    it("clears stale tool call history when time gap exceeds threshold", () => {
+      const state = createState();
+      // Simulate a heartbeat cycle: record some tool calls
+      for (let i = 0; i < 5; i += 1) {
+        recordToolCall(state, "read", { path: "/a.txt" }, `hb1-${i}`);
+      }
+      expect(state.toolCallHistory?.length).toBe(5);
+
+      // Simulate time gap > STALE_HISTORY_GAP_MS by backdating all entries
+      for (const entry of state.toolCallHistory ?? []) {
+        entry.timestamp = Date.now() - STALE_HISTORY_GAP_MS - 1000;
+      }
+
+      // Next heartbeat cycle records a tool call — stale history should be cleared first
+      recordToolCall(state, "read", { path: "/a.txt" }, "hb2-0");
+
+      // History should only contain the new call, not the stale ones
+      expect(state.toolCallHistory?.length).toBe(1);
+    });
+
+    it("does not clear history when calls are within the time window", () => {
+      const state = createState();
+      for (let i = 0; i < 5; i += 1) {
+        recordToolCall(state, "read", { path: "/a.txt" }, `call-${i}`);
+      }
+      expect(state.toolCallHistory?.length).toBe(5);
+
+      // Record another call immediately — history should not be cleared
+      recordToolCall(state, "read", { path: "/a.txt" }, "call-5");
+      expect(state.toolCallHistory?.length).toBe(6);
+    });
+
+    it("prevents false positive loop detection across separate heartbeat cycles", () => {
+      const state = createState();
+      const config = enabledLoopDetectionConfig;
+
+      // First heartbeat: record identical tool calls (below warning threshold)
+      for (let i = 0; i < WARNING_THRESHOLD - 2; i += 1) {
+        recordToolCall(state, "message", { text: "status" }, `hb1-${i}`, config);
+      }
+      const firstResult = detectToolCallLoop(state, "message", { text: "status" }, config);
+      expect(firstResult.stuck).toBe(false);
+
+      // Backdate all entries to simulate time passing between heartbeat cycles
+      for (const entry of state.toolCallHistory ?? []) {
+        entry.timestamp = Date.now() - STALE_HISTORY_GAP_MS - 1000;
+      }
+
+      // Second heartbeat: same tool calls should NOT accumulate with first cycle
+      for (let i = 0; i < WARNING_THRESHOLD - 2; i += 1) {
+        recordToolCall(state, "message", { text: "status" }, `hb2-${i}`, config);
+      }
+      const secondResult = detectToolCallLoop(state, "message", { text: "status" }, config);
+      // Without the fix, this would be a false positive warning because
+      // history from both cycles would be combined
+      expect(secondResult.stuck).toBe(false);
     });
   });
 });

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -651,5 +651,32 @@ describe("tool-loop-detection", () => {
       // history from both cycles would be combined
       expect(secondResult.stuck).toBe(false);
     });
+
+    it("detectToolCallLoop ignores stale history even when called before recordToolCall (real call ordering)", () => {
+      const state = createState();
+      const config = enabledLoopDetectionConfig;
+
+      // First heartbeat: drive history to WARNING_THRESHOLD with real ordering
+      // (detect before record, mirroring runBeforeToolCallHook).
+      for (let i = 0; i < WARNING_THRESHOLD; i += 1) {
+        detectToolCallLoop(state, "message", { text: "status" }, config);
+        recordToolCall(state, "message", { text: "status" }, `hb1-${i}`, config);
+      }
+
+      // Backdate all entries to simulate time passing between heartbeat cycles
+      for (const entry of state.toolCallHistory ?? []) {
+        entry.timestamp = Date.now() - STALE_HISTORY_GAP_MS - 1000;
+      }
+
+      // Second heartbeat: the FIRST detectToolCallLoop call must not see the
+      // stale WARNING_THRESHOLD entries — this is the exact scenario that was
+      // a false positive before the staleness guard was added to the detector.
+      const result = detectToolCallLoop(state, "message", { text: "status" }, config);
+      expect(result.stuck).toBe(false);
+
+      // After detection, record the call to mirror real ordering.
+      recordToolCall(state, "message", { text: "status" }, "hb2-0", config);
+      expect(state.toolCallHistory?.length).toBe(1);
+    });
   });
 });

--- a/src/agents/tool-loop-detection.test.ts
+++ b/src/agents/tool-loop-detection.test.ts
@@ -601,11 +601,13 @@ describe("tool-loop-detection", () => {
         recordToolCall(state, "read", { path: "/a.txt" }, `hb1-${i}`);
       }
       expect(state.toolCallHistory?.length).toBe(5);
-
-      // Simulate time gap > STALE_HISTORY_GAP_MS by backdating all entries
+      // Mark as finished so they can be cleared
       for (const entry of state.toolCallHistory ?? []) {
-        entry.timestamp = Date.now() - STALE_HISTORY_GAP_MS - 1000;
+        entry.resultHash = "finished";
       }
+
+      // Simulate time gap > STALE_HISTORY_GAP_MS by backdating lastToolCallAt
+      state.lastToolCallAt = Date.now() - STALE_HISTORY_GAP_MS - 1000;
 
       // Next heartbeat cycle records a tool call — stale history should be cleared first
       recordToolCall(state, "read", { path: "/a.txt" }, "hb2-0");
@@ -634,13 +636,16 @@ describe("tool-loop-detection", () => {
       for (let i = 0; i < WARNING_THRESHOLD - 2; i += 1) {
         recordToolCall(state, "message", { text: "status" }, `hb1-${i}`, config);
       }
+      // Mark as finished so they can be cleared
+      for (const entry of state.toolCallHistory ?? []) {
+        entry.resultHash = "finished";
+      }
+
       const firstResult = detectToolCallLoop(state, "message", { text: "status" }, config);
       expect(firstResult.stuck).toBe(false);
 
-      // Backdate all entries to simulate time passing between heartbeat cycles
-      for (const entry of state.toolCallHistory ?? []) {
-        entry.timestamp = Date.now() - STALE_HISTORY_GAP_MS - 1000;
-      }
+      // Backdate lastToolCallAt to simulate time passing between heartbeat cycles
+      state.lastToolCallAt = Date.now() - STALE_HISTORY_GAP_MS - 1000;
 
       // Second heartbeat: same tool calls should NOT accumulate with first cycle
       for (let i = 0; i < WARNING_THRESHOLD - 2; i += 1) {
@@ -661,12 +666,13 @@ describe("tool-loop-detection", () => {
       for (let i = 0; i < WARNING_THRESHOLD; i += 1) {
         detectToolCallLoop(state, "message", { text: "status" }, config);
         recordToolCall(state, "message", { text: "status" }, `hb1-${i}`, config);
+        // Mark as finished so they can be cleared
+        const last = state.toolCallHistory?.at(-1);
+        if (last) last.resultHash = "finished";
       }
 
-      // Backdate all entries to simulate time passing between heartbeat cycles
-      for (const entry of state.toolCallHistory ?? []) {
-        entry.timestamp = Date.now() - STALE_HISTORY_GAP_MS - 1000;
-      }
+      // Backdate lastToolCallAt to simulate time passing between heartbeat cycles
+      state.lastToolCallAt = Date.now() - STALE_HISTORY_GAP_MS - 1000;
 
       // Second heartbeat: the FIRST detectToolCallLoop call must not see the
       // stale WARNING_THRESHOLD entries — this is the exact scenario that was
@@ -677,6 +683,59 @@ describe("tool-loop-detection", () => {
       // After detection, record the call to mirror real ordering.
       recordToolCall(state, "message", { text: "status" }, "hb2-0", config);
       expect(state.toolCallHistory?.length).toBe(1);
+    });
+
+    it("does not reset history for a long-running tool if subsequent call is recent", () => {
+      const state = createState();
+      const config = enabledLoopDetectionConfig;
+
+      // Start a tool call at T=0
+      recordToolCall(state, "slow-tool", { id: 1 }, "call-1", config);
+      
+      // Simulate the tool running for 65s (exceeding STALE_HISTORY_GAP_MS)
+      // but the outcome AND the next call happen immediately after it finishes.
+      state.lastToolCallAt = Date.now() - STALE_HISTORY_GAP_MS - 5000;
+
+      // Outcome arrives at T=65s
+      recordToolCallOutcome(state, {
+        toolName: "slow-tool",
+        toolParams: { id: 1 },
+        toolCallId: "call-1",
+        result: "done",
+        config
+      });
+
+      // Now lastToolCallAt is updated to Now.
+      // Next call arrives at T=65.1s
+      const result = detectToolCallLoop(state, "slow-tool", { id: 1 }, config);
+      
+      // History should NOT have been cleared because recordToolCallOutcome refreshed lastToolCallAt
+      const stats = getToolCallStats(state);
+      expect(stats.totalCalls).toBe(1);
+    });
+
+    it("recordToolCallOutcome respects staleness guard", () => {
+      const state = createState();
+      recordToolCall(state, "tool", { id: 1 }, "call-1");
+      expect(state.toolCallHistory?.length).toBe(1);
+      const last = state.toolCallHistory?.at(-1);
+      if (last) last.resultHash = "finished";
+
+      // Backdate lastToolCallAt to make history stale
+      state.lastToolCallAt = Date.now() - STALE_HISTORY_GAP_MS - 1000;
+
+      // Late-arriving outcome from the previous stale cycle
+      recordToolCallOutcome(state, {
+        toolName: "tool",
+        toolParams: { id: 1 },
+        toolCallId: "call-1",
+        result: "late"
+      });
+
+      // History should have been cleared by state.toolCallHistory = effectiveHistory(state)
+      // and then since no match was found (history was empty), it should have pushed the outcome.
+      expect(state.toolCallHistory?.length).toBe(1);
+      expect(state.toolCallHistory?.[0]?.resultHash).toBeDefined();
     });
   });
 });

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -368,6 +368,23 @@ function canonicalPairKey(signatureA: string, signatureB: string): string {
 }
 
 /**
+ * Return a non-stale view of the tool call history.  When the most recent
+ * entry is older than STALE_HISTORY_GAP_MS the entire history is considered
+ * stale (e.g. leftover from a previous heartbeat cycle) and an empty array
+ * is returned.  This helper is shared between detection and recording so that
+ * stale entries never influence loop decisions regardless of call ordering.
+ */
+function effectiveHistory(
+  history: NonNullable<SessionState["toolCallHistory"]>,
+): NonNullable<SessionState["toolCallHistory"]> {
+  const lastEntry = history.at(-1);
+  if (lastEntry && Date.now() - lastEntry.timestamp > STALE_HISTORY_GAP_MS) {
+    return [];
+  }
+  return history;
+}
+
+/**
  * Detect if an agent is stuck in a repetitive tool call loop.
  * Checks if the same tool+params combination has been called excessively.
  */
@@ -381,7 +398,9 @@ export function detectToolCallLoop(
   if (!resolvedConfig.enabled) {
     return { stuck: false };
   }
-  const history = state.toolCallHistory ?? [];
+  // Use staleness-aware view so stale history from a previous heartbeat
+  // cycle never causes false-positive warnings (#40144).
+  const history = effectiveHistory(state.toolCallHistory ?? []);
   const currentHash = hashToolCall(toolName, params);
   const noProgress = getNoProgressStreak(history, toolName, currentHash);
   const noProgressStreak = noProgress.count;
@@ -514,10 +533,7 @@ export function recordToolCall(
 
   // Clear stale history when there's a significant time gap (e.g. between
   // heartbeat cycles) to prevent false positive loop detection (#40144).
-  const lastEntry = state.toolCallHistory.at(-1);
-  if (lastEntry && Date.now() - lastEntry.timestamp > STALE_HISTORY_GAP_MS) {
-    state.toolCallHistory = [];
-  }
+  state.toolCallHistory = effectiveHistory(state.toolCallHistory);
 
   state.toolCallHistory.push({
     toolName,

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -375,10 +375,13 @@ function canonicalPairKey(signatureA: string, signatureB: string): string {
  * stale entries never influence loop decisions regardless of call ordering.
  */
 function effectiveHistory(
-  history: NonNullable<SessionState["toolCallHistory"]>,
+  state: SessionState,
 ): NonNullable<SessionState["toolCallHistory"]> {
-  const lastEntry = history.at(-1);
-  if (lastEntry && Date.now() - lastEntry.timestamp > STALE_HISTORY_GAP_MS) {
+  const history = state.toolCallHistory ?? [];
+  if (history.length > 0 && history.some((h) => h.resultHash === undefined)) {
+    return history;
+  }
+  if (state.lastToolCallAt && Date.now() - state.lastToolCallAt > STALE_HISTORY_GAP_MS) {
     return [];
   }
   return history;
@@ -400,7 +403,10 @@ export function detectToolCallLoop(
   }
   // Use staleness-aware view so stale history from a previous heartbeat
   // cycle never causes false-positive warnings (#40144).
-  const history = effectiveHistory(state.toolCallHistory ?? []);
+  state.toolCallHistory = effectiveHistory(state);
+  state.lastToolCallAt = Date.now();
+
+  const history = state.toolCallHistory;
   const currentHash = hashToolCall(toolName, params);
   const noProgress = getNoProgressStreak(history, toolName, currentHash);
   const noProgressStreak = noProgress.count;
@@ -533,7 +539,8 @@ export function recordToolCall(
 
   // Clear stale history when there's a significant time gap (e.g. between
   // heartbeat cycles) to prevent false positive loop detection (#40144).
-  state.toolCallHistory = effectiveHistory(state.toolCallHistory);
+  state.toolCallHistory = effectiveHistory(state);
+  state.lastToolCallAt = Date.now();
 
   state.toolCallHistory.push({
     toolName,
@@ -572,9 +579,10 @@ export function recordToolCallOutcome(
     return;
   }
 
-  if (!state.toolCallHistory) {
-    state.toolCallHistory = [];
-  }
+  // Record outcome also respects staleness to prevent late-arriving results
+  // from reviving a stale history context.
+  state.toolCallHistory = effectiveHistory(state);
+  state.lastToolCallAt = Date.now();
 
   const argsHash = hashToolCall(params.toolName, params.toolParams);
   let matched = false;

--- a/src/agents/tool-loop-detection.ts
+++ b/src/agents/tool-loop-detection.ts
@@ -28,6 +28,8 @@ export const TOOL_CALL_HISTORY_SIZE = 30;
 export const WARNING_THRESHOLD = 10;
 export const CRITICAL_THRESHOLD = 20;
 export const GLOBAL_CIRCUIT_BREAKER_THRESHOLD = 30;
+/** If the most recent tool call is older than this, consider the history stale and reset. */
+export const STALE_HISTORY_GAP_MS = 60_000;
 const DEFAULT_LOOP_DETECTION_CONFIG = {
   enabled: false,
   historySize: TOOL_CALL_HISTORY_SIZE,
@@ -507,6 +509,13 @@ export function recordToolCall(
 ): void {
   const resolvedConfig = resolveLoopDetectionConfig(config);
   if (!state.toolCallHistory) {
+    state.toolCallHistory = [];
+  }
+
+  // Clear stale history when there's a significant time gap (e.g. between
+  // heartbeat cycles) to prevent false positive loop detection (#40144).
+  const lastEntry = state.toolCallHistory.at(-1);
+  if (lastEntry && Date.now() - lastEntry.timestamp > STALE_HISTORY_GAP_MS) {
     state.toolCallHistory = [];
   }
 

--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -8,6 +8,7 @@ export type SessionState = {
   queueDepth: number;
   toolCallHistory?: ToolCallRecord[];
   toolLoopWarningBuckets?: Map<string, number>;
+  lastToolCallAt?: number;
   commandPollCounts?: Map<string, { count: number; lastPollAt: number }>;
 };
 


### PR DESCRIPTION
This PR addresses the issue where stale tool call history could lead to false positive loop detections. It clears \	oolCallHistory\ when a significant time gap is detected between calls, ensuring that loops are only detected within a continuous context. Closes #40144. (Based on work from #40656)