### PR TITLE
feat(msteams): support federated credentials and certificate auth

### DIFF
--- a/extensions/msteams/src/errors.ts
+++ b/extensions/msteams/src/errors.ts
@@ -193,7 +193,7 @@ export function formatMSTeamsSendErrorHint(
   classification: MSTeamsSendErrorClassification,
 ): string | undefined {
   if (classification.kind === "auth") {
-    return "check msteams appId/appPassword/tenantId (or env vars MSTEAMS_APP_ID/MSTEAMS_APP_PASSWORD/MSTEAMS_TENANT_ID)";
+    return "check msteams appId/tenantId and auth config (appPassword, certificate, or federated credential)";
   }
   if (classification.kind === "throttled") {
     return "Teams throttled the bot; backing off may help";

--- a/extensions/msteams/src/probe.ts
+++ b/extensions/msteams/src/probe.ts
@@ -55,7 +55,8 @@ export async function probeMSTeams(cfg?: MSTeamsConfig): Promise<ProbeMSTeamsRes
   if (!creds) {
     return {
       ok: false,
-      error: "missing credentials (appId, appPassword, tenantId)",
+      error:
+        "missing credentials (appId, tenantId, and one of: appPassword, certificate, or federated credential)",
     };
   }
 

--- a/extensions/msteams/src/sdk.ts
+++ b/extensions/msteams/src/sdk.ts
@@ -12,11 +12,28 @@ export function buildMSTeamsAuthConfig(
   creds: MSTeamsCredentials,
   sdk: MSTeamsSdk,
 ): MSTeamsAuthConfig {
-  return sdk.getAuthConfigWithDefaults({
+  const base: Parameters<MSTeamsSdk["getAuthConfigWithDefaults"]>[0] = {
     clientId: creds.appId,
-    clientSecret: creds.appPassword,
     tenantId: creds.tenantId,
-  });
+  };
+
+  switch (creds.authType) {
+    case "certificate":
+      base.certPemFile = creds.certPemFile;
+      base.certKeyFile = creds.certKeyFile;
+      if (creds.sendX5C != null) base.sendX5C = creds.sendX5C;
+      break;
+    case "federatedCredential":
+      if (creds.ficClientId) base.FICClientId = creds.ficClientId;
+      if (creds.widAssertionFile) base.WIDAssertionFile = creds.widAssertionFile;
+      break;
+    case "clientSecret":
+    default:
+      base.clientSecret = creds.appPassword;
+      break;
+  }
+
+  return sdk.getAuthConfigWithDefaults(base);
 }
 
 export function createMSTeamsAdapter(

--- a/extensions/msteams/src/token.ts
+++ b/extensions/msteams/src/token.ts
@@ -5,36 +5,89 @@ import {
   normalizeSecretInputString,
 } from "./secret-input.js";
 
+export type MSTeamsAuthType = "clientSecret" | "certificate" | "federatedCredential";
+
 export type MSTeamsCredentials = {
   appId: string;
   appPassword: string;
   tenantId: string;
+  authType: MSTeamsAuthType;
+  certPemFile?: string;
+  certKeyFile?: string;
+  sendX5C?: boolean;
+  ficClientId?: string;
+  widAssertionFile?: string;
 };
 
 export function hasConfiguredMSTeamsCredentials(cfg?: MSTeamsConfig): boolean {
-  return Boolean(
-    normalizeSecretInputString(cfg?.appId) &&
-    hasConfiguredSecretInput(cfg?.appPassword) &&
-    normalizeSecretInputString(cfg?.tenantId),
-  );
+  const appId = normalizeSecretInputString(cfg?.appId);
+  const tenantId = normalizeSecretInputString(cfg?.tenantId);
+  if (!appId || !tenantId) return false;
+
+  const authType = cfg?.authType ?? "clientSecret";
+
+  switch (authType) {
+    case "certificate":
+      return Boolean(cfg?.certPemFile && cfg?.certKeyFile);
+    case "federatedCredential":
+      return Boolean(cfg?.ficClientId || cfg?.widAssertionFile);
+    case "clientSecret":
+    default:
+      return Boolean(hasConfiguredSecretInput(cfg?.appPassword));
+  }
 }
 
 export function resolveMSTeamsCredentials(cfg?: MSTeamsConfig): MSTeamsCredentials | undefined {
   const appId =
     normalizeSecretInputString(cfg?.appId) ||
     normalizeSecretInputString(process.env.MSTEAMS_APP_ID);
-  const appPassword =
-    normalizeResolvedSecretInputString({
-      value: cfg?.appPassword,
-      path: "channels.msteams.appPassword",
-    }) || normalizeSecretInputString(process.env.MSTEAMS_APP_PASSWORD);
   const tenantId =
     normalizeSecretInputString(cfg?.tenantId) ||
     normalizeSecretInputString(process.env.MSTEAMS_TENANT_ID);
 
-  if (!appId || !appPassword || !tenantId) {
+  if (!appId || !tenantId) {
     return undefined;
   }
 
-  return { appId, appPassword, tenantId };
+  const authType: MSTeamsAuthType = cfg?.authType ?? "clientSecret";
+
+  switch (authType) {
+    case "certificate": {
+      const certPemFile = cfg?.certPemFile;
+      const certKeyFile = cfg?.certKeyFile;
+      if (!certPemFile || !certKeyFile) return undefined;
+      return {
+        appId,
+        appPassword: "", // not used for certificate auth
+        tenantId,
+        authType,
+        certPemFile,
+        certKeyFile,
+        sendX5C: cfg?.sendX5C,
+      };
+    }
+    case "federatedCredential": {
+      const ficClientId = cfg?.ficClientId;
+      const widAssertionFile = cfg?.widAssertionFile;
+      if (!ficClientId && !widAssertionFile) return undefined;
+      return {
+        appId,
+        appPassword: "", // not used for federated auth
+        tenantId,
+        authType,
+        ficClientId,
+        widAssertionFile,
+      };
+    }
+    case "clientSecret":
+    default: {
+      const appPassword =
+        normalizeResolvedSecretInputString({
+          value: cfg?.appPassword,
+          path: "channels.msteams.appPassword",
+        }) || normalizeSecretInputString(process.env.MSTEAMS_APP_PASSWORD);
+      if (!appPassword) return undefined;
+      return { appId, appPassword, tenantId, authType: "clientSecret" };
+    }
+  }
 }

--- a/src/config/types.msteams.ts
+++ b/src/config/types.msteams.ts
@@ -61,6 +61,31 @@ export type MSTeamsConfig = {
   appId?: string;
   /** Azure Bot App Password / Client Secret. */
   appPassword?: SecretInput;
+  /**
+   * Authentication type for the bot.
+   * - "clientSecret" (default): Uses appPassword (client secret).
+   * - "certificate": Uses certPemFile + certKeyFile for certificate-based auth.
+   * - "federatedCredential": Uses FIC (First-party Integration Channel) client ID
+   *   with workload identity federation (no secret needed).
+   */
+  authType?: "clientSecret" | "certificate" | "federatedCredential";
+  /** Path to the certificate PEM file (used when authType is "certificate"). */
+  certPemFile?: string;
+  /** Path to the certificate key file (used when authType is "certificate"). */
+  certKeyFile?: string;
+  /** Whether to send the X5C param for SNI authentication (used with certificate auth). */
+  sendX5C?: boolean;
+  /**
+   * The FIC (First-party Integration Channel) client ID for federated credential auth.
+   * This is the client ID of a user-assigned managed identity with a federated credential
+   * configured on the App Registration.
+   */
+  ficClientId?: string;
+  /**
+   * Path to the workload identity assertion file (e.g., K8s service account token).
+   * Used with federated credential auth when running in Kubernetes or similar environments.
+   */
+  widAssertionFile?: string;
   /** Azure AD Tenant ID (for single-tenant bots). */
   tenantId?: string;
   /** Webhook server configuration. */


### PR DESCRIPTION
## Summary

Adds support for alternative authentication methods in the MS Teams channel, enabling passwordless bot authentication for enterprise tenants that block client secrets via tenant-wide policy.

Fixes #40855

## Changes

**New config fields** under `channels.msteams`:
- `authType`: `'clientSecret'` (default) | `'certificate'` | `'federatedCredential'`
- `certPemFile` / `certKeyFile` / `sendX5C`: for certificate-based auth
- `ficClientId`: FIC client ID for federated credential auth
- `widAssertionFile`: workload identity assertion file path (K8s / workload identity)

**Files changed:**
- `src/config/types.msteams.ts` — Added new config type fields
- `extensions/msteams/src/token.ts` — Updated credential resolution to support all three auth types
- `extensions/msteams/src/sdk.ts` — Updated `buildMSTeamsAuthConfig` to pass the right fields to the SDK based on auth type
- `extensions/msteams/src/errors.ts` — Updated error hint message
- `extensions/msteams/src/probe.ts` — Updated probe error message

## How it works

The `@microsoft/agents-hosting` SDK's `AuthConfiguration` already supports `certPemFile`, `certKeyFile`, `FICClientId`, and `WIDAssertionFile`. This PR exposes those capabilities through OpenClaw's config schema.

## Backward compatibility

Fully backward compatible — existing `appId` + `appPassword` configs continue to work unchanged (default `authType` is `'clientSecret'`).

## Example configs

**Certificate auth:**
```yaml
channels:
  msteams:
    appId: '<app-id>'
    tenantId: '<tenant-id>'
    authType: certificate
    certPemFile: /path/to/cert.pem
    certKeyFile: /path/to/key.pem
```

**Federated credential:**
```yaml
channels:
  msteams:
    appId: '<app-id>'
    tenantId: '<tenant-id>'
    authType: federatedCredential
    ficClientId: '<managed-identity-client-id>'
```