### PR TITLE
fix(telegram): clear previous draft on forceNewMessage to prevent stale drafts

### DIFF
--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -357,6 +357,7 @@ describe("createTelegramDraftStream", () => {
     expect(typeof firstDraftId).toBe("number");
     expect(clearCall?.[1]).toBe(firstDraftId);
     expect(clearCall?.[2]).toBe(""); // clear call sends empty text
+    expect(clearCall?.[3]).toEqual({ message_thread_id: 42 });
     expect(typeof secondDraftId).toBe("number");
     expect(firstDraftId).not.toBe(secondDraftId);
     expect(api.sendMessageDraft.mock.calls[2]?.[2]).toBe("Message B");

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -325,7 +325,12 @@ describe("createTelegramDraftStream", () => {
       resolveFirstDraft = resolve;
     });
     const api = {
-      sendMessageDraft: vi.fn().mockReturnValueOnce(firstDraftSend).mockResolvedValueOnce(true),
+      // Expect 3 calls: first draft, clear previous draft, second draft
+      sendMessageDraft: vi
+        .fn()
+        .mockReturnValueOnce(firstDraftSend)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true),
       sendMessage: vi.fn().mockResolvedValue({ message_id: 17 }),
       editMessageText: vi.fn().mockResolvedValue(true),
       deleteMessage: vi.fn().mockResolvedValue(true),
@@ -344,18 +349,22 @@ describe("createTelegramDraftStream", () => {
     resolveFirstDraft?.(true);
     await stream.flush();
 
-    expect(api.sendMessageDraft).toHaveBeenCalledTimes(2);
+    // forceNewMessage clears the previous draft before allocating a new one
+    expect(api.sendMessageDraft).toHaveBeenCalledTimes(3);
     const firstDraftId = api.sendMessageDraft.mock.calls[0]?.[1];
-    const secondDraftId = api.sendMessageDraft.mock.calls[1]?.[1];
+    const clearCall = api.sendMessageDraft.mock.calls[1];
+    const secondDraftId = api.sendMessageDraft.mock.calls[2]?.[1];
     expect(typeof firstDraftId).toBe("number");
+    expect(clearCall?.[1]).toBe(firstDraftId);
+    expect(clearCall?.[2]).toBe(""); // clear call sends empty text
     expect(typeof secondDraftId).toBe("number");
     expect(firstDraftId).not.toBe(secondDraftId);
-    expect(api.sendMessageDraft.mock.calls[1]?.[2]).toBe("Message B");
+    expect(api.sendMessageDraft.mock.calls[2]?.[2]).toBe("Message B");
     expect(api.sendMessage).not.toHaveBeenCalled();
     expect(api.editMessageText).not.toHaveBeenCalled();
   });
 
-  it("shares draft-id allocation across distinct module instances", async () => {
+it("shares draft-id allocation across distinct module instances", async () => {
     const draftA = await importFreshModule<typeof import("./draft-stream.js")>(
       import.meta.url,
       "./draft-stream.js?scope=shared-a",
@@ -393,6 +402,36 @@ describe("createTelegramDraftStream", () => {
     } finally {
       draftA.__testing.resetTelegramDraftStreamForTests();
     }
+  });
+
+  it("clears previous draft when forceNewMessage is called to prevent stale drafts", async () => {
+    // Regression test for #40750: stale draft preview can reappear after final
+    // message is delivered when forceNewMessage is called during streaming.
+    const api = createMockDraftApi();
+    const stream = createThreadedDraftStream(api, { id: 42, scope: "dm" });
+
+    stream.update("First draft");
+    await stream.flush();
+    expect(api.sendMessageDraft).toHaveBeenCalledTimes(1);
+    const firstDraftId = api.sendMessageDraft.mock.calls[0]?.[1];
+
+    stream.forceNewMessage();
+    // Allow async clear to complete
+    await vi.waitFor(() => expect(api.sendMessageDraft).toHaveBeenCalledTimes(2));
+
+    // The second call should be a clear (empty text) for the first draft
+    const clearCall = api.sendMessageDraft.mock.calls[1];
+    expect(clearCall?.[1]).toBe(firstDraftId);
+    expect(clearCall?.[2]).toBe("");
+
+    stream.update("Second draft");
+    await stream.flush();
+
+    // Third call is the new draft with different id
+    expect(api.sendMessageDraft).toHaveBeenCalledTimes(3);
+    const secondDraftId = api.sendMessageDraft.mock.calls[2]?.[1];
+    expect(secondDraftId).not.toBe(firstDraftId);
+    expect(api.sendMessageDraft.mock.calls[2]?.[2]).toBe("Second draft");
   });
 
   it("creates new message after forceNewMessage is called", async () => {

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -364,7 +364,7 @@ describe("createTelegramDraftStream", () => {
     expect(api.editMessageText).not.toHaveBeenCalled();
   });
 
-it("shares draft-id allocation across distinct module instances", async () => {
+  it("shares draft-id allocation across distinct module instances", async () => {
     const draftA = await importFreshModule<typeof import("./draft-stream.js")>(
       import.meta.url,
       "./draft-stream.js?scope=shared-a",

--- a/extensions/telegram/src/draft-stream.test.ts
+++ b/extensions/telegram/src/draft-stream.test.ts
@@ -423,6 +423,7 @@ describe("createTelegramDraftStream", () => {
     const clearCall = api.sendMessageDraft.mock.calls[1];
     expect(clearCall?.[1]).toBe(firstDraftId);
     expect(clearCall?.[2]).toBe("");
+    expect(clearCall?.[3]).toEqual({ message_thread_id: 42 });
 
     stream.update("Second draft");
     await stream.flush();

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -366,6 +366,24 @@ export function createTelegramDraftStream(params: {
     warnPrefix: "telegram stream preview cleanup failed",
   });
 
+  const clearDraftPreview = async (
+    draftId: number | undefined,
+    options?: { skipThread?: boolean },
+  ): Promise<void> => {
+    if (resolvedDraftApi == null || draftId == null) {
+      return;
+    }
+    const clearThreadParams =
+      !options?.skipThread && threadParams?.message_thread_id != null
+        ? { message_thread_id: threadParams.message_thread_id }
+        : undefined;
+    try {
+      await resolvedDraftApi(chatId, draftId, "", clearThreadParams);
+    } catch {
+      // Best-effort cleanup; draft clear failure is cosmetic.
+    }
+  };
+
   const forceNewMessage = () => {
     // Boundary rotation may call stop() to finalize the previous draft.
     // Re-open the stream lifecycle for the next assistant segment.
@@ -373,8 +391,15 @@ export function createTelegramDraftStream(params: {
     generation += 1;
     messageSendAttempted = false;
     streamMessageId = undefined;
+    // Clear the previous draft preview before allocating a new one.
+    // This prevents stale drafts from reappearing after the final message is
+    // delivered (fixes #40750).
+    const previousDraftId = streamDraftId;
     if (previewTransport === "draft") {
       streamDraftId = allocateTelegramDraftId();
+    }
+    if (previousDraftId != null && previousDraftId !== streamDraftId) {
+      void clearDraftPreview(previousDraftId);
     }
     lastSentText = "";
     lastSentParseMode = undefined;
@@ -413,18 +438,8 @@ export function createTelegramDraftStream(params: {
         streamMessageId = Math.trunc(sentId);
         // Clear the draft so Telegram's input area doesn't briefly show a
         // stale copy alongside the newly materialized real message.
-        if (resolvedDraftApi != null && streamDraftId != null) {
-          const clearDraftId = streamDraftId;
-          const clearThreadParams =
-            usedThreadParams && threadParams?.message_thread_id != null
-              ? { message_thread_id: threadParams.message_thread_id }
-              : undefined;
-          try {
-            await resolvedDraftApi(chatId, clearDraftId, "", clearThreadParams);
-          } catch {
-            // Best-effort cleanup; draft clear failure is cosmetic.
-          }
-        }
+        // If thread params failed, clear without thread params to match.
+        await clearDraftPreview(streamDraftId, { skipThread: !usedThreadParams });
         return streamMessageId;
       }
     } catch (err) {

--- a/extensions/telegram/src/draft-stream.ts
+++ b/extensions/telegram/src/draft-stream.ts
@@ -384,6 +384,21 @@ export function createTelegramDraftStream(params: {
     }
   };
 
+  let pendingDraftClear: Promise<void> = Promise.resolve();
+  const enqueueDraftClearPreview = (
+    draftId: number | undefined,
+    options?: { skipThread?: boolean },
+  ): void => {
+    if (draftId == null) {
+      return;
+    }
+    pendingDraftClear = pendingDraftClear
+      .catch(() => {
+        // Keep the queue alive even if one clear fails.
+      })
+      .then(() => clearDraftPreview(draftId, options));
+  };
+
   const forceNewMessage = () => {
     // Boundary rotation may call stop() to finalize the previous draft.
     // Re-open the stream lifecycle for the next assistant segment.
@@ -399,7 +414,7 @@ export function createTelegramDraftStream(params: {
       streamDraftId = allocateTelegramDraftId();
     }
     if (previousDraftId != null && previousDraftId !== streamDraftId) {
-      void clearDraftPreview(previousDraftId);
+      enqueueDraftClearPreview(previousDraftId);
     }
     lastSentText = "";
     lastSentParseMode = undefined;


### PR DESCRIPTION
## Summary

Fixes #40750 - Telegram DM can re-show a stale draft preview after the final reply is already delivered.

## Problem

When `forceNewMessage()` is called during streaming (e.g., after a thinking block ends or boundary rotation), the previous draft preview could reappear in Telegram DM. This happened because:

1. `forceNewMessage()` allocates a new `streamDraftId`
2. The old draft ID was simply discarded
3. The old draft preview remained on Telegram's servers
4. Late network responses or race conditions could cause the old draft to briefly reappear after the final message was delivered

In Telegram DM, this manifested as a pinned-message-style banner at the top of the chat showing stale content after the conversation had already moved on.

## Solution

- Clear the previous draft preview before allocating a new draft ID in `forceNewMessage()`
- Extract `clearDraftPreview` helper function for code reuse with `materialize()`
- Add regression test specifically for this race condition scenario

## Testing

- All existing draft-stream tests pass (28 tests)
- Added new regression test `clears previous draft when forceNewMessage is called to prevent stale drafts`
- Updated `rotates draft_id when forceNewMessage races an in-flight DM draft send` test to account for the new clear call