### PR TITLE
telegram: treat explicit network request failures as recoverable in send context

### DIFF
--- a/src/telegram/network-errors.test.ts
+++ b/src/telegram/network-errors.test.ts
@@ -39,9 +39,9 @@ describe("isRecoverableTelegramNetworkError", () => {
     expect(isRecoverableTelegramNetworkError(err, { context: "polling" })).toBe(true);
   });
 
-  it("skips broad message matches for send context", () => {
+  it("keeps broad snippet matching disabled for send context", () => {
     const networkRequestErr = new Error("Network request for 'sendMessage' failed!");
-    expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "send" })).toBe(false);
+    expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "send" })).toBe(true);
     expect(isRecoverableTelegramNetworkError(networkRequestErr, { context: "polling" })).toBe(true);
 
     const undiciSnippetErr = new Error("Undici: socket failure");

--- a/src/telegram/network-errors.ts
+++ b/src/telegram/network-errors.ts
@@ -78,6 +78,13 @@ function collectTelegramErrorCandidates(err: unknown) {
   });
 }
 
+function isExplicitNetworkRequestFailureMessage(message: string): boolean {
+  if (!message) {
+    return false;
+  }
+  return message.includes("network request for") && message.includes("failed");
+}
+
 function normalizeCode(code?: string): string {
   return code?.trim().toUpperCase() ?? "";
 }
@@ -150,7 +157,12 @@ export function isRecoverableTelegramNetworkError(
     if (message && ALWAYS_RECOVERABLE_MESSAGES.has(message)) {
       return true;
     }
-    if (message && GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE.test(message)) {
+    // Keep explicit grammY network request failures recoverable in send context,
+    // and preserve the stricter "failed after" envelope pattern globally.
+    if (
+      (message && GRAMMY_NETWORK_REQUEST_FAILED_AFTER_RE.test(message)) ||
+      (!allowMessageMatch && isExplicitNetworkRequestFailureMessage(message))
+    ) {
       return true;
     }
     if (allowMessageMatch && message) {


### PR DESCRIPTION
## Summary

- Problem: explicit network request failure messages during Telegram sends could be classified as non-recoverable in send context.
- Why it matters: transient send failures may fail fast instead of using the existing retry path.
- What changed: send-context classification now treats explicit `network request for ... failed` messages as recoverable, and the tests were updated accordingly.
- What did NOT change: polling behavior, retry policy outside this message class, and external API contracts remain unchanged.

## Change Type (select all)

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #28317

## User-visible / Behavior Changes

Telegram sends now retry a specific class of explicit network request failure messages that were previously treated as non-recoverable in send context.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw dev checkout
- Model/provider: N/A
- Integration/channel (if any): Telegram
- Relevant config (redacted): default Telegram channel setup

### Steps

1. Create an error matching grammY's explicit `Network request for 'sendMessage' failed!` pattern.
2. Evaluate recoverable classification in send context.
3. Run/update the Telegram network error tests.

### Expected

- Explicit transient network request failures in send context are classified as recoverable.

### Actual

- After this change, the explicit network request failure pattern is recoverable in send context.

## Evidence

- [x] Failing test/log before + passing after
- [ ] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: explicit send failure message is recoverable; polling behavior stays recoverable as before.
- Edge cases checked: broad snippet matching remains constrained in send context outside this explicit message class.
- What you did **not** verify: live Telegram outage reproduction against production traffic.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/telegram/network-errors.ts`, `src/telegram/network-errors.test.ts`
- Known bad symptoms reviewers should watch for: recoverable classification becoming too permissive in send context.

## Risks and Mitigations

- Risk: send-context retry classification could still be broader than intended.
  - Mitigation: the change is limited to explicit network-request-failure wording and is covered by tests.
