### PR TITLE
Surface install hints for stable/beta bundled plugins with unresolved package dependencies

### DIFF
--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -26,6 +26,42 @@ async function importFreshPluginTestModules() {
   };
 }
 
+async function importPluginTestModulesWithMocks(options?: { packageRoot?: string | null }) {
+  vi.resetModules();
+  vi.unmock("node:fs");
+  vi.unmock("node:fs/promises");
+  vi.unmock("node:module");
+  vi.unmock("./hook-runner-global.js");
+  vi.unmock("./hooks.js");
+  vi.unmock("./loader.js");
+  vi.unmock("jiti");
+  if (options && "packageRoot" in options) {
+    const packageRoot = options.packageRoot ?? null;
+    vi.doMock("../infra/openclaw-root.js", async () => {
+      const actual = await vi.importActual<typeof import("../infra/openclaw-root.js")>(
+        "../infra/openclaw-root.js",
+      );
+      return {
+        ...actual,
+        resolveOpenClawPackageRootSync: () => packageRoot,
+      };
+    });
+  } else {
+    vi.unmock("../infra/openclaw-root.js");
+  }
+  const [loader, hookRunnerGlobal, hooks] = await Promise.all([
+    import("./loader.js"),
+    import("./hook-runner-global.js"),
+    import("./hooks.js"),
+  ]);
+  vi.unmock("../infra/openclaw-root.js");
+  return {
+    ...loader,
+    ...hookRunnerGlobal,
+    ...hooks,
+  };
+}
+
 const {
   __testing,
   createHookRunner,
@@ -305,6 +341,29 @@ function createPluginSdkAliasFixture(params?: {
   return { root, srcFile, distFile };
 }
 
+function makeTaggedGitRepo(tag: string): string {
+  const repoRoot = makeTempDir();
+  fs.writeFileSync(path.join(repoRoot, "README.md"), `# ${tag}\n`, "utf-8");
+  execFileSync("git", ["init", "-q"], { cwd: repoRoot });
+  execFileSync("git", ["add", "README.md"], { cwd: repoRoot });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=OpenClaw Tests",
+      "-c",
+      "user.email=tests@openclaw.invalid",
+      "commit",
+      "-qm",
+      "init",
+    ],
+    { cwd: repoRoot },
+  );
+  execFileSync("git", ["tag", tag], { cwd: repoRoot });
+  execFileSync("git", ["checkout", "-q", tag], { cwd: repoRoot });
+  return repoRoot;
+}
+
 afterEach(() => {
   if (prevBundledDir === undefined) {
     delete process.env.OPENCLAW_BUNDLED_PLUGINS_DIR;
@@ -412,6 +471,64 @@ module.exports = { id: "feishu", register() {} };`,
       ),
     ).toBe(true);
   });
+
+  it.each([
+    {
+      tag: "v2026.3.8",
+      expectedChannel: "stable",
+    },
+    {
+      tag: "v2026.3.8-beta.1",
+      expectedChannel: "beta",
+    },
+  ])(
+    "reports an install hint for %s tagged git checkouts with unresolved package dependencies",
+    async ({ tag, expectedChannel }) => {
+      const repoRoot = makeTaggedGitRepo(tag);
+      const bundledDir = makeTempDir();
+      const pluginDir = path.join(bundledDir, "feishu");
+      const importedMarker = path.join(pluginDir, "imported.txt");
+      writePackagedPlugin({
+        id: "feishu",
+        dir: pluginDir,
+        dependencies: {
+          "@larksuiteoapi/node-sdk": "^1.59.0",
+        },
+        install: {
+          npmSpec: "@openclaw/feishu",
+        },
+        body: `require("node:fs").writeFileSync(${JSON.stringify(importedMarker)}, "loaded", "utf-8");
+module.exports = { id: "feishu", register() {} };`,
+      });
+
+      const { loadOpenClawPlugins: loadPluginsFromTaggedCheckout } =
+        await importPluginTestModulesWithMocks({
+          packageRoot: repoRoot,
+        });
+
+      const registry = withEnv({ OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir }, () =>
+        loadPluginsFromTaggedCheckout({
+          cache: false,
+          config: {
+            plugins: {
+              allow: ["feishu"],
+              entries: {
+                feishu: { enabled: true },
+              },
+            },
+          },
+        }),
+      );
+
+      const feishu = registry.plugins.find((entry) => entry.id === "feishu");
+      expect(feishu?.status).toBe("error");
+      expect(feishu?.error).toContain(
+        `plugin requires separate installation on ${expectedChannel}`,
+      );
+      expect(feishu?.error).toContain("openclaw plugins install @openclaw/feishu");
+      expect(fs.existsSync(importedMarker)).toBe(false);
+    },
+  );
 
   it("keeps bundled package plugins loadable on dev even when their declared dependencies are unresolved", () => {
     const bundledDir = makeTempDir();

--- a/src/plugins/loader.test.ts
+++ b/src/plugins/loader.test.ts
@@ -81,6 +81,7 @@ function writePlugin(params: {
   const dir = params.dir ?? makeTempDir();
   const filename = params.filename ?? `${params.id}.cjs`;
   const file = path.join(dir, filename);
+  fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(file, params.body, "utf-8");
   fs.writeFileSync(
     path.join(dir, "openclaw.plugin.json"),
@@ -95,6 +96,46 @@ function writePlugin(params: {
     "utf-8",
   );
   return { dir, file, id: params.id };
+}
+
+function writePackagedPlugin(params: {
+  id: string;
+  body: string;
+  dir?: string;
+  filename?: string;
+  packageName?: string;
+  version?: string;
+  description?: string;
+  dependencies?: Record<string, string>;
+  install?: { npmSpec?: string; localPath?: string; defaultChoice?: "npm" | "local" };
+}): TempPlugin {
+  const dir = params.dir ?? path.join(makeTempDir(), params.id);
+  const filename = params.filename ?? "index.cjs";
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify(
+      {
+        name: params.packageName ?? `@openclaw/${params.id}`,
+        version: params.version ?? "1.0.0",
+        description: params.description,
+        dependencies: params.dependencies,
+        openclaw: {
+          extensions: [`./${filename}`],
+          ...(params.install ? { install: params.install } : {}),
+        },
+      },
+      null,
+      2,
+    ),
+    "utf-8",
+  );
+  return writePlugin({
+    id: params.id,
+    body: params.body,
+    dir,
+    filename,
+  });
 }
 
 function loadBundledMemoryPluginRegistry(options?: {
@@ -324,6 +365,138 @@ describe("loadOpenClawPlugins", () => {
     });
 
     expectTelegramLoaded(registry);
+  });
+
+  it("reports an install hint for stable bundled plugins with unresolved package dependencies", () => {
+    const bundledDir = makeTempDir();
+    const pluginDir = path.join(bundledDir, "feishu");
+    const importedMarker = path.join(pluginDir, "imported.txt");
+    writePackagedPlugin({
+      id: "feishu",
+      dir: pluginDir,
+      dependencies: {
+        "@larksuiteoapi/node-sdk": "^1.59.0",
+      },
+      install: {
+        npmSpec: "@openclaw/feishu",
+      },
+      body: `require("node:fs").writeFileSync(${JSON.stringify(importedMarker)}, "loaded", "utf-8");
+module.exports = { id: "feishu", register() {} };`,
+    });
+
+    const registry = withEnv({ OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir }, () =>
+      loadOpenClawPlugins({
+        cache: false,
+        config: {
+          update: { channel: "stable" },
+          plugins: {
+            allow: ["feishu"],
+            entries: {
+              feishu: { enabled: true },
+            },
+          },
+        },
+      }),
+    );
+
+    const feishu = registry.plugins.find((entry) => entry.id === "feishu");
+    expect(feishu?.status).toBe("error");
+    expect(feishu?.error).toContain("openclaw plugins install @openclaw/feishu");
+    expect(feishu?.error).toContain("@larksuiteoapi/node-sdk");
+    expect(fs.existsSync(importedMarker)).toBe(false);
+    expect(
+      registry.diagnostics.some(
+        (diag) =>
+          diag.pluginId === "feishu" &&
+          String(diag.message).includes("openclaw plugins install @openclaw/feishu"),
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps bundled package plugins loadable on dev even when their declared dependencies are unresolved", () => {
+    const bundledDir = makeTempDir();
+    const pluginDir = path.join(bundledDir, "feishu");
+    const importedMarker = path.join(pluginDir, "imported.txt");
+    writePackagedPlugin({
+      id: "feishu",
+      dir: pluginDir,
+      dependencies: {
+        "@larksuiteoapi/node-sdk": "^1.59.0",
+      },
+      install: {
+        npmSpec: "@openclaw/feishu",
+      },
+      body: `require("node:fs").writeFileSync(${JSON.stringify(importedMarker)}, "loaded", "utf-8");
+module.exports = { id: "feishu", register() {} };`,
+    });
+
+    const registry = withEnv({ OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir }, () =>
+      loadOpenClawPlugins({
+        cache: false,
+        config: {
+          update: { channel: "dev" },
+          plugins: {
+            allow: ["feishu"],
+            entries: {
+              feishu: { enabled: true },
+            },
+          },
+        },
+      }),
+    );
+
+    const feishu = registry.plugins.find((entry) => entry.id === "feishu");
+    expect(feishu?.status).toBe("loaded");
+    expect(fs.existsSync(importedMarker)).toBe(true);
+  });
+
+  it("lets a later installed copy load when the bundled stable copy is missing package dependencies", () => {
+    const bundledDir = makeTempDir();
+    writePackagedPlugin({
+      id: "feishu",
+      dir: path.join(bundledDir, "feishu"),
+      dependencies: {
+        "@larksuiteoapi/node-sdk": "^1.59.0",
+      },
+      install: {
+        npmSpec: "@openclaw/feishu",
+      },
+      body: `module.exports = { id: "feishu", register() {} };`,
+    });
+
+    const stateDir = makeTempDir();
+    const globalPluginDir = path.join(stateDir, "extensions", "feishu");
+    writePlugin({
+      id: "feishu",
+      dir: globalPluginDir,
+      filename: "index.cjs",
+      body: `module.exports = { id: "feishu", register() {} };`,
+    });
+
+    const registry = withEnv(
+      {
+        OPENCLAW_BUNDLED_PLUGINS_DIR: bundledDir,
+        OPENCLAW_STATE_DIR: stateDir,
+      },
+      () =>
+        loadOpenClawPlugins({
+          cache: false,
+          config: {
+            update: { channel: "stable" },
+            plugins: {
+              allow: ["feishu"],
+              entries: {
+                feishu: { enabled: true },
+              },
+            },
+          },
+        }),
+    );
+
+    const feishuEntries = registry.plugins.filter((entry) => entry.id === "feishu");
+    expect(feishuEntries).toHaveLength(1);
+    expect(feishuEntries[0]?.status).toBe("loaded");
+    expect(feishuEntries[0]?.origin).toBe("global");
   });
 
   it("loads bundled channel plugins when channels.<id>.enabled=true", () => {

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -446,7 +447,30 @@ function activatePluginRegistry(registry: PluginRegistry, cacheKey: string): voi
   initializeGlobalHookRunner(registry);
 }
 
-function resolveLoaderInstallKind(): "git" | "package" | "unknown" {
+type LoaderInstallContext = {
+  installKind: "git" | "package" | "unknown";
+  gitTag: string | null;
+  gitBranch: string | null;
+};
+
+let cachedLoaderInstallContext: LoaderInstallContext | null = null;
+
+function readLoaderGitMetadata(root: string, args: string[]): string | null {
+  try {
+    const output = execFileSync("git", ["-C", root, ...args], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return output || null;
+  } catch {
+    return null;
+  }
+}
+
+function resolveLoaderInstallContext(): LoaderInstallContext {
+  if (cachedLoaderInstallContext) {
+    return cachedLoaderInstallContext;
+  }
   const root =
     resolveOpenClawPackageRootSync({
       moduleUrl: import.meta.url,
@@ -454,9 +478,27 @@ function resolveLoaderInstallKind(): "git" | "package" | "unknown" {
       cwd: process.cwd(),
     }) ?? null;
   if (!root) {
-    return "unknown";
+    cachedLoaderInstallContext = {
+      installKind: "unknown",
+      gitTag: null,
+      gitBranch: null,
+    };
+    return cachedLoaderInstallContext;
   }
-  return fs.existsSync(path.join(root, ".git")) ? "git" : "package";
+  if (!fs.existsSync(path.join(root, ".git"))) {
+    cachedLoaderInstallContext = {
+      installKind: "package",
+      gitTag: null,
+      gitBranch: null,
+    };
+    return cachedLoaderInstallContext;
+  }
+  cachedLoaderInstallContext = {
+    installKind: "git",
+    gitTag: readLoaderGitMetadata(root, ["describe", "--tags", "--exact-match"]),
+    gitBranch: readLoaderGitMetadata(root, ["rev-parse", "--abbrev-ref", "HEAD"]),
+  };
+  return cachedLoaderInstallContext;
 }
 
 function readPluginPackageDependencies(rootDir: string): string[] {
@@ -670,9 +712,17 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const manifestByRoot = new Map(
     manifestRegistry.plugins.map((record) => [record.rootDir, record]),
   );
+  const installContext = resolveLoaderInstallContext();
   const effectiveChannel = resolveEffectiveUpdateChannel({
     configChannel: normalizeUpdateChannel(cfg.update?.channel),
-    installKind: resolveLoaderInstallKind(),
+    installKind: installContext.installKind,
+    git:
+      installContext.gitTag || installContext.gitBranch
+        ? {
+            tag: installContext.gitTag,
+            branch: installContext.gitBranch,
+          }
+        : undefined,
   }).channel;
 
   const seenIds = new Map<string, PluginRecord["origin"]>();

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -6,8 +6,10 @@ import type { OpenClawConfig } from "../config/config.js";
 import type { GatewayRequestHandler } from "../gateway/server-methods/types.js";
 import { openBoundaryFileSync } from "../infra/boundary-file-read.js";
 import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
+import { normalizeUpdateChannel, resolveEffectiveUpdateChannel } from "../infra/update-channels.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveUserPath } from "../utils.js";
+import { resolveBundledPluginsDir } from "./bundled-dir.js";
 import { clearPluginCommands } from "./commands.js";
 import {
   applyTestPluginDefaults,
@@ -444,6 +446,114 @@ function activatePluginRegistry(registry: PluginRegistry, cacheKey: string): voi
   initializeGlobalHookRunner(registry);
 }
 
+function resolveLoaderInstallKind(): "git" | "package" | "unknown" {
+  const root =
+    resolveOpenClawPackageRootSync({
+      moduleUrl: import.meta.url,
+      argv1: process.argv[1],
+      cwd: process.cwd(),
+    }) ?? null;
+  if (!root) {
+    return "unknown";
+  }
+  return fs.existsSync(path.join(root, ".git")) ? "git" : "package";
+}
+
+function readPluginPackageDependencies(rootDir: string): string[] {
+  const packagePath = path.join(rootDir, "package.json");
+  if (!fs.existsSync(packagePath)) {
+    return [];
+  }
+  try {
+    const raw = fs.readFileSync(packagePath, "utf8");
+    const parsed = JSON.parse(raw) as { dependencies?: Record<string, unknown> };
+    return Object.keys(parsed.dependencies ?? {});
+  } catch {
+    return [];
+  }
+}
+
+function collectDependencySearchRoots(params: { rootDir: string; ceilingDir: string }): string[] {
+  const roots: string[] = [];
+  let cursor = path.resolve(params.rootDir);
+  const ceiling = path.resolve(params.ceilingDir);
+  while (true) {
+    roots.push(cursor);
+    if (cursor === ceiling) {
+      break;
+    }
+    const parent = path.dirname(cursor);
+    if (parent === cursor) {
+      break;
+    }
+    cursor = parent;
+  }
+  return roots;
+}
+
+function hasResolvableDependency(params: {
+  dependency: string;
+  rootDir: string;
+  ceilingDir: string;
+}): boolean {
+  const dependencyParts = params.dependency.split("/");
+  for (const searchRoot of collectDependencySearchRoots({
+    rootDir: params.rootDir,
+    ceilingDir: params.ceilingDir,
+  })) {
+    const packageDir = path.join(searchRoot, "node_modules", ...dependencyParts);
+    if (fs.existsSync(packageDir)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function resolveBundledDependencyCeiling(rootDir: string): string {
+  const bundledDir = resolveBundledPluginsDir();
+  if (!bundledDir) {
+    return rootDir;
+  }
+  const resolvedBundledDir = path.resolve(bundledDir);
+  if (!isPathInside(resolvedBundledDir, rootDir) && resolvedBundledDir !== path.resolve(rootDir)) {
+    return rootDir;
+  }
+  if (path.basename(resolvedBundledDir) === "extensions") {
+    return path.dirname(resolvedBundledDir);
+  }
+  return resolvedBundledDir;
+}
+
+function resolveMissingPluginDependencies(rootDir: string): string[] {
+  const dependencies = readPluginPackageDependencies(rootDir);
+  if (dependencies.length === 0) {
+    return [];
+  }
+  const ceilingDir = resolveBundledDependencyCeiling(rootDir);
+  const missing: string[] = [];
+  for (const dependency of dependencies) {
+    if (!hasResolvableDependency({ dependency, rootDir, ceilingDir })) {
+      missing.push(dependency);
+    }
+  }
+  return missing;
+}
+
+function buildBundledInstallRequiredMessage(params: {
+  npmSpec: string;
+  channel: "stable" | "beta";
+  missingDependencies: string[];
+}): string {
+  const missing =
+    params.missingDependencies.length > 0
+      ? ` Missing runtime dependencies: ${params.missingDependencies.join(", ")}.`
+      : "";
+  return (
+    `plugin requires separate installation on ${params.channel}; ` +
+    `run \`openclaw plugins install ${params.npmSpec}\` and restart the gateway.${missing}`
+  );
+}
+
 export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegistry {
   // Test env: default-disable plugins unless explicitly configured.
   // This keeps unit/gateway suites fast and avoids loading heavyweight plugin deps by accident.
@@ -560,8 +670,13 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
   const manifestByRoot = new Map(
     manifestRegistry.plugins.map((record) => [record.rootDir, record]),
   );
+  const effectiveChannel = resolveEffectiveUpdateChannel({
+    configChannel: normalizeUpdateChannel(cfg.update?.channel),
+    installKind: resolveLoaderInstallKind(),
+  }).channel;
 
   const seenIds = new Map<string, PluginRecord["origin"]>();
+  const deferredBundledInstallRequired = new Map<string, PluginRecord>();
   const memorySlot = normalized.slots.memory;
   let selectedMemoryPluginId: string | null = null;
   let memorySlotMatched = false;
@@ -631,6 +746,25 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
       registry.plugins.push(record);
       seenIds.set(pluginId, candidate.origin);
       continue;
+    }
+
+    const bundledNpmSpec = candidate.packageManifest?.install?.npmSpec?.trim();
+    if (
+      candidate.origin === "bundled" &&
+      bundledNpmSpec &&
+      (effectiveChannel === "stable" || effectiveChannel === "beta")
+    ) {
+      const missingDependencies = resolveMissingPluginDependencies(candidate.rootDir);
+      if (missingDependencies.length > 0) {
+        record.status = "error";
+        record.error = buildBundledInstallRequiredMessage({
+          npmSpec: bundledNpmSpec,
+          channel: effectiveChannel,
+          missingDependencies,
+        });
+        deferredBundledInstallRequired.set(pluginId, record);
+        continue;
+      }
     }
 
     // Fast-path bundled memory plugins that are guaranteed disabled by slot policy.
@@ -797,6 +931,19 @@ export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegi
         diagnosticMessagePrefix: "plugin failed during register: ",
       });
     }
+  }
+
+  for (const [pluginId, record] of deferredBundledInstallRequired) {
+    if (seenIds.has(pluginId)) {
+      continue;
+    }
+    registry.plugins.push(record);
+    registry.diagnostics.push({
+      level: "error",
+      pluginId: record.id,
+      source: record.source,
+      message: record.error ?? "plugin requires separate installation",
+    });
   }
 
   if (typeof memorySlot === "string" && !memorySlotMatched) {


### PR DESCRIPTION
Fixes #40832

## Summary

This PR narrows a confusing failure mode for bundled plugins in stable/beta installs.

Previously, if a bundled plugin declared package dependencies that were not resolvable from the active published artifact, OpenClaw would still try to import the bundled entry and then fail with a raw plugin load error.

This change detects that state earlier and turns it into an install-required error with a concrete npm install hint.

## What changed

In the plugin loader:

- detect the effective update channel (`stable`, `beta`, or `dev`)
- for bundled plugins on `stable`/`beta`, inspect declared package dependencies
- if those dependencies are not resolvable from the bundled artifact path, do not import the plugin entry
- surface an install-required error using the plugin's `install.npmSpec`
- defer that bundled error record so a later installed copy can still load and win

This keeps `dev` behavior unchanged.

## Why this approach

This is a narrow runtime fix for an artifact inconsistency.

It avoids:
- hoisting optional plugin dependency trees into the root package
- changing the broader plugin packaging model
- changing dev-checkout behavior

It does improve:
- runtime diagnostics
- `plugins doctor` output quality
- fallback behavior when an installed copy exists

## Tests

Added regression coverage for:

- stable bundled plugin with unresolved package dependencies returns an install hint and does not import
- dev bundled plugin with the same unresolved dependency setup still loads
- stable bundled plugin with unresolved dependencies does not block a later installed copy from loading

## Verification

Ran:

```bash
pnpm vitest run src/plugins/loader.test.ts
```

All tests in that suite passed.
