### PR TITLE
fix(update): align entrypoint candidate order with program-args

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -411,8 +411,14 @@ async function runPackageInstallUpdate(params: {
         stdoutTail: null,
       });
     }
-    const entryPath = path.join(verifiedPackageRoot, "dist", "entry.js");
-    if (await pathExists(entryPath)) {
+    let entryPath: string | undefined;
+    for (const candidate of resolveGatewayInstallEntrypointCandidates(verifiedPackageRoot)) {
+      if (await pathExists(candidate)) {
+        entryPath = candidate;
+        break;
+      }
+    }
+    if (entryPath) {
       const doctorStep = await runUpdateStep({
         name: `${CLI_NAME} doctor`,
         argv: [resolveNodeRunner(), entryPath, "doctor", "--non-interactive"],

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -113,10 +113,10 @@ function resolveGatewayInstallEntrypointCandidates(root?: string): string[] {
     return [];
   }
   return [
-    path.join(root, "dist", "entry.js"),
-    path.join(root, "dist", "entry.mjs"),
     path.join(root, "dist", "index.js"),
     path.join(root, "dist", "index.mjs"),
+    path.join(root, "dist", "entry.js"),
+    path.join(root, "dist", "entry.mjs"),
   ];
 }
 


### PR DESCRIPTION
## Summary

- Fix gateway entrypoint mismatch after `openclaw update` by aligning candidate order in `resolveGatewayInstallEntrypointCandidates` to match `appendDistCandidates` in `program-args.ts`
- `index.js` is now checked before `entry.js`, preventing the stale old entrypoint from being picked when both files exist

## Problem

After every `openclaw update`, `openclaw doctor` reports:

```
Gateway service entrypoint does not match the current install.
(dist/entry.js -> dist/index.js)
```

**Root cause:** `resolveGatewayInstallEntrypointCandidates()` in `update-command.ts` listed candidates as `entry.js → index.js`, while `appendDistCandidates()` in `program-args.ts` uses the correct order `index.js → entry.js`. When the old `entry.js` still exists after npm update, the stale file is found first and the plist gets reinstalled pointing to it.

Reproduced across 4 consecutive upgrades (2026.2.26 → 3.1 → 3.2 → 3.7 → 3.8) on macOS with LaunchAgent.

## Changes

**`src/cli/update-cli/update-command.ts`** — Swap entrypoint candidate order from `entry.js, entry.mjs, index.js, index.mjs` to `index.js, index.mjs, entry.js, entry.mjs` (matching `program-args.ts`).

## Test plan

- [ ] Run `openclaw update` on macOS — verify `openclaw doctor` no longer reports entrypoint mismatch
- [ ] Verify `gateway install --force` is no longer needed as a manual workaround
- [ ] Check that legacy installs using `entry.js` still work (fallback candidate order preserved)

Closes #40811

🤖 Generated with [Claude Code](https://claude.com/claude-code)