### PR TITLE
fix: default expectsCompletionMessage to false for subagent spawns

### DIFF
--- a/src/agents/subagent-spawn.ts
+++ b/src/agents/subagent-spawn.ts
@@ -272,7 +272,7 @@ export async function spawnSubagentDirect(
       : params.cleanup === "keep" || params.cleanup === "delete"
         ? params.cleanup
         : "keep";
-  const expectsCompletionMessage = params.expectsCompletionMessage !== false;
+  const expectsCompletionMessage = params.expectsCompletionMessage === true;
   const requesterOrigin = normalizeDeliveryContext({
     channel: ctx.agentChannel,
     accountId: ctx.agentAccountId,

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -170,7 +170,7 @@ export function createSessionsSpawnTool(
           mode,
           cleanup,
           sandbox,
-          expectsCompletionMessage: true,
+          expectsCompletionMessage: false,
           attachments,
           attachMountPath:
             params.attachAs && typeof params.attachAs === "object"


### PR DESCRIPTION
## Summary

- Change the default `expectsCompletionMessage` from `true` to `false` so subagent results are delivered to the parent agent's session for review (Path B / queue-steer) instead of being sent directly to the user's channel (Path A / direct-send).
- This is a 2-line change across 2 files: the hardcoded value in `sessions-spawn-tool.ts` and the fallback default in `spawnSubagentDirect`.

## Problem

When a parent agent (e.g. a WhatsApp-bound agent) spawns a subagent for research, the subagent's raw output — prefixed with `"✅ Subagent {label} finished"` — is posted directly to the user's channel via `sendSubagentAnnounceDirectly` (Path A). The parent agent never gets a chance to review, rewrite, or quality-gate the results.

This happens because:
1. `sessions-spawn-tool.ts` hardcodes `expectsCompletionMessage: true` (line 173)
2. `spawnSubagentDirect` defaults `undefined` to `true` via `!== false` (line 275)
3. Path A in `subagent-announce.ts` fires when `expectsCompletionMessage === true && hasCompletionDirectTarget` — sending raw output directly to the channel

The LLM cannot override this because `expectsCompletionMessage` is not in the tool schema — the value is hardcoded before being passed to `spawnSubagentDirect`.

## Fix

- `sessions-spawn-tool.ts`: `expectsCompletionMessage: true` → `expectsCompletionMessage: false`
- `subagent-spawn.ts`: `params.expectsCompletionMessage !== false` → `params.expectsCompletionMessage === true`

With the default set to `false`, the announce flow takes the queue/steer path first (`maybeQueueSubagentAnnounce`), delivering results as an internal system message to the parent session with the instruction: *"Convert the result above into your normal assistant voice and send that user-facing update now."* The parent reviews, rewrites, and delivers — which is the expected workflow for any agent that maintains a conversational persona.

Callers that explicitly need direct channel delivery can still pass `expectsCompletionMessage: true` via `spawnSubagentDirect`.

## Test plan

- [ ] Spawn a subagent from a channel-bound agent (e.g. WhatsApp or Discord) with `mode="run"`
- [ ] Verify the parent agent receives results as an internal system message (not posted directly to the channel)
- [ ] Verify the parent agent reviews and delivers in its own voice
- [ ] Verify no `"✅ Subagent ... finished"` prefix appears in the user-facing channel
- [ ] Verify callers passing `expectsCompletionMessage: true` via `spawnSubagentDirect` still get Path A behavior


Made with [Cursor](https://cursor.com)