### PR TITLE
fix(config): skip empty sensitive values in raw redaction to prevent RangeError

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -12214,98 +12214,98 @@
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "7f413afd37447cd321d79286be0f58d7a9875d9b",
         "is_verified": false,
-        "line_number": 78
+        "line_number": 79
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "abb1aabcd0e49019c2873944a40671a80ccd64c7",
         "is_verified": false,
-        "line_number": 84
+        "line_number": 85
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "83a9937c6de261ffda22304834f30fe6c8f97926",
         "is_verified": false,
-        "line_number": 88
+        "line_number": 89
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "c21afa950dee2a70f3e0f6ffdfbc87f8edb90262",
         "is_verified": false,
-        "line_number": 91
+        "line_number": 92
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "3732e17b2d11ed6c64fef02c341958007af154e7",
         "is_verified": false,
-        "line_number": 95
+        "line_number": 96
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "3732e17b2d11ed6c64fef02c341958007af154e7",
         "is_verified": false,
-        "line_number": 95
+        "line_number": 96
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "87ac76dfc9cba93bead43c191e31bd099a97cc11",
         "is_verified": false,
-        "line_number": 227
+        "line_number": 228
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "8e22880b4e96bab354e1da6c91d2f58dabde3555",
         "is_verified": false,
-        "line_number": 397
+        "line_number": 398
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "8e22880b4e96bab354e1da6c91d2f58dabde3555",
         "is_verified": false,
-        "line_number": 397
+        "line_number": 398
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "a9c732e05044a08c760cce7f6d142cd0d35a19e5",
         "is_verified": false,
-        "line_number": 455
+        "line_number": 456
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "50843dd5651cfafbe7c5611c1eed195c63e6e3fd",
         "is_verified": false,
-        "line_number": 771
+        "line_number": 772
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "927e7cdedcb8f71af399a49fb90a381df8b8df28",
         "is_verified": false,
-        "line_number": 1007
+        "line_number": 1008
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "1996cc327bd39dad69cd8feb24250dafd51e7c08",
         "is_verified": false,
-        "line_number": 1013
+        "line_number": 1014
       },
       {
         "type": "Secret Keyword",
         "filename": "src/config/redact-snapshot.test.ts",
         "hashed_secret": "a5c0a65a4fa8874a486aa5072671927ceba82a90",
         "is_verified": false,
-        "line_number": 1037
+        "line_number": 1038
       }
     ],
     "src/config/schema.help.ts": [

--- a/src/config/redact-snapshot.raw.ts
+++ b/src/config/redact-snapshot.raw.ts
@@ -6,7 +6,12 @@ export function replaceSensitiveValuesInRaw(params: {
   sensitiveValues: string[];
   redactedSentinel: string;
 }): string {
-  const values = [...params.sensitiveValues].toSorted((a, b) => b.length - a.length);
+  // Filter out empty strings before sorting: replaceAll("", sentinel) inserts
+  // the sentinel between every character, which can balloon the string to
+  // hundreds of megabytes and throw a RangeError: Invalid string length.
+  const values = [...params.sensitiveValues]
+    .filter((v) => v.length > 0)
+    .toSorted((a, b) => b.length - a.length);
   let result = params.raw;
   for (const value of values) {
     result = result.replaceAll(value, params.redactedSentinel);

--- a/src/config/redact-snapshot.test.ts
+++ b/src/config/redact-snapshot.test.ts
@@ -5,6 +5,7 @@ import {
   redactConfigSnapshot,
   restoreRedactedValues as restoreRedactedValues_orig,
 } from "./redact-snapshot.js";
+import { replaceSensitiveValuesInRaw } from "./redact-snapshot.raw.js";
 import { __test__ } from "./schema.hints.js";
 import type { ConfigUiHints } from "./schema.js";
 import type { ConfigFileSnapshot } from "./types.openclaw.js";
@@ -1093,6 +1094,37 @@ describe("restoreRedactedValues", () => {
     const result = restoreRedactedValues(incoming, original, hints) as typeof incoming;
     expect(result.channels.slack.accounts[0].botToken).toBe("original-token-first-account");
     expect(result.channels.slack.accounts[1].botToken).toBe("user-provided-new-token-value");
+  });
+});
+
+describe("replaceSensitiveValuesInRaw", () => {
+  it("does not throw RangeError when sensitiveValues contains an empty string", () => {
+    // Regression for #40818: config.get crashed with RangeError: Invalid string
+    // length when a sensitive field (e.g. talk.apiKey) was set to "". The empty
+    // string caused replaceAll("", sentinel) to insert the sentinel between every
+    // character of the raw config, ballooning a ~1KB string into hundreds of MB.
+    const raw = '{"talk":{"apiKey":""}}';
+    expect(() =>
+      replaceSensitiveValuesInRaw({
+        raw,
+        sensitiveValues: ["", ""],
+        redactedSentinel: REDACTED_SENTINEL,
+      }),
+    ).not.toThrow();
+    // Empty strings must be skipped — no mutation of the raw text.
+    const result = replaceSensitiveValuesInRaw({
+      raw,
+      sensitiveValues: ["", "real-secret"],
+      redactedSentinel: REDACTED_SENTINEL,
+    });
+    expect(result).not.toContain("real-secret");
+    expect(result).toBe(raw.replaceAll("real-secret", REDACTED_SENTINEL));
+  });
+
+  it("redactConfigSnapshot does not throw when a sensitive field is an empty string", () => {
+    const config = { talk: { apiKey: "" } };
+    const snapshot = makeSnapshot(config);
+    expect(() => redactConfigSnapshot(snapshot, mainSchemaHints)).not.toThrow();
   });
 });
 


### PR DESCRIPTION
When a sensitive config field (e.g. `talk.apiKey`) is set to an empty string, `collectSensitiveValues` adds `""` to the sensitive values list. The subsequent `replaceAll("", sentinel)` call inserts the sentinel between every character of the raw config string, turning a ~1KB config into hundreds of MB and throwing `RangeError: Invalid string length`.

This caused `config.get` to fail entirely, breaking the dashboard Agents page and the `openclaw gateway call config.get` CLI command.

Root cause: `replaceSensitiveValuesInRaw` iterated over all sensitive values including empty strings. `String.prototype.replaceAll("", x)` inserts `x` between every character, so even a modest config file produces a string that exceeds Node's max string length.

Fix: Filter out empty strings before iterating. An empty sensitive value carries no redaction information, so skipping it is safe and correct.

Testing: Added two regression tests — one targeting `replaceSensitiveValuesInRaw` directly with empty `sensitiveValues`, and one testing the full `redactConfigSnapshot` path with `talk.apiKey: ""`.

Fixes #40818

---
AI-assisted (Claude). Fully tested and reviewed.