### PR TITLE
Backup: add exclude patterns to create

### DIFF
--- a/src/cli/program/register.backup.test.ts
+++ b/src/cli/program/register.backup.test.ts
@@ -90,6 +90,35 @@ describe("registerBackupCommand", () => {
     );
   });
 
+  it("forwards --exclude patterns to backup create", async () => {
+    await runCli([
+      "backup",
+      "create",
+      "--exclude",
+      "node_modules",
+      "--exclude",
+      "*.log",
+    ]);
+
+    expect(backupCreateCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        exclude: ["node_modules", "*.log"],
+      }),
+    );
+  });
+
+  it("forwards --exclude-file to backup create", async () => {
+    await runCli(["backup", "create", "--exclude-file", ".openclawignore"]);
+
+    expect(backupCreateCommand).toHaveBeenCalledWith(
+      runtime,
+      expect.objectContaining({
+        excludeFile: ".openclawignore",
+      }),
+    );
+  });
+
   it("runs backup verify with forwarded options", async () => {
     await runCli(["backup", "verify", "/tmp/openclaw-backup.tar.gz", "--json"]);
 

--- a/src/cli/program/register.backup.ts
+++ b/src/cli/program/register.backup.ts
@@ -26,6 +26,13 @@ export function registerBackupCommand(program: Command) {
     .option("--verify", "Verify the archive after writing it", false)
     .option("--only-config", "Back up only the active JSON config file", false)
     .option("--no-include-workspace", "Exclude workspace directories from the backup")
+    .option(
+      "--exclude <pattern>",
+      "Exclude files matching a .gitignore-style pattern (repeatable)",
+      (val: string, prev: string[]) => [...prev, val],
+      [] as string[],
+    )
+    .option("--exclude-file <path>", "Read exclude patterns from a file (one pattern per line)")
     .addHelpText(
       "after",
       () =>
@@ -48,6 +55,14 @@ export function registerBackupCommand(program: Command) {
             "Back up state/config without agent workspace files.",
           ],
           ["openclaw backup create --only-config", "Back up only the active JSON config file."],
+          [
+            'openclaw backup create --exclude "node_modules" --exclude "*.log"',
+            "Exclude node_modules directories and log files from the backup.",
+          ],
+          [
+            "openclaw backup create --exclude-file .openclawignore",
+            "Read exclude patterns from a file.",
+          ],
         ])}`,
     )
     .action(async (opts) => {
@@ -59,6 +74,8 @@ export function registerBackupCommand(program: Command) {
           verify: Boolean(opts.verify),
           onlyConfig: Boolean(opts.onlyConfig),
           includeWorkspace: opts.includeWorkspace as boolean,
+          exclude: opts.exclude as string[],
+          excludeFile: opts.excludeFile as string | undefined,
         });
       });
     });

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -467,13 +467,14 @@ describe("backup commands", () => {
     const backupDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backups-efile-"));
     const excludeFile = path.join(tempHome.home, ".openclawignore");
     try {
-      await fs.writeFile(excludeFile, "# comment\n*.log\n\n.env\n", "utf8");
+      await fs.writeFile(excludeFile, "# comment\n*.log\n!keep.txt\n\n.env\n", "utf8");
       await fs.writeFile(
         path.join(stateDir, "openclaw.json"),
         JSON.stringify({ agents: { defaults: { workspace: externalWorkspace } } }),
         "utf8",
       );
       await fs.writeFile(path.join(externalWorkspace, "SOUL.md"), "# soul\n", "utf8");
+      await fs.writeFile(path.join(externalWorkspace, "keep.txt"), "keep\n", "utf8");
       await fs.writeFile(path.join(externalWorkspace, "app.log"), "log\n", "utf8");
       await fs.writeFile(path.join(externalWorkspace, ".env"), "SECRET=1\n", "utf8");
 
@@ -485,13 +486,14 @@ describe("backup commands", () => {
         nowMs: Date.UTC(2026, 2, 9, 13, 0, 0),
       });
 
-      expect(result.excludePatterns).toEqual(["*.log", ".env"]);
+      expect(result.excludePatterns).toEqual(["*.log", "!keep.txt", ".env"]);
 
       const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-extract-efile-"));
       try {
         await tar.x({ file: result.archivePath, cwd: extractDir, gzip: true });
         const archiveRoot = path.join(extractDir, result.archiveRoot);
         const workspaceAsset = result.assets.find((a) => a.kind === "workspace");
+        expect(workspaceAsset).toBeDefined();
         const encodedWorkspace = path.join(
           archiveRoot,
           "payload",
@@ -499,6 +501,7 @@ describe("backup commands", () => {
         );
 
         await expect(fs.access(path.join(encodedWorkspace, "SOUL.md"))).resolves.toBeUndefined();
+        await expect(fs.access(path.join(encodedWorkspace, "keep.txt"))).resolves.toBeUndefined();
         await expect(fs.access(path.join(encodedWorkspace, "app.log"))).rejects.toThrow();
         await expect(fs.access(path.join(encodedWorkspace, ".env"))).rejects.toThrow();
       } finally {

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -408,6 +408,108 @@ describe("backup commands", () => {
     expect(result.assets[0]?.kind).toBe("config");
   });
 
+  it("excludes files matching --exclude patterns from the archive", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const externalWorkspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-excl-"));
+    const backupDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backups-excl-"));
+    try {
+      await fs.writeFile(
+        path.join(stateDir, "openclaw.json"),
+        JSON.stringify({ agents: { defaults: { workspace: externalWorkspace } } }),
+        "utf8",
+      );
+      await fs.writeFile(path.join(stateDir, "state.txt"), "state\n", "utf8");
+      await fs.mkdir(path.join(externalWorkspace, "node_modules", "pkg"), { recursive: true });
+      await fs.writeFile(path.join(externalWorkspace, "node_modules", "pkg", "index.js"), "// pkg\n", "utf8");
+      await fs.writeFile(path.join(externalWorkspace, "SOUL.md"), "# soul\n", "utf8");
+      await fs.writeFile(path.join(externalWorkspace, "debug.log"), "log\n", "utf8");
+
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+      const result = await backupCreateCommand(runtime, {
+        output: backupDir,
+        includeWorkspace: true,
+        exclude: ["node_modules", "*.log"],
+        nowMs: Date.UTC(2026, 2, 9, 12, 0, 0),
+      });
+
+      expect(result.excludePatterns).toEqual(["node_modules", "*.log"]);
+
+      const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-extract-excl-"));
+      try {
+        await tar.x({ file: result.archivePath, cwd: extractDir, gzip: true });
+        const archiveRoot = path.join(extractDir, result.archiveRoot);
+
+        const workspaceAsset = result.assets.find((a) => a.kind === "workspace");
+        expect(workspaceAsset).toBeDefined();
+        const encodedWorkspace = path.join(
+          archiveRoot,
+          "payload",
+          encodeAbsolutePathForBackupArchive(workspaceAsset!.sourcePath),
+        );
+
+        // SOUL.md should be present
+        await expect(fs.access(path.join(encodedWorkspace, "SOUL.md"))).resolves.toBeUndefined();
+        // node_modules and *.log should be excluded
+        await expect(fs.access(path.join(encodedWorkspace, "node_modules"))).rejects.toThrow();
+        await expect(fs.access(path.join(encodedWorkspace, "debug.log"))).rejects.toThrow();
+      } finally {
+        await fs.rm(extractDir, { recursive: true, force: true });
+      }
+    } finally {
+      await fs.rm(externalWorkspace, { recursive: true, force: true });
+      await fs.rm(backupDir, { recursive: true, force: true });
+    }
+  });
+
+  it("reads exclude patterns from --exclude-file", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const externalWorkspace = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-workspace-efile-"));
+    const backupDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backups-efile-"));
+    const excludeFile = path.join(tempHome.home, ".openclawignore");
+    try {
+      await fs.writeFile(excludeFile, "# comment\n*.log\n\n.env\n", "utf8");
+      await fs.writeFile(
+        path.join(stateDir, "openclaw.json"),
+        JSON.stringify({ agents: { defaults: { workspace: externalWorkspace } } }),
+        "utf8",
+      );
+      await fs.writeFile(path.join(externalWorkspace, "SOUL.md"), "# soul\n", "utf8");
+      await fs.writeFile(path.join(externalWorkspace, "app.log"), "log\n", "utf8");
+      await fs.writeFile(path.join(externalWorkspace, ".env"), "SECRET=1\n", "utf8");
+
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+      const result = await backupCreateCommand(runtime, {
+        output: backupDir,
+        includeWorkspace: true,
+        excludeFile,
+        nowMs: Date.UTC(2026, 2, 9, 13, 0, 0),
+      });
+
+      expect(result.excludePatterns).toEqual(["*.log", ".env"]);
+
+      const extractDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-backup-extract-efile-"));
+      try {
+        await tar.x({ file: result.archivePath, cwd: extractDir, gzip: true });
+        const archiveRoot = path.join(extractDir, result.archiveRoot);
+        const workspaceAsset = result.assets.find((a) => a.kind === "workspace");
+        const encodedWorkspace = path.join(
+          archiveRoot,
+          "payload",
+          encodeAbsolutePathForBackupArchive(workspaceAsset!.sourcePath),
+        );
+
+        await expect(fs.access(path.join(encodedWorkspace, "SOUL.md"))).resolves.toBeUndefined();
+        await expect(fs.access(path.join(encodedWorkspace, "app.log"))).rejects.toThrow();
+        await expect(fs.access(path.join(encodedWorkspace, ".env"))).rejects.toThrow();
+      } finally {
+        await fs.rm(extractDir, { recursive: true, force: true });
+      }
+    } finally {
+      await fs.rm(externalWorkspace, { recursive: true, force: true });
+      await fs.rm(backupDir, { recursive: true, force: true });
+    }
+  });
+
   it("allows config-only backups even when the config file is invalid", async () => {
     const configPath = path.join(tempHome.home, "custom-config.json");
     process.env.OPENCLAW_CONFIG_PATH = configPath;

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -296,7 +296,7 @@ function matchesExcludePattern(relativePath: string, patterns: string[]): boolea
       : stripped.includes("/")
         ? stripped
         : `**/${stripped}`;
-    if (minimatch(normalized, glob, { dot: true })) {
+    if (minimatch(normalized, glob, { dot: true, nonegate: true })) {
       return true;
     }
   }

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import * as tar from "tar";
+import { minimatch } from "minimatch";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveHomeDir, resolveUserPath } from "../utils.js";
 import { resolveRuntimeServiceVersion } from "../version.js";
@@ -25,6 +26,8 @@ export type BackupCreateOptions = {
   verify?: boolean;
   json?: boolean;
   nowMs?: number;
+  exclude?: string[];
+  excludeFile?: string;
 };
 
 type BackupManifestAsset = {
@@ -43,6 +46,7 @@ type BackupManifest = {
   options: {
     includeWorkspace: boolean;
     onlyConfig?: boolean;
+    excludePatterns?: string[];
   };
   paths: {
     stateDir: string;
@@ -67,6 +71,7 @@ export type BackupCreateResult = {
   includeWorkspace: boolean;
   onlyConfig: boolean;
   verified: boolean;
+  excludePatterns: string[];
   assets: BackupAsset[];
   skipped: Array<{
     kind: string;
@@ -194,6 +199,7 @@ function buildManifest(params: {
   archiveRoot: string;
   includeWorkspace: boolean;
   onlyConfig: boolean;
+  excludePatterns: string[];
   assets: BackupAsset[];
   skipped: BackupCreateResult["skipped"];
   stateDir: string;
@@ -211,6 +217,7 @@ function buildManifest(params: {
     options: {
       includeWorkspace: params.includeWorkspace,
       onlyConfig: params.onlyConfig,
+      ...(params.excludePatterns.length > 0 && { excludePatterns: params.excludePatterns }),
     },
     paths: {
       stateDir: params.stateDir,
@@ -271,6 +278,58 @@ function remapArchiveEntryPath(params: {
   return buildBackupArchivePath(params.archiveRoot, normalizedEntry);
 }
 
+async function loadExcludeFile(filePath: string): Promise<string[]> {
+  const content = await fs.readFile(resolveUserPath(filePath), "utf8");
+  return content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+}
+
+function matchesExcludePattern(relativePath: string, patterns: string[]): boolean {
+  const normalized = relativePath.replaceAll("\\", "/");
+  for (const raw of patterns) {
+    const stripped = raw.endsWith("/") ? raw.slice(0, -1) : raw;
+    const isAnchored = stripped.startsWith("/");
+    const glob = isAnchored
+      ? stripped.slice(1)
+      : stripped.includes("/")
+        ? stripped
+        : `**/${stripped}`;
+    if (minimatch(normalized, glob, { dot: true })) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function buildExcludeFilter(params: {
+  manifestPath: string;
+  assets: BackupAsset[];
+  patterns: string[];
+}): (entryPath: string) => boolean {
+  if (params.patterns.length === 0) {
+    return () => true;
+  }
+  return (entryPath: string) => {
+    const normalized = path.resolve(entryPath);
+    if (normalized === params.manifestPath) {
+      return true;
+    }
+    const asset = params.assets.find(
+      (a) => normalized === a.sourcePath || normalized.startsWith(a.sourcePath + path.sep),
+    );
+    if (!asset) {
+      return true;
+    }
+    const relative = normalized.slice(asset.sourcePath.length).replace(/^[/\\]/, "");
+    if (!relative) {
+      return true;
+    }
+    return !matchesExcludePattern(relative, params.patterns);
+  };
+}
+
 export async function backupCreateCommand(
   runtime: RuntimeEnv,
   opts: BackupCreateOptions = {},
@@ -280,6 +339,9 @@ export async function backupCreateCommand(
   const onlyConfig = Boolean(opts.onlyConfig);
   const includeWorkspace = onlyConfig ? false : (opts.includeWorkspace ?? true);
   const plan = await resolveBackupPlanFromDisk({ includeWorkspace, onlyConfig, nowMs });
+
+  const filePatterns = opts.excludeFile ? await loadExcludeFile(opts.excludeFile) : [];
+  const excludePatterns = [...(opts.exclude ?? []), ...filePatterns];
   const outputPath = await resolveOutputPath({
     output: opts.output,
     nowMs,
@@ -318,6 +380,7 @@ export async function backupCreateCommand(
     includeWorkspace,
     onlyConfig,
     verified: false,
+    excludePatterns,
     assets: plan.included,
     skipped: plan.skipped,
   };
@@ -333,6 +396,7 @@ export async function backupCreateCommand(
         archiveRoot,
         includeWorkspace,
         onlyConfig,
+        excludePatterns,
         assets: result.assets,
         skipped: result.skipped,
         stateDir: plan.stateDir,
@@ -342,12 +406,19 @@ export async function backupCreateCommand(
       });
       await fs.writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
 
+      const excludeFilter = buildExcludeFilter({
+        manifestPath,
+        assets: result.assets,
+        patterns: excludePatterns,
+      });
+
       await tar.c(
         {
           file: tempArchivePath,
           gzip: true,
           portable: true,
           preservePaths: true,
+          filter: excludeFilter,
           onWriteEntry: (entry) => {
             entry.path = remapArchiveEntryPath({
               entryPath: entry.path,


### PR DESCRIPTION
## Summary
- add repeatable `--exclude` and `--exclude-file` options to `openclaw backup create`
- apply gitignore-style exclude patterns when building backup archives and record them in the manifest
- cover CLI forwarding plus archive exclusion behavior in backup tests

## Testing
- `pnpm test src/commands/backup.test.ts src/cli/program/register.backup.test.ts` *(fails in this environment because `@mariozechner/pi-ai/oauth` cannot be resolved from `src/agents/auth-profiles/oauth.ts`; `src/cli/program/register.backup.test.ts` passes)*

Closes #40786
