### PR TITLE
docs: document that heartbeat does not support model fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Docs: https://docs.openclaw.ai
 
 ### Changes
 
+- Docs/heartbeat: clarify `heartbeat.model` fallback behavior: the fallback chain is skipped only when `heartbeat.model` uses a different provider than the primary and is not itself listed in the configured fallbacks; same-provider overrides and no-override runs follow the standard fallback chain. (#40875)
+
 ### Breaking
 
 ### Fixes

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -210,6 +210,8 @@ Use `accountId` to target a specific account on multi-account channels like Tele
 
 - `every`: heartbeat interval (duration string; default unit = minutes).
 - `model`: optional model override for heartbeat runs (`provider/model`).
+  - When `model` is not set, or uses the same provider as `agents.defaults.model.primary`, the standard fallback chain applies.
+  - **When `model` is set to a model on a different provider**, the configured fallback chain does not apply unless the override model is itself listed in `agents.defaults.model.fallbacks` — if that model fails (e.g. due to rate limits), the heartbeat errors out without trying other models. Prefer a model with generous rate limits to reduce failure risk.
 - `includeReasoning`: when enabled, also deliver the separate `Reasoning:` message when available (same shape as `/reasoning on`).
 - `lightContext`: when true, heartbeat runs use lightweight bootstrap context and keep only `HEARTBEAT.md` from workspace bootstrap files.
 - `session`: optional session key for heartbeat runs.


### PR DESCRIPTION
## Summary

- **Problem:** The `model` field note in the heartbeat docs made an overly broad claim ("heartbeat runs do not support the fallback mechanism"), which is factually incorrect.
- **Why it matters:** Operators diagnosing heartbeat failures could be misled; the blanket statement also obscures valid fallback protection they actually have.
- **What changed:** The note now accurately documents all cases based on `src/agents/model-fallback.ts:303-317`:
  - No `model` override → standard fallback chain applies.
  - `model` set, same provider as primary → standard fallback chain applies.
  - `model` set, different provider → fallback chain is skipped **unless** the override model is itself listed in `agents.defaults.model.fallbacks`.
- **What did NOT change:** No code changes; runtime behavior is unchanged.

## Change Type (select all)

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Security hardening
- [ ] Chore/infra

## Scope (select all touched areas)

- [ ] Gateway / orchestration
- [ ] Skills / tool execution
- [ ] Auth / tokens
- [ ] Memory / storage
- [ ] Integrations
- [ ] API / contracts
- [ ] UI / DX
- [ ] CI/CD / infra

## Linked Issue/PR

- Related #

## User-visible / Behavior Changes

Docs only. Operators reading `docs/gateway/heartbeat.md` now see an accurate description of when fallback applies to heartbeat runs.

## Security Impact (required)

- New permissions/capabilities? No
- Secrets/tokens handling changed? No
- New/changed network calls? No
- Command/tool execution surface changed? No
- Data access scope changed? No

## Repro + Verification

Docs-only change; no runtime repro needed.

### Evidence

- Source verified in `src/agents/model-fallback.ts:303-317`: fallback candidates are determined by provider matching and whether the override model appears in the configured fallback list.

## Human Verification (required)

- Verified scenarios: traced `heartbeat.model` through `heartbeat-runner.ts` → `get-reply.ts` → `resolveFallbackCandidates` in `model-fallback.ts`; confirmed all three branches.
- Edge cases checked: no override; same-provider override; different-provider override not in fallbacks; different-provider override that is itself a configured fallback.
- What you did **not** verify: live rate-limit scenario triggering fallback during a heartbeat run.

## Review Conversations

- [x] I replied to or resolved every bot review conversation I addressed in this PR.
- [x] I left unresolved only the conversations that still need reviewer or maintainer judgment.

## Compatibility / Migration

- Backward compatible? Yes
- Config/env changes? No
- Migration needed? No

## Failure Recovery (if this breaks)

- How to disable/revert this change quickly: revert the one-line change to `docs/gateway/heartbeat.md`
- Files/config to restore: none
- Known bad symptoms reviewers should watch for: none (docs only)

## Risks and Mitigations

None.