### PR TITLE
fix(config): avoid raw redaction overflow on empty secrets

### DIFF
--- a/src/config/redact-snapshot.raw.test.ts
+++ b/src/config/redact-snapshot.raw.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { replaceSensitiveValuesInRaw } from "./redact-snapshot.raw.js";
+
+const TEST_REDACTED_SENTINEL = "__OPENCLAW_REDACTED__";
+
+describe("replaceSensitiveValuesInRaw", () => {
+  it("ignores empty sensitive values while redacting real secrets", () => {
+    const raw = JSON.stringify({
+      gateway: {
+        auth: {
+          token: "",
+          password: "",
+          webhookSecret: "",
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            apiKey: "sk-secret-value",
+          },
+        },
+      },
+      padding: "x".repeat(100_000),
+    });
+
+    const result = replaceSensitiveValuesInRaw({
+      raw,
+      sensitiveValues: ["", "", "", "sk-secret-value"],
+      redactedSentinel: TEST_REDACTED_SENTINEL,
+    });
+
+    expect(result).toContain(`"apiKey":"${TEST_REDACTED_SENTINEL}"`);
+    expect(result).toContain('"token":""');
+    expect(result).toContain('"password":""');
+    expect(result).toContain('"webhookSecret":""');
+  });
+});

--- a/src/config/redact-snapshot.raw.ts
+++ b/src/config/redact-snapshot.raw.ts
@@ -6,7 +6,9 @@ export function replaceSensitiveValuesInRaw(params: {
   sensitiveValues: string[];
   redactedSentinel: string;
 }): string {
-  const values = [...params.sensitiveValues].toSorted((a, b) => b.length - a.length);
+  const values = params.sensitiveValues
+    .filter((value) => value.length > 0)
+    .toSorted((a, b) => b.length - a.length);
   let result = params.raw;
   for (const value of values) {
     result = result.replaceAll(value, params.redactedSentinel);


### PR DESCRIPTION
## Summary
- skip empty sensitive values before raw config redaction runs `replaceAll`
- add a regression test covering repeated empty sensitive values plus a real secret

## Root Cause
`config.get` redacts the raw config by calling `replaceAll` for each collected sensitive value.
When multiple sensitive fields are empty strings, `replaceAll("", sentinel)` expands the raw text exponentially and can raise `RangeError: Invalid string length`.

## Verification
- `pnpm exec vitest run src/config/redact-snapshot.raw.test.ts src/config/redact-snapshot.test.ts src/gateway/server.config-patch.test.ts`
- `pnpm exec oxfmt --check src/config/redact-snapshot.raw.ts src/config/redact-snapshot.raw.test.ts`
- `pnpm exec oxlint src/config/redact-snapshot.raw.ts src/config/redact-snapshot.raw.test.ts`

Fixes #40818
