### PR TITLE
media-understanding: log image processing failures when no outputs are produced

### DIFF
--- a/src/media-understanding/runner.ts
+++ b/src/media-understanding/runner.ts
@@ -798,6 +798,28 @@ export async function runCapability(params: {
   if (shouldLogVerbose()) {
     logVerbose(`Media understanding ${formatDecisionSummary(decision)}`);
   }
+  if (capability === "image" && outputs.length === 0 && selected.length > 0) {
+    const allAttempts = attachmentDecisions.flatMap((a) => a.attempts);
+    const failedAttempts = allAttempts.filter(
+      (a) => a.outcome !== "skipped" && a.outcome !== "success",
+    );
+    if (failedAttempts.length > 0) {
+      const reasons = failedAttempts
+        .map((a) =>
+          a.type === "provider"
+            ? `${a.provider}/${a.model ?? "?"}: ${a.outcome}`
+            : `cli: ${a.outcome}`,
+        )
+        .join(", ");
+      console.warn(
+        `[media-understanding] image understanding failed for ${selected.length} attachment(s) — image(s) will not reach the model. Tried: ${reasons}`,
+      );
+    } else if (allAttempts.length === 0) {
+      console.warn(
+        `[media-understanding] no image understanding providers resolved — image(s) will not reach the model unless the primary model supports vision natively`,
+      );
+    }
+  }
   return {
     outputs,
     decision,


### PR DESCRIPTION
## Summary

- Problem: image attachments can be selected for processing but still produce no outputs, with too little diagnostic information.
- Why it matters: operators cannot easily tell whether attempts failed inside the image-understanding pipeline.
- What changed: failure-path warning logs now explain when selected image attachments produce no outputs and include attempt/provider details when available.
- What did NOT change: successful image-understanding behavior, model selection, and attachment routing remain unchanged.

## Change Type (select all)

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [x] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Closes #
- Related #28317

## User-visible / Behavior Changes

Failure cases in image understanding now emit clearer warnings when selected image attachments produce no outputs.

## Security Impact (required)

- New permissions/capabilities? (`No`)
- Secrets/tokens handling changed? (`No`)
- New/changed network calls? (`No`)
- Command/tool execution surface changed? (`No`)
- Data access scope changed? (`No`)
- If any `Yes`, explain risk + mitigation:

## Repro + Verification

### Environment

- OS: macOS
- Runtime/container: local OpenClaw dev checkout
- Model/provider: image-understanding providers
- Integration/channel (if any): media-understanding pipeline
- Relevant config (redacted): default image-understanding provider chain

### Steps

1. Select one or more image attachments for image capability processing.
2. Ensure the processing path produces no outputs.
3. Inspect the emitted warnings.

### Expected

- A warning explains failure-path context, including attempt/provider details when available.

### Actual

- The failure path now emits diagnostic warnings instead of failing silently.

## Evidence

- [ ] Failing test/log before + passing after
- [x] Trace/log snippets
- [ ] Screenshot/recording
- [ ] Perf numbers (if relevant)

## Human Verification (required)

What you personally verified (not just CI), and how:

- Verified scenarios: no-output image path with failed attempts emits warnings with useful context.
- Edge cases checked: success path remains unchanged; warning only triggers when selected images produce zero outputs.
- What you did **not** verify: every provider-specific failure mode in production.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? (`Yes`)
- Config/env changes? (`No`)
- Migration needed? (`No`)
- If yes, exact upgrade steps:

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert this commit.
- Files/config to restore: `src/media-understanding/runner.ts`
- Known bad symptoms reviewers should watch for: noisy logs in image-understanding failure paths.

## Risks and Mitigations

- Risk: warning volume could increase in environments with frequent image-understanding failures.
  - Mitigation: the new logs are limited to selected-image zero-output failure paths and include actionable context.
