### PR TITLE
fix(install): detect and warn about multiple Node.js environments

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1392,44 +1392,40 @@ warn_multiple_node_environments() {
     local active_node=""
     active_node="$(command -v node 2>/dev/null || true)"
 
-    # Check for nvm
+    # Check for nvm (always count if installed, regardless of active node)
     if [[ -n "${NVM_DIR:-}" ]] || [[ -d "$HOME/.nvm" ]]; then
         envs_found+=("nvm (~/.nvm)")
     fi
 
-    # Check for fnm
+    # Check for fnm (always count if installed)
     if [[ -n "${FNM_DIR:-}" ]] || [[ -d "$HOME/.local/share/fnm" ]] || [[ -d "$HOME/.fnm" ]] || command -v fnm &>/dev/null; then
         envs_found+=("fnm")
     fi
 
-    # Check for volta
+    # Check for volta (always count if installed)
     if [[ -n "${VOLTA_HOME:-}" ]] || [[ -d "$HOME/.volta" ]] || command -v volta &>/dev/null; then
         envs_found+=("volta (~/.volta)")
     fi
 
-    # Check for Homebrew node (macOS)
+    # Check for Homebrew node (macOS) - always count if exists
     if [[ -x "/opt/homebrew/bin/node" ]] || [[ -x "/usr/local/bin/node" ]]; then
-        if [[ "$active_node" != "/opt/homebrew/bin/node" && "$active_node" != "/usr/local/bin/node" ]]; then
-            envs_found+=("homebrew")
-        fi
+        envs_found+=("homebrew")
     fi
 
-    # Check for system node
+    # Check for system node - always count if exists
     if [[ -x "/usr/bin/node" ]]; then
-        if [[ "$active_node" != "/usr/bin/node" ]]; then
-            envs_found+=("system (/usr/bin/node)")
-        fi
+        envs_found+=("system (/usr/bin/node)")
     fi
 
     # Warn if multiple environments detected
     if [[ ${#envs_found[@]} -gt 1 ]]; then
         ui_warn "Multiple Node.js environments detected: ${envs_found[*]}"
         echo ""
-        echo "  ${INFO}This can cause confusion if openclaw is installed in different locations.${NC}"
-        echo "  ${INFO}Current active node: ${active_node:-none}${NC}"
+        echo -e "  ${INFO}This can cause confusion if openclaw is installed in different locations.${NC}"
+        echo -e "  ${INFO}Current active node: ${active_node:-none}${NC}"
         echo ""
-        echo "  ${MUTED}Recommendation: Use one Node version manager consistently.${NC}"
-        echo "  ${MUTED}After installing, verify with: which openclaw${NC}"
+        echo -e "  ${MUTED}Recommendation: Use one Node version manager consistently.${NC}"
+        echo -e "  ${MUTED}After installing, verify with: which openclaw${NC}"
         echo ""
     fi
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1385,6 +1385,55 @@ ensure_node22_active_shell() {
     return 1
 }
 
+# Detect multiple Node.js environments and warn users
+# This helps prevent confusion when multiple openclaw installations exist
+warn_multiple_node_environments() {
+    local envs_found=()
+    local active_node=""
+    active_node="$(command -v node 2>/dev/null || true)"
+
+    # Check for nvm
+    if [[ -n "${NVM_DIR:-}" ]] || [[ -d "$HOME/.nvm" ]]; then
+        envs_found+=("nvm (~/.nvm)")
+    fi
+
+    # Check for fnm
+    if [[ -n "${FNM_DIR:-}" ]] || [[ -d "$HOME/.local/share/fnm" ]] || [[ -d "$HOME/.fnm" ]] || command -v fnm &>/dev/null; then
+        envs_found+=("fnm")
+    fi
+
+    # Check for volta
+    if [[ -n "${VOLTA_HOME:-}" ]] || [[ -d "$HOME/.volta" ]] || command -v volta &>/dev/null; then
+        envs_found+=("volta (~/.volta)")
+    fi
+
+    # Check for Homebrew node (macOS)
+    if [[ -x "/opt/homebrew/bin/node" ]] || [[ -x "/usr/local/bin/node" ]]; then
+        if [[ "$active_node" != "/opt/homebrew/bin/node" && "$active_node" != "/usr/local/bin/node" ]]; then
+            envs_found+=("homebrew")
+        fi
+    fi
+
+    # Check for system node
+    if [[ -x "/usr/bin/node" ]]; then
+        if [[ "$active_node" != "/usr/bin/node" ]]; then
+            envs_found+=("system (/usr/bin/node)")
+        fi
+    fi
+
+    # Warn if multiple environments detected
+    if [[ ${#envs_found[@]} -gt 1 ]]; then
+        ui_warn "Multiple Node.js environments detected: ${envs_found[*]}"
+        echo ""
+        echo "  ${INFO}This can cause confusion if openclaw is installed in different locations.${NC}"
+        echo "  ${INFO}Current active node: ${active_node:-none}${NC}"
+        echo ""
+        echo "  ${MUTED}Recommendation: Use one Node version manager consistently.${NC}"
+        echo "  ${MUTED}After installing, verify with: which openclaw${NC}"
+        echo ""
+    fi
+}
+
 check_node() {
     if command -v node &> /dev/null; then
         NODE_VERSION="$(node_major_version || true)"
@@ -2259,6 +2308,9 @@ main() {
     local skip_onboard=false
 
     ui_stage "Preparing environment"
+
+    # Warn about multiple Node environments
+    warn_multiple_node_environments
 
     # Step 1: Homebrew (macOS only)
     install_homebrew


### PR DESCRIPTION
## Summary

Addresses #40839 - Install script: detect multiple Node.js environments and warn

## Problem

Users with multiple Node.js installations (nvm + homebrew, fnm + system, etc.) can accidentally install OpenClaw in different `node_modules` directories, leading to:
- Version mismatches between shell sessions
- Confusion about which installation is active
- Running stale versions unexpectedly

## Solution

Added `warn_multiple_node_environments()` function that:

1. **Detects** common Node.js version managers:
   - nvm (`~/.nvm`, `NVM_DIR`)
   - fnm (`~/.fnm`, `~/.local/share/fnm`, `FNM_DIR`)
   - volta (`~/.volta`, `VOLTA_HOME`)
   - Homebrew (`/opt/homebrew/bin/node`, `/usr/local/bin/node`)
   - System (`/usr/bin/node`)

2. **Warns** when multiple environments are found:
```
⚠ Multiple Node.js environments detected: nvm (~/.nvm) homebrew

  This can cause confusion if openclaw is installed in different locations.
  Current active node: /Users/user/.nvm/versions/node/v22.12.0/bin/node

  Recommendation: Use one Node version manager consistently.
  After installing, verify with: which openclaw
```

## Changes

- Added `warn_multiple_node_environments()` function in `scripts/install.sh`
- Called during "Preparing environment" stage before Node.js installation

## Testing

Tested locally with nvm + homebrew node installed - warning displays correctly.

Closes #40839