### PR TITLE
fix: include reset archive transcripts in usage/cost calculations

### DIFF
--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -474,6 +474,35 @@ example
     });
   });
 
+  it("deduplicates sessions when both active .jsonl and reset archive coexist", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-dedup-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const userMsg = { type: "message", timestamp: "2026-03-12T10:00:00.000Z", message: { role: "user", content: "hello" } };
+
+    // Write both a reset archive AND a fresh active file for the same session ID
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-dup.jsonl.reset.2026-03-12T09-00-00.000Z"),
+      JSON.stringify(userMsg),
+      "utf-8",
+    );
+    // Active file has a later mtime — written after
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-dup.jsonl"),
+      JSON.stringify({ ...userMsg, message: { role: "user", content: "resumed" } }),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      const sessions = await discoverAllSessions();
+      // Must deduplicate: only one entry for sess-dup
+      expect(sessions.filter((s) => s.sessionId === "sess-dup").length).toBe(1);
+      // Should keep the active file (later mtime) — firstUserMessage from it
+      expect(sessions.find((s) => s.sessionId === "sess-dup")?.firstUserMessage).toBe("resumed");
+    });
+  });
+
   it("preserves totals and cumulative values when downsampling timeseries", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-timeseries-downsample-"));
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -390,6 +390,90 @@ example
     expect(logs?.[0]?.content).toBe("hello there");
   });
 
+  it("includes reset archive files in cost usage summary", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cost-reset-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    const now = new Date();
+    const entry = {
+      type: "message",
+      timestamp: now.toISOString(),
+      message: {
+        role: "assistant",
+        provider: "openai",
+        model: "gpt-5.2",
+        usage: {
+          input: 100,
+          output: 200,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 300,
+          cost: { total: 0.05 },
+        },
+      },
+    };
+
+    // Write an active session file
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-active.jsonl"),
+      JSON.stringify(entry),
+      "utf-8",
+    );
+
+    // Write a reset archive file (same format, different naming)
+    const resetEntry = {
+      ...entry,
+      message: {
+        ...entry.message,
+        usage: {
+          input: 500,
+          output: 1000,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 1500,
+          cost: { total: 0.25 },
+        },
+      },
+    };
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-active.jsonl.reset.2026-03-01T10-00-00.000Z"),
+      JSON.stringify(resetEntry),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      const summary = await loadCostUsageSummary({ days: 30 });
+      // Should include both active (300 tokens) and reset archive (1500 tokens)
+      expect(summary.totals.totalTokens).toBe(1800);
+      expect(summary.totals.totalCost).toBeCloseTo(0.30, 5);
+    });
+  });
+
+  it("discovers reset archive sessions", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-discover-reset-"));
+    const sessionsDir = path.join(root, "agents", "main", "sessions");
+    await fs.mkdir(sessionsDir, { recursive: true });
+
+    // Write a reset archive file only (no active .jsonl)
+    await fs.writeFile(
+      path.join(sessionsDir, "sess-archived.jsonl.reset.2026-03-01T10-00-00.000Z"),
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-03-01T10:00:00.000Z",
+        message: { role: "user", content: "archived message" },
+      }),
+      "utf-8",
+    );
+
+    await withStateDir(root, async () => {
+      const sessions = await discoverAllSessions();
+      expect(sessions.length).toBe(1);
+      expect(sessions[0]?.sessionId).toBe("sess-archived");
+      expect(sessions[0]?.firstUserMessage).toBe("archived message");
+    });
+  });
+
   it("preserves totals and cumulative values when downsampling timeseries", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-timeseries-downsample-"));
     const sessionsDir = path.join(root, "agents", "main", "sessions");

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -227,12 +227,14 @@ const isTranscriptFile = (name: string): boolean =>
  * - Reset:  `<sessionId>.jsonl.reset.<timestamp>` → `<sessionId>`
  */
 const extractSessionId = (name: string): string => {
-  // Strip .jsonl or .jsonl.reset.<timestamp> suffix from the end.
-  // Using a regex anchored at $ avoids the edge case where the session ID
-  // itself contains ".jsonl" (indexOf would truncate too early).
-  // [^.]* in the reset group prevents greedy match across dots
-  // (e.g. session ID "abc.jsonl.reset.foo" with an active .jsonl file).
-  return name.replace(/\.jsonl(\.reset\.[^.]*)?$/, "");
+  // Use lastIndexOf to find the rightmost ".jsonl" marker.
+  // This correctly handles both:
+  //   active:  "<id>.jsonl"               → "<id>"
+  //   reset:   "<id>.jsonl.reset.<ts>"     → "<id>"
+  // Including session IDs that themselves contain ".jsonl.reset." substrings
+  // (indexOf would truncate too early; a regex with .* would greedily over-match).
+  const idx = name.lastIndexOf(".jsonl");
+  return idx !== -1 ? name.slice(0, idx) : name;
 };
 
 async function* readJsonlRecords(filePath: string): AsyncGenerator<Record<string, unknown>> {

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -230,7 +230,9 @@ const extractSessionId = (name: string): string => {
   // Strip .jsonl or .jsonl.reset.<timestamp> suffix from the end.
   // Using a regex anchored at $ avoids the edge case where the session ID
   // itself contains ".jsonl" (indexOf would truncate too early).
-  return name.replace(/\.jsonl(\.reset\..*)?$/, "");
+  // [^.]* in the reset group prevents greedy match across dots
+  // (e.g. session ID "abc.jsonl.reset.foo" with an active .jsonl file).
+  return name.replace(/\.jsonl(\.reset\.[^.]*)?$/, "");
 };
 
 async function* readJsonlRecords(filePath: string): AsyncGenerator<Record<string, unknown>> {

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -214,6 +214,23 @@ const applyCostTotal = (totals: CostUsageTotals, costTotal: number | undefined) 
   totals.totalCost += costTotal;
 };
 
+/**
+ * Check whether a filename is a JSONL transcript (active or reset-archived).
+ * Active files end in `.jsonl`; reset archives match `*.jsonl.reset.<timestamp>`.
+ */
+const isTranscriptFile = (name: string): boolean =>
+  name.endsWith(".jsonl") || /\.jsonl\.reset\.\d{4}-/.test(name);
+
+/**
+ * Extract the session ID from a transcript filename.
+ * - Active: `<sessionId>.jsonl` → `<sessionId>`
+ * - Reset:  `<sessionId>.jsonl.reset.<timestamp>` → `<sessionId>`
+ */
+const extractSessionId = (name: string): string => {
+  const jsonlIdx = name.indexOf(".jsonl");
+  return jsonlIdx >= 0 ? name.slice(0, jsonlIdx) : name;
+};
+
 async function* readJsonlRecords(filePath: string): AsyncGenerator<Record<string, unknown>> {
   const fileStream = fs.createReadStream(filePath, { encoding: "utf-8" });
   const rl = readline.createInterface({ input: fileStream, crlfDelay: Infinity });
@@ -318,7 +335,7 @@ export async function loadCostUsageSummary(params?: {
   const files = (
     await Promise.all(
       entries
-        .filter((entry) => entry.isFile() && entry.name.endsWith(".jsonl"))
+        .filter((entry) => entry.isFile() && isTranscriptFile(entry.name))
         .map(async (entry) => {
           const filePath = path.join(sessionsDir, entry.name);
           const stats = await fs.promises.stat(filePath).catch(() => null);
@@ -393,7 +410,7 @@ export async function discoverAllSessions(params?: {
   const discovered: DiscoveredSession[] = [];
 
   for (const entry of entries) {
-    if (!entry.isFile() || !entry.name.endsWith(".jsonl")) {
+    if (!entry.isFile() || !isTranscriptFile(entry.name)) {
       continue;
     }
 
@@ -409,8 +426,8 @@ export async function discoverAllSessions(params?: {
     }
     // Do not exclude by endMs: a session can have activity in range even if it continued later.
 
-    // Extract session ID from filename (remove .jsonl)
-    const sessionId = entry.name.slice(0, -6);
+    // Extract session ID from filename
+    const sessionId = extractSessionId(entry.name);
 
     // Try to read first user message for label extraction
     let firstUserMessage: string | undefined;

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -227,8 +227,10 @@ const isTranscriptFile = (name: string): boolean =>
  * - Reset:  `<sessionId>.jsonl.reset.<timestamp>` → `<sessionId>`
  */
 const extractSessionId = (name: string): string => {
-  const jsonlIdx = name.indexOf(".jsonl");
-  return jsonlIdx >= 0 ? name.slice(0, jsonlIdx) : name;
+  // Strip .jsonl or .jsonl.reset.<timestamp> suffix from the end.
+  // Using a regex anchored at $ avoids the edge case where the session ID
+  // itself contains ".jsonl" (indexOf would truncate too early).
+  return name.replace(/\.jsonl(\.reset\..*)?$/, "");
 };
 
 async function* readJsonlRecords(filePath: string): AsyncGenerator<Record<string, unknown>> {
@@ -472,8 +474,19 @@ export async function discoverAllSessions(params?: {
     });
   }
 
+  // Deduplicate by sessionId: when both an active .jsonl and a .jsonl.reset.*
+  // exist for the same session (the common post-reset state), keep the entry
+  // with the latest mtime (the active file) to avoid duplicate rows in the UI.
+  const bySessionId = new Map<string, DiscoveredSession>();
+  for (const session of discovered) {
+    const existing = bySessionId.get(session.sessionId);
+    if (!existing || session.mtime > existing.mtime) {
+      bySessionId.set(session.sessionId, session);
+    }
+  }
+
   // Sort by mtime descending (most recent first)
-  return discovered.toSorted((a, b) => b.mtime - a.mtime);
+  return [...bySessionId.values()].toSorted((a, b) => b.mtime - a.mtime);
 }
 
 export async function loadSessionCostSummary(params: {

--- a/src/infra/session-cost-usage.ts
+++ b/src/infra/session-cost-usage.ts
@@ -216,10 +216,15 @@ const applyCostTotal = (totals: CostUsageTotals, costTotal: number | undefined) 
 
 /**
  * Check whether a filename is a JSONL transcript (active or reset-archived).
- * Active files end in `.jsonl`; reset archives match `*.jsonl.reset.<timestamp>`.
+ * Active files end in `.jsonl`.
+ * Reset archives match exactly `<id>.jsonl.reset.<ISO-timestamp>` where the
+ * timestamp uses hyphens instead of colons (filesystem-safe ISO 8601), e.g.
+ * `2026-03-14T09-05-00.000Z`. The pattern is anchored to `$` to exclude any
+ * further-archived variants such as `*.jsonl.reset.<ts>.deleted.<ts>`.
  */
+const RESET_ARCHIVE_RE = /\.jsonl\.reset\.\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d+Z$/;
 const isTranscriptFile = (name: string): boolean =>
-  name.endsWith(".jsonl") || /\.jsonl\.reset\.\d{4}-/.test(name);
+  name.endsWith(".jsonl") || RESET_ARCHIVE_RE.test(name);
 
 /**
  * Extract the session ID from a transcript filename.


### PR DESCRIPTION
Fixes #40870

## Problem

`loadCostUsageSummary` and `discoverAllSessions` only scan files ending in `.jsonl`, missing reset archive transcripts (`*.jsonl.reset.<timestamp>`) created when sessions are reset. This causes the Usage dashboard to significantly undercount tokens and cost — in one measured case by **85%** (showing 30M tokens instead of 204M).

## Changes

- Add `isTranscriptFile()` helper that matches both active `.jsonl` and `.jsonl.reset.<timestamp>` archive patterns
- Add `extractSessionId()` helper to derive session ID from either naming convention
- Update `loadCostUsageSummary` file filter to use `isTranscriptFile()`
- Update `discoverAllSessions` file filter and session ID extraction

## Tests

Two new test cases:
- **`includes reset archive files in cost usage summary`** — verifies tokens from both active and reset-archived files are summed
- **`discovers reset archive sessions`** — verifies reset-only sessions appear in discovery with correct session ID and first message