### PR TITLE
feat(telegram): add apiRoot config for custom Bot API URL

### DIFF
--- a/src/config/schema.help.ts
+++ b/src/config/schema.help.ts
@@ -1389,6 +1389,8 @@ export const FIELD_HELP: Record<string, string> = {
   "channels.telegram.retry.jitter": "Jitter factor (0-1) applied to Telegram retry delays.",
   "channels.telegram.network.autoSelectFamily":
     "Override Node autoSelectFamily for Telegram (true=enable, false=disable).",
+  "channels.telegram.apiRoot":
+    "Custom Telegram Bot API root URL (e.g. https://my-proxy.example.com). Overrides the default https://api.telegram.org. Useful for self-hosted Bot API servers or API proxies.",
   "channels.telegram.timeoutSeconds":
     "Max seconds before Telegram API requests are aborted (default: 500 per grammY).",
   "channels.whatsapp.dmPolicy":

--- a/src/config/schema.labels.ts
+++ b/src/config/schema.labels.ts
@@ -673,6 +673,7 @@ export const FIELD_LABELS: Record<string, string> = {
   "channels.telegram.retry.maxDelayMs": "Telegram Retry Max Delay (ms)",
   "channels.telegram.retry.jitter": "Telegram Retry Jitter",
   "channels.telegram.network.autoSelectFamily": "Telegram autoSelectFamily",
+  "channels.telegram.apiRoot": "Telegram API Root URL",
   "channels.telegram.timeoutSeconds": "Telegram API Timeout (seconds)",
   "channels.telegram.capabilities.inlineButtons": "Telegram Inline Buttons",
   "channels.whatsapp.dmPolicy": "WhatsApp DM Policy",

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -129,6 +129,8 @@ export type TelegramAccountConfig = {
   retry?: OutboundRetryConfig;
   /** Network transport overrides for Telegram. */
   network?: TelegramNetworkConfig;
+  /** Custom Telegram Bot API root URL. Overrides the default https://api.telegram.org. */
+  apiRoot?: string;
   proxy?: string;
   webhookUrl?: string;
   webhookSecret?: string;

--- a/src/config/zod-schema.providers-core.ts
+++ b/src/config/zod-schema.providers-core.ts
@@ -183,6 +183,13 @@ export const TelegramAccountSchemaBase = z
       })
       .strict()
       .optional(),
+    apiRoot: z
+      .string()
+      .url()
+      .optional()
+      .describe(
+        "Custom Telegram Bot API root URL. Overrides the default https://api.telegram.org. Useful for self-hosted Bot API servers or API proxies.",
+      ),
     proxy: z.string().optional(),
     webhookUrl: z
       .string()

--- a/src/telegram/bot.ts
+++ b/src/telegram/bot.ts
@@ -133,11 +133,13 @@ export function createTelegramBot(opts: TelegramBotOptions) {
     typeof telegramCfg?.timeoutSeconds === "number" && Number.isFinite(telegramCfg.timeoutSeconds)
       ? Math.max(1, Math.floor(telegramCfg.timeoutSeconds))
       : undefined;
+  const apiRoot = telegramCfg.apiRoot;
   const client: ApiClientOptions | undefined =
-    shouldProvideFetch || timeoutSeconds
+    shouldProvideFetch || timeoutSeconds || apiRoot
       ? {
           ...(shouldProvideFetch && fetchImpl ? { fetch: fetchForClient } : {}),
           ...(timeoutSeconds ? { timeoutSeconds } : {}),
+          ...(apiRoot ? { apiRoot } : {}),
         }
       : undefined;
 

--- a/src/telegram/probe.ts
+++ b/src/telegram/probe.ts
@@ -21,10 +21,11 @@ export async function probeTelegram(
   token: string,
   timeoutMs: number,
   proxyUrl?: string,
+  apiRoot?: string,
 ): Promise<TelegramProbe> {
   const started = Date.now();
   const fetcher = proxyUrl ? makeProxyFetch(proxyUrl) : fetch;
-  const base = `${TELEGRAM_API_BASE}/bot${token}`;
+  const base = `${(apiRoot ?? TELEGRAM_API_BASE).replace(/\/+$/, "")}/bot${token}`;
   const retryDelayMs = Math.max(50, Math.min(1000, timeoutMs));
 
   const result: TelegramProbe = {


### PR DESCRIPTION
## Summary

Add `channels.telegram.apiRoot` config field to override the default `https://api.telegram.org` endpoint.

## Motivation

This enables several use cases:
- **Self-hosted Telegram Bot API servers** — users running [tdlib/telegram-bot-api](https://github.com/tdlib/telegram-bot-api) locally
- **API proxies** — e.g. a Cloudflare Worker proxying Bot API calls (our use case: [OneClickClaw](https://github.com/alrinny/one-click-claw) provisions VPS instances running OpenClaw, each with a proxy token routed through a CF Worker)
- **Restricted environments** — networks where direct access to `api.telegram.org` is blocked

grammY already supports `apiRoot` via `ApiClientOptions` — this PR simply threads the config value through.

## Changes

| File | Change |
|------|--------|
| `types.telegram.ts` | Added `apiRoot?: string` to `TelegramAccountConfig` |
| `zod-schema.providers-core.ts` | Added `apiRoot` with `.url()` validation to Zod schema |
| `telegram/bot.ts` | Pass `apiRoot` to grammY `ApiClientOptions` |
| `telegram/probe.ts` | Support `apiRoot` in `probeTelegram()` for startup health checks |
| `schema.help.ts` | Added help text |
| `schema.labels.ts` | Added UI label |

## Example config

```json
{
  "channels": {
    "telegram": {
      "botToken": "...",
      "apiRoot": "https://my-proxy.example.com"
    }
  }
}
```

## Follow-up

File download URLs in `delivery.resolve-media.ts` still use hardcoded `api.telegram.org`. A follow-up PR can thread `apiRoot` through the media download context for full coverage.

## Testing

- Lint passes (biome, 0 warnings, 0 errors)
- All changes are additive and backwards-compatible (field is optional, defaults to grammY's default `https://api.telegram.org`)