### PR TITLE
fix(browser): avoid restart guidance for attachOnly timeout

### DIFF
--- a/src/browser/client-fetch.loopback-auth.test.ts
+++ b/src/browser/client-fetch.loopback-auth.test.ts
@@ -135,6 +135,30 @@ describe("fetchBrowserJson loopback auth", () => {
     }
     expect(thrown.message).toContain("Chrome CDP handshake timeout");
     expect(thrown.message).toContain("Do NOT retry the browser tool");
+    expect(thrown.message).toContain("Restart the OpenClaw gateway");
+    expect(thrown.message).not.toContain("Can't reach the OpenClaw browser control service");
+  });
+
+  it("avoids restart-gateway guidance for attachOnly profile timeout", async () => {
+    mocks.loadConfig.mockReturnValue({
+      browser: {
+        attachOnly: true,
+      },
+    });
+    mocks.dispatch.mockRejectedValueOnce(new Error("timed out"));
+
+    const thrown = await fetchBrowserJson<{ ok: boolean }>("/tabs?profile=openclaw").catch(
+      (err: unknown) => err,
+    );
+
+    expect(thrown).toBeInstanceOf(Error);
+    if (!(thrown instanceof Error)) {
+      throw new Error(`Expected Error, got ${String(thrown)}`);
+    }
+    expect(thrown.message).toContain("Browser CDP is not reachable for attachOnly profiles");
+    expect(thrown.message).toContain("Restarting the OpenClaw gateway will not help");
+    expect(thrown.message).not.toContain("Restart the OpenClaw gateway");
+    expect(thrown.message).toContain("Do NOT retry the browser tool");
     expect(thrown.message).not.toContain("Can't reach the OpenClaw browser control service");
   });
 

--- a/src/browser/client-fetch.loopback-auth.test.ts
+++ b/src/browser/client-fetch.loopback-auth.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../config/config.js";
 import type { BrowserDispatchResponse } from "./routes/dispatcher.js";
 
 function okDispatchResponse(): BrowserDispatchResponse {
@@ -6,13 +7,7 @@ function okDispatchResponse(): BrowserDispatchResponse {
 }
 
 const mocks = vi.hoisted(() => ({
-  loadConfig: vi.fn(() => ({
-    gateway: {
-      auth: {
-        token: "loopback-token",
-      },
-    },
-  })),
+  loadConfig: vi.fn<() => OpenClawConfig>(),
   startBrowserControlServiceFromConfig: vi.fn(async () => ({ ok: true })),
   dispatch: vi.fn(async (): Promise<BrowserDispatchResponse> => okDispatchResponse()),
 }));

--- a/src/browser/client-fetch.ts
+++ b/src/browser/client-fetch.ts
@@ -2,6 +2,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { loadConfig } from "../config/config.js";
 import { isLoopbackHost } from "../gateway/net.js";
 import { getBridgeAuthForPort } from "./bridge-auth-registry.js";
+import { resolveBrowserConfig, resolveProfile } from "./config.js";
 import { resolveBrowserControlAuth } from "./control-auth.js";
 import {
   createBrowserControlContext,
@@ -114,6 +115,33 @@ function isRateLimitStatus(status: number): boolean {
   return status === 429;
 }
 
+function looksLikeTimeoutError(message: string): boolean {
+  const msgLower = message.toLowerCase();
+  return (
+    msgLower.includes("timed out") ||
+    msgLower.includes("timeout") ||
+    msgLower.includes("aborted") ||
+    msgLower.includes("abort") ||
+    msgLower.includes("aborterror")
+  );
+}
+
+function isAttachOnlyDispatcherRequest(url: string): boolean {
+  if (isAbsoluteHttp(url)) {
+    return false;
+  }
+  try {
+    const cfg = loadConfig();
+    const resolved = resolveBrowserConfig(cfg?.browser, cfg);
+    const parsed = new URL(url, "http://localhost");
+    const profileName = parsed.searchParams.get("profile")?.trim() || resolved.defaultProfile;
+    const profile = resolveProfile(resolved, profileName);
+    return profile?.attachOnly ?? resolved.attachOnly;
+  } catch {
+    return false;
+  }
+}
+
 function isBrowserbaseUrl(url: string): boolean {
   if (!isAbsoluteHttp(url)) {
     return false;
@@ -132,7 +160,15 @@ export function resolveBrowserRateLimitMessage(url: string): string {
     : BROWSER_SERVICE_RATE_LIMIT_MESSAGE;
 }
 
-function resolveBrowserFetchOperatorHint(url: string): string {
+function resolveBrowserFetchOperatorHint(
+  url: string,
+  opts?: { attachOnly?: boolean; timeoutLike?: boolean },
+): string {
+  if (opts?.attachOnly) {
+    return opts.timeoutLike
+      ? "Browser CDP is not reachable for attachOnly profiles. Restarting the OpenClaw gateway will not help; ensure Chrome is running with a reachable --remote-debugging-port endpoint."
+      : "Browser CDP is not reachable for attachOnly profiles. Restarting the OpenClaw gateway will not help.";
+  }
   const isLocal = !isAbsoluteHttp(url);
   return isLocal
     ? `Restart the OpenClaw gateway (OpenClaw.app menubar, or \`${formatCliCommand("openclaw gateway")}\`).`
@@ -163,7 +199,11 @@ async function discardResponseBody(res: Response): Promise<void> {
 
 function enhanceDispatcherPathError(url: string, err: unknown): Error {
   const msg = normalizeErrorMessage(err);
-  const suffix = `${resolveBrowserFetchOperatorHint(url)} ${BROWSER_TOOL_MODEL_HINT}`;
+  const timeoutLike = looksLikeTimeoutError(msg);
+  const suffix = `${resolveBrowserFetchOperatorHint(url, {
+    attachOnly: isAttachOnlyDispatcherRequest(url),
+    timeoutLike,
+  })} ${BROWSER_TOOL_MODEL_HINT}`;
   const normalized = msg.endsWith(".") ? msg : `${msg}.`;
   return new Error(`${normalized} ${suffix}`, err instanceof Error ? { cause: err } : undefined);
 }
@@ -171,13 +211,7 @@ function enhanceDispatcherPathError(url: string, err: unknown): Error {
 function enhanceBrowserFetchError(url: string, err: unknown, timeoutMs: number): Error {
   const operatorHint = resolveBrowserFetchOperatorHint(url);
   const msg = String(err);
-  const msgLower = msg.toLowerCase();
-  const looksLikeTimeout =
-    msgLower.includes("timed out") ||
-    msgLower.includes("timeout") ||
-    msgLower.includes("aborted") ||
-    msgLower.includes("abort") ||
-    msgLower.includes("aborterror");
+  const looksLikeTimeout = looksLikeTimeoutError(msg);
   if (looksLikeTimeout) {
     return new Error(
       appendBrowserToolModelHint(


### PR DESCRIPTION
## Summary
- avoid suggesting gateway restart when dispatcher-path failures happen on attachOnly profiles
- add attachOnly-specific timeout guidance clarifying CDP is unreachable and gateway restart will not help
- cover this behavior with a focused client-fetch test

## Testing
- pnpm test src/browser/client-fetch.loopback-auth.test.ts

Fixes openclaw/openclaw#40793