### PR TITLE
fix(telegram): accept @bot suffix in inline directives

### DIFF
--- a/src/auto-reply/model.test.ts
+++ b/src/auto-reply/model.test.ts
@@ -29,6 +29,13 @@ describe("extractModelDirective", () => {
       expect(result.rawModel).toBe("anthropic/claude-opus-4-5");
     });
 
+    it("accepts Telegram bot username suffixes on /model", () => {
+      const result = extractModelDirective("/model@CiwardMacBot gpt-5");
+      expect(result.hasDirective).toBe(true);
+      expect(result.rawModel).toBe("gpt-5");
+      expect(result.cleaned).toBe("");
+    });
+
     it("extracts /model with profile override", () => {
       const result = extractModelDirective("/model gpt-5@myprofile");
       expect(result.hasDirective).toBe(true);

--- a/src/auto-reply/model.ts
+++ b/src/auto-reply/model.ts
@@ -1,5 +1,6 @@
 import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
 import { escapeRegExp } from "../utils.js";
+import { INLINE_DIRECTIVE_BOT_SUFFIX_PATTERN } from "./reply/directive-parsing.js";
 
 export function extractModelDirective(
   body?: string,
@@ -15,7 +16,10 @@ export function extractModelDirective(
   }
 
   const modelMatch = body.match(
-    /(?:^|\s)\/model(?=$|\s|:)\s*:?\s*([A-Za-z0-9_.:@-]+(?:\/[A-Za-z0-9_.:@-]+)*)?/i,
+    new RegExp(
+      String.raw`(?:^|\s)\/model${INLINE_DIRECTIVE_BOT_SUFFIX_PATTERN}(?=$|\s|:)\s*:?\s*([A-Za-z0-9_.:@-]+(?:\/[A-Za-z0-9_.:@-]+)*)?`,
+      "i",
+    ),
   );
 
   const aliases = (options?.aliases ?? []).map((alias) => alias.trim()).filter(Boolean);
@@ -24,7 +28,7 @@ export function extractModelDirective(
       ? null
       : body.match(
           new RegExp(
-            `(?:^|\\s)\\/(${aliases.map(escapeRegExp).join("|")})(?=$|\\s|:)(?:\\s*:\\s*)?`,
+            `(?:^|\\s)\\/(${aliases.map(escapeRegExp).join("|")})${INLINE_DIRECTIVE_BOT_SUFFIX_PATTERN}(?=$|\\s|:)(?:\\s*:\\s*)?`,
             "i",
           ),
         );

--- a/src/auto-reply/reply.directive.parse.test.ts
+++ b/src/auto-reply/reply.directive.parse.test.ts
@@ -43,6 +43,13 @@ describe("directive parsing", () => {
     expect(res.reasoningLevel).toBe("on");
   });
 
+  it("accepts Telegram bot username suffixes on think directives", () => {
+    const res = extractThinkDirective("/think@CiwardMacBot high please");
+    expect(res.hasDirective).toBe(true);
+    expect(res.thinkLevel).toBe("high");
+    expect(res.cleaned).toBe("please");
+  });
+
   it("matches reasoning stream directive", () => {
     const res = extractReasoningDirective("/reasoning stream please");
     expect(res.hasDirective).toBe(true);
@@ -134,6 +141,13 @@ describe("directive parsing", () => {
     expect(res.cleaned).toBe("please now");
   });
 
+  it("accepts Telegram bot username suffixes on exec directives", () => {
+    const res = extractExecDirective("/exec@CiwardMacBot host=gateway");
+    expect(res.hasDirective).toBe(true);
+    expect(res.execHost).toBe("gateway");
+    expect(res.cleaned).toBe("");
+  });
+
   it("captures invalid exec host values", () => {
     const res = extractExecDirective("/exec host=spaceship");
     expect(res.hasDirective).toBe(true);
@@ -148,6 +162,13 @@ describe("directive parsing", () => {
     expect(res.queueMode).toBe("interrupt");
     expect(res.queueReset).toBe(false);
     expect(res.cleaned).toBe("please now");
+  });
+
+  it("accepts Telegram bot username suffixes on queue directives", () => {
+    const res = extractQueueDirective("/queue@CiwardMacBot interrupt");
+    expect(res.hasDirective).toBe(true);
+    expect(res.queueMode).toBe("interrupt");
+    expect(res.cleaned).toBe("");
   });
 
   it("preserves spacing when stripping think directives before paths", () => {
@@ -178,6 +199,12 @@ describe("directive parsing", () => {
     const res = extractStatusDirective("thats not /usage:/tmp/hello");
     expect(res.hasDirective).toBe(false);
     expect(res.cleaned).toBe("thats not /usage:/tmp/hello");
+  });
+
+  it("accepts Telegram bot username suffixes on status directives", () => {
+    const res = extractStatusDirective("/status@CiwardMacBot");
+    expect(res.hasDirective).toBe(true);
+    expect(res.cleaned).toBe("");
   });
 
   it("parses queue options and modes", () => {

--- a/src/auto-reply/reply/directive-parsing.ts
+++ b/src/auto-reply/reply/directive-parsing.ts
@@ -1,3 +1,5 @@
+export const INLINE_DIRECTIVE_BOT_SUFFIX_PATTERN = String.raw`(?:@[A-Za-z0-9_]+)?`;
+
 export function skipDirectiveArgPrefix(raw: string): number {
   let i = 0;
   const len = raw.length;

--- a/src/auto-reply/reply/directives.ts
+++ b/src/auto-reply/reply/directives.ts
@@ -10,6 +10,7 @@ import {
   type ThinkLevel,
   type VerboseLevel,
 } from "../thinking.js";
+import { INLINE_DIRECTIVE_BOT_SUFFIX_PATTERN } from "./directive-parsing.js";
 
 type ExtractedLevel<T> = {
   cleaned: string;
@@ -23,7 +24,12 @@ const matchLevelDirective = (
   names: string[],
 ): { start: number; end: number; rawLevel?: string } | null => {
   const namePattern = names.map(escapeRegExp).join("|");
-  const match = body.match(new RegExp(`(?:^|\\s)\\/(?:${namePattern})(?=$|\\s|:)`, "i"));
+  const match = body.match(
+    new RegExp(
+      `(?:^|\\s)\\/(?:${namePattern})${INLINE_DIRECTIVE_BOT_SUFFIX_PATTERN}(?=$|\\s|:)`,
+      "i",
+    ),
+  );
   if (!match || match.index === undefined) {
     return null;
   }
@@ -79,7 +85,10 @@ const extractSimpleDirective = (
 ): { cleaned: string; hasDirective: boolean } => {
   const namePattern = names.map(escapeRegExp).join("|");
   const match = body.match(
-    new RegExp(`(?:^|\\s)\\/(?:${namePattern})(?=$|\\s|:)(?:\\s*:\\s*)?`, "i"),
+    new RegExp(
+      `(?:^|\\s)\\/(?:${namePattern})${INLINE_DIRECTIVE_BOT_SUFFIX_PATTERN}(?=$|\\s|:)(?:\\s*:\\s*)?`,
+      "i",
+    ),
   );
   const cleaned = match ? body.replace(match[0], " ").replace(/\s+/g, " ").trim() : body.trim();
   return {

--- a/src/auto-reply/reply/exec/directive.ts
+++ b/src/auto-reply/reply/exec/directive.ts
@@ -1,5 +1,9 @@
 import type { ExecAsk, ExecHost, ExecSecurity } from "../../../infra/exec-approvals.js";
-import { skipDirectiveArgPrefix, takeDirectiveToken } from "../directive-parsing.js";
+import {
+  INLINE_DIRECTIVE_BOT_SUFFIX_PATTERN,
+  skipDirectiveArgPrefix,
+  takeDirectiveToken,
+} from "../directive-parsing.js";
 
 type ExecDirectiveParse = {
   cleaned: string;
@@ -172,7 +176,7 @@ export function extractExecDirective(body?: string): ExecDirectiveParse {
       invalidNode: false,
     };
   }
-  const re = /(?:^|\s)\/exec(?=$|\s|:)/i;
+  const re = new RegExp(`(?:^|\\s)\\/exec${INLINE_DIRECTIVE_BOT_SUFFIX_PATTERN}(?=$|\\s|:)`, "i");
   const match = re.exec(body);
   if (!match) {
     return {
@@ -186,7 +190,7 @@ export function extractExecDirective(body?: string): ExecDirectiveParse {
     };
   }
   const start = match.index + match[0].indexOf("/exec");
-  const argsStart = start + "/exec".length;
+  const argsStart = match.index + match[0].length;
   const parsed = parseExecDirectiveArgs(body.slice(argsStart));
   const cleanedRaw = `${body.slice(0, start)} ${body.slice(argsStart + parsed.consumed)}`;
   const cleaned = cleanedRaw.replace(/\s+/g, " ").trim();

--- a/src/auto-reply/reply/queue/directive.ts
+++ b/src/auto-reply/reply/queue/directive.ts
@@ -1,5 +1,9 @@
 import { parseDurationMs } from "../../../cli/parse-duration.js";
-import { skipDirectiveArgPrefix, takeDirectiveToken } from "../directive-parsing.js";
+import {
+  INLINE_DIRECTIVE_BOT_SUFFIX_PATTERN,
+  skipDirectiveArgPrefix,
+  takeDirectiveToken,
+} from "../directive-parsing.js";
 import { normalizeQueueDropPolicy, normalizeQueueMode } from "./normalize.js";
 import type { QueueDropPolicy, QueueMode } from "./types.js";
 
@@ -143,7 +147,7 @@ export function extractQueueDirective(body?: string): {
       hasOptions: false,
     };
   }
-  const re = /(?:^|\s)\/queue(?=$|\s|:)/i;
+  const re = new RegExp(`(?:^|\\s)\\/queue${INLINE_DIRECTIVE_BOT_SUFFIX_PATTERN}(?=$|\\s|:)`, "i");
   const match = re.exec(body);
   if (!match) {
     return {
@@ -154,7 +158,7 @@ export function extractQueueDirective(body?: string): {
     };
   }
   const start = match.index + match[0].indexOf("/queue");
-  const argsStart = start + "/queue".length;
+  const argsStart = match.index + match[0].length;
   const args = body.slice(argsStart);
   const parsed = parseQueueDirectiveArgs(args);
   const cleanedRaw = `${body.slice(0, start)} ${body.slice(argsStart + parsed.consumed)}`;


### PR DESCRIPTION
## Summary
- allow inline directives to match Telegram group command bodies like `/model@BotName`
- share the optional `@bot_username` suffix pattern across model, status, thinking, exec, and queue directives
- keep exec/queue argument slicing aligned with the full matched command token

## Problem
Telegram groups append `@BotUsername` to slash commands. Native command handling already normalizes that suffix, but inline directives bypassed that path and silently failed.

Fixes #40637.

## Verification
- /Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/vitest run src/auto-reply/model.test.ts src/auto-reply/reply.directive.parse.test.ts
- /Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/oxfmt --check src/auto-reply/model.ts src/auto-reply/model.test.ts src/auto-reply/reply.directive.parse.test.ts src/auto-reply/reply/directive-parsing.ts src/auto-reply/reply/directives.ts src/auto-reply/reply/exec/directive.ts src/auto-reply/reply/queue/directive.ts
- /Users/majunxian/Desktop/PyProject/openclaw/node_modules/.bin/oxlint src/auto-reply/model.ts src/auto-reply/model.test.ts src/auto-reply/reply.directive.parse.test.ts src/auto-reply/reply/directive-parsing.ts src/auto-reply/reply/directives.ts src/auto-reply/reply/exec/directive.ts src/auto-reply/reply/queue/directive.ts